### PR TITLE
pss-imp-mod-02-catalog

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -847,6 +847,24 @@
       "minimum": 34.25
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/internal/service",
+      "minimum": 0.74
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire",
+      "minimum": 45.45
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes",
       "exception": {
         "kind": "measurement",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -799,6 +799,24 @@
       "minimum": 74.07
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active unit coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/internal/service",
+      "minimum": 81.30
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire",
+      "minimum": 54.50
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes",
       "exception": {
         "kind": "measurement",

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -3360,6 +3360,24 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/models/internal/services/catalog",
+      "disposition": "retain",
+      "destination": "models",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/catalog/internal/service",
+      "disposition": "retain",
+      "destination": "models",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/catalog/wire",
+      "disposition": "retain",
+      "destination": "models",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/models/internal/services/runtime_scopes",
       "disposition": "retain",
       "destination": "models",

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -215,6 +215,9 @@
     "pkg/services/models/internal/local",
     "pkg/services/models/internal/managedruntime",
     "pkg/services/models/internal/service",
+    "pkg/services/models/internal/services/catalog",
+    "pkg/services/models/internal/services/catalog/internal/service",
+    "pkg/services/models/internal/services/catalog/wire",
     "pkg/services/models/internal/services/runtime_scopes",
     "pkg/services/models/internal/services/runtime_scopes/internal/service",
     "pkg/services/models/internal/services/runtime_scopes/wire",
@@ -1241,6 +1244,21 @@
       "packagePath": "pkg/services/models/internal/service",
       "disposition": "retain",
       "destination": "models"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/catalog",
+      "disposition": "retain",
+      "destination": "models/internal/services/catalog"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/catalog/internal/service",
+      "disposition": "retain",
+      "destination": "models/internal/services/catalog"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/catalog/wire",
+      "disposition": "retain",
+      "destination": "models/internal/services/catalog"
     },
     {
       "packagePath": "pkg/services/models/internal/services/runtime_scopes",

--- a/pkg/services/models/catalog_contract.go
+++ b/pkg/services/models/catalog_contract.go
@@ -145,6 +145,7 @@ func (detail Detail) Clone() Detail {
 	detail.Capabilities = make([]Capability, len(capabilities))
 	for i, capability := range capabilities {
 		detail.Capabilities[i] = capability
+		detail.Capabilities[i].ModelProvider = cloneStringPointer(capability.ModelProvider)
 		detail.Capabilities[i].Operations = cloneOperations(capability.Operations)
 		detail.Capabilities[i].ResourceNames = append([]string(nil), capability.ResourceNames...)
 	}

--- a/pkg/services/models/internal/host/contract.go
+++ b/pkg/services/models/internal/host/contract.go
@@ -207,11 +207,14 @@ func ManagedRuntimeFromSnapshot(snapshot ReadinessSnapshot) managedruntime.Runti
 	if snapshot.FailureClass != FailureClassNone {
 		diagnostics["failureClass"] = string(snapshot.FailureClass)
 	}
-	operations := make([]managedruntime.Operation, len(snapshot.Identity.SupportedOperations))
-	for index, operation := range snapshot.Identity.SupportedOperations {
-		operations[index] = operation
-		operations[index].Inputs = cloneOperationSlots(operation.Inputs)
-		operations[index].Outputs = cloneOperationSlots(operation.Outputs)
+	var operations []managedruntime.Operation
+	if snapshot.Identity.SupportedOperations != nil {
+		operations = make([]managedruntime.Operation, len(snapshot.Identity.SupportedOperations))
+		for index, operation := range snapshot.Identity.SupportedOperations {
+			operations[index] = operation
+			operations[index].Inputs = cloneOperationSlots(operation.Inputs)
+			operations[index].Outputs = cloneOperationSlots(operation.Outputs)
+		}
 	}
 	return managedruntime.Runtime{
 		Identity: snapshot.Identity.Name, ReadinessState: snapshot.ReadinessState,
@@ -221,6 +224,9 @@ func ManagedRuntimeFromSnapshot(snapshot ReadinessSnapshot) managedruntime.Runti
 }
 
 func cloneOperationSlots(slots []managedruntime.OperationSlot) []managedruntime.OperationSlot {
+	if slots == nil {
+		return nil
+	}
 	cloned := make([]managedruntime.OperationSlot, len(slots))
 	for index, slot := range slots {
 		cloned[index] = slot

--- a/pkg/services/models/internal/local/managed_runtime.go
+++ b/pkg/services/models/internal/local/managed_runtime.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -126,6 +127,58 @@ func ManagedRuntimeReadinessForFactory(
 		return managedruntime.Runtime{}, fmt.Errorf("%w: empty model name", managedruntime.ErrNotFound)
 	}
 	return managedRuntimeForCatalog(runtimeCfg, modelName, runtimeCacheInspector, sourceResolver)
+}
+
+// ManagedRuntimeReadinessForFactoryContext returns the current readiness
+// projection while preserving cancellation across the cache fact boundary.
+func ManagedRuntimeReadinessForFactoryContext(
+	ctx context.Context,
+	runtimeCfg *models.RuntimeConfig,
+	modelName string,
+	runtimeCacheInspector RuntimeCacheInspector,
+	sourceResolver ManagedRuntimeSourceResolver,
+) (managedruntime.Runtime, error) {
+	if err := ctx.Err(); err != nil {
+		return managedruntime.Runtime{}, err
+	}
+	baseline, err := ManagedRuntimeReadinessForFactory(
+		runtimeCfg,
+		modelName,
+		nil,
+		sourceResolver,
+	)
+	if err != nil {
+		return managedruntime.Runtime{}, err
+	}
+	if runtimeCacheInspector == nil {
+		return baseline, nil
+	}
+	inspection, err := runtimeCacheInspector.InspectRuntimeCache(ctx, runtimeCfg, modelName)
+	if err != nil {
+		return managedruntime.Runtime{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return managedruntime.Runtime{}, err
+	}
+	detail, err := GetModelWithRuntime(
+		runtimeCfg,
+		modelName,
+		fixedRuntimeCacheInspector{inspection: inspection},
+		sourceResolver,
+	)
+	return detail.ManagedRuntime, err
+}
+
+type fixedRuntimeCacheInspector struct {
+	inspection RuntimeCacheInspection
+}
+
+func (inspector fixedRuntimeCacheInspector) InspectRuntimeCache(
+	context.Context,
+	*models.RuntimeConfig,
+	string,
+) (RuntimeCacheInspection, error) {
+	return inspector.inspection, nil
 }
 
 // EnsureManagedRuntimeReadyForInvocation classifies one managed runtime using

--- a/pkg/services/models/internal/local/runtime_dependency_test.go
+++ b/pkg/services/models/internal/local/runtime_dependency_test.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	managedruntime "github.com/portpowered/infinite-you/pkg/services/models/internal/managedruntime"
@@ -153,6 +154,94 @@ func TestManagedRuntimeReadinessForFactory_UsesCacheInspectionWhenProvided(t *te
 	}
 }
 
+func TestManagedRuntimeReadinessForFactoryContext_ReportsDetailedCurrentCacheFacts(t *testing.T) {
+	t.Parallel()
+
+	loaded := mustLoadedCatalogConfig(t, catalogFactoryConfig(true))
+	readiness, err := ManagedRuntimeReadinessForFactoryContext(
+		context.Background(),
+		loaded,
+		"OMNIVOICE_Q4_K_M",
+		staticRuntimeCacheInspector{inspection: RuntimeCacheInspection{
+			Supported:          true,
+			Installed:          true,
+			Revision:           "rev-current",
+			CachePath:          "/cache/current",
+			InstalledFileCount: 2,
+		}},
+		DefaultManagedRuntimeSourceResolver(),
+	)
+	if err != nil {
+		t.Fatalf("ManagedRuntimeReadinessForFactoryContext: %v", err)
+	}
+	if readiness.ReadinessState != managedruntime.ReadinessStateReady ||
+		readiness.LifecycleState != managedruntime.LifecycleStateInstalled ||
+		readiness.Diagnostics["revision"] != "rev-current" ||
+		readiness.Diagnostics["cachePath"] != "/cache/current" ||
+		readiness.Diagnostics["installedFileCount"] != "2" {
+		t.Fatalf("current readiness = %#v, want detached detailed cache facts", readiness)
+	}
+}
+
+func TestManagedRuntimeReadinessForFactoryContext_PreservesCancellationAndDependencyFailures(t *testing.T) {
+	t.Parallel()
+
+	loaded := mustLoadedCatalogConfig(t, catalogFactoryConfig(true))
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := ManagedRuntimeReadinessForFactoryContext(
+		canceled, loaded, "OMNIVOICE_Q4_K_M", nil, nil,
+	); !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-canceled readiness error = %v, want context.Canceled", err)
+	}
+	if _, err := ManagedRuntimeReadinessForFactoryContext(
+		context.Background(), nil, "OMNIVOICE_Q4_K_M", nil, nil,
+	); err == nil {
+		t.Fatal("nil runtime config unexpectedly succeeded")
+	}
+	if _, err := ManagedRuntimeReadinessForFactoryContext(
+		context.Background(), loaded, " ", nil, nil,
+	); !errors.Is(err, managedruntime.ErrNotFound) {
+		t.Fatalf("empty model readiness error = %v, want not found", err)
+	}
+	if _, err := ManagedRuntimeReadinessForFactoryContext(
+		context.Background(), loaded, "OMNIVOICE_Q4_K_M", nil, nil,
+	); err != nil {
+		t.Fatalf("readiness without cache inspector: %v", err)
+	}
+	if _, err := ManagedRuntimeReadinessForFactoryContext(
+		context.Background(),
+		loaded,
+		"unknown-model",
+		staticRuntimeCacheInspector{},
+		nil,
+	); !errors.Is(err, managedruntime.ErrNotFound) {
+		t.Fatalf("unknown model readiness error = %v, want not found", err)
+	}
+
+	dependencyErr := errors.New("cache inspection failed")
+	if _, err := ManagedRuntimeReadinessForFactoryContext(
+		context.Background(),
+		loaded,
+		"OMNIVOICE_Q4_K_M",
+		staticRuntimeCacheInspector{err: dependencyErr},
+		nil,
+	); !errors.Is(err, dependencyErr) {
+		t.Fatalf("cache dependency error = %v, want %v", err, dependencyErr)
+	}
+
+	during, cancelDuring := context.WithCancel(context.Background())
+	if _, err := ManagedRuntimeReadinessForFactoryContext(
+		during,
+		loaded,
+		"OMNIVOICE_Q4_K_M",
+		cancelingRuntimeCacheInspector{cancel: cancelDuring},
+		nil,
+	); !errors.Is(err, context.Canceled) {
+		t.Fatalf("during-query cancellation error = %v, want context.Canceled", err)
+	}
+}
+
 type staticRuntimeCacheInspector struct {
 	inspection RuntimeCacheInspection
 	err        error
@@ -160,4 +249,17 @@ type staticRuntimeCacheInspector struct {
 
 func (s staticRuntimeCacheInspector) InspectRuntimeCache(_ context.Context, _ *modelRuntimeConfig, _ string) (RuntimeCacheInspection, error) {
 	return s.inspection, s.err
+}
+
+type cancelingRuntimeCacheInspector struct {
+	cancel context.CancelFunc
+}
+
+func (s cancelingRuntimeCacheInspector) InspectRuntimeCache(
+	context.Context,
+	*modelRuntimeConfig,
+	string,
+) (RuntimeCacheInspection, error) {
+	s.cancel()
+	return RuntimeCacheInspection{}, nil
 }

--- a/pkg/services/models/internal/service/runtime_factory.go
+++ b/pkg/services/models/internal/service/runtime_factory.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -199,10 +201,23 @@ func (o *Root) OpenRuntimeScope(
 }
 
 func (o *Root) CloseRuntimeScope(
-	context.Context,
-	models.CloseRuntimeScopeRequest,
+	ctx context.Context,
+	request models.CloseRuntimeScopeRequest,
 ) (models.CloseRuntimeScopeResult, error) {
-	return models.CloseRuntimeScopeResult{}, models.ErrUnsupportedOperation
+	if o == nil || o.runtimeScopes == nil {
+		return models.CloseRuntimeScopeResult{}, models.ErrUnsupportedOperation
+	}
+	if err := ctx.Err(); err != nil {
+		return models.CloseRuntimeScopeResult{}, err
+	}
+	if request.Scope.IsZero() {
+		return models.CloseRuntimeScopeResult{}, models.ErrRuntimeScopeInvalid
+	}
+	err := o.runtimeScopes.Close(runtimescopes.Reference(request.Scope.String()))
+	if err != nil {
+		return models.CloseRuntimeScopeResult{}, runtimeScopeError(err)
+	}
+	return models.CloseRuntimeScopeResult{Scope: request.Scope, Closed: true}, nil
 }
 
 func (o *Root) ListCatalog(
@@ -226,10 +241,26 @@ func (o *Root) GetCatalogModel(
 }
 
 func (o *Root) GetModelReadiness(
-	context.Context,
-	models.GetModelReadinessRequest,
+	ctx context.Context,
+	request models.GetModelReadinessRequest,
 ) (models.GetModelReadinessResult, error) {
-	return models.GetModelReadinessResult{}, models.ErrUnsupportedOperation
+	if o == nil || o.catalog == nil {
+		return models.GetModelReadinessResult{}, models.ErrUnsupportedOperation
+	}
+	return o.catalog.GetModelReadiness(ctx, request)
+}
+
+func runtimeScopeError(err error) error {
+	switch {
+	case errors.Is(err, runtimescopes.ErrScopeForeign):
+		return fmt.Errorf("%w: %v", models.ErrRuntimeScopeForeign, err)
+	case errors.Is(err, runtimescopes.ErrScopeClosed):
+		return fmt.Errorf("%w: %v", models.ErrRuntimeScopeClosed, err)
+	case errors.Is(err, runtimescopes.ErrScopeUnknown):
+		return fmt.Errorf("%w: %v", models.ErrRuntimeScopeStale, err)
+	default:
+		return models.ErrUnavailable
+	}
 }
 
 func (o *Root) PrepareModelAssets(

--- a/pkg/services/models/internal/service/runtime_factory.go
+++ b/pkg/services/models/internal/service/runtime_factory.go
@@ -10,6 +10,8 @@ import (
 	modelassets "github.com/portpowered/infinite-you/pkg/services/models/internal/assets"
 	modelhost "github.com/portpowered/infinite-you/pkg/services/models/internal/host"
 	localmodels "github.com/portpowered/infinite-you/pkg/services/models/internal/local"
+	modelcatalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
 	"go.uber.org/zap"
 )
 
@@ -37,6 +39,8 @@ type Root struct {
 	runtimeInspect  localmodels.InspectFile
 	runtimeTempDir  localmodels.TempDirectory
 	runtimeTempFile localmodels.CreateTempFile
+	runtimeScopes   runtimescopes.Service
+	catalog         modelcatalog.Service
 	process         models.ProcessDependencies
 }
 
@@ -65,6 +69,8 @@ func NewRoot(
 	runtimeInspect localmodels.InspectFile,
 	runtimeTempDir localmodels.TempDirectory,
 	runtimeTempFile localmodels.CreateTempFile,
+	runtimeScopes runtimescopes.Service,
+	catalogService modelcatalog.Service,
 	processDependencies ...models.ProcessDependencies,
 ) (*Root, error) {
 	if strings.TrimSpace(assetPlatform.OperatingSystem) == "" || strings.TrimSpace(assetPlatform.Architecture) == "" {
@@ -105,6 +111,12 @@ func NewRoot(
 		assetCreate == nil || assetOpen == nil {
 		return nil, missingDependencyError("model asset cache operations")
 	}
+	if runtimeScopes == nil {
+		return nil, missingDependencyError("Models Runtime Scopes service")
+	}
+	if catalogService == nil {
+		return nil, missingDependencyError("Models Catalog service")
+	}
 	process := models.ProcessDependencies{}
 	if len(processDependencies) > 0 {
 		process = processDependencies[0]
@@ -123,6 +135,7 @@ func NewRoot(
 		processLauncher: processLauncher, hostHTTP: hostHTTP, hostClock: hostClock,
 		runtimeRunner: runtimeRunner, runtimeHTTP: runtimeHTTP,
 		runtimeInspect: runtimeInspect, runtimeTempDir: runtimeTempDir, runtimeTempFile: runtimeTempFile,
+		runtimeScopes: runtimeScopes, catalog: catalogService,
 		process: process,
 	}, nil
 }
@@ -158,10 +171,31 @@ func (o *Root) ForRuntime(binding models.RuntimeBinding) (models.Service, error)
 }
 
 func (o *Root) OpenRuntimeScope(
-	context.Context,
-	models.OpenRuntimeScopeRequest,
+	ctx context.Context,
+	request models.OpenRuntimeScopeRequest,
 ) (models.OpenRuntimeScopeResult, error) {
-	return models.OpenRuntimeScopeResult{}, models.ErrUnsupportedOperation
+	if o == nil || o.runtimeScopes == nil {
+		return models.OpenRuntimeScopeResult{}, models.ErrUnsupportedOperation
+	}
+	if err := ctx.Err(); err != nil {
+		return models.OpenRuntimeScopeResult{}, err
+	}
+	config := request.Config.Clone()
+	ref, err := o.runtimeScopes.Open(models.RuntimeBinding{
+		CacheDirectory: config.CacheDirectory,
+		RuntimeConfig: func() *models.RuntimeConfig {
+			runtimeConfig := config.Runtime
+			return &runtimeConfig
+		},
+	})
+	if err != nil {
+		return models.OpenRuntimeScopeResult{}, err
+	}
+	scope, err := (models.RuntimeScopeRef{}).Parse(string(ref))
+	if err != nil {
+		return models.OpenRuntimeScopeResult{}, err
+	}
+	return models.OpenRuntimeScopeResult{Scope: scope}, nil
 }
 
 func (o *Root) CloseRuntimeScope(
@@ -172,10 +206,13 @@ func (o *Root) CloseRuntimeScope(
 }
 
 func (o *Root) ListCatalog(
-	context.Context,
-	models.ListModelsRequest,
+	ctx context.Context,
+	request models.ListModelsRequest,
 ) (models.ListModelsResult, error) {
-	return models.ListModelsResult{}, models.ErrUnsupportedOperation
+	if o == nil || o.catalog == nil {
+		return models.ListModelsResult{}, models.ErrUnsupportedOperation
+	}
+	return o.catalog.ListCatalog(ctx, request)
 }
 
 func (o *Root) GetCatalogModel(

--- a/pkg/services/models/internal/service/runtime_factory.go
+++ b/pkg/services/models/internal/service/runtime_factory.go
@@ -216,10 +216,13 @@ func (o *Root) ListCatalog(
 }
 
 func (o *Root) GetCatalogModel(
-	context.Context,
-	models.GetModelRequest,
+	ctx context.Context,
+	request models.GetModelRequest,
 ) (models.GetModelResult, error) {
-	return models.GetModelResult{}, models.ErrUnsupportedOperation
+	if o == nil || o.catalog == nil {
+		return models.GetModelResult{}, models.ErrUnsupportedOperation
+	}
+	return o.catalog.GetCatalogModel(ctx, request)
 }
 
 func (o *Root) GetModelReadiness(

--- a/pkg/services/models/internal/service/service_test.go
+++ b/pkg/services/models/internal/service/service_test.go
@@ -288,6 +288,47 @@ func TestRootListCatalogReturnsStableDetachedScopedProjection(t *testing.T) {
 	assertScopedCatalog(t, afterMutation)
 }
 
+func TestRootGetCatalogModelDelegatesScopedLookup(t *testing.T) {
+	t.Parallel()
+
+	root := newScopedCatalogRoot(t)
+	opened, err := root.OpenRuntimeScope(context.Background(), models.OpenRuntimeScopeRequest{
+		Config: models.RuntimeScopeConfig{Runtime: models.RuntimeConfig{
+			Workers: []models.RuntimeWorker{
+				scopedCatalogWorker("summarizer", "scoped-model", "summarize"),
+				scopedCatalogWorker("generator", "SCOPED-MODEL", "generate"),
+			},
+			Resources: []models.RuntimeResource{
+				scopedCatalogResource("zeta-cache", "scoped-model", "MODELSCOPE"),
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("OpenRuntimeScope: %v", err)
+	}
+
+	got, err := root.GetCatalogModel(context.Background(), models.GetModelRequest{
+		Scope: opened.Scope, Name: " scoped-model ", Operation: "generate",
+	})
+	if err != nil {
+		t.Fatalf("GetCatalogModel: %v", err)
+	}
+	if localmodels.CanonicalModelName(got.Model.Name) != "SCOPED-MODEL" ||
+		len(got.Model.Operations) != 2 ||
+		got.Model.Operations[0].Name != "generate" ||
+		len(got.Model.Sources) != 1 ||
+		got.Model.Sources[0].Provider != localmodels.ManagedRuntimeSourceKindManagedMirror {
+		t.Fatalf("GetCatalogModel = %#v, want delegated stable scoped detail", got)
+	}
+
+	_, err = root.GetCatalogModel(context.Background(), models.GetModelRequest{
+		Scope: opened.Scope, Name: "scoped-model", Operation: "embed",
+	})
+	if !errors.Is(err, models.ErrUnsupportedOperation) {
+		t.Fatalf("unsupported GetCatalogModel error = %v, want ErrUnsupportedOperation", err)
+	}
+}
+
 func newScopedCatalogRoot(t *testing.T) *Root {
 	t.Helper()
 	scopes, err := runtimescopeswire.NewService(func() string { return "catalog-root-test" })

--- a/pkg/services/models/internal/service/service_test.go
+++ b/pkg/services/models/internal/service/service_test.go
@@ -3,14 +3,18 @@ package service
 import (
 	"context"
 	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 	modelassets "github.com/portpowered/infinite-you/pkg/services/models/internal/assets"
 	modelhost "github.com/portpowered/infinite-you/pkg/services/models/internal/host"
 	localmodels "github.com/portpowered/infinite-you/pkg/services/models/internal/local"
+	catalogwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire"
+	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
 	"go.uber.org/zap"
-	"strings"
-	"testing"
-	"time"
 )
 
 func TestNewRootRejectsMissingHostPlatform(t *testing.T) {
@@ -27,6 +31,7 @@ func TestNewRootRejectsMissingHostPlatform(t *testing.T) {
 			nil, modelassets.Endpoints{},
 			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
 			nil, nil, nil, nil, nil, nil, nil, nil,
+			nil, nil,
 		)
 		if opener != nil || !errors.Is(err, ErrInvalidDependencies) || !strings.Contains(err.Error(), "model asset host platform") {
 			t.Fatalf("NewRoot(%#v) = (%#v, %v), want missing host-platform dependency", platform, opener, err)
@@ -231,6 +236,144 @@ func TestService_ReleaseLease_ReturnsLeaseNotFoundWhenHostMissing(t *testing.T) 
 	if !errors.Is(err, models.ErrHostLeaseNotFound) {
 		t.Fatalf("ReleaseLease nil host = %v, want ErrHostLeaseNotFound", err)
 	}
+}
+
+func TestRootListCatalogReturnsStableDetachedScopedProjection(t *testing.T) {
+	t.Parallel()
+
+	root := newScopedCatalogRoot(t)
+	request := models.OpenRuntimeScopeRequest{Config: models.RuntimeScopeConfig{
+		CacheDirectory: "original-cache",
+		Runtime: models.RuntimeConfig{
+			FactoryDirectory: "selected-factory",
+			Workers: []models.RuntimeWorker{
+				scopedCatalogWorker("zeta", "zeta-model", "summarize"),
+				scopedCatalogWorker("alpha-generate", " alpha-model ", "generate"),
+				scopedCatalogWorker("alpha-embed", "ALPHA-MODEL", "embed"),
+			},
+			Resources: []models.RuntimeResource{
+				scopedCatalogResource("zeta-cache", "zeta-model", ""),
+				scopedCatalogResource("alpha-cache", "ALPHA-MODEL", "MODELSCOPE"),
+			},
+		},
+	}}
+	opened, err := root.OpenRuntimeScope(context.Background(), request)
+	if err != nil {
+		t.Fatalf("OpenRuntimeScope: %v", err)
+	}
+
+	// The accepted scope owns the effective snapshot taken at open time.
+	request.Config.Runtime.Workers[0].Model = "mutated-model"
+	request.Config.Runtime.Resources[1].Provider = "mutated-provider"
+
+	first, err := root.ListCatalog(context.Background(), models.ListModelsRequest{Scope: opened.Scope})
+	if err != nil {
+		t.Fatalf("ListCatalog: %v", err)
+	}
+	assertScopedCatalog(t, first)
+
+	second, err := root.ListCatalog(context.Background(), models.ListModelsRequest{Scope: opened.Scope})
+	if err != nil {
+		t.Fatalf("ListCatalog repeated: %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("repeated ListCatalog differs:\nfirst:  %#v\nsecond: %#v", first, second)
+	}
+
+	mutateScopedCatalogResult(first)
+	afterMutation, err := root.ListCatalog(context.Background(), models.ListModelsRequest{Scope: opened.Scope})
+	if err != nil {
+		t.Fatalf("ListCatalog after caller mutation: %v", err)
+	}
+	assertScopedCatalog(t, afterMutation)
+}
+
+func newScopedCatalogRoot(t *testing.T) *Root {
+	t.Helper()
+	scopes, err := runtimescopeswire.NewService(func() string { return "catalog-root-test" })
+	if err != nil {
+		t.Fatalf("construct Runtime Scopes: %v", err)
+	}
+	catalog, err := catalogwire.NewService(scopes)
+	if err != nil {
+		t.Fatalf("construct Catalog: %v", err)
+	}
+	return &Root{runtimeScopes: scopes, catalog: catalog}
+}
+
+func scopedCatalogWorker(name, model, operation string) models.RuntimeWorker {
+	return models.RuntimeWorker{
+		Name:          name,
+		Type:          models.RuntimeWorkerTypeInference,
+		Model:         model,
+		ModelLocality: models.RuntimeModelLocalityLocal,
+		Operations: []models.RuntimeOperation{{
+			Name: operation,
+			Inputs: []models.RuntimeOperationSlot{{
+				Name: "input", ContentTypes: []string{
+					models.RuntimeContentTypeText,
+					models.RuntimeContentTypeAudio,
+				},
+			}},
+		}},
+		Resources: []models.RuntimeResource{{Name: modelResourceName(model)}},
+	}
+}
+
+func modelResourceName(model string) string {
+	if localmodels.CanonicalModelName(model) == "ALPHA-MODEL" {
+		return "alpha-cache"
+	}
+	return "zeta-cache"
+}
+
+func scopedCatalogResource(name, model, provider string) models.RuntimeResource {
+	return models.RuntimeResource{
+		Name: name, Type: models.RuntimeResourceTypeModel, Capacity: 1,
+		Model: model, Backend: "GGUF", LoadPolicy: "ON_DEMAND", Provider: provider,
+	}
+}
+
+func assertScopedCatalog(t *testing.T, result models.ListModelsResult) {
+	t.Helper()
+	if len(result.Models) != 2 {
+		t.Fatalf("ListCatalog models = %#v, want two canonical identities", result.Models)
+	}
+	alpha := result.Models[0]
+	if localmodels.CanonicalModelName(alpha.Name) != "ALPHA-MODEL" {
+		t.Fatalf("first model = %q, want canonical ALPHA-MODEL identity", alpha.Name)
+	}
+	if len(alpha.Operations) != 2 ||
+		alpha.Operations[0].Name != "embed" ||
+		alpha.Operations[1].Name != "generate" {
+		t.Fatalf("alpha operations = %#v, want embed then generate", alpha.Operations)
+	}
+	if got := alpha.Operations[0].Inputs[0].ContentTypes; !reflect.DeepEqual(
+		got,
+		[]string{models.RuntimeContentTypeAudio, models.RuntimeContentTypeText},
+	) {
+		t.Fatalf("alpha content types = %#v, want deterministic AUDIO/TEXT order", got)
+	}
+	if len(alpha.Resources) != 1 || alpha.Resources[0].Model == nil ||
+		*alpha.Resources[0].Model != "ALPHA-MODEL" {
+		t.Fatalf("alpha resources = %#v, want detached model resource", alpha.Resources)
+	}
+	if alpha.Status != models.StatusReady ||
+		alpha.ManagedRuntime.Diagnostics["sourceKind"] != localmodels.ManagedRuntimeSourceKindManagedMirror {
+		t.Fatalf("alpha status/runtime = %#v, want ready managed-mirror projection", alpha)
+	}
+	if localmodels.CanonicalModelName(result.Models[1].Name) != "ZETA-MODEL" {
+		t.Fatalf("second model = %q, want ZETA-MODEL", result.Models[1].Name)
+	}
+}
+
+func mutateScopedCatalogResult(result models.ListModelsResult) {
+	result.Models[0].Name = "mutated"
+	result.Models[0].Operations[0].Name = "mutated"
+	result.Models[0].Operations[0].Inputs[0].ContentTypes[0] = "mutated"
+	*result.Models[0].Resources[0].Model = "mutated"
+	result.Models[0].ManagedRuntime.SupportedOperations[0].Name = "mutated"
+	result.Models[0].ManagedRuntime.Diagnostics["sourceKind"] = "mutated"
 }
 
 func assertContractOnlyUnsupported(t *testing.T, operation string, err error) {

--- a/pkg/services/models/internal/service/service_test.go
+++ b/pkg/services/models/internal/service/service_test.go
@@ -329,6 +329,216 @@ func TestRootGetCatalogModelDelegatesScopedLookup(t *testing.T) {
 	}
 }
 
+func TestRootCatalogMatchesDirectPrivateCatalogBehavior(t *testing.T) {
+	t.Parallel()
+
+	scopes, err := runtimescopeswire.NewService(func() string { return "parent-parity-test" })
+	if err != nil {
+		t.Fatalf("construct Runtime Scopes: %v", err)
+	}
+	currentReadiness := models.Runtime{
+		ReadinessState: models.ReadinessStateMissing,
+		LifecycleState: models.LifecycleStateNotInstalled,
+		Diagnostics:    map[string]string{"observation": "initial"},
+	}
+	privateCatalog, err := catalogwire.NewService(
+		scopes,
+		func(context.Context, models.RuntimeConfig, models.Detail) (models.Runtime, error) {
+			return currentReadiness.Clone(), nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("construct Catalog: %v", err)
+	}
+	root := &Root{runtimeScopes: scopes, catalog: privateCatalog}
+	opened := openScopedCatalogModel(t, root, "parity-model", "generate")
+
+	directList, err := privateCatalog.ListCatalog(
+		context.Background(),
+		models.ListModelsRequest{Scope: opened.Scope},
+	)
+	if err != nil {
+		t.Fatalf("direct ListCatalog: %v", err)
+	}
+	rootList, err := root.ListCatalog(context.Background(), models.ListModelsRequest{Scope: opened.Scope})
+	if err != nil || !reflect.DeepEqual(rootList, directList) {
+		t.Fatalf("root ListCatalog = (%#v, %v), want direct result %#v", rootList, err, directList)
+	}
+
+	getRequest := models.GetModelRequest{
+		Scope: opened.Scope, Name: " parity-model ", Operation: "generate",
+	}
+	directModel, err := privateCatalog.GetCatalogModel(context.Background(), getRequest)
+	if err != nil {
+		t.Fatalf("direct GetCatalogModel: %v", err)
+	}
+	rootModel, err := root.GetCatalogModel(context.Background(), getRequest)
+	if err != nil || !reflect.DeepEqual(rootModel, directModel) {
+		t.Fatalf("root GetCatalogModel = (%#v, %v), want direct result %#v", rootModel, err, directModel)
+	}
+
+	assertRootReadinessMatchesPrivate(t, root, privateCatalog, opened.Scope, currentReadiness)
+	currentReadiness.ReadinessState = models.ReadinessStateReady
+	currentReadiness.LifecycleState = models.LifecycleStateInstalled
+	currentReadiness.Diagnostics["observation"] = "transitioned"
+	assertRootReadinessMatchesPrivate(t, root, privateCatalog, opened.Scope, currentReadiness)
+}
+
+func TestRootCatalogMatchesDirectPrivateCatalogFailures(t *testing.T) {
+	t.Parallel()
+
+	scopes, err := runtimescopeswire.NewService(func() string { return "parent-error-parity-test" })
+	if err != nil {
+		t.Fatalf("construct Runtime Scopes: %v", err)
+	}
+	readinessErr := error(nil)
+	privateCatalog, err := catalogwire.NewService(
+		scopes,
+		func(context.Context, models.RuntimeConfig, models.Detail) (models.Runtime, error) {
+			return models.Runtime{}, readinessErr
+		},
+	)
+	if err != nil {
+		t.Fatalf("construct Catalog: %v", err)
+	}
+	root := &Root{runtimeScopes: scopes, catalog: privateCatalog}
+	opened := openScopedCatalogModel(t, root, "parity-model", "generate")
+
+	assertCatalogGetFailureParity(t, root, privateCatalog, models.GetModelRequest{
+		Scope: opened.Scope, Name: "missing-model",
+	}, models.ErrNotFound)
+	assertCatalogGetFailureParity(t, root, privateCatalog, models.GetModelRequest{
+		Scope: opened.Scope, Name: "parity-model", Operation: "embed",
+	}, models.ErrUnsupportedOperation)
+	assertCatalogListFailureParity(
+		t, root, privateCatalog, context.Background(), models.RuntimeScopeRef{}, models.ErrRuntimeScopeInvalid,
+	)
+
+	unavailableRef, err := scopes.Open(models.RuntimeBinding{
+		RuntimeConfig: func() *models.RuntimeConfig { return nil },
+	})
+	if err != nil {
+		t.Fatalf("open unavailable scope: %v", err)
+	}
+	unavailableScope, err := (models.RuntimeScopeRef{}).Parse(string(unavailableRef))
+	if err != nil {
+		t.Fatalf("parse unavailable scope: %v", err)
+	}
+	assertCatalogListFailureParity(
+		t, root, privateCatalog, context.Background(), unavailableScope, models.ErrUnavailable,
+	)
+
+	if _, err := root.CloseRuntimeScope(
+		context.Background(),
+		models.CloseRuntimeScopeRequest{Scope: opened.Scope},
+	); err != nil {
+		t.Fatalf("close parity scope: %v", err)
+	}
+	assertCatalogListFailureParity(
+		t, root, privateCatalog, context.Background(), opened.Scope, models.ErrRuntimeScopeClosed,
+	)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	assertCatalogListFailureParity(t, root, privateCatalog, canceled, unavailableScope, context.Canceled)
+}
+
+func TestScopedCatalogPreservesCompatibilityBehavior(t *testing.T) {
+	t.Parallel()
+
+	runtimeConfig := models.RuntimeConfig{
+		Workers: []models.RuntimeWorker{
+			scopedCatalogWorker("compatibility-worker", "compatibility-model", "generate"),
+		},
+	}
+	entry := localmodels.BuildCatalogWithRuntime(
+		&runtimeConfig,
+		nil,
+		localmodels.DefaultManagedRuntimeSourceResolver(),
+	)[localmodels.CanonicalModelName("compatibility-model")]
+	currentReadiness := entry.Detail.ManagedRuntime.Clone()
+	host := &compatibilityParityHost{snapshot: readinessSnapshot(currentReadiness)}
+	compatibility, err := NewService(
+		func() *models.RuntimeConfig { return &runtimeConfig },
+		host,
+		constructionAssetPuller{},
+		zap.NewNop(),
+		time.Now,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("construct compatibility service: %v", err)
+	}
+
+	scopes, err := runtimescopeswire.NewService(func() string { return "compatibility-parity-test" })
+	if err != nil {
+		t.Fatalf("construct Runtime Scopes: %v", err)
+	}
+	privateCatalog, err := catalogwire.NewService(
+		scopes,
+		func(context.Context, models.RuntimeConfig, models.Detail) (models.Runtime, error) {
+			return currentReadiness.Clone(), nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("construct Catalog: %v", err)
+	}
+	root := &Root{runtimeScopes: scopes, catalog: privateCatalog}
+	opened, err := root.OpenRuntimeScope(context.Background(), models.OpenRuntimeScopeRequest{
+		Config: models.RuntimeScopeConfig{Runtime: runtimeConfig},
+	})
+	if err != nil {
+		t.Fatalf("OpenRuntimeScope: %v", err)
+	}
+
+	legacyList, err := compatibility.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("compatibility ListModels: %v", err)
+	}
+	scopedList, err := root.ListCatalog(
+		context.Background(),
+		models.ListModelsRequest{Scope: opened.Scope},
+	)
+	if err != nil || !reflect.DeepEqual(legacyList.Results, scopedList.Models) {
+		t.Fatalf("catalog list parity = (legacy %#v, scoped %#v, %v)", legacyList.Results, scopedList.Models, err)
+	}
+
+	legacyDetail, err := compatibility.GetModel(context.Background(), "compatibility-model")
+	if err != nil {
+		t.Fatalf("compatibility GetModel: %v", err)
+	}
+	scopedDetail, err := root.GetCatalogModel(context.Background(), models.GetModelRequest{
+		Scope: opened.Scope, Name: "compatibility-model", Operation: "generate",
+	})
+	if err != nil {
+		t.Fatalf("GetCatalogModel: %v", err)
+	}
+	scopedCompatibilityFields := scopedDetail.Model.Clone()
+	scopedCompatibilityFields.Sources = nil
+	if !reflect.DeepEqual(legacyDetail, scopedCompatibilityFields) {
+		t.Fatalf("catalog get parity = (legacy %#v, scoped %#v)", legacyDetail, scopedCompatibilityFields)
+	}
+
+	currentReadiness.ReadinessState = models.ReadinessStateReady
+	currentReadiness.LifecycleState = models.LifecycleStateInstalled
+	host.snapshot = readinessSnapshot(currentReadiness)
+	legacyReadiness, err := compatibility.InspectRuntime(context.Background(), "compatibility-model")
+	if err != nil {
+		t.Fatalf("compatibility InspectRuntime: %v", err)
+	}
+	scopedReadiness, err := root.GetModelReadiness(context.Background(), models.GetModelReadinessRequest{
+		Scope: opened.Scope, Name: "compatibility-model", Operation: "generate",
+	})
+	if err != nil || !reflect.DeepEqual(legacyReadiness, scopedReadiness.Readiness) {
+		t.Fatalf(
+			"readiness parity = (legacy %#v, scoped %#v, %v)",
+			legacyReadiness,
+			scopedReadiness.Readiness,
+			err,
+		)
+	}
+}
+
 func TestRootClosesScopeAndPreservesClosedClassification(t *testing.T) {
 	t.Parallel()
 
@@ -364,6 +574,107 @@ func TestRootClosesScopeAndPreservesClosedClassification(t *testing.T) {
 		models.GetModelReadinessRequest{Scope: opened.Scope, Name: "closed-model"},
 	); !errors.Is(err, models.ErrRuntimeScopeClosed) {
 		t.Fatalf("GetModelReadiness closed scope error = %v, want ErrRuntimeScopeClosed", err)
+	}
+}
+
+type compatibilityParityHost struct {
+	constructionModelHost
+	snapshot modelhost.ReadinessSnapshot
+}
+
+func (host *compatibilityParityHost) InspectReadiness(
+	context.Context,
+	*models.RuntimeConfig,
+	string,
+) (modelhost.ReadinessSnapshot, error) {
+	return host.snapshot, nil
+}
+
+func readinessSnapshot(runtime models.Runtime) modelhost.ReadinessSnapshot {
+	return modelhost.ReadinessSnapshot{
+		Identity: modelhost.Identity{
+			Name:                runtime.Identity,
+			Locality:            runtime.Locality,
+			SupportedOperations: runtime.SupportedOperations,
+		},
+		ReadinessState: runtime.ReadinessState,
+		LifecycleState: runtime.LifecycleState,
+		Diagnostics:    runtime.Diagnostics,
+	}
+}
+
+func openScopedCatalogModel(t *testing.T, root *Root, name, operation string) models.OpenRuntimeScopeResult {
+	t.Helper()
+	opened, err := root.OpenRuntimeScope(context.Background(), models.OpenRuntimeScopeRequest{
+		Config: models.RuntimeScopeConfig{Runtime: models.RuntimeConfig{
+			Workers: []models.RuntimeWorker{scopedCatalogWorker("worker", name, operation)},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("OpenRuntimeScope: %v", err)
+	}
+	return opened
+}
+
+func assertRootReadinessMatchesPrivate(
+	t *testing.T,
+	root *Root,
+	privateCatalog interface {
+		GetModelReadiness(context.Context, models.GetModelReadinessRequest) (models.GetModelReadinessResult, error)
+	},
+	scope models.RuntimeScopeRef,
+	want models.Runtime,
+) {
+	t.Helper()
+	request := models.GetModelReadinessRequest{Scope: scope, Name: "parity-model", Operation: "generate"}
+	direct, err := privateCatalog.GetModelReadiness(context.Background(), request)
+	if err != nil {
+		t.Fatalf("direct GetModelReadiness: %v", err)
+	}
+	got, err := root.GetModelReadiness(context.Background(), request)
+	if err != nil || !reflect.DeepEqual(got, direct) {
+		t.Fatalf("root GetModelReadiness = (%#v, %v), want direct result %#v", got, err, direct)
+	}
+	if got.Readiness.ReadinessState != want.ReadinessState ||
+		got.Readiness.LifecycleState != want.LifecycleState ||
+		got.Readiness.Diagnostics["observation"] != want.Diagnostics["observation"] {
+		t.Fatalf("root readiness = %#v, want current facts %#v", got.Readiness, want)
+	}
+}
+
+func assertCatalogGetFailureParity(
+	t *testing.T,
+	root *Root,
+	privateCatalog interface {
+		GetCatalogModel(context.Context, models.GetModelRequest) (models.GetModelResult, error)
+	},
+	request models.GetModelRequest,
+	want error,
+) {
+	t.Helper()
+	_, directErr := privateCatalog.GetCatalogModel(context.Background(), request)
+	_, rootErr := root.GetCatalogModel(context.Background(), request)
+	if !errors.Is(directErr, want) || !errors.Is(rootErr, want) {
+		t.Fatalf("GetCatalogModel errors = (direct %v, root %v), want %v", directErr, rootErr, want)
+	}
+}
+
+func assertCatalogListFailureParity(
+	t *testing.T,
+	root *Root,
+	privateCatalog interface {
+		ListCatalog(context.Context, models.ListModelsRequest) (models.ListModelsResult, error)
+	},
+	ctx context.Context,
+	scope models.RuntimeScopeRef,
+	want error,
+) {
+	t.Helper()
+	request := models.ListModelsRequest{Scope: scope}
+	_, directErr := privateCatalog.ListCatalog(ctx, request)
+	_, rootErr := root.ListCatalog(ctx, request)
+	if !errors.Is(directErr, want) || !errors.Is(rootErr, want) {
+		t.Fatalf("ListCatalog errors = (direct %v, root %v), want %v", directErr, rootErr, want)
 	}
 }
 

--- a/pkg/services/models/internal/service/service_test.go
+++ b/pkg/services/models/internal/service/service_test.go
@@ -329,6 +329,44 @@ func TestRootGetCatalogModelDelegatesScopedLookup(t *testing.T) {
 	}
 }
 
+func TestRootClosesScopeAndPreservesClosedClassification(t *testing.T) {
+	t.Parallel()
+
+	root := newScopedCatalogRoot(t)
+	opened, err := root.OpenRuntimeScope(context.Background(), models.OpenRuntimeScopeRequest{
+		Config: models.RuntimeScopeConfig{Runtime: models.RuntimeConfig{
+			Workers: []models.RuntimeWorker{
+				scopedCatalogWorker("worker", "closed-model", "generate"),
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("OpenRuntimeScope: %v", err)
+	}
+	closed, err := root.CloseRuntimeScope(
+		context.Background(),
+		models.CloseRuntimeScopeRequest{Scope: opened.Scope},
+	)
+	if err != nil {
+		t.Fatalf("CloseRuntimeScope: %v", err)
+	}
+	if !closed.Closed || closed.Scope != opened.Scope {
+		t.Fatalf("CloseRuntimeScope = %#v, want closed issued scope", closed)
+	}
+	if _, err := root.CloseRuntimeScope(
+		context.Background(),
+		models.CloseRuntimeScopeRequest{Scope: opened.Scope},
+	); !errors.Is(err, models.ErrRuntimeScopeClosed) {
+		t.Fatalf("repeated CloseRuntimeScope error = %v, want ErrRuntimeScopeClosed", err)
+	}
+	if _, err := root.GetModelReadiness(
+		context.Background(),
+		models.GetModelReadinessRequest{Scope: opened.Scope, Name: "closed-model"},
+	); !errors.Is(err, models.ErrRuntimeScopeClosed) {
+		t.Fatalf("GetModelReadiness closed scope error = %v, want ErrRuntimeScopeClosed", err)
+	}
+}
+
 func newScopedCatalogRoot(t *testing.T) *Root {
 	t.Helper()
 	scopes, err := runtimescopeswire.NewService(func() string { return "catalog-root-test" })

--- a/pkg/services/models/internal/service/service_test.go
+++ b/pkg/services/models/internal/service/service_test.go
@@ -343,7 +343,7 @@ func TestRootCatalogMatchesDirectPrivateCatalogBehavior(t *testing.T) {
 	}
 	privateCatalog, err := catalogwire.NewService(
 		scopes,
-		func(context.Context, models.RuntimeConfig, models.Detail) (models.Runtime, error) {
+		func(context.Context, models.RuntimeScopeConfig, models.Detail) (models.Runtime, error) {
 			return currentReadiness.Clone(), nil
 		},
 	)
@@ -394,7 +394,7 @@ func TestRootCatalogMatchesDirectPrivateCatalogFailures(t *testing.T) {
 	readinessErr := error(nil)
 	privateCatalog, err := catalogwire.NewService(
 		scopes,
-		func(context.Context, models.RuntimeConfig, models.Detail) (models.Runtime, error) {
+		func(context.Context, models.RuntimeScopeConfig, models.Detail) (models.Runtime, error) {
 			return models.Runtime{}, readinessErr
 		},
 	)
@@ -476,7 +476,7 @@ func TestScopedCatalogPreservesCompatibilityBehavior(t *testing.T) {
 	}
 	privateCatalog, err := catalogwire.NewService(
 		scopes,
-		func(context.Context, models.RuntimeConfig, models.Detail) (models.Runtime, error) {
+		func(context.Context, models.RuntimeScopeConfig, models.Detail) (models.Runtime, error) {
 			return currentReadiness.Clone(), nil
 		},
 	)

--- a/pkg/services/models/internal/services/catalog/internal/service/readiness_test.go
+++ b/pkg/services/models/internal/services/catalog/internal/service/readiness_test.go
@@ -1,0 +1,243 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	catalogwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+)
+
+func TestGetModelReadinessReportsCurrentDetachedTransitions(t *testing.T) {
+	t.Parallel()
+
+	scopes := newRuntimeScopes(t, "catalog-readiness-transitions")
+	privateRef := openReadinessScope(t, scopes)
+	facts := readinessTransitions()
+	queryIndex := 0
+	service, err := catalogwire.NewService(
+		scopes,
+		func(_ context.Context, _ models.RuntimeConfig, detail models.Detail) (models.Runtime, error) {
+			if detail.Name != "scoped-model" {
+				t.Fatalf("readiness detail name = %q, want canonical scoped-model", detail.Name)
+			}
+			current := facts[queryIndex%len(facts)]
+			queryIndex++
+			return current, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("construct Catalog: %v", err)
+	}
+	request := models.GetModelReadinessRequest{
+		Scope: publicScope(t, privateRef), Name: " SCOPED-MODEL ", Operation: "generate",
+	}
+
+	for index, want := range facts {
+		got, queryErr := service.GetModelReadiness(context.Background(), request)
+		if queryErr != nil {
+			t.Fatalf("GetModelReadiness transition %d: %v", index, queryErr)
+		}
+		assertCurrentReadiness(t, got, want)
+		mutateReadinessResult(got)
+	}
+
+	again, err := service.GetModelReadiness(context.Background(), request)
+	if err != nil {
+		t.Fatalf("GetModelReadiness after caller mutation: %v", err)
+	}
+	assertCurrentReadiness(t, again, facts[0])
+	if queryIndex != len(facts)+1 {
+		t.Fatalf("readiness query count = %d, want %d", queryIndex, len(facts)+1)
+	}
+}
+
+func TestGetModelReadinessValidatesIdentityAndOperationBeforeQuery(t *testing.T) {
+	t.Parallel()
+
+	scopes := newRuntimeScopes(t, "catalog-readiness-validation")
+	privateRef := openReadinessScope(t, scopes)
+	queryCount := 0
+	service, err := catalogwire.NewService(
+		scopes,
+		func(context.Context, models.RuntimeConfig, models.Detail) (models.Runtime, error) {
+			queryCount++
+			return models.Runtime{
+				ReadinessState: models.ReadinessStateUnsupported,
+				LifecycleState: models.LifecycleStateNotApplicable,
+			}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("construct Catalog: %v", err)
+	}
+	scope := publicScope(t, privateRef)
+
+	tests := []struct {
+		name    string
+		request models.GetModelReadinessRequest
+		want    error
+	}{
+		{
+			name:    "empty identity",
+			request: models.GetModelReadinessRequest{Scope: scope},
+			want:    models.ErrNotFound,
+		},
+		{
+			name:    "unknown identity",
+			request: models.GetModelReadinessRequest{Scope: scope, Name: "missing"},
+			want:    models.ErrNotFound,
+		},
+		{
+			name: "unsupported operation",
+			request: models.GetModelReadinessRequest{
+				Scope: scope, Name: "scoped-model", Operation: "embed",
+			},
+			want: models.ErrUnsupportedOperation,
+		},
+	}
+	for _, test := range tests {
+		if _, queryErr := service.GetModelReadiness(context.Background(), test.request); !errors.Is(queryErr, test.want) {
+			t.Errorf("%s error = %v, want %v", test.name, queryErr, test.want)
+		}
+	}
+	if queryCount != 0 {
+		t.Fatalf("invalid readiness requests called query %d times, want 0", queryCount)
+	}
+
+	got, err := service.GetModelReadiness(context.Background(), models.GetModelReadinessRequest{
+		Scope: scope, Name: "scoped-model", Operation: "generate",
+	})
+	if err != nil {
+		t.Fatalf("supported readiness: %v", err)
+	}
+	if got.Readiness.ReadinessState != models.ReadinessStateUnsupported ||
+		got.Readiness.LifecycleState != models.LifecycleStateNotApplicable {
+		t.Fatalf("supported non-ready result = %#v, want UNSUPPORTED/NOT_APPLICABLE", got)
+	}
+	if queryCount != 1 {
+		t.Fatalf("supported readiness query count = %d, want 1", queryCount)
+	}
+}
+
+func openReadinessScope(
+	t *testing.T,
+	scopes runtimescopes.Service,
+) runtimescopes.Reference {
+	t.Helper()
+	privateRef, err := scopes.Open(models.RuntimeBinding{
+		RuntimeConfig: func() *models.RuntimeConfig {
+			summarizer := catalogWorker("summarizer", "scoped-model", "summarize")
+			summarizer.Operations[0].Inputs[0].Required = true
+			generator := catalogWorker("generator", "SCOPED-MODEL", "generate")
+			generator.Operations[0].Inputs[0].Required = true
+			return &models.RuntimeConfig{
+				Workers: []models.RuntimeWorker{
+					summarizer,
+					generator,
+				},
+				Resources: []models.RuntimeResource{{
+					Name: "model-cache", Type: models.RuntimeResourceTypeModel,
+					Model: "SCOPED-MODEL", Backend: "GGUF", Provider: "MODELSCOPE",
+				}},
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("open readiness scope: %v", err)
+	}
+	return privateRef
+}
+
+func readinessTransitions() []models.Runtime {
+	return []models.Runtime{
+		readinessFact(models.ReadinessStateMissing, models.LifecycleStateNotInstalled, "missing"),
+		readinessFact(models.ReadinessStateLoading, models.LifecycleStateInstalling, "loading"),
+		readinessFact(models.ReadinessStateReady, models.LifecycleStateInstalled, "ready"),
+		readinessFact(models.ReadinessStateFailed, models.LifecycleStateNotInstalled, "failed"),
+		readinessFact(models.ReadinessStateUnsupported, models.LifecycleStateNotApplicable, "unsupported"),
+	}
+}
+
+func readinessFact(
+	readiness models.ReadinessState,
+	lifecycle models.LifecycleState,
+	transition string,
+) models.Runtime {
+	required := true
+	return models.Runtime{
+		Identity:       "query-owned-alias",
+		ReadinessState: readiness,
+		LifecycleState: lifecycle,
+		SupportedOperations: []models.Operation{{
+			Name: "query-owned-operation",
+			Inputs: []models.OperationSlot{{
+				Name: "input", ContentTypes: []string{"QUERY"}, Required: &required,
+			}},
+		}},
+		Diagnostics: map[string]string{
+			"transition": transition,
+			"revision":   "current-revision",
+		},
+	}
+}
+
+func assertCurrentReadiness(
+	t *testing.T,
+	got models.GetModelReadinessResult,
+	want models.Runtime,
+) {
+	t.Helper()
+	if got.ModelName != "scoped-model" || got.Readiness.Identity != "scoped-model" {
+		t.Fatalf("readiness identity = (%q, %q), want canonical scoped-model", got.ModelName, got.Readiness.Identity)
+	}
+	if got.Readiness.ReadinessState != want.ReadinessState ||
+		got.Readiness.LifecycleState != want.LifecycleState {
+		t.Fatalf(
+			"readiness state = (%s, %s), want (%s, %s)",
+			got.Readiness.ReadinessState,
+			got.Readiness.LifecycleState,
+			want.ReadinessState,
+			want.LifecycleState,
+		)
+	}
+	if got.Readiness.Locality != models.LocalityLocal {
+		t.Fatalf("readiness locality = %q, want LOCAL", got.Readiness.Locality)
+	}
+	if operationNames := readinessOperationNames(got.Readiness); !reflect.DeepEqual(
+		operationNames,
+		[]string{"generate", "summarize"},
+	) {
+		t.Fatalf("readiness operations = %#v, want catalog operations", operationNames)
+	}
+	required := got.Readiness.SupportedOperations[0].Inputs[0].Required
+	if required == nil || !*required {
+		t.Fatalf("readiness required input = %v, want detached true pointer", required)
+	}
+	if got.Readiness.Diagnostics["sourceId"] != "managed-mirror:SCOPED-MODEL" ||
+		got.Readiness.Diagnostics["transition"] != want.Diagnostics["transition"] ||
+		got.Readiness.Diagnostics["revision"] != "current-revision" {
+		t.Fatalf("readiness diagnostics = %#v, want source and current facts", got.Readiness.Diagnostics)
+	}
+}
+
+func readinessOperationNames(runtime models.Runtime) []string {
+	names := make([]string, len(runtime.SupportedOperations))
+	for index, operation := range runtime.SupportedOperations {
+		names[index] = operation.Name
+	}
+	return names
+}
+
+func mutateReadinessResult(result models.GetModelReadinessResult) {
+	result.ModelName = "mutated"
+	result.Readiness.Identity = "mutated"
+	result.Readiness.SupportedOperations[0].Name = "mutated"
+	result.Readiness.SupportedOperations[0].Inputs[0].ContentTypes[0] = "mutated"
+	*result.Readiness.SupportedOperations[0].Inputs[0].Required = false
+	result.Readiness.Diagnostics["sourceId"] = "mutated"
+	result.Readiness.Diagnostics["transition"] = "mutated"
+}

--- a/pkg/services/models/internal/services/catalog/internal/service/readiness_test.go
+++ b/pkg/services/models/internal/services/catalog/internal/service/readiness_test.go
@@ -20,7 +20,7 @@ func TestGetModelReadinessReportsCurrentDetachedTransitions(t *testing.T) {
 	queryIndex := 0
 	service, err := catalogwire.NewService(
 		scopes,
-		func(_ context.Context, _ models.RuntimeConfig, detail models.Detail) (models.Runtime, error) {
+		func(_ context.Context, _ models.RuntimeScopeConfig, detail models.Detail) (models.Runtime, error) {
 			if detail.Name != "scoped-model" {
 				t.Fatalf("readiness detail name = %q, want canonical scoped-model", detail.Name)
 			}
@@ -63,7 +63,7 @@ func TestGetModelReadinessValidatesIdentityAndOperationBeforeQuery(t *testing.T)
 	queryCount := 0
 	service, err := catalogwire.NewService(
 		scopes,
-		func(context.Context, models.RuntimeConfig, models.Detail) (models.Runtime, error) {
+		func(context.Context, models.RuntimeScopeConfig, models.Detail) (models.Runtime, error) {
 			queryCount++
 			return models.Runtime{
 				ReadinessState: models.ReadinessStateUnsupported,

--- a/pkg/services/models/internal/services/catalog/internal/service/service.go
+++ b/pkg/services/models/internal/services/catalog/internal/service/service.go
@@ -28,26 +28,9 @@ func (s *service) ListCatalog(
 	ctx context.Context,
 	request models.ListModelsRequest,
 ) (models.ListModelsResult, error) {
-	if err := ctx.Err(); err != nil {
-		return models.ListModelsResult{}, err
-	}
-	if request.Scope.IsZero() {
-		return models.ListModelsResult{}, models.ErrRuntimeScopeInvalid
-	}
-	if s == nil || s.scopes == nil {
-		return models.ListModelsResult{}, models.ErrUnavailable
-	}
-
-	binding, err := s.scopes.Resolve(runtimescopes.Reference(request.Scope.String()))
+	runtimeConfig, err := s.resolveRuntimeConfig(ctx, request.Scope)
 	if err != nil {
-		return models.ListModelsResult{}, catalogScopeError(err)
-	}
-	if binding.RuntimeConfig == nil {
-		return models.ListModelsResult{}, models.ErrUnavailable
-	}
-	runtimeConfig := binding.RuntimeConfig()
-	if runtimeConfig == nil {
-		return models.ListModelsResult{}, models.ErrUnavailable
+		return models.ListModelsResult{}, err
 	}
 
 	entries := localmodels.BuildCatalogWithRuntime(
@@ -64,6 +47,67 @@ func (s *service) ListCatalog(
 			localmodels.CanonicalModelName(result.Models[j].Name)
 	})
 	return result, nil
+}
+
+func (s *service) GetCatalogModel(
+	ctx context.Context,
+	request models.GetModelRequest,
+) (models.GetModelResult, error) {
+	runtimeConfig, err := s.resolveRuntimeConfig(ctx, request.Scope)
+	if err != nil {
+		return models.GetModelResult{}, err
+	}
+	if err := request.Validate(); err != nil {
+		return models.GetModelResult{}, err
+	}
+
+	entries := localmodels.BuildCatalogWithRuntime(
+		runtimeConfig,
+		nil,
+		localmodels.DefaultManagedRuntimeSourceResolver(),
+	)
+	entry, ok := entries[localmodels.CanonicalModelName(request.Name)]
+	if !ok {
+		return models.GetModelResult{}, fmt.Errorf("%w: %s", models.ErrNotFound, request.Name)
+	}
+	detail := stableDetail(entry.Detail)
+	if operation := request.Operation; operation != "" && !supportsOperation(detail, operation) {
+		return models.GetModelResult{}, fmt.Errorf(
+			"%w: model %q does not support operation %q",
+			models.ErrUnsupportedOperation,
+			detail.Name,
+			operation,
+		)
+	}
+	return models.GetModelResult{Model: detail}, nil
+}
+
+func (s *service) resolveRuntimeConfig(
+	ctx context.Context,
+	scope models.RuntimeScopeRef,
+) (*models.RuntimeConfig, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if scope.IsZero() {
+		return nil, models.ErrRuntimeScopeInvalid
+	}
+	if s == nil || s.scopes == nil {
+		return nil, models.ErrUnavailable
+	}
+
+	binding, err := s.scopes.Resolve(runtimescopes.Reference(scope.String()))
+	if err != nil {
+		return nil, catalogScopeError(err)
+	}
+	if binding.RuntimeConfig == nil {
+		return nil, models.ErrUnavailable
+	}
+	runtimeConfig := binding.RuntimeConfig()
+	if runtimeConfig == nil {
+		return nil, models.ErrUnavailable
+	}
+	return runtimeConfig, nil
 }
 
 func catalogScopeError(err error) error {
@@ -86,6 +130,62 @@ func stableSummary(summary models.Summary) models.Summary {
 	})
 	sortOperations(summary.ManagedRuntime.SupportedOperations)
 	return summary
+}
+
+func stableDetail(detail models.Detail) models.Detail {
+	detail = detail.Clone()
+	detail.Summary = stableSummary(detail.Summary)
+	if len(detail.Sources) == 0 {
+		detail.Sources = sourceMetadata(detail.ManagedRuntime.Diagnostics)
+	}
+	for i := range detail.Capabilities {
+		sortOperations(detail.Capabilities[i].Operations)
+		sort.Strings(detail.Capabilities[i].ResourceNames)
+	}
+	sort.Slice(detail.Capabilities, func(i, j int) bool {
+		return detail.Capabilities[i].Worker < detail.Capabilities[j].Worker
+	})
+	sort.Slice(detail.Sources, func(i, j int) bool {
+		left, right := detail.Sources[i], detail.Sources[j]
+		if left.Provider != right.Provider {
+			return left.Provider < right.Provider
+		}
+		if left.Reference != right.Reference {
+			return left.Reference < right.Reference
+		}
+		return left.Revision < right.Revision
+	})
+	return detail
+}
+
+func sourceMetadata(diagnostics map[string]string) []models.SourceMetadata {
+	provider := diagnostics["sourceKind"]
+	reference := diagnostics["sourceId"]
+	revision := diagnostics["revision"]
+	if provider == "" && reference == "" && revision == "" {
+		return nil
+	}
+	return []models.SourceMetadata{{
+		Provider:  provider,
+		Reference: reference,
+		Revision:  revision,
+	}}
+}
+
+func supportsOperation(detail models.Detail, requested string) bool {
+	for _, operation := range detail.Operations {
+		if operation.Name == requested {
+			return true
+		}
+	}
+	for _, capability := range detail.Capabilities {
+		for _, operation := range capability.Operations {
+			if operation.Name == requested {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func sortOperations(operations []models.Operation) {

--- a/pkg/services/models/internal/services/catalog/internal/service/service.go
+++ b/pkg/services/models/internal/services/catalog/internal/service/service.go
@@ -29,13 +29,13 @@ func (s *service) ListCatalog(
 	ctx context.Context,
 	request models.ListModelsRequest,
 ) (models.ListModelsResult, error) {
-	runtimeConfig, err := s.resolveRuntimeConfig(ctx, request.Scope)
+	scopeConfig, err := s.resolveScopeConfig(ctx, request.Scope)
 	if err != nil {
 		return models.ListModelsResult{}, err
 	}
 
 	entries := localmodels.BuildCatalogWithRuntime(
-		runtimeConfig,
+		&scopeConfig.Runtime,
 		nil,
 		localmodels.DefaultManagedRuntimeSourceResolver(),
 	)
@@ -57,11 +57,11 @@ func (s *service) GetCatalogModel(
 	ctx context.Context,
 	request models.GetModelRequest,
 ) (models.GetModelResult, error) {
-	runtimeConfig, err := s.resolveRuntimeConfig(ctx, request.Scope)
+	scopeConfig, err := s.resolveScopeConfig(ctx, request.Scope)
 	if err != nil {
 		return models.GetModelResult{}, err
 	}
-	detail, err := catalogDetail(runtimeConfig, request.Name, request.Operation)
+	detail, err := catalogDetail(&scopeConfig.Runtime, request.Name, request.Operation)
 	if err != nil {
 		return models.GetModelResult{}, err
 	}
@@ -75,18 +75,18 @@ func (s *service) GetModelReadiness(
 	ctx context.Context,
 	request models.GetModelReadinessRequest,
 ) (models.GetModelReadinessResult, error) {
-	runtimeConfig, err := s.resolveRuntimeConfig(ctx, request.Scope)
+	scopeConfig, err := s.resolveScopeConfig(ctx, request.Scope)
 	if err != nil {
 		return models.GetModelReadinessResult{}, err
 	}
-	detail, err := catalogDetail(runtimeConfig, request.Name, request.Operation)
+	detail, err := catalogDetail(&scopeConfig.Runtime, request.Name, request.Operation)
 	if err != nil {
 		return models.GetModelReadinessResult{}, err
 	}
 	if s.readiness == nil {
 		return models.GetModelReadinessResult{}, models.ErrUnavailable
 	}
-	readiness, err := s.readiness(ctx, *runtimeConfig, detail.Clone())
+	readiness, err := s.readiness(ctx, scopeConfig.Clone(), detail.Clone())
 	if err != nil {
 		if contextError := ctx.Err(); contextError != nil {
 			return models.GetModelReadinessResult{}, contextError
@@ -135,32 +135,35 @@ func catalogDetail(
 	return detail, nil
 }
 
-func (s *service) resolveRuntimeConfig(
+func (s *service) resolveScopeConfig(
 	ctx context.Context,
 	scope models.RuntimeScopeRef,
-) (*models.RuntimeConfig, error) {
+) (models.RuntimeScopeConfig, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return models.RuntimeScopeConfig{}, err
 	}
 	if scope.IsZero() {
-		return nil, models.ErrRuntimeScopeInvalid
+		return models.RuntimeScopeConfig{}, models.ErrRuntimeScopeInvalid
 	}
 	if s == nil || s.scopes == nil {
-		return nil, models.ErrUnavailable
+		return models.RuntimeScopeConfig{}, models.ErrUnavailable
 	}
 
 	binding, err := s.scopes.Resolve(runtimescopes.Reference(scope.String()))
 	if err != nil {
-		return nil, catalogScopeError(err)
+		return models.RuntimeScopeConfig{}, catalogScopeError(err)
 	}
 	if binding.RuntimeConfig == nil {
-		return nil, models.ErrUnavailable
+		return models.RuntimeScopeConfig{}, models.ErrUnavailable
 	}
 	runtimeConfig := binding.RuntimeConfig()
 	if runtimeConfig == nil {
-		return nil, models.ErrUnavailable
+		return models.RuntimeScopeConfig{}, models.ErrUnavailable
 	}
-	return runtimeConfig, nil
+	return models.RuntimeScopeConfig{
+		CacheDirectory: binding.CacheDirectory,
+		Runtime:        *runtimeConfig,
+	}.Clone(), nil
 }
 
 func catalogScopeError(err error) error {

--- a/pkg/services/models/internal/services/catalog/internal/service/service.go
+++ b/pkg/services/models/internal/services/catalog/internal/service/service.go
@@ -1,0 +1,108 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	localmodels "github.com/portpowered/infinite-you/pkg/services/models/internal/local"
+	catalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+)
+
+type service struct {
+	scopes runtimescopes.Service
+}
+
+var _ catalog.Service = (*service)(nil)
+
+// New constructs an inert catalog over the Models-owned Runtime Scopes
+// authority.
+func New(scopes runtimescopes.Service) catalog.Service {
+	return &service{scopes: scopes}
+}
+
+func (s *service) ListCatalog(
+	ctx context.Context,
+	request models.ListModelsRequest,
+) (models.ListModelsResult, error) {
+	if err := ctx.Err(); err != nil {
+		return models.ListModelsResult{}, err
+	}
+	if request.Scope.IsZero() {
+		return models.ListModelsResult{}, models.ErrRuntimeScopeInvalid
+	}
+	if s == nil || s.scopes == nil {
+		return models.ListModelsResult{}, models.ErrUnavailable
+	}
+
+	binding, err := s.scopes.Resolve(runtimescopes.Reference(request.Scope.String()))
+	if err != nil {
+		return models.ListModelsResult{}, catalogScopeError(err)
+	}
+	if binding.RuntimeConfig == nil {
+		return models.ListModelsResult{}, models.ErrUnavailable
+	}
+	runtimeConfig := binding.RuntimeConfig()
+	if runtimeConfig == nil {
+		return models.ListModelsResult{}, models.ErrUnavailable
+	}
+
+	entries := localmodels.BuildCatalogWithRuntime(
+		runtimeConfig,
+		nil,
+		localmodels.DefaultManagedRuntimeSourceResolver(),
+	)
+	result := models.ListModelsResult{Models: make([]models.Summary, 0, len(entries))}
+	for _, entry := range entries {
+		result.Models = append(result.Models, stableSummary(entry.Summary))
+	}
+	sort.Slice(result.Models, func(i, j int) bool {
+		return localmodels.CanonicalModelName(result.Models[i].Name) <
+			localmodels.CanonicalModelName(result.Models[j].Name)
+	})
+	return result, nil
+}
+
+func catalogScopeError(err error) error {
+	switch {
+	case errors.Is(err, runtimescopes.ErrScopeForeign):
+		return fmt.Errorf("%w: %v", models.ErrRuntimeScopeForeign, err)
+	case errors.Is(err, runtimescopes.ErrScopeUnknown):
+		return fmt.Errorf("%w: %v", models.ErrRuntimeScopeStale, err)
+	default:
+		return models.ErrUnavailable
+	}
+}
+
+func stableSummary(summary models.Summary) models.Summary {
+	summary = summary.Clone()
+	sortOperations(summary.Operations)
+	sort.Strings(summary.Modalities)
+	sort.Slice(summary.Resources, func(i, j int) bool {
+		return summary.Resources[i].Name < summary.Resources[j].Name
+	})
+	sortOperations(summary.ManagedRuntime.SupportedOperations)
+	return summary
+}
+
+func sortOperations(operations []models.Operation) {
+	for i := range operations {
+		sortOperationSlots(operations[i].Inputs)
+		sortOperationSlots(operations[i].Outputs)
+	}
+	sort.Slice(operations, func(i, j int) bool {
+		return operations[i].Name < operations[j].Name
+	})
+}
+
+func sortOperationSlots(slots []models.OperationSlot) {
+	for i := range slots {
+		sort.Strings(slots[i].ContentTypes)
+	}
+	sort.Slice(slots, func(i, j int) bool {
+		return slots[i].Name < slots[j].Name
+	})
+}

--- a/pkg/services/models/internal/services/catalog/internal/service/service.go
+++ b/pkg/services/models/internal/services/catalog/internal/service/service.go
@@ -13,15 +13,16 @@ import (
 )
 
 type service struct {
-	scopes runtimescopes.Service
+	scopes    runtimescopes.Service
+	readiness catalog.ReadinessQuery
 }
 
 var _ catalog.Service = (*service)(nil)
 
 // New constructs an inert catalog over the Models-owned Runtime Scopes
 // authority.
-func New(scopes runtimescopes.Service) catalog.Service {
-	return &service{scopes: scopes}
+func New(scopes runtimescopes.Service, readiness catalog.ReadinessQuery) catalog.Service {
+	return &service{scopes: scopes, readiness: readiness}
 }
 
 func (s *service) ListCatalog(
@@ -40,6 +41,9 @@ func (s *service) ListCatalog(
 	)
 	result := models.ListModelsResult{Models: make([]models.Summary, 0, len(entries))}
 	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return models.ListModelsResult{}, err
+		}
 		result.Models = append(result.Models, stableSummary(entry.Summary))
 	}
 	sort.Slice(result.Models, func(i, j int) bool {
@@ -57,29 +61,78 @@ func (s *service) GetCatalogModel(
 	if err != nil {
 		return models.GetModelResult{}, err
 	}
-	if err := request.Validate(); err != nil {
+	detail, err := catalogDetail(runtimeConfig, request.Name, request.Operation)
+	if err != nil {
 		return models.GetModelResult{}, err
 	}
+	if err := ctx.Err(); err != nil {
+		return models.GetModelResult{}, err
+	}
+	return models.GetModelResult{Model: detail}, nil
+}
 
+func (s *service) GetModelReadiness(
+	ctx context.Context,
+	request models.GetModelReadinessRequest,
+) (models.GetModelReadinessResult, error) {
+	runtimeConfig, err := s.resolveRuntimeConfig(ctx, request.Scope)
+	if err != nil {
+		return models.GetModelReadinessResult{}, err
+	}
+	detail, err := catalogDetail(runtimeConfig, request.Name, request.Operation)
+	if err != nil {
+		return models.GetModelReadinessResult{}, err
+	}
+	if s.readiness == nil {
+		return models.GetModelReadinessResult{}, models.ErrUnavailable
+	}
+	readiness, err := s.readiness(ctx, *runtimeConfig, detail.Clone())
+	if err != nil {
+		if contextError := ctx.Err(); contextError != nil {
+			return models.GetModelReadinessResult{}, contextError
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return models.GetModelReadinessResult{}, err
+		}
+		return models.GetModelReadinessResult{}, models.ErrUnavailable
+	}
+	if err := ctx.Err(); err != nil {
+		return models.GetModelReadinessResult{}, err
+	}
+	return models.GetModelReadinessResult{
+		ModelName: detail.Name,
+		Readiness: stableRuntime(readiness),
+	}, nil
+}
+
+func catalogDetail(
+	runtimeConfig *models.RuntimeConfig,
+	name string,
+	operation string,
+) (models.Detail, error) {
+	request := models.GetModelRequest{Name: name, Operation: operation}
+	if err := request.Validate(); err != nil {
+		return models.Detail{}, err
+	}
 	entries := localmodels.BuildCatalogWithRuntime(
 		runtimeConfig,
 		nil,
 		localmodels.DefaultManagedRuntimeSourceResolver(),
 	)
-	entry, ok := entries[localmodels.CanonicalModelName(request.Name)]
+	entry, ok := entries[localmodels.CanonicalModelName(name)]
 	if !ok {
-		return models.GetModelResult{}, fmt.Errorf("%w: %s", models.ErrNotFound, request.Name)
+		return models.Detail{}, fmt.Errorf("%w: %s", models.ErrNotFound, name)
 	}
 	detail := stableDetail(entry.Detail)
-	if operation := request.Operation; operation != "" && !supportsOperation(detail, operation) {
-		return models.GetModelResult{}, fmt.Errorf(
+	if operation != "" && !supportsOperation(detail, operation) {
+		return models.Detail{}, fmt.Errorf(
 			"%w: model %q does not support operation %q",
 			models.ErrUnsupportedOperation,
 			detail.Name,
 			operation,
 		)
 	}
-	return models.GetModelResult{Model: detail}, nil
+	return detail, nil
 }
 
 func (s *service) resolveRuntimeConfig(
@@ -114,11 +167,19 @@ func catalogScopeError(err error) error {
 	switch {
 	case errors.Is(err, runtimescopes.ErrScopeForeign):
 		return fmt.Errorf("%w: %v", models.ErrRuntimeScopeForeign, err)
+	case errors.Is(err, runtimescopes.ErrScopeClosed):
+		return fmt.Errorf("%w: %v", models.ErrRuntimeScopeClosed, err)
 	case errors.Is(err, runtimescopes.ErrScopeUnknown):
 		return fmt.Errorf("%w: %v", models.ErrRuntimeScopeStale, err)
 	default:
 		return models.ErrUnavailable
 	}
+}
+
+func stableRuntime(runtime models.Runtime) models.Runtime {
+	runtime = runtime.Clone()
+	sortOperations(runtime.SupportedOperations)
+	return runtime
 }
 
 func stableSummary(summary models.Summary) models.Summary {

--- a/pkg/services/models/internal/services/catalog/internal/service/service.go
+++ b/pkg/services/models/internal/services/catalog/internal/service/service.go
@@ -101,7 +101,7 @@ func (s *service) GetModelReadiness(
 	}
 	return models.GetModelReadinessResult{
 		ModelName: detail.Name,
-		Readiness: stableRuntime(readiness),
+		Readiness: stableReadiness(detail, readiness),
 	}, nil
 }
 
@@ -180,6 +180,31 @@ func stableRuntime(runtime models.Runtime) models.Runtime {
 	runtime = runtime.Clone()
 	sortOperations(runtime.SupportedOperations)
 	return runtime
+}
+
+func stableReadiness(detail models.Detail, current models.Runtime) models.Runtime {
+	current = current.Clone()
+	current.Identity = detail.Name
+	if current.Locality == "" {
+		current.Locality = detail.ProviderLocality
+	}
+	current.SupportedOperations = detail.ManagedRuntime.Clone().SupportedOperations
+	current.Diagnostics = mergeDiagnostics(
+		detail.ManagedRuntime.Diagnostics,
+		current.Diagnostics,
+	)
+	return stableRuntime(current)
+}
+
+func mergeDiagnostics(base, current map[string]string) map[string]string {
+	merged := make(map[string]string, len(base)+len(current))
+	for key, value := range base {
+		merged[key] = value
+	}
+	for key, value := range current {
+		merged[key] = value
+	}
+	return merged
 }
 
 func stableSummary(summary models.Summary) models.Summary {

--- a/pkg/services/models/internal/services/catalog/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/catalog/internal/service/service_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
@@ -78,12 +79,174 @@ func TestListCatalogRejectsUnavailableScopedConfiguration(t *testing.T) {
 	}
 }
 
+func TestGetCatalogModelReturnsStableDetachedDetail(t *testing.T) {
+	t.Parallel()
+
+	scopes, err := runtimescopeswire.NewService(func() string { return "catalog-get-test" })
+	if err != nil {
+		t.Fatalf("construct Runtime Scopes: %v", err)
+	}
+	privateRef, err := scopes.Open(models.RuntimeBinding{
+		RuntimeConfig: func() *models.RuntimeConfig {
+			return &models.RuntimeConfig{
+				Workers: []models.RuntimeWorker{
+					catalogWorker("zeta-worker", " scoped-model ", "summarize"),
+					catalogWorker("alpha-worker", "SCOPED-MODEL", "generate"),
+				},
+				Resources: []models.RuntimeResource{{
+					Name: "model-cache", Type: models.RuntimeResourceTypeModel,
+					Model: "SCOPED-MODEL", Backend: "GGUF", Provider: "MODELSCOPE",
+				}},
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("open scope: %v", err)
+	}
+	service, err := catalogwire.NewService(scopes)
+	if err != nil {
+		t.Fatalf("construct Catalog: %v", err)
+	}
+	request := models.GetModelRequest{
+		Scope: publicScope(t, privateRef), Name: "  scoped-model  ", Operation: "generate",
+	}
+
+	first, err := service.GetCatalogModel(context.Background(), request)
+	if err != nil {
+		t.Fatalf("GetCatalogModel: %v", err)
+	}
+	assertCatalogDetail(t, first.Model)
+	second, err := service.GetCatalogModel(context.Background(), request)
+	if err != nil {
+		t.Fatalf("GetCatalogModel repeated: %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("repeated result differs:\nfirst:  %#v\nsecond: %#v", first, second)
+	}
+
+	first.Model.Name = "mutated"
+	first.Model.Operations[0].Name = "mutated"
+	first.Model.Operations[0].Inputs[0].ContentTypes[0] = "mutated"
+	first.Model.Capabilities[0].Worker = "mutated"
+	*first.Model.Capabilities[0].ModelProvider = "mutated"
+	first.Model.Capabilities[0].ResourceNames[0] = "mutated"
+	first.Model.Sources[0].Reference = "mutated"
+	first.Model.Diagnostics["workers"] = "mutated"
+	first.Model.ManagedRuntime.Diagnostics["sourceId"] = "mutated"
+
+	afterMutation, err := service.GetCatalogModel(context.Background(), request)
+	if err != nil {
+		t.Fatalf("GetCatalogModel after mutation: %v", err)
+	}
+	assertCatalogDetail(t, afterMutation.Model)
+}
+
+func TestGetCatalogModelClassifiesLookupAndOperationFailures(t *testing.T) {
+	t.Parallel()
+
+	scopes, err := runtimescopeswire.NewService(func() string { return "catalog-get-errors-test" })
+	if err != nil {
+		t.Fatalf("construct Runtime Scopes: %v", err)
+	}
+	privateRef, err := scopes.Open(models.RuntimeBinding{
+		RuntimeConfig: func() *models.RuntimeConfig {
+			return &models.RuntimeConfig{
+				Workers: []models.RuntimeWorker{catalogWorker("worker", "known-model", "generate")},
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("open scope: %v", err)
+	}
+	service, err := catalogwire.NewService(scopes)
+	if err != nil {
+		t.Fatalf("construct Catalog: %v", err)
+	}
+	scope := publicScope(t, privateRef)
+
+	for _, test := range []struct {
+		name    string
+		request models.GetModelRequest
+		want    error
+	}{
+		{name: "empty identity", request: models.GetModelRequest{Scope: scope}, want: models.ErrNotFound},
+		{name: "unknown identity", request: models.GetModelRequest{Scope: scope, Name: "missing"}, want: models.ErrNotFound},
+		{
+			name: "unsupported operation",
+			request: models.GetModelRequest{
+				Scope: scope, Name: "known-model", Operation: "embed",
+			},
+			want: models.ErrUnsupportedOperation,
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := service.GetCatalogModel(context.Background(), test.request); !errors.Is(err, test.want) {
+				t.Fatalf("GetCatalogModel error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
 func TestConstructionRejectsMissingRuntimeScopes(t *testing.T) {
 	t.Parallel()
 
 	service, err := catalogwire.NewService(nil)
 	if err == nil || service != nil {
 		t.Fatalf("NewService(nil) = (%#v, %v), want nil service and error", service, err)
+	}
+}
+
+func catalogWorker(name, model, operation string) models.RuntimeWorker {
+	return models.RuntimeWorker{
+		Name: name, Type: models.RuntimeWorkerTypeInference,
+		Model: model, ModelLocality: models.RuntimeModelLocalityLocal,
+		ModelProvider: "configured-provider",
+		Operations: []models.RuntimeOperation{{
+			Name: operation,
+			Inputs: []models.RuntimeOperationSlot{{
+				Name: "input", ContentTypes: []string{
+					models.RuntimeContentTypeText,
+					models.RuntimeContentTypeAudio,
+				},
+			}},
+		}},
+		Resources: []models.RuntimeResource{{Name: "model-cache"}},
+	}
+}
+
+func assertCatalogDetail(t *testing.T, detail models.Detail) {
+	t.Helper()
+	if detail.Name != "scoped-model" {
+		t.Fatalf("model name = %q, want scoped-model", detail.Name)
+	}
+	if got := []string{detail.Operations[0].Name, detail.Operations[1].Name}; !reflect.DeepEqual(
+		got,
+		[]string{"generate", "summarize"},
+	) {
+		t.Fatalf("operations = %#v, want stable generate/summarize order", detail.Operations)
+	}
+	if got := detail.Operations[0].Inputs[0].ContentTypes; !reflect.DeepEqual(
+		got,
+		[]string{models.RuntimeContentTypeAudio, models.RuntimeContentTypeText},
+	) {
+		t.Fatalf("content types = %#v, want stable AUDIO/TEXT order", got)
+	}
+	if len(detail.Capabilities) != 2 ||
+		detail.Capabilities[0].Worker != "alpha-worker" ||
+		detail.Capabilities[0].ModelProvider == nil ||
+		*detail.Capabilities[0].ModelProvider != "configured-provider" {
+		t.Fatalf("capabilities = %#v, want stable configured bindings", detail.Capabilities)
+	}
+	if len(detail.Sources) != 1 ||
+		detail.Sources[0].Provider != "MANAGED_MIRROR" ||
+		detail.Sources[0].Reference != "managed-mirror:SCOPED-MODEL" {
+		t.Fatalf("sources = %#v, want configured managed source", detail.Sources)
+	}
+	if detail.Diagnostics["workers"] != "alpha-worker,zeta-worker" ||
+		detail.ManagedRuntime.Diagnostics["sourceId"] != "managed-mirror:SCOPED-MODEL" {
+		t.Fatalf("diagnostics = %#v / %#v, want detached discovery facts", detail.Diagnostics, detail.ManagedRuntime.Diagnostics)
 	}
 }
 

--- a/pkg/services/models/internal/services/catalog/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/catalog/internal/service/service_test.go
@@ -1,0 +1,97 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	catalogwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
+)
+
+func TestListCatalogClassifiesScopeBeforeProjection(t *testing.T) {
+	t.Parallel()
+
+	scopes, err := runtimescopeswire.NewService(func() string { return "catalog-service-test" })
+	if err != nil {
+		t.Fatalf("construct Runtime Scopes: %v", err)
+	}
+	service, err := catalogwire.NewService(scopes)
+	if err != nil {
+		t.Fatalf("construct Catalog: %v", err)
+	}
+
+	if _, err := service.ListCatalog(
+		context.Background(),
+		models.ListModelsRequest{},
+	); !errors.Is(err, models.ErrRuntimeScopeInvalid) {
+		t.Fatalf("ListCatalog empty scope error = %v, want ErrRuntimeScopeInvalid", err)
+	}
+
+	stale, err := (models.RuntimeScopeRef{}).Parse("stale")
+	if err != nil {
+		t.Fatalf("parse stale scope: %v", err)
+	}
+	if _, err := service.ListCatalog(
+		context.Background(),
+		models.ListModelsRequest{Scope: stale},
+	); !errors.Is(err, models.ErrRuntimeScopeStale) {
+		t.Fatalf("ListCatalog stale scope error = %v, want ErrRuntimeScopeStale", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := service.ListCatalog(
+		ctx,
+		models.ListModelsRequest{Scope: stale},
+	); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ListCatalog canceled error = %v, want context.Canceled", err)
+	}
+}
+
+func TestListCatalogRejectsUnavailableScopedConfiguration(t *testing.T) {
+	t.Parallel()
+
+	scopes, err := runtimescopeswire.NewService(func() string { return "catalog-unavailable-test" })
+	if err != nil {
+		t.Fatalf("construct Runtime Scopes: %v", err)
+	}
+	privateRef, err := scopes.Open(models.RuntimeBinding{
+		RuntimeConfig: func() *models.RuntimeConfig { return nil },
+	})
+	if err != nil {
+		t.Fatalf("open unavailable scope: %v", err)
+	}
+	scope := publicScope(t, privateRef)
+	service, err := catalogwire.NewService(scopes)
+	if err != nil {
+		t.Fatalf("construct Catalog: %v", err)
+	}
+
+	if _, err := service.ListCatalog(
+		context.Background(),
+		models.ListModelsRequest{Scope: scope},
+	); !errors.Is(err, models.ErrUnavailable) {
+		t.Fatalf("ListCatalog unavailable error = %v, want ErrUnavailable", err)
+	}
+}
+
+func TestConstructionRejectsMissingRuntimeScopes(t *testing.T) {
+	t.Parallel()
+
+	service, err := catalogwire.NewService(nil)
+	if err == nil || service != nil {
+		t.Fatalf("NewService(nil) = (%#v, %v), want nil service and error", service, err)
+	}
+}
+
+func publicScope(t *testing.T, ref runtimescopes.Reference) models.RuntimeScopeRef {
+	t.Helper()
+	scope, err := (models.RuntimeScopeRef{}).Parse(string(ref))
+	if err != nil {
+		t.Fatalf("parse public scope: %v", err)
+	}
+	return scope
+}

--- a/pkg/services/models/internal/services/catalog/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/catalog/internal/service/service_test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
+	catalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
 	catalogwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire"
 	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
 	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
@@ -196,6 +198,265 @@ func TestConstructionRejectsMissingRuntimeScopes(t *testing.T) {
 	if err == nil || service != nil {
 		t.Fatalf("NewService(nil) = (%#v, %v), want nil service and error", service, err)
 	}
+}
+
+func TestCatalogOperationsPreserveEveryScopeClassification(t *testing.T) {
+	t.Parallel()
+
+	scopes := newRuntimeScopes(t, "catalog-scope-classifications")
+	foreignScopes := newRuntimeScopes(t, "catalog-scope-foreign")
+	service := newCatalogService(t, scopes)
+	closedRef := openCatalogScope(t, scopes, "closed-model", "generate")
+	if err := scopes.Close(closedRef); err != nil {
+		t.Fatalf("close scope: %v", err)
+	}
+	foreignRef := openCatalogScope(t, foreignScopes, "foreign-model", "generate")
+	stale, err := (models.RuntimeScopeRef{}).Parse("stale-scope")
+	if err != nil {
+		t.Fatalf("parse stale scope: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		scope models.RuntimeScopeRef
+		want  error
+	}{
+		{name: "missing", want: models.ErrRuntimeScopeInvalid},
+		{name: "closed", scope: publicScope(t, closedRef), want: models.ErrRuntimeScopeClosed},
+		{name: "stale", scope: stale, want: models.ErrRuntimeScopeStale},
+		{name: "foreign", scope: publicScope(t, foreignRef), want: models.ErrRuntimeScopeForeign},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := service.ListCatalog(
+				context.Background(),
+				models.ListModelsRequest{Scope: test.scope},
+			); !errors.Is(err, test.want) {
+				t.Errorf("ListCatalog error = %v, want %v", err, test.want)
+			}
+			if _, err := service.GetCatalogModel(
+				context.Background(),
+				models.GetModelRequest{Scope: test.scope},
+			); !errors.Is(err, test.want) {
+				t.Errorf("GetCatalogModel error = %v, want %v", err, test.want)
+			}
+			if _, err := service.GetModelReadiness(
+				context.Background(),
+				models.GetModelReadinessRequest{Scope: test.scope},
+			); !errors.Is(err, test.want) {
+				t.Errorf("GetModelReadiness error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestCatalogOperationsKeepOpenScopesIsolatedAfterOneCloses(t *testing.T) {
+	t.Parallel()
+
+	scopes := newRuntimeScopes(t, "catalog-scope-isolation")
+	service := newCatalogService(t, scopes)
+	firstRef := openCatalogScope(t, scopes, "shared-model", "generate")
+	secondRef := openCatalogScope(t, scopes, "shared-model", "embed")
+	firstScope := publicScope(t, firstRef)
+	secondScope := publicScope(t, secondRef)
+
+	first, err := service.GetModelReadiness(context.Background(), models.GetModelReadinessRequest{
+		Scope: firstScope, Name: "shared-model", Operation: "generate",
+	})
+	if err != nil {
+		t.Fatalf("first readiness: %v", err)
+	}
+	second, err := service.GetModelReadiness(context.Background(), models.GetModelReadinessRequest{
+		Scope: secondScope, Name: "shared-model", Operation: "embed",
+	})
+	if err != nil {
+		t.Fatalf("second readiness: %v", err)
+	}
+	if first.Readiness.SupportedOperations[0].Name != "generate" ||
+		second.Readiness.SupportedOperations[0].Name != "embed" {
+		t.Fatalf("readiness crossed scopes: first=%#v second=%#v", first, second)
+	}
+
+	if err := scopes.Close(firstRef); err != nil {
+		t.Fatalf("close first scope: %v", err)
+	}
+	if _, err := service.ListCatalog(
+		context.Background(),
+		models.ListModelsRequest{Scope: firstScope},
+	); !errors.Is(err, models.ErrRuntimeScopeClosed) {
+		t.Fatalf("closed first scope error = %v, want ErrRuntimeScopeClosed", err)
+	}
+	remaining, err := service.GetCatalogModel(context.Background(), models.GetModelRequest{
+		Scope: secondScope, Name: "shared-model", Operation: "embed",
+	})
+	if err != nil {
+		t.Fatalf("remaining scope get: %v", err)
+	}
+	if remaining.Model.Operations[0].Name != "embed" {
+		t.Fatalf("remaining scope detail = %#v, want isolated embed operation", remaining)
+	}
+}
+
+func TestCatalogOperationsReturnUnavailableForLiveScopeWithoutCatalog(t *testing.T) {
+	t.Parallel()
+
+	scopes := newRuntimeScopes(t, "catalog-unavailable-all-operations")
+	privateRef, err := scopes.Open(models.RuntimeBinding{
+		RuntimeConfig: func() *models.RuntimeConfig { return nil },
+	})
+	if err != nil {
+		t.Fatalf("open unavailable scope: %v", err)
+	}
+	scope := publicScope(t, privateRef)
+	service := newCatalogService(t, scopes)
+
+	if _, err := service.ListCatalog(
+		context.Background(),
+		models.ListModelsRequest{Scope: scope},
+	); !errors.Is(err, models.ErrUnavailable) || err.Error() != models.ErrUnavailable.Error() {
+		t.Errorf("ListCatalog error = %v, want sanitized ErrUnavailable", err)
+	}
+	if _, err := service.GetCatalogModel(
+		context.Background(),
+		models.GetModelRequest{Scope: scope},
+	); !errors.Is(err, models.ErrUnavailable) || err.Error() != models.ErrUnavailable.Error() {
+		t.Errorf("GetCatalogModel error = %v, want sanitized ErrUnavailable", err)
+	}
+	if _, err := service.GetModelReadiness(
+		context.Background(),
+		models.GetModelReadinessRequest{Scope: scope},
+	); !errors.Is(err, models.ErrUnavailable) || err.Error() != models.ErrUnavailable.Error() {
+		t.Errorf("GetModelReadiness error = %v, want sanitized ErrUnavailable", err)
+	}
+}
+
+func TestCatalogOperationsHonorCancellationBeforeAndDuringReadinessQuery(t *testing.T) {
+	t.Parallel()
+
+	scopes := newRuntimeScopes(t, "catalog-cancellation")
+	queryStarted := make(chan struct{})
+	service, err := catalogwire.NewService(
+		scopes,
+		func(ctx context.Context, _ models.RuntimeConfig, _ models.Detail) (models.Runtime, error) {
+			close(queryStarted)
+			<-ctx.Done()
+			return models.Runtime{}, ctx.Err()
+		},
+	)
+	if err != nil {
+		t.Fatalf("construct Catalog: %v", err)
+	}
+	privateRef := openCatalogScope(t, scopes, "cancel-model", "generate")
+	scope := publicScope(t, privateRef)
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := service.ListCatalog(
+		cancelled,
+		models.ListModelsRequest{Scope: scope},
+	); !errors.Is(err, context.Canceled) {
+		t.Errorf("ListCatalog pre-canceled error = %v, want context.Canceled", err)
+	}
+	if _, err := service.GetCatalogModel(
+		cancelled,
+		models.GetModelRequest{Scope: scope},
+	); !errors.Is(err, context.Canceled) {
+		t.Errorf("GetCatalogModel pre-canceled error = %v, want context.Canceled", err)
+	}
+	if _, err := service.GetModelReadiness(
+		cancelled,
+		models.GetModelReadinessRequest{Scope: scope},
+	); !errors.Is(err, context.Canceled) {
+		t.Errorf("GetModelReadiness pre-canceled error = %v, want context.Canceled", err)
+	}
+
+	ctx, cancelDuring := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, queryErr := service.GetModelReadiness(ctx, models.GetModelReadinessRequest{
+			Scope: scope, Name: "cancel-model", Operation: "generate",
+		})
+		result <- queryErr
+	}()
+	select {
+	case <-queryStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("readiness query did not start")
+	}
+	cancelDuring()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled readiness error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("canceled readiness query did not stop")
+	}
+	if _, err := scopes.Resolve(privateRef); err != nil {
+		t.Fatalf("canceled query changed scope state: %v", err)
+	}
+}
+
+func TestReadinessDependencyFailuresAreSanitizedAsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	scopes := newRuntimeScopes(t, "catalog-readiness-failure")
+	service, err := catalogwire.NewService(
+		scopes,
+		func(context.Context, models.RuntimeConfig, models.Detail) (models.Runtime, error) {
+			return models.Runtime{}, errors.New(`inspect C:\private\model-cache: access denied`)
+		},
+	)
+	if err != nil {
+		t.Fatalf("construct Catalog: %v", err)
+	}
+	scope := publicScope(t, openCatalogScope(t, scopes, "failed-model", "generate"))
+	if _, err := service.GetModelReadiness(
+		context.Background(),
+		models.GetModelReadinessRequest{Scope: scope, Name: "failed-model"},
+	); !errors.Is(err, models.ErrUnavailable) || err.Error() != models.ErrUnavailable.Error() {
+		t.Fatalf("GetModelReadiness error = %v, want sanitized ErrUnavailable", err)
+	}
+}
+
+func newRuntimeScopes(t *testing.T, issuer string) runtimescopes.Service {
+	t.Helper()
+	scopes, err := runtimescopeswire.NewService(func() string { return issuer })
+	if err != nil {
+		t.Fatalf("construct Runtime Scopes: %v", err)
+	}
+	return scopes
+}
+
+func newCatalogService(t *testing.T, scopes runtimescopes.Service) catalog.Service {
+	t.Helper()
+	service, err := catalogwire.NewService(scopes)
+	if err != nil {
+		t.Fatalf("construct Catalog: %v", err)
+	}
+	return service
+}
+
+func openCatalogScope(
+	t *testing.T,
+	scopes runtimescopes.Service,
+	model string,
+	operation string,
+) runtimescopes.Reference {
+	t.Helper()
+	privateRef, err := scopes.Open(models.RuntimeBinding{
+		RuntimeConfig: func() *models.RuntimeConfig {
+			return &models.RuntimeConfig{
+				Workers: []models.RuntimeWorker{catalogWorker("worker", model, operation)},
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("open catalog scope: %v", err)
+	}
+	return privateRef
 }
 
 func catalogWorker(name, model, operation string) models.RuntimeWorker {

--- a/pkg/services/models/internal/services/catalog/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/catalog/internal/service/service_test.go
@@ -339,7 +339,7 @@ func TestCatalogOperationsHonorCancellationBeforeAndDuringReadinessQuery(t *test
 	queryStarted := make(chan struct{})
 	service, err := catalogwire.NewService(
 		scopes,
-		func(ctx context.Context, _ models.RuntimeConfig, _ models.Detail) (models.Runtime, error) {
+		func(ctx context.Context, _ models.RuntimeScopeConfig, _ models.Detail) (models.Runtime, error) {
 			close(queryStarted)
 			<-ctx.Done()
 			return models.Runtime{}, ctx.Err()
@@ -405,7 +405,7 @@ func TestReadinessDependencyFailuresAreSanitizedAsUnavailable(t *testing.T) {
 	scopes := newRuntimeScopes(t, "catalog-readiness-failure")
 	service, err := catalogwire.NewService(
 		scopes,
-		func(context.Context, models.RuntimeConfig, models.Detail) (models.Runtime, error) {
+		func(context.Context, models.RuntimeScopeConfig, models.Detail) (models.Runtime, error) {
 			return models.Runtime{}, errors.New(`inspect C:\private\model-cache: access denied`)
 		},
 	)

--- a/pkg/services/models/internal/services/catalog/service.go
+++ b/pkg/services/models/internal/services/catalog/service.go
@@ -12,4 +12,10 @@ import (
 type Service interface {
 	ListCatalog(context.Context, models.ListModelsRequest) (models.ListModelsResult, error)
 	GetCatalogModel(context.Context, models.GetModelRequest) (models.GetModelResult, error)
+	GetModelReadiness(context.Context, models.GetModelReadinessRequest) (models.GetModelReadinessResult, error)
 }
+
+// ReadinessQuery reads current Models-owned readiness facts for one validated
+// catalog model. Inputs and outputs are detached values; implementations must
+// honor context cancellation and must not expose runtime or cache handles.
+type ReadinessQuery func(context.Context, models.RuntimeConfig, models.Detail) (models.Runtime, error)

--- a/pkg/services/models/internal/services/catalog/service.go
+++ b/pkg/services/models/internal/services/catalog/service.go
@@ -11,4 +11,5 @@ import (
 // runtime configuration held by the Models Runtime Scopes authority.
 type Service interface {
 	ListCatalog(context.Context, models.ListModelsRequest) (models.ListModelsResult, error)
+	GetCatalogModel(context.Context, models.GetModelRequest) (models.GetModelResult, error)
 }

--- a/pkg/services/models/internal/services/catalog/service.go
+++ b/pkg/services/models/internal/services/catalog/service.go
@@ -1,0 +1,14 @@
+// Package catalog defines the parent-private Models catalog service.
+package catalog
+
+import (
+	"context"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+// Service serves detached, deterministically ordered discovery values for
+// runtime configuration held by the Models Runtime Scopes authority.
+type Service interface {
+	ListCatalog(context.Context, models.ListModelsRequest) (models.ListModelsResult, error)
+}

--- a/pkg/services/models/internal/services/catalog/service.go
+++ b/pkg/services/models/internal/services/catalog/service.go
@@ -18,4 +18,4 @@ type Service interface {
 // ReadinessQuery reads current Models-owned readiness facts for one validated
 // catalog model. Inputs and outputs are detached values; implementations must
 // honor context cancellation and must not expose runtime or cache handles.
-type ReadinessQuery func(context.Context, models.RuntimeConfig, models.Detail) (models.Runtime, error)
+type ReadinessQuery func(context.Context, models.RuntimeScopeConfig, models.Detail) (models.Runtime, error)

--- a/pkg/services/models/internal/services/catalog/wire/wire.go
+++ b/pkg/services/models/internal/services/catalog/wire/wire.go
@@ -2,8 +2,10 @@
 package wire
 
 import (
+	"context"
 	"fmt"
 
+	models "github.com/portpowered/infinite-you/pkg/services/models"
 	catalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/internal/service"
 	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
@@ -11,9 +13,30 @@ import (
 
 // NewService constructs an inert catalog over the supplied Runtime Scopes
 // authority.
-func NewService(scopes runtimescopes.Service) (catalog.Service, error) {
+func NewService(
+	scopes runtimescopes.Service,
+	readinessQueries ...catalog.ReadinessQuery,
+) (catalog.Service, error) {
 	if scopes == nil {
 		return nil, fmt.Errorf("Models Catalog runtime scopes service is required")
 	}
-	return internalservice.New(scopes), nil
+	readiness := catalog.ReadinessQuery(catalogReadiness)
+	if len(readinessQueries) > 0 {
+		readiness = readinessQueries[0]
+	}
+	if readiness == nil {
+		return nil, fmt.Errorf("Models Catalog readiness query is required")
+	}
+	return internalservice.New(scopes, readiness), nil
+}
+
+func catalogReadiness(
+	ctx context.Context,
+	_ models.RuntimeConfig,
+	detail models.Detail,
+) (models.Runtime, error) {
+	if err := ctx.Err(); err != nil {
+		return models.Runtime{}, err
+	}
+	return detail.ManagedRuntime.Clone(), nil
 }

--- a/pkg/services/models/internal/services/catalog/wire/wire.go
+++ b/pkg/services/models/internal/services/catalog/wire/wire.go
@@ -32,7 +32,7 @@ func NewService(
 
 func catalogReadiness(
 	ctx context.Context,
-	_ models.RuntimeConfig,
+	_ models.RuntimeScopeConfig,
 	detail models.Detail,
 ) (models.Runtime, error) {
 	if err := ctx.Err(); err != nil {

--- a/pkg/services/models/internal/services/catalog/wire/wire.go
+++ b/pkg/services/models/internal/services/catalog/wire/wire.go
@@ -1,0 +1,19 @@
+// Package wire constructs the private Models Catalog subservice.
+package wire
+
+import (
+	"fmt"
+
+	catalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/internal/service"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+)
+
+// NewService constructs an inert catalog over the supplied Runtime Scopes
+// authority.
+func NewService(scopes runtimescopes.Service) (catalog.Service, error) {
+	if scopes == nil {
+		return nil, fmt.Errorf("Models Catalog runtime scopes service is required")
+	}
+	return internalservice.New(scopes), nil
+}

--- a/pkg/services/models/internal/services/catalog/wire/wire_test.go
+++ b/pkg/services/models/internal/services/catalog/wire/wire_test.go
@@ -1,0 +1,39 @@
+package wire
+
+import (
+	"context"
+	"testing"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+)
+
+func TestNewServiceIsInert(t *testing.T) {
+	t.Parallel()
+
+	scopes := panicScopes{}
+	readiness := func(context.Context, models.RuntimeConfig, models.Detail) (models.Runtime, error) {
+		panic("readiness query called during catalog construction")
+	}
+	service, err := NewService(scopes, readiness)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService returned nil service")
+	}
+}
+
+type panicScopes struct{}
+
+func (panicScopes) Open(models.RuntimeBinding) (runtimescopes.Reference, error) {
+	panic("scope opened during catalog construction")
+}
+
+func (panicScopes) Resolve(runtimescopes.Reference) (models.RuntimeBinding, error) {
+	panic("scope resolved during catalog construction")
+}
+
+func (panicScopes) Close(runtimescopes.Reference) error {
+	panic("scope closed during catalog construction")
+}

--- a/pkg/services/models/internal/services/catalog/wire/wire_test.go
+++ b/pkg/services/models/internal/services/catalog/wire/wire_test.go
@@ -12,7 +12,7 @@ func TestNewServiceIsInert(t *testing.T) {
 	t.Parallel()
 
 	scopes := panicScopes{}
-	readiness := func(context.Context, models.RuntimeConfig, models.Detail) (models.Runtime, error) {
+	readiness := func(context.Context, models.RuntimeScopeConfig, models.Detail) (models.Runtime, error) {
 		panic("readiness query called during catalog construction")
 	}
 	service, err := NewService(scopes, readiness)

--- a/pkg/services/models/internal/services/runtime_scopes/internal/service/concurrency_test.go
+++ b/pkg/services/models/internal/services/runtime_scopes/internal/service/concurrency_test.go
@@ -119,8 +119,8 @@ func TestConcurrentResolveAndCloseReturnOnlyLiveOrStaleOutcomes(t *testing.T) {
 						errCh <- fmt.Errorf("closing scope resolved %q, want closing", got)
 						return
 					}
-				case errors.Is(err, runtimescopes.ErrScopeUnknown):
-				// Close linearized first, so the stale outcome is contract-valid.
+				case errors.Is(err, runtimescopes.ErrScopeClosed):
+					// Close linearized first, so the closed outcome is contract-valid.
 				default:
 					errCh <- fmt.Errorf("resolve closing scope: %w", err)
 					return
@@ -156,8 +156,8 @@ func TestConcurrentResolveAndCloseReturnOnlyLiveOrStaleOutcomes(t *testing.T) {
 		t.Error(err)
 	}
 
-	if _, err := service.Resolve(closingRef); !errors.Is(err, runtimescopes.ErrScopeUnknown) {
-		t.Fatalf("Resolve closed scope error = %v, want ErrScopeUnknown", err)
+	if _, err := service.Resolve(closingRef); !errors.Is(err, runtimescopes.ErrScopeClosed) {
+		t.Fatalf("Resolve closed scope error = %v, want ErrScopeClosed", err)
 	}
 	assertFactoryDirectory(t, service, liveRef, "live")
 }

--- a/pkg/services/models/internal/services/runtime_scopes/internal/service/service.go
+++ b/pkg/services/models/internal/services/runtime_scopes/internal/service/service.go
@@ -16,6 +16,7 @@ type service struct {
 	issuerToken  string
 	nextScopeID  uint64
 	liveBindings map[runtimescopes.Reference]models.RuntimeBinding
+	closedScopes map[runtimescopes.Reference]struct{}
 }
 
 var _ runtimescopes.Service = (*service)(nil)
@@ -25,6 +26,7 @@ func New(issuerID string) runtimescopes.Service {
 	return &service{
 		issuerToken:  opaqueToken("issuer", issuerID),
 		liveBindings: make(map[runtimescopes.Reference]models.RuntimeBinding),
+		closedScopes: make(map[runtimescopes.Reference]struct{}),
 	}
 }
 
@@ -57,7 +59,11 @@ func (s *service) Resolve(ref runtimescopes.Reference) (models.RuntimeBinding, e
 
 	s.mu.RLock()
 	binding, ok := s.liveBindings[ref]
+	_, closed := s.closedScopes[ref]
 	s.mu.RUnlock()
+	if closed {
+		return models.RuntimeBinding{}, fmt.Errorf("%w: reference identifies a closed scope", runtimescopes.ErrScopeClosed)
+	}
 	if !ok {
 		return models.RuntimeBinding{}, fmt.Errorf("%w: reference does not identify a live scope", runtimescopes.ErrScopeUnknown)
 	}
@@ -74,10 +80,14 @@ func (s *service) Close(ref runtimescopes.Reference) error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if _, closed := s.closedScopes[ref]; closed {
+		return fmt.Errorf("%w: reference identifies a closed scope", runtimescopes.ErrScopeClosed)
+	}
 	if _, ok := s.liveBindings[ref]; !ok {
 		return fmt.Errorf("%w: reference does not identify a live scope", runtimescopes.ErrScopeUnknown)
 	}
 	delete(s.liveBindings, ref)
+	s.closedScopes[ref] = struct{}{}
 	return nil
 }
 

--- a/pkg/services/models/internal/services/runtime_scopes/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/runtime_scopes/internal/service/service_test.go
@@ -125,11 +125,11 @@ func TestCloseInvalidatesOnlyTheSelectedScope(t *testing.T) {
 	if err := service.Close(firstRef); err != nil {
 		t.Fatalf("Close first scope: %v", err)
 	}
-	if _, err := service.Resolve(firstRef); !errors.Is(err, runtimescopes.ErrScopeUnknown) {
-		t.Fatalf("Resolve closed scope error = %v, want ErrScopeUnknown", err)
+	if _, err := service.Resolve(firstRef); !errors.Is(err, runtimescopes.ErrScopeClosed) {
+		t.Fatalf("Resolve closed scope error = %v, want ErrScopeClosed", err)
 	}
-	if err := service.Close(firstRef); !errors.Is(err, runtimescopes.ErrScopeUnknown) {
-		t.Fatalf("Close closed scope error = %v, want ErrScopeUnknown", err)
+	if err := service.Close(firstRef); !errors.Is(err, runtimescopes.ErrScopeClosed) {
+		t.Fatalf("Close closed scope error = %v, want ErrScopeClosed", err)
 	}
 
 	resolved, err := service.Resolve(secondRef)

--- a/pkg/services/models/internal/services/runtime_scopes/service.go
+++ b/pkg/services/models/internal/services/runtime_scopes/service.go
@@ -16,6 +16,10 @@ var ErrScopeUnknown = errors.New("models runtime scope is unknown")
 // service instance.
 var ErrScopeForeign = errors.New("models runtime scope is foreign")
 
+// ErrScopeClosed reports a reference that this Runtime Scopes service issued
+// and explicitly closed.
+var ErrScopeClosed = errors.New("models runtime scope is closed")
+
 // Reference is an opaque identifier issued by a Runtime Scopes service.
 type Reference string
 

--- a/pkg/services/models/managed_runtime_contract.go
+++ b/pkg/services/models/managed_runtime_contract.go
@@ -82,6 +82,9 @@ type OperationSlot struct {
 }
 
 func cloneOperations(operations []Operation) []Operation {
+	if operations == nil {
+		return nil
+	}
 	cloned := make([]Operation, len(operations))
 	for i, operation := range operations {
 		cloned[i] = operation
@@ -92,6 +95,9 @@ func cloneOperations(operations []Operation) []Operation {
 }
 
 func cloneOperationSlots(slots []OperationSlot) []OperationSlot {
+	if slots == nil {
+		return nil
+	}
 	cloned := make([]OperationSlot, len(slots))
 	for i, slot := range slots {
 		cloned[i] = slot

--- a/pkg/services/models/wire/wire.go
+++ b/pkg/services/models/wire/wire.go
@@ -4,10 +4,12 @@ package wire
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"time"
 
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	platformrandom "github.com/portpowered/infinite-you/pkg/platform/random"
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 	"github.com/portpowered/infinite-you/pkg/services/models/internal/artifacts"
 	modelassets "github.com/portpowered/infinite-you/pkg/services/models/internal/assets"
@@ -45,6 +47,7 @@ func NewService(
 	runtimeTempFile models.RuntimeCreateTempFile,
 	logger *zap.Logger,
 	now func() time.Time,
+	issuerEntropy platformrandom.Source,
 	pullMetrics models.PullMetricsRecorder,
 	hostLogger models.HostDiagnosticLogger,
 	hostMetrics models.HostMetricsRecorder,
@@ -69,9 +72,11 @@ func NewService(
 	if runtimeTempFile != nil {
 		createTempFile = runtimeTempFileAdapter{next: runtimeTempFile}.create
 	}
-	runtimeScopes, err := runtimescopeswire.NewService(func() string {
-		return runtimeScopeIssuerID(now, assetHTTP, hostHTTP)
-	})
+	issuerID, err := runtimeScopeIssuerID(issuerEntropy)
+	if err != nil {
+		return nil, fmt.Errorf("construct Models Runtime Scopes issuer identity: %w", err)
+	}
+	runtimeScopes, err := runtimescopeswire.NewService(func() string { return issuerID })
 	if err != nil {
 		return nil, err
 	}
@@ -148,11 +153,19 @@ func newCatalogReadinessQuery(edges catalogReadinessEdges) catalog.ReadinessQuer
 	}
 }
 
-func runtimeScopeIssuerID(now func() time.Time, assetHTTP models.AssetHTTPDoer, hostHTTP models.HostHTTPDoer) string {
-	if now == nil {
-		return ""
+func runtimeScopeIssuerID(entropy platformrandom.Source) (string, error) {
+	if entropy == nil {
+		return "", fmt.Errorf("issuer entropy is required")
 	}
-	return fmt.Sprintf("%d:%p:%p", now().UTC().UnixNano(), assetHTTP, hostHTTP)
+	var identity [16]byte
+	for index := range identity {
+		value, err := entropy.Int63n(256)
+		if err != nil {
+			return "", err
+		}
+		identity[index] = byte(value)
+	}
+	return hex.EncodeToString(identity[:]), nil
 }
 
 // NewInvocationArtifactExporter constructs the Models-owned invocation artifact exporter.

--- a/pkg/services/models/wire/wire.go
+++ b/pkg/services/models/wire/wire.go
@@ -14,6 +14,7 @@ import (
 	modelhost "github.com/portpowered/infinite-you/pkg/services/models/internal/host"
 	localmodels "github.com/portpowered/infinite-you/pkg/services/models/internal/local"
 	modelsservice "github.com/portpowered/infinite-you/pkg/services/models/internal/service"
+	catalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
 	catalogwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire"
 	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
 	"go.uber.org/zap"
@@ -74,7 +75,14 @@ func NewService(
 	if err != nil {
 		return nil, err
 	}
-	catalogService, err := catalogwire.NewService(runtimeScopes)
+	catalogService, err := catalogwire.NewService(runtimeScopes, newCatalogReadinessQuery(catalogReadinessEdges{
+		platform: localmodels.HostPlatform(assetPlatform), client: assetHTTP, endpoints: defaultEndpoints,
+		mkdirAll: modelassets.MakeDirectories(assetMkdirAll), stat: modelassets.InspectPath(assetStat),
+		home: modelassets.ResolveHomeDirectory(assetHome), writeFile: modelassets.WriteFile(assetWriteFile),
+		rename: modelassets.RenamePath(assetRename), remove: modelassets.RemovePath(assetRemove),
+		readFile: modelassets.ReadFile(assetReadFile), readDir: modelassets.ReadDirectory(assetReadDir),
+		create: modelassets.CreateFile(assetCreate), open: modelassets.OpenFile(assetOpen),
+	}))
 	if err != nil {
 		return nil, err
 	}
@@ -98,6 +106,46 @@ func NewService(
 		return nil, err
 	}
 	return service, nil
+}
+
+type catalogReadinessEdges struct {
+	platform  localmodels.HostPlatform
+	client    modelassets.HTTPDoer
+	endpoints modelassets.Endpoints
+	mkdirAll  modelassets.MakeDirectories
+	stat      modelassets.InspectPath
+	home      modelassets.ResolveHomeDirectory
+	writeFile modelassets.WriteFile
+	rename    modelassets.RenamePath
+	remove    modelassets.RemovePath
+	readFile  modelassets.ReadFile
+	readDir   modelassets.ReadDirectory
+	create    modelassets.CreateFile
+	open      modelassets.OpenFile
+}
+
+func newCatalogReadinessQuery(edges catalogReadinessEdges) catalog.ReadinessQuery {
+	return func(
+		ctx context.Context,
+		scope models.RuntimeScopeConfig,
+		detail models.Detail,
+	) (models.Runtime, error) {
+		puller, err := localmodels.NewAssetPuller(
+			scope.CacheDirectory, edges.platform, edges.client, edges.endpoints,
+			edges.mkdirAll, edges.stat, edges.home, edges.writeFile, edges.rename,
+			edges.remove, edges.readFile, edges.readDir, edges.create, edges.open,
+		)
+		if err != nil {
+			return models.Runtime{}, err
+		}
+		return localmodels.ManagedRuntimeReadinessForFactoryContext(
+			ctx,
+			&scope.Runtime,
+			detail.Name,
+			puller,
+			localmodels.DefaultManagedRuntimeSourceResolver(),
+		)
+	}
 }
 
 func runtimeScopeIssuerID(now func() time.Time, assetHTTP models.AssetHTTPDoer, hostHTTP models.HostHTTPDoer) string {

--- a/pkg/services/models/wire/wire.go
+++ b/pkg/services/models/wire/wire.go
@@ -4,6 +4,7 @@ package wire
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
@@ -13,6 +14,8 @@ import (
 	modelhost "github.com/portpowered/infinite-you/pkg/services/models/internal/host"
 	localmodels "github.com/portpowered/infinite-you/pkg/services/models/internal/local"
 	modelsservice "github.com/portpowered/infinite-you/pkg/services/models/internal/service"
+	catalogwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire"
+	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
 	"go.uber.org/zap"
 )
 
@@ -65,6 +68,16 @@ func NewService(
 	if runtimeTempFile != nil {
 		createTempFile = runtimeTempFileAdapter{next: runtimeTempFile}.create
 	}
+	runtimeScopes, err := runtimescopeswire.NewService(func() string {
+		return runtimeScopeIssuerID(now, assetHTTP, hostHTTP)
+	})
+	if err != nil {
+		return nil, err
+	}
+	catalogService, err := catalogwire.NewService(runtimeScopes)
+	if err != nil {
+		return nil, err
+	}
 	service, err := modelsservice.NewRoot(
 		localmodels.HostPlatform(assetPlatform), assetHTTP, defaultEndpoints,
 		modelassets.MakeDirectories(assetMkdirAll), modelassets.InspectPath(assetStat),
@@ -75,6 +88,7 @@ func NewService(
 		launcher, hostHTTP, clock,
 		runtimeRunner, runtimeHTTP, localmodels.InspectFile(runtimeInspect),
 		localmodels.TempDirectory(runtimeTempDir), createTempFile,
+		runtimeScopes, catalogService,
 		models.ProcessDependencies{
 			Logger: logger, Clock: now, PullMetrics: pullMetrics,
 			HostLogger: hostLogger, HostMetrics: hostMetrics, LocalHooks: localHooks,
@@ -84,6 +98,13 @@ func NewService(
 		return nil, err
 	}
 	return service, nil
+}
+
+func runtimeScopeIssuerID(now func() time.Time, assetHTTP models.AssetHTTPDoer, hostHTTP models.HostHTTPDoer) string {
+	if now == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d:%p:%p", now().UTC().UnixNano(), assetHTTP, hostHTTP)
 }
 
 // NewInvocationArtifactExporter constructs the Models-owned invocation artifact exporter.

--- a/pkg/services/models/wire/wire_test.go
+++ b/pkg/services/models/wire/wire_test.go
@@ -2,6 +2,7 @@ package wire
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -12,9 +13,48 @@ import (
 	"time"
 
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	platformrandom "github.com/portpowered/infinite-you/pkg/platform/random"
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 	"go.uber.org/zap"
 )
+
+func TestProductionCompositionRejectsScopesFromAnotherModelsAuthority(t *testing.T) {
+	t.Parallel()
+
+	entropy := &sequentialEntropySource{}
+	now := func() time.Time { return time.Unix(123, 456) }
+	left := newProductionTestServiceWithDependencies(t, now, entropy)
+	right := newProductionTestServiceWithDependencies(t, now, entropy)
+	config := models.RuntimeScopeConfig{Runtime: models.RuntimeConfig{
+		Workers: []models.RuntimeWorker{{
+			Name:          "voice-local",
+			Type:          models.RuntimeWorkerTypeModel,
+			Model:         "OMNIVOICE_Q4_K_M",
+			ModelLocality: models.RuntimeModelLocalityLocal,
+			Operations:    []models.RuntimeOperation{{Name: "TTS"}},
+		}},
+	}}
+	leftScope, err := left.OpenRuntimeScope(
+		context.Background(),
+		models.OpenRuntimeScopeRequest{Config: config},
+	)
+	if err != nil {
+		t.Fatalf("open left runtime scope: %v", err)
+	}
+	rightScope, err := right.OpenRuntimeScope(
+		context.Background(),
+		models.OpenRuntimeScopeRequest{Config: config},
+	)
+	if err != nil {
+		t.Fatalf("open right runtime scope: %v", err)
+	}
+	if leftScope.Scope.String() == rightScope.Scope.String() {
+		t.Fatalf("separate Models authorities issued the same first scope %q", leftScope.Scope.String())
+	}
+
+	assertForeignCatalogScope(t, "left rejects right", left, rightScope.Scope)
+	assertForeignCatalogScope(t, "right rejects left", right, leftScope.Scope)
+}
 
 func TestProductionCompositionReportsCurrentScopedReadinessWithCompatibilityParity(t *testing.T) {
 	t.Parallel()
@@ -98,6 +138,15 @@ func TestProductionCompositionReportsCurrentScopedReadinessWithCompatibilityPari
 
 func newProductionTestService(t *testing.T) models.Service {
 	t.Helper()
+	return newProductionTestServiceWithDependencies(t, time.Now, platformrandom.CryptoSource{})
+}
+
+func newProductionTestServiceWithDependencies(
+	t *testing.T,
+	now func() time.Time,
+	issuerEntropy platformrandom.Source,
+) models.Service {
+	t.Helper()
 	service, err := NewService(
 		models.AssetHostPlatform{OperatingSystem: runtime.GOOS, Architecture: runtime.GOARCH},
 		http.DefaultClient,
@@ -123,7 +172,8 @@ func newProductionTestService(t *testing.T) models.Service {
 			return os.CreateTemp(dir, pattern)
 		},
 		zap.NewNop(),
-		time.Now,
+		now,
+		issuerEntropy,
 		nil,
 		nil,
 		nil,
@@ -133,6 +183,55 @@ func newProductionTestService(t *testing.T) models.Service {
 		t.Fatalf("NewService: %v", err)
 	}
 	return service
+}
+
+type sequentialEntropySource struct {
+	next int64
+}
+
+func (source *sequentialEntropySource) Int63n(upperBound int64) (int64, error) {
+	source.next++
+	return source.next % upperBound, nil
+}
+
+func assertForeignCatalogScope(
+	t *testing.T,
+	name string,
+	service models.Service,
+	foreignScope models.RuntimeScopeRef,
+) {
+	t.Helper()
+
+	list, err := service.ListCatalog(
+		context.Background(),
+		models.ListModelsRequest{Scope: foreignScope},
+	)
+	if !errors.Is(err, models.ErrRuntimeScopeForeign) {
+		t.Fatalf("%s ListCatalog error = %v, want ErrRuntimeScopeForeign", name, err)
+	}
+	if len(list.Models) != 0 {
+		t.Fatalf("%s ListCatalog returned foreign models: %#v", name, list.Models)
+	}
+
+	get, err := service.GetCatalogModel(context.Background(), models.GetModelRequest{
+		Scope: foreignScope, Name: "OMNIVOICE_Q4_K_M", Operation: "TTS",
+	})
+	if !errors.Is(err, models.ErrRuntimeScopeForeign) {
+		t.Fatalf("%s GetCatalogModel error = %v, want ErrRuntimeScopeForeign", name, err)
+	}
+	if get.Model.Name != "" {
+		t.Fatalf("%s GetCatalogModel returned foreign model: %#v", name, get.Model)
+	}
+
+	readiness, err := service.GetModelReadiness(context.Background(), models.GetModelReadinessRequest{
+		Scope: foreignScope, Name: "OMNIVOICE_Q4_K_M", Operation: "TTS",
+	})
+	if !errors.Is(err, models.ErrRuntimeScopeForeign) {
+		t.Fatalf("%s GetModelReadiness error = %v, want ErrRuntimeScopeForeign", name, err)
+	}
+	if readiness.ModelName != "" || readiness.Readiness.Identity != "" {
+		t.Fatalf("%s GetModelReadiness returned foreign readiness: %#v", name, readiness)
+	}
 }
 
 func assertReadinessParity(t *testing.T, scoped, compatibility models.Runtime) {

--- a/pkg/services/models/wire/wire_test.go
+++ b/pkg/services/models/wire/wire_test.go
@@ -1,0 +1,192 @@
+package wire
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+	"time"
+
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	"go.uber.org/zap"
+)
+
+func TestProductionCompositionReportsCurrentScopedReadinessWithCompatibilityParity(t *testing.T) {
+	t.Parallel()
+
+	service := newProductionTestService(t)
+	cacheDirectory := t.TempDir()
+	runtimeConfig := models.RuntimeConfig{
+		Workers: []models.RuntimeWorker{{
+			Name:          "voice-local",
+			Type:          models.RuntimeWorkerTypeModel,
+			Model:         "OMNIVOICE_Q4_K_M",
+			ModelLocality: models.RuntimeModelLocalityLocal,
+			Operations:    []models.RuntimeOperation{{Name: "TTS"}},
+			Resources: []models.RuntimeResource{{
+				Name: "omnivoice-cache", Capacity: 1,
+			}},
+		}},
+		Resources: []models.RuntimeResource{{
+			Name:       "omnivoice-cache",
+			Type:       models.RuntimeResourceTypeModel,
+			Capacity:   1,
+			Model:      "OMNIVOICE_Q4_K_M",
+			Backend:    "GGUF",
+			LoadPolicy: "ON_DEMAND",
+		}},
+	}
+	opened, err := service.OpenRuntimeScope(context.Background(), models.OpenRuntimeScopeRequest{
+		Config: models.RuntimeScopeConfig{
+			CacheDirectory: cacheDirectory,
+			Runtime:        runtimeConfig,
+		},
+	})
+	if err != nil {
+		t.Fatalf("OpenRuntimeScope: %v", err)
+	}
+	request := models.GetModelReadinessRequest{
+		Scope: opened.Scope, Name: "OMNIVOICE_Q4_K_M", Operation: "TTS",
+	}
+	missing, err := service.GetModelReadiness(context.Background(), request)
+	if err != nil {
+		t.Fatalf("GetModelReadiness before cache transition: %v", err)
+	}
+	if missing.Readiness.ReadinessState != models.ReadinessStateMissing {
+		t.Fatalf("initial scoped readiness = %s, want MISSING", missing.Readiness.ReadinessState)
+	}
+
+	bound, err := service.ForRuntime(models.RuntimeBinding{
+		CacheDirectory: cacheDirectory,
+		RuntimeConfig:  func() *models.RuntimeConfig { return &runtimeConfig },
+	})
+	if err != nil {
+		t.Fatalf("ForRuntime: %v", err)
+	}
+	revisionDirectory := filepath.Join(cacheDirectory, "OMNIVOICE_Q4_K_M", "rev-live")
+	if err := os.MkdirAll(revisionDirectory, 0o755); err != nil {
+		t.Fatalf("create model revision directory: %v", err)
+	}
+	for _, name := range []string{
+		"omnivoice-base-Q4_K_M.gguf",
+		"omnivoice-tokenizer-Q4_K_M.gguf",
+	} {
+		if err := os.WriteFile(filepath.Join(revisionDirectory, name), []byte("fixture"), 0o644); err != nil {
+			t.Fatalf("write model cache file %s: %v", name, err)
+		}
+	}
+
+	current, err := service.GetModelReadiness(context.Background(), request)
+	if err != nil {
+		t.Fatalf("GetModelReadiness after cache transition: %v", err)
+	}
+	if current.Readiness.ReadinessState != models.ReadinessStateReady ||
+		current.Readiness.LifecycleState != models.LifecycleStateInstalled {
+		t.Fatalf("current scoped readiness = %#v, want READY/INSTALLED", current.Readiness)
+	}
+	compatibility, err := bound.InspectRuntime(context.Background(), "OMNIVOICE_Q4_K_M")
+	if err != nil {
+		t.Fatalf("InspectRuntime after cache transition: %v", err)
+	}
+	assertReadinessParity(t, current.Readiness, compatibility)
+}
+
+func newProductionTestService(t *testing.T) models.Service {
+	t.Helper()
+	service, err := NewService(
+		models.AssetHostPlatform{OperatingSystem: runtime.GOOS, Architecture: runtime.GOARCH},
+		http.DefaultClient,
+		models.RuntimeAssetEndpoints{},
+		os.MkdirAll,
+		os.Stat,
+		os.UserHomeDir,
+		os.WriteFile,
+		os.Rename,
+		os.Remove,
+		os.ReadFile,
+		os.ReadDir,
+		func(path string) (io.WriteCloser, error) { return os.Create(path) },
+		func(path string) (io.ReadCloser, error) { return os.Open(path) },
+		inertProcessLauncher{},
+		http.DefaultClient,
+		inertHostClock{},
+		inertCommandRunner{},
+		http.DefaultClient,
+		os.Stat,
+		os.TempDir,
+		func(dir, pattern string) (models.RuntimeTempFile, error) {
+			return os.CreateTemp(dir, pattern)
+		},
+		zap.NewNop(),
+		time.Now,
+		nil,
+		nil,
+		nil,
+		models.LocalRuntimeHooks{},
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	return service
+}
+
+func assertReadinessParity(t *testing.T, scoped, compatibility models.Runtime) {
+	t.Helper()
+	if scoped.Identity != compatibility.Identity ||
+		scoped.ReadinessState != compatibility.ReadinessState ||
+		scoped.LifecycleState != compatibility.LifecycleState ||
+		scoped.Locality != compatibility.Locality ||
+		!reflect.DeepEqual(scoped.SupportedOperations, compatibility.SupportedOperations) {
+		t.Fatalf(
+			"production readiness parity = (scoped %#v, compatibility %#v)",
+			scoped,
+			compatibility,
+		)
+	}
+	for _, key := range []string{
+		"cachePath", "installedFileCount", "revision",
+		"sourceId", "sourceKind", "resolverNotes",
+	} {
+		if scoped.Diagnostics[key] != compatibility.Diagnostics[key] {
+			t.Fatalf(
+				"production readiness diagnostic %q = (scoped %q, compatibility %q)",
+				key,
+				scoped.Diagnostics[key],
+				compatibility.Diagnostics[key],
+			)
+		}
+	}
+}
+
+type inertProcessLauncher struct{}
+
+func (inertProcessLauncher) Start(
+	context.Context,
+	models.HostProcessStartSpec,
+) (models.HostManagedProcess, error) {
+	panic("process launcher called during readiness inspection")
+}
+
+type inertHostClock struct{}
+
+func (inertHostClock) Now() time.Time {
+	return time.Unix(0, 0)
+}
+
+func (inertHostClock) NewTimer(time.Duration) models.HostTimer {
+	panic("host timer created during readiness inspection")
+}
+
+type inertCommandRunner struct{}
+
+func (inertCommandRunner) Run(
+	context.Context,
+	platformprocess.CommandRequest,
+) (platformprocess.CommandResult, error) {
+	panic("runtime command called during readiness inspection")
+}

--- a/pkg/wire/models_runtime.go
+++ b/pkg/wire/models_runtime.go
@@ -14,6 +14,7 @@ import (
 
 	platformclock "github.com/portpowered/infinite-you/pkg/platform/clock"
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	platformrandom "github.com/portpowered/infinite-you/pkg/platform/random"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorysessionwire "github.com/portpowered/infinite-you/pkg/services/factory_sessions/wire"
 	"github.com/portpowered/infinite-you/pkg/services/models"
@@ -143,6 +144,7 @@ func provideModelsService(edges serviceedges.Edges) (models.Service, error) {
 		runtimeTempFile,
 		zap.NewNop(),
 		time.Now,
+		platformrandom.CryptoSource{},
 		edges.ModelPullMetricsRecorder,
 		factorysessionwire.ModelHostDiagnosticLogger(zap.NewNop()),
 		factorysessionwire.ModelHostDiagnosticMetrics(edges.InvocationMetricsRecorder),

--- a/ui/src/features/workflow-activity/components/current-activity-card/test-support/react-flow-current-activity-card-component.harness.tsx
+++ b/ui/src/features/workflow-activity/components/current-activity-card/test-support/react-flow-current-activity-card-component.harness.tsx
@@ -30,8 +30,6 @@ import { resetCurrentActivityGraphLayoutCacheForTests } from "../../../hooks/rea
 import type { CurrentActivitySelection } from "../../../lib/react-flow-current-activity-card-types";
 import { ReactFlowCurrentActivityCard } from "../../react-flow-current-activity-card";
 
-export const PADDING_CLASS_PATTERN = /(^|\s)p[trblxy]?-[^\s]+/;
-
 export interface RenderCurrentActivityOptions {
   activateFactory?: (
     input: FactoryImportConfirmInput,
@@ -222,54 +220,6 @@ export function renderWithQueryClient(view: ReactElement) {
   );
 }
 
-export function createFactoryImportValue(): FactoryPngImportValue {
-  return {
-    factory: {
-      name: "Dropped Factory",
-      workTypes: [],
-      workers: [],
-      workstations: [],
-    },
-    previewImageSrc: "blob:factory-preview",
-    revokePreviewImageSrc: vi.fn(),
-    schemaVersion: "portos.agent-factory.png.v1",
-  };
-}
-
-export function createImportController(
-  overrides: Partial<CurrentActivityImportController> = {},
-): CurrentActivityImportController {
-  return {
-    activateImport: vi.fn().mockResolvedValue(undefined),
-    activationState: { status: "idle" },
-    clearActivationError: vi.fn(),
-    clearError: vi.fn(),
-    closeImportPreview: vi.fn(),
-    dropState: { status: "idle" },
-    importPreviewState: { status: "idle" },
-    onDragEnter: vi.fn(),
-    onDragLeave: vi.fn(),
-    onDragOver: vi.fn(),
-    onDrop: vi.fn(),
-    ...overrides,
-  };
-}
-
-export function createFileDropTransfer(files: File[]): {
-  dataTransfer: {
-    dropEffect: string;
-    files: File[];
-    types: string[];
-  };
-} {
-  return {
-    dataTransfer: {
-      dropEffect: "none",
-      files,
-      types: ["Files"],
-    },
-  };
-}
 let restoreBrowserTestShims: (() => void) | null = null;
 
 export function registerCurrentActivityCardTestLifecycle(): void {


### PR DESCRIPTION
{
  "project": "PSS IMP-MOD-02 — Parent-Private Models Catalog",
  "branchName": "pss-imp-mod-02-catalog",
  "description": "Implement the Models parent-private catalog and expose deterministic scoped model identity, operation, source, status, and readiness discovery through the accepted ListCatalog, GetCatalogModel, and GetModelReadiness root operations. Every request resolves through an open opaque runtime scope, returns detached values, preserves established behavior and failure classifications, and remains composed inertly through the Models parent and existing service-local wire boundary.",
  "context": {
    "customerAsk": "Implement IMP-MOD-02 as the Models parent-private catalog, composed only through the Models parent and its existing service-local wire boundary. Provide deterministic scoped identity, supported operation, source, status, and readiness discovery through the accepted root operations; enforce runtime-scope lifecycle and ownership; preserve managed-model identity, contractual aliases, configuration precedence, readiness, cancellation, availability, and compatibility behavior; return detached values; and keep all unrelated services, transports, generated surfaces, shared composition, UI, and later Models packets out of scope.",
    "problem": "The accepted scoped catalog root methods still lack their production implementation, while equivalent discovery and readiness behavior is divided among local catalog assembly, service adapters, host projection, and compatibility methods. That split risks inconsistent identity resolution, ordering, configuration precedence, readiness, and error classification, and it can leak implementation coupling instead of providing one private Models authority.",
    "solution": "Create one parent-private Models catalog that resolves accepted open runtime scopes to detached configuration, applies established identity, alias, operation, source, status, and precedence rules, and queries narrow injected Models-owned readiness facts. Delegate the accepted root operations from the Models parent, deep-clone and deterministically order results, preserve cancellation and distinct failure classifications, keep construction inert, and narrow compatibility implementation only after focused parity proof."
  },
  "acceptanceCriteria": [
    "ListCatalog on an open scope returns the complete scoped model catalog in a stable order, preserving accepted managed-model identity, contractual aliases, operation, binding, source, status, and runtime-configuration precedence.",
    "GetCatalogModel returns the matching detached detail for a supported identity and operation; unknown models and unsupported operations retain their existing distinct Models-owned not-found and unsupported classifications.",
    "GetModelReadiness returns current scoped readiness facts and reflects Models-owned runtime or cache readiness transitions without exposing mutable or implementation-owned state.",
    "Missing, closed, stale, and foreign scope references retain their accepted distinct classifications across all three operations, while a valid scope whose catalog cannot be served returns ErrUnavailable.",
    "Results are immutable from the caller's perspective: mutating any returned list, detail, readiness, nested slice, pointer, or map cannot alter later results or another scope, and all observable ordering is deterministic.",
    "The Models parent and existing Models wire boundary compose the private catalog inertly, preserve context cancellation and compatibility behavior, and add no Workers, Providers, transport, generated-contract, root-process, or lifecycle dependencies.",
    "Go typecheck and compile validation, gofmt, focused vet and lint, Models ownership and architecture checks, and the narrow focused Models tests pass."
  ],
  "userStories": [
    {
      "id": "pss-imp-mod-02-catalog-001",
      "title": "List a deterministic catalog for an open runtime scope",
      "description": "As a Models consumer, I want to list the models available in one open runtime scope so that discovery consistently reflects that Factory Session's effective configuration.",
      "acceptanceCriteria": [
        "ListCatalog resolves the supplied open RuntimeScopeRef and returns all models derived from that scope's detached runtime configuration.",
        "Model identity, locality, operations, modalities, resources, source-backed status, and managed-runtime facts preserve current Models behavior and runtime configuration precedence.",
        "Managed-model names and only aliases already supported by the accepted behavior resolve to the same canonical catalog identities; no new alias is introduced.",
        "Models and every nested order-insensitive collection are returned in a documented stable order for equivalent effective configuration, independent of map iteration or request repetition.",
        "Mutating a returned summary or any nested slice, pointer, or map does not change a later list result or the result for another open scope.",
        "Focused catalog tests cover effective-configuration precedence, deterministic ordering, canonical identity and existing aliases, and detached list values.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-mod-02-catalog-002",
      "title": "Discover one model and validate requested operation support",
      "description": "As a Models consumer, I want to inspect one scoped model by its supported identity and operation so that I can discover its binding, source, status, and capabilities without importing Models internals.",
      "acceptanceCriteria": [
        "GetCatalogModel on an open scope returns the accepted detached detail for a canonical model identity or an already-contractual alias.",
        "The detail preserves configured binding and capability facts, supported operations, source provider, reference, and revision metadata, catalog status, and managed-runtime discovery fields.",
        "A requested operation succeeds only when that operation is supported by the model summary or its configured capabilities.",
        "An unknown or empty model identity returns the existing Models-owned not-found classification, while a known model with an unsupported operation returns ErrUnsupportedOperation; neither is reported as catalog unavailability or a scope failure.",
        "Repeated get results are deterministically ordered and detached, so caller mutation of capabilities, operations, resources, sources, diagnostics, or nested values cannot affect later discovery.",
        "Focused catalog tests cover canonical and contractual-alias lookup, supported and unsupported operations, unknown or empty identity, source and binding projection, and detached detail values.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-mod-02-catalog-003",
      "title": "Preserve scope lifecycle, isolation, availability, and cancellation outcomes",
      "description": "As a Models consumer, I want catalog requests to honor runtime scope ownership and cancellation so that invalid sessions cannot read another session's configuration and callers can stop discovery promptly.",
      "acceptanceCriteria": [
        "ListCatalog, GetCatalogModel, and GetModelReadiness resolve through the accepted Runtime Scopes authority before reading catalog or readiness facts.",
        "Missing, closed, stale, and foreign references return their existing distinct Models-owned classifications for each root operation and never fall through to not-found, unsupported-operation, or unavailable results.",
        "Two simultaneously open scopes remain isolated even when model names are equal, and closing one scope does not change the other scope's catalog or readiness results.",
        "When a valid scope cannot provide an effective catalog, list, get, and readiness return ErrUnavailable without leaking internal dependency errors, filesystem locations, or partial mutable results.",
        "A context canceled before or during Models-owned catalog or readiness work stops the request promptly and returns the established cancellation outcome without changing scope or readiness state.",
        "Focused service tests cover all scope classifications across all three operations, two-scope isolation, unavailable catalog behavior, and cancellation before and during an injected readiness query.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-mod-02-catalog-004",
      "title": "Report current detached model readiness",
      "description": "As a Models consumer, I want to query a scoped model's current readiness so that I can distinguish missing, loading, ready, failed, and unsupported runtime states without receiving a host, cache, or runtime handle.",
      "acceptanceCriteria": [
        "GetModelReadiness applies the same model identity and requested-operation validation as GetCatalogModel before querying readiness facts.",
        "The result contains the canonical model name and current accepted readiness, lifecycle, supported-operation, source, and diagnostic facts available through the Models-owned readiness contract.",
        "Successive requests reflect injected Models-owned readiness transitions, including missing or not-installed, loading, ready or installed, failed, and unsupported states, without requiring catalog reconstruction or service reconstruction.",
        "Unknown models and unsupported requested operations retain the same distinct classifications as catalog get, while valid non-ready states retain their existing readiness semantics rather than being collapsed into ErrUnavailable.",
        "Returned readiness values, supported operations, and diagnostics are detached; caller mutation cannot affect later readiness or catalog results.",
        "Focused readiness tests use deterministic injected facts to cover each transition, error classification, operation validation, cancellation, and detached return behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-mod-02-catalog-005",
      "title": "Serve catalog behavior through the Models parent with compatibility parity",
      "description": "As a maintainer, I want the process-scoped Models parent to delegate catalog operations to one private child so that peers use a singular root contract while existing consumers retain catalog and readiness behavior during migration.",
      "acceptanceCriteria": [
        "The already-constructed Models root delegates ListCatalog, GetCatalogModel, and GetModelReadiness to the same parent-private catalog instance and does not return or expose that child.",
        "Catalog construction is inert and uses only injected Models-owned runtime scope, configuration, and readiness or cache fact boundaries; constructing the Models service starts no host, process, pull, filesystem, network, timer, or background work.",
        "Root results and error classifications match direct private catalog behavior for representative success, unavailable catalog, unknown model, unsupported operation, scope lifecycle failure, readiness transition, and cancellation cases.",
        "Existing ListModels, GetModel, and InspectRuntime behavior remains available and has parity with the corresponding scoped root behavior for equivalent configuration and readiness facts; only redundant Models-owned implementation may be narrowed after parity is proved.",
        "Deprecated public methods required by later consumer migrations are not removed or changed, and the public models.Service contract is not expanded or reshaped.",
        "Composition introduces no Workers or Providers dependency and does not change CLI, HTTP, MCP, OpenAPI or generated clients, pkg/root, pkg/wire, pkg/initializer, UI, or broad functional-test topology.",
        "Focused parent-composition and compatibility tests prove delegation, inert construction, behavioral parity, and absence of leaked nested service or implementation handles.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}
