### PR TITLE
pss-ctr-prov-root-contract

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -937,6 +937,16 @@
       "minimum": 28.57
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings",
       "minimum": 3.85
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -871,6 +871,10 @@
       "minimum": 94.11
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers",
+      "minimum": 72.85
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings",
       "minimum": 83.56
     },

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -3450,6 +3450,12 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/providers",
+      "disposition": "retain",
+      "destination": "providers",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/recordings",
       "disposition": "retain",
       "destination": "recordings",

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -258,7 +258,6 @@
     "pkg/services/workers/executor/agentrun",
     "pkg/services/workers/interface",
     "pkg/services/workers/internal/services/runners",
-    "pkg/services/workers/internal/services/runners/internal/inference",
     "pkg/services/workers/internal/services/runners/internal/script",
     "pkg/services/workers/internal/services/runners/internal/service",
     "pkg/services/workers/internal/services/runners/internal/testkit",
@@ -1459,11 +1458,6 @@
     },
     {
       "packagePath": "pkg/services/workers/internal/services/runners",
-      "disposition": "retain",
-      "destination": "workers/internal/services/runners"
-    },
-    {
-      "packagePath": "pkg/services/workers/internal/services/runners/internal/inference",
       "disposition": "retain",
       "destination": "workers/internal/services/runners"
     },

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -230,6 +230,7 @@
     "pkg/services/provider_sessions/codex",
     "pkg/services/provider_sessions/cursor",
     "pkg/services/provider_sessions/service",
+    "pkg/services/providers",
     "pkg/services/recordings",
     "pkg/services/recordings/artifacts",
     "pkg/services/recordings/events",
@@ -257,6 +258,7 @@
     "pkg/services/workers/executor/agentrun",
     "pkg/services/workers/interface",
     "pkg/services/workers/internal/services/runners",
+    "pkg/services/workers/internal/services/runners/internal/inference",
     "pkg/services/workers/internal/services/runners/internal/script",
     "pkg/services/workers/internal/services/runners/internal/service",
     "pkg/services/workers/internal/services/runners/internal/testkit",
@@ -1321,6 +1323,11 @@
       "destination": "provider_sessions"
     },
     {
+      "packagePath": "pkg/services/providers",
+      "disposition": "retain",
+      "destination": "providers"
+    },
+    {
       "packagePath": "pkg/services/recordings",
       "disposition": "retain",
       "destination": "recordings"
@@ -1452,6 +1459,11 @@
     },
     {
       "packagePath": "pkg/services/workers/internal/services/runners",
+      "disposition": "retain",
+      "destination": "workers/internal/services/runners"
+    },
+    {
+      "packagePath": "pkg/services/workers/internal/services/runners/internal/inference",
       "disposition": "retain",
       "destination": "workers/internal/services/runners"
     },

--- a/pkg/services/providers/catalog_characterization_test.go
+++ b/pkg/services/providers/catalog_characterization_test.go
@@ -1,0 +1,177 @@
+package providers_test
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+// catalogPeerFake implements the published Providers Service catalog slices
+// using only Providers root contracts.
+type catalogPeerFake struct {
+	providers map[providers.ID]providers.Descriptor
+}
+
+var _ providers.Service = (*catalogPeerFake)(nil)
+
+func newCatalogPeerFake(entries ...providers.Descriptor) *catalogPeerFake {
+	catalog := make(map[providers.ID]providers.Descriptor, len(entries))
+	for _, entry := range entries {
+		catalog[entry.ID] = entry.Clone()
+	}
+	return &catalogPeerFake{providers: catalog}
+}
+
+func (fake *catalogPeerFake) ListProviders(
+	_ context.Context,
+	_ providers.ListProvidersRequest,
+) (providers.ListProvidersResult, error) {
+	ids := make([]providers.ID, 0, len(fake.providers))
+	for id := range fake.providers {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		return ids[i].String() < ids[j].String()
+	})
+
+	results := make([]providers.Descriptor, 0, len(ids))
+	for _, id := range ids {
+		results = append(results, fake.providers[id].Clone())
+	}
+	return providers.ListProvidersResult{Providers: results}, nil
+}
+
+func (fake *catalogPeerFake) GetProvider(
+	_ context.Context,
+	request providers.GetProviderRequest,
+) (providers.GetProviderResult, error) {
+	if err := request.Validate(); err != nil {
+		return providers.GetProviderResult{}, err
+	}
+	descriptor, ok := fake.providers[request.ID]
+	if !ok {
+		return providers.GetProviderResult{}, providers.ErrUnknownProvider
+	}
+	if descriptor.Availability != providers.AvailabilitySelectable ||
+		descriptor.Readiness != providers.ReadinessReady ||
+		hasMissingPrerequisite(descriptor.Prerequisites) {
+		return providers.GetProviderResult{}, providers.ErrProviderUnavailable
+	}
+	return providers.GetProviderResult{Provider: descriptor.Clone()}, nil
+}
+
+func hasMissingPrerequisite(prerequisites []providers.Prerequisite) bool {
+	for _, prerequisite := range prerequisites {
+		if prerequisite.Status == providers.PrerequisiteMissing {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCatalogContract_Characterization_ListAndGetSuccess(t *testing.T) {
+	t.Parallel()
+
+	codex := providers.Descriptor{
+		ID:           providers.IDCodex,
+		Aliases:      []string{"openai-codex"},
+		DisplayName:  "Codex",
+		Availability: providers.AvailabilitySelectable,
+		Readiness:    providers.ReadinessReady,
+		Capabilities: []providers.Capability{
+			providers.CapabilityPromptSubmission,
+			providers.CapabilityNativeStreaming,
+		},
+	}
+	cursor := providers.Descriptor{
+		ID:           providers.IDCursor,
+		DisplayName:  "Cursor",
+		Availability: providers.AvailabilitySupportedButUnavailable,
+		Readiness:    providers.ReadinessUnavailable,
+		Prerequisites: []providers.Prerequisite{{
+			Kind:        providers.PrerequisiteConfiguration,
+			Name:        "executable",
+			Status:      providers.PrerequisiteMissing,
+			Description: "cursor-agent must be installed",
+		}},
+		Capabilities: []providers.Capability{providers.CapabilityPromptSubmission},
+	}
+
+	var service providers.Service = newCatalogPeerFake(codex, cursor)
+
+	list, err := service.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if err != nil {
+		t.Fatalf("ListProviders() = %v", err)
+	}
+	if len(list.Providers) != 2 {
+		t.Fatalf("len(Providers) = %d, want 2", len(list.Providers))
+	}
+	byID := make(map[providers.ID]providers.Descriptor, len(list.Providers))
+	for _, provider := range list.Providers {
+		byID[provider.ID] = provider
+	}
+	if byID[providers.IDCodex].DisplayName != "Codex" ||
+		byID[providers.IDCursor].Availability != providers.AvailabilitySupportedButUnavailable {
+		t.Fatalf("Providers = %#v", list.Providers)
+	}
+	if byID[providers.IDCodex].Capabilities[0] != providers.CapabilityPromptSubmission {
+		t.Fatalf("codex capabilities = %#v", byID[providers.IDCodex].Capabilities)
+	}
+
+	got, err := service.GetProvider(context.Background(), providers.GetProviderRequest{ID: providers.IDCodex})
+	if err != nil {
+		t.Fatalf("GetProvider(codex) = %v", err)
+	}
+	if got.Provider.DisplayName != "Codex" ||
+		got.Provider.Availability != providers.AvailabilitySelectable ||
+		len(got.Provider.Capabilities) != 2 {
+		t.Fatalf("GetProvider(codex) = %#v", got.Provider)
+	}
+}
+
+func TestCatalogContract_Characterization_TypedFailures(t *testing.T) {
+	t.Parallel()
+
+	service := newCatalogPeerFake(providers.Descriptor{
+		ID:           providers.IDCodex,
+		DisplayName:  "Codex",
+		Availability: providers.AvailabilitySelectable,
+		Readiness:    providers.ReadinessReady,
+	})
+
+	assertGetErrorIs(t, service, providers.GetProviderRequest{}, providers.ErrInvalidID)
+	assertGetErrorIs(t, service, providers.GetProviderRequest{ID: providers.IDClaude}, providers.ErrUnknownProvider)
+	assertGetErrorIs(t, service, providers.GetProviderRequest{ID: providers.IDCodex + "-stale"}, providers.ErrUnknownProvider)
+
+	unavailable := providers.Descriptor{
+		ID:           providers.IDCursor,
+		DisplayName:  "Cursor",
+		Availability: providers.AvailabilitySupportedButUnavailable,
+		Readiness:    providers.ReadinessUnavailable,
+		Prerequisites: []providers.Prerequisite{{
+			Kind:        providers.PrerequisiteDependency,
+			Name:        "cursor-agent",
+			Status:      providers.PrerequisiteMissing,
+			Description: "install cursor-agent",
+		}},
+	}
+	service = newCatalogPeerFake(unavailable)
+	assertGetErrorIs(t, service, providers.GetProviderRequest{ID: providers.IDCursor}, providers.ErrProviderUnavailable)
+}
+
+func assertGetErrorIs(
+	t *testing.T,
+	service providers.Service,
+	request providers.GetProviderRequest,
+	want error,
+) {
+	t.Helper()
+
+	_, err := service.GetProvider(context.Background(), request)
+	if !errors.Is(err, want) {
+		t.Fatalf("GetProvider(%#v) error = %v, want %v", request, err, want)
+	}
+}

--- a/pkg/services/providers/catalog_contract.go
+++ b/pkg/services/providers/catalog_contract.go
@@ -1,0 +1,124 @@
+package providers
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrUnknownProvider reports that a provider identity is not present in the
+// catalog.
+var ErrUnknownProvider = errors.New("provider is unknown")
+
+// ErrProviderUnavailable reports that a catalog provider exists but is not
+// selectable because availability or prerequisite facts block use.
+var ErrProviderUnavailable = errors.New("provider is unavailable")
+
+// Availability identifies why a catalog provider is or is not selectable.
+// Support posture is static catalog metadata and does not imply live readiness.
+type Availability string
+
+const (
+	AvailabilityCatalogOnly             Availability = "catalog-only"
+	AvailabilityNotSupported            Availability = "not-supported"
+	AvailabilitySupportedButUnavailable Availability = "supported-but-unavailable"
+	AvailabilitySelectable              Availability = "selectable"
+)
+
+// Readiness identifies the current provider availability outcome.
+type Readiness string
+
+const (
+	ReadinessReady       Readiness = "ready"
+	ReadinessUnavailable Readiness = "unavailable"
+	ReadinessDegraded    Readiness = "degraded"
+)
+
+// PrerequisiteKind identifies a sanitized requirement for provider readiness.
+type PrerequisiteKind string
+
+const (
+	PrerequisiteConfiguration PrerequisiteKind = "configuration"
+	PrerequisiteCredential    PrerequisiteKind = "credential"
+	PrerequisiteDependency    PrerequisiteKind = "dependency"
+)
+
+// PrerequisiteStatus identifies whether a provider prerequisite is satisfied.
+type PrerequisiteStatus string
+
+const (
+	PrerequisiteSatisfied PrerequisiteStatus = "satisfied"
+	PrerequisiteMissing   PrerequisiteStatus = "missing"
+)
+
+// Prerequisite is a provider-neutral readiness requirement. Description is
+// intended for bounded setup guidance, never raw environment or native output.
+type Prerequisite struct {
+	Kind        PrerequisiteKind
+	Name        string
+	Status      PrerequisiteStatus
+	Description string
+}
+
+// Clone returns a detached prerequisite copy.
+func (prerequisite Prerequisite) Clone() Prerequisite {
+	return prerequisite
+}
+
+// Capability is one provider-neutral execution or response-fidelity feature.
+type Capability string
+
+const (
+	CapabilityPromptSubmission   Capability = "prompt_submission"
+	CapabilityImageInput         Capability = "image_input"
+	CapabilitySessionResume      Capability = "session_resume"
+	CapabilityStructuredOutput   Capability = "structured_output"
+	CapabilityNativeStreaming    Capability = "native_streaming"
+	CapabilityMessageDeltas      Capability = "message_deltas"
+	CapabilityMessageSnapshots   Capability = "message_snapshots"
+	CapabilityReasoningSummaries Capability = "reasoning_summaries"
+	CapabilityToolLifecycle      Capability = "tool_lifecycle"
+	CapabilityToolOutputDeltas   Capability = "tool_output_deltas"
+	CapabilityFileChanges        Capability = "file_changes"
+	CapabilityPlans              Capability = "plans"
+	CapabilityUsage              Capability = "usage"
+	CapabilityStableItemIDs      Capability = "stable_item_ids"
+	CapabilityProviderReconnect  Capability = "provider_reconnect"
+)
+
+// ListProvidersRequest is the plain catalog list request vocabulary.
+type ListProvidersRequest struct{}
+
+// ListProvidersResult is the detached result of one catalog list.
+type ListProvidersResult struct {
+	Providers []Descriptor
+}
+
+// GetProviderRequest is the plain catalog get request. Peers identify a
+// provider by Providers-owned ID without importing Workers provider registry
+// types.
+type GetProviderRequest struct {
+	ID ID
+}
+
+// Validate checks request fields whose validity does not depend on catalog
+// state.
+func (request GetProviderRequest) Validate() error {
+	if err := request.ID.Validate(); err != nil {
+		return fmt.Errorf("%w", err)
+	}
+	return nil
+}
+
+// GetProviderResult is the detached result of one catalog lookup.
+type GetProviderResult struct {
+	Provider Descriptor
+}
+
+func clonePrerequisites(prerequisites []Prerequisite) []Prerequisite {
+	if prerequisites == nil {
+		return nil
+	}
+	cloned := make([]Prerequisite, len(prerequisites))
+	copy(cloned, prerequisites)
+	return cloned
+}

--- a/pkg/services/providers/doc.go
+++ b/pkg/services/providers/doc.go
@@ -1,0 +1,20 @@
+// Package providers is the public Providers service boundary.
+//
+// Peer-facing root contract (source of truth for published slices):
+//   - Service — singular cross-service seam (catalog, availability/capabilities,
+//     and one-attempt Execute slices publish additively on this interface)
+//   - ID, Descriptor, SessionRef — Providers-owned identity vocabulary
+//   - detached request, result, value, and typed-error contracts
+//
+// Construction/process-edge ports exist so Wire and owner constructors can
+// assemble a production Service. They are not the peer-facing source of truth
+// for catalog enumeration, availability/capability facts, or one normalized
+// execution attempt: cross-service callers invoke Service methods without
+// supplying Workers provider registry/conductor types, concrete adapters, or
+// transport/UI concerns.
+//
+// Transitional pkg/services/workers/provider/** implementations remain in place
+// for later IMP-PROV-* absorption. Nested catalog/execution implementation
+// moves, Wire/root/initializer wiring, CLI-manifest, and OpenAPI package-motion
+// edits remain out of scope for the root-contract packet.
+package providers

--- a/pkg/services/providers/execute_characterization_test.go
+++ b/pkg/services/providers/execute_characterization_test.go
@@ -1,0 +1,152 @@
+package providers_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+// executePeerFake implements the published Providers Service execute slice
+// using only Providers root contracts.
+type executePeerFake struct {
+	catalogPeerFake
+	cancelAttemptID string
+}
+
+func newExecutePeerFake(cancelAttemptID string, entries ...providers.Descriptor) *executePeerFake {
+	return &executePeerFake{
+		catalogPeerFake: *newCatalogPeerFake(entries...),
+		cancelAttemptID: cancelAttemptID,
+	}
+}
+
+func (fake *executePeerFake) Execute(
+	_ context.Context,
+	request providers.ExecuteRequest,
+) (providers.ExecuteResult, error) {
+	if err := request.Validate(); err != nil {
+		return providers.ExecuteResult{}, err
+	}
+	if _, ok := fake.providers[request.Provider]; !ok {
+		return providers.ExecuteResult{}, providers.ErrUnknownProvider
+	}
+	if request.AttemptID == fake.cancelAttemptID {
+		return providers.ExecuteResult{}, providers.ExecuteFailure{
+			Kind:    providers.ExecuteFailureKindCanceled,
+			Message: "attempt cancelled by peer policy",
+		}
+	}
+
+	session := providers.SessionRef{
+		Provider: request.Provider,
+		Kind:     providers.SessionIDKind,
+		ID:       "session-" + request.AttemptID,
+	}
+	return providers.ExecuteResult{
+		Content:    strings.TrimSpace(request.UserMessage) + "-result",
+		SessionRef: &session,
+		Diagnostics: &providers.ExecuteDiagnostics{
+			DurationMillis: 42,
+			Progress: []providers.ExecuteProgress{{
+				Phase:  "completed",
+				Detail: "one attempt finished",
+			}},
+		},
+	}, nil
+}
+
+func (fake *catalogPeerFake) Execute(
+	_ context.Context,
+	_ providers.ExecuteRequest,
+) (providers.ExecuteResult, error) {
+	return providers.ExecuteResult{}, providers.ErrExecuteFailed
+}
+
+func TestExecuteContract_Characterization_SuccessWithSessionRef(t *testing.T) {
+	t.Parallel()
+
+	service := newExecutePeerFake("cancel-attempt", providers.Descriptor{
+		ID:           providers.IDCodex,
+		DisplayName:  "Codex",
+		Availability: providers.AvailabilitySelectable,
+		Readiness:    providers.ReadinessReady,
+	})
+
+	var root providers.Service = service
+	result, err := root.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:    providers.IDCodex,
+		AttemptID:   "attempt-1",
+		UserMessage: "hello",
+	})
+	if err != nil {
+		t.Fatalf("Execute() = %v", err)
+	}
+	if result.Content != "hello-result" {
+		t.Fatalf("Content = %q, want hello-result", result.Content)
+	}
+	if result.SessionRef == nil ||
+		result.SessionRef.Provider != providers.IDCodex ||
+		result.SessionRef.Kind != providers.SessionIDKind ||
+		result.SessionRef.ID != "session-attempt-1" {
+		t.Fatalf("SessionRef = %#v", result.SessionRef)
+	}
+	if result.Diagnostics == nil ||
+		result.Diagnostics.DurationMillis != 42 ||
+		len(result.Diagnostics.Progress) != 1 ||
+		result.Diagnostics.Progress[0].Phase != "completed" {
+		t.Fatalf("Diagnostics = %#v", result.Diagnostics)
+	}
+
+	cloned := result.Clone()
+	if cloned.SessionRef == result.SessionRef {
+		t.Fatal("ExecuteResult.Clone() shares SessionRef pointer")
+	}
+	if cloned.Diagnostics == result.Diagnostics {
+		t.Fatal("ExecuteResult.Clone() shares Diagnostics pointer")
+	}
+}
+
+func TestExecuteContract_Characterization_TypedFailures(t *testing.T) {
+	t.Parallel()
+
+	service := newExecutePeerFake("cancel-attempt", providers.Descriptor{
+		ID:           providers.IDCodex,
+		DisplayName:  "Codex",
+		Availability: providers.AvailabilitySelectable,
+		Readiness:    providers.ReadinessReady,
+	})
+
+	_, err := service.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:  providers.IDCodex,
+		AttemptID: "cancel-attempt",
+	})
+	if !errors.Is(err, providers.ErrExecuteCancelled) {
+		t.Fatalf("cancelled Execute() error = %v, want ErrExecuteCancelled", err)
+	}
+	var failure providers.ExecuteFailure
+	if !errors.As(err, &failure) {
+		t.Fatalf("cancelled Execute() error = %T(%v), want ExecuteFailure", err, err)
+	}
+	if failure.Kind != providers.ExecuteFailureKindCanceled {
+		t.Fatalf("failure.Kind = %q, want canceled", failure.Kind)
+	}
+
+	_, err = service.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:  providers.IDClaude,
+		AttemptID: "attempt-2",
+	})
+	if !errors.Is(err, providers.ErrUnknownProvider) {
+		t.Fatalf("unknown provider Execute() error = %v, want ErrUnknownProvider", err)
+	}
+
+	_, err = service.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:  providers.IDCodex,
+		AttemptID: "",
+	})
+	if !errors.Is(err, providers.ErrExecuteFailed) {
+		t.Fatalf("invalid attempt Execute() error = %v, want ErrExecuteFailed", err)
+	}
+}

--- a/pkg/services/providers/execute_contract.go
+++ b/pkg/services/providers/execute_contract.go
@@ -1,0 +1,171 @@
+package providers
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrExecuteCancelled reports that one provider execution attempt was cancelled
+// through context cancellation or an explicit provider-side cancel outcome.
+var ErrExecuteCancelled = errors.New("provider execution cancelled")
+
+// ErrExecuteTimeout reports that one provider execution attempt exceeded its
+// deadline.
+var ErrExecuteTimeout = errors.New("provider execution timed out")
+
+// ErrExecuteFailed reports a normalized provider execution failure that is not
+// one of the more specific cancellation or timeout outcomes.
+var ErrExecuteFailed = errors.New("provider execution failed")
+
+// ExecuteFailureKind is a provider-neutral one-attempt failure category.
+// Providers owns the normalized attempt outcome; Workers and other callers own
+// retry, throttle, and scheduling policy.
+type ExecuteFailureKind string
+
+const (
+	ExecuteFailureKindCanceled       ExecuteFailureKind = "canceled"
+	ExecuteFailureKindTimeout        ExecuteFailureKind = "timeout"
+	ExecuteFailureKindAuthentication ExecuteFailureKind = "authentication"
+	ExecuteFailureKindInvalidRequest ExecuteFailureKind = "invalid_request"
+	ExecuteFailureKindThrottled      ExecuteFailureKind = "throttled"
+	ExecuteFailureKindDependency     ExecuteFailureKind = "dependency"
+	ExecuteFailureKindUnknown        ExecuteFailureKind = "unknown"
+)
+
+// ExecuteFailure retains normalized one-attempt failure facts peers can branch
+// on with errors.Is / errors.As without importing Workers provider internals.
+type ExecuteFailure struct {
+	Kind    ExecuteFailureKind
+	Message string
+}
+
+func (failure ExecuteFailure) Error() string {
+	message := strings.TrimSpace(failure.Message)
+	if message == "" {
+		return sentinelForExecuteFailureKind(failure.Kind).Error()
+	}
+	return fmt.Sprintf("%s: %s", sentinelForExecuteFailureKind(failure.Kind).Error(), message)
+}
+
+func (failure ExecuteFailure) Unwrap() error {
+	return sentinelForExecuteFailureKind(failure.Kind)
+}
+
+func sentinelForExecuteFailureKind(kind ExecuteFailureKind) error {
+	switch kind {
+	case ExecuteFailureKindCanceled:
+		return ErrExecuteCancelled
+	case ExecuteFailureKindTimeout:
+		return ErrExecuteTimeout
+	default:
+		return ErrExecuteFailed
+	}
+}
+
+// ExecuteRequest is the plain one-attempt execute vocabulary. Providers owns
+// exactly one normalized native attempt per call; callers own selection,
+// retry, throttle, and scheduling policy.
+type ExecuteRequest struct {
+	Provider         ID
+	AttemptID        string
+	SystemPrompt     string
+	UserMessage      string
+	OutputSchema     string
+	ResumeSession    *SessionRef
+	WorkingDirectory string
+	Worktree         string
+}
+
+// Validate checks request fields whose validity does not depend on catalog
+// state.
+func (request ExecuteRequest) Validate() error {
+	if err := request.Provider.Validate(); err != nil {
+		return fmt.Errorf("%w", err)
+	}
+	if strings.TrimSpace(request.AttemptID) == "" {
+		return fmt.Errorf("%w: empty attempt id", ErrExecuteFailed)
+	}
+	if request.ResumeSession != nil {
+		if err := request.ResumeSession.Validate(); err != nil {
+			return fmt.Errorf("%w", err)
+		}
+	}
+	return nil
+}
+
+// Clone returns a detached execute-request copy.
+func (request ExecuteRequest) Clone() ExecuteRequest {
+	cloned := request
+	if request.ResumeSession != nil {
+		resume := request.ResumeSession.Clone()
+		cloned.ResumeSession = &resume
+	}
+	return cloned
+}
+
+// ExecuteProgress carries bounded in-flight progress facts for one attempt.
+// Providers exposes this detached value for peer contracts without requiring
+// transport or Workers provider streaming types.
+type ExecuteProgress struct {
+	Phase    string
+	Detail   string
+	Metadata map[string]string
+}
+
+// Clone returns a detached progress copy.
+func (progress ExecuteProgress) Clone() ExecuteProgress {
+	progress.Metadata = cloneStringMap(progress.Metadata)
+	return progress
+}
+
+// ExecuteDiagnostics carries sanitized one-attempt diagnostic facts on success
+// or failure without raw provider command output.
+type ExecuteDiagnostics struct {
+	DurationMillis int64
+	Progress       []ExecuteProgress
+	Metadata       map[string]string
+}
+
+// Clone returns a detached diagnostics copy.
+func (diagnostics ExecuteDiagnostics) Clone() ExecuteDiagnostics {
+	progress := diagnostics.Progress
+	diagnostics.Progress = make([]ExecuteProgress, len(progress))
+	for i := range progress {
+		diagnostics.Progress[i] = progress[i].Clone()
+	}
+	diagnostics.Metadata = cloneStringMap(diagnostics.Metadata)
+	return diagnostics
+}
+
+// ExecuteResult is the detached result of one normalized provider attempt.
+type ExecuteResult struct {
+	Content     string
+	SessionRef  *SessionRef
+	Diagnostics *ExecuteDiagnostics
+}
+
+// Clone returns a detached execute-result copy.
+func (result ExecuteResult) Clone() ExecuteResult {
+	cloned := result
+	if result.SessionRef != nil {
+		session := result.SessionRef.Clone()
+		cloned.SessionRef = &session
+	}
+	if result.Diagnostics != nil {
+		diagnostics := result.Diagnostics.Clone()
+		cloned.Diagnostics = &diagnostics
+	}
+	return cloned
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}

--- a/pkg/services/providers/identity_characterization_test.go
+++ b/pkg/services/providers/identity_characterization_test.go
@@ -1,0 +1,49 @@
+package providers_test
+
+import (
+	"testing"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+func TestIdentityContract_Characterization_RoundTripsDescriptorAndSessionRef(t *testing.T) {
+	t.Parallel()
+
+	original := providers.Descriptor{
+		ID:          providers.IDCodex,
+		Aliases:     []string{"openai-codex", "codex-cli"},
+		DisplayName: "Codex",
+	}
+	if err := original.ID.Validate(); err != nil {
+		t.Fatalf("ID.Validate() = %v", err)
+	}
+
+	roundTripped := original.Clone()
+	if roundTripped.ID != original.ID ||
+		roundTripped.DisplayName != original.DisplayName ||
+		len(roundTripped.Aliases) != len(original.Aliases) {
+		t.Fatalf("descriptor round trip = %#v, want %#v", roundTripped, original)
+	}
+	for i := range original.Aliases {
+		if roundTripped.Aliases[i] != original.Aliases[i] {
+			t.Fatalf("alias[%d] = %q, want %q", i, roundTripped.Aliases[i], original.Aliases[i])
+		}
+	}
+	if &roundTripped.Aliases[0] == &original.Aliases[0] {
+		t.Fatal("descriptor clone shares alias backing array")
+	}
+
+	session := providers.SessionRef{
+		Provider: providers.IDCodex,
+		Kind:     providers.SessionIDKind,
+		ID:       "session-root-1",
+	}
+	if err := session.Validate(); err != nil {
+		t.Fatalf("SessionRef.Validate() = %v", err)
+	}
+
+	clonedSession := session.Clone()
+	if clonedSession != session {
+		t.Fatalf("session ref round trip = %#v, want %#v", clonedSession, session)
+	}
+}

--- a/pkg/services/providers/identity_contract.go
+++ b/pkg/services/providers/identity_contract.go
@@ -48,19 +48,24 @@ func (id ID) String() string {
 }
 
 // Descriptor is the Providers-owned enumeration value for one catalog provider.
-// Availability, capability, and prerequisite facts publish on later catalog
-// slices; this value carries the identity facts peers need to list and name
-// providers without importing Workers provider internals.
+// It carries identity, availability, capability, and prerequisite facts peers
+// need to list and select providers without importing Workers provider internals.
 type Descriptor struct {
-	ID          ID
-	Aliases     []string
-	DisplayName string
+	ID            ID
+	Aliases       []string
+	DisplayName   string
+	Availability  Availability
+	Readiness     Readiness
+	Prerequisites []Prerequisite
+	Capabilities  []Capability
 }
 
 // Clone returns a detached descriptor copy.
 func (descriptor Descriptor) Clone() Descriptor {
 	cloned := descriptor
 	cloned.Aliases = append([]string(nil), descriptor.Aliases...)
+	cloned.Prerequisites = clonePrerequisites(descriptor.Prerequisites)
+	cloned.Capabilities = append([]Capability(nil), descriptor.Capabilities...)
 	return cloned
 }
 

--- a/pkg/services/providers/identity_contract.go
+++ b/pkg/services/providers/identity_contract.go
@@ -1,0 +1,93 @@
+package providers
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrInvalidID reports that a provider identity string is empty or otherwise
+// unusable as a Providers-owned ID.
+var ErrInvalidID = errors.New("provider id is invalid")
+
+// ErrInvalidSessionRef reports that a detached SessionRef is missing required
+// provider, kind, or id fields.
+var ErrInvalidSessionRef = errors.New("provider session ref is invalid")
+
+// ID is the Providers-owned canonical provider identity. Peers enumerate and
+// select providers through this typed vocabulary rather than Workers provider
+// registry or manifest types.
+type ID string
+
+const (
+	IDAgy      ID = "agy"
+	IDClaude   ID = "claude"
+	IDCodex    ID = "codex"
+	IDCursor   ID = "agent"
+	IDGemini   ID = "gemini"
+	IDKiro     ID = "kiro-cli"
+	IDOpenCode ID = "opencode"
+	IDPi       ID = "pi"
+)
+
+// SessionIDKind is the canonical session-ref kind for provider-issued session
+// identifiers emitted by Execute and consumed by Provider Sessions.
+const SessionIDKind = "session_id"
+
+// Validate checks that the provider ID is non-empty after trimming.
+func (id ID) Validate() error {
+	if strings.TrimSpace(string(id)) == "" {
+		return fmt.Errorf("%w: empty provider id", ErrInvalidID)
+	}
+	return nil
+}
+
+// String returns the canonical provider id string.
+func (id ID) String() string {
+	return string(id)
+}
+
+// Descriptor is the Providers-owned enumeration value for one catalog provider.
+// Availability, capability, and prerequisite facts publish on later catalog
+// slices; this value carries the identity facts peers need to list and name
+// providers without importing Workers provider internals.
+type Descriptor struct {
+	ID          ID
+	Aliases     []string
+	DisplayName string
+}
+
+// Clone returns a detached descriptor copy.
+func (descriptor Descriptor) Clone() Descriptor {
+	cloned := descriptor
+	cloned.Aliases = append([]string(nil), descriptor.Aliases...)
+	return cloned
+}
+
+// SessionRef is the detached typed provider-session identity in the
+// Providers-owned vocabulary (provider + kind + id). It does not embed Workers
+// provider, Petri/JavaScript, concrete adapter, transport, or UI types.
+type SessionRef struct {
+	Provider ID
+	Kind     string
+	ID       string
+}
+
+// Validate checks that provider, kind, and id are all non-empty after trimming.
+func (ref SessionRef) Validate() error {
+	if err := ref.Provider.Validate(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(ref.Kind) == "" {
+		return fmt.Errorf("%w: empty session kind", ErrInvalidSessionRef)
+	}
+	if strings.TrimSpace(ref.ID) == "" {
+		return fmt.Errorf("%w: empty session id", ErrInvalidSessionRef)
+	}
+	return nil
+}
+
+// Clone returns a detached session-ref copy.
+func (ref SessionRef) Clone() SessionRef {
+	return ref
+}

--- a/pkg/services/providers/root_contract_characterization_test.go
+++ b/pkg/services/providers/root_contract_characterization_test.go
@@ -3,11 +3,6 @@ package providers_test
 import (
 	"context"
 	"errors"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
-	"strings"
 	"testing"
 
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
@@ -190,85 +185,5 @@ func TestRootContract_FakePeerConstructionIsInert(t *testing.T) {
 	var service providers.Service = fake
 	if service == nil {
 		t.Fatal("constructed Service is nil")
-	}
-}
-
-func TestRootContract_PackageBoundary_AvoidsForbiddenPeers(t *testing.T) {
-	t.Parallel()
-
-	assertPackageAvoidsForbiddenPeers(
-		t,
-		"github.com/portpowered/infinite-you/pkg/services/providers",
-		false,
-	)
-}
-
-func TestRootContract_TestPackageBoundary_AvoidsForbiddenPeers(t *testing.T) {
-	t.Parallel()
-
-	assertPackageAvoidsForbiddenPeers(
-		t,
-		"github.com/portpowered/infinite-you/pkg/services/providers",
-		true,
-	)
-}
-
-func assertPackageAvoidsForbiddenPeers(t *testing.T, importPath string, includeTestDeps ...bool) {
-	t.Helper()
-
-	args := []string{
-		"go",
-		"list",
-		"-deps",
-		"-f",
-		"{{if not .Standard}}{{.ImportPath}}{{end}}",
-	}
-	if len(includeTestDeps) > 0 && includeTestDeps[0] {
-		args = append(args, "-test")
-	}
-	args = append(args, importPath)
-
-	cmd := exec.Command(args[0], args[1:]...)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("go list deps for %s: %v\n%s", importPath, err, output)
-	}
-
-	forbiddenRoots := []string{
-		"github.com/portpowered/infinite-you/pkg/services/workers/provider",
-		"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/petri",
-		"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/javascript",
-		"github.com/portpowered/infinite-you/pkg/transports",
-		"github.com/portpowered/infinite-you/ui",
-		"github.com/portpowered/infinite-you/pkg/wire",
-		"github.com/portpowered/infinite-you/pkg/root",
-		"github.com/portpowered/infinite-you/pkg/initializer",
-	}
-	for _, dep := range strings.Fields(string(output)) {
-		for _, forbidden := range forbiddenRoots {
-			if dep == forbidden || strings.HasPrefix(dep, forbidden+"/") {
-				t.Fatalf("%s must not import %s; found dependency %s", importPath, forbidden, dep)
-			}
-		}
-	}
-}
-
-func TestRootContract_TransitionalWorkersProviderRemainsInPlace(t *testing.T) {
-	t.Parallel()
-
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("resolve test source path")
-	}
-	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", ".."))
-	requiredPaths := []string{
-		"pkg/services/workers/provider/registry/registry.go",
-		"pkg/services/workers/provider/conductor/conductor.go",
-	}
-	for _, relative := range requiredPaths {
-		path := filepath.Join(repoRoot, filepath.FromSlash(relative))
-		if _, err := os.Stat(path); err != nil {
-			t.Fatalf("transitional workers provider path %s must remain present: %v", relative, err)
-		}
 	}
 }

--- a/pkg/services/providers/root_contract_characterization_test.go
+++ b/pkg/services/providers/root_contract_characterization_test.go
@@ -1,0 +1,274 @@
+package providers_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+// TestRootContractInvariants_AllSlicesThroughSingularService seals the
+// Providers root-contract packet: every published slice (catalog list/get and
+// one-attempt Execute) is reachable through one named providers.Service, a
+// peer-shaped fake can exercise success and typed-failure paths using only the
+// root package, and no second peer-facing Providers authority is required.
+func TestRootContractInvariants_AllSlicesThroughSingularService(t *testing.T) {
+	t.Parallel()
+
+	codex := providers.Descriptor{
+		ID:           providers.IDCodex,
+		DisplayName:  "Codex",
+		Availability: providers.AvailabilitySelectable,
+		Readiness:    providers.ReadinessReady,
+		Capabilities: []providers.Capability{providers.CapabilityPromptSubmission},
+	}
+	service := newExecutePeerFake("cancel-attempt", codex)
+	var root providers.Service = service
+
+	assertSealCatalogSuccess(t, root)
+	assertSealCatalogFailures(t, root, codex)
+	assertSealExecuteSuccess(t, root)
+	assertSealExecuteFailures(t, root)
+}
+
+func assertSealCatalogSuccess(t *testing.T, service providers.Service) {
+	t.Helper()
+
+	list, err := service.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if err != nil {
+		t.Fatalf("ListProviders() = %v", err)
+	}
+	if len(list.Providers) != 1 || list.Providers[0].ID != providers.IDCodex {
+		t.Fatalf("ListProviders() = %#v, want one codex descriptor", list.Providers)
+	}
+
+	got, err := service.GetProvider(context.Background(), providers.GetProviderRequest{ID: providers.IDCodex})
+	if err != nil {
+		t.Fatalf("GetProvider(codex) = %v", err)
+	}
+	if got.Provider.DisplayName != "Codex" ||
+		got.Provider.Availability != providers.AvailabilitySelectable {
+		t.Fatalf("GetProvider(codex) = %#v", got.Provider)
+	}
+}
+
+func assertSealCatalogFailures(t *testing.T, service providers.Service, codex providers.Descriptor) {
+	t.Helper()
+
+	assertGetErrorIs(t, service, providers.GetProviderRequest{}, providers.ErrInvalidID)
+	assertGetErrorIs(t, service, providers.GetProviderRequest{ID: providers.IDClaude}, providers.ErrUnknownProvider)
+
+	unavailable := providers.Descriptor{
+		ID:           providers.IDCursor,
+		DisplayName:  "Cursor",
+		Availability: providers.AvailabilitySupportedButUnavailable,
+		Readiness:    providers.ReadinessUnavailable,
+		Prerequisites: []providers.Prerequisite{{
+			Kind:   providers.PrerequisiteDependency,
+			Name:   "cursor-agent",
+			Status: providers.PrerequisiteMissing,
+		}},
+	}
+	blocked := newExecutePeerFake("cancel-attempt", codex, unavailable)
+	assertGetErrorIs(
+		t,
+		blocked,
+		providers.GetProviderRequest{ID: providers.IDCursor},
+		providers.ErrProviderUnavailable,
+	)
+}
+
+func assertSealExecuteSuccess(t *testing.T, service providers.Service) {
+	t.Helper()
+
+	result, err := service.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:    providers.IDCodex,
+		AttemptID:   "seal-attempt",
+		UserMessage: "hello seal",
+	})
+	if err != nil {
+		t.Fatalf("Execute() = %v", err)
+	}
+	if result.Content != "hello seal-result" {
+		t.Fatalf("Execute() content = %q, want hello seal-result", result.Content)
+	}
+	if result.SessionRef == nil || result.SessionRef.ID != "session-seal-attempt" {
+		t.Fatalf("Execute() SessionRef = %#v", result.SessionRef)
+	}
+}
+
+func assertSealExecuteFailures(t *testing.T, service providers.Service) {
+	t.Helper()
+
+	_, err := service.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:  providers.IDCodex,
+		AttemptID: "cancel-attempt",
+	})
+	if !errors.Is(err, providers.ErrExecuteCancelled) {
+		t.Fatalf("cancelled Execute() error = %v, want ErrExecuteCancelled", err)
+	}
+	var failure providers.ExecuteFailure
+	if !errors.As(err, &failure) {
+		t.Fatalf("cancelled Execute() error = %T(%v), want ExecuteFailure", err, err)
+	}
+
+	_, err = service.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:  providers.IDClaude,
+		AttemptID: "seal-unknown",
+	})
+	if !errors.Is(err, providers.ErrUnknownProvider) {
+		t.Fatalf("unknown provider Execute() error = %v, want ErrUnknownProvider", err)
+	}
+}
+
+func TestRootContract_ContractValuesStayInertWhenHeld(t *testing.T) {
+	t.Parallel()
+
+	descriptor := providers.Descriptor{
+		ID:          providers.IDCodex,
+		Aliases:     []string{"openai-codex"},
+		DisplayName: "Codex",
+	}
+	clonedDescriptor := descriptor.Clone()
+	descriptor.DisplayName = "mutated"
+	if clonedDescriptor.DisplayName == "mutated" {
+		t.Fatal("Descriptor.Clone() shares mutable display name state")
+	}
+
+	request := providers.ExecuteRequest{
+		Provider:    providers.IDCodex,
+		AttemptID:   "inert-attempt",
+		UserMessage: "hello",
+	}
+	clonedRequest := request.Clone()
+	request.UserMessage = "mutated"
+	if clonedRequest.UserMessage == "mutated" {
+		t.Fatal("ExecuteRequest.Clone() shares mutable user message state")
+	}
+
+	session := providers.SessionRef{
+		Provider: providers.IDCodex,
+		Kind:     providers.SessionIDKind,
+		ID:       "session-inert",
+	}
+	if err := session.Validate(); err != nil {
+		t.Fatalf("SessionRef.Validate() = %v", err)
+	}
+	if cloned := session.Clone(); cloned != session {
+		t.Fatalf("SessionRef.Clone() = %#v, want %#v", cloned, session)
+	}
+
+	// Holding contract values must not require a Service implementation or
+	// perform adapter/registry/conductor/process work.
+	var (
+		_ providers.Descriptor     = descriptor
+		_ providers.ExecuteRequest = request
+		_ providers.SessionRef     = session
+		_ providers.ListProvidersRequest
+		_ providers.GetProviderRequest
+		_ providers.ExecuteResult
+	)
+}
+
+func TestRootContract_FakePeerConstructionIsInert(t *testing.T) {
+	t.Parallel()
+
+	fake := newExecutePeerFake("cancel-attempt")
+	if fake.providers == nil {
+		t.Fatal("fake peer construction returned nil catalog map")
+	}
+	if len(fake.providers) != 0 {
+		t.Fatalf("fake peer construction initialized catalog entries = %d, want 0", len(fake.providers))
+	}
+
+	var service providers.Service = fake
+	if service == nil {
+		t.Fatal("constructed Service is nil")
+	}
+}
+
+func TestRootContract_PackageBoundary_AvoidsForbiddenPeers(t *testing.T) {
+	t.Parallel()
+
+	assertPackageAvoidsForbiddenPeers(
+		t,
+		"github.com/portpowered/infinite-you/pkg/services/providers",
+		false,
+	)
+}
+
+func TestRootContract_TestPackageBoundary_AvoidsForbiddenPeers(t *testing.T) {
+	t.Parallel()
+
+	assertPackageAvoidsForbiddenPeers(
+		t,
+		"github.com/portpowered/infinite-you/pkg/services/providers",
+		true,
+	)
+}
+
+func assertPackageAvoidsForbiddenPeers(t *testing.T, importPath string, includeTestDeps ...bool) {
+	t.Helper()
+
+	args := []string{
+		"go",
+		"list",
+		"-deps",
+		"-f",
+		"{{if not .Standard}}{{.ImportPath}}{{end}}",
+	}
+	if len(includeTestDeps) > 0 && includeTestDeps[0] {
+		args = append(args, "-test")
+	}
+	args = append(args, importPath)
+
+	cmd := exec.Command(args[0], args[1:]...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list deps for %s: %v\n%s", importPath, err, output)
+	}
+
+	forbiddenRoots := []string{
+		"github.com/portpowered/infinite-you/pkg/services/workers/provider",
+		"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/petri",
+		"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/javascript",
+		"github.com/portpowered/infinite-you/pkg/transports",
+		"github.com/portpowered/infinite-you/ui",
+		"github.com/portpowered/infinite-you/pkg/wire",
+		"github.com/portpowered/infinite-you/pkg/root",
+		"github.com/portpowered/infinite-you/pkg/initializer",
+	}
+	for _, dep := range strings.Fields(string(output)) {
+		for _, forbidden := range forbiddenRoots {
+			if dep == forbidden || strings.HasPrefix(dep, forbidden+"/") {
+				t.Fatalf("%s must not import %s; found dependency %s", importPath, forbidden, dep)
+			}
+		}
+	}
+}
+
+func TestRootContract_TransitionalWorkersProviderRemainsInPlace(t *testing.T) {
+	t.Parallel()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", ".."))
+	requiredPaths := []string{
+		"pkg/services/workers/provider/registry/registry.go",
+		"pkg/services/workers/provider/conductor/conductor.go",
+	}
+	for _, relative := range requiredPaths {
+		path := filepath.Join(repoRoot, filepath.FromSlash(relative))
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("transitional workers provider path %s must remain present: %v", relative, err)
+		}
+	}
+}

--- a/pkg/services/providers/service_contract.go
+++ b/pkg/services/providers/service_contract.go
@@ -1,0 +1,20 @@
+package providers
+
+import "context"
+
+// Service is the singular cross-service Providers root authority. Peer packages
+// depend on this one named interface for Providers-owned catalog enumeration,
+// availability/capability facts, and one normalized execution attempt rather
+// than Workers provider registry/conductor types or concrete adapter packages.
+// Execute publishes additively on this same interface in later CTR-PROV slices.
+type Service interface {
+	// ListProviders returns detached catalog descriptors for every known
+	// provider, including availability and capability facts. Unavailable or
+	// prerequisite-blocked providers remain listed with their catalog facts.
+	ListProviders(context.Context, ListProvidersRequest) (ListProvidersResult, error)
+	// GetProvider returns one detached catalog descriptor for a Providers-owned
+	// provider identity. Invalid identity fails with ErrInvalidID, unknown
+	// identity fails with ErrUnknownProvider, and blocked availability or
+	// prerequisite facts fail with ErrProviderUnavailable.
+	GetProvider(context.Context, GetProviderRequest) (GetProviderResult, error)
+}

--- a/pkg/services/providers/service_contract.go
+++ b/pkg/services/providers/service_contract.go
@@ -6,7 +6,8 @@ import "context"
 // depend on this one named interface for Providers-owned catalog enumeration,
 // availability/capability facts, and one normalized execution attempt rather
 // than Workers provider registry/conductor types or concrete adapter packages.
-// Execute publishes additively on this same interface in later CTR-PROV slices.
+// Providers owns exactly one native attempt per Execute call; callers own
+// selection, retry, throttle, and scheduling policy.
 type Service interface {
 	// ListProviders returns detached catalog descriptors for every known
 	// provider, including availability and capability facts. Unavailable or
@@ -17,4 +18,10 @@ type Service interface {
 	// identity fails with ErrUnknownProvider, and blocked availability or
 	// prerequisite facts fail with ErrProviderUnavailable.
 	GetProvider(context.Context, GetProviderRequest) (GetProviderResult, error)
+	// Execute performs exactly one normalized provider attempt. Invalid request
+	// identity fails with ErrInvalidID. Attempt failures return typed
+	// Providers-owned errors such as ErrExecuteCancelled, ErrExecuteTimeout, and
+	// ErrExecuteFailed that peers can branch on with errors.Is / errors.As.
+	// Successful results may carry an optional detached SessionRef.
+	Execute(context.Context, ExecuteRequest) (ExecuteResult, error)
 }


### PR DESCRIPTION
{
  "project": "CTR-PROV: Publish the standalone Providers root contract",
  "branchName": "pss-ctr-prov-root-contract",
  "description": "Publish an inert, contract-only Providers root at pkg/services/providers with additive typed request/result/value/error contracts for provider IDs/descriptors, availability/capabilities, one-attempt Execute, and SessionRef, characterized so a fake peer can implement the seam without Workers provider internals, Petri/JavaScript types, concrete adapters, or transport/UI concerns while leaving transitional workers/provider implementations in place.",
  "context": {
    "customerAsk": "Implement CTR-PROV by publishing the standalone Providers root at pkg/services/providers with additive, typed, detached request/result/value/error contracts for provider IDs/descriptors, availability/capabilities, one-attempt execute, and SessionRef. Characterize the published slices so a fake peer can implement them without importing Workers provider internals, Petri/JavaScript types, concrete adapter packages, or transport/UI concerns. Keep construction inert and leave transitional pkg/services/workers/provider/** adapters, catalog, registry, and conductor implementations in place for later IMP-PROV-* absorption; do not relocate concrete adapters, delete workers/provider, or start Claude/Codex/Pi/OpenCode/Agy migrations in this packet. Do not implement IMP-WRK-04 agent runner, IMP-WRK-07 hosted runner, Automation hosted-sources polling moves, Models assets/host/lease packets, OpenAPI or generated API artifact changes, CLI manifests/root/run/server behavior, pkg/root, pkg/wire, pkg/initializer, UI code, or broad functional-test topology. Any ownership-inventory or package-target-manifest updates must register only the Providers root and remain lease-minimal. Require focused root-contract characterization tests, gofmt, vet/lint, architecture/ownership checks, and make verify-fast.",
    "problem": "Provider catalog, availability, capability, native execution, and session-ref extraction still live under transitional pkg/services/workers/provider. Peers that need provider identity or one normalized attempt must import Workers provider internals. IMP-WRK-04 and later IMP-PROV-* absorption are gated on a published standalone Providers root contract that does not yet exist as a peer-facing package.",
    "solution": "Publish an inert, contract-only Providers root at pkg/services/providers that exposes one named Service seam and plain Providers-owned types for identity/descriptors, availability/capabilities, one-attempt Execute, and detached SessionRef. Prove the seam with fake-peer characterization tests and leave all concrete Workers provider implementations in place for later IMP-PROV-* packets."
  },
  "acceptanceCriteria": [
    "AC-1: pkg/services/providers exists as a peer-facing root whose public surface is limited to one named Service interface plus plain request, result, value, and typed-error contracts for IDs/descriptors, availability/capabilities, one-attempt execute, and SessionRef",
    "AC-2: A fake peer implements the full published Service using only Providers root types and exercises success and typed-failure paths for catalog and execute slices without importing Workers provider internals, Petri/JavaScript types, concrete adapter packages, or transport/UI packages",
    "AC-3: Constructing or holding the published root contract types performs no work against adapters, processes, registry, conductor, Wire, or Initializer; transitional pkg/services/workers/provider/** remains in place and is not relocated or deleted",
    "AC-4: Any ownership-inventory or package-target-manifest edits register only the Providers root package and stay lease-minimal",
    "AC-5: Changed paths exclude OpenAPI/generated clients, CLI manifests/root/run/server behavior, pkg/root, pkg/wire, pkg/initializer, UI, IMP-WRK-04/07, Automation hosted-sources moves, Models assets/host/lease work, and broad functional-test topology",
    "AC-6: Quality checks pass (gofmt, vet/lint, architecture/ownership checks, focused Providers root-contract tests, and make verify-fast)"
  ],
  "userStories": [
    {
      "id": "pss-ctr-prov-root-contract-001",
      "title": "Publish Providers identity and SessionRef vocabulary",
      "description": "As a peer-service maintainer, I want Providers-owned provider IDs, descriptors, and a detached SessionRef value type so I can name providers and carry execution-produced session identity without importing Workers provider packages.",
      "acceptanceCriteria": [
        "pkg/services/providers publishes typed provider identity (ID or equivalent), descriptor/value fields needed for peer enumeration, and detached SessionRef (provider + kind + id) as Providers-owned plain values",
        "Published identity and SessionRef types do not embed Workers provider, Petri/JavaScript, concrete adapter, transport, or UI types",
        "A focused characterization test constructs and round-trips identity/SessionRef values through Providers root types only and asserts field retention",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-ctr-prov-root-contract-002",
      "title": "Publish catalog list/get and availability/capability slices",
      "description": "As a peer-service maintainer, I want additive List/Get and availability/capability operations on one Providers Service so I can enumerate providers and read capability/prerequisite facts through detached request/result/error contracts.",
      "acceptanceCriteria": [
        "Singular Providers Service exposes additive catalog operations that list and get providers by Providers-owned identity and return detached descriptors including availability and capability facts",
        "Unknown-provider, unavailable/prerequisite-failed, and invalid-identity cases return typed Providers-owned errors that peers can branch with errors.Is / errors.As",
        "A fake peer implements the catalog slices using only Providers root contracts and a characterization test asserts success list/get plus at least one typed failure path",
        "Method signatures do not require Workers provider registry/conductor types, concrete adapters, or effect ports from the caller",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-ctr-prov-root-contract-003",
      "title": "Publish one-attempt Execute request/result/error contracts",
      "description": "As a Workers or peer maintainer, I want a Providers Execute slice for exactly one normalized attempt so selection/retry policy can stay in Workers while Providers owns native attempt outcomes and optional SessionRef emission.",
      "acceptanceCriteria": [
        "Singular Providers Service exposes one-attempt Execute with Providers-owned request, result, progress/diagnostic value shapes as needed for a detached peer contract, and typed failure facts",
        "Successful execute results may carry an optional detached SessionRef; failure paths return typed Providers-owned errors distinct from catalog unknown-ID failures where applicable",
        "A fake peer implements Execute using only Providers root contracts and a characterization test asserts one success path (with optional SessionRef) and at least one typed failure/cancellation-class outcome",
        "Contract documentation or type comments state that Providers owns one attempt and does not encode Workers retry/throttle/scheduling policy",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-ctr-prov-root-contract-004",
      "title": "Prove inert construction and forbidden-dependency isolation",
      "description": "As a reviewer, I want characterization proof that the published root stays inert and that a fake peer can implement the full seam without forbidden imports so CTR-PROV unlocks later packets without leaking Workers provider internals.",
      "acceptanceCriteria": [
        "Characterization suite exercises the full published Service through a fake peer and covers catalog success/failure plus execute success/failure outcomes already published",
        "Fake-peer and root-contract test packages import only Providers root (and stdlib/test helpers); they do not import pkg/services/workers/provider/**, Petri/JavaScript orchestration types, concrete adapter packages, transport packages, or UI packages",
        "Holding/using the published contract types performs no adapter/registry/conductor/process work; no production Wire/pkg/root/pkg/initializer wiring is added for Providers in this packet",
        "Transitional pkg/services/workers/provider/** remains present and unchanged in purpose (no relocate/delete of catalog, registry, conductor, or adapters)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-ctr-prov-root-contract-005",
      "title": "Lease-minimal ownership registration and verify-fast gate",
      "description": "As a Packaged Service Structure steward, I want the new Providers root package registered only where ownership/package-target manifests require it, then verified with the narrow quality gate so later IMP-PROV-* packets can lease against a known root.",
      "acceptanceCriteria": [
        "If ownership-inventory or package-target-manifest updates are required for the new package to pass architecture/ownership checks, they register only pkg/services/providers (Providers root) and do not expand into nested Catalog/Execution implementation paths or unrelated owners",
        "Focused Providers root-contract tests pass; gofmt and vet/lint are clean for changed Go files",
        "Architecture/ownership checks that apply to the changed paths pass",
        "make verify-fast passes",
        "Diff stays inside Providers root contracts/tests plus any lease-minimal manifest registration; no OpenAPI, CLI, Wire/root/initializer, UI, Workers runner, Automation hosted-sources, or Models assets/host/lease changes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}
