### PR TITLE
test(ui): migrate shim-compatible component tests to Bun

### DIFF
--- a/ui/scripts/component-test-files.ts
+++ b/ui/scripts/component-test-files.ts
@@ -18,14 +18,26 @@ const VITEST_COMPATIBILITY_PATTERNS: Array<{
     reason: "declares a Vitest environment",
   },
 ];
-const BUN_COMPATIBLE_VI_APIS = new Set(["fn", "mocked"]);
+const BUN_NATIVE_VI_APIS = new Set(["fn", "mocked"]);
+const BUN_SHIMMED_VI_APIS = new Set([
+  "clearAllMocks",
+  "restoreAllMocks",
+  "spyOn",
+  "stubGlobal",
+  "unstubAllGlobals",
+]);
 
 function findUnsupportedViApis(source: string): string[] {
+  const usesBunViShim = /import\s*\{\s*bunVi\s+as\s+vi\s*\}/.test(source);
   return [
     ...new Set(
       [...source.matchAll(/\bvi\.([A-Za-z_]+)/g)]
         .map((match) => match[1])
-        .filter((api) => !BUN_COMPATIBLE_VI_APIS.has(api)),
+        .filter(
+          (api) =>
+            !BUN_NATIVE_VI_APIS.has(api) &&
+            !(usesBunViShim && BUN_SHIMMED_VI_APIS.has(api)),
+        ),
     ),
   ].sort();
 }

--- a/ui/src/api/events/api.component.test.ts
+++ b/ui/src/api/events/api.component.test.ts
@@ -1,3 +1,4 @@
+import { bunVi as vi } from "../../testing/bun/vi-compat";
 import {
   openFactoryEventStream,
   probeFactoryEventStreamRecovery,

--- a/ui/src/components/dashboard/visualization-dependencies.test.tsx
+++ b/ui/src/components/dashboard/visualization-dependencies.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen } from "@testing-library/react";
-
 import { Background, ReactFlow, ReactFlowProvider } from "@xyflow/react";
 import * as d3 from "d3";
 import { useMemo } from "react";
 import GridLayout from "react-grid-layout";
+import { bunVi as vi } from "../../testing/bun/vi-compat";
 
 import "@xyflow/react/dist/style.css";
 import "react-grid-layout/css/styles.css";

--- a/ui/src/features/bento/components/dashboard-widget-frame/dashboard-widget-composition.test.tsx
+++ b/ui/src/features/bento/components/dashboard-widget-frame/dashboard-widget-composition.test.tsx
@@ -1,10 +1,11 @@
+import { bunVi as vi } from "../../../../testing/bun/vi-compat";
 import "../../../../testing/vitest-dom-capabilities.setup";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { FactorySessionEventReplayDisclosure } from "../../../factory-session-detail/components/event-replay/factory-session-event-replay-disclosure";
 import { ProviderSessionWidget } from "../../../provider-session-detail/components/provider-session-widget";

--- a/ui/src/features/dashboard/hooks/event-stream/useFactoryEventStream.test.tsx
+++ b/ui/src/features/dashboard/hooks/event-stream/useFactoryEventStream.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
-
 import { FACTORY_EVENT_TYPES } from "../../../../api/events";
 import { DEFAULT_FACTORY_SESSION_ID } from "../../../../api/session-routing";
+import { bunVi as vi } from "../../../../testing/bun/vi-compat";
 import {
   CURRENT_FACTORY_DEFINITION_QUERY_KEY,
   CURRENT_FACTORY_DOCUMENT_QUERY_KEY,

--- a/ui/src/features/dashboard/session/dashboard-session-provider.test.tsx
+++ b/ui/src/features/dashboard/session/dashboard-session-provider.test.tsx
@@ -7,9 +7,9 @@ import {
   waitFor,
 } from "@testing-library/react";
 import type { ReactNode } from "react";
-
 import { DEFAULT_FACTORY_SESSION_ID } from "../../../api/session-routing";
 import { buildSessionScope } from "../../../api/session-scope";
+import { bunVi as vi } from "../../../testing/bun/vi-compat";
 import {
   resetDashboardSessionStore,
   useDashboardSessionStore,

--- a/ui/src/testing/bun/component-test-files.test.ts
+++ b/ui/src/testing/bun/component-test-files.test.ts
@@ -12,7 +12,7 @@ describe("classifyComponentTestSource", () => {
     ).toMatchObject({ runner: "bun" });
   });
 
-  it("assigns vi.fn and vi.mocked tests to Bun", () => {
+  it("assigns native vi helpers to Bun", () => {
     expect(
       classifyComponentTestSource(
         "src/features/example/example-card.test.tsx",
@@ -21,8 +21,18 @@ describe("classifyComponentTestSource", () => {
     ).toMatchObject({ runner: "bun" });
   });
 
+  it("assigns extended helpers to Bun when the test imports the Bun vi shim", () => {
+    expect(
+      classifyComponentTestSource(
+        "src/features/example/example-card.test.tsx",
+        "import { bunVi as vi } from '../../../testing/bun/vi-compat'; vi.stubGlobal('fetch', vi.fn()); vi.unstubAllGlobals(); vi.spyOn(console, 'warn'); vi.clearAllMocks(); vi.restoreAllMocks();",
+      ),
+    ).toMatchObject({ runner: "bun" });
+  });
+
   it.each([
     ["vi.useFakeTimers();", "uses unsupported Vitest APIs: useFakeTimers"],
+    ["vi.mock('./dependency');", "uses unsupported Vitest APIs: mock"],
     [
       "vi.stubGlobal('fetch', vi.fn()); vi.unstubAllGlobals();",
       "uses unsupported Vitest APIs: stubGlobal, unstubAllGlobals",


### PR DESCRIPTION
## What changed

- teaches the component classifier to recognize the explicit Bun vi compatibility shim
- moves five proven global-stub component tests from Vitest to Bun
- keeps unsupported mock, timer, and package-build-dependent tests in the Vitest compatibility lane

## Why

These tests only need lightweight spy and global-stub behavior. Keeping them in Vitest adds transform, environment, and worker overhead without adding browser fidelity.

A sixth candidate was deliberately retained on Vitest after clean Linux CI showed that its transitive visualizer dependency still resolves a built components-package subpath. That boundary will be reconciled before migration.

## Impact

The component split is now 222 Bun files and 140 Vitest compatibility files. The complete local component lane runs in 91.08 seconds against a 150-second budget.

## Validation

- bun run test:component: 362 files and 1,944 tests passed; 91.08 seconds
- bun run test:unit: 388 files and 3,199 tests passed; 18.41 seconds
- bun run typecheck
- bun run check:test-lanes
- Biome check on all changed files