### PR TITLE
standardized-provider-migrate-kiro

### DIFF
--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -1035,8 +1035,9 @@ response-stream output.
   that error before closing the provider response writer so
   `inferencecontract.ExecuteInvocation` remains the single owner of canonical,
   non-retryable cancellation. Bind the
-  migrated provider as a registry catalog Integration
-  (`gemini.NewIntegration`) from `BuiltInRegistrations`, and let
+  migrated providers as registry catalog Integrations
+  (`gemini.NewIntegration`, `kiro.NewIntegration`) from
+  `BuiltInRegistrations`, and let
   `UsesNativeRunner` route Integrations that no longer advertise the
   native-runtime compatibility marker through `conductor.Invoke` without adding
   a concrete-provider switch in shared orchestration. Process composition
@@ -1059,11 +1060,13 @@ response-stream output.
   Integration against the shared inference contract through
   `inferencecontract.ExecuteInvocation` for the success and failure postures
   that apply to that provider's authored support/capability set (for Gemini:
-  prompt_submission + message_snapshots success, plus native
-  auth/invalid/throttle/timeout/unknown failures). Do not invent streaming or
-  tool-lifecycle factories just to call `inferencecontract/testkit.Run` when the
-  manifest does not advertise those capabilities; keep selection on the
-  registry Integration boundary rather than Adapter internals. Native
+  prompt_submission + message_snapshots success; for Kiro:
+  prompt_submission + session_resume + message_snapshots success; plus each
+  provider's native auth/invalid/throttle/timeout/unknown failures). Do not
+  invent streaming or tool-lifecycle factories just to call
+  `inferencecontract/testkit.Run` when the manifest does not advertise those
+  capabilities; keep selection on the registry Integration boundary rather
+  than Adapter internals. Native
   JSONL fixture tests should
   fragment reads and flush an unterminated final record so command selection,
   decoder buffering, and final-result parsing are proven independently.

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -64,6 +64,15 @@ primary-result behavior.
   in the cloned `ProviderInferenceRequest.SessionID`, while direct protocol
   callers can use `InvocationRequest.ProviderSession`; a migrated provider must
   normalize both accepted inputs before applying its emitted-session rules.
+- Retryable conductor failures must preserve both retry posture and any
+  Provider Session when they cross into the Worker failure contract. A neutral
+  `unknown` failure with `Retryable=true` maps to retryable
+  `internal_server_error`, and the next attempt must require session-resume
+  capability while carrying that session ID. Wrap provider-boundary recording
+  around the final decorated runner so registry-selected conductor calls and
+  retained native calls each emit one canonical inference request/response
+  pair; otherwise conductor failures and replacement sessions disappear from
+  Factory events.
 
 - Review-gated factories that must revise rejected work should preserve the
   original input on the work-stage route, retain non-empty worker output in the

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -215,7 +215,8 @@ primary-result behavior.
   resolve onto their canonical conductor identity. Bundled built-ins remain on
   the provider-native Infer/command path until their package-owned Integration
   replaces the native-runtime compatibility stub; `UsesNativeRunner` keeps the
-  stub on the native path and routes migrated Integrations (currently Gemini)
+  stub on the native path and routes migrated Integrations (currently Gemini
+  and Kiro)
   through the conductor without a concrete-provider switch in shared
   orchestration. Aggregate dispatch/failure branches and `ProviderOverride`
   remain intact and bypass the registry/conductor decorators. Concurrent cancel,
@@ -1024,7 +1025,7 @@ response-stream output.
   only that provider's corresponding aggregate command/decode/failure/timeout/
   session branches (and relocate aggregate-owned tests into the provider
   package); leave the aggregate shell, ProviderOverride, and other providers
-  intact. Move Gemini-native failure and timeout parsing into the same package
+  intact. Move provider-native failure and timeout parsing into the same package
   (`ParseProviderFailure`, `TimeoutFailureResult`, `Adapter.ClassifyFailure`) so
   the conductor path consumes provider-owned normalized facts; aggregate exit
   and timeout bridges may only thin-delegate until legacy deletion. Treat all

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -55,6 +55,12 @@ primary-result behavior.
   environment and working-directory delivery through `root.BuildProcess` with
   an injected command-runner edge; do not expose configured secrets in events
   or assertion output.
+- Final-only provider integrations should keep native final stdout as response
+  content and derive resumable Provider Session metadata only from explicit
+  structured fields that satisfy the provider's identifier contract. If a
+  successful resumed invocation emits no replacement identifier, preserve the
+  validated requested Provider Session; never recover identifiers from
+  free-form assistant text.
 
 - Review-gated factories that must revise rejected work should preserve the
   original input on the work-stage route, retain non-empty worker output in the

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -60,7 +60,10 @@ primary-result behavior.
   structured fields that satisfy the provider's identifier contract. If a
   successful resumed invocation emits no replacement identifier, preserve the
   validated requested Provider Session; never recover identifiers from
-  free-form assistant text.
+  free-form assistant text. The product runner carries configured resume state
+  in the cloned `ProviderInferenceRequest.SessionID`, while direct protocol
+  callers can use `InvocationRequest.ProviderSession`; a migrated provider must
+  normalize both accepted inputs before applying its emitted-session rules.
 
 - Review-gated factories that must revise rejected work should preserve the
   original input on the work-stage route, retain non-empty worker output in the

--- a/pkg/services/workers/construction/service.go
+++ b/pkg/services/workers/construction/service.go
@@ -193,12 +193,13 @@ func (s *Service) Build(
 		effectiveSkipPermissions := effectiveWorkerSkipPermissions(def, invocationSkipPermissionsOverride)
 		runner, err := s.providerRunner(
 			runtimeConfig, def, logger, effectiveSkipPermissions,
-			providerOverride, inferenceProgressPublisher, inferenceRecorder, clock,
+			providerOverride, inferenceProgressPublisher,
 		)
 		if err != nil {
 			return Result{}, err
 		}
 		runner = decorateProviderRunner(runner, def, runnerDecorators, effectiveSkipPermissions)
+		runner = recordProviderRunner(runner, inferenceRecorder, clock)
 		inference := workerexecutor.NewAgentExecutorWithRunner(
 			runtimeConfig,
 			runner,
@@ -293,8 +294,6 @@ func (s *Service) providerRunner(
 	effectiveSkipPermissions bool,
 	providerOverride providercontract.Provider,
 	inferenceProgressPublisher workerprovider.InferenceProgressPublisher,
-	inferenceRecorder workerprovider.InferenceEventRecorder,
-	clock func() time.Time,
 ) (workers.Runner, error) {
 	var runner workers.Runner
 	if providerOverride != nil {
@@ -320,21 +319,43 @@ func (s *Service) providerRunner(
 		}
 		runner = built
 	}
-	if inferenceRecorder == nil {
-		return runner, nil
-	}
-	if providerOverride != nil {
-		return workerexecutor.RunnerFromProvider(workerprovider.NewRecordingProvider(
-			providerOverride, inferenceRecorder, clock,
-		)), nil
-	}
-	providerRunner, ok := runner.(*workerprovider.ScriptWrapProvider)
-	if !ok {
-		return runner, nil
+	return runner, nil
+}
+
+// runnerProviderAdapter lets the provider-boundary recorder observe the final
+// decorated runner. Registry-selected conductor routes and retained native
+// routes therefore emit the same canonical inference events exactly once.
+type runnerProviderAdapter struct {
+	runner workers.Runner
+}
+
+func recordProviderRunner(
+	runner workers.Runner,
+	recorder workerprovider.InferenceEventRecorder,
+	clock func() time.Time,
+) workers.Runner {
+	if recorder == nil {
+		return runner
 	}
 	return workerexecutor.RunnerFromProvider(workerprovider.NewRecordingProvider(
-		providerRunner, inferenceRecorder, clock,
-	)), nil
+		runnerProviderAdapter{runner: runner},
+		recorder,
+		clock,
+	))
+}
+
+func (a runnerProviderAdapter) Infer(
+	ctx context.Context,
+	request workerexecution.ProviderInferenceRequest,
+) (workerexecution.InferenceResponse, error) {
+	if a.runner == nil {
+		return workerexecution.InferenceResponse{}, workerprovider.NewProviderError(
+			workerexecution.WorkFailureTypeMisconfigured,
+			"recording runner requires an implementation",
+			nil,
+		)
+	}
+	return a.runner.Execute(ctx, request)
 }
 
 // effectiveSkipPermissionsRunner installs invocation-local policy outside all

--- a/pkg/services/workers/executor/agent.go
+++ b/pkg/services/workers/executor/agent.go
@@ -503,6 +503,13 @@ func (ae *AgentExecutor) inferWithRetry(ctx context.Context, req workerexecution
 		if !decision.Retryable || retryCount >= ae.retryConfig.maxRetries {
 			return workerexecution.InferenceResponse{}, retryCount, providerErr
 		}
+		if session := providerErr.ProviderSession; session != nil && strings.TrimSpace(session.ID) != "" {
+			req.SessionID = strings.TrimSpace(session.ID)
+			req.RequiredOptionalCapabilities = appendRunnerCapabilityIfMissing(
+				req.RequiredOptionalCapabilities,
+				workerexecution.RunnerOptionalCapabilitySessionResume,
+			)
+		}
 
 		baseDelay := ae.retryConfig.initialBackoff << retryCount
 		jitter, jitterErr := ae.retryConfig.jitter(baseDelay)
@@ -525,6 +532,18 @@ func (ae *AgentExecutor) inferWithRetry(ctx context.Context, req workerexecution
 			return workerexecution.InferenceResponse{}, retryCount, err
 		}
 	}
+}
+
+func appendRunnerCapabilityIfMissing(
+	capabilities []workerexecution.RunnerOptionalCapability,
+	capability workerexecution.RunnerOptionalCapability,
+) []workerexecution.RunnerOptionalCapability {
+	for _, existing := range capabilities {
+		if existing == capability {
+			return capabilities
+		}
+	}
+	return append(capabilities, capability)
 }
 
 type providerRunnerAdapter struct {

--- a/pkg/services/workers/executor/agent_inference_test.go
+++ b/pkg/services/workers/executor/agent_inference_test.go
@@ -13,6 +13,7 @@ import (
 	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
 
 	"github.com/portpowered/infinite-you/pkg/services/work"
+	workerprovider "github.com/portpowered/infinite-you/pkg/services/workers/provider"
 )
 
 func TestAgentExecutor_ModelOperationOutputUsesCanonicalWorkContent(t *testing.T) {
@@ -57,6 +58,91 @@ func TestAgentExecutor_ModelOperationOutputUsesCanonicalWorkContent(t *testing.T
 	if len(content) != 1 || content[0].Type != work.WorkContentPartTypeAudio || content[0].File != audioPath {
 		t.Fatalf("output = %#v, want canonical audio WorkContent", content)
 	}
+}
+
+func TestAgentExecutor_RetryableFailureResumesProviderSession(t *testing.T) {
+	const sessionID = "675f9238-5f05-456c-9a9f-f8fe486f49e4"
+	provider := &agentMockProvider{
+		errors: []error{
+			workerprovider.NewProviderErrorWithSession(
+				workerexecution.WorkFailureTypeInternalServerError,
+				"temporarily unavailable",
+				nil,
+				&workerexecution.ProviderSessionMetadata{
+					Provider: string(modelprovider.ProviderKiro),
+					Kind:     providerSessionKindSessionID,
+					ID:       sessionID,
+				},
+			),
+			nil,
+		},
+		responses: []workerexecution.InferenceResponse{
+			{},
+			{
+				Content: "Recovered. COMPLETE",
+				ProviderSession: &workerexecution.ProviderSessionMetadata{
+					Provider: string(modelprovider.ProviderKiro),
+					Kind:     providerSessionKindSessionID,
+					ID:       sessionID,
+				},
+			},
+		},
+	}
+	executor := NewAgentExecutor(
+		staticRuntimeConfig{
+			Workers: map[string]*workerconfig.FactoryWorkerConfig{
+				"worker-a": {Model: "kiro-auto", ModelProvider: string(modelprovider.ProviderKiro)},
+			},
+		},
+		provider,
+		nil,
+		time.Now,
+		deterministicRetryRandom,
+	)
+	executor.retryConfig.sleep = func(context.Context, time.Duration) error { return nil }
+	executor.retryConfig.jitter = func(time.Duration) (time.Duration, error) { return 0, nil }
+
+	result, err := executor.Execute(context.Background(), testAgentRequest(
+		work.WorkDispatch{
+			DispatchID:   "d-kiro-retry",
+			TransitionID: "t-1",
+			WorkerType:   "worker-a",
+		},
+		withAgentPrompts("sys", "msg"),
+	))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if provider.callCount != 2 {
+		t.Fatalf("provider call count = %d, want 2", provider.callCount)
+	}
+	if provider.lastReq.SessionID != sessionID {
+		t.Fatalf("retry SessionID = %q, want %q", provider.lastReq.SessionID, sessionID)
+	}
+	if !containsRunnerCapability(
+		provider.lastReq.RequiredOptionalCapabilities,
+		workerexecution.RunnerOptionalCapabilitySessionResume,
+	) {
+		t.Fatalf(
+			"retry capabilities = %#v, want session resume",
+			provider.lastReq.RequiredOptionalCapabilities,
+		)
+	}
+	if result.ProviderSession == nil || result.ProviderSession.ID != sessionID {
+		t.Fatalf("result Provider Session = %#v, want %q", result.ProviderSession, sessionID)
+	}
+}
+
+func containsRunnerCapability(
+	capabilities []workerexecution.RunnerOptionalCapability,
+	want workerexecution.RunnerOptionalCapability,
+) bool {
+	for _, capability := range capabilities {
+		if capability == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestInferenceRequestForExecutionRequest_ForwardsModelOperationContract(t *testing.T) {

--- a/pkg/services/workers/provider/inference_provider.go
+++ b/pkg/services/workers/provider/inference_provider.go
@@ -26,7 +26,6 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/workers/provider/commandenv"
 	cursorpkg "github.com/portpowered/infinite-you/pkg/services/workers/provider/cursor"
 	providercontract "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
-	kiropkg "github.com/portpowered/infinite-you/pkg/services/workers/provider/kiro"
 
 	"github.com/portpowered/infinite-you/pkg/services/work"
 )
@@ -662,11 +661,6 @@ func parseProviderExitFailure(provider string, result CommandResult) parsedProvi
 			failure:       ProviderFailureResult{Reason: parsed.Reason, Message: parsed.Message},
 			internalCause: codexexitfailure.ExitInternalCause(result.ExitCode),
 		}
-	case string(modelprovider.ProviderKiro):
-		failure := kiropkg.ParseProviderFailure(kiropkg.FailureInput{
-			Stdout: result.Stdout, Stderr: result.Stderr, ExitCode: result.ExitCode,
-		})
-		return parsedProviderFailure{failure: ProviderFailureResult{Reason: failure.Reason, Message: failure.Message}}
 	case string(modelprovider.ProviderOpenCode):
 		failure := opencodeadapter.ParseProviderFailure(opencodeadapter.FailureInput{
 			Stdout: result.Stdout, Stderr: result.Stderr, ExitCode: result.ExitCode,
@@ -775,8 +769,6 @@ func parseProviderTimeoutFailure(provider string, result CommandResult) Provider
 		if codexError, ok := extractCodexErrorLine(result); ok {
 			message = codexError
 		}
-	case string(modelprovider.ProviderKiro):
-		message = kiropkg.TimeoutFailureMessage
 	}
 	return ProviderFailureResult{
 		Reason:  workerexecution.WorkFailureTypeTimeout,

--- a/pkg/services/workers/provider/inference_provider_exit_failure_test.go
+++ b/pkg/services/workers/provider/inference_provider_exit_failure_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/services/workers/provider/adapter"
-	kiropkg "github.com/portpowered/infinite-you/pkg/services/workers/provider/kiro"
 )
 
 // pkgmaintcheck:ignore-cyclomatic-complexity service-ownership migration preserves this decision flow; simplify branches and remove this exemption.
@@ -154,48 +153,6 @@ func TestScriptWrapProvider_Infer_GenericNonCodexExitFailuresPreserveMessageAndC
 	for _, tc := range genericNonCodexExitFailureTestCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			assertInferenceExitFailure(t, tc)
-		})
-	}
-}
-
-func TestScriptWrapProvider_Infer_NormalizedIdentitySelectsOneCanonicalFailureResult(t *testing.T) {
-	t.Parallel()
-	testCases := []struct {
-		provider    string
-		result      CommandResult
-		runErr      error
-		wantReason  workerexecution.WorkFailureType
-		wantFamily  workerexecution.WorkFailureFamily
-		wantMessage string
-	}{
-		{
-			provider:    "  KIRO-CLI  ",
-			result:      CommandResult{ExitCode: 1, Stderr: []byte("ERROR: Unauthorized")},
-			wantReason:  workerexecution.WorkFailureTypeAuthFailure,
-			wantFamily:  workerexecution.WorkFailureFamilyTerminal,
-			wantMessage: "Kiro authentication failed. Sign in again and retry.",
-		},
-		{
-			provider:    "  KIRO-CLI  ",
-			result:      CommandResult{Stderr: []byte("private timeout transcript")},
-			runErr:      context.DeadlineExceeded,
-			wantReason:  workerexecution.WorkFailureTypeTimeout,
-			wantFamily:  workerexecution.WorkFailureFamilyRetryable,
-			wantMessage: kiropkg.TimeoutFailureMessage,
-		},
-	}
-
-	for _, tc := range testCases {
-		wantTerminal := tc.wantFamily == workerexecution.WorkFailureFamilyTerminal
-		provider := NewScriptWrapProviderWithDependencies(false, nil, &recordingProviderExec{result: tc.result, err: tc.runErr}, nil, nil, nil, "", nil, nil)
-		_, err := provider.Infer(context.Background(), workerexecution.ProviderInferenceRequest{ModelProvider: tc.provider, UserMessage: "private prompt"})
-		assertNormalizedProviderFailure(t, err, normalizedProviderFailureExpectation{
-			wantType:          tc.wantReason,
-			wantFamily:        tc.wantFamily,
-			wantMessage:       tc.wantMessage,
-			wantRetryable:     tc.wantReason == workerexecution.WorkFailureTypeTimeout || tc.wantReason == workerexecution.WorkFailureTypeThrottled,
-			wantTerminal:      wantTerminal,
-			wantThrottlePause: tc.wantReason == workerexecution.WorkFailureTypeThrottled,
 		})
 	}
 }
@@ -476,13 +433,6 @@ type exitFailureInferenceTestCase struct {
 
 func genericNonCodexExitFailureTestCases() []exitFailureInferenceTestCase {
 	return []exitFailureInferenceTestCase{
-		{
-			name:        "KiroFallsBackToProviderExitCodeWhenOutputMissing",
-			provider:    string(modelprovider.ProviderKiro),
-			result:      CommandResult{ExitCode: 9},
-			wantMessage: "kiro-cli exited with code 9",
-			wantType:    workerexecution.WorkFailureTypeUnknown,
-		},
 		{
 			name:     "OpenCodeUsesStructuredAuthenticationFailure",
 			provider: string(modelprovider.ProviderOpenCode),

--- a/pkg/services/workers/provider/inference_provider_test.go
+++ b/pkg/services/workers/provider/inference_provider_test.go
@@ -722,26 +722,6 @@ type nonCodexInferencePayloadTestCase struct {
 func nonCodexInferencePayloadTestCases() []nonCodexInferencePayloadTestCase {
 	return []nonCodexInferencePayloadTestCase{
 		{
-			name: "Kiro",
-			req: workerexecution.ProviderInferenceRequest{
-				ModelProvider: string(modelprovider.ProviderKiro),
-				SystemPrompt:  "You are a careful reviewer.",
-				SessionID:     "kiro-session-123",
-				UserMessage:   "run the tests",
-				EnvVars: map[string]string{
-					"AGENT_FACTORY_KIRO_ENV": "enabled",
-				},
-			},
-			wantArgs: []string{
-				"chat",
-				"--no-interactive",
-				"--resume-id",
-				"kiro-session-123",
-				"System instructions:\nYou are a careful reviewer.\n\nUser request:\nrun the tests",
-			},
-			wantEnv: "AGENT_FACTORY_KIRO_ENV=enabled",
-		},
-		{
 			name: "Cursor",
 			req: workerexecution.ProviderInferenceRequest{
 				ModelProvider: string(modelprovider.ProviderCursor),

--- a/pkg/services/workers/provider/kiro/command.go
+++ b/pkg/services/workers/provider/kiro/command.go
@@ -13,8 +13,7 @@ import (
 )
 
 // Adapter owns Kiro command construction for the registry-backed conductor
-// path. Response decoding and failure normalization are added by the remaining
-// Kiro migration slices.
+// path. Failure normalization is added by the remaining Kiro migration slice.
 type Adapter struct{}
 
 // NewAdapter constructs the stateless Kiro adapter.

--- a/pkg/services/workers/provider/kiro/command.go
+++ b/pkg/services/workers/provider/kiro/command.go
@@ -1,0 +1,105 @@
+package kiro
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
+	workerprocess "github.com/portpowered/infinite-you/pkg/services/workers/process"
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/adapter"
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/commandenv"
+)
+
+// Adapter owns Kiro command construction for the registry-backed conductor
+// path. Response decoding and failure normalization are added by the remaining
+// Kiro migration slices.
+type Adapter struct{}
+
+// NewAdapter constructs the stateless Kiro adapter.
+func NewAdapter() *Adapter { return &Adapter{} }
+
+// Identity returns Kiro's stable registry key.
+func (*Adapter) Identity() adapter.Identity {
+	return adapter.Identity(modelprovider.ProviderKiro)
+}
+
+// BuildCommand assembles Kiro argv and subprocess execution context.
+func (*Adapter) BuildCommand(_ context.Context, input adapter.CommandContext) (adapter.CommandBuildResult, error) {
+	args, err := BuildArgs(input.Request, input.SkipPermissions)
+	if err != nil {
+		return adapter.CommandBuildResult{}, err
+	}
+	return adapter.CommandBuildResult{Request: BuildCommandRequest(input.Request, args)}, nil
+}
+
+// BuildArgs constructs Kiro CLI arguments while preserving the established
+// prompt, resume, and permission behavior.
+func BuildArgs(req workerexecution.ProviderInferenceRequest, skipPermissions bool) ([]string, error) {
+	if err := validateOptionalCapabilities(req); err != nil {
+		return nil, err
+	}
+	args := []string{"chat", "--no-interactive"}
+	if req.SessionID != "" {
+		args = append(args, "--resume-id", req.SessionID)
+	}
+	if skipPermissions {
+		args = append(args, "--trust-all-tools")
+	}
+	if prompt := BuildPrompt(req); prompt != "" {
+		args = append(args, prompt)
+	}
+	return args, nil
+}
+
+// BuildPrompt combines Kiro system instructions and the user request into the
+// single positional prompt accepted by kiro-cli.
+func BuildPrompt(req workerexecution.ProviderInferenceRequest) string {
+	systemPrompt := strings.TrimSpace(req.SystemPrompt)
+	userMessage := strings.TrimSpace(req.UserMessage)
+	switch {
+	case systemPrompt == "":
+		return userMessage
+	case userMessage == "":
+		return systemPrompt
+	default:
+		return "System instructions:\n" + systemPrompt + "\n\nUser request:\n" + userMessage
+	}
+}
+
+// BuildCommandRequest owns Kiro subprocess request assembly, including the
+// shared deterministic environment policy and dispatch metadata.
+func BuildCommandRequest(req workerexecution.ProviderInferenceRequest, args []string) workerprocess.CommandRequest {
+	command := workerprocess.SubprocessRequestBase(req.Dispatch)
+	command.Command = string(modelprovider.ProviderKiro)
+	command.Args = append([]string(nil), args...)
+	command.Env = commandenv.Build(req.ProcessEnvironment, req.EnvVars)
+	command.WorkDir = req.WorkingDirectory
+	command.InputTokens = append([]any(nil), req.InputTokens...)
+	if req.WorkerType != "" {
+		command.WorkerType = req.WorkerType
+	}
+	if req.WorkstationType != "" {
+		command.WorkstationName = req.WorkstationType
+	}
+	if req.ProjectID != "" {
+		command.ProjectID = req.ProjectID
+	}
+	return command
+}
+
+func validateOptionalCapabilities(req workerexecution.ProviderInferenceRequest) error {
+	unsupported := map[workerexecution.RunnerOptionalCapability]string{
+		workerexecution.RunnerOptionalCapabilityImageInput:       "image input is not supported by the kiro runner in v1",
+		workerexecution.RunnerOptionalCapabilityStructuredOutput: "structured output is not supported by the kiro runner in v1",
+		workerexecution.RunnerOptionalCapabilityWorkingDirectory: "working directory is not supported by the kiro runner in v1",
+		workerexecution.RunnerOptionalCapabilityWorktree:         "worktree selection is not supported by the kiro runner in v1",
+	}
+	for _, capability := range req.RequiredOptionalCapabilities {
+		if message, blocked := unsupported[capability]; blocked {
+			return errors.New(message)
+		}
+	}
+	return nil
+}

--- a/pkg/services/workers/provider/kiro/command_test.go
+++ b/pkg/services/workers/provider/kiro/command_test.go
@@ -1,0 +1,197 @@
+package kiro_test
+
+import (
+	"context"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/adapter"
+	kiropkg "github.com/portpowered/infinite-you/pkg/services/workers/provider/kiro"
+)
+
+const privateKiroToken = "kiro-fixture-secret"
+
+func TestAdapterIdentity(t *testing.T) {
+	t.Parallel()
+	if got := kiropkg.NewAdapter().Identity(); got != adapter.Identity(modelprovider.ProviderKiro) {
+		t.Fatalf("Identity() = %q, want %q", got, modelprovider.ProviderKiro)
+	}
+}
+
+func TestBuildArgs_PreservesPromptResumeAndPermissionBehavior(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name            string
+		req             workerexecution.ProviderInferenceRequest
+		skipPermissions bool
+		want            []string
+	}{
+		{
+			name: "NewInvocation",
+			req: workerexecution.ProviderInferenceRequest{
+				UserMessage: "summarize the workspace",
+			},
+			want: []string{"chat", "--no-interactive", "summarize the workspace"},
+		},
+		{
+			name: "ComposedPrompt",
+			req: workerexecution.ProviderInferenceRequest{
+				SystemPrompt: "  You are a careful reviewer. ",
+				UserMessage:  " run the tests  ",
+			},
+			want: []string{
+				"chat",
+				"--no-interactive",
+				"System instructions:\nYou are a careful reviewer.\n\nUser request:\nrun the tests",
+			},
+		},
+		{
+			name: "ResumedInvocation",
+			req: workerexecution.ProviderInferenceRequest{
+				SessionID:   "kiro-session-123",
+				UserMessage: "continue the review",
+			},
+			want: []string{
+				"chat", "--no-interactive",
+				"--resume-id", "kiro-session-123",
+				"continue the review",
+			},
+		},
+		{
+			name: "SkipPermissions",
+			req: workerexecution.ProviderInferenceRequest{
+				UserMessage: "run the tests",
+			},
+			skipPermissions: true,
+			want:            []string{"chat", "--no-interactive", "--trust-all-tools", "run the tests"},
+		},
+		{
+			name: "SystemInstructionsOnly",
+			req: workerexecution.ProviderInferenceRequest{
+				SystemPrompt: "Review carefully.",
+			},
+			want: []string{"chat", "--no-interactive", "Review carefully."},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := kiropkg.BuildArgs(tc.req, tc.skipPermissions)
+			if err != nil {
+				t.Fatalf("BuildArgs() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("BuildArgs() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildArgs_RejectsUnsupportedCapabilityRequirements(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		capability workerexecution.RunnerOptionalCapability
+		wantErr    string
+	}{
+		{
+			name:       "ImageInput",
+			capability: workerexecution.RunnerOptionalCapabilityImageInput,
+			wantErr:    "image input is not supported by the kiro runner in v1",
+		},
+		{
+			name:       "StructuredOutput",
+			capability: workerexecution.RunnerOptionalCapabilityStructuredOutput,
+			wantErr:    "structured output is not supported by the kiro runner in v1",
+		},
+		{
+			name:       "WorkingDirectory",
+			capability: workerexecution.RunnerOptionalCapabilityWorkingDirectory,
+			wantErr:    "working directory is not supported by the kiro runner in v1",
+		},
+		{
+			name:       "Worktree",
+			capability: workerexecution.RunnerOptionalCapabilityWorktree,
+			wantErr:    "worktree selection is not supported by the kiro runner in v1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := kiropkg.BuildArgs(workerexecution.ProviderInferenceRequest{
+				UserMessage:                  "summarize the workspace",
+				RequiredOptionalCapabilities: []workerexecution.RunnerOptionalCapability{tc.capability},
+			}, false)
+			if err == nil || err.Error() != tc.wantErr {
+				t.Fatalf("BuildArgs() error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildCommand_WiresEnvironmentAndDispatchMetadata(t *testing.T) {
+	t.Parallel()
+
+	built, err := kiropkg.NewAdapter().BuildCommand(context.Background(), adapter.CommandContext{
+		SkipPermissions: true,
+		Request: workerexecution.ProviderInferenceRequest{
+			Dispatch:         work.WorkDispatch{DispatchID: "dispatch-kiro-command"},
+			UserMessage:      "review the workspace",
+			WorkingDirectory: "workspace",
+			WorkerType:       "agent-worker",
+			WorkstationType:  "review-work",
+			ProjectID:        "project-kiro",
+			InputTokens:      []any{"input-token"},
+			ProcessEnvironment: []string{
+				"KIRO_PROCESS_VALUE=base",
+			},
+			EnvVars: map[string]string{
+				"KIRO_API_TOKEN": privateKiroToken,
+				"KIRO_TEST_ENV":  "configured",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildCommand() error = %v", err)
+	}
+
+	if built.Request.Command != string(modelprovider.ProviderKiro) {
+		t.Fatalf("command = %q, want %q", built.Request.Command, modelprovider.ProviderKiro)
+	}
+	wantArgs := []string{"chat", "--no-interactive", "--trust-all-tools", "review the workspace"}
+	if !reflect.DeepEqual(built.Request.Args, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", built.Request.Args, wantArgs)
+	}
+	if built.Request.DispatchID != "dispatch-kiro-command" ||
+		built.Request.WorkerType != "agent-worker" ||
+		built.Request.WorkstationName != "review-work" ||
+		built.Request.ProjectID != "project-kiro" ||
+		built.Request.WorkDir != "workspace" ||
+		!reflect.DeepEqual(built.Request.InputTokens, []any{"input-token"}) {
+		t.Fatalf("execution context = %#v", built.Request)
+	}
+	for _, arg := range built.Request.Args {
+		if strings.Contains(arg, privateKiroToken) {
+			t.Fatalf("secret leaked into argv: %#v", built.Request.Args)
+		}
+	}
+	for _, want := range []string{
+		"KIRO_PROCESS_VALUE=base",
+		"KIRO_API_TOKEN=" + privateKiroToken,
+		"KIRO_TEST_ENV=configured",
+		"GIT_TERMINAL_PROMPT=0",
+	} {
+		if !slices.Contains(built.Request.Env, want) {
+			t.Fatalf("command env = %#v, want %q", built.Request.Env, want)
+		}
+	}
+}

--- a/pkg/services/workers/provider/kiro/conformance_test.go
+++ b/pkg/services/workers/provider/kiro/conformance_test.go
@@ -1,0 +1,256 @@
+package kiro_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	workerprocess "github.com/portpowered/infinite-you/pkg/services/workers/process"
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/conductor"
+	inference "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+	kiropkg "github.com/portpowered/infinite-you/pkg/services/workers/provider/kiro"
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/registry"
+)
+
+func TestKiroIntegrationSatisfiesApplicableSharedContract(t *testing.T) {
+	t.Parallel()
+
+	integration := kiropkg.NewIntegration(kiropkg.IntegrationDependencies{
+		CommandRunner: &conformanceRunner{},
+	})
+	if err := inference.ValidateIdentity(integration.Identity()); err != nil {
+		t.Fatalf("ValidateIdentity() error = %v", err)
+	}
+	if integration.Identity() != "kiro" {
+		t.Fatalf("Identity() = %q, want kiro", integration.Identity())
+	}
+
+	maximum := integration.MaximumCapabilities()
+	if err := inference.ValidateMaximumCapabilities(maximum); err != nil {
+		t.Fatalf("ValidateMaximumCapabilities() error = %v", err)
+	}
+	wantMaximum := []inference.Capability{
+		inference.CapabilityPromptSubmission,
+		inference.CapabilitySessionResume,
+		inference.CapabilityMessageSnapshots,
+	}
+	if got := maximum.Values(); !reflect.DeepEqual(got, wantMaximum) {
+		t.Fatalf("MaximumCapabilities() = %v, want %v", got, wantMaximum)
+	}
+
+	discovery, err := integration.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if err := inference.ValidateDiscovery(discovery); err != nil {
+		t.Fatalf("ValidateDiscovery() error = %v", err)
+	}
+	if discovery.Readiness() != inference.ReadinessReady {
+		t.Fatalf("Discover() readiness = %q, want ready", discovery.Readiness())
+	}
+
+	request := kiroConformanceRequest("inv-kiro-capabilities")
+	negotiated, err := integration.Capabilities(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Capabilities() error = %v", err)
+	}
+	if err := inference.ValidateNegotiatedCapabilities(maximum, negotiated); err != nil {
+		t.Fatalf("ValidateNegotiatedCapabilities() error = %v", err)
+	}
+	for _, required := range request.RequiredCapabilities().Values() {
+		if !negotiated.Has(required) {
+			t.Fatalf("Capabilities() omitted required capability %q", required)
+		}
+	}
+}
+
+func TestBuiltInRegistrySelectsKiroByCanonicalIdentityAndAlias(t *testing.T) {
+	t.Parallel()
+
+	providers := newKiroRegistry(t, &conformanceRunner{})
+	for _, identity := range []string{" KIRO ", "kiro-cli"} {
+		entry, err := providers.Lookup(identity)
+		if err != nil {
+			t.Fatalf("Lookup(%q) error = %v", identity, err)
+		}
+		if entry.Identity() != "kiro" {
+			t.Fatalf("Lookup(%q) identity = %q, want kiro", identity, entry.Identity())
+		}
+		integration, err := providers.Integration(identity)
+		if err != nil {
+			t.Fatalf("Integration(%q) error = %v", identity, err)
+		}
+		if integration.Identity() != "kiro" {
+			t.Fatalf("Integration(%q) identity = %q, want kiro", identity, integration.Identity())
+		}
+	}
+	if providers.UsesNativeRunner("kiro") {
+		t.Fatal("UsesNativeRunner(kiro) = true, want neutral conductor route")
+	}
+	if !providers.UsesNativeRunner(workers.RunnerIDCodex) {
+		t.Fatal("UsesNativeRunner(codex) = false, want retained native route")
+	}
+}
+
+func TestConductorInvokesKiroThroughInjectedCommandBoundary(t *testing.T) {
+	t.Parallel()
+
+	runner := &conformanceRunner{result: workerprocess.CommandResult{
+		Stdout: []byte("kiro conductor answer"),
+	}}
+	destination := &conformanceDestination{}
+	err := conductor.New(newKiroRegistry(t, runner)).Invoke(
+		context.Background(),
+		"kiro-cli",
+		kiroConformanceRequest("inv-kiro-conductor"),
+		destination,
+	)
+	if err != nil {
+		t.Fatalf("conductor.Invoke(kiro-cli) error = %v", err)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("command runner calls = %d, want 1", runner.calls)
+	}
+	if runner.request.Command != "kiro-cli" {
+		t.Fatalf("command = %q, want kiro-cli", runner.request.Command)
+	}
+	if !containsConformanceArgPair(runner.request.Args, "--resume-id", kiroSessionID) {
+		t.Fatalf("args = %#v, want --resume-id %s", runner.request.Args, kiroSessionID)
+	}
+	if destination.closes != 1 || destination.completion == nil {
+		t.Fatalf("destination closes = %d completion = %#v, want exactly one close", destination.closes, destination.completion)
+	}
+	response := destination.completion.Response()
+	if response == nil || destination.completion.Failure() != nil {
+		t.Fatalf("completion = %#v, want successful response", destination.completion)
+	}
+	if response.Content() != "kiro conductor answer" {
+		t.Fatalf("response content = %q, want kiro conductor answer", response.Content())
+	}
+	if len(destination.events) != 3 {
+		t.Fatalf("events = %d, want final-only lifecycle", len(destination.events))
+	}
+}
+
+func TestRegistrySelectedKiroFailureClosesExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	runner := &conformanceRunner{result: workerprocess.CommandResult{
+		ExitCode: 1,
+		Stderr:   []byte(`{"error":{"type":"authentication_error","message":"token=customer-secret"}}`),
+	}}
+	destination := &conformanceDestination{}
+	integration, err := newKiroRegistry(t, runner).Integration("kiro")
+	if err != nil {
+		t.Fatalf("Integration(kiro) error = %v", err)
+	}
+	if err := inference.ExecuteInvocation(
+		context.Background(),
+		integration,
+		kiroConformanceRequest("inv-kiro-failure"),
+		destination,
+	); err != nil {
+		t.Fatalf("ExecuteInvocation() error = %v", err)
+	}
+	if destination.closes != 1 || destination.completion == nil {
+		t.Fatalf("destination closes = %d completion = %#v, want exactly one close", destination.closes, destination.completion)
+	}
+	failure := destination.completion.Failure()
+	if failure == nil || destination.completion.Response() != nil {
+		t.Fatalf("completion = %#v, want normalized failure", destination.completion)
+	}
+	if failure.Kind() != inference.FailureAuthentication ||
+		failure.Message() != "Kiro authentication failed. Sign in again and retry." {
+		t.Fatalf(
+			"failure = %q/%q, want authentication/Kiro authentication failed. Sign in again and retry.",
+			failure.Kind(),
+			failure.Message(),
+		)
+	}
+	if len(destination.events) != 0 {
+		t.Fatalf("failure events = %#v, want none", destination.events)
+	}
+}
+
+const kiroSessionID = "675f9238-5f05-456c-9a9f-f8fe486f49e4"
+
+func kiroConformanceRequest(invocationID string) inference.InvocationRequest {
+	session := inference.NewProviderSession("kiro", "session_id", kiroSessionID, nil)
+	return inference.NewInvocationRequest(inference.InvocationInput{
+		InvocationID:    invocationID,
+		Model:           "claude-sonnet-4",
+		SystemPrompt:    "Follow the factory instructions.",
+		UserMessage:     "complete the requested work",
+		ProviderSession: &session,
+		Required: inference.NewCapabilitySet(
+			inference.CapabilityPromptSubmission,
+			inference.CapabilitySessionResume,
+			inference.CapabilityMessageSnapshots,
+		),
+	})
+}
+
+func newKiroRegistry(t *testing.T, runner workerprocess.CommandRunner) *registry.Registry {
+	t.Helper()
+	registrations, err := registry.BuiltInRegistrations(registry.BuiltInDependencies{
+		CommandRunner: runner,
+	})
+	if err != nil {
+		t.Fatalf("BuiltInRegistrations() error = %v", err)
+	}
+	providers, err := registry.New(registrations...)
+	if err != nil {
+		t.Fatalf("registry.New() error = %v", err)
+	}
+	return providers
+}
+
+type conformanceRunner struct {
+	calls   int
+	request workerprocess.CommandRequest
+	result  workerprocess.CommandResult
+	err     error
+}
+
+func (r *conformanceRunner) Run(
+	_ context.Context,
+	request workerprocess.CommandRequest,
+) (workerprocess.CommandResult, error) {
+	r.calls++
+	r.request = request
+	return r.result, r.err
+}
+
+type conformanceDestination struct {
+	events     []inference.EventDraft
+	completion *inference.Completion
+	closes     int
+}
+
+func (d *conformanceDestination) WriteEvent(
+	_ context.Context,
+	event inference.EventDraft,
+) error {
+	d.events = append(d.events, event)
+	return nil
+}
+
+func (d *conformanceDestination) Close(
+	_ context.Context,
+	completion inference.Completion,
+) error {
+	d.closes++
+	cloned := completion
+	d.completion = &cloned
+	return nil
+}
+
+func containsConformanceArgPair(args []string, flag, value string) bool {
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] == flag && args[index+1] == value {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/services/workers/provider/kiro/failure.go
+++ b/pkg/services/workers/provider/kiro/failure.go
@@ -1,12 +1,15 @@
 package kiro
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"unicode"
 
 	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/adapter"
 )
 
 const (
@@ -37,6 +40,55 @@ type FailureResult struct {
 
 func ParseProviderFailure(input FailureInput) FailureResult {
 	return parseProviderFailure(input)
+}
+
+// TimeoutFailureResult returns the canonical Kiro timeout outcome used when
+// the command boundary reports deadline expiration without provider output.
+func TimeoutFailureResult() FailureResult {
+	return knownKiroFailure(workerexecution.WorkFailureTypeTimeout)
+}
+
+// ClassifyFailure translates Kiro subprocess outcomes into the bounded facts
+// consumed by the neutral conductor. Cancellation remains an invocation-level
+// concern and is propagated by Integration.Invoke before classification.
+func (*Adapter) ClassifyFailure(ctx context.Context, input adapter.FailureContext) adapter.FailureResult {
+	if !kiroFailureNeedsClassification(input) {
+		return adapter.FailureResult{}
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) ||
+		errors.Is(input.CommandError, context.DeadlineExceeded) {
+		return normalizedKiroFailureResult(TimeoutFailureResult(), input.CommandError)
+	}
+	parsed := ParseProviderFailure(FailureInput{
+		Stdout:   input.CommandResult.Stdout,
+		Stderr:   input.CommandResult.Stderr,
+		ExitCode: input.CommandResult.ExitCode,
+	})
+	return normalizedKiroFailureResult(parsed, errors.Join(
+		input.CommandError, input.DecodeError, input.FlushError, input.ParseError,
+	))
+}
+
+func kiroFailureNeedsClassification(input adapter.FailureContext) bool {
+	return input.CommandError != nil ||
+		input.CommandResult.ExitCode != 0 ||
+		input.DecodeError != nil ||
+		input.FlushError != nil ||
+		input.ParseError != nil
+}
+
+func normalizedKiroFailureResult(parsed FailureResult, cause error) adapter.FailureResult {
+	providerErr := workerexecution.NewProviderError(parsed.Reason, parsed.Message, cause)
+	decision := workerexecution.FailureDecisionFromMetadata(&workerexecution.WorkFailureMetadata{
+		Family: providerErr.Family,
+		Type:   providerErr.Type,
+	})
+	return adapter.FailureResult{Failure: &adapter.FailureFacts{
+		Family:  providerErr.Family,
+		Type:    providerErr.Type,
+		Message: providerErr.Message,
+		Retry:   adapter.RetryGuidance{Retryable: decision.Retryable},
+	}}
 }
 
 func tailForErrorScan(output []byte) string {
@@ -279,13 +331,34 @@ func unsafeKiroUnknownDetail(detail string) bool {
 	if strings.HasPrefix(detail, "{") || strings.HasPrefix(detail, "[") || strings.Contains(detail, "=") {
 		return true
 	}
+	if containsPrivatePath(lower) {
+		return true
+	}
 	return containsAny(lower,
 		"prompt", "transcript", "response draft", "model output", "user message",
 		"request body", "request payload", "input content", "output content",
 		"progress", "cleanup", "credential", "secret", "password",
 		"api key", "api_key", "access key", "authorization", "bearer ",
 		"access token", "refresh token", "session token", "environment", "env var",
+		"token:", "sk-", "ghp_", "github_pat_", "akia",
 	)
+}
+
+func containsPrivatePath(detail string) bool {
+	if containsAny(detail,
+		"/home/", "/users/", "/tmp/", "/var/tmp/", "/private/",
+		`:\users\`, `:\documents and settings\`, `\appdata\`,
+	) {
+		return true
+	}
+	for index := 0; index+2 < len(detail); index++ {
+		if detail[index] >= 'a' && detail[index] <= 'z' &&
+			detail[index+1] == ':' &&
+			(detail[index+2] == '\\' || detail[index+2] == '/') {
+			return true
+		}
+	}
+	return false
 }
 
 func truncateKiroFailureMessage(message string) string {

--- a/pkg/services/workers/provider/kiro/integration.go
+++ b/pkg/services/workers/provider/kiro/integration.go
@@ -84,12 +84,26 @@ func (i *Integration) Invoke(
 	if errors.Is(runErr, context.Canceled) {
 		return runErr
 	}
+	requestedSession := validRequestedSession(request.ProviderSession())
+	if requestedSession == nil {
+		// The product runner carries configured resume state in Execution while
+		// direct protocol callers can supply ProviderSession. Normalize both
+		// accepted entry paths before applying Kiro's emitted-session semantics.
+		requestedSession = newProviderSession(providerRequest.SessionID)
+	}
+	resultSession := responseFromOutput(
+		result.Stdout,
+		result.Stderr,
+		requestedSession,
+	).ProviderSession()
 	classified := NewAdapter().ClassifyFailure(ctx, adapter.FailureContext{
 		CommandResult: result,
 		CommandError:  runErr,
 	})
 	if classified.Failure != nil {
-		return writer.Close(ctx, inference.FailedCompletion(failureFromKiroFacts(*classified.Failure)))
+		return writer.Close(ctx, inference.FailedCompletion(
+			failureFromKiroFacts(*classified.Failure, resultSession),
+		))
 	}
 	if runErr != nil {
 		return writer.Close(ctx, inference.FailedCompletion(inference.NewFailure(inference.FailureInput{
@@ -98,13 +112,6 @@ func (i *Integration) Invoke(
 		})))
 	}
 
-	requestedSession := validRequestedSession(request.ProviderSession())
-	if requestedSession == nil {
-		// The product runner carries configured resume state in Execution while
-		// direct protocol callers can supply ProviderSession. Normalize both
-		// accepted entry paths before applying Kiro's emitted-session semantics.
-		requestedSession = newProviderSession(providerRequest.SessionID)
-	}
 	response := responseFromOutput(result.Stdout, result.Stderr, requestedSession)
 	if err := writeFinalOnlyProgress(ctx, writer, request.InvocationID(), response.Content()); err != nil {
 		return err
@@ -112,11 +119,15 @@ func (i *Integration) Invoke(
 	return writer.Close(ctx, inference.SuccessfulCompletion(response))
 }
 
-func failureFromKiroFacts(facts adapter.FailureFacts) inference.Failure {
+func failureFromKiroFacts(
+	facts adapter.FailureFacts,
+	session *inference.ProviderSession,
+) inference.Failure {
 	return inference.NewFailure(inference.FailureInput{
-		Kind:      kiroFailureKind(facts.Type),
-		Message:   facts.Message,
-		Retryable: facts.Retry.Retryable,
+		Kind:            kiroFailureKind(facts.Type),
+		Message:         facts.Message,
+		Retryable:       facts.Retry.Retryable,
+		ProviderSession: session,
 	})
 }
 

--- a/pkg/services/workers/provider/kiro/integration.go
+++ b/pkg/services/workers/provider/kiro/integration.go
@@ -1,0 +1,201 @@
+package kiro
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
+	workerprocess "github.com/portpowered/infinite-you/pkg/services/workers/process"
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/adapter"
+	inference "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+)
+
+// IntegrationDependencies are the execution collaborators used by Kiro's
+// registry-backed integration.
+type IntegrationDependencies struct {
+	CommandRunner workerprocess.CommandRunner
+}
+
+// Integration is Kiro's provider-owned neutral-conductor implementation.
+type Integration struct {
+	runner workerprocess.CommandRunner
+}
+
+// NewIntegration constructs Kiro's integration. A nil runner is reserved for
+// inert registry composition; invocation requires a composed command runner.
+func NewIntegration(deps ...IntegrationDependencies) *Integration {
+	integration := &Integration{}
+	if len(deps) > 0 {
+		integration.runner = deps[0].CommandRunner
+	}
+	return integration
+}
+
+func (*Integration) Identity() inference.Identity {
+	return inference.Identity(providerIdentity)
+}
+
+func (*Integration) MaximumCapabilities() inference.CapabilitySet {
+	return inference.NewCapabilitySet(
+		inference.CapabilityPromptSubmission,
+		inference.CapabilitySessionResume,
+		inference.CapabilityMessageSnapshots,
+	)
+}
+
+func (*Integration) Discover(context.Context) (inference.Discovery, error) {
+	return inference.NewDiscovery(inference.ReadinessReady), nil
+}
+
+func (i *Integration) Capabilities(
+	context.Context,
+	inference.InvocationRequest,
+) (inference.CapabilitySet, error) {
+	return i.MaximumCapabilities(), nil
+}
+
+// Invoke runs Kiro once, translates its final-only response, and closes the
+// response writer with exactly one authoritative completion.
+func (i *Integration) Invoke(
+	ctx context.Context,
+	request inference.InvocationRequest,
+	writer inference.ResponseWriter,
+) error {
+	providerRequest := kiroRequestFromInvocation(request)
+	built, err := NewAdapter().BuildCommand(ctx, adapter.CommandContext{
+		Request:         providerRequest,
+		SkipPermissions: providerRequest.SkipPermissions,
+	})
+	if err != nil {
+		return writer.Close(ctx, inference.FailedCompletion(inference.NewFailure(inference.FailureInput{
+			Kind:    inference.FailureInvalidRequest,
+			Message: err.Error(),
+		})))
+	}
+
+	result, runErr := i.commandRunner().Run(ctx, built.Request)
+	if errors.Is(runErr, context.Canceled) || errors.Is(runErr, context.DeadlineExceeded) {
+		return runErr
+	}
+	if runErr != nil || result.ExitCode != 0 {
+		return writer.Close(ctx, inference.FailedCompletion(inference.NewFailure(inference.FailureInput{
+			Kind:    inference.FailureUnknown,
+			Message: "Kiro command did not complete successfully.",
+		})))
+	}
+
+	response := responseFromOutput(result.Stdout, result.Stderr, request.ProviderSession())
+	if err := writeFinalOnlyProgress(ctx, writer, request.InvocationID(), response.Content()); err != nil {
+		return err
+	}
+	return writer.Close(ctx, inference.SuccessfulCompletion(response))
+}
+
+func (i *Integration) commandRunner() workerprocess.CommandRunner {
+	if i != nil && i.runner != nil {
+		return i.runner
+	}
+	return workerprocess.CommandRunnerWithLogging(nil, nil, nil)
+}
+
+func kiroRequestFromInvocation(request inference.InvocationRequest) workerexecution.ProviderInferenceRequest {
+	providerRequest := request.Execution()
+	if providerRequest.Dispatch.DispatchID == "" {
+		providerRequest.Dispatch.DispatchID = request.InvocationID()
+	}
+	providerRequest.ModelProvider = string(modelprovider.ProviderKiro)
+	providerRequest.Model = request.Model()
+	providerRequest.SystemPrompt = request.SystemPrompt()
+	providerRequest.UserMessage = request.UserMessage()
+	providerRequest.OutputSchema = request.OutputSchema()
+	if session := validRequestedSession(request.ProviderSession()); session != nil {
+		providerRequest.SessionID = session.ID()
+	}
+	return providerRequest
+}
+
+func writeFinalOnlyProgress(
+	ctx context.Context,
+	writer inference.ResponseWriter,
+	runID, content string,
+) error {
+	events, err := finalOnlyProgressEvents(runID, content)
+	if err != nil {
+		return err
+	}
+	for _, event := range events {
+		if err := writer.WriteEvent(ctx, event); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func finalOnlyProgressEvents(runID, content string) ([]inference.EventDraft, error) {
+	started, err := finalOnlyRunEvent(runID, workerexecution.PhaseStarted)
+	if err != nil {
+		return nil, err
+	}
+	message, err := finalOnlyMessageEvent(runID, content)
+	if err != nil {
+		return nil, err
+	}
+	completed, err := finalOnlyRunEvent(runID, workerexecution.PhaseCompleted)
+	if err != nil {
+		return nil, err
+	}
+	return []inference.EventDraft{started, message, completed}, nil
+}
+
+func finalOnlyRunEvent(runID string, phase workerexecution.Phase) (inference.EventDraft, error) {
+	payload, err := json.Marshal(workerexecution.RunPayload{Status: string(phase)})
+	if err != nil {
+		return inference.EventDraft{}, fmt.Errorf("marshal Kiro run payload: %w", err)
+	}
+	return inference.NewEventDraft(inference.EventDraftInput{
+		RunID:   runID,
+		Kind:    workerexecution.KindRun,
+		Phase:   phase,
+		Payload: payload,
+		Provenance: workerexecution.Provenance{
+			Delivery:        workerexecution.DeliverySynthesized,
+			Fidelity:        workerexecution.FidelityLifecycleOnly,
+			NativeEventType: "command_completion",
+			Provider:        providerIdentity,
+			Representation:  workerexecution.RepresentationNotification,
+		},
+	})
+}
+
+func finalOnlyMessageEvent(runID, content string) (inference.EventDraft, error) {
+	payload, err := json.Marshal(workerexecution.MessagePayload{
+		Role: "assistant",
+		ContentBlocks: []workerexecution.ContentBlock{{
+			Kind: workerexecution.ContentBlockText,
+			Text: strings.Clone(content),
+		}},
+	})
+	if err != nil {
+		return inference.EventDraft{}, fmt.Errorf("marshal Kiro message payload: %w", err)
+	}
+	return inference.NewEventDraft(inference.EventDraftInput{
+		RunID:   runID,
+		Kind:    workerexecution.KindMessage,
+		Phase:   workerexecution.PhaseCompleted,
+		ItemID:  "kiro-final",
+		Payload: payload,
+		Provenance: workerexecution.Provenance{
+			Delivery:        workerexecution.DeliveryNativeFinal,
+			Fidelity:        workerexecution.FidelityFinalOnly,
+			NativeEventType: "final_response",
+			Provider:        providerIdentity,
+			Representation:  workerexecution.RepresentationSnapshot,
+		},
+	})
+}
+
+var _ inference.Integration = (*Integration)(nil)

--- a/pkg/services/workers/provider/kiro/integration.go
+++ b/pkg/services/workers/provider/kiro/integration.go
@@ -78,13 +78,23 @@ func (i *Integration) Invoke(
 	}
 
 	result, runErr := i.commandRunner().Run(ctx, built.Request)
-	if errors.Is(runErr, context.Canceled) || errors.Is(runErr, context.DeadlineExceeded) {
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return ctx.Err()
+	}
+	if errors.Is(runErr, context.Canceled) {
 		return runErr
 	}
-	if runErr != nil || result.ExitCode != 0 {
+	classified := NewAdapter().ClassifyFailure(ctx, adapter.FailureContext{
+		CommandResult: result,
+		CommandError:  runErr,
+	})
+	if classified.Failure != nil {
+		return writer.Close(ctx, inference.FailedCompletion(failureFromKiroFacts(*classified.Failure)))
+	}
+	if runErr != nil {
 		return writer.Close(ctx, inference.FailedCompletion(inference.NewFailure(inference.FailureInput{
 			Kind:    inference.FailureUnknown,
-			Message: "Kiro command did not complete successfully.",
+			Message: "Kiro invocation failed.",
 		})))
 	}
 
@@ -93,6 +103,31 @@ func (i *Integration) Invoke(
 		return err
 	}
 	return writer.Close(ctx, inference.SuccessfulCompletion(response))
+}
+
+func failureFromKiroFacts(facts adapter.FailureFacts) inference.Failure {
+	return inference.NewFailure(inference.FailureInput{
+		Kind:      kiroFailureKind(facts.Type),
+		Message:   facts.Message,
+		Retryable: facts.Retry.Retryable,
+	})
+}
+
+func kiroFailureKind(failureType workerexecution.WorkFailureType) inference.FailureKind {
+	switch failureType {
+	case workerexecution.WorkFailureTypeTimeout:
+		return inference.FailureTimeout
+	case workerexecution.WorkFailureTypeThrottled:
+		return inference.FailureThrottled
+	case workerexecution.WorkFailureTypeAuthFailure:
+		return inference.FailureAuthentication
+	case workerexecution.WorkFailureTypePermanentBadRequest:
+		return inference.FailureInvalidRequest
+	case workerexecution.WorkFailureTypeMisconfigured:
+		return inference.FailureDependency
+	default:
+		return inference.FailureUnknown
+	}
 }
 
 func (i *Integration) commandRunner() workerprocess.CommandRunner {

--- a/pkg/services/workers/provider/kiro/integration.go
+++ b/pkg/services/workers/provider/kiro/integration.go
@@ -98,7 +98,14 @@ func (i *Integration) Invoke(
 		})))
 	}
 
-	response := responseFromOutput(result.Stdout, result.Stderr, request.ProviderSession())
+	requestedSession := validRequestedSession(request.ProviderSession())
+	if requestedSession == nil {
+		// The product runner carries configured resume state in Execution while
+		// direct protocol callers can supply ProviderSession. Normalize both
+		// accepted entry paths before applying Kiro's emitted-session semantics.
+		requestedSession = newProviderSession(providerRequest.SessionID)
+	}
+	response := responseFromOutput(result.Stdout, result.Stderr, requestedSession)
 	if err := writeFinalOnlyProgress(ctx, writer, request.InvocationID(), response.Content()); err != nil {
 		return err
 	}

--- a/pkg/services/workers/provider/kiro/integration_failure_test.go
+++ b/pkg/services/workers/provider/kiro/integration_failure_test.go
@@ -1,0 +1,196 @@
+package kiro
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	workerprocess "github.com/portpowered/infinite-you/pkg/services/workers/process"
+	inference "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+)
+
+type integrationFailureCase struct {
+	name        string
+	result      workerprocess.CommandResult
+	err         error
+	wantKind    inference.FailureKind
+	wantMessage string
+	wantRetry   bool
+	rejected    []string
+}
+
+func TestIntegrationNormalizesKnownKiroFailures(t *testing.T) {
+	t.Parallel()
+
+	runIntegrationFailureCases(t, []integrationFailureCase{
+		{
+			name: "structured authentication",
+			result: workerprocess.CommandResult{
+				ExitCode: 1,
+				Stderr:   []byte(`{"error":{"type":"authentication_error","message":"Bearer private-token"}}`),
+			},
+			wantKind:    inference.FailureAuthentication,
+			wantMessage: kiroAuthFailureMessage,
+			rejected:    []string{"Bearer", "private-token"},
+		},
+		{
+			name: "structured invalid request",
+			result: workerprocess.CommandResult{
+				ExitCode: 1,
+				Stderr:   []byte(`{"status":422,"message":"private customer request"}`),
+			},
+			wantKind:    inference.FailureInvalidRequest,
+			wantMessage: kiroBadRequestFailureMessage,
+			rejected:    []string{"private customer request"},
+		},
+		{
+			name: "structured throttle outranks text",
+			result: workerprocess.CommandResult{
+				ExitCode: 1,
+				Stdout:   []byte(`{"error":{"code":"ThrottlingException","message":"capacity secret"}}`),
+				Stderr:   []byte("ERROR: authentication required"),
+			},
+			wantKind:    inference.FailureThrottled,
+			wantMessage: kiroThrottleFailureMessage,
+			wantRetry:   true,
+			rejected:    []string{"authentication required", "capacity secret"},
+		},
+		{
+			name: "temporary service failure",
+			result: workerprocess.CommandResult{
+				ExitCode: 1,
+				Stderr:   []byte(`{"type":"error","errorType":"ServiceUnavailableException","message":"host /tmp/private"}`),
+			},
+			wantKind:    inference.FailureUnknown,
+			wantMessage: kiroServerFailureMessage,
+			wantRetry:   true,
+			rejected:    []string{"/tmp/private"},
+		},
+	})
+}
+
+func TestIntegrationNormalizesMalformedUnknownAndDeadlineFailures(t *testing.T) {
+	t.Parallel()
+
+	runIntegrationFailureCases(t, []integrationFailureCase{
+		{
+			name: "malformed structured record falls back to text",
+			result: workerprocess.CommandResult{
+				ExitCode: 1,
+				Stderr: []byte(
+					"ERROR: {\"type\":\"error\", malformed\nERROR: request timed out while waiting for Kiro",
+				),
+			},
+			wantKind:    inference.FailureTimeout,
+			wantMessage: TimeoutFailureMessage,
+			wantRetry:   true,
+			rejected:    []string{"malformed", "while waiting"},
+		},
+		{
+			name: "unsafe unknown detail falls back to exit code",
+			result: workerprocess.CommandResult{
+				ExitCode: 17,
+				Stderr:   []byte(`Error: failed reading C:\Users\alice\private\project`),
+			},
+			wantKind:    inference.FailureUnknown,
+			wantMessage: "kiro-cli exited with code 17",
+			rejected:    []string{`C:\Users\alice`, "private"},
+		},
+		{
+			name:        "command deadline",
+			err:         context.DeadlineExceeded,
+			wantKind:    inference.FailureTimeout,
+			wantMessage: TimeoutFailureMessage,
+			wantRetry:   true,
+		},
+	})
+}
+
+func runIntegrationFailureCases(t *testing.T, testCases []integrationFailureCase) {
+	t.Helper()
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := &recordingRunner{result: testCase.result, err: testCase.err}
+			writer := &recordingWriter{}
+			err := inference.ExecuteInvocation(
+				context.Background(),
+				NewIntegration(IntegrationDependencies{CommandRunner: runner}),
+				failureInvocationRequest("inv-kiro-"+testCase.name),
+				writer,
+			)
+			if err != nil {
+				t.Fatalf("ExecuteInvocation() error = %v", err)
+			}
+			assertKiroFailureCompletion(t, writer, testCase)
+		})
+	}
+}
+
+func assertKiroFailureCompletion(
+	t *testing.T,
+	writer *recordingWriter,
+	want integrationFailureCase,
+) {
+	t.Helper()
+	if writer.closes != 1 || writer.completion.Response() != nil || len(writer.events) != 0 {
+		t.Fatalf(
+			"completion = %#v, closes = %d, events = %#v; want one failed close",
+			writer.completion, writer.closes, writer.events,
+		)
+	}
+	failure := writer.completion.Failure()
+	if failure == nil ||
+		failure.Kind() != want.wantKind ||
+		failure.Message() != want.wantMessage ||
+		failure.Retryable() != want.wantRetry {
+		t.Fatalf(
+			"failure = %#v, want kind=%q message=%q retryable=%v",
+			failure, want.wantKind, want.wantMessage, want.wantRetry,
+		)
+	}
+	for _, rejected := range want.rejected {
+		if strings.Contains(failure.Message(), rejected) {
+			t.Fatalf("failure message leaked %q: %q", rejected, failure.Message())
+		}
+	}
+}
+
+func TestIntegrationPropagatesCancellationForProtocolNormalization(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingRunner{err: context.Canceled}
+	writer := &recordingWriter{}
+	err := inference.ExecuteInvocation(
+		context.Background(),
+		NewIntegration(IntegrationDependencies{CommandRunner: runner}),
+		failureInvocationRequest("inv-kiro-canceled"),
+		writer,
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ExecuteInvocation() error = %v, want context.Canceled", err)
+	}
+	if writer.closes != 1 || writer.completion.Response() != nil || len(writer.events) != 0 {
+		t.Fatalf(
+			"completion = %#v, closes = %d, events = %#v; want one failed close",
+			writer.completion, writer.closes, writer.events,
+		)
+	}
+	failure := writer.completion.Failure()
+	if failure == nil ||
+		failure.Kind() != inference.FailureCanceled ||
+		failure.Message() != "provider invocation was canceled" ||
+		failure.Retryable() {
+		t.Fatalf("failure = %#v, want canonical non-retryable cancellation", failure)
+	}
+}
+
+func failureInvocationRequest(id string) inference.InvocationRequest {
+	return inference.NewInvocationRequest(inference.InvocationInput{
+		InvocationID: id,
+		UserMessage:  "private customer request",
+	})
+}

--- a/pkg/services/workers/provider/kiro/integration_failure_test.go
+++ b/pkg/services/workers/provider/kiro/integration_failure_test.go
@@ -17,6 +17,7 @@ type integrationFailureCase struct {
 	wantKind    inference.FailureKind
 	wantMessage string
 	wantRetry   bool
+	wantSession string
 	rejected    []string
 }
 
@@ -60,11 +61,15 @@ func TestIntegrationNormalizesKnownKiroFailures(t *testing.T) {
 			name: "temporary service failure",
 			result: workerprocess.CommandResult{
 				ExitCode: 1,
-				Stderr:   []byte(`{"type":"error","errorType":"ServiceUnavailableException","message":"host /tmp/private"}`),
+				Stderr: []byte(
+					`{"event":"session.created","session_id":"` + resumedSessionID + `"}` + "\n" +
+						`{"type":"error","errorType":"ServiceUnavailableException","message":"host /tmp/private"}`,
+				),
 			},
 			wantKind:    inference.FailureUnknown,
 			wantMessage: kiroServerFailureMessage,
 			wantRetry:   true,
+			wantSession: resumedSessionID,
 			rejected:    []string{"/tmp/private"},
 		},
 	})
@@ -152,10 +157,33 @@ func assertKiroFailureCompletion(
 			failure, want.wantKind, want.wantMessage, want.wantRetry,
 		)
 	}
+	assertKiroFailureSession(t, failure.ProviderSession(), want.wantSession)
 	for _, rejected := range want.rejected {
 		if strings.Contains(failure.Message(), rejected) {
 			t.Fatalf("failure message leaked %q: %q", rejected, failure.Message())
 		}
+	}
+}
+
+func assertKiroFailureSession(
+	t *testing.T,
+	session *inference.ProviderSession,
+	wantSession string,
+) {
+	t.Helper()
+	if wantSession == "" {
+		if session != nil {
+			t.Fatalf("failure Provider Session = %#v, want nil", session)
+		}
+		return
+	}
+	if session == nil || session.Provider() != providerIdentity || session.ID() != wantSession {
+		t.Fatalf(
+			"failure Provider Session = %#v, want provider=%q id=%q",
+			session,
+			providerIdentity,
+			wantSession,
+		)
 	}
 }
 

--- a/pkg/services/workers/provider/kiro/response.go
+++ b/pkg/services/workers/provider/kiro/response.go
@@ -1,0 +1,86 @@
+package kiro
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/google/uuid"
+
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	inference "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+)
+
+const (
+	providerIdentity    = "kiro"
+	providerSessionKind = "session_id"
+)
+
+type sessionRecord struct {
+	SessionID string `json:"session_id"`
+}
+
+// responseFromOutput preserves Kiro's final-only stdout and attaches only an
+// explicit, canonical Kiro session. Free-form model text is never interpreted
+// as provider-session metadata.
+func responseFromOutput(
+	stdout, stderr []byte,
+	requested *inference.ProviderSession,
+) inference.Response {
+	session := validRequestedSession(requested)
+	if emitted := providerSessionFromOutput(stdout, stderr); emitted != nil {
+		session = emitted
+	}
+	return inference.NewResponse(inference.ResponseInput{
+		Content:         string(stdout),
+		ProviderSession: session,
+	})
+}
+
+func providerSessionFromOutput(streams ...[]byte) *inference.ProviderSession {
+	var latest *inference.ProviderSession
+	for _, stream := range streams {
+		normalized := bytes.ReplaceAll(stream, []byte("\r\n"), []byte("\n"))
+		for _, line := range bytes.Split(normalized, []byte("\n")) {
+			var record sessionRecord
+			if json.Unmarshal(bytes.TrimSpace(line), &record) != nil {
+				continue
+			}
+			if session := newProviderSession(record.SessionID); session != nil {
+				latest = session
+			}
+		}
+	}
+	return latest
+}
+
+func validRequestedSession(session *inference.ProviderSession) *inference.ProviderSession {
+	if session == nil ||
+		!isKiroProvider(session.Provider()) ||
+		strings.TrimSpace(session.Kind()) != providerSessionKind {
+		return nil
+	}
+	return newProviderSession(session.ID())
+}
+
+func isKiroProvider(provider string) bool {
+	provider = strings.TrimSpace(provider)
+	return strings.EqualFold(provider, providerIdentity) ||
+		strings.EqualFold(provider, string(modelprovider.ProviderKiro))
+}
+
+func newProviderSession(sessionID string) *inference.ProviderSession {
+	sessionID = strings.TrimSpace(sessionID)
+	parsed, err := uuid.Parse(sessionID)
+	if err != nil || parsed == uuid.Nil || len(sessionID) != len(parsed.String()) ||
+		!strings.EqualFold(sessionID, parsed.String()) {
+		return nil
+	}
+	session := inference.NewProviderSession(
+		providerIdentity,
+		providerSessionKind,
+		parsed.String(),
+		nil,
+	)
+	return &session
+}

--- a/pkg/services/workers/provider/kiro/response_test.go
+++ b/pkg/services/workers/provider/kiro/response_test.go
@@ -205,6 +205,7 @@ func containsArgPair(args []string, flag, value string) bool {
 type recordingRunner struct {
 	request workerprocess.CommandRequest
 	result  workerprocess.CommandResult
+	err     error
 	calls   int
 }
 
@@ -214,7 +215,7 @@ func (r *recordingRunner) Run(
 ) (workerprocess.CommandResult, error) {
 	r.calls++
 	r.request = request
-	return r.result, nil
+	return r.result, r.err
 }
 
 type recordingWriter struct {

--- a/pkg/services/workers/provider/kiro/response_test.go
+++ b/pkg/services/workers/provider/kiro/response_test.go
@@ -1,0 +1,235 @@
+package kiro
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	workerprocess "github.com/portpowered/infinite-you/pkg/services/workers/process"
+	inference "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+)
+
+const (
+	newSessionID     = "f2946a26-3735-4b08-8d05-c928010302d5"
+	resumedSessionID = "675f9238-5f05-456c-9a9f-f8fe486f49e4"
+)
+
+func TestResponseFromOutputNormalizesProviderSessions(t *testing.T) {
+	t.Parallel()
+
+	requested := newKiroSession(resumedSessionID)
+	testCases := []struct {
+		name      string
+		stdout    string
+		stderr    string
+		requested *inference.ProviderSession
+		wantID    string
+	}{
+		{
+			name:   "new session",
+			stdout: "new session answer",
+			stderr: `{"event":"session.created","session_id":"` + newSessionID + `"}`,
+			wantID: newSessionID,
+		},
+		{
+			name:      "resumed session is preserved without emitted metadata",
+			stdout:    "continued answer",
+			requested: &requested,
+			wantID:    resumedSessionID,
+		},
+		{
+			name:      "emitted session updates resumed session",
+			stdout:    "continued answer",
+			stderr:    `{"session_id":"` + newSessionID + `"}`,
+			requested: &requested,
+			wantID:    newSessionID,
+		},
+		{
+			name:   "absent session stays absent",
+			stdout: "answer without session metadata",
+		},
+		{
+			name:   "empty structured session stays absent",
+			stdout: "answer with empty session metadata",
+			stderr: `{"session_id":""}`,
+		},
+		{
+			name:      "malformed structured session preserves resumed session",
+			stdout:    "valid answer",
+			stderr:    `{"session_id":"not-a-uuid"}`,
+			requested: &requested,
+			wantID:    resumedSessionID,
+		},
+		{
+			name:   "arbitrary text is not a session",
+			stdout: "answer mentioning session_id: " + newSessionID,
+		},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			response := responseFromOutput(
+				[]byte(testCase.stdout),
+				[]byte(testCase.stderr),
+				testCase.requested,
+			)
+			if response.Content() != testCase.stdout {
+				t.Fatalf("Content() = %q, want %q", response.Content(), testCase.stdout)
+			}
+			session := response.ProviderSession()
+			if testCase.wantID == "" {
+				if session != nil {
+					t.Fatalf("ProviderSession() = %#v, want nil", session)
+				}
+				return
+			}
+			if session == nil ||
+				session.Provider() != "kiro" ||
+				session.Kind() != providerSessionKind ||
+				session.ID() != testCase.wantID {
+				t.Fatalf("ProviderSession() = %#v, want kiro/session_id/%s", session, testCase.wantID)
+			}
+		})
+	}
+}
+
+func TestIntegrationWritesFinalOnlyLifecycleAndClosesOnce(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingRunner{result: workerprocess.CommandResult{
+		Stdout: []byte("Kiro completed the work."),
+		Stderr: []byte(`{"session_id":"` + newSessionID + `"}`),
+	}}
+	writer := &recordingWriter{}
+	integration := NewIntegration(IntegrationDependencies{CommandRunner: runner})
+
+	err := inference.ExecuteInvocation(
+		context.Background(),
+		integration,
+		inference.NewInvocationRequest(inference.InvocationInput{
+			InvocationID: "inv-kiro-response",
+			UserMessage:  "complete the task",
+		}),
+		writer,
+	)
+	if err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("runner calls = %d, want 1", runner.calls)
+	}
+	if writer.closes != 1 {
+		t.Fatalf("writer closes = %d, want 1", writer.closes)
+	}
+	if len(writer.events) != 3 {
+		t.Fatalf("events = %d, want 3", len(writer.events))
+	}
+	assertFinalOnlyLifecycle(t, writer.events, "Kiro completed the work.")
+
+	response := writer.completion.Response()
+	if response == nil || response.Content() != "Kiro completed the work." {
+		t.Fatalf("completion response = %#v", response)
+	}
+	session := response.ProviderSession()
+	if session == nil || session.ID() != newSessionID ||
+		session.Provider() != "kiro" || session.Kind() != providerSessionKind {
+		t.Fatalf("completion provider session = %#v", session)
+	}
+}
+
+func TestIntegrationUsesAuthoritativeRequestedSessionForResume(t *testing.T) {
+	t.Parallel()
+
+	requested := newKiroSession(resumedSessionID)
+	runner := &recordingRunner{result: workerprocess.CommandResult{
+		Stdout: []byte("resumed answer"),
+	}}
+	writer := &recordingWriter{}
+	err := NewIntegration(IntegrationDependencies{CommandRunner: runner}).Invoke(
+		context.Background(),
+		inference.NewInvocationRequest(inference.InvocationInput{
+			InvocationID:    "inv-kiro-resume",
+			UserMessage:     "continue",
+			ProviderSession: &requested,
+		}),
+		writer,
+	)
+	if err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+	if !containsArgPair(runner.request.Args, "--resume-id", resumedSessionID) {
+		t.Fatalf("command args = %#v, want --resume-id %s", runner.request.Args, resumedSessionID)
+	}
+	session := writer.completion.Response().ProviderSession()
+	if session == nil || session.ID() != resumedSessionID {
+		t.Fatalf("completion provider session = %#v, want preserved session", session)
+	}
+}
+
+func assertFinalOnlyLifecycle(t *testing.T, events []inference.EventDraft, content string) {
+	t.Helper()
+	drafts := make([]workers.Draft, 0, len(events))
+	for _, event := range events {
+		drafts = append(drafts, event.Draft())
+	}
+	if drafts[0].Kind != workers.KindRun || drafts[0].Phase != workers.PhaseStarted ||
+		drafts[1].Kind != workers.KindMessage || drafts[1].Phase != workers.PhaseCompleted ||
+		drafts[2].Kind != workers.KindRun || drafts[2].Phase != workers.PhaseCompleted {
+		t.Fatalf("final-only lifecycle = %#v", drafts)
+	}
+	var payload workers.MessagePayload
+	if err := json.Unmarshal(drafts[1].Payload, &payload); err != nil {
+		t.Fatalf("decode message payload: %v", err)
+	}
+	if len(payload.ContentBlocks) != 1 || payload.ContentBlocks[0].Text != content {
+		t.Fatalf("message payload = %#v, want content %q", payload, content)
+	}
+}
+
+func newKiroSession(id string) inference.ProviderSession {
+	return inference.NewProviderSession("kiro", providerSessionKind, id, nil)
+}
+
+func containsArgPair(args []string, flag, value string) bool {
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] == flag && args[index+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+type recordingRunner struct {
+	request workerprocess.CommandRequest
+	result  workerprocess.CommandResult
+	calls   int
+}
+
+func (r *recordingRunner) Run(
+	_ context.Context,
+	request workerprocess.CommandRequest,
+) (workerprocess.CommandResult, error) {
+	r.calls++
+	r.request = request
+	return r.result, nil
+}
+
+type recordingWriter struct {
+	events     []inference.EventDraft
+	completion inference.Completion
+	closes     int
+}
+
+func (w *recordingWriter) WriteEvent(_ context.Context, event inference.EventDraft) error {
+	w.events = append(w.events, event)
+	return nil
+}
+
+func (w *recordingWriter) Close(_ context.Context, completion inference.Completion) error {
+	w.closes++
+	w.completion = completion
+	return nil
+}

--- a/pkg/services/workers/provider/provider_behavior.go
+++ b/pkg/services/workers/provider/provider_behavior.go
@@ -124,10 +124,6 @@ type codexProviderBehavior struct {
 	logger logging.Logger
 }
 
-type kiroProviderBehavior struct {
-	logger logging.Logger
-}
-
 type cursorProviderBehavior struct {
 	sharedNonCodexProviderBehavior
 	logger logging.Logger
@@ -147,8 +143,6 @@ func providerBehaviorFor(provider string, logger logging.Logger) providerBehavio
 	switch provider {
 	case string(modelprovider.ProviderCodex):
 		return codexProviderBehavior{logger: logger}
-	case string(modelprovider.ProviderKiro):
-		return kiroProviderBehavior{logger: logger}
 	case string(modelprovider.ProviderCursor):
 		return cursorProviderBehavior{logger: logger}
 	case string(modelprovider.ProviderOpenCode):
@@ -251,27 +245,6 @@ func BuildCodexStructuredCommand(
 	return behavior.BuildCommandRequest(req, args), cleanup, nil
 }
 
-func (b kiroProviderBehavior) BuildArgs(_ context.Context, req workerexecution.ProviderInferenceRequest, skipPermissions bool, _ *ProviderBuildContext) ([]string, error) {
-	if err := validateKiroOptionalCapabilities(req); err != nil {
-		return nil, err
-	}
-	args := []string{"chat", "--no-interactive"}
-	if req.SessionID != "" {
-		args = append(args, "--resume-id", req.SessionID)
-	}
-	if skipPermissions {
-		args = append(args, "--trust-all-tools")
-	}
-	if prompt := buildKiroPrompt(req); prompt != "" {
-		args = append(args, prompt)
-	}
-	return args, nil
-}
-
-func (kiroProviderBehavior) BuildCommandRequest(req workerexecution.ProviderInferenceRequest, args []string) CommandRequest {
-	return buildBaseProviderCommandRequest(req, args)
-}
-
 // pkgmaintcheck:ignore-cyclomatic-complexity service-ownership migration preserves this decision flow; simplify branches and remove this exemption.
 func (b cursorProviderBehavior) BuildArgs(_ context.Context, req workerexecution.ProviderInferenceRequest, skipPermissions bool, buildCtx *ProviderBuildContext) ([]string, error) {
 	if err := validateCursorOptionalCapabilities(req); err != nil {
@@ -329,7 +302,7 @@ func (b cursorProviderBehavior) BuildArgs(_ context.Context, req workerexecution
 func buildCursorPrompt(req workerexecution.ProviderInferenceRequest) string {
 	prompt := strings.TrimSpace(req.UserMessage)
 	if strings.TrimSpace(req.SystemPrompt) != "" {
-		prompt = buildKiroPrompt(req)
+		prompt = buildCombinedPrompt(req)
 	}
 	return prompt
 }
@@ -410,21 +383,6 @@ func validateCodexOptionalCapabilities(req workerexecution.ProviderInferenceRequ
 	return nil
 }
 
-func validateKiroOptionalCapabilities(req workerexecution.ProviderInferenceRequest) error {
-	unsupported := map[workerexecution.RunnerOptionalCapability]string{
-		workerexecution.RunnerOptionalCapabilityImageInput:       "image input is not supported by the kiro runner in v1",
-		workerexecution.RunnerOptionalCapabilityStructuredOutput: "structured output is not supported by the kiro runner in v1",
-		workerexecution.RunnerOptionalCapabilityWorkingDirectory: "working directory is not supported by the kiro runner in v1",
-		workerexecution.RunnerOptionalCapabilityWorktree:         "worktree selection is not supported by the kiro runner in v1",
-	}
-	for _, capability := range req.RequiredOptionalCapabilities {
-		if message, blocked := unsupported[capability]; blocked {
-			return errors.New(message)
-		}
-	}
-	return nil
-}
-
 func validateCursorOptionalCapabilities(req workerexecution.ProviderInferenceRequest) error {
 	unsupported := map[workerexecution.RunnerOptionalCapability]string{
 		workerexecution.RunnerOptionalCapabilityImageInput:       "image input is not supported by the cursor-cli runner in v1",
@@ -452,7 +410,7 @@ func validateOpenCodeOptionalCapabilities(req workerexecution.ProviderInferenceR
 	return nil
 }
 
-func buildKiroPrompt(req workerexecution.ProviderInferenceRequest) string {
+func buildCombinedPrompt(req workerexecution.ProviderInferenceRequest) string {
 	systemPrompt := strings.TrimSpace(req.SystemPrompt)
 	userMessage := strings.TrimSpace(req.UserMessage)
 	switch {

--- a/pkg/services/workers/provider/provider_behavior_test.go
+++ b/pkg/services/workers/provider/provider_behavior_test.go
@@ -270,89 +270,6 @@ func TestCodexProviderBehavior_BuildArgs_MaterializesLocalFileURLWithoutCopy(t *
 	assertStringSlicesEqual(t, want, args)
 }
 
-func TestKiroProviderBehavior_BuildArgs(t *testing.T) {
-	t.Parallel()
-	testCases := []struct {
-		name            string
-		req             workerexecution.ProviderInferenceRequest
-		skipPermissions bool
-		want            []string
-	}{
-		{
-			name: "BasicPrompt",
-			req: workerexecution.ProviderInferenceRequest{
-				ModelProvider: string(modelprovider.ProviderKiro),
-				UserMessage:   "summarize the workspace",
-			},
-			want: []string{"chat", "--no-interactive", "summarize the workspace"},
-		},
-		{
-			name: "ComposedContextAndUserPrompt",
-			req: workerexecution.ProviderInferenceRequest{
-				ModelProvider: string(modelprovider.ProviderKiro),
-				SystemPrompt:  "You are a careful reviewer.",
-				UserMessage:   "run the tests",
-			},
-			want: []string{
-				"chat",
-				"--no-interactive",
-				"System instructions:\nYou are a careful reviewer.\n\nUser request:\nrun the tests",
-			},
-		},
-		{
-			name: "EmptyPrompt",
-			req: workerexecution.ProviderInferenceRequest{
-				ModelProvider: string(modelprovider.ProviderKiro),
-			},
-			want: []string{"chat", "--no-interactive"},
-		},
-		{
-			name: "TrustedTools",
-			req: workerexecution.ProviderInferenceRequest{
-				ModelProvider: string(modelprovider.ProviderKiro),
-				UserMessage:   "run the tests",
-			},
-			skipPermissions: true,
-			want:            []string{"chat", "--no-interactive", "--trust-all-tools", "run the tests"},
-		},
-		{
-			name: "ResumeSession",
-			req: workerexecution.ProviderInferenceRequest{
-				ModelProvider: string(modelprovider.ProviderKiro),
-				UserMessage:   "continue the review",
-				SessionID:     "kiro-session-123",
-			},
-			want: []string{"chat", "--no-interactive", "--resume-id", "kiro-session-123", "continue the review"},
-		},
-	}
-
-	behavior := providerBehaviorFor(string(modelprovider.ProviderKiro), logging.NoopLogger{})
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			args, err := behavior.BuildArgs(context.Background(), tc.req, tc.skipPermissions, nil)
-			if err != nil {
-				t.Fatalf("BuildArgs returned error: %v", err)
-			}
-			assertStringSlicesEqual(t, tc.want, args)
-		})
-	}
-}
-
-func TestKiroProviderBehavior_BuildArgs_RejectsUnsupportedOptionalCapabilities(t *testing.T) {
-	t.Parallel()
-	behavior := kiroProviderBehavior{logger: logging.NoopLogger{}}
-	_, err := behavior.BuildArgs(context.Background(), workerexecution.ProviderInferenceRequest{
-		ModelProvider: string(modelprovider.ProviderKiro),
-		UserMessage:   "summarize the workspace",
-		RequiredOptionalCapabilities: []workerexecution.RunnerOptionalCapability{
-			workerexecution.RunnerOptionalCapabilityStructuredOutput,
-		},
-	}, false, nil)
-	if err == nil || err.Error() != "structured output is not supported by the kiro runner in v1" {
-		t.Fatalf("BuildArgs error = %v, want structured output rejection", err)
-	}
-}
-
 func TestCursorProviderBehavior_BuildArgs(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
@@ -433,7 +350,7 @@ func TestCursorProviderBehavior_BuildArgs_WindowsLongPromptUsesArgumentFile(t *t
 		t.Fatalf("prompt argument = %q, want @file reference", promptArg)
 	}
 	promptPath := strings.TrimPrefix(promptArg, "@")
-	wantPrompt := buildKiroPrompt(req)
+	wantPrompt := buildCombinedPrompt(req)
 	if gotPrompt := temporaryFiles.file.content.String(); gotPrompt != wantPrompt {
 		t.Fatalf("prompt file content differs: got %d bytes, want %d", len(gotPrompt), len(wantPrompt))
 	}
@@ -749,19 +666,6 @@ func nonCodexCommandRequestTestCases() []nonCodexCommandRequestTestCase {
 			wantEnv: "AGENT_FACTORY_PROVIDER=claude",
 		},
 		{
-			name: "Kiro",
-			req: workerexecution.ProviderInferenceRequest{
-				ModelProvider: string(modelprovider.ProviderKiro),
-				UserMessage:   "review this",
-				EnvVars: map[string]string{
-					"AGENT_FACTORY_PROVIDER": "kiro",
-				},
-				InputTokens: InputTokens(token),
-			},
-			args:    []string{"chat", "--no-interactive", "review this"},
-			wantEnv: "AGENT_FACTORY_PROVIDER=kiro",
-		},
-		{
 			name: "Cursor",
 			req: workerexecution.ProviderInferenceRequest{
 				ModelProvider: string(modelprovider.ProviderCursor),
@@ -788,62 +692,6 @@ func nonCodexCommandRequestTestCases() []nonCodexCommandRequestTestCase {
 			args:    []string{"run", "review this"},
 			wantEnv: "AGENT_FACTORY_PROVIDER=opencode",
 		},
-	}
-}
-
-func TestScriptWrapProvider_Infer_KiroKnownFailuresUseCanonicalParserAndPolicy(t *testing.T) {
-	t.Parallel()
-	fixtureNames := []string{
-		"kiro_structured_authentication_error",
-		"kiro_structured_invalid_request_stdout",
-		"kiro_text_authentication_stdout",
-		"kiro_structured_throttle_precedes_text",
-		"kiro_text_capacity_error",
-		"kiro_text_timeout_malformed_structured",
-		"kiro_structured_service_unavailable",
-	}
-
-	for _, name := range fixtureNames {
-		entry := providerErrorCorpusEntryForTest(t, name)
-		t.Run(providerErrorCorpusEntryLabel(entry), func(t *testing.T) {
-			provider := NewScriptWrapProviderWithDependencies(false, nil, &recordingProviderExec{result: entry.CommandResult()}, nil, nil, nil, "", nil, nil)
-			_, err := provider.Infer(context.Background(), workerexecution.ProviderInferenceRequest{
-				ModelProvider: string(modelprovider.ProviderKiro),
-				UserMessage:   "private prompt that must stay out of normalized failures",
-			})
-			assertNormalizedProviderFailure(t, err, normalizedProviderFailureExpectation{
-				wantType: entry.ExpectedType, wantFamily: entry.ExpectedFamily,
-				wantMessage:   knownKiroFailure(entry.ExpectedType).Message,
-				rejectTexts:   append(entry.RejectMessageContains, "private prompt"),
-				wantRetryable: entry.Retryable, wantTerminal: !entry.Retryable,
-				wantThrottlePause: entry.TriggersThrottlePause,
-			})
-		})
-	}
-}
-
-func TestScriptWrapProvider_Infer_KiroUnknownFailuresUseBoundedParserMessages(t *testing.T) {
-	t.Parallel()
-	testCases := map[string]string{
-		"kiro_unknown_stderr_excerpt_precedes_stdout":     "Kiro error: model registry handshake failed",
-		"kiro_unknown_stdout_excerpt_after_unsafe_stderr": "Kiro error: plugin bridge failed",
-		"kiro_unknown_noise_only_exit_fallback":           "kiro-cli exited with code 11",
-	}
-
-	for name, wantMessage := range testCases {
-		entry := providerErrorCorpusEntryForTest(t, name)
-		t.Run(providerErrorCorpusEntryLabel(entry), func(t *testing.T) {
-			provider := NewScriptWrapProviderWithDependencies(false, nil, &recordingProviderExec{result: entry.CommandResult()}, nil, nil, nil, "", nil, nil)
-			_, err := provider.Infer(context.Background(), workerexecution.ProviderInferenceRequest{
-				ModelProvider: string(modelprovider.ProviderKiro),
-				UserMessage:   "private prompt that must stay out of normalized failures",
-			})
-			assertNormalizedProviderFailure(t, err, normalizedProviderFailureExpectation{
-				wantType: workerexecution.WorkFailureTypeUnknown, wantFamily: workerexecution.WorkFailureFamilyTerminal,
-				wantMessage: wantMessage, rejectTexts: append(entry.RejectMessageContains, "private prompt"),
-				wantTerminal: true,
-			})
-		})
 	}
 }
 
@@ -959,21 +807,6 @@ func s14SkipPermissionsProviderCases() []s14ProviderCase {
 			},
 			unsafeArgCheck: func(args []string) bool {
 				return strings.Contains(strings.Join(args, " "), "--dangerously-bypass-approvals-and-sandbox")
-			},
-		},
-		{
-			provider:     modelprovider.ProviderKiro,
-			unsafeMarker: "--trust-all-tools",
-			unsafeReq: workerexecution.ProviderInferenceRequest{
-				ModelProvider: string(modelprovider.ProviderKiro),
-				UserMessage:   "run the tests",
-			},
-			safeReq: workerexecution.ProviderInferenceRequest{
-				ModelProvider: string(modelprovider.ProviderKiro),
-				UserMessage:   "run the tests",
-			},
-			unsafeArgCheck: func(args []string) bool {
-				return strings.Contains(strings.Join(args, " "), "--trust-all-tools")
 			},
 		},
 		{
@@ -1114,10 +947,13 @@ func TestAggregateSurfacesOmitMigratedGeminiBranches(t *testing.T) {
 	})
 }
 
-func TestAggregateSurfacesRetainNonGeminiProviders(t *testing.T) {
+// Migrated Kiro must no longer own aggregate command/failure/timeout branches.
+// Production selection stays on registry + conductor; these assertions prove
+// the legacy Kiro-named ownership is gone.
+func TestAggregateSurfacesOmitMigratedKiroBranches(t *testing.T) {
 	t.Parallel()
 
-	t.Run("kiro_command_construction", func(t *testing.T) {
+	t.Run("command_construction", func(t *testing.T) {
 		t.Parallel()
 		behavior := providerBehaviorFor(string(modelprovider.ProviderKiro), logging.NoopLogger{})
 		args, err := behavior.BuildArgs(context.Background(), workerexecution.ProviderInferenceRequest{
@@ -1127,31 +963,27 @@ func TestAggregateSurfacesRetainNonGeminiProviders(t *testing.T) {
 		if err != nil {
 			t.Fatalf("BuildArgs error = %v", err)
 		}
-		wantPrefix := []string{"chat", "--no-interactive", "summarize the workspace"}
-		if strings.Join(args, "\x00") != strings.Join(wantPrefix, "\x00") {
-			t.Fatalf("kiro args = %#v, want %#v", args, wantPrefix)
+		if len(args) > 0 && args[0] == "chat" {
+			t.Fatalf("aggregate still owns Kiro argv: %#v", args)
 		}
 	})
 
-	t.Run("kiro_exit_failure", func(t *testing.T) {
+	t.Run("exit_failure", func(t *testing.T) {
 		t.Parallel()
 		parsed := parseProviderExitFailure(string(modelprovider.ProviderKiro), CommandResult{
 			ExitCode: 1,
 			Stderr:   []byte("ERROR: Unauthorized"),
 		})
-		if parsed.failure.Reason != workerexecution.WorkFailureTypeAuthFailure {
-			t.Fatalf("kiro failure reason = %q, want auth failure", parsed.failure.Reason)
+		if parsed.failure.Message == "Kiro authentication failed. Sign in again and retry." {
+			t.Fatal("aggregate still owns Kiro exit-failure parsing")
 		}
 	})
 
-	t.Run("kiro_timeout_failure", func(t *testing.T) {
+	t.Run("timeout_failure", func(t *testing.T) {
 		t.Parallel()
 		parsed := parseProviderTimeoutFailure(string(modelprovider.ProviderKiro), CommandResult{})
-		if parsed.Reason != workerexecution.WorkFailureTypeTimeout {
-			t.Fatalf("kiro timeout reason = %q, want timeout", parsed.Reason)
-		}
-		if parsed.Message == "" {
-			t.Fatal("kiro timeout message is empty")
+		if parsed.Message == "Kiro request timed out." {
+			t.Fatal("aggregate still owns Kiro timeout parsing")
 		}
 	})
 }

--- a/pkg/services/workers/provider/provider_behavior_test.go
+++ b/pkg/services/workers/provider/provider_behavior_test.go
@@ -947,47 +947,6 @@ func TestAggregateSurfacesOmitMigratedGeminiBranches(t *testing.T) {
 	})
 }
 
-// Migrated Kiro must no longer own aggregate command/failure/timeout branches.
-// Production selection stays on registry + conductor; these assertions prove
-// the legacy Kiro-named ownership is gone.
-func TestAggregateSurfacesOmitMigratedKiroBranches(t *testing.T) {
-	t.Parallel()
-
-	t.Run("command_construction", func(t *testing.T) {
-		t.Parallel()
-		behavior := providerBehaviorFor(string(modelprovider.ProviderKiro), logging.NoopLogger{})
-		args, err := behavior.BuildArgs(context.Background(), workerexecution.ProviderInferenceRequest{
-			ModelProvider: string(modelprovider.ProviderKiro),
-			UserMessage:   "summarize the workspace",
-		}, false, nil)
-		if err != nil {
-			t.Fatalf("BuildArgs error = %v", err)
-		}
-		if len(args) > 0 && args[0] == "chat" {
-			t.Fatalf("aggregate still owns Kiro argv: %#v", args)
-		}
-	})
-
-	t.Run("exit_failure", func(t *testing.T) {
-		t.Parallel()
-		parsed := parseProviderExitFailure(string(modelprovider.ProviderKiro), CommandResult{
-			ExitCode: 1,
-			Stderr:   []byte("ERROR: Unauthorized"),
-		})
-		if parsed.failure.Message == "Kiro authentication failed. Sign in again and retry." {
-			t.Fatal("aggregate still owns Kiro exit-failure parsing")
-		}
-	})
-
-	t.Run("timeout_failure", func(t *testing.T) {
-		t.Parallel()
-		parsed := parseProviderTimeoutFailure(string(modelprovider.ProviderKiro), CommandResult{})
-		if parsed.Message == "Kiro request timed out." {
-			t.Fatal("aggregate still owns Kiro timeout parsing")
-		}
-	})
-}
-
 func containsArgPair(args []string, flag, value string) bool {
 	for index := 0; index+1 < len(args); index++ {
 		if args[index] == flag && args[index+1] == value {

--- a/pkg/services/workers/provider/provider_errors_test.go
+++ b/pkg/services/workers/provider/provider_errors_test.go
@@ -15,7 +15,6 @@ import (
 	opencodeadapter "github.com/portpowered/infinite-you/pkg/services/workers/provider/adapter/opencode"
 	claudeexitfailure "github.com/portpowered/infinite-you/pkg/services/workers/provider/claude/exitfailure"
 	codexexitfailure "github.com/portpowered/infinite-you/pkg/services/workers/provider/codex/exitfailure"
-	kiropkg "github.com/portpowered/infinite-you/pkg/services/workers/provider/kiro"
 )
 
 const (
@@ -58,23 +57,6 @@ func codexTextFailureMessage(reason workerexecution.WorkFailureType) string {
 	default:
 		return ""
 	}
-}
-
-func knownKiroFailure(reason workerexecution.WorkFailureType) ProviderFailureResult {
-	message := ""
-	switch reason {
-	case workerexecution.WorkFailureTypeAuthFailure:
-		message = "Kiro authentication failed. Sign in again and retry."
-	case workerexecution.WorkFailureTypePermanentBadRequest:
-		message = "Kiro rejected the request as invalid."
-	case workerexecution.WorkFailureTypeThrottled:
-		message = "Kiro is temporarily unavailable due to usage or capacity limits."
-	case workerexecution.WorkFailureTypeTimeout:
-		message = kiropkg.TimeoutFailureMessage
-	case workerexecution.WorkFailureTypeInternalServerError:
-		message = "Kiro encountered a temporary service error."
-	}
-	return ProviderFailureResult{Reason: reason, Message: message}
 }
 
 func ParseClaudeProviderFailure(result CommandResult) ProviderFailureResult {
@@ -948,11 +930,6 @@ func TestParseProviderExitFailure_RoutesOwnedProviderPackages(t *testing.T) {
 		{
 			provider: string(modelprovider.ProviderClaude),
 			result:   CommandResult{ExitCode: 1, Stderr: []byte(`API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"sign in"}}`)},
-			want:     workerexecution.WorkFailureTypeAuthFailure,
-		},
-		{
-			provider: string(modelprovider.ProviderKiro),
-			result:   CommandResult{ExitCode: 1, Stderr: []byte("ERROR: Unauthorized")},
 			want:     workerexecution.WorkFailureTypeAuthFailure,
 		},
 		{

--- a/pkg/services/workers/provider/registry/builtins.go
+++ b/pkg/services/workers/provider/registry/builtins.go
@@ -9,6 +9,7 @@ import (
 	workerprocess "github.com/portpowered/infinite-you/pkg/services/workers/process"
 	"github.com/portpowered/infinite-you/pkg/services/workers/provider/gemini"
 	inference "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/kiro"
 )
 
 const nativeRuntimePrerequisite = "provider-native-runtime"
@@ -100,6 +101,11 @@ func migratedBuiltInIntegration(identity inference.Identity, runner workerproces
 			return gemini.NewIntegration()
 		}
 		return gemini.NewIntegration(gemini.IntegrationDependencies{CommandRunner: runner})
+	case "kiro":
+		if runner == nil {
+			return kiro.NewIntegration()
+		}
+		return kiro.NewIntegration(kiro.IntegrationDependencies{CommandRunner: runner})
 	default:
 		return nil
 	}

--- a/pkg/services/workers/service/registry_runner.go
+++ b/pkg/services/workers/service/registry_runner.go
@@ -177,15 +177,16 @@ func (d *conductorCollectingDestination) result() (workers.RunnerExecutionResult
 }
 
 func providerErrorFromConductorFailure(failure inference.Failure) error {
-	return workerprovider.NewProviderError(
-		workFailureTypeFromConductorFailure(failure.Kind()),
+	return workerprovider.NewProviderErrorWithSession(
+		workFailureTypeFromConductorFailure(failure),
 		failure.Message(),
 		fmt.Errorf("conductor failure: %s", failure.Kind()),
+		providerSessionFromConductor(failure.ProviderSession()),
 	)
 }
 
-func workFailureTypeFromConductorFailure(kind inference.FailureKind) workers.WorkFailureType {
-	switch kind {
+func workFailureTypeFromConductorFailure(failure inference.Failure) workers.WorkFailureType {
+	switch failure.Kind() {
 	case inference.FailureTimeout:
 		return workers.WorkFailureTypeTimeout
 	case inference.FailureThrottled:
@@ -199,6 +200,9 @@ func workFailureTypeFromConductorFailure(kind inference.FailureKind) workers.Wor
 	case inference.FailureCanceled:
 		return workers.WorkFailureTypeUnknown
 	default:
+		if failure.Retryable() {
+			return workers.WorkFailureTypeInternalServerError
+		}
 		return workers.WorkFailureTypeUnknown
 	}
 }

--- a/pkg/services/workers/service/registry_runner_test.go
+++ b/pkg/services/workers/service/registry_runner_test.go
@@ -248,7 +248,7 @@ func TestConductorInvocationRunnerPreservesNativeBuiltInPath(t *testing.T) {
 func TestConductorInvocationRunnerRoutesMigratedGeminiThroughConductor(t *testing.T) {
 	t.Parallel()
 
-	commandRunner := &geminiConductorCommandRunner{
+	commandRunner := &builtInConductorCommandRunner{
 		result: workers.CommandResult{Stdout: []byte("gemini via conductor")},
 	}
 	providers := geminiConductorRegistry(t, commandRunner)
@@ -282,6 +282,63 @@ func TestConductorInvocationRunnerRoutesMigratedGeminiThroughConductor(t *testin
 	}
 	if providers.UsesNativeRunner("gemini") {
 		t.Fatal("UsesNativeRunner(gemini) = true, want conductor route")
+	}
+}
+
+func TestConductorInvocationRunnerPreservesKiroResumeSessionWithoutReplacement(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "675f9238-5f05-456c-9a9f-f8fe486f49e4"
+	commandRunner := &builtInConductorCommandRunner{
+		result: workers.CommandResult{Stdout: []byte("kiro resumed via conductor")},
+	}
+	registrations, err := providerregistry.BuiltInRegistrations(
+		providerregistry.BuiltInDependencies{CommandRunner: commandRunner},
+	)
+	if err != nil {
+		t.Fatalf("BuiltInRegistrations() error = %v", err)
+	}
+	providers, err := providerregistry.New(registrations...)
+	if err != nil {
+		t.Fatalf("registry.New() error = %v", err)
+	}
+	native := &conductorRouteRecordingRunner{}
+	runner := conductorInvocationRunner{
+		next:      native,
+		conductor: conductor.New(providers),
+		providers: providers,
+	}
+
+	result, err := runner.Execute(context.Background(), workers.RunnerExecutionRequest{
+		Dispatch:      work.WorkDispatch{DispatchID: "dispatch-kiro-resume"},
+		RunnerID:      workers.RunnerIDKiro,
+		ModelProvider: workers.RunnerIDKiro,
+		UserMessage:   "continue",
+		SessionID:     sessionID,
+		RequiredOptionalCapabilities: []workers.RunnerOptionalCapability{
+			workers.RunnerOptionalCapabilitySessionResume,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute(kiro resume) error = %v", err)
+	}
+	if result.Content != "kiro resumed via conductor" {
+		t.Fatalf("Execute(kiro resume) content = %q", result.Content)
+	}
+	if commandRunner.calls != 1 {
+		t.Fatalf("Kiro command runner calls = %d, want 1", commandRunner.calls)
+	}
+	if native.calls != 0 {
+		t.Fatalf("native runner calls = %d, want 0", native.calls)
+	}
+	if !containsRunnerArgPair(commandRunner.request.Args, "--resume-id", sessionID) {
+		t.Fatalf("Kiro command args = %#v, want --resume-id %s", commandRunner.request.Args, sessionID)
+	}
+	if result.ProviderSession == nil ||
+		result.ProviderSession.Provider != workers.RunnerIDKiro ||
+		result.ProviderSession.Kind != "session_id" ||
+		result.ProviderSession.ID != sessionID {
+		t.Fatalf("Kiro provider session = %#v, want preserved kiro/session_id/%s", result.ProviderSession, sessionID)
 	}
 }
 
@@ -463,17 +520,26 @@ func geminiConductorRegistry(t *testing.T, runner workers.CommandRunner) *provid
 	return providers
 }
 
-type geminiConductorCommandRunner struct {
+type builtInConductorCommandRunner struct {
 	calls   int
 	request workers.CommandRequest
 	result  workers.CommandResult
 }
 
-func (r *geminiConductorCommandRunner) Run(
+func (r *builtInConductorCommandRunner) Run(
 	_ context.Context,
 	request workers.CommandRequest,
 ) (workers.CommandResult, error) {
 	r.calls++
 	r.request = request
 	return r.result, nil
+}
+
+func containsRunnerArgPair(args []string, flag, value string) bool {
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] == flag && args[index+1] == value {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/services/workers/service/registry_runner_test.go
+++ b/pkg/services/workers/service/registry_runner_test.go
@@ -185,6 +185,36 @@ func (i *successfulConductorIntegration) Invoke(
 	})))
 }
 
+type failingConductorIntegration struct {
+	identity inference.Identity
+	failure  inference.Failure
+}
+
+func (i *failingConductorIntegration) Identity() inference.Identity { return i.identity }
+
+func (*failingConductorIntegration) MaximumCapabilities() inference.CapabilitySet {
+	return inference.NewCapabilitySet(inference.CapabilityPromptSubmission)
+}
+
+func (*failingConductorIntegration) Discover(context.Context) (inference.Discovery, error) {
+	return inference.NewDiscovery(inference.ReadinessReady), nil
+}
+
+func (i *failingConductorIntegration) Capabilities(
+	context.Context,
+	inference.InvocationRequest,
+) (inference.CapabilitySet, error) {
+	return i.MaximumCapabilities(), nil
+}
+
+func (i *failingConductorIntegration) Invoke(
+	ctx context.Context,
+	_ inference.InvocationRequest,
+	writer inference.ResponseWriter,
+) error {
+	return writer.Close(ctx, inference.FailedCompletion(i.failure))
+}
+
 func TestConductorInvocationRunnerRoutesExternalIntegrationsThroughConductor(t *testing.T) {
 	t.Parallel()
 
@@ -210,6 +240,64 @@ func TestConductorInvocationRunnerRoutesExternalIntegrationsThroughConductor(t *
 	}
 	if integration.calls != 1 {
 		t.Fatalf("integration invoke calls = %d, want 1", integration.calls)
+	}
+	if native.calls != 0 {
+		t.Fatalf("native runner calls = %d, want 0", native.calls)
+	}
+}
+
+func TestConductorInvocationRunnerPreservesRetryableUnknownFailurePolicy(t *testing.T) {
+	t.Parallel()
+
+	const providerID = "customer.retryable"
+	session := inference.NewProviderSession(providerID, "session_id", "session-retry-1", nil)
+	integration := &failingConductorIntegration{
+		identity: inference.Identity(providerID),
+		failure: inference.NewFailure(inference.FailureInput{
+			Kind:            inference.FailureUnknown,
+			Message:         "provider is temporarily unavailable",
+			Retryable:       true,
+			ProviderSession: &session,
+		}),
+	}
+	builtIns, err := providerregistry.BuiltInRegistrations()
+	if err != nil {
+		t.Fatalf("BuiltInRegistrations() error = %v", err)
+	}
+	manifest := externalConductorManifest(t, providerID, "retryable")
+	providers, err := providerregistry.New(append(
+		builtIns,
+		providerregistry.ExternalRegistration(manifest, integration),
+	)...)
+	if err != nil {
+		t.Fatalf("registry.New() error = %v", err)
+	}
+	native := &conductorRouteRecordingRunner{}
+	runner := conductorInvocationRunner{
+		next:      native,
+		conductor: conductor.New(providers),
+		providers: providers,
+	}
+
+	_, err = runner.Execute(context.Background(), workers.RunnerExecutionRequest{
+		Dispatch: work.WorkDispatch{DispatchID: "dispatch-retryable-1"},
+		RunnerID: providerID,
+	})
+	var providerErr *workerprovider.ProviderError
+	if !errors.As(err, &providerErr) {
+		t.Fatalf("Execute() error = %v, want *ProviderError", err)
+	}
+	if providerErr.Type != workers.WorkFailureTypeInternalServerError {
+		t.Fatalf("provider error type = %q, want %q", providerErr.Type, workers.WorkFailureTypeInternalServerError)
+	}
+	decision := workerprovider.WorkFailureDecisionFromProviderError(providerErr)
+	if !decision.Retryable || decision.Terminal || decision.TriggersThrottlePause {
+		t.Fatalf("failure decision = %#v, want retryable non-terminal non-throttle", decision)
+	}
+	if providerErr.ProviderSession == nil ||
+		providerErr.ProviderSession.Provider != providerID ||
+		providerErr.ProviderSession.ID != "session-retry-1" {
+		t.Fatalf("provider session = %#v, want preserved retry session", providerErr.ProviderSession)
 	}
 	if native.calls != 0 {
 		t.Fatalf("native runner calls = %d, want 0", native.calls)

--- a/tests/functional/providers/kiro/process_harness_test.go
+++ b/tests/functional/providers/kiro/process_harness_test.go
@@ -1,0 +1,162 @@
+package kiro
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const functionalSessionID = "675f9238-5f05-456c-9a9f-f8fe486f49e4"
+
+func TestKiroConductorSuccessThroughRootBuildProcess(t *testing.T) {
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
+	workerConfig := strings.Replace(
+		support.BuildModelWorkerConfig(modelprovider.ProviderKiro, "kiro-auto"),
+		"stopToken: COMPLETE",
+		"skipPermissions: true\nstopToken: COMPLETE",
+		1,
+	)
+	support.WriteAgentConfig(t, dir, "worker", workerConfig)
+	support.WriteWorkstationConfig(t, dir, "process", `---
+type: MODEL_WORKSTATION
+env:
+  KIRO_CONTEXT_FIXTURE: configured
+---
+Test workstation.
+`)
+	testutil.WriteSeedFile(t, dir, "task", []byte(`{"title":"kiro conductor success"}`))
+
+	runner := testutil.NewProviderCommandRunner(platformprocess.CommandResult{
+		Stdout: []byte("kiro functional answer COMPLETE"),
+		Stderr: []byte(`{"event":"session.created","session_id":"` + functionalSessionID + `"}`),
+	})
+	_, listed, _ := support.RunFactoryToCompletionWithEdgesAndObservations(t, dir, serviceedges.Edges{
+		ProviderCommandRunner: runner,
+	}, 20*time.Second)
+
+	if got := support.CountWorkAtCustomerState(listed, "task:done"); got != 1 {
+		t.Fatalf("completed work = %d, want 1; listed=%#v", got, listed)
+	}
+	if got := support.CountWorkAtCustomerState(listed, "task:failed"); got != 0 {
+		t.Fatalf("failed work = %d, want 0", got)
+	}
+	if runner.CallCount() != 1 {
+		t.Fatalf("Kiro command runner calls = %d, want 1 through conductor", runner.CallCount())
+	}
+	request := runner.LastRequest()
+	if request.Command != "kiro-cli" {
+		t.Fatalf("command = %q, want kiro-cli", request.Command)
+	}
+	if len(request.Args) < 4 ||
+		request.Args[0] != "chat" ||
+		request.Args[1] != "--no-interactive" ||
+		!containsArg(request.Args, "--trust-all-tools") {
+		t.Fatalf("args = %#v, want Kiro chat and trust-all-tools flags", request.Args)
+	}
+	if containsArg(request.Args, "--resume-id") {
+		t.Fatalf("new invocation args = %#v, must not contain --resume-id", request.Args)
+	}
+	prompt := request.Args[len(request.Args)-1]
+	if !strings.Contains(prompt, "System instructions:") ||
+		!strings.Contains(prompt, "Process the input task.") ||
+		!strings.Contains(prompt, "User request:") ||
+		!strings.Contains(prompt, "Test workstation.") {
+		t.Fatalf("prompt = %q, want composed system instructions and work request", prompt)
+	}
+	if !containsEnv(request.Env, "KIRO_CONTEXT_FIXTURE=configured") {
+		t.Fatal("command environment omitted configured Kiro context")
+	}
+}
+
+func TestKiroRejectsUnsupportedWorkingDirectoryBeforeProviderIO(t *testing.T) {
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
+	support.WriteAgentConfig(t, dir, "worker", support.BuildModelWorkerConfig(
+		modelprovider.ProviderKiro,
+		"kiro-auto",
+	))
+	support.WriteWorkstationConfig(t, dir, "process", `---
+type: MODEL_WORKSTATION
+workingDirectory: .
+---
+Test workstation.
+`)
+	testutil.WriteSeedFile(t, dir, "task", []byte(`{"title":"kiro invalid capability"}`))
+
+	runner := testutil.NewProviderCommandRunner(platformprocess.CommandResult{
+		Stdout: []byte("provider must not run"),
+	})
+	_, listed, _ := support.RunFactoryToCompletionWithEdgesAndObservations(t, dir, serviceedges.Edges{
+		ProviderCommandRunner: runner,
+	}, 20*time.Second)
+
+	if got := support.CountWorkAtCustomerState(listed, "task:failed"); got != 1 {
+		t.Fatalf("failed work = %d, want 1 unsupported-capability failure; listed=%#v", got, listed)
+	}
+	if runner.CallCount() != 0 {
+		t.Fatalf("Kiro command runner calls = %d, want no provider I/O", runner.CallCount())
+	}
+}
+
+func TestKiroNativeFailureThroughRootBuildProcessIsSafe(t *testing.T) {
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
+	support.WriteAgentConfig(t, dir, "worker", support.BuildModelWorkerConfig(
+		modelprovider.ProviderKiro,
+		"kiro-auto",
+	))
+	testutil.WriteSeedFile(t, dir, "task", []byte(`{"title":"kiro native failure"}`))
+
+	const leaked = `C:\private\kiro-token.txt`
+	runner := testutil.NewProviderCommandRunner(platformprocess.CommandResult{
+		ExitCode: 1,
+		Stderr: []byte(
+			`{"type":"error","error":{"type":"authentication_error","message":"token path ` + leaked + ` leaked"}}`,
+		),
+	})
+	_, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(t, dir, serviceedges.Edges{
+		ProviderCommandRunner: runner,
+	}, 20*time.Second)
+
+	if got := support.CountWorkAtCustomerState(listed, "task:failed"); got != 1 {
+		t.Fatalf("failed work = %d, want 1; listed=%#v", got, listed)
+	}
+	if got := support.CountWorkAtCustomerState(listed, "task:done"); got != 0 {
+		t.Fatalf("completed work = %d, want 0 after provider failure", got)
+	}
+	if runner.CallCount() != 1 {
+		t.Fatalf("Kiro command runner calls = %d, want 1", runner.CallCount())
+	}
+	encoded, err := json.Marshal(events)
+	if err != nil {
+		t.Fatalf("marshal Factory events: %v", err)
+	}
+	payload := string(encoded)
+	if strings.Contains(payload, leaked) ||
+		strings.Contains(payload, "kiro-token") {
+		t.Fatalf("Factory events leaked unsafe Kiro failure detail: %s", payload)
+	}
+}
+
+func containsArg(args []string, expected string) bool {
+	for _, arg := range args {
+		if arg == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func containsEnv(env []string, expected string) bool {
+	for _, value := range env {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/functional/providers/kiro/process_harness_test.go
+++ b/tests/functional/providers/kiro/process_harness_test.go
@@ -10,10 +10,14 @@ import (
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
-const functionalSessionID = "675f9238-5f05-456c-9a9f-f8fe486f49e4"
+const (
+	functionalSessionID            = "675f9238-5f05-456c-9a9f-f8fe486f49e4"
+	functionalReplacementSessionID = "4b11c29d-332f-4fa2-b5d3-cd0fb02f75b0"
+)
 
 func TestKiroConductorSuccessThroughRootBuildProcess(t *testing.T) {
 	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
@@ -72,6 +76,92 @@ Test workstation.
 	}
 	if !containsEnv(request.Env, "KIRO_CONTEXT_FIXTURE=configured") {
 		t.Fatal("command environment omitted configured Kiro context")
+	}
+}
+
+func TestKiroConductorResumeThroughRootBuildProcess(t *testing.T) {
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
+	support.WriteAgentConfig(t, dir, "worker", support.BuildModelWorkerConfig(
+		modelprovider.ProviderKiro,
+		"kiro-auto",
+	))
+	testutil.WriteSeedFile(t, dir, "task", []byte(`{"title":"kiro conductor resume"}`))
+
+	runner := testutil.NewProviderCommandRunner(
+		platformprocess.CommandResult{
+			ExitCode: 1,
+			Stderr: []byte(
+				`{"event":"session.created","session_id":"` + functionalSessionID + `"}` + "\n" +
+					`{"type":"error","errorType":"ServiceUnavailableException","message":"temporary service failure"}`,
+			),
+		},
+		platformprocess.CommandResult{
+			Stdout: []byte("kiro resumed answer COMPLETE"),
+			Stderr: []byte(
+				`{"event":"session.created","session_id":"` + functionalReplacementSessionID + `"}`,
+			),
+		},
+	)
+	_, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(t, dir, serviceedges.Edges{
+		ProviderCommandRunner: runner,
+	}, 20*time.Second)
+
+	if got := support.CountWorkAtCustomerState(listed, "task:done"); got != 1 {
+		t.Fatalf("completed work = %d, want 1; listed=%#v", got, listed)
+	}
+	if runner.CallCount() != 2 {
+		t.Fatalf("Kiro command runner calls = %d, want one failed attempt and one resumed retry", runner.CallCount())
+	}
+	requests := runner.Requests()
+	if containsArg(requests[0].Args, "--resume-id") {
+		t.Fatalf("first invocation args = %#v, must not contain --resume-id", requests[0].Args)
+	}
+	if !containsArgPair(requests[1].Args, "--resume-id", functionalSessionID) {
+		t.Fatalf("resumed retry args = %#v, want --resume-id %s", requests[1].Args, functionalSessionID)
+	}
+	assertKiroRetryProviderSessions(t, events)
+	encoded, err := json.Marshal(events)
+	if err != nil {
+		t.Fatalf("marshal Factory events: %v", err)
+	}
+	payload := string(encoded)
+	if !strings.Contains(payload, functionalSessionID) ||
+		!strings.Contains(payload, functionalReplacementSessionID) ||
+		!strings.Contains(payload, `"provider":"kiro"`) {
+		t.Fatalf("Factory events omitted preserved Kiro Provider Session: %s", payload)
+	}
+}
+
+func assertKiroRetryProviderSessions(t *testing.T, events []factoryapi.FactoryEvent) {
+	t.Helper()
+	var failedSessionID, succeededSessionID string
+	for _, event := range events {
+		if event.Type != factoryapi.FactoryEventTypeInferenceResponse {
+			continue
+		}
+		payload, err := event.Payload.AsInferenceResponseEventPayload()
+		if err != nil {
+			t.Fatalf("decode inference response: %v", err)
+		}
+		if payload.ProviderSession == nil || payload.ProviderSession.Id == nil {
+			continue
+		}
+		switch payload.Outcome {
+		case factoryapi.InferenceOutcomeFailed:
+			failedSessionID = *payload.ProviderSession.Id
+		case factoryapi.InferenceOutcomeSucceeded:
+			succeededSessionID = *payload.ProviderSession.Id
+		}
+	}
+	if failedSessionID != functionalSessionID {
+		t.Fatalf("failed attempt Provider Session = %q, want preserved %q", failedSessionID, functionalSessionID)
+	}
+	if succeededSessionID != functionalReplacementSessionID {
+		t.Fatalf(
+			"successful attempt Provider Session = %q, want replacement %q",
+			succeededSessionID,
+			functionalReplacementSessionID,
+		)
 	}
 }
 
@@ -146,6 +236,15 @@ func TestKiroNativeFailureThroughRootBuildProcessIsSafe(t *testing.T) {
 func containsArg(args []string, expected string) bool {
 	for _, arg := range args {
 		if arg == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func containsArgPair(args []string, flag, value string) bool {
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] == flag && args[index+1] == value {
 			return true
 		}
 	}


### PR DESCRIPTION
{
  "project": "Standardized Providers: Kiro Neutral-Conductor Migration",
  "branchName": "standardized-provider-migrate-kiro",
  "description": "Migrate Kiro into pkg/services/workers/provider/kiro as a registry-backed integration invoked through the accepted neutral conductor. The project gives Kiro end-to-end ownership of command construction, resume and session behavior, output decoding, and safe failure normalization, proves the path through shared conformance and root.BuildProcess functional behavior, and then removes only the superseded Kiro legacy branches.",
  "context": {
    "customerAsk": "Make Kiro a standardized provider integration selected through the authoritative registry and invoked through the neutral conductor. Move Kiro-specific command, resume, session, decode, timeout, and failure behavior out of aggregate provider switches, establish provider-scoped conformance and functional evidence, and delete only the Kiro branches replaced by that integration.",
    "problem": "The provider catalog, protocol and testkit, registry, open configuration, and neutral conductor are accepted, and Gemini has completed the reference migration. Kiro is still only partially migrated: package-owned failure logic coexists with Kiro-specific command and routing branches in shared provider execution. This split ownership permits legacy and neutral behavior to diverge and forces shared orchestration to retain knowledge of Kiro's concrete identity.",
    "solution": "Implement the accepted inference integration and adapter behavior within the Kiro provider package while preserving Kiro's CLI, resume, session, and safe failure behavior. Bind that implementation to Kiro's existing manifest identity in the authoritative registry, invoke it through the neutral conductor and response writer, prove it through provider, conformance, composition, and root-built functional tests, and remove only the exact Kiro legacy branches covered by the replacement."
  },
  "acceptanceCriteria": [
    "AC-1: Kiro command construction, prompt composition, permission handling, resume behavior, output decoding, and provider-session extraction are owned by the Kiro integration rather than Kiro cases in aggregate shared switches.",
    "AC-2: Kiro success, timeout, cancellation, known failure, malformed-output, and unknown failure outcomes produce the accepted normalized completion behavior, and persisted or emitted customer-visible failures do not leak unsafe raw provider details.",
    "AC-3: The existing Kiro manifest identity resolves to the Kiro integration in the authoritative registry and executes through the neutral conductor with no new Kiro switch in shared orchestration.",
    "AC-4: Kiro passes applicable shared provider conformance checks, including identity, advertised and negotiated capabilities, discovery, terminal completion, and failure behavior.",
    "AC-5: Provider-scoped functional coverage under tests/functional/providers/kiro proves Kiro through root.BuildProcess and typed external-effect replacement without importing Kiro implementation internals.",
    "AC-6: Only Kiro's superseded command, decode, failure, timeout, session, and resume cases are removed; other provider branches, ProviderOverride, and the aggregate provider shell remain behaviorally unchanged.",
    "AC-7: Quality gates pass: typecheck, focused and applicable broader tests, make lint, applicable make verify-fast constituents on Windows, and required PR checks."
  ],
  "userStories": [
    {
      "id": "standardized-provider-migrate-kiro-001",
      "title": "Preserve Kiro invocation and resume behavior in its provider package",
      "description": "As a Kiro user, I want standardized Kiro invocations to retain the existing CLI, prompt, environment, permission, and resume semantics so the migration does not change how my work is submitted.",
      "acceptanceCriteria": [
        "A normal Kiro invocation builds the kiro-cli chat --no-interactive command and passes the requested model-work prompt using the established system-instructions and user-request composition.",
        "A resumed invocation passes the requested provider session with --resume-id, while a new invocation does not add a resume flag.",
        "Configured environment and dispatch metadata reach the Kiro command, and skip-permissions requests add --trust-all-tools.",
        "Image input, structured output, working directory, and worktree requirements fail before provider I/O with the established Kiro unsupported-capability messages.",
        "Focused Kiro command and resume tests cover new, resumed, skip-permissions, prompt-composition, environment, and rejected-capability cases.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented provider-owned Kiro command construction, prompt composition, resume and skip-permissions flags, environment and dispatch propagation, unsupported-capability validation, and focused command tests. Verified with go test ./pkg/services/workers/provider/kiro, make test, make verify-fast, and make lint."
    },
    {
      "id": "standardized-provider-migrate-kiro-002",
      "title": "Normalize Kiro responses and provider sessions",
      "description": "As a Factory runtime consumer, I want Kiro output and session information normalized through the accepted response contract so successful and resumed work can be recorded and continued consistently.",
      "acceptanceCriteria": [
        "Successful Kiro output is decoded into the accepted final-only lifecycle and response shape, with exactly one terminal successful completion from the response writer.",
        "When Kiro output supplies a valid provider session identifier, the completion exposes normalized Kiro provider-session metadata using the accepted session kind.",
        "Resumed work preserves or updates the authoritative Kiro provider-session reference according to Kiro's accepted output semantics, without treating arbitrary output text as a session identifier.",
        "Empty or malformed session data cannot create an invalid provider-session reference and does not corrupt an otherwise valid terminal outcome.",
        "Focused Kiro decode and session tests cover a new session, a resumed session, absent session data, malformed session data, and successful output.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented Kiro's final-only neutral-conductor integration, canonical lifecycle/message drafts, exactly-once successful completion, strict structured UUID session extraction, and resumed-session preservation/update behavior. Verified with go test ./pkg/services/workers/provider/kiro, make test, make verify-fast, and make lint."
    },
    {
      "id": "standardized-provider-migrate-kiro-003",
      "title": "Return safe Kiro failures through the response writer",
      "description": "As an operator, I want Kiro failures to be classified into safe, stable outcomes so I can understand retry or terminal behavior without secrets or unsafe provider output appearing in Factory events.",
      "acceptanceCriteria": [
        "Recognized Kiro authentication, invalid-request, throttling/capacity, timeout, and temporary-service failures map to the accepted normalized failure kinds, messages, and retry posture.",
        "Structured failures take the accepted precedence over lower-confidence text signals, while malformed structured output falls back safely to bounded text classification or an exit-code message.",
        "Deadline expiration returns the canonical Kiro timeout outcome, and cancellation propagates through the conductor without being rewritten as a provider-local unknown failure.",
        "Unknown failure messages are bounded and sanitized so control characters, credential-like values, private paths, prompts, and unrelated progress output are not exposed in the terminal completion or downstream events.",
        "Every failure invocation closes the response writer exactly once with no successful completion after failure.",
        "Focused Kiro failure tests cover known structured and text cases, malformed records, unknown output, deadline expiration, cancellation, and unsafe-detail rejection.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Wired Kiro's provider-owned structured/text failure classifier into the neutral-conductor Integration, preserved protocol-owned cancellation, normalized deadlines and retry posture, strengthened unsafe unknown-detail rejection, and proved exactly-once failed completion without success events. Verified with go test ./pkg/services/workers/provider/kiro, make test, make verify-fast, and make lint."
    },
    {
      "id": "standardized-provider-migrate-kiro-004",
      "title": "Select Kiro through the authoritative registry and neutral conductor",
      "description": "As an integration author, I want Kiro selected by its manifest identity and invoked through the common provider protocol so shared orchestration does not need a Kiro-specific execution branch.",
      "acceptanceCriteria": [
        "The authoritative built-in registry binds the existing selectable Kiro manifest identity to the Kiro integration and preserves the manifest's advertised capabilities.",
        "Registry lookup followed by the neutral invocation entrypoint executes the Kiro integration for Kiro aliases and canonical identity without routing through a provider-native compatibility stub.",
        "No shared registry, conductor, Factory Session, or worker orchestration decision switches on Kiro's concrete identity to invoke Kiro.",
        "Kiro satisfies the applicable shared provider conformance protocol for identity, maximum and negotiated capabilities, discovery, success, failure, and exactly-once terminal completion.",
        "Focused registry/conductor composition tests prove Kiro uses the injected command boundary and the accepted response-writer path.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Bound the existing Kiro catalog identity to its package-owned Integration in BuiltInRegistrations, preserving manifest capabilities and selecting canonical and kiro-cli aliases through the neutral conductor. Added applicable identity, capability, discovery, success, failure, exactly-once terminal, injected command-boundary, and registry composition coverage. Verified with focused provider/conductor/registry/contract tests, make test, make verify-fast, and make lint."
    },
    {
      "id": "standardized-provider-migrate-kiro-005",
      "title": "Cut Factory execution over to Kiro and retire only its legacy branches",
      "description": "As a Factory user, I want Kiro-backed work to execute through the standardized product graph so I receive the same successful, resumable, and safe failure behavior without retaining duplicate Kiro execution paths.",
      "acceptanceCriteria": [
        "Provider-scoped functional tests construct the product graph through root.BuildProcess, replace only typed external effects, select Kiro through normal Factory configuration, and observe exactly one Kiro command execution through the neutral conductor.",
        "The functional success path reaches the expected completed Work state and proves the requested Kiro command, prompt, environment, permission, and resume/session behavior at the external command boundary.",
        "Functional invalid-capability and native-failure paths reach the expected failed Work state without unnecessary provider I/O, unsafe failure detail, or implementation-internal imports.",
        "Only the Kiro command, decode, failure, timeout, session, and resume cases replaced by the standardized integration are removed from legacy aggregate execution.",
        "Gemini, Cursor, Claude, Codex, Pi, OpenCode, and Agy behavior remains on its existing path; the aggregate shell and ProviderOverride remain available.",
        "Focused Kiro package, registry/conductor composition, conformance, and tests/functional/providers/kiro suites pass together before broader quality gates run.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": "Added root.BuildProcess Kiro functional coverage for successful conductor execution, command/prompt/environment/permission/new-session behavior, unsupported-capability rejection before provider I/O, and safe native failure. Removed only Kiro's superseded aggregate command, failure, timeout, session, and resume branches and legacy-only tests while retaining the aggregate shell, ProviderOverride, and other providers. Verified with focused Kiro/provider/registry/conductor/contract/functional tests, make test, make verify-fast, and make lint."
    }
  ]
}
