### PR TITLE
Fix browser integration build race and cache setup

### DIFF
--- a/.github/actions/setup-ui-browser/action.yml
+++ b/.github/actions/setup-ui-browser/action.yml
@@ -1,0 +1,34 @@
+name: Setup UI browser dependencies
+description: Restore exact-lockfile UI dependencies and Playwright Chromium for browser tests
+
+inputs:
+  bun-version:
+    description: Bun version used to install the UI dependency tree
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
+    - id: ui-dependencies
+      name: Restore UI dependencies
+      uses: actions/cache@v4
+      with:
+        path: ui/node_modules
+        key: ui-node-modules-v1-${{ runner.os }}-${{ runner.arch }}-bun-${{ inputs.bun-version }}-${{ hashFiles('ui/bun.lock') }}
+    - name: Install UI dependencies
+      if: steps.ui-dependencies.outputs.cache-hit != 'true'
+      shell: bash
+      run: make ui-deps
+    - id: playwright-browser
+      name: Restore Playwright Chromium
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-chromium-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('ui/bun.lock') }}
+    - name: Install Playwright Chromium
+      if: steps.playwright-browser.outputs.cache-hit != 'true'
+      shell: bash
+      run: make ui-install-playwright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,10 +171,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: ./.github/actions/setup-ui-browser
         with:
           bun-version: ${{ env.BUN_VERSION }}
-      - run: make ui-deps ui-install-playwright ui-integration-test
+      - run: make ui-integration-test
 
   frontend-storybook:
     name: Frontend Storybook
@@ -184,10 +184,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: ./.github/actions/setup-ui-browser
         with:
           bun-version: ${{ env.BUN_VERSION }}
-      - run: make ui-deps ui-install-playwright ui-storybook-integration-test
+      - run: make ui-storybook-integration-test
 
   backend-coverage:
     name: Backend ${{ matrix.label }} Coverage
@@ -234,10 +234,10 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
-      - uses: oven-sh/setup-bun@v2
+      - uses: ./.github/actions/setup-ui-browser
         with:
           bun-version: ${{ env.BUN_VERSION }}
-      - run: make ui-deps ui-install-playwright ui-durable-session-real-backend-integration-test
+      - run: make ui-durable-session-real-backend-integration-test
 
   api-package:
     name: API Contract And Package

--- a/ui/integration/browser-build-lock.mjs
+++ b/ui/integration/browser-build-lock.mjs
@@ -1,0 +1,24 @@
+export async function runSharedBrowserBuild({
+  build,
+  buildCacheKey,
+  buildState = globalThis,
+  ready,
+}) {
+  if (!buildState[buildCacheKey]) {
+    const buildPromise = Promise.resolve()
+      .then(async () => {
+        if (!(await ready())) {
+          await build();
+        }
+      })
+      .catch((error) => {
+        if (buildState[buildCacheKey] === buildPromise) {
+          delete buildState[buildCacheKey];
+        }
+        throw error;
+      });
+    buildState[buildCacheKey] = buildPromise;
+  }
+
+  await buildState[buildCacheKey];
+}

--- a/ui/integration/browser-build-lock.test.mjs
+++ b/ui/integration/browser-build-lock.test.mjs
@@ -1,0 +1,58 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+
+import { runSharedBrowserBuild } from "./browser-build-lock.mjs";
+
+describe("shared browser build lock", () => {
+  it("shares one pending build across concurrent preview setup", async () => {
+    const buildState = {};
+    let releaseBuild;
+    const build = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          releaseBuild = resolve;
+        }),
+    );
+    const ready = vi.fn().mockResolvedValue(false);
+    const options = {
+      build,
+      buildCacheKey: "browser-build",
+      buildState,
+      ready,
+    };
+
+    const builds = [
+      runSharedBrowserBuild(options),
+      runSharedBrowserBuild(options),
+      runSharedBrowserBuild(options),
+    ];
+    await vi.waitFor(() => expect(build).toHaveBeenCalledOnce());
+    releaseBuild();
+    await Promise.all(builds);
+
+    expect(ready).toHaveBeenCalledOnce();
+    expect(build).toHaveBeenCalledOnce();
+  });
+
+  it("clears a failed build so a later preview can retry", async () => {
+    const buildState = {};
+    const build = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("build failed"))
+      .mockResolvedValueOnce(undefined);
+    const options = {
+      build,
+      buildCacheKey: "browser-build",
+      buildState,
+      ready: vi.fn().mockResolvedValue(false),
+    };
+
+    await expect(runSharedBrowserBuild(options)).rejects.toThrow(
+      "build failed",
+    );
+    await expect(runSharedBrowserBuild(options)).resolves.toBeUndefined();
+
+    expect(build).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/integration/browser-test-harness.mjs
+++ b/ui/integration/browser-test-harness.mjs
@@ -12,6 +12,8 @@ import { fileURLToPath } from "node:url";
 
 import { chromium } from "playwright";
 
+import { runSharedBrowserBuild } from "./browser-build-lock.mjs";
+
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.resolve(dirname, "..");
 const replayFixtureDirectory = path.join(dirname, "fixtures");
@@ -997,21 +999,22 @@ async function createBrowserPreview(ports = null) {
     ? `${browserBuildCacheKey}:sourcemaps`
     : browserBuildCacheKey;
 
-  const globalBuildState = globalThis;
-  if (!globalBuildState[buildCacheKey] && !(await browserDistReady())) {
-    await runRuntime(
-      ["run", "build"],
-      {
-        AGENT_FACTORY_PROFILE_SOURCEMAPS: sourceMapBuild ? "true" : "false",
-      },
-      buildTimeoutMs,
-      {
-        nodeEnv: "production",
-        stripVitestEnv: true,
-      },
-    );
-  }
-  globalBuildState[buildCacheKey] = true;
+  await runSharedBrowserBuild({
+    build: () =>
+      runRuntime(
+        ["run", "build"],
+        {
+          AGENT_FACTORY_PROFILE_SOURCEMAPS: sourceMapBuild ? "true" : "false",
+        },
+        buildTimeoutMs,
+        {
+          nodeEnv: "production",
+          stripVitestEnv: true,
+        },
+      ),
+    buildCacheKey,
+    ready: browserDistReady,
+  });
 
   const previewProcess = spawnRuntime(
     [


### PR DESCRIPTION
## Summary

- serialize the shared UI production build inside each Vitest worker so concurrent real-backend previews cannot race on `ui/dist`
- cache exact-lockfile `ui/node_modules` and Playwright Chromium for the three browser CI lanes
- skip dependency and browser installation when their cache is restored

## Root cause

The real-backend suite starts three scenarios concurrently. Each scenario could observe an incomplete or absent `ui/dist` and start `bun run build`; those builds concurrently cleaned and normalized `dist/assets`, causing the main failure with `ENOENT` while scanning that directory.

## Validation

- `bunx vitest run integration/browser-build-lock.test.mjs integration/browser-test-harness.port-availability.test.mjs`
- cold-bundle `make ui-durable-session-real-backend-integration-test` (4 checks passed in 63s)
- focused Biome check for the changed browser harness files
- YAML parsing for the workflow and composite action
- `make verify-fast` attempted but exceeded the local 10-minute command cap