### PR TITLE
schema-cli-run-invocation-composition

### DIFF
--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -743,6 +743,13 @@ response-stream output.
   do not limit reserved-spelling checks to parameters with named CLI bindings.
   Named and explicit-file selectors must not enter this composition
   policy; equivalent selected signatures produce equivalent results.
+  Preserve a nil selected signature as explicit compatibility mode rather than
+  replacing it with an empty active signature: compatibility mode exposes only
+  static inputs and delegates positional text, stdin, and API content to the
+  Work-owned compatibility normalizer. It must not synthesize Factory
+  parameters, unknown-named policy, defaults, validation, help, or completion
+  facts, and both CLI-shaped and API-structured named inputs must fail instead
+  of being ignored.
   Keep effective-scope spelling and inheritance checks in
   `internal/contractvalidator` so schema-valid manifests still receive stable,
   path-specific semantic diagnostics before generation or consumption.

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -718,7 +718,11 @@ response-stream output.
   Static-plus-Factory composition is owned by
   `pkg/transports/cli/climanifest.ComposeRunInputs`: pass the validated `you.run`
   command and only the selected Factory's `InvocationSignatureConfig`. The pure
-  projection keeps manifest inputs separate from dynamic Factory parameters and
+  projection keeps manifest inputs separate from dynamic Factory parameters,
+  detaches all returned collections, and exposes canonical/preferred names,
+  default shape, normalized value mode, cardinality/consumption, type hints,
+  sensitivity, and bindings without requiring downstream adapters to reinterpret
+  the authored signature. It
   rejects command-name, long-name, alias, shorthand, positional, stdin-owner,
   and stable-binding collisions with sorted diagnostics that identify both
   owners. Named and explicit-file selectors must not enter this composition

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -3,6 +3,14 @@
 Use this map when changing factory invocation input, return-policy, or
 primary-result behavior.
 
+- Selection-aware `you run` schema resolution belongs at the CLI read boundary:
+  resolve an already-selected named Factory config path or explicit Factory
+  source through the read-only Factory Definitions loader, check cancellation
+  before and after each synchronous lookup, and pass only the loaded invocation
+  signature into pure `climanifest.ComposeRunInputs`. Keep selection identity,
+  catalog provenance, and filesystem location out of the effective schema so
+  equivalent definitions produce the same downstream facts without
+  materialization, sessions, provider startup, or runtime probing.
 - A conductor-routed native integration must carry the complete cloned
   `workers.ProviderInferenceRequest` through `inferencecontract.InvocationRequest`.
   Keep provider selection and response delivery conductor-owned, while the

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -407,6 +407,11 @@ response-stream output.
   alias-backed, and compatibility fallback inputs. Transport stories should
   adapt CLI or API payloads into `NormalizeArgumentsInput` rather than
   re-implementing binding, default, or validation rules at the boundary.
+  Compare transport parity through canonical values and semantic provenance
+  (explicit versus default) because physical CLI and structured API source
+  labels intentionally differ. Validation diagnostics for sensitive parameters
+  must retain the stable error code and parameter identity while replacing the
+  rejected value with the Work-owned redaction marker.
 - JavaScript named-factory lookup carries the authored `argsSchema` and `defaultPolicy` through `pkg/orchestrators/javascript/source/` into `pkg/factory/sessions/execution/PrepareStart`. Validate resolved arguments before runtime execution and resolve policy with that default; `workflowruntime.Request.ArgsSchema` preserves the same no-side-effect guard for direct runtime callers.
 - `pkg/work/invocation/interpolation.go` owns runtime `${parameter}` interpolation
   for signature-backed worker and workstation fields plus pre-dispatch

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -725,7 +725,10 @@ response-stream output.
   the authored signature. It
   rejects command-name, long-name, alias, shorthand, positional, stdin-owner,
   and stable-binding collisions with sorted diagnostics that identify both
-  owners. Named and explicit-file selectors must not enter this composition
+  owners. Check canonical parameter names, preferred external names, and every
+  alias independently after applying the shared Work normalization trimming;
+  do not limit reserved-spelling checks to parameters with named CLI bindings.
+  Named and explicit-file selectors must not enter this composition
   policy; equivalent selected signatures produce equivalent results.
   Keep effective-scope spelling and inheritance checks in
   `internal/contractvalidator` so schema-valid manifests still receive stable,

--- a/packages/model-providers/metadata/manifest.json
+++ b/packages/model-providers/metadata/manifest.json
@@ -2,7 +2,7 @@
   "formatVersion": "1.0.0",
   "packageId": "you-agent-factory.model-providers",
   "packageVersion": "0.0.0",
-  "sourceCommit": "c5473c7a9c7e023727d659dfc5f84887a7d31979",
+  "sourceCommit": "d27eee741041069b1edd64681f5f58c9b0224871",
   "familyFormatVersions": {
     "model-providers": "1.0.0"
   },

--- a/pkg/services/work/arguments.go
+++ b/pkg/services/work/arguments.go
@@ -646,7 +646,7 @@ func validateArgumentValue(def parameterDefinition, value string) error {
 	if len(def.choices) > 0 && !slices.Contains(def.choices, value) {
 		return &ArgumentError{
 			Code:      ArgumentErrorCodeStringValidationMismatch,
-			Message:   fmt.Sprintf("parameter %q value %q is not one of the declared choices", def.name, value),
+			Message:   fmt.Sprintf("parameter %q value %s is not one of the declared choices", def.name, argumentValueDiagnostic(def, value)),
 			Parameter: def.name,
 		}
 	}
@@ -657,7 +657,7 @@ func validateArgumentValue(def parameterDefinition, value string) error {
 		if _, err := strconv.ParseBool(strings.TrimSpace(value)); err != nil {
 			return &ArgumentError{
 				Code:      ArgumentErrorCodeStringValidationMismatch,
-				Message:   fmt.Sprintf("parameter %q value %q is not a valid BOOLEAN_STRING", def.name, value),
+				Message:   fmt.Sprintf("parameter %q value %s is not a valid BOOLEAN_STRING", def.name, argumentValueDiagnostic(def, value)),
 				Parameter: def.name,
 			}
 		}
@@ -665,7 +665,7 @@ func validateArgumentValue(def parameterDefinition, value string) error {
 		if _, err := strconv.ParseFloat(strings.TrimSpace(value), 64); err != nil {
 			return &ArgumentError{
 				Code:      ArgumentErrorCodeStringValidationMismatch,
-				Message:   fmt.Sprintf("parameter %q value %q is not a valid NUMBER_STRING", def.name, value),
+				Message:   fmt.Sprintf("parameter %q value %s is not a valid NUMBER_STRING", def.name, argumentValueDiagnostic(def, value)),
 				Parameter: def.name,
 			}
 		}
@@ -673,6 +673,13 @@ func validateArgumentValue(def parameterDefinition, value string) error {
 		return newArgumentError(ArgumentErrorCodeInvalidActiveSignature, fmt.Sprintf("parameter %q uses unsupported typeHint %q", def.name, def.typeHint), def.name, "")
 	}
 	return nil
+}
+
+func argumentValueDiagnostic(def parameterDefinition, value string) string {
+	if def.sensitive {
+		return "<redacted>"
+	}
+	return strconv.Quote(value)
 }
 
 func newArgumentError(code ArgumentErrorCode, message, parameter, argument string) *ArgumentError {

--- a/pkg/services/work/arguments.go
+++ b/pkg/services/work/arguments.go
@@ -220,11 +220,11 @@ func namedArgumentValuesFromAny(value any) ([]string, error) {
 }
 
 func normalizeCompatibilityArguments(input NormalizeArgumentsInput) (NormalizedArguments, error) {
-	if len(input.NamedArgs) > 0 {
+	if argument, found := compatibilityNamedArgument(input); found {
 		return NormalizedArguments{}, &ArgumentError{
 			Code:     ArgumentErrorCodeInvalidActiveSignature,
 			Message:  "named arguments require a factory invocationSignature",
-			Argument: strings.TrimSpace(input.NamedArgs[0].Key),
+			Argument: argument,
 		}
 	}
 	if len(input.CompatibilityContent) > 0 {
@@ -264,6 +264,16 @@ func normalizeCompatibilityArguments(input NormalizeArgumentsInput) (NormalizedA
 		resolved.Source = InputSourceLabel(ArgumentSourceKindCompatibilityText)
 	}
 	return NormalizedArguments{CompatibilityInput: &resolved}, nil
+}
+
+func compatibilityNamedArgument(input NormalizeArgumentsInput) (string, bool) {
+	if len(input.NamedArgs) > 0 {
+		return strings.TrimSpace(input.NamedArgs[0].Key), true
+	}
+	if len(input.DirectArgs) > 0 {
+		return strings.TrimSpace(input.DirectArgs[0].Key), true
+	}
+	return "", false
 }
 
 func normalizeSignatureArguments(input NormalizeArgumentsInput) (NormalizedArguments, error) {

--- a/pkg/services/work/arguments_test.go
+++ b/pkg/services/work/arguments_test.go
@@ -360,6 +360,134 @@ func TestNormalizeArguments_CompatibilityPreservesAPIContentFallback(t *testing.
 	}
 }
 
+func TestNormalizeArguments_CompatibilityAcceptsOnlyDocumentedInputSources(t *testing.T) {
+	positionalText := "from compatibility text"
+	stdinText := "from stdin"
+	tests := []struct {
+		name       string
+		input      NormalizeArgumentsInput
+		wantText   string
+		wantSource InputSourceLabel
+	}{
+		{
+			name: "positional arguments",
+			input: NormalizeArgumentsInput{
+				PositionalArgs: []string{"from", "arguments"},
+			},
+			wantText:   "from arguments",
+			wantSource: InputSourcePositionalText,
+		},
+		{
+			name: "stdin",
+			input: NormalizeArgumentsInput{
+				StdinText: &stdinText,
+			},
+			wantText:   stdinText,
+			wantSource: InputSourceStdinText,
+		},
+		{
+			name: "compatibility text",
+			input: NormalizeArgumentsInput{
+				CompatibilityText: &positionalText,
+			},
+			wantText:   positionalText,
+			wantSource: InputSourceLabel(ArgumentSourceKindCompatibilityText),
+		},
+		{
+			name: "compatibility content",
+			input: NormalizeArgumentsInput{
+				CompatibilityContent: []WorkContentPart{{
+					Type: WorkContentPartTypeText,
+					Text: "from content",
+				}},
+			},
+			wantText:   "from content",
+			wantSource: InputSourceLabel(ArgumentSourceKindCompatibilityContent),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := NormalizeArguments(test.input)
+			if err != nil {
+				t.Fatalf("NormalizeArguments: %v", err)
+			}
+			if got.CompatibilityInput == nil ||
+				got.CompatibilityInput.Text != test.wantText ||
+				got.CompatibilityInput.Source != test.wantSource {
+				t.Fatalf("compatibility input = %#v, want text %q source %q", got.CompatibilityInput, test.wantText, test.wantSource)
+			}
+			if len(got.Arguments) != 0 || len(got.UnknownNamedArgs) != 0 {
+				t.Fatalf("no-signature input synthesized argument facts: %#v", got)
+			}
+		})
+	}
+}
+
+func TestNormalizeArguments_CompatibilityRejectsSignatureOnlyNamedInputs(t *testing.T) {
+	tests := []struct {
+		name  string
+		input NormalizeArgumentsInput
+	}{
+		{
+			name: "CLI named argument",
+			input: NormalizeArgumentsInput{
+				NamedArgs: []NamedArgumentInput{{Key: "mode", Values: []string{"fast"}}},
+			},
+		},
+		{
+			name: "API structured argument",
+			input: NormalizeArgumentsInput{
+				DirectArgs: []NamedArgumentInput{{Key: "mode", Values: []string{"fast"}}},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := NormalizeArguments(test.input)
+			assertArgumentErrorCode(t, err, ArgumentErrorCodeInvalidActiveSignature)
+			if got.CompatibilityInput != nil || len(got.Arguments) != 0 {
+				t.Fatalf("rejected named input returned partial facts: %#v", got)
+			}
+		})
+	}
+}
+
+func TestNormalizeArguments_CompatibilitySourceConflictsUseStableCode(t *testing.T) {
+	positionalText := "from compatibility text"
+	stdinText := "from stdin"
+	tests := []NormalizeArgumentsInput{
+		{PositionalArgs: []string{"from arguments"}, StdinText: &stdinText},
+		{CompatibilityText: &positionalText, StdinText: &stdinText},
+		{
+			CompatibilityContent: []WorkContentPart{{
+				Type: WorkContentPartTypeText,
+				Text: "from content",
+			}},
+			PositionalArgs: []string{"from arguments"},
+		},
+	}
+	for index, input := range tests {
+		got, err := NormalizeArguments(input)
+		if got.CompatibilityInput != nil {
+			t.Fatalf("case %d returned partial compatibility input: %#v", index, got)
+		}
+		var inputErr *InputError
+		var argumentErr *ArgumentError
+		switch {
+		case errors.As(err, &inputErr):
+			if inputErr.Code != InputErrorCodeSourceConflict {
+				t.Fatalf("case %d code = %q, want source conflict", index, inputErr.Code)
+			}
+		case errors.As(err, &argumentErr):
+			if argumentErr.Code != ArgumentErrorCodeSourceConflict {
+				t.Fatalf("case %d code = %q, want source conflict", index, argumentErr.Code)
+			}
+		default:
+			t.Fatalf("case %d error = %v, want stable source-conflict error", index, err)
+		}
+	}
+}
+
 func TestNamedArgumentInputsFromAnyMap_SortsAndAcceptsStringsAndStringArrays(t *testing.T) {
 	got, err := NamedArgumentInputsFromAnyMap(map[string]any{
 		"mode": "fast",

--- a/pkg/services/work/arguments_test.go
+++ b/pkg/services/work/arguments_test.go
@@ -185,6 +185,144 @@ func TestNormalizeArguments_SignatureRejectsUnroutableStdin(t *testing.T) {
 	assertArgumentErrorCode(t, err, ArgumentErrorCodeUnroutableStdin)
 }
 
+func TestNormalizeArguments_CLIAndStructuredInputsHaveCanonicalParity(t *testing.T) {
+	stdin := "from stdin"
+	signature := &InvocationSignatureConfig{Parameters: []InvocationParameterConfig{
+		positionalParameter("topic", 1, true),
+		{
+			Name:      "files",
+			ValueMode: valueModeVariadic,
+			Bindings: []InvocationParameterBindingConfig{{
+				Kind: bindingKindPositional, Position: 2,
+			}},
+		},
+		{
+			Name: "tags", ExternalName: "tag", Aliases: []string{"t"},
+			ValueMode: valueModeRepeated, Sensitive: true,
+			Bindings: []InvocationParameterBindingConfig{{Kind: bindingKindNamed}},
+		},
+		namedParameter("format", "", nil, false, "", "json"),
+		stdinParameter("body", ""),
+	}}
+	cli, err := NormalizeArguments(NormalizeArgumentsInput{
+		Signature:      signature,
+		PositionalArgs: []string{"runtime schemas", "one.txt", "two.txt"},
+		NamedArgs: []NamedArgumentInput{{
+			Key: "t", Values: []string{"internal", "release"},
+		}},
+		StdinText: &stdin,
+	})
+	if err != nil {
+		t.Fatalf("NormalizeArguments(CLI): %v", err)
+	}
+	api, err := NormalizeArguments(NormalizeArgumentsInput{
+		Signature: signature,
+		DirectArgs: []NamedArgumentInput{
+			{Key: "topic", Values: []string{"runtime schemas"}},
+			{Key: "files", Values: []string{"one.txt", "two.txt"}},
+			{Key: "tags", Values: []string{"internal", "release"}},
+			{Key: "body", Values: []string{"from stdin"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeArguments(API): %v", err)
+	}
+
+	cliFacts := canonicalArgumentFacts(cli)
+	apiFacts := canonicalArgumentFacts(api)
+	if !reflect.DeepEqual(cliFacts, apiFacts) {
+		t.Fatalf("canonical CLI facts = %#v, want API parity %#v", cliFacts, apiFacts)
+	}
+}
+
+func TestNormalizeArguments_CLIAndStructuredInputsShareFailureCodes(t *testing.T) {
+	invalidSecret := "credential-that-must-not-leak"
+	stdin := "unroutable"
+	required := signatureConfig(positionalParameter("topic", 1, true))
+	namedOnly := signatureConfig(namedParameter("output", "", nil, false, "", ""))
+	choiceSignature := signatureConfig(InvocationParameterConfig{
+		Name: "token", Sensitive: true, Choices: []string{"allowed"},
+		Bindings: []InvocationParameterBindingConfig{{Kind: bindingKindNamed}},
+	})
+	typeSignature := signatureConfig(InvocationParameterConfig{
+		Name: "token", Sensitive: true, TypeHint: typeHintNumberString,
+		Bindings: []InvocationParameterBindingConfig{{Kind: bindingKindNamed}},
+	})
+	conflictSignature := signatureConfig(InvocationParameterConfig{
+		Name: "topic",
+		Bindings: []InvocationParameterBindingConfig{
+			{Kind: bindingKindPositional, Position: 1},
+			{Kind: bindingKindNamed},
+		},
+	})
+
+	tests := []struct {
+		name string
+		want ArgumentErrorCode
+		cli  NormalizeArgumentsInput
+		api  NormalizeArgumentsInput
+	}{
+		{
+			name: "missing required input", want: ArgumentErrorCodeMissingRequiredInput,
+			cli: NormalizeArgumentsInput{Signature: required},
+			api: NormalizeArgumentsInput{Signature: required},
+		},
+		{
+			name: "unknown argument", want: ArgumentErrorCodeUnknownArgument,
+			cli: NormalizeArgumentsInput{Signature: namedOnly, NamedArgs: []NamedArgumentInput{{Key: "mystery", Values: []string{"value"}}}},
+			api: NormalizeArgumentsInput{Signature: namedOnly, DirectArgs: []NamedArgumentInput{{Key: "mystery", Values: []string{"value"}}}},
+		},
+		{
+			name: "source conflict", want: ArgumentErrorCodeSourceConflict,
+			cli: NormalizeArgumentsInput{
+				Signature: conflictSignature, PositionalArgs: []string{"first"},
+				NamedArgs: []NamedArgumentInput{{Key: "topic", Values: []string{"second"}}},
+			},
+			api: NormalizeArgumentsInput{
+				Signature: conflictSignature,
+				DirectArgs: []NamedArgumentInput{
+					{Key: "topic", Values: []string{"first"}},
+					{Key: "topic", Values: []string{"second"}},
+				},
+			},
+		},
+		{
+			name: "choice validation mismatch", want: ArgumentErrorCodeStringValidationMismatch,
+			cli: NormalizeArgumentsInput{Signature: choiceSignature, NamedArgs: []NamedArgumentInput{{Key: "token", Values: []string{invalidSecret}}}},
+			api: NormalizeArgumentsInput{Signature: choiceSignature, DirectArgs: []NamedArgumentInput{{Key: "token", Values: []string{invalidSecret}}}},
+		},
+		{
+			name: "type validation mismatch", want: ArgumentErrorCodeStringValidationMismatch,
+			cli: NormalizeArgumentsInput{Signature: typeSignature, NamedArgs: []NamedArgumentInput{{Key: "token", Values: []string{invalidSecret}}}},
+			api: NormalizeArgumentsInput{Signature: typeSignature, DirectArgs: []NamedArgumentInput{{Key: "token", Values: []string{invalidSecret}}}},
+		},
+		{
+			name: "positional overflow", want: ArgumentErrorCodePositionalOverflow,
+			cli: NormalizeArgumentsInput{Signature: required, PositionalArgs: []string{"one", "two"}},
+			api: NormalizeArgumentsInput{Signature: required, PositionalArgs: []string{"one", "two"}},
+		},
+		{
+			name: "unroutable stdin", want: ArgumentErrorCodeUnroutableStdin,
+			cli: NormalizeArgumentsInput{Signature: namedOnly, StdinText: &stdin},
+			api: NormalizeArgumentsInput{Signature: namedOnly, StdinText: &stdin},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, cliErr := NormalizeArguments(test.cli)
+			_, apiErr := NormalizeArguments(test.api)
+			assertArgumentErrorCode(t, cliErr, test.want)
+			assertArgumentErrorCode(t, apiErr, test.want)
+			for _, err := range []error{cliErr, apiErr} {
+				if strings.Contains(err.Error(), invalidSecret) {
+					t.Fatalf("sensitive value leaked in diagnostic: %v", err)
+				}
+			}
+		})
+	}
+}
+
 func TestNormalizeArguments_CompatibilityFallsBackToSharedTextResolver(t *testing.T) {
 	stdin := "from stdin"
 	got, err := NormalizeArguments(NormalizeArgumentsInput{
@@ -307,4 +445,33 @@ func assertArgumentErrorCode(t *testing.T, err error, want ArgumentErrorCode) {
 	if argumentErr.Code != want {
 		t.Fatalf("code = %q, want %q", argumentErr.Code, want)
 	}
+}
+
+type canonicalArgumentFact struct {
+	Values     []string
+	Provenance string
+	Sensitive  bool
+	Redacted   bool
+}
+
+func canonicalArgumentFacts(normalized NormalizedArguments) map[string]canonicalArgumentFact {
+	facts := make(map[string]canonicalArgumentFact, len(normalized.Arguments))
+	for name, argument := range normalized.Arguments {
+		provenance := "explicit"
+		redacted := false
+		if len(argument.Sources) > 0 {
+			provenance = "default"
+		}
+		for _, source := range argument.Sources {
+			if source.Kind != ArgumentSourceKindDefault {
+				provenance = "explicit"
+			}
+			redacted = redacted || source.Redact
+		}
+		facts[name] = canonicalArgumentFact{
+			Values:     append([]string(nil), argument.Values...),
+			Provenance: provenance, Sensitive: argument.Sensitive, Redacted: redacted,
+		}
+	}
+	return facts
 }

--- a/pkg/transports/cli/climanifest/composition.go
+++ b/pkg/transports/cli/climanifest/composition.go
@@ -85,6 +85,11 @@ type reservedSpelling struct {
 	owner string
 }
 
+type factorySpelling struct {
+	path  string
+	value string
+}
+
 // ComposeRunInputs combines a validated static command and selected Factory
 // signature without mutating either contract. Any collision rejects the
 // composition; callers must not use the returned schema when diagnostics are
@@ -237,19 +242,19 @@ func compositionDiagnostics(manifest Manifest, command Command, parameters []wor
 	positions, stdinOwner, bindingIDs := reservedStaticInputs(command)
 	var diagnostics []CompositionDiagnostic
 	for index, parameter := range parameters {
-		owner := parameter.Name
+		owner := strings.TrimSpace(parameter.Name)
 		path := fmt.Sprintf("/invocationSignature/parameters/%d", index)
-		if staticOwner, collision := bindingIDs[parameter.Name]; collision {
-			diagnostics = append(diagnostics, newCompositionDiagnostic(CompositionCollisionBindingID, path+"/name", parameter.Name, staticOwner, owner))
+		if staticOwner, collision := bindingIDs[owner]; collision {
+			diagnostics = append(diagnostics, newCompositionDiagnostic(CompositionCollisionBindingID, path+"/name", owner, staticOwner, owner))
 		}
-		for field, value := range factoryNamedSpellings(parameter) {
-			for _, reserved := range spellings[value] {
-				diagnostics = append(diagnostics, newCompositionDiagnostic(collisionCode(reserved.kind), path+field, value, reserved.owner, owner))
+		for _, spelling := range factorySpellings(parameter) {
+			for _, reserved := range spellings[spelling.value] {
+				diagnostics = append(diagnostics, newCompositionDiagnostic(collisionCode(reserved.kind), path+spelling.path, spelling.value, reserved.owner, owner))
 			}
 		}
 		for bindingIndex, binding := range parameter.Bindings {
 			bindingPath := fmt.Sprintf("%s/bindings/%d", path, bindingIndex)
-			switch binding.Kind {
+			switch strings.TrimSpace(binding.Kind) {
 			case work.InvocationParameterBindingKindPositional:
 				if staticOwner, collision := positions[binding.Position]; collision {
 					diagnostics = append(diagnostics, newCompositionDiagnostic(CompositionCollisionPosition, bindingPath+"/position", fmt.Sprint(binding.Position), staticOwner, owner))
@@ -301,7 +306,8 @@ func reservedStaticInputs(command Command) (map[int]string, string, map[string]s
 	positions := make(map[int]string)
 	bindingIDs := make(map[string]string)
 	stdinOwner := ""
-	for _, argument := range command.Arguments {
+	for _, argumentID := range sortedArgumentIDs(command.Arguments) {
+		argument := command.Arguments[argumentID]
 		// Factory positions are 1-based while static manifest slots are 0-based.
 		positions[argument.Position+1] = argument.ID
 		addBindingOwners(bindingIDs, argument.ID, argument.HandlerBindingID)
@@ -309,7 +315,8 @@ func reservedStaticInputs(command Command) (map[int]string, string, map[string]s
 			stdinOwner = argument.ID
 		}
 	}
-	for _, flag := range command.Flags {
+	for _, flagID := range sortedFlagIDs(command.Flags) {
+		flag := command.Flags[flagID]
 		addBindingOwners(bindingIDs, flag.ID, flag.HandlerBindingID)
 		if stdinOwner == "" && containsString(flag.AcceptedSources, SourceStdin) {
 			stdinOwner = flag.ID
@@ -318,27 +325,21 @@ func reservedStaticInputs(command Command) (map[int]string, string, map[string]s
 	return positions, stdinOwner, bindingIDs
 }
 
-func factoryNamedSpellings(parameter work.InvocationParameterConfig) map[string]string {
-	hasNamedBinding := false
-	for _, binding := range parameter.Bindings {
-		if binding.Kind == work.InvocationParameterBindingKindNamed || binding.Kind == work.InvocationParameterBindingKindNamedRest {
-			hasNamedBinding = true
-			break
-		}
+func factorySpellings(parameter work.InvocationParameterConfig) []factorySpelling {
+	spellings := make([]factorySpelling, 0, len(parameter.Aliases)+2)
+	if name := strings.TrimSpace(parameter.Name); name != "" {
+		spellings = append(spellings, factorySpelling{path: "/name", value: name})
 	}
-	if !hasNamedBinding {
-		return nil
-	}
-	primary := parameter.ExternalName
-	if primary == "" {
-		primary = parameter.Name
-	}
-	spellings := map[string]string{"/externalName": primary}
-	if parameter.ExternalName == "" {
-		spellings = map[string]string{"/name": primary}
+	if externalName := strings.TrimSpace(parameter.ExternalName); externalName != "" {
+		spellings = append(spellings, factorySpelling{path: "/externalName", value: externalName})
 	}
 	for index, alias := range parameter.Aliases {
-		spellings[fmt.Sprintf("/aliases/%d", index)] = alias
+		if trimmed := strings.TrimSpace(alias); trimmed != "" {
+			spellings = append(spellings, factorySpelling{
+				path:  fmt.Sprintf("/aliases/%d", index),
+				value: trimmed,
+			})
+		}
 	}
 	return spellings
 }
@@ -394,6 +395,15 @@ func sortedCommandIDs(commands map[string]Command) []string {
 func sortedFlagIDs(flags map[string]Flag) []string {
 	ids := make([]string, 0, len(flags))
 	for id := range flags {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func sortedArgumentIDs(arguments map[string]Argument) []string {
+	ids := make([]string, 0, len(arguments))
+	for id := range arguments {
 		ids = append(ids, id)
 	}
 	sort.Strings(ids)

--- a/pkg/transports/cli/climanifest/composition.go
+++ b/pkg/transports/cli/climanifest/composition.go
@@ -3,6 +3,7 @@ package climanifest
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/portpowered/infinite-you/pkg/services/work"
 )
@@ -17,13 +18,23 @@ const (
 	CompositionCollisionBindingID   = "cli.composition.binding-id-collision"
 )
 
+const (
+	EffectiveValueConsumptionSingle               = "single-value"
+	EffectiveValueConsumptionRepeated             = "repeated-values"
+	EffectiveValueConsumptionRemainingPositionals = "remaining-positionals"
+	EffectiveValueConsumptionFileContents         = "file-contents"
+
+	EffectiveUnboundedCardinality = -1
+)
+
 // EffectiveInputSchema is the immutable result of composing one static CLI
 // command with one selected Factory invocation signature. Static inputs remain
 // manifest-owned; the Factory contributes only invocation parameters.
 type EffectiveInputSchema struct {
-	CommandID         string
-	StaticInputs      []EffectiveStaticInput
-	FactoryParameters []EffectiveFactoryParameter
+	CommandID                  string
+	UnknownNamedArgumentPolicy string
+	StaticInputs               []EffectiveStaticInput
+	FactoryParameters          []EffectiveFactoryParameter
 }
 
 // EffectiveStaticInput is one manifest-owned input in the selected command.
@@ -37,12 +48,27 @@ type EffectiveStaticInput struct {
 	ConsumesStdin    bool
 }
 
-// EffectiveFactoryParameter is one selected-Factory dynamic input. BindingID
-// is the parameter's canonical name, which is the stable key used by normalized
-// invocation argument maps and handler interpolation.
+// EffectiveFactoryParameter is one selected-Factory dynamic input with the
+// normalized facts consumed by help, validation, normalization, and completion.
+// BindingID and CanonicalName are the stable key used by normalized invocation
+// argument maps and handler interpolation.
 type EffectiveFactoryParameter struct {
-	BindingID string
-	Parameter work.InvocationParameterConfig
+	BindingID             string
+	CanonicalName         string
+	PreferredExternalName string
+	Aliases               []string
+	Description           string
+	Required              bool
+	Choices               []string
+	DefaultValue          *string
+	DefaultValues         []string
+	ValueMode             string
+	ValueConsumption      string
+	MinimumValues         int
+	MaximumValues         int
+	TypeHint              string
+	Sensitive             bool
+	Bindings              []work.InvocationParameterBindingConfig
 }
 
 // CompositionDiagnostic identifies both owners of one rejected collision.
@@ -70,9 +96,10 @@ func ComposeRunInputs(manifest Manifest, commandID string, signature work.Invoca
 	}
 
 	schema := EffectiveInputSchema{
-		CommandID:         commandID,
-		StaticInputs:      projectStaticInputs(command),
-		FactoryParameters: projectFactoryParameters(signature.Parameters),
+		CommandID:                  commandID,
+		UnknownNamedArgumentPolicy: normalizedUnknownNamedArgumentPolicy(signature.UnknownNamedArgumentPolicy),
+		StaticInputs:               projectStaticInputs(command),
+		FactoryParameters:          projectFactoryParameters(signature.Parameters),
 	}
 	diagnostics := compositionDiagnostics(manifest, command, signature.Parameters)
 	if len(diagnostics) != 0 {
@@ -121,15 +148,88 @@ func projectStaticInputs(command Command) []EffectiveStaticInput {
 func projectFactoryParameters(parameters []work.InvocationParameterConfig) []EffectiveFactoryParameter {
 	projected := make([]EffectiveFactoryParameter, 0, len(parameters))
 	for _, parameter := range parameters {
-		clone := parameter
-		clone.Aliases = append([]string(nil), parameter.Aliases...)
-		clone.Choices = append([]string(nil), parameter.Choices...)
-		clone.DefaultValues = append([]string(nil), parameter.DefaultValues...)
-		clone.Bindings = append([]work.InvocationParameterBindingConfig(nil), parameter.Bindings...)
-		projected = append(projected, EffectiveFactoryParameter{BindingID: parameter.Name, Parameter: clone})
+		canonicalName := strings.TrimSpace(parameter.Name)
+		preferredExternalName := strings.TrimSpace(parameter.ExternalName)
+		if preferredExternalName == "" {
+			preferredExternalName = canonicalName
+		}
+		valueMode := work.NormalizeInvocationValueMode(parameter.ValueMode)
+		minimumValues, maximumValues, consumption := effectiveValueFacts(valueMode, parameter.Required)
+		projected = append(projected, EffectiveFactoryParameter{
+			BindingID:             canonicalName,
+			CanonicalName:         canonicalName,
+			PreferredExternalName: preferredExternalName,
+			Aliases:               normalizedNonEmptyStrings(parameter.Aliases),
+			Description:           parameter.Description,
+			Required:              parameter.Required,
+			Choices:               append([]string(nil), parameter.Choices...),
+			DefaultValue:          cloneDefaultValue(parameter.DefaultValue),
+			DefaultValues:         append([]string(nil), parameter.DefaultValues...),
+			ValueMode:             valueMode,
+			ValueConsumption:      consumption,
+			MinimumValues:         minimumValues,
+			MaximumValues:         maximumValues,
+			TypeHint:              strings.TrimSpace(parameter.TypeHint),
+			Sensitive:             parameter.Sensitive,
+			Bindings:              normalizedBindings(parameter.Bindings),
+		})
 	}
 	sort.Slice(projected, func(i, j int) bool { return projected[i].BindingID < projected[j].BindingID })
 	return projected
+}
+
+func normalizedUnknownNamedArgumentPolicy(policy string) string {
+	trimmed := strings.TrimSpace(policy)
+	if trimmed == "" {
+		return work.InvocationUnknownNamedArgumentPolicyReject
+	}
+	return trimmed
+}
+
+func normalizedNonEmptyStrings(values []string) []string {
+	var normalized []string
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			normalized = append(normalized, trimmed)
+		}
+	}
+	return normalized
+}
+
+func normalizedBindings(bindings []work.InvocationParameterBindingConfig) []work.InvocationParameterBindingConfig {
+	normalized := make([]work.InvocationParameterBindingConfig, len(bindings))
+	for index, binding := range bindings {
+		normalized[index] = work.InvocationParameterBindingConfig{
+			Kind:     strings.TrimSpace(binding.Kind),
+			Position: binding.Position,
+		}
+	}
+	return normalized
+}
+
+func cloneDefaultValue(value string) *string {
+	if value == "" {
+		return nil
+	}
+	cloned := value
+	return &cloned
+}
+
+func effectiveValueFacts(valueMode string, required bool) (int, int, string) {
+	minimumValues := 0
+	if required {
+		minimumValues = 1
+	}
+	switch valueMode {
+	case work.InvocationParameterValueModeRepeated:
+		return minimumValues, EffectiveUnboundedCardinality, EffectiveValueConsumptionRepeated
+	case work.InvocationParameterValueModeVariadic:
+		return minimumValues, EffectiveUnboundedCardinality, EffectiveValueConsumptionRemainingPositionals
+	case work.InvocationParameterValueModeFileContents:
+		return minimumValues, 1, EffectiveValueConsumptionFileContents
+	default:
+		return minimumValues, 1, EffectiveValueConsumptionSingle
+	}
 }
 
 func compositionDiagnostics(manifest Manifest, command Command, parameters []work.InvocationParameterConfig) []CompositionDiagnostic {

--- a/pkg/transports/cli/climanifest/composition.go
+++ b/pkg/transports/cli/climanifest/composition.go
@@ -25,6 +25,9 @@ const (
 	EffectiveValueConsumptionFileContents         = "file-contents"
 
 	EffectiveUnboundedCardinality = -1
+
+	EffectiveFactoryInputModeSignature     = "signature"
+	EffectiveFactoryInputModeCompatibility = "compatibility"
 )
 
 // EffectiveInputSchema is the immutable result of composing one static CLI
@@ -32,6 +35,7 @@ const (
 // manifest-owned; the Factory contributes only invocation parameters.
 type EffectiveInputSchema struct {
 	CommandID                  string
+	FactoryInputMode           string
 	UnknownNamedArgumentPolicy string
 	StaticInputs               []EffectiveStaticInput
 	FactoryParameters          []EffectiveFactoryParameter
@@ -91,21 +95,27 @@ type factorySpelling struct {
 }
 
 // ComposeRunInputs combines a validated static command and selected Factory
-// signature without mutating either contract. Any collision rejects the
-// composition; callers must not use the returned schema when diagnostics are
-// present.
-func ComposeRunInputs(manifest Manifest, commandID string, signature work.InvocationSignatureConfig) (EffectiveInputSchema, []CompositionDiagnostic, error) {
+// signature without mutating either contract. A nil signature preserves the
+// documented compatibility-input mode. Any collision rejects the composition;
+// callers must not use the returned schema when diagnostics are present.
+func ComposeRunInputs(manifest Manifest, commandID string, signature *work.InvocationSignatureConfig) (EffectiveInputSchema, []CompositionDiagnostic, error) {
 	command, ok := manifest.Commands[commandID]
 	if !ok {
 		return EffectiveInputSchema{}, nil, fmt.Errorf("CLI manifest missing static command %q", commandID)
 	}
 
 	schema := EffectiveInputSchema{
-		CommandID:                  commandID,
-		UnknownNamedArgumentPolicy: normalizedUnknownNamedArgumentPolicy(signature.UnknownNamedArgumentPolicy),
-		StaticInputs:               projectStaticInputs(command),
-		FactoryParameters:          projectFactoryParameters(signature.Parameters),
+		CommandID:        commandID,
+		FactoryInputMode: EffectiveFactoryInputModeCompatibility,
+		StaticInputs:     projectStaticInputs(command),
 	}
+	if signature == nil {
+		return schema, nil, nil
+	}
+
+	schema.FactoryInputMode = EffectiveFactoryInputModeSignature
+	schema.UnknownNamedArgumentPolicy = normalizedUnknownNamedArgumentPolicy(signature.UnknownNamedArgumentPolicy)
+	schema.FactoryParameters = projectFactoryParameters(signature.Parameters)
 	diagnostics := compositionDiagnostics(manifest, command, signature.Parameters)
 	if len(diagnostics) != 0 {
 		return EffectiveInputSchema{}, diagnostics, nil

--- a/pkg/transports/cli/climanifest/composition_test.go
+++ b/pkg/transports/cli/climanifest/composition_test.go
@@ -100,13 +100,18 @@ func TestComposeRunInputsPreservesSupportedTypeHints(t *testing.T) {
 
 func TestComposeRunInputsRejectsEveryReservedStaticNamespace(t *testing.T) {
 	manifest := compositionManifest()
+	root := manifest.Commands["you"]
+	root.Aliases = []string{"execute"}
+	manifest.Commands["you"] = root
 	signature := work.InvocationSignatureConfig{Parameters: []work.InvocationParameterConfig{
-		{Name: "you.run.binding.output", ExternalName: "output", Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindNamed}}},
-		{Name: "command", ExternalName: "run", Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindNamed}}},
-		{Name: "alias", ExternalName: "emit", Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindNamed}}},
+		{Name: " you.run.binding.output ", ExternalName: " output ", Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindNamed}}},
+		{Name: "run", Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindPositional, Position: 2}}},
+		{Name: "command-alias", ExternalName: "execute", Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindNamed}}},
+		{Name: "alias", Aliases: []string{" emit "}, Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindNamed}}},
 		{Name: "short", ExternalName: "v", Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindNamed}}},
 		{Name: "position", Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindPositional, Position: 1}}},
-		{Name: "stdin", Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindStdin}}},
+		{Name: "stdin", Bindings: []work.InvocationParameterBindingConfig{{Kind: " STDIN "}}},
+		{Name: "you.run.flag.named", Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindPositional, Position: 2}}},
 	}}
 
 	effective, diagnostics, err := ComposeRunInputs(manifest, "you.run", signature)
@@ -117,13 +122,15 @@ func TestComposeRunInputsRejectsEveryReservedStaticNamespace(t *testing.T) {
 		t.Fatalf("effective schema = %#v, want rejected composition to produce no schema", effective)
 	}
 	want := []CompositionDiagnostic{
-		{Code: CompositionCollisionAlias, Path: "/invocationSignature/parameters/2/externalName", StaticOwner: "you.run.flag.output", FactoryOwner: "alias"},
+		{Code: CompositionCollisionAlias, Path: "/invocationSignature/parameters/3/aliases/0", StaticOwner: "you.run.flag.output", FactoryOwner: "alias"},
 		{Code: CompositionCollisionBindingID, Path: "/invocationSignature/parameters/0/name", StaticOwner: "you.run.flag.output", FactoryOwner: "you.run.binding.output"},
-		{Code: CompositionCollisionCommandName, Path: "/invocationSignature/parameters/1/externalName", StaticOwner: "you.run", FactoryOwner: "command"},
+		{Code: CompositionCollisionBindingID, Path: "/invocationSignature/parameters/7/name", StaticOwner: "you.run.flag.named", FactoryOwner: "you.run.flag.named"},
+		{Code: CompositionCollisionCommandName, Path: "/invocationSignature/parameters/1/name", StaticOwner: "you.run", FactoryOwner: "run"},
+		{Code: CompositionCollisionCommandName, Path: "/invocationSignature/parameters/2/externalName", StaticOwner: "you", FactoryOwner: "command-alias"},
 		{Code: CompositionCollisionLongName, Path: "/invocationSignature/parameters/0/externalName", StaticOwner: "you.run.flag.output", FactoryOwner: "you.run.binding.output"},
-		{Code: CompositionCollisionPosition, Path: "/invocationSignature/parameters/4/bindings/0/position", StaticOwner: "you.run.arg.0", FactoryOwner: "position"},
-		{Code: CompositionCollisionShorthand, Path: "/invocationSignature/parameters/3/externalName", StaticOwner: "you.flag.verbose", FactoryOwner: "short"},
-		{Code: CompositionCollisionStdin, Path: "/invocationSignature/parameters/5/bindings/0/kind", StaticOwner: "you.run.arg.0", FactoryOwner: "stdin"},
+		{Code: CompositionCollisionPosition, Path: "/invocationSignature/parameters/5/bindings/0/position", StaticOwner: "you.run.arg.0", FactoryOwner: "position"},
+		{Code: CompositionCollisionShorthand, Path: "/invocationSignature/parameters/4/externalName", StaticOwner: "you.flag.verbose", FactoryOwner: "short"},
+		{Code: CompositionCollisionStdin, Path: "/invocationSignature/parameters/6/bindings/0/kind", StaticOwner: "you.run.arg.0", FactoryOwner: "stdin"},
 	}
 	if len(diagnostics) != len(want) {
 		t.Fatalf("diagnostics = %#v, want %#v", diagnostics, want)
@@ -136,6 +143,43 @@ func TestComposeRunInputsRejectsEveryReservedStaticNamespace(t *testing.T) {
 		if got.Message == "" {
 			t.Fatalf("diagnostic[%d] has no owner-aware message", index)
 		}
+	}
+}
+
+func TestComposeRunInputsCollisionDiagnosticsAreDeterministic(t *testing.T) {
+	manifest := compositionManifest()
+	signature := work.InvocationSignatureConfig{Parameters: []work.InvocationParameterConfig{
+		{Name: "output", Aliases: []string{"v", "emit"}, Bindings: []work.InvocationParameterBindingConfig{
+			{Kind: work.InvocationParameterBindingKindPositional, Position: 1},
+			{Kind: work.InvocationParameterBindingKindStdin},
+		}},
+	}}
+
+	_, want, err := ComposeRunInputs(manifest, "you.run", signature)
+	if err != nil || len(want) == 0 {
+		t.Fatalf("ComposeRunInputs() err=%v diagnostics=%#v", err, want)
+	}
+	for iteration := 0; iteration < 25; iteration++ {
+		_, got, repeatErr := ComposeRunInputs(manifest, "you.run", signature)
+		if repeatErr != nil || !reflect.DeepEqual(got, want) {
+			t.Fatalf("iteration %d diagnostics=%#v err=%v, want %#v", iteration, got, repeatErr, want)
+		}
+	}
+}
+
+func TestComposeRunInputsPreservesNonCollidingStaticInputs(t *testing.T) {
+	manifest := compositionManifest()
+	signature := work.InvocationSignatureConfig{Parameters: []work.InvocationParameterConfig{{
+		Name: "query", ExternalName: "search", Aliases: []string{"q"},
+		Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindNamed}},
+	}}}
+
+	effective, diagnostics, err := ComposeRunInputs(manifest, "you.run", signature)
+	if err != nil || len(diagnostics) != 0 {
+		t.Fatalf("ComposeRunInputs() err=%v diagnostics=%#v", err, diagnostics)
+	}
+	if !reflect.DeepEqual(effective.StaticInputs, projectStaticInputs(manifest.Commands["you.run"])) {
+		t.Fatalf("static inputs changed during non-colliding composition: %#v", effective.StaticInputs)
 	}
 }
 

--- a/pkg/transports/cli/climanifest/composition_test.go
+++ b/pkg/transports/cli/climanifest/composition_test.go
@@ -7,38 +7,94 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/work"
 )
 
-func TestComposeRunInputsProducesImmutableEffectiveSchema(t *testing.T) {
-	manifest := compositionManifest()
-	signature := work.InvocationSignatureConfig{Parameters: []work.InvocationParameterConfig{
-		{
-			Name:          "prompt",
-			ExternalName:  "prompt",
-			Aliases:       []string{"request"},
-			DefaultValues: []string{"one", "two"},
-			Bindings:      []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindNamed}},
-		},
-	}}
-
+func TestComposeRunInputsProducesCompleteEffectiveSchema(t *testing.T) {
+	manifest, signature := completeCompositionFixture()
 	effective, diagnostics, err := ComposeRunInputs(manifest, "you.run", signature)
 	if err != nil || len(diagnostics) != 0 {
 		t.Fatalf("ComposeRunInputs() err=%v diagnostics=%#v", err, diagnostics)
 	}
-	if len(effective.StaticInputs) != 4 {
+	if len(effective.StaticInputs) != 3 {
 		t.Fatalf("static inputs = %#v, want all global and run inputs", effective.StaticInputs)
 	}
-	if got := effective.FactoryParameters[0]; got.BindingID != "prompt" || !reflect.DeepEqual(got.Parameter.DefaultValues, []string{"one", "two"}) {
-		t.Fatalf("Factory parameter = %#v, want signature parameter and defaults", got)
+	if effective.UnknownNamedArgumentPolicy != work.InvocationUnknownNamedArgumentPolicyAllow {
+		t.Fatalf("unknown named argument policy = %q", effective.UnknownNamedArgumentPolicy)
+	}
+	want := completeEffectiveParameters()
+	if !reflect.DeepEqual(effective.FactoryParameters, want) {
+		t.Fatalf("Factory parameters = %#v, want %#v", effective.FactoryParameters, want)
+	}
+
+	again, againDiagnostics, err := ComposeRunInputs(manifest, "you.run", signature)
+	if err != nil || len(againDiagnostics) != 0 || !reflect.DeepEqual(again, effective) {
+		t.Fatalf("repeated composition differs: first=%#v second=%#v diagnostics=%#v err=%v", effective, again, againDiagnostics, err)
+	}
+}
+
+func TestComposeRunInputsDetachesCallerAndResultCollections(t *testing.T) {
+	manifest, signature := completeCompositionFixture()
+	effective, diagnostics, err := ComposeRunInputs(manifest, "you.run", signature)
+	if err != nil || len(diagnostics) != 0 {
+		t.Fatalf("ComposeRunInputs() err=%v diagnostics=%#v", err, diagnostics)
+	}
+	again, againDiagnostics, err := ComposeRunInputs(manifest, "you.run", signature)
+	if err != nil || len(againDiagnostics) != 0 {
+		t.Fatalf("second ComposeRunInputs() err=%v diagnostics=%#v", err, againDiagnostics)
 	}
 
 	effective.StaticInputs[0].PublicSpellings[0] = "changed"
-	effective.FactoryParameters[0].Parameter.Aliases[0] = "changed"
-	effective.FactoryParameters[0].Parameter.DefaultValues[0] = "changed"
-	effective.FactoryParameters[0].Parameter.Bindings[0].Kind = "changed"
+	effective.FactoryParameters[0].Aliases[0] = "changed"
+	effective.FactoryParameters[0].Choices[0] = "changed"
+	effective.FactoryParameters[0].Bindings[0].Kind = "changed"
+	effective.FactoryParameters[1].DefaultValues[0] = "changed"
 	if manifest.Commands["you.run"].Flags["global"].Long != "verbose" {
 		t.Fatal("composition mutated the static manifest")
 	}
-	if signature.Parameters[0].Aliases[0] != "request" || signature.Parameters[0].DefaultValues[0] != "one" || signature.Parameters[0].Bindings[0].Kind != work.InvocationParameterBindingKindNamed {
+	if signature.Parameters[0].Aliases[0] != "exact-alias" || signature.Parameters[0].Choices[0] != "true" ||
+		signature.Parameters[0].Bindings[0].Kind != work.InvocationParameterBindingKindNamed ||
+		signature.Parameters[1].DefaultValues[0] != "one" {
 		t.Fatal("composition mutated the Factory invocation signature")
+	}
+	if !reflect.DeepEqual(again.FactoryParameters, completeEffectiveParameters()) || again.StaticInputs[0].PublicSpellings[0] == "changed" {
+		t.Fatalf("returned schema shares caller-owned or prior result collections: %#v", again)
+	}
+
+	signature.Parameters[0].Aliases[0] = "caller-changed"
+	signature.Parameters[0].Choices[0] = "caller-changed"
+	signature.Parameters[0].Bindings[0].Kind = "caller-changed"
+	signature.Parameters[1].DefaultValues[0] = "caller-changed"
+	staticCommand := manifest.Commands["you.run"]
+	outputFlag := staticCommand.Flags["output"]
+	outputFlag.Aliases[0] = "caller-changed"
+	staticCommand.Flags["output"] = outputFlag
+	manifest.Commands["you.run"] = staticCommand
+	if !reflect.DeepEqual(again.FactoryParameters, completeEffectiveParameters()) || staticInputByID(t, again.StaticInputs, "you.run.flag.output").PublicSpellings[1] != "emit" {
+		t.Fatalf("caller-owned mutations changed a resolved schema: %#v", again)
+	}
+}
+
+func TestComposeRunInputsPreservesSupportedTypeHints(t *testing.T) {
+	supported := []string{
+		work.InvocationParameterTypeHintString,
+		work.InvocationParameterTypeHintPath,
+		work.InvocationParameterTypeHintFilePath,
+		work.InvocationParameterTypeHintDirectoryPath,
+		work.InvocationParameterTypeHintNumberString,
+		work.InvocationParameterTypeHintBooleanString,
+	}
+	for _, typeHint := range supported {
+		t.Run(typeHint, func(t *testing.T) {
+			signature := work.InvocationSignatureConfig{Parameters: []work.InvocationParameterConfig{{
+				Name: "value", TypeHint: typeHint,
+				Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindNamed}},
+			}}}
+			effective, diagnostics, err := ComposeRunInputs(compositionManifest(), "you.run", signature)
+			if err != nil || len(diagnostics) != 0 {
+				t.Fatalf("ComposeRunInputs() err=%v diagnostics=%#v", err, diagnostics)
+			}
+			if got := effective.FactoryParameters[0].TypeHint; got != typeHint {
+				t.Fatalf("TypeHint = %q, want %q", got, typeHint)
+			}
+		})
 	}
 }
 
@@ -139,4 +195,85 @@ func compositionManifest() Manifest {
 			},
 		},
 	}}
+}
+
+func completeCompositionFixture() (Manifest, work.InvocationSignatureConfig) {
+	manifest := compositionManifest()
+	command := manifest.Commands["you.run"]
+	delete(command.Arguments, "input")
+	manifest.Commands["you.run"] = command
+	signature := work.InvocationSignatureConfig{
+		UnknownNamedArgumentPolicy: work.InvocationUnknownNamedArgumentPolicyAllow,
+		Parameters: []work.InvocationParameterConfig{
+			{
+				Name: "exact", Description: "one exact string", ExternalName: "exact-value",
+				Aliases: []string{"exact-alias"}, TypeHint: work.InvocationParameterTypeHintBooleanString,
+				Required: true, Sensitive: true, Choices: []string{"true", "false"}, DefaultValue: "true",
+				Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindNamed}},
+			},
+			{
+				Name: "files", TypeHint: work.InvocationParameterTypeHintFilePath,
+				ValueMode: work.InvocationParameterValueModeRepeated, DefaultValues: []string{"one", "two"},
+				Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindNamed}},
+			},
+			{
+				Name: "input", ValueMode: work.InvocationParameterValueModeFileContents,
+				TypeHint: work.InvocationParameterTypeHintPath,
+				Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindStdin}},
+			},
+			{
+				Name: "rest", ValueMode: work.InvocationParameterValueModeVariadic,
+				TypeHint: work.InvocationParameterTypeHintDirectoryPath,
+				Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindPositional, Position: 1}},
+			},
+		},
+	}
+	return manifest, signature
+}
+
+func completeEffectiveParameters() []EffectiveFactoryParameter {
+	return []EffectiveFactoryParameter{
+		{
+			BindingID: "exact", CanonicalName: "exact", PreferredExternalName: "exact-value",
+			Aliases: []string{"exact-alias"}, Description: "one exact string", Required: true,
+			Choices: []string{"true", "false"}, DefaultValue: stringPointer("true"),
+			ValueMode: work.InvocationParameterValueModeExact, ValueConsumption: EffectiveValueConsumptionSingle,
+			MinimumValues: 1, MaximumValues: 1, TypeHint: work.InvocationParameterTypeHintBooleanString,
+			Sensitive: true, Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindNamed}},
+		},
+		{
+			BindingID: "files", CanonicalName: "files", PreferredExternalName: "files",
+			DefaultValues: []string{"one", "two"},
+			ValueMode:     work.InvocationParameterValueModeRepeated, ValueConsumption: EffectiveValueConsumptionRepeated,
+			MinimumValues: 0, MaximumValues: EffectiveUnboundedCardinality, TypeHint: work.InvocationParameterTypeHintFilePath,
+			Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindNamed}},
+		},
+		{
+			BindingID: "input", CanonicalName: "input", PreferredExternalName: "input",
+			ValueMode: work.InvocationParameterValueModeFileContents, ValueConsumption: EffectiveValueConsumptionFileContents,
+			MinimumValues: 0, MaximumValues: 1, TypeHint: work.InvocationParameterTypeHintPath,
+			Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindStdin}},
+		},
+		{
+			BindingID: "rest", CanonicalName: "rest", PreferredExternalName: "rest",
+			ValueMode: work.InvocationParameterValueModeVariadic, ValueConsumption: EffectiveValueConsumptionRemainingPositionals,
+			MinimumValues: 0, MaximumValues: EffectiveUnboundedCardinality, TypeHint: work.InvocationParameterTypeHintDirectoryPath,
+			Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindPositional, Position: 1}},
+		},
+	}
+}
+
+func stringPointer(value string) *string {
+	return &value
+}
+
+func staticInputByID(t *testing.T, inputs []EffectiveStaticInput, id string) EffectiveStaticInput {
+	t.Helper()
+	for _, input := range inputs {
+		if input.ID == id {
+			return input
+		}
+	}
+	t.Fatalf("static input %q not found in %#v", id, inputs)
+	return EffectiveStaticInput{}
 }

--- a/pkg/transports/cli/climanifest/composition_test.go
+++ b/pkg/transports/cli/climanifest/composition_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestComposeRunInputsProducesCompleteEffectiveSchema(t *testing.T) {
 	manifest, signature := completeCompositionFixture()
-	effective, diagnostics, err := ComposeRunInputs(manifest, "you.run", signature)
+	effective, diagnostics, err := ComposeRunInputs(manifest, "you.run", &signature)
 	if err != nil || len(diagnostics) != 0 {
 		t.Fatalf("ComposeRunInputs() err=%v diagnostics=%#v", err, diagnostics)
 	}
@@ -24,7 +24,7 @@ func TestComposeRunInputsProducesCompleteEffectiveSchema(t *testing.T) {
 		t.Fatalf("Factory parameters = %#v, want %#v", effective.FactoryParameters, want)
 	}
 
-	again, againDiagnostics, err := ComposeRunInputs(manifest, "you.run", signature)
+	again, againDiagnostics, err := ComposeRunInputs(manifest, "you.run", &signature)
 	if err != nil || len(againDiagnostics) != 0 || !reflect.DeepEqual(again, effective) {
 		t.Fatalf("repeated composition differs: first=%#v second=%#v diagnostics=%#v err=%v", effective, again, againDiagnostics, err)
 	}
@@ -32,11 +32,11 @@ func TestComposeRunInputsProducesCompleteEffectiveSchema(t *testing.T) {
 
 func TestComposeRunInputsDetachesCallerAndResultCollections(t *testing.T) {
 	manifest, signature := completeCompositionFixture()
-	effective, diagnostics, err := ComposeRunInputs(manifest, "you.run", signature)
+	effective, diagnostics, err := ComposeRunInputs(manifest, "you.run", &signature)
 	if err != nil || len(diagnostics) != 0 {
 		t.Fatalf("ComposeRunInputs() err=%v diagnostics=%#v", err, diagnostics)
 	}
-	again, againDiagnostics, err := ComposeRunInputs(manifest, "you.run", signature)
+	again, againDiagnostics, err := ComposeRunInputs(manifest, "you.run", &signature)
 	if err != nil || len(againDiagnostics) != 0 {
 		t.Fatalf("second ComposeRunInputs() err=%v diagnostics=%#v", err, againDiagnostics)
 	}
@@ -87,7 +87,7 @@ func TestComposeRunInputsPreservesSupportedTypeHints(t *testing.T) {
 				Name: "value", TypeHint: typeHint,
 				Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindNamed}},
 			}}}
-			effective, diagnostics, err := ComposeRunInputs(compositionManifest(), "you.run", signature)
+			effective, diagnostics, err := ComposeRunInputs(compositionManifest(), "you.run", &signature)
 			if err != nil || len(diagnostics) != 0 {
 				t.Fatalf("ComposeRunInputs() err=%v diagnostics=%#v", err, diagnostics)
 			}
@@ -114,7 +114,7 @@ func TestComposeRunInputsRejectsEveryReservedStaticNamespace(t *testing.T) {
 		{Name: "you.run.flag.named", Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindPositional, Position: 2}}},
 	}}
 
-	effective, diagnostics, err := ComposeRunInputs(manifest, "you.run", signature)
+	effective, diagnostics, err := ComposeRunInputs(manifest, "you.run", &signature)
 	if err != nil {
 		t.Fatalf("ComposeRunInputs() error = %v", err)
 	}
@@ -155,12 +155,12 @@ func TestComposeRunInputsCollisionDiagnosticsAreDeterministic(t *testing.T) {
 		}},
 	}}
 
-	_, want, err := ComposeRunInputs(manifest, "you.run", signature)
+	_, want, err := ComposeRunInputs(manifest, "you.run", &signature)
 	if err != nil || len(want) == 0 {
 		t.Fatalf("ComposeRunInputs() err=%v diagnostics=%#v", err, want)
 	}
 	for iteration := 0; iteration < 25; iteration++ {
-		_, got, repeatErr := ComposeRunInputs(manifest, "you.run", signature)
+		_, got, repeatErr := ComposeRunInputs(manifest, "you.run", &signature)
 		if repeatErr != nil || !reflect.DeepEqual(got, want) {
 			t.Fatalf("iteration %d diagnostics=%#v err=%v, want %#v", iteration, got, repeatErr, want)
 		}
@@ -174,7 +174,7 @@ func TestComposeRunInputsPreservesNonCollidingStaticInputs(t *testing.T) {
 		Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindNamed}},
 	}}}
 
-	effective, diagnostics, err := ComposeRunInputs(manifest, "you.run", signature)
+	effective, diagnostics, err := ComposeRunInputs(manifest, "you.run", &signature)
 	if err != nil || len(diagnostics) != 0 {
 		t.Fatalf("ComposeRunInputs() err=%v diagnostics=%#v", err, diagnostics)
 	}
@@ -192,11 +192,11 @@ func TestComposeRunInputsNamedAndFileSelectionsAreEquivalent(t *testing.T) {
 		Name: "query", ExternalName: "query", DefaultValue: "all", Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindNamed}},
 	}}}
 
-	named, namedDiagnostics, err := ComposeRunInputs(manifest, "you.run", namedFactorySignature)
+	named, namedDiagnostics, err := ComposeRunInputs(manifest, "you.run", &namedFactorySignature)
 	if err != nil {
 		t.Fatalf("named composition error = %v", err)
 	}
-	file, fileDiagnostics, err := ComposeRunInputs(manifest, "you.run", fileFactorySignature)
+	file, fileDiagnostics, err := ComposeRunInputs(manifest, "you.run", &fileFactorySignature)
 	if err != nil {
 		t.Fatalf("file composition error = %v", err)
 	}
@@ -210,16 +210,43 @@ func TestComposeRunInputsNamedAndFileSelectionsAreEquivalent(t *testing.T) {
 	fileColliding := work.InvocationSignatureConfig{Parameters: []work.InvocationParameterConfig{{
 		Name: "query", ExternalName: "output", Bindings: []work.InvocationParameterBindingConfig{{Kind: work.InvocationParameterBindingKindNamed}},
 	}}}
-	_, namedCollisionDiagnostics, _ := ComposeRunInputs(manifest, "you.run", namedColliding)
-	_, fileCollisionDiagnostics, _ := ComposeRunInputs(manifest, "you.run", fileColliding)
+	_, namedCollisionDiagnostics, _ := ComposeRunInputs(manifest, "you.run", &namedColliding)
+	_, fileCollisionDiagnostics, _ := ComposeRunInputs(manifest, "you.run", &fileColliding)
 	if !reflect.DeepEqual(namedCollisionDiagnostics, fileCollisionDiagnostics) {
 		t.Fatalf("equivalent selection diagnostics differ: named=%#v file=%#v", namedCollisionDiagnostics, fileCollisionDiagnostics)
 	}
 }
 
 func TestComposeRunInputsRequiresStaticCommand(t *testing.T) {
-	if _, _, err := ComposeRunInputs(Manifest{}, "you.run", work.InvocationSignatureConfig{}); err == nil {
+	if _, _, err := ComposeRunInputs(Manifest{}, "you.run", nil); err == nil {
 		t.Fatal("ComposeRunInputs() error = nil, want missing static command failure")
+	}
+}
+
+func TestComposeRunInputsKeepsNoSignatureCompatibilityDistinct(t *testing.T) {
+	manifest := compositionManifest()
+	compatibility, diagnostics, err := ComposeRunInputs(manifest, "you.run", nil)
+	if err != nil || len(diagnostics) != 0 {
+		t.Fatalf("compatibility composition err=%v diagnostics=%#v", err, diagnostics)
+	}
+	if compatibility.FactoryInputMode != EffectiveFactoryInputModeCompatibility {
+		t.Fatalf("FactoryInputMode = %q, want compatibility", compatibility.FactoryInputMode)
+	}
+	if compatibility.UnknownNamedArgumentPolicy != "" || len(compatibility.FactoryParameters) != 0 {
+		t.Fatalf("no-signature schema synthesized signature facts: %#v", compatibility)
+	}
+	if !reflect.DeepEqual(compatibility.StaticInputs, projectStaticInputs(manifest.Commands["you.run"])) {
+		t.Fatalf("compatibility static inputs = %#v", compatibility.StaticInputs)
+	}
+
+	emptySignature := work.InvocationSignatureConfig{}
+	signature, signatureDiagnostics, err := ComposeRunInputs(manifest, "you.run", &emptySignature)
+	if err != nil || len(signatureDiagnostics) != 0 {
+		t.Fatalf("empty signature composition err=%v diagnostics=%#v", err, signatureDiagnostics)
+	}
+	if signature.FactoryInputMode != EffectiveFactoryInputModeSignature ||
+		signature.UnknownNamedArgumentPolicy != work.InvocationUnknownNamedArgumentPolicyReject {
+		t.Fatalf("empty active signature facts = %#v", signature)
 	}
 }
 

--- a/pkg/transports/cli/root.go
+++ b/pkg/transports/cli/root.go
@@ -723,6 +723,9 @@ func resolveRunNamedFactorySelection(
 	resolveNamedFactoryRoots NamedFactoryRootsResolver,
 	resolveNamedFactoryCandidatePaths interfaces.NamedFactoryCandidatePathsResolver,
 ) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if namedFactoryCatalog == nil {
 		return fmt.Errorf("Factory Definitions named-factory catalog is required")
 	}
@@ -737,6 +740,9 @@ func resolveRunNamedFactorySelection(
 		return fmt.Errorf("resolve current working directory for --named: process working directory is required")
 	}
 	roots, err := resolveNamedFactoryRoots(homeDir, cwd)
+	if contextErr := ctx.Err(); contextErr != nil {
+		return contextErr
+	}
 	if err != nil {
 		return fmt.Errorf("resolve named-Factory roots: %w", err)
 	}
@@ -745,12 +751,18 @@ func resolveRunNamedFactorySelection(
 		roots.Global,
 		cfg.NamedFactoryName,
 	)
+	if contextErr := ctx.Err(); contextErr != nil {
+		return contextErr
+	}
 	if err != nil {
 		candidates, candidateErr := resolveNamedFactoryCandidatePaths(
 			roots.Project,
 			roots.Global,
 			cfg.NamedFactoryName,
 		)
+		if contextErr := ctx.Err(); contextErr != nil {
+			return contextErr
+		}
 		if candidateErr != nil {
 			return err
 		}
@@ -783,6 +795,7 @@ func resolveRunFactoryPrompt(
 		signatureSource = cfg.FactoryConfigPath
 	}
 	signature, err := runcli.ResolveFactoryInvocationSignature(
+		cmd.Context(),
 		cfg.LoadFactoryConfigFile,
 		signatureSource,
 	)

--- a/pkg/transports/cli/root_run_test.go
+++ b/pkg/transports/cli/root_run_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -303,6 +304,62 @@ func TestResolveRunNamedFactorySelectionForwardsFailureToInjectedCandidatePaths(
 	}
 	if candidateCalls != 1 {
 		t.Fatalf("candidate resolver calls = %d, want 1", candidateCalls)
+	}
+}
+
+func TestResolveRunNamedFactorySelectionHonorsCancellationWithoutSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		cancelCatalog bool
+	}{
+		{name: "before lookup"},
+		{name: "during catalog lookup", cancelCatalog: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(startupcli.WithWorkingDirectory(context.Background(), "customer-repo"))
+			catalogCalls := 0
+			catalog := rootNamedFactoryCatalogFake{resolve: func(string, string, string) (*interfaces.NamedFactoryResolution, error) {
+				catalogCalls++
+				if test.cancelCatalog {
+					cancel()
+				}
+				return &interfaces.NamedFactoryResolution{FactoryDir: "selected-factory"}, nil
+			}}
+			if !test.cancelCatalog {
+				cancel()
+			}
+			cfg := &runcli.RunConfig{NamedFactoryName: "alpha"}
+
+			err := resolveRunNamedFactorySelection(
+				ctx,
+				cfg,
+				"customer-home",
+				catalog,
+				func(string, string) (interfaces.NamedFactoryRoots, error) {
+					return interfaces.NamedFactoryRoots{Project: "project", Global: "global"}, nil
+				},
+				func(string, string, string) (interfaces.NamedFactoryCandidatePaths, error) {
+					t.Fatal("candidate lookup must not run for a canceled successful catalog lookup")
+					return interfaces.NamedFactoryCandidatePaths{}, nil
+				},
+			)
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("error = %v, want context cancellation", err)
+			}
+			if cfg.Dir != "" || cfg.NamedFactoryResolution != nil {
+				t.Fatalf("canceled lookup returned partial selection: %#v", cfg)
+			}
+			wantCalls := 0
+			if test.cancelCatalog {
+				wantCalls = 1
+			}
+			if catalogCalls != wantCalls {
+				t.Fatalf("catalog calls = %d, want %d", catalogCalls, wantCalls)
+			}
+		})
 	}
 }
 

--- a/pkg/transports/cli/run/factory_invocation_help.go
+++ b/pkg/transports/cli/run/factory_invocation_help.go
@@ -56,10 +56,7 @@ func ResolveFactoryInvocationInputSchema(
 	if err != nil {
 		return climanifest.EffectiveInputSchema{}, nil, err
 	}
-	if signature == nil {
-		signature = &interfaces.InvocationSignatureConfig{}
-	}
-	return climanifest.ComposeRunInputs(manifest, commandID, *signature)
+	return climanifest.ComposeRunInputs(manifest, commandID, signature)
 }
 
 type factoryInvocationHelpData struct {

--- a/pkg/transports/cli/run/factory_invocation_help.go
+++ b/pkg/transports/cli/run/factory_invocation_help.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -9,14 +10,19 @@ import (
 	"strings"
 
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/transports/cli/climanifest"
 )
 
 func ResolveFactoryInvocationSignature(
+	ctx context.Context,
 	load interfaces.FactoryConfigFileLoader,
 	sourcePath string,
 ) (*interfaces.InvocationSignatureConfig, error) {
 	if strings.TrimSpace(sourcePath) == "" {
 		return nil, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 	if load == nil {
 		return nil, fmt.Errorf("Factory Definitions config file loader is required")
@@ -25,10 +31,35 @@ func ResolveFactoryInvocationSignature(
 	if err != nil {
 		return nil, err
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if cfg.InvocationSignature == nil {
 		return nil, nil
 	}
 	return cfg.InvocationSignature, nil
+}
+
+// ResolveFactoryInvocationInputSchema performs the read-only selection lookup
+// around pure static-plus-Factory composition. The source path may identify a
+// named Factory's already-resolved config or an explicit authored Factory
+// source; selection identity and location are intentionally absent from the
+// returned schema.
+func ResolveFactoryInvocationInputSchema(
+	ctx context.Context,
+	manifest climanifest.Manifest,
+	commandID string,
+	load interfaces.FactoryConfigFileLoader,
+	sourcePath string,
+) (climanifest.EffectiveInputSchema, []climanifest.CompositionDiagnostic, error) {
+	signature, err := ResolveFactoryInvocationSignature(ctx, load, sourcePath)
+	if err != nil {
+		return climanifest.EffectiveInputSchema{}, nil, err
+	}
+	if signature == nil {
+		signature = &interfaces.InvocationSignatureConfig{}
+	}
+	return climanifest.ComposeRunInputs(manifest, commandID, *signature)
 }
 
 type factoryInvocationHelpData struct {

--- a/pkg/transports/cli/run/factory_invocation_input_test.go
+++ b/pkg/transports/cli/run/factory_invocation_input_test.go
@@ -125,6 +125,44 @@ func TestResolveFactoryInvocationInputSchemaHonorsCancellationWithoutPartialResu
 	}
 }
 
+func TestResolveFactoryInvocationInputSchemaNoSignatureNamedAndFileSelectionsAreEquivalent(t *testing.T) {
+	t.Parallel()
+
+	namedPath := filepath.Join("project", "factory", "legacy", interfaces.FactoryConfigFile)
+	filePath := filepath.Join("fixtures", "legacy-factory.yaml")
+	load := interfaces.FactoryConfigFileLoader(func(path string) (*interfaces.FactoryConfig, error) {
+		switch path {
+		case namedPath, filePath:
+			return &interfaces.FactoryConfig{Name: filepath.Base(filepath.Dir(path))}, nil
+		default:
+			return nil, errors.New("unexpected Factory path")
+		}
+	})
+
+	manifest := runSchemaFixtureManifest()
+	named, namedDiagnostics, err := ResolveFactoryInvocationInputSchema(
+		context.Background(), manifest, "you.run", load, namedPath,
+	)
+	if err != nil {
+		t.Fatalf("named selection: %v", err)
+	}
+	file, fileDiagnostics, err := ResolveFactoryInvocationInputSchema(
+		context.Background(), manifest, "you.run", load, filePath,
+	)
+	if err != nil {
+		t.Fatalf("file selection: %v", err)
+	}
+	if !reflect.DeepEqual(named, file) || !reflect.DeepEqual(namedDiagnostics, fileDiagnostics) {
+		t.Fatalf("no-signature selections differ: named=%#v/%#v file=%#v/%#v", named, namedDiagnostics, file, fileDiagnostics)
+	}
+	if named.FactoryInputMode != climanifest.EffectiveFactoryInputModeCompatibility {
+		t.Fatalf("FactoryInputMode = %q, want compatibility", named.FactoryInputMode)
+	}
+	if named.UnknownNamedArgumentPolicy != "" || len(named.FactoryParameters) != 0 {
+		t.Fatalf("no-signature selection synthesized signature facts: %#v", named)
+	}
+}
+
 func cloneInvocationSignatureFixture(signature interfaces.InvocationSignatureConfig) *interfaces.InvocationSignatureConfig {
 	cloned := signature
 	cloned.Parameters = append([]interfaces.InvocationParameterConfig(nil), signature.Parameters...)

--- a/pkg/transports/cli/run/factory_invocation_input_test.go
+++ b/pkg/transports/cli/run/factory_invocation_input_test.go
@@ -1,14 +1,156 @@
 package run
 
 import (
+	"context"
+	"errors"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/work"
+	"github.com/portpowered/infinite-you/pkg/transports/cli/climanifest"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
+
+func TestResolveFactoryInvocationInputSchemaNamedAndFileSelectionsAreEquivalent(t *testing.T) {
+	t.Parallel()
+
+	fixtureSignature := interfaces.InvocationSignatureConfig{
+		Parameters: []interfaces.InvocationParameterConfig{{
+			Name:         "query",
+			ExternalName: "search",
+			Aliases:      []string{"q"},
+			DefaultValue: "all",
+			Bindings: []interfaces.InvocationParameterBindingConfig{{
+				Kind: work.InvocationParameterBindingKindNamed,
+			}},
+		}},
+	}
+	namedPath := filepath.Join("project", "factory", "named-fixture", interfaces.FactoryConfigFile)
+	filePath := filepath.Join("fixtures", "portable-factory.yaml")
+	selectedConfigs := map[string]*interfaces.FactoryConfig{
+		namedPath: {
+			Name:                "named-catalog-identity",
+			InvocationSignature: cloneInvocationSignatureFixture(fixtureSignature),
+		},
+		filePath: {
+			Name:                "portable-file-identity",
+			InvocationSignature: cloneInvocationSignatureFixture(fixtureSignature),
+		},
+	}
+	expectedNamed := interfaces.FactoryConfig{
+		Name:                selectedConfigs[namedPath].Name,
+		InvocationSignature: cloneInvocationSignatureFixture(*selectedConfigs[namedPath].InvocationSignature),
+	}
+	expectedFile := interfaces.FactoryConfig{
+		Name:                selectedConfigs[filePath].Name,
+		InvocationSignature: cloneInvocationSignatureFixture(*selectedConfigs[filePath].InvocationSignature),
+	}
+	loadedPaths := make([]string, 0, 2)
+	load := interfaces.FactoryConfigFileLoader(func(path string) (*interfaces.FactoryConfig, error) {
+		loadedPaths = append(loadedPaths, path)
+		return selectedConfigs[path], nil
+	})
+
+	manifest := runSchemaFixtureManifest()
+	named, namedDiagnostics, err := ResolveFactoryInvocationInputSchema(
+		context.Background(), manifest, "you.run", load, namedPath,
+	)
+	if err != nil {
+		t.Fatalf("named selection: %v", err)
+	}
+	file, fileDiagnostics, err := ResolveFactoryInvocationInputSchema(
+		context.Background(), manifest, "you.run", load, filePath,
+	)
+	if err != nil {
+		t.Fatalf("file selection: %v", err)
+	}
+	if !reflect.DeepEqual(named, file) || !reflect.DeepEqual(namedDiagnostics, fileDiagnostics) {
+		t.Fatalf("equivalent selections differ: named=%#v/%#v file=%#v/%#v", named, namedDiagnostics, file, fileDiagnostics)
+	}
+	if !reflect.DeepEqual(loadedPaths, []string{namedPath, filePath}) {
+		t.Fatalf("read-only loader paths = %#v", loadedPaths)
+	}
+	if !reflect.DeepEqual(*selectedConfigs[namedPath], expectedNamed) ||
+		!reflect.DeepEqual(*selectedConfigs[filePath], expectedFile) {
+		t.Fatalf("schema resolution mutated a selected Factory config")
+	}
+}
+
+func TestResolveFactoryInvocationInputSchemaHonorsCancellationWithoutPartialResult(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		cancelLoad bool
+	}{
+		{name: "before lookup"},
+		{name: "during lookup", cancelLoad: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			loadCalls := 0
+			load := interfaces.FactoryConfigFileLoader(func(string) (*interfaces.FactoryConfig, error) {
+				loadCalls++
+				if test.cancelLoad {
+					cancel()
+				}
+				return &interfaces.FactoryConfig{InvocationSignature: &interfaces.InvocationSignatureConfig{}}, nil
+			})
+			if !test.cancelLoad {
+				cancel()
+			}
+
+			schema, diagnostics, err := ResolveFactoryInvocationInputSchema(
+				ctx, runSchemaFixtureManifest(), "you.run", load, "fixture/factory.json",
+			)
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("error = %v, want context cancellation", err)
+			}
+			if !reflect.DeepEqual(schema, climanifest.EffectiveInputSchema{}) || diagnostics != nil {
+				t.Fatalf("canceled lookup returned partial result: schema=%#v diagnostics=%#v", schema, diagnostics)
+			}
+			wantCalls := 0
+			if test.cancelLoad {
+				wantCalls = 1
+			}
+			if loadCalls != wantCalls {
+				t.Fatalf("loader calls = %d, want %d", loadCalls, wantCalls)
+			}
+		})
+	}
+}
+
+func cloneInvocationSignatureFixture(signature interfaces.InvocationSignatureConfig) *interfaces.InvocationSignatureConfig {
+	cloned := signature
+	cloned.Parameters = append([]interfaces.InvocationParameterConfig(nil), signature.Parameters...)
+	for index := range cloned.Parameters {
+		cloned.Parameters[index].Aliases = append([]string(nil), signature.Parameters[index].Aliases...)
+		cloned.Parameters[index].Bindings = append(
+			[]interfaces.InvocationParameterBindingConfig(nil),
+			signature.Parameters[index].Bindings...,
+		)
+	}
+	return &cloned
+}
+
+func runSchemaFixtureManifest() climanifest.Manifest {
+	return climanifest.Manifest{Commands: map[string]climanifest.Command{
+		"you": {ID: "you", Name: "you"},
+		"you.run": {
+			ID:   "you.run",
+			Name: "run",
+			Flags: map[string]climanifest.Flag{
+				"factory": {ID: "you.run.flag.factory", Long: "factory"},
+				"named":   {ID: "you.run.flag.named", Long: "named"},
+			},
+		},
+	}}
+}
 
 func TestJavaScriptWorkflowPathRecognizesSupportedExtensions(t *testing.T) {
 	t.Parallel()

--- a/tests/functional/cli/input_contract/canonical_input_contract_test.go
+++ b/tests/functional/cli/input_contract/canonical_input_contract_test.go
@@ -28,7 +28,7 @@ func TestCanonicalRunInputCompositionAndResolution(t *testing.T) {
 		}},
 	}}}
 
-	effective, diagnostics, err := climanifest.ComposeRunInputs(manifest, "you.run", signature)
+	effective, diagnostics, err := climanifest.ComposeRunInputs(manifest, "you.run", &signature)
 	if err != nil || len(diagnostics) != 0 {
 		t.Fatalf("ComposeRunInputs() err=%v diagnostics=%#v", err, diagnostics)
 	}


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "schema-cli-run-invocation-composition",
  "description": "Compose the validated static `you run` command record with a selected Factory's invocation signature into one deterministic, immutable effective runtime command schema. Preserve all supported binding and parameter facts, reject reserved static collisions, keep named and explicit-file selection equivalent, prove CLI/API canonical normalization parity, retain only documented no-signature compatibility behavior, and perform no Factory materialization, mutation, writes, or runtime probing.",
  "context": {
    "customerAsk": "Implement Schema-Driven CLI Task 6 as a pure runtime-composition lane. Compose the existing static `you run` command record with the selected Factory's `invocationSignature` so later CLI, API, help, validation, normalization, and completion adapters can consume one effective command schema. Preserve POSITIONAL, NAMED, and STDIN bindings; requiredness; aliases; choices; defaults; value modes; type hints; and sensitivity. Static CLI inputs remain reserved, collisions fail deterministically, named and explicit Factory-file selection produce equivalent facts, CLI and API normalization remain equivalent, and Factories without signatures retain only documented compatibility behavior.",
    "problem": "The schema-driven CLI foundation can represent static command inputs and the Factory contract can represent dynamic invocation parameters, but `you run` does not yet have one complete runtime schema that deterministically composes the two. Downstream adapters can therefore disagree about input existence, binding, completion, canonical argument keys, sensitivity, or failure behavior. Inconsistent composition could also let a Factory parameter shadow a reserved static input or make named Factory selection differ from an equivalent explicit Factory-file run.",
    "solution": "Provide a transport-neutral resolver that accepts the validated static `you run` command record and an already loaded selected Factory invocation signature, then returns one immutable effective runtime command schema. Preserve the normalized facts needed by later help, validation, normalization, and completion adapters; reject all static/dynamic collisions with stable sorted diagnostics and no partial schema; use the shared Work-owned canonical argument normalizer for CLI/API parity; preserve explicit no-signature compatibility behavior; and keep any selection lookup cancellation-aware and free of materialization, mutation, writes, sessions, provider activity, or runtime probing."
  },
  "acceptanceCriteria": [
    "AC-1: Equivalent invocation signatures selected by Factory name or explicit Factory file resolve to the same effective help, validation, normalization, and completion facts and the same canonical parameter keys.",
    "AC-2: The effective schema preserves POSITIONAL, NAMED, and STDIN bindings; requiredness; aliases; choices; defaults; EXACT, REPEATED, VARIADIC, and FILE_CONTENTS value modes; supported type hints; and sensitivity.",
    "AC-3: A Factory parameter that collides with any reserved static `you run` spelling, stable binding ID, positional slot, or stdin consumer is rejected deterministically; the static input is never shadowed and no partial schema is returned.",
    "AC-4: Identical CLI-shaped and API-shaped invocation inputs normalize to equivalent canonical argument maps, provenance/redaction facts where applicable, and stable failure codes.",
    "AC-5: A Factory without an invocation signature retains only the documented compatibility input behavior and does not gain signature-only named, default, validation, help, or completion facts.",
    "AC-6: Composition is deterministic and side-effect free; any required Factory lookup honors cancellation and does not materialize, mutate, probe, or write a Factory or start runtime/provider activity.",
    "AC-7: Quality checks pass (typecheck, lint, tests, including `make verify-fast`)."
  ],
  "userStories": [
    {
      "id": "schema-cli-run-invocation-composition-001",
      "title": "Resolve complete signature facts into one effective run schema",
      "description": "As a downstream command adapter, I want one effective schema that combines the static `you run` record with the selected Factory signature so help, validation, normalization, and completion can project the same input contract.",
      "acceptanceCriteria": [
        "For each signature parameter, the resolved schema exposes its canonical parameter name, preferred external name, aliases, description, requiredness, choices, supported default shape, value mode, type hint, sensitivity, and declared bindings.",
        "POSITIONAL bindings retain their 1-based position, NAMED bindings retain all accepted spellings, and STDIN bindings retain their input-channel fact.",
        "EXACT, REPEATED, VARIADIC, and FILE_CONTENTS modes resolve to the corresponding cardinality/value-consumption facts needed by validation and completion.",
        "Factory-owned collections and the static command record are detached from the result: mutating caller-owned inputs or returned collections after resolution cannot mutate another value.",
        "Repeated resolution of equal inputs produces deeply equivalent, deterministically ordered output.",
        "Focused composition tests cover positional, named, stdin, aliases, requiredness, choices, scalar and repeated defaults, all supported value modes, type hints, and sensitivity.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "schema-cli-run-invocation-composition-002",
      "title": "Reject reserved static input collisions deterministically",
      "description": "As a CLI user, I want static `you run` inputs to keep their documented meaning when a Factory declares a conflicting parameter so my input is never silently routed to the wrong owner.",
      "acceptanceCriteria": [
        "Composition rejects Factory names, external names, and aliases that collide with reserved static command names, command aliases, flag long names, flag aliases, or shorthands.",
        "Composition rejects Factory parameters that collide with a static stable input/binding ID, occupied positional slot, or static stdin consumer.",
        "On collision, static input ownership remains authoritative, no partial effective schema is returned, and the diagnostic identifies the stable code, Factory parameter, static owner, and conflicting path or binding.",
        "Multiple collisions are returned in stable deterministic order regardless of map iteration order or repeated execution.",
        "Non-colliding parameters continue to compose without changing static input semantics.",
        "Focused tests cover spelling, alias, shorthand, stable-ID, positional, stdin, multiple-collision, and non-collision cases.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "schema-cli-run-invocation-composition-003",
      "title": "Make named and explicit Factory resolution equivalent and safe",
      "description": "As a CLI user, I want selecting a Factory by name or by explicit Factory file to yield the same invocation contract so selection syntax does not change accepted inputs or guidance.",
      "acceptanceCriteria": [
        "Equivalent Factory definitions selected by name and explicit file produce deeply equivalent effective schema facts for help, validation, normalization, and completion.",
        "Selection identity, catalog provenance, and filesystem location do not alter canonical parameter keys, ordering, defaults, validation facts, or completion facts.",
        "Any selection-aware lookup accepts and propagates context cancellation before returning a schema; cancellation is reported without a partial result.",
        "Lookup and composition do not materialize built-ins, modify the selected Factory object, write Factory/config files, initialize a Factory Session, start providers, or probe runtime readiness.",
        "Fixture-based tests prove named/file parity, cancellation behavior, and absence of the prohibited filesystem and runtime side effects.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "schema-cli-run-invocation-composition-004",
      "title": "Preserve CLI and API canonical normalization parity",
      "description": "As an integrator, I want equivalent CLI and API invocation inputs to normalize identically so transport choice does not change the Factory's arguments or validation outcome.",
      "acceptanceCriteria": [
        "CLI-shaped positional, named, alias, repeated, variadic, stdin, and defaulted inputs and equivalent API structured inputs produce the same map keyed by canonical Factory parameter names.",
        "The equivalent normalized results retain matching value order, source/provenance meaning, and sensitivity/redaction facts where those facts are represented by the shared normalizer.",
        "Equivalent invalid CLI and API inputs return the same stable failure code for missing required input, unknown argument, source conflict, choice/type validation mismatch, positional overflow, and unroutable stdin.",
        "Sensitive values never appear in parity-test diagnostics or other resolver-visible failure detail.",
        "Parity tests use the same fixture signatures for both input shapes and assert canonical results and codes rather than transport-specific prose.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "schema-cli-run-invocation-composition-005",
      "title": "Retain only documented no-signature compatibility behavior",
      "description": "As a user of an older Factory without an invocation signature, I want its documented compatibility input behavior to continue without silently enabling signature-only features.",
      "acceptanceCriteria": [
        "A Factory with no invocation signature accepts the documented single compatibility text/content path, including the documented positional-text or stdin alternative where applicable.",
        "Conflicting compatibility input sources fail with the existing stable source-conflict code.",
        "Named arguments, aliases, signature defaults, choices, required-parameter validation, and signature-derived completion facts are not synthesized for a no-signature Factory.",
        "A no-signature Factory selected by name and the equivalent explicit file produce the same compatibility result and failure codes.",
        "Focused compatibility tests cover accepted positional/stdin/content behavior, source conflicts, and rejection of signature-only named inputs.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}
