### PR TITLE
pss-fnd-07-petri-public-surface-prohibition

### DIFF
--- a/cmd/pkgboundarycheck/main.go
+++ b/cmd/pkgboundarycheck/main.go
@@ -341,6 +341,7 @@ type config struct {
 	writeTransportBehaviorBaseline    bool
 	writeProductionDefaultBaseline    bool
 	writeTestBehaviorBaseline         bool
+	writePetriPublicSurfaceBaseline   bool
 }
 
 type scanResult struct {
@@ -379,6 +380,9 @@ type scanResult struct {
 	testBehaviorFindings               []testBehaviorFinding
 	staleTestBehaviorEntries           []testBehaviorBaselineEntry
 	testBehaviorBaselineCount          int
+	petriPublicSurfaceFindings         []petriPublicSurfaceFinding
+	stalePetriPublicSurfaceEntries     []petriPublicSurfaceBaselineEntry
+	petriPublicSurfaceBaselineCount    int
 }
 
 type retiredPackageRoot struct {
@@ -530,6 +534,13 @@ func main() {
 		}
 		return
 	}
+	if cfg.writePetriPublicSurfaceBaseline {
+		if err := createPetriPublicSurfaceBaseline(cfg); err != nil {
+			fmt.Fprintln(stderrWriter, err)
+			exitFunc(1)
+		}
+		return
+	}
 	if err := run(cfg, stdoutWriter, stderrWriter); err != nil {
 		fmt.Fprintln(stderrWriter, err)
 		exitFunc(1)
@@ -569,6 +580,12 @@ func parseConfig() config {
 		"create-test-behavior-boundary-baseline",
 		false,
 		"create the exact deletion-only test behavior baseline; fails when the file exists or no debt exists",
+	)
+	flag.BoolVar(
+		&cfg.writePetriPublicSurfaceBaseline,
+		"create-petri-public-surface-baseline",
+		false,
+		"create the exact deletion-only Petri public-surface baseline; fails when the file exists or no debt exists",
 	)
 	flag.Parse()
 	return cfg
@@ -618,6 +635,8 @@ func runWithPolicy(cfg config, policy boundaryPolicy, stdout io.Writer, stderr i
 		len(findings.staleInitializerBehaviorEntries)
 	blockingViolationCount += len(findings.testBehaviorFindings) +
 		len(findings.staleTestBehaviorEntries)
+	blockingViolationCount += len(findings.petriPublicSurfaceFindings) +
+		len(findings.stalePetriPublicSurfaceEntries)
 	if blockingViolationCount == 0 {
 		fmt.Fprintln(stdout, "[agent-factory:pkg-boundary] package boundary passed (no blocking package-boundary violations)")
 		writePeerServiceBaselineSummary(stdout, findings.peerServiceBaselineCount)
@@ -628,6 +647,7 @@ func runWithPolicy(cfg config, policy boundaryPolicy, stdout io.Writer, stderr i
 		writeProductionDefaultBaselineSummary(stdout, findings.productionDefaultBaselineCount)
 		writeInitializerBehaviorBaselineSummary(stdout, findings.initializerBehaviorBaselineCount)
 		writeTestBehaviorBaselineSummary(stdout, findings.testBehaviorBaselineCount)
+		writePetriPublicSurfaceBaselineSummary(stdout, findings.petriPublicSurfaceBaselineCount)
 		writeGeneratedCodeExceptionSummary(stdout, policy)
 		return nil
 	}
@@ -671,6 +691,9 @@ func runWithPolicy(cfg config, policy boundaryPolicy, stdout io.Writer, stderr i
 	writeTestBehaviorFindings(stderr, findings.testBehaviorFindings)
 	writeStaleTestBehaviorBaselineEntries(stderr, findings.staleTestBehaviorEntries)
 	writeTestBehaviorBaselineSummary(stderr, findings.testBehaviorBaselineCount)
+	writePetriPublicSurfaceFindings(stderr, findings.petriPublicSurfaceFindings)
+	writeStalePetriPublicSurfaceBaselineEntries(stderr, findings.stalePetriPublicSurfaceEntries)
+	writePetriPublicSurfaceBaselineSummary(stderr, findings.petriPublicSurfaceBaselineCount)
 	writeGeneratedCodeExceptionSummary(stderr, policy)
 	return fmt.Errorf("[agent-factory:pkg-boundary] found %d package-boundary violation(s)", blockingViolationCount)
 }
@@ -887,6 +910,20 @@ func scanRepo(cfg config, policy boundaryPolicy) (scanResult, error) {
 		return scanResult{}, err
 	}
 	result.initializerBehaviorBaselineCount = len(initializerBehaviorBaseline.Entries)
+	petriPublicSurfaceFindings, err := scanPetriPublicSurface(repoRoot)
+	if err != nil {
+		return scanResult{}, err
+	}
+	petriPublicSurfaceBaseline, err := loadPetriPublicSurfaceBaseline(repoRoot)
+	if err != nil {
+		return scanResult{}, err
+	}
+	result.petriPublicSurfaceFindings, result.stalePetriPublicSurfaceEntries, err =
+		partitionPetriPublicSurfaceFindings(petriPublicSurfaceFindings, petriPublicSurfaceBaseline)
+	if err != nil {
+		return scanResult{}, err
+	}
+	result.petriPublicSurfaceBaselineCount = len(petriPublicSurfaceBaseline.Entries)
 
 	slices.SortFunc(result.rootPackageFindings, func(left, right rootPackageFinding) int {
 		return strings.Compare(left.packagePath, right.packagePath)

--- a/cmd/pkgboundarycheck/petri_public_surface.go
+++ b/cmd/pkgboundarycheck/petri_public_surface.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+const (
+	petriPublicSurfaceRequiredOwner   = "Factory Runtime internals"
+	petriPublicSurfaceInternalPrefix  = "pkg/services/factory_runtime/internal/"
+	factoryDefinitionsContractsImport = repositoryImportPrefix + "pkg/services/factory_definitions/contracts"
+)
+
+// prohibitedPetriPublicSurfaceSymbols maps raw Petri live-engine symbols to the
+// shape name used in diagnostics. Authored Factory Definition selection of
+// orchestrator.kind = PETRI is intentionally absent: configuration is allowed.
+var prohibitedPetriPublicSurfaceSymbols = map[string]string{
+	"Net":                    "raw net",
+	"RuntimeNet":             "raw net",
+	"PetriMarking":           "raw marking",
+	"PetriMarkingSnapshot":   "raw marking",
+	"RuntimeToken":           "raw token",
+	"RuntimeTokenColor":      "raw token",
+	"PetriTransition":        "raw transition",
+	"EnabledTransition":      "enabled-transition engine shape",
+	"EngineStateSnapshot":    "engine snapshot",
+	"StateSnapshot":          "engine snapshot",
+	"NewEngineStateSnapshot": "engine snapshot",
+}
+
+var petriPublicSurfaceWatchedImports = map[string]struct{}{
+	factoryRuntimeRootImportPath:      {},
+	factoryDefinitionsImportPath:      {},
+	factoryDefinitionsContractsImport: {},
+}
+
+type petriPublicSurfaceFinding struct {
+	Surface    string
+	Symbol     string
+	Shape      string
+	ImportPath string
+	FilePath   string
+	Line       int
+}
+
+func scanPetriPublicSurface(repoRoot string) ([]petriPublicSurfaceFinding, error) {
+	var findings []petriPublicSurfaceFinding
+	seen := map[string]struct{}{}
+	err := filepath.WalkDir(repoRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", "node_modules", "vendor":
+				if path != repoRoot {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" {
+			return nil
+		}
+		rel, err := filepath.Rel(repoRoot, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if isFactoryRuntimeInternalPath(rel) {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if bytesContainGeneratedMarker(content) {
+			return nil
+		}
+		fset := token.NewFileSet()
+		parsed, err := parser.ParseFile(fset, path, content, 0)
+		if err != nil {
+			return fmt.Errorf("parse Petri public surface file %s: %w", rel, err)
+		}
+
+		importsByName := map[string]string{}
+		dotImports := map[string]struct{}{}
+		for _, spec := range parsed.Imports {
+			importPath, unquoteErr := strconv.Unquote(spec.Path.Value)
+			if unquoteErr != nil {
+				continue
+			}
+			if !isPetriPublicSurfaceWatchedImport(importPath) {
+				continue
+			}
+			if spec.Name != nil && spec.Name.Name == "." {
+				dotImports[importPath] = struct{}{}
+				continue
+			}
+			if spec.Name != nil && spec.Name.Name == "_" {
+				continue
+			}
+			name := filepath.Base(importPath)
+			if spec.Name != nil {
+				name = spec.Name.Name
+			} else if importPath == factoryDefinitionsImportPath {
+				name = "factorydefinitions"
+			} else if importPath == factoryDefinitionsContractsImport {
+				name = "contracts"
+			} else if importPath == factoryRuntimeRootImportPath {
+				name = "factory"
+			}
+			importsByName[name] = importPath
+		}
+
+		record := func(symbol, importPath string, pos token.Pos) {
+			shape, prohibited := prohibitedPetriPublicSurfaceSymbols[symbol]
+			if !prohibited {
+				return
+			}
+			line := fset.Position(pos).Line
+			key := fmt.Sprintf("%s|%s|%s|%d", rel, symbol, importPath, line)
+			if _, exists := seen[key]; exists {
+				return
+			}
+			seen[key] = struct{}{}
+			findings = append(findings, petriPublicSurfaceFinding{
+				Surface:    rel,
+				Symbol:     symbol,
+				Shape:      shape,
+				ImportPath: importPath,
+				FilePath:   rel,
+				Line:       line,
+			})
+		}
+
+		ast.Inspect(parsed, func(node ast.Node) bool {
+			switch typed := node.(type) {
+			case *ast.SelectorExpr:
+				identifier, ok := typed.X.(*ast.Ident)
+				if !ok {
+					return true
+				}
+				importPath, imported := importsByName[identifier.Name]
+				if !imported {
+					return true
+				}
+				record(typed.Sel.Name, importPath, typed.Sel.Pos())
+			case *ast.Ident:
+				if len(dotImports) == 0 {
+					return true
+				}
+				if _, prohibited := prohibitedPetriPublicSurfaceSymbols[typed.Name]; !prohibited {
+					return true
+				}
+				for importPath := range dotImports {
+					record(typed.Name, importPath, typed.Pos())
+				}
+			case *ast.IndexListExpr:
+				if selector, ok := typed.X.(*ast.SelectorExpr); ok {
+					identifier, ok := selector.X.(*ast.Ident)
+					if !ok {
+						return true
+					}
+					importPath, imported := importsByName[identifier.Name]
+					if !imported {
+						return true
+					}
+					record(selector.Sel.Name, importPath, selector.Sel.Pos())
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scan Petri public surface: %w", err)
+	}
+	slices.SortFunc(findings, func(left, right petriPublicSurfaceFinding) int {
+		if order := strings.Compare(left.FilePath, right.FilePath); order != 0 {
+			return order
+		}
+		if order := strings.Compare(left.Symbol, right.Symbol); order != 0 {
+			return order
+		}
+		return left.Line - right.Line
+	})
+	return findings, nil
+}
+
+func isFactoryRuntimeInternalPath(filePath string) bool {
+	return strings.HasPrefix(filePath, petriPublicSurfaceInternalPrefix)
+}
+
+func isPetriPublicSurfaceWatchedImport(importPath string) bool {
+	_, ok := petriPublicSurfaceWatchedImports[importPath]
+	return ok
+}
+
+func writePetriPublicSurfaceFindings(stderr io.Writer, findings []petriPublicSurfaceFinding) {
+	for _, finding := range findings {
+		fmt.Fprintf(
+			stderr,
+			"[agent-factory:pkg-boundary] prohibited Petri public surface: %s (%s:%d)\n",
+			finding.Symbol,
+			finding.FilePath,
+			finding.Line,
+		)
+		fmt.Fprintf(stderr, "  surface: %s\n", finding.Surface)
+		fmt.Fprintf(stderr, "  symbol: %s (%s)\n", finding.Symbol, finding.Shape)
+		fmt.Fprintf(
+			stderr,
+			"  required owner: %s (%s)\n",
+			petriPublicSurfaceRequiredOwner,
+			strings.TrimSuffix(petriPublicSurfaceInternalPrefix, "/"),
+		)
+		fmt.Fprintln(
+			stderr,
+			"  remediation: keep raw nets, markings, tokens, transitions/enabled-transition engine shapes, and engine snapshots inside Factory Runtime internals; authored orchestrator.kind = PETRI remains allowed as configuration.",
+		)
+	}
+}
+
+func petriPublicSurfaceFindingSummary(findings []petriPublicSurfaceFinding) string {
+	parts := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		parts = append(parts, fmt.Sprintf("%s|%s|%s|%d", finding.FilePath, finding.Symbol, finding.Shape, finding.Line))
+	}
+	return strings.Join(parts, "\n")
+}

--- a/cmd/pkgboundarycheck/petri_public_surface.go
+++ b/cmd/pkgboundarycheck/petri_public_surface.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -17,7 +18,25 @@ const (
 	petriPublicSurfaceRequiredOwner   = "Factory Runtime internals"
 	petriPublicSurfaceInternalPrefix  = "pkg/services/factory_runtime/internal/"
 	factoryDefinitionsContractsImport = repositoryImportPrefix + "pkg/services/factory_definitions/contracts"
+	petriPublicSurfaceBaselinePath    = "petri-public-surface-baseline.json"
+	petriPublicSurfaceBaselineStage   = "imp-run-01-petri-boundary-retirement"
+	petriPublicSurfaceDeletionGate    = "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
 )
+
+type petriPublicSurfaceBaseline struct {
+	Version int                              `json:"version"`
+	Entries []petriPublicSurfaceBaselineEntry `json:"entries"`
+}
+
+type petriPublicSurfaceBaselineEntry struct {
+	FilePath     string `json:"filePath"`
+	Symbol       string `json:"symbol"`
+	Shape        string `json:"shape"`
+	ImportPath   string `json:"importPath"`
+	Count        int    `json:"count"`
+	Stage        string `json:"stage"`
+	DeletionGate string `json:"deletionGate"`
+}
 
 // prohibitedPetriPublicSurfaceSymbols maps raw Petri live-engine symbols to the
 // shape name used in diagnostics. Authored Factory Definition selection of
@@ -78,122 +97,144 @@ func scanPetriPublicSurface(repoRoot string) ([]petriPublicSurfaceFinding, error
 		if isFactoryRuntimeInternalPath(rel) {
 			return nil
 		}
-		content, err := os.ReadFile(path)
+		fileFindings, err := scanPetriPublicSurfaceFile(path, rel, seen)
 		if err != nil {
 			return err
 		}
-		if bytesContainGeneratedMarker(content) {
-			return nil
-		}
-		fset := token.NewFileSet()
-		parsed, err := parser.ParseFile(fset, path, content, 0)
-		if err != nil {
-			return fmt.Errorf("parse Petri public surface file %s: %w", rel, err)
-		}
-
-		importsByName := map[string]string{}
-		dotImports := map[string]struct{}{}
-		for _, spec := range parsed.Imports {
-			importPath, unquoteErr := strconv.Unquote(spec.Path.Value)
-			if unquoteErr != nil {
-				continue
-			}
-			if !isPetriPublicSurfaceWatchedImport(importPath) {
-				continue
-			}
-			if spec.Name != nil && spec.Name.Name == "." {
-				dotImports[importPath] = struct{}{}
-				continue
-			}
-			if spec.Name != nil && spec.Name.Name == "_" {
-				continue
-			}
-			name := filepath.Base(importPath)
-			if spec.Name != nil {
-				name = spec.Name.Name
-			} else if importPath == factoryDefinitionsImportPath {
-				name = "factorydefinitions"
-			} else if importPath == factoryDefinitionsContractsImport {
-				name = "contracts"
-			} else if importPath == factoryRuntimeRootImportPath {
-				name = "factory"
-			}
-			importsByName[name] = importPath
-		}
-
-		record := func(symbol, importPath string, pos token.Pos) {
-			shape, prohibited := prohibitedPetriPublicSurfaceSymbols[symbol]
-			if !prohibited {
-				return
-			}
-			line := fset.Position(pos).Line
-			key := fmt.Sprintf("%s|%s|%s|%d", rel, symbol, importPath, line)
-			if _, exists := seen[key]; exists {
-				return
-			}
-			seen[key] = struct{}{}
-			findings = append(findings, petriPublicSurfaceFinding{
-				Surface:    rel,
-				Symbol:     symbol,
-				Shape:      shape,
-				ImportPath: importPath,
-				FilePath:   rel,
-				Line:       line,
-			})
-		}
-
-		ast.Inspect(parsed, func(node ast.Node) bool {
-			switch typed := node.(type) {
-			case *ast.SelectorExpr:
-				identifier, ok := typed.X.(*ast.Ident)
-				if !ok {
-					return true
-				}
-				importPath, imported := importsByName[identifier.Name]
-				if !imported {
-					return true
-				}
-				record(typed.Sel.Name, importPath, typed.Sel.Pos())
-			case *ast.Ident:
-				if len(dotImports) == 0 {
-					return true
-				}
-				if _, prohibited := prohibitedPetriPublicSurfaceSymbols[typed.Name]; !prohibited {
-					return true
-				}
-				for importPath := range dotImports {
-					record(typed.Name, importPath, typed.Pos())
-				}
-			case *ast.IndexListExpr:
-				if selector, ok := typed.X.(*ast.SelectorExpr); ok {
-					identifier, ok := selector.X.(*ast.Ident)
-					if !ok {
-						return true
-					}
-					importPath, imported := importsByName[identifier.Name]
-					if !imported {
-						return true
-					}
-					record(selector.Sel.Name, importPath, selector.Sel.Pos())
-				}
-			}
-			return true
-		})
+		findings = append(findings, fileFindings...)
 		return nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("scan Petri public surface: %w", err)
 	}
-	slices.SortFunc(findings, func(left, right petriPublicSurfaceFinding) int {
-		if order := strings.Compare(left.FilePath, right.FilePath); order != 0 {
-			return order
-		}
-		if order := strings.Compare(left.Symbol, right.Symbol); order != 0 {
-			return order
-		}
-		return left.Line - right.Line
-	})
+	slices.SortFunc(findings, comparePetriPublicSurfaceFindings)
 	return findings, nil
+}
+
+func comparePetriPublicSurfaceFindings(left, right petriPublicSurfaceFinding) int {
+	if order := strings.Compare(left.FilePath, right.FilePath); order != 0 {
+		return order
+	}
+	if order := strings.Compare(left.Symbol, right.Symbol); order != 0 {
+		return order
+	}
+	return left.Line - right.Line
+}
+
+func scanPetriPublicSurfaceFile(path, rel string, seen map[string]struct{}) ([]petriPublicSurfaceFinding, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if bytesContainGeneratedMarker(content) {
+		return nil, nil
+	}
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, path, content, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parse Petri public surface file %s: %w", rel, err)
+	}
+	importsByName, dotImports := petriPublicSurfaceImports(parsed)
+	var findings []petriPublicSurfaceFinding
+	record := func(symbol, importPath string, pos token.Pos) {
+		shape, prohibited := prohibitedPetriPublicSurfaceSymbols[symbol]
+		if !prohibited {
+			return
+		}
+		line := fset.Position(pos).Line
+		key := fmt.Sprintf("%s|%s|%s|%d", rel, symbol, importPath, line)
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+		findings = append(findings, petriPublicSurfaceFinding{
+			Surface:    rel,
+			Symbol:     symbol,
+			Shape:      shape,
+			ImportPath: importPath,
+			FilePath:   rel,
+			Line:       line,
+		})
+	}
+	inspectPetriPublicSurfaceAST(parsed, importsByName, dotImports, record)
+	return findings, nil
+}
+
+func petriPublicSurfaceImports(parsed *ast.File) (map[string]string, map[string]struct{}) {
+	importsByName := map[string]string{}
+	dotImports := map[string]struct{}{}
+	for _, spec := range parsed.Imports {
+		importPath, unquoteErr := strconv.Unquote(spec.Path.Value)
+		if unquoteErr != nil || !isPetriPublicSurfaceWatchedImport(importPath) {
+			continue
+		}
+		if spec.Name != nil && spec.Name.Name == "." {
+			dotImports[importPath] = struct{}{}
+			continue
+		}
+		if spec.Name != nil && spec.Name.Name == "_" {
+			continue
+		}
+		name := filepath.Base(importPath)
+		if spec.Name != nil {
+			name = spec.Name.Name
+		} else if importPath == factoryDefinitionsImportPath {
+			name = "factorydefinitions"
+		} else if importPath == factoryDefinitionsContractsImport {
+			name = "contracts"
+		} else if importPath == factoryRuntimeRootImportPath {
+			name = "factory"
+		}
+		importsByName[name] = importPath
+	}
+	return importsByName, dotImports
+}
+
+func inspectPetriPublicSurfaceAST(
+	parsed *ast.File,
+	importsByName map[string]string,
+	dotImports map[string]struct{},
+	record func(symbol, importPath string, pos token.Pos),
+) {
+	ast.Inspect(parsed, func(node ast.Node) bool {
+		switch typed := node.(type) {
+		case *ast.SelectorExpr:
+			identifier, ok := typed.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			importPath, imported := importsByName[identifier.Name]
+			if !imported {
+				return true
+			}
+			record(typed.Sel.Name, importPath, typed.Sel.Pos())
+		case *ast.Ident:
+			if len(dotImports) == 0 {
+				return true
+			}
+			if _, prohibited := prohibitedPetriPublicSurfaceSymbols[typed.Name]; !prohibited {
+				return true
+			}
+			for importPath := range dotImports {
+				record(typed.Name, importPath, typed.Pos())
+			}
+		case *ast.IndexListExpr:
+			selector, ok := typed.X.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			identifier, ok := selector.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			importPath, imported := importsByName[identifier.Name]
+			if !imported {
+				return true
+			}
+			record(selector.Sel.Name, importPath, selector.Sel.Pos())
+		}
+		return true
+	})
 }
 
 func isFactoryRuntimeInternalPath(filePath string) bool {
@@ -235,4 +276,231 @@ func petriPublicSurfaceFindingSummary(findings []petriPublicSurfaceFinding) stri
 		parts = append(parts, fmt.Sprintf("%s|%s|%s|%d", finding.FilePath, finding.Symbol, finding.Shape, finding.Line))
 	}
 	return strings.Join(parts, "\n")
+}
+
+func petriPublicSurfaceKey(filePath, symbol, importPath string) string {
+	return filepath.ToSlash(filePath) + "\x00" + symbol + "\x00" + importPath
+}
+
+func aggregatePetriPublicSurfaceFindings(findings []petriPublicSurfaceFinding) []petriPublicSurfaceBaselineEntry {
+	type aggregate struct {
+		entry    petriPublicSurfaceBaselineEntry
+		firstIdx int
+	}
+	byKey := map[string]*aggregate{}
+	order := make([]string, 0, len(findings))
+	for index, finding := range findings {
+		key := petriPublicSurfaceKey(finding.FilePath, finding.Symbol, finding.ImportPath)
+		existing, ok := byKey[key]
+		if !ok {
+			byKey[key] = &aggregate{
+				entry: petriPublicSurfaceBaselineEntry{
+					FilePath:   finding.FilePath,
+					Symbol:     finding.Symbol,
+					Shape:      finding.Shape,
+					ImportPath: finding.ImportPath,
+					Count:      1,
+				},
+				firstIdx: index,
+			}
+			order = append(order, key)
+			continue
+		}
+		existing.entry.Count++
+	}
+	entries := make([]petriPublicSurfaceBaselineEntry, 0, len(order))
+	for _, key := range order {
+		entries = append(entries, byKey[key].entry)
+	}
+	slices.SortFunc(entries, func(left, right petriPublicSurfaceBaselineEntry) int {
+		if order := strings.Compare(left.FilePath, right.FilePath); order != 0 {
+			return order
+		}
+		if order := strings.Compare(left.Symbol, right.Symbol); order != 0 {
+			return order
+		}
+		return strings.Compare(left.ImportPath, right.ImportPath)
+	})
+	return entries
+}
+
+func loadPetriPublicSurfaceBaseline(repoRoot string) (petriPublicSurfaceBaseline, error) {
+	payload, err := os.ReadFile(filepath.Join(repoRoot, petriPublicSurfaceBaselinePath))
+	if os.IsNotExist(err) {
+		return petriPublicSurfaceBaseline{}, nil
+	}
+	if err != nil {
+		return petriPublicSurfaceBaseline{}, fmt.Errorf("read Petri public surface baseline: %w", err)
+	}
+	var baseline petriPublicSurfaceBaseline
+	if err := json.Unmarshal(payload, &baseline); err != nil {
+		return petriPublicSurfaceBaseline{}, fmt.Errorf("decode Petri public surface baseline: %w", err)
+	}
+	if baseline.Version != 1 {
+		return petriPublicSurfaceBaseline{}, fmt.Errorf("Petri public surface baseline version = %d, want 1", baseline.Version)
+	}
+	if err := requireNonEmptyMigrationBaseline(petriPublicSurfaceBaselinePath, len(baseline.Entries)); err != nil {
+		return petriPublicSurfaceBaseline{}, err
+	}
+	return baseline, nil
+}
+
+func partitionPetriPublicSurfaceFindings(
+	findings []petriPublicSurfaceFinding,
+	baseline petriPublicSurfaceBaseline,
+) ([]petriPublicSurfaceFinding, []petriPublicSurfaceBaselineEntry, error) {
+	baselineByKey := make(map[string]petriPublicSurfaceBaselineEntry, len(baseline.Entries))
+	for _, entry := range baseline.Entries {
+		if err := validatePetriPublicSurfaceBaselineEntry(entry); err != nil {
+			return nil, nil, err
+		}
+		key := petriPublicSurfaceKey(entry.FilePath, entry.Symbol, entry.ImportPath)
+		if _, duplicate := baselineByKey[key]; duplicate {
+			return nil, nil, fmt.Errorf(
+				"duplicate Petri public surface baseline entry: %s %s %s",
+				entry.FilePath,
+				entry.Symbol,
+				entry.ImportPath,
+			)
+		}
+		baselineByKey[key] = entry
+	}
+
+	aggregated := aggregatePetriPublicSurfaceFindings(findings)
+	blockingKeys := map[string]struct{}{}
+	seen := map[string]struct{}{}
+	for _, edge := range aggregated {
+		key := petriPublicSurfaceKey(edge.FilePath, edge.Symbol, edge.ImportPath)
+		seen[key] = struct{}{}
+		entry, recorded := baselineByKey[key]
+		if !recorded || entry.Count != edge.Count || entry.Shape != edge.Shape {
+			blockingKeys[key] = struct{}{}
+		}
+	}
+
+	var blocking []petriPublicSurfaceFinding
+	for _, finding := range findings {
+		key := petriPublicSurfaceKey(finding.FilePath, finding.Symbol, finding.ImportPath)
+		if _, blocked := blockingKeys[key]; blocked {
+			blocking = append(blocking, finding)
+		}
+	}
+
+	var stale []petriPublicSurfaceBaselineEntry
+	for key, entry := range baselineByKey {
+		if _, found := seen[key]; !found {
+			stale = append(stale, entry)
+		}
+	}
+	slices.SortFunc(stale, func(left, right petriPublicSurfaceBaselineEntry) int {
+		return strings.Compare(
+			petriPublicSurfaceKey(left.FilePath, left.Symbol, left.ImportPath),
+			petriPublicSurfaceKey(right.FilePath, right.Symbol, right.ImportPath),
+		)
+	})
+	return blocking, stale, nil
+}
+
+func validatePetriPublicSurfaceBaselineEntry(entry petriPublicSurfaceBaselineEntry) error {
+	if entry.FilePath == "" || entry.Symbol == "" || entry.Shape == "" || entry.ImportPath == "" ||
+		entry.Count < 1 || entry.Stage != petriPublicSurfaceBaselineStage ||
+		entry.DeletionGate != petriPublicSurfaceDeletionGate {
+		return fmt.Errorf("Petri public surface baseline entry is incomplete or has an unrecognized deletion gate: %#v", entry)
+	}
+	filePath := filepath.ToSlash(entry.FilePath)
+	if strings.ContainsAny(filePath, "*?[]") || !strings.HasSuffix(filePath, ".go") {
+		return fmt.Errorf("Petri public surface baseline entry must be an exact Go file path: %s", entry.FilePath)
+	}
+	if isFactoryRuntimeInternalPath(filePath) {
+		return fmt.Errorf("Petri public surface baseline entry must not cover Factory Runtime internals: %s", entry.FilePath)
+	}
+	if strings.ContainsAny(entry.Symbol, "*?[]") {
+		return fmt.Errorf("Petri public surface baseline entry must be exact and cannot contain wildcards: %#v", entry)
+	}
+	shape, prohibited := prohibitedPetriPublicSurfaceSymbols[entry.Symbol]
+	if !prohibited || shape != entry.Shape {
+		return fmt.Errorf("Petri public surface baseline entry names an unrecognized rule: %s %s", entry.Symbol, entry.Shape)
+	}
+	if !isPetriPublicSurfaceWatchedImport(entry.ImportPath) {
+		return fmt.Errorf("Petri public surface baseline entry names an unwatched import: %s", entry.ImportPath)
+	}
+	return nil
+}
+
+func createPetriPublicSurfaceBaseline(cfg config) error {
+	repoRoot, err := filepath.Abs(cfg.root)
+	if err != nil {
+		return fmt.Errorf("resolve repo root: %w", err)
+	}
+	path := filepath.Join(repoRoot, petriPublicSurfaceBaselinePath)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return fmt.Errorf("create Petri public surface baseline: %w", err)
+	}
+	findings, err := scanPetriPublicSurface(repoRoot)
+	if err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return err
+	}
+	if len(findings) == 0 {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return fmt.Errorf("refuse to create empty %s; absence is the zero-debt state", petriPublicSurfaceBaselinePath)
+	}
+	baseline := petriPublicSurfaceBaseline{Version: 1}
+	for _, edge := range aggregatePetriPublicSurfaceFindings(findings) {
+		baseline.Entries = append(baseline.Entries, petriPublicSurfaceBaselineEntry{
+			FilePath:     edge.FilePath,
+			Symbol:       edge.Symbol,
+			Shape:        edge.Shape,
+			ImportPath:   edge.ImportPath,
+			Count:        edge.Count,
+			Stage:        petriPublicSurfaceBaselineStage,
+			DeletionGate: petriPublicSurfaceDeletionGate,
+		})
+	}
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(baseline); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("encode Petri public surface baseline: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close Petri public surface baseline: %w", err)
+	}
+	fmt.Fprintf(
+		stdoutWriter,
+		"[agent-factory:pkg-boundary] created %s with %d deletion-only edge(s)\n",
+		petriPublicSurfaceBaselinePath,
+		len(baseline.Entries),
+	)
+	return nil
+}
+
+func writeStalePetriPublicSurfaceBaselineEntries(writer io.Writer, entries []petriPublicSurfaceBaselineEntry) {
+	for _, entry := range entries {
+		fmt.Fprintf(
+			writer,
+			"[agent-factory:pkg-boundary] stale Petri public surface baseline entry: %s %s %s\n",
+			entry.FilePath,
+			entry.Symbol,
+			entry.ImportPath,
+		)
+		fmt.Fprintf(writer, "  remediation: remove this entry from %s in the same change.\n", petriPublicSurfaceBaselinePath)
+	}
+}
+
+func writePetriPublicSurfaceBaselineSummary(writer io.Writer, count int) {
+	if count > 0 {
+		fmt.Fprintf(
+			writer,
+			"[agent-factory:pkg-boundary] active Petri public-surface migration baseline: %d exact file/symbol edge(s)\n",
+			count,
+		)
+		fmt.Fprintln(
+			writer,
+			"  deletion gate: retire each leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete its exact baseline entry.",
+		)
+	}
 }

--- a/cmd/pkgboundarycheck/petri_public_surface_test.go
+++ b/cmd/pkgboundarycheck/petri_public_surface_test.go
@@ -156,6 +156,98 @@ func leak() {
 	}
 }
 
+func TestScanPetriPublicSurfaceRejectsRequiredPublicSurfaceCategories(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		filePath   string
+		source     string
+		symbol     string
+		shape      string
+		symbolLine string
+	}{
+		{
+			name:     "public API",
+			filePath: "pkg/api/public_petri_leak.go",
+			source: `package api
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+func leak(net runtime.Net) {}
+`,
+			symbol:     "Net",
+			shape:      "raw net",
+			symbolLine: "symbol: Net (raw net)",
+		},
+		{
+			name:     "transport",
+			filePath: "pkg/transports/http/petri_marking_leak.go",
+			source: `package http
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+func leak(marking runtime.PetriMarkingSnapshot) {}
+`,
+			symbol:     "PetriMarkingSnapshot",
+			shape:      "raw marking",
+			symbolLine: "symbol: PetriMarkingSnapshot (raw marking)",
+		},
+		{
+			name:     "integration contract",
+			filePath: "pkg/transports/http/contracttests/petri_token_contract_test.go",
+			source: `package contracttests
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+func leak(token runtime.RuntimeToken) {}
+`,
+			symbol:     "RuntimeToken",
+			shape:      "raw token",
+			symbolLine: "symbol: RuntimeToken (raw token)",
+		},
+		{
+			name:     "functional test",
+			filePath: "tests/functional/runtime_api/petri_engine_snapshot_test.go",
+			source: `package runtime_api
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+func assertEngineSnapshot(snapshot runtime.StateSnapshot) {}
+`,
+			symbol:     "StateSnapshot",
+			shape:      "engine snapshot",
+			symbolLine: "symbol: StateSnapshot (engine snapshot)",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			repoRoot := t.TempDir()
+			writeGoSourceFile(t, repoRoot, tc.filePath, tc.source)
+
+			findings, err := scanPetriPublicSurface(repoRoot)
+			if err != nil {
+				t.Fatalf("scanPetriPublicSurface() error = %v", err)
+			}
+			joined := petriPublicSurfaceFindingSummary(findings)
+			wantFinding := tc.filePath + "|" + tc.symbol + "|" + tc.shape + "|"
+			if !strings.Contains(joined, wantFinding) {
+				t.Fatalf("findings = %q, want %q", joined, wantFinding)
+			}
+
+			stderr := &bytes.Buffer{}
+			writePetriPublicSurfaceFindings(stderr, findings)
+			diagnostic := stderr.String()
+			for _, want := range []string{
+				"prohibited Petri public surface",
+				"surface: " + tc.filePath,
+				tc.symbolLine,
+				"required owner: Factory Runtime internals",
+				"pkg/services/factory_runtime/internal",
+			} {
+				if !strings.Contains(diagnostic, want) {
+					t.Fatalf("diagnostics = %q, want %q", diagnostic, want)
+				}
+			}
+		})
+	}
+}
+
 func TestScanPetriPublicSurfaceAllowsRuntimeInternalVocabulary(t *testing.T) {
 	t.Parallel()
 	repoRoot := t.TempDir()

--- a/cmd/pkgboundarycheck/petri_public_surface_test.go
+++ b/cmd/pkgboundarycheck/petri_public_surface_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -32,14 +35,26 @@ func TestPetriPublicSurfaceProhibitionEncodesRequiredVocabulary(t *testing.T) {
 func TestScanPetriPublicSurfaceRejectsEachRawVocabularyOutsideRuntimeInternals(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name       string
-		filePath   string
-		source     string
-		symbol     string
-		shape      string
-		symbolLine string
-	}{
+	for _, tc := range petriPublicSurfaceOutsideVocabularyCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assertPetriPublicSurfaceFixtureFails(t, tc)
+		})
+	}
+}
+
+type petriPublicSurfaceFixtureCase struct {
+	name       string
+	filePath   string
+	source     string
+	symbol     string
+	shape      string
+	symbolLine string
+}
+
+func petriPublicSurfaceOutsideVocabularyCases() []petriPublicSurfaceFixtureCase {
+	return []petriPublicSurfaceFixtureCase{
 		{
 			name:     "raw net",
 			filePath: "pkg/workers/outside/net_leak.go",
@@ -47,9 +62,7 @@ func TestScanPetriPublicSurfaceRejectsEachRawVocabularyOutsideRuntimeInternals(t
 import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 func leak(net runtime.Net) {}
 `,
-			symbol:     "Net",
-			shape:      "raw net",
-			symbolLine: "symbol: Net (raw net)",
+			symbol: "Net", shape: "raw net", symbolLine: "symbol: Net (raw net)",
 		},
 		{
 			name:     "raw marking",
@@ -58,8 +71,7 @@ func leak(net runtime.Net) {}
 import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 func leak(marking runtime.PetriMarkingSnapshot) {}
 `,
-			symbol:     "PetriMarkingSnapshot",
-			shape:      "raw marking",
+			symbol: "PetriMarkingSnapshot", shape: "raw marking",
 			symbolLine: "symbol: PetriMarkingSnapshot (raw marking)",
 		},
 		{
@@ -69,9 +81,7 @@ func leak(marking runtime.PetriMarkingSnapshot) {}
 import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 func leak(token runtime.RuntimeToken) {}
 `,
-			symbol:     "RuntimeToken",
-			shape:      "raw token",
-			symbolLine: "symbol: RuntimeToken (raw token)",
+			symbol: "RuntimeToken", shape: "raw token", symbolLine: "symbol: RuntimeToken (raw token)",
 		},
 		{
 			name:     "raw transition",
@@ -80,8 +90,7 @@ func leak(token runtime.RuntimeToken) {}
 import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 func leak(transition runtime.PetriTransition) {}
 `,
-			symbol:     "PetriTransition",
-			shape:      "raw transition",
+			symbol: "PetriTransition", shape: "raw transition",
 			symbolLine: "symbol: PetriTransition (raw transition)",
 		},
 		{
@@ -91,8 +100,7 @@ func leak(transition runtime.PetriTransition) {}
 import contracts "github.com/portpowered/infinite-you/pkg/services/factory_definitions/contracts"
 func leak(et contracts.EnabledTransition) {}
 `,
-			symbol:     "EnabledTransition",
-			shape:      "enabled-transition engine shape",
+			symbol: "EnabledTransition", shape: "enabled-transition engine shape",
 			symbolLine: "symbol: EnabledTransition (enabled-transition engine shape)",
 		},
 		{
@@ -102,8 +110,7 @@ func leak(et contracts.EnabledTransition) {}
 import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 func leak(snapshot runtime.StateSnapshot) {}
 `,
-			symbol:     "StateSnapshot",
-			shape:      "engine snapshot",
+			symbol: "StateSnapshot", shape: "engine snapshot",
 			symbolLine: "symbol: StateSnapshot (engine snapshot)",
 		},
 		{
@@ -115,58 +122,57 @@ func leak() {
   _ = contracts.NewEngineStateSnapshot[any, any](nil, nil, nil)
 }
 `,
-			symbol:     "NewEngineStateSnapshot",
-			shape:      "engine snapshot",
+			symbol: "NewEngineStateSnapshot", shape: "engine snapshot",
 			symbolLine: "symbol: NewEngineStateSnapshot (engine snapshot)",
 		},
 	}
+}
 
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			repoRoot := t.TempDir()
-			writeGoSourceFile(t, repoRoot, tc.filePath, tc.source)
+func assertPetriPublicSurfaceFixtureFails(t *testing.T, tc petriPublicSurfaceFixtureCase) {
+	t.Helper()
+	repoRoot := t.TempDir()
+	writeGoSourceFile(t, repoRoot, tc.filePath, tc.source)
 
-			findings, err := scanPetriPublicSurface(repoRoot)
-			if err != nil {
-				t.Fatalf("scanPetriPublicSurface() error = %v", err)
-			}
-			joined := petriPublicSurfaceFindingSummary(findings)
-			wantFinding := tc.filePath + "|" + tc.symbol + "|" + tc.shape + "|"
-			if !strings.Contains(joined, wantFinding) {
-				t.Fatalf("findings = %q, want %q", joined, wantFinding)
-			}
+	findings, err := scanPetriPublicSurface(repoRoot)
+	if err != nil {
+		t.Fatalf("scanPetriPublicSurface() error = %v", err)
+	}
+	joined := petriPublicSurfaceFindingSummary(findings)
+	wantFinding := tc.filePath + "|" + tc.symbol + "|" + tc.shape + "|"
+	if !strings.Contains(joined, wantFinding) {
+		t.Fatalf("findings = %q, want %q", joined, wantFinding)
+	}
 
-			stderr := &bytes.Buffer{}
-			writePetriPublicSurfaceFindings(stderr, findings)
-			diagnostic := stderr.String()
-			for _, want := range []string{
-				"prohibited Petri public surface",
-				"surface: " + tc.filePath,
-				tc.symbolLine,
-				"required owner: Factory Runtime internals",
-				"pkg/services/factory_runtime/internal",
-			} {
-				if !strings.Contains(diagnostic, want) {
-					t.Fatalf("diagnostics = %q, want %q", diagnostic, want)
-				}
-			}
-		})
+	stderr := &bytes.Buffer{}
+	writePetriPublicSurfaceFindings(stderr, findings)
+	diagnostic := stderr.String()
+	for _, want := range []string{
+		"prohibited Petri public surface",
+		"surface: " + tc.filePath,
+		tc.symbolLine,
+		"required owner: Factory Runtime internals",
+		"pkg/services/factory_runtime/internal",
+	} {
+		if !strings.Contains(diagnostic, want) {
+			t.Fatalf("diagnostics = %q, want %q", diagnostic, want)
+		}
 	}
 }
 
 func TestScanPetriPublicSurfaceRejectsRequiredPublicSurfaceCategories(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name       string
-		filePath   string
-		source     string
-		symbol     string
-		shape      string
-		symbolLine string
-	}{
+	for _, tc := range petriPublicSurfaceCategoryCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assertPetriPublicSurfaceFixtureFails(t, tc)
+		})
+	}
+}
+
+func petriPublicSurfaceCategoryCases() []petriPublicSurfaceFixtureCase {
+	return []petriPublicSurfaceFixtureCase{
 		{
 			name:     "public API",
 			filePath: "pkg/api/public_petri_leak.go",
@@ -174,9 +180,7 @@ func TestScanPetriPublicSurfaceRejectsRequiredPublicSurfaceCategories(t *testing
 import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 func leak(net runtime.Net) {}
 `,
-			symbol:     "Net",
-			shape:      "raw net",
-			symbolLine: "symbol: Net (raw net)",
+			symbol: "Net", shape: "raw net", symbolLine: "symbol: Net (raw net)",
 		},
 		{
 			name:     "transport",
@@ -185,8 +189,7 @@ func leak(net runtime.Net) {}
 import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 func leak(marking runtime.PetriMarkingSnapshot) {}
 `,
-			symbol:     "PetriMarkingSnapshot",
-			shape:      "raw marking",
+			symbol: "PetriMarkingSnapshot", shape: "raw marking",
 			symbolLine: "symbol: PetriMarkingSnapshot (raw marking)",
 		},
 		{
@@ -196,9 +199,7 @@ func leak(marking runtime.PetriMarkingSnapshot) {}
 import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 func leak(token runtime.RuntimeToken) {}
 `,
-			symbol:     "RuntimeToken",
-			shape:      "raw token",
-			symbolLine: "symbol: RuntimeToken (raw token)",
+			symbol: "RuntimeToken", shape: "raw token", symbolLine: "symbol: RuntimeToken (raw token)",
 		},
 		{
 			name:     "functional test",
@@ -207,44 +208,9 @@ func leak(token runtime.RuntimeToken) {}
 import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 func assertEngineSnapshot(snapshot runtime.StateSnapshot) {}
 `,
-			symbol:     "StateSnapshot",
-			shape:      "engine snapshot",
+			symbol: "StateSnapshot", shape: "engine snapshot",
 			symbolLine: "symbol: StateSnapshot (engine snapshot)",
 		},
-	}
-
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			repoRoot := t.TempDir()
-			writeGoSourceFile(t, repoRoot, tc.filePath, tc.source)
-
-			findings, err := scanPetriPublicSurface(repoRoot)
-			if err != nil {
-				t.Fatalf("scanPetriPublicSurface() error = %v", err)
-			}
-			joined := petriPublicSurfaceFindingSummary(findings)
-			wantFinding := tc.filePath + "|" + tc.symbol + "|" + tc.shape + "|"
-			if !strings.Contains(joined, wantFinding) {
-				t.Fatalf("findings = %q, want %q", joined, wantFinding)
-			}
-
-			stderr := &bytes.Buffer{}
-			writePetriPublicSurfaceFindings(stderr, findings)
-			diagnostic := stderr.String()
-			for _, want := range []string{
-				"prohibited Petri public surface",
-				"surface: " + tc.filePath,
-				tc.symbolLine,
-				"required owner: Factory Runtime internals",
-				"pkg/services/factory_runtime/internal",
-			} {
-				if !strings.Contains(diagnostic, want) {
-					t.Fatalf("diagnostics = %q, want %q", diagnostic, want)
-				}
-			}
-		})
 	}
 }
 
@@ -292,5 +258,212 @@ func selectKind() string { return kind }
 	}
 	if len(findings) != 0 {
 		t.Fatalf("findings = %#v, want none for authored orchestrator.kind = PETRI", findings)
+	}
+}
+
+func TestRunRejectsPetriPublicSurfaceLeakOutsideRuntimeInternals(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	const filePath = "pkg/transports/http/petri_leak.go"
+	writeGoSourceFile(t, repoRoot, filePath, `package http
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+func leak(net runtime.Net) {}
+`)
+
+	stderr := &bytes.Buffer{}
+	err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, &bytes.Buffer{}, stderr)
+	if err == nil {
+		t.Fatal("run() error = nil, want Petri public-surface prohibition failure")
+	}
+	got := stderr.String()
+	for _, want := range []string{
+		"prohibited Petri public surface: Net",
+		filePath,
+		"symbol: Net (raw net)",
+		"required owner: Factory Runtime internals",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("run() stderr = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestRunAcceptsExactPetriPublicSurfaceDeletionOnlyBaseline(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	const filePath = "pkg/transports/http/petri_leak.go"
+	writeGoSourceFile(t, repoRoot, filePath, `package http
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+func leak(net runtime.Net) {}
+`)
+	writePetriPublicSurfaceTestBaseline(t, repoRoot, petriPublicSurfaceBaselineEntry{
+		FilePath:     filePath,
+		Symbol:       "Net",
+		Shape:        "raw net",
+		ImportPath:   factoryRuntimeRootImportPath,
+		Count:        1,
+		Stage:        petriPublicSurfaceBaselineStage,
+		DeletionGate: petriPublicSurfaceDeletionGate,
+	})
+
+	stderr := &bytes.Buffer{}
+	if err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, &bytes.Buffer{}, stderr); err != nil {
+		t.Fatalf("run() error = %v, want exact deletion-only baseline accepted; stderr=%q", err, stderr.String())
+	}
+}
+
+func TestRunRejectsStalePetriPublicSurfaceBaselineEntry(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	const filePath = "pkg/transports/http/petri_leak.go"
+	writeGoSourceFile(t, repoRoot, filePath, `package http
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+func leak(net runtime.Net) {}
+`)
+	writePetriPublicSurfaceTestBaseline(t, repoRoot, petriPublicSurfaceBaselineEntry{
+		FilePath:     filePath,
+		Symbol:       "Net",
+		Shape:        "raw net",
+		ImportPath:   factoryRuntimeRootImportPath,
+		Count:        1,
+		Stage:        petriPublicSurfaceBaselineStage,
+		DeletionGate: petriPublicSurfaceDeletionGate,
+	})
+
+	writeGoSourceFile(t, repoRoot, filePath, "package http\nfunc clean() {}\n")
+	stderr := &bytes.Buffer{}
+	err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, &bytes.Buffer{}, stderr)
+	if err == nil || !strings.Contains(stderr.String(), "stale Petri public surface baseline entry") {
+		t.Fatalf("run() error = %v, stderr=%q, want exact stale-baseline rejection", err, stderr.String())
+	}
+}
+
+func TestRunRejectsPetriPublicSurfaceBaselineGrowth(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	const baselinePath = "pkg/transports/http/petri_leak.go"
+	const growthPath = "pkg/transports/cli/new_petri_leak.go"
+	writeGoSourceFile(t, repoRoot, baselinePath, `package http
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+func leak(net runtime.Net) {}
+`)
+	writePetriPublicSurfaceTestBaseline(t, repoRoot, petriPublicSurfaceBaselineEntry{
+		FilePath:     baselinePath,
+		Symbol:       "Net",
+		Shape:        "raw net",
+		ImportPath:   factoryRuntimeRootImportPath,
+		Count:        1,
+		Stage:        petriPublicSurfaceBaselineStage,
+		DeletionGate: petriPublicSurfaceDeletionGate,
+	})
+	writeGoSourceFile(t, repoRoot, growthPath, `package cli
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+func leak(token runtime.RuntimeToken) {}
+`)
+
+	stderr := &bytes.Buffer{}
+	err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, &bytes.Buffer{}, stderr)
+	if err == nil {
+		t.Fatal("run() error = nil, want baseline growth rejected")
+	}
+	got := stderr.String()
+	if !strings.Contains(got, "prohibited Petri public surface: RuntimeToken") {
+		t.Fatalf("run() stderr = %q, want new RuntimeToken finding blocked", got)
+	}
+	if strings.Contains(got, "prohibited Petri public surface: Net") {
+		t.Fatalf("run() stderr = %q, baselined Net must remain non-blocking", got)
+	}
+}
+
+func TestPetriPublicSurfaceBaselineRejectsWildcardOrWrongDeletionGate(t *testing.T) {
+	t.Parallel()
+
+	cases := []petriPublicSurfaceBaselineEntry{
+		{
+			FilePath: "pkg/transports/http/*.go", Symbol: "Net", Shape: "raw net",
+			ImportPath: factoryRuntimeRootImportPath, Count: 1,
+			Stage: petriPublicSurfaceBaselineStage, DeletionGate: petriPublicSurfaceDeletionGate,
+		},
+		{
+			FilePath: "pkg/transports/http/petri_leak.go", Symbol: "Net", Shape: "raw net",
+			ImportPath: factoryRuntimeRootImportPath, Count: 1,
+			Stage: petriPublicSurfaceBaselineStage, DeletionGate: "broad allowance",
+		},
+	}
+	for _, entry := range cases {
+		if _, _, err := partitionPetriPublicSurfaceFindings(nil, petriPublicSurfaceBaseline{
+			Version: 1,
+			Entries: []petriPublicSurfaceBaselineEntry{entry},
+		}); err == nil {
+			t.Fatalf("partition error = nil for invalid entry %#v", entry)
+		}
+	}
+}
+
+func TestCreatePetriPublicSurfaceBaselineWritesExactDeletionOnlyEntries(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	const filePath = "pkg/transports/http/petri_leak.go"
+	writeGoSourceFile(t, repoRoot, filePath, `package http
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+func leak(net runtime.Net) {
+	_ = runtime.Net{}
+}
+`)
+
+	if err := createPetriPublicSurfaceBaseline(config{root: repoRoot}); err != nil {
+		t.Fatalf("createPetriPublicSurfaceBaseline() error = %v", err)
+	}
+	payload, err := os.ReadFile(filepath.Join(repoRoot, petriPublicSurfaceBaselinePath))
+	if err != nil {
+		t.Fatalf("read created baseline: %v", err)
+	}
+	var baseline petriPublicSurfaceBaseline
+	if err := json.Unmarshal(payload, &baseline); err != nil {
+		t.Fatalf("decode created baseline: %v", err)
+	}
+	if baseline.Version != 1 || len(baseline.Entries) != 1 {
+		t.Fatalf("created baseline = %#v, want one exact Net edge", baseline)
+	}
+	entry := baseline.Entries[0]
+	if entry.FilePath != filePath || entry.Symbol != "Net" || entry.Count != 2 ||
+		entry.Stage != petriPublicSurfaceBaselineStage || entry.DeletionGate != petriPublicSurfaceDeletionGate {
+		t.Fatalf("created entry = %#v, want exact aggregated Net edge with count 2", entry)
+	}
+
+	stderr := &bytes.Buffer{}
+	if err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, &bytes.Buffer{}, stderr); err != nil {
+		t.Fatalf("run() after create error = %v; stderr=%q", err, stderr.String())
+	}
+}
+
+func TestCreatePetriPublicSurfaceBaselineRejectsEmptyDebt(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	writeGoSourceFile(t, repoRoot, "pkg/transports/http/clean.go", "package http\nfunc clean() {}\n")
+	err := createPetriPublicSurfaceBaseline(config{root: repoRoot})
+	if err == nil {
+		t.Fatal("createPetriPublicSurfaceBaseline() error = nil, want empty-debt rejection")
+	}
+	if _, statErr := os.Stat(filepath.Join(repoRoot, petriPublicSurfaceBaselinePath)); !os.IsNotExist(statErr) {
+		t.Fatalf("empty baseline artifact stat error = %v, want file absent", statErr)
+	}
+}
+
+func writePetriPublicSurfaceTestBaseline(t *testing.T, repoRoot string, entries ...petriPublicSurfaceBaselineEntry) {
+	t.Helper()
+	baseline := petriPublicSurfaceBaseline{Version: 1, Entries: entries}
+	payload, err := json.MarshalIndent(baseline, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal Petri public surface baseline: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, petriPublicSurfaceBaselinePath), append(payload, '\n'), 0o644); err != nil {
+		t.Fatalf("write Petri public surface baseline: %v", err)
 	}
 }

--- a/cmd/pkgboundarycheck/petri_public_surface_test.go
+++ b/cmd/pkgboundarycheck/petri_public_surface_test.go
@@ -29,45 +29,130 @@ func TestPetriPublicSurfaceProhibitionEncodesRequiredVocabulary(t *testing.T) {
 	}
 }
 
-func TestScanPetriPublicSurfaceRejectsRawVocabularyOutsideRuntimeInternals(t *testing.T) {
+func TestScanPetriPublicSurfaceRejectsEachRawVocabularyOutsideRuntimeInternals(t *testing.T) {
 	t.Parallel()
-	repoRoot := t.TempDir()
-	writeGoSourceFile(t, repoRoot, "pkg/transports/http/petri_leak.go", `package http
+
+	cases := []struct {
+		name       string
+		filePath   string
+		source     string
+		symbol     string
+		shape      string
+		symbolLine string
+	}{
+		{
+			name:     "raw net",
+			filePath: "pkg/workers/outside/net_leak.go",
+			source: `package outside
 import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+func leak(net runtime.Net) {}
+`,
+			symbol:     "Net",
+			shape:      "raw net",
+			symbolLine: "symbol: Net (raw net)",
+		},
+		{
+			name:     "raw marking",
+			filePath: "pkg/workers/outside/marking_leak.go",
+			source: `package outside
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+func leak(marking runtime.PetriMarkingSnapshot) {}
+`,
+			symbol:     "PetriMarkingSnapshot",
+			shape:      "raw marking",
+			symbolLine: "symbol: PetriMarkingSnapshot (raw marking)",
+		},
+		{
+			name:     "raw token",
+			filePath: "pkg/workers/outside/token_leak.go",
+			source: `package outside
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+func leak(token runtime.RuntimeToken) {}
+`,
+			symbol:     "RuntimeToken",
+			shape:      "raw token",
+			symbolLine: "symbol: RuntimeToken (raw token)",
+		},
+		{
+			name:     "raw transition",
+			filePath: "pkg/workers/outside/transition_leak.go",
+			source: `package outside
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+func leak(transition runtime.PetriTransition) {}
+`,
+			symbol:     "PetriTransition",
+			shape:      "raw transition",
+			symbolLine: "symbol: PetriTransition (raw transition)",
+		},
+		{
+			name:     "enabled-transition engine shape",
+			filePath: "pkg/workers/outside/enabled_transition_leak.go",
+			source: `package outside
+import contracts "github.com/portpowered/infinite-you/pkg/services/factory_definitions/contracts"
+func leak(et contracts.EnabledTransition) {}
+`,
+			symbol:     "EnabledTransition",
+			shape:      "enabled-transition engine shape",
+			symbolLine: "symbol: EnabledTransition (enabled-transition engine shape)",
+		},
+		{
+			name:     "engine snapshot",
+			filePath: "pkg/workers/outside/engine_snapshot_leak.go",
+			source: `package outside
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+func leak(snapshot runtime.StateSnapshot) {}
+`,
+			symbol:     "StateSnapshot",
+			shape:      "engine snapshot",
+			symbolLine: "symbol: StateSnapshot (engine snapshot)",
+		},
+		{
+			name:     "engine state snapshot constructor",
+			filePath: "pkg/workers/outside/engine_state_snapshot_leak.go",
+			source: `package outside
+import contracts "github.com/portpowered/infinite-you/pkg/services/factory_definitions/contracts"
 func leak() {
-  _ = runtime.Net{}
-  _ = runtime.PetriMarkingSnapshot{}
-  _ = runtime.RuntimeToken{}
-  _ = runtime.PetriTransition{}
-  _ = runtime.StateSnapshot{}
+  _ = contracts.NewEngineStateSnapshot[any, any](nil, nil, nil)
 }
-`)
-
-	findings, err := scanPetriPublicSurface(repoRoot)
-	if err != nil {
-		t.Fatalf("scanPetriPublicSurface() error = %v", err)
-	}
-	joined := petriPublicSurfaceFindingSummary(findings)
-	for _, symbol := range []string{"Net", "PetriMarkingSnapshot", "RuntimeToken", "PetriTransition", "StateSnapshot"} {
-		want := "pkg/transports/http/petri_leak.go|" + symbol + "|"
-		if !strings.Contains(joined, want) {
-			t.Fatalf("findings = %q, want symbol %q on transport surface", joined, symbol)
-		}
+`,
+			symbol:     "NewEngineStateSnapshot",
+			shape:      "engine snapshot",
+			symbolLine: "symbol: NewEngineStateSnapshot (engine snapshot)",
+		},
 	}
 
-	stderr := &bytes.Buffer{}
-	writePetriPublicSurfaceFindings(stderr, findings)
-	diagnostic := stderr.String()
-	for _, want := range []string{
-		"prohibited Petri public surface",
-		"surface: pkg/transports/http/petri_leak.go",
-		"symbol: Net",
-		"required owner: Factory Runtime internals",
-		"pkg/services/factory_runtime/internal",
-	} {
-		if !strings.Contains(diagnostic, want) {
-			t.Fatalf("diagnostics = %q, want %q", diagnostic, want)
-		}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			repoRoot := t.TempDir()
+			writeGoSourceFile(t, repoRoot, tc.filePath, tc.source)
+
+			findings, err := scanPetriPublicSurface(repoRoot)
+			if err != nil {
+				t.Fatalf("scanPetriPublicSurface() error = %v", err)
+			}
+			joined := petriPublicSurfaceFindingSummary(findings)
+			wantFinding := tc.filePath + "|" + tc.symbol + "|" + tc.shape + "|"
+			if !strings.Contains(joined, wantFinding) {
+				t.Fatalf("findings = %q, want %q", joined, wantFinding)
+			}
+
+			stderr := &bytes.Buffer{}
+			writePetriPublicSurfaceFindings(stderr, findings)
+			diagnostic := stderr.String()
+			for _, want := range []string{
+				"prohibited Petri public surface",
+				"surface: " + tc.filePath,
+				tc.symbolLine,
+				"required owner: Factory Runtime internals",
+				"pkg/services/factory_runtime/internal",
+			} {
+				if !strings.Contains(diagnostic, want) {
+					t.Fatalf("diagnostics = %q, want %q", diagnostic, want)
+				}
+			}
+		})
 	}
 }
 
@@ -115,24 +200,5 @@ func selectKind() string { return kind }
 	}
 	if len(findings) != 0 {
 		t.Fatalf("findings = %#v, want none for authored orchestrator.kind = PETRI", findings)
-	}
-}
-
-func TestScanPetriPublicSurfaceRejectsEnabledTransitionEngineShape(t *testing.T) {
-	t.Parallel()
-	repoRoot := t.TempDir()
-	writeGoSourceFile(t, repoRoot, "pkg/apisurface/enabled.go", `package apisurface
-import contracts "github.com/portpowered/infinite-you/pkg/services/factory_definitions/contracts"
-func leak(et contracts.EnabledTransition) {}
-`)
-
-	findings, err := scanPetriPublicSurface(repoRoot)
-	if err != nil {
-		t.Fatalf("scanPetriPublicSurface() error = %v", err)
-	}
-	joined := petriPublicSurfaceFindingSummary(findings)
-	want := "pkg/apisurface/enabled.go|EnabledTransition|"
-	if !strings.Contains(joined, want) {
-		t.Fatalf("findings = %q, want %q", joined, want)
 	}
 }

--- a/cmd/pkgboundarycheck/petri_public_surface_test.go
+++ b/cmd/pkgboundarycheck/petri_public_surface_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPetriPublicSurfaceProhibitionEncodesRequiredVocabulary(t *testing.T) {
+	t.Parallel()
+
+	requiredShapes := map[string]string{
+		"Net":                  "raw net",
+		"PetriMarkingSnapshot": "raw marking",
+		"RuntimeToken":         "raw token",
+		"PetriTransition":      "raw transition",
+		"EnabledTransition":    "enabled-transition engine shape",
+		"EngineStateSnapshot":  "engine snapshot",
+		"StateSnapshot":        "engine snapshot",
+	}
+	for symbol, shape := range requiredShapes {
+		got, ok := prohibitedPetriPublicSurfaceSymbols[symbol]
+		if !ok {
+			t.Fatalf("prohibitedPetriPublicSurfaceSymbols missing %q", symbol)
+		}
+		if got != shape {
+			t.Fatalf("prohibitedPetriPublicSurfaceSymbols[%q] = %q, want %q", symbol, got, shape)
+		}
+	}
+}
+
+func TestScanPetriPublicSurfaceRejectsRawVocabularyOutsideRuntimeInternals(t *testing.T) {
+	t.Parallel()
+	repoRoot := t.TempDir()
+	writeGoSourceFile(t, repoRoot, "pkg/transports/http/petri_leak.go", `package http
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+func leak() {
+  _ = runtime.Net{}
+  _ = runtime.PetriMarkingSnapshot{}
+  _ = runtime.RuntimeToken{}
+  _ = runtime.PetriTransition{}
+  _ = runtime.StateSnapshot{}
+}
+`)
+
+	findings, err := scanPetriPublicSurface(repoRoot)
+	if err != nil {
+		t.Fatalf("scanPetriPublicSurface() error = %v", err)
+	}
+	joined := petriPublicSurfaceFindingSummary(findings)
+	for _, symbol := range []string{"Net", "PetriMarkingSnapshot", "RuntimeToken", "PetriTransition", "StateSnapshot"} {
+		want := "pkg/transports/http/petri_leak.go|" + symbol + "|"
+		if !strings.Contains(joined, want) {
+			t.Fatalf("findings = %q, want symbol %q on transport surface", joined, symbol)
+		}
+	}
+
+	stderr := &bytes.Buffer{}
+	writePetriPublicSurfaceFindings(stderr, findings)
+	diagnostic := stderr.String()
+	for _, want := range []string{
+		"prohibited Petri public surface",
+		"surface: pkg/transports/http/petri_leak.go",
+		"symbol: Net",
+		"required owner: Factory Runtime internals",
+		"pkg/services/factory_runtime/internal",
+	} {
+		if !strings.Contains(diagnostic, want) {
+			t.Fatalf("diagnostics = %q, want %q", diagnostic, want)
+		}
+	}
+}
+
+func TestScanPetriPublicSurfaceAllowsRuntimeInternalVocabulary(t *testing.T) {
+	t.Parallel()
+	repoRoot := t.TempDir()
+	writeGoSourceFile(t, repoRoot, "pkg/services/factory_runtime/internal/orchestrators/petri/engine.go", `package petri
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+func internalEngine() {
+  _ = runtime.Net{}
+  _ = runtime.PetriMarkingSnapshot{}
+  _ = runtime.RuntimeToken{}
+  _ = runtime.PetriTransition{}
+  _ = runtime.StateSnapshot{}
+  _ = runtime.EngineStateSnapshot[any, any]{}
+}
+`)
+
+	findings, err := scanPetriPublicSurface(repoRoot)
+	if err != nil {
+		t.Fatalf("scanPetriPublicSurface() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("findings = %#v, want none for Factory Runtime internals", findings)
+	}
+}
+
+func TestScanPetriPublicSurfaceAllowsAuthoredOrchestratorKindPetri(t *testing.T) {
+	t.Parallel()
+	repoRoot := t.TempDir()
+	writeGoSourceFile(t, repoRoot, "pkg/services/factory_definitions/config_authoring.go", `package factory_definitions
+import contracts "github.com/portpowered/infinite-you/pkg/services/factory_definitions/contracts"
+func authoredPetriFactory() contracts.FactoryOrchestratorConfig {
+  return contracts.FactoryOrchestratorConfig{Kind: contracts.OrchestratorKindPetri}
+}
+`)
+	writeGoSourceFile(t, repoRoot, "pkg/transports/mapping/factoryconfig/orchestrator.go", `package factoryconfig
+const kind = "PETRI"
+func selectKind() string { return kind }
+`)
+
+	findings, err := scanPetriPublicSurface(repoRoot)
+	if err != nil {
+		t.Fatalf("scanPetriPublicSurface() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("findings = %#v, want none for authored orchestrator.kind = PETRI", findings)
+	}
+}
+
+func TestScanPetriPublicSurfaceRejectsEnabledTransitionEngineShape(t *testing.T) {
+	t.Parallel()
+	repoRoot := t.TempDir()
+	writeGoSourceFile(t, repoRoot, "pkg/apisurface/enabled.go", `package apisurface
+import contracts "github.com/portpowered/infinite-you/pkg/services/factory_definitions/contracts"
+func leak(et contracts.EnabledTransition) {}
+`)
+
+	findings, err := scanPetriPublicSurface(repoRoot)
+	if err != nil {
+		t.Fatalf("scanPetriPublicSurface() error = %v", err)
+	}
+	joined := petriPublicSurfaceFindingSummary(findings)
+	want := "pkg/apisurface/enabled.go|EnabledTransition|"
+	if !strings.Contains(joined, want) {
+		t.Fatalf("findings = %q, want %q", joined, want)
+	}
+}

--- a/docs/internal/processes/runtime-cleanup-relevant-files.md
+++ b/docs/internal/processes/runtime-cleanup-relevant-files.md
@@ -334,8 +334,10 @@ The architecture checker encodes a Petri-public-surface prohibition in
 transitions/enabled-transition engine shapes, and engine snapshots are rejected
 outside `pkg/services/factory_runtime/internal/`. Authored Factory Definition
 `orchestrator.kind = PETRI` remains allowed as configuration. Focused fixtures
-live in `petri_public_surface_test.go`; wiring onto the live lint path and any
-deletion-only baseline remain a follow-on gate for IMP-RUN-01.
+in `petri_public_surface_test.go` cover vocabulary shapes and the required
+public-surface categories (public API, transport, integration contract, and
+functional test). Wiring onto the live lint path and any deletion-only baseline
+remain a follow-on gate for IMP-RUN-01.
 
 ## Focused Verification
 

--- a/docs/internal/processes/runtime-cleanup-relevant-files.md
+++ b/docs/internal/processes/runtime-cleanup-relevant-files.md
@@ -329,6 +329,14 @@ is allowed only when the text explicitly describes internal implementation
 details or `pkg/orchestrators/petri` ownership. It should not be the primary wording for
 customer-facing Factory Session, Work, or event-stream behavior.
 
+The architecture checker encodes a Petri-public-surface prohibition in
+`cmd/pkgboundarycheck/petri_public_surface.go`: raw nets, markings, tokens,
+transitions/enabled-transition engine shapes, and engine snapshots are rejected
+outside `pkg/services/factory_runtime/internal/`. Authored Factory Definition
+`orchestrator.kind = PETRI` remains allowed as configuration. Focused fixtures
+live in `petri_public_surface_test.go`; wiring onto the live lint path and any
+deletion-only baseline remain a follow-on gate for IMP-RUN-01.
+
 ## Focused Verification
 
 For runtime-cleanup documentation changes, run a changed-docs vocabulary check

--- a/docs/internal/processes/runtime-cleanup-relevant-files.md
+++ b/docs/internal/processes/runtime-cleanup-relevant-files.md
@@ -336,8 +336,10 @@ outside `pkg/services/factory_runtime/internal/`. Authored Factory Definition
 `orchestrator.kind = PETRI` remains allowed as configuration. Focused fixtures
 in `petri_public_surface_test.go` cover vocabulary shapes and the required
 public-surface categories (public API, transport, integration contract, and
-functional test). Wiring onto the live lint path and any deletion-only baseline
-remain a follow-on gate for IMP-RUN-01.
+functional test). The prohibition runs on the `make lint` package-boundary path;
+pre-existing live-tree debt is inventory-only in
+`petri-public-surface-baseline.json` with an exact deletion gate pointing at
+Runtime Petri-boundary retirement / IMP-RUN-01 (no new baseline growth).
 
 ## Focused Verification
 

--- a/petri-public-surface-baseline.json
+++ b/petri-public-surface-baseline.json
@@ -1,0 +1,2390 @@
+{
+  "version": 1,
+  "entries": [
+    {
+      "filePath": "internal/testutil/assertions.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "internal/testutil/assertions.go",
+      "symbol": "PetriTransition",
+      "shape": "raw transition",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "internal/testutil/assertions_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "internal/testutil/assertions_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "internal/testutil/deadcode_contract_test.go",
+      "symbol": "PetriTransition",
+      "shape": "raw transition",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "internal/testutil/mock_factory.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "internal/testutil/mock_factory.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 4,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "internal/testutil/mock_factory.go",
+      "symbol": "NewEngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "internal/testutil/mock_factory.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 4,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "internal/testutil/mock_factory.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "internal/testutil/mock_factory_session.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "internal/testutil/mock_factory_session.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "internal/testutil/mock_factory_session.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "internal/testutil/mockfactory/mock_factory_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "internal/testutil/mockfactory/mock_factory_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "internal/testutil/mockfactory/mock_factory_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "internal/testutil/mockfactory/mock_factory_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_definitions/contracts_root.go",
+      "symbol": "EnabledTransition",
+      "shape": "enabled-transition engine shape",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/contracts",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_definitions/contracts_root.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/contracts",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/definitionmapping/maptests/config_mapper_equivalence_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 10,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/definitionmapping/maptests/config_mapper_equivalence_test.go",
+      "symbol": "PetriTransition",
+      "shape": "raw transition",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 14,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/definitionmapping/maptests/config_mapper_input_guards_any_child_failed_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/definitionmapping/maptests/config_mapper_input_guards_dynamic_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/definitionmapping/maptests/config_mapper_input_guards_static_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/definitionmapping/maptests/config_mapper_resources_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 5,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/definitionmapping/maptests/config_mapper_resources_test.go",
+      "symbol": "PetriTransition",
+      "shape": "raw transition",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/definitionmapping/maptests/config_mapper_resources_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 4,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/definitionmapping/maptests/config_mapper_resources_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/definitionmapping/maptests/config_mapper_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/definitionmapping/maptests/config_mapper_test.go",
+      "symbol": "PetriTransition",
+      "shape": "raw transition",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/definitionmapping/maptests/config_mapper_workstation_cron_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/engine/engine.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 10,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/engine/engine_dispatch_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 9,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/engine/engine_runtime_snapshot_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/engine/engine_submission_hook_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 7,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/engine/engine_test_helpers_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 7,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/engine/engine_tick_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 5,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/engine/runtime_state.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/engine/runtime_state_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/engine/submission_hooks.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/engine/work_move_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/execution_contracts.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/hosting.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/ingest/filewatcher_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/interfaces.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/public_work_tokens_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/public_work_tokens_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 15,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/public_work_tokens_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 10,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/replayhooks/adapter.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/runtime/dispatch_result_hook.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/runtime/dispatch_result_hook_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 9,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/runtime/factory.go",
+      "symbol": "EnabledTransition",
+      "shape": "enabled-transition engine shape",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/runtime/factory.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/runtime/factory_buffered_pause_lossless_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/runtime/factory_buffered_pause_result_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/runtime/factory_buffered_pause_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/runtime/factory_modes_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 6,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/runtime/factory_runtime_test_helpers_test.go",
+      "symbol": "EnabledTransition",
+      "shape": "enabled-transition engine shape",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/runtime/factory_runtime_test_helpers_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 15,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/scheduler/cron_time_enablement_test.go",
+      "symbol": "EnabledTransition",
+      "shape": "enabled-transition engine shape",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/scheduler/enablement.go",
+      "symbol": "EnabledTransition",
+      "shape": "enabled-transition engine shape",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 23,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/scheduler/enablement.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 7,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/scheduler/enablement_test_helpers_test.go",
+      "symbol": "EnabledTransition",
+      "shape": "enabled-transition engine shape",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/scheduler/fifo.go",
+      "symbol": "EnabledTransition",
+      "shape": "enabled-transition engine shape",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/scheduler/fifo.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/scheduler/fifo_test.go",
+      "symbol": "EnabledTransition",
+      "shape": "enabled-transition engine shape",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 4,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/scheduler/interfaces.go",
+      "symbol": "EnabledTransition",
+      "shape": "enabled-transition engine shape",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/scheduler/interfaces.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/scheduler/work_queue.go",
+      "symbol": "EnabledTransition",
+      "shape": "enabled-transition engine shape",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/scheduler/work_queue.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 4,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/scheduler/work_queue_priority_test.go",
+      "symbol": "EnabledTransition",
+      "shape": "enabled-transition engine shape",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 14,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/scheduler/work_queue_priority_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 14,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/scheduler/work_queue_test.go",
+      "symbol": "EnabledTransition",
+      "shape": "enabled-transition engine shape",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 6,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/scheduler/work_queue_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/scheduler/work_queue_test_helpers_test.go",
+      "symbol": "EnabledTransition",
+      "shape": "enabled-transition engine shape",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/service/host/lifecycle.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/service/host/lifecycle_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 7,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/service/host/metrics.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/service/host/operations.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/service/host/operations_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/service/host/replacement_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/state/engine_state.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 4,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/state/engine_state_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 6,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/state/recording_projection_migration_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 7,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/state/recording_projection_migration_test.go",
+      "symbol": "PetriTransition",
+      "shape": "raw transition",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 4,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/cascading_failure.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/circuitbreaker.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/circuitbreakertests/circuitbreaker_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 12,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/dispatchertests/dispatcher_cron_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 4,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/dispatchertests/dispatcher_test.go",
+      "symbol": "EnabledTransition",
+      "shape": "enabled-transition engine shape",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 4,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/dispatchertests/dispatcher_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 13,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/dispatchertests/dispatcher_throttle_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 14,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/dispatchertests/noop_dispatcher_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 5,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/goalroutingtests/transitioner_goal_routing_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/history_transitioner_pipeline_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 7,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/interfaces.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/noop_dispatcher.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/subsystem_dispatcher.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 9,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/subsystem_history.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/subsystem_history_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/subsystem_transitioner.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 4,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/subsystem_transitioner_classifier_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/subsystem_transitioner_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 6,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/subsystem_transitioner_worker_batch_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/termination.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/subsystems/terminationtests/termination_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 8,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_runtime/testkit/runtime.go",
+      "symbol": "PetriMarking",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/controlplane/read_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/controlplane/read_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/controlplane/read_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/execution/fixtures/helpers_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/execution/fixtures/helpers_test.go",
+      "symbol": "PetriTransition",
+      "shape": "raw transition",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/invocation/runtime_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/invocation/runtime_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/invocation/runtime_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/invocation/snapshot.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/invocation/snapshot.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/invocation/snapshot.go",
+      "symbol": "RuntimeNet",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/runtimebinding/binding_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/runtimebinding/binding_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/runtimebinding/binding_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/services/identity/internal/service/projection_logical_identity_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/services/identity/internal/service/projection_logical_identity_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/services/identity/internal/service/projection_logical_identity_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/services/live_runtime/internal/service/service.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/services/live_runtime/internal/service/service_test.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/services/live_runtime/service.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/contracts.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/projection.go",
+      "symbol": "EnabledTransition",
+      "shape": "enabled-transition engine shape",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/projection.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/projection.go",
+      "symbol": "RuntimeNet",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/projection_build.go",
+      "symbol": "EnabledTransition",
+      "shape": "enabled-transition engine shape",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/projection_test.go",
+      "symbol": "EnabledTransition",
+      "shape": "enabled-transition engine shape",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/projection_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 11,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/projection_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 18,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/projection_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 17,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/projection_test.go",
+      "symbol": "PetriTransition",
+      "shape": "raw transition",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/projection_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 15,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/projection_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 8,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/stop_summary.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 4,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/stop_summary.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 12,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/stop_summary_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/stop_summary_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/stop_summary_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/stop_summary_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionprojection/stop_summary_test.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionservice/lifecycle_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionservice/lifecycle_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionservice/lifecycle_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionservice/runtime_factory_state.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionservice/runtime_factory_state.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionservice/runtime_factory_state.go",
+      "symbol": "RuntimeNet",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionservice/runtime_gateway.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionservice/runtime_sessions.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionservice/runtime_sessions.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionservice/runtime_sessions.go",
+      "symbol": "RuntimeNet",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionservice/work_runtime_adapter.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/internal/sessionservice/work_runtime_resolver_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/projection_contract.go",
+      "symbol": "EnabledTransition",
+      "shape": "enabled-transition engine shape",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/projection_contract.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/service_contracts.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_sessions/stop_summary_contract.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_visualization/runtime_source.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_visualization/service.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/factory_visualization/service_test.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/recordings/projections/projectiontests/selected_tick_cross_boundary_smoke_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/recordings/projections/projectiontests/selected_tick_cross_boundary_smoke_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/recordings/projections/projectiontests/selected_tick_cross_boundary_smoke_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/work/service/service.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/executor/agent_inference_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/executor/agent_inference_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/executor/portable_script_execution_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/executor/portable_script_execution_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/executor/script_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 4,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/executor/script_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 4,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/executor/workstation/codex_worktree_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/executor/workstation/codex_worktree_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/executor/workstation/workstation_executor_timeout_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 10,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/executor/workstation/workstation_executor_timeout_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 10,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/executor/workstation/workstation_runtime_path_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/executor/workstation/workstation_runtime_path_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/executor/workstation/workstation_session_context_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/executor/workstation/workstation_session_context_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/executor/workstation_executor_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 19,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/executor/workstation_executor_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 15,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/prompting/prompt_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 17,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/prompting/prompt_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 25,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/provider/codex/adapter_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/provider/codex/adapter_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/provider/inference_provider_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/provider/inference_provider_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/provider/inference_provider_test_helpers_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 9,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/provider/inference_provider_test_helpers_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 7,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/provider/provider_behavior_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/provider/provider_behavior_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/provider/structured/executor_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/provider/structured/executor_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/services/agents/decision_envelope_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/services/agents/decision_envelope_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/services/inference/inference_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/services/inference/inference_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/services/testing/runner_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 6,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/services/testing/runner_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 6,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/template_fields_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 13,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/services/workers/template_fields_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 13,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/dashboard/dashboard.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/dashboard/dashboard.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 5,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/dashboard/dashboard.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/dashboard/dashboard_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 9,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/dashboard/dashboard_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 11,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/dashboard/dashboard_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 16,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/dashboard/dashboard_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 10,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/dashboard/dashboard_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 4,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/invocation_observability.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/invocation_observability.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/invocation_observability.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/run.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/run.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/run.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/run_clean_invocation.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 8,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/run_clean_invocation.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 9,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/run_clean_invocation.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 8,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/run_dashboard_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 9,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/run_dashboard_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 9,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/run_dashboard_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 9,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/run_dashboard_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/run_dashboard_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/run_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 5,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/run_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 6,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/run_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 7,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/run_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 8,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/cli/run/run_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/http/application/handler_test.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/http/server_factory_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/http/server_factory_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/http/server_factory_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/http/servertests/factorysessionsse/server_test_util_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/http/servertests/factorysessionsse/server_test_util_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/http/servertests/factorysessionsse/server_test_util_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/mapping/composition/factory_status.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/mapping/composition/factory_status_test.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 8,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/mapping/composition/services.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/mapping/contract.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/mapping/contract.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/mapping/contract.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/mapping/runtime_api.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/mapping/runtime_api.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/mapping/runtime_api.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/mapping/runtime_api_test.go",
+      "symbol": "EngineStateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/mapping/runtime_api_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "pkg/transports/mapping/runtime_api_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "tests/stress/input_tokens_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 7,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "tests/stress/meta_factory_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "tests/stress/poison_token_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "tests/stress/poison_token_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "tests/stress/process_harness_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "tests/stress/process_harness_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "tests/stress/process_harness_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "tests/stress/race_condition_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "tests/stress/size_cleanup_helpers_test.go",
+      "symbol": "Net",
+      "shape": "raw net",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 5,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "tests/stress/size_cleanup_helpers_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 5,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "tests/stress/size_cleanup_helpers_test.go",
+      "symbol": "PetriTransition",
+      "shape": "raw transition",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 3,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "tests/stress/throughput_test.go",
+      "symbol": "PetriMarkingSnapshot",
+      "shape": "raw marking",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 2,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "tests/stress/throughput_test.go",
+      "symbol": "RuntimeToken",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
+      "filePath": "tests/stress/throughput_test.go",
+      "symbol": "RuntimeTokenColor",
+      "shape": "raw token",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 5,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    }
+  ]
+}


### PR DESCRIPTION
{
  "project": "FND-07 Petri-Public-Surface Prohibition",
  "branchName": "pss-fnd-07-petri-public-surface-prohibition",
  "description": "Add the Petri-public-surface prohibition so raw nets, markings, tokens, transitions, and engine snapshots fail outside Factory Runtime internals, unlocking IMP-RUN-01 while staying limited to architecture checker and fixtures.",
  "context": {
    "customerAsk": "Add the Petri-public-surface prohibition so raw nets, markings, tokens, transitions, and engine snapshots fail outside Runtime internals. This unlocks later IMP-RUN-01.",
    "problem": "Raw Petri live-engine vocabulary can still appear on public API, transport, integration, and functional-test surfaces, and there is no complete architecture-checker prohibition proving those leaks fail outside Runtime internals.",
    "solution": "Extend the architecture checker with an explicit Petri-public-surface prohibition, prove fail/pass behavior with focused fixtures across the required public-surface categories, and record any pre-existing live-tree debt only as exact deletion-only baseline entries without migrating Runtime orchestration or changing customer-facing contracts."
  },
  "acceptanceCriteria": [
    "Checker fixtures that place raw nets, markings, or tokens outside Factory Runtime internals fail with stable, actionable Petri-public-surface diagnostics.",
    "Checker fixtures that place the same raw Petri vocabulary inside Factory Runtime internals pass.",
    "Prohibition fixtures cover public API, transports, integration contracts, and functional-test fixture surfaces as distinct failing cases.",
    "Forbidden vocabulary includes raw nets, markings, tokens, transitions/enabled-transition engine shapes, and engine snapshots; authored Factory Definition orchestrator.kind = PETRI remains allowed as configuration.",
    "Scope stays on architecture checker and fixtures: no Runtime orchestration migration, no customer-facing CLI/OpenAPI contract changes solely for package motion, and no provider-conductor or CLI-manifest lease work.",
    "Focused Petri-boundary checker tests pass, and quality checks pass (typecheck, lint, tests)."
  ],
  "userStories": [
    {
      "id": "pss-fnd-07-petri-public-surface-prohibition-001",
      "title": "Encode Petri prohibition and Runtime-internal exemption",
      "description": "As a maintainer enforcing packaged Runtime boundaries, I want the architecture checker to define which raw Petri engine symbols are forbidden and which Runtime-internal paths remain allowed so later migrations have a stable rule to obey.",
      "acceptanceCriteria": [
        "The checker encodes a Petri-public-surface prohibition covering raw nets, markings, tokens, transitions/enabled-transition engine shapes, and engine snapshots.",
        "Factory Runtime internal packages are an explicit exemption; a fixture that uses the forbidden vocabulary only inside Runtime internals passes the checker.",
        "Authored Factory Definition orchestrator-kind configuration that selects PETRI is not treated as a live-engine prohibition failure.",
        "Diagnostics name the offending surface, symbol or shape, and that the required owner is Factory Runtime internals.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Scanner and focused fixtures land in cmd/pkgboundarycheck; live lint wiring and deletion-only baseline deferred to story 004."
    },
    {
      "id": "pss-fnd-07-petri-public-surface-prohibition-002",
      "title": "Fail raw Petri usage outside Runtime internals",
      "description": "As a reviewer, I want fixtures outside Runtime internals that construct or assert raw nets, markings, or tokens to fail the architecture checker so Petri leaks are blocked before IMP-RUN-01 lands.",
      "acceptanceCriteria": [
        "A fixture outside Factory Runtime internals that references a raw net fails the Petri-public-surface prohibition.",
        "A fixture outside Factory Runtime internals that references a raw marking fails the Petri-public-surface prohibition.",
        "A fixture outside Factory Runtime internals that references a raw token fails the Petri-public-surface prohibition.",
        "Equivalent fixtures for transitions/enabled-transition engine shapes and engine snapshots also fail.",
        "Focused checker tests assert these failures through observable checker output, not by scanning repository file inventories.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Distinct outside-Runtime fixtures cover net, marking, token, transition, enabled-transition, and engine snapshot shapes; assertions use scan findings plus writePetriPublicSurfaceFindings diagnostics."
    },
    {
      "id": "pss-fnd-07-petri-public-surface-prohibition-003",
      "title": "Cover public API, transport, integration, and functional-test surfaces",
      "description": "As a packaged-structure executor, I want prohibition fixtures for public API, transports, integration contracts, and functional-test fixtures so every required public-surface class is mechanically guarded.",
      "acceptanceCriteria": [
        "A public-API-shaped fixture that embeds raw Petri live-engine vocabulary fails the prohibition.",
        "A transport-shaped fixture that embeds raw Petri live-engine vocabulary fails the prohibition.",
        "An integration-contract-shaped fixture that embeds raw Petri live-engine vocabulary fails the prohibition.",
        "A functional-test fixture that manufactures or asserts raw nets, markings, tokens, transitions, or engine snapshots fails the prohibition.",
        "The four surface categories are represented as distinct fixtures so a reviewer can verify coverage without inventing additional scans.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Distinct fixtures under pkg/api, pkg/transports/http, pkg/transports/http/contracttests, and tests/functional/runtime_api; assertions use scan findings plus writePetriPublicSurfaceFindings diagnostics."
    },
    {
      "id": "pss-fnd-07-petri-public-surface-prohibition-004",
      "title": "Wire prohibition into lint and preserve existing debt as deletion-only",
      "description": "As a CI consumer, I want the Petri-public-surface prohibition exercised on the architecture-checker path used by lint so new leaks fail merge gates while pre-existing debt, if any, remains exact deletion-only inventory for IMP-RUN-01.",
      "acceptanceCriteria": [
        "The Petri-public-surface prohibition runs as part of the architecture checker path already covered by make lint / package-boundary lint targets.",
        "Focused Petri-boundary checker tests pass.",
        "If the live repository still contains prohibited surfaces, each finding is recorded only as an exact deletion-only baseline entry with a deletion gate pointing at Runtime Petri-boundary retirement / IMP-RUN-01; no new baseline growth is allowed afterward.",
        "This story does not migrate Factory Runtime orchestration packages, does not change customer-facing CLI/OpenAPI contracts solely for package motion, and does not take provider-conductor or CLI-manifest leases.",
        "make verify-fast and make lint pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Wired scanPetriPublicSurface into run()/make pkg-boundary; petri-public-surface-baseline.json records 265 exact deletion-only edges with IMP-RUN-01 deletion gate; baseline growth and stale entries block."
    }
  ]
}
