### PR TITLE
Fix API manifest source provenance

### DIFF
--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -372,5 +372,5 @@
   "formatVersion": "1.0.0",
   "packageId": "you-agent-factory.api",
   "packageVersion": "0.0.0",
-  "sourceCommit": "5237accefc8b0d164719bdeb0e40048f5ccbb574"
+  "sourceCommit": "86f81440244e701c308f6b0c836cbb4db220213c"
 }


### PR DESCRIPTION
## What changed

Refreshes the generated API package manifest's `sourceCommit` to the current canonical API source identity on `main`.

## Why

`main` changed `api/openapi.yaml` in `86f81440244e701c308f6b0c836cbb4db220213c`, but the generated manifest still recorded `5237accefc8b0d164719bdeb0e40048f5ccbb574`. That makes contract stale-staging checks fail for unrelated changes. Landing this independently also lets Recordings PR #1295 remove the shared generated-file change from its owner-local diff, as required by its blocking conversation feedback.

## Validation

- `make contracts-check`
- `go test ./pkg/services/workers/interface -run TestMockWorkersSchema_StaleStagingDetectedByContractCheck -count=1`
- `git diff --check`

`make typecheck` reaches the UI compiler but the fresh worktree's installed TypeScript 6 rejects existing `baseUrl` settings (TS5101); this PR does not touch UI or TypeScript configuration.