### PR TITLE
test(ui): accelerate compatible component tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
   backend-coverage:
     name: Backend ${{ matrix.label }} Coverage
     needs: classify
-    if: always() && needs.classify.outputs.run_backend == 'true'
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 35
     strategy:
@@ -221,22 +221,27 @@ jobs:
           - suite: functional
             label: Functional
     steps:
+      - name: Skip unselected backend coverage lane
+        if: needs.classify.outputs.run_backend != 'true'
+        run: echo "Backend coverage was not selected by CI classification."
       - uses: actions/checkout@v4
+        if: needs.classify.outputs.run_backend == 'true'
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
       - uses: actions/setup-go@v5
+        if: needs.classify.outputs.run_backend == 'true'
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
       - name: Build backend
-        if: matrix.suite == 'unit'
+        if: needs.classify.outputs.run_backend == 'true' && matrix.suite == 'unit'
         run: make build
       - name: Run backend coverage
-        if: matrix.suite == 'unit'
+        if: needs.classify.outputs.run_backend == 'true' && matrix.suite == 'unit'
         run: make test-unit-coverage
       - name: Run backend functional coverage and visualization
-        if: matrix.suite == 'functional'
+        if: needs.classify.outputs.run_backend == 'true' && matrix.suite == 'functional'
         run: make functional-test-viz
 
   ui-backend-integration:
@@ -259,24 +264,32 @@ jobs:
   api-package:
     name: API Contract And Package
     needs: classify
-    if: always() && needs.classify.outputs.run_api_package == 'true'
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
+      - name: Skip unselected API contract and package lane
+        if: needs.classify.outputs.run_api_package != 'true'
+        run: echo "API contract and package verification was not selected by CI classification."
       - uses: actions/checkout@v4
+        if: needs.classify.outputs.run_api_package == 'true'
         with:
           fetch-depth: 0
       - uses: actions/setup-go@v5
+        if: needs.classify.outputs.run_api_package == 'true'
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
       - uses: oven-sh/setup-bun@v2
+        if: needs.classify.outputs.run_api_package == 'true'
         with:
           bun-version: ${{ env.BUN_VERSION }}
       - uses: actions/setup-node@v4
+        if: needs.classify.outputs.run_api_package == 'true'
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - run: make ui-deps contracts-smoke api-smoke api-package-verify
+      - if: needs.classify.outputs.run_api_package == 'true'
+        run: make ui-deps contracts-smoke api-smoke api-package-verify
 
   packaged-factories-package:
     name: Packaged Factories Package

--- a/ui/scripts/component-test-files.ts
+++ b/ui/scripts/component-test-files.ts
@@ -17,11 +17,18 @@ const VITEST_COMPATIBILITY_PATTERNS: Array<{
     pattern: /@vitest-environment/,
     reason: "declares a Vitest environment",
   },
-  {
-    pattern: /\bvi\./,
-    reason: "uses Vitest mocking or timer APIs",
-  },
 ];
+const BUN_COMPATIBLE_VI_APIS = new Set(["fn", "mocked"]);
+
+function findUnsupportedViApis(source: string): string[] {
+  return [
+    ...new Set(
+      [...source.matchAll(/\bvi\.([A-Za-z_]+)/g)]
+        .map((match) => match[1])
+        .filter((api) => !BUN_COMPATIBLE_VI_APIS.has(api)),
+    ),
+  ].sort();
+}
 
 export interface ClassifiedComponentTestFile {
   path: string;
@@ -34,7 +41,11 @@ export function classifyComponentTestSource(
   source: string,
 ): ClassifiedComponentTestFile {
   if (path.endsWith(EXPLICIT_BUN_COMPONENT_SUFFIX)) {
-    return { path, reason: "explicit native Bun component test", runner: "bun" };
+    return {
+      path,
+      reason: "explicit native Bun component test",
+      runner: "bun",
+    };
   }
 
   if (source.includes(VITEST_COMPONENT_MARKER)) {
@@ -53,6 +64,15 @@ export function classifyComponentTestSource(
         runner: "vitest",
       };
     }
+  }
+
+  const unsupportedViApis = findUnsupportedViApis(source);
+  if (unsupportedViApis.length > 0) {
+    return {
+      path,
+      reason: `uses unsupported Vitest APIs: ${unsupportedViApis.join(", ")}`,
+      runner: "vitest",
+    };
   }
 
   return {

--- a/ui/src/components/prompt-editor/monaco-guard-selector-editor.test.tsx
+++ b/ui/src/components/prompt-editor/monaco-guard-selector-editor.test.tsx
@@ -1,3 +1,4 @@
+// @component-test-runner vitest: Bun 1.3.12 on Linux does not reliably flush Monaco palette MutationObservers.
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ComponentProps } from "react";
 import { beforeEach } from "vitest";

--- a/ui/src/features/dashboard/components/topology-replay/hosted-topology-replay.test.tsx
+++ b/ui/src/features/dashboard/components/topology-replay/hosted-topology-replay.test.tsx
@@ -1,3 +1,4 @@
+// @component-test-runner vitest: components package declarations contain relative imports Bun cannot execute.
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import type { FactoryVisualizationLayoutV1 } from "@you-agent-factory/client";

--- a/ui/src/features/workflow-activity/components/current-activity-card/react-flow-current-activity-card-editor-chrome.test.tsx
+++ b/ui/src/features/workflow-activity/components/current-activity-card/react-flow-current-activity-card-editor-chrome.test.tsx
@@ -1,3 +1,4 @@
+// @component-test-runner vitest: components package declarations contain relative imports Bun cannot execute.
 import "../../../../testing/vitest-dom-capabilities.setup";
 
 import "@testing-library/jest-dom/vitest";

--- a/ui/src/features/workflow-activity/components/current-activity-card/react-flow-current-activity-card-import-flows.test.tsx
+++ b/ui/src/features/workflow-activity/components/current-activity-card/react-flow-current-activity-card-import-flows.test.tsx
@@ -1,3 +1,4 @@
+// @component-test-runner vitest: components package declarations contain relative imports Bun cannot execute.
 import "../../../../testing/vitest-dom-capabilities.setup";
 
 import "@testing-library/jest-dom/vitest";

--- a/ui/src/features/workflow-activity/lib/use-measured-current-activity-graph-viewport.test.tsx
+++ b/ui/src/features/workflow-activity/lib/use-measured-current-activity-graph-viewport.test.tsx
@@ -19,30 +19,49 @@ function HookProbe() {
   );
 }
 
-describe("useMeasuredCurrentActivityGraphViewport", () => {
-  const originalResizeObserver = globalThis.ResizeObserver;
-  const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(
-    window.navigator,
-    "userAgent",
-  );
-  const originalBoundingClientRect =
-    HTMLElement.prototype.getBoundingClientRect;
-  const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
-  const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+const originalBoundingClientRectDescriptor = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  "getBoundingClientRect",
+);
+const originalResizeObserver = globalThis.ResizeObserver;
+const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(
+  window.navigator,
+  "userAgent",
+);
+const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
 
-  afterEach(() => {
-    globalThis.ResizeObserver = originalResizeObserver;
-    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
-    globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
-    if (originalNavigatorDescriptor) {
-      Object.defineProperty(
-        window.navigator,
-        "userAgent",
-        originalNavigatorDescriptor,
-      );
-    }
-    HTMLElement.prototype.getBoundingClientRect = originalBoundingClientRect;
+function setBoundingClientRect(
+  value: typeof HTMLElement.prototype.getBoundingClientRect,
+) {
+  Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value,
   });
+}
+
+function restoreBrowserGlobals() {
+  globalThis.ResizeObserver = originalResizeObserver;
+  globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+  globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+  if (originalNavigatorDescriptor) {
+    Object.defineProperty(
+      window.navigator,
+      "userAgent",
+      originalNavigatorDescriptor,
+    );
+  }
+  if (originalBoundingClientRectDescriptor) {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      "getBoundingClientRect",
+      originalBoundingClientRectDescriptor,
+    );
+  }
+}
+
+describe("useMeasuredCurrentActivityGraphViewport", () => {
+  afterEach(restoreBrowserGlobals);
 
   it("waits for non-zero viewport dimensions before marking the graph ready", () => {
     let resizeCallback: ResizeObserverCallback | undefined;
@@ -65,18 +84,20 @@ describe("useMeasuredCurrentActivityGraphViewport", () => {
     });
     globalThis.ResizeObserver =
       ResizeObserverMock as unknown as typeof ResizeObserver;
-    HTMLElement.prototype.getBoundingClientRect = () =>
-      ({
-        bottom: 0,
-        height: 0,
-        left: 0,
-        right: 0,
-        top: 0,
-        width: 0,
-        x: 0,
-        y: 0,
-        toJSON: () => ({}),
-      }) as DOMRect;
+    setBoundingClientRect(
+      () =>
+        ({
+          bottom: 0,
+          height: 0,
+          left: 0,
+          right: 0,
+          top: 0,
+          width: 0,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        }) as DOMRect,
+    );
 
     render(<HookProbe />);
 
@@ -125,7 +146,7 @@ describe("useMeasuredCurrentActivityGraphViewport", () => {
       return 1;
     }) as typeof requestAnimationFrame;
     globalThis.cancelAnimationFrame = vi.fn();
-    HTMLElement.prototype.getBoundingClientRect = () => {
+    setBoundingClientRect(() => {
       measureCount += 1;
       const width = measureCount >= 2 ? 640 : 0;
       const height = measureCount >= 2 ? 480 : 0;
@@ -141,7 +162,7 @@ describe("useMeasuredCurrentActivityGraphViewport", () => {
         y: 0,
         toJSON: () => ({}),
       } as DOMRect;
-    };
+    });
 
     render(<HookProbe />);
 

--- a/ui/src/testing/bun/component-test-files.test.ts
+++ b/ui/src/testing/bun/component-test-files.test.ts
@@ -12,8 +12,21 @@ describe("classifyComponentTestSource", () => {
     ).toMatchObject({ runner: "bun" });
   });
 
+  it("assigns vi.fn and vi.mocked tests to Bun", () => {
+    expect(
+      classifyComponentTestSource(
+        "src/features/example/example-card.test.tsx",
+        "const callback = vi.fn(); vi.mocked(callback);",
+      ),
+    ).toMatchObject({ runner: "bun" });
+  });
+
   it.each([
-    ["vi.useFakeTimers();", "uses Vitest mocking or timer APIs"],
+    ["vi.useFakeTimers();", "uses unsupported Vitest APIs: useFakeTimers"],
+    [
+      "vi.stubGlobal('fetch', vi.fn()); vi.unstubAllGlobals();",
+      "uses unsupported Vitest APIs: stubGlobal, unstubAllGlobals",
+    ],
   ])("keeps %s in Vitest", (source, reason) => {
     expect(
       classifyComponentTestSource(


### PR DESCRIPTION
## Summary

- route component tests that only use `vi.fn` and `vi.mocked` through the native Bun lane
- keep unsupported Vitest APIs and platform/build-dependent tests as documented compatibility exceptions
- make DOM geometry replacement portable across Bun and Vitest
- keep required backend/API check contexts successful as cheap no-ops when CI classification intentionally skips those lanes

## Why

The previous component split was safe but overly conservative: any `vi.*` reference stayed in Vitest. Bun already supports the common mock-function subset, so 76 more files can run in the faster lane without changing test coverage.

The repository ruleset also requires backend and API contexts on every PR, while the classifier omitted those contexts for frontend-only changes. Required jobs now remain present without performing unrelated expensive work.

## Impact

- Bun ownership: 141 to 217 files
- Vitest compatibility: 221 to 145 files
- local component duration: 112.10s to 92.66s
- local unit duration: 17.79s
- browserless coverage remains unchanged

## Validation

- `cd ui && bun run test:unit`
- `cd ui && bun run test:component`
- `cd ui && bun run tsc`
- `cd ui && bun run check:test-lanes`
- Biome check on all changed UI files
- parsed `.github/workflows/ci.yml` with the repository YAML dependency