### PR TITLE
fnd-002-test-metadata-parser

### DIFF
--- a/docs/internal/baselines/README.md
+++ b/docs/internal/baselines/README.md
@@ -14,3 +14,10 @@ entries and lowering accepted debt over expanding a baseline.
 `backend-package-file-count.json` is an exact deletion-only ratchet. The package
 file-count gate rejects new oversized packages, count increases, and entries
 that were not lowered or removed when the corresponding package shrank.
+
+`functional-undocumented-tests.json` is an exact deletion-only ledger of
+customer-facing `tests/functional` `Test*` identities that lack a conventional
+Go-doc description. `internal/functionaltestmetadata` compares the current
+undocumented customer set against that baseline: removals succeed, newly
+undocumented customer tests and baseline expansions fail. Harness/internal
+helpers are excluded from the ledger.

--- a/docs/internal/baselines/functional-undocumented-tests.json
+++ b/docs/internal/baselines/functional-undocumented-tests.json
@@ -1,0 +1,1794 @@
+{
+  "version": 1,
+  "stage": "functional-undocumented-tests",
+  "entries": [
+    {
+      "file": "acceptance/harness_smoke_test.go",
+      "name": "TestBuiltCLIHarness_IsolatesHomeAndLogDirectoriesAcrossSessions"
+    },
+    {
+      "file": "acceptance/harness_smoke_test.go",
+      "name": "TestBuiltCLIHarness_NonZeroExitIncludesDiagnostics"
+    },
+    {
+      "file": "acceptance/harness_smoke_test.go",
+      "name": "TestBuiltCLIHarness_WithNoExternalServerReservesUnusedPort"
+    },
+    {
+      "file": "acceptance/install_outcomes_test.go",
+      "name": "TestFreshInstall_EmptyHomeProducesDocumentedCustomerOutcome"
+    },
+    {
+      "file": "acceptance/install_outcomes_test.go",
+      "name": "TestMigratedInstall_ExistingConfigIsPreservedWithoutRewrite"
+    },
+    {
+      "file": "acceptance/install_outcomes_test.go",
+      "name": "TestMigratedInstall_JSONReportsSkippedAndCreatedOutcomes"
+    },
+    {
+      "file": "acceptance/install_outcomes_test.go",
+      "name": "TestMigratedInstall_MaterializesMissingPackagedDefaultsWithoutCorruption"
+    },
+    {
+      "file": "acceptance/invalid_quiet_outcomes_test.go",
+      "name": "TestInvalidGoal_InvalidTopology_RejectsWithDocumentedGraphReferenceError"
+    },
+    {
+      "file": "acceptance/invalid_quiet_outcomes_test.go",
+      "name": "TestInvalidGoal_OutputModesExitNonZero"
+    },
+    {
+      "file": "acceptance/invoke_repeat_subagent_outcomes_test.go",
+      "name": "TestGoalRepeat_RepeatedNamedRunsAssignDistinctInvocationIdentityAndReuseInstalledCopy"
+    },
+    {
+      "file": "acceptance/invoke_repeat_subagent_outcomes_test.go",
+      "name": "TestLocalModelInvoke_MissingReadiness_FailsWithDocumentedBootstrapGuidance"
+    },
+    {
+      "file": "acceptance/invoke_repeat_subagent_outcomes_test.go",
+      "name": "TestSubagentInvocation_SuccessfulNamedRun_ReturnsAuthoritativePrimaryResultJSON"
+    },
+    {
+      "file": "acceptance/output_outcomes_test.go",
+      "name": "TestInvocationOutput_TerminalFailureExitsNonZero"
+    },
+    {
+      "file": "acceptance/provider_outcomes_test.go",
+      "name": "TestProviderPosture_Absent_UnresolvedDefaultRejectsWithDocumentedGuidance"
+    },
+    {
+      "file": "acceptance/provider_outcomes_test.go",
+      "name": "TestProviderPosture_Configured_ExplicitHomeConfigEnablesNamedGoalSuccessPath"
+    },
+    {
+      "file": "acceptance/provider_outcomes_test.go",
+      "name": "TestProviderPosture_Discovered_EnvDefaultResolvesWithoutFileProvider"
+    },
+    {
+      "file": "bootstrap_portability/agent_factory_export_import_fixture_test.go",
+      "name": "TestAgentFactoryExportImportFixture_AuthoredLayoutInterpolatesProjectSpecificPromptContent"
+    },
+    {
+      "file": "bootstrap_portability/agent_factory_export_import_fixture_test.go",
+      "name": "TestAgentFactoryExportImportFixture_FlattenedPayloadKeepsCanonicalArrayRoutes"
+    },
+    {
+      "file": "bootstrap_portability/api_export_import_e2e_smoke_test.go",
+      "name": "TestExportImportSmoke_ExportedFactoryCanBeReimportedThroughCustomerPath"
+    },
+    {
+      "file": "bootstrap_portability/api_export_import_e2e_smoke_test.go",
+      "name": "TestExportImportSmoke_ImportedFactoryPersistsThinSplitRuntimeLayout"
+    },
+    {
+      "file": "bootstrap_portability/api_export_import_e2e_smoke_test.go",
+      "name": "TestExportImportSmoke_PreservesBatchInboxGitkeepAfterImport"
+    },
+    {
+      "file": "bootstrap_portability/api_export_import_e2e_smoke_test.go",
+      "name": "TestExportImportSmoke_PreservesPortableLayoutThroughExportImportAndActivation"
+    },
+    {
+      "file": "bootstrap_portability/api_export_import_e2e_smoke_test.go",
+      "name": "TestExportImportSmoke_PublicShareImportSurfaceCarriesDetachedStarterWork"
+    },
+    {
+      "file": "bootstrap_portability/automat_portability_fixture_test.go",
+      "name": "TestAutomatPortabilityFixture_ExpandRestoresPortableRuntimeLayout"
+    },
+    {
+      "file": "bootstrap_portability/automat_portability_fixture_test.go",
+      "name": "TestAutomatPortabilityFixture_ExpandedLayoutIsDispatchReadyForBoundedSmoke"
+    },
+    {
+      "file": "bootstrap_portability/automat_portability_fixture_test.go",
+      "name": "TestAutomatPortabilityFixture_FlattenPreservesPortableBundleContract"
+    },
+    {
+      "file": "bootstrap_portability/automat_portability_fixture_test.go",
+      "name": "TestAutomatPortabilityFixture_ModelsBoundedPortableRuntimeLayout"
+    },
+    {
+      "file": "bootstrap_portability/automat_portability_integration_test.go",
+      "name": "TestAutomatPortabilityFixture_IntegrationSmoke_CoversFlattenExpandAndBoundedReadiness"
+    },
+    {
+      "file": "bootstrap_portability/cli_init_factory_test.go",
+      "name": "TestInitFactory_ClaudeEndToEndUsesClaudeStarterWorker"
+    },
+    {
+      "file": "bootstrap_portability/export_import_fixture_test.go",
+      "name": "TestExportImportFixture_BuildsCanonicalExportAndImportContractsFromAuthoredFixture"
+    },
+    {
+      "file": "bootstrap_portability/export_import_fixture_test.go",
+      "name": "TestExportImportFixture_PersistedFactoryExposesReusableCurrentFactorySignals"
+    },
+    {
+      "file": "bootstrap_portability/export_import_nested_docs_test.go",
+      "name": "TestExportImportSmoke_PreservesNestedFactoryDocsThroughExportImport"
+    },
+    {
+      "file": "bootstrap_portability/factory_config_portability_long_test.go",
+      "name": "TestFactoryConfigPortability_FlattenInlineScriptBackedFactoryExecutesStandalone"
+    },
+    {
+      "file": "bootstrap_portability/factory_config_portability_long_test.go",
+      "name": "TestFatFactory_LoadOnlyStandaloneFileUsesSharedMappingPath"
+    },
+    {
+      "file": "bootstrap_portability/factory_config_portability_long_test.go",
+      "name": "TestFatFactory_StandaloneCanonicalFileExecutesWithInlineDefinitions"
+    },
+    {
+      "file": "bootstrap_portability/metadata_contract/factory_metadata_contract_test.go",
+      "name": "TestFactoryMetadataContractLoadsLegacyExamplesAndRendersCanonicalHelp"
+    },
+    {
+      "file": "bootstrap_portability/metadata_contract/factory_metadata_contract_test.go",
+      "name": "TestFactoryMetadataSnapshotRejectsInvalidProgrammaticExampleArguments"
+    },
+    {
+      "file": "bootstrap_portability/watcher_current_factory_activation_long_test.go",
+      "name": "TestCurrentFactoryActivationFixture_ActivatesSecondPersistedFactoryAndResolvesCurrentFactory"
+    },
+    {
+      "file": "bootstrap_portability/watcher_current_factory_activation_long_test.go",
+      "name": "TestCurrentFactoryActivationFixture_LiveAPIReadsFollowActivatedFactory"
+    },
+    {
+      "file": "bootstrap_portability/watcher_current_factory_activation_long_test.go",
+      "name": "TestCurrentFactoryActivationFixture_WatchedFileExecutionFollowsActivatedFactory"
+    },
+    {
+      "file": "cli/dynamic_workflows/dynamic_workflow_run_test.go",
+      "name": "TestRunJavaScriptFactoryResponseStreamPublishesCanonicalLifecycle"
+    },
+    {
+      "file": "cli/factory_run/events/events_test.go",
+      "name": "TestSuccessfulInvocationEmitsCanonicalNDJSON"
+    },
+    {
+      "file": "cli/factory_run/events/javascript_test.go",
+      "name": "TestJavaScriptInvocationEmitsCanonicalPhaseAndCheckpointEvents"
+    },
+    {
+      "file": "cli/factory_run/output/failure_test.go",
+      "name": "TestInvocationFailureOutputContracts"
+    },
+    {
+      "file": "cli/factory_run/output/output_test.go",
+      "name": "TestSuccessfulInvocationOutputModes"
+    },
+    {
+      "file": "cli/factory_run/yaml_io_parity/yaml_io_parity_test.go",
+      "name": "TestPackagedFactoryJSONAndYAMLValidateFlattenAndRunParity"
+    },
+    {
+      "file": "cli/factory_run/yaml_io_parity/yaml_io_parity_test.go",
+      "name": "TestPublicBlockingValidationRetainsJSONAndYAMLSourceContext"
+    },
+    {
+      "file": "cli/factory_run/yaml_io_parity/yaml_io_parity_test.go",
+      "name": "TestPublicMappingFailuresRetainJSONAndYAMLSourceContext"
+    },
+    {
+      "file": "cli/factory_run/yaml_io_parity/yaml_io_parity_test.go",
+      "name": "TestRejectedAuthoredSourcesFailBeforeRuntimeExecution"
+    },
+    {
+      "file": "cli/factory_run/yaml_io_parity/yaml_io_parity_test.go",
+      "name": "TestRuntimeMappingFailureRetainsSelectedSourceContext"
+    },
+    {
+      "file": "cli/factory_run/yaml_io_parity/yaml_io_parity_test.go",
+      "name": "TestYAMLCreateAndUpdateRemainRunnableAfterCanonicalPersistence"
+    },
+    {
+      "file": "cli/input_contract/canonical_input_contract_test.go",
+      "name": "TestCanonicalFactoryGroupRejectsUnknownSubcommand"
+    },
+    {
+      "file": "cli/input_contract/canonical_input_contract_test.go",
+      "name": "TestCanonicalRunInputCompositionAndResolution"
+    },
+    {
+      "file": "cli/input_contract/canonical_input_contract_test.go",
+      "name": "TestGenericRepresentativeProjectionIsObservableThroughApplicationRoot"
+    },
+    {
+      "file": "cli/input_contract/canonical_input_contract_test.go",
+      "name": "TestGenericSessionProjectionCoversProductionCommandShapes"
+    },
+    {
+      "file": "cli/input_contract/canonical_input_contract_test.go",
+      "name": "TestGenericSessionProjectionEnforcesProductionInputContracts"
+    },
+    {
+      "file": "cli/input_contract/canonical_input_contract_test.go",
+      "name": "TestGenericSessionProjectionParsesVariadicInputsThroughApplicationRoot"
+    },
+    {
+      "file": "cli/input_contract/generic_constructor_contract_test.go",
+      "name": "TestNewCommandTreeAcceptsRepresentativeGeneratedFlagRecords"
+    },
+    {
+      "file": "cli/input_contract/generic_constructor_contract_test.go",
+      "name": "TestNewCommandTreeAppliesOptionalDefaultsAndFixedCardinality"
+    },
+    {
+      "file": "cli/input_contract/generic_constructor_contract_test.go",
+      "name": "TestNewCommandTreeAppliesTypedDefaultsAndRejectsInvalidInvocations"
+    },
+    {
+      "file": "cli/input_contract/generic_constructor_contract_test.go",
+      "name": "TestNewCommandTreeAssignsTypedPositionalArgumentsByStableInputID"
+    },
+    {
+      "file": "cli/input_contract/generic_constructor_contract_test.go",
+      "name": "TestNewCommandTreeBuildsSyntheticHierarchyDeterministically"
+    },
+    {
+      "file": "cli/input_contract/generic_constructor_contract_test.go",
+      "name": "TestNewCommandTreeEnforcesEveryRelationshipKindBeforeHandler"
+    },
+    {
+      "file": "cli/input_contract/generic_constructor_contract_test.go",
+      "name": "TestNewCommandTreeParsesSchemaNeutralTypedFlagsByStableInputID"
+    },
+    {
+      "file": "cli/input_contract/generic_constructor_contract_test.go",
+      "name": "TestNewCommandTreeRejectsInvalidArgumentAndRelationshipRecords"
+    },
+    {
+      "file": "cli/input_contract/generic_constructor_contract_test.go",
+      "name": "TestNewCommandTreeRejectsInvalidFlagRecordsBeforeReturningTree"
+    },
+    {
+      "file": "cli/input_contract/generic_constructor_contract_test.go",
+      "name": "TestNewCommandTreeRejectsInvalidManifestBeforeReturningTree"
+    },
+    {
+      "file": "cli/input_contract/generic_constructor_coverage_test.go",
+      "name": "TestNewCommandTreeDispatchesByStableHandlerIDWithNormalizedInputs"
+    },
+    {
+      "file": "cli/input_contract/generic_constructor_coverage_test.go",
+      "name": "TestNewCommandTreeDispatchesScalarBooleanAndInt64Arguments"
+    },
+    {
+      "file": "cli/input_contract/generic_constructor_coverage_test.go",
+      "name": "TestNewCommandTreeKeepsNonRunnableCommandsOnCobraHelpPath"
+    },
+    {
+      "file": "cli/input_contract/generic_constructor_coverage_test.go",
+      "name": "TestNewCommandTreeProjectsMatchingInheritedPresentation"
+    },
+    {
+      "file": "cli/input_contract/generic_constructor_coverage_test.go",
+      "name": "TestNewCommandTreeProjectsSchemaHelpLifecycleAndCompletion"
+    },
+    {
+      "file": "cli/input_contract/generic_constructor_coverage_test.go",
+      "name": "TestNewCommandTreeRejectsInvalidHandlerBindingsBeforeExecution"
+    },
+    {
+      "file": "cli/input_contract/generic_constructor_coverage_test.go",
+      "name": "TestNewCommandTreeRejectsInvalidLifecycleAndCompletionBeforeProjection"
+    },
+    {
+      "file": "cli/input_contract/generic_constructor_coverage_test.go",
+      "name": "TestNewCommandTreeRejectsRepeatedScalarArgumentValueTypes"
+    },
+    {
+      "file": "cli/mcp_resume/resume_non_regression_test.go",
+      "name": "TestMCPResumeSmokeLane_ResumeControlStaysOnCanonicalFactorySessionTools"
+    },
+    {
+      "file": "cli/mcp_resume/resume_non_regression_test.go",
+      "name": "TestMCPResumeSmokeLane_ResumeReadModelsUseSharedFactorySessionVocabulary"
+    },
+    {
+      "file": "cli/mcp_resume/resume_non_regression_test.go",
+      "name": "TestMCPResumeSmokeLane_RuntimeBackedAsyncServeRegression"
+    },
+    {
+      "file": "cli/mcp_resume/serve_runtime_resume_smoke_test.go",
+      "name": "TestRunServe_RuntimeResumeSmoke_DispatchContinuityPreservesCompletedChildDispatchesWithoutReplay"
+    },
+    {
+      "file": "cli/mcp_resume/serve_runtime_resume_smoke_test.go",
+      "name": "TestRunServe_RuntimeResumeSmoke_InterruptedSessionResumesThroughMCPControl"
+    },
+    {
+      "file": "cli/mcp_resume/serve_runtime_resume_smoke_test.go",
+      "name": "TestRunServe_RuntimeResumeSmoke_RunningSessionResumeReturnsTypedNoOpAndPreservesSessionRead"
+    },
+    {
+      "file": "cli/mcp_resume/serve_runtime_resume_smoke_test.go",
+      "name": "TestRunServe_RuntimeResumeSmoke_TerminalSessionResumeReturnsTypedRejectionAndPreservesSessionRead"
+    },
+    {
+      "file": "cli/mcp_resume/serve_runtime_smoke_test.go",
+      "name": "TestRunServe_RuntimeSmoke_DiscoveryAsyncPollAndResult"
+    },
+    {
+      "file": "cli/named_invocation/named_invocation_test.go",
+      "name": "TestRun_NamedGoalHermeticInvocationSucceedsWithoutListeningServer"
+    },
+    {
+      "file": "cli/named_invocation/named_invocation_test.go",
+      "name": "TestRun_NamedSubagentHermeticInvocationSucceedsWithoutListeningServer"
+    },
+    {
+      "file": "cli/root_discovery/root_discovery_test.go",
+      "name": "TestBareRootPrintsConciseHelpWithoutProductEffects"
+    },
+    {
+      "file": "cli/session/session_enumeration_test.go",
+      "name": "TestSessionEnumeration"
+    },
+    {
+      "file": "cli/session/session_enumeration_test.go",
+      "name": "TestSessionEnumerationJSON"
+    },
+    {
+      "file": "cli/session_resume/resume_non_regression_test.go",
+      "name": "TestCLIResumeSmokeLane_NonResumeTerminalSessionShowPreservesShippedCLIReadSemantics"
+    },
+    {
+      "file": "cli/session_resume/resume_non_regression_test.go",
+      "name": "TestCLIResumeSmokeLane_ResumeInspectionStaysOnSharedSessionHTTPSurface"
+    },
+    {
+      "file": "cli/session_resume/resume_smoke_test.go",
+      "name": "TestCLIResumeSmoke_DurableResumeContinuityPreservesCompletedChildDispatchesWithoutReplay"
+    },
+    {
+      "file": "cli/session_resume/resume_smoke_test.go",
+      "name": "TestCLIResumeSmoke_InterruptedJavaScriptFactorySessionResumesThroughSharedSessionCommands"
+    },
+    {
+      "file": "cli/session_resume/resume_smoke_test.go",
+      "name": "TestCLIResumeSmoke_RunningSessionResumeReturnsTypedNoOpAndPreservesSessionRead"
+    },
+    {
+      "file": "cli/session_resume/resume_smoke_test.go",
+      "name": "TestCLIResumeSmoke_TerminalSessionResumeReturnsTypedRejectionAndPreservesSessionRead"
+    },
+    {
+      "file": "config_init/config_init_test.go",
+      "name": "TestInit_ConfigCreationFailureSurfacesActionableCLIError"
+    },
+    {
+      "file": "config_init/config_init_test.go",
+      "name": "TestInit_DoubleRunJSONReportsSkippedOutcomes"
+    },
+    {
+      "file": "config_init/config_init_test.go",
+      "name": "TestInit_DoubleRunReportsSkippedOutcomes"
+    },
+    {
+      "file": "config_init/config_init_test.go",
+      "name": "TestInit_ExistingConfigReportsSkippedWithoutRewrite"
+    },
+    {
+      "file": "config_init/config_init_test.go",
+      "name": "TestInit_FactoryMaterializationFailureSurfacesActionableCLIError"
+    },
+    {
+      "file": "config_init/config_init_test.go",
+      "name": "TestInit_FreshHomeCreatesSystemConfigAndReportsOutcome"
+    },
+    {
+      "file": "config_init/config_init_test.go",
+      "name": "TestInit_JSONEmitsStructuredSummary"
+    },
+    {
+      "file": "config_init/config_init_test.go",
+      "name": "TestInit_UsesProvidedHomeDirWithoutReadingProcessHome"
+    },
+    {
+      "file": "guards_batch/cascading_failure_test.go",
+      "name": "TestCascadingFailure_CompletedNotCascaded"
+    },
+    {
+      "file": "guards_batch/cascading_failure_test.go",
+      "name": "TestCascadingFailure_DirectChild"
+    },
+    {
+      "file": "guards_batch/cascading_failure_test.go",
+      "name": "TestCascadingFailure_Transitive"
+    },
+    {
+      "file": "guards_batch/concurrency_limit_long_test.go",
+      "name": "TestConcurrencyLimit_BlocksExcessDispatches"
+    },
+    {
+      "file": "guards_batch/concurrency_limit_long_test.go",
+      "name": "TestConcurrencyLimit_ReducedCapacityStillCompletes"
+    },
+    {
+      "file": "guards_batch/concurrency_limit_long_test.go",
+      "name": "TestConcurrencyLimit_ResourceReleasedOnFailure"
+    },
+    {
+      "file": "guards_batch/concurrency_limit_long_test.go",
+      "name": "TestConcurrencyLimit_ResourceTokensConsumedDuringProcessing"
+    },
+    {
+      "file": "guards_batch/dependency_terminal_test.go",
+      "name": "TestDependencyTerminal_BlockedDuringProcessing"
+    },
+    {
+      "file": "guards_batch/dependency_terminal_test.go",
+      "name": "TestDependencyTerminal_BlockedUntilArchived"
+    },
+    {
+      "file": "guards_batch/dependency_terminal_test.go",
+      "name": "TestDependencyTerminal_BothComplete"
+    },
+    {
+      "file": "guards_batch/dependency_tracking_test.go",
+      "name": "TestDependencyTracking_BlocksUntilSatisfied"
+    },
+    {
+      "file": "guards_batch/dependency_tracking_test.go",
+      "name": "TestDependencyTracking_NoDepsPassThrough"
+    },
+    {
+      "file": "guards_batch/executor_failure_test.go",
+      "name": "TestExecutorFailure_NoFailureArcs"
+    },
+    {
+      "file": "guards_batch/executor_failure_test.go",
+      "name": "TestExecutorFailure_OutcomeFailed_NoFailureArcs"
+    },
+    {
+      "file": "guards_batch/executor_failure_test.go",
+      "name": "TestExecutorFailure_WithFailureArcs"
+    },
+    {
+      "file": "guards_batch/executor_failure_test.go",
+      "name": "TestExecutorSuccess_TokenAtOutputPlace"
+    },
+    {
+      "file": "guards_batch/failed_immutability_long_test.go",
+      "name": "TestFailedImmutability_CannotBeReDispatched"
+    },
+    {
+      "file": "guards_batch/failed_immutability_long_test.go",
+      "name": "TestFailedImmutability_NoDuplicateTokens"
+    },
+    {
+      "file": "guards_batch/failed_immutability_long_test.go",
+      "name": "TestFailedImmutability_ReviewerFailure"
+    },
+    {
+      "file": "guards_batch/partial_batch_long_test.go",
+      "name": "TestPartialBatch_ProviderExitFailureRoutesTokenToFailedWithContext"
+    },
+    {
+      "file": "guards_batch/partial_batch_long_test.go",
+      "name": "TestPartialBatch_RetryableProviderFailuresRetryThroughScriptWrapPath"
+    },
+    {
+      "file": "guards_batch/partial_batch_long_test.go",
+      "name": "TestPartialBatch_SomeTokensFail"
+    },
+    {
+      "file": "guards_batch/partial_batch_long_test.go",
+      "name": "TestPartialBatch_SomeTokensRejected_RoutedViaRejectionArcs"
+    },
+    {
+      "file": "guards_batch/partial_batch_long_test.go",
+      "name": "TestPartialBatch_TemplateResolvesFromTags"
+    },
+    {
+      "file": "guards_batch/partial_batch_long_test.go",
+      "name": "TestPartialBatch_ThrottledProviderFailureWithoutAuthoredGuardEventuallyFails"
+    },
+    {
+      "file": "guards_batch/resource_contention_test.go",
+      "name": "TestConfigDriven_ResourceContention"
+    },
+    {
+      "file": "guards_batch/resource_token_name_test.go",
+      "name": "TestResourceGated_DispatchTokenName"
+    },
+    {
+      "file": "operator_settings/configcore/operator_config_core_test.go",
+      "name": "TestOperatorConfigCore_PromptedAndPresuppliedUpdatesShareAtomicBehavior"
+    },
+    {
+      "file": "providers/cli_script_executor_test.go",
+      "name": "TestScriptExecutor_ArgTemplating"
+    },
+    {
+      "file": "providers/cli_script_executor_test.go",
+      "name": "TestScriptExecutor_ArgTemplatingWithTags"
+    },
+    {
+      "file": "providers/cli_script_executor_test.go",
+      "name": "TestScriptExecutor_AsyncWorkerPoolTemplateFallbackScenarios"
+    },
+    {
+      "file": "providers/cli_script_executor_test.go",
+      "name": "TestScriptExecutor_Failure"
+    },
+    {
+      "file": "providers/cli_script_executor_test.go",
+      "name": "TestScriptExecutor_FailureRoutesToFailedPlace"
+    },
+    {
+      "file": "providers/cli_script_executor_test.go",
+      "name": "TestScriptExecutor_PreservesTokenColor"
+    },
+    {
+      "file": "providers/cli_script_executor_test.go",
+      "name": "TestScriptExecutor_RuntimeConfigMergePreservesCanonicalTopologyAndPromptTemplates"
+    },
+    {
+      "file": "providers/cli_script_executor_test.go",
+      "name": "TestScriptExecutor_RuntimeWorkstationConfigResolvesWorkingDirectoryAndEnv"
+    },
+    {
+      "file": "providers/cli_script_executor_test.go",
+      "name": "TestScriptExecutor_RuntimeWorkstationTimeoutRequeuesAndRetriesOnLaterTick"
+    },
+    {
+      "file": "providers/cli_script_executor_test.go",
+      "name": "TestScriptExecutor_Success"
+    },
+    {
+      "file": "providers/cli_script_executor_test.go",
+      "name": "TestScriptExecutor_SuccessWithColorMetadata"
+    },
+    {
+      "file": "providers/cli_script_executor_test.go",
+      "name": "TestScriptExecutor_WorkTypeIDFromTargetPlace"
+    },
+    {
+      "file": "providers/cli_script_executor_timeout_long_test.go",
+      "name": "TestScriptExecutor_RuntimeWorkerTimeoutFromLoadedConfigRequeuesAndRetriesOnLaterTick"
+    },
+    {
+      "file": "providers/cli_template_resolution_long_test.go",
+      "name": "TestTemplateTests_ScriptExecutorDropsResourceTokensFromArgTemplates"
+    },
+    {
+      "file": "providers/cli_template_resolution_long_test.go",
+      "name": "TestTemplateTests_ScriptExecutorOrdersMultipleInputsByWorkstationConfigWithResources"
+    },
+    {
+      "file": "providers/cli_template_resolution_long_test.go",
+      "name": "TestTemplateTests_ScriptWrapClaudeResolvesWorkstationExecutionTemplates"
+    },
+    {
+      "file": "providers/cli_template_resolution_long_test.go",
+      "name": "TestTemplateTests_ScriptWrapCodexResolvesWorkstationExecutionTemplates"
+    },
+    {
+      "file": "providers/cli_template_resolution_long_test.go",
+      "name": "TestTemplateTests_ScriptWrapCursorResolvesWorkstationExecutionTemplates"
+    },
+    {
+      "file": "providers/cli_template_resolution_long_test.go",
+      "name": "TestTemplateTests_ScriptWrapDropsResourceTokensFromWorkstationTemplates"
+    },
+    {
+      "file": "providers/cli_template_resolution_long_test.go",
+      "name": "TestTemplateTests_ScriptWrapOrdersMultipleInputsByWorkstationConfigWithResources"
+    },
+    {
+      "file": "providers/cli_timeout_cleanup_smoke_test.go",
+      "name": "TestIntegrationSmoke_ProcessTreeHelper"
+    },
+    {
+      "file": "providers/cli_timeout_cleanup_smoke_test.go",
+      "name": "TestIntegrationSmoke_TimeoutCancelsProcessTreeAndClearsActiveExecution"
+    },
+    {
+      "file": "providers/cli_timeout_cleanup_smoke_test.go",
+      "name": "TestIntegrationSmoke_TimeoutRequeuesWorkAndSucceedsOnLaterAttempt"
+    },
+    {
+      "file": "providers/codex/process_harness_test.go",
+      "name": "TestRootBuiltProcessExecutesThroughSharedSupport"
+    },
+    {
+      "file": "providers/codex_content_test.go",
+      "name": "TestCodexContentDispatch_MixedContentEmitsOrderedImageArgs"
+    },
+    {
+      "file": "providers/codex_content_test.go",
+      "name": "TestCodexContentDispatch_TextOnlyContentDoesNotEmitImageArgs"
+    },
+    {
+      "file": "providers/codex_worktree_workstation_test.go",
+      "name": "TestCodexWorktreeWorkstationDispatch_MaterializesCheckoutAndOmitsCLIWorktreeFlag"
+    },
+    {
+      "file": "providers/cursor_provider_command_test.go",
+      "name": "TestCursorProviderCommand_DispatchesAgentWithRenderedPrompt"
+    },
+    {
+      "file": "providers/cursor_provider_command_test.go",
+      "name": "TestCursorProviderCommand_PublicModelProviderEnumRoutesToAgent"
+    },
+    {
+      "file": "providers/cursor_provider_command_test.go",
+      "name": "TestCursorProviderCommand_SkipPermissionsPassesForceFlag"
+    },
+    {
+      "file": "providers/mock_workers_agent_test.go",
+      "name": "TestMockWorkers_AgentDefaultAcceptMovesWorkToOutputPlace"
+    },
+    {
+      "file": "providers/mock_workers_agent_test.go",
+      "name": "TestMockWorkers_AgentRejectConfigRoutesFailureWithoutLoggingCommandOutput"
+    },
+    {
+      "file": "providers/mock_workers_agent_test.go",
+      "name": "TestMockWorkers_AgentRejectConfigWithZeroExitCodeIsRejectedAtCustomerBoundary"
+    },
+    {
+      "file": "providers/mock_workers_cli_http_stability_smoke_long_test.go",
+      "name": "TestMockWorkers_CLIServiceModeStartupWorkFileSupportsRepeatedLiveHTTPPollingBeforeCompletion"
+    },
+    {
+      "file": "providers/mock_workers_end_to_end_smoke_test.go",
+      "name": "TestMockWorkers_EndToEndSmokeRunsMixedOutcomesWithoutLiveProviderCredentials"
+    },
+    {
+      "file": "providers/mock_workers_script_test.go",
+      "name": "TestMockWorkers_ScriptConfigExecutesCommandRunnerSideEffect"
+    },
+    {
+      "file": "providers/mock_workers_script_test.go",
+      "name": "TestMockWorkers_ScriptDefaultAcceptProducesSuccessfulScriptResult"
+    },
+    {
+      "file": "providers/mock_workers_script_test.go",
+      "name": "TestMockWorkers_ScriptHelper"
+    },
+    {
+      "file": "providers/mock_workers_script_test.go",
+      "name": "TestMockWorkers_ScriptRejectConfigRoutesFailureAndLogsCommandOutput"
+    },
+    {
+      "file": "providers/mock_workers_script_test.go",
+      "name": "TestMockWorkers_ScriptRejectConfigWithZeroExitCodeStillRoutesFailure"
+    },
+    {
+      "file": "providers/mock_workers_service_runner_test.go",
+      "name": "TestMockWorkers_ServiceCommandRunnerCompletesModelAndScriptWorkers"
+    },
+    {
+      "file": "providers/packaged_script_runtime_test.go",
+      "name": "TestPackagedScriptRuntime_FreshInstallExecutesFactoryRelativeScript"
+    },
+    {
+      "file": "providers/packaged_script_runtime_test.go",
+      "name": "TestPackagedScriptRuntime_NonZeroExitUsesStandardFailureOutcome"
+    },
+    {
+      "file": "providers/runtime_logging_smoke_test.go",
+      "name": "TestRuntimeLoggingSmoke_SuccessAndFailureRespectOutputEnvAndRollingPolicies"
+    },
+    {
+      "file": "replay_contracts/canonical_topology_snapshot_projection_test.go",
+      "name": "TestCanonicalTopologySnapshotsPreservePublicIdentityAndResourceEvidence"
+    },
+    {
+      "file": "replay_contracts/replay_event_stream_artifact_smoke_long_test.go",
+      "name": "TestReplayEventStreamArtifactSmoke_ReplaysCheckedInSampleArtifact"
+    },
+    {
+      "file": "replay_contracts/replay_event_stream_artifact_smoke_long_test.go",
+      "name": "TestReplayEventStreamArtifactSmoke_ReplaysCheckedInSampleArtifactWithCopiedRootFactoryDefinition"
+    },
+    {
+      "file": "replay_contracts/replay_factory_only_serialization_smoke_long_test.go",
+      "name": "TestReplayFactoryOnlySerializationSmoke_RecordReplayUsesRunStartedFactoryPayload"
+    },
+    {
+      "file": "replay_contracts/replay_legacy_unary_retirement_smoke_long_test.go",
+      "name": "TestLegacyUnaryRetirementSmoke_ReplaySubmitsCanonicalBatchWorkRequests"
+    },
+    {
+      "file": "replay_contracts/replay_record_end_to_end_long_test.go",
+      "name": "TestRecordReplayEndToEnd_CLIRecordReplayAndRegressionHarnessSucceed"
+    },
+    {
+      "file": "replay_contracts/replay_record_end_to_end_long_test.go",
+      "name": "TestRecordReplayEndToEnd_DefaultLiveRecordingPathReplaysThroughExistingFlow"
+    },
+    {
+      "file": "replay_contracts/replay_record_end_to_end_long_test.go",
+      "name": "TestRecordReplayEndToEnd_ProviderCommandDiagnosticsPersistRedactedEnv"
+    },
+    {
+      "file": "replay_contracts/replay_regression_harness_long_test.go",
+      "name": "TestReplayRegressionHarness_AssertsExpectedDivergence"
+    },
+    {
+      "file": "replay_contracts/replay_regression_harness_long_test.go",
+      "name": "TestReplayRegressionHarness_LoadsArtifactAndAssertsSuccessfulReplay"
+    },
+    {
+      "file": "replay_contracts/replay_runtime_config_smoke_long_test.go",
+      "name": "TestReplayRuntimeConfigSmoke_CanonicalWorkstationsDriveDispatchAndReplay"
+    },
+    {
+      "file": "replay_contracts/replay_script_boundary_events_test.go",
+      "name": "TestReplayScriptBoundaryEvents_CanonicalHistoryAndArtifactIncludeScriptResponseBoundary"
+    },
+    {
+      "file": "replay_contracts/replay_script_boundary_events_test.go",
+      "name": "TestReplayScriptBoundaryEvents_CanonicalHistoryIncludesScriptRequestBoundary"
+    },
+    {
+      "file": "replay_contracts/replay_script_boundary_events_test.go",
+      "name": "TestReplayScriptBoundaryEvents_ProcessFailureBoundaryPersistsInCanonicalHistoryAndArtifact"
+    },
+    {
+      "file": "replay_contracts/replay_thin_event_dual_dispatch_smoke_long_test.go",
+      "name": "TestReplayThinEventDualDispatchSmoke_ReplayAndReadersReuseSharedArtifact"
+    },
+    {
+      "file": "replay_contracts/replay_thin_event_dual_dispatch_smoke_test.go",
+      "name": "TestReplayThinEventDualDispatchSmoke_SharedArtifactCapturesModelAndScriptDispatches"
+    },
+    {
+      "file": "replay_contracts/replay_thin_event_dual_dispatch_smoke_test.go",
+      "name": "TestReplayThinEventDualDispatchSmoke_SharedArtifactGuardsThinRawContract"
+    },
+    {
+      "file": "replay_contracts/replay_work_dispatch_contract_smoke_long_test.go",
+      "name": "TestReplayWorkDispatchContractSmoke_CanonicalWorkRequestPreservesPayload"
+    },
+    {
+      "file": "replay_contracts/replay_work_dispatch_contract_smoke_long_test.go",
+      "name": "TestReplayWorkDispatchContractSmoke_LegacySubmitRequestAdapterPreservesPayload"
+    },
+    {
+      "file": "replay_contracts/replay_work_dispatch_contract_smoke_long_test.go",
+      "name": "TestReplayWorkDispatchContractSmoke_RecordReplayKeepsSplitContractCorrelation"
+    },
+    {
+      "file": "replay_contracts/worker_public_contract_smoke_long_test.go",
+      "name": "TestWorkerPublicContractSmoke_CanonicalWorkerExecutesAndKeepsRuntimeOnlyFieldsPrivate"
+    },
+    {
+      "file": "runtime_api/api_batch_submission_boundary_smoke_long_test.go",
+      "name": "TestFactoryRequestBatch_PublicBatchShapeStaysAlignedAcrossWatchedFileAndHTTP"
+    },
+    {
+      "file": "runtime_api/api_cleanup_smoke_test.go",
+      "name": "TestCleanupSmoke_BackendDashboardAndCanonicalEventsExposeOnlyCleanedFactorySurfaces"
+    },
+    {
+      "file": "runtime_api/api_config_driven_submit_query_smoke_test.go",
+      "name": "TestConfigDriven_RESTAPISubmitAndQuery"
+    },
+    {
+      "file": "runtime_api/api_cron_workstations_smoke_test.go",
+      "name": "TestCronWorkstations_ServiceModeExpiryConsumesStaleTriggerWithTerminalOutputAndDefaultWindow"
+    },
+    {
+      "file": "runtime_api/api_cron_workstations_smoke_test.go",
+      "name": "TestCronWorkstations_ServiceModeImplicitFailureRoutingMovesFailedCronWorkIntoFailedState"
+    },
+    {
+      "file": "runtime_api/api_factory_event_mapping_test.go",
+      "name": "TestFactoryEventTransportMappingRejectsMalformedCanonicalPayload"
+    },
+    {
+      "file": "runtime_api/api_functional_server_override_regression_test.go",
+      "name": "TestFunctionalServerOverrideCompatibilityRegression_MockWorkersAndProviderOverride"
+    },
+    {
+      "file": "runtime_api/api_functionallong_compile_smoke_test.go",
+      "name": "TestRuntimeAPI_CompilesWithFunctionalLongTag"
+    },
+    {
+      "file": "runtime_api/api_generated_schema_deserialization_smoke_test.go",
+      "name": "TestGeneratedSchemaDeserializationSmoke_FileAndRecordedTransportRejectRetiredFieldsAtSameBoundaryStage"
+    },
+    {
+      "file": "runtime_api/api_generated_schema_deserialization_smoke_test.go",
+      "name": "TestGeneratedSchemaDeserializationSmoke_FileHTTPAndReplayTransportsStayAligned"
+    },
+    {
+      "file": "runtime_api/api_generated_smoke_test.go",
+      "name": "TestGeneratedAPIIntegrationSmoke_BatchUpsertAcceptsWorksContent"
+    },
+    {
+      "file": "runtime_api/api_generated_smoke_test.go",
+      "name": "TestGeneratedAPIIntegrationSmoke_CLIWorkTypeNameReachesLiveAPIHandler"
+    },
+    {
+      "file": "runtime_api/api_generated_smoke_test.go",
+      "name": "TestGeneratedAPIIntegrationSmoke_OpenAPIGeneratedServerAndLiveRuntimeStayAligned"
+    },
+    {
+      "file": "runtime_api/api_generated_smoke_test.go",
+      "name": "TestGeneratedAPIIntegrationSmoke_SubmitWorkContentAcceptsCanonicalParts"
+    },
+    {
+      "file": "runtime_api/api_generated_smoke_test.go",
+      "name": "TestGeneratedAPIIntegrationSmoke_SubmitWorkItemsAcceptHeaderOnlyStructuredSubmission"
+    },
+    {
+      "file": "runtime_api/api_generated_smoke_test.go",
+      "name": "TestGeneratedAPIIntegrationSmoke_SubmitWorkItemsAcceptMixedTextAndImageSubmissionOnSupportedRunner"
+    },
+    {
+      "file": "runtime_api/api_generated_smoke_test.go",
+      "name": "TestGeneratedAPIIntegrationSmoke_SubmitWorkItemsAcceptOrderedTextSubmission"
+    },
+    {
+      "file": "runtime_api/api_generated_smoke_test.go",
+      "name": "TestGeneratedAPIIntegrationSmoke_SubmitWorkItemsRejectEmptyStructuredSubmission"
+    },
+    {
+      "file": "runtime_api/api_generated_smoke_test.go",
+      "name": "TestGeneratedAPIIntegrationSmoke_SubmitWorkItemsRejectForgedStructuredFileReference"
+    },
+    {
+      "file": "runtime_api/api_generated_smoke_test.go",
+      "name": "TestGeneratedAPIIntegrationSmoke_SubmitWorkItemsRejectMixedTextAndImageSubmissionOnUnsupportedRunner"
+    },
+    {
+      "file": "runtime_api/api_inference_events_test.go",
+      "name": "TestInferenceEvents_HTTPStreamAndPublicWorkCorrelateRetryAttempts"
+    },
+    {
+      "file": "runtime_api/api_inference_events_test.go",
+      "name": "TestInferenceEvents_ModelProviderAttemptsRecordInCanonicalHistoryAndArtifact"
+    },
+    {
+      "file": "runtime_api/api_inference_events_test.go",
+      "name": "TestInferenceEvents_ScriptWorkersDoNotEmitInferenceEvents"
+    },
+    {
+      "file": "runtime_api/api_inference_events_test.go",
+      "name": "TestInferenceEvents_ThinEventSmoke_CapturesThinnedDispatchInferenceSequenceAndReconstructsViews"
+    },
+    {
+      "file": "runtime_api/api_manual_work_recovery_test.go",
+      "name": "TestManualWorkRecovery_CascadeFailureThenAPIMovesResumeProgress"
+    },
+    {
+      "file": "runtime_api/api_model_local_inference_long_test.go",
+      "name": "TestRealLocalInference_OMNIVOICEModelInvokeAndDirectAPIProduceAudio"
+    },
+    {
+      "file": "runtime_api/api_model_transport_smoke_test.go",
+      "name": "TestModelTransportSmoke_ServiceModeStartupAndDirectModelRoutesStayAligned"
+    },
+    {
+      "file": "runtime_api/api_ootb_experience_smoke_long_test.go",
+      "name": "TestOOTBExperience_APIPreseededSimplePipelineCompletes"
+    },
+    {
+      "file": "runtime_api/api_ootb_experience_smoke_long_test.go",
+      "name": "TestOOTBExperience_APIPreseededTwoStagePipelineCompletes"
+    },
+    {
+      "file": "runtime_api/api_ootb_experience_smoke_long_test.go",
+      "name": "TestOOTBExperience_APIStatusStaysQueryableAcrossCompletion"
+    },
+    {
+      "file": "runtime_api/api_packaged_deep_research_invocation_test.go",
+      "name": "TestSessionInvocationAPI_PackagedDeepResearchUsesMaterializedFactorySource"
+    },
+    {
+      "file": "runtime_api/api_packaged_goal_invocation_test.go",
+      "name": "TestPackagedGoalBuiltInTopology_SubmitWhilePausedResumesThroughSessionControl"
+    },
+    {
+      "file": "runtime_api/api_packaged_goal_invocation_test.go",
+      "name": "TestSessionInvocationAPI_PackagedGoalContinueRepeatsBeforeCompletion"
+    },
+    {
+      "file": "runtime_api/api_packaged_goal_invocation_test.go",
+      "name": "TestSessionInvocationAPI_PackagedGoalRejectRepeatsBeforeCompletion"
+    },
+    {
+      "file": "runtime_api/api_packaged_goal_invocation_test.go",
+      "name": "TestSessionInvocationAPI_PackagedGoalReturnsExplicitSummaryPrimaryResult"
+    },
+    {
+      "file": "runtime_api/api_packaged_goal_invocation_test.go",
+      "name": "TestSessionInvocationAPI_PackagedGoalWorkerFailureReturnsFailedStatusDetails"
+    },
+    {
+      "file": "runtime_api/api_packaged_quorum_invocation_test.go",
+      "name": "TestSessionInvocationAPI_PackagedQuorumAppliesRoleArguments"
+    },
+    {
+      "file": "runtime_api/api_packaged_quorum_invocation_test.go",
+      "name": "TestSessionInvocationAPI_PackagedQuorumGatesMergeUntilBothBranchesComplete"
+    },
+    {
+      "file": "runtime_api/api_packaged_review_invocation_test.go",
+      "name": "TestSessionInvocationAPI_PackagedReviewRejectsThenApprovesRevision"
+    },
+    {
+      "file": "runtime_api/api_packaged_review_invocation_test.go",
+      "name": "TestSessionInvocationAPI_PackagedReviewReturnsApprovedCandidate"
+    },
+    {
+      "file": "runtime_api/api_packaged_review_invocation_test.go",
+      "name": "TestSessionInvocationAPI_PackagedReviewWorkerFailureReturnsFailedStatus"
+    },
+    {
+      "file": "runtime_api/api_request_batch_boundary_smoke_test.go",
+      "name": "TestGeneratedAPIIntegrationSmoke_BatchWorkTypeNameNormalizesRuntimeWork"
+    },
+    {
+      "file": "runtime_api/api_runtime_config_alignment_smoke_test.go",
+      "name": "TestRuntimeConfigAlignmentSmoke_CanonicalOnlyBoundaryStaysAlignedAcrossExecutionAndRejectsRetiredAliases"
+    },
+    {
+      "file": "runtime_api/api_runtime_log_policy_test.go",
+      "name": "TestFunctionalAPIServer_RuntimeLogDirectoryIsAProcessInput"
+    },
+    {
+      "file": "runtime_api/api_runtime_log_policy_test.go",
+      "name": "TestFunctionalAPIServer_UsesProductionRuntimeFileLoggingDefault"
+    },
+    {
+      "file": "runtime_api/api_service_config_override_alignment_test.go",
+      "name": "TestServiceConfigOverrideAlignment_FunctionalHTTPServerProviderCommandRunner"
+    },
+    {
+      "file": "runtime_api/api_service_config_override_alignment_test.go",
+      "name": "TestServiceConfigOverrideAlignment_FunctionalHTTPServerScriptCommandRunner"
+    },
+    {
+      "file": "runtime_api/api_service_mode_observability_smoke_test.go",
+      "name": "TestObservabilitySmoke_PublicStatusSessionWorkAndEventsAlignAcrossRuntimeTransitions"
+    },
+    {
+      "file": "runtime_api/api_service_mode_observability_smoke_test.go",
+      "name": "TestServiceModeSmoke_EmptyStartupIdleSubmissionAndPostCompletionIdleStayReachableUntilCanceled"
+    },
+    {
+      "file": "runtime_api/api_session_invocation_test.go",
+      "name": "TestSessionInvocationAPI_CanceledRequestContextStopsRequest"
+    },
+    {
+      "file": "runtime_api/api_session_invocation_test.go",
+      "name": "TestSessionInvocationAPI_PausedSessionReturnsPausedStatus"
+    },
+    {
+      "file": "runtime_api/api_session_invocation_test.go",
+      "name": "TestSessionInvocationAPI_RejectsArgsWithoutActiveSignature"
+    },
+    {
+      "file": "runtime_api/api_session_invocation_test.go",
+      "name": "TestSessionInvocationAPI_RejectsInvalidStructuredArgValueShape"
+    },
+    {
+      "file": "runtime_api/api_session_invocation_test.go",
+      "name": "TestSessionInvocationAPI_RejectsWhitespaceOnlyText"
+    },
+    {
+      "file": "runtime_api/api_session_invocation_test.go",
+      "name": "TestSessionInvocationAPI_ReturnsPrimaryResult"
+    },
+    {
+      "file": "runtime_api/api_session_invocation_test.go",
+      "name": "TestSessionInvocationAPI_TimeoutReturnsTimedOutStatus"
+    },
+    {
+      "file": "runtime_api/api_session_invocation_test.go",
+      "name": "TestSessionInvocationAPI_UnresolvedPrimaryResultReturnsFailedStatus"
+    },
+    {
+      "file": "runtime_api/api_submit_runtime_work_trace_shaping_smoke_test.go",
+      "name": "TestSubmitRuntimeWork_EmitsCanonicalTraceAwareBatchEvent"
+    },
+    {
+      "file": "runtime_api/api_throttle_failure_regression_test.go",
+      "name": "TestRetryableThrottleFailureWithoutGuardUsesDefaultRetryLimitAndFailsWork"
+    },
+    {
+      "file": "runtime_api/dashboard_engine_state_test.go",
+      "name": "TestDashboard_EngineStateSnapshot_EndToEnd"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_docs_test.go",
+      "name": "TestCurrentFactoryEvents_InitialStructureIncludesBundledFileContent"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_docs_test.go",
+      "name": "TestCurrentFactoryPUT_DocsCreateEditRenameDeleteRoundTrip"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_docs_test.go",
+      "name": "TestCurrentFactoryPUT_DocsSaveEmitsFactoryChangeWithBundledFilesAndVersion"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_docs_test.go",
+      "name": "TestCurrentFactoryPUT_RejectsDuplicateDocTargetPaths"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_docs_test.go",
+      "name": "TestCurrentFactoryPUT_RejectsInvalidDocTargets"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_docs_test.go",
+      "name": "TestCurrentFactoryPUT_ShellEscapedBundledInlineReplayReturnsPayloadInvalid"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_layout_test.go",
+      "name": "TestCurrentFactoryEvents_ExposePortableLayoutOnInitialStructureAndFactoryChange"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_layout_test.go",
+      "name": "TestCurrentFactoryPUT_AcceptsLayoutForKnownBundledDocNode"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_layout_test.go",
+      "name": "TestCurrentFactoryPUT_AcceptsLayoutNodeMissingSize"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_layout_test.go",
+      "name": "TestCurrentFactoryPUT_PrunesStaleLayoutWithoutReturningEphemeralLayoutMetadata"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_layout_test.go",
+      "name": "TestCurrentFactoryPUT_RejectsLayoutForUnknownBundledDocNode"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_layout_validation_test.go",
+      "name": "TestCurrentFactoryPUT_PrePersistLayoutFailureRetainsStructuredPath"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_layout_variants_test.go",
+      "name": "TestCurrentFactoryPUT_AcceptsPortableLayoutEdgeWithMultipleWaypoints"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_layout_variants_test.go",
+      "name": "TestCurrentFactoryPUT_AcceptsPortableLayoutEdgeWithOneWaypoint"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_layout_variants_test.go",
+      "name": "TestCurrentFactoryPUT_AcceptsPortableLayoutMultipleNodesWithSize"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_layout_variants_test.go",
+      "name": "TestCurrentFactoryPUT_AcceptsPortableLayoutMultipleNodesWithoutSize"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_session_import_test.go",
+      "name": "TestCurrentFactoryPUT_NonDefaultSessionImportIsolatesDefaultFactoryAndMaterializesBundledFiles"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_test.go",
+      "name": "TestCurrentFactoryPUT_DefaultFactoryAcceptsFullCurrentFactoryReadbackDocument"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_test.go",
+      "name": "TestCurrentFactoryPUT_DefaultFactoryMaterializesBundledFilesAndReturns"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_test.go",
+      "name": "TestCurrentFactoryPUT_FactoryChangeVersionsAdvanceOnEverySave"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_test.go",
+      "name": "TestCurrentFactoryPUT_RejectsTypeCountCollisionBeforePersistingDefaultFactory"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_test.go",
+      "name": "TestCurrentFactoryPUT_RequiresAdvancedSaveVersion"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_test.go",
+      "name": "TestCurrentFactoryPUT_ReturnsCanonicalTopologyValidationTargets"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_test.go",
+      "name": "TestCurrentFactoryPUT_ReturnsMultipleTopologyValidationTargets"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_test.go",
+      "name": "TestCurrentFactoryPUT_SaveDefaultFactoryDefinitionPersistsAndRunsReplacement"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_test.go",
+      "name": "TestCurrentFactoryPUT_SaveEditableCurrentFactoryDefinitionEmitsCanonicalFactoryChangeEvent"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_current_factory_put_test.go",
+      "name": "TestCurrentFactoryPUT_SessionScopedNamedFactoryTransformationReadbackIsIsolated"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_import_replace_current_split_layout_test.go",
+      "name": "TestFactoryTransformation_ReplaceCurrentImportMatchesCreateNamedSplitLayout"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_named_factory_layout_test.go",
+      "name": "TestFactoryTransformation_CreateNamedFactoryPreservesPortableLayoutThroughActivationAndReadback"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_named_factory_layout_test.go",
+      "name": "TestFactoryTransformation_UpsertNamedFactoryReplacePreservesPortableLayout"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_named_factory_test.go",
+      "name": "TestFactoryTransformation_CreateNamedFactoryEmitsCanonicalFactoryChangeEvent"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_named_factory_test.go",
+      "name": "TestFactoryTransformation_CreateNamedFactoryReadbackAndWorkSurface"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_named_factory_test.go",
+      "name": "TestFactoryTransformation_CreateNamedFactory_ReturnsBobOnFailureTarget"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_named_factory_test.go",
+      "name": "TestFactoryTransformation_CreateNamedFactory_ReturnsMultipleTopologyValidationTargets"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_named_factory_test.go",
+      "name": "TestFactoryTransformation_NamedFactoryPortableFilesReadBackThroughCanonicalContract"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_session_factory_save_version_test.go",
+      "name": "TestSessionFactoryPUT_UpsertCreateAllowsOmittedVersion"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_session_factory_save_version_test.go",
+      "name": "TestSessionFactoryPUT_UpsertReplaceDoesNotReturnAlreadyExists"
+    },
+    {
+      "file": "runtime_api/factory_transformation/api_session_factory_save_version_test.go",
+      "name": "TestSessionFactoryPUT_UpsertReplaceRejectsStaleVersion"
+    },
+    {
+      "file": "runtime_api/topology_projection_smoke_long_test.go",
+      "name": "TestEndToEndTopologyProjectionSmoke_LiveEventsAndReplayConfigMatch"
+    },
+    {
+      "file": "sessionparity/compare_test.go",
+      "name": "TestCompare_ReportsAdjacentLargeEventSequences"
+    },
+    {
+      "file": "sessionparity/compare_test.go",
+      "name": "TestCompare_ReportsEveryRetainedFactMismatch"
+    },
+    {
+      "file": "sessionparity/compare_test.go",
+      "name": "TestCompare_ReportsMissingUnexpectedDuplicateAndReorderedFacts"
+    },
+    {
+      "file": "sessionparity/compare_test.go",
+      "name": "TestNormalizers_ExcludeTransportDetailsAndRetainSessionFacts"
+    },
+    {
+      "file": "sessionparity/contract_test.go",
+      "name": "TestProjectionContract_PreservesOptionalStableFactAbsence"
+    },
+    {
+      "file": "sessionparity/contract_test.go",
+      "name": "TestProjectionContract_RetainsEveryStableFactorySessionFact"
+    },
+    {
+      "file": "sessionparity/fixtures_test.go",
+      "name": "TestTerminalFixtureObservations_AreDeterministic"
+    },
+    {
+      "file": "sessionparity/fixtures_test.go",
+      "name": "TestTerminalFixtureObservations_NormalizeAcrossCustomerInterfaces"
+    },
+    {
+      "file": "sessionparity/normalize_test.go",
+      "name": "TestNormalizeCLIJSON_PreservesCustomerVisibleCollectionOrder"
+    },
+    {
+      "file": "sessionparity/normalize_test.go",
+      "name": "TestNormalizeMCP_RejectsReorderedCanonicalEventCursors"
+    },
+    {
+      "file": "sessionparity/normalize_test.go",
+      "name": "TestNormalizers_MapRepresentativeRealCustomerShapes"
+    },
+    {
+      "file": "sessionparity/normalize_test.go",
+      "name": "TestNormalizers_PreserveDistinctLargeIntegerResultValues"
+    },
+    {
+      "file": "sessionparity/normalize_test.go",
+      "name": "TestNormalizers_RejectEveryMissingRequiredScalarFact"
+    },
+    {
+      "file": "smoke/archive_terminal_test.go",
+      "name": "TestArchiveTerminal_MultipleTokensAllTerminate"
+    },
+    {
+      "file": "smoke/archive_terminal_test.go",
+      "name": "TestArchiveTerminal_NoFurtherFiring"
+    },
+    {
+      "file": "smoke/cli_docs_smoke_test.go",
+      "name": "TestDocsCommandSmoke_AuthoringFactoriesDescribesMinimalGoalRepeater"
+    },
+    {
+      "file": "smoke/cli_docs_smoke_test.go",
+      "name": "TestDocsCommandSmoke_PackagedTopicsRemainAvailableOutsideRepositoryDocsTree"
+    },
+    {
+      "file": "smoke/cli_factory_prompt_run_smoke_test.go",
+      "name": "TestFactoryPromptRun_RealCLIAmbiguousPromptAndStdinFailsBeforeRuntimeStartup"
+    },
+    {
+      "file": "smoke/cli_factory_prompt_run_smoke_test.go",
+      "name": "TestFactoryPromptRun_RealCLICleanInvocationStdoutRemainsPipeableAcrossRuns"
+    },
+    {
+      "file": "smoke/cli_factory_prompt_run_smoke_test.go",
+      "name": "TestFactoryPromptRun_RealCLIFailureWritesNoSuccessPayloadToStdout"
+    },
+    {
+      "file": "smoke/cli_factory_prompt_run_smoke_test.go",
+      "name": "TestFactoryPromptRun_RealCLIRejectsConflictingPositionalAndStdinInput"
+    },
+    {
+      "file": "smoke/cli_factory_prompt_run_smoke_test.go",
+      "name": "TestFactoryPromptRun_RealCLIRejectsFactoryWithoutDefaultHandling"
+    },
+    {
+      "file": "smoke/cli_factory_prompt_run_smoke_test.go",
+      "name": "TestFactoryPromptRun_RealCLIStdinOnlyCleanInvocationStdoutRemainsPipeable"
+    },
+    {
+      "file": "smoke/cli_factory_prompt_run_smoke_test.go",
+      "name": "TestFactoryPromptRun_RealCLIWritesPrimaryResultFromPositionalText"
+    },
+    {
+      "file": "smoke/cli_factory_prompt_run_smoke_test.go",
+      "name": "TestFactoryPromptRun_RealCLIWritesPrimaryResultFromStdin"
+    },
+    {
+      "file": "smoke/cli_factory_prompt_run_smoke_test.go",
+      "name": "TestNamedFactoryRun_RealCLIResolvesGlobalFactoryFromUnrelatedWorkingDirectory"
+    },
+    {
+      "file": "smoke/cli_factory_prompt_run_smoke_test.go",
+      "name": "TestPackagedGoalRun_RealCLIWritesSummaryPrimaryResult"
+    },
+    {
+      "file": "smoke/cli_javascript_factory_run_smoke_test.go",
+      "name": "TestJavaScriptFactoryRun_RealCLIProvesOrderedTwoStagePipeline"
+    },
+    {
+      "file": "smoke/cli_javascript_factory_run_smoke_test.go",
+      "name": "TestJavaScriptFactoryRun_RealCLIUsesMockWorkersAndReturnsPrimaryResult"
+    },
+    {
+      "file": "smoke/cli_named_deep_research_smoke_test.go",
+      "name": "TestNamedDeepResearchCLI_DefaultInvocationReturnsLeadSynthesis"
+    },
+    {
+      "file": "smoke/cli_named_deep_research_smoke_test.go",
+      "name": "TestNamedDeepResearchCLI_InvokesConfiguredBoundedResearchWithApprovedFlags"
+    },
+    {
+      "file": "smoke/cli_named_goal_invocation_parity_smoke_test.go",
+      "name": "TestNamedGoalInvocationParity_EmptyInputRejectedWithStableCode"
+    },
+    {
+      "file": "smoke/cli_named_goal_invocation_parity_smoke_test.go",
+      "name": "TestNamedGoalInvocationParity_NamedFactoryCLIAndAPIShareSuccessOutcome"
+    },
+    {
+      "file": "smoke/cli_named_goal_invocation_parity_smoke_test.go",
+      "name": "TestNamedGoalInvocationParity_PositionalCLIAndAPIShareSuccessOutcome"
+    },
+    {
+      "file": "smoke/cli_named_goal_invocation_parity_smoke_test.go",
+      "name": "TestNamedGoalInvocationParity_SourceConflictRejectedBeforeInvocation"
+    },
+    {
+      "file": "smoke/cli_named_goal_invocation_parity_smoke_test.go",
+      "name": "TestNamedGoalInvocationParity_StdinCLIAndAPITextShareSuccessOutcome"
+    },
+    {
+      "file": "smoke/cli_named_goal_invocation_parity_smoke_test.go",
+      "name": "TestNamedGoalInvocationParity_UnresolvedPrimaryResultReportsStableFailure"
+    },
+    {
+      "file": "smoke/cli_named_goal_operator_controls_smoke_test.go",
+      "name": "TestNamedGoalOperatorControls_ClIPauseResumeDrainsBufferedGoalsInOrder"
+    },
+    {
+      "file": "smoke/cli_named_goal_operator_controls_smoke_test.go",
+      "name": "TestNamedGoalOperatorControls_InterruptedGoalInspectSurfacesDispatchAndStopSummary"
+    },
+    {
+      "file": "smoke/cli_named_goal_operator_controls_smoke_test.go",
+      "name": "TestNamedGoalOperatorControls_PauseBuffersSubmitUntilResume"
+    },
+    {
+      "file": "smoke/cli_named_goal_operator_controls_smoke_test.go",
+      "name": "TestNamedGoalOperatorControls_PauseResumeRecordsLifecycleControlEventsForReplay"
+    },
+    {
+      "file": "smoke/cli_named_goal_routing_smoke_test.go",
+      "name": "TestNamedGoalRouting_AcceptedCompletesWithPrimaryResult"
+    },
+    {
+      "file": "smoke/cli_named_goal_routing_smoke_test.go",
+      "name": "TestNamedGoalRouting_ClassifierNonSuccessOutcomesSurfaceDistinctStates"
+    },
+    {
+      "file": "smoke/cli_named_goal_routing_smoke_test.go",
+      "name": "TestNamedGoalRouting_InterruptedSuppressesSuccessPrimaryResult"
+    },
+    {
+      "file": "smoke/cli_named_goal_routing_smoke_test.go",
+      "name": "TestNamedGoalRouting_ReworkLoopsBackThenCompletesWithGoalContext"
+    },
+    {
+      "file": "smoke/cli_named_goal_routing_smoke_test.go",
+      "name": "TestNamedGoalRouting_StructuredUnknownDecisionRoutesToFailed"
+    },
+    {
+      "file": "smoke/cli_named_goal_routing_smoke_test.go",
+      "name": "TestNamedGoalRouting_UnknownClassifierLabelRoutesToFailed"
+    },
+    {
+      "file": "smoke/cli_named_goal_run_smoke_test.go",
+      "name": "TestNamedGoalRun_RealCLICompletesBatchInvocationWithPrimaryResultOnStdout"
+    },
+    {
+      "file": "smoke/cli_named_goal_run_smoke_test.go",
+      "name": "TestNamedGoalRun_RealCLIExitsAfterBatchCompletionWithoutContinuousMode"
+    },
+    {
+      "file": "smoke/cli_named_quorum_invocation_smoke_test.go",
+      "name": "TestNamedQuorumRun_RealCLIAcceptsRoleFlagsAndReturnsOneMergeResult"
+    },
+    {
+      "file": "smoke/cli_named_review_invocation_smoke_test.go",
+      "name": "TestNamedReviewInvocationVariants_RealCLIRequireApprovalAfterRejection"
+    },
+    {
+      "file": "smoke/cli_run_mode_compat_smoke_test.go",
+      "name": "TestRunModeCompat_RealCLIFactoryTextInvocationSuppressesOperatorChatter"
+    },
+    {
+      "file": "smoke/cli_run_mode_compat_smoke_test.go",
+      "name": "TestRunModeCompat_RealCLINamedGoalBatchStdoutDoesNotIncludeOperatorChatter"
+    },
+    {
+      "file": "smoke/cli_run_mode_compat_smoke_test.go",
+      "name": "TestRunModeCompat_RealCLIOperatorContinuousRunReportsStartupOutputWithoutQuiet"
+    },
+    {
+      "file": "smoke/cli_submit_batch_smoke_test.go",
+      "name": "TestSubmitBatch_RealCLIUpsertsToRunningFactory"
+    },
+    {
+      "file": "smoke/cli_work_move_smoke_test.go",
+      "name": "TestWorkMove_RealCLIMovesSubmittedWork"
+    },
+    {
+      "file": "smoke/cold_start_long_test.go",
+      "name": "TestColdStart_SingleTokenReachesTerminal"
+    },
+    {
+      "file": "smoke/cold_start_test.go",
+      "name": "TestColdStart_MixedPreSeededAndLateSubmit"
+    },
+    {
+      "file": "smoke/cold_start_test.go",
+      "name": "TestColdStart_PreSeededTokensProcessed"
+    },
+    {
+      "file": "smoke/config_driven_execution_test.go",
+      "name": "TestConfigDrivenExecution_AddWorkType"
+    },
+    {
+      "file": "smoke/config_driven_execution_test.go",
+      "name": "TestConfigDrivenExecution_GlobalConfigDrivesDefaultsAndWorkerPreset"
+    },
+    {
+      "file": "smoke/config_driven_execution_test.go",
+      "name": "TestConfigDrivenExecution_HappyPath"
+    },
+    {
+      "file": "smoke/config_driven_execution_test.go",
+      "name": "TestConfigDrivenExecution_HappyPathFailureRouting"
+    },
+    {
+      "file": "smoke/end_to_end_dispatch_test.go",
+      "name": "TestEndToEndDispatch_CompletesThroughCustomerProcess"
+    },
+    {
+      "file": "smoke/end_to_end_dispatch_test.go",
+      "name": "TestEndToEndDispatch_MultipleWorkItemsCompleteIndependently"
+    },
+    {
+      "file": "smoke/guarded_loop_breaker_long_test.go",
+      "name": "TestIntegrationSmoke_GuardedLoopBreakerRoutesOverLimitExampleWorkToFailed"
+    },
+    {
+      "file": "smoke/guarded_loop_breaker_test.go",
+      "name": "TestIntegrationSmoke_GuardedLoopBreakerExampleRejectsRetiredExhaustionRulesAtBoundary"
+    },
+    {
+      "file": "smoke/service_config_override_alignment_long_test.go",
+      "name": "TestServiceConfigOverrideAlignment_CustomerProcessScriptCommandRunner"
+    },
+    {
+      "file": "smoke/service_harness_smoke_long_test.go",
+      "name": "TestCustomerProcess_HappyPath"
+    },
+    {
+      "file": "smoke/service_harness_smoke_long_test.go",
+      "name": "TestCustomerProcess_MultipleWorkItems"
+    },
+    {
+      "file": "smoke/service_harness_smoke_long_test.go",
+      "name": "TestCustomerProcess_NoopFallback"
+    },
+    {
+      "file": "smoke/service_lifecycle_smoke_long_test.go",
+      "name": "TestServiceLifecycle_CopyFixtureDirParallelCopiesStayIsolated"
+    },
+    {
+      "file": "smoke/service_lifecycle_smoke_long_test.go",
+      "name": "TestServiceLifecycle_EmptyPreseedDirectoryRemainsIdle"
+    },
+    {
+      "file": "smoke/service_lifecycle_smoke_long_test.go",
+      "name": "TestServiceLifecycle_InitInputCompletesThroughFactoryService"
+    },
+    {
+      "file": "smoke/service_lifecycle_smoke_long_test.go",
+      "name": "TestServiceLifecycle_PreseededWorkCompletesOnStartup"
+    },
+    {
+      "file": "smoke/service_lifecycle_smoke_long_test.go",
+      "name": "TestServiceLifecycle_TerminalStatusSignalsForSeededWatcherInput"
+    },
+    {
+      "file": "smoke/service_lifecycle_smoke_long_test.go",
+      "name": "TestServiceLifecycle_WorkFileSubmissionCompletesTwoStagePipeline"
+    },
+    {
+      "file": "smoke/service_pipeline_config_behavior_test.go",
+      "name": "TestServicePipelineConfigBehavior_SimplePipelineCompletesOneTask"
+    },
+    {
+      "file": "smoke/service_pipeline_config_behavior_test.go",
+      "name": "TestServicePipelineConfigBehavior_TwoStagePipelineCompletesAcrossBothWorkers"
+    },
+    {
+      "file": "smoke/stateless_execution_long_test.go",
+      "name": "TestStatelessExecution_DifferentWorkstationsResolveDifferentWorkers"
+    },
+    {
+      "file": "smoke/stateless_execution_long_test.go",
+      "name": "TestStatelessExecution_SharedExecutorResolvesDifferentWorkstations"
+    },
+    {
+      "file": "smoke/stateless_loaded_config_smoke_long_test.go",
+      "name": "TestStatelessExecutionSmoke_LoadedConfigDrivesExecution"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestBackendCoverageAliasesSmoke_RedirectToIndependentLanes"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestBackendVerificationLaneScriptSmoke_PreservesFailureExitAndLog"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestBackendVerificationLaneScriptSmoke_UsesCanonicalOwnedCommandAndCapturesLog"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestConcurrentUIVerificationLanesScriptSmoke_DoesNotWaitForDetachedLogHandle"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestConcurrentUIVerificationLanesScriptSmoke_FailureReportsExactLaneRerun"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestConcurrentUIVerificationLanesScriptSmoke_RunsBothOwnedLanesConcurrently"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestLongTestsCommandSmoke_FailureReportsExactSpecialtyLaneRerun"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestShardedUICoverageScriptSmoke_CleansStaleVitestReportBlobsBeforeShards"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestShardedUICoverageScriptSmoke_FailureReportsExactShardRerun"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestShardedUICoverageScriptSmoke_RunsAllShardsThenMerge"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestUICoverageCommandSmoke_RunsPackageCoverageThenReplayCheck"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestUIPackageCoverageCommandSmoke_InvokesPackageOwnedCoverageScript"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestVerifyCompatibilityAliasSmoke_RedirectsToCanonicalPRTier"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestVerifyExtendedCommandSmoke_UsesOnlyExplicitLongSuitesAfterPRTier"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestVerifyFastCommandSmoke_ContractFailureStopsLaterSuites"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestVerifyFastCommandSmoke_FailureReportsOwnedSuiteAndRerunCommand"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestVerifyFastCommandSmoke_UsesOnlyShortOwnedSuites"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestVerifyPRCommandSmoke_FailureReportsExactLaneRerun"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestVerifyPRCommandSmoke_UsesRequiredLanesOnce"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestVerifyPRInferenceCommandSmoke_FailureReportsOwnedRerunCommand"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestVerifyPRInferenceCommandSmoke_RunsSingleNamedRegressionOnly"
+    },
+    {
+      "file": "smoke/verify_fast_command_smoke_test.go",
+      "name": "TestVerifyPRInferenceCommandSmoke_StaysOutsideRequiredPRAndExtendedTiers"
+    },
+    {
+      "file": "work/visualization/dependency_graph_test.go",
+      "name": "TestDependencyGraphVisualization_RendersCompleteEscapedFlowchart"
+    },
+    {
+      "file": "workflow/cli_ralph_init_smoke_test.go",
+      "name": "TestIntegrationSmoke_RalphInitScaffoldCompletesFromGeneratedLoop"
+    },
+    {
+      "file": "workflow/cli_ralph_init_smoke_test.go",
+      "name": "TestIntegrationSmoke_RalphInitScaffoldExhaustsNonConvergingLoop"
+    },
+    {
+      "file": "workflow/code_review_loop_long_test.go",
+      "name": "TestCodeReviewLoop"
+    },
+    {
+      "file": "workflow/config_driven_retry_loop_breaker_test.go",
+      "name": "TestConfigDrivenRetryLoopBreaker_SucceedsBeforeLimit"
+    },
+    {
+      "file": "workflow/config_driven_retry_loop_breaker_test.go",
+      "name": "TestConfigDrivenRetryLoopBreaker_TerminatesAfterMaxRetries"
+    },
+    {
+      "file": "workflow/conflict_resolution_test.go",
+      "name": "TestConflictResolution_ResolverFails"
+    },
+    {
+      "file": "workflow/conflict_resolution_test.go",
+      "name": "TestConflictResolution_ReviewApproveFirstTry"
+    },
+    {
+      "file": "workflow/conflict_resolution_test.go",
+      "name": "TestConflictResolution_ReviewFailResolveReReview"
+    },
+    {
+      "file": "workflow/dispatcher_workflow_long_test.go",
+      "name": "TestDispatcherWorkflow_ExecutionPoolIsolation"
+    },
+    {
+      "file": "workflow/dispatcher_workflow_long_test.go",
+      "name": "TestDispatcherWorkflow_MultipleSeedFiles"
+    },
+    {
+      "file": "workflow/dispatcher_workflow_long_test.go",
+      "name": "TestDispatcherWorkflow_ReviewFailurePerItem"
+    },
+    {
+      "file": "workflow/dispatcher_workflow_long_test.go",
+      "name": "TestDispatcherWorkflow_SingleSeedFile"
+    },
+    {
+      "file": "workflow/dispatcher_workflow_long_test.go",
+      "name": "TestDispatcherWorkflow_TwoSeedFiles"
+    },
+    {
+      "file": "workflow/idea_plan_review_execute_with_limits_long_test.go",
+      "name": "TestIdeaPlanExecuteReviewWithLimitsFailsOnExecutorFullPass"
+    },
+    {
+      "file": "workflow/logical_move_long_test.go",
+      "name": "TestLogicalMove_PreservesTokenColor"
+    },
+    {
+      "file": "workflow/logical_move_long_test.go",
+      "name": "TestLogicalMove_Success"
+    },
+    {
+      "file": "workflow/multi_output_color_propagation_long_test.go",
+      "name": "TestMultiOutputColorPropagation"
+    },
+    {
+      "file": "workflow/multi_output_color_propagation_long_test.go",
+      "name": "TestMultiOutputColorPropagation_NameAvailableDownstream"
+    },
+    {
+      "file": "workflow/multi_output_color_propagation_test.go",
+      "name": "TestDocReviewerExamplePNGFanoutPreservesSharedNameDownstream"
+    },
+    {
+      "file": "workflow/multi_output_color_propagation_test.go",
+      "name": "TestMultiOutputReviewerFanoutPreservesSharedNameDownstream"
+    },
+    {
+      "file": "workflow/multi_output_color_propagation_test.go",
+      "name": "TestNtoN_TypeMatching"
+    },
+    {
+      "file": "workflow/multi_output_long_test.go",
+      "name": "TestMultiOutput_NoStopWordsConfigured"
+    },
+    {
+      "file": "workflow/multi_output_long_test.go",
+      "name": "TestMultiOutput_OutputTokensInheritInputLineage"
+    },
+    {
+      "file": "workflow/multi_output_long_test.go",
+      "name": "TestMultiOutput_SecondStopWord"
+    },
+    {
+      "file": "workflow/multi_output_long_test.go",
+      "name": "TestMultiOutput_WithStopWord"
+    },
+    {
+      "file": "workflow/multi_output_long_test.go",
+      "name": "TestMultiOutput_WithoutStopWord"
+    },
+    {
+      "file": "workflow/name_propagation_long_test.go",
+      "name": "TestNamePropagation_InPromptTemplate"
+    },
+    {
+      "file": "workflow/name_propagation_long_test.go",
+      "name": "TestNamePropagation_MarkdownFile"
+    },
+    {
+      "file": "workflow/ralph_loop_long_test.go",
+      "name": "TestRalphLoop_TemplateFieldsResolvePerIteration"
+    },
+    {
+      "file": "workflow/ralph_loop_test.go",
+      "name": "TestRalphLoop_ConvergesOnReviewerAccept"
+    },
+    {
+      "file": "workflow/rejection_path_test.go",
+      "name": "TestRejectionPath_NoRejectionArcsFailsToken"
+    },
+    {
+      "file": "workflow/rejection_path_test.go",
+      "name": "TestRejectionPath_NoRejectionArcsFailureRecordSet"
+    },
+    {
+      "file": "workflow/rejection_path_test.go",
+      "name": "TestRejectionPath_NoRejectionArcsReleasesResources"
+    },
+    {
+      "file": "workflow/rejection_path_test.go",
+      "name": "TestRejectionPath_WithRejectionArcsRoutesViaArcs"
+    },
+    {
+      "file": "workflow/repeater_parameterized_long_test.go",
+      "name": "TestRepeater_GuardedLoopBreakerTerminatesRejectedRepeater"
+    },
+    {
+      "file": "workflow/repeater_parameterized_long_test.go",
+      "name": "TestRepeater_RefiresOnRejectedStopsOnAccepted"
+    },
+    {
+      "file": "workflow/repeater_parameterized_long_test.go",
+      "name": "TestRepeater_ResourceReleaseBetweenIterations_ServiceHarness"
+    },
+    {
+      "file": "workflow/repeater_parameterized_test.go",
+      "name": "TestParameterizedFields_UnresolvedTemplateRoutesToFailure"
+    },
+    {
+      "file": "workflow/repeater_parameterized_test.go",
+      "name": "TestParameterizedFields_WorkingDirectoryResolvesFromTags"
+    },
+    {
+      "file": "workflow/repeater_parameterized_test.go",
+      "name": "TestRepeater_ResourceReleaseBetweenIterations"
+    },
+    {
+      "file": "workflow/repeater_parameterized_test.go",
+      "name": "TestRepeater_YieldsBetweenIterations"
+    },
+    {
+      "file": "workflow/review_retry_exhaustion_long_test.go",
+      "name": "TestReviewRetryLoopBreaker_FeedbackPropagated"
+    },
+    {
+      "file": "workflow/review_retry_exhaustion_long_test.go",
+      "name": "TestReviewRetryLoopBreaker_SucceedsBeforeLimit"
+    },
+    {
+      "file": "workflow/review_retry_exhaustion_long_test.go",
+      "name": "TestReviewRetryLoopBreaker_TerminatesAfterMaxRetries"
+    },
+    {
+      "file": "workflow/watcher_multichannel_submission_long_test.go",
+      "name": "TestMultiChannelFileWatcher_DefaultSubmission"
+    },
+    {
+      "file": "workflow/watcher_multichannel_submission_long_test.go",
+      "name": "TestMultiChannelFileWatcher_DynamicExecDir"
+    },
+    {
+      "file": "workflow/watcher_multichannel_submission_long_test.go",
+      "name": "TestMultiChannelFileWatcher_ExecutionIDSubmission"
+    },
+    {
+      "file": "workflow/workstation_stopwords_long_test.go",
+      "name": "TestWorkstationStopWords_ThroughCustomerProcess"
+    }
+  ]
+}

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -75,10 +75,14 @@
   Durable top-level `Test*` inventory for functional-test visualization lives in
   `internal/functionaltestmetadata`: walk `*_test.go` with `go/parser` /
   `go/ast`, emit slash-normalized file/package/name/line metadata, take the
-  first Go-doc sentence through `go/doc.Synopsis`, and fail closed with a
+  first Go-doc sentence through `go/doc.Synopsis`, attach file-level
+  `//go:build` (preferring it over legacy `// +build`) expressions as
+  `BuildTags`, and capture explicit golden fixture/manifest paths from a
+  `//golden: <path>` doc directive or a test-owned `golden` /
+  `goldenManifest` / `goldenFixture` string declaration. Fail closed with a
   file-scoped error on malformed source. Later FND cells consume that package
-  for build tags, golden refs, customer-versus-harness classification, and the
-  undocumented baseline; do not reintroduce regex or line-scraping inventories.
+  for customer-versus-harness classification and the undocumented baseline; do
+  not reintroduce regex or line-scraping inventories.
   `make functional-boundary-check` also owns the deletion-only inventory of
   grandfathered `tests/functional/providers/*_test.go` files: existing entries
   must be removed in the same change as their files migrate so stale exceptions

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -84,8 +84,14 @@
   (`ClassificationHarness`); all other inventoried `Test*` records are
   `ClassificationCustomer`. `CustomerScenarioCount` equals the customer
   record count only. Fail closed with a file-scoped error on malformed
-  source. Later FND cells consume that package for the undocumented
-  baseline; do not reintroduce regex or line-scraping inventories.
+  source. Undocumented customer identities are enforced against the exact
+  deletion-only ledger
+  `docs/internal/baselines/functional-undocumented-tests.json` via
+  `CheckAgainstBaseline` / `ValidateBaselineUpdate` (subset or identical
+  match succeeds; new undocumented customer tests and baseline expansions
+  fail; harness/internal helpers stay out of the ledger). Later FND cells
+  wire that check into Make/CI; do not reintroduce regex or line-scraping
+  inventories.
   `make functional-boundary-check` also owns the deletion-only inventory of
   grandfathered `tests/functional/providers/*_test.go` files: existing entries
   must be removed in the same change as their files migrate so stale exceptions

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -72,6 +72,13 @@
   `go list ./tests/functional/...` result, the shared-support exclusion, and
   required provider-destination validation in both callers. Required package
   validation protects topology but must not become an execution allowlist.
+  Durable top-level `Test*` inventory for functional-test visualization lives in
+  `internal/functionaltestmetadata`: walk `*_test.go` with `go/parser` /
+  `go/ast`, emit slash-normalized file/package/name/line metadata, take the
+  first Go-doc sentence through `go/doc.Synopsis`, and fail closed with a
+  file-scoped error on malformed source. Later FND cells consume that package
+  for build tags, golden refs, customer-versus-harness classification, and the
+  undocumented baseline; do not reintroduce regex or line-scraping inventories.
   `make functional-boundary-check` also owns the deletion-only inventory of
   grandfathered `tests/functional/providers/*_test.go` files: existing entries
   must be removed in the same change as their files migrate so stale exceptions

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -79,10 +79,13 @@
   `//go:build` (preferring it over legacy `// +build`) expressions as
   `BuildTags`, and capture explicit golden fixture/manifest paths from a
   `//golden: <path>` doc directive or a test-owned `golden` /
-  `goldenManifest` / `goldenFixture` string declaration. Fail closed with a
-  file-scoped error on malformed source. Later FND cells consume that package
-  for customer-versus-harness classification and the undocumented baseline; do
-  not reintroduce regex or line-scraping inventories.
+  `goldenManifest` / `goldenFixture` string declaration. Classify
+  `internal/**` and `*helpers*_test.go` paths as harness verification
+  (`ClassificationHarness`); all other inventoried `Test*` records are
+  `ClassificationCustomer`. `CustomerScenarioCount` equals the customer
+  record count only. Fail closed with a file-scoped error on malformed
+  source. Later FND cells consume that package for the undocumented
+  baseline; do not reintroduce regex or line-scraping inventories.
   `make functional-boundary-check` also owns the deletion-only inventory of
   grandfathered `tests/functional/providers/*_test.go` files: existing entries
   must be removed in the same change as their files migrate so stale exceptions

--- a/internal/functionaltestmetadata/baseline.go
+++ b/internal/functionaltestmetadata/baseline.go
@@ -1,0 +1,183 @@
+package functionaltestmetadata
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+)
+
+const (
+	// BaselineStage identifies the functional undocumented-test ledger.
+	BaselineStage = "functional-undocumented-tests"
+	// BaselineVersion is the current on-disk baseline schema version.
+	BaselineVersion = 1
+)
+
+// BaselineEntry is one exact undocumented customer Test* identity.
+type BaselineEntry struct {
+	File string `json:"file"`
+	Name string `json:"name"`
+}
+
+// Identity returns the stable catalog identity for this baseline entry.
+func (e BaselineEntry) Identity() string {
+	return e.File + "::" + e.Name
+}
+
+// Baseline is an exact deletion-only ledger of undocumented customer Test*
+// identities. Removals are allowed; expansions are rejected.
+type Baseline struct {
+	Version int             `json:"version"`
+	Stage   string          `json:"stage"`
+	Entries []BaselineEntry `json:"entries"`
+}
+
+// UndocumentedCustomerIdentities returns stable identities for customer
+// scenario records that lack a conventional Go-doc description. Harness and
+// internal helpers are excluded.
+func UndocumentedCustomerIdentities(records []Record) []string {
+	identities := make([]string, 0)
+	for _, record := range records {
+		if record.Undocumented && record.IsCustomerScenario() {
+			identities = append(identities, record.Identity())
+		}
+	}
+	slices.Sort(identities)
+	return slices.Clip(slices.Compact(identities))
+}
+
+// BaselineFromRecords builds an exact baseline from inventoried records,
+// including only undocumented customer scenarios.
+func BaselineFromRecords(records []Record) Baseline {
+	identities := UndocumentedCustomerIdentities(records)
+	entries := make([]BaselineEntry, 0, len(identities))
+	for _, identity := range identities {
+		file, name, ok := splitIdentity(identity)
+		if !ok {
+			continue
+		}
+		entries = append(entries, BaselineEntry{File: file, Name: name})
+	}
+	return Baseline{
+		Version: BaselineVersion,
+		Stage:   BaselineStage,
+		Entries: entries,
+	}
+}
+
+// LoadBaseline reads an exact undocumented-test baseline JSON file.
+func LoadBaseline(path string) (Baseline, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Baseline{}, fmt.Errorf("read undocumented-test baseline %s: %w", normalizePath(path), err)
+	}
+	baseline, err := ParseBaseline(data)
+	if err != nil {
+		return Baseline{}, fmt.Errorf("parse undocumented-test baseline %s: %w", normalizePath(path), err)
+	}
+	return baseline, nil
+}
+
+// ParseBaseline decodes and normalizes an exact undocumented-test baseline.
+func ParseBaseline(data []byte) (Baseline, error) {
+	var baseline Baseline
+	if err := json.Unmarshal(data, &baseline); err != nil {
+		return Baseline{}, err
+	}
+	if baseline.Version == 0 {
+		baseline.Version = BaselineVersion
+	}
+	if baseline.Stage == "" {
+		baseline.Stage = BaselineStage
+	}
+	for i := range baseline.Entries {
+		baseline.Entries[i].File = normalizePath(baseline.Entries[i].File)
+		baseline.Entries[i].Name = strings.TrimSpace(baseline.Entries[i].Name)
+		if baseline.Entries[i].File == "" || baseline.Entries[i].Name == "" {
+			return Baseline{}, fmt.Errorf("baseline entry %d is missing file or name", i)
+		}
+	}
+	slices.SortFunc(baseline.Entries, compareBaselineEntries)
+	baseline.Entries = slices.CompactFunc(baseline.Entries, func(a, b BaselineEntry) bool {
+		return a.Identity() == b.Identity()
+	})
+	return baseline, nil
+}
+
+// Identities returns sorted unique baseline identities.
+func (b Baseline) Identities() []string {
+	identities := make([]string, 0, len(b.Entries))
+	for _, entry := range b.Entries {
+		identities = append(identities, entry.Identity())
+	}
+	slices.Sort(identities)
+	return slices.Clip(slices.Compact(identities))
+}
+
+// CheckAgainstBaseline compares inventoried undocumented customer tests with
+// an exact deletion-only baseline. Success requires the undocumented set to be
+// identical to or a strict subset of the baseline. Newly undocumented customer
+// tests absent from the baseline fail with an actionable identity.
+func CheckAgainstBaseline(records []Record, baseline Baseline) error {
+	allowed := make(map[string]struct{}, len(baseline.Entries))
+	for _, entry := range baseline.Entries {
+		allowed[entry.Identity()] = struct{}{}
+	}
+
+	var unexpected []string
+	for _, identity := range UndocumentedCustomerIdentities(records) {
+		if _, ok := allowed[identity]; !ok {
+			unexpected = append(unexpected, identity)
+		}
+	}
+	if len(unexpected) == 0 {
+		return nil
+	}
+	slices.Sort(unexpected)
+	return fmt.Errorf(
+		"new undocumented customer test(s) absent from deletion-only baseline: %s",
+		strings.Join(unexpected, ", "),
+	)
+}
+
+// ValidateBaselineUpdate enforces deletion-only baseline edits: the proposed
+// baseline may only remove identities. Expanding the baseline with new
+// undocumented identities is rejected.
+func ValidateBaselineUpdate(previous, next Baseline) error {
+	allowed := make(map[string]struct{}, len(previous.Entries))
+	for _, entry := range previous.Entries {
+		allowed[entry.Identity()] = struct{}{}
+	}
+
+	var expansions []string
+	for _, identity := range next.Identities() {
+		if _, ok := allowed[identity]; !ok {
+			expansions = append(expansions, identity)
+		}
+	}
+	if len(expansions) == 0 {
+		return nil
+	}
+	slices.Sort(expansions)
+	return fmt.Errorf(
+		"illegal undocumented-test baseline expansion (deletion-only): %s",
+		strings.Join(expansions, ", "),
+	)
+}
+
+func compareBaselineEntries(a, b BaselineEntry) int {
+	if a.File != b.File {
+		return strings.Compare(a.File, b.File)
+	}
+	return strings.Compare(a.Name, b.Name)
+}
+
+func splitIdentity(identity string) (file, name string, ok bool) {
+	file, name, found := strings.Cut(identity, "::")
+	if !found || file == "" || name == "" {
+		return "", "", false
+	}
+	return file, name, true
+}

--- a/internal/functionaltestmetadata/baseline_repo_test.go
+++ b/internal/functionaltestmetadata/baseline_repo_test.go
@@ -1,0 +1,45 @@
+package functionaltestmetadata_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/functionaltestmetadata"
+)
+
+func TestCommittedBaselineMatchesCurrentUndocumentedCustomerTests(t *testing.T) {
+	t.Parallel()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	functionalRoot := filepath.Join(repoRoot, "tests", "functional")
+	baselinePath := filepath.Join(repoRoot, "docs", "internal", "baselines", "functional-undocumented-tests.json")
+
+	records, err := functionaltestmetadata.Parse(functionalRoot)
+	if err != nil {
+		t.Fatalf("Parse(%s) error = %v", functionalRoot, err)
+	}
+	baseline, err := functionaltestmetadata.LoadBaseline(baselinePath)
+	if err != nil {
+		t.Fatalf("LoadBaseline(%s) error = %v", baselinePath, err)
+	}
+
+	current := functionaltestmetadata.BaselineFromRecords(records)
+	if len(current.Entries) != len(baseline.Entries) {
+		t.Fatalf("committed baseline has %d entries, parser discovered %d undocumented customer tests", len(baseline.Entries), len(current.Entries))
+	}
+	if err := functionaltestmetadata.CheckAgainstBaseline(records, baseline); err != nil {
+		t.Fatalf("CheckAgainstBaseline(repo) error = %v", err)
+	}
+	// Exact match: no stale committed entries either for the initial freeze.
+	if err := functionaltestmetadata.ValidateBaselineUpdate(current, baseline); err != nil {
+		t.Fatalf("committed baseline drifted from parser discovery: %v", err)
+	}
+	if err := functionaltestmetadata.ValidateBaselineUpdate(baseline, current); err != nil {
+		t.Fatalf("parser discovery drifted from committed baseline: %v", err)
+	}
+}

--- a/internal/functionaltestmetadata/baseline_test.go
+++ b/internal/functionaltestmetadata/baseline_test.go
@@ -1,0 +1,249 @@
+package functionaltestmetadata_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/functionaltestmetadata"
+)
+
+func TestCheckAgainstBaselineAcceptsIdenticalMatch(t *testing.T) {
+	t.Parallel()
+
+	root := writeTree(t, map[string]string{
+		"smoke/doc_test.go": `package smoke
+
+import "testing"
+
+// TestDocumented is covered by Go doc.
+func TestDocumented(t *testing.T) {}
+`,
+		"smoke/undoc_test.go": `package smoke
+
+import "testing"
+
+func TestLegacyUndocumented(t *testing.T) {}
+`,
+	})
+
+	records, err := functionaltestmetadata.Parse(root)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	baseline := functionaltestmetadata.BaselineFromRecords(records)
+	if len(baseline.Entries) != 1 {
+		t.Fatalf("baseline entries = %d, want 1: %#v", len(baseline.Entries), baseline.Entries)
+	}
+	if err := functionaltestmetadata.CheckAgainstBaseline(records, baseline); err != nil {
+		t.Fatalf("CheckAgainstBaseline() identical match error = %v", err)
+	}
+}
+
+func TestCheckAgainstBaselineAcceptsDeletionSubset(t *testing.T) {
+	t.Parallel()
+
+	previousRoot := writeTree(t, map[string]string{
+		"smoke/a_test.go": `package smoke
+
+import "testing"
+
+func TestAlpha(t *testing.T) {}
+
+func TestBeta(t *testing.T) {}
+`,
+	})
+	previousRecords, err := functionaltestmetadata.Parse(previousRoot)
+	if err != nil {
+		t.Fatalf("Parse(previous) error = %v", err)
+	}
+	baseline := functionaltestmetadata.BaselineFromRecords(previousRecords)
+	if len(baseline.Entries) != 2 {
+		t.Fatalf("previous baseline entries = %d, want 2", len(baseline.Entries))
+	}
+
+	// Suite and baseline both shrink by deleting TestBeta (deletion success).
+	shrunkRoot := writeTree(t, map[string]string{
+		"smoke/a_test.go": `package smoke
+
+import "testing"
+
+func TestAlpha(t *testing.T) {}
+`,
+	})
+	shrunkRecords, err := functionaltestmetadata.Parse(shrunkRoot)
+	if err != nil {
+		t.Fatalf("Parse(shrunk) error = %v", err)
+	}
+	shrunkBaseline := functionaltestmetadata.Baseline{
+		Version: functionaltestmetadata.BaselineVersion,
+		Stage:   functionaltestmetadata.BaselineStage,
+		Entries: []functionaltestmetadata.BaselineEntry{
+			{File: "smoke/a_test.go", Name: "TestAlpha"},
+		},
+	}
+	if err := functionaltestmetadata.ValidateBaselineUpdate(baseline, shrunkBaseline); err != nil {
+		t.Fatalf("ValidateBaselineUpdate(deletion) error = %v", err)
+	}
+	if err := functionaltestmetadata.CheckAgainstBaseline(shrunkRecords, shrunkBaseline); err != nil {
+		t.Fatalf("CheckAgainstBaseline(deletion) error = %v", err)
+	}
+
+	// Undocumented set may also be a strict subset while a stale baseline entry remains.
+	if err := functionaltestmetadata.CheckAgainstBaseline(shrunkRecords, baseline); err != nil {
+		t.Fatalf("CheckAgainstBaseline(subset with stale baseline entry) error = %v", err)
+	}
+}
+
+func TestCheckAgainstBaselineRejectsNewUndocumentedCustomerTest(t *testing.T) {
+	t.Parallel()
+
+	baseline := functionaltestmetadata.Baseline{
+		Version: functionaltestmetadata.BaselineVersion,
+		Stage:   functionaltestmetadata.BaselineStage,
+		Entries: []functionaltestmetadata.BaselineEntry{
+			{File: "smoke/legacy_test.go", Name: "TestLegacy"},
+		},
+	}
+
+	root := writeTree(t, map[string]string{
+		"smoke/legacy_test.go": `package smoke
+
+import "testing"
+
+func TestLegacy(t *testing.T) {}
+`,
+		"smoke/new_test.go": `package smoke
+
+import "testing"
+
+func TestBrandNewUndocumented(t *testing.T) {}
+`,
+	})
+	records, err := functionaltestmetadata.Parse(root)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	err = functionaltestmetadata.CheckAgainstBaseline(records, baseline)
+	if err == nil {
+		t.Fatal("CheckAgainstBaseline() error = nil, want new undocumented failure")
+	}
+	if !strings.Contains(err.Error(), "smoke/new_test.go::TestBrandNewUndocumented") {
+		t.Fatalf("error %q missing actionable identity for new undocumented test", err)
+	}
+}
+
+func TestValidateBaselineUpdateRejectsIllegalExpansion(t *testing.T) {
+	t.Parallel()
+
+	previous := functionaltestmetadata.Baseline{
+		Version: functionaltestmetadata.BaselineVersion,
+		Stage:   functionaltestmetadata.BaselineStage,
+		Entries: []functionaltestmetadata.BaselineEntry{
+			{File: "smoke/a_test.go", Name: "TestAlpha"},
+		},
+	}
+	expanded := functionaltestmetadata.Baseline{
+		Version: functionaltestmetadata.BaselineVersion,
+		Stage:   functionaltestmetadata.BaselineStage,
+		Entries: []functionaltestmetadata.BaselineEntry{
+			{File: "smoke/a_test.go", Name: "TestAlpha"},
+			{File: "smoke/b_test.go", Name: "TestBeta"},
+		},
+	}
+
+	err := functionaltestmetadata.ValidateBaselineUpdate(previous, expanded)
+	if err == nil {
+		t.Fatal("ValidateBaselineUpdate() error = nil, want illegal expansion failure")
+	}
+	if !strings.Contains(err.Error(), "smoke/b_test.go::TestBeta") {
+		t.Fatalf("error %q missing expanded identity", err)
+	}
+	if !strings.Contains(err.Error(), "deletion-only") {
+		t.Fatalf("error %q should mention deletion-only policy", err)
+	}
+}
+
+func TestUndocumentedBaselineExcludesHarnessAndInternal(t *testing.T) {
+	t.Parallel()
+
+	root := writeTree(t, map[string]string{
+		"smoke/customer_test.go": `package smoke
+
+import "testing"
+
+func TestCustomerUndocumented(t *testing.T) {}
+`,
+		"smoke/helpers_test.go": `package smoke
+
+import "testing"
+
+func TestHelperUndocumented(t *testing.T) {}
+`,
+		"internal/support/harness_test.go": `package support
+
+import "testing"
+
+func TestInternalUndocumented(t *testing.T) {}
+`,
+	})
+
+	records, err := functionaltestmetadata.Parse(root)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	identities := functionaltestmetadata.UndocumentedCustomerIdentities(records)
+	if len(identities) != 1 || identities[0] != "smoke/customer_test.go::TestCustomerUndocumented" {
+		t.Fatalf("UndocumentedCustomerIdentities = %#v, want only customer identity", identities)
+	}
+	baseline := functionaltestmetadata.BaselineFromRecords(records)
+	if len(baseline.Entries) != 1 {
+		t.Fatalf("baseline entries = %#v, want only customer", baseline.Entries)
+	}
+	for _, identity := range identities {
+		if strings.Contains(identity, "helpers") || strings.Contains(identity, "internal/") {
+			t.Fatalf("harness/internal identity leaked into customer baseline: %s", identity)
+		}
+	}
+	if err := functionaltestmetadata.CheckAgainstBaseline(records, baseline); err != nil {
+		t.Fatalf("CheckAgainstBaseline() error = %v", err)
+	}
+}
+
+func TestLoadBaselineRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	baseline := functionaltestmetadata.Baseline{
+		Version: functionaltestmetadata.BaselineVersion,
+		Stage:   functionaltestmetadata.BaselineStage,
+		Entries: []functionaltestmetadata.BaselineEntry{
+			{File: `smoke\windows_test.go`, Name: "TestWindows"},
+			{File: "smoke/a_test.go", Name: "TestAlpha"},
+		},
+	}
+	data, err := json.Marshal(baseline)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	loaded, err := functionaltestmetadata.LoadBaseline(path)
+	if err != nil {
+		t.Fatalf("LoadBaseline() error = %v", err)
+	}
+	if len(loaded.Entries) != 2 {
+		t.Fatalf("loaded entries = %#v, want 2", loaded.Entries)
+	}
+	if loaded.Entries[0].File != "smoke/a_test.go" || loaded.Entries[0].Name != "TestAlpha" {
+		t.Fatalf("first entry = %#v, want sorted smoke/a_test.go::TestAlpha", loaded.Entries[0])
+	}
+	if loaded.Entries[1].File != "smoke/windows_test.go" {
+		t.Fatalf("Windows path not normalized: %#v", loaded.Entries[1])
+	}
+}

--- a/internal/functionaltestmetadata/doc.go
+++ b/internal/functionaltestmetadata/doc.go
@@ -17,7 +17,15 @@
 // Harness records remain in the inventory so later report rendering can mention
 // them without mixing them into customer totals.
 //
-// Later foundation cells consume this package for catalog generation and the
-// undocumented-test baseline. This package stays side-effect free aside from
-// reading source files.
+// Undocumented customer Test* identities are frozen in an exact deletion-only
+// baseline (see Baseline, CheckAgainstBaseline, and ValidateBaselineUpdate).
+// Helper-only and internal/** undocumented helpers never enter that ledger.
+// CheckAgainstBaseline succeeds when the current undocumented customer set is
+// identical to or a strict subset of the baseline; newly undocumented customer
+// tests absent from the baseline fail closed with an actionable identity.
+// ValidateBaselineUpdate rejects baseline expansions.
+//
+// Later foundation cells consume this package for catalog generation and CI
+// enforcement. This package stays side-effect free aside from reading source
+// and baseline files.
 package functionaltestmetadata

--- a/internal/functionaltestmetadata/doc.go
+++ b/internal/functionaltestmetadata/doc.go
@@ -1,6 +1,12 @@
 // Package functionaltestmetadata inventories top-level Test* declarations under
 // a functional-test source tree using the Go AST.
 //
+// Records include file-level build-constraint expressions and explicit golden
+// fixture/manifest references when declared. Golden references are read from:
+//   - a //golden: <path> directive in the test's doc comment, or
+//   - a test-owned const/var string named golden, goldenManifest, goldenFixture,
+//     Golden, GoldenManifest, or GoldenFixture inside the Test* body.
+//
 // Later foundation cells consume this package for catalog generation, build-tag
 // and golden labeling, customer-versus-harness classification, and the
 // undocumented-test baseline. This package stays side-effect free aside from

--- a/internal/functionaltestmetadata/doc.go
+++ b/internal/functionaltestmetadata/doc.go
@@ -7,8 +7,17 @@
 //   - a test-owned const/var string named golden, goldenManifest, goldenFixture,
 //     Golden, GoldenManifest, or GoldenFixture inside the Test* body.
 //
-// Later foundation cells consume this package for catalog generation, build-tag
-// and golden labeling, customer-versus-harness classification, and the
+// Classification separates customer scenarios from harness verification:
+//   - paths under internal/** are ClassificationHarness
+//   - *_test.go basenames containing "helpers" are ClassificationHarness
+//     (helper-only / shared-helper verification, including files with no Test*)
+//   - all other inventoried Test* records are ClassificationCustomer
+//
+// CustomerScenarioCount equals the number of ClassificationCustomer records.
+// Harness records remain in the inventory so later report rendering can mention
+// them without mixing them into customer totals.
+//
+// Later foundation cells consume this package for catalog generation and the
 // undocumented-test baseline. This package stays side-effect free aside from
 // reading source files.
 package functionaltestmetadata

--- a/internal/functionaltestmetadata/doc.go
+++ b/internal/functionaltestmetadata/doc.go
@@ -1,0 +1,8 @@
+// Package functionaltestmetadata inventories top-level Test* declarations under
+// a functional-test source tree using the Go AST.
+//
+// Later foundation cells consume this package for catalog generation, build-tag
+// and golden labeling, customer-versus-harness classification, and the
+// undocumented-test baseline. This package stays side-effect free aside from
+// reading source files.
+package functionaltestmetadata

--- a/internal/functionaltestmetadata/parse.go
+++ b/internal/functionaltestmetadata/parse.go
@@ -3,6 +3,7 @@ package functionaltestmetadata
 import (
 	"fmt"
 	"go/ast"
+	"go/build/constraint"
 	"go/doc"
 	"go/parser"
 	"go/token"
@@ -10,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -79,6 +81,11 @@ func parseTestFile(absolutePath, relativePath string) ([]Record, error) {
 		return nil, fmt.Errorf("parse functional test file %s: %w", relativePath, err)
 	}
 
+	buildTags, err := fileBuildTags(file, relativePath)
+	if err != nil {
+		return nil, err
+	}
+
 	records := make([]Record, 0)
 	for _, declaration := range file.Decls {
 		function, ok := declaration.(*ast.FuncDecl)
@@ -87,24 +94,63 @@ func parseTestFile(absolutePath, relativePath string) ([]Record, error) {
 		}
 
 		record := Record{
-			File:    relativePath,
-			Package: file.Name.Name,
-			Name:    function.Name.Name,
-			Line:    fileSet.Position(function.Pos()).Line,
+			File:      relativePath,
+			Package:   file.Name.Name,
+			Name:      function.Name.Name,
+			Line:      fileSet.Position(function.Pos()).Line,
+			BuildTags: cloneStrings(buildTags),
 		}
 		description, undocumented := descriptionFromDoc(function.Doc)
 		record.Description = description
 		record.Undocumented = undocumented
+		record.Golden = goldenReference(function)
 		records = append(records, record)
 	}
 	return records, nil
+}
+
+func fileBuildTags(file *ast.File, relativePath string) ([]string, error) {
+	var goBuild []string
+	var plusBuild []string
+	for _, group := range file.Comments {
+		if group.Pos() >= file.Package {
+			break
+		}
+		for _, comment := range group.List {
+			text := comment.Text
+			switch {
+			case constraint.IsGoBuild(text):
+				expr, err := constraint.Parse(text)
+				if err != nil {
+					return nil, fmt.Errorf("parse build constraint in %s: %w", relativePath, err)
+				}
+				goBuild = append(goBuild, expr.String())
+			case constraint.IsPlusBuild(text):
+				expr, err := constraint.Parse(text)
+				if err != nil {
+					return nil, fmt.Errorf("parse build constraint in %s: %w", relativePath, err)
+				}
+				plusBuild = append(plusBuild, expr.String())
+			}
+		}
+	}
+	// Prefer //go:build when present, matching the go command.
+	tags := plusBuild
+	if len(goBuild) > 0 {
+		tags = goBuild
+	}
+	if len(tags) == 0 {
+		return nil, nil
+	}
+	slices.Sort(tags)
+	return slices.Clip(slices.Compact(tags)), nil
 }
 
 func descriptionFromDoc(group *ast.CommentGroup) (string, bool) {
 	if group == nil {
 		return "", true
 	}
-	text := strings.TrimSpace(group.Text())
+	text := strings.TrimSpace(docTextWithoutGolden(group))
 	if text == "" {
 		return "", true
 	}
@@ -113,6 +159,121 @@ func descriptionFromDoc(group *ast.CommentGroup) (string, bool) {
 		return "", true
 	}
 	return synopsis, false
+}
+
+// docTextWithoutGolden returns ordinary Go-doc text with //golden: directive
+// lines removed so catalog descriptions stay free of machine labels.
+func docTextWithoutGolden(group *ast.CommentGroup) string {
+	if group == nil {
+		return ""
+	}
+	var lines []string
+	for _, comment := range group.List {
+		if _, ok := parseGoldenDirective(comment.Text); ok {
+			continue
+		}
+		body := strings.TrimSpace(comment.Text)
+		switch {
+		case strings.HasPrefix(body, "//"):
+			lines = append(lines, strings.TrimSpace(body[2:]))
+		case strings.HasPrefix(body, "/*"):
+			lines = append(lines, strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(body, "/*"), "*/")))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func goldenReference(function *ast.FuncDecl) string {
+	if path := goldenFromComments(function.Doc); path != "" {
+		return path
+	}
+	return goldenFromBody(function.Body)
+}
+
+func goldenFromComments(group *ast.CommentGroup) string {
+	if group == nil {
+		return ""
+	}
+	for _, comment := range group.List {
+		if path, ok := parseGoldenDirective(comment.Text); ok {
+			return path
+		}
+	}
+	return ""
+}
+
+func parseGoldenDirective(commentText string) (string, bool) {
+	body := strings.TrimSpace(commentText)
+	switch {
+	case strings.HasPrefix(body, "//"):
+		body = strings.TrimSpace(body[2:])
+	case strings.HasPrefix(body, "/*"):
+		body = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(body, "/*"), "*/"))
+	default:
+		return "", false
+	}
+	if len(body) < len("golden:") || !strings.EqualFold(body[:len("golden:")], "golden:") {
+		return "", false
+	}
+	path := strings.TrimSpace(body[len("golden:"):])
+	if path == "" {
+		return "", false
+	}
+	return normalizePath(path), true
+}
+
+func goldenFromBody(body *ast.BlockStmt) string {
+	if body == nil {
+		return ""
+	}
+	var found string
+	ast.Inspect(body, func(node ast.Node) bool {
+		if found != "" {
+			return false
+		}
+		decl, ok := node.(*ast.GenDecl)
+		if !ok || (decl.Tok != token.CONST && decl.Tok != token.VAR) {
+			return true
+		}
+		for _, spec := range decl.Specs {
+			valueSpec, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range valueSpec.Names {
+				if name == nil || !isGoldenDeclName(name.Name) || i >= len(valueSpec.Values) {
+					continue
+				}
+				if path, ok := stringLiteralPath(valueSpec.Values[i]); ok {
+					found = path
+					return false
+				}
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func isGoldenDeclName(name string) bool {
+	switch name {
+	case "golden", "goldenManifest", "goldenFixture", "Golden", "GoldenManifest", "GoldenFixture":
+		return true
+	default:
+		return false
+	}
+}
+
+func stringLiteralPath(expr ast.Expr) (string, bool) {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	unquoted, err := strconv.Unquote(lit.Value)
+	if err != nil || strings.TrimSpace(unquoted) == "" {
+		return "", false
+	}
+	return normalizePath(unquoted), true
 }
 
 // isTestName mirrors go test discovery: "Test" or "Test" followed by an
@@ -143,4 +304,11 @@ func compareRecords(a, b Record) int {
 // slash-separated path identity.
 func normalizePath(path string) string {
 	return filepath.ToSlash(filepath.Clean(filepath.FromSlash(strings.ReplaceAll(path, "\\", "/"))))
+}
+
+func cloneStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	return slices.Clone(values)
 }

--- a/internal/functionaltestmetadata/parse.go
+++ b/internal/functionaltestmetadata/parse.go
@@ -86,6 +86,7 @@ func parseTestFile(absolutePath, relativePath string) ([]Record, error) {
 		return nil, err
 	}
 
+	classification := classifyPath(relativePath)
 	records := make([]Record, 0)
 	for _, declaration := range file.Decls {
 		function, ok := declaration.(*ast.FuncDecl)
@@ -94,11 +95,12 @@ func parseTestFile(absolutePath, relativePath string) ([]Record, error) {
 		}
 
 		record := Record{
-			File:      relativePath,
-			Package:   file.Name.Name,
-			Name:      function.Name.Name,
-			Line:      fileSet.Position(function.Pos()).Line,
-			BuildTags: cloneStrings(buildTags),
+			File:           relativePath,
+			Package:        file.Name.Name,
+			Name:           function.Name.Name,
+			Line:           fileSet.Position(function.Pos()).Line,
+			BuildTags:      cloneStrings(buildTags),
+			Classification: classification,
 		}
 		description, undocumented := descriptionFromDoc(function.Doc)
 		record.Description = description
@@ -107,6 +109,30 @@ func parseTestFile(absolutePath, relativePath string) ([]Record, error) {
 		records = append(records, record)
 	}
 	return records, nil
+}
+
+// classifyPath labels a repository-relative *_test.go path as customer or
+// harness verification. Paths under internal/** and helper-only filenames
+// (basename contains "helpers") are harness; everything else is customer.
+func classifyPath(relativePath string) Classification {
+	normalized := normalizePath(relativePath)
+	if isInternalSupportPath(normalized) || isHelperOnlyFile(normalized) {
+		return ClassificationHarness
+	}
+	return ClassificationCustomer
+}
+
+func isInternalSupportPath(relativePath string) bool {
+	return relativePath == "internal" || strings.HasPrefix(relativePath, "internal/")
+}
+
+func isHelperOnlyFile(relativePath string) bool {
+	base := filepath.Base(relativePath)
+	name := strings.TrimSuffix(base, "_test.go")
+	if name == base {
+		return false
+	}
+	return strings.Contains(name, "helpers")
 }
 
 func fileBuildTags(file *ast.File, relativePath string) ([]string, error) {

--- a/internal/functionaltestmetadata/parse.go
+++ b/internal/functionaltestmetadata/parse.go
@@ -1,0 +1,146 @@
+package functionaltestmetadata
+
+import (
+	"fmt"
+	"go/ast"
+	"go/doc"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Parse walks root for *_test.go files and inventories every top-level Test*
+// declaration. Paths in returned records are relative to root, slash-normalized,
+// and ordered stably by file then name. Malformed source fails closed with a
+// file-scoped error rather than returning a partial inventory.
+func Parse(root string) ([]Record, error) {
+	absRoot, err := resolveRoot(root)
+	if err != nil {
+		return nil, err
+	}
+
+	var records []Record
+	err = filepath.WalkDir(absRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("walk %s: %w", normalizePath(path), walkErr)
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(entry.Name(), "_test.go") {
+			return nil
+		}
+
+		relative, err := filepath.Rel(absRoot, path)
+		if err != nil {
+			return fmt.Errorf("resolve relative path for %s: %w", normalizePath(path), err)
+		}
+		fileRecords, err := parseTestFile(path, normalizePath(relative))
+		if err != nil {
+			return err
+		}
+		records = append(records, fileRecords...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	slices.SortFunc(records, compareRecords)
+	return records, nil
+}
+
+func resolveRoot(root string) (string, error) {
+	cleaned := filepath.Clean(filepath.FromSlash(strings.ReplaceAll(root, "\\", "/")))
+	absRoot, err := filepath.Abs(cleaned)
+	if err != nil {
+		return "", fmt.Errorf("resolve functional test root %q: %w", root, err)
+	}
+	info, err := os.Stat(absRoot)
+	if err != nil {
+		return "", fmt.Errorf("stat functional test root %s: %w", normalizePath(absRoot), err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("functional test root %s is not a directory", normalizePath(absRoot))
+	}
+	return absRoot, nil
+}
+
+func parseTestFile(absolutePath, relativePath string) ([]Record, error) {
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, absolutePath, nil, parser.ParseComments)
+	if err != nil {
+		return nil, fmt.Errorf("parse functional test file %s: %w", relativePath, err)
+	}
+
+	records := make([]Record, 0)
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Recv != nil || function.Name == nil || !isTestName(function.Name.Name) {
+			continue
+		}
+
+		record := Record{
+			File:    relativePath,
+			Package: file.Name.Name,
+			Name:    function.Name.Name,
+			Line:    fileSet.Position(function.Pos()).Line,
+		}
+		description, undocumented := descriptionFromDoc(function.Doc)
+		record.Description = description
+		record.Undocumented = undocumented
+		records = append(records, record)
+	}
+	return records, nil
+}
+
+func descriptionFromDoc(group *ast.CommentGroup) (string, bool) {
+	if group == nil {
+		return "", true
+	}
+	text := strings.TrimSpace(group.Text())
+	if text == "" {
+		return "", true
+	}
+	synopsis := strings.TrimSpace(doc.Synopsis(text))
+	if synopsis == "" {
+		return "", true
+	}
+	return synopsis, false
+}
+
+// isTestName mirrors go test discovery: "Test" or "Test" followed by an
+// uppercase letter.
+func isTestName(name string) bool {
+	const prefix = "Test"
+	if !strings.HasPrefix(name, prefix) {
+		return false
+	}
+	if len(name) == len(prefix) {
+		return true
+	}
+	r, _ := utf8.DecodeRuneInString(name[len(prefix):])
+	return unicode.IsUpper(r)
+}
+
+func compareRecords(a, b Record) int {
+	if a.File != b.File {
+		return strings.Compare(a.File, b.File)
+	}
+	if a.Name != b.Name {
+		return strings.Compare(a.Name, b.Name)
+	}
+	return a.Line - b.Line
+}
+
+// normalizePath converts OS-specific or mixed separators into a stable
+// slash-separated path identity.
+func normalizePath(path string) string {
+	return filepath.ToSlash(filepath.Clean(filepath.FromSlash(strings.ReplaceAll(path, "\\", "/"))))
+}

--- a/internal/functionaltestmetadata/parse_test.go
+++ b/internal/functionaltestmetadata/parse_test.go
@@ -45,6 +45,14 @@ func TestGamma(t *testing.T) {}
 	if records[0].Line <= 0 || records[1].Line <= records[0].Line {
 		t.Fatalf("source lines not increasing within file: %#v", records[:2])
 	}
+	for _, record := range records {
+		if record.Classification != functionaltestmetadata.ClassificationCustomer {
+			t.Fatalf("%s Classification = %q, want %q", record.Name, record.Classification, functionaltestmetadata.ClassificationCustomer)
+		}
+	}
+	if got := functionaltestmetadata.CustomerScenarioCount(records); got != 3 {
+		t.Fatalf("CustomerScenarioCount = %d, want 3", got)
+	}
 }
 
 func TestParseMarksMissingDocAsUndocumentedWithoutInventingText(t *testing.T) {
@@ -453,6 +461,173 @@ func TestParseNormalizesWindowsStyleGoldenPaths(t *testing.T) {
 	}
 }
 
+func TestParseClassifiesInternalSupportAsHarness(t *testing.T) {
+	t.Parallel()
+
+	root := writeTree(t, map[string]string{
+		"internal/support/paths_test.go": `package support_test
+
+import "testing"
+
+// TestDefaultSessionEventsURL verifies harness URL helpers.
+func TestDefaultSessionEventsURL(t *testing.T) {}
+`,
+		"smoke/customer_test.go": `package smoke
+
+import "testing"
+
+// TestCustomerColdStart is a customer-facing scenario.
+func TestCustomerColdStart(t *testing.T) {}
+`,
+	})
+
+	records, err := functionaltestmetadata.Parse(root)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("Parse() returned %d records, want 2: %#v", len(records), records)
+	}
+
+	byName := map[string]functionaltestmetadata.Record{}
+	for _, record := range records {
+		byName[record.Name] = record
+	}
+
+	internal := byName["TestDefaultSessionEventsURL"]
+	if internal.Classification != functionaltestmetadata.ClassificationHarness {
+		t.Fatalf("internal Classification = %q, want %q", internal.Classification, functionaltestmetadata.ClassificationHarness)
+	}
+	if internal.IsCustomerScenario() {
+		t.Fatalf("internal record must not count as a customer scenario")
+	}
+
+	customer := byName["TestCustomerColdStart"]
+	if customer.Classification != functionaltestmetadata.ClassificationCustomer {
+		t.Fatalf("customer Classification = %q, want %q", customer.Classification, functionaltestmetadata.ClassificationCustomer)
+	}
+	if got := functionaltestmetadata.CustomerScenarioCount(records); got != 1 {
+		t.Fatalf("CustomerScenarioCount = %d, want 1 (internal excluded)", got)
+	}
+}
+
+func TestParseExcludesHelperOnlyFilesFromCustomerCounts(t *testing.T) {
+	t.Parallel()
+
+	root := writeTree(t, map[string]string{
+		"smoke/helpers_test.go": `package smoke
+
+func sharedHelper() {}
+`,
+		"smoke/short_helpers_contract_test.go": `package smoke
+
+import "testing"
+
+// TestHelperContract verifies shared helper behavior only.
+func TestHelperContract(t *testing.T) {}
+`,
+		"smoke/customer_test.go": `package smoke
+
+import "testing"
+
+// TestCustomerScenario is a customer-facing proof.
+func TestCustomerScenario(t *testing.T) {}
+`,
+	})
+
+	records, err := functionaltestmetadata.Parse(root)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("Parse() returned %d records, want 2 (helper-only file with no Test* emits nothing): %#v", len(records), records)
+	}
+
+	byName := map[string]functionaltestmetadata.Record{}
+	for _, record := range records {
+		byName[record.Name] = record
+	}
+
+	helper := byName["TestHelperContract"]
+	if helper.Classification != functionaltestmetadata.ClassificationHarness {
+		t.Fatalf("helpers Classification = %q, want %q", helper.Classification, functionaltestmetadata.ClassificationHarness)
+	}
+	if helper.IsCustomerScenario() {
+		t.Fatalf("helper-only Test* must not count as a customer scenario")
+	}
+
+	customer := byName["TestCustomerScenario"]
+	if customer.Classification != functionaltestmetadata.ClassificationCustomer {
+		t.Fatalf("customer Classification = %q, want %q", customer.Classification, functionaltestmetadata.ClassificationCustomer)
+	}
+	if got := functionaltestmetadata.CustomerScenarioCount(records); got != 1 {
+		t.Fatalf("CustomerScenarioCount = %d, want 1 after helper-only exclusion", got)
+	}
+}
+
+func TestParseClassifiesMixedCustomerScenarioFile(t *testing.T) {
+	t.Parallel()
+
+	root := writeTree(t, map[string]string{
+		"smoke/mixed_test.go": `package smoke
+
+import "testing"
+
+func localHelper(t *testing.T) {
+	t.Helper()
+}
+
+// TestAlpha is the first customer scenario in a mixed file.
+func TestAlpha(t *testing.T) {}
+
+// TestBeta is the second customer scenario in a mixed file.
+func TestBeta(t *testing.T) {}
+`,
+		"internal/support/harness_test.go": `package support
+
+import "testing"
+
+// TestHarnessOnly stays out of customer totals.
+func TestHarnessOnly(t *testing.T) {}
+`,
+		"smoke/helpers_test.go": `package smoke
+
+func unusedSharedHelper() string { return "ok" }
+`,
+	})
+
+	records, err := functionaltestmetadata.Parse(root)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(records) != 3 {
+		t.Fatalf("Parse() returned %d records, want 3: %#v", len(records), records)
+	}
+
+	customerNames := make([]string, 0, 2)
+	for _, record := range records {
+		switch record.Name {
+		case "TestAlpha", "TestBeta":
+			if record.Classification != functionaltestmetadata.ClassificationCustomer {
+				t.Fatalf("%s Classification = %q, want %q", record.Name, record.Classification, functionaltestmetadata.ClassificationCustomer)
+			}
+			customerNames = append(customerNames, record.Name)
+		case "TestHarnessOnly":
+			if record.Classification != functionaltestmetadata.ClassificationHarness {
+				t.Fatalf("TestHarnessOnly Classification = %q, want %q", record.Classification, functionaltestmetadata.ClassificationHarness)
+			}
+		default:
+			t.Fatalf("unexpected record %#v", record)
+		}
+	}
+	if len(customerNames) != 2 {
+		t.Fatalf("customer names = %#v, want TestAlpha and TestBeta", customerNames)
+	}
+	if got := functionaltestmetadata.CustomerScenarioCount(records); got != 2 {
+		t.Fatalf("CustomerScenarioCount = %d, want 2 (equals inventoried customer Test* after exclusions)", got)
+	}
+}
+
 func assertRecord(t *testing.T, got functionaltestmetadata.Record, file, pkg, name, description string, undocumented bool) {
 	t.Helper()
 	if got.File != file {
@@ -470,13 +645,16 @@ func assertRecord(t *testing.T, got functionaltestmetadata.Record, file, pkg, na
 	if got.Undocumented != undocumented {
 		t.Fatalf("Undocumented = %v, want %v", got.Undocumented, undocumented)
 	}
+	if got.Classification == "" {
+		t.Fatalf("Classification is empty on %#v", got)
+	}
 }
 
 func assertRecordsEqual(t *testing.T, got, want functionaltestmetadata.Record) {
 	t.Helper()
 	if got.File != want.File || got.Package != want.Package || got.Name != want.Name ||
 		got.Line != want.Line || got.Description != want.Description || got.Undocumented != want.Undocumented ||
-		got.Golden != want.Golden {
+		got.Golden != want.Golden || got.Classification != want.Classification {
 		t.Fatalf("records differ:\ngot  %#v\nwant %#v", got, want)
 	}
 	if len(got.BuildTags) != len(want.BuildTags) {

--- a/internal/functionaltestmetadata/parse_test.go
+++ b/internal/functionaltestmetadata/parse_test.go
@@ -147,9 +147,7 @@ func TestMid(t *testing.T) {}
 		if first[i].Name != wantNames[i] || first[i].File != wantFiles[i] {
 			t.Fatalf("record[%d] = %s::%s, want %s::%s", i, first[i].File, first[i].Name, wantFiles[i], wantNames[i])
 		}
-		if first[i] != second[i] {
-			t.Fatalf("repeated parse diverged at index %d: %#v vs %#v", i, first[i], second[i])
-		}
+		assertRecordsEqual(t, first[i], second[i])
 	}
 }
 
@@ -271,6 +269,190 @@ func TestOnly(t *testing.T) {}
 	}
 }
 
+func TestParseCapturesFileLevelBuildTags(t *testing.T) {
+	t.Parallel()
+
+	root := writeTree(t, map[string]string{
+		"long/tagged_test.go": `//go:build functionallong
+
+package long
+
+import "testing"
+
+// TestLongOnly is gated by the functionallong build tag.
+func TestLongOnly(t *testing.T) {}
+`,
+		"short/untagged_test.go": `package short
+
+import "testing"
+
+// TestShort has no file-level build constraints.
+func TestShort(t *testing.T) {}
+`,
+		"platform/negated_test.go": `//go:build !windows
+
+package platform
+
+import "testing"
+
+// TestNotWindows excludes Windows hosts.
+func TestNotWindows(t *testing.T) {}
+`,
+	})
+
+	records, err := functionaltestmetadata.Parse(root)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(records) != 3 {
+		t.Fatalf("Parse() returned %d records, want 3: %#v", len(records), records)
+	}
+
+	byName := map[string]functionaltestmetadata.Record{}
+	for _, record := range records {
+		byName[record.Name] = record
+	}
+
+	if got := byName["TestLongOnly"].BuildTags; len(got) != 1 || got[0] != "functionallong" {
+		t.Fatalf("TestLongOnly.BuildTags = %#v, want [functionallong]", got)
+	}
+	if got := byName["TestNotWindows"].BuildTags; len(got) != 1 || got[0] != "!windows" {
+		t.Fatalf("TestNotWindows.BuildTags = %#v, want [!windows]", got)
+	}
+	if got := byName["TestShort"].BuildTags; len(got) != 0 {
+		t.Fatalf("TestShort.BuildTags = %#v, want empty (no fabricated default)", got)
+	}
+}
+
+func TestParsePrefersGoBuildOverPlusBuild(t *testing.T) {
+	t.Parallel()
+
+	root := writeTree(t, map[string]string{
+		"pkg/both_test.go": `//go:build functionallong
+// +build functionallong
+
+package pkg
+
+import "testing"
+
+// TestBothConstraints prefers the go:build expression.
+func TestBothConstraints(t *testing.T) {}
+`,
+	})
+
+	records, err := functionaltestmetadata.Parse(root)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("Parse() returned %d records, want 1", len(records))
+	}
+	if got := records[0].BuildTags; len(got) != 1 || got[0] != "functionallong" {
+		t.Fatalf("BuildTags = %#v, want exactly [functionallong]", got)
+	}
+}
+
+func TestParseCapturesGoldenFromCommentDirective(t *testing.T) {
+	t.Parallel()
+
+	root := writeTree(t, map[string]string{
+		"workers/inference/codex/golden_success_test.go": `package codex
+
+import "testing"
+
+// TestCodexGoldenSuccess replays the sanitized success transcript.
+//golden: docs/temp/functional/provider-sessions/codex/success/manifest.json
+func TestCodexGoldenSuccess(t *testing.T) {}
+`,
+		"workers/inference/codex/plain_test.go": `package codex
+
+import "testing"
+
+// TestCodexPlain has no golden declaration.
+func TestCodexPlain(t *testing.T) {}
+`,
+	})
+
+	records, err := functionaltestmetadata.Parse(root)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("Parse() returned %d records, want 2: %#v", len(records), records)
+	}
+
+	byName := map[string]functionaltestmetadata.Record{}
+	for _, record := range records {
+		byName[record.Name] = record
+	}
+
+	wantGolden := "docs/temp/functional/provider-sessions/codex/success/manifest.json"
+	if got := byName["TestCodexGoldenSuccess"].Golden; got != wantGolden {
+		t.Fatalf("Golden = %q, want %q", got, wantGolden)
+	}
+	if byName["TestCodexGoldenSuccess"].Description != "TestCodexGoldenSuccess replays the sanitized success transcript." {
+		t.Fatalf("Description polluted by golden directive: %#v", byName["TestCodexGoldenSuccess"])
+	}
+	if got := byName["TestCodexPlain"].Golden; got != "" {
+		t.Fatalf("TestCodexPlain.Golden = %q, want empty (no fabricated reference)", got)
+	}
+}
+
+func TestParseCapturesGoldenFromTestOwnedDeclaration(t *testing.T) {
+	t.Parallel()
+
+	root := writeTree(t, map[string]string{
+		"workers/inference/claude/golden_failure_test.go": `package claude
+
+import "testing"
+
+// TestClaudeGoldenFailure uses a test-owned golden manifest declaration.
+func TestClaudeGoldenFailure(t *testing.T) {
+	const goldenManifest = "docs/temp/functional/provider-sessions/claude/failure/manifest.json"
+	_ = goldenManifest
+}
+`,
+	})
+
+	records, err := functionaltestmetadata.Parse(root)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("Parse() returned %d records, want 1", len(records))
+	}
+	want := "docs/temp/functional/provider-sessions/claude/failure/manifest.json"
+	if records[0].Golden != want {
+		t.Fatalf("Golden = %q, want %q", records[0].Golden, want)
+	}
+	if records[0].Description != "TestClaudeGoldenFailure uses a test-owned golden manifest declaration." {
+		t.Fatalf("Description = %q, want ordinary doc synopsis", records[0].Description)
+	}
+}
+
+func TestParseNormalizesWindowsStyleGoldenPaths(t *testing.T) {
+	t.Parallel()
+
+	root := writeTree(t, map[string]string{
+		"pkg/golden_test.go": "package pkg\n\nimport \"testing\"\n\n" +
+			"// TestGoldenPath normalizes separators in golden references.\n" +
+			"//golden: docs\\temp\\functional\\provider-sessions\\cursor\\success\\manifest.json\n" +
+			"func TestGoldenPath(t *testing.T) {}\n",
+	})
+
+	records, err := functionaltestmetadata.Parse(root)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("Parse() returned %d records, want 1", len(records))
+	}
+	want := "docs/temp/functional/provider-sessions/cursor/success/manifest.json"
+	if records[0].Golden != want {
+		t.Fatalf("Golden = %q, want slash-normalized %q", records[0].Golden, want)
+	}
+}
+
 func assertRecord(t *testing.T, got functionaltestmetadata.Record, file, pkg, name, description string, undocumented bool) {
 	t.Helper()
 	if got.File != file {
@@ -287,6 +469,23 @@ func assertRecord(t *testing.T, got functionaltestmetadata.Record, file, pkg, na
 	}
 	if got.Undocumented != undocumented {
 		t.Fatalf("Undocumented = %v, want %v", got.Undocumented, undocumented)
+	}
+}
+
+func assertRecordsEqual(t *testing.T, got, want functionaltestmetadata.Record) {
+	t.Helper()
+	if got.File != want.File || got.Package != want.Package || got.Name != want.Name ||
+		got.Line != want.Line || got.Description != want.Description || got.Undocumented != want.Undocumented ||
+		got.Golden != want.Golden {
+		t.Fatalf("records differ:\ngot  %#v\nwant %#v", got, want)
+	}
+	if len(got.BuildTags) != len(want.BuildTags) {
+		t.Fatalf("BuildTags length %d != %d:\ngot  %#v\nwant %#v", len(got.BuildTags), len(want.BuildTags), got, want)
+	}
+	for i := range got.BuildTags {
+		if got.BuildTags[i] != want.BuildTags[i] {
+			t.Fatalf("BuildTags[%d] = %q, want %q", i, got.BuildTags[i], want.BuildTags[i])
+		}
 	}
 }
 

--- a/internal/functionaltestmetadata/parse_test.go
+++ b/internal/functionaltestmetadata/parse_test.go
@@ -1,0 +1,306 @@
+package functionaltestmetadata_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/functionaltestmetadata"
+)
+
+func TestParseInventoriesTopLevelTestMetadata(t *testing.T) {
+	t.Parallel()
+
+	root := writeTree(t, map[string]string{
+		"smoke/documented_test.go": `package smoke
+
+import "testing"
+
+// TestAlpha verifies the happy path for cold start.
+func TestAlpha(t *testing.T) {}
+
+// TestBeta checks retries after a transient failure.
+func TestBeta(t *testing.T) {}
+`,
+		"smoke/undocumented_test.go": `package smoke
+
+import "testing"
+
+func TestGamma(t *testing.T) {}
+`,
+	})
+
+	records, err := functionaltestmetadata.Parse(root)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(records) != 3 {
+		t.Fatalf("Parse() returned %d records, want 3: %#v", len(records), records)
+	}
+
+	assertRecord(t, records[0], "smoke/documented_test.go", "smoke", "TestAlpha", "TestAlpha verifies the happy path for cold start.", false)
+	assertRecord(t, records[1], "smoke/documented_test.go", "smoke", "TestBeta", "TestBeta checks retries after a transient failure.", false)
+	assertRecord(t, records[2], "smoke/undocumented_test.go", "smoke", "TestGamma", "", true)
+	if records[0].Line <= 0 || records[1].Line <= records[0].Line {
+		t.Fatalf("source lines not increasing within file: %#v", records[:2])
+	}
+}
+
+func TestParseMarksMissingDocAsUndocumentedWithoutInventingText(t *testing.T) {
+	t.Parallel()
+
+	root := writeTree(t, map[string]string{
+		"pkg/missing_test.go": `package pkg
+
+import "testing"
+
+func TestWithoutDoc(t *testing.T) {}
+`,
+	})
+
+	records, err := functionaltestmetadata.Parse(root)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("Parse() returned %d records, want 1", len(records))
+	}
+	if !records[0].Undocumented {
+		t.Fatalf("Undocumented = false, want true")
+	}
+	if records[0].Description != "" {
+		t.Fatalf("Description = %q, want empty", records[0].Description)
+	}
+}
+
+func TestParseDoesNotExpandTableDrivenCases(t *testing.T) {
+	t.Parallel()
+
+	root := writeTree(t, map[string]string{
+		"pkg/table_test.go": `package pkg
+
+import "testing"
+
+// TestTable covers multiple cases inside one top-level Test*.
+func TestTable(t *testing.T) {
+	cases := []struct{ name string }{
+		{name: "one"},
+		{name: "two"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {})
+	}
+}
+`,
+	})
+
+	records, err := functionaltestmetadata.Parse(root)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("Parse() returned %d records, want 1 enclosing Test*: %#v", len(records), records)
+	}
+	if records[0].Name != "TestTable" {
+		t.Fatalf("Name = %q, want TestTable", records[0].Name)
+	}
+}
+
+func TestParseReturnsStableOrderAcrossRepeatedRuns(t *testing.T) {
+	t.Parallel()
+
+	root := writeTree(t, map[string]string{
+		"b/second_test.go": `package b
+
+import "testing"
+
+// TestZ comes last alphabetically by name within file.
+func TestZ(t *testing.T) {}
+
+// TestA comes first alphabetically by name within file.
+func TestA(t *testing.T) {}
+`,
+		"a/first_test.go": `package a
+
+import "testing"
+
+// TestMid is the only test in the earlier file path.
+func TestMid(t *testing.T) {}
+`,
+	})
+
+	first, err := functionaltestmetadata.Parse(root)
+	if err != nil {
+		t.Fatalf("Parse() first error = %v", err)
+	}
+	second, err := functionaltestmetadata.Parse(root)
+	if err != nil {
+		t.Fatalf("Parse() second error = %v", err)
+	}
+	if len(first) != 3 {
+		t.Fatalf("Parse() returned %d records, want 3", len(first))
+	}
+	wantNames := []string{"TestMid", "TestA", "TestZ"}
+	wantFiles := []string{"a/first_test.go", "b/second_test.go", "b/second_test.go"}
+	for i := range first {
+		if first[i].Name != wantNames[i] || first[i].File != wantFiles[i] {
+			t.Fatalf("record[%d] = %s::%s, want %s::%s", i, first[i].File, first[i].Name, wantFiles[i], wantNames[i])
+		}
+		if first[i] != second[i] {
+			t.Fatalf("repeated parse diverged at index %d: %#v vs %#v", i, first[i], second[i])
+		}
+	}
+}
+
+func TestParseFailsClosedOnMalformedSource(t *testing.T) {
+	t.Parallel()
+
+	root := writeTree(t, map[string]string{
+		"pkg/good_test.go": `package pkg
+
+import "testing"
+
+// TestGood is valid.
+func TestGood(t *testing.T) {}
+`,
+		"pkg/bad_test.go": `package pkg
+
+func TestBroken(t *testing.T {
+`,
+	})
+
+	records, err := functionaltestmetadata.Parse(root)
+	if err == nil {
+		t.Fatalf("Parse() error = nil, want malformed-source failure; records=%#v", records)
+	}
+	if !strings.Contains(err.Error(), "pkg/bad_test.go") {
+		t.Fatalf("Parse() error = %v, want actionable file-scoped path pkg/bad_test.go", err)
+	}
+	if records != nil {
+		t.Fatalf("Parse() records = %#v, want nil on failure", records)
+	}
+}
+
+func TestParseNormalizesWindowsStylePaths(t *testing.T) {
+	t.Parallel()
+
+	root := writeTree(t, map[string]string{
+		"smoke/path_test.go": `package smoke
+
+import "testing"
+
+// TestPathIdentity stays stable across separators.
+func TestPathIdentity(t *testing.T) {}
+`,
+	})
+
+	windowsRoot := strings.ReplaceAll(root, "/", `\`)
+	records, err := functionaltestmetadata.Parse(windowsRoot)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("Parse() returned %d records, want 1", len(records))
+	}
+	if records[0].File != "smoke/path_test.go" {
+		t.Fatalf("File = %q, want slash-normalized smoke/path_test.go", records[0].File)
+	}
+	if strings.Contains(records[0].File, `\`) {
+		t.Fatalf("File still contains backslashes: %q", records[0].File)
+	}
+	if got := records[0].Identity(); got != "smoke/path_test.go::TestPathIdentity" {
+		t.Fatalf("Identity() = %q, want smoke/path_test.go::TestPathIdentity", got)
+	}
+}
+
+func TestParsePreservesMarkdownSensitiveDescriptions(t *testing.T) {
+	t.Parallel()
+
+	root := writeTree(t, map[string]string{
+		"pkg/markdown_test.go": "package pkg\n\nimport \"testing\"\n\n" +
+			"// TestMarkdown checks `code`, *emphasis*, _italics_, and [link](https://example.com).\n" +
+			"func TestMarkdown(t *testing.T) {}\n",
+	})
+
+	records, err := functionaltestmetadata.Parse(root)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("Parse() returned %d records, want 1", len(records))
+	}
+	want := "TestMarkdown checks `code`, *emphasis*, _italics_, and [link](https://example.com)."
+	if records[0].Description != want {
+		t.Fatalf("Description = %q, want %q", records[0].Description, want)
+	}
+	if records[0].Name != "TestMarkdown" || records[0].File != "pkg/markdown_test.go" {
+		t.Fatalf("surrounding fields corrupted: %#v", records[0])
+	}
+}
+
+func TestParseSkipsNonTestHelpersAndLowercaseNames(t *testing.T) {
+	t.Parallel()
+
+	root := writeTree(t, map[string]string{
+		"pkg/helpers_test.go": `package pkg
+
+import "testing"
+
+func helper(t *testing.T) {}
+
+func testLower(t *testing.T) {}
+
+type harness struct{}
+
+func (h harness) TestMethod(t *testing.T) {}
+
+// TestOnly counts as the sole inventory record.
+func TestOnly(t *testing.T) {}
+`,
+		"pkg/doc.go": `package pkg
+`,
+	})
+
+	records, err := functionaltestmetadata.Parse(root)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(records) != 1 || records[0].Name != "TestOnly" {
+		t.Fatalf("Parse() = %#v, want only TestOnly", records)
+	}
+}
+
+func assertRecord(t *testing.T, got functionaltestmetadata.Record, file, pkg, name, description string, undocumented bool) {
+	t.Helper()
+	if got.File != file {
+		t.Fatalf("File = %q, want %q", got.File, file)
+	}
+	if got.Package != pkg {
+		t.Fatalf("Package = %q, want %q", got.Package, pkg)
+	}
+	if got.Name != name {
+		t.Fatalf("Name = %q, want %q", got.Name, name)
+	}
+	if got.Description != description {
+		t.Fatalf("Description = %q, want %q", got.Description, description)
+	}
+	if got.Undocumented != undocumented {
+		t.Fatalf("Undocumented = %v, want %v", got.Undocumented, undocumented)
+	}
+}
+
+func writeTree(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for relative, contents := range files {
+		path := filepath.Join(root, filepath.FromSlash(relative))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	return root
+}

--- a/internal/functionaltestmetadata/record.go
+++ b/internal/functionaltestmetadata/record.go
@@ -1,0 +1,24 @@
+package functionaltestmetadata
+
+// Record is one inventoried top-level Test* declaration.
+type Record struct {
+	// File is the repository-relative source path using forward slashes.
+	File string `json:"file"`
+	// Package is the Go package name declared in the source file.
+	Package string `json:"package"`
+	// Name is the Test* function name.
+	Name string `json:"name"`
+	// Line is the 1-based source line of the function declaration.
+	Line int `json:"line"`
+	// Description is the first sentence of the conventional Go doc comment.
+	// Empty when Undocumented is true.
+	Description string `json:"description,omitempty"`
+	// Undocumented is true when the declaration has no conventional Go doc
+	// comment first sentence.
+	Undocumented bool `json:"undocumented"`
+}
+
+// Identity returns the stable catalog identity for this record.
+func (r Record) Identity() string {
+	return r.File + "::" + r.Name
+}

--- a/internal/functionaltestmetadata/record.go
+++ b/internal/functionaltestmetadata/record.go
@@ -1,5 +1,19 @@
 package functionaltestmetadata
 
+// Classification labels whether an inventoried Test* is a customer scenario or
+// harness/internal verification. Customer scenario counts use only
+// ClassificationCustomer records.
+type Classification string
+
+const (
+	// ClassificationCustomer is a customer-facing functional scenario.
+	ClassificationCustomer Classification = "customer"
+	// ClassificationHarness is harness/internal or helper-only verification.
+	// These records remain in the inventory for later report rendering but do
+	// not increment customer scenario counts.
+	ClassificationHarness Classification = "harness"
+)
+
 // Record is one inventoried top-level Test* declaration.
 type Record struct {
 	// File is the repository-relative source path using forward slashes.
@@ -24,9 +38,29 @@ type Record struct {
 	// //golden: comment or a test-owned golden string declaration. Empty when
 	// no golden is declared; never fabricated.
 	Golden string `json:"golden,omitempty"`
+	// Classification is customer versus harness/helper verification.
+	Classification Classification `json:"classification"`
 }
 
 // Identity returns the stable catalog identity for this record.
 func (r Record) Identity() string {
 	return r.File + "::" + r.Name
+}
+
+// IsCustomerScenario reports whether this record counts toward customer
+// scenario totals.
+func (r Record) IsCustomerScenario() bool {
+	return r.Classification == ClassificationCustomer
+}
+
+// CustomerScenarioCount returns the number of inventoried top-level customer
+// Test* records after excluding harness/internal and helper-only entries.
+func CustomerScenarioCount(records []Record) int {
+	count := 0
+	for _, record := range records {
+		if record.IsCustomerScenario() {
+			count++
+		}
+	}
+	return count
 }

--- a/internal/functionaltestmetadata/record.go
+++ b/internal/functionaltestmetadata/record.go
@@ -16,6 +16,14 @@ type Record struct {
 	// Undocumented is true when the declaration has no conventional Go doc
 	// comment first sentence.
 	Undocumented bool `json:"undocumented"`
+	// BuildTags are the file-level //go:build (or legacy // +build) constraint
+	// expressions that apply to this test. Empty when the file has no build
+	// constraints; never fabricated with a default tag.
+	BuildTags []string `json:"buildTags,omitempty"`
+	// Golden is an explicit fixture/manifest path declared for this test via a
+	// //golden: comment or a test-owned golden string declaration. Empty when
+	// no golden is declared; never fabricated.
+	Golden string `json:"golden,omitempty"`
 }
 
 // Identity returns the stable catalog identity for this record.


### PR DESCRIPTION
{
  "project": "Parse Functional Test Metadata with the Go AST",
  "branchName": "fnd-002-test-metadata-parser",
  "description": "Implement a Go AST-backed parser that inventories top-level Test* declarations under tests/functional with stable file, package, name, first Go-doc sentence, build tags, and golden references; exclude helpers and tests/functional/internal/** from customer scenario counts; and enforce an exact deletion-only undocumented-test baseline with focused parser package tests.",
  "context": {
    "customerAsk": "Implement a Go AST-backed parser that inventories top-level Test* declarations, Go doc comments, build constraints, and golden declarations under tests/functional. Exclude helpers and tests/functional/internal/** from customer counts, and add an exact deletion-only undocumented-test baseline. Focused tests must cover malformed source, Windows paths, build tags, table tests, and Markdown-sensitive descriptions.",
    "problem": "The functional-test visualization plan needs a durable inventory of every top-level Test* with its first Go-doc sentence and related labels, but no durable AST-backed metadata parser exists yet, so catalog generation cannot reliably distinguish customer scenarios from harness helpers, detect golden-backed tests, or enforce undocumented-test debt.",
    "solution": "Own a focused Go package that walks functional-test sources with go/parser and go/ast, emits stable per-test metadata, classifies customer-scenario versus harness/internal entries, captures build tags and golden fixture references, and compares undocumented customer tests against an exact deletion-only baseline for later visualization cells to consume."
  },
  "acceptanceCriteria": [
    "Parsing a functional-test tree returns stable metadata for each top-level Test*: source file path, Go package name, test function name, first Go-doc sentence as description, build tags, and golden fixture references when present.",
    "Helper-only files and paths under tests/functional/internal/** are excluded from customer scenario counts while remaining identifiable as harness verification when present.",
    "Dynamic table-driven cases are not emitted as separate catalog records; only top-level Test* declarations are inventoried as customer scenarios.",
    "An exact undocumented-test baseline exists for legacy customer tests that lack a conventional Go-doc description, and the baseline is deletion-only: removals succeed, additions fail.",
    "Newly undocumented customer tests that are absent from the baseline fail immediately with an actionable identity for the offending test.",
    "Focused parser package tests cover malformed source, Windows-style paths, build tags, table tests, and Markdown-sensitive descriptions, and demonstrate stable ordering across repeated runs.",
    "Quality gate: typecheck, make lint, and the focused parser package tests pass; make test and make verify-fast remain green for this lane."
  ],
  "userStories": [
    {
      "id": "fnd-002-test-metadata-parser-001",
      "title": "Inventory top-level Test* metadata from Go AST",
      "description": "As a maintainer, I want every top-level functional Test* inventoried with stable file, package, name, and first-sentence description so later catalog generation has a durable metadata source.",
      "acceptanceCriteria": [
        "Given a functional-test source root, the parser inventories only top-level functions whose names match Test* and returns file path, package name, function name, and source line for each.",
        "When a conventional Go doc comment is present, the description is exactly the first sentence of that comment; when absent, the record is marked undocumented without inventing text.",
        "Repeated parses of the same tree return the same records in the same stable order.",
        "Dynamic table-driven cases are not separate inventory records; only the enclosing top-level Test* is counted.",
        "Malformed source that cannot be parsed fails with an actionable file-scoped error instead of partial silent success.",
        "Windows-style path inputs normalize to stable path identity in returned metadata.",
        "Descriptions that contain Markdown-sensitive characters are preserved literally without corrupting surrounding metadata fields.",
        "Focused parser package tests cover successful inventory, undocumented absence, table-test non-expansion, malformed source, Windows paths, and Markdown-sensitive descriptions.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "fnd-002-test-metadata-parser-002",
      "title": "Capture build tags and golden fixture references",
      "description": "As a maintainer, I want build constraints and golden declarations attached to inventoried tests so short/long and golden-backed scenarios can be labeled accurately later.",
      "acceptanceCriteria": [
        "File-level build constraints applicable to an inventoried test are returned as explicit build-tag metadata on that record.",
        "Tests with no build constraints report an empty or equivalent absent tag set rather than a fabricated default tag.",
        "Golden-backed tests that declare a fixture or manifest reference via a source comment or test-owned declaration expose that reference in metadata.",
        "Tests without a golden declaration expose no fabricated golden reference.",
        "Focused parser package tests cover tagged files, untagged files, golden-present, and golden-absent cases.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "fnd-002-test-metadata-parser-003",
      "title": "Exclude helpers and internal support from customer scenario counts",
      "description": "As a maintainer, I want helper-only files and tests/functional/internal/** excluded from customer scenario counts so inventory summaries reflect customer-facing proofs only.",
      "acceptanceCriteria": [
        "Files under tests/functional/internal/** are classified as harness/internal verification and do not increment customer scenario counts.",
        "Helper-only files that contain no customer Test* scenarios (or only shared helpers) are excluded from customer scenario counts.",
        "Customer scenario counts equal the number of inventoried top-level customer Test* records after those exclusions.",
        "Classification is explicit in parser output so later report rendering can still mention harness verification without mixing it into customer totals.",
        "Focused parser package tests cover an internal-support path, a helper-only file, and a mixed customer-scenario file.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "fnd-002-test-metadata-parser-004",
      "title": "Enforce an exact deletion-only undocumented-test baseline",
      "description": "As a maintainer, I want legacy undocumented customer tests frozen in an exact deletion-only baseline so debt can shrink and new undocumented customer tests fail immediately.",
      "acceptanceCriteria": [
        "An exact baseline enumerates the current undocumented customer Test* identities discovered by the parser.",
        "A parse/check against that baseline succeeds when the undocumented set is identical or a strict subset of the baseline.",
        "Removing an undocumented test from both the suite and the baseline succeeds; the baseline shrinks only by deletion.",
        "Adding a newly undocumented customer test that is absent from the baseline fails with an actionable identity for that test.",
        "Expanding the baseline to introduce new undocumented identities is rejected; the baseline is deletion-only.",
        "Helper-only and tests/functional/internal/** undocumented helpers do not enter the customer undocumented baseline.",
        "Focused parser package tests cover identical match, deletion success, new undocumented failure, and illegal baseline expansion.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)