### PR TITLE
ft-wave1-cli-flags

### DIFF
--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -1211,9 +1211,29 @@
       "deletion_only_batch": "n/a"
     },
     {
-      "source_path": "tests/functional/cli/root_discovery/root_discovery_test.go",
-      "package": "you-agent-factory/tests/functional/cli/root_discovery",
-      "scenario": "TestRemovedInitInputFailsBeforeConfigurationMutation",
+      "source_path": "tests/functional/transport/cli/parameters/flags_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/parameters",
+      "scenario": "TestCLIFlagAfterPositionalValueUsesDocumentedParsing",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/parameters/flags_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/parameters/flags_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/parameters",
+      "scenario": "TestCLIStringBooleanAndRepeatedFlagsReachRequest",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/parameters/flags_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/parameters/flags_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/parameters",
+      "scenario": "TestCLIUnknownFlagFailsBeforeLifecycleStart",
       "lane": "short",
       "destination": "tests/functional/transport/cli/parameters/flags_test.go",
       "catch_all": "none",
@@ -5915,14 +5935,14 @@
       "workstations": 5,
       "orchestration": 3
     },
-    "customer_top_level_Test_scenarios": 569,
+    "customer_top_level_Test_scenarios": 571,
     "files_with_customer_Test": 200,
     "functional_test_go_files": 251,
     "helper_only_non_customer_files": 46,
     "internal_harness_Test_functions": 15,
     "internal_harness_test_files": 5,
     "lane_functionallong": 117,
-    "lane_short": 452
+    "lane_short": 454
   },
   "schema_note": "Machine-readable companion to migration-ledger.md Inventory. Required row fields match the ledger schema. Non-catch-all rows mapped by FND-007-006; catch-all rows mapped by FND-007-003\u2026005.",
   "runtime_api_mapping": {

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -78,7 +78,7 @@ intentionally small enough to distribute across many agents.
   - `TestOptionalSessionIDUsesDefaultWhenOmitted` verifies default session
     targeting and explicit override.
 
-- [ ] `tests/functional/transport/cli/parameters/flags_test.go`
+- [x] `tests/functional/transport/cli/parameters/flags_test.go`
   - `TestCLIStringBooleanAndRepeatedFlagsReachRequest` verifies flag mapping at
     the external observation edge.
   - `TestCLIUnknownFlagFailsBeforeLifecycleStart` verifies stable diagnostics.

--- a/tests/functional/cli/root_discovery/root_discovery_test.go
+++ b/tests/functional/cli/root_discovery/root_discovery_test.go
@@ -60,40 +60,6 @@ func TestBareRootPrintsConciseHelpWithoutProductEffects(t *testing.T) {
 	}
 }
 
-// TestRemovedInitInputFailsBeforeConfigurationMutation proves an unsupported
-// init input is rejected before operator configuration can change.
-func TestRemovedInitInputFailsBeforeConfigurationMutation(t *testing.T) {
-	var mutations atomic.Int32
-	process, err := root.BuildProcess(t.Context(), serviceedges.Edges{
-		OperatorSettingsFileSystem: mutationTrackingOperatorSettingsFileSystem{
-			mutations: &mutations,
-		},
-	})
-	if err != nil {
-		t.Fatalf("BuildProcess() error = %v", err)
-	}
-
-	stdout, stderr, executeErr := executeFactoryArgs(
-		t,
-		process,
-		t.TempDir(),
-		[]string{"you", "init", "--dir", "legacy-factory"},
-		false,
-		t.Context(),
-	)
-	if executeErr == nil || !strings.Contains(executeErr.Error(), "unknown flag: --dir") {
-		t.Fatalf(
-			"removed init input error = %v, want unknown flag; stdout=%q stderr=%q",
-			executeErr,
-			stdout,
-			stderr,
-		)
-	}
-	if mutations.Load() != 0 {
-		t.Fatalf("removed init input configuration mutations = %d, want 0", mutations.Load())
-	}
-}
-
 // TestManifestProjectedRepresentativeHandlersAcceptCanonicalInputs proves the
 // generated Session and Work leaves reach their typed transport handlers through
 // the public process root with the canonical argument and flag shapes.
@@ -834,30 +800,3 @@ func (fileSystem failingOperatorSettingsFileSystem) Rename(string, string) error
 	return fs.ErrPermission
 }
 
-type mutationTrackingOperatorSettingsFileSystem struct {
-	mutations *atomic.Int32
-}
-
-func (mutationTrackingOperatorSettingsFileSystem) ReadFile(string) ([]byte, error) {
-	return nil, fs.ErrNotExist
-}
-
-func (fileSystem mutationTrackingOperatorSettingsFileSystem) MkdirAll(string, fs.FileMode) error {
-	fileSystem.mutations.Add(1)
-	return nil
-}
-
-func (fileSystem mutationTrackingOperatorSettingsFileSystem) Remove(string) error {
-	fileSystem.mutations.Add(1)
-	return nil
-}
-
-func (fileSystem mutationTrackingOperatorSettingsFileSystem) Chmod(string, fs.FileMode) error {
-	fileSystem.mutations.Add(1)
-	return nil
-}
-
-func (fileSystem mutationTrackingOperatorSettingsFileSystem) Rename(string, string) error {
-	fileSystem.mutations.Add(1)
-	return nil
-}

--- a/tests/functional/transport/cli/parameters/flags_test.go
+++ b/tests/functional/transport/cli/parameters/flags_test.go
@@ -1,6 +1,9 @@
 package parameters_test
 
 import (
+	"io/fs"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
@@ -53,4 +56,61 @@ func TestCLIStringBooleanAndRepeatedFlagsReachRequest(t *testing.T) {
 	if !found || !phase.Changed || phase.Value != "active" {
 		t.Fatalf("observed repeated --phase parse = %#v found=%v, want last supplied value active", phase, found)
 	}
+}
+
+// TestCLIUnknownFlagFailsBeforeLifecycleStart proves an unknown or removed CLI
+// flag is rejected with a stable diagnostic before operator configuration or
+// other lifecycle-mutating external effects can start.
+func TestCLIUnknownFlagFailsBeforeLifecycleStart(t *testing.T) {
+	var mutations atomic.Int32
+	process := support.BuildProcess(t, serviceedges.Edges{
+		OperatorSettingsFileSystem: mutationTrackingOperatorSettingsFileSystem{
+			mutations: &mutations,
+		},
+	})
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "init", "--dir", "legacy-factory",
+	})
+	inputs.WorkingDirectory = t.TempDir()
+
+	executeErr := process.Execute(inputs.Input)
+	if executeErr == nil || !strings.Contains(executeErr.Error(), "unknown flag: --dir") {
+		t.Fatalf(
+			"removed init flag error = %v, want unknown flag: --dir; stdout=%q stderr=%q",
+			executeErr,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+	if mutations.Load() != 0 {
+		t.Fatalf("configuration mutations after unknown flag = %d, want 0", mutations.Load())
+	}
+}
+
+type mutationTrackingOperatorSettingsFileSystem struct {
+	mutations *atomic.Int32
+}
+
+func (mutationTrackingOperatorSettingsFileSystem) ReadFile(string) ([]byte, error) {
+	return nil, fs.ErrNotExist
+}
+
+func (fileSystem mutationTrackingOperatorSettingsFileSystem) MkdirAll(string, fs.FileMode) error {
+	fileSystem.mutations.Add(1)
+	return nil
+}
+
+func (fileSystem mutationTrackingOperatorSettingsFileSystem) Remove(string) error {
+	fileSystem.mutations.Add(1)
+	return nil
+}
+
+func (fileSystem mutationTrackingOperatorSettingsFileSystem) Chmod(string, fs.FileMode) error {
+	fileSystem.mutations.Add(1)
+	return nil
+}
+
+func (fileSystem mutationTrackingOperatorSettingsFileSystem) Rename(string, string) error {
+	fileSystem.mutations.Add(1)
+	return nil
 }

--- a/tests/functional/transport/cli/parameters/flags_test.go
+++ b/tests/functional/transport/cli/parameters/flags_test.go
@@ -1,0 +1,56 @@
+package parameters_test
+
+import (
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	cliobservation "github.com/portpowered/infinite-you/pkg/transports/cli/observation"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+// TestCLIStringBooleanAndRepeatedFlagsReachRequest proves string, boolean, and
+// repeated CLI flags reach the external observation edge with the
+// customer-supplied values without starting product handlers.
+func TestCLIStringBooleanAndRepeatedFlagsReachRequest(t *testing.T) {
+	var observation cliobservation.Result
+	process := support.BuildProcess(t, serviceedges.Edges{
+		CLIObserver: cliobservation.Capture(&observation),
+	})
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you",
+		"--server", "https://factory.example",
+		"-v",
+		"session", "dispatches", "session-customer",
+		"--phase", "queued",
+		"--phase", "active",
+		"--json",
+	})
+	inputs.WorkingDirectory = t.TempDir()
+
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf("Process.Execute(session dispatches observation) error = %v", err)
+	}
+	if observation.Parse.CommandPath != "you session dispatches" {
+		t.Fatalf("observed command path = %q, want you session dispatches", observation.Parse.CommandPath)
+	}
+	if len(observation.Parse.Positionals) != 1 || observation.Parse.Positionals[0] != "session-customer" {
+		t.Fatalf("observed positional parse = %#v", observation.Parse.Positionals)
+	}
+
+	server, found := cliobservation.Flag(observation.Parse, "server")
+	if !found || !server.Changed || server.Value != "https://factory.example" {
+		t.Fatalf("observed --server parse = %#v found=%v", server, found)
+	}
+	verbose, found := cliobservation.Flag(observation.Parse, "verbose")
+	if !found || !verbose.Changed || verbose.Value != "true" {
+		t.Fatalf("observed -v/--verbose parse = %#v found=%v", verbose, found)
+	}
+	jsonOutput, found := cliobservation.Flag(observation.Parse, "json")
+	if !found || !jsonOutput.Changed || jsonOutput.Value != "true" {
+		t.Fatalf("observed --json parse = %#v found=%v", jsonOutput, found)
+	}
+	phase, found := cliobservation.Flag(observation.Parse, "phase")
+	if !found || !phase.Changed || phase.Value != "active" {
+		t.Fatalf("observed repeated --phase parse = %#v found=%v, want last supplied value active", phase, found)
+	}
+}

--- a/tests/functional/transport/cli/parameters/flags_test.go
+++ b/tests/functional/transport/cli/parameters/flags_test.go
@@ -87,6 +87,43 @@ func TestCLIUnknownFlagFailsBeforeLifecycleStart(t *testing.T) {
 	}
 }
 
+// TestCLIFlagAfterPositionalValueUsesDocumentedParsing proves known flags that
+// follow a positional value are still parsed at the external observation edge,
+// matching the documented public CLI interspersed-flag behavior for manifest
+// commands such as session dispatches.
+func TestCLIFlagAfterPositionalValueUsesDocumentedParsing(t *testing.T) {
+	var observation cliobservation.Result
+	process := support.BuildProcess(t, serviceedges.Edges{
+		CLIObserver: cliobservation.Capture(&observation),
+	})
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you",
+		"session", "dispatches", "session-customer",
+		"--json",
+		"--phase", "queued",
+	})
+	inputs.WorkingDirectory = t.TempDir()
+
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf("Process.Execute(session dispatches after-positional flags) error = %v", err)
+	}
+	if observation.Parse.CommandPath != "you session dispatches" {
+		t.Fatalf("observed command path = %q, want you session dispatches", observation.Parse.CommandPath)
+	}
+	if len(observation.Parse.Positionals) != 1 || observation.Parse.Positionals[0] != "session-customer" {
+		t.Fatalf("observed positional parse = %#v", observation.Parse.Positionals)
+	}
+
+	jsonOutput, found := cliobservation.Flag(observation.Parse, "json")
+	if !found || !jsonOutput.Changed || jsonOutput.Value != "true" {
+		t.Fatalf("observed --json after positional = %#v found=%v", jsonOutput, found)
+	}
+	phase, found := cliobservation.Flag(observation.Parse, "phase")
+	if !found || !phase.Changed || phase.Value != "queued" {
+		t.Fatalf("observed --phase after positional = %#v found=%v", phase, found)
+	}
+}
+
 type mutationTrackingOperatorSettingsFileSystem struct {
 	mutations *atomic.Int32
 }


### PR DESCRIPTION
{
  "project": "CLI Flag Mapping and Validation Functional Coverage",
  "branchName": "ft-wave1-cli-flags",
  "description": "Implement the transport-owned functional cell at tests/functional/transport/cli/parameters/flags_test.go so the public CLI proves string, boolean, and repeated flag mapping at the external observation edge, unknown-flag rejection before lifecycle startup, and documented parsing when flags follow positional values, consuming the mapped migration-ledger row without Work, Session, Worker, or Factory semantic widening.",
  "context": {
    "customerAsk": "Implement only tests/functional/transport/cli/parameters/flags_test.go. Through the public CLI boundary, prove string, boolean, and repeated flag mapping at an external observation edge; unknown-flag rejection before lifecycle startup; and documented parsing when flags follow positional values. Consume the applicable migration-ledger row, preserve lane bindings, add customer-readable Go doc comments, keep domain semantics outside transport, and verify focused tests, functional-boundary-check, and metadata.",
    "problem": "The checklist destination for CLI flag mapping and validation does not exist yet, while the only mapped legacy scenario still lives under root_discovery and couples unknown-flag rejection to broader discovery concerns. Maintainers lack a focused, catalogued transport proof that typed flags reach the observation edge, unknown flags fail before lifecycle startup, and flag-after-positional parsing matches the documented contract.",
    "solution": "Implement the typed flag-mapping, unknown-flag pre-lifecycle rejection, and flag-after-positional parsing scenarios in tests/functional/transport/cli/parameters/flags_test.go through the public CLI/root.BuildProcess boundary with edges.Edges for the observation and mutation-tracking edges, with customer-readable Go docs on every top-level Test. Consume the mapped migration-ledger obligation as transport flag validation only, preserve the short lane binding, apply narrowly coupled metadata/deletion updates, and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/transport/cli/parameters/flags_test.go exists as the transport-owned functional cell and covers typed flag mapping, unknown-flag rejection before lifecycle start, and flag-after-positional parsing.",
    "Through the public CLI boundary, string, boolean, and repeated flag values are observable at the external CLI observation edge with the customer-supplied values.",
    "An unknown flag fails with a stable, actionable diagnostic and does not start lifecycle or configuration-mutating effects.",
    "When a flag appears after a positional value, parsing matches the documented public CLI behavior and is proven by observable parse or error outcomes.",
    "Coverage uses root.BuildProcess/public CLI helpers and edges.Edges only for external effects; it does not import service implementations or internal Petri primitives, and does not assert Work, Session, Worker, or Factory product semantics.",
    "Every top-level Test* has a customer-readable Go doc comment; the applicable migration-ledger row is consumed with lane short preserved and only narrowly coupled metadata/ownership/deletion updates for this cell.",
    "Focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave1-cli-flags-001",
      "title": "Prove string, boolean, and repeated flags reach the observation edge",
      "description": "As a maintainer, I want a transport-owned functional test that supplies string, boolean, and repeated CLI flags through the public process boundary and reads them back from the external CLI observation edge, so customers can trust typed flag mapping without relying on catch-all CLI packages.",
      "acceptanceCriteria": [
        "tests/functional/transport/cli/parameters/flags_test.go includes TestCLIStringBooleanAndRepeatedFlagsReachRequest (or equivalent top-level name matching the checklist intent).",
        "The test builds the customer process through root.BuildProcess / approved support helpers and installs an external CLI observer via edges.Edges (for example CLIObserver: cliobservation.Capture(...)).",
        "After executing a public CLI command with representative string, boolean, and repeated flags, the observation edge records those flag names and customer-supplied values (including repeated cardinality / ordered repeats as applicable).",
        "Assertions stay on parse/observation transport outcomes and do not assert Work submission, Session lifecycle, Worker execution, or Factory orchestration semantics.",
        "The top-level test has a customer-readable Go doc comment describing the observable flag-mapping behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-flags-002",
      "title": "Prove unknown flags fail before lifecycle startup",
      "description": "As a CLI customer, I want unknown flags rejected with a stable diagnostic before any lifecycle or configuration mutation starts, so typos and removed inputs cannot partially activate the product.",
      "acceptanceCriteria": [
        "The flags cell includes TestCLIUnknownFlagFailsBeforeLifecycleStart (or equivalent top-level name matching the checklist intent).",
        "Executing a public CLI invocation with an unknown / removed flag fails and the diagnostic names the unknown flag in a stable, actionable way (for example contains unknown flag: --...).",
        "Lifecycle / configuration-mutating external effects do not run: observer-tracked or edge-tracked side effects remain at zero (absorbing the mapped TestRemovedInitInputFailsBeforeConfigurationMutation obligation as transport unknown-flag rejection before mutation).",
        "The test does not widen into Factory definition loading success, Session controls, or Work semantics beyond proving pre-lifecycle rejection.",
        "The top-level test has a customer-readable Go doc comment describing the unknown-flag failure behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-flags-003",
      "title": "Prove documented parsing when flags follow positional values",
      "description": "As a CLI customer, I want flags that appear after positional values to parse according to the documented public contract, so command lines remain predictable when customers interleave positionals and flags.",
      "acceptanceCriteria": [
        "The flags cell includes TestCLIFlagAfterPositionalValueUsesDocumentedParsing (or equivalent top-level name matching the checklist intent).",
        "The test invokes the public CLI with at least one positional value followed by a known flag (and value when required) and asserts the documented outcome: either the flag is observed as parsed with the expected value, or the documented rejection/diagnostic occurs — matching current public CLI / packaged docs behavior, not an invented private rule.",
        "Evidence is an external observation (parse edge and/or public stderr/error text), not assertions against private parser implementation types.",
        "Assertions remain transport parameter-contract focused and do not prove domain payload semantics.",
        "The top-level test has a customer-readable Go doc comment describing the flag-after-positional behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-flags-004",
      "title": "Consume migration-ledger row and close cell verification gates",
      "description": "As a maintainer executing Wave 1 migration, I want this cell to absorb the mapped ledger obligation, preserve its short-lane binding, and pass focused boundary/metadata gates, so the destination is catalogued correctly without a broad CLI catch-all rewrite.",
      "acceptanceCriteria": [
        "The migration-ledger mapping for TestRemovedInitInputFailsBeforeConfigurationMutation to tests/functional/transport/cli/parameters/flags_test.go is consumed by this cell's coverage as unknown-flag rejection before lifecycle/configuration mutation, without reintroducing unrelated root-discovery product-activation scenarios into the parameters package.",
        "Lane binding remains short; specialty_targets remain none unless the ledger already requires otherwise for this row.",
        "Only narrowly coupled ownership, deletion-only migration, coverage, or catalog metadata required for this cell are updated; neighboring root-discovery destinations are left alone.",
        "Focused package tests for tests/functional/transport/cli/parameters pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as transport/cli/parameters).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)