### PR TITLE
ft-wave1-poller

### DIFF
--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -5889,6 +5889,36 @@
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/workstations/poller/poller_test.go",
+      "package": "you-agent-factory/tests/functional/workstations/poller",
+      "scenario": "TestPollerCreatesWorkFromExternalItems",
+      "lane": "short",
+      "destination": "tests/functional/workstations/poller/poller_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/workstations/poller/poller_test.go",
+      "package": "you-agent-factory/tests/functional/workstations/poller",
+      "scenario": "TestPollerEmptyResultCreatesNoWork",
+      "lane": "short",
+      "destination": "tests/functional/workstations/poller/poller_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/workstations/poller/poller_test.go",
+      "package": "you-agent-factory/tests/functional/workstations/poller",
+      "scenario": "TestPollerRecoverableFailureRetriesWithoutDuplicates",
+      "lane": "short",
+      "destination": "tests/functional/workstations/poller/poller_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
     }
   ],
   "scanned_at_utc": "2026-07-27T12:57:10Z",
@@ -5896,7 +5926,7 @@
     "by_catch_all": {
       "bootstrap_portability": 27,
       "guards_batch": 28,
-      "none": 223,
+      "none": 226,
       "replay_contracts": 24,
       "runtime_api": 108,
       "smoke": 89,
@@ -5922,16 +5952,16 @@
       "work": 2,
       "workers": 2,
       "workflow": 71,
-      "workstations": 2
+      "workstations": 5
     },
-    "customer_top_level_Test_scenarios": 570,
+    "customer_top_level_Test_scenarios": 573,
     "files_with_customer_Test": 200,
     "functional_test_go_files": 236,
     "helper_only_non_customer_files": 35,
     "internal_harness_Test_functions": 15,
     "internal_harness_test_files": 5,
     "lane_functionallong": 122,
-    "lane_short": 448
+    "lane_short": 451
   },
   "schema_note": "Machine-readable companion to migration-ledger.md Inventory. Required row fields match the ledger schema. Non-catch-all rows mapped by FND-007-006; catch-all rows mapped by FND-007-003\u2026005.",
   "runtime_api_mapping": {

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -437,7 +437,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestRepeaterHonorsEachConfiguredStopWord`.
   - `TestRepeaterLoopBreakerTerminatesNonConvergingWork`.
 
-- [ ] `tests/functional/workstations/poller/poller_test.go`
+- [x] `tests/functional/workstations/poller/poller_test.go`
   - `TestPollerCreatesWorkFromExternalItems`.
   - `TestPollerEmptyResultCreatesNoWork`.
   - `TestPollerRecoverableFailureRetriesWithoutDuplicates`.

--- a/tests/functional/sessions/cli/resolved_session_family_test.go
+++ b/tests/functional/sessions/cli/resolved_session_family_test.go
@@ -21,6 +21,9 @@ import (
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 )
 
+// TestBuildProcessRoutesEverySessionLeafThroughResolvedProductionComposition proves
+// every public session CLI leaf command executes through root.BuildProcess against
+// the resolved production composition without bypassing the customer process boundary.
 func TestBuildProcessRoutesEverySessionLeafThroughResolvedProductionComposition(t *testing.T) {
 	var requests sessionRequests
 	server := httptest.NewServer(http.HandlerFunc(requests.handle))
@@ -95,6 +98,8 @@ func TestBuildProcessRoutesEverySessionLeafThroughResolvedProductionComposition(
 	}
 }
 
+// TestBuildProcessRejectsDeprecatedPortBeforeSubmitDispatch proves submit rejects
+// deprecated --port wiring before any dispatch attempt and directs callers to --server.
 func TestBuildProcessRejectsDeprecatedPortBeforeSubmitDispatch(t *testing.T) {
 	process, err := root.BuildProcess(context.Background(), serviceedges.Edges{})
 	if err != nil {

--- a/tests/functional/transport/submit/submit_test.go
+++ b/tests/functional/transport/submit/submit_test.go
@@ -27,6 +27,8 @@ const functionalBatch = `{
 	]
 }`
 
+// TestSubmitFamilyExecutesThroughRootBuiltProcess proves batch dry-run and unary
+// submit commands execute through root.BuildProcess with the expected customer output.
 func TestSubmitFamilyExecutesThroughRootBuiltProcess(t *testing.T) {
 	process, err := root.BuildProcess(t.Context(), serviceedges.Edges{})
 	if err != nil {
@@ -105,6 +107,8 @@ func TestSubmitFamilyExecutesThroughRootBuiltProcess(t *testing.T) {
 	})
 }
 
+// TestSubmitFamilyEnqueuesWorkBeforeDownstreamStructuredOutputFailure proves live
+// unary submit enqueues Work before a downstream structured-output failure surfaces.
 func TestSubmitFamilyEnqueuesWorkBeforeDownstreamStructuredOutputFailure(t *testing.T) {
 	factoryDir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
 	support.ClearSeedInputs(t, factoryDir)

--- a/tests/functional/work/cli/resolved_work_family_test.go
+++ b/tests/functional/work/cli/resolved_work_family_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// TestResolvedWorkFamilyExecutesEveryPublicOperationFromStableInputs proves list,
+// show, move, and visualize work CLI commands execute through resolved handlers.
 func TestResolvedWorkFamilyExecutesEveryPublicOperationFromStableInputs(t *testing.T) {
 	var listed workcli.ListConfig
 	var shown workcli.ShowConfig

--- a/tests/functional/workstations/poller/doc.go
+++ b/tests/functional/workstations/poller/doc.go
@@ -1,0 +1,3 @@
+// Package poller owns customer functional coverage for POLLER workstation
+// ingress through the public process boundary.
+package poller

--- a/tests/functional/workstations/poller/poller_test.go
+++ b/tests/functional/workstations/poller/poller_test.go
@@ -3,10 +3,12 @@ package poller
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
@@ -88,6 +90,64 @@ func TestPollerEmptyResultCreatesNoWork(t *testing.T) {
 	}
 }
 
+// TestPollerRecoverableFailureRetriesWithoutDuplicates proves a POLLER
+// workstation retries after a recoverable external poll failure and admits each
+// external item exactly once. The scenario replaces only the script poller
+// command edge and controllable process clock, injects a transient command
+// failure followed by a successful poll batch, and observes admission through
+// public Work listings without duplicate submission for the same external item.
+func TestPollerRecoverableFailureRetriesWithoutDuplicates(t *testing.T) {
+	dir := scaffoldScriptPollerFactory(t)
+	support.ClearSeedInputs(t, dir)
+
+	fakeClock := clockwork.NewFakeClock()
+	runner := newPollerRetrySequenceCommandRunner(t, []pollerIngressRunOutcome{
+		{err: errors.New("transient poll source unavailable")},
+		{stdout: pollerExternalWorkRequestJSON(t)},
+	})
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir: dir,
+		Edges: serviceedges.Edges{
+			ScriptCommandRunner: runner,
+			Clock:               fakeClock,
+		},
+	})
+	defer server.Stop(t)
+
+	outputLocation := support.WorkCustomerLocation(pollerWorkTypeName, pollerOutputStateName)
+	baseline := support.ListDefaultSessionWork(t, server.URL())
+	if got := support.CountWorkAtCustomerState(baseline, outputLocation); got != 0 {
+		t.Fatalf("baseline CountWorkAtCustomerState(%q) = %d, want 0 before retry scenario", outputLocation, got)
+	}
+
+	waitForPollCycle(t, runner, 10*time.Second)
+	afterFailure := support.ListDefaultSessionWork(t, server.URL())
+	if got := support.CountWorkAtCustomerState(afterFailure, outputLocation); got != 0 {
+		t.Fatalf("CountWorkAtCustomerState(%q) = %d after failed poll, want 0; listed=%#v", outputLocation, got, afterFailure.Results)
+	}
+
+	waitForFakeClockWaiters(t, fakeClock, 1)
+	fakeClock.Advance(100 * time.Millisecond)
+
+	waitForRunnerCalls(t, runner, 2, 10*time.Second)
+	listed := waitForListedWorkAtCustomerState(t, server.URL(), outputLocation, 1, 10*time.Second)
+	if got := support.CountWorkAtCustomerState(listed, outputLocation); got != 1 {
+		t.Fatalf("CountWorkAtCustomerState(%q) = %d, want 1 after successful retry; listed=%#v", outputLocation, got, listed.Results)
+	}
+	if !support.HasWorkAtCustomerState(listed, pollerExternalWorkID, outputLocation) {
+		t.Fatalf("listed work = %#v, want work %q at %q", listed.Results, pollerExternalWorkID, outputLocation)
+	}
+
+	waitForRunnerCalls(t, runner, 3, 10*time.Second)
+	stable := support.ListDefaultSessionWork(t, server.URL())
+	if got := support.CountWorkAtCustomerState(stable, outputLocation); got != 1 {
+		t.Fatalf("CountWorkAtCustomerState(%q) = %d after post-success restart, want 1 (no duplicate); listed=%#v", outputLocation, got, stable.Results)
+	}
+	if runner.callCount() < 2 {
+		t.Fatalf("poller command calls = %d, want at least failed poll and successful retry", runner.callCount())
+	}
+}
+
 func scaffoldScriptPollerFactory(t *testing.T) string {
 	t.Helper()
 	return support.ScaffoldFactory(t, map[string]any{
@@ -137,13 +197,48 @@ func pollerExternalWorkRequestJSON(t *testing.T) []byte {
 	return payload
 }
 
-func waitForPollCycle(t *testing.T, runner *pollerIngressCommandRunner, timeout time.Duration) {
+type pollerPollCycleObserver interface {
+	callCount() int
+	pollCycleDone() <-chan struct{}
+}
+
+func waitForPollCycle(t *testing.T, runner pollerPollCycleObserver, timeout time.Duration) {
 	t.Helper()
 
 	select {
-	case <-runner.pollDone:
+	case <-runner.pollCycleDone():
 	case <-time.After(timeout):
 		t.Fatalf("timed out waiting for poller poll cycle; calls=%d", runner.callCount())
+	}
+}
+
+func waitForRunnerCalls(t *testing.T, runner pollerPollCycleObserver, want int, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if runner.callCount() >= want {
+			return
+		}
+		select {
+		case <-ticker.C:
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for %d poller command call(s); got %d", want, runner.callCount())
+		}
+	}
+}
+
+func waitForFakeClockWaiters(t *testing.T, fakeClock *clockwork.FakeClock, waiters int) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := fakeClock.BlockUntilContext(ctx, waiters); err != nil {
+		t.Fatalf("timed out waiting for %d fake-clock waiter(s): %v", waiters, err)
 	}
 }
 
@@ -180,6 +275,12 @@ func waitForListedWorkAtCustomerState(
 	}
 }
 
+type pollerIngressRunOutcome struct {
+	stdout   []byte
+	err      error
+	exitCode int
+}
+
 type pollerIngressCommandRunner struct {
 	mu       sync.Mutex
 	stdout   []byte
@@ -202,10 +303,7 @@ func (r *pollerIngressCommandRunner) Run(_ context.Context, _ platformprocess.Co
 	stdout := append([]byte(nil), r.stdout...)
 	r.mu.Unlock()
 
-	select {
-	case r.pollDone <- struct{}{}:
-	default:
-	}
+	r.signalPollCycle()
 
 	if callNumber == 1 {
 		return platformprocess.CommandResult{Stdout: stdout}, nil
@@ -219,4 +317,74 @@ func (r *pollerIngressCommandRunner) callCount() int {
 	return r.calls
 }
 
+func (r *pollerIngressCommandRunner) pollCycleDone() <-chan struct{} {
+	return r.pollDone
+}
+
+func (r *pollerIngressCommandRunner) signalPollCycle() {
+	select {
+	case r.pollDone <- struct{}{}:
+	default:
+	}
+}
+
+type pollerRetrySequenceCommandRunner struct {
+	mu       sync.Mutex
+	outcomes []pollerIngressRunOutcome
+	calls    int
+	pollDone chan struct{}
+}
+
+func newPollerRetrySequenceCommandRunner(t *testing.T, outcomes []pollerIngressRunOutcome) *pollerRetrySequenceCommandRunner {
+	t.Helper()
+	copied := make([]pollerIngressRunOutcome, len(outcomes))
+	for i, outcome := range outcomes {
+		if outcome.stdout != nil {
+			copied[i].stdout = append([]byte(nil), outcome.stdout...)
+		}
+		copied[i].err = outcome.err
+		copied[i].exitCode = outcome.exitCode
+	}
+	return &pollerRetrySequenceCommandRunner{
+		outcomes: copied,
+		pollDone: make(chan struct{}, 8),
+	}
+}
+
+func (r *pollerRetrySequenceCommandRunner) Run(_ context.Context, _ platformprocess.CommandRequest) (platformprocess.CommandResult, error) {
+	r.mu.Lock()
+	r.calls++
+	callNumber := r.calls
+	var outcome pollerIngressRunOutcome
+	if callNumber-1 < len(r.outcomes) {
+		outcome = r.outcomes[callNumber-1]
+	}
+	r.mu.Unlock()
+
+	r.signalPollCycle()
+
+	if outcome.err != nil {
+		return platformprocess.CommandResult{}, outcome.err
+	}
+	return platformprocess.CommandResult{Stdout: outcome.stdout, ExitCode: outcome.exitCode}, nil
+}
+
+func (r *pollerRetrySequenceCommandRunner) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+func (r *pollerRetrySequenceCommandRunner) pollCycleDone() <-chan struct{} {
+	return r.pollDone
+}
+
+func (r *pollerRetrySequenceCommandRunner) signalPollCycle() {
+	select {
+	case r.pollDone <- struct{}{}:
+	default:
+	}
+}
+
 var _ platformprocess.CommandRunner = (*pollerIngressCommandRunner)(nil)
+var _ platformprocess.CommandRunner = (*pollerRetrySequenceCommandRunner)(nil)

--- a/tests/functional/workstations/poller/poller_test.go
+++ b/tests/functional/workstations/poller/poller_test.go
@@ -1,0 +1,177 @@
+package poller
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	pollerWorkTypeName        = "story"
+	pollerOutputStateName     = "queued"
+	pollerExternalWorkID      = "external-issue-101"
+	pollerExternalRequestID   = "poller-external-batch-1"
+	pollerScriptCommand       = "factory/scripts/poller.sh"
+	pollerWorkstationName     = "poll-tasks"
+	pollerWorkerName          = "script-poller"
+)
+
+// TestPollerCreatesWorkFromExternalItems proves a POLLER workstation running
+// through root.BuildProcess admits Work when a controlled external poll source
+// returns identifiable items. The scenario replaces only the script poller
+// command edge and observes admission through the public Work listing.
+func TestPollerCreatesWorkFromExternalItems(t *testing.T) {
+	dir := scaffoldScriptPollerFactory(t)
+	support.ClearSeedInputs(t, dir)
+
+	runner := newPollerIngressCommandRunner(t, pollerExternalWorkRequestJSON(t))
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir: dir,
+		Edges: serviceedges.Edges{
+			ScriptCommandRunner: runner,
+		},
+	})
+	defer server.Stop(t)
+
+	outputLocation := support.WorkCustomerLocation(pollerWorkTypeName, pollerOutputStateName)
+	listed := waitForListedWorkAtCustomerState(t, server.URL(), outputLocation, 1, 10*time.Second)
+	if got := support.CountWorkAtCustomerState(listed, outputLocation); got != 1 {
+		t.Fatalf("CountWorkAtCustomerState(%q) = %d, want 1; listed=%#v", outputLocation, got, listed)
+	}
+	if !support.HasWorkAtCustomerState(listed, pollerExternalWorkID, outputLocation) {
+		t.Fatalf("listed work = %#v, want work %q at %q", listed.Results, pollerExternalWorkID, outputLocation)
+	}
+	if runner.callCount() < 1 {
+		t.Fatalf("poller command calls = %d, want at least one external poll invocation", runner.callCount())
+	}
+}
+
+func scaffoldScriptPollerFactory(t *testing.T) string {
+	t.Helper()
+	return support.ScaffoldFactory(t, map[string]any{
+		"name": "poller-external-items",
+		"workTypes": []map[string]any{{
+			"name": pollerWorkTypeName,
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": pollerOutputStateName, "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []map[string]string{{
+			"name":    pollerWorkerName,
+			"type":    "SCRIPT_WORKER",
+			"command": pollerScriptCommand,
+		}},
+		"workstations": []map[string]any{{
+			"name":      pollerWorkstationName,
+			"behavior":  "POLLER",
+			"worker":    pollerWorkerName,
+			"inputs":    []map[string]string{{"workType": pollerWorkTypeName, "state": "init"}},
+			"outputs":   []map[string]string{{"workType": pollerWorkTypeName, "state": pollerOutputStateName}},
+			"onFailure": []map[string]string{{"workType": pollerWorkTypeName, "state": "failed"}},
+		}},
+	})
+}
+
+func pollerExternalWorkRequestJSON(t *testing.T) []byte {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"requestId": pollerExternalRequestID,
+		"type":      "FACTORY_REQUEST_BATCH",
+		"works": []map[string]any{{
+			"name":         "external-issue-101",
+			"workId":       pollerExternalWorkID,
+			"workTypeName": pollerWorkTypeName,
+			"payload": map[string]string{
+				"id":    "ISSUE-101",
+				"title": "External ingress item",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal poller work request: %v", err)
+	}
+	return payload
+}
+
+func waitForListedWorkAtCustomerState(
+	t *testing.T,
+	baseURL string,
+	location string,
+	wantCount int,
+	timeout time.Duration,
+) factoryapi.ListWorkResponse {
+	t.Helper()
+
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	var last factoryapi.ListWorkResponse
+	for {
+		last = support.ListDefaultSessionWork(t, baseURL)
+		if support.CountWorkAtCustomerState(last, location) >= wantCount {
+			return last
+		}
+		select {
+		case <-ticker.C:
+		case <-deadline.C:
+			t.Fatalf(
+				"timed out waiting for %d work at %s; listed=%#v",
+				wantCount,
+				location,
+				last.Results,
+			)
+		}
+	}
+}
+
+type pollerIngressCommandRunner struct {
+	mu       sync.Mutex
+	stdout   []byte
+	calls    int
+	pollDone chan struct{}
+}
+
+func newPollerIngressCommandRunner(t *testing.T, stdout []byte) *pollerIngressCommandRunner {
+	t.Helper()
+	return &pollerIngressCommandRunner{
+		stdout:   append([]byte(nil), stdout...),
+		pollDone: make(chan struct{}, 1),
+	}
+}
+
+func (r *pollerIngressCommandRunner) Run(_ context.Context, _ platformprocess.CommandRequest) (platformprocess.CommandResult, error) {
+	r.mu.Lock()
+	r.calls++
+	callNumber := r.calls
+	stdout := append([]byte(nil), r.stdout...)
+	r.mu.Unlock()
+
+	select {
+	case r.pollDone <- struct{}{}:
+	default:
+	}
+
+	if callNumber == 1 {
+		return platformprocess.CommandResult{Stdout: stdout}, nil
+	}
+	return platformprocess.CommandResult{}, nil
+}
+
+func (r *pollerIngressCommandRunner) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+var _ platformprocess.CommandRunner = (*pollerIngressCommandRunner)(nil)

--- a/tests/functional/workstations/poller/poller_test.go
+++ b/tests/functional/workstations/poller/poller_test.go
@@ -53,6 +53,41 @@ func TestPollerCreatesWorkFromExternalItems(t *testing.T) {
 	}
 }
 
+// TestPollerEmptyResultCreatesNoWork proves a POLLER workstation does not admit
+// Work when the external poll source returns a successful empty result. The
+// scenario replaces only the script poller command edge, waits for the empty
+// poll cycle to finish through a deterministic observation edge, and asserts
+// the public Work listing at the poller output location is unchanged.
+func TestPollerEmptyResultCreatesNoWork(t *testing.T) {
+	dir := scaffoldScriptPollerFactory(t)
+	support.ClearSeedInputs(t, dir)
+
+	runner := newPollerIngressCommandRunner(t, nil)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir: dir,
+		Edges: serviceedges.Edges{
+			ScriptCommandRunner: runner,
+		},
+	})
+	defer server.Stop(t)
+
+	outputLocation := support.WorkCustomerLocation(pollerWorkTypeName, pollerOutputStateName)
+	baseline := support.ListDefaultSessionWork(t, server.URL())
+	if got := support.CountWorkAtCustomerState(baseline, outputLocation); got != 0 {
+		t.Fatalf("baseline CountWorkAtCustomerState(%q) = %d, want 0 before empty poll", outputLocation, got)
+	}
+
+	waitForPollCycle(t, runner, 10*time.Second)
+
+	listed := support.ListDefaultSessionWork(t, server.URL())
+	if got := support.CountWorkAtCustomerState(listed, outputLocation); got != 0 {
+		t.Fatalf("CountWorkAtCustomerState(%q) = %d, want 0 after empty poll; listed=%#v", outputLocation, got, listed.Results)
+	}
+	if runner.callCount() < 1 {
+		t.Fatalf("poller command calls = %d, want at least one empty poll invocation", runner.callCount())
+	}
+}
+
 func scaffoldScriptPollerFactory(t *testing.T) string {
 	t.Helper()
 	return support.ScaffoldFactory(t, map[string]any{
@@ -100,6 +135,16 @@ func pollerExternalWorkRequestJSON(t *testing.T) []byte {
 		t.Fatalf("marshal poller work request: %v", err)
 	}
 	return payload
+}
+
+func waitForPollCycle(t *testing.T, runner *pollerIngressCommandRunner, timeout time.Duration) {
+	t.Helper()
+
+	select {
+	case <-runner.pollDone:
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for poller poll cycle; calls=%d", runner.callCount())
+	}
 }
 
 func waitForListedWorkAtCustomerState(


### PR DESCRIPTION
{
  "project": "Poller Workstation Submission and Retry Functional Coverage",
  "branchName": "ft-wave1-poller",
  "description": "Add customer functional coverage in tests/functional/workstations/poller/poller_test.go that, through root.BuildProcess with the external polling effect replaced via edges.Edges, proves external items create Work, an empty poll result creates no Work, and a recoverable poll failure retries without duplicate submission. Use deterministic synchronization rather than sleeps, add customer-readable Go doc comments, avoid service/internal Petri imports, update only narrowly coupled metadata, and verify focused tests plus functional-boundary-check and metadata checks.",
  "context": {
    "customerAsk": "Implement only tests/functional/workstations/poller/poller_test.go. Through root.BuildProcess with the external polling effect replaced via edges.Edges, prove external items create Work, an empty result creates no Work, and a recoverable poll failure retries without duplicate submission. Use deterministic synchronization rather than sleeps, add customer-readable Go doc comments, avoid service/internal Petri imports, and run focused tests plus functional-boundary-check and metadata verification.",
    "problem": "Wave 0 accepts workstations/poller cells, but no Wave 1 poller cell exists. Poller Work admission, empty-poll no-op, and retry-without-duplicate behavior lack an independently reviewable black-box proof at the customer process boundary; existing coverage lives in package-local Automations/Workers tests that import service implementations rather than public Work/Factory Event projections.",
    "solution": "Implement tests/functional/workstations/poller/poller_test.go with TestPollerCreatesWorkFromExternalItems, TestPollerEmptyResultCreatesNoWork, and TestPollerRecoverableFailureRetriesWithoutDuplicates via root.BuildProcess and edges.Edges replacements for the external polling effect; assert public Work/Factory Event outcomes with deterministic observation edges; update only narrowly coupled ownership/coverage/catalog metadata; verify focused package tests, functional-boundary-check, and metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/workstations/poller/poller_test.go exists and owns TestPollerCreatesWorkFromExternalItems, TestPollerEmptyResultCreatesNoWork, and TestPollerRecoverableFailureRetriesWithoutDuplicates.",
    "All scenarios build the customer process through root.BuildProcess (or the approved support wrapper) and replace only external polling-related effects through edges.Edges.",
    "Outcomes are asserted via public Work listings and/or Factory Event projections, not Automations/Workers service internals or Petri markings.",
    "External items create observable Work; empty poll results create no Work; recoverable failure then success submits each external item once without duplicates.",
    "Synchronization uses deterministic wait/observation edges, not wall-clock time.Sleep; every top-level Test* has a customer-readable Go doc comment; tests do not import service implementations or internal Petri primitives.",
    "Only narrowly coupled ownership/coverage/catalog metadata required for this cell is updated.",
    "Quality gate: typecheck, lint, and targeted verification pass — focused package tests for the new cell, make functional-boundary-check, and functional-test metadata/catalog verification required for this cell."
  ],
  "userStories": [
    {
      "id": "ft-wave1-poller-001",
      "title": "Prove external items create Work",
      "description": "As a maintainer, I want a customer functional scenario that runs a POLLER workstation through the public process boundary with a controlled external poll source returning items, so that reviewers can trust poller ingress creates ordinary Work without inspecting service internals.",
      "acceptanceCriteria": [
        "tests/functional/workstations/poller/poller_test.go defines TestPollerCreatesWorkFromExternalItems with a customer-readable Go doc comment describing the external-item → Work admission outcome.",
        "The scenario builds the application through root.BuildProcess / approved support harness and replaces only external polling-related effects via edges.Edges (for example hosted HTTP/clock/secret edges and/or a script command runner that emits a canonical batch).",
        "After deterministic observation of admission (no wall-clock sleeps), public Work projections show new Work created from the injected external items at the Factory-configured poller output location.",
        "The test does not import service implementation packages or internal Petri primitives.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-poller-002",
      "title": "Prove empty poll result creates no Work",
      "description": "As a maintainer, I want a customer functional scenario that drives a successful empty poll through the same public boundary, so that empty ingress cycles never fabricate Work.",
      "acceptanceCriteria": [
        "TestPollerEmptyResultCreatesNoWork exists in tests/functional/workstations/poller/poller_test.go with a customer-readable Go doc comment describing the empty-poll no-Work outcome.",
        "The scenario injects a successful empty external poll result through edges.Edges and waits with a deterministic observation that the empty poll has completed (not a fixed sleep).",
        "Public Work listings show no new Work created for that empty poll cycle (Work count attributable to the poller remains zero / unchanged from the pre-poll baseline).",
        "The test does not import service implementation packages or internal Petri primitives.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-poller-003",
      "title": "Prove recoverable failure retries without duplicates",
      "description": "As a maintainer, I want a customer functional scenario that injects a recoverable poll failure followed by a successful poll returning the same external item(s), so that retry behavior is proven not to duplicate Work submission.",
      "acceptanceCriteria": [
        "TestPollerRecoverableFailureRetriesWithoutDuplicates exists in tests/functional/workstations/poller/poller_test.go with a customer-readable Go doc comment describing retry-without-duplicate submission.",
        "The scenario replaces external polling effects so the first poll attempt fails recoverably and a later attempt succeeds with identifiable external item(s); waits use controllable clock / deterministic observation edges rather than wall-clock sleeps.",
        "After the successful retry settles, public Work projections show exactly one admitted Work per distinct external item (no duplicate submission for the same external identity / payload).",
        "The test does not import service implementation packages or internal Petri primitives.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-poller-004",
      "title": "Align cell metadata and pass verification gates",
      "description": "As a maintainer, I want narrowly coupled ownership / coverage / catalog metadata updated for this destination cell and the focused verification gates run green, so the Wave 1 poller cell is inventoriable without a broad catch-all rewrite.",
      "acceptanceCriteria": [
        "Checklist / ownership / coverage / catalog metadata are touched only as required for tests/functional/workstations/poller/poller_test.go (for example marking the cell covered); no broad unrelated cleanup.",
        "Focused package tests for tests/functional/workstations/poller pass for the new cell’s lane tags.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (customer-readable Go docs inventoriable; domain ownership inferred as workstations/poller).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)