### PR TITLE
schema-cli-selected-factory-completion-projection

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1221,6 +1221,10 @@
       "minimum": 47.50
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/cli/completionprojection",
+      "minimum": 0.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/climanifest",
       "minimum": 2.80
     },

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1238,7 +1238,13 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/completionprojection",
-      "minimum": 0.00
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/config",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1221,10 +1221,6 @@
       "minimum": 47.50
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/cli/completionprojection",
-      "minimum": 0.00
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/climanifest",
       "minimum": 2.80
     },
@@ -1239,6 +1235,10 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/commandregistry",
       "minimum": 59.14
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/cli/completionprojection",
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/config",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1107,6 +1107,10 @@
       "minimum": 90.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/cli/completionprojection",
+      "minimum": 84.93
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/climanifest",
       "minimum": 87.85
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1107,10 +1107,6 @@
       "minimum": 90.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/cli/completionprojection",
-      "minimum": 84.93
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/climanifest",
       "minimum": 87.85
     },
@@ -1125,6 +1121,10 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/commandregistry",
       "minimum": 87.86
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/cli/completionprojection",
+      "minimum": 84.93
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/config",

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -3962,6 +3962,12 @@
       "destinationKind": "family"
     },
     {
+      "packagePath": "pkg/transports/cli/completionprojection",
+      "disposition": "retain",
+      "destination": "transports",
+      "destinationKind": "family"
+    },
+    {
       "packagePath": "pkg/transports/cli/config",
       "disposition": "retain",
       "destination": "transports",

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -296,6 +296,7 @@
     "pkg/transports/cli/cliserver",
     "pkg/transports/cli/commandidentity",
     "pkg/transports/cli/commandregistry",
+    "pkg/transports/cli/completionprojection",
     "pkg/transports/cli/config",
     "pkg/transports/cli/configinit",
     "pkg/transports/cli/dashboard",
@@ -1629,6 +1630,11 @@
     },
     {
       "packagePath": "pkg/transports/cli/commandregistry",
+      "disposition": "retain",
+      "destination": "transports"
+    },
+    {
+      "packagePath": "pkg/transports/cli/completionprojection",
       "disposition": "retain",
       "destination": "transports"
     },

--- a/pkg/transports/cli/completionprojection/projection.go
+++ b/pkg/transports/cli/completionprojection/projection.go
@@ -60,6 +60,10 @@ func Project(
 	schema climanifest.EffectiveInputSchema,
 	completionContext Context,
 ) (Projection, error) {
+	if schema.FactoryInputMode != climanifest.EffectiveFactoryInputModeSignature {
+		return Projection{}, nil
+	}
+
 	switch completionContext.Target {
 	case TargetFlags:
 		return projectFlags(schema), nil
@@ -92,6 +96,10 @@ func projectValues(schema climanifest.EffectiveInputSchema, bindingID string) Pr
 }
 
 func parameterValues(parameter climanifest.EffectiveFactoryParameter) Projection {
+	if parameter.Sensitive {
+		return Projection{}
+	}
+
 	values := parameter.Choices
 	if len(values) == 0 && parameter.TypeHint == work.InvocationParameterTypeHintBooleanString {
 		values = []string{documentedBooleanTrue, documentedBooleanFalse}

--- a/pkg/transports/cli/completionprojection/projection.go
+++ b/pkg/transports/cli/completionprojection/projection.go
@@ -4,6 +4,7 @@ package completionprojection
 
 import (
 	"context"
+	"strings"
 
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/transports/cli/climanifest"
@@ -13,7 +14,13 @@ const (
 	TargetFlags  = "flags"
 	TargetValues = "values"
 
-	CandidateKindFlag = "flag"
+	CandidateKindFlag  = "flag"
+	CandidateKindValue = "value"
+
+	DirectiveKindFilesystemDelegation = "filesystem-delegation"
+
+	documentedBooleanTrue  = "true"
+	documentedBooleanFalse = "false"
 )
 
 // Context identifies the kind of completion requested by a future shell
@@ -53,10 +60,17 @@ func Project(
 	schema climanifest.EffectiveInputSchema,
 	completionContext Context,
 ) (Projection, error) {
-	if completionContext.Target != TargetFlags {
+	switch completionContext.Target {
+	case TargetFlags:
+		return projectFlags(schema), nil
+	case TargetValues:
+		return projectValues(schema, completionContext.ParameterBindingID), nil
+	default:
 		return Projection{}, nil
 	}
+}
 
+func projectFlags(schema climanifest.EffectiveInputSchema) Projection {
 	var candidates []Candidate
 	for _, parameter := range schema.FactoryParameters {
 		if !hasNamedBinding(parameter.Bindings) {
@@ -64,7 +78,35 @@ func Project(
 		}
 		candidates = append(candidates, flagCandidates(parameter)...)
 	}
-	return Projection{Candidates: candidates}, nil
+	return Projection{Candidates: candidates}
+}
+
+func projectValues(schema climanifest.EffectiveInputSchema, bindingID string) Projection {
+	for _, parameter := range schema.FactoryParameters {
+		if parameter.BindingID != bindingID {
+			continue
+		}
+		return parameterValues(parameter)
+	}
+	return Projection{}
+}
+
+func parameterValues(parameter climanifest.EffectiveFactoryParameter) Projection {
+	values := parameter.Choices
+	if len(values) == 0 && parameter.TypeHint == work.InvocationParameterTypeHintBooleanString {
+		values = []string{documentedBooleanTrue, documentedBooleanFalse}
+	}
+
+	projection := Projection{
+		Candidates: valueCandidates(parameter, values),
+	}
+	if parameter.TypeHint == work.InvocationParameterTypeHintFilePath {
+		projection.Directives = []Directive{{
+			Kind:               DirectiveKindFilesystemDelegation,
+			ParameterBindingID: parameter.BindingID,
+		}}
+	}
+	return projection
 }
 
 func hasNamedBinding(bindings []work.InvocationParameterBindingConfig) bool {
@@ -93,4 +135,43 @@ func flagCandidates(parameter climanifest.EffectiveFactoryParameter) []Candidate
 		})
 	}
 	return candidates
+}
+
+func valueCandidates(parameter climanifest.EffectiveFactoryParameter, values []string) []Candidate {
+	if len(values) == 0 {
+		return nil
+	}
+	description := valueDescription(parameter)
+	candidates := make([]Candidate, 0, len(values))
+	for _, value := range values {
+		candidates = append(candidates, Candidate{
+			Kind:               CandidateKindValue,
+			ParameterBindingID: parameter.BindingID,
+			Value:              value,
+			Description:        description,
+		})
+	}
+	return candidates
+}
+
+func valueDescription(parameter climanifest.EffectiveFactoryParameter) string {
+	description := strings.TrimSpace(parameter.Description)
+	if parameter.Sensitive {
+		return description
+	}
+
+	defaultDescription := ""
+	switch {
+	case parameter.DefaultValue != nil:
+		defaultDescription = "Default: " + *parameter.DefaultValue + "."
+	case len(parameter.DefaultValues) > 0:
+		defaultDescription = "Defaults: " + strings.Join(parameter.DefaultValues, ", ") + "."
+	}
+	if description == "" {
+		return defaultDescription
+	}
+	if defaultDescription == "" {
+		return description
+	}
+	return description + " " + defaultDescription
 }

--- a/pkg/transports/cli/completionprojection/projection.go
+++ b/pkg/transports/cli/completionprojection/projection.go
@@ -56,48 +56,67 @@ type Projection struct {
 // completion facts. It consumes detached values only and performs no selection,
 // runtime, shell, filesystem, or process-global work.
 func Project(
-	_ context.Context,
+	ctx context.Context,
 	schema climanifest.EffectiveInputSchema,
 	completionContext Context,
 ) (Projection, error) {
+	if err := cancellationError(ctx); err != nil {
+		return Projection{}, err
+	}
+	if err := validateSchema(ctx, schema); err != nil {
+		return Projection{}, err
+	}
 	if schema.FactoryInputMode != climanifest.EffectiveFactoryInputModeSignature {
 		return Projection{}, nil
 	}
 
 	switch completionContext.Target {
 	case TargetFlags:
-		return projectFlags(schema), nil
+		return projectFlags(ctx, schema)
 	case TargetValues:
-		return projectValues(schema, completionContext.ParameterBindingID), nil
+		return projectValues(ctx, schema, completionContext.ParameterBindingID)
 	default:
 		return Projection{}, nil
 	}
 }
 
-func projectFlags(schema climanifest.EffectiveInputSchema) Projection {
+func projectFlags(ctx context.Context, schema climanifest.EffectiveInputSchema) (Projection, error) {
 	var candidates []Candidate
 	for _, parameter := range schema.FactoryParameters {
+		if err := cancellationError(ctx); err != nil {
+			return Projection{}, err
+		}
 		if !hasNamedBinding(parameter.Bindings) {
 			continue
 		}
 		candidates = append(candidates, flagCandidates(parameter)...)
 	}
-	return Projection{Candidates: candidates}
+	return Projection{Candidates: candidates}, nil
 }
 
-func projectValues(schema climanifest.EffectiveInputSchema, bindingID string) Projection {
+func projectValues(
+	ctx context.Context,
+	schema climanifest.EffectiveInputSchema,
+	bindingID string,
+) (Projection, error) {
 	for _, parameter := range schema.FactoryParameters {
+		if err := cancellationError(ctx); err != nil {
+			return Projection{}, err
+		}
 		if parameter.BindingID != bindingID {
 			continue
 		}
-		return parameterValues(parameter)
+		return parameterValues(ctx, parameter)
 	}
-	return Projection{}
+	return Projection{}, nil
 }
 
-func parameterValues(parameter climanifest.EffectiveFactoryParameter) Projection {
+func parameterValues(
+	ctx context.Context,
+	parameter climanifest.EffectiveFactoryParameter,
+) (Projection, error) {
 	if parameter.Sensitive {
-		return Projection{}
+		return Projection{}, nil
 	}
 
 	values := parameter.Choices
@@ -105,16 +124,18 @@ func parameterValues(parameter climanifest.EffectiveFactoryParameter) Projection
 		values = []string{documentedBooleanTrue, documentedBooleanFalse}
 	}
 
-	projection := Projection{
-		Candidates: valueCandidates(parameter, values),
+	candidates, err := valueCandidates(ctx, parameter, values)
+	if err != nil {
+		return Projection{}, err
 	}
+	projection := Projection{Candidates: candidates}
 	if parameter.TypeHint == work.InvocationParameterTypeHintFilePath {
 		projection.Directives = []Directive{{
 			Kind:               DirectiveKindFilesystemDelegation,
 			ParameterBindingID: parameter.BindingID,
 		}}
 	}
-	return projection
+	return projection, nil
 }
 
 func hasNamedBinding(bindings []work.InvocationParameterBindingConfig) bool {
@@ -145,13 +166,20 @@ func flagCandidates(parameter climanifest.EffectiveFactoryParameter) []Candidate
 	return candidates
 }
 
-func valueCandidates(parameter climanifest.EffectiveFactoryParameter, values []string) []Candidate {
+func valueCandidates(
+	ctx context.Context,
+	parameter climanifest.EffectiveFactoryParameter,
+	values []string,
+) ([]Candidate, error) {
 	if len(values) == 0 {
-		return nil
+		return nil, nil
 	}
 	description := valueDescription(parameter)
 	candidates := make([]Candidate, 0, len(values))
 	for _, value := range values {
+		if err := cancellationError(ctx); err != nil {
+			return nil, err
+		}
 		candidates = append(candidates, Candidate{
 			Kind:               CandidateKindValue,
 			ParameterBindingID: parameter.BindingID,
@@ -159,7 +187,7 @@ func valueCandidates(parameter climanifest.EffectiveFactoryParameter, values []s
 			Description:        description,
 		})
 	}
-	return candidates
+	return candidates, nil
 }
 
 func valueDescription(parameter climanifest.EffectiveFactoryParameter) string {

--- a/pkg/transports/cli/completionprojection/projection.go
+++ b/pkg/transports/cli/completionprojection/projection.go
@@ -1,0 +1,96 @@
+// Package completionprojection maps an already-resolved selected-Factory
+// invocation schema into detached facts for shell-specific completion adapters.
+package completionprojection
+
+import (
+	"context"
+
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	"github.com/portpowered/infinite-you/pkg/transports/cli/climanifest"
+)
+
+const (
+	TargetFlags  = "flags"
+	TargetValues = "values"
+
+	CandidateKindFlag = "flag"
+)
+
+// Context identifies the kind of completion requested by a future shell
+// adapter. EnteredPrefix is carried only as input to matching policy and must
+// never be copied into returned facts or errors.
+type Context struct {
+	Target             string
+	ParameterBindingID string
+	EnteredPrefix      string
+}
+
+// Candidate is one ordered, detached completion choice.
+type Candidate struct {
+	Kind               string
+	ParameterBindingID string
+	Value              string
+	Description        string
+}
+
+// Directive describes work that a future shell adapter should perform.
+type Directive struct {
+	Kind               string
+	ParameterBindingID string
+}
+
+// Projection contains all completion facts for one request.
+type Projection struct {
+	Candidates []Candidate
+	Directives []Directive
+}
+
+// Project deterministically maps an effective selected-Factory schema to
+// completion facts. It consumes detached values only and performs no selection,
+// runtime, shell, filesystem, or process-global work.
+func Project(
+	_ context.Context,
+	schema climanifest.EffectiveInputSchema,
+	completionContext Context,
+) (Projection, error) {
+	if completionContext.Target != TargetFlags {
+		return Projection{}, nil
+	}
+
+	var candidates []Candidate
+	for _, parameter := range schema.FactoryParameters {
+		if !hasNamedBinding(parameter.Bindings) {
+			continue
+		}
+		candidates = append(candidates, flagCandidates(parameter)...)
+	}
+	return Projection{Candidates: candidates}, nil
+}
+
+func hasNamedBinding(bindings []work.InvocationParameterBindingConfig) bool {
+	for _, binding := range bindings {
+		if binding.Kind == work.InvocationParameterBindingKindNamed {
+			return true
+		}
+	}
+	return false
+}
+
+func flagCandidates(parameter climanifest.EffectiveFactoryParameter) []Candidate {
+	candidates := make([]Candidate, 0, len(parameter.Aliases)+1)
+	candidates = append(candidates, Candidate{
+		Kind:               CandidateKindFlag,
+		ParameterBindingID: parameter.BindingID,
+		Value:              "--" + parameter.PreferredExternalName,
+		Description:        parameter.Description,
+	})
+	for _, alias := range parameter.Aliases {
+		candidates = append(candidates, Candidate{
+			Kind:               CandidateKindFlag,
+			ParameterBindingID: parameter.BindingID,
+			Value:              "--" + alias,
+			Description:        parameter.Description,
+		})
+	}
+	return candidates
+}

--- a/pkg/transports/cli/completionprojection/projection_test.go
+++ b/pkg/transports/cli/completionprojection/projection_test.go
@@ -116,6 +116,109 @@ func TestProjectFlagsHasSelectionParityAndIsRepeatable(t *testing.T) {
 	}
 }
 
+func TestProjectValuesPreservesDeclaredChoiceOrder(t *testing.T) {
+	schema := effectiveSchema(climanifest.EffectiveFactoryParameter{
+		BindingID:   "format",
+		Description: "output format",
+		Choices:     []string{"json", "text", "markdown"},
+	})
+
+	got := projectValues(t, schema, "format")
+	want := completionprojection.Projection{Candidates: []completionprojection.Candidate{
+		valueCandidate("format", "json", "output format"),
+		valueCandidate("format", "text", "output format"),
+		valueCandidate("format", "markdown", "output format"),
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Project() = %#v, want %#v", got, want)
+	}
+}
+
+func TestProjectValuesUsesDocumentedBooleanForms(t *testing.T) {
+	schema := effectiveSchema(climanifest.EffectiveFactoryParameter{
+		BindingID:   "confirm",
+		Description: "confirm execution",
+		TypeHint:    work.InvocationParameterTypeHintBooleanString,
+	})
+
+	got := projectValues(t, schema, "confirm")
+	want := completionprojection.Projection{Candidates: []completionprojection.Candidate{
+		valueCandidate("confirm", "true", "confirm execution"),
+		valueCandidate("confirm", "false", "confirm execution"),
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Project() = %#v, want %#v", got, want)
+	}
+}
+
+func TestProjectValuesRequestsFilesystemDelegationForFileInput(t *testing.T) {
+	schema := effectiveSchema(climanifest.EffectiveFactoryParameter{
+		BindingID:   "config",
+		Description: "configuration file",
+		TypeHint:    work.InvocationParameterTypeHintFilePath,
+	})
+
+	got := projectValues(t, schema, "config")
+	want := completionprojection.Projection{Directives: []completionprojection.Directive{{
+		Kind:               completionprojection.DirectiveKindFilesystemDelegation,
+		ParameterBindingID: "config",
+	}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Project() = %#v, want %#v", got, want)
+	}
+}
+
+func TestProjectValuesInventsNoFreeTextCandidates(t *testing.T) {
+	defaultValue := "write a release note"
+	schema := effectiveSchema(climanifest.EffectiveFactoryParameter{
+		BindingID:     "prompt",
+		Description:   "request text",
+		TypeHint:      work.InvocationParameterTypeHintString,
+		DefaultValue:  &defaultValue,
+		DefaultValues: nil,
+	})
+
+	got := projectValues(t, schema, "prompt")
+	if !reflect.DeepEqual(got, completionprojection.Projection{}) {
+		t.Fatalf("Project() = %#v, want empty projection", got)
+	}
+}
+
+func TestProjectValuesAddsDefaultsOnlyToDescriptionMetadata(t *testing.T) {
+	defaultValue := "json"
+	schema := effectiveSchema(
+		climanifest.EffectiveFactoryParameter{
+			BindingID:    "format",
+			Description:  "output format",
+			Choices:      []string{"text", "json"},
+			DefaultValue: &defaultValue,
+		},
+		climanifest.EffectiveFactoryParameter{
+			BindingID:     "labels",
+			Choices:       []string{"bug", "feature"},
+			DefaultValues: []string{"bug", "feature"},
+		},
+	)
+
+	scalar := projectValues(t, schema, "format")
+	wantScalar := completionprojection.Projection{Candidates: []completionprojection.Candidate{
+		valueCandidate("format", "text", "output format Default: json."),
+		valueCandidate("format", "json", "output format Default: json."),
+	}}
+	if !reflect.DeepEqual(scalar, wantScalar) {
+		t.Fatalf("scalar Project() = %#v, want %#v", scalar, wantScalar)
+	}
+
+	repeated := projectValues(t, schema, "labels")
+	wantRepeated := completionprojection.Projection{Candidates: []completionprojection.Candidate{
+		valueCandidate("labels", "bug", "Defaults: bug, feature."),
+		valueCandidate("labels", "feature", "Defaults: bug, feature."),
+	}}
+	if !reflect.DeepEqual(repeated, wantRepeated) {
+		t.Fatalf("repeated Project() = %#v, want %#v", repeated, wantRepeated)
+	}
+}
+
 func effectiveSchema(parameters ...climanifest.EffectiveFactoryParameter) climanifest.EffectiveInputSchema {
 	return climanifest.EffectiveInputSchema{
 		CommandID:         "you.run",
@@ -144,6 +247,35 @@ func flagCandidate(bindingID, value, description string) completionprojection.Ca
 		Value:              value,
 		Description:        description,
 	}
+}
+
+func valueCandidate(bindingID, value, description string) completionprojection.Candidate {
+	return completionprojection.Candidate{
+		Kind:               completionprojection.CandidateKindValue,
+		ParameterBindingID: bindingID,
+		Value:              value,
+		Description:        description,
+	}
+}
+
+func projectValues(
+	t *testing.T,
+	schema climanifest.EffectiveInputSchema,
+	bindingID string,
+) completionprojection.Projection {
+	t.Helper()
+	got, err := completionprojection.Project(
+		context.Background(),
+		schema,
+		completionprojection.Context{
+			Target:             completionprojection.TargetValues,
+			ParameterBindingID: bindingID,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	return got
 }
 
 func cloneSchema(schema climanifest.EffectiveInputSchema) climanifest.EffectiveInputSchema {

--- a/pkg/transports/cli/completionprojection/projection_test.go
+++ b/pkg/transports/cli/completionprojection/projection_test.go
@@ -3,6 +3,7 @@ package completionprojection_test
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/portpowered/infinite-you/pkg/services/work"
@@ -219,6 +220,103 @@ func TestProjectValuesAddsDefaultsOnlyToDescriptionMetadata(t *testing.T) {
 	}
 }
 
+func TestProjectSensitiveParameterExposesOnlyItsAddressableFlag(t *testing.T) {
+	const (
+		sensitiveChoiceSentinel     = "sensitive-choice-sentinel"
+		sensitiveDefaultSentinel    = "sensitive-default-sentinel"
+		sensitivePrefixSentinel     = "sensitive-prefix-sentinel"
+		sensitiveDiagnosticSentinel = "sensitive-diagnostic-sentinel"
+	)
+	defaultValue := sensitiveDefaultSentinel
+	schema := effectiveSchema(climanifest.EffectiveFactoryParameter{
+		BindingID:             "credential",
+		PreferredExternalName: "credential",
+		Aliases:               []string{"auth"},
+		Description:           "credential input",
+		Choices:               []string{sensitiveChoiceSentinel},
+		DefaultValue:          &defaultValue,
+		TypeHint:              work.InvocationParameterTypeHintFilePath,
+		Sensitive:             true,
+		Bindings: []work.InvocationParameterBindingConfig{{
+			Kind: work.InvocationParameterBindingKindNamed,
+		}},
+	})
+
+	flags, err := completionprojection.Project(
+		context.Background(),
+		schema,
+		completionprojection.Context{
+			Target:        completionprojection.TargetFlags,
+			EnteredPrefix: sensitivePrefixSentinel,
+		},
+	)
+	if err != nil {
+		t.Fatal("flag projection returned an error")
+	}
+	wantFlags := completionprojection.Projection{Candidates: []completionprojection.Candidate{
+		flagCandidate("credential", "--credential", "credential input"),
+		flagCandidate("credential", "--auth", "credential input"),
+	}}
+	if !reflect.DeepEqual(flags, wantFlags) {
+		t.Fatal("sensitive parameter flag projection differs from addressable flag facts")
+	}
+
+	values, err := completionprojection.Project(
+		context.Background(),
+		schema,
+		completionprojection.Context{
+			Target:             completionprojection.TargetValues,
+			ParameterBindingID: "credential",
+			EnteredPrefix:      sensitivePrefixSentinel,
+		},
+	)
+	if err != nil {
+		t.Fatal("value projection returned an error")
+	}
+	if !reflect.DeepEqual(values, completionprojection.Projection{}) {
+		t.Fatal("sensitive parameter produced value or directive facts")
+	}
+
+	assertProjectionOmitsText(t, flags,
+		sensitiveChoiceSentinel,
+		sensitiveDefaultSentinel,
+		sensitivePrefixSentinel,
+		sensitiveDiagnosticSentinel,
+	)
+	assertProjectionOmitsText(t, values,
+		sensitiveChoiceSentinel,
+		sensitiveDefaultSentinel,
+		sensitivePrefixSentinel,
+		sensitiveDiagnosticSentinel,
+	)
+}
+
+func TestProjectNoSignatureReturnsNoSignatureCompletionFacts(t *testing.T) {
+	schema := climanifest.EffectiveInputSchema{
+		CommandID:        "you.run",
+		FactoryInputMode: climanifest.EffectiveFactoryInputModeCompatibility,
+		StaticInputs: []climanifest.EffectiveStaticInput{{
+			ID:              "you.run.arg.0",
+			Kind:            "argument",
+			ConsumesStdin:   true,
+			PublicSpellings: []string{"input"},
+		}},
+	}
+
+	for _, completionContext := range []completionprojection.Context{
+		{Target: completionprojection.TargetFlags},
+		{Target: completionprojection.TargetValues, ParameterBindingID: "input"},
+	} {
+		got, err := completionprojection.Project(context.Background(), schema, completionContext)
+		if err != nil {
+			t.Fatal("no-signature projection returned an error")
+		}
+		if !reflect.DeepEqual(got, completionprojection.Projection{}) {
+			t.Fatal("no-signature Factory produced signature-only completion facts")
+		}
+	}
+}
+
 func effectiveSchema(parameters ...climanifest.EffectiveFactoryParameter) climanifest.EffectiveInputSchema {
 	return climanifest.EffectiveInputSchema{
 		CommandID:         "you.run",
@@ -290,4 +388,29 @@ func cloneSchema(schema climanifest.EffectiveInputSchema) climanifest.EffectiveI
 		)
 	}
 	return cloned
+}
+
+func assertProjectionOmitsText(
+	t *testing.T,
+	projection completionprojection.Projection,
+	omitted ...string,
+) {
+	t.Helper()
+	for _, candidate := range projection.Candidates {
+		for _, text := range omitted {
+			if strings.Contains(candidate.Value, text) ||
+				strings.Contains(candidate.Description, text) ||
+				strings.Contains(candidate.ParameterBindingID, text) {
+				t.Fatal("projection retained confidential candidate text")
+			}
+		}
+	}
+	for _, directive := range projection.Directives {
+		for _, text := range omitted {
+			if strings.Contains(directive.Kind, text) ||
+				strings.Contains(directive.ParameterBindingID, text) {
+				t.Fatal("projection retained confidential directive text")
+			}
+		}
+	}
 }

--- a/pkg/transports/cli/completionprojection/projection_test.go
+++ b/pkg/transports/cli/completionprojection/projection_test.go
@@ -1,0 +1,161 @@
+package completionprojection_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	"github.com/portpowered/infinite-you/pkg/transports/cli/climanifest"
+	"github.com/portpowered/infinite-you/pkg/transports/cli/completionprojection"
+)
+
+func TestProjectFlagsPreservesEffectiveSchemaOrderAndAliases(t *testing.T) {
+	schema := effectiveSchema(
+		namedParameter("alpha", "first", []string{"a", "one"}),
+		namedParameter("beta", "second", []string{"b"}),
+	)
+
+	got, err := completionprojection.Project(
+		context.Background(),
+		schema,
+		completionprojection.Context{Target: completionprojection.TargetFlags},
+	)
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	want := completionprojection.Projection{Candidates: []completionprojection.Candidate{
+		flagCandidate("alpha", "--first", "alpha description"),
+		flagCandidate("alpha", "--a", "alpha description"),
+		flagCandidate("alpha", "--one", "alpha description"),
+		flagCandidate("beta", "--second", "beta description"),
+		flagCandidate("beta", "--b", "beta description"),
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Project() = %#v, want %#v", got, want)
+	}
+}
+
+func TestProjectFlagsDoesNotInventFlagsForPositionalOrStdinBindings(t *testing.T) {
+	schema := effectiveSchema(
+		climanifest.EffectiveFactoryParameter{
+			BindingID:             "position",
+			PreferredExternalName: "position",
+			Aliases:               []string{"p"},
+			Bindings: []work.InvocationParameterBindingConfig{{
+				Kind:     work.InvocationParameterBindingKindPositional,
+				Position: 1,
+			}},
+		},
+		climanifest.EffectiveFactoryParameter{
+			BindingID:             "stdin",
+			PreferredExternalName: "stdin",
+			Aliases:               []string{"s"},
+			Bindings: []work.InvocationParameterBindingConfig{{
+				Kind: work.InvocationParameterBindingKindStdin,
+			}},
+		},
+		namedParameter("named", "query", []string{"q"}),
+	)
+
+	got, err := completionprojection.Project(
+		context.Background(),
+		schema,
+		completionprojection.Context{Target: completionprojection.TargetFlags},
+	)
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	want := completionprojection.Projection{Candidates: []completionprojection.Candidate{
+		flagCandidate("named", "--query", "named description"),
+		flagCandidate("named", "--q", "named description"),
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Project() = %#v, want %#v", got, want)
+	}
+}
+
+func TestProjectFlagsHasSelectionParityAndIsRepeatable(t *testing.T) {
+	namedSelection := effectiveSchema(
+		namedParameter("format", "format", []string{"f"}),
+		namedParameter("query", "search", []string{"q", "find"}),
+	)
+	explicitFileSelection := cloneSchema(namedSelection)
+	completionContext := completionprojection.Context{
+		Target:        completionprojection.TargetFlags,
+		EnteredPrefix: "--se",
+	}
+
+	named, err := completionprojection.Project(context.Background(), namedSelection, completionContext)
+	if err != nil {
+		t.Fatalf("named Project() error = %v", err)
+	}
+	fromFile, err := completionprojection.Project(context.Background(), explicitFileSelection, completionContext)
+	if err != nil {
+		t.Fatalf("explicit-file Project() error = %v", err)
+	}
+	again, err := completionprojection.Project(context.Background(), namedSelection, completionContext)
+	if err != nil {
+		t.Fatalf("repeated Project() error = %v", err)
+	}
+	if !reflect.DeepEqual(named, fromFile) || !reflect.DeepEqual(named, again) {
+		t.Fatalf("equivalent projections differ: named=%#v file=%#v again=%#v", named, fromFile, again)
+	}
+
+	named.Candidates[0].Value = "--changed"
+	if explicitFileSelection.FactoryParameters[0].PreferredExternalName != "format" {
+		t.Fatal("projection shares mutable state with the effective schema")
+	}
+	repeatedAfterMutation, err := completionprojection.Project(context.Background(), namedSelection, completionContext)
+	if err != nil {
+		t.Fatalf("Project() after result mutation error = %v", err)
+	}
+	if !reflect.DeepEqual(repeatedAfterMutation, again) {
+		t.Fatalf("result mutation changed repeated projection: got=%#v want=%#v", repeatedAfterMutation, again)
+	}
+}
+
+func effectiveSchema(parameters ...climanifest.EffectiveFactoryParameter) climanifest.EffectiveInputSchema {
+	return climanifest.EffectiveInputSchema{
+		CommandID:         "you.run",
+		FactoryInputMode:  climanifest.EffectiveFactoryInputModeSignature,
+		FactoryParameters: parameters,
+	}
+}
+
+func namedParameter(bindingID, externalName string, aliases []string) climanifest.EffectiveFactoryParameter {
+	return climanifest.EffectiveFactoryParameter{
+		BindingID:             bindingID,
+		CanonicalName:         bindingID,
+		PreferredExternalName: externalName,
+		Aliases:               aliases,
+		Description:           bindingID + " description",
+		Bindings: []work.InvocationParameterBindingConfig{{
+			Kind: work.InvocationParameterBindingKindNamed,
+		}},
+	}
+}
+
+func flagCandidate(bindingID, value, description string) completionprojection.Candidate {
+	return completionprojection.Candidate{
+		Kind:               completionprojection.CandidateKindFlag,
+		ParameterBindingID: bindingID,
+		Value:              value,
+		Description:        description,
+	}
+}
+
+func cloneSchema(schema climanifest.EffectiveInputSchema) climanifest.EffectiveInputSchema {
+	cloned := schema
+	cloned.FactoryParameters = make([]climanifest.EffectiveFactoryParameter, len(schema.FactoryParameters))
+	for index, parameter := range schema.FactoryParameters {
+		cloned.FactoryParameters[index] = parameter
+		cloned.FactoryParameters[index].Aliases = append([]string(nil), parameter.Aliases...)
+		cloned.FactoryParameters[index].Bindings = append(
+			[]work.InvocationParameterBindingConfig(nil),
+			parameter.Bindings...,
+		)
+	}
+	return cloned
+}

--- a/pkg/transports/cli/completionprojection/projection_test.go
+++ b/pkg/transports/cli/completionprojection/projection_test.go
@@ -2,9 +2,11 @@ package completionprojection_test
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/transports/cli/climanifest"
@@ -317,11 +319,119 @@ func TestProjectNoSignatureReturnsNoSignatureCompletionFacts(t *testing.T) {
 	}
 }
 
+func TestProjectRejectsInvalidSchemaAtomicallyWithoutConfidentialErrorText(t *testing.T) {
+	const (
+		prefixSentinel     = "entered-prefix-sentinel"
+		sensitiveSentinel  = "sensitive-value-sentinel"
+		diagnosticSentinel = "sensitive-diagnostic-sentinel"
+	)
+	schema := effectiveSchema(
+		namedParameter("valid", "valid", nil),
+		climanifest.EffectiveFactoryParameter{
+			BindingID:     "invalid",
+			CanonicalName: "invalid",
+			Sensitive:     true,
+			Choices:       []string{sensitiveSentinel},
+			Bindings: []work.InvocationParameterBindingConfig{{
+				Kind: diagnosticSentinel,
+			}},
+		},
+	)
+
+	got, err := completionprojection.Project(
+		context.Background(),
+		schema,
+		completionprojection.Context{
+			Target:        completionprojection.TargetFlags,
+			EnteredPrefix: prefixSentinel,
+		},
+	)
+	if !errors.Is(err, completionprojection.ErrInvalidSchema) {
+		t.Fatalf("Project() error = %v, want ErrInvalidSchema", err)
+	}
+	if !reflect.DeepEqual(got, completionprojection.Projection{}) {
+		t.Fatalf("Project() = %#v, want atomic empty failure", got)
+	}
+	assertErrorOmitsText(t, err, prefixSentinel, sensitiveSentinel, diagnosticSentinel)
+}
+
+func TestProjectRejectsStaticDynamicAndDynamicAliasCollisionsAtomically(t *testing.T) {
+	tests := map[string]climanifest.EffectiveInputSchema{
+		"static dynamic": func() climanifest.EffectiveInputSchema {
+			schema := effectiveSchema(
+				namedParameter("first", "first", nil),
+				namedParameter("second", "reserved", nil),
+			)
+			schema.StaticInputs = []climanifest.EffectiveStaticInput{{
+				ID:              "you.run.flag.reserved",
+				Kind:            "flag",
+				PublicSpellings: []string{"reserved"},
+			}}
+			return schema
+		}(),
+		"dynamic alias": effectiveSchema(
+			namedParameter("first", "first", []string{"shared"}),
+			namedParameter("second", "second", []string{"shared"}),
+		),
+	}
+
+	for name, schema := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := completionprojection.Project(
+				context.Background(),
+				schema,
+				completionprojection.Context{Target: completionprojection.TargetFlags},
+			)
+			if !errors.Is(err, completionprojection.ErrSchemaCollision) {
+				t.Fatalf("Project() error = %v, want ErrSchemaCollision", err)
+			}
+			if !reflect.DeepEqual(got, completionprojection.Projection{}) {
+				t.Fatalf("Project() = %#v, want atomic empty failure", got)
+			}
+		})
+	}
+}
+
+func TestProjectCancellationBeforeAndDuringProjectionIsAtomic(t *testing.T) {
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	for name, ctx := range map[string]context.Context{
+		"before": cancelled,
+		"during": newCancelAfterErrContext(5),
+	} {
+		t.Run(name, func(t *testing.T) {
+			schema := effectiveSchema(
+				namedParameter("first", "first", nil),
+				namedParameter("second", "second", nil),
+			)
+			got, err := completionprojection.Project(
+				ctx,
+				schema,
+				completionprojection.Context{Target: completionprojection.TargetFlags},
+			)
+			if !errors.Is(err, completionprojection.ErrCancelled) ||
+				!errors.Is(err, context.Canceled) {
+				t.Fatalf("Project() error = %v, want documented cancellation error", err)
+			}
+			if !reflect.DeepEqual(got, completionprojection.Projection{}) {
+				t.Fatalf("Project() = %#v, want atomic empty cancellation", got)
+			}
+		})
+	}
+}
+
 func effectiveSchema(parameters ...climanifest.EffectiveFactoryParameter) climanifest.EffectiveInputSchema {
+	for index := range parameters {
+		if parameters[index].CanonicalName == "" {
+			parameters[index].CanonicalName = parameters[index].BindingID
+		}
+	}
 	return climanifest.EffectiveInputSchema{
-		CommandID:         "you.run",
-		FactoryInputMode:  climanifest.EffectiveFactoryInputModeSignature,
-		FactoryParameters: parameters,
+		CommandID:                  "you.run",
+		FactoryInputMode:           climanifest.EffectiveFactoryInputModeSignature,
+		UnknownNamedArgumentPolicy: work.InvocationUnknownNamedArgumentPolicyReject,
+		FactoryParameters:          parameters,
 	}
 }
 
@@ -413,4 +523,51 @@ func assertProjectionOmitsText(
 			}
 		}
 	}
+}
+
+func assertErrorOmitsText(t *testing.T, err error, omitted ...string) {
+	t.Helper()
+	for _, text := range omitted {
+		if strings.Contains(err.Error(), text) {
+			t.Fatal("projection error retained confidential input text")
+		}
+	}
+}
+
+type cancelAfterErrContext struct {
+	remainingChecks int
+	done            chan struct{}
+	cancelled       bool
+}
+
+func newCancelAfterErrContext(remainingChecks int) *cancelAfterErrContext {
+	return &cancelAfterErrContext{
+		remainingChecks: remainingChecks,
+		done:            make(chan struct{}),
+	}
+}
+
+func (ctx *cancelAfterErrContext) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+func (ctx *cancelAfterErrContext) Done() <-chan struct{} {
+	return ctx.done
+}
+
+func (ctx *cancelAfterErrContext) Err() error {
+	if ctx.cancelled {
+		return context.Canceled
+	}
+	ctx.remainingChecks--
+	if ctx.remainingChecks <= 0 {
+		close(ctx.done)
+		ctx.cancelled = true
+		return context.Canceled
+	}
+	return nil
+}
+
+func (ctx *cancelAfterErrContext) Value(any) any {
+	return nil
 }

--- a/pkg/transports/cli/completionprojection/validation.go
+++ b/pkg/transports/cli/completionprojection/validation.go
@@ -1,0 +1,194 @@
+package completionprojection
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	"github.com/portpowered/infinite-you/pkg/transports/cli/climanifest"
+)
+
+var (
+	// ErrInvalidSchema is returned without schema details so malformed
+	// sensitive values cannot enter completion diagnostics.
+	ErrInvalidSchema = errors.New("selected-Factory completion schema is invalid")
+	// ErrSchemaCollision reports a detached static/dynamic or dynamic/dynamic
+	// input collision without retaining either colliding value.
+	ErrSchemaCollision = errors.New("selected-Factory completion schema has colliding inputs")
+	// ErrCancelled is stable for callers and still matches context.Canceled.
+	ErrCancelled = fmt.Errorf("selected-Factory completion projection cancelled: %w", context.Canceled)
+)
+
+func cancellationError(ctx context.Context) error {
+	if ctx == nil || ctx.Err() != nil {
+		return ErrCancelled
+	}
+	return nil
+}
+
+func validateSchema(ctx context.Context, schema climanifest.EffectiveInputSchema) error {
+	if err := cancellationError(ctx); err != nil {
+		return err
+	}
+	signatureMode, err := validateSchemaShape(schema)
+	if err != nil || !signatureMode {
+		return err
+	}
+
+	staticSpellings, staticBindingIDs := staticInputFacts(schema.StaticInputs)
+	collisions := collisionFacts{
+		staticSpellings:   staticSpellings,
+		staticBindingIDs:  staticBindingIDs,
+		dynamicSpellings:  make(map[string]string),
+		dynamicBindingIDs: make(map[string]struct{}),
+	}
+	for _, parameter := range schema.FactoryParameters {
+		if err := cancellationError(ctx); err != nil {
+			return err
+		}
+		if err := collisions.addParameter(parameter); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateSchemaShape(schema climanifest.EffectiveInputSchema) (bool, error) {
+	if strings.TrimSpace(schema.CommandID) == "" {
+		return false, ErrInvalidSchema
+	}
+	switch schema.FactoryInputMode {
+	case climanifest.EffectiveFactoryInputModeCompatibility:
+		if len(schema.FactoryParameters) != 0 ||
+			schema.UnknownNamedArgumentPolicy != "" {
+			return false, ErrInvalidSchema
+		}
+		return false, nil
+	case climanifest.EffectiveFactoryInputModeSignature:
+	default:
+		return false, ErrInvalidSchema
+	}
+	switch schema.UnknownNamedArgumentPolicy {
+	case work.InvocationUnknownNamedArgumentPolicyReject,
+		work.InvocationUnknownNamedArgumentPolicyAllow,
+		work.InvocationUnknownNamedArgumentPolicyCollect:
+	default:
+		return false, ErrInvalidSchema
+	}
+	return true, nil
+}
+
+type collisionFacts struct {
+	staticSpellings   map[string]struct{}
+	staticBindingIDs  map[string]struct{}
+	dynamicSpellings  map[string]string
+	dynamicBindingIDs map[string]struct{}
+}
+
+func (facts *collisionFacts) addParameter(
+	parameter climanifest.EffectiveFactoryParameter,
+) error {
+	if err := validateParameter(parameter); err != nil {
+		return err
+	}
+	if _, exists := facts.staticBindingIDs[parameter.BindingID]; exists {
+		return ErrSchemaCollision
+	}
+	if _, exists := facts.dynamicBindingIDs[parameter.BindingID]; exists {
+		return ErrSchemaCollision
+	}
+	facts.dynamicBindingIDs[parameter.BindingID] = struct{}{}
+
+	parameterSpellings, err := uniqueParameterSpellings(parameter)
+	if err != nil {
+		return err
+	}
+	for spelling := range parameterSpellings {
+		if _, exists := facts.staticSpellings[spelling]; exists {
+			return ErrSchemaCollision
+		}
+		if owner, exists := facts.dynamicSpellings[spelling]; exists &&
+			owner != parameter.BindingID {
+			return ErrSchemaCollision
+		}
+		facts.dynamicSpellings[spelling] = parameter.BindingID
+	}
+	return nil
+}
+
+func staticInputFacts(
+	inputs []climanifest.EffectiveStaticInput,
+) (map[string]struct{}, map[string]struct{}) {
+	spellings := make(map[string]struct{})
+	bindingIDs := make(map[string]struct{})
+	for _, input := range inputs {
+		if input.ID != "" {
+			bindingIDs[input.ID] = struct{}{}
+		}
+		if input.HandlerBindingID != "" {
+			bindingIDs[input.HandlerBindingID] = struct{}{}
+		}
+		if input.Kind == "flag" {
+			for _, spelling := range input.PublicSpellings {
+				if spelling = strings.TrimSpace(spelling); spelling != "" {
+					spellings[spelling] = struct{}{}
+				}
+			}
+		}
+	}
+	return spellings, bindingIDs
+}
+
+func validateParameter(parameter climanifest.EffectiveFactoryParameter) error {
+	if parameter.BindingID == "" ||
+		parameter.BindingID != strings.TrimSpace(parameter.BindingID) ||
+		parameter.CanonicalName != parameter.BindingID {
+		return ErrInvalidSchema
+	}
+	if parameter.PreferredExternalName != strings.TrimSpace(parameter.PreferredExternalName) {
+		return ErrInvalidSchema
+	}
+	if parameter.DefaultValue != nil && len(parameter.DefaultValues) != 0 {
+		return ErrInvalidSchema
+	}
+	for _, binding := range parameter.Bindings {
+		switch binding.Kind {
+		case work.InvocationParameterBindingKindNamed,
+			work.InvocationParameterBindingKindNamedRest,
+			work.InvocationParameterBindingKindPositional,
+			work.InvocationParameterBindingKindStdin:
+		default:
+			return ErrInvalidSchema
+		}
+		if binding.Kind == work.InvocationParameterBindingKindNamed &&
+			strings.TrimSpace(parameter.PreferredExternalName) == "" {
+			return ErrInvalidSchema
+		}
+	}
+	for _, alias := range parameter.Aliases {
+		if alias == "" || alias != strings.TrimSpace(alias) {
+			return ErrInvalidSchema
+		}
+	}
+	return nil
+}
+
+func uniqueParameterSpellings(
+	parameter climanifest.EffectiveFactoryParameter,
+) (map[string]struct{}, error) {
+	spellings := make(map[string]struct{}, len(parameter.Aliases)+2)
+	spellings[parameter.CanonicalName] = struct{}{}
+	if parameter.PreferredExternalName != "" &&
+		parameter.PreferredExternalName != parameter.CanonicalName {
+		spellings[parameter.PreferredExternalName] = struct{}{}
+	}
+	for _, alias := range parameter.Aliases {
+		if _, exists := spellings[alias]; exists {
+			return nil, ErrSchemaCollision
+		}
+		spellings[alias] = struct{}{}
+	}
+	return spellings, nil
+}


### PR DESCRIPTION
{
  "project": "Schema-Driven CLI selected-Factory completion projection",
  "branchName": "schema-cli-selected-factory-completion-projection",
  "description": "Add a pure, deterministic CLI transport projection that converts an already-resolved selected-Factory effective invocation schema into detached, ordered, sensitive-safe completion candidate and directive facts for later shell adapters, without changing the public command surface or performing Factory, catalog, provider, Factory Session, filesystem, Cobra, or process-global work.",
  "context": {
    "customerAsk": "Project the already-resolved effective selected-Factory invocation schema into detached completion candidate and directive facts. Equivalent named and explicit-file schemas must produce identical ordered flag, alias, enum, boolean, file, free-text, default-description, and no-signature outcomes without runtime or I/O activity.",
    "problem": "Selected-Factory resolution and run request preparation now agree on one detached effective invocation schema, but there is no transport-neutral completion projection. Independent future shell adapters could drift in candidate names, ordering, descriptions, typed behavior, default handling, or secrecy, and completion-time failures could leak partial results or trigger forbidden runtime work.",
    "solution": "Add an additive focused CLI subpackage that purely maps the effective schema and completion context to ordered candidate and directive values. It will preserve signature-defined flags and aliases, typed value semantics, sensitive-safe default descriptions, no-signature compatibility, deterministic atomic errors, and a value-only dependency boundary that cannot reach Cobra, pflag, catalogs, providers, Factory Sessions, filesystems, writes, or process-global state."
  },
  "acceptanceCriteria": [
    "AC-1: Equivalent effective schemas obtained through named and explicit-file Factory selection produce identical candidate and directive facts, ordering, and descriptions.",
    "AC-2: Signature-defined flags and aliases are addressable; enum and documented boolean candidates are deterministic; file inputs request filesystem delegation; and free-text inputs invent no values.",
    "AC-3: Non-sensitive defaults appear only in description metadata, while sensitive defaults, entered prefixes, values, and diagnostics never appear in candidates, descriptions, returned errors, logs, or fixtures.",
    "AC-4: A Factory without an invocation signature produces no signature-only flag, alias, value, default-description, or file-delegation fact.",
    "AC-5: Invalid or colliding effective schemas and context cancellation return stable deterministic errors, an empty result, and no side effects.",
    "AC-6: The detached projection has no Cobra, pflag, catalog, provider, Factory Session, filesystem, write, or process-global dependency or capability.",
    "AC-7: Quality checks pass (typecheck, lint, tests)."
  ],
  "userStories": [
    {
      "id": "schema-cli-selected-factory-completion-projection-001",
      "title": "Project flags and aliases with selection parity",
      "description": "As a shell-adapter developer, I want equivalent selected-Factory schemas to produce one ordered set of parameter flag and alias facts so that completion does not vary with how the Factory was selected.",
      "acceptanceCriteria": [
        "Every signature-defined named parameter produces an addressable primary flag fact, followed by its aliases in declared schema order.",
        "Positional and stdin bindings do not invent named flag candidates.",
        "Equivalent detached effective schemas from named and explicit-file selection produce identical candidates, descriptions, directive facts, and ordering without consulting selection provenance.",
        "Repeated projection of the same effective schema and completion context returns the same detached result.",
        "Focused pure tests prove named/file parity, aliases, binding behavior, and deterministic ordering.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "schema-cli-selected-factory-completion-projection-002",
      "title": "Project typed value candidates and directives",
      "description": "As a CLI user, I want completion behavior to reflect each Factory parameter's declared type so that suggested values are useful without inventing input or performing I/O.",
      "acceptanceCriteria": [
        "Enum inputs expose only their declared values in deterministic declared order.",
        "Boolean inputs expose only the boolean forms documented by the effective schema, in a stable order.",
        "File inputs return a detached filesystem-delegation directive and do not inspect the filesystem or manufacture path candidates.",
        "Free-text inputs return no invented value candidates.",
        "A non-sensitive default may be appended only to candidate description metadata and is never emitted as a candidate value or directive payload.",
        "Focused pure tests prove enum, boolean, file, free-text, and default-description behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "schema-cli-selected-factory-completion-projection-003",
      "title": "Preserve confidentiality and no-signature compatibility",
      "description": "As a Factory author, I want completion to preserve sensitive input boundaries and legacy no-signature behavior so that interactive use cannot disclose secrets or add unsupported invocation features.",
      "acceptanceCriteria": [
        "Sensitive defaults and values are omitted from candidate values, descriptions, and directive facts.",
        "Entered prefixes and sensitive diagnostics are never copied into returned errors or other result metadata.",
        "Tests use non-secret sentinels and assert that sensitive defaults, values, prefixes, and diagnostics are absent from results and error text without recording those values in golden files, logs, or retained fixtures.",
        "A Factory with no invocation signature returns an empty selected-Factory completion projection: no signature-only flag, alias, value, default-description, or file-delegation fact.",
        "Focused pure tests prove sensitivity behavior and no-signature compatibility.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "schema-cli-selected-factory-completion-projection-004",
      "title": "Reject invalid or cancelled projection atomically",
      "description": "As a shell-adapter developer, I want invalid schemas, collisions, and cancellation to fail deterministically without partial candidates or side effects so that completion remains safe and predictable.",
      "acceptanceCriteria": [
        "Invalid effective-schema input returns a stable deterministic error and a zero/empty result rather than a partial candidate set.",
        "Static/dynamic name or alias collisions reported by the effective schema are rejected with a stable deterministic error and no partial result.",
        "Cancellation observed before or during projection returns the documented cancellation error and a zero/empty result.",
        "Error results do not include entered prefixes, sensitive values, sensitive defaults, or sensitive diagnostics.",
        "The callable projection boundary accepts detached values and cancellation only; it has no means to materialize a Factory, query a catalog, call a provider, start a Factory Session, access the filesystem, write state, invoke Cobra/pflag, or use process-global state.",
        "Focused pure tests prove invalid input, collisions, cancellation, all-or-nothing results, and zero runtime/I/O activity by construction.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
