### PR TITLE
public-release-packages

### DIFF
--- a/.github/workflows/development-package.yml
+++ b/.github/workflows/development-package.yml
@@ -49,6 +49,9 @@ jobs:
           - name: Packaged Factories consumption
             command: make packaged-factory-package-smoke
             needs_playwright: false
+          - name: Complete public package release
+            command: make public-release-package-smoke
+            needs_playwright: false
           - name: Public frontend package release
             command: make ui-public-package-release
             needs_playwright: true

--- a/.github/workflows/development-package.yml
+++ b/.github/workflows/development-package.yml
@@ -113,58 +113,7 @@ jobs:
       - name: Install dashboard dependencies
         run: make ui-deps
 
-      - name: Authorize, prepare, and smoke the exact candidate without publishing
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p .artifacts/api-development-candidate
-          node scripts/api-package-development-command.mjs \
-            --action dry-run \
-            --event-name "${{ github.event_name }}" \
-            --output-directory .artifacts/api-development-candidate/package \
-            --package-directory packages/api \
-            --pull-request-head-sha "${{ github.event.pull_request.head.sha }}" \
-            --ref "${{ github.ref }}" \
-            --repository "${{ github.repository }}" \
-            --run-id "${{ github.run_id }}" \
-            --source-commit "${{ github.event.pull_request.head.sha }}" \
-            --workspace-directory "${{ github.workspace }}" \
-            | tee .artifacts/api-development-candidate/dry-run-outcome.json
-
-      - name: Upload the preserved candidate and evidence
-        uses: actions/upload-artifact@v4
-        with:
-          name: api-development-candidate-${{ github.run_id }}
-          path: .artifacts/api-development-candidate/
-          if-no-files-found: error
-          retention-days: 7
-
-      - name: Authorize, prepare, and smoke the exact Packaged Factories candidate without publishing
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p .artifacts/packaged-factories-development-candidate/package
-          node scripts/packaged-factories-package-pr-dry-run.mjs \
-            --event-name "${{ github.event_name }}" \
-            --output-directory .artifacts/packaged-factories-development-candidate/package \
-            --package-directory packages/packaged-factories \
-            --pull-request-head-sha "${{ github.event.pull_request.head.sha }}" \
-            --ref "${{ github.ref }}" \
-            --repository "${{ github.repository }}" \
-            --run-id "${{ github.run_id }}" \
-            --source-commit "${{ github.event.pull_request.head.sha }}" \
-            --workspace-directory "${{ github.workspace }}" \
-            | tee .artifacts/packaged-factories-development-candidate/dry-run-outcome.json
-
-      - name: Upload the preserved Packaged Factories candidate and evidence
-        uses: actions/upload-artifact@v4
-        with:
-          name: packaged-factories-development-candidate-${{ github.run_id }}
-          path: .artifacts/packaged-factories-development-candidate/
-          if-no-files-found: error
-          retention-days: 7
-
-      - name: Prepare the canonical frontend package candidates
+      - name: Prepare the frontend-only development package candidates
         run: >-
           make ui-public-package-publish-prepare
           PACKAGE_VERSION="0.0.0-dev.${{ github.run_id }}.${{ github.event.pull_request.head.sha }}"
@@ -208,47 +157,7 @@ jobs:
       - name: Install dashboard dependencies
         run: make ui-deps
 
-      - name: Authorize and prepare the exact protected-main candidate
-        run: >-
-          node scripts/api-package-development-command.mjs
-          --action prepare-main
-          --event-name "${{ github.event_name }}"
-          --output-directory .artifacts/api-development-candidate
-          --package-directory packages/api
-          --ref "${{ github.ref }}"
-          --repository "${{ github.repository }}"
-          --run-id "${{ github.run_id }}"
-          --source-commit "${{ github.sha }}"
-
-      - name: Upload the preserved candidate and evidence
-        uses: actions/upload-artifact@v4
-        with:
-          name: api-development-main-candidate-${{ github.run_id }}
-          path: .artifacts/api-development-candidate/
-          if-no-files-found: error
-          retention-days: 7
-
-      - name: Authorize and prepare the exact protected-main Packaged Factories candidate
-        run: >-
-          node scripts/packaged-factories-package-development-command.mjs
-          --action prepare-main
-          --event-name "${{ github.event_name }}"
-          --output-directory .artifacts/packaged-factories-development-candidate
-          --package-directory packages/packaged-factories
-          --ref "${{ github.ref }}"
-          --repository "${{ github.repository }}"
-          --run-id "${{ github.run_id }}"
-          --source-commit "${{ github.sha }}"
-
-      - name: Upload the preserved Packaged Factories candidate and evidence
-        uses: actions/upload-artifact@v4
-        with:
-          name: packaged-factories-development-main-candidate-${{ github.run_id }}
-          path: .artifacts/packaged-factories-development-candidate/
-          if-no-files-found: error
-          retention-days: 7
-
-      - name: Prepare the canonical frontend package candidates
+      - name: Prepare the frontend-only development package candidates
         run: >-
           make ui-public-package-publish-prepare
           PACKAGE_VERSION="0.0.0-dev.${{ github.run_id }}.${{ github.sha }}"
@@ -292,49 +201,13 @@ jobs:
       - name: Pin trusted-publishing-compatible npm
         run: npm install --global npm@${{ env.NPM_VERSION }}
 
-      - name: Download the preserved candidate
-        uses: actions/download-artifact@v4
-        with:
-          name: api-development-main-candidate-${{ github.run_id }}
-          path: .artifacts/api-development-candidate
-
-      - name: Download the preserved Packaged Factories candidate
-        uses: actions/download-artifact@v4
-        with:
-          name: packaged-factories-development-main-candidate-${{ github.run_id }}
-          path: .artifacts/packaged-factories-development-candidate
-
-      - name: Download the canonical frontend package candidates
+      - name: Download the frontend-only development package candidates
         uses: actions/download-artifact@v4
         with:
           name: public-development-main-candidate-${{ github.run_id }}
           path: .artifacts/public-development-candidate
 
-      - name: Authorize, reconcile, publish once when absent, and verify exact consumption
-        run: >-
-          node scripts/api-package-development-command.mjs
-          --action publish-main
-          --candidate-directory .artifacts/api-development-candidate
-          --event-name "${{ github.event_name }}"
-          --prerequisite-result "${{ needs.validate.result }}"
-          --ref "${{ github.ref }}"
-          --repository "${{ github.repository }}"
-          --source-commit "${{ github.sha }}"
-          --workspace-directory "${{ github.workspace }}"
-
-      - name: Authorize, reconcile, publish, and verify the exact Packaged Factories candidate
-        run: >-
-          node scripts/packaged-factories-package-development-command.mjs
-          --action publish-main
-          --candidate-directory .artifacts/packaged-factories-development-candidate
-          --event-name "${{ github.event_name }}"
-          --prerequisite-result "${{ needs.validate.result }}"
-          --ref "${{ github.ref }}"
-          --repository "${{ github.repository }}"
-          --source-commit "${{ github.sha }}"
-          --workspace-directory "${{ github.workspace }}"
-
-      - name: Publish and verify the canonical frontend package family
+      - name: Publish and verify the frontend-only development package family
         working-directory: ui
         run: >-
           npm run publish:public-packages --

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,8 @@ jobs:
           release_version="${release_tag#v}"
           printf 'release_version=%s\n' "$release_version" >> "$GITHUB_OUTPUT"
 
-  prepare-data-package-candidates:
-    name: Prepare Data Package Candidates
+  prepare-public-package-candidate:
+    name: Prepare Complete Public Package Candidate
     needs: resolve-release-tag
     runs-on: ubuntu-latest
     steps:
@@ -87,41 +87,35 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Prepare the API candidate from the release commit
+      - name: Set up Bun for the frontend package workspace
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install frontend package dependencies
+        working-directory: ui
+        run: bun install --frozen-lockfile
+
+      - name: Prepare the complete public package candidate from the release commit
         run: >-
-          node scripts/api-package-candidate.mjs
-          --output-directory .artifacts/api-release-candidate
-          --package-directory packages/api
+          node scripts/public-release-package-candidate.mjs
+          --output-directory .artifacts/public-release-candidate
           --run-id "${{ github.run_id }}"
           --source-commit "${{ github.event.workflow_run.head_sha }}"
+          --version "${{ needs.resolve-release-tag.outputs.release_version }}"
 
-      - name: Prepare the Packaged Factories candidate from the release commit
-        run: >-
-          node scripts/packaged-factories-package-candidate.mjs
-          --output-directory .artifacts/packaged-factories-release-candidate
-          --package-directory packages/packaged-factories
-          --run-id "${{ github.run_id }}"
-          --source-commit "${{ github.event.workflow_run.head_sha }}"
-
-      - name: Upload the API candidate and evidence
+      - name: Upload the complete public package candidate and evidence
         uses: actions/upload-artifact@v4
         with:
-          name: api-release-candidate-${{ github.run_id }}
-          path: .artifacts/api-release-candidate/
-          if-no-files-found: error
-
-      - name: Upload the Packaged Factories candidate and evidence
-        uses: actions/upload-artifact@v4
-        with:
-          name: packaged-factories-release-candidate-${{ github.run_id }}
-          path: .artifacts/packaged-factories-release-candidate/
+          name: public-release-candidate-${{ github.run_id }}
+          path: .artifacts/public-release-candidate/
           if-no-files-found: error
 
   publish-release:
     name: Publish GitHub Release
     needs:
       - resolve-release-tag
-      - prepare-data-package-candidates
+      - prepare-public-package-candidate
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -163,43 +157,31 @@ jobs:
         working-directory: ui
         run: bun install --frozen-lockfile
 
-      - name: Download the preserved API candidate
+      - name: Download the preserved complete public package candidate
         uses: actions/download-artifact@v4
         with:
-          name: api-release-candidate-${{ github.run_id }}
-          path: .artifacts/api-release-candidate
-
-      - name: Download the preserved Packaged Factories candidate
-        uses: actions/download-artifact@v4
-        with:
-          name: packaged-factories-release-candidate-${{ github.run_id }}
-          path: .artifacts/packaged-factories-release-candidate
+          name: public-release-candidate-${{ github.run_id }}
+          path: .artifacts/public-release-candidate
 
       - name: Reconcile, publish, and verify the exact API candidate
         run: >-
           node scripts/api-package-publish.mjs
-          --candidate-directory .artifacts/api-release-candidate
+          --candidate-directory .artifacts/public-release-candidate/api
           --expected-source-commit "${{ github.event.workflow_run.head_sha }}"
           --workspace-directory .
 
       - name: Reconcile, publish, and verify the exact Packaged Factories candidate
         run: >-
           node scripts/packaged-factories-package-publish.mjs
-          --candidate-directory .artifacts/packaged-factories-release-candidate
+          --candidate-directory .artifacts/public-release-candidate/packaged-factories
           --expected-source-commit "${{ github.event.workflow_run.head_sha }}"
           --workspace-directory .
-
-      - name: Prepare the canonical frontend package release candidates
-        run: >-
-          make ui-public-package-publish-prepare
-          PACKAGE_VERSION="${{ needs.resolve-release-tag.outputs.release_version }}"
-          PACKAGE_OUTPUT=".artifacts/public-release-candidate"
 
       - name: Publish and verify the canonical frontend package family
         working-directory: ui
         run: >-
           npm run publish:public-packages --
-          --candidate-directory ../.artifacts/public-release-candidate
+          --candidate-directory ../.artifacts/public-release-candidate/frontend
           --tag latest --provenance
 
       - name: Publish GitHub release assets from the tagged commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,26 +163,12 @@ jobs:
           name: public-release-candidate-${{ github.run_id }}
           path: .artifacts/public-release-candidate
 
-      - name: Reconcile, publish, and verify the exact API candidate
+      - name: Reconcile, publish, and verify the complete reviewed public package set
         run: >-
-          node scripts/api-package-publish.mjs
-          --candidate-directory .artifacts/public-release-candidate/api
+          node scripts/public-release-package-publish.mjs
+          --candidate-directory .artifacts/public-release-candidate
           --expected-source-commit "${{ github.event.workflow_run.head_sha }}"
           --workspace-directory .
-
-      - name: Reconcile, publish, and verify the exact Packaged Factories candidate
-        run: >-
-          node scripts/packaged-factories-package-publish.mjs
-          --candidate-directory .artifacts/public-release-candidate/packaged-factories
-          --expected-source-commit "${{ github.event.workflow_run.head_sha }}"
-          --workspace-directory .
-
-      - name: Publish and verify the canonical frontend package family
-        working-directory: ui
-        run: >-
-          npm run publish:public-packages --
-          --candidate-directory ../.artifacts/public-release-candidate/frontend
-          --tag latest --provenance
 
       - name: Publish GitHub release assets from the tagged commit
         env:

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ endef
 
 .PHONY: generate-api generate-go-api generate-go-server-api generate-go-client-api generate-ui-api generate-wire
 
-.PHONY: wire-smoke api-smoke api-package-pack-smoke packaged-factory-package-smoke packaged-factory-package-script-test packaged-factory-package-pack-check packaged-factory-package-candidate-dry-run packaged-factory-package-consumer-smoke model-provider-package-smoke model-provider-reference-input-smoke
+.PHONY: wire-smoke api-smoke api-package-pack-smoke packaged-factory-package-smoke packaged-factory-package-script-test packaged-factory-package-pack-check packaged-factory-package-candidate-dry-run packaged-factory-package-consumer-smoke public-release-package-smoke model-provider-package-smoke model-provider-reference-input-smoke
 .PHONY: contracts-validate contracts-generate contracts-check contracts-smoke
 
 .PHONY: cli-contract-smoke cli-manifest-generate cli-manifest-check
@@ -205,6 +205,9 @@ packaged-factory-package-candidate-dry-run: packaged-factory-catalog-check
 	node scripts/packaged-factories-package-pr-dry-run.mjs --event-name pull_request --prerequisite-result success --ref refs/pull/local/head --repository portpowered/you-agent-factory --run-id 1 --source-commit $(shell git rev-parse HEAD) --pull-request-head-sha $(shell git rev-parse HEAD) --package-directory packages/packaged-factories --output-directory .artifacts/packaged-factories-local-dry-run --workspace-directory .
 
 packaged-factory-package-consumer-smoke: packaged-factory-package-candidate-dry-run
+
+public-release-package-smoke:
+	node --test scripts/public-package-set.test.mjs scripts/public-release-package-publish.test.mjs scripts/public-release-package-candidate.test.mjs
 
 model-provider-package-smoke:
 	node --test scripts/model-provider-package.test.mjs

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ api-smoke:
 	$(MAKE) provider-parity-smoke
 
 api-package-pack-smoke:
-	node --test scripts/api-package-contract.test.mjs scripts/api-package-pack.test.mjs scripts/api-package-candidate.test.mjs scripts/api-package-registry.test.mjs scripts/api-package-consumer.test.mjs scripts/api-package-pr-dry-run.test.mjs scripts/api-package-publish.test.mjs scripts/api-package-development-workflow.test.mjs
+	node --test scripts/package-export-validation.test.mjs scripts/api-package-contract.test.mjs scripts/api-package-pack.test.mjs scripts/api-package-candidate.test.mjs scripts/api-package-registry.test.mjs scripts/api-package-consumer.test.mjs scripts/api-package-pr-dry-run.test.mjs scripts/api-package-publish.test.mjs scripts/api-package-development-workflow.test.mjs
 
 packaged-factory-package-smoke: packaged-factory-catalog-check packaged-factory-package-script-test
 

--- a/docs/internal/development/cli-release-policy.md
+++ b/docs/internal/development/cli-release-policy.md
@@ -5,14 +5,38 @@ This repository releases from a maintainer-created semantic-version tag on
 checkout; that command verifies readiness and pushes only the tag. GitHub
 Actions owns every publication side effect.
 
-## Data package candidates
+## Public package sets
 
-`@you-agent-factory/api` and
-`@you-agent-factory/packaged-factories` use one candidate identity policy. A
-candidate version has the form
-`0.0.0-dev.<workflow-run-id>.<first-12-source-commit-characters>`. Candidate
-evidence and the staged contract manifest record the same full source commit.
-The checked-in package versions remain the `0.0.0` staging placeholder.
+Development publication covers only the five-package frontend family:
+`@you-agent-factory/client`, `@you-agent-factory/factory-replay`,
+`@you-agent-factory/factory-emulator`, `@you-agent-factory/components`, and
+`@you-agent-factory/factory-visualizers`. Each protected-main candidate uses
+the immutable version
+`0.0.0-dev.<workflow-run-id>.<reviewed-source-commit>`. Pull-request runs
+prepare the same frontend-only shape without publishing it.
+
+Tagged releases use one complete seven-package set. They add
+`@you-agent-factory/api` and `@you-agent-factory/packaged-factories` to the
+frontend family, and every tarball uses the requested stable release version.
+Candidate preparation stages patched manifests in temporary directories; the
+checked-in package versions remain the `0.0.0` staging placeholder.
+
+To prepare the complete tagged-release candidate locally without publishing,
+run this from the repository root with an empty output directory:
+
+```bash
+node scripts/public-release-package-candidate.mjs \
+  --output-directory .artifacts/public-release-candidate \
+  --run-id 1 \
+  --source-commit "$(git rev-parse HEAD)" \
+  --version 1.2.3
+```
+
+The command writes the seven tarballs and their evidence beneath
+`.artifacts/public-release-candidate`. It does not contact the npm publication
+endpoint.
+
+## Packaged Factories contract
 
 The Packaged Factories package is data-only. Its supported npm exports are:
 
@@ -46,18 +70,18 @@ evidence, and installed-consumer evidence.
 
 Pull-request jobs can generate, pack, install, verify, and preserve candidates,
 but they have no npm publication step or publication credentials. The
-Development Package workflow prepares separate API and Packaged Factories
-artifacts from the reviewed pull-request head. A protected `main` run prepares
-and uploads each candidate before a later job downloads and publishes it.
+Development Package workflow prepares only the frontend family from the
+reviewed pull-request head. A protected `main` run preserves that exact
+frontend-only candidate before a later job publishes it with provenance under
+the `dev` distribution tag. API and Packaged Factories artifacts are not part
+of development candidate preparation or publication.
 
-The tagged Release workflow follows the same boundary. One job prepares both
-data-package candidates from
-`github.event.workflow_run.head_sha` and preserves them under distinct artifact
-names. The publication job downloads those candidates, requires their evidence
-to name that exact source commit, and never repacks mutable checkout sources.
-Trusted npm publication uses provenance and the candidate's `dev` distribution
-tag. The frontend package family retains its separate release-version and
-`latest`-tag policy.
+The tagged Release workflow prepares the complete seven-package set from
+`github.event.workflow_run.head_sha` and preserves it as one artifact. The
+publication job requires the top-level and child evidence to name that exact
+source commit and release version, and it never repacks mutable checkout
+sources. Trusted npm publication uses provenance and the `latest` distribution
+tag.
 
 ## Reconciliation and recovery
 

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -280,6 +280,12 @@ Wave 0 functional-tests-expansion planning authority lives under
   commit: API, Packaged Factories, and the canonical frontend family share one
   stable release version, preserve source manifests and frontend build outputs,
   and are recorded exactly once in `release-candidate-evidence.json`. The
+  shared `scripts/package-export-validation.mjs` check rejects any packed API,
+  Packaged Factories, or frontend candidate missing a concrete export target or
+  every match for a wildcard target. Keep the legacy
+  `factories/goal/factory.json` compatibility artifact as a separate Packaged
+  Factories required-file check, outside the general export-map contract, and
+  keep lifecycle scripts disabled for every candidate pack.
   tagged Release workflow uploads that complete set as one artifact and
   publishes only its downloaded package directories after rechecking their
   source commit. Local

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -280,7 +280,10 @@ Wave 0 functional-tests-expansion planning authority lives under
   every match for a wildcard target. Keep the legacy
   `factories/goal/factory.json` compatibility artifact as a separate Packaged
   Factories required-file check, outside the general export-map contract, and
-  keep lifecycle scripts disabled for every candidate pack.
+  keep lifecycle scripts disabled for every candidate pack. Prove that behavior
+  at the API, Packaged Factories, and frontend production packing boundaries
+  with lifecycle-hook sentinel fixtures; command-argument inventory assertions
+  are not sufficient release evidence.
   tagged Release workflow uploads that complete set as one artifact. Its
   `scripts/public-release-package-publish.mjs` boundary rejects unknown scopes,
   duplicates, missing or extra packages, source-commit drift, and child

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -23,10 +23,12 @@
   canonical five-package family, stages manifests with one version and aligned
   internal dependency pins, and writes registry-format tarballs plus evidence
   under `.artifacts/public-packages` by default. The Development Package
-  workflow runs this command as a read-only pull-request dry run, publishes an
-  immutable `dev` version after protected `main` succeeds, and the tagged
-  release workflow publishes the release semver under `latest`. Publication
-  uses npm trusted publishing and verifies every exact version after upload.
+  workflow runs this command as a frontend-only pull-request dry run and
+  publishes only this family at an immutable `dev` version after protected
+  `main` succeeds. API and Packaged Factories join the frontend family only in
+  the complete tagged-release candidate, which publishes one release semver
+  under `latest`. Publication uses npm trusted publishing and verifies every
+  exact version after upload.
 
 - `.github/workflows/ci.yml` owns pull-request and `main` CI lane scheduling.
   Build, Lint, and API are independent Ubuntu jobs, respectively rerunnable
@@ -257,24 +259,11 @@ Wave 0 functional-tests-expansion planning authority lives under
   scripts, lockfiles, workspaces, and links, resolve artifacts only through
   public package specifiers, and validate both generated representations
   against the installed schema before removing the consumer.
-  Pull-request authorization is shared through
-  `scripts/package-development-policy.mjs`; keep the API compatibility re-export
-  and require every candidate to match the reviewed full head SHA after
-  prerequisites succeed. The Development Package pull-request job runs
-  `scripts/packaged-factories-package-pr-dry-run.mjs` without registry access
-  and preserves the exact tarball, candidate evidence, consumer evidence, and
-  no-publish outcome for review. Keep generation, identity, inventory, pack,
-  and installed-consumer failures stage-specific.
-  Protected-main publication must download that package's preserved candidate,
-  rebind its evidence source commit to the protected workflow head, and use the
-  shared `scripts/package-registry.mjs` and
-  `scripts/package-publication.mjs` mechanics. Package wrappers own exact npm
-  identity and installed-consumer semantics; shared orchestration owns local
-  digest verification, immutable-version reconciliation, publish-at-most-once
-  behavior, and bounded retries for transient lookup, download, visibility, and
-  registry-consumer install failures. Candidate identity/digest, immutable
-  conflict, registry integrity, authentication, permission, and installed-data
-  contract failures remain fail-fast and retain classified diagnostics.
+  The data-package development policy and dry-run helpers remain available as
+  focused local verification tools, but the Development Package workflow does
+  not prepare or publish API or Packaged Factories candidates. Protected-main
+  development publication preserves and publishes only the frontend family at
+  `0.0.0-dev.<run-id>.<reviewed-source-commit>`.
   `scripts/public-release-package-candidate.mjs` prepares the tagged-release
   candidate set from the successful release-candidate workflow's exact head
   commit: API, Packaged Factories, and the canonical frontend family share one

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -30,6 +30,12 @@
   under `latest`. Publication uses npm trusted publishing and verifies every
   exact version after upload.
 
+- `make public-release-package-smoke` is the required complete-set release
+  behavior gate. It exercises scope validation, real seven-package candidate
+  preparation, and protected publication preflight from the repository root on
+  every Development Package workflow run. Keep the command portable when it
+  invokes npm outside an npm script, including on Windows.
+
 - `.github/workflows/ci.yml` owns pull-request and `main` CI lane scheduling.
   Build, Lint, and API are independent Ubuntu jobs, respectively rerunnable
   with `make verify-build`, `make verify-lint`, and `make verify-api`. Keep
@@ -278,8 +284,9 @@ Wave 0 functional-tests-expansion planning authority lives under
   tagged Release workflow uploads that complete set as one artifact. Its
   `scripts/public-release-package-publish.mjs` boundary rejects unknown scopes,
   duplicates, missing or extra packages, source-commit drift, and child
-  evidence or tarball paths that do not match the reviewed top-level evidence
-  before publishing any package. The frontend publisher accepts only the
+  evidence or tarball paths that do not match the reviewed top-level evidence,
+  and preflights every represented tarball against all recorded artifact
+  digests before publishing any package. The frontend publisher accepts only the
   `frontend-only` development scope, while the protected tagged publisher
   requires the complete `tagged-release` scope. Local
   maintainers can isolate generation, drift, script tests, exact packing,

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -275,10 +275,14 @@ Wave 0 functional-tests-expansion planning authority lives under
   registry-consumer install failures. Candidate identity/digest, immutable
   conflict, registry integrity, authentication, permission, and installed-data
   contract failures remain fail-fast and retain classified diagnostics.
-  The tagged Release workflow prepares API and Packaged Factories candidates
-  together from the successful release-candidate workflow's exact head commit,
-  uploads them under separate artifact names, and publishes only those
-  downloaded directories after rechecking their source commit. Local
+  `scripts/public-release-package-candidate.mjs` prepares the tagged-release
+  candidate set from the successful release-candidate workflow's exact head
+  commit: API, Packaged Factories, and the canonical frontend family share one
+  stable release version, preserve source manifests and frontend build outputs,
+  and are recorded exactly once in `release-candidate-evidence.json`. The
+  tagged Release workflow uploads that complete set as one artifact and
+  publishes only its downloaded package directories after rechecking their
+  source commit. Local
   maintainers can isolate generation, drift, script tests, exact packing,
   pull-request dry-run, and clean-consumer behavior through the focused
   `packaged-factory-*` Make targets documented in

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -286,9 +286,13 @@ Wave 0 functional-tests-expansion planning authority lives under
   `factories/goal/factory.json` compatibility artifact as a separate Packaged
   Factories required-file check, outside the general export-map contract, and
   keep lifecycle scripts disabled for every candidate pack.
-  tagged Release workflow uploads that complete set as one artifact and
-  publishes only its downloaded package directories after rechecking their
-  source commit. Local
+  tagged Release workflow uploads that complete set as one artifact. Its
+  `scripts/public-release-package-publish.mjs` boundary rejects unknown scopes,
+  duplicates, missing or extra packages, source-commit drift, and child
+  evidence or tarball paths that do not match the reviewed top-level evidence
+  before publishing any package. The frontend publisher accepts only the
+  `frontend-only` development scope, while the protected tagged publisher
+  requires the complete `tagged-release` scope. Local
   maintainers can isolate generation, drift, script tests, exact packing,
   pull-request dry-run, and clean-consumer behavior through the focused
   `packaged-factory-*` Make targets documented in

--- a/packages/packaged-factories/package.json
+++ b/packages/packaged-factories/package.json
@@ -13,6 +13,7 @@
   "files": [
     "README.md",
     "LICENSE.md",
+    "factories/goal/factory.json",
     "generated/manifest.json",
     "generated/factories",
     "schemas/factory.schema.json",

--- a/scripts/api-package-candidate.mjs
+++ b/scripts/api-package-candidate.mjs
@@ -25,6 +25,7 @@ export async function prepareCandidate({
 	runId,
 	sourceCommit,
 	version,
+	distTag,
 }) {
 	return prepareReleaseCandidate({
 		packageDirectory,
@@ -33,6 +34,7 @@ export async function prepareCandidate({
 		sourceCommit,
 		packageName: API_PACKAGE_NAME,
 		version,
+		distTag,
 		pack: packAndVerify,
 	});
 }

--- a/scripts/api-package-candidate.mjs
+++ b/scripts/api-package-candidate.mjs
@@ -6,6 +6,7 @@ import { packAndVerify } from "./api-package-pack.mjs";
 import {
 	DEVELOPMENT_DIST_TAG,
 	SHORT_SHA_LENGTH,
+	assertReleaseVersion,
 	deriveCandidateVersion,
 	prepareReleaseCandidate,
 } from "./package-release-candidate.mjs";
@@ -14,6 +15,7 @@ export const API_PACKAGE_NAME = "@you-agent-factory/api";
 export {
 	DEVELOPMENT_DIST_TAG,
 	SHORT_SHA_LENGTH,
+	assertReleaseVersion,
 	deriveCandidateVersion,
 };
 
@@ -22,6 +24,7 @@ export async function prepareCandidate({
 	outputDirectory,
 	runId,
 	sourceCommit,
+	version,
 }) {
 	return prepareReleaseCandidate({
 		packageDirectory,
@@ -29,6 +32,7 @@ export async function prepareCandidate({
 		runId,
 		sourceCommit,
 		packageName: API_PACKAGE_NAME,
+		version,
 		pack: packAndVerify,
 	});
 }
@@ -40,6 +44,7 @@ async function main() {
 			"package-directory": { type: "string" },
 			"run-id": { type: "string" },
 			"source-commit": { type: "string" },
+			version: { type: "string" },
 		},
 		strict: true,
 	});
@@ -48,6 +53,7 @@ async function main() {
 		outputDirectory: values["output-directory"],
 		runId: values["run-id"],
 		sourceCommit: values["source-commit"],
+		version: values.version,
 	});
 	process.stdout.write(`${JSON.stringify(result.evidence)}\n`);
 }

--- a/scripts/api-package-candidate.test.mjs
+++ b/scripts/api-package-candidate.test.mjs
@@ -66,6 +66,29 @@ test("candidate identity rejects incomplete or non-canonical inputs", () => {
 	}
 });
 
+test("tagged release candidates use the requested stable release version", async (t) => {
+	const outputDirectory = await temporaryDirectory(t, "you-api-release-candidate-");
+	const result = await prepareCandidate({
+		packageDirectory,
+		outputDirectory,
+		runId: "42",
+		sourceCommit,
+		version: "1.2.3",
+	});
+
+	assert.equal(result.evidence.candidateVersion, "1.2.3");
+	await assert.rejects(
+		prepareCandidate({
+			packageDirectory,
+			outputDirectory: await temporaryDirectory(t, "you-api-invalid-release-"),
+			runId: "42",
+			sourceCommit,
+			version: "1.2.3-rc.1",
+		}),
+		/release version must be a stable semantic version/,
+	);
+});
+
 test("preparation packs one attributable candidate without mutating package sources", async (t) => {
 	const outputDirectory = await temporaryDirectory(t, "you-api-candidate-output-");
 	const packageManifestPath = join(packageDirectory, "package.json");

--- a/scripts/api-package-pack.mjs
+++ b/scripts/api-package-pack.mjs
@@ -1,6 +1,8 @@
 import { spawn } from "node:child_process";
-import { access } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
+
+import { assertPackedExportTargets } from "./package-export-validation.mjs";
 
 export const REVIEWED_PACK_FILES = Object.freeze([
 	"README.md",
@@ -153,6 +155,13 @@ export async function packPackage({ packageDirectory, packDestination }) {
 
 export async function packAndVerify(input) {
 	const packed = await packPackage(input);
+	const manifest = JSON.parse(
+		await readFile(
+			join(resolve(input.packageDirectory), "package.json"),
+			"utf8",
+		),
+	);
+	assertPackedExportTargets(packed.packageName, manifest.exports, packed.files);
 	assertReviewedInventory(packed.files);
 	return packed;
 }

--- a/scripts/api-package-pack.test.mjs
+++ b/scripts/api-package-pack.test.mjs
@@ -1,82 +1,128 @@
 import assert from "node:assert/strict";
-import { cp, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import {
+	cp,
+	mkdir,
+	mkdtemp,
+	readFile,
+	rm,
+	unlink,
+	writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import {
-  REVIEWED_PACK_FILES,
-  packAndVerify,
-} from "./api-package-pack.mjs";
+import { packAndVerify, REVIEWED_PACK_FILES } from "./api-package-pack.mjs";
 
-const packageDirectory = fileURLToPath(new URL("../packages/api", import.meta.url));
+const packageDirectory = fileURLToPath(
+	new URL("../packages/api", import.meta.url),
+);
 
 async function temporaryDirectory(t, name) {
-  const directory = await mkdtemp(join(tmpdir(), name));
-  t.after(() => rm(directory, { recursive: true, force: true }));
-  return directory;
+	const directory = await mkdtemp(join(tmpdir(), name));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	return directory;
 }
 
 test("real npm tarball contains the complete reviewed inventory deterministically", async (t) => {
-  const firstDestination = await temporaryDirectory(t, "you-api-pack-first-");
-  const secondDestination = await temporaryDirectory(t, "you-api-pack-second-");
+	const firstDestination = await temporaryDirectory(t, "you-api-pack-first-");
+	const secondDestination = await temporaryDirectory(t, "you-api-pack-second-");
 
-  const first = await packAndVerify({
-    packageDirectory,
-    packDestination: firstDestination,
-  });
-  const second = await packAndVerify({
-    packageDirectory,
-    packDestination: secondDestination,
-  });
+	const first = await packAndVerify({
+		packageDirectory,
+		packDestination: firstDestination,
+	});
+	const second = await packAndVerify({
+		packageDirectory,
+		packDestination: secondDestination,
+	});
 
-  assert.deepEqual(
-    first.files,
-    [...REVIEWED_PACK_FILES].sort((left, right) => left.localeCompare(right)),
-  );
-  assert.deepEqual(second.files, first.files);
-  assert.notEqual(first.tarballPath, second.tarballPath);
+	assert.deepEqual(
+		first.files,
+		[...REVIEWED_PACK_FILES].sort((left, right) => left.localeCompare(right)),
+	);
+	assert.deepEqual(second.files, first.files);
+	assert.notEqual(first.tarballPath, second.tarballPath);
 });
 
 test("real npm tarball reports every forbidden admitted path deterministically", async (t) => {
-  const fixtureRoot = await temporaryDirectory(t, "you-api-pack-forbidden-");
-  const fixturePackage = join(fixtureRoot, "package");
-  const packDestination = join(fixtureRoot, "packed");
-  await cp(packageDirectory, fixturePackage, { recursive: true });
-  await mkdir(packDestination);
+	const fixtureRoot = await temporaryDirectory(t, "you-api-pack-forbidden-");
+	const fixturePackage = join(fixtureRoot, "package");
+	const packDestination = join(fixtureRoot, "packed");
+	await cp(packageDirectory, fixturePackage, { recursive: true });
+	await mkdir(packDestination);
 
-  const manifestPath = join(fixturePackage, "package.json");
-  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
-  manifest.files = ["README.md", "LICENSE.md", "generated"];
-  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+	const manifestPath = join(fixturePackage, "package.json");
+	const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+	manifest.files = ["README.md", "LICENSE.md", "generated"];
+	await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 
-  const forbiddenFiles = [
-    "generated/cache/contracts/data.json",
-    "generated/client/openapi.ts",
-    "generated/components/foo.json",
-    "generated/javascript/runtime.js",
-    "generated/runtime/you.exe",
-    "generated/ui/App.tsx",
-    "generated/unrelated.json",
-    "generated/validators/factory.js",
-  ];
-  for (const path of forbiddenFiles) {
-    const target = join(fixturePackage, ...path.split("/"));
-    await mkdir(dirname(target), { recursive: true });
-    await writeFile(target, path);
-  }
+	const forbiddenFiles = [
+		"generated/cache/contracts/data.json",
+		"generated/client/openapi.ts",
+		"generated/components/foo.json",
+		"generated/javascript/runtime.js",
+		"generated/runtime/you.exe",
+		"generated/ui/App.tsx",
+		"generated/unrelated.json",
+		"generated/validators/factory.js",
+	];
+	for (const path of forbiddenFiles) {
+		const target = join(fixturePackage, ...path.split("/"));
+		await mkdir(dirname(target), { recursive: true });
+		await writeFile(target, path);
+	}
 
-  await assert.rejects(
-    packAndVerify({ packageDirectory: fixturePackage, packDestination }),
-    (error) => {
-      const expected = [
-        "[api-package-pack] tarball inventory rejected",
-        "unexpected package files:",
-        ...forbiddenFiles.map((path) => `  ${path}`),
-      ].join("\n");
-      assert.equal(error.message, expected);
-      return true;
-    },
-  );
+	await assert.rejects(
+		packAndVerify({ packageDirectory: fixturePackage, packDestination }),
+		(error) => {
+			const expected = [
+				"[api-package-pack] tarball inventory rejected",
+				"unexpected package files:",
+				...forbiddenFiles.map((path) => `  ${path}`),
+			].join("\n");
+			assert.equal(error.message, expected);
+			return true;
+		},
+	);
+});
+
+test("real npm tarball rejects a missing concrete export target", async (t) => {
+	const fixtureRoot = await temporaryDirectory(t, "you-api-pack-concrete-");
+	const fixturePackage = join(fixtureRoot, "package");
+	await cp(packageDirectory, fixturePackage, { recursive: true });
+	await unlink(join(fixturePackage, "generated", "openapi", "openapi.yaml"));
+
+	await assert.rejects(
+		packAndVerify({
+			packageDirectory: fixturePackage,
+			packDestination: fixtureRoot,
+		}),
+		{
+			message:
+				"@you-agent-factory/api candidate omits export target generated/openapi/openapi.yaml",
+		},
+	);
+});
+
+test("real npm tarball rejects an unmatched wildcard export target", async (t) => {
+	const fixtureRoot = await temporaryDirectory(t, "you-api-pack-wildcard-");
+	const fixturePackage = join(fixtureRoot, "package");
+	await cp(packageDirectory, fixturePackage, { recursive: true });
+	await rm(join(fixturePackage, "generated", "joined"), {
+		recursive: true,
+		force: true,
+	});
+
+	await assert.rejects(
+		packAndVerify({
+			packageDirectory: fixturePackage,
+			packDestination: fixtureRoot,
+		}),
+		{
+			message:
+				"@you-agent-factory/api candidate omits export target generated/joined/*",
+		},
+	);
 });

--- a/scripts/api-package-pack.test.mjs
+++ b/scripts/api-package-pack.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+	access,
 	cp,
 	mkdir,
 	mkdtemp,
@@ -24,6 +25,32 @@ async function temporaryDirectory(t, name) {
 	t.after(() => rm(directory, { recursive: true, force: true }));
 	return directory;
 }
+
+test("candidate packing suppresses lifecycle script side effects", async (t) => {
+	const fixtureRoot = await temporaryDirectory(t, "you-api-pack-lifecycle-");
+	const fixturePackage = join(fixtureRoot, "package");
+	const packDestination = join(fixtureRoot, "packed");
+	const sentinel = join(fixtureRoot, "lifecycle-ran");
+	await cp(packageDirectory, fixturePackage, { recursive: true });
+	await mkdir(packDestination);
+
+	const manifestPath = join(fixturePackage, "package.json");
+	const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+	manifest.scripts = { prepack: "node create-sentinel.mjs" };
+	await Promise.all([
+		writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`),
+		writeFile(
+			join(fixturePackage, "create-sentinel.mjs"),
+			`import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(sentinel)}, "ran");\n`,
+		),
+	]);
+
+	await packAndVerify({
+		packageDirectory: fixturePackage,
+		packDestination,
+	});
+	await assert.rejects(access(sentinel), { code: "ENOENT" });
+});
 
 test("real npm tarball contains the complete reviewed inventory deterministically", async (t) => {
 	const firstDestination = await temporaryDirectory(t, "you-api-pack-first-");

--- a/scripts/api-package-publish.test.mjs
+++ b/scripts/api-package-publish.test.mjs
@@ -215,6 +215,7 @@ test("publish directory loads the preserved candidate and cleans its external co
 	const result = await publishCandidateDirectory(
 		{
 			candidateDirectory: "/preserved",
+			expectedDistTag: "latest",
 			expectedSourceCommit: evidence.sourceCommit,
 			workspaceDirectory: "/workspace",
 		},
@@ -227,6 +228,7 @@ test("publish directory loads the preserved candidate and cleans its external co
 				consumerDirectory = input.consumerDirectory;
 				await access(consumerDirectory);
 				assert.equal(input.evidence, evidence);
+				assert.equal(input.expectedDistTag, "latest");
 				assert.equal(input.registryClient, registryClient);
 				assert.equal(input.tarballPath, "/preserved/candidate.tgz");
 				assert.equal(input.workspaceDirectory, "/workspace");

--- a/scripts/api-package-registry.mjs
+++ b/scripts/api-package-registry.mjs
@@ -26,7 +26,7 @@ export function reconcileCandidate(input) {
 	return reconcilePackageCandidate({
 		...input,
 		expectedPackageName: API_PACKAGE_NAME,
-		expectedDistTag: DEVELOPMENT_DIST_TAG,
+		expectedDistTag: input.expectedDistTag ?? DEVELOPMENT_DIST_TAG,
 	});
 }
 

--- a/scripts/api-package-registry.test.mjs
+++ b/scripts/api-package-registry.test.mjs
@@ -70,6 +70,26 @@ test("absent version returns one publish decision without mutating registry stat
 	assert.deepEqual(registryClient.calls, { lookup: 1, download: 0, publish: 0 });
 });
 
+test("stable latest candidate is accepted by protected release reconciliation", async (t) => {
+	const candidate = await candidateFixture(t);
+	candidate.evidence.candidateVersion = "1.2.3";
+	candidate.evidence.distTag = "latest";
+	const registryClient = registrySpy({
+		lookup: async () => ({ status: "absent" }),
+		download: async () => assert.fail("absent versions must not be downloaded"),
+	});
+
+	const result = await reconcileCandidate({
+		...candidate,
+		expectedDistTag: "latest",
+		registryClient,
+	});
+
+	assert.equal(result.outcome, RECONCILIATION_OUTCOMES.PUBLISH_REQUIRED);
+	assert.equal(result.candidateVersion, "1.2.3");
+	assert.equal(result.distTag, "latest");
+});
+
 test("matching existing version is verified without publish or tag mutation", async (t) => {
 	const candidate = await candidateFixture(t);
 	const registryClient = registrySpy({

--- a/scripts/package-export-validation.mjs
+++ b/scripts/package-export-validation.mjs
@@ -1,0 +1,51 @@
+function normalizedPackedPath(file) {
+	const path = typeof file === "string" ? file : file?.path;
+	return typeof path === "string"
+		? path.replaceAll("\\", "/").replace(/^package\//, "")
+		: null;
+}
+
+function exportTargets(value) {
+	if (typeof value === "string") {
+		return [value.replace(/^\.\//, "")];
+	}
+	if (Array.isArray(value)) {
+		return value.flatMap(exportTargets);
+	}
+	if (typeof value === "object" && value !== null) {
+		return Object.values(value).flatMap(exportTargets);
+	}
+	return [];
+}
+
+function matchesTarget(path, target) {
+	const wildcard = target.indexOf("*");
+	if (wildcard === -1) {
+		return path === target;
+	}
+	const prefix = target.slice(0, wildcard);
+	const suffix = target.slice(wildcard + 1);
+	return path.startsWith(prefix) && path.endsWith(suffix);
+}
+
+function packedPathSet(files) {
+	return new Set((files ?? []).map(normalizedPackedPath).filter(Boolean));
+}
+
+export function assertPackedExportTargets(packageName, exports, files) {
+	const packedPaths = packedPathSet(files);
+	for (const target of new Set(exportTargets(exports))) {
+		if (![...packedPaths].some((path) => matchesTarget(path, target))) {
+			throw new Error(`${packageName} candidate omits export target ${target}`);
+		}
+	}
+}
+
+export function assertPackedRequiredFiles(packageName, requiredFiles, files) {
+	const packedPaths = packedPathSet(files);
+	for (const requiredFile of requiredFiles) {
+		if (!packedPaths.has(requiredFile)) {
+			throw new Error(`${packageName} candidate omits ${requiredFile}`);
+		}
+	}
+}

--- a/scripts/package-export-validation.test.mjs
+++ b/scripts/package-export-validation.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	assertPackedExportTargets,
+	assertPackedRequiredFiles,
+} from "./package-export-validation.mjs";
+
+const packageName = "@you-agent-factory/example";
+const exports = {
+	".": {
+		types: "./dist/index.d.ts",
+		import: "./dist/index.js",
+		default: "./dist/index.js",
+	},
+	"./styles.css": "./dist/styles.css",
+	"./joined/*": "./generated/joined/*",
+};
+
+test("complete concrete and wildcard export targets are accepted", () => {
+	assert.doesNotThrow(() =>
+		assertPackedExportTargets(packageName, exports, [
+			{ path: "dist/index.d.ts" },
+			{ path: "dist/index.js" },
+			{ path: "dist/styles.css" },
+			{ path: "generated/joined/contracts/manifest.schema.json" },
+		]),
+	);
+});
+
+test("a missing concrete export reports its package and target", () => {
+	assert.throws(
+		() =>
+			assertPackedExportTargets(packageName, exports, [
+				"dist/index.d.ts",
+				"dist/index.js",
+				"generated/joined/contracts/manifest.schema.json",
+			]),
+		{
+			message: `${packageName} candidate omits export target dist/styles.css`,
+		},
+	);
+});
+
+test("an unmatched wildcard export reports its package and pattern", () => {
+	assert.throws(
+		() =>
+			assertPackedExportTargets(packageName, exports, [
+				"dist/index.d.ts",
+				"dist/index.js",
+				"dist/styles.css",
+			]),
+		{
+			message: `${packageName} candidate omits export target generated/joined/*`,
+		},
+	);
+});
+
+test("required compatibility files are checked separately from exports", () => {
+	const required = ["factories/goal/factory.json"];
+	assert.doesNotThrow(() =>
+		assertPackedRequiredFiles(packageName, required, [
+			{ path: "factories/goal/factory.json" },
+		]),
+	);
+	assert.throws(
+		() =>
+			assertPackedRequiredFiles(packageName, required, [
+				{ path: "generated/factories/goal/factory.json" },
+			]),
+		{
+			message: `${packageName} candidate omits factories/goal/factory.json`,
+		},
+	);
+});

--- a/scripts/package-publication.mjs
+++ b/scripts/package-publication.mjs
@@ -174,6 +174,7 @@ async function retryRegistryOperation({
 
 async function verifyPublishedRegistryState({
 	evidence,
+	expectedDistTag,
 	tarballPath,
 	registryClient,
 	reconcile,
@@ -188,6 +189,7 @@ async function verifyPublishedRegistryState({
 		async operation() {
 			const result = await reconcile({
 				evidence,
+				expectedDistTag,
 				tarballPath,
 				registryClient,
 			});
@@ -211,6 +213,7 @@ async function verifyPublishedRegistryState({
 
 async function reconcileInitialRegistryState({
 	evidence,
+	expectedDistTag,
 	tarballPath,
 	registryClient,
 	reconcile,
@@ -222,7 +225,8 @@ async function reconcileInitialRegistryState({
 		attempts: verificationAttempts,
 		delayMs: verificationDelayMs,
 		sleep,
-		operation: () => reconcile({ evidence, tarballPath, registryClient }),
+		operation: () =>
+			reconcile({ evidence, expectedDistTag, tarballPath, registryClient }),
 		exhaustedFailure(lastError) {
 			return lastError;
 		},
@@ -255,6 +259,7 @@ export async function publishAndVerifyCandidate(
 	{
 		consumerDirectory,
 		evidence,
+		expectedDistTag,
 		registryClient,
 		tarballPath,
 		workspaceDirectory,
@@ -270,6 +275,7 @@ export async function publishAndVerifyCandidate(
 	const sleep = dependencies.sleep ?? wait;
 	const initial = await reconcileInitialRegistryState({
 		evidence,
+		expectedDistTag,
 		tarballPath,
 		registryClient,
 		reconcile,
@@ -296,6 +302,7 @@ export async function publishAndVerifyCandidate(
 		try {
 			await verifyPublishedRegistryState({
 				evidence,
+				expectedDistTag,
 				tarballPath,
 				registryClient,
 				reconcile,
@@ -349,7 +356,12 @@ async function candidateFiles(candidateDirectory) {
 }
 
 export async function publishCandidateDirectory(
-	{ candidateDirectory, expectedSourceCommit, workspaceDirectory },
+	{
+		candidateDirectory,
+		expectedDistTag,
+		expectedSourceCommit,
+		workspaceDirectory,
+	},
 	dependencies,
 ) {
 	const loadCandidate = dependencies.candidateFiles ?? candidateFiles;
@@ -372,6 +384,7 @@ export async function publishCandidateDirectory(
 		return await publishAndVerify({
 			...candidate,
 			consumerDirectory,
+			expectedDistTag,
 			registryClient,
 			workspaceDirectory,
 		});

--- a/scripts/package-registry.mjs
+++ b/scripts/package-registry.mjs
@@ -24,6 +24,7 @@ const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/;
 const SOURCE_COMMIT_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
 const CANDIDATE_VERSION_PATTERN =
 	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-dev\.([1-9]\d*)\.([0-9a-f]{12})$/;
+const RELEASE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const DEFAULT_REGISTRY_TIMEOUT_MS = 30_000;
 
 export class RegistryReconciliationError extends Error {
@@ -52,11 +53,16 @@ function requireCandidateEvidence(
 	const versionMatch = CANDIDATE_VERSION_PATTERN.exec(
 		evidence.candidateVersion,
 	);
+	const releaseVersionMatches =
+		expectedDistTag === "latest" &&
+		RELEASE_VERSION_PATTERN.test(evidence.candidateVersion ?? "");
+	const developmentVersionMatches =
+		expectedDistTag === "dev" &&
+		versionMatch?.[5] === evidence.sourceCommit?.slice(0, 12);
 	if (
 		evidence.packageName !== expectedPackageName ||
-		!versionMatch ||
+		(!developmentVersionMatches && !releaseVersionMatches) ||
 		!SOURCE_COMMIT_PATTERN.test(evidence.sourceCommit ?? "") ||
-		versionMatch[5] !== evidence.sourceCommit.slice(0, 12) ||
 		!SHA256_PATTERN.test(evidence.contractDigest ?? "") ||
 		!SHA256_PATTERN.test(evidence.artifactDigest ?? "") ||
 		!Array.isArray(evidence.inventory) ||

--- a/scripts/package-release-candidate.mjs
+++ b/scripts/package-release-candidate.mjs
@@ -50,6 +50,26 @@ export function deriveCandidateVersion({ baseVersion, runId, sourceCommit }) {
 	return `${validatedBaseVersion}-dev.${validatedRunId}.${validatedSourceCommit.slice(0, SHORT_SHA_LENGTH)}`;
 }
 
+export function assertReleaseVersion(version) {
+	const validatedVersion = requireString(version, "release version");
+	if (!STABLE_SEMVER_PATTERN.test(validatedVersion)) {
+		throw new Error(
+			"[package-release-candidate] release version must be a stable semantic version",
+		);
+	}
+	return validatedVersion;
+}
+
+export function assertSourceCommit(sourceCommit) {
+	const validatedSourceCommit = requireString(sourceCommit, "source commit");
+	if (!SOURCE_COMMIT_PATTERN.test(validatedSourceCommit)) {
+		throw new Error(
+			"[package-release-candidate] source commit must be a full lowercase Git object ID",
+		);
+	}
+	return validatedSourceCommit;
+}
+
 async function sha256(path) {
 	return `sha256:${createHash("sha256").update(await readFile(path)).digest("hex")}`;
 }
@@ -96,6 +116,7 @@ export async function prepareReleaseCandidate({
 	runId,
 	sourceCommit,
 	packageName,
+	version,
 	contractManifestPath = "generated/manifest.json",
 	distTag = DEVELOPMENT_DIST_TAG,
 	pack,
@@ -117,11 +138,15 @@ export async function prepareReleaseCandidate({
 			`[package-release-candidate] package name must be ${expectedPackageName}`,
 		);
 	}
-	const candidateVersion = deriveCandidateVersion({
-		baseVersion: manifest.version,
-		runId,
-		sourceCommit,
-	});
+	const validatedSourceCommit = assertSourceCommit(sourceCommit);
+	const candidateVersion =
+		version === undefined
+			? deriveCandidateVersion({
+				baseVersion: manifest.version,
+				runId,
+				sourceCommit: validatedSourceCommit,
+			})
+			: assertReleaseVersion(version);
 
 	await requireEmptyOutputDirectory(outputRoot);
 	const stagingRoot = await mkdtemp(
@@ -137,7 +162,7 @@ export async function prepareReleaseCandidate({
 		const stagedContractManifest = await stageProvenance(
 			stagedPackage,
 			contractManifestPath,
-			sourceCommit,
+			validatedSourceCommit,
 		);
 
 		const packed = await pack({
@@ -156,7 +181,7 @@ export async function prepareReleaseCandidate({
 		const evidence = {
 			packageName: packed.packageName,
 			candidateVersion,
-			sourceCommit,
+			sourceCommit: validatedSourceCommit,
 			contractDigest: await sha256(stagedContractManifest),
 			artifactDigest: await sha256(packed.tarballPath),
 			inventory: [...packed.files].sort((left, right) =>

--- a/scripts/packaged-factories-package-candidate.mjs
+++ b/scripts/packaged-factories-package-candidate.mjs
@@ -24,6 +24,7 @@ export async function prepareCandidate({
 	runId,
 	sourceCommit,
 	version,
+	distTag,
 	verifyGeneratedCatalog = runCatalogDriftCheck,
 }) {
 	const repositoryRoot = resolve(packageDirectory, "..", "..");
@@ -35,6 +36,7 @@ export async function prepareCandidate({
 		sourceCommit,
 		packageName: PACKAGED_FACTORIES_PACKAGE_NAME,
 		version,
+		distTag,
 		pack: packAndVerify,
 	});
 }

--- a/scripts/packaged-factories-package-candidate.mjs
+++ b/scripts/packaged-factories-package-candidate.mjs
@@ -4,6 +4,7 @@ import { parseArgs } from "node:util";
 
 import {
 	DEVELOPMENT_DIST_TAG,
+	assertReleaseVersion,
 	deriveCandidateVersion,
 	prepareReleaseCandidate,
 } from "./package-release-candidate.mjs";
@@ -15,13 +16,14 @@ import {
 export const PACKAGED_FACTORIES_PACKAGE_NAME =
 	"@you-agent-factory/packaged-factories";
 
-export { DEVELOPMENT_DIST_TAG, deriveCandidateVersion };
+export { DEVELOPMENT_DIST_TAG, assertReleaseVersion, deriveCandidateVersion };
 
 export async function prepareCandidate({
 	packageDirectory,
 	outputDirectory,
 	runId,
 	sourceCommit,
+	version,
 	verifyGeneratedCatalog = runCatalogDriftCheck,
 }) {
 	const repositoryRoot = resolve(packageDirectory, "..", "..");
@@ -32,6 +34,7 @@ export async function prepareCandidate({
 		runId,
 		sourceCommit,
 		packageName: PACKAGED_FACTORIES_PACKAGE_NAME,
+		version,
 		pack: packAndVerify,
 	});
 }
@@ -43,6 +46,7 @@ async function main() {
 			"package-directory": { type: "string" },
 			"run-id": { type: "string" },
 			"source-commit": { type: "string" },
+			version: { type: "string" },
 		},
 		strict: true,
 	});
@@ -51,6 +55,7 @@ async function main() {
 		outputDirectory: values["output-directory"],
 		runId: values["run-id"],
 		sourceCommit: values["source-commit"],
+		version: values.version,
 	});
 	process.stdout.write(`${JSON.stringify(result.evidence)}\n`);
 }

--- a/scripts/packaged-factories-package-candidate.test.mjs
+++ b/scripts/packaged-factories-package-candidate.test.mjs
@@ -44,6 +44,7 @@ function expectedInventory(contractManifest) {
 		factory.yaml.locator,
 	]);
 	return [
+		"factories/goal/factory.json",
 		"LICENSE.md",
 		"README.md",
 		"generated/README.md",

--- a/scripts/packaged-factories-package-pack.mjs
+++ b/scripts/packaged-factories-package-pack.mjs
@@ -3,10 +3,19 @@ import { createHash } from "node:crypto";
 import { access, lstat, readFile, realpath } from "node:fs/promises";
 import { isAbsolute, join, relative, resolve } from "node:path";
 
+import {
+	assertPackedExportTargets,
+	assertPackedRequiredFiles,
+} from "./package-export-validation.mjs";
+
 const DIAGNOSTIC_PREFIX = "[packaged-factories-package-pack]";
+export const REQUIRED_COMPATIBILITY_FILES = Object.freeze([
+	"factories/goal/factory.json",
+]);
 const STATIC_PACK_FILES = Object.freeze([
 	"LICENSE.md",
 	"README.md",
+	...REQUIRED_COMPATIBILITY_FILES,
 	"generated/README.md",
 	"generated/manifest.json",
 	"package.json",
@@ -360,6 +369,16 @@ export async function packAndVerify({
 	await assertNoSymlinkFiles(packageRoot, expectedFiles);
 	const stdout = await npmPack(packageRoot, destination);
 	const report = parsePackReport(stdout);
+	const packageManifest = await readJSON(
+		join(packageRoot, "package.json"),
+		"package manifest",
+	);
+	assertPackedExportTargets(report.name, packageManifest.exports, report.files);
+	assertPackedRequiredFiles(
+		report.name,
+		REQUIRED_COMPATIBILITY_FILES,
+		report.files,
+	);
 	assertReviewedInventory(report.files, expectedFiles);
 	await assertRegularContainedFiles(packageRoot, expectedFiles);
 	const artifactFiles = expectedFiles.filter((path) =>

--- a/scripts/packaged-factories-package-pack.test.mjs
+++ b/scripts/packaged-factories-package-pack.test.mjs
@@ -174,6 +174,19 @@ test("repository-relative flattened artifact dependencies are rejected", async (
 	);
 });
 
+test("missing Goal factory compatibility artifact is rejected separately", async (t) => {
+	const { packageRoot, packDestination } = await fixturePackage(t);
+	await unlink(join(packageRoot, "factories", "goal", "factory.json"));
+
+	await assert.rejects(
+		packAndVerify({ packageDirectory: packageRoot, packDestination }),
+		{
+			message:
+				"@you-agent-factory/packaged-factories candidate omits factories/goal/factory.json",
+		},
+	);
+});
+
 test("npm report digest mismatch is rejected", async (t) => {
 	const { packageRoot, packDestination } = await fixturePackage(t);
 	const tarball = join(packDestination, "candidate.tgz");

--- a/scripts/packaged-factories-package-pack.test.mjs
+++ b/scripts/packaged-factories-package-pack.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import {
+	access,
 	cp,
 	mkdir,
 	mkdtemp,
@@ -16,7 +17,6 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
-	npmPackArguments,
 	packAndVerify,
 	reviewedPackFiles,
 } from "./packaged-factories-package-pack.mjs";
@@ -37,6 +37,24 @@ async function fixturePackage(t) {
 	await cp(packageDirectory, packageRoot, { recursive: true });
 	return { packageRoot, packDestination: root };
 }
+
+test("candidate packing suppresses lifecycle script side effects", async (t) => {
+	const { packageRoot, packDestination } = await fixturePackage(t);
+	const sentinel = join(packDestination, "lifecycle-ran");
+	const manifestPath = join(packageRoot, "package.json");
+	const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+	manifest.scripts = { prepack: "node create-sentinel.mjs" };
+	await Promise.all([
+		writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`),
+		writeFile(
+			join(packageRoot, "create-sentinel.mjs"),
+			`import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(sentinel)}, "ran");\n`,
+		),
+	]);
+
+	await packAndVerify({ packageDirectory: packageRoot, packDestination });
+	await assert.rejects(access(sentinel), { code: "ENOENT" });
+});
 
 test("real npm tarball contains the manifest-derived reviewed inventory deterministically", async (t) => {
 	const firstDestination = await temporaryDirectory(
@@ -65,10 +83,6 @@ test("real npm tarball contains the manifest-derived reviewed inventory determin
 		await readFile(first.tarballPath),
 	);
 	assert.notEqual(second.tarballPath, first.tarballPath);
-	assert.ok(
-		npmPackArguments("package", "output").includes("--ignore-scripts"),
-		"npm pack must disable lifecycle scripts",
-	);
 });
 
 test("missing and stale generated artifacts are reported separately", async (t) => {

--- a/scripts/packaged-factories-package-registry.mjs
+++ b/scripts/packaged-factories-package-registry.mjs
@@ -21,6 +21,6 @@ export function reconcileCandidate(input) {
 	return reconcilePackageCandidate({
 		...input,
 		expectedPackageName: PACKAGED_FACTORIES_PACKAGE_NAME,
-		expectedDistTag: DEVELOPMENT_DIST_TAG,
+		expectedDistTag: input.expectedDistTag ?? DEVELOPMENT_DIST_TAG,
 	});
 }

--- a/scripts/packaged-factories-package-registry.test.mjs
+++ b/scripts/packaged-factories-package-registry.test.mjs
@@ -69,6 +69,28 @@ test("Packaged Factories reconciliation distinguishes absent and identical versi
 	assert.equal(existing.outcome, RECONCILIATION_OUTCOMES.VERIFIED_EXISTING);
 });
 
+test("Packaged Factories reconciliation accepts a stable latest candidate", async (t) => {
+	const candidate = await candidateFixture(t);
+	candidate.evidence.candidateVersion = "1.2.3";
+	candidate.evidence.distTag = "latest";
+	const result = await reconcileCandidate({
+		...candidate,
+		expectedDistTag: "latest",
+		registryClient: {
+			async lookupVersion() {
+				return { status: "absent" };
+			},
+			async downloadTarball() {
+				assert.fail("absent versions are not downloaded");
+			},
+		},
+	});
+
+	assert.equal(result.outcome, RECONCILIATION_OUTCOMES.PUBLISH_REQUIRED);
+	assert.equal(result.candidateVersion, "1.2.3");
+	assert.equal(result.distTag, "latest");
+});
+
 test("Packaged Factories reconciliation rejects another package identity before registry IO", async (t) => {
 	const candidate = await candidateFixture(t);
 	candidate.evidence.packageName = "@you-agent-factory/api";

--- a/scripts/public-package-set.mjs
+++ b/scripts/public-package-set.mjs
@@ -1,0 +1,76 @@
+export const FRONTEND_ONLY_CANDIDATE_SCOPE = "frontend-only";
+export const TAGGED_RELEASE_CANDIDATE_SCOPE = "tagged-release";
+
+export const FRONTEND_PUBLIC_PACKAGE_NAMES = Object.freeze([
+	"@you-agent-factory/client",
+	"@you-agent-factory/factory-replay",
+	"@you-agent-factory/factory-emulator",
+	"@you-agent-factory/components",
+	"@you-agent-factory/factory-visualizers",
+]);
+
+export const TAGGED_RELEASE_PUBLIC_PACKAGE_NAMES = Object.freeze([
+	"@you-agent-factory/api",
+	"@you-agent-factory/packaged-factories",
+	...FRONTEND_PUBLIC_PACKAGE_NAMES,
+]);
+
+const stableVersionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const publicVersionPattern =
+	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+export function expectedPackageNamesForScope(scope) {
+	if (scope === FRONTEND_ONLY_CANDIDATE_SCOPE) {
+		return FRONTEND_PUBLIC_PACKAGE_NAMES;
+	}
+	if (scope === TAGGED_RELEASE_CANDIDATE_SCOPE) {
+		return TAGGED_RELEASE_PUBLIC_PACKAGE_NAMES;
+	}
+	throw new Error(
+		`[public-package-set] unknown candidate scope: ${scope ?? "missing"}`,
+	);
+}
+
+export function assertCandidateSetEvidence(evidence, expectedScope) {
+	const expectedNames = expectedPackageNamesForScope(evidence?.scope);
+	if (expectedScope !== undefined && evidence.scope !== expectedScope) {
+		throw new Error(
+			`[public-package-set] expected ${expectedScope} candidate scope, found ${evidence.scope}`,
+		);
+	}
+	const versionPattern =
+		evidence.scope === TAGGED_RELEASE_CANDIDATE_SCOPE
+			? stableVersionPattern
+			: publicVersionPattern;
+	if (
+		typeof evidence.version !== "string" ||
+		!versionPattern.test(evidence.version)
+	) {
+		throw new Error(
+			`[public-package-set] invalid ${evidence.scope} candidate version: ${evidence.version ?? "missing"}`,
+		);
+	}
+	if (!Array.isArray(evidence.packages)) {
+		throw new Error("[public-package-set] candidate packages must be an array");
+	}
+	if (evidence.packages.length !== expectedNames.length) {
+		throw new Error(
+			`[public-package-set] candidate count mismatch for ${evidence.scope}: expected ${expectedNames.length}, found ${evidence.packages.length}`,
+		);
+	}
+	const names = evidence.packages.map(({ name }) => name);
+	if (new Set(names).size !== names.length) {
+		throw new Error(
+			"[public-package-set] candidate set contains duplicate package names",
+		);
+	}
+	for (const name of expectedNames) {
+		const candidate = evidence.packages.find((entry) => entry.name === name);
+		if (!candidate || candidate.version !== evidence.version) {
+			throw new Error(
+				`[public-package-set] missing exact candidate for ${name}@${evidence.version}`,
+			);
+		}
+	}
+	return expectedNames;
+}

--- a/scripts/public-package-set.test.mjs
+++ b/scripts/public-package-set.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	assertCandidateSetEvidence,
+	FRONTEND_ONLY_CANDIDATE_SCOPE,
+	FRONTEND_PUBLIC_PACKAGE_NAMES,
+	TAGGED_RELEASE_CANDIDATE_SCOPE,
+	TAGGED_RELEASE_PUBLIC_PACKAGE_NAMES,
+} from "./public-package-set.mjs";
+
+function evidence(scope, names, version = "1.2.3") {
+	return {
+		scope,
+		version,
+		packages: names.map((name) => ({ name, version })),
+	};
+}
+
+test("accepts the exact package family selected by each known scope", () => {
+	assert.deepEqual(
+		assertCandidateSetEvidence(
+			evidence(FRONTEND_ONLY_CANDIDATE_SCOPE, FRONTEND_PUBLIC_PACKAGE_NAMES),
+			FRONTEND_ONLY_CANDIDATE_SCOPE,
+		),
+		FRONTEND_PUBLIC_PACKAGE_NAMES,
+	);
+	assert.deepEqual(
+		assertCandidateSetEvidence(
+			evidence(
+				TAGGED_RELEASE_CANDIDATE_SCOPE,
+				TAGGED_RELEASE_PUBLIC_PACKAGE_NAMES,
+			),
+			TAGGED_RELEASE_CANDIDATE_SCOPE,
+		),
+		TAGGED_RELEASE_PUBLIC_PACKAGE_NAMES,
+	);
+});
+
+test("rejects unknown candidate scopes", () => {
+	assert.throws(
+		() => assertCandidateSetEvidence(evidence("all-packages", [])),
+		/unknown candidate scope/,
+	);
+});
+
+test("rejects duplicate package names", () => {
+	const candidate = evidence(
+		FRONTEND_ONLY_CANDIDATE_SCOPE,
+		FRONTEND_PUBLIC_PACKAGE_NAMES,
+	);
+	candidate.packages[1].name = candidate.packages[0].name;
+	assert.throws(
+		() => assertCandidateSetEvidence(candidate),
+		/duplicate package names/,
+	);
+});
+
+test("rejects missing packages and mismatched candidate counts", () => {
+	const candidate = evidence(
+		TAGGED_RELEASE_CANDIDATE_SCOPE,
+		TAGGED_RELEASE_PUBLIC_PACKAGE_NAMES.slice(0, -1),
+	);
+	assert.throws(
+		() => assertCandidateSetEvidence(candidate),
+		/candidate count mismatch/,
+	);
+});
+
+test("rejects a package whose version differs from the coherent set", () => {
+	const candidate = evidence(
+		FRONTEND_ONLY_CANDIDATE_SCOPE,
+		FRONTEND_PUBLIC_PACKAGE_NAMES,
+	);
+	candidate.packages[0].version = "1.2.4";
+	assert.throws(
+		() => assertCandidateSetEvidence(candidate),
+		/missing exact candidate/,
+	);
+});
+
+test("requires a stable version for a tagged release set", () => {
+	assert.throws(
+		() =>
+			assertCandidateSetEvidence(
+				evidence(
+					TAGGED_RELEASE_CANDIDATE_SCOPE,
+					TAGGED_RELEASE_PUBLIC_PACKAGE_NAMES,
+					"1.2.3-rc.1",
+				),
+			),
+		/invalid tagged-release candidate version/,
+	);
+});

--- a/scripts/public-release-package-candidate.mjs
+++ b/scripts/public-release-package-candidate.mjs
@@ -2,24 +2,15 @@ import { mkdir, readdir, writeFile } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { parseArgs } from "node:util";
-
+import { preparePublicPackageCandidates } from "../ui/scripts/public-package-publish.mjs";
+import { prepareCandidate as prepareApiCandidate } from "./api-package-candidate.mjs";
+import { prepareCandidate as preparePackagedFactoriesCandidate } from "./packaged-factories-package-candidate.mjs";
 import {
-	API_PACKAGE_NAME,
-	prepareCandidate as prepareApiCandidate,
-} from "./api-package-candidate.mjs";
-import {
-	PACKAGED_FACTORIES_PACKAGE_NAME,
-	prepareCandidate as preparePackagedFactoriesCandidate,
-} from "./packaged-factories-package-candidate.mjs";
-import { PUBLIC_PACKAGES, preparePublicPackageCandidates } from "../ui/scripts/public-package-publish.mjs";
+	assertCandidateSetEvidence,
+	TAGGED_RELEASE_CANDIDATE_SCOPE,
+} from "./public-package-set.mjs";
 
-export const TAGGED_RELEASE_CANDIDATE_SCOPE = "tagged-release";
-
-const EXPECTED_PACKAGE_NAMES = Object.freeze([
-	API_PACKAGE_NAME,
-	PACKAGED_FACTORIES_PACKAGE_NAME,
-	...PUBLIC_PACKAGES.map(({ name }) => name),
-]);
+export { TAGGED_RELEASE_CANDIDATE_SCOPE };
 
 async function requireEmptyOutputDirectory(outputDirectory) {
 	await mkdir(outputDirectory, { recursive: true });
@@ -37,24 +28,6 @@ function candidateRecord({ name, version, tarballPath, outputDirectory }) {
 		version,
 		tarball: join(outputDirectory, filename).replaceAll("\\", "/"),
 	};
-}
-
-function assertCompleteCandidateSet(packages, version) {
-	if (packages.length !== EXPECTED_PACKAGE_NAMES.length) {
-		throw new Error("[public-release-package-candidate] candidate set is incomplete");
-	}
-	const names = packages.map(({ name }) => name);
-	if (new Set(names).size !== names.length) {
-		throw new Error("[public-release-package-candidate] candidate set has duplicate package names");
-	}
-	for (const expectedName of EXPECTED_PACKAGE_NAMES) {
-		const candidate = packages.find(({ name }) => name === expectedName);
-		if (!candidate || candidate.version !== version) {
-			throw new Error(
-				`[public-release-package-candidate] missing ${expectedName}@${version}`,
-			);
-		}
-	}
 }
 
 export async function prepareTaggedReleaseCandidate({
@@ -77,6 +50,7 @@ export async function prepareTaggedReleaseCandidate({
 			runId,
 			sourceCommit,
 			version,
+			distTag: "latest",
 		}),
 		preparePackagedFactoriesCandidate({
 			packageDirectory: packagedFactoriesPackageDirectory,
@@ -84,8 +58,12 @@ export async function prepareTaggedReleaseCandidate({
 			runId,
 			sourceCommit,
 			version,
+			distTag: "latest",
 		}),
-		preparePublicPackageCandidates({ version, outputDirectory: frontendOutput }),
+		preparePublicPackageCandidates({
+			version,
+			outputDirectory: frontendOutput,
+		}),
 	]);
 	const packages = [
 		candidateRecord({
@@ -109,13 +87,13 @@ export async function prepareTaggedReleaseCandidate({
 			}),
 		),
 	];
-	assertCompleteCandidateSet(packages, version);
 	const evidence = {
 		scope: TAGGED_RELEASE_CANDIDATE_SCOPE,
 		version,
 		sourceCommit,
 		packages,
 	};
+	assertCandidateSetEvidence(evidence, TAGGED_RELEASE_CANDIDATE_SCOPE);
 	const evidencePath = join(root, "release-candidate-evidence.json");
 	await writeFile(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`);
 	return { evidence, evidencePath };
@@ -140,7 +118,10 @@ async function main() {
 	process.stdout.write(`${JSON.stringify(result.evidence)}\n`);
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
 	main().catch((error) => {
 		process.stderr.write(`${error.message}\n`);
 		process.exitCode = 1;

--- a/scripts/public-release-package-candidate.mjs
+++ b/scripts/public-release-package-candidate.mjs
@@ -1,0 +1,148 @@
+import { mkdir, readdir, writeFile } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+
+import {
+	API_PACKAGE_NAME,
+	prepareCandidate as prepareApiCandidate,
+} from "./api-package-candidate.mjs";
+import {
+	PACKAGED_FACTORIES_PACKAGE_NAME,
+	prepareCandidate as preparePackagedFactoriesCandidate,
+} from "./packaged-factories-package-candidate.mjs";
+import { PUBLIC_PACKAGES, preparePublicPackageCandidates } from "../ui/scripts/public-package-publish.mjs";
+
+export const TAGGED_RELEASE_CANDIDATE_SCOPE = "tagged-release";
+
+const EXPECTED_PACKAGE_NAMES = Object.freeze([
+	API_PACKAGE_NAME,
+	PACKAGED_FACTORIES_PACKAGE_NAME,
+	...PUBLIC_PACKAGES.map(({ name }) => name),
+]);
+
+async function requireEmptyOutputDirectory(outputDirectory) {
+	await mkdir(outputDirectory, { recursive: true });
+	if ((await readdir(outputDirectory)).length !== 0) {
+		throw new Error(
+			"[public-release-package-candidate] output directory must be empty",
+		);
+	}
+}
+
+function candidateRecord({ name, version, tarballPath, outputDirectory }) {
+	const filename = basename(tarballPath);
+	return {
+		name,
+		version,
+		tarball: join(outputDirectory, filename).replaceAll("\\", "/"),
+	};
+}
+
+function assertCompleteCandidateSet(packages, version) {
+	if (packages.length !== EXPECTED_PACKAGE_NAMES.length) {
+		throw new Error("[public-release-package-candidate] candidate set is incomplete");
+	}
+	const names = packages.map(({ name }) => name);
+	if (new Set(names).size !== names.length) {
+		throw new Error("[public-release-package-candidate] candidate set has duplicate package names");
+	}
+	for (const expectedName of EXPECTED_PACKAGE_NAMES) {
+		const candidate = packages.find(({ name }) => name === expectedName);
+		if (!candidate || candidate.version !== version) {
+			throw new Error(
+				`[public-release-package-candidate] missing ${expectedName}@${version}`,
+			);
+		}
+	}
+}
+
+export async function prepareTaggedReleaseCandidate({
+	outputDirectory,
+	runId,
+	sourceCommit,
+	version,
+	apiPackageDirectory = "packages/api",
+	packagedFactoriesPackageDirectory = "packages/packaged-factories",
+}) {
+	const root = resolve(outputDirectory);
+	await requireEmptyOutputDirectory(root);
+	const apiOutput = join(root, "api");
+	const packagedFactoriesOutput = join(root, "packaged-factories");
+	const frontendOutput = join(root, "frontend");
+	const [api, packagedFactories, frontend] = await Promise.all([
+		prepareApiCandidate({
+			packageDirectory: apiPackageDirectory,
+			outputDirectory: apiOutput,
+			runId,
+			sourceCommit,
+			version,
+		}),
+		preparePackagedFactoriesCandidate({
+			packageDirectory: packagedFactoriesPackageDirectory,
+			outputDirectory: packagedFactoriesOutput,
+			runId,
+			sourceCommit,
+			version,
+		}),
+		preparePublicPackageCandidates({ version, outputDirectory: frontendOutput }),
+	]);
+	const packages = [
+		candidateRecord({
+			name: api.evidence.packageName,
+			version: api.evidence.candidateVersion,
+			tarballPath: api.tarballPath,
+			outputDirectory: "api",
+		}),
+		candidateRecord({
+			name: packagedFactories.evidence.packageName,
+			version: packagedFactories.evidence.candidateVersion,
+			tarballPath: packagedFactories.tarballPath,
+			outputDirectory: "packaged-factories",
+		}),
+		...frontend.packages.map(({ name, version: candidateVersion, filename }) =>
+			candidateRecord({
+				name,
+				version: candidateVersion,
+				tarballPath: filename,
+				outputDirectory: "frontend",
+			}),
+		),
+	];
+	assertCompleteCandidateSet(packages, version);
+	const evidence = {
+		scope: TAGGED_RELEASE_CANDIDATE_SCOPE,
+		version,
+		sourceCommit,
+		packages,
+	};
+	const evidencePath = join(root, "release-candidate-evidence.json");
+	await writeFile(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`);
+	return { evidence, evidencePath };
+}
+
+async function main() {
+	const { values } = parseArgs({
+		options: {
+			"output-directory": { type: "string" },
+			"run-id": { type: "string" },
+			"source-commit": { type: "string" },
+			version: { type: "string" },
+		},
+		strict: true,
+	});
+	const result = await prepareTaggedReleaseCandidate({
+		outputDirectory: values["output-directory"],
+		runId: values["run-id"],
+		sourceCommit: values["source-commit"],
+		version: values.version,
+	});
+	process.stdout.write(`${JSON.stringify(result.evidence)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+	main().catch((error) => {
+		process.stderr.write(`${error.message}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/scripts/public-release-package-candidate.test.mjs
+++ b/scripts/public-release-package-candidate.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+	TAGGED_RELEASE_CANDIDATE_SCOPE,
+	prepareTaggedReleaseCandidate,
+} from "./public-release-package-candidate.mjs";
+
+const sourceCommit = "0123456789abcdef0123456789abcdef01234567";
+
+async function exists(path) {
+	try {
+		await access(path);
+		return true;
+	} catch (error) {
+		if (error?.code === "ENOENT") return false;
+		throw error;
+	}
+}
+
+test("tagged release preparation stages each public package once at the requested version without changing source manifests", async (t) => {
+	const outputDirectory = await mkdtemp(
+		join(tmpdir(), "you-complete-release-candidate-"),
+	);
+	t.after(() => rm(outputDirectory, { recursive: true, force: true }));
+	const manifests = [
+		"packages/api/package.json",
+		"packages/packaged-factories/package.json",
+		"ui/packages/client/package.json",
+		"ui/packages/factory-replay/package.json",
+		"ui/packages/factory-emulator/package.json",
+		"ui/packages/components/package.json",
+		"ui/packages/factory-visualizers/package.json",
+	];
+	const before = await Promise.all(manifests.map((path) => readFile(path)));
+	const buildOutputsBefore = await Promise.all(
+		manifests.map((path) => exists(path.replace("package.json", "dist"))),
+	);
+
+	const result = await prepareTaggedReleaseCandidate({
+		outputDirectory,
+		runId: "42",
+		sourceCommit,
+		version: "1.2.3",
+	});
+
+	assert.equal(result.evidence.scope, TAGGED_RELEASE_CANDIDATE_SCOPE);
+	assert.equal(result.evidence.version, "1.2.3");
+	assert.equal(result.evidence.sourceCommit, sourceCommit);
+	assert.equal(result.evidence.packages.length, 7);
+	assert.equal(
+		new Set(result.evidence.packages.map(({ name }) => name)).size,
+		result.evidence.packages.length,
+	);
+	for (const candidate of result.evidence.packages) {
+		assert.equal(candidate.version, "1.2.3");
+		assert.match(candidate.tarball, /^(api|packaged-factories|frontend)\/.+\.tgz$/);
+	}
+	assert.deepEqual(
+		await Promise.all(manifests.map((path) => readFile(path))),
+		before,
+	);
+	assert.deepEqual(
+		await Promise.all(
+			manifests.map((path) => exists(path.replace("package.json", "dist"))),
+		),
+		buildOutputsBefore,
+	);
+	assert.ok((await readdir(outputDirectory)).includes("release-candidate-evidence.json"));
+});

--- a/scripts/public-release-package-candidate.test.mjs
+++ b/scripts/public-release-package-candidate.test.mjs
@@ -1,12 +1,12 @@
 import assert from "node:assert/strict";
-import { access, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { access, mkdtemp, readdir, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
 import {
-	TAGGED_RELEASE_CANDIDATE_SCOPE,
 	prepareTaggedReleaseCandidate,
+	TAGGED_RELEASE_CANDIDATE_SCOPE,
 } from "./public-release-package-candidate.mjs";
 
 const sourceCommit = "0123456789abcdef0123456789abcdef01234567";
@@ -57,7 +57,10 @@ test("tagged release preparation stages each public package once at the requeste
 	);
 	for (const candidate of result.evidence.packages) {
 		assert.equal(candidate.version, "1.2.3");
-		assert.match(candidate.tarball, /^(api|packaged-factories|frontend)\/.+\.tgz$/);
+		assert.match(
+			candidate.tarball,
+			/^(api|packaged-factories|frontend)\/.+\.tgz$/,
+		);
 	}
 	assert.deepEqual(
 		await Promise.all(manifests.map((path) => readFile(path))),
@@ -69,5 +72,17 @@ test("tagged release preparation stages each public package once at the requeste
 		),
 		buildOutputsBefore,
 	);
-	assert.ok((await readdir(outputDirectory)).includes("release-candidate-evidence.json"));
+	assert.ok(
+		(await readdir(outputDirectory)).includes(
+			"release-candidate-evidence.json",
+		),
+	);
+	for (const directory of ["api", "packaged-factories"]) {
+		const childEvidence = JSON.parse(
+			await readFile(
+				join(outputDirectory, directory, "candidate-evidence.json"),
+			),
+		);
+		assert.equal(childEvidence.distTag, "latest");
+	}
 });

--- a/scripts/public-release-package-publish.mjs
+++ b/scripts/public-release-package-publish.mjs
@@ -1,0 +1,184 @@
+import { readdir, readFile } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+import { publishPublicPackageCandidates } from "../ui/scripts/public-package-publish.mjs";
+import { API_PACKAGE_NAME } from "./api-package-candidate.mjs";
+import { publishCandidateDirectory as publishApiCandidate } from "./api-package-publish.mjs";
+import { PACKAGED_FACTORIES_PACKAGE_NAME } from "./packaged-factories-package-candidate.mjs";
+import { publishCandidateDirectory as publishPackagedFactoriesCandidate } from "./packaged-factories-package-publish.mjs";
+import {
+	assertCandidateSetEvidence,
+	FRONTEND_ONLY_CANDIDATE_SCOPE,
+	TAGGED_RELEASE_CANDIDATE_SCOPE,
+} from "./public-package-set.mjs";
+
+async function readJson(path) {
+	return JSON.parse(await readFile(path, "utf8"));
+}
+
+async function singleTarballName(directory) {
+	const tarballs = (await readdir(directory)).filter((name) =>
+		name.endsWith(".tgz"),
+	);
+	if (tarballs.length !== 1) {
+		throw new Error(
+			`[public-release-package-publish] ${directory} must contain exactly one tarball`,
+		);
+	}
+	return tarballs[0];
+}
+
+function assertTopLevelRecord(evidence, name, version, tarball) {
+	const record = evidence.packages.find((candidate) => candidate.name === name);
+	if (record?.version !== version || record.tarball !== tarball) {
+		throw new Error(
+			`[public-release-package-publish] top-level evidence does not represent ${name}@${version} at ${tarball}`,
+		);
+	}
+}
+
+async function assertSinglePackageEvidence({
+	root,
+	directory,
+	expectedName,
+	evidence,
+}) {
+	const candidateDirectory = join(root, directory);
+	const child = await readJson(
+		join(candidateDirectory, "candidate-evidence.json"),
+	);
+	const tarballName = await singleTarballName(candidateDirectory);
+	if (
+		child.packageName !== expectedName ||
+		child.candidateVersion !== evidence.version ||
+		child.sourceCommit !== evidence.sourceCommit ||
+		child.distTag !== "latest"
+	) {
+		throw new Error(
+			`[public-release-package-publish] child evidence does not match ${expectedName}`,
+		);
+	}
+	assertTopLevelRecord(
+		evidence,
+		expectedName,
+		child.candidateVersion,
+		`${directory}/${tarballName}`,
+	);
+}
+
+async function assertFrontendEvidence(root, evidence) {
+	const child = await readJson(
+		join(root, "frontend", "public-package-candidates.json"),
+	);
+	assertCandidateSetEvidence(child, FRONTEND_ONLY_CANDIDATE_SCOPE);
+	if (child.version !== evidence.version) {
+		throw new Error(
+			"[public-release-package-publish] frontend evidence version does not match tagged release",
+		);
+	}
+	for (const candidate of child.packages) {
+		if (basename(candidate.filename) !== candidate.filename) {
+			throw new Error(
+				`[public-release-package-publish] invalid frontend tarball filename for ${candidate.name}`,
+			);
+		}
+		assertTopLevelRecord(
+			evidence,
+			candidate.name,
+			candidate.version,
+			`frontend/${candidate.filename}`,
+		);
+	}
+}
+
+export async function validateTaggedReleaseCandidate({
+	candidateDirectory,
+	expectedSourceCommit,
+}) {
+	const root = resolve(candidateDirectory);
+	const evidence = await readJson(
+		join(root, "release-candidate-evidence.json"),
+	);
+	assertCandidateSetEvidence(evidence, TAGGED_RELEASE_CANDIDATE_SCOPE);
+	if (evidence.sourceCommit !== expectedSourceCommit) {
+		throw new Error(
+			"[public-release-package-publish] preserved candidate source commit does not match the protected workflow commit",
+		);
+	}
+	await Promise.all([
+		assertSinglePackageEvidence({
+			root,
+			directory: "api",
+			expectedName: API_PACKAGE_NAME,
+			evidence,
+		}),
+		assertSinglePackageEvidence({
+			root,
+			directory: "packaged-factories",
+			expectedName: PACKAGED_FACTORIES_PACKAGE_NAME,
+			evidence,
+		}),
+		assertFrontendEvidence(root, evidence),
+	]);
+	return { evidence, root };
+}
+
+export async function publishTaggedReleaseCandidate(
+	{ candidateDirectory, expectedSourceCommit, workspaceDirectory },
+	dependencies = {},
+) {
+	const publishApi = dependencies.publishApiCandidate ?? publishApiCandidate;
+	const publishPackagedFactories =
+		dependencies.publishPackagedFactoriesCandidate ??
+		publishPackagedFactoriesCandidate;
+	const publishFrontend =
+		dependencies.publishFrontendCandidates ?? publishPublicPackageCandidates;
+	const { evidence, root } = await validateTaggedReleaseCandidate({
+		candidateDirectory,
+		expectedSourceCommit,
+	});
+	const api = await publishApi({
+		candidateDirectory: join(root, "api"),
+		expectedSourceCommit,
+		workspaceDirectory,
+	});
+	const packagedFactories = await publishPackagedFactories({
+		candidateDirectory: join(root, "packaged-factories"),
+		expectedSourceCommit,
+		workspaceDirectory,
+	});
+	const frontend = await publishFrontend({
+		candidateDirectory: join(root, "frontend"),
+		tag: "latest",
+		provenance: true,
+	});
+	return { evidence, publications: { api, packagedFactories, frontend } };
+}
+
+async function main() {
+	const { values } = parseArgs({
+		options: {
+			"candidate-directory": { type: "string" },
+			"expected-source-commit": { type: "string" },
+			"workspace-directory": { type: "string" },
+		},
+		strict: true,
+	});
+	const result = await publishTaggedReleaseCandidate({
+		candidateDirectory: values["candidate-directory"],
+		expectedSourceCommit: values["expected-source-commit"],
+		workspaceDirectory: values["workspace-directory"],
+	});
+	process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+	main().catch((error) => {
+		process.stderr.write(`${error.message}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/scripts/public-release-package-publish.mjs
+++ b/scripts/public-release-package-publish.mjs
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readdir, readFile } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -29,6 +30,49 @@ async function singleTarballName(directory) {
 	return tarballs[0];
 }
 
+function digest(contents, algorithm, encoding = "hex") {
+	return createHash(algorithm).update(contents).digest(encoding);
+}
+
+async function assertTarballDigests({
+	name,
+	tarballPath,
+	artifactDigest,
+	integrity,
+	shasum,
+}) {
+	let contents;
+	try {
+		contents = await readFile(tarballPath);
+	} catch (error) {
+		throw new Error(
+			`[public-release-package-publish] represented tarball is not readable for ${name}`,
+			{ cause: error },
+		);
+	}
+	if (
+		artifactDigest !== undefined &&
+		artifactDigest !== `sha256:${digest(contents, "sha256")}`
+	) {
+		throw new Error(
+			`[public-release-package-publish] candidate digest mismatch for ${name}`,
+		);
+	}
+	if (shasum !== undefined && shasum !== digest(contents, "sha1")) {
+		throw new Error(
+			`[public-release-package-publish] candidate shasum mismatch for ${name}`,
+		);
+	}
+	if (
+		integrity !== undefined &&
+		integrity !== `sha512-${digest(contents, "sha512", "base64")}`
+	) {
+		throw new Error(
+			`[public-release-package-publish] candidate integrity mismatch for ${name}`,
+		);
+	}
+}
+
 function assertTopLevelRecord(evidence, name, version, tarball) {
 	const record = evidence.packages.find((candidate) => candidate.name === name);
 	if (record?.version !== version || record.tarball !== tarball) {
@@ -53,7 +97,11 @@ async function assertSinglePackageEvidence({
 		child.packageName !== expectedName ||
 		child.candidateVersion !== evidence.version ||
 		child.sourceCommit !== evidence.sourceCommit ||
-		child.distTag !== "latest"
+		child.distTag !== "latest" ||
+		!/^sha256:[0-9a-f]{64}$/.test(child.contractDigest ?? "") ||
+		!/^sha256:[0-9a-f]{64}$/.test(child.artifactDigest ?? "") ||
+		!Array.isArray(child.inventory) ||
+		child.inventory.some((path) => typeof path !== "string")
 	) {
 		throw new Error(
 			`[public-release-package-publish] child evidence does not match ${expectedName}`,
@@ -65,6 +113,11 @@ async function assertSinglePackageEvidence({
 		child.candidateVersion,
 		`${directory}/${tarballName}`,
 	);
+	await assertTarballDigests({
+		name: expectedName,
+		tarballPath: join(candidateDirectory, tarballName),
+		artifactDigest: child.artifactDigest,
+	});
 }
 
 async function assertFrontendEvidence(root, evidence) {
@@ -78,9 +131,14 @@ async function assertFrontendEvidence(root, evidence) {
 		);
 	}
 	for (const candidate of child.packages) {
-		if (basename(candidate.filename) !== candidate.filename) {
+		if (
+			typeof candidate.filename !== "string" ||
+			basename(candidate.filename) !== candidate.filename ||
+			!/^[0-9a-f]{40}$/.test(candidate.shasum ?? "") ||
+			!/^sha512-[A-Za-z0-9+/]+={0,2}$/.test(candidate.integrity ?? "")
+		) {
 			throw new Error(
-				`[public-release-package-publish] invalid frontend tarball filename for ${candidate.name}`,
+				`[public-release-package-publish] invalid frontend tarball evidence for ${candidate.name}`,
 			);
 		}
 		assertTopLevelRecord(
@@ -89,6 +147,12 @@ async function assertFrontendEvidence(root, evidence) {
 			candidate.version,
 			`frontend/${candidate.filename}`,
 		);
+		await assertTarballDigests({
+			name: candidate.name,
+			tarballPath: join(root, "frontend", candidate.filename),
+			integrity: candidate.integrity,
+			shasum: candidate.shasum,
+		});
 	}
 }
 
@@ -140,11 +204,13 @@ export async function publishTaggedReleaseCandidate(
 	});
 	const api = await publishApi({
 		candidateDirectory: join(root, "api"),
+		expectedDistTag: "latest",
 		expectedSourceCommit,
 		workspaceDirectory,
 	});
 	const packagedFactories = await publishPackagedFactories({
 		candidateDirectory: join(root, "packaged-factories"),
+		expectedDistTag: "latest",
 		expectedSourceCommit,
 		workspaceDirectory,
 	});

--- a/scripts/public-release-package-publish.test.mjs
+++ b/scripts/public-release-package-publish.test.mjs
@@ -1,5 +1,13 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import {
+	mkdir,
+	mkdtemp,
+	readFile,
+	rm,
+	unlink,
+	writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -19,6 +27,14 @@ async function writeJson(path, value) {
 	await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
 }
 
+function digests(contents) {
+	return {
+		artifactDigest: `sha256:${createHash("sha256").update(contents).digest("hex")}`,
+		integrity: `sha512-${createHash("sha512").update(contents).digest("base64")}`,
+		shasum: createHash("sha1").update(contents).digest("hex"),
+	};
+}
+
 async function candidateFixture(t) {
 	const root = await mkdtemp(join(tmpdir(), "you-tagged-publisher-"));
 	t.after(() => rm(root, { recursive: true, force: true }));
@@ -29,27 +45,37 @@ async function candidateFixture(t) {
 	);
 	const apiTarball = "you-agent-factory-api-1.2.3.tgz";
 	const factoriesTarball = "you-agent-factory-packaged-factories-1.2.3.tgz";
+	const apiContents = "api";
+	const factoriesContents = "factories";
 	await Promise.all([
-		writeFile(join(root, "api", apiTarball), "api"),
-		writeFile(join(root, "packaged-factories", factoriesTarball), "factories"),
+		writeFile(join(root, "api", apiTarball), apiContents),
+		writeFile(
+			join(root, "packaged-factories", factoriesTarball),
+			factoriesContents,
+		),
 		writeJson(join(root, "api", "candidate-evidence.json"), {
 			packageName: "@you-agent-factory/api",
 			candidateVersion: version,
 			sourceCommit,
 			distTag: "latest",
+			contractDigest: digests("api-contract").artifactDigest,
+			artifactDigest: digests(apiContents).artifactDigest,
+			inventory: ["package.json"],
 		}),
 		writeJson(join(root, "packaged-factories", "candidate-evidence.json"), {
 			packageName: "@you-agent-factory/packaged-factories",
 			candidateVersion: version,
 			sourceCommit,
 			distTag: "latest",
+			contractDigest: digests("factories-contract").artifactDigest,
+			artifactDigest: digests(factoriesContents).artifactDigest,
+			inventory: ["package.json"],
 		}),
 	]);
-	const frontendPackages = FRONTEND_PUBLIC_PACKAGE_NAMES.map((name, index) => ({
-		name,
-		version,
-		filename: `frontend-${index}.tgz`,
-	}));
+	const frontendPackages = FRONTEND_PUBLIC_PACKAGE_NAMES.map((name, index) => {
+		const filename = `frontend-${index}.tgz`;
+		return { name, version, filename, ...digests(filename) };
+	});
 	await Promise.all(
 		frontendPackages.map(({ filename }) =>
 			writeFile(join(root, "frontend", filename), filename),
@@ -120,6 +146,8 @@ test("validates the complete reviewed set before publishing each represented chi
 		["api", "packaged-factories", "frontend"],
 	);
 	assert.equal(calls[0][1].expectedSourceCommit, sourceCommit);
+	assert.equal(calls[0][1].expectedDistTag, "latest");
+	assert.equal(calls[1][1].expectedDistTag, "latest");
 	assert.equal(calls[2][1].tag, "latest");
 	assert.equal(calls[2][1].provenance, true);
 });
@@ -181,6 +209,73 @@ for (const testCase of [
 				recordingPublishers(calls),
 			),
 			testCase.expected,
+		);
+		assert.deepEqual(calls, []);
+	});
+}
+
+for (const field of ["shasum", "integrity"]) {
+	test(`mismatched frontend ${field} prevents every publication side effect`, async (t) => {
+		const { root } = await candidateFixture(t);
+		const evidencePath = join(
+			root,
+			"frontend",
+			"public-package-candidates.json",
+		);
+		const child = JSON.parse(await readFile(evidencePath, "utf8"));
+		child.packages[0][field] =
+			field === "shasum" ? "0".repeat(40) : `sha512-${"A".repeat(88)}`;
+		await writeJson(evidencePath, child);
+		const calls = [];
+
+		await assert.rejects(
+			publishTaggedReleaseCandidate(
+				{
+					candidateDirectory: root,
+					expectedSourceCommit: sourceCommit,
+					workspaceDirectory: "workspace",
+				},
+				recordingPublishers(calls),
+			),
+			new RegExp(`candidate ${field} mismatch`),
+		);
+		assert.deepEqual(calls, []);
+	});
+}
+
+for (const testCase of [
+	{ child: "api", action: "corrupt", tarball: "you-agent-factory-api-1.2.3.tgz" },
+	{ child: "api", action: "remove", tarball: "you-agent-factory-api-1.2.3.tgz" },
+	{
+		child: "packaged-factories",
+		action: "corrupt",
+		tarball: "you-agent-factory-packaged-factories-1.2.3.tgz",
+	},
+	{
+		child: "packaged-factories",
+		action: "remove",
+		tarball: "you-agent-factory-packaged-factories-1.2.3.tgz",
+	},
+	{ child: "frontend", action: "corrupt", tarball: "frontend-0.tgz" },
+	{ child: "frontend", action: "remove", tarball: "frontend-0.tgz" },
+]) {
+	test(`${testCase.action === "remove" ? "missing" : "corrupt"} ${testCase.child} tarball prevents every publication side effect`, async (t) => {
+		const { root } = await candidateFixture(t);
+		const tarballPath = join(root, testCase.child, testCase.tarball);
+		if (testCase.action === "remove") await unlink(tarballPath);
+		else await writeFile(tarballPath, "tampered");
+		const calls = [];
+
+		await assert.rejects(
+			publishTaggedReleaseCandidate(
+				{
+					candidateDirectory: root,
+					expectedSourceCommit: sourceCommit,
+					workspaceDirectory: "workspace",
+				},
+				recordingPublishers(calls),
+			),
+			/candidate (?:digest|shasum|integrity) mismatch|represented tarball is not readable|exactly one tarball/,
 		);
 		assert.deepEqual(calls, []);
 	});

--- a/scripts/public-release-package-publish.test.mjs
+++ b/scripts/public-release-package-publish.test.mjs
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+	FRONTEND_ONLY_CANDIDATE_SCOPE,
+	FRONTEND_PUBLIC_PACKAGE_NAMES,
+	TAGGED_RELEASE_CANDIDATE_SCOPE,
+	TAGGED_RELEASE_PUBLIC_PACKAGE_NAMES,
+} from "./public-package-set.mjs";
+import { publishTaggedReleaseCandidate } from "./public-release-package-publish.mjs";
+
+const sourceCommit = "0123456789abcdef0123456789abcdef01234567";
+const version = "1.2.3";
+
+async function writeJson(path, value) {
+	await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function candidateFixture(t) {
+	const root = await mkdtemp(join(tmpdir(), "you-tagged-publisher-"));
+	t.after(() => rm(root, { recursive: true, force: true }));
+	await Promise.all(
+		["api", "packaged-factories", "frontend"].map((directory) =>
+			mkdir(join(root, directory)),
+		),
+	);
+	const apiTarball = "you-agent-factory-api-1.2.3.tgz";
+	const factoriesTarball = "you-agent-factory-packaged-factories-1.2.3.tgz";
+	await Promise.all([
+		writeFile(join(root, "api", apiTarball), "api"),
+		writeFile(join(root, "packaged-factories", factoriesTarball), "factories"),
+		writeJson(join(root, "api", "candidate-evidence.json"), {
+			packageName: "@you-agent-factory/api",
+			candidateVersion: version,
+			sourceCommit,
+			distTag: "latest",
+		}),
+		writeJson(join(root, "packaged-factories", "candidate-evidence.json"), {
+			packageName: "@you-agent-factory/packaged-factories",
+			candidateVersion: version,
+			sourceCommit,
+			distTag: "latest",
+		}),
+	]);
+	const frontendPackages = FRONTEND_PUBLIC_PACKAGE_NAMES.map((name, index) => ({
+		name,
+		version,
+		filename: `frontend-${index}.tgz`,
+	}));
+	await Promise.all(
+		frontendPackages.map(({ filename }) =>
+			writeFile(join(root, "frontend", filename), filename),
+		),
+	);
+	await writeJson(join(root, "frontend", "public-package-candidates.json"), {
+		scope: FRONTEND_ONLY_CANDIDATE_SCOPE,
+		version,
+		packages: frontendPackages,
+	});
+	const tarballs = new Map([
+		["@you-agent-factory/api", `api/${apiTarball}`],
+		[
+			"@you-agent-factory/packaged-factories",
+			`packaged-factories/${factoriesTarball}`,
+		],
+		...frontendPackages.map(({ name, filename }) => [
+			name,
+			`frontend/${filename}`,
+		]),
+	]);
+	const evidence = {
+		scope: TAGGED_RELEASE_CANDIDATE_SCOPE,
+		version,
+		sourceCommit,
+		packages: TAGGED_RELEASE_PUBLIC_PACKAGE_NAMES.map((name) => ({
+			name,
+			version,
+			tarball: tarballs.get(name),
+		})),
+	};
+	await writeJson(join(root, "release-candidate-evidence.json"), evidence);
+	return { evidence, root };
+}
+
+function recordingPublishers(calls) {
+	return {
+		async publishApiCandidate(input) {
+			calls.push(["api", input]);
+			return "api-published";
+		},
+		async publishPackagedFactoriesCandidate(input) {
+			calls.push(["packaged-factories", input]);
+			return "factories-published";
+		},
+		async publishFrontendCandidates(input) {
+			calls.push(["frontend", input]);
+			return "frontend-published";
+		},
+	};
+}
+
+test("validates the complete reviewed set before publishing each represented child candidate", async (t) => {
+	const { evidence, root } = await candidateFixture(t);
+	const calls = [];
+	const result = await publishTaggedReleaseCandidate(
+		{
+			candidateDirectory: root,
+			expectedSourceCommit: sourceCommit,
+			workspaceDirectory: "workspace",
+		},
+		recordingPublishers(calls),
+	);
+
+	assert.deepEqual(result.evidence, evidence);
+	assert.deepEqual(
+		calls.map(([name]) => name),
+		["api", "packaged-factories", "frontend"],
+	);
+	assert.equal(calls[0][1].expectedSourceCommit, sourceCommit);
+	assert.equal(calls[2][1].tag, "latest");
+	assert.equal(calls[2][1].provenance, true);
+});
+
+for (const testCase of [
+	{
+		name: "unknown scope",
+		mutate(evidence) {
+			evidence.scope = "complete";
+		},
+		expected: /unknown candidate scope/,
+	},
+	{
+		name: "duplicate package",
+		mutate(evidence) {
+			evidence.packages[1].name = evidence.packages[0].name;
+		},
+		expected: /duplicate package names/,
+	},
+	{
+		name: "missing expected package",
+		mutate(evidence) {
+			evidence.packages.pop();
+		},
+		expected: /candidate count mismatch/,
+	},
+	{
+		name: "mismatched candidate count",
+		mutate(evidence) {
+			evidence.packages.push({
+				name: "@you-agent-factory/unreviewed",
+				version,
+				tarball: "frontend/unreviewed.tgz",
+			});
+		},
+		expected: /candidate count mismatch/,
+	},
+	{
+		name: "unrepresented child tarball",
+		mutate(evidence) {
+			evidence.packages[0].tarball = "api/different.tgz";
+		},
+		expected: /top-level evidence does not represent/,
+	},
+]) {
+	test(`rejects ${testCase.name} before any package publication`, async (t) => {
+		const { evidence, root } = await candidateFixture(t);
+		testCase.mutate(evidence);
+		await writeJson(join(root, "release-candidate-evidence.json"), evidence);
+		const calls = [];
+
+		await assert.rejects(
+			publishTaggedReleaseCandidate(
+				{
+					candidateDirectory: root,
+					expectedSourceCommit: sourceCommit,
+					workspaceDirectory: "workspace",
+				},
+				recordingPublishers(calls),
+			),
+			testCase.expected,
+		);
+		assert.deepEqual(calls, []);
+	});
+}

--- a/ui/scripts/public-package-publish.mjs
+++ b/ui/scripts/public-package-publish.mjs
@@ -15,6 +15,10 @@ import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 
 import { assertPackedExportTargets } from "../../scripts/package-export-validation.mjs";
+import {
+  assertCandidateSetEvidence,
+  FRONTEND_ONLY_CANDIDATE_SCOPE,
+} from "../../scripts/public-package-set.mjs";
 
 const uiRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const semverPattern =
@@ -55,6 +59,12 @@ export function patchPublicPackageManifest(manifest, version) {
     }
   }
   return next;
+}
+
+export function assertFrontendCandidateEvidence(evidence) {
+  assertPublishVersion(evidence?.version);
+  assertCandidateSetEvidence(evidence, FRONTEND_ONLY_CANDIDATE_SCOPE);
+  return evidence;
 }
 
 export const npmPackArguments = (stagedDirectory, outputDirectory) => [
@@ -199,7 +209,11 @@ export async function preparePublicPackageCandidates({
         shasum: report.shasum,
       });
     }
-    const evidence = { version, packages: candidates };
+    const evidence = {
+      scope: FRONTEND_ONLY_CANDIDATE_SCOPE,
+      version,
+      packages: candidates,
+    };
     await writeFile(
       path.join(resolvedOutput, "public-package-candidates.json"),
       `${JSON.stringify(evidence, null, 2)}\n`,
@@ -262,18 +276,7 @@ export async function publishPublicPackageCandidates({
       "utf8",
     ),
   );
-  assertPublishVersion(evidence.version);
-  if (evidence.packages.length !== PUBLIC_PACKAGES.length) {
-    throw new Error("Public package candidate set is incomplete");
-  }
-  if (
-    new Set(evidence.packages.map(({ name }) => name)).size !==
-    evidence.packages.length
-  ) {
-    throw new Error(
-      "Public package candidate set contains duplicate package names",
-    );
-  }
+  assertFrontendCandidateEvidence(evidence);
   for (const packageSpec of PUBLIC_PACKAGES) {
     const candidate = evidence.packages.find(
       ({ name }) => name === packageSpec.name,

--- a/ui/scripts/public-package-publish.mjs
+++ b/ui/scripts/public-package-publish.mjs
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
 import {
   cp,
   mkdir,
@@ -67,7 +68,7 @@ export function assertFrontendCandidateEvidence(evidence) {
   return evidence;
 }
 
-export const npmPackArguments = (stagedDirectory, outputDirectory) => [
+const npmPackArguments = (stagedDirectory, outputDirectory) => [
   "pack",
   stagedDirectory,
   "--json",
@@ -110,10 +111,27 @@ function run(command, args, options = {}) {
 
 function runNpm(args, options = {}) {
   if (process.platform !== "win32") return run("npm", args, options);
-  if (!process.env.npm_execpath) {
-    throw new Error("npm_execpath is required to run npm safely on Windows");
+  const configuredNpmCli = process.env.npm_execpath;
+  const npmCli =
+    configuredNpmCli &&
+    /(?:^|[\\/])npm(?:-cli)?\.[cm]?js$/i.test(configuredNpmCli) &&
+    existsSync(configuredNpmCli)
+      ? configuredNpmCli
+      : path.join(
+          path.dirname(process.execPath),
+          "node_modules/npm/bin/npm-cli.js",
+        );
+  if (!existsSync(npmCli)) {
+    throw new Error("npm CLI could not be resolved safely on Windows");
   }
-  return run(process.execPath, [process.env.npm_execpath, ...args], options);
+  return run(process.execPath, [npmCli, ...args], options);
+}
+
+export function packCandidate({ stagedDirectory, outputDirectory }) {
+  return runNpm(npmPackArguments(stagedDirectory, outputDirectory), {
+    cwd: uiRoot,
+    capture: true,
+  });
 }
 
 async function stagePackage({ packageSpec, version, stagingRoot }) {
@@ -190,10 +208,10 @@ export async function preparePublicPackageCandidates({
         version,
         stagingRoot,
       });
-      const { stdout } = await runNpm(
-        npmPackArguments(stagedDirectory, resolvedOutput),
-        { cwd: uiRoot, capture: true },
-      );
+      const { stdout } = await packCandidate({
+        stagedDirectory,
+        outputDirectory: resolvedOutput,
+      });
       const [report] = JSON.parse(stdout);
       if (report?.name !== packageSpec.name || report?.version !== version) {
         throw new Error(

--- a/ui/scripts/public-package-publish.mjs
+++ b/ui/scripts/public-package-publish.mjs
@@ -1,7 +1,14 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import {
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -108,19 +115,52 @@ async function stagePackage({ packageSpec, version, stagingRoot }) {
   return stagedDirectory;
 }
 
+async function snapshotBuildOutputs(stagingRoot) {
+  const snapshots = [];
+  for (const packageSpec of PUBLIC_PACKAGES) {
+    const sourceDirectory = path.join(
+      uiRoot,
+      "packages",
+      packageSpec.directory,
+    );
+    const outputDirectory = path.join(sourceDirectory, "dist");
+    const backupDirectory = path.join(
+      stagingRoot,
+      ".build-output-backups",
+      packageSpec.directory,
+    );
+    try {
+      await stat(outputDirectory);
+      await cp(outputDirectory, backupDirectory, { recursive: true });
+      snapshots.push({ outputDirectory, backupDirectory });
+    } catch (error) {
+      if (error?.code === "ENOENT") snapshots.push({ outputDirectory });
+      else throw error;
+    }
+  }
+  return snapshots;
+}
+
+async function restoreBuildOutputs(snapshots) {
+  for (const { outputDirectory, backupDirectory } of snapshots) {
+    await rm(outputDirectory, { recursive: true, force: true });
+    if (backupDirectory)
+      await cp(backupDirectory, outputDirectory, { recursive: true });
+  }
+}
+
 export async function preparePublicPackageCandidates({
   version,
   outputDirectory,
 }) {
   assertPublishVersion(version);
   const resolvedOutput = path.resolve(outputDirectory);
-  const stagingRoot = await mkdtemp(
-    path.join(tmpdir(), "you-public-packages-"),
-  );
+  const stagingRoot = await mkdtemp(path.join(uiRoot, ".you-public-packages-"));
   await mkdir(resolvedOutput, { recursive: true });
   await run("bun", ["run", "link:public-package-dependencies"], {
     cwd: uiRoot,
   });
+  const buildOutputs = await snapshotBuildOutputs(stagingRoot);
   const candidates = [];
   try {
     for (const packageSpec of PUBLIC_PACKAGES) {
@@ -160,6 +200,7 @@ export async function preparePublicPackageCandidates({
     );
     return evidence;
   } finally {
+    await restoreBuildOutputs(buildOutputs);
     await rm(stagingRoot, { recursive: true, force: true });
   }
 }

--- a/ui/scripts/public-package-publish.mjs
+++ b/ui/scripts/public-package-publish.mjs
@@ -14,6 +14,8 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 
+import { assertPackedExportTargets } from "../../scripts/package-export-validation.mjs";
+
 const uiRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const semverPattern =
   /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
@@ -54,6 +56,15 @@ export function patchPublicPackageManifest(manifest, version) {
   }
   return next;
 }
+
+export const npmPackArguments = (stagedDirectory, outputDirectory) => [
+  "pack",
+  stagedDirectory,
+  "--json",
+  "--ignore-scripts",
+  "--pack-destination",
+  outputDirectory,
+];
 
 function run(command, args, options = {}) {
   return new Promise((resolve, reject) => {
@@ -112,7 +123,7 @@ async function stagePackage({ packageSpec, version, stagingRoot }) {
     );
   }
   await writeFile(manifestPath, `${JSON.stringify(patched, null, 2)}\n`);
-  return stagedDirectory;
+  return { manifest: patched, stagedDirectory };
 }
 
 async function snapshotBuildOutputs(stagingRoot) {
@@ -164,19 +175,13 @@ export async function preparePublicPackageCandidates({
   const candidates = [];
   try {
     for (const packageSpec of PUBLIC_PACKAGES) {
-      const stagedDirectory = await stagePackage({
+      const { manifest, stagedDirectory } = await stagePackage({
         packageSpec,
         version,
         stagingRoot,
       });
       const { stdout } = await runNpm(
-        [
-          "pack",
-          stagedDirectory,
-          "--json",
-          "--pack-destination",
-          resolvedOutput,
-        ],
+        npmPackArguments(stagedDirectory, resolvedOutput),
         { cwd: uiRoot, capture: true },
       );
       const [report] = JSON.parse(stdout);
@@ -185,6 +190,7 @@ export async function preparePublicPackageCandidates({
           `npm pack returned unexpected identity for ${packageSpec.name}`,
         );
       }
+      assertPackedExportTargets(report.name, manifest.exports, report.files);
       candidates.push({
         name: report.name,
         version: report.version,

--- a/ui/scripts/public-package-publish.test.mjs
+++ b/ui/scripts/public-package-publish.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import {
   assertPublishVersion,
+  npmPackArguments,
   PUBLIC_PACKAGES,
   patchPublicPackageManifest,
 } from "./public-package-publish.mjs";
@@ -59,5 +60,11 @@ describe("public package publishing", () => {
       },
     });
     expect(manifest.version).toBe("0.0.0");
+  });
+
+  test("candidate packing disables lifecycle scripts", () => {
+    expect(npmPackArguments("/staged/package", "/candidate")).toContain(
+      "--ignore-scripts",
+    );
   });
 });

--- a/ui/scripts/public-package-publish.test.mjs
+++ b/ui/scripts/public-package-publish.test.mjs
@@ -1,3 +1,6 @@
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, expect, test } from "vitest";
 import {
   FRONTEND_ONLY_CANDIDATE_SCOPE,
@@ -6,8 +9,8 @@ import {
 import {
   assertFrontendCandidateEvidence,
   assertPublishVersion,
-  npmPackArguments,
   PUBLIC_PACKAGES,
+  packCandidate,
   patchPublicPackageManifest,
 } from "./public-package-publish.mjs";
 
@@ -66,10 +69,40 @@ describe("public package publishing", () => {
     expect(manifest.version).toBe("0.0.0");
   });
 
-  test("candidate packing disables lifecycle scripts", () => {
-    expect(npmPackArguments("/staged/package", "/candidate")).toContain(
-      "--ignore-scripts",
+  test("candidate packing suppresses lifecycle script side effects", async () => {
+    const root = await mkdtemp(
+      path.join(tmpdir(), "you-package-lifecycle-fixture-"),
     );
+    const stagedDirectory = path.join(root, "package");
+    const outputDirectory = path.join(root, "candidate");
+    const sentinel = path.join(root, "lifecycle-ran");
+    try {
+      await Promise.all([mkdir(stagedDirectory), mkdir(outputDirectory)]);
+      await Promise.all([
+        writeFile(
+          path.join(stagedDirectory, "package.json"),
+          `${JSON.stringify({
+            name: "@you-agent-factory/lifecycle-fixture",
+            version: "1.0.0",
+            scripts: { prepack: "node create-sentinel.mjs" },
+          })}\n`,
+        ),
+        writeFile(
+          path.join(stagedDirectory, "create-sentinel.mjs"),
+          `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(sentinel)}, "ran");\n`,
+        ),
+      ]);
+      const { stdout } = await packCandidate({
+        stagedDirectory,
+        outputDirectory,
+      });
+      expect(JSON.parse(stdout)[0].name).toBe(
+        "@you-agent-factory/lifecycle-fixture",
+      );
+      await expect(access(sentinel)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   test("accepts only a complete frontend-only development candidate", () => {

--- a/ui/scripts/public-package-publish.test.mjs
+++ b/ui/scripts/public-package-publish.test.mjs
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "vitest";
-
 import {
+  FRONTEND_ONLY_CANDIDATE_SCOPE,
+  TAGGED_RELEASE_CANDIDATE_SCOPE,
+} from "../../scripts/public-package-set.mjs";
+import {
+  assertFrontendCandidateEvidence,
   assertPublishVersion,
   npmPackArguments,
   PUBLIC_PACKAGES,
@@ -66,5 +70,23 @@ describe("public package publishing", () => {
     expect(npmPackArguments("/staged/package", "/candidate")).toContain(
       "--ignore-scripts",
     );
+  });
+
+  test("accepts only a complete frontend-only development candidate", () => {
+    const evidence = {
+      scope: FRONTEND_ONLY_CANDIDATE_SCOPE,
+      version: "0.0.0-dev.123.abcdef123456",
+      packages: PUBLIC_PACKAGES.map(({ name }) => ({
+        name,
+        version: "0.0.0-dev.123.abcdef123456",
+      })),
+    };
+    expect(assertFrontendCandidateEvidence(evidence)).toBe(evidence);
+    expect(() =>
+      assertFrontendCandidateEvidence({
+        ...evidence,
+        scope: TAGGED_RELEASE_CANDIDATE_SCOPE,
+      }),
+    ).toThrow("expected frontend-only candidate scope");
   });
 });


### PR DESCRIPTION
{
  "project": "Repair Public npm Package Releases",
  "branchName": "public-release-packages",
  "description": "Repair the inherited public-package release work so tagged releases publish one coherent, verified npm package set: API contracts, Packaged Factories, and the frontend package family, while preserving frontend-only development candidates.",
  "context": {
    "customerAsk": "Take over agent/fix-public-package-releases, rebase it from main, and fix the public package release behavior.",
    "problem": "The public release workflow separates API and Packaged Factories from the frontend npm family, allowing tagged releases to omit intended public contracts or publish tarballs whose public contents were not directly verified. The inherited branch begins to unify the candidate set but requires behavior-focused completion and verification.",
    "solution": "Use explicit frontend-only and tagged-release package sets in the existing candidate-and-publish flow. Stage API, Packaged Factories, and frontend packages together for tagged releases; verify every packed public export and the retained compatibility artifact before publication; and preserve frontend-only immutable development candidates."
  },
  "acceptanceCriteria": [
    "A tagged release candidate contains @you-agent-factory/api, @you-agent-factory/packaged-factories, and every supported frontend public package at the requested valid release version.",
    "The API and Packaged Factories manifests are publishable public npm metadata at the release baseline, and candidate staging sets the requested release version without rewriting source manifests.",
    "Candidate creation rejects a tarball that omits any declared export target, including wildcard export patterns that have no packed match, or the required Packaged Factories compatibility artifact.",
    "Protected release publication accepts only a complete, coherent release candidate set and publishes/verifies the exact tarballs represented by its evidence.",
    "Development-package workflows continue to prepare only the frontend package family with immutable development versions and do not publish API or Packaged Factories artifacts.",
    "Release documentation distinguishes development from tagged-release package coverage and gives maintainers a non-publishing candidate command.",
    "Quality gate: typecheck, lint, focused package-release tests, relevant package pack/consumer checks, and applicable repository tests pass."
  ],
  "userStories": [
    {
      "id": "public-release-packages-001",
      "title": "Prepare a complete tagged-release candidate",
      "description": "As a release maintainer, I want a tagged release to stage every supported public npm package at one version so customers receive a coherent public package set.",
      "acceptanceCriteria": [
        "A release preparation invocation includes the API contract package, the data-only Packaged Factories package, and the existing frontend public package family.",
        "Every staged release tarball reports the requested valid release version and its expected package identity.",
        "Preparing a release candidate does not modify checked-in package manifests or build outputs.",
        "Candidate evidence identifies whether it is a frontend-only development set or the complete tagged-release set and lists each produced tarball once.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "public-release-packages-002",
      "title": "Reject incomplete public tarballs before publication",
      "description": "As a release reviewer, I want candidate preparation to reject missing public package files so a package cannot publish an export that customers cannot install.",
      "acceptanceCriteria": [
        "Candidate preparation fails with the package name and missing path when a concrete manifest export target is absent from its packed tarball.",
        "A wildcard export is accepted only when at least one packed file matches its declared pattern; an unmatched pattern fails before publication.",
        "The Packaged Factories release candidate verifies the established supported factory JSON compatibility artifact is packed even while its legacy deep-path contract remains isolated from general export validation.",
        "Package packing disables lifecycle scripts for candidate creation.",
        "Focused regression tests cover complete exports and each missing-export or missing-required-file failure outcome.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "public-release-packages-003",
      "title": "Publish only the complete protected release set",
      "description": "As a release maintainer, I want the protected release workflow to use the complete candidate set so the npm registry receives all and only the reviewed release artifacts.",
      "acceptanceCriteria": [
        "The tagged-release workflow requests preparation of the complete release package set before the publication step.",
        "Publication rejects evidence with an unknown scope, duplicate package name, missing expected package, or mismatched candidate count.",
        "The publisher uses the candidate scope to select its expected package set and preserves existing validation of package name, version, and tarball evidence.",
        "A normal frontend-only development candidate remains publishable only as the frontend package family and cannot be mistaken for a tagged-release candidate.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "public-release-packages-004",
      "title": "Preserve development release behavior and document the split",
      "description": "As a maintainer, I want development and tagged-release package behavior documented and exercised so I can reproduce a safe candidate without accidentally widening a development publication.",
      "acceptanceCriteria": [
        "Development workflow candidates retain immutable versions based on the established public release baseline, run identifier, and reviewed commit.",
        "Development workflow preparation continues to omit the API and Packaged Factories packages.",
        "Maintainer documentation states that development publication covers the frontend family, while tagged releases publish the complete public npm set, and provides the non-publishing candidate command.",
        "Documentation does not promise new runtime APIs, UI behavior, or package imports beyond the packages' declared public contracts.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
