### PR TITLE
fnd-004-markdown-generator

### DIFF
--- a/cmd/functionaltestviz/main.go
+++ b/cmd/functionaltestviz/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/portpowered/infinite-you/internal/functionaltestviz"
+)
+
+type config struct {
+	repositoryRoot      string
+	functionalRoot      string
+	coverageSummaryPath string
+	outputPath          string
+}
+
+func main() {
+	cfg := parseConfig()
+	if err := run(cfg, os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func parseConfig() config {
+	var cfg config
+	flag.StringVar(&cfg.repositoryRoot, "root", ".", "repository root used to resolve golden manifests and default paths")
+	flag.StringVar(&cfg.functionalRoot, "functional-root", "", "functional test tree to inventory (default: <root>/tests/functional)")
+	flag.StringVar(&cfg.coverageSummaryPath, "coverage-summary", "", "path to gocoveragecheck coverage-summary JSON (required)")
+	flag.StringVar(&cfg.outputPath, "output", "", "Markdown output path (default: <root>/.artifacts/functional-test-viz/functional-tests.md)")
+	flag.Parse()
+	return cfg
+}
+
+func run(cfg config, stdout, stderr io.Writer) error {
+	generateCfg := functionaltestviz.GenerateConfig{
+		RepositoryRoot:      cfg.repositoryRoot,
+		FunctionalRoot:      cfg.functionalRoot,
+		CoverageSummaryPath: cfg.coverageSummaryPath,
+		OutputPath:          cfg.outputPath,
+	}
+	if err := functionaltestviz.Generate(generateCfg); err != nil {
+		return err
+	}
+	outputPath := cfg.outputPath
+	if outputPath == "" {
+		root := cfg.repositoryRoot
+		if root == "" {
+			root = "."
+		}
+		outputPath = filepath.Join(root, filepath.FromSlash(functionaltestviz.DefaultOutputPath))
+	}
+	_, _ = fmt.Fprintf(stderr, "[agent-factory:functional-test-viz] wrote catalog to %s\n", outputPath)
+	_, _ = fmt.Fprintln(stdout, "ok")
+	return nil
+}

--- a/cmd/functionaltestviz/main_test.go
+++ b/cmd/functionaltestviz/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunRequiresCoverageSummary(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err := run(config{
+		repositoryRoot: t.TempDir(),
+	}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "coverage-summary path is required") {
+		t.Fatalf("run() error = %v, want required coverage-summary guidance", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestRunWritesCatalog(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	functionalRoot := filepath.Join(root, "tests", "functional", "transport")
+	if err := os.MkdirAll(functionalRoot, 0o755); err != nil {
+		t.Fatalf("mkdir functional root: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(functionalRoot, "help_test.go"),
+		[]byte("package transport\n\nimport \"testing\"\n\n// TestHelp verifies help.\nfunc TestHelp(t *testing.T) {}\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("write fixture test: %v", err)
+	}
+
+	coveragePath := filepath.Join(root, "coverage-summary.json")
+	const coverage = `{
+  "coveredStatements": 0,
+  "measurableStatements": 0,
+  "coveragePercent": 0.0,
+  "packages": []
+}
+`
+	if err := os.WriteFile(coveragePath, []byte(coverage), 0o644); err != nil {
+		t.Fatalf("write coverage summary: %v", err)
+	}
+
+	outputPath := filepath.Join(root, "out", "functional-tests.md")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if err := run(config{
+		repositoryRoot:      root,
+		coverageSummaryPath: coveragePath,
+		outputPath:          outputPath,
+	}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if stdout.String() != "ok\n" {
+		t.Fatalf("stdout = %q, want ok", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "wrote catalog to") {
+		t.Fatalf("stderr = %q, want wrote-catalog message", stderr.String())
+	}
+	got, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if !strings.Contains(string(got), "TestHelp") {
+		t.Fatalf("output missing TestHelp:\n%s", got)
+	}
+}

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -92,6 +92,18 @@
   fail; harness/internal helpers stay out of the ledger). Later FND cells
   wire that check into Make/CI; do not reintroduce regex or line-scraping
   inventories.
+  The maintainer-readable Markdown catalog generator lives in
+  `internal/functionaltestviz` with thin CLI entrypoint
+  `cmd/functionaltestviz`. It consumes inventoried
+  `functionaltestmetadata.Record` values plus an existing
+  `gocoveragecheck` coverage-summary JSON file (never a second `.out`
+  profile parser), attaches golden manifest provenance fail-closed, and
+  writes `.artifacts/functional-test-viz/functional-tests.md` by default
+  via `Generate` / `WriteCatalogFile`. Report semantics stay in the library;
+  Make/CI upload wiring remains a later cell (`make functional-test-viz` is
+  intentionally not owned here). Prove rendering with focused package/cmd
+  golden fixtures under `internal/functionaltestviz/testdata/` rather than
+  executing the full functional suite.
   `make functional-boundary-check` also owns the deletion-only inventory of
   grandfathered `tests/functional/providers/*_test.go` files: existing entries
   must be removed in the same change as their files migrate so stale exceptions

--- a/internal/functionaltestviz/catalog_golden_test.go
+++ b/internal/functionaltestviz/catalog_golden_test.go
@@ -1,0 +1,159 @@
+package functionaltestviz_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/functionaltestmetadata"
+	"github.com/portpowered/infinite-you/internal/functionaltestviz"
+)
+
+func TestRenderCatalogMarkdownFullReportGolden(t *testing.T) {
+	t.Parallel()
+
+	floor := 66.66
+	records := functionaltestviz.ClassifyRecords([]functionaltestmetadata.Record{
+		{
+			File:           "transport/cli/process/help_test.go",
+			Package:        "process",
+			Name:           "TestHelp",
+			Line:           12,
+			Description:    "verifies help output",
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+		{
+			File:           "workers/inference/openai/invoke_long_test.go",
+			Package:        "openai",
+			Name:           "TestInvoke",
+			Line:           40,
+			Description:    "verifies provider invoke replay",
+			BuildTags:      []string{"functionallong"},
+			Golden:         "testdata/goldens/openai/invoke/manifest.json",
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+		{
+			File:           "factory/definitions/load_test.go",
+			Package:        "definitions",
+			Name:           "TestLoad",
+			Line:           7,
+			Undocumented:   true,
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+		{
+			File:           "guards/policy/enforce_test.go",
+			Package:        "policy",
+			Name:           "TestEnforce",
+			Line:           15,
+			Description:    "verifies guard enforcement",
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+		{
+			File:           "runtime_api/session_test.go",
+			Package:        "runtime_api",
+			Name:           "TestSession",
+			Line:           5,
+			Undocumented:   true,
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+		{
+			File:           "internal/support/helpers_test.go",
+			Package:        "support",
+			Name:           "TestHelper",
+			Line:           3,
+			Classification: functionaltestmetadata.ClassificationHarness,
+		},
+	})
+	records[1].Provenance = functionaltestviz.GoldenProvenance{
+		Provider:      "openai",
+		Case:          "invoke",
+		FidelityClass: "partial-stream",
+		ID:            "openai-invoke",
+		ManifestPath:  "testdata/goldens/openai/invoke/manifest.json",
+	}
+
+	inputs := functionaltestviz.CatalogInputs{
+		Records: records,
+		Coverage: functionaltestviz.CoverageSummary{
+			CoveredStatements:    8,
+			MeasurableStatements: 10,
+			CoveragePercent:      80.0,
+			Packages: []functionaltestviz.PackageCoverage{
+				{
+					Package:              "github.com/portpowered/infinite-you/pkg/service",
+					CoveredStatements:    0,
+					MeasurableStatements: 0,
+					CoveragePercent:      0.0,
+					MeasurementException: &functionaltestviz.MeasurementException{
+						Kind:          "measurement",
+						Justification: "no measurable statements",
+						Owner:         "backend-quality",
+						Deadline:      "2027-07-15",
+						RemovalGate:   "profile reports measurable statements",
+					},
+				},
+				{
+					Package:              "github.com/portpowered/infinite-you/pkg/config",
+					CoveredStatements:    3,
+					MeasurableStatements: 3,
+					CoveragePercent:      100.0,
+					PackageFloor:         &floor,
+				},
+			},
+		},
+	}
+
+	first, err := functionaltestviz.RenderCatalogMarkdown(inputs)
+	if err != nil {
+		t.Fatalf("RenderCatalogMarkdown first: %v", err)
+	}
+	second, err := functionaltestviz.RenderCatalogMarkdown(inputs)
+	if err != nil {
+		t.Fatalf("RenderCatalogMarkdown second: %v", err)
+	}
+	if first != second {
+		t.Fatalf("repeated full-report renders diverged:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+
+	assertFullReportCoversRepresentativeSections(t, first)
+
+	goldenPath := filepath.Join("testdata", "full-report", "functional-tests.md")
+	golden, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden %s: %v", goldenPath, err)
+	}
+	if !bytes.Equal([]byte(first), golden) {
+		t.Fatalf("full-report markdown differs from golden %s:\ngot:\n%s\nwant:\n%s", goldenPath, first, golden)
+	}
+}
+
+func assertFullReportCoversRepresentativeSections(t *testing.T, catalog string) {
+	t.Helper()
+	required := []string{
+		"# Functional tests\n",
+		"## Domain summaries\n",
+		"### transport\n",
+		"### workers\n",
+		"### guards / resources\n",
+		"### observability / product / resilience\n",
+		"## Test catalog\n",
+		"- Labels: short\n",
+		"- Labels: long-only, golden-backed\n",
+		"- Labels: short, undocumented\n",
+		"- Labels: short, deprecated, undocumented\n",
+		"  - Golden provenance:\n",
+		"## Documentation debt\n",
+		"### Undocumented customer tests\n",
+		"### Deprecated tests\n",
+		"## Package coverage\n",
+		"| `github.com/portpowered/infinite-you/pkg/config` |",
+		"## Harness verification\n",
+	}
+	for _, fragment := range required {
+		if !strings.Contains(catalog, fragment) {
+			t.Fatalf("full report missing %q:\n%s", fragment, catalog)
+		}
+	}
+}

--- a/internal/functionaltestviz/catalog_golden_test.go
+++ b/internal/functionaltestviz/catalog_golden_test.go
@@ -14,7 +14,36 @@ import (
 func TestRenderCatalogMarkdownFullReportGolden(t *testing.T) {
 	t.Parallel()
 
-	floor := 66.66
+	inputs := functionaltestviz.CatalogInputs{
+		Records:  fullReportFixtureRecords(),
+		Coverage: fullReportCoverageSummary(),
+	}
+
+	first, err := functionaltestviz.RenderCatalogMarkdown(inputs)
+	if err != nil {
+		t.Fatalf("RenderCatalogMarkdown first: %v", err)
+	}
+	second, err := functionaltestviz.RenderCatalogMarkdown(inputs)
+	if err != nil {
+		t.Fatalf("RenderCatalogMarkdown second: %v", err)
+	}
+	if first != second {
+		t.Fatalf("repeated full-report renders diverged:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+
+	assertFullReportCoversRepresentativeSections(t, first)
+
+	goldenPath := filepath.Join("testdata", "full-report", "functional-tests.md")
+	golden, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden %s: %v", goldenPath, err)
+	}
+	if !bytes.Equal([]byte(first), golden) {
+		t.Fatalf("full-report markdown differs from golden %s:\ngot:\n%s\nwant:\n%s", goldenPath, first, golden)
+	}
+}
+
+func fullReportFixtureRecords() []functionaltestviz.ClassifiedRecord {
 	records := functionaltestviz.ClassifyRecords([]functionaltestmetadata.Record{
 		{
 			File:           "transport/cli/process/help_test.go",
@@ -73,59 +102,37 @@ func TestRenderCatalogMarkdownFullReportGolden(t *testing.T) {
 		ID:            "openai-invoke",
 		ManifestPath:  "testdata/goldens/openai/invoke/manifest.json",
 	}
+	return records
+}
 
-	inputs := functionaltestviz.CatalogInputs{
-		Records: records,
-		Coverage: functionaltestviz.CoverageSummary{
-			CoveredStatements:    8,
-			MeasurableStatements: 10,
-			CoveragePercent:      80.0,
-			Packages: []functionaltestviz.PackageCoverage{
-				{
-					Package:              "github.com/portpowered/infinite-you/pkg/service",
-					CoveredStatements:    0,
-					MeasurableStatements: 0,
-					CoveragePercent:      0.0,
-					MeasurementException: &functionaltestviz.MeasurementException{
-						Kind:          "measurement",
-						Justification: "no measurable statements",
-						Owner:         "backend-quality",
-						Deadline:      "2027-07-15",
-						RemovalGate:   "profile reports measurable statements",
-					},
-				},
-				{
-					Package:              "github.com/portpowered/infinite-you/pkg/config",
-					CoveredStatements:    3,
-					MeasurableStatements: 3,
-					CoveragePercent:      100.0,
-					PackageFloor:         &floor,
+func fullReportCoverageSummary() functionaltestviz.CoverageSummary {
+	floor := 66.66
+	return functionaltestviz.CoverageSummary{
+		CoveredStatements:    8,
+		MeasurableStatements: 10,
+		CoveragePercent:      80.0,
+		Packages: []functionaltestviz.PackageCoverage{
+			{
+				Package:              "github.com/portpowered/infinite-you/pkg/service",
+				CoveredStatements:    0,
+				MeasurableStatements: 0,
+				CoveragePercent:      0.0,
+				MeasurementException: &functionaltestviz.MeasurementException{
+					Kind:          "measurement",
+					Justification: "no measurable statements",
+					Owner:         "backend-quality",
+					Deadline:      "2027-07-15",
+					RemovalGate:   "profile reports measurable statements",
 				},
 			},
+			{
+				Package:              "github.com/portpowered/infinite-you/pkg/config",
+				CoveredStatements:    3,
+				MeasurableStatements: 3,
+				CoveragePercent:      100.0,
+				PackageFloor:         &floor,
+			},
 		},
-	}
-
-	first, err := functionaltestviz.RenderCatalogMarkdown(inputs)
-	if err != nil {
-		t.Fatalf("RenderCatalogMarkdown first: %v", err)
-	}
-	second, err := functionaltestviz.RenderCatalogMarkdown(inputs)
-	if err != nil {
-		t.Fatalf("RenderCatalogMarkdown second: %v", err)
-	}
-	if first != second {
-		t.Fatalf("repeated full-report renders diverged:\nfirst:\n%s\nsecond:\n%s", first, second)
-	}
-
-	assertFullReportCoversRepresentativeSections(t, first)
-
-	goldenPath := filepath.Join("testdata", "full-report", "functional-tests.md")
-	golden, err := os.ReadFile(goldenPath)
-	if err != nil {
-		t.Fatalf("read golden %s: %v", goldenPath, err)
-	}
-	if !bytes.Equal([]byte(first), golden) {
-		t.Fatalf("full-report markdown differs from golden %s:\ngot:\n%s\nwant:\n%s", goldenPath, first, golden)
 	}
 }
 

--- a/internal/functionaltestviz/classify.go
+++ b/internal/functionaltestviz/classify.go
@@ -29,6 +29,8 @@ type ClassifiedRecord struct {
 	GoldenBacked bool
 	Undocumented bool
 	Deprecated   bool
+	// Provenance is attached by AttachGoldenProvenance for golden-backed tests.
+	Provenance GoldenProvenance
 }
 
 // CatalogInputs is the assembled catalog input set: classified inventory plus

--- a/internal/functionaltestviz/classify.go
+++ b/internal/functionaltestviz/classify.go
@@ -1,0 +1,115 @@
+package functionaltestviz
+
+import (
+	"path"
+	"strings"
+
+	"github.com/portpowered/infinite-you/internal/functionaltestmetadata"
+)
+
+// Known deprecated / deletion-only functional package roots. Paths under these
+// owners are labeled deprecated in the catalog until ownership reaches zero.
+var deprecatedFunctionalPackageRoots = map[string]struct{}{
+	"runtime_api": {},
+}
+
+const (
+	// LaneShort is the default functional lane (not gated by functionallong).
+	LaneShort = "short"
+	// LaneLongOnly is the long-only functional lane gated by functionallong.
+	LaneLongOnly = "long-only"
+)
+
+// ClassifiedRecord is one inventoried functional Test* with catalog labels.
+type ClassifiedRecord struct {
+	Record       functionaltestmetadata.Record
+	Domain       string
+	Package      string
+	Lane         string
+	GoldenBacked bool
+	Undocumented bool
+	Deprecated   bool
+}
+
+// CatalogInputs is the assembled catalog input set: classified inventory plus
+// decoded coverage-summary JSON.
+type CatalogInputs struct {
+	Records  []ClassifiedRecord
+	Coverage CoverageSummary
+}
+
+// AssembleCatalogInputs classifies inventoried metadata records and loads the
+// required coverage-summary JSON path. Coverage is consumed only by decoding
+// that JSON; no coverage-profile parser is used.
+func AssembleCatalogInputs(records []functionaltestmetadata.Record, coverageSummaryPath string) (CatalogInputs, error) {
+	coverage, err := LoadCoverageSummary(coverageSummaryPath)
+	if err != nil {
+		return CatalogInputs{}, err
+	}
+	return CatalogInputs{
+		Records:  ClassifyRecords(records),
+		Coverage: coverage,
+	}, nil
+}
+
+// ClassifyRecords derives domain ownership and catalog labels for each record.
+// Ordering of the returned slice matches the input order.
+func ClassifyRecords(records []functionaltestmetadata.Record) []ClassifiedRecord {
+	out := make([]ClassifiedRecord, 0, len(records))
+	for _, record := range records {
+		out = append(out, ClassifyRecord(record))
+	}
+	return out
+}
+
+// ClassifyRecord derives domain ownership and catalog labels for one record.
+func ClassifyRecord(record functionaltestmetadata.Record) ClassifiedRecord {
+	domain := DomainFromFile(record.File)
+	return ClassifiedRecord{
+		Record:       record,
+		Domain:       domain,
+		Package:      record.Package,
+		Lane:         LaneFromBuildTags(record.BuildTags),
+		GoldenBacked: strings.TrimSpace(record.Golden) != "",
+		Undocumented: record.Undocumented,
+		Deprecated:   IsDeprecatedDomain(domain),
+	}
+}
+
+// DomainFromFile returns the functional domain noun from a repository-relative
+// or functional-root-relative source path (tests/functional/<domain>/...).
+func DomainFromFile(file string) string {
+	normalized := path.Clean("/" + strings.ReplaceAll(file, "\\", "/"))
+	normalized = strings.TrimPrefix(normalized, "/")
+	parts := strings.Split(normalized, "/")
+	if len(parts) == 0 || parts[0] == "" || parts[0] == "." {
+		return ""
+	}
+	if parts[0] == "tests" && len(parts) >= 3 && parts[1] == "functional" {
+		return parts[2]
+	}
+	return parts[0]
+}
+
+// LaneFromBuildTags reports short versus long-only from file-level build tags.
+// A record is long-only when any constraint expression includes functionallong
+// without a leading negation of that tag.
+func LaneFromBuildTags(buildTags []string) string {
+	for _, tag := range buildTags {
+		trimmed := strings.TrimSpace(tag)
+		if trimmed == "" {
+			continue
+		}
+		if strings.Contains(trimmed, "functionallong") && !strings.Contains(trimmed, "!functionallong") {
+			return LaneLongOnly
+		}
+	}
+	return LaneShort
+}
+
+// IsDeprecatedDomain reports whether a functional domain root is a known
+// deletion-only / deprecated package path.
+func IsDeprecatedDomain(domain string) bool {
+	_, ok := deprecatedFunctionalPackageRoots[domain]
+	return ok
+}

--- a/internal/functionaltestviz/classify_test.go
+++ b/internal/functionaltestviz/classify_test.go
@@ -1,0 +1,251 @@
+package functionaltestviz_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/functionaltestmetadata"
+	"github.com/portpowered/infinite-you/internal/functionaltestviz"
+)
+
+func TestDecodeCoverageSummaryAcceptsGocoveragecheckShape(t *testing.T) {
+	t.Parallel()
+
+	const raw = `{
+  "coveredStatements": 8,
+  "measurableStatements": 10,
+  "coveragePercent": 80.0,
+  "packages": [
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/config",
+      "coveredStatements": 3,
+      "measurableStatements": 3,
+      "coveragePercent": 100.0,
+      "packageFloor": 66.66,
+      "measurementException": null
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/service",
+      "coveredStatements": 0,
+      "measurableStatements": 0,
+      "coveragePercent": 0.0,
+      "packageFloor": null,
+      "measurementException": {
+        "kind": "measurement",
+        "justification": "no measurable statements",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "profile reports measurable statements"
+      }
+    }
+  ]
+}
+`
+	summary, err := functionaltestviz.DecodeCoverageSummary([]byte(raw))
+	if err != nil {
+		t.Fatalf("DecodeCoverageSummary() error = %v", err)
+	}
+	if summary.CoveredStatements != 8 || summary.MeasurableStatements != 10 {
+		t.Fatalf("totals = %d/%d, want 8/10", summary.CoveredStatements, summary.MeasurableStatements)
+	}
+	if summary.CoveragePercent != 80.0 {
+		t.Fatalf("coveragePercent = %v, want 80.0", summary.CoveragePercent)
+	}
+	if len(summary.Packages) != 2 {
+		t.Fatalf("packages len = %d, want 2", len(summary.Packages))
+	}
+	if summary.Packages[0].PackageFloor == nil || *summary.Packages[0].PackageFloor != 66.66 {
+		t.Fatalf("packages[0].packageFloor = %v, want 66.66", summary.Packages[0].PackageFloor)
+	}
+	if summary.Packages[1].MeasurementException == nil {
+		t.Fatal("packages[1].measurementException is nil, want structured exception")
+	}
+	if got := summary.Packages[1].MeasurementException.Kind; got != "measurement" {
+		t.Fatalf("measurementException.kind = %q, want measurement", got)
+	}
+}
+
+func TestLoadCoverageSummaryFailsClosedForMissingAndMalformed(t *testing.T) {
+	t.Parallel()
+
+	missing := filepath.Join(t.TempDir(), "missing-coverage-summary.json")
+	_, err := functionaltestviz.LoadCoverageSummary(missing)
+	if err == nil {
+		t.Fatal("LoadCoverageSummary(missing) error = nil, want actionable error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("LoadCoverageSummary(missing) error = %v, want not-found guidance", err)
+	}
+
+	_, err = functionaltestviz.LoadCoverageSummary("")
+	if err == nil || !strings.Contains(err.Error(), "required") {
+		t.Fatalf("LoadCoverageSummary(\"\") error = %v, want required-path guidance", err)
+	}
+
+	badPath := filepath.Join(t.TempDir(), "bad.json")
+	if writeErr := os.WriteFile(badPath, []byte(`{"coveredStatements":1`), 0o644); writeErr != nil {
+		t.Fatalf("write malformed summary: %v", writeErr)
+	}
+	_, err = functionaltestviz.LoadCoverageSummary(badPath)
+	if err == nil || !strings.Contains(err.Error(), "invalid coverage-summary JSON") {
+		t.Fatalf("LoadCoverageSummary(malformed) error = %v, want invalid JSON guidance", err)
+	}
+
+	_, err = functionaltestviz.DecodeCoverageSummary([]byte(`{"coveredStatements":1,"measurableStatements":1,"coveragePercent":100}`))
+	if err == nil || !strings.Contains(err.Error(), "packages") {
+		t.Fatalf("DecodeCoverageSummary(missing packages) error = %v, want packages guidance", err)
+	}
+}
+
+func TestAssembleCatalogInputsClassifiesRecordsAndLoadsCoverage(t *testing.T) {
+	t.Parallel()
+
+	summaryPath := filepath.Join(t.TempDir(), "coverage-summary.json")
+	const raw = `{
+  "coveredStatements": 1,
+  "measurableStatements": 2,
+  "coveragePercent": 50.0,
+  "packages": [
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/example",
+      "coveredStatements": 1,
+      "measurableStatements": 2,
+      "coveragePercent": 50.0,
+      "packageFloor": 40.0,
+      "measurementException": null
+    }
+  ]
+}
+`
+	if err := os.WriteFile(summaryPath, []byte(raw), 0o644); err != nil {
+		t.Fatalf("write coverage summary: %v", err)
+	}
+
+	records := []functionaltestmetadata.Record{
+		{
+			File:           "transport/cli/process/help_test.go",
+			Package:        "process",
+			Name:           "TestHelp",
+			Line:           10,
+			Description:    "verifies help output",
+			BuildTags:      nil,
+			Golden:         "",
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+		{
+			File:           "workers/inference/openai/invoke_long_test.go",
+			Package:        "openai",
+			Name:           "TestInvoke",
+			Line:           20,
+			Description:    "verifies provider invoke",
+			BuildTags:      []string{"functionallong"},
+			Golden:         "testdata/goldens/openai/manifest.json",
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+		{
+			File:           "runtime_api/session_test.go",
+			Package:        "runtime_api",
+			Name:           "TestSession",
+			Line:           5,
+			Undocumented:   true,
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+		{
+			File:           "tests/functional/factory/definitions/validate_test.go",
+			Package:        "definitions",
+			Name:           "TestValidate",
+			Line:           8,
+			Description:    "validates factory definitions",
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+		{
+			File:           "internal/support/helpers_test.go",
+			Package:        "support",
+			Name:           "TestHelper",
+			Line:           3,
+			Classification: functionaltestmetadata.ClassificationHarness,
+		},
+	}
+
+	inputs, err := functionaltestviz.AssembleCatalogInputs(records, summaryPath)
+	if err != nil {
+		t.Fatalf("AssembleCatalogInputs() error = %v", err)
+	}
+	if inputs.Coverage.CoveredStatements != 1 || inputs.Coverage.MeasurableStatements != 2 {
+		t.Fatalf("coverage totals = %d/%d, want 1/2", inputs.Coverage.CoveredStatements, inputs.Coverage.MeasurableStatements)
+	}
+	if len(inputs.Records) != len(records) {
+		t.Fatalf("classified len = %d, want %d", len(inputs.Records), len(records))
+	}
+
+	assertClassified(t, inputs.Records[0], "transport", "process", functionaltestviz.LaneShort, false, false, false)
+	assertClassified(t, inputs.Records[1], "workers", "openai", functionaltestviz.LaneLongOnly, true, false, false)
+	assertClassified(t, inputs.Records[2], "runtime_api", "runtime_api", functionaltestviz.LaneShort, false, true, true)
+	assertClassified(t, inputs.Records[3], "factory", "definitions", functionaltestviz.LaneShort, false, false, false)
+	assertClassified(t, inputs.Records[4], "internal", "support", functionaltestviz.LaneShort, false, false, false)
+}
+
+func TestLaneFromBuildTagsDetectsLongOnlyWithoutFabricatingDefaults(t *testing.T) {
+	t.Parallel()
+
+	if got := functionaltestviz.LaneFromBuildTags(nil); got != functionaltestviz.LaneShort {
+		t.Fatalf("LaneFromBuildTags(nil) = %q, want %q", got, functionaltestviz.LaneShort)
+	}
+	if got := functionaltestviz.LaneFromBuildTags([]string{"!functionallong"}); got != functionaltestviz.LaneShort {
+		t.Fatalf("LaneFromBuildTags(!functionallong) = %q, want %q", got, functionaltestviz.LaneShort)
+	}
+	if got := functionaltestviz.LaneFromBuildTags([]string{"functionallong"}); got != functionaltestviz.LaneLongOnly {
+		t.Fatalf("LaneFromBuildTags(functionallong) = %q, want %q", got, functionaltestviz.LaneLongOnly)
+	}
+	if got := functionaltestviz.LaneFromBuildTags([]string{"linux && functionallong"}); got != functionaltestviz.LaneLongOnly {
+		t.Fatalf("LaneFromBuildTags(compound) = %q, want %q", got, functionaltestviz.LaneLongOnly)
+	}
+}
+
+func TestDomainFromFileHandlesWindowsSeparatorsAndRepoRelativePaths(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		file string
+		want string
+	}{
+		{file: `transport\cli\help_test.go`, want: "transport"},
+		{file: "tests/functional/sessions/lifecycle/open_test.go", want: "sessions"},
+		{file: "guards/policy_test.go", want: "guards"},
+		{file: "", want: ""},
+	}
+	for _, tc := range cases {
+		if got := functionaltestviz.DomainFromFile(tc.file); got != tc.want {
+			t.Fatalf("DomainFromFile(%q) = %q, want %q", tc.file, got, tc.want)
+		}
+	}
+}
+
+func assertClassified(
+	t *testing.T,
+	got functionaltestviz.ClassifiedRecord,
+	domain, pkg, lane string,
+	goldenBacked, undocumented, deprecated bool,
+) {
+	t.Helper()
+	if got.Domain != domain {
+		t.Fatalf("Domain = %q, want %q", got.Domain, domain)
+	}
+	if got.Package != pkg {
+		t.Fatalf("Package = %q, want %q", got.Package, pkg)
+	}
+	if got.Lane != lane {
+		t.Fatalf("Lane = %q, want %q", got.Lane, lane)
+	}
+	if got.GoldenBacked != goldenBacked {
+		t.Fatalf("GoldenBacked = %v, want %v", got.GoldenBacked, goldenBacked)
+	}
+	if got.Undocumented != undocumented {
+		t.Fatalf("Undocumented = %v, want %v", got.Undocumented, undocumented)
+	}
+	if got.Deprecated != deprecated {
+		t.Fatalf("Deprecated = %v, want %v", got.Deprecated, deprecated)
+	}
+}

--- a/internal/functionaltestviz/coverage.go
+++ b/internal/functionaltestviz/coverage.go
@@ -1,0 +1,109 @@
+package functionaltestviz
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// CoverageSummary mirrors the machine-readable coverage-summary JSON owned by
+// cmd/gocoveragecheck. Downstream visualizers decode this artifact instead of
+// re-parsing coverage profiles.
+type CoverageSummary struct {
+	CoveredStatements    int                   `json:"coveredStatements"`
+	MeasurableStatements int                   `json:"measurableStatements"`
+	CoveragePercent      float64               `json:"coveragePercent"`
+	Packages             []PackageCoverage     `json:"packages"`
+}
+
+// PackageCoverage reports one measured production package, including the
+// package-gate floor or measurement exception used for that run.
+type PackageCoverage struct {
+	Package              string                `json:"package"`
+	CoveredStatements    int                   `json:"coveredStatements"`
+	MeasurableStatements int                   `json:"measurableStatements"`
+	CoveragePercent      float64               `json:"coveragePercent"`
+	PackageFloor         *float64              `json:"packageFloor"`
+	MeasurementException *MeasurementException `json:"measurementException"`
+}
+
+// MeasurementException mirrors the structured exception object emitted by
+// gocoveragecheck when a package is ungated for measurement reasons.
+type MeasurementException struct {
+	Kind          string `json:"kind"`
+	Justification string `json:"justification"`
+	Owner         string `json:"owner"`
+	Deadline      string `json:"deadline"`
+	RemovalGate   string `json:"removalGate"`
+}
+
+// LoadCoverageSummary reads and decodes a coverage-summary JSON file.
+// Missing paths and malformed documents fail with actionable errors.
+func LoadCoverageSummary(path string) (CoverageSummary, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return CoverageSummary{}, fmt.Errorf("coverage-summary path is required")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return CoverageSummary{}, fmt.Errorf("coverage-summary file not found: %s", path)
+		}
+		return CoverageSummary{}, fmt.Errorf("read coverage-summary %s: %w", path, err)
+	}
+	summary, err := DecodeCoverageSummary(data)
+	if err != nil {
+		return CoverageSummary{}, fmt.Errorf("decode coverage-summary %s: %w", path, err)
+	}
+	return summary, nil
+}
+
+// DecodeCoverageSummary decodes coverage-summary JSON bytes.
+func DecodeCoverageSummary(data []byte) (CoverageSummary, error) {
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return CoverageSummary{}, fmt.Errorf("coverage-summary JSON is empty")
+	}
+	var summary CoverageSummary
+	if err := json.Unmarshal(data, &summary); err != nil {
+		return CoverageSummary{}, fmt.Errorf("invalid coverage-summary JSON: %w", err)
+	}
+	if err := validateCoverageSummary(summary); err != nil {
+		return CoverageSummary{}, err
+	}
+	return summary, nil
+}
+
+func validateCoverageSummary(summary CoverageSummary) error {
+	if summary.Packages == nil {
+		return fmt.Errorf("coverage-summary JSON missing required packages array")
+	}
+	if summary.MeasurableStatements < 0 || summary.CoveredStatements < 0 {
+		return fmt.Errorf("coverage-summary JSON has negative statement totals")
+	}
+	if summary.CoveredStatements > summary.MeasurableStatements {
+		return fmt.Errorf(
+			"coverage-summary JSON coveredStatements (%d) exceeds measurableStatements (%d)",
+			summary.CoveredStatements,
+			summary.MeasurableStatements,
+		)
+	}
+	for i, pkg := range summary.Packages {
+		if strings.TrimSpace(pkg.Package) == "" {
+			return fmt.Errorf("coverage-summary JSON packages[%d] missing package path", i)
+		}
+		if pkg.MeasurableStatements < 0 || pkg.CoveredStatements < 0 {
+			return fmt.Errorf("coverage-summary JSON packages[%d] (%s) has negative statement totals", i, pkg.Package)
+		}
+		if pkg.CoveredStatements > pkg.MeasurableStatements {
+			return fmt.Errorf(
+				"coverage-summary JSON packages[%d] (%s) coveredStatements (%d) exceeds measurableStatements (%d)",
+				i,
+				pkg.Package,
+				pkg.CoveredStatements,
+				pkg.MeasurableStatements,
+			)
+		}
+	}
+	return nil
+}

--- a/internal/functionaltestviz/coverage_markdown.go
+++ b/internal/functionaltestviz/coverage_markdown.go
@@ -1,0 +1,104 @@
+package functionaltestviz
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// RenderPackageCoverageMarkdown renders overall statement totals and a
+// stable-ordered per-production-package table from coverage-summary JSON
+// fields only (no profile recomputation).
+func RenderPackageCoverageMarkdown(summary CoverageSummary) string {
+	packages := StableOrderedPackages(summary.Packages)
+
+	var b strings.Builder
+	b.WriteString("## Package coverage\n\n")
+	b.WriteString(fmt.Sprintf("- Covered statements: %d\n", summary.CoveredStatements))
+	b.WriteString(fmt.Sprintf("- Measurable statements: %d\n", summary.MeasurableStatements))
+	b.WriteString(fmt.Sprintf("- Coverage percent: %s%%\n\n", formatCoveragePercent(summary.CoveragePercent)))
+
+	if len(packages) == 0 {
+		b.WriteString("- _No production packages in coverage summary._\n")
+		return b.String()
+	}
+
+	b.WriteString("| Package | Covered | Measurable | Coverage % | Floor | Measurement exception |\n")
+	b.WriteString("| --- | ---: | ---: | ---: | ---: | --- |\n")
+	for _, pkg := range packages {
+		b.WriteString("| `")
+		b.WriteString(pkg.Package)
+		b.WriteString("` | ")
+		b.WriteString(strconv.Itoa(pkg.CoveredStatements))
+		b.WriteString(" | ")
+		b.WriteString(strconv.Itoa(pkg.MeasurableStatements))
+		b.WriteString(" | ")
+		b.WriteString(formatCoveragePercent(pkg.CoveragePercent))
+		b.WriteString(" | ")
+		b.WriteString(formatOptionalFloor(pkg.PackageFloor))
+		b.WriteString(" | ")
+		b.WriteString(formatMeasurementException(pkg.MeasurementException))
+		b.WriteString(" |\n")
+	}
+	return b.String()
+}
+
+// StableOrderedPackages returns a copy of packages sorted by import path.
+func StableOrderedPackages(packages []PackageCoverage) []PackageCoverage {
+	ordered := make([]PackageCoverage, len(packages))
+	copy(ordered, packages)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].Package < ordered[j].Package
+	})
+	return ordered
+}
+
+func formatCoveragePercent(value float64) string {
+	return strconv.FormatFloat(value, 'f', 1, 64)
+}
+
+func formatOptionalFloor(floor *float64) string {
+	if floor == nil {
+		return "—"
+	}
+	return strconv.FormatFloat(*floor, 'f', -1, 64)
+}
+
+func formatMeasurementException(exception *MeasurementException) string {
+	if exception == nil {
+		return "—"
+	}
+	parts := make([]string, 0, 4)
+	if kind := strings.TrimSpace(exception.Kind); kind != "" {
+		parts = append(parts, kind)
+	}
+	if justification := strings.TrimSpace(exception.Justification); justification != "" {
+		parts = append(parts, justification)
+	}
+	meta := make([]string, 0, 3)
+	if owner := strings.TrimSpace(exception.Owner); owner != "" {
+		meta = append(meta, "owner="+owner)
+	}
+	if deadline := strings.TrimSpace(exception.Deadline); deadline != "" {
+		meta = append(meta, "deadline="+deadline)
+	}
+	if removalGate := strings.TrimSpace(exception.RemovalGate); removalGate != "" {
+		meta = append(meta, "removalGate="+removalGate)
+	}
+	body := strings.Join(parts, ": ")
+	if len(meta) == 0 {
+		if body == "" {
+			return "—"
+		}
+		return escapeTableCell(body)
+	}
+	if body == "" {
+		return escapeTableCell(strings.Join(meta, "; "))
+	}
+	return escapeTableCell(body + " (" + strings.Join(meta, "; ") + ")")
+}
+
+func escapeTableCell(value string) string {
+	return strings.ReplaceAll(value, "|", "\\|")
+}

--- a/internal/functionaltestviz/coverage_markdown_test.go
+++ b/internal/functionaltestviz/coverage_markdown_test.go
@@ -1,0 +1,163 @@
+package functionaltestviz_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/functionaltestmetadata"
+	"github.com/portpowered/infinite-you/internal/functionaltestviz"
+)
+
+func TestStableOrderedPackagesSortsByImportPath(t *testing.T) {
+	t.Parallel()
+
+	packages := []functionaltestviz.PackageCoverage{
+		{Package: "github.com/portpowered/infinite-you/pkg/zeta"},
+		{Package: "github.com/portpowered/infinite-you/pkg/alpha"},
+		{Package: "github.com/portpowered/infinite-you/pkg/beta"},
+	}
+	ordered := functionaltestviz.StableOrderedPackages(packages)
+	want := []string{
+		"github.com/portpowered/infinite-you/pkg/alpha",
+		"github.com/portpowered/infinite-you/pkg/beta",
+		"github.com/portpowered/infinite-you/pkg/zeta",
+	}
+	if len(ordered) != len(want) {
+		t.Fatalf("ordered len = %d, want %d", len(ordered), len(want))
+	}
+	for i := range want {
+		if ordered[i].Package != want[i] {
+			t.Fatalf("ordered[%d] = %q, want %q", i, ordered[i].Package, want[i])
+		}
+	}
+	if packages[0].Package != "github.com/portpowered/infinite-you/pkg/zeta" {
+		t.Fatal("StableOrderedPackages mutated input slice")
+	}
+}
+
+func TestRenderPackageCoverageMarkdownUsesSummaryFieldsOnly(t *testing.T) {
+	t.Parallel()
+
+	floor := 66.66
+	summary := functionaltestviz.CoverageSummary{
+		CoveredStatements:    8,
+		MeasurableStatements: 10,
+		CoveragePercent:      80.0,
+		Packages: []functionaltestviz.PackageCoverage{
+			{
+				Package:              "github.com/portpowered/infinite-you/pkg/service",
+				CoveredStatements:    0,
+				MeasurableStatements: 0,
+				CoveragePercent:      0.0,
+				PackageFloor:         nil,
+				MeasurementException: &functionaltestviz.MeasurementException{
+					Kind:          "measurement",
+					Justification: "no measurable statements",
+					Owner:         "backend-quality",
+					Deadline:      "2027-07-15",
+					RemovalGate:   "profile reports measurable statements",
+				},
+			},
+			{
+				Package:              "github.com/portpowered/infinite-you/pkg/config",
+				CoveredStatements:    3,
+				MeasurableStatements: 3,
+				CoveragePercent:      100.0,
+				PackageFloor:         &floor,
+				MeasurementException: nil,
+			},
+		},
+	}
+
+	first := functionaltestviz.RenderPackageCoverageMarkdown(summary)
+	second := functionaltestviz.RenderPackageCoverageMarkdown(summary)
+	if first != second {
+		t.Fatalf("repeated coverage renders diverged:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+
+	if !strings.HasPrefix(first, "## Package coverage\n\n") {
+		t.Fatalf("coverage section heading missing:\n%s", first)
+	}
+	if !strings.Contains(first, "- Covered statements: 8\n") {
+		t.Fatalf("overall covered statements missing:\n%s", first)
+	}
+	if !strings.Contains(first, "- Measurable statements: 10\n") {
+		t.Fatalf("overall measurable statements missing:\n%s", first)
+	}
+	if !strings.Contains(first, "- Coverage percent: 80.0%\n") {
+		t.Fatalf("overall coverage percent missing:\n%s", first)
+	}
+
+	configIdx := strings.Index(first, "| `github.com/portpowered/infinite-you/pkg/config` |")
+	serviceIdx := strings.Index(first, "| `github.com/portpowered/infinite-you/pkg/service` |")
+	if configIdx < 0 || serviceIdx < 0 || configIdx >= serviceIdx {
+		t.Fatalf("packages must render in stable path order:\n%s", first)
+	}
+	if !strings.Contains(first, "| `github.com/portpowered/infinite-you/pkg/config` | 3 | 3 | 100.0 | 66.66 | — |") {
+		t.Fatalf("config package row missing floor rendering:\n%s", first)
+	}
+	if !strings.Contains(first, "| `github.com/portpowered/infinite-you/pkg/service` | 0 | 0 | 0.0 | — | measurement: no measurable statements (owner=backend-quality; deadline=2027-07-15; removalGate=profile reports measurable statements) |") {
+		t.Fatalf("service package row missing measurement exception:\n%s", first)
+	}
+}
+
+func TestRenderPackageCoverageMarkdownEmptyPackages(t *testing.T) {
+	t.Parallel()
+
+	got := functionaltestviz.RenderPackageCoverageMarkdown(functionaltestviz.CoverageSummary{
+		CoveredStatements:    0,
+		MeasurableStatements: 0,
+		CoveragePercent:      0.0,
+		Packages:             []functionaltestviz.PackageCoverage{},
+	})
+	if !strings.Contains(got, "- Covered statements: 0\n") {
+		t.Fatalf("zero overall totals missing:\n%s", got)
+	}
+	if !strings.Contains(got, "- _No production packages in coverage summary._\n") {
+		t.Fatalf("empty packages presentation missing:\n%s", got)
+	}
+	if strings.Contains(got, "| Package |") {
+		t.Fatalf("empty packages must not render a table:\n%s", got)
+	}
+}
+
+func TestRenderCatalogMarkdownAppendsPackageCoverageAfterDebt(t *testing.T) {
+	t.Parallel()
+
+	floor := 40.0
+	records := functionaltestviz.ClassifyRecords([]functionaltestmetadata.Record{
+		customerRecord("transport/cli/process/help_test.go", "process", "TestHelp"),
+	})
+	catalog, err := functionaltestviz.RenderCatalogMarkdown(functionaltestviz.CatalogInputs{
+		Records: records,
+		Coverage: functionaltestviz.CoverageSummary{
+			CoveredStatements:    1,
+			MeasurableStatements: 2,
+			CoveragePercent:      50.0,
+			Packages: []functionaltestviz.PackageCoverage{
+				{
+					Package:              "github.com/portpowered/infinite-you/pkg/example",
+					CoveredStatements:    1,
+					MeasurableStatements: 2,
+					CoveragePercent:      50.0,
+					PackageFloor:         &floor,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RenderCatalogMarkdown: %v", err)
+	}
+
+	debtIdx := strings.Index(catalog, "## Documentation debt\n")
+	coverageIdx := strings.Index(catalog, "## Package coverage\n")
+	if debtIdx < 0 || coverageIdx < 0 || coverageIdx <= debtIdx {
+		t.Fatalf("catalog must append package coverage after documentation debt:\n%s", catalog)
+	}
+	if !strings.Contains(catalog, "- Coverage percent: 50.0%\n") {
+		t.Fatalf("overall coverage percent missing from catalog:\n%s", catalog)
+	}
+	if !strings.Contains(catalog, "| `github.com/portpowered/infinite-you/pkg/example` | 1 | 2 | 50.0 | 40 | — |") {
+		t.Fatalf("package coverage row missing from catalog:\n%s", catalog)
+	}
+}

--- a/internal/functionaltestviz/debt_markdown.go
+++ b/internal/functionaltestviz/debt_markdown.go
@@ -1,0 +1,64 @@
+package functionaltestviz
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/portpowered/infinite-you/internal/functionaltestmetadata"
+)
+
+// DebtReport lists stable identities for undocumented and deprecated customer
+// debt. Harness records are excluded.
+type DebtReport struct {
+	Undocumented []string
+	Deprecated   []string
+}
+
+// BuildDebtReport collects undocumented and deprecated customer identities in
+// stable sorted order (file::name).
+func BuildDebtReport(records []ClassifiedRecord) DebtReport {
+	undocumented := make([]string, 0)
+	deprecated := make([]string, 0)
+	for _, record := range records {
+		if record.Record.Classification != functionaltestmetadata.ClassificationCustomer {
+			continue
+		}
+		identity := record.Record.Identity()
+		if record.Undocumented {
+			undocumented = append(undocumented, identity)
+		}
+		if record.Deprecated {
+			deprecated = append(deprecated, identity)
+		}
+	}
+	sort.Strings(undocumented)
+	sort.Strings(deprecated)
+	return DebtReport{
+		Undocumented: undocumented,
+		Deprecated:   deprecated,
+	}
+}
+
+// RenderDebtMarkdown renders explicit undocumented and deprecated debt sections.
+func RenderDebtMarkdown(report DebtReport) string {
+	var b strings.Builder
+	b.WriteString("## Documentation debt\n\n")
+	b.WriteString("### Undocumented customer tests\n\n")
+	b.WriteString(renderDebtIdentityList(report.Undocumented, "No undocumented customer tests."))
+	b.WriteString("\n### Deprecated tests\n\n")
+	b.WriteString(renderDebtIdentityList(report.Deprecated, "No deprecated tests."))
+	return b.String()
+}
+
+func renderDebtIdentityList(identities []string, emptyMessage string) string {
+	if len(identities) == 0 {
+		return "- _" + emptyMessage + "_\n"
+	}
+	var b strings.Builder
+	for _, identity := range identities {
+		b.WriteString("- `")
+		b.WriteString(identity)
+		b.WriteString("`\n")
+	}
+	return b.String()
+}

--- a/internal/functionaltestviz/debt_markdown_test.go
+++ b/internal/functionaltestviz/debt_markdown_test.go
@@ -1,0 +1,156 @@
+package functionaltestviz_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/functionaltestmetadata"
+	"github.com/portpowered/infinite-you/internal/functionaltestviz"
+)
+
+func TestBuildDebtReportListsStableIdentitiesAndExcludesHarness(t *testing.T) {
+	t.Parallel()
+
+	records := functionaltestviz.ClassifyRecords([]functionaltestmetadata.Record{
+		{
+			File:           "factory/definitions/load_test.go",
+			Package:        "definitions",
+			Name:           "TestLoad",
+			Line:           7,
+			Undocumented:   true,
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+		{
+			File:           "runtime_api/session_test.go",
+			Package:        "runtime_api",
+			Name:           "TestSession",
+			Line:           3,
+			Description:    "legacy session path",
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+		{
+			File:           "runtime_api/zzzz_other_test.go",
+			Package:        "runtime_api",
+			Name:           "TestOther",
+			Line:           9,
+			Undocumented:   true,
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+		{
+			File:           "internal/support/helpers_test.go",
+			Package:        "support",
+			Name:           "TestHelper",
+			Line:           3,
+			Undocumented:   true,
+			Classification: functionaltestmetadata.ClassificationHarness,
+		},
+		{
+			File:           "aaa/first_undocumented_test.go",
+			Package:        "first",
+			Name:           "TestFirst",
+			Line:           1,
+			Undocumented:   true,
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+	})
+
+	report := functionaltestviz.BuildDebtReport(records)
+	wantUndocumented := []string{
+		"aaa/first_undocumented_test.go::TestFirst",
+		"factory/definitions/load_test.go::TestLoad",
+		"runtime_api/zzzz_other_test.go::TestOther",
+	}
+	if len(report.Undocumented) != len(wantUndocumented) {
+		t.Fatalf("undocumented = %#v, want %#v", report.Undocumented, wantUndocumented)
+	}
+	for i := range wantUndocumented {
+		if report.Undocumented[i] != wantUndocumented[i] {
+			t.Fatalf("undocumented[%d] = %q, want %q", i, report.Undocumented[i], wantUndocumented[i])
+		}
+	}
+	wantDeprecated := []string{
+		"runtime_api/session_test.go::TestSession",
+		"runtime_api/zzzz_other_test.go::TestOther",
+	}
+	if len(report.Deprecated) != len(wantDeprecated) {
+		t.Fatalf("deprecated = %#v, want %#v", report.Deprecated, wantDeprecated)
+	}
+	for i := range wantDeprecated {
+		if report.Deprecated[i] != wantDeprecated[i] {
+			t.Fatalf("deprecated[%d] = %q, want %q", i, report.Deprecated[i], wantDeprecated[i])
+		}
+	}
+}
+
+func TestRenderDebtMarkdownIsStableAndExplicit(t *testing.T) {
+	t.Parallel()
+
+	report := functionaltestviz.DebtReport{
+		Undocumented: []string{"factory/definitions/load_test.go::TestLoad"},
+		Deprecated:   []string{"runtime_api/session_test.go::TestSession"},
+	}
+	first := functionaltestviz.RenderDebtMarkdown(report)
+	second := functionaltestviz.RenderDebtMarkdown(report)
+	if first != second {
+		t.Fatalf("repeated debt renders diverged:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+	if !strings.Contains(first, "## Documentation debt\n\n### Undocumented customer tests\n\n") {
+		t.Fatalf("undocumented debt heading missing:\n%s", first)
+	}
+	if !strings.Contains(first, "- `factory/definitions/load_test.go::TestLoad`\n") {
+		t.Fatalf("undocumented identity missing:\n%s", first)
+	}
+	if !strings.Contains(first, "### Deprecated tests\n\n- `runtime_api/session_test.go::TestSession`\n") {
+		t.Fatalf("deprecated identity missing:\n%s", first)
+	}
+
+	empty := functionaltestviz.RenderDebtMarkdown(functionaltestviz.DebtReport{})
+	if !strings.Contains(empty, "- _No undocumented customer tests._\n") {
+		t.Fatalf("empty undocumented presentation missing:\n%s", empty)
+	}
+	if !strings.Contains(empty, "- _No deprecated tests._\n") {
+		t.Fatalf("empty deprecated presentation missing:\n%s", empty)
+	}
+}
+
+func TestRenderCatalogMarkdownIncludesDebtSections(t *testing.T) {
+	t.Parallel()
+
+	records := functionaltestviz.ClassifyRecords([]functionaltestmetadata.Record{
+		{
+			File:           "factory/definitions/load_test.go",
+			Package:        "definitions",
+			Name:           "TestLoad",
+			Line:           7,
+			Undocumented:   true,
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+		{
+			File:           "runtime_api/session_test.go",
+			Package:        "runtime_api",
+			Name:           "TestSession",
+			Line:           3,
+			Description:    "legacy session path",
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+	})
+	catalog, err := functionaltestviz.RenderCatalogMarkdown(functionaltestviz.CatalogInputs{Records: records})
+	if err != nil {
+		t.Fatalf("RenderCatalogMarkdown: %v", err)
+	}
+	if !strings.Contains(catalog, "  - Labels: short, undocumented\n") {
+		t.Fatalf("undocumented row label missing:\n%s", catalog)
+	}
+	if !strings.Contains(catalog, "  - Labels: short, deprecated\n") {
+		t.Fatalf("deprecated row label missing:\n%s", catalog)
+	}
+	if !strings.Contains(catalog, "## Documentation debt\n") {
+		t.Fatalf("debt section missing:\n%s", catalog)
+	}
+	if !strings.Contains(catalog, "- `factory/definitions/load_test.go::TestLoad`\n") {
+		t.Fatalf("undocumented debt identity missing:\n%s", catalog)
+	}
+	if !strings.Contains(catalog, "- `runtime_api/session_test.go::TestSession`\n") {
+		t.Fatalf("deprecated debt identity missing:\n%s", catalog)
+	}
+}

--- a/internal/functionaltestviz/detail_markdown.go
+++ b/internal/functionaltestviz/detail_markdown.go
@@ -134,6 +134,33 @@ func renderDetailRecord(record ClassifiedRecord) string {
 		b.WriteString(strings.Join(labels, ", "))
 		b.WriteString("\n")
 	}
+	if record.GoldenBacked {
+		b.WriteString(renderGoldenProvenance(record.Provenance))
+	}
+	return b.String()
+}
+
+func renderGoldenProvenance(provenance GoldenProvenance) string {
+	if !provenance.Present() {
+		return "  - Golden provenance: ERROR: missing attached provenance\n"
+	}
+	var b strings.Builder
+	b.WriteString("  - Golden provenance:\n")
+	b.WriteString("    - Provider: `")
+	b.WriteString(provenance.Provider)
+	b.WriteString("`\n")
+	b.WriteString("    - Case: `")
+	b.WriteString(provenance.Case)
+	b.WriteString("`\n")
+	b.WriteString("    - Fidelity class: `")
+	b.WriteString(provenance.FidelityClass)
+	b.WriteString("`\n")
+	b.WriteString("    - Golden id: `")
+	b.WriteString(provenance.ID)
+	b.WriteString("`\n")
+	b.WriteString("    - Manifest: `")
+	b.WriteString(provenance.ManifestPath)
+	b.WriteString("`\n")
 	return b.String()
 }
 

--- a/internal/functionaltestviz/detail_markdown.go
+++ b/internal/functionaltestviz/detail_markdown.go
@@ -1,0 +1,188 @@
+package functionaltestviz
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/portpowered/infinite-you/internal/functionaltestmetadata"
+)
+
+// DetailCatalog groups classified records for the detailed per-test Markdown
+// section. Customer scenarios are bucketed in browse order; harness records
+// are kept separate so they do not read as customer scenarios.
+type DetailCatalog struct {
+	CustomerBuckets []DetailBucket
+	OtherCustomer   []ClassifiedRecord
+	Harness         []ClassifiedRecord
+}
+
+// DetailBucket is one browse-order domain bucket with stable-sorted customer rows.
+type DetailBucket struct {
+	Domain  string
+	Records []ClassifiedRecord
+}
+
+// BuildDetailCatalog partitions classified records into browse-order customer
+// buckets, out-of-order customer domains, and harness verification rows.
+func BuildDetailCatalog(records []ClassifiedRecord) DetailCatalog {
+	bucketRecords := make(map[string][]ClassifiedRecord, len(DomainBrowseOrder))
+	var otherCustomer []ClassifiedRecord
+	var harness []ClassifiedRecord
+
+	for _, record := range records {
+		if record.Record.Classification == functionaltestmetadata.ClassificationHarness {
+			harness = append(harness, record)
+			continue
+		}
+		if record.Record.Classification != functionaltestmetadata.ClassificationCustomer {
+			continue
+		}
+		bucket, ok := SummaryBucketForDomain(record.Domain)
+		if !ok {
+			otherCustomer = append(otherCustomer, record)
+			continue
+		}
+		bucketRecords[bucket] = append(bucketRecords[bucket], record)
+	}
+
+	customerBuckets := make([]DetailBucket, 0, len(DomainBrowseOrder))
+	for _, bucket := range DomainBrowseOrder {
+		rows := bucketRecords[bucket]
+		sortDetailRecords(rows)
+		customerBuckets = append(customerBuckets, DetailBucket{
+			Domain:  bucket,
+			Records: rows,
+		})
+	}
+
+	sortDetailRecords(otherCustomer)
+	sortDetailRecords(harness)
+
+	return DetailCatalog{
+		CustomerBuckets: customerBuckets,
+		OtherCustomer:   otherCustomer,
+		Harness:         harness,
+	}
+}
+
+// RenderDetailCatalogMarkdown renders the detailed per-test catalog section.
+func RenderDetailCatalogMarkdown(catalog DetailCatalog) string {
+	var b strings.Builder
+	b.WriteString("## Test catalog\n")
+
+	for _, bucket := range catalog.CustomerBuckets {
+		b.WriteString("\n")
+		b.WriteString(renderDetailBucket(bucket))
+	}
+
+	if len(catalog.OtherCustomer) > 0 {
+		b.WriteString("\n\n### Other domains\n\n")
+		for _, record := range catalog.OtherCustomer {
+			b.WriteString(renderDetailRecord(record))
+			b.WriteString("\n")
+		}
+	}
+
+	if len(catalog.Harness) > 0 {
+		b.WriteString("\n\n## Harness verification\n\n")
+		for _, record := range catalog.Harness {
+			b.WriteString(renderDetailRecord(record))
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
+}
+
+func renderDetailBucket(bucket DetailBucket) string {
+	var b strings.Builder
+	b.WriteString("### ")
+	b.WriteString(bucket.Domain)
+	b.WriteString("\n")
+	if len(bucket.Records) == 0 {
+		b.WriteString("\n- _No customer scenarios._\n")
+		return b.String()
+	}
+	b.WriteString("\n")
+	for _, record := range bucket.Records {
+		b.WriteString(renderDetailRecord(record))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func renderDetailRecord(record ClassifiedRecord) string {
+	var b strings.Builder
+	b.WriteString("- **")
+	b.WriteString(record.Record.Name)
+	b.WriteString("** — ")
+	b.WriteString(renderDetailDescription(record))
+	b.WriteString("\n")
+	b.WriteString("  - Source: `")
+	b.WriteString(formatSourceLocation(record.Record.File, record.Record.Line))
+	b.WriteString("`\n")
+	b.WriteString("  - Domain: `")
+	b.WriteString(record.Domain)
+	b.WriteString("`\n")
+	b.WriteString("  - Package: `")
+	b.WriteString(record.Package)
+	b.WriteString("`\n")
+	labels := detailRecordLabels(record)
+	if len(labels) > 0 {
+		b.WriteString("  - Labels: ")
+		b.WriteString(strings.Join(labels, ", "))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func renderDetailDescription(record ClassifiedRecord) string {
+	if record.Undocumented {
+		return "(undocumented)"
+	}
+	if strings.TrimSpace(record.Record.Description) == "" {
+		return "(undocumented)"
+	}
+	return record.Record.Description
+}
+
+func detailRecordLabels(record ClassifiedRecord) []string {
+	labels := make([]string, 0, 4)
+	if record.Lane == LaneLongOnly {
+		labels = append(labels, "long-only")
+	} else {
+		labels = append(labels, "short")
+	}
+	if record.GoldenBacked {
+		labels = append(labels, "golden-backed")
+	}
+	if record.Deprecated {
+		labels = append(labels, "deprecated")
+	}
+	if record.Undocumented {
+		labels = append(labels, "undocumented")
+	}
+	return labels
+}
+
+func formatSourceLocation(file string, line int) string {
+	if line <= 0 {
+		return file
+	}
+	return fmt.Sprintf("%s:%d", file, line)
+}
+
+func sortDetailRecords(records []ClassifiedRecord) {
+	sort.SliceStable(records, func(i, j int) bool {
+		left := records[i]
+		right := records[j]
+		if cmp := strings.Compare(left.Domain, right.Domain); cmp != 0 {
+			return cmp < 0
+		}
+		if cmp := strings.Compare(left.Record.File, right.Record.File); cmp != 0 {
+			return cmp < 0
+		}
+		return strings.Compare(left.Record.Name, right.Record.Name) < 0
+	})
+}

--- a/internal/functionaltestviz/detail_markdown_test.go
+++ b/internal/functionaltestviz/detail_markdown_test.go
@@ -1,0 +1,132 @@
+package functionaltestviz_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/functionaltestmetadata"
+	"github.com/portpowered/infinite-you/internal/functionaltestviz"
+)
+
+func TestBuildDetailCatalogGroupsBrowseOrderAndSeparatesHarness(t *testing.T) {
+	t.Parallel()
+
+	records := functionaltestviz.ClassifyRecords([]functionaltestmetadata.Record{
+		customerRecord("workers/mock/replace_test.go", "mock", "TestReplace"),
+		customerRecord("transport/http/routing/route_test.go", "routing", "TestRoute"),
+		customerRecord("transport/cli/process/help_test.go", "process", "TestHelp"),
+		customerRecord("runtime_api/session_test.go", "runtime_api", "TestSession"),
+		{
+			File:           "internal/support/helpers_test.go",
+			Package:        "support",
+			Name:           "TestHelper",
+			Line:           3,
+			Classification: functionaltestmetadata.ClassificationHarness,
+		},
+	})
+
+	catalog := functionaltestviz.BuildDetailCatalog(records)
+	if len(catalog.CustomerBuckets) != len(functionaltestviz.DomainBrowseOrder) {
+		t.Fatalf("customer buckets len = %d, want %d", len(catalog.CustomerBuckets), len(functionaltestviz.DomainBrowseOrder))
+	}
+	if catalog.CustomerBuckets[0].Domain != functionaltestviz.DomainBucketTransport {
+		t.Fatalf("first bucket = %q, want transport", catalog.CustomerBuckets[0].Domain)
+	}
+	if len(catalog.CustomerBuckets[0].Records) != 2 {
+		t.Fatalf("transport rows = %d, want 2", len(catalog.CustomerBuckets[0].Records))
+	}
+	if catalog.CustomerBuckets[0].Records[0].Record.Name != "TestHelp" {
+		t.Fatalf("transport first row = %q, want TestHelp (file sort)", catalog.CustomerBuckets[0].Records[0].Record.Name)
+	}
+	if catalog.CustomerBuckets[0].Records[1].Record.Name != "TestRoute" {
+		t.Fatalf("transport second row = %q, want TestRoute", catalog.CustomerBuckets[0].Records[1].Record.Name)
+	}
+	if len(catalog.OtherCustomer) != 1 || catalog.OtherCustomer[0].Record.Name != "TestSession" {
+		t.Fatalf("other customer = %#v, want single TestSession", catalog.OtherCustomer)
+	}
+	if len(catalog.Harness) != 1 || catalog.Harness[0].Record.Name != "TestHelper" {
+		t.Fatalf("harness = %#v, want single TestHelper", catalog.Harness)
+	}
+}
+
+func TestRenderDetailCatalogMarkdownIncludesLabelsAndStableOrdering(t *testing.T) {
+	t.Parallel()
+
+	records := functionaltestviz.ClassifyRecords([]functionaltestmetadata.Record{
+		{
+			File:           "workers/inference/openai/invoke_test.go",
+			Package:        "openai",
+			Name:           "TestInvoke",
+			Line:           42,
+			Description:    "verifies provider replay",
+			BuildTags:      []string{"functionallong"},
+			Golden:         "tests/functional/workers/inference/openai/goldens/invoke/manifest.json",
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+		{
+			File:           "factory/definitions/load_test.go",
+			Package:        "definitions",
+			Name:           "TestLoad",
+			Line:           7,
+			Undocumented:   true,
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+		{
+			File:           "internal/support/helpers_test.go",
+			Package:        "support",
+			Name:           "TestHelper",
+			Line:           3,
+			Classification: functionaltestmetadata.ClassificationHarness,
+		},
+	})
+	catalog := functionaltestviz.BuildDetailCatalog(records)
+
+	first := functionaltestviz.RenderDetailCatalogMarkdown(catalog)
+	second := functionaltestviz.RenderDetailCatalogMarkdown(catalog)
+	if first != second {
+		t.Fatalf("repeated detail renders diverged:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+
+	if !strings.Contains(first, "## Test catalog\n") {
+		t.Fatalf("missing test catalog heading:\n%s", first)
+	}
+	if !strings.Contains(first, "### workers\n\n- **TestInvoke** — verifies provider replay\n") {
+		t.Fatalf("workers detail row missing or wrong:\n%s", first)
+	}
+	if !strings.Contains(first, "  - Source: `workers/inference/openai/invoke_test.go:42`\n") {
+		t.Fatalf("source location missing:\n%s", first)
+	}
+	if !strings.Contains(first, "  - Labels: long-only, golden-backed\n") {
+		t.Fatalf("labels missing:\n%s", first)
+	}
+	if !strings.Contains(first, "- **TestLoad** — (undocumented)\n") {
+		t.Fatalf("undocumented marker missing:\n%s", first)
+	}
+	if !strings.Contains(first, "  - Labels: short, undocumented\n") {
+		t.Fatalf("undocumented label missing:\n%s", first)
+	}
+	if !strings.Contains(first, "## Harness verification\n\n- **TestHelper**") {
+		t.Fatalf("harness section missing:\n%s", first)
+	}
+	if strings.Count(first, "TestHelper") != 1 {
+		t.Fatalf("harness must not appear in customer catalog:\n%s", first)
+	}
+}
+
+func TestRenderCatalogMarkdownAppendsDetailAfterDomainSummaries(t *testing.T) {
+	t.Parallel()
+
+	records := functionaltestviz.ClassifyRecords([]functionaltestmetadata.Record{
+		customerRecord("transport/cli/process/help_test.go", "process", "TestHelp"),
+	})
+	catalog := functionaltestviz.RenderCatalogMarkdown(functionaltestviz.CatalogInputs{Records: records})
+
+	summaryIdx := strings.Index(catalog, "## Domain summaries\n")
+	detailIdx := strings.Index(catalog, "## Test catalog\n")
+	if summaryIdx < 0 || detailIdx < 0 || detailIdx <= summaryIdx {
+		t.Fatalf("catalog must contain domain summaries before detail catalog:\n%s", catalog)
+	}
+	if !strings.Contains(catalog, "- **TestHelp** — scenario\n") {
+		t.Fatalf("customer detail row missing:\n%s", catalog)
+	}
+}

--- a/internal/functionaltestviz/detail_markdown_test.go
+++ b/internal/functionaltestviz/detail_markdown_test.go
@@ -60,7 +60,7 @@ func TestRenderDetailCatalogMarkdownIncludesLabelsAndStableOrdering(t *testing.T
 			Line:           42,
 			Description:    "verifies provider replay",
 			BuildTags:      []string{"functionallong"},
-			Golden:         "tests/functional/workers/inference/openai/goldens/invoke/manifest.json",
+			Golden:         "docs/temp/functional/provider-sessions/openai/invoke/manifest.json",
 			Classification: functionaltestmetadata.ClassificationCustomer,
 		},
 		{
@@ -79,6 +79,13 @@ func TestRenderDetailCatalogMarkdownIncludesLabelsAndStableOrdering(t *testing.T
 			Classification: functionaltestmetadata.ClassificationHarness,
 		},
 	})
+	records[0].Provenance = functionaltestviz.GoldenProvenance{
+		Provider:      "openai",
+		Case:          "invoke",
+		FidelityClass: "partial-stream",
+		ID:            "openai-invoke",
+		ManifestPath:  "docs/temp/functional/provider-sessions/openai/invoke/manifest.json",
+	}
 	catalog := functionaltestviz.BuildDetailCatalog(records)
 
 	first := functionaltestviz.RenderDetailCatalogMarkdown(catalog)
@@ -98,6 +105,21 @@ func TestRenderDetailCatalogMarkdownIncludesLabelsAndStableOrdering(t *testing.T
 	}
 	if !strings.Contains(first, "  - Labels: long-only, golden-backed\n") {
 		t.Fatalf("labels missing:\n%s", first)
+	}
+	if !strings.Contains(first, "  - Golden provenance:\n    - Provider: `openai`\n") {
+		t.Fatalf("golden provenance missing:\n%s", first)
+	}
+	if !strings.Contains(first, "    - Case: `invoke`\n") {
+		t.Fatalf("golden case missing:\n%s", first)
+	}
+	if !strings.Contains(first, "    - Fidelity class: `partial-stream`\n") {
+		t.Fatalf("golden fidelity class missing:\n%s", first)
+	}
+	if !strings.Contains(first, "    - Golden id: `openai-invoke`\n") {
+		t.Fatalf("golden id missing:\n%s", first)
+	}
+	if !strings.Contains(first, "    - Manifest: `docs/temp/functional/provider-sessions/openai/invoke/manifest.json`\n") {
+		t.Fatalf("golden manifest path missing:\n%s", first)
 	}
 	if !strings.Contains(first, "- **TestLoad** — (undocumented)\n") {
 		t.Fatalf("undocumented marker missing:\n%s", first)
@@ -119,12 +141,19 @@ func TestRenderCatalogMarkdownAppendsDetailAfterDomainSummaries(t *testing.T) {
 	records := functionaltestviz.ClassifyRecords([]functionaltestmetadata.Record{
 		customerRecord("transport/cli/process/help_test.go", "process", "TestHelp"),
 	})
-	catalog := functionaltestviz.RenderCatalogMarkdown(functionaltestviz.CatalogInputs{Records: records})
+	catalog, err := functionaltestviz.RenderCatalogMarkdown(functionaltestviz.CatalogInputs{Records: records})
+	if err != nil {
+		t.Fatalf("RenderCatalogMarkdown: %v", err)
+	}
 
 	summaryIdx := strings.Index(catalog, "## Domain summaries\n")
 	detailIdx := strings.Index(catalog, "## Test catalog\n")
+	debtIdx := strings.Index(catalog, "## Documentation debt\n")
 	if summaryIdx < 0 || detailIdx < 0 || detailIdx <= summaryIdx {
 		t.Fatalf("catalog must contain domain summaries before detail catalog:\n%s", catalog)
+	}
+	if debtIdx < 0 || debtIdx <= detailIdx {
+		t.Fatalf("catalog must append documentation debt after detail catalog:\n%s", catalog)
 	}
 	if !strings.Contains(catalog, "- **TestHelp** — scenario\n") {
 		t.Fatalf("customer detail row missing:\n%s", catalog)

--- a/internal/functionaltestviz/detail_markdown_test.go
+++ b/internal/functionaltestviz/detail_markdown_test.go
@@ -149,11 +149,15 @@ func TestRenderCatalogMarkdownAppendsDetailAfterDomainSummaries(t *testing.T) {
 	summaryIdx := strings.Index(catalog, "## Domain summaries\n")
 	detailIdx := strings.Index(catalog, "## Test catalog\n")
 	debtIdx := strings.Index(catalog, "## Documentation debt\n")
+	coverageIdx := strings.Index(catalog, "## Package coverage\n")
 	if summaryIdx < 0 || detailIdx < 0 || detailIdx <= summaryIdx {
 		t.Fatalf("catalog must contain domain summaries before detail catalog:\n%s", catalog)
 	}
 	if debtIdx < 0 || debtIdx <= detailIdx {
 		t.Fatalf("catalog must append documentation debt after detail catalog:\n%s", catalog)
+	}
+	if coverageIdx < 0 || coverageIdx <= debtIdx {
+		t.Fatalf("catalog must append package coverage after documentation debt:\n%s", catalog)
 	}
 	if !strings.Contains(catalog, "- **TestHelp** — scenario\n") {
 		t.Fatalf("customer detail row missing:\n%s", catalog)

--- a/internal/functionaltestviz/doc.go
+++ b/internal/functionaltestviz/doc.go
@@ -3,4 +3,7 @@
 //
 // Coverage input is the gocoveragecheck coverage-summary JSON artifact only.
 // This package does not parse coverage profiles (.out).
+//
+// Golden-backed rows require AttachGoldenProvenance (or equivalent fixture
+// setup) before RenderCatalogMarkdown; missing manifests fail closed.
 package functionaltestviz

--- a/internal/functionaltestviz/doc.go
+++ b/internal/functionaltestviz/doc.go
@@ -7,4 +7,8 @@
 // Golden-backed rows require AttachGoldenProvenance (or equivalent fixture
 // setup) before RenderCatalogMarkdown; missing manifests fail closed.
 // Package coverage is rendered from CoverageSummary JSON fields only.
+//
+// Generate writes the catalog to DefaultOutputPath (or a configured path),
+// creating parent directories as needed. Make/CI wiring is intentionally out of
+// scope for this package (owned by FND-005).
 package functionaltestviz

--- a/internal/functionaltestviz/doc.go
+++ b/internal/functionaltestviz/doc.go
@@ -1,0 +1,6 @@
+// Package functionaltestviz assembles and renders the functional-test Markdown
+// catalog consumed by maintainers and later Make/CI wiring (FND-005).
+//
+// Coverage input is the gocoveragecheck coverage-summary JSON artifact only.
+// This package does not parse coverage profiles (.out).
+package functionaltestviz

--- a/internal/functionaltestviz/doc.go
+++ b/internal/functionaltestviz/doc.go
@@ -6,4 +6,5 @@
 //
 // Golden-backed rows require AttachGoldenProvenance (or equivalent fixture
 // setup) before RenderCatalogMarkdown; missing manifests fail closed.
+// Package coverage is rendered from CoverageSummary JSON fields only.
 package functionaltestviz

--- a/internal/functionaltestviz/domains.go
+++ b/internal/functionaltestviz/domains.go
@@ -1,0 +1,172 @@
+package functionaltestviz
+
+import (
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/portpowered/infinite-you/internal/functionaltestmetadata"
+)
+
+// Browse-order domain summary bucket display names from
+// docs/temp/functional-tests-expansion/plan.md.
+const (
+	DomainBucketTransport                      = "transport"
+	DomainBucketWorkers                        = "workers"
+	DomainBucketOrchestration                  = "orchestration"
+	DomainBucketWorkstations                   = "workstations"
+	DomainBucketWork                           = "work"
+	DomainBucketSessions                       = "sessions"
+	DomainBucketFactory                        = "factory"
+	DomainBucketProviderSessions               = "provider_sessions"
+	DomainBucketEvents                         = "events"
+	DomainBucketModels                         = "models"
+	DomainBucketGuardsResources                = "guards / resources"
+	DomainBucketObservabilityProductResilience = "observability / product / resilience"
+)
+
+// DomainBrowseOrder is the fixed prioritized summary order for the Markdown
+// catalog opening. Domains with zero customer scenarios still appear.
+var DomainBrowseOrder = []string{
+	DomainBucketTransport,
+	DomainBucketWorkers,
+	DomainBucketOrchestration,
+	DomainBucketWorkstations,
+	DomainBucketWork,
+	DomainBucketSessions,
+	DomainBucketFactory,
+	DomainBucketProviderSessions,
+	DomainBucketEvents,
+	DomainBucketModels,
+	DomainBucketGuardsResources,
+	DomainBucketObservabilityProductResilience,
+}
+
+// leafDomainToSummaryBucket maps functional path domain nouns onto browse-order
+// summary buckets. Coalesced domains share one bucket display name.
+var leafDomainToSummaryBucket = map[string]string{
+	"transport":         DomainBucketTransport,
+	"workers":           DomainBucketWorkers,
+	"orchestration":     DomainBucketOrchestration,
+	"workstations":      DomainBucketWorkstations,
+	"work":              DomainBucketWork,
+	"sessions":          DomainBucketSessions,
+	"factory":           DomainBucketFactory,
+	"provider_sessions": DomainBucketProviderSessions,
+	"events":            DomainBucketEvents,
+	"models":            DomainBucketModels,
+	"guards":            DomainBucketGuardsResources,
+	"resources":         DomainBucketGuardsResources,
+	"observability":     DomainBucketObservabilityProductResilience,
+	"product":           DomainBucketObservabilityProductResilience,
+	"resilience":        DomainBucketObservabilityProductResilience,
+}
+
+// NamedCount is a stable-sorted name/count pair for package or subsection tallies.
+type NamedCount struct {
+	Name  string
+	Count int
+}
+
+// DomainSummary is one prioritized domain bucket in the catalog opening.
+type DomainSummary struct {
+	Domain            string
+	CustomerScenarios int
+	Packages          []NamedCount
+	Subsections       []NamedCount
+}
+
+// SummaryBucketForDomain returns the browse-order summary bucket for a leaf
+// domain noun. ok is false when the domain is outside the prioritized catalog
+// opening (for example deletion-only catch-alls).
+func SummaryBucketForDomain(domain string) (string, bool) {
+	bucket, ok := leafDomainToSummaryBucket[strings.TrimSpace(domain)]
+	return bucket, ok
+}
+
+// SubsectionFromFile returns the first path segment under the leaf domain, or
+// empty when the file sits directly under the domain root.
+func SubsectionFromFile(file string) string {
+	normalized := path.Clean("/" + strings.ReplaceAll(file, "\\", "/"))
+	normalized = strings.TrimPrefix(normalized, "/")
+	parts := strings.Split(normalized, "/")
+	if len(parts) == 0 || parts[0] == "" || parts[0] == "." {
+		return ""
+	}
+	start := 0
+	if parts[0] == "tests" && len(parts) >= 3 && parts[1] == "functional" {
+		start = 2
+	}
+	if len(parts) <= start+1 {
+		return ""
+	}
+	candidate := parts[start+1]
+	if candidate == "" || strings.HasSuffix(candidate, ".go") {
+		return ""
+	}
+	return candidate
+}
+
+// BuildDomainSummaries aggregates customer scenario counts (plus package and
+// subsection tallies) into the fixed browse-order buckets. Harness/internal
+// records do not increment customer totals.
+func BuildDomainSummaries(records []ClassifiedRecord) []DomainSummary {
+	type mutableSummary struct {
+		customerScenarios int
+		packages          map[string]int
+		subsections       map[string]int
+	}
+	byBucket := make(map[string]*mutableSummary, len(DomainBrowseOrder))
+	for _, bucket := range DomainBrowseOrder {
+		byBucket[bucket] = &mutableSummary{
+			packages:    map[string]int{},
+			subsections: map[string]int{},
+		}
+	}
+
+	for _, record := range records {
+		if record.Record.Classification != functionaltestmetadata.ClassificationCustomer {
+			continue
+		}
+		bucket, ok := SummaryBucketForDomain(record.Domain)
+		if !ok {
+			continue
+		}
+		summary := byBucket[bucket]
+		summary.customerScenarios++
+		if pkg := strings.TrimSpace(record.Package); pkg != "" {
+			summary.packages[pkg]++
+		}
+		if subsection := SubsectionFromFile(record.Record.File); subsection != "" {
+			summary.subsections[subsection]++
+		}
+	}
+
+	out := make([]DomainSummary, 0, len(DomainBrowseOrder))
+	for _, bucket := range DomainBrowseOrder {
+		mutable := byBucket[bucket]
+		out = append(out, DomainSummary{
+			Domain:            bucket,
+			CustomerScenarios: mutable.customerScenarios,
+			Packages:          sortedNamedCounts(mutable.packages),
+			Subsections:       sortedNamedCounts(mutable.subsections),
+		})
+	}
+	return out
+}
+
+func sortedNamedCounts(counts map[string]int) []NamedCount {
+	if len(counts) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(counts))
+	for name := range counts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]NamedCount, 0, len(names))
+	for _, name := range names {
+		out = append(out, NamedCount{Name: name, Count: counts[name]})
+	}
+	return out
+}

--- a/internal/functionaltestviz/generate.go
+++ b/internal/functionaltestviz/generate.go
@@ -1,0 +1,118 @@
+package functionaltestviz
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/portpowered/infinite-you/internal/functionaltestmetadata"
+)
+
+// DefaultOutputPath is the repository-relative Markdown catalog artifact path.
+// Parent directories are created as needed when writing.
+const DefaultOutputPath = ".artifacts/functional-test-viz/functional-tests.md"
+
+// DefaultFunctionalRoot is the repository-relative functional test tree parsed
+// for catalog inventory.
+const DefaultFunctionalRoot = "tests/functional"
+
+// GenerateConfig configures the callable Markdown catalog writer.
+type GenerateConfig struct {
+	// RepositoryRoot resolves golden manifest paths and default relative
+	// functional/output paths. Empty defaults to ".".
+	RepositoryRoot string
+	// FunctionalRoot is the functional test tree passed to
+	// functionaltestmetadata.Parse. Empty defaults to
+	// RepositoryRoot/tests/functional.
+	FunctionalRoot string
+	// CoverageSummaryPath is the required gocoveragecheck coverage-summary JSON
+	// path. Relative paths are used as given (process-relative).
+	CoverageSummaryPath string
+	// OutputPath is the Markdown destination. Empty defaults to
+	// RepositoryRoot/DefaultOutputPath. Parent directories are created as needed.
+	OutputPath string
+}
+
+// Generate loads functionaltestmetadata inventory and coverage-summary JSON,
+// attaches golden provenance, renders the catalog, and writes Markdown to the
+// configured output path. It does not run the functional suite.
+func Generate(cfg GenerateConfig) error {
+	normalized, err := normalizeGenerateConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	records, err := functionaltestmetadata.Parse(normalized.FunctionalRoot)
+	if err != nil {
+		return fmt.Errorf("parse functional test metadata from %s: %w", normalized.FunctionalRoot, err)
+	}
+
+	inputs, err := AssembleCatalogInputs(records, normalized.CoverageSummaryPath)
+	if err != nil {
+		return err
+	}
+
+	withProvenance, err := AttachGoldenProvenance(inputs.Records, normalized.RepositoryRoot)
+	if err != nil {
+		return err
+	}
+	inputs.Records = withProvenance
+
+	markdown, err := RenderCatalogMarkdown(inputs)
+	if err != nil {
+		return err
+	}
+	return WriteCatalogFile(normalized.OutputPath, markdown)
+}
+
+// WriteCatalogFile writes Markdown to path, creating parent directories as needed.
+func WriteCatalogFile(path, markdown string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return fmt.Errorf("catalog output path is required")
+	}
+	dir := filepath.Dir(path)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create catalog output directory %s: %w", dir, err)
+		}
+	}
+	if err := os.WriteFile(path, []byte(markdown), 0o644); err != nil {
+		return fmt.Errorf("write catalog markdown %s: %w", path, err)
+	}
+	return nil
+}
+
+func normalizeGenerateConfig(cfg GenerateConfig) (GenerateConfig, error) {
+	root := strings.TrimSpace(cfg.RepositoryRoot)
+	if root == "" {
+		root = "."
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return GenerateConfig{}, fmt.Errorf("resolve repository root %q: %w", root, err)
+	}
+
+	functionalRoot := strings.TrimSpace(cfg.FunctionalRoot)
+	if functionalRoot == "" {
+		functionalRoot = filepath.Join(absRoot, filepath.FromSlash(DefaultFunctionalRoot))
+	}
+
+	coveragePath := strings.TrimSpace(cfg.CoverageSummaryPath)
+	if coveragePath == "" {
+		return GenerateConfig{}, fmt.Errorf("coverage-summary path is required")
+	}
+
+	outputPath := strings.TrimSpace(cfg.OutputPath)
+	if outputPath == "" {
+		outputPath = filepath.Join(absRoot, filepath.FromSlash(DefaultOutputPath))
+	}
+
+	return GenerateConfig{
+		RepositoryRoot:      absRoot,
+		FunctionalRoot:      functionalRoot,
+		CoverageSummaryPath: coveragePath,
+		OutputPath:          outputPath,
+	}, nil
+}

--- a/internal/functionaltestviz/generate_test.go
+++ b/internal/functionaltestviz/generate_test.go
@@ -1,0 +1,192 @@
+package functionaltestviz_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/functionaltestviz"
+)
+
+func TestWriteCatalogFileCreatesParentDirectories(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	outputPath := filepath.Join(root, ".artifacts", "functional-test-viz", "functional-tests.md")
+	const body = "# Functional tests\n"
+	if err := functionaltestviz.WriteCatalogFile(outputPath, body); err != nil {
+		t.Fatalf("WriteCatalogFile: %v", err)
+	}
+	got, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read written catalog: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("written catalog = %q, want %q", got, body)
+	}
+}
+
+func TestWriteCatalogFileRequiresPath(t *testing.T) {
+	t.Parallel()
+
+	err := functionaltestviz.WriteCatalogFile("  ", "# Functional tests\n")
+	if err == nil || !strings.Contains(err.Error(), "required") {
+		t.Fatalf("WriteCatalogFile(\"\") error = %v, want required-path guidance", err)
+	}
+}
+
+func TestGenerateWritesDefaultArtifactPath(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	functionalRoot := filepath.Join(root, "tests", "functional")
+	writeGenerateFixtures(t, root, functionalRoot)
+
+	coveragePath := filepath.Join(root, "coverage-summary.json")
+	if err := os.WriteFile(coveragePath, []byte(generateCoverageSummaryJSON), 0o644); err != nil {
+		t.Fatalf("write coverage summary: %v", err)
+	}
+
+	if err := functionaltestviz.Generate(functionaltestviz.GenerateConfig{
+		RepositoryRoot:      root,
+		CoverageSummaryPath: coveragePath,
+	}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	outputPath := filepath.Join(root, filepath.FromSlash(functionaltestviz.DefaultOutputPath))
+	first, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read generated catalog: %v", err)
+	}
+	if !strings.Contains(string(first), "# Functional tests\n") {
+		t.Fatalf("generated catalog missing heading:\n%s", first)
+	}
+	if !strings.Contains(string(first), "TestHelp") {
+		t.Fatalf("generated catalog missing inventoried test:\n%s", first)
+	}
+	if !strings.Contains(string(first), "Golden provenance:") {
+		t.Fatalf("generated catalog missing golden provenance:\n%s", first)
+	}
+	if !strings.Contains(string(first), "## Package coverage\n") {
+		t.Fatalf("generated catalog missing package coverage:\n%s", first)
+	}
+
+	if err := functionaltestviz.Generate(functionaltestviz.GenerateConfig{
+		RepositoryRoot:      root,
+		CoverageSummaryPath: coveragePath,
+	}); err != nil {
+		t.Fatalf("Generate second: %v", err)
+	}
+	second, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read regenerated catalog: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Fatalf("consecutive Generate writes diverged:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+func TestGenerateFailsClosedForMissingCoverageSummary(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	functionalRoot := filepath.Join(root, "tests", "functional")
+	if err := os.MkdirAll(filepath.Join(functionalRoot, "transport"), 0o755); err != nil {
+		t.Fatalf("mkdir functional root: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(functionalRoot, "transport", "help_test.go"),
+		[]byte("package transport\n\n// TestHelp verifies help.\nfunc TestHelp(t *testing.T) {}\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("write fixture test: %v", err)
+	}
+
+	err := functionaltestviz.Generate(functionaltestviz.GenerateConfig{
+		RepositoryRoot:      root,
+		CoverageSummaryPath: filepath.Join(root, "missing-coverage-summary.json"),
+		OutputPath:          filepath.Join(root, "out.md"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("Generate(missing coverage) error = %v, want not-found guidance", err)
+	}
+}
+
+func writeGenerateFixtures(t *testing.T, root, functionalRoot string) {
+	t.Helper()
+
+	transportDir := filepath.Join(functionalRoot, "transport", "cli")
+	workersDir := filepath.Join(functionalRoot, "workers", "inference", "openai")
+	runtimeDir := filepath.Join(functionalRoot, "runtime_api")
+	harnessDir := filepath.Join(functionalRoot, "internal", "support")
+	manifestDir := filepath.Join(root, "testdata", "goldens", "openai", "invoke")
+	for _, dir := range []string{transportDir, workersDir, runtimeDir, harnessDir, manifestDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	files := map[string]string{
+		filepath.Join(transportDir, "help_test.go"): `package cli
+
+import "testing"
+
+// TestHelp verifies help output.
+func TestHelp(t *testing.T) {}
+`,
+		filepath.Join(workersDir, "invoke_long_test.go"): `//go:build functionallong
+
+package openai
+
+import "testing"
+
+// TestInvoke verifies provider invoke replay.
+//
+//golden: testdata/goldens/openai/invoke/manifest.json
+func TestInvoke(t *testing.T) {}
+`,
+		filepath.Join(runtimeDir, "session_test.go"): `package runtime_api
+
+import "testing"
+
+func TestSession(t *testing.T) {}
+`,
+		filepath.Join(harnessDir, "helpers_test.go"): `package support
+
+import "testing"
+
+func TestHelper(t *testing.T) {}
+`,
+		filepath.Join(manifestDir, "manifest.json"): `{
+  "id": "openai-invoke",
+  "provider": "openai",
+  "case": "invoke",
+  "fidelityClass": "partial-stream"
+}
+`,
+	}
+	for path, body := range files {
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write fixture %s: %v", path, err)
+		}
+	}
+}
+
+const generateCoverageSummaryJSON = `{
+  "coveredStatements": 1,
+  "measurableStatements": 2,
+  "coveragePercent": 50.0,
+  "packages": [
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/example",
+      "coveredStatements": 1,
+      "measurableStatements": 2,
+      "coveragePercent": 50.0,
+      "packageFloor": 40.0,
+      "measurementException": null
+    }
+  ]
+}
+`

--- a/internal/functionaltestviz/golden.go
+++ b/internal/functionaltestviz/golden.go
@@ -1,0 +1,169 @@
+package functionaltestviz
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// GoldenProvenance is fixture provenance loaded from a golden manifest.json.
+type GoldenProvenance struct {
+	Provider      string
+	Case          string
+	FidelityClass string
+	ID            string
+	ManifestPath  string
+}
+
+// Present reports whether provenance was attached from a manifest.
+func (p GoldenProvenance) Present() bool {
+	return strings.TrimSpace(p.ManifestPath) != ""
+}
+
+// goldenManifestFile mirrors the provider-session golden manifest contract
+// fields needed for catalog provenance. The generator does not load the full
+// provider golden harness.
+type goldenManifestFile struct {
+	ID            string `json:"id"`
+	Provider      string `json:"provider"`
+	Case          string `json:"case"`
+	FidelityClass string `json:"fidelityClass"`
+}
+
+// AttachGoldenProvenance loads manifest provenance for every golden-backed
+// record. Missing or malformed manifests fail closed with an actionable error;
+// provenance is never silently omitted.
+//
+// Paths in Record.Golden are resolved relative to baseDir when baseDir is
+// non-empty; otherwise they are used as given (absolute or process-relative).
+func AttachGoldenProvenance(records []ClassifiedRecord, baseDir string) ([]ClassifiedRecord, error) {
+	out := make([]ClassifiedRecord, len(records))
+	copy(out, records)
+	for i := range out {
+		if !out[i].GoldenBacked {
+			continue
+		}
+		manifestPath := strings.TrimSpace(out[i].Record.Golden)
+		if manifestPath == "" {
+			return nil, fmt.Errorf(
+				"golden-backed test %s missing golden manifest path",
+				out[i].Record.Identity(),
+			)
+		}
+		provenance, err := LoadGoldenProvenance(resolveManifestPath(baseDir, manifestPath), manifestPath)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"golden provenance for %s (%s): %w",
+				out[i].Record.Identity(),
+				manifestPath,
+				err,
+			)
+		}
+		out[i].Provenance = provenance
+	}
+	return out, nil
+}
+
+// LoadGoldenProvenance reads and validates a golden manifest at resolvedPath.
+// catalogPath is the path recorded in Provenance.ManifestPath (usually the
+// inventory golden reference).
+func LoadGoldenProvenance(resolvedPath, catalogPath string) (GoldenProvenance, error) {
+	resolvedPath = strings.TrimSpace(resolvedPath)
+	catalogPath = strings.TrimSpace(catalogPath)
+	if catalogPath == "" {
+		catalogPath = resolvedPath
+	}
+	if resolvedPath == "" {
+		return GoldenProvenance{}, fmt.Errorf("golden manifest path is required")
+	}
+	data, err := os.ReadFile(resolvedPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return GoldenProvenance{}, fmt.Errorf("golden manifest not found: %s", catalogPath)
+		}
+		return GoldenProvenance{}, fmt.Errorf("read golden manifest %s: %w", catalogPath, err)
+	}
+	return DecodeGoldenProvenance(data, catalogPath)
+}
+
+// DecodeGoldenProvenance decodes and validates golden manifest JSON bytes.
+func DecodeGoldenProvenance(data []byte, catalogPath string) (GoldenProvenance, error) {
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return GoldenProvenance{}, fmt.Errorf("golden manifest JSON is empty: %s", catalogPath)
+	}
+	var manifest goldenManifestFile
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return GoldenProvenance{}, fmt.Errorf("invalid golden manifest JSON %s: %w", catalogPath, err)
+	}
+	if err := validateGoldenManifest(manifest, catalogPath); err != nil {
+		return GoldenProvenance{}, err
+	}
+	return GoldenProvenance{
+		Provider:      strings.TrimSpace(manifest.Provider),
+		Case:          strings.TrimSpace(manifest.Case),
+		FidelityClass: strings.TrimSpace(manifest.FidelityClass),
+		ID:            strings.TrimSpace(manifest.ID),
+		ManifestPath:  catalogPath,
+	}, nil
+}
+
+// RequireGoldenProvenance fails when any golden-backed record lacks attached
+// provenance. Use after AttachGoldenProvenance (or equivalent fixture setup).
+func RequireGoldenProvenance(records []ClassifiedRecord) error {
+	var missing []string
+	for _, record := range records {
+		if !record.GoldenBacked {
+			continue
+		}
+		if record.Provenance.Present() {
+			continue
+		}
+		identity := record.Record.Identity()
+		golden := strings.TrimSpace(record.Record.Golden)
+		if golden == "" {
+			missing = append(missing, identity+" (empty golden path)")
+			continue
+		}
+		missing = append(missing, identity+" ("+golden+")")
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"golden-backed test(s) missing attached provenance; call AttachGoldenProvenance before rendering: %s",
+		strings.Join(missing, ", "),
+	)
+}
+
+func validateGoldenManifest(manifest goldenManifestFile, catalogPath string) error {
+	var missing []string
+	if strings.TrimSpace(manifest.ID) == "" {
+		missing = append(missing, "id")
+	}
+	if strings.TrimSpace(manifest.Provider) == "" {
+		missing = append(missing, "provider")
+	}
+	if strings.TrimSpace(manifest.Case) == "" {
+		missing = append(missing, "case")
+	}
+	if strings.TrimSpace(manifest.FidelityClass) == "" {
+		missing = append(missing, "fidelityClass")
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"golden manifest %s missing required field(s): %s",
+		catalogPath,
+		strings.Join(missing, ", "),
+	)
+}
+
+func resolveManifestPath(baseDir, manifestPath string) string {
+	if filepath.IsAbs(manifestPath) || strings.TrimSpace(baseDir) == "" {
+		return manifestPath
+	}
+	return filepath.Join(baseDir, filepath.FromSlash(manifestPath))
+}

--- a/internal/functionaltestviz/golden_test.go
+++ b/internal/functionaltestviz/golden_test.go
@@ -1,0 +1,141 @@
+package functionaltestviz_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/functionaltestmetadata"
+	"github.com/portpowered/infinite-you/internal/functionaltestviz"
+)
+
+func TestAttachGoldenProvenanceLoadsManifestFields(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	manifestRel := "docs/temp/functional/provider-sessions/harness/load-smoke/manifest.json"
+	manifestAbs := filepath.Join(root, filepath.FromSlash(manifestRel))
+	if err := os.MkdirAll(filepath.Dir(manifestAbs), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	const body = `{
+  "schemaVersion": 1,
+  "id": "harness-load-smoke",
+  "provider": "harness",
+  "fidelityClass": "partial-stream",
+  "case": "load-smoke"
+}
+`
+	if err := os.WriteFile(manifestAbs, []byte(body), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	records := functionaltestviz.ClassifyRecords([]functionaltestmetadata.Record{
+		{
+			File:           "workers/inference/harness/load_test.go",
+			Package:        "harness",
+			Name:           "TestLoadSmoke",
+			Line:           12,
+			Description:    "loads golden fixture",
+			Golden:         manifestRel,
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+		customerRecord("transport/cli/process/help_test.go", "process", "TestHelp"),
+	})
+
+	enriched, err := functionaltestviz.AttachGoldenProvenance(records, root)
+	if err != nil {
+		t.Fatalf("AttachGoldenProvenance: %v", err)
+	}
+	if !enriched[0].Provenance.Present() {
+		t.Fatal("expected provenance on golden-backed record")
+	}
+	got := enriched[0].Provenance
+	if got.Provider != "harness" || got.Case != "load-smoke" || got.FidelityClass != "partial-stream" || got.ID != "harness-load-smoke" {
+		t.Fatalf("provenance = %#v", got)
+	}
+	if got.ManifestPath != manifestRel {
+		t.Fatalf("ManifestPath = %q, want %q", got.ManifestPath, manifestRel)
+	}
+	if enriched[1].Provenance.Present() {
+		t.Fatal("non-golden record must not gain provenance")
+	}
+}
+
+func TestAttachGoldenProvenanceFailsClosedForMissingAndMalformed(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	missing := functionaltestviz.ClassifyRecords([]functionaltestmetadata.Record{
+		{
+			File:           "workers/inference/openai/missing_test.go",
+			Package:        "openai",
+			Name:           "TestMissing",
+			Line:           4,
+			Description:    "missing golden",
+			Golden:         "missing/manifest.json",
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+	})
+	_, err := functionaltestviz.AttachGoldenProvenance(missing, root)
+	if err == nil {
+		t.Fatal("expected missing manifest error")
+	}
+	if !strings.Contains(err.Error(), "golden manifest not found") {
+		t.Fatalf("error %q should mention missing manifest", err)
+	}
+	if !strings.Contains(err.Error(), "workers/inference/openai/missing_test.go::TestMissing") {
+		t.Fatalf("error %q should include stable identity", err)
+	}
+
+	badRel := "bad/manifest.json"
+	badAbs := filepath.Join(root, filepath.FromSlash(badRel))
+	if err := os.MkdirAll(filepath.Dir(badAbs), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(badAbs, []byte(`{"id":"only-id"}`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	malformed := functionaltestviz.ClassifyRecords([]functionaltestmetadata.Record{
+		{
+			File:           "workers/inference/openai/bad_test.go",
+			Package:        "openai",
+			Name:           "TestBad",
+			Line:           8,
+			Description:    "bad golden",
+			Golden:         badRel,
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+	})
+	_, err = functionaltestviz.AttachGoldenProvenance(malformed, root)
+	if err == nil {
+		t.Fatal("expected malformed manifest error")
+	}
+	if !strings.Contains(err.Error(), "missing required field") {
+		t.Fatalf("error %q should mention missing required fields", err)
+	}
+}
+
+func TestRenderCatalogMarkdownFailsClosedWithoutAttachedProvenance(t *testing.T) {
+	t.Parallel()
+
+	records := functionaltestviz.ClassifyRecords([]functionaltestmetadata.Record{
+		{
+			File:           "workers/inference/openai/invoke_test.go",
+			Package:        "openai",
+			Name:           "TestInvoke",
+			Line:           42,
+			Description:    "verifies provider replay",
+			Golden:         "docs/temp/functional/provider-sessions/openai/invoke/manifest.json",
+			Classification: functionaltestmetadata.ClassificationCustomer,
+		},
+	})
+	_, err := functionaltestviz.RenderCatalogMarkdown(functionaltestviz.CatalogInputs{Records: records})
+	if err == nil {
+		t.Fatal("expected missing provenance error")
+	}
+	if !strings.Contains(err.Error(), "missing attached provenance") {
+		t.Fatalf("error %q should mention missing attached provenance", err)
+	}
+}

--- a/internal/functionaltestviz/summary_markdown.go
+++ b/internal/functionaltestviz/summary_markdown.go
@@ -6,14 +6,20 @@ import (
 )
 
 // RenderCatalogMarkdown renders the functional-test Markdown catalog.
-// Later stories append golden/debt sections and package coverage.
-func RenderCatalogMarkdown(inputs CatalogInputs) string {
+// Golden-backed records must already carry attached provenance; missing
+// provenance fails closed. Later stories append package coverage.
+func RenderCatalogMarkdown(inputs CatalogInputs) (string, error) {
+	if err := RequireGoldenProvenance(inputs.Records); err != nil {
+		return "", err
+	}
 	var b strings.Builder
 	b.WriteString("# Functional tests\n\n")
 	b.WriteString(RenderDomainSummariesMarkdown(BuildDomainSummaries(inputs.Records)))
 	b.WriteString("\n")
 	b.WriteString(RenderDetailCatalogMarkdown(BuildDetailCatalog(inputs.Records)))
-	return b.String()
+	b.WriteString("\n")
+	b.WriteString(RenderDebtMarkdown(BuildDebtReport(inputs.Records)))
+	return b.String(), nil
 }
 
 // RenderDomainSummariesMarkdown renders prioritized domain summary sections in

--- a/internal/functionaltestviz/summary_markdown.go
+++ b/internal/functionaltestviz/summary_markdown.go
@@ -6,12 +6,13 @@ import (
 )
 
 // RenderCatalogMarkdown renders the functional-test Markdown catalog.
-// Story fnd-004-markdown-generator-002 owns the prioritized domain-summary
-// opening; later stories append detail rows, debt, and package coverage.
+// Later stories append golden/debt sections and package coverage.
 func RenderCatalogMarkdown(inputs CatalogInputs) string {
 	var b strings.Builder
 	b.WriteString("# Functional tests\n\n")
 	b.WriteString(RenderDomainSummariesMarkdown(BuildDomainSummaries(inputs.Records)))
+	b.WriteString("\n")
+	b.WriteString(RenderDetailCatalogMarkdown(BuildDetailCatalog(inputs.Records)))
 	return b.String()
 }
 

--- a/internal/functionaltestviz/summary_markdown.go
+++ b/internal/functionaltestviz/summary_markdown.go
@@ -1,0 +1,58 @@
+package functionaltestviz
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RenderCatalogMarkdown renders the functional-test Markdown catalog.
+// Story fnd-004-markdown-generator-002 owns the prioritized domain-summary
+// opening; later stories append detail rows, debt, and package coverage.
+func RenderCatalogMarkdown(inputs CatalogInputs) string {
+	var b strings.Builder
+	b.WriteString("# Functional tests\n\n")
+	b.WriteString(RenderDomainSummariesMarkdown(BuildDomainSummaries(inputs.Records)))
+	return b.String()
+}
+
+// RenderDomainSummariesMarkdown renders prioritized domain summary sections in
+// DomainBrowseOrder. Empty domains still appear with an explicit zero count.
+func RenderDomainSummariesMarkdown(summaries []DomainSummary) string {
+	var b strings.Builder
+	b.WriteString("## Domain summaries\n")
+	for _, summary := range summaries {
+		b.WriteString("\n")
+		b.WriteString(renderDomainSummarySection(summary))
+	}
+	return b.String()
+}
+
+func renderDomainSummarySection(summary DomainSummary) string {
+	var b strings.Builder
+	b.WriteString("### ")
+	b.WriteString(summary.Domain)
+	b.WriteString("\n\n")
+	b.WriteString(fmt.Sprintf("- Customer scenarios: %d\n", summary.CustomerScenarios))
+	if summary.CustomerScenarios == 0 {
+		return b.String()
+	}
+	if len(summary.Packages) > 0 {
+		b.WriteString("- Packages: ")
+		b.WriteString(formatNamedCounts(summary.Packages))
+		b.WriteString("\n")
+	}
+	if len(summary.Subsections) > 0 {
+		b.WriteString("- Subsections: ")
+		b.WriteString(formatNamedCounts(summary.Subsections))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func formatNamedCounts(counts []NamedCount) string {
+	parts := make([]string, 0, len(counts))
+	for _, item := range counts {
+		parts = append(parts, fmt.Sprintf("`%s` (%d)", item.Name, item.Count))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/functionaltestviz/summary_markdown.go
+++ b/internal/functionaltestviz/summary_markdown.go
@@ -7,7 +7,8 @@ import (
 
 // RenderCatalogMarkdown renders the functional-test Markdown catalog.
 // Golden-backed records must already carry attached provenance; missing
-// provenance fails closed. Later stories append package coverage.
+// provenance fails closed. Package coverage is rendered from summary JSON
+// fields only.
 func RenderCatalogMarkdown(inputs CatalogInputs) (string, error) {
 	if err := RequireGoldenProvenance(inputs.Records); err != nil {
 		return "", err
@@ -19,6 +20,8 @@ func RenderCatalogMarkdown(inputs CatalogInputs) (string, error) {
 	b.WriteString(RenderDetailCatalogMarkdown(BuildDetailCatalog(inputs.Records)))
 	b.WriteString("\n")
 	b.WriteString(RenderDebtMarkdown(BuildDebtReport(inputs.Records)))
+	b.WriteString("\n")
+	b.WriteString(RenderPackageCoverageMarkdown(inputs.Coverage))
 	return b.String(), nil
 }
 

--- a/internal/functionaltestviz/summary_markdown_test.go
+++ b/internal/functionaltestviz/summary_markdown_test.go
@@ -1,0 +1,182 @@
+package functionaltestviz_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/functionaltestmetadata"
+	"github.com/portpowered/infinite-you/internal/functionaltestviz"
+)
+
+func TestBuildDomainSummariesUsesBrowseOrderAndExcludesHarness(t *testing.T) {
+	t.Parallel()
+
+	records := functionaltestviz.ClassifyRecords([]functionaltestmetadata.Record{
+		customerRecord("transport/cli/process/help_test.go", "process", "TestHelp"),
+		customerRecord("transport/http/routing/route_test.go", "routing", "TestRoute"),
+		customerRecord("workers/mock/replace_test.go", "mock", "TestReplace"),
+		customerRecord("guards/global_test.go", "guards", "TestGlobal"),
+		customerRecord("resources/concurrency_test.go", "resources", "TestConcurrency"),
+		customerRecord("observability/logging/redaction_test.go", "logging", "TestRedaction"),
+		customerRecord("product/docs/contract_test.go", "docs", "TestContract"),
+		customerRecord("resilience/process/restart_test.go", "process", "TestRestart"),
+		customerRecord("runtime_api/session_test.go", "runtime_api", "TestSession"),
+		{
+			File:           "internal/support/helpers_test.go",
+			Package:        "support",
+			Name:           "TestHelper",
+			Line:           3,
+			Classification: functionaltestmetadata.ClassificationHarness,
+		},
+	})
+
+	summaries := functionaltestviz.BuildDomainSummaries(records)
+	if len(summaries) != len(functionaltestviz.DomainBrowseOrder) {
+		t.Fatalf("summaries len = %d, want %d", len(summaries), len(functionaltestviz.DomainBrowseOrder))
+	}
+	for i, wantDomain := range functionaltestviz.DomainBrowseOrder {
+		if summaries[i].Domain != wantDomain {
+			t.Fatalf("summaries[%d].Domain = %q, want %q", i, summaries[i].Domain, wantDomain)
+		}
+	}
+
+	byDomain := map[string]functionaltestviz.DomainSummary{}
+	for _, summary := range summaries {
+		byDomain[summary.Domain] = summary
+	}
+
+	assertSummaryCount(t, byDomain["transport"], 2)
+	assertNamedCounts(t, byDomain["transport"].Packages, []functionaltestviz.NamedCount{
+		{Name: "process", Count: 1},
+		{Name: "routing", Count: 1},
+	})
+	assertNamedCounts(t, byDomain["transport"].Subsections, []functionaltestviz.NamedCount{
+		{Name: "cli", Count: 1},
+		{Name: "http", Count: 1},
+	})
+
+	assertSummaryCount(t, byDomain["workers"], 1)
+	assertSummaryCount(t, byDomain["orchestration"], 0)
+	assertSummaryCount(t, byDomain["workstations"], 0)
+	assertSummaryCount(t, byDomain["work"], 0)
+	assertSummaryCount(t, byDomain["sessions"], 0)
+	assertSummaryCount(t, byDomain["factory"], 0)
+	assertSummaryCount(t, byDomain["provider_sessions"], 0)
+	assertSummaryCount(t, byDomain["events"], 0)
+	assertSummaryCount(t, byDomain["models"], 0)
+	assertSummaryCount(t, byDomain[functionaltestviz.DomainBucketGuardsResources], 2)
+	assertSummaryCount(t, byDomain[functionaltestviz.DomainBucketObservabilityProductResilience], 3)
+
+	// Harness + runtime_api must not inflate prioritized customer totals.
+	totalCustomer := 0
+	for _, summary := range summaries {
+		totalCustomer += summary.CustomerScenarios
+	}
+	if totalCustomer != 8 {
+		t.Fatalf("browse-order customer total = %d, want 8 (harness and runtime_api excluded)", totalCustomer)
+	}
+}
+
+func TestRenderDomainSummariesMarkdownIsStableAndIncludesZeros(t *testing.T) {
+	t.Parallel()
+
+	records := functionaltestviz.ClassifyRecords([]functionaltestmetadata.Record{
+		customerRecord("transport/cli/process/help_test.go", "process", "TestHelp"),
+		customerRecord("workers/inference/openai/invoke_test.go", "openai", "TestInvoke"),
+		{
+			File:           "internal/support/helpers_test.go",
+			Package:        "support",
+			Name:           "TestHelper",
+			Line:           3,
+			Classification: functionaltestmetadata.ClassificationHarness,
+		},
+	})
+	summaries := functionaltestviz.BuildDomainSummaries(records)
+
+	first := functionaltestviz.RenderDomainSummariesMarkdown(summaries)
+	second := functionaltestviz.RenderDomainSummariesMarkdown(summaries)
+	if first != second {
+		t.Fatalf("repeated renders diverged:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+
+	catalog := functionaltestviz.RenderCatalogMarkdown(functionaltestviz.CatalogInputs{Records: records})
+	if !strings.HasPrefix(catalog, "# Functional tests\n\n## Domain summaries\n") {
+		t.Fatalf("catalog does not begin with title + domain summaries:\n%s", catalog)
+	}
+	if !strings.Contains(catalog, "### transport\n\n- Customer scenarios: 1\n") {
+		t.Fatalf("transport summary missing or wrong:\n%s", catalog)
+	}
+	if !strings.Contains(catalog, "- Packages: `process` (1)\n") {
+		t.Fatalf("transport package tally missing:\n%s", catalog)
+	}
+	if !strings.Contains(catalog, "- Subsections: `cli` (1)\n") {
+		t.Fatalf("transport subsection tally missing:\n%s", catalog)
+	}
+	if !strings.Contains(catalog, "### orchestration\n\n- Customer scenarios: 0\n") {
+		t.Fatalf("zero orchestration domain missing:\n%s", catalog)
+	}
+	if strings.Contains(catalog, "support") || strings.Contains(catalog, "TestHelper") {
+		t.Fatalf("harness leaked into domain summaries:\n%s", catalog)
+	}
+
+	// Browse-order headings must appear exactly once each, in order.
+	offset := 0
+	for _, domain := range functionaltestviz.DomainBrowseOrder {
+		heading := "### " + domain + "\n"
+		idx := strings.Index(catalog[offset:], heading)
+		if idx < 0 {
+			t.Fatalf("missing ordered heading %q after offset %d in:\n%s", domain, offset, catalog)
+		}
+		offset += idx + len(heading)
+	}
+}
+
+func TestSubsectionFromFileHandlesRepoRelativeAndRootRelativePaths(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		file string
+		want string
+	}{
+		{file: "transport/cli/process/help_test.go", want: "cli"},
+		{file: "tests/functional/sessions/lifecycle/open_test.go", want: "lifecycle"},
+		{file: `guards\policy_test.go`, want: ""},
+		{file: "models/catalog_test.go", want: ""},
+		{file: "", want: ""},
+	}
+	for _, tc := range cases {
+		if got := functionaltestviz.SubsectionFromFile(tc.file); got != tc.want {
+			t.Fatalf("SubsectionFromFile(%q) = %q, want %q", tc.file, got, tc.want)
+		}
+	}
+}
+
+func customerRecord(file, pkg, name string) functionaltestmetadata.Record {
+	return functionaltestmetadata.Record{
+		File:           file,
+		Package:        pkg,
+		Name:           name,
+		Line:           10,
+		Description:    "scenario",
+		Classification: functionaltestmetadata.ClassificationCustomer,
+	}
+}
+
+func assertSummaryCount(t *testing.T, summary functionaltestviz.DomainSummary, want int) {
+	t.Helper()
+	if summary.CustomerScenarios != want {
+		t.Fatalf("%s customer scenarios = %d, want %d", summary.Domain, summary.CustomerScenarios, want)
+	}
+}
+
+func assertNamedCounts(t *testing.T, got, want []functionaltestviz.NamedCount) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("named counts len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("named counts[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/functionaltestviz/summary_markdown_test.go
+++ b/internal/functionaltestviz/summary_markdown_test.go
@@ -115,8 +115,12 @@ func TestRenderDomainSummariesMarkdownIsStableAndIncludesZeros(t *testing.T) {
 	if !strings.Contains(catalog, "### orchestration\n\n- Customer scenarios: 0\n") {
 		t.Fatalf("zero orchestration domain missing:\n%s", catalog)
 	}
-	if strings.Contains(catalog, "support") || strings.Contains(catalog, "TestHelper") {
-		t.Fatalf("harness leaked into domain summaries:\n%s", catalog)
+	summarySection := catalog
+	if detailIdx := strings.Index(catalog, "## Test catalog\n"); detailIdx >= 0 {
+		summarySection = catalog[:detailIdx]
+	}
+	if strings.Contains(summarySection, "support") || strings.Contains(summarySection, "TestHelper") {
+		t.Fatalf("harness leaked into domain summaries:\n%s", summarySection)
 	}
 
 	// Browse-order headings must appear exactly once each, in order.

--- a/internal/functionaltestviz/summary_markdown_test.go
+++ b/internal/functionaltestviz/summary_markdown_test.go
@@ -99,7 +99,10 @@ func TestRenderDomainSummariesMarkdownIsStableAndIncludesZeros(t *testing.T) {
 		t.Fatalf("repeated renders diverged:\nfirst:\n%s\nsecond:\n%s", first, second)
 	}
 
-	catalog := functionaltestviz.RenderCatalogMarkdown(functionaltestviz.CatalogInputs{Records: records})
+	catalog, err := functionaltestviz.RenderCatalogMarkdown(functionaltestviz.CatalogInputs{Records: records})
+	if err != nil {
+		t.Fatalf("RenderCatalogMarkdown: %v", err)
+	}
 	if !strings.HasPrefix(catalog, "# Functional tests\n\n## Domain summaries\n") {
 		t.Fatalf("catalog does not begin with title + domain summaries:\n%s", catalog)
 	}

--- a/internal/functionaltestviz/testdata/full-report/functional-tests.md
+++ b/internal/functionaltestviz/testdata/full-report/functional-tests.md
@@ -1,0 +1,177 @@
+# Functional tests
+
+## Domain summaries
+
+### transport
+
+- Customer scenarios: 1
+- Packages: `process` (1)
+- Subsections: `cli` (1)
+
+### workers
+
+- Customer scenarios: 1
+- Packages: `openai` (1)
+- Subsections: `inference` (1)
+
+### orchestration
+
+- Customer scenarios: 0
+
+### workstations
+
+- Customer scenarios: 0
+
+### work
+
+- Customer scenarios: 0
+
+### sessions
+
+- Customer scenarios: 0
+
+### factory
+
+- Customer scenarios: 1
+- Packages: `definitions` (1)
+- Subsections: `definitions` (1)
+
+### provider_sessions
+
+- Customer scenarios: 0
+
+### events
+
+- Customer scenarios: 0
+
+### models
+
+- Customer scenarios: 0
+
+### guards / resources
+
+- Customer scenarios: 1
+- Packages: `policy` (1)
+- Subsections: `policy` (1)
+
+### observability / product / resilience
+
+- Customer scenarios: 0
+
+## Test catalog
+
+### transport
+
+- **TestHelp** — verifies help output
+  - Source: `transport/cli/process/help_test.go:12`
+  - Domain: `transport`
+  - Package: `process`
+  - Labels: short
+
+
+### workers
+
+- **TestInvoke** — verifies provider invoke replay
+  - Source: `workers/inference/openai/invoke_long_test.go:40`
+  - Domain: `workers`
+  - Package: `openai`
+  - Labels: long-only, golden-backed
+  - Golden provenance:
+    - Provider: `openai`
+    - Case: `invoke`
+    - Fidelity class: `partial-stream`
+    - Golden id: `openai-invoke`
+    - Manifest: `testdata/goldens/openai/invoke/manifest.json`
+
+
+### orchestration
+
+- _No customer scenarios._
+
+### workstations
+
+- _No customer scenarios._
+
+### work
+
+- _No customer scenarios._
+
+### sessions
+
+- _No customer scenarios._
+
+### factory
+
+- **TestLoad** — (undocumented)
+  - Source: `factory/definitions/load_test.go:7`
+  - Domain: `factory`
+  - Package: `definitions`
+  - Labels: short, undocumented
+
+
+### provider_sessions
+
+- _No customer scenarios._
+
+### events
+
+- _No customer scenarios._
+
+### models
+
+- _No customer scenarios._
+
+### guards / resources
+
+- **TestEnforce** — verifies guard enforcement
+  - Source: `guards/policy/enforce_test.go:15`
+  - Domain: `guards`
+  - Package: `policy`
+  - Labels: short
+
+
+### observability / product / resilience
+
+- _No customer scenarios._
+
+
+### Other domains
+
+- **TestSession** — (undocumented)
+  - Source: `runtime_api/session_test.go:5`
+  - Domain: `runtime_api`
+  - Package: `runtime_api`
+  - Labels: short, deprecated, undocumented
+
+
+
+## Harness verification
+
+- **TestHelper** — (undocumented)
+  - Source: `internal/support/helpers_test.go:3`
+  - Domain: `internal`
+  - Package: `support`
+  - Labels: short
+
+
+## Documentation debt
+
+### Undocumented customer tests
+
+- `factory/definitions/load_test.go::TestLoad`
+- `runtime_api/session_test.go::TestSession`
+
+### Deprecated tests
+
+- `runtime_api/session_test.go::TestSession`
+
+## Package coverage
+
+- Covered statements: 8
+- Measurable statements: 10
+- Coverage percent: 80.0%
+
+| Package | Covered | Measurable | Coverage % | Floor | Measurement exception |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `github.com/portpowered/infinite-you/pkg/config` | 3 | 3 | 100.0 | 66.66 | — |
+| `github.com/portpowered/infinite-you/pkg/service` | 0 | 0 | 0.0 | — | measurement: no measurable statements (owner=backend-quality; deadline=2027-07-15; removalGate=profile reports measurable statements) |


### PR DESCRIPTION
{
  "project": "Prioritized Functional-Test Markdown Catalog Generator",
  "branchName": "fnd-004-markdown-generator",
  "description": "Implement a Markdown catalog generator that consumes internal/functionaltestmetadata and gocoveragecheck coverage-summary JSON to write .artifacts/functional-test-viz/functional-tests.md with prioritized domain summaries, detailed per-test rows, golden fixture provenance, undocumented/deprecated debt, and per-production-package statement coverage. Ordering must be stable; prove rendering with focused golden/unit tests. Do not wire Make/CI (FND-005).",
  "context": {
    "customerAsk": "Implement a Markdown catalog generator that consumes internal/functionaltestmetadata and gocoveragecheck coverage-summary JSON to write .artifacts/functional-test-viz/functional-tests.md with prioritized domain summaries (transport → workers → orchestration → workstations → work → sessions → factory → provider_sessions → events → models → guards/resources → observability/product/resilience), detailed per-test rows (description, source file:line, domain, package, short/long/golden/deprecated/undocumented labels), golden fixture provenance, undocumented/deprecated debt, and per-production-package statement coverage. Ordering must be stable; the report itself must have golden/focused tests. Do not wire Make/CI yet (that is FND-005).",
    "problem": "Functional coverage and AST metadata exist as machine-readable inputs, but there is no durable human-browsable report that presents them in product browse order with source links, debt labels, golden provenance, and package coverage. Without that catalog, maintainers cannot audit suite shape or debt from a single artifact, and later Make/CI integration has nothing stable to invoke.",
    "solution": "Add a focused generator (library + thin command entrypoint) that loads functionaltestmetadata records and existing coverage-summary JSON (no second coverage-profile parser), derives domain ownership and short/long/golden/deprecated/undocumented labels, renders a deterministically ordered Markdown catalog to .artifacts/functional-test-viz/functional-tests.md, and proves rendering with fixture-backed golden/unit tests that do not run the full functional suite."
  },
  "acceptanceCriteria": [
    "Generator reads AST metadata records and coverage-summary JSON without inventing a second coverage parser.",
    "Markdown opens with prioritized domain summaries in the browse order from docs/temp/functional-tests-expansion/plan.md, then detailed test rows with source links.",
    "Golden-backed tests show fixture provenance; undocumented and deprecated debt are explicit sections or labels.",
    "Per-production-package functional statement coverage is rendered from the JSON summary.",
    "Ordering is stable across repeated runs; focused golden/unit tests cover report rendering without running the full functional suite.",
    "Does not add make functional-test-viz or CI upload wiring (owned by FND-005).",
    "Typecheck, lint, and focused tests pass (make test, make verify-fast)."
  ],
  "userStories": [
    {
      "id": "fnd-004-markdown-generator-001",
      "title": "Assemble catalog inputs from metadata and coverage JSON",
      "description": "As a maintainer, I want the generator to load functionaltestmetadata records and an existing coverage-summary JSON file so the catalog reuses the merged inventory and coverage contracts instead of re-parsing profiles.",
      "acceptanceCriteria": [
        "Generator accepts inventoried functionaltestmetadata.Record values (or an equivalent inventory produced by that package) and a coverage-summary JSON document matching gocoveragecheck JSON output",
        "Coverage is consumed only by decoding the summary JSON; no coverage-profile (.out) parser is added",
        "Malformed or missing required coverage-summary input fails with an actionable error",
        "Each record is classified with domain (from conforming tests/functional/<domain>/... path), package, short vs long-only (from build tags such as functionallong), golden-backed (non-empty golden ref), undocumented, and deprecated (known deletion-only / deprecated package paths such as runtime_api)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented in internal/functionaltestviz: AssembleCatalogInputs + ClassifyRecords + Decode/LoadCoverageSummary. Focused package tests + make test + make verify-fast passed."
    },
    {
      "id": "fnd-004-markdown-generator-002",
      "title": "Render prioritized domain summary opening",
      "description": "As a maintainer, I want the Markdown report to open with domain summaries in plan browse order so I can see suite shape by product area before diving into individual tests.",
      "acceptanceCriteria": [
        "Generated Markdown begins with domain summary sections in this order: transport → workers → orchestration → workstations → work → sessions → factory → provider_sessions → events → models → guards/resources → observability/product/resilience",
        "Each domain summary reports customer scenario counts (and package/subsection tallies when present) without mixing harness/internal records into customer totals",
        "Domains with zero customer scenarios still appear in order with an explicit empty/zero presentation",
        "Repeated renders of the same inputs produce identical summary ordering and content",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented BuildDomainSummaries + RenderDomainSummariesMarkdown / RenderCatalogMarkdown in internal/functionaltestviz. Browse-order buckets coalesce guards/resources and observability/product/resilience; harness excluded from customer totals; zero domains still render. Focused package tests + make test + make verify-fast passed."
    },
    {
      "id": "fnd-004-markdown-generator-003",
      "title": "Render detailed per-test catalog rows",
      "description": "As a maintainer, I want every inventoried top-level test listed with description, source link, domain, package, and labels so I can jump from the catalog to the owning scenario.",
      "acceptanceCriteria": [
        "After domain summaries, the Markdown includes a detailed catalog of top-level tests",
        "Each customer row shows: test name, description (or explicit undocumented marker), source file:line link/path, domain, package, and labels for short, long-only, golden-backed, deprecated, and undocumented as applicable",
        "Harness/internal records are either omitted from customer detail rows or clearly separated so they do not look like customer scenarios",
        "Row ordering within a domain is stable (deterministic sort key, e.g. file then name)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented BuildDetailCatalog + RenderDetailCatalogMarkdown; RenderCatalogMarkdown appends browse-order detail rows with stable (domain, file, name) sort, labels, source file:line, and separate harness section. Focused package tests + make test + make verify-fast passed."
    },
    {
      "id": "fnd-004-markdown-generator-004",
      "title": "Surface golden provenance and documentation debt",
      "description": "As a maintainer, I want golden-backed tests to show fixture provenance and undocumented/deprecated debt to appear as explicit sections or labels so coverage gaps and migration debt are visible without hunting source.",
      "acceptanceCriteria": [
        "Golden-backed rows include fixture provenance from the referenced manifest when present: provider, case, fidelity class, golden id, and manifest path",
        "Missing referenced golden manifests fail closed with an actionable error (or an explicit failing catalog diagnostic—generator must not silently omit provenance)",
        "Undocumented customer tests appear with an explicit undocumented label and an explicit debt section listing their stable identities",
        "Deprecated tests/packages appear with an explicit deprecated label and an explicit debt section",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Implemented AttachGoldenProvenance / DecodeGoldenProvenance (fail-closed on missing/malformed manifests), per-row golden provenance in detail rows, BuildDebtReport + RenderDebtMarkdown for undocumented/deprecated stable identities, and RenderCatalogMarkdown now requires attached provenance then appends debt sections. Focused package tests + make test + make verify-fast passed."
    },
    {
      "id": "fnd-004-markdown-generator-005",
      "title": "Render per-production-package statement coverage",
      "description": "As a maintainer, I want the catalog to include per-production-package functional statement coverage from the coverage-summary JSON so package floors and measured coverage are visible beside the test inventory.",
      "acceptanceCriteria": [
        "Markdown includes overall covered/measurable statement totals and coverage percent from the summary JSON",
        "Markdown includes a stable-ordered per-production-package table/list with package path, covered/measurable statements, coverage percent, and floor or measurement-exception fields when present in the JSON",
        "Package coverage content is taken from the summary JSON fields only (no recomputation from profiles)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": "Implemented RenderPackageCoverageMarkdown + StableOrderedPackages; RenderCatalogMarkdown appends package coverage after debt using CoverageSummary JSON fields only (overall totals + stable path-ordered table with floor/exception). Focused package tests + make test + make verify-fast passed."
    },
    {
      "id": "fnd-004-markdown-generator-006",
      "title": "Ship callable writer with golden rendering tests (no Make/CI)",
      "description": "As a maintainer, I want a thin command or package entrypoint that writes functional-tests.md to the artifact path and is proven by focused golden fixtures so FND-005 can invoke it later without owning report semantics.",
      "acceptanceCriteria": [
        "Entrypoint writes Markdown to a configurable output path defaulting to .artifacts/functional-test-viz/functional-tests.md, creating parent directories as needed",
        "Full-report golden/unit fixtures cover representative domains, labels, golden provenance, debt sections, and package coverage without executing the full functional suite",
        "Two consecutive renders with identical fixture inputs produce byte-identical Markdown",
        "Repository does not gain make functional-test-viz or CI upload wiring as part of this cell",
        "Typecheck passes",
        "Tests pass",
        "Verification commands for the cell: focused generator package/cmd tests, make test, make verify-fast"
      ],
      "priority": 6,
      "passes": true,
      "notes": "Implemented Generate/WriteCatalogFile in internal/functionaltestviz plus thin cmd/functionaltestviz entrypoint. Full-report golden at testdata/full-report/functional-tests.md; consecutive Generate writes are byte-identical. No Make/CI wiring. Focused package/cmd tests + make test + make verify-fast passed."
    }
  ]
}

Made with [Cursor](https://cursor.com)