### PR TITLE
pss-imp-prov-01-catalog

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -947,6 +947,56 @@
       }
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/service",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/internal/service",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/wire",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/wire",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings",
       "minimum": 3.85
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -875,6 +875,32 @@
       "minimum": 72.85
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/service",
+      "minimum": 100.00
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active unit coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/internal/service",
+      "minimum": 91.07
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/wire",
+      "minimum": 100.00
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/wire",
+      "minimum": 75.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings",
       "minimum": 83.56
     },

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -231,6 +231,11 @@
     "pkg/services/provider_sessions/cursor",
     "pkg/services/provider_sessions/service",
     "pkg/services/providers",
+    "pkg/services/providers/internal/service",
+    "pkg/services/providers/internal/services/catalog",
+    "pkg/services/providers/internal/services/catalog/internal/service",
+    "pkg/services/providers/internal/services/catalog/wire",
+    "pkg/services/providers/wire",
     "pkg/services/recordings",
     "pkg/services/recordings/artifacts",
     "pkg/services/recordings/events",
@@ -1323,6 +1328,31 @@
     },
     {
       "packagePath": "pkg/services/providers",
+      "disposition": "retain",
+      "destination": "providers"
+    },
+    {
+      "packagePath": "pkg/services/providers/internal/service",
+      "disposition": "retain",
+      "destination": "providers"
+    },
+    {
+      "packagePath": "pkg/services/providers/internal/services/catalog",
+      "disposition": "retain",
+      "destination": "providers/internal/services/catalog"
+    },
+    {
+      "packagePath": "pkg/services/providers/internal/services/catalog/internal/service",
+      "disposition": "retain",
+      "destination": "providers/internal/services/catalog"
+    },
+    {
+      "packagePath": "pkg/services/providers/internal/services/catalog/wire",
+      "disposition": "retain",
+      "destination": "providers/internal/services/catalog"
+    },
+    {
+      "packagePath": "pkg/services/providers/wire",
       "disposition": "retain",
       "destination": "providers"
     },

--- a/pkg/services/providers/internal/service/service.go
+++ b/pkg/services/providers/internal/service/service.go
@@ -1,0 +1,52 @@
+// Package service implements the published Providers root Service by
+// delegating catalog list/get to the parent-private catalog subservice.
+package service
+
+import (
+	"context"
+	"fmt"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	catalog "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog"
+)
+
+// Service fulfills the published Providers root contract.
+type Service struct {
+	catalog catalog.Service
+}
+
+var _ providers.Service = (*Service)(nil)
+
+// New constructs an inert Providers root facade over the supplied catalog.
+func New(catalogService catalog.Service) (providers.Service, error) {
+	if catalogService == nil {
+		return nil, fmt.Errorf("construct Providers: catalog is required")
+	}
+	return &Service{catalog: catalogService}, nil
+}
+
+func (s *Service) ListProviders(
+	ctx context.Context,
+	request providers.ListProvidersRequest,
+) (providers.ListProvidersResult, error) {
+	return s.catalog.ListProviders(ctx, request)
+}
+
+func (s *Service) GetProvider(
+	ctx context.Context,
+	request providers.GetProviderRequest,
+) (providers.GetProviderResult, error) {
+	return s.catalog.GetProvider(ctx, request)
+}
+
+// Execute remains unimplemented in IMP-PROV-01; IMP-PROV-02 owns execution
+// absorption behind the published root slice.
+func (s *Service) Execute(
+	_ context.Context,
+	request providers.ExecuteRequest,
+) (providers.ExecuteResult, error) {
+	if err := request.Validate(); err != nil {
+		return providers.ExecuteResult{}, err
+	}
+	return providers.ExecuteResult{}, providers.ErrExecuteFailed
+}

--- a/pkg/services/providers/internal/service/service_test.go
+++ b/pkg/services/providers/internal/service/service_test.go
@@ -1,0 +1,240 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	providerservice "github.com/portpowered/infinite-you/pkg/services/providers/internal/service"
+	catalog "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog"
+	catalogwire "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/wire"
+	providerswire "github.com/portpowered/infinite-you/pkg/services/providers/wire"
+)
+
+func TestNew_RejectsNilCatalog(t *testing.T) {
+	t.Parallel()
+
+	service, err := providerservice.New(nil)
+	if err == nil || service != nil {
+		t.Fatalf("New(nil) = (%v, %v), want error", service, err)
+	}
+}
+
+func TestRootDelegatesListAndGetToCatalog(t *testing.T) {
+	t.Parallel()
+
+	catalogService, err := catalogwire.NewService()
+	if err != nil {
+		t.Fatalf("catalogwire.NewService() = %v", err)
+	}
+	root, err := providerservice.New(catalogService)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	list, err := root.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if err != nil {
+		t.Fatalf("ListProviders() = %v", err)
+	}
+	if len(list.Providers) != 8 {
+		t.Fatalf("len(Providers) = %d, want 8", len(list.Providers))
+	}
+
+	got, err := root.GetProvider(context.Background(), providers.GetProviderRequest{ID: providers.IDCodex})
+	if err != nil {
+		t.Fatalf("GetProvider(codex) = %v", err)
+	}
+	if got.Provider.ID != providers.IDCodex {
+		t.Fatalf("GetProvider(codex).Provider.ID = %q, want codex", got.Provider.ID)
+	}
+
+	byAlias, err := root.GetProvider(context.Background(), providers.GetProviderRequest{ID: providers.ID("cursor")})
+	if err != nil {
+		t.Fatalf("GetProvider(cursor) = %v", err)
+	}
+	if byAlias.Provider.ID != providers.IDCursor {
+		t.Fatalf("GetProvider(cursor).Provider.ID = %q, want agent", byAlias.Provider.ID)
+	}
+}
+
+func TestRootCatalogTypedFailuresMatchPrivateCatalog(t *testing.T) {
+	t.Parallel()
+
+	root := mustRootService(t)
+
+	assertGetErrorIs(t, root, providers.GetProviderRequest{}, providers.ErrInvalidID)
+	assertGetErrorIs(t, root, providers.GetProviderRequest{ID: providers.IDClaude + "-stale"}, providers.ErrUnknownProvider)
+	assertGetErrorIs(t, root, providers.GetProviderRequest{ID: providers.IDAgy}, providers.ErrProviderUnavailable)
+
+	list, err := root.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if err != nil {
+		t.Fatalf("ListProviders() = %v", err)
+	}
+	if _, ok := indexProviders(list.Providers)[providers.IDAgy]; !ok {
+		t.Fatal("ListProviders() missing unavailable agy provider")
+	}
+}
+
+func TestRootCatalogProbeFailureMatchesPrivateCatalog(t *testing.T) {
+	t.Parallel()
+
+	root, err := providerswire.NewService(catalogwire.WithProbeQuery(func(
+		_ context.Context,
+		descriptor providers.Descriptor,
+	) (catalog.ProbeFacts, error) {
+		if descriptor.ID == providers.IDCodex {
+			return catalog.ProbeFacts{}, errors.New("native probe stderr: /Users/customer/.codex/output")
+		}
+		return catalog.ProbeFacts{
+			Readiness:     descriptor.Readiness,
+			Prerequisites: descriptor.Prerequisites,
+		}, nil
+	}))
+	if err != nil {
+		t.Fatalf("NewService() = %v", err)
+	}
+
+	list, err := root.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if err != nil {
+		t.Fatalf("ListProviders() = %v", err)
+	}
+	codex := indexProviders(list.Providers)[providers.IDCodex]
+	if codex.Readiness != providers.ReadinessUnavailable {
+		t.Fatalf("codex readiness = %q, want unavailable after probe failure", codex.Readiness)
+	}
+	if strings.Contains(codex.Prerequisites[0].Description, "/Users/") {
+		t.Fatalf("probe failure description leaked native output: %q", codex.Prerequisites[0].Description)
+	}
+
+	assertGetErrorIs(t, root, providers.GetProviderRequest{ID: providers.IDCodex}, providers.ErrProviderUnavailable)
+}
+
+func TestRootExecuteRemainsUnimplemented(t *testing.T) {
+	t.Parallel()
+
+	root := mustRootService(t)
+
+	_, err := root.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:    providers.IDCodex,
+		AttemptID:   "attempt-1",
+		UserMessage: "hello",
+	})
+	if !errors.Is(err, providers.ErrExecuteFailed) {
+		t.Fatalf("Execute() error = %v, want ErrExecuteFailed", err)
+	}
+
+	_, err = root.Execute(context.Background(), providers.ExecuteRequest{
+		Provider: providers.IDCodex,
+	})
+	if !errors.Is(err, providers.ErrExecuteFailed) {
+		t.Fatalf("invalid Execute() error = %v, want ErrExecuteFailed", err)
+	}
+}
+
+func TestRootConstructionIsInert(t *testing.T) {
+	t.Parallel()
+
+	root, err := providerswire.NewService()
+	if err != nil {
+		t.Fatalf("NewService() = %v", err)
+	}
+	if root == nil {
+		t.Fatal("NewService() returned nil")
+	}
+	var _ providers.Service = root
+}
+
+func TestPackageBoundary_AvoidsWorkersProviderInternals(t *testing.T) {
+	t.Parallel()
+
+	assertPackageAvoidsForbiddenPeers(
+		t,
+		"github.com/portpowered/infinite-you/pkg/services/providers/internal/service",
+	)
+}
+
+func TestTransitionalWorkersProviderRemainsInPlace(t *testing.T) {
+	t.Parallel()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "..", "..", ".."))
+	requiredPaths := []string{
+		"pkg/services/workers/provider/registry/registry.go",
+		"pkg/services/workers/provider/conductor/conductor.go",
+	}
+	for _, relative := range requiredPaths {
+		path := filepath.Join(repoRoot, filepath.FromSlash(relative))
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("transitional workers provider path %s must remain present: %v", relative, err)
+		}
+	}
+}
+
+func mustRootService(t *testing.T) providers.Service {
+	t.Helper()
+
+	root, err := providerswire.NewService()
+	if err != nil {
+		t.Fatalf("NewService() = %v", err)
+	}
+	return root
+}
+
+func assertGetErrorIs(
+	t *testing.T,
+	service providers.Service,
+	request providers.GetProviderRequest,
+	want error,
+) {
+	t.Helper()
+
+	_, err := service.GetProvider(context.Background(), request)
+	if !errors.Is(err, want) {
+		t.Fatalf("GetProvider(%#v) error = %v, want %v", request, err, want)
+	}
+}
+
+func indexProviders(descriptors []providers.Descriptor) map[providers.ID]providers.Descriptor {
+	byID := make(map[providers.ID]providers.Descriptor, len(descriptors))
+	for _, descriptor := range descriptors {
+		byID[descriptor.ID] = descriptor
+	}
+	return byID
+}
+
+func assertPackageAvoidsForbiddenPeers(t *testing.T, importPath string) {
+	t.Helper()
+
+	cmd := exec.Command(
+		"go",
+		"list",
+		"-deps",
+		"-f",
+		"{{if not .Standard}}{{.ImportPath}}{{end}}",
+		importPath,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list deps for %s: %v\n%s", importPath, err, output)
+	}
+
+	forbiddenRoots := []string{
+		"github.com/portpowered/infinite-you/pkg/services/workers/provider",
+	}
+	for _, dep := range strings.Fields(string(output)) {
+		for _, forbidden := range forbiddenRoots {
+			if dep == forbidden || strings.HasPrefix(dep, forbidden+"/") {
+				t.Fatalf("%s must not import %s; found dependency %s", importPath, forbidden, dep)
+			}
+		}
+	}
+}

--- a/pkg/services/providers/internal/services/catalog/internal/service/options.go
+++ b/pkg/services/providers/internal/services/catalog/internal/service/options.go
@@ -1,0 +1,14 @@
+package service
+
+import catalog "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog"
+
+// Option configures catalog construction.
+type Option func(*service)
+
+// WithProbeQuery injects request-time readiness probing. Construction remains
+// inert; probe side effects occur only during ListProviders and GetProvider.
+func WithProbeQuery(query catalog.ProbeQuery) Option {
+	return func(s *service) {
+		s.probe = query
+	}
+}

--- a/pkg/services/providers/internal/services/catalog/internal/service/projection.go
+++ b/pkg/services/providers/internal/services/catalog/internal/service/projection.go
@@ -1,0 +1,160 @@
+package service
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	modelproviders "github.com/portpowered/infinite-you/packages/model-providers"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+func projectPublishedCatalog() ([]providers.Descriptor, error) {
+	catalog, err := modelproviders.Catalog()
+	if err != nil {
+		return nil, err
+	}
+	return projectManifests(catalog.Providers)
+}
+
+func projectManifests(manifests []factoryapi.ProviderManifest) ([]providers.Descriptor, error) {
+	descriptors := make([]providers.Descriptor, 0, len(manifests))
+	for _, manifest := range manifests {
+		descriptor, err := projectManifest(manifest)
+		if err != nil {
+			return nil, err
+		}
+		descriptors = append(descriptors, descriptor)
+	}
+	sort.Slice(descriptors, func(i, j int) bool {
+		return descriptors[i].ID.String() < descriptors[j].ID.String()
+	})
+	return descriptors, nil
+}
+
+func projectManifest(manifest factoryapi.ProviderManifest) (providers.Descriptor, error) {
+	canonicalID := canonicalProvidersID(manifest.Id)
+	if err := canonicalID.Validate(); err != nil {
+		return providers.Descriptor{}, fmt.Errorf("project provider %q: %w", manifest.Id, err)
+	}
+	availability := projectAvailability(manifest)
+	return providers.Descriptor{
+		ID:            canonicalID,
+		Aliases:       projectAliases(manifest.Id, manifest.Aliases, canonicalID),
+		DisplayName:   localizedValue(manifest.DisplayName),
+		Availability:  availability,
+		Readiness:     projectReadiness(availability),
+		Prerequisites: nil,
+		Capabilities:  projectCapabilities(manifest),
+	}, nil
+}
+
+func canonicalProvidersID(manifestID string) providers.ID {
+	switch strings.ToLower(strings.TrimSpace(manifestID)) {
+	case "cursor":
+		return providers.IDCursor
+	case "kiro":
+		return providers.IDKiro
+	default:
+		return providers.ID(manifestID)
+	}
+}
+
+func projectAliases(manifestID string, aliases []string, canonical providers.ID) []string {
+	seen := make(map[string]struct{}, len(aliases)+1)
+	collected := make([]string, 0, len(aliases)+1)
+	add := func(value string) {
+		normalized := strings.ToLower(strings.TrimSpace(value))
+		if normalized == "" || normalized == canonical.String() {
+			return
+		}
+		if _, ok := seen[normalized]; ok {
+			return
+		}
+		seen[normalized] = struct{}{}
+		collected = append(collected, normalized)
+	}
+	for _, alias := range aliases {
+		add(alias)
+	}
+	add(manifestID)
+	sort.Strings(collected)
+	return collected
+}
+
+func projectAvailability(manifest factoryapi.ProviderManifest) providers.Availability {
+	switch manifest.TechnicalSupportLevel {
+	case factoryapi.ProviderTechnicalSupportLevelNotSupported:
+		return providers.AvailabilityNotSupported
+	}
+	switch manifest.ImplementationAvailability {
+	case factoryapi.ProviderImplementationAvailabilityCatalogOnly:
+		return providers.AvailabilityCatalogOnly
+	case factoryapi.ProviderImplementationAvailabilityBundled,
+		factoryapi.ProviderImplementationAvailabilityExternallySupplied:
+		return providers.AvailabilitySelectable
+	default:
+		return providers.AvailabilitySupportedButUnavailable
+	}
+}
+
+func projectReadiness(availability providers.Availability) providers.Readiness {
+	switch availability {
+	case providers.AvailabilitySelectable:
+		return providers.ReadinessReady
+	default:
+		return providers.ReadinessUnavailable
+	}
+}
+
+func projectCapabilities(manifest factoryapi.ProviderManifest) []providers.Capability {
+	execution := manifest.MaximumExecutionCapabilities
+	response := manifest.MaximumResponseFidelityCapabilities
+	capabilities := make([]providers.Capability, 0, len(allProviderCapabilities()))
+	appendIf := func(enabled bool, capability providers.Capability) {
+		if enabled {
+			capabilities = append(capabilities, capability)
+		}
+	}
+	appendIf(execution.PromptSubmission, providers.CapabilityPromptSubmission)
+	appendIf(execution.ImageInput, providers.CapabilityImageInput)
+	appendIf(execution.SessionResume, providers.CapabilitySessionResume)
+	appendIf(execution.StructuredOutput, providers.CapabilityStructuredOutput)
+	appendIf(response.NativeStreaming, providers.CapabilityNativeStreaming)
+	appendIf(response.MessageDeltas, providers.CapabilityMessageDeltas)
+	appendIf(response.MessageSnapshots, providers.CapabilityMessageSnapshots)
+	appendIf(response.ReasoningSummaries, providers.CapabilityReasoningSummaries)
+	appendIf(response.ToolLifecycle, providers.CapabilityToolLifecycle)
+	appendIf(response.ToolOutputDeltas, providers.CapabilityToolOutputDeltas)
+	appendIf(response.FileChanges, providers.CapabilityFileChanges)
+	appendIf(response.Plans, providers.CapabilityPlans)
+	appendIf(response.Usage, providers.CapabilityUsage)
+	appendIf(response.StableItemIds, providers.CapabilityStableItemIDs)
+	appendIf(response.ProviderReconnect, providers.CapabilityProviderReconnect)
+	return capabilities
+}
+
+func localizedValue(value factoryapi.NameValue) string {
+	return strings.TrimSpace(value.Value)
+}
+
+func allProviderCapabilities() []providers.Capability {
+	return []providers.Capability{
+		providers.CapabilityPromptSubmission,
+		providers.CapabilityImageInput,
+		providers.CapabilitySessionResume,
+		providers.CapabilityStructuredOutput,
+		providers.CapabilityNativeStreaming,
+		providers.CapabilityMessageDeltas,
+		providers.CapabilityMessageSnapshots,
+		providers.CapabilityReasoningSummaries,
+		providers.CapabilityToolLifecycle,
+		providers.CapabilityToolOutputDeltas,
+		providers.CapabilityFileChanges,
+		providers.CapabilityPlans,
+		providers.CapabilityUsage,
+		providers.CapabilityStableItemIDs,
+		providers.CapabilityProviderReconnect,
+	}
+}

--- a/pkg/services/providers/internal/services/catalog/internal/service/projection.go
+++ b/pkg/services/providers/internal/services/catalog/internal/service/projection.go
@@ -33,6 +33,11 @@ func projectManifests(manifests []factoryapi.ProviderManifest) ([]providers.Desc
 	return descriptors, nil
 }
 
+// ProjectManifestsForTest projects manifests for focused catalog characterization tests.
+func ProjectManifestsForTest(manifests []factoryapi.ProviderManifest) ([]providers.Descriptor, error) {
+	return projectManifests(manifests)
+}
+
 func projectManifest(manifest factoryapi.ProviderManifest) (providers.Descriptor, error) {
 	canonicalID := canonicalProvidersID(manifest.Id)
 	if err := canonicalID.Validate(); err != nil {
@@ -45,7 +50,7 @@ func projectManifest(manifest factoryapi.ProviderManifest) (providers.Descriptor
 		DisplayName:   localizedValue(manifest.DisplayName),
 		Availability:  availability,
 		Readiness:     projectReadiness(availability),
-		Prerequisites: nil,
+		Prerequisites: projectStaticPrerequisites(manifest),
 		Capabilities:  projectCapabilities(manifest),
 	}, nil
 }
@@ -106,6 +111,62 @@ func projectReadiness(availability providers.Availability) providers.Readiness {
 	default:
 		return providers.ReadinessUnavailable
 	}
+}
+
+func projectStaticPrerequisites(manifest factoryapi.ProviderManifest) []providers.Prerequisite {
+	displayName := localizedValue(manifest.DisplayName)
+	if displayName == "" {
+		displayName = strings.TrimSpace(manifest.Id)
+	}
+	prerequisites := make([]providers.Prerequisite, 0,
+		len(manifest.Discovery.ConfigurationKeys)+
+			len(manifest.Discovery.EndpointKinds)+
+			len(manifest.Discovery.ExecutableNames),
+	)
+	for _, key := range manifest.Discovery.ConfigurationKeys {
+		prerequisites = append(prerequisites, providers.Prerequisite{
+			Kind:        providers.PrerequisiteConfiguration,
+			Name:        strings.TrimSpace(key),
+			Status:      providers.PrerequisiteSatisfied,
+			Description: fmt.Sprintf("%s lists configuration key %q.", displayName, strings.TrimSpace(key)),
+		})
+	}
+	for _, kind := range manifest.Discovery.EndpointKinds {
+		kindName := strings.TrimSpace(string(kind))
+		prerequisites = append(prerequisites, providers.Prerequisite{
+			Kind:        providers.PrerequisiteConfiguration,
+			Name:        kindName,
+			Status:      providers.PrerequisiteSatisfied,
+			Description: fmt.Sprintf("%s supports %s transport.", displayName, kindName),
+		})
+	}
+	for _, executable := range manifest.Discovery.ExecutableNames {
+		executable = strings.TrimSpace(executable)
+		prerequisites = append(prerequisites, providers.Prerequisite{
+			Kind:        providers.PrerequisiteDependency,
+			Name:        executable,
+			Status:      providers.PrerequisiteSatisfied,
+			Description: fmt.Sprintf("%s uses the %q executable.", displayName, executable),
+		})
+	}
+	if len(prerequisites) == 0 {
+		return nil
+	}
+	sort.Slice(prerequisites, func(i, j int) bool {
+		left := prerequisiteSortKey(prerequisites[i])
+		right := prerequisiteSortKey(prerequisites[j])
+		return left < right
+	})
+	return prerequisites
+}
+
+func prerequisiteSortKey(prerequisite providers.Prerequisite) string {
+	return strings.Join([]string{
+		string(prerequisite.Kind),
+		prerequisite.Name,
+		string(prerequisite.Status),
+		prerequisite.Description,
+	}, "\x00")
 }
 
 func projectCapabilities(manifest factoryapi.ProviderManifest) []providers.Capability {

--- a/pkg/services/providers/internal/services/catalog/internal/service/projection_test.go
+++ b/pkg/services/providers/internal/services/catalog/internal/service/projection_test.go
@@ -1,0 +1,136 @@
+package service_test
+
+import (
+	"strings"
+	"testing"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/internal/service"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+func TestProjectAvailabilityPostures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		manifest      factoryapi.ProviderManifest
+		wantAvail     providers.Availability
+		wantReadiness providers.Readiness
+	}{
+		{
+			name: "not-supported",
+			manifest: factoryapi.ProviderManifest{
+				Id:                         "blocked",
+				TechnicalSupportLevel:      factoryapi.ProviderTechnicalSupportLevelNotSupported,
+				ImplementationAvailability: factoryapi.ProviderImplementationAvailabilityBundled,
+			},
+			wantAvail:     providers.AvailabilityNotSupported,
+			wantReadiness: providers.ReadinessUnavailable,
+		},
+		{
+			name: "catalog-only",
+			manifest: factoryapi.ProviderManifest{
+				Id:                         "catalog-only",
+				TechnicalSupportLevel:      factoryapi.ProviderTechnicalSupportLevelExperimental,
+				ImplementationAvailability: factoryapi.ProviderImplementationAvailabilityCatalogOnly,
+			},
+			wantAvail:     providers.AvailabilityCatalogOnly,
+			wantReadiness: providers.ReadinessUnavailable,
+		},
+		{
+			name: "selectable bundled",
+			manifest: factoryapi.ProviderManifest{
+				Id:                         "selectable",
+				TechnicalSupportLevel:      factoryapi.ProviderTechnicalSupportLevelProduction,
+				ImplementationAvailability: factoryapi.ProviderImplementationAvailabilityBundled,
+			},
+			wantAvail:     providers.AvailabilitySelectable,
+			wantReadiness: providers.ReadinessReady,
+		},
+		{
+			name: "selectable externally supplied",
+			manifest: factoryapi.ProviderManifest{
+				Id:                         "external",
+				TechnicalSupportLevel:      factoryapi.ProviderTechnicalSupportLevelExperimental,
+				ImplementationAvailability: factoryapi.ProviderImplementationAvailabilityExternallySupplied,
+			},
+			wantAvail:     providers.AvailabilitySelectable,
+			wantReadiness: providers.ReadinessReady,
+		},
+		{
+			name: "supported-but-unavailable default",
+			manifest: factoryapi.ProviderManifest{
+				Id:                         "unsupported-impl",
+				TechnicalSupportLevel:      factoryapi.ProviderTechnicalSupportLevelExperimental,
+				ImplementationAvailability: factoryapi.ProviderImplementationAvailability("unknown"),
+			},
+			wantAvail:     providers.AvailabilitySupportedButUnavailable,
+			wantReadiness: providers.ReadinessUnavailable,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			descriptors, err := internalservice.ProjectManifestsForTest([]factoryapi.ProviderManifest{testCase.manifest})
+			if err != nil {
+				t.Fatalf("ProjectManifestsForTest() = %v", err)
+			}
+			if len(descriptors) != 1 {
+				t.Fatalf("len(descriptors) = %d, want 1", len(descriptors))
+			}
+			got := descriptors[0]
+			if got.Availability != testCase.wantAvail {
+				t.Fatalf("availability = %q, want %q", got.Availability, testCase.wantAvail)
+			}
+			if got.Readiness != testCase.wantReadiness {
+				t.Fatalf("readiness = %q, want %q", got.Readiness, testCase.wantReadiness)
+			}
+		})
+	}
+}
+
+func TestProjectStaticPrerequisites(t *testing.T) {
+	t.Parallel()
+
+	manifest := factoryapi.ProviderManifest{
+		Id: "cursor",
+		DisplayName: factoryapi.NameValue{
+			Type:  factoryapi.LOCALIZABLEASSET,
+			Value: "Cursor CLI",
+		},
+		Discovery: factoryapi.ProviderDiscoveryPrerequisites{
+			ConfigurationKeys: []string{"CURSOR_API_KEY"},
+			EndpointKinds: []factoryapi.ProviderDiscoveryEndpointKind{
+				factoryapi.ProviderDiscoveryEndpointKindStdio,
+			},
+			ExecutableNames: []string{"agent"},
+		},
+		TechnicalSupportLevel:      factoryapi.ProviderTechnicalSupportLevelExperimental,
+		ImplementationAvailability: factoryapi.ProviderImplementationAvailabilityBundled,
+	}
+
+	descriptors, err := internalservice.ProjectManifestsForTest([]factoryapi.ProviderManifest{manifest})
+	if err != nil {
+		t.Fatalf("ProjectManifestsForTest() = %v", err)
+	}
+	prerequisites := descriptors[0].Prerequisites
+	if len(prerequisites) != 3 {
+		t.Fatalf("len(prerequisites) = %d, want 3", len(prerequisites))
+	}
+	for _, prerequisite := range prerequisites {
+		if prerequisite.Status != providers.PrerequisiteSatisfied {
+			t.Fatalf("prerequisite %q status = %q, want satisfied", prerequisite.Name, prerequisite.Status)
+		}
+		if prerequisite.Description == "" {
+			t.Fatalf("prerequisite %q missing bounded description", prerequisite.Name)
+		}
+		if strings.Contains(prerequisite.Description, "C:\\") ||
+			strings.Contains(prerequisite.Description, "/Users/") ||
+			len(prerequisite.Description) > 256 {
+			t.Fatalf("prerequisite description leaks sensitive detail: %q", prerequisite.Description)
+		}
+	}
+}

--- a/pkg/services/providers/internal/services/catalog/internal/service/service.go
+++ b/pkg/services/providers/internal/services/catalog/internal/service/service.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"context"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	catalog "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog"
+)
+
+type service struct {
+	providers []providers.Descriptor
+}
+
+var _ catalog.Service = (*service)(nil)
+
+// New constructs an inert catalog over the accepted standardized provider
+// catalog publication.
+func New() (catalog.Service, error) {
+	descriptors, err := projectPublishedCatalog()
+	if err != nil {
+		return nil, err
+	}
+	return &service{providers: descriptors}, nil
+}
+
+func (s *service) ListProviders(
+	ctx context.Context,
+	_ providers.ListProvidersRequest,
+) (providers.ListProvidersResult, error) {
+	if err := ctx.Err(); err != nil {
+		return providers.ListProvidersResult{}, err
+	}
+	results := make([]providers.Descriptor, len(s.providers))
+	for i, descriptor := range s.providers {
+		results[i] = descriptor.Clone()
+	}
+	return providers.ListProvidersResult{Providers: results}, nil
+}

--- a/pkg/services/providers/internal/services/catalog/internal/service/service.go
+++ b/pkg/services/providers/internal/services/catalog/internal/service/service.go
@@ -12,23 +12,28 @@ type service struct {
 	providers []providers.Descriptor
 	byID      map[providers.ID]providers.Descriptor
 	aliases   map[string]providers.ID
+	probe     catalog.ProbeQuery
 }
 
 var _ catalog.Service = (*service)(nil)
 
 // New constructs an inert catalog over the accepted standardized provider
 // catalog publication.
-func New() (catalog.Service, error) {
+func New(options ...Option) (catalog.Service, error) {
 	descriptors, err := projectPublishedCatalog()
 	if err != nil {
 		return nil, err
 	}
 	byID, aliases := indexDescriptors(descriptors)
-	return &service{
+	s := &service{
 		providers: descriptors,
 		byID:      byID,
 		aliases:   aliases,
-	}, nil
+	}
+	for _, option := range options {
+		option(s)
+	}
+	return s, nil
 }
 
 func indexDescriptors(descriptors []providers.Descriptor) (
@@ -56,7 +61,11 @@ func (s *service) ListProviders(
 	}
 	results := make([]providers.Descriptor, len(s.providers))
 	for i, descriptor := range s.providers {
-		results[i] = descriptor.Clone()
+		merged, err := s.applyProbe(ctx, descriptor)
+		if err != nil {
+			return providers.ListProvidersResult{}, err
+		}
+		results[i] = merged
 	}
 	return providers.ListProvidersResult{Providers: results}, nil
 }
@@ -79,10 +88,71 @@ func (s *service) GetProvider(
 	if !ok {
 		return providers.GetProviderResult{}, providers.ErrUnknownProvider
 	}
-	if !isProviderSelectable(descriptor) {
+	merged, err := s.applyProbe(ctx, descriptor)
+	if err != nil {
+		return providers.GetProviderResult{}, err
+	}
+	if !isProviderSelectable(merged) {
 		return providers.GetProviderResult{}, providers.ErrProviderUnavailable
 	}
-	return providers.GetProviderResult{Provider: descriptor.Clone()}, nil
+	return providers.GetProviderResult{Provider: merged}, nil
+}
+
+func (s *service) applyProbe(
+	ctx context.Context,
+	descriptor providers.Descriptor,
+) (providers.Descriptor, error) {
+	if s.probe == nil {
+		return descriptor.Clone(), nil
+	}
+	if err := ctx.Err(); err != nil {
+		return providers.Descriptor{}, err
+	}
+	facts, err := s.probe(ctx, descriptor.Clone())
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return providers.Descriptor{}, ctxErr
+		}
+		facts = probeFailureFacts(descriptor)
+	}
+	return mergeProbeFacts(descriptor, facts), nil
+}
+
+func mergeProbeFacts(
+	base providers.Descriptor,
+	facts catalog.ProbeFacts,
+) providers.Descriptor {
+	merged := base.Clone()
+	merged.Readiness = facts.Readiness
+	if facts.Prerequisites != nil {
+		merged.Prerequisites = clonePrerequisites(facts.Prerequisites)
+	}
+	return merged
+}
+
+func probeFailureFacts(descriptor providers.Descriptor) catalog.ProbeFacts {
+	name := descriptor.DisplayName
+	if strings.TrimSpace(name) == "" {
+		name = descriptor.ID.String()
+	}
+	return catalog.ProbeFacts{
+		Readiness: providers.ReadinessUnavailable,
+		Prerequisites: []providers.Prerequisite{{
+			Kind:        providers.PrerequisiteDependency,
+			Name:        "readiness-probe",
+			Status:      providers.PrerequisiteMissing,
+			Description: name + " readiness probe failed.",
+		}},
+	}
+}
+
+func clonePrerequisites(prerequisites []providers.Prerequisite) []providers.Prerequisite {
+	if prerequisites == nil {
+		return nil
+	}
+	cloned := make([]providers.Prerequisite, len(prerequisites))
+	copy(cloned, prerequisites)
+	return cloned
 }
 
 func isProviderSelectable(descriptor providers.Descriptor) bool {

--- a/pkg/services/providers/internal/services/catalog/internal/service/service.go
+++ b/pkg/services/providers/internal/services/catalog/internal/service/service.go
@@ -79,7 +79,28 @@ func (s *service) GetProvider(
 	if !ok {
 		return providers.GetProviderResult{}, providers.ErrUnknownProvider
 	}
+	if !isProviderSelectable(descriptor) {
+		return providers.GetProviderResult{}, providers.ErrProviderUnavailable
+	}
 	return providers.GetProviderResult{Provider: descriptor.Clone()}, nil
+}
+
+func isProviderSelectable(descriptor providers.Descriptor) bool {
+	if descriptor.Availability != providers.AvailabilitySelectable ||
+		descriptor.Readiness != providers.ReadinessReady ||
+		hasMissingPrerequisite(descriptor.Prerequisites) {
+		return false
+	}
+	return true
+}
+
+func hasMissingPrerequisite(prerequisites []providers.Prerequisite) bool {
+	for _, prerequisite := range prerequisites {
+		if prerequisite.Status == providers.PrerequisiteMissing {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *service) resolveID(id providers.ID) (providers.ID, bool) {

--- a/pkg/services/providers/internal/services/catalog/internal/service/service.go
+++ b/pkg/services/providers/internal/services/catalog/internal/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"strings"
 
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 	catalog "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog"
@@ -9,6 +10,8 @@ import (
 
 type service struct {
 	providers []providers.Descriptor
+	byID      map[providers.ID]providers.Descriptor
+	aliases   map[string]providers.ID
 }
 
 var _ catalog.Service = (*service)(nil)
@@ -20,7 +23,28 @@ func New() (catalog.Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &service{providers: descriptors}, nil
+	byID, aliases := indexDescriptors(descriptors)
+	return &service{
+		providers: descriptors,
+		byID:      byID,
+		aliases:   aliases,
+	}, nil
+}
+
+func indexDescriptors(descriptors []providers.Descriptor) (
+	map[providers.ID]providers.Descriptor,
+	map[string]providers.ID,
+) {
+	byID := make(map[providers.ID]providers.Descriptor, len(descriptors))
+	aliases := make(map[string]providers.ID, len(descriptors))
+	for _, descriptor := range descriptors {
+		byID[descriptor.ID] = descriptor
+		aliases[strings.ToLower(descriptor.ID.String())] = descriptor.ID
+		for _, alias := range descriptor.Aliases {
+			aliases[alias] = descriptor.ID
+		}
+	}
+	return byID, aliases
 }
 
 func (s *service) ListProviders(
@@ -35,4 +59,31 @@ func (s *service) ListProviders(
 		results[i] = descriptor.Clone()
 	}
 	return providers.ListProvidersResult{Providers: results}, nil
+}
+
+func (s *service) GetProvider(
+	ctx context.Context,
+	request providers.GetProviderRequest,
+) (providers.GetProviderResult, error) {
+	if err := ctx.Err(); err != nil {
+		return providers.GetProviderResult{}, err
+	}
+	if err := request.Validate(); err != nil {
+		return providers.GetProviderResult{}, err
+	}
+	canonical, ok := s.resolveID(request.ID)
+	if !ok {
+		return providers.GetProviderResult{}, providers.ErrUnknownProvider
+	}
+	descriptor, ok := s.byID[canonical]
+	if !ok {
+		return providers.GetProviderResult{}, providers.ErrUnknownProvider
+	}
+	return providers.GetProviderResult{Provider: descriptor.Clone()}, nil
+}
+
+func (s *service) resolveID(id providers.ID) (providers.ID, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(id.String()))
+	canonical, ok := s.aliases[normalized]
+	return canonical, ok
 }

--- a/pkg/services/providers/internal/services/catalog/internal/service/service_test.go
+++ b/pkg/services/providers/internal/services/catalog/internal/service/service_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"slices"
 	"testing"
@@ -307,6 +308,72 @@ func TestGetProviderReturnsDetachedValues(t *testing.T) {
 		third.Provider.Capabilities[0] == providers.CapabilityUsage &&
 		first.Provider.Capabilities[0] == providers.CapabilityUsage {
 		t.Fatal("third get capabilities share mutation from first result")
+	}
+}
+
+func TestGetProviderTypedFailures(t *testing.T) {
+	t.Parallel()
+
+	service, err := internalservice.New()
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	assertGetErrorIs(t, service, providers.GetProviderRequest{}, providers.ErrInvalidID)
+	assertGetErrorIs(
+		t,
+		service,
+		providers.GetProviderRequest{ID: providers.ID("unknown-provider")},
+		providers.ErrUnknownProvider,
+	)
+	assertGetErrorIs(
+		t,
+		service,
+		providers.GetProviderRequest{ID: providers.IDCodex + "-stale"},
+		providers.ErrUnknownProvider,
+	)
+	assertGetErrorIs(
+		t,
+		service,
+		providers.GetProviderRequest{ID: providers.IDAgy},
+		providers.ErrProviderUnavailable,
+	)
+
+	list, err := service.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if err != nil {
+		t.Fatalf("ListProviders() = %v", err)
+	}
+	agy, ok := indexProviders(list.Providers)[providers.IDAgy]
+	if !ok {
+		t.Fatal("ListProviders() missing unavailable agy provider")
+	}
+	if agy.Availability != providers.AvailabilityNotSupported {
+		t.Fatalf("agy availability = %q, want %q", agy.Availability, providers.AvailabilityNotSupported)
+	}
+}
+
+func assertGetErrorIs(
+	t *testing.T,
+	service interface {
+		GetProvider(
+			context.Context,
+			providers.GetProviderRequest,
+		) (providers.GetProviderResult, error)
+	},
+	request providers.GetProviderRequest,
+	want error,
+) {
+	t.Helper()
+
+	result, err := service.GetProvider(context.Background(), request)
+	if err == nil {
+		t.Fatalf("GetProvider(%#v) = %#v, want error %v", request, result, want)
+	}
+	if !errors.Is(err, want) {
+		t.Fatalf("GetProvider(%#v) error = %v, want %v", request, err, want)
+	}
+	if !reflect.DeepEqual(result.Provider, providers.Descriptor{}) {
+		t.Fatalf("GetProvider(%#v) provider = %#v, want zero descriptor on failure", request, result.Provider)
 	}
 }
 

--- a/pkg/services/providers/internal/services/catalog/internal/service/service_test.go
+++ b/pkg/services/providers/internal/services/catalog/internal/service/service_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"context"
+	"reflect"
 	"slices"
 	"testing"
 
@@ -172,6 +173,140 @@ func TestListProvidersProjectsIdentityMetadataAndCapabilities(t *testing.T) {
 	kiro := indexProviders(list.Providers)[providers.IDKiro]
 	if !slices.Contains(kiro.Aliases, "kiro") {
 		t.Fatalf("kiro aliases = %#v, want kiro manifest id alias", kiro.Aliases)
+	}
+}
+
+func TestGetProviderResolvesCanonicalID(t *testing.T) {
+	t.Parallel()
+
+	service, err := internalservice.New()
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	got, err := service.GetProvider(context.Background(), providers.GetProviderRequest{ID: providers.IDCodex})
+	if err != nil {
+		t.Fatalf("GetProvider(codex) = %v", err)
+	}
+	if got.Provider.ID != providers.IDCodex {
+		t.Fatalf("provider id = %q, want %q", got.Provider.ID, providers.IDCodex)
+	}
+	if got.Provider.DisplayName != "Codex" {
+		t.Fatalf("display name = %q, want Codex", got.Provider.DisplayName)
+	}
+	if got.Provider.Availability != providers.AvailabilitySelectable {
+		t.Fatalf("availability = %q, want selectable", got.Provider.Availability)
+	}
+	if got.Provider.Readiness != providers.ReadinessReady {
+		t.Fatalf("readiness = %q, want ready", got.Provider.Readiness)
+	}
+	if !slices.Contains(got.Provider.Capabilities, providers.CapabilityPromptSubmission) {
+		t.Fatalf("capabilities = %#v, want prompt_submission", got.Provider.Capabilities)
+	}
+}
+
+func TestGetProviderResolvesAcceptedAliases(t *testing.T) {
+	t.Parallel()
+
+	service, err := internalservice.New()
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		requestID providers.ID
+		wantID    providers.ID
+		wantName  string
+		wantAlias string
+	}{
+		{
+			name:      "cursor manifest id alias",
+			requestID: providers.ID("cursor"),
+			wantID:    providers.IDCursor,
+			wantName:  "Cursor CLI",
+			wantAlias: "cursor",
+		},
+		{
+			name:      "kiro manifest id alias",
+			requestID: providers.ID("kiro"),
+			wantID:    providers.IDKiro,
+			wantName:  "Kiro CLI",
+			wantAlias: "kiro",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			byAlias, err := service.GetProvider(context.Background(), providers.GetProviderRequest{ID: testCase.requestID})
+			if err != nil {
+				t.Fatalf("GetProvider(%q) = %v", testCase.requestID, err)
+			}
+			byCanonical, err := service.GetProvider(context.Background(), providers.GetProviderRequest{ID: testCase.wantID})
+			if err != nil {
+				t.Fatalf("GetProvider(%q) = %v", testCase.wantID, err)
+			}
+
+			if byAlias.Provider.ID != testCase.wantID {
+				t.Fatalf("alias lookup id = %q, want %q", byAlias.Provider.ID, testCase.wantID)
+			}
+			if byAlias.Provider.DisplayName != testCase.wantName {
+				t.Fatalf("alias lookup display name = %q, want %q", byAlias.Provider.DisplayName, testCase.wantName)
+			}
+			if !slices.Contains(byAlias.Provider.Aliases, testCase.wantAlias) {
+				t.Fatalf("alias lookup aliases = %#v, want %q", byAlias.Provider.Aliases, testCase.wantAlias)
+			}
+			if !reflect.DeepEqual(byAlias.Provider, byCanonical.Provider) {
+				t.Fatalf("alias lookup = %#v, want canonical lookup %#v", byAlias.Provider, byCanonical.Provider)
+			}
+		})
+	}
+}
+
+func TestGetProviderReturnsDetachedValues(t *testing.T) {
+	t.Parallel()
+
+	service, err := internalservice.New()
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	first, err := service.GetProvider(context.Background(), providers.GetProviderRequest{ID: providers.IDCodex})
+	if err != nil {
+		t.Fatalf("first GetProvider() = %v", err)
+	}
+	second, err := service.GetProvider(context.Background(), providers.GetProviderRequest{ID: providers.IDCodex})
+	if err != nil {
+		t.Fatalf("second GetProvider() = %v", err)
+	}
+	if !reflect.DeepEqual(first.Provider, second.Provider) {
+		t.Fatalf("repeated get = %#v, want %#v", first.Provider, second.Provider)
+	}
+
+	first.Provider.DisplayName = "mutated"
+	if len(first.Provider.Aliases) > 0 {
+		first.Provider.Aliases[0] = "mutated"
+	}
+	if len(first.Provider.Capabilities) > 0 {
+		first.Provider.Capabilities[0] = providers.CapabilityUsage
+	}
+
+	third, err := service.GetProvider(context.Background(), providers.GetProviderRequest{ID: providers.IDCodex})
+	if err != nil {
+		t.Fatalf("third GetProvider() = %v", err)
+	}
+	if third.Provider.DisplayName == "mutated" {
+		t.Fatalf("third get display name = %q, want detached copy", third.Provider.DisplayName)
+	}
+	if len(third.Provider.Aliases) > 0 && third.Provider.Aliases[0] == "mutated" {
+		t.Fatal("third get aliases share mutation from first result")
+	}
+	if len(third.Provider.Capabilities) > 0 &&
+		third.Provider.Capabilities[0] == providers.CapabilityUsage &&
+		first.Provider.Capabilities[0] == providers.CapabilityUsage {
+		t.Fatal("third get capabilities share mutation from first result")
 	}
 }
 

--- a/pkg/services/providers/internal/services/catalog/internal/service/service_test.go
+++ b/pkg/services/providers/internal/services/catalog/internal/service/service_test.go
@@ -1,0 +1,192 @@
+package service_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/internal/service"
+)
+
+func TestListProvidersReturnsCompleteEnumeration(t *testing.T) {
+	t.Parallel()
+
+	service, err := internalservice.New()
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	list, err := service.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if err != nil {
+		t.Fatalf("ListProviders() = %v", err)
+	}
+	if len(list.Providers) != 8 {
+		t.Fatalf("len(Providers) = %d, want 8", len(list.Providers))
+	}
+
+	byID := indexProviders(list.Providers)
+	for _, id := range []providers.ID{
+		providers.IDAgy,
+		providers.IDClaude,
+		providers.IDCodex,
+		providers.IDCursor,
+		providers.IDGemini,
+		providers.IDKiro,
+		providers.IDOpenCode,
+		providers.IDPi,
+	} {
+		if _, ok := byID[id]; !ok {
+			t.Fatalf("Providers missing %q", id)
+		}
+	}
+}
+
+func TestListProvidersOrderIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	service, err := internalservice.New()
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	first, err := service.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if err != nil {
+		t.Fatalf("first ListProviders() = %v", err)
+	}
+	second, err := service.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if err != nil {
+		t.Fatalf("second ListProviders() = %v", err)
+	}
+
+	ids := providerIDs(first.Providers)
+	if !slices.IsSorted(ids) {
+		t.Fatalf("provider IDs = %v, want canonical sorted order", ids)
+	}
+	if !slices.Equal(providerIDs(second.Providers), ids) {
+		t.Fatalf("repeated list order = %v, want %v", providerIDs(second.Providers), ids)
+	}
+}
+
+func TestListProvidersIncludesNonSelectableEntries(t *testing.T) {
+	t.Parallel()
+
+	service, err := internalservice.New()
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	list, err := service.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if err != nil {
+		t.Fatalf("ListProviders() = %v", err)
+	}
+
+	agy := indexProviders(list.Providers)[providers.IDAgy]
+	if agy.Availability != providers.AvailabilityNotSupported {
+		t.Fatalf("agy availability = %q, want %q", agy.Availability, providers.AvailabilityNotSupported)
+	}
+	if agy.Readiness != providers.ReadinessUnavailable {
+		t.Fatalf("agy readiness = %q, want %q", agy.Readiness, providers.ReadinessUnavailable)
+	}
+}
+
+func TestListProvidersReturnsDetachedValues(t *testing.T) {
+	t.Parallel()
+
+	service, err := internalservice.New()
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	first, err := service.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if err != nil {
+		t.Fatalf("first ListProviders() = %v", err)
+	}
+	if len(first.Providers) == 0 {
+		t.Fatal("first ListProviders() returned no providers")
+	}
+
+	first.Providers[0].DisplayName = "mutated"
+	if len(first.Providers[0].Aliases) > 0 {
+		first.Providers[0].Aliases[0] = "mutated"
+	}
+	if len(first.Providers[0].Capabilities) > 0 {
+		first.Providers[0].Capabilities[0] = providers.CapabilityUsage
+	}
+
+	second, err := service.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if err != nil {
+		t.Fatalf("second ListProviders() = %v", err)
+	}
+	if second.Providers[0].DisplayName == "mutated" {
+		t.Fatalf("second list display name = %q, want detached copy", second.Providers[0].DisplayName)
+	}
+	if len(second.Providers[0].Aliases) > 0 && second.Providers[0].Aliases[0] == "mutated" {
+		t.Fatal("second list aliases share mutation from first result")
+	}
+	if len(second.Providers[0].Capabilities) > 0 &&
+		second.Providers[0].Capabilities[0] == providers.CapabilityUsage &&
+		first.Providers[0].Capabilities[0] == providers.CapabilityUsage {
+		t.Fatal("second list capabilities share mutation from first result")
+	}
+}
+
+func TestListProvidersProjectsIdentityMetadataAndCapabilities(t *testing.T) {
+	t.Parallel()
+
+	service, err := internalservice.New()
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	list, err := service.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if err != nil {
+		t.Fatalf("ListProviders() = %v", err)
+	}
+
+	codex := indexProviders(list.Providers)[providers.IDCodex]
+	if codex.DisplayName != "Codex" {
+		t.Fatalf("codex display name = %q, want Codex", codex.DisplayName)
+	}
+	if codex.Availability != providers.AvailabilitySelectable {
+		t.Fatalf("codex availability = %q, want selectable", codex.Availability)
+	}
+	if codex.Readiness != providers.ReadinessReady {
+		t.Fatalf("codex readiness = %q, want ready", codex.Readiness)
+	}
+	if !slices.Contains(codex.Capabilities, providers.CapabilityPromptSubmission) {
+		t.Fatalf("codex capabilities = %#v, want prompt_submission", codex.Capabilities)
+	}
+
+	cursor := indexProviders(list.Providers)[providers.IDCursor]
+	if cursor.ID != providers.IDCursor {
+		t.Fatalf("cursor id = %q, want %q", cursor.ID, providers.IDCursor)
+	}
+	if !slices.Contains(cursor.Aliases, "cursor") {
+		t.Fatalf("cursor aliases = %#v, want cursor manifest id alias", cursor.Aliases)
+	}
+	if cursor.DisplayName != "Cursor CLI" {
+		t.Fatalf("cursor display name = %q, want Cursor CLI", cursor.DisplayName)
+	}
+
+	kiro := indexProviders(list.Providers)[providers.IDKiro]
+	if !slices.Contains(kiro.Aliases, "kiro") {
+		t.Fatalf("kiro aliases = %#v, want kiro manifest id alias", kiro.Aliases)
+	}
+}
+
+func indexProviders(descriptors []providers.Descriptor) map[providers.ID]providers.Descriptor {
+	byID := make(map[providers.ID]providers.Descriptor, len(descriptors))
+	for _, descriptor := range descriptors {
+		byID[descriptor.ID] = descriptor
+	}
+	return byID
+}
+
+func providerIDs(descriptors []providers.Descriptor) []string {
+	ids := make([]string, len(descriptors))
+	for i, descriptor := range descriptors {
+		ids[i] = descriptor.ID.String()
+	}
+	return ids
+}

--- a/pkg/services/providers/internal/services/catalog/internal/service/service_test.go
+++ b/pkg/services/providers/internal/services/catalog/internal/service/service_test.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	catalog "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/internal/service"
 )
 
@@ -350,6 +352,91 @@ func TestGetProviderTypedFailures(t *testing.T) {
 	if agy.Availability != providers.AvailabilityNotSupported {
 		t.Fatalf("agy availability = %q, want %q", agy.Availability, providers.AvailabilityNotSupported)
 	}
+}
+
+func TestGetProviderBlocksOnMissingPrerequisiteProbeFacts(t *testing.T) {
+	t.Parallel()
+
+	service, err := internalservice.New(
+		internalservice.WithProbeQuery(func(
+			_ context.Context,
+			descriptor providers.Descriptor,
+		) (catalog.ProbeFacts, error) {
+			if descriptor.ID != providers.IDCodex {
+				return catalog.ProbeFacts{
+					Readiness:     descriptor.Readiness,
+					Prerequisites: descriptor.Prerequisites,
+				}, nil
+			}
+			return catalog.ProbeFacts{
+				Readiness: providers.ReadinessUnavailable,
+				Prerequisites: []providers.Prerequisite{{
+					Kind:        providers.PrerequisiteDependency,
+					Name:        "codex",
+					Status:      providers.PrerequisiteMissing,
+					Description: "install codex CLI",
+				}},
+			}, nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	assertGetErrorIs(t, service, providers.GetProviderRequest{ID: providers.IDCodex}, providers.ErrProviderUnavailable)
+
+	list, err := service.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if err != nil {
+		t.Fatalf("ListProviders() = %v", err)
+	}
+	codex := indexProviders(list.Providers)[providers.IDCodex]
+	if codex.Readiness != providers.ReadinessUnavailable {
+		t.Fatalf("codex readiness = %q, want unavailable", codex.Readiness)
+	}
+	if len(codex.Prerequisites) != 1 ||
+		codex.Prerequisites[0].Status != providers.PrerequisiteMissing {
+		t.Fatalf("codex prerequisites = %#v, want one missing prerequisite", codex.Prerequisites)
+	}
+}
+
+func TestProbeFailureSurfacesUnavailableCatalogFacts(t *testing.T) {
+	t.Parallel()
+
+	service, err := internalservice.New(
+		internalservice.WithProbeQuery(func(
+			_ context.Context,
+			descriptor providers.Descriptor,
+		) (catalog.ProbeFacts, error) {
+			if descriptor.ID == providers.IDCodex {
+				return catalog.ProbeFacts{}, errors.New("native probe stderr: /Users/customer/.codex/output")
+			}
+			return catalog.ProbeFacts{
+				Readiness:     descriptor.Readiness,
+				Prerequisites: descriptor.Prerequisites,
+			}, nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	list, err := service.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if err != nil {
+		t.Fatalf("ListProviders() = %v", err)
+	}
+	codex := indexProviders(list.Providers)[providers.IDCodex]
+	if codex.Readiness != providers.ReadinessUnavailable {
+		t.Fatalf("codex readiness = %q, want unavailable after probe failure", codex.Readiness)
+	}
+	if len(codex.Prerequisites) != 1 ||
+		codex.Prerequisites[0].Status != providers.PrerequisiteMissing {
+		t.Fatalf("codex prerequisites = %#v, want probe-class missing prerequisite", codex.Prerequisites)
+	}
+	if strings.Contains(codex.Prerequisites[0].Description, "/Users/") {
+		t.Fatalf("probe failure description leaked native output: %q", codex.Prerequisites[0].Description)
+	}
+
+	assertGetErrorIs(t, service, providers.GetProviderRequest{ID: providers.IDCodex}, providers.ErrProviderUnavailable)
 }
 
 func assertGetErrorIs(

--- a/pkg/services/providers/internal/services/catalog/service.go
+++ b/pkg/services/providers/internal/services/catalog/service.go
@@ -11,4 +11,5 @@ import (
 // projected from the accepted standardized provider catalog.
 type Service interface {
 	ListProviders(context.Context, providers.ListProvidersRequest) (providers.ListProvidersResult, error)
+	GetProvider(context.Context, providers.GetProviderRequest) (providers.GetProviderResult, error)
 }

--- a/pkg/services/providers/internal/services/catalog/service.go
+++ b/pkg/services/providers/internal/services/catalog/service.go
@@ -13,3 +13,17 @@ type Service interface {
 	ListProviders(context.Context, providers.ListProvidersRequest) (providers.ListProvidersResult, error)
 	GetProvider(context.Context, providers.GetProviderRequest) (providers.GetProviderResult, error)
 }
+
+// ProbeFacts are live readiness and prerequisite facts for one projected catalog
+// provider. Descriptions must stay bounded and must not include raw environment
+// values, filesystem paths, or native probe output.
+type ProbeFacts struct {
+	Readiness     providers.Readiness
+	Prerequisites []providers.Prerequisite
+}
+
+// ProbeQuery reports current readiness facts for one projected catalog provider.
+// Inputs and outputs are detached Providers-owned values; implementations must
+// honor context cancellation and must not expose Workers types through the
+// catalog boundary.
+type ProbeQuery func(context.Context, providers.Descriptor) (ProbeFacts, error)

--- a/pkg/services/providers/internal/services/catalog/service.go
+++ b/pkg/services/providers/internal/services/catalog/service.go
@@ -1,0 +1,14 @@
+// Package catalog defines the parent-private Providers catalog service.
+package catalog
+
+import (
+	"context"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+// Service serves detached, deterministically ordered provider descriptors
+// projected from the accepted standardized provider catalog.
+type Service interface {
+	ListProviders(context.Context, providers.ListProvidersRequest) (providers.ListProvidersResult, error)
+}

--- a/pkg/services/providers/internal/services/catalog/wire/wire.go
+++ b/pkg/services/providers/internal/services/catalog/wire/wire.go
@@ -1,0 +1,19 @@
+// Package wire constructs the parent-private Providers catalog subservice.
+package wire
+
+import (
+	catalog "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog"
+	catalogservice "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/internal/service"
+)
+
+// Option configures catalog construction.
+type Option = catalogservice.Option
+
+// WithProbeQuery configures request-time readiness probing for catalog list/get.
+var WithProbeQuery = catalogservice.WithProbeQuery
+
+// NewService constructs an inert catalog over the accepted standardized
+// provider catalog publication.
+func NewService(options ...Option) (catalog.Service, error) {
+	return catalogservice.New(options...)
+}

--- a/pkg/services/providers/root_catalog_delegation_test.go
+++ b/pkg/services/providers/root_catalog_delegation_test.go
@@ -1,0 +1,59 @@
+package providers_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	providerswire "github.com/portpowered/infinite-you/pkg/services/providers/wire"
+)
+
+func TestRootCatalogDelegation_FulfillsPublishedListAndGet(t *testing.T) {
+	t.Parallel()
+
+	var root providers.Service
+	root, err := providerswire.NewService()
+	if err != nil {
+		t.Fatalf("NewService() = %v", err)
+	}
+
+	list, err := root.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if err != nil {
+		t.Fatalf("ListProviders() = %v", err)
+	}
+	if len(list.Providers) < 2 {
+		t.Fatalf("ListProviders() = %#v, want multiple known providers", list.Providers)
+	}
+
+	got, err := root.GetProvider(context.Background(), providers.GetProviderRequest{ID: providers.IDCodex})
+	if err != nil {
+		t.Fatalf("GetProvider(codex) = %v", err)
+	}
+	if got.Provider.ID != providers.IDCodex {
+		t.Fatalf("GetProvider(codex).Provider.ID = %q", got.Provider.ID)
+	}
+
+	assertGetErrorIs(t, root, providers.GetProviderRequest{}, providers.ErrInvalidID)
+	assertGetErrorIs(t, root, providers.GetProviderRequest{ID: providers.IDAgy}, providers.ErrProviderUnavailable)
+}
+
+func TestRootCatalogDelegation_ConstructionIsInert(t *testing.T) {
+	t.Parallel()
+
+	service, err := providerswire.NewService()
+	if err != nil {
+		t.Fatalf("NewService() = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil")
+	}
+
+	_, err = service.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:  providers.IDCodex,
+		AttemptID: "root-delegation-attempt",
+	})
+	if !errors.Is(err, providers.ErrExecuteFailed) {
+		t.Fatalf("Execute() error = %v, want ErrExecuteFailed until IMP-PROV-02", err)
+	}
+}

--- a/pkg/services/providers/wire/wire.go
+++ b/pkg/services/providers/wire/wire.go
@@ -1,0 +1,22 @@
+// Package wire constructs the published Providers root Service from the
+// parent-private catalog subservice.
+package wire
+
+import (
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	providerservice "github.com/portpowered/infinite-you/pkg/services/providers/internal/service"
+	catalogwire "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/wire"
+)
+
+// Option configures catalog construction for the root facade.
+type Option = catalogwire.Option
+
+// NewService constructs an inert Providers root Service that fulfills
+// ListProviders and GetProvider through one private catalog instance.
+func NewService(options ...Option) (providers.Service, error) {
+	catalogService, err := catalogwire.NewService(options...)
+	if err != nil {
+		return nil, err
+	}
+	return providerservice.New(catalogService)
+}


### PR DESCRIPTION
{
  "project": "PSS IMP-PROV-01 — Absorb Providers Catalog",
  "branchName": "pss-imp-prov-01-catalog",
  "description": "Absorb the accepted standardized provider catalog into the parent-private Providers Catalog at pkg/services/providers/internal/services/catalog so the published Providers root ListProviders/GetProvider slices are fulfilled by that private catalog rather than a second inventory. Preserve deterministic enumeration, identity/alias canonicalization, capability and availability/prerequisite/readiness facts, and typed probe/unknown/unavailable failures while keeping descriptors detached, construction inert, and Workers transitional provider sources in place.",
  "context": {
    "customerAsk": "Implement IMP-PROV-01 by absorbing the accepted standardized provider catalog into the parent-private Providers Catalog subservice at pkg/services/providers/internal/services/catalog so the published Providers root ListProviders/GetProvider slices are fulfilled by that private catalog rather than a second inventory. Preserve deterministic enumeration order, identity canonicalization/aliases, capability facts, availability/prerequisite/readiness outcomes, and actionable probe/unknown/unavailable failures already owned by the accepted catalog foundations and CTR-PROV contracts. Keep catalog descriptors detached and Providers-owned; do not expose Workers provider registry/conductor types, concrete adapter packages, Petri/JavaScript types, or transport/UI concerns through the catalog boundary. Construction must remain inert. Treat pkg/services/workers/provider/** catalog-facing transitional sources as read/absorb sources only; do not delete the transitional Workers provider tree, relocate concrete adapters, or implement IMP-PROV-02 execution/registry/conductor absorption in this packet. Do not start IMP-PROV-03..06 adapter migrations, IMP-WRK-04 agent runner, IMP-WRK-07 hosted runner, IMP-RUN-03, IMP-SES-06, IMP-MOD-03, OpenAPI or generated API artifact changes, CLI manifests/root/run/server behavior, pkg/root, pkg/wire, pkg/initializer, UI code, or broad functional-test topology. Any ownership-inventory, package-target-manifest, or Go coverage-manifest updates must register only the new Catalog package paths and remain lease-minimal. Require focused catalog unit/characterization tests for deterministic list/get, unknown identity, unavailable/prerequisite-blocked facts, and probe failures; gofmt; vet/lint; architecture/ownership checks; and make verify-fast.",
    "problem": "CTR-PROV published the Providers root ListProviders/GetProvider contracts, but those catalog slices still have no production fulfillment. The accepted standardized catalog and transitional Workers-owned catalog/registry behavior remain the live sources of truth, so peers cannot obtain a Providers-owned detached catalog without inventing a second inventory or importing Workers provider internals.",
    "solution": "Create one parent-private Providers Catalog that absorbs standardized catalog publication into Providers-owned descriptors and fulfills the published root ListProviders/GetProvider slices through that private child. Preserve deterministic order, identity/alias canonicalization, capability and availability/prerequisite/readiness facts, and typed unknown/unavailable/probe failures. Keep construction inert, leave the Workers provider tree and adapters in place, and leave Execute/registry/conductor absorption to IMP-PROV-02."
  },
  "acceptanceCriteria": [
    "ListProviders returns every known provider as a detached Providers-owned descriptor in a stable deterministic order, including catalog-only, not-supported, and unavailable/prerequisite-blocked entries with their availability, readiness, prerequisite, and capability facts.",
    "GetProvider resolves a Providers-owned canonical identity or an already accepted alias to one detached descriptor; invalid identity, unknown identity, and unavailable/prerequisite-blocked providers retain the accepted distinct Providers-owned typed failures.",
    "Availability, readiness, prerequisite, and capability facts plus actionable probe failures preserve the behavior already owned by the accepted catalog foundations and CTR-PROV contracts; callers never receive Workers registry/conductor types, concrete adapter packages, Petri/JavaScript types, or transport/UI types through the catalog boundary.",
    "Returned descriptors and nested slices are immutable from the caller's perspective: mutating a list or get result cannot alter later results, and construction of the catalog and any Providers root facade that fulfills List/Get remains inert.",
    "The published Providers root ListProviders/GetProvider slices are fulfilled by the single private catalog rather than a second inventory; transitional pkg/services/workers/provider/** remains present and is not deleted or relocated; Execute/registry/conductor absorption and adapter migrations remain out of scope.",
    "Any ownership-inventory, package-target-manifest, or Go coverage-manifest updates register only the new Catalog package paths and stay lease-minimal; OpenAPI, CLI, pkg/root, pkg/wire, pkg/initializer, UI, and broad functional-test topology are unchanged.",
    "Quality checks pass (gofmt, focused vet/lint, architecture/ownership checks for changed paths, focused catalog tests, and make verify-fast)."
  ],
  "userStories": [
    {
      "id": "pss-imp-prov-01-catalog-001",
      "title": "List providers through a parent-private catalog",
      "description": "As a Providers consumer, I want ListProviders to return every known provider as a detached Providers-owned descriptor in deterministic order so enumeration no longer depends on Workers provider internals or a second inventory.",
      "acceptanceCriteria": [
        "A parent-private Catalog capability exists under pkg/services/providers/internal/services/catalog and projects the accepted standardized provider catalog into Providers-owned Descriptor values.",
        "ListProviders returns all known providers, including catalog-only, not-supported, and unavailable/prerequisite-blocked entries, rather than only currently selectable ones.",
        "Each listed descriptor carries Providers-owned identity, display metadata, aliases, availability, readiness, prerequisites, and capability facts already owned by the accepted catalog foundations and CTR-PROV contracts.",
        "List order is deterministic for equivalent catalog inputs and independent of map iteration or request repetition.",
        "Mutating a returned list entry, alias slice, prerequisite slice, or capability slice does not change a later list result.",
        "Focused catalog tests cover complete enumeration, deterministic order, inclusion of non-selectable entries, and detached list values.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-prov-01-catalog-002",
      "title": "Resolve one provider by canonical identity or alias",
      "description": "As a Providers consumer, I want GetProvider to resolve a canonical Providers identity or an already accepted alias to one detached descriptor so selection and validation use one identity vocabulary.",
      "acceptanceCriteria": [
        "GetProvider returns the matching detached descriptor for a selectable canonical Providers ID.",
        "Already accepted aliases resolve to the same canonical identity and descriptor facts as the canonical ID; no new alias is invented in this packet.",
        "Successful get results preserve availability, readiness, prerequisites, capabilities, display metadata, and alias facts for that provider.",
        "Repeated get results for the same identity are detached and byte-equivalent in observable fields; caller mutation cannot affect later results.",
        "Focused catalog tests cover canonical lookup, accepted-alias canonicalization, and detached get values for at least two distinct providers.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-prov-01-catalog-003",
      "title": "Preserve typed invalid, unknown, and unavailable catalog failures",
      "description": "As a Providers consumer, I want catalog lookup failures to keep the accepted distinct Providers-owned typed errors so peers can branch with errors.Is / errors.As without parsing strings or importing Workers types.",
      "acceptanceCriteria": [
        "Empty or otherwise invalid provider identity returns ErrInvalidID (or the accepted equivalent) and does not report unknown or unavailable.",
        "A well-formed identity that is not present in the catalog returns ErrUnknownProvider.",
        "A known provider whose availability or missing prerequisites block selection returns ErrProviderUnavailable on GetProvider, while ListProviders still includes that provider with its blocked facts.",
        "Failure paths do not leak Workers registry/conductor types, concrete adapter packages, filesystem paths, raw native output, or partial mutable descriptors.",
        "Focused catalog tests assert each typed failure with errors.Is and cover list-still-includes-unavailable behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-prov-01-catalog-004",
      "title": "Preserve readiness, prerequisite, and actionable probe outcomes",
      "description": "As a Providers consumer, I want availability, readiness, prerequisite, and probe outcomes to remain actionable catalog facts so I can distinguish static catalog posture from live blocked/probe failures without executing a provider attempt.",
      "acceptanceCriteria": [
        "Static availability classifications (catalog-only, not-supported, supported-but-unavailable, selectable) and readiness facts project into Providers-owned descriptor vocabulary.",
        "Prerequisite facts retain kind, name, status, and bounded description semantics already owned by the accepted catalog foundations; descriptions never include raw environment or native probe output.",
        "Actionable probe failures that block readiness/selectability surface as Providers-owned unavailable/probe-class catalog outcomes rather than opaque internal errors or Execute-slice failures.",
        "Capability snapshots on listed/get descriptors remain Providers-owned values and do not require importing Workers inference/capability types.",
        "Focused catalog tests cover representative static availability postures, missing-prerequisite blocked get, and at least one actionable probe-failure path using injected/controllable probe behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-prov-01-catalog-005",
      "title": "Fulfill Providers root List/Get through the private catalog",
      "description": "As a maintainer, I want the published Providers root ListProviders/GetProvider slices to delegate to one private Catalog instance so peers use the singular root contract without a second inventory, while Execute and Workers transitional sources remain out of this packet's absorption scope.",
      "acceptanceCriteria": [
        "The Providers root Service fulfillment for ListProviders and GetProvider delegates to the same parent-private Catalog instance and does not expose that child to peers.",
        "Catalog and root-facade construction are inert: constructing them starts no adapter, process, registry, conductor, network, timer, Wire, or Initializer work.",
        "Root list/get success and typed-failure outcomes match the private catalog behavior for representative selectable, unavailable, unknown, invalid, and probe-failure cases.",
        "Transitional pkg/services/workers/provider/** remains present; catalog-facing sources may be read/absorbed, but the tree is not deleted and concrete adapters are not relocated; Execute/registry/conductor absorption is not implemented.",
        "Any ownership-inventory, package-target-manifest, or Go coverage-manifest updates register only the new Catalog package paths and remain lease-minimal; OpenAPI/generated clients, CLI manifests/root/run/server, pkg/root, pkg/wire, pkg/initializer, UI, and broad functional-test topology are unchanged.",
        "Focused composition/characterization tests prove root delegation, inert construction, and absence of leaked Workers provider types through the root catalog boundary; gofmt, focused vet/lint, applicable architecture/ownership checks, and make verify-fast pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}
