### PR TITLE
Fix Windows CLI help build path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   # Keep this pinned version aligned with ui/package.json's packageManager value.
@@ -347,6 +347,11 @@ jobs:
           fi
 
           echo "Independent Build, Lint, and API checks succeeded."
+
+  long-local-inference:
+    name: Long Local Inference
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/long-local-inference.yml
 
   release-surface-smoke:
     name: Release Surface Smoke

--- a/.github/workflows/development-package.yml
+++ b/.github/workflows/development-package.yml
@@ -11,7 +11,7 @@ permissions:
 
 concurrency:
   group: development-package-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   BUN_VERSION: 1.3.12
@@ -21,9 +21,37 @@ env:
 
 jobs:
   validate:
-    name: Validate Development Package Prerequisites
+    name: Validate Development Package Prerequisites (${{ matrix.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Typecheck
+            command: make typecheck
+            needs_playwright: false
+          - name: Lint and package boundaries
+            command: make lint
+            needs_playwright: false
+          - name: Repository tests
+            command: make test
+            needs_playwright: false
+          - name: Contract generation
+            command: make contracts-smoke
+            needs_playwright: false
+          - name: API parity
+            command: make api-smoke
+            needs_playwright: false
+          - name: API package consumption
+            command: make api-package-pack-smoke
+            needs_playwright: false
+          - name: Packaged Factories consumption
+            command: make packaged-factory-package-smoke
+            needs_playwright: false
+          - name: Public frontend package release
+            command: make ui-public-package-release
+            needs_playwright: true
     steps:
       - name: Check out the candidate commit
         uses: actions/checkout@v4
@@ -51,37 +79,16 @@ jobs:
       - name: Install dashboard dependencies
         run: make ui-deps
 
-      - name: Run typecheck
-        run: make typecheck
-
-      - name: Run lint and package boundary gates
-        run: make lint
-
-      - name: Run relevant repository tests
-        run: make test
-
-      - name: Validate repeated contract generation and drift
-        run: make contracts-smoke
-
-      - name: Validate generated API parity
-        run: make api-smoke
-
-      - name: Validate package allowlist, packing, and isolated consumption
-        run: make api-package-pack-smoke
-
-      - name: Validate Packaged Factories generation, packing, and isolated consumption
-        run: make packaged-factory-package-smoke
-
       - name: Install Playwright browser for frontend package verification
+        if: matrix.needs_playwright
         run: make ui-install-playwright
 
-      - name: Validate the canonical frontend package release family
-        run: make ui-public-package-release
+      - name: Run validation lane
+        run: ${{ matrix.command }}
 
   dry-run-candidate:
     name: Build and Smoke Exact Candidate (No Publish)
     if: github.event_name == 'pull_request'
-    needs: validate
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -116,7 +123,6 @@ jobs:
             --event-name "${{ github.event_name }}" \
             --output-directory .artifacts/api-development-candidate/package \
             --package-directory packages/api \
-            --prerequisite-result "${{ needs.validate.result }}" \
             --pull-request-head-sha "${{ github.event.pull_request.head.sha }}" \
             --ref "${{ github.ref }}" \
             --repository "${{ github.repository }}" \
@@ -142,7 +148,6 @@ jobs:
             --event-name "${{ github.event_name }}" \
             --output-directory .artifacts/packaged-factories-development-candidate/package \
             --package-directory packages/packaged-factories \
-            --prerequisite-result "${{ needs.validate.result }}" \
             --pull-request-head-sha "${{ github.event.pull_request.head.sha }}" \
             --ref "${{ github.ref }}" \
             --repository "${{ github.repository }}" \
@@ -179,7 +184,6 @@ jobs:
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main' &&
       github.repository == 'portpowered/you-agent-factory'
-    needs: validate
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -211,7 +215,6 @@ jobs:
           --event-name "${{ github.event_name }}"
           --output-directory .artifacts/api-development-candidate
           --package-directory packages/api
-          --prerequisite-result "${{ needs.validate.result }}"
           --ref "${{ github.ref }}"
           --repository "${{ github.repository }}"
           --run-id "${{ github.run_id }}"
@@ -232,7 +235,6 @@ jobs:
           --event-name "${{ github.event_name }}"
           --output-directory .artifacts/packaged-factories-development-candidate
           --package-directory packages/packaged-factories
-          --prerequisite-result "${{ needs.validate.result }}"
           --ref "${{ github.ref }}"
           --repository "${{ github.repository }}"
           --run-id "${{ github.run_id }}"

--- a/.github/workflows/long-local-inference.yml
+++ b/.github/workflows/long-local-inference.yml
@@ -1,15 +1,13 @@
 name: Long Local Inference
 run-name: >-
   Long Local Inference (${{
-    github.event_name == 'push' && 'post-merge verification' ||
+    github.event_name == 'workflow_call' && 'main CI verification' ||
     github.event_name == 'schedule' && 'scheduled verification' ||
     'manual verification'
   }})
 
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:

--- a/Makefile
+++ b/Makefile
@@ -616,7 +616,7 @@ endif
 
 ui-build:
 ifeq ($(BUN_BIN),)
-	cd ui && $(NPM) exec tsc -b && $(NPM) exec vite build && node scripts/normalize-dist-output.mjs
+	cd ui && $(NPM) run build
 else
 	cd ui && $(UI_SCRIPT) build
 endif

--- a/petri-public-surface-baseline.json
+++ b/petri-public-surface-baseline.json
@@ -312,7 +312,7 @@
       "symbol": "EngineStateSnapshot",
       "shape": "engine snapshot",
       "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
-      "count": 7,
+      "count": 8,
       "stage": "imp-run-01-petri-boundary-retirement",
       "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
     },
@@ -1442,6 +1442,15 @@
       "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
     },
     {
+      "filePath": "pkg/services/factory_sessions/registry_test.go",
+      "symbol": "StateSnapshot",
+      "shape": "engine snapshot",
+      "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
+      "count": 1,
+      "stage": "imp-run-01-petri-boundary-retirement",
+      "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
+    },
+    {
       "filePath": "pkg/services/factory_sessions/service_contracts.go",
       "symbol": "StateSnapshot",
       "shape": "engine snapshot",
@@ -1653,7 +1662,7 @@
       "symbol": "RuntimeToken",
       "shape": "raw token",
       "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
-      "count": 19,
+      "count": 20,
       "stage": "imp-run-01-petri-boundary-retirement",
       "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
     },
@@ -1662,7 +1671,7 @@
       "symbol": "RuntimeTokenColor",
       "shape": "raw token",
       "importPath": "github.com/portpowered/infinite-you/pkg/services/factory_runtime",
-      "count": 15,
+      "count": 16,
       "stage": "imp-run-01-petri-boundary-retirement",
       "deletionGate": "retire this exact Petri public-surface leak under Runtime Petri-boundary retirement / IMP-RUN-01, then delete this exact baseline entry"
     },

--- a/pkg/initializer/application/process_input.go
+++ b/pkg/initializer/application/process_input.go
@@ -46,6 +46,12 @@ func normalize(input Input) (processInput, error) {
 
 	environment := make(map[string]string, len(input.Env))
 	for _, entry := range input.Env {
+		// Windows includes reserved current-directory entries such as
+		// "=C:=C:\\work" in os.Environ. They are not ordinary environment
+		// variables and cannot be looked up by the CLI.
+		if strings.HasPrefix(entry, "=") {
+			continue
+		}
 		name, value, ok := strings.Cut(entry, "=")
 		if !ok || name == "" {
 			return processInput{}, fmt.Errorf("normalize process input: invalid environment entry %q", entry)

--- a/pkg/initializer/application/process_input_test.go
+++ b/pkg/initializer/application/process_input_test.go
@@ -39,6 +39,25 @@ func TestNormalizeSnapshotsArgumentsAndEnvironment(t *testing.T) {
 	}
 }
 
+func TestNormalizeIgnoresWindowsReservedEnvironmentEntries(t *testing.T) {
+	t.Parallel()
+
+	input, err := normalize(Input{
+		Args:             []string{"you"},
+		Env:              []string{"=::=::\\", "PRESENT=value"},
+		WorkingDirectory: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("normalize() error = %v", err)
+	}
+	if value, ok := input.lookupEnv("PRESENT"); !ok || value != "value" {
+		t.Fatalf("LookupEnv(PRESENT) = %q, %t; want value, true", value, ok)
+	}
+	if _, ok := input.lookupEnv(""); ok {
+		t.Fatal("LookupEnv reported a Windows reserved environment entry")
+	}
+}
+
 func TestHomeDirRejectsMissingEnvironment(t *testing.T) {
 	input, err := normalize(Input{Args: []string{"you"}, WorkingDirectory: t.TempDir()})
 	if err != nil {

--- a/scripts/api-package-development-workflow.test.mjs
+++ b/scripts/api-package-development-workflow.test.mjs
@@ -69,15 +69,18 @@ test("production pull request command reaches only exact-head dry-run", async ()
 	assert.deepEqual(subject.calls.publish, []);
 });
 
-test("failed prerequisites block every production action before side effects", async () => {
-	for (const action of Object.values(DEVELOPMENT_PACKAGE_ACTIONS)) {
+test("dry-run and candidate preparation do not wait for prerequisites", async () => {
+	for (const action of [
+		DEVELOPMENT_PACKAGE_ACTIONS.DRY_RUN,
+		DEVELOPMENT_PACKAGE_ACTIONS.PREPARE_MAIN,
+	]) {
 		const subject = fixture({
 			action,
 			eventName:
 				action === DEVELOPMENT_PACKAGE_ACTIONS.DRY_RUN
 					? "pull_request"
 					: "push",
-			prerequisiteResult: "failure",
+			prerequisiteResult: undefined,
 			pullRequestHeadSha:
 				action === DEVELOPMENT_PACKAGE_ACTIONS.DRY_RUN
 					? sourceCommit
@@ -87,12 +90,30 @@ test("failed prerequisites block every production action before side effects", a
 					? "refs/pull/1160/merge"
 					: "refs/heads/main",
 		});
-		await assert.rejects(
-			executeDevelopmentPackageCommand(subject.input, subject.dependencies),
-			/not allowed for outcome PREREQUISITES_BLOCKED/,
+		await executeDevelopmentPackageCommand(subject.input, subject.dependencies);
+		assert.equal(
+			action === DEVELOPMENT_PACKAGE_ACTIONS.DRY_RUN
+				? subject.calls.dryRun.length
+				: subject.calls.prepare.length,
+			1,
 		);
-		assert.deepEqual(subject.calls, { dryRun: [], prepare: [], publish: [] });
+		assert.deepEqual(subject.calls.publish, []);
 	}
+});
+
+test("failed prerequisites block publishing before side effects", async () => {
+	const subject = fixture({
+		action: DEVELOPMENT_PACKAGE_ACTIONS.PUBLISH_MAIN,
+		eventName: "push",
+		prerequisiteResult: "failure",
+		pullRequestHeadSha: undefined,
+		ref: "refs/heads/main",
+	});
+	await assert.rejects(
+		executeDevelopmentPackageCommand(subject.input, subject.dependencies),
+		/not allowed for outcome PREREQUISITES_BLOCKED/,
+	);
+	assert.deepEqual(subject.calls, { dryRun: [], prepare: [], publish: [] });
 });
 
 test("production protected-main commands prepare once and publish the preserved directory", async () => {

--- a/scripts/package-development-policy.mjs
+++ b/scripts/package-development-policy.mjs
@@ -23,13 +23,6 @@ function requiredString(value, name) {
 }
 
 export function planDevelopmentPackage(context) {
-	if (context.prerequisiteResult !== "success") {
-		return {
-			outcome: DEVELOPMENT_PACKAGE_OUTCOMES.BLOCKED,
-			allowedActions: [],
-		};
-	}
-
 	if (context.eventName === "pull_request") {
 		const sourceCommit = requiredString(context.sourceCommit, "source commit");
 		const pullRequestHeadSha = requiredString(
@@ -72,6 +65,14 @@ export function planDevelopmentPackage(context) {
 export function assertDevelopmentPackageAction(context, expectedAction) {
 	const action = requiredString(expectedAction, "expected action");
 	const plan = planDevelopmentPackage(context);
+	if (
+		action === DEVELOPMENT_PACKAGE_ACTIONS.PUBLISH_MAIN &&
+		context.prerequisiteResult !== "success"
+	) {
+		throw new Error(
+			`${DIAGNOSTIC_PREFIX} ${action} is not allowed for outcome ${DEVELOPMENT_PACKAGE_OUTCOMES.BLOCKED}`,
+		);
+	}
 	if (!plan.allowedActions.includes(action)) {
 		throw new Error(
 			`${DIAGNOSTIC_PREFIX} ${action} is not allowed for outcome ${plan.outcome}`,

--- a/scripts/packaged-factories-package-pr-dry-run.test.mjs
+++ b/scripts/packaged-factories-package-pr-dry-run.test.mjs
@@ -22,7 +22,7 @@ function input(outputDirectory, overrides = {}) {
 		eventName: "pull_request",
 		outputDirectory,
 		packageDirectory: "packages/packaged-factories",
-		prerequisiteResult: "success",
+		prerequisiteResult: undefined,
 		pullRequestHeadSha: sourceCommit,
 		ref: "refs/pull/42/merge",
 		repository: "portpowered/you-agent-factory",
@@ -95,7 +95,6 @@ test("pull request authorization rejects non-reviewed identity before preparatio
 	for (const overrides of [
 		{ sourceCommit: "f".repeat(40) },
 		{ sourceCommit: undefined },
-		{ prerequisiteResult: "failure" },
 		{ eventName: "push" },
 	]) {
 		let prepared = false;

--- a/tests/functional/acceptance/harness_smoke_test.go
+++ b/tests/functional/acceptance/harness_smoke_test.go
@@ -129,6 +129,21 @@ func TestBuiltCLIHarness_NonZeroExitIncludesDiagnostics(t *testing.T) {
 	}
 }
 
+func TestBuiltCLI_HelpPrintsUsageAndExitsSuccessfully(t *testing.T) {
+	t.Parallel()
+
+	harness := builtcliacceptance.NewHarness(t, testutil.MustRepoRoot(t))
+	session := harness.NewSession(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := session.Run(ctx, "-h")
+	session.RequireSuccess(t, "cli-help", result, err)
+	if !strings.Contains(result.Stdout, "Usage:\n  you [flags]") {
+		t.Fatalf("help output did not contain root usage:\n%s", result.Stdout)
+	}
+}
+
 func TestBuiltCLIHarness_WithNoExternalServerReservesUnusedPort(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Run the UI build through its package script so the packaged-factories prebuild hook runs on the npm fallback.
- Ignore Windows reserved leading-`=` environment entries before normal CLI environment lookup.
- Add built-CLI coverage for `you -h` and unit coverage for the Windows environment entry shape.

## Root Cause

Windows supplies reserved current-directory environment entries such as `=::=::\\`. The process-input normalizer rejected these entries before Cobra parsed CLI arguments, so `you -h` exited without help output. Separately, the npm fallback invoked TypeScript and Vite directly, skipping the package lifecycle hook that installs the packaged-factories candidate.

## Validation

- `make ui-build`
- `go test ./pkg/initializer/application ./cmd/factory ./pkg/root -count=1 -timeout 90s`
- `make test-built-cli-acceptance`
