### PR TITLE
ft-wave1-js-durability-resume

### DIFF
--- a/tests/functional/orchestration/javascript/durability/resume_test.go
+++ b/tests/functional/orchestration/javascript/durability/resume_test.go
@@ -1,0 +1,507 @@
+package durability_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+// TestJavaScriptInterruptedSessionResumesWithoutRepeatingCompletedChildren proves
+// that a durable JavaScript Factory Session interrupted after the first child
+// dispatch completes resumes through the public lifecycle boundary without
+// replaying completed children: completed Dispatch identities stay COMPLETED,
+// only the remaining child dispatch continues, and the session reaches a
+// successful terminal outcome.
+func TestJavaScriptInterruptedSessionResumesWithoutRepeatingCompletedChildren(t *testing.T) {
+	const workflowName = "resumable-two-step-fake-children"
+	projectRoot := setupJavaScriptDurabilityResumeWorkflowFixture(t, workflowName)
+	provider := newJavaScriptDurabilityResumeBlockingProvider(workflowName)
+
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir: projectRoot,
+		Edges:      serviceedges.Edges{ProviderOverride: provider},
+	})
+	baseURL := strings.TrimSuffix(server.URL(), "/")
+
+	sessionID := startInterruptedJavaScriptDurabilitySession(t, baseURL, provider, workflowName)
+
+	before := readDurableJavaScriptSession(t, baseURL, sessionID)
+	assertDurableProgressCounts(t, before.Progress, 1, 2, 0)
+	if before.Status != factoryapi.FactorySessionDurableLifecycleStatusInterrupted {
+		t.Fatalf("pre-resume status = %q, want INTERRUPTED", before.Status)
+	}
+
+	beforeDispatches := listJavaScriptSessionDispatches(t, baseURL, sessionID)
+	dispatchOneBefore := requireDispatchSummary(
+		t,
+		beforeDispatches,
+		"dispatch-1",
+		factoryapi.FactoryDispatchStatusCOMPLETED,
+	)
+	dispatchTwoBefore := requireDispatchSummary(
+		t,
+		beforeDispatches,
+		"dispatch-2",
+		factoryapi.FactoryDispatchStatusINTERRUPTED,
+		factoryapi.FactoryDispatchStatusRUNNING,
+	)
+	if len(beforeDispatches.Dispatches) != 2 {
+		t.Fatalf("pre-resume dispatch count = %d, want 2", len(beforeDispatches.Dispatches))
+	}
+
+	resumeResponse := resumeJavaScriptSession(t, baseURL, sessionID)
+	if resumeResponse.Operation != factoryapi.FactorySessionLifecycleControlKindResume {
+		t.Fatalf("resume operation = %q, want RESUME", resumeResponse.Operation)
+	}
+	if resumeResponse.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
+		t.Fatalf("resume outcome = %q, want ACCEPTED", resumeResponse.Outcome)
+	}
+	if resumeResponse.SessionId != sessionID {
+		t.Fatalf("resume sessionId = %q, want %q", resumeResponse.SessionId, sessionID)
+	}
+
+	after := waitForDurableJavaScriptSessionStatus(
+		t,
+		baseURL,
+		sessionID,
+		factoryapi.FactorySessionDurableLifecycleStatusSucceeded,
+		8*time.Second,
+	)
+	assertDurableProgressCounts(t, after.Progress, 2, 2, 0)
+	if after.Lifecycle == nil || after.Lifecycle.InterruptedAt == nil || after.Lifecycle.ResumedAt == nil {
+		t.Fatalf("post-resume lifecycle = %#v, want interruptedAt and resumedAt continuity", after.Lifecycle)
+	}
+	if before.Lifecycle == nil || before.Lifecycle.InterruptedAt == nil {
+		t.Fatal("pre-resume lifecycle missing interruptedAt")
+	}
+	if !after.Lifecycle.InterruptedAt.Equal(*before.Lifecycle.InterruptedAt) {
+		t.Fatalf(
+			"interruptedAt changed across resume: before=%s after=%s",
+			before.Lifecycle.InterruptedAt,
+			after.Lifecycle.InterruptedAt,
+		)
+	}
+	if after.ResultSummary == nil || after.ResultSummary.ResultStatus != factoryapi.FactorySessionResultStatusFinal {
+		t.Fatalf("post-resume resultSummary = %#v, want FINAL", after.ResultSummary)
+	}
+
+	afterDispatches := listJavaScriptSessionDispatches(t, baseURL, sessionID)
+	if len(afterDispatches.Dispatches) != 2 {
+		t.Fatalf("post-resume dispatch count = %d, want 2 (no replayed child dispatches)", len(afterDispatches.Dispatches))
+	}
+	dispatchOneAfter := requireDispatchSummary(
+		t,
+		afterDispatches,
+		"dispatch-1",
+		factoryapi.FactoryDispatchStatusCOMPLETED,
+	)
+	requireDispatchSummary(t, afterDispatches, "dispatch-2", factoryapi.FactoryDispatchStatusCOMPLETED)
+	assertDispatchSummaryParity(t, dispatchOneBefore, dispatchOneAfter)
+	if dispatchTwoBefore.Status == factoryapi.FactoryDispatchStatusINTERRUPTED {
+		dispatchTwoAfter := requireDispatchSummary(
+			t,
+			afterDispatches,
+			"dispatch-2",
+			factoryapi.FactoryDispatchStatusCOMPLETED,
+		)
+		if dispatchTwoAfter.Id != dispatchTwoBefore.Id {
+			t.Fatalf("dispatch-2 id changed across resume: %q -> %q", dispatchTwoBefore.Id, dispatchTwoAfter.Id)
+		}
+	}
+
+	if provider.callCount() != 3 {
+		t.Fatalf(
+			"provider infer calls = %d, want exactly 3 (step-one once, blocked step-two once, resumed step-two once)",
+			provider.callCount(),
+		)
+	}
+}
+
+func setupJavaScriptDurabilityResumeWorkflowFixture(t *testing.T, workflowName string) string {
+	t.Helper()
+
+	projectRoot := support.ScaffoldSingleStepFactory(t, "js-durability-resume")
+	workflowDir := filepath.Join(projectRoot, ".claude", "workflows")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("mkdir workflows: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "..", "fixtures", "javascript_runtime", workflowName+".workflow.js"))
+	if err != nil {
+		t.Fatalf("read workflow fixture %s: %v", workflowName, err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, workflowName+".js"), raw, 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	return projectRoot
+}
+
+func startInterruptedJavaScriptDurabilitySession(
+	t *testing.T,
+	baseURL string,
+	provider *javascriptDurabilityResumeBlockingProvider,
+	workflowName string,
+) string {
+	t.Helper()
+
+	started := postJavaScriptDurabilityJSON[factoryapi.FactorySessionExecutionResponse](
+		t,
+		baseURL+"/factory-sessions/async",
+		factoryapi.FactorySessionExecutionRequest{
+			RequestId: "req-js-durability-resume-interrupt-001",
+			Source: factoryapi.FactorySessionExecutionSource{
+				Kind:         factoryapi.FactorySessionExecutionSourceKindWorkflowName,
+				WorkflowName: strPtr(workflowName),
+			},
+			Args: &map[string]any{
+				"subject": "workflows",
+			},
+		},
+	)
+	sessionID := started.SessionId
+	if sessionID == "" {
+		t.Fatal("session id unexpectedly empty")
+	}
+
+	waitForJavaScriptDispatchStatus(
+		t,
+		baseURL,
+		sessionID,
+		"dispatch-1",
+		factoryapi.FactoryDispatchStatusCOMPLETED,
+		5*time.Second,
+	)
+	waitForJavaScriptDispatchStatus(
+		t,
+		baseURL,
+		sessionID,
+		"dispatch-2",
+		factoryapi.FactoryDispatchStatusRUNNING,
+		5*time.Second,
+	)
+
+	reason := "javascript durability resume interrupt"
+	postJavaScriptDurabilityJSON[factoryapi.FactorySessionLifecycleControlResponse](
+		t,
+		baseURL+"/factory-sessions/"+sessionID+"/interrupt-dispatch",
+		factoryapi.FactorySessionInterruptDispatchRequest{
+			DispatchId: "dispatch-2",
+			Reason:     &reason,
+		},
+	)
+	provider.waitForCanceledInfer(t, 5*time.Second)
+	waitForDurableJavaScriptSessionStatus(
+		t,
+		baseURL,
+		sessionID,
+		factoryapi.FactorySessionDurableLifecycleStatusInterrupted,
+		5*time.Second,
+	)
+	return sessionID
+}
+
+func readDurableJavaScriptSession(
+	t *testing.T,
+	baseURL string,
+	sessionID string,
+) factoryapi.FactorySessionDurableReadModel {
+	t.Helper()
+
+	response := support.GetJSON[factoryapi.FactorySessionGetResponse](
+		t,
+		baseURL+"/factory-sessions/"+sessionID,
+	)
+	session, err := response.AsFactorySessionDurableReadModel()
+	if err != nil {
+		t.Fatalf("decode durable session read model: %v", err)
+	}
+	return session
+}
+
+func resumeJavaScriptSession(
+	t *testing.T,
+	baseURL string,
+	sessionID string,
+) factoryapi.FactorySessionLifecycleControlResponse {
+	t.Helper()
+
+	return postJavaScriptDurabilityJSON[factoryapi.FactorySessionLifecycleControlResponse](
+		t,
+		baseURL+"/factory-sessions/"+sessionID+"/resume",
+		factoryapi.FactorySessionLifecycleControlRequest{},
+	)
+}
+
+func listJavaScriptSessionDispatches(
+	t *testing.T,
+	baseURL string,
+	sessionID string,
+) factoryapi.ListFactorySessionDispatchesResponse {
+	t.Helper()
+
+	listed := support.GetJSON[factoryapi.ListFactorySessionDispatchesResponse](
+		t,
+		baseURL+"/factory-sessions/"+sessionID+"/dispatches",
+	)
+	if listed.SessionId != sessionID {
+		t.Fatalf("dispatch sessionId = %q, want %q", listed.SessionId, sessionID)
+	}
+	if listed.Dispatches == nil {
+		t.Fatal("dispatch list unexpectedly missing")
+	}
+	return listed
+}
+
+func waitForDurableJavaScriptSessionStatus(
+	t *testing.T,
+	baseURL string,
+	sessionID string,
+	want factoryapi.FactorySessionDurableLifecycleStatus,
+	timeout time.Duration,
+) factoryapi.FactorySessionDurableReadModel {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		session := readDurableJavaScriptSession(t, baseURL, sessionID)
+		if session.Status == want {
+			return session
+		}
+		time.Sleep(15 * time.Millisecond)
+	}
+	session := readDurableJavaScriptSession(t, baseURL, sessionID)
+	t.Fatalf("session %s status = %q, want %q within %s", sessionID, session.Status, want, timeout)
+	return session
+}
+
+func waitForJavaScriptDispatchStatus(
+	t *testing.T,
+	baseURL string,
+	sessionID string,
+	dispatchID string,
+	want factoryapi.FactoryDispatchStatus,
+	timeout time.Duration,
+) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		listed := listJavaScriptSessionDispatches(t, baseURL, sessionID)
+		for _, dispatch := range listed.Dispatches {
+			if dispatch.Id != dispatchID {
+				continue
+			}
+			if dispatch.Status == want {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("dispatch %s did not reach %s within %s", dispatchID, want, timeout)
+}
+
+func postJavaScriptDurabilityJSON[T any](t *testing.T, endpoint string, request any) T {
+	t.Helper()
+
+	payload, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("marshal request for %s: %v", endpoint, err)
+	}
+	response, err := http.Post(endpoint, "application/json", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("POST %s: %v", endpoint, err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read POST %s response: %v", endpoint, err)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		t.Fatalf("POST %s status = %d\n%s", endpoint, response.StatusCode, body)
+	}
+	var decoded T
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("decode POST %s response: %v\n%s", endpoint, err, body)
+	}
+	return decoded
+}
+
+func assertDurableProgressCounts(
+	t *testing.T,
+	progress *factoryapi.FactorySessionDurableProgressCounts,
+	wantCompleted, wantTotal, wantInFlight int,
+) {
+	t.Helper()
+	if progress == nil {
+		t.Fatalf("progress = nil, want completed=%d total=%d inFlight=%d", wantCompleted, wantTotal, wantInFlight)
+	}
+	if intValueOrZero(progress.CompletedDispatches) != wantCompleted {
+		t.Fatalf("completedDispatches = %#v, want %d", progress.CompletedDispatches, wantCompleted)
+	}
+	if intValueOrZero(progress.TotalDispatches) != wantTotal {
+		t.Fatalf("totalDispatches = %#v, want %d", progress.TotalDispatches, wantTotal)
+	}
+	if intValueOrZero(progress.InFlightDispatches) != wantInFlight {
+		t.Fatalf("inFlightDispatches = %#v, want %d", progress.InFlightDispatches, wantInFlight)
+	}
+}
+
+func intValueOrZero(value *int) int {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
+func requireDispatchSummary(
+	t *testing.T,
+	listed factoryapi.ListFactorySessionDispatchesResponse,
+	dispatchID string,
+	allowedStatuses ...factoryapi.FactoryDispatchStatus,
+) factoryapi.FactorySessionDispatchSummary {
+	t.Helper()
+
+	for _, dispatch := range listed.Dispatches {
+		if dispatch.Id != dispatchID {
+			continue
+		}
+		for _, want := range allowedStatuses {
+			if dispatch.Status == want {
+				return dispatch
+			}
+		}
+		t.Fatalf("dispatch %s status = %q, want one of %#v", dispatchID, dispatch.Status, allowedStatuses)
+	}
+	t.Fatalf("dispatch %s missing from %#v", dispatchID, listed.Dispatches)
+	return factoryapi.FactorySessionDispatchSummary{}
+}
+
+func assertDispatchSummaryParity(
+	t *testing.T,
+	before, after factoryapi.FactorySessionDispatchSummary,
+) {
+	t.Helper()
+
+	if before.Id != after.Id {
+		t.Fatalf("dispatch id changed: %q -> %q", before.Id, after.Id)
+	}
+	if before.Status != after.Status && after.Status != factoryapi.FactoryDispatchStatusCOMPLETED {
+		t.Fatalf("dispatch %s status drifted unexpectedly: before=%q after=%q", before.Id, before.Status, after.Status)
+	}
+	if before.DispatchKind != after.DispatchKind {
+		t.Fatalf("dispatch %s kind changed: %q -> %q", before.Id, before.DispatchKind, after.DispatchKind)
+	}
+	if before.OutputArtifactIds != nil && after.OutputArtifactIds != nil {
+		if len(*before.OutputArtifactIds) != len(*after.OutputArtifactIds) {
+			t.Fatalf(
+				"dispatch %s outputArtifactIds length changed: before=%#v after=%#v",
+				before.Id,
+				*before.OutputArtifactIds,
+				*after.OutputArtifactIds,
+			)
+		}
+		for i := range *before.OutputArtifactIds {
+			if (*before.OutputArtifactIds)[i] != (*after.OutputArtifactIds)[i] {
+				t.Fatalf(
+					"dispatch %s outputArtifactIds changed: before=%#v after=%#v",
+					before.Id,
+					*before.OutputArtifactIds,
+					*after.OutputArtifactIds,
+				)
+			}
+		}
+	}
+}
+
+func strPtr(value string) *string {
+	return &value
+}
+
+type javascriptDurabilityResumeBlockingProvider struct {
+	mu              sync.Mutex
+	calls           int
+	blockedOnce     bool
+	contextCanceled int
+	workflowName    string
+}
+
+func newJavaScriptDurabilityResumeBlockingProvider(workflowName string) *javascriptDurabilityResumeBlockingProvider {
+	return &javascriptDurabilityResumeBlockingProvider{workflowName: workflowName}
+}
+
+func (p *javascriptDurabilityResumeBlockingProvider) callCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+func (p *javascriptDurabilityResumeBlockingProvider) Infer(
+	ctx context.Context,
+	_ workerexecution.ProviderInferenceRequest,
+) (workerexecution.InferenceResponse, error) {
+	p.mu.Lock()
+	p.calls++
+	call := p.calls
+	alreadyBlocked := p.blockedOnce
+	p.mu.Unlock()
+
+	if call == 1 {
+		return workerexecution.InferenceResponse{
+			Content: fmt.Sprintf(`{"text":"live:%s:step-one:step-one:workflows","label":"step-one"}`, p.workflowName),
+			ProviderSession: &workerexecution.ProviderSessionMetadata{
+				Provider: "mock",
+				Kind:     "session_id",
+				ID:       "live-provider-session-1",
+			},
+		}, nil
+	}
+
+	if !alreadyBlocked {
+		p.mu.Lock()
+		p.blockedOnce = true
+		p.mu.Unlock()
+
+		<-ctx.Done()
+		p.mu.Lock()
+		p.contextCanceled++
+		p.mu.Unlock()
+		return workerexecution.InferenceResponse{}, ctx.Err()
+	}
+
+	return workerexecution.InferenceResponse{
+		Content: fmt.Sprintf(`{"text":"live:%s:step-two:step-two:workflows","label":"step-two"}`, p.workflowName),
+		ProviderSession: &workerexecution.ProviderSessionMetadata{
+			Provider: "mock",
+			Kind:     "session_id",
+			ID:       "live-provider-session-2",
+		},
+	}, nil
+}
+
+func (p *javascriptDurabilityResumeBlockingProvider) waitForCanceledInfer(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		p.mu.Lock()
+		canceled := p.contextCanceled
+		p.mu.Unlock()
+		if canceled > 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("provider Infer did not observe canceled workflow context")
+}

--- a/tests/functional/orchestration/javascript/durability/resume_test.go
+++ b/tests/functional/orchestration/javascript/durability/resume_test.go
@@ -201,6 +201,98 @@ func TestJavaScriptResumeRestoresCheckpointAndFinalResult(t *testing.T) {
 	assertResumableTwoStepFinalPrimaryResult(t, result, workflowName)
 }
 
+// TestJavaScriptCorruptCheckpointFailsActionably proves that resuming a durable
+// JavaScript Factory Session with a corrupt persisted checkpoint fails through the
+// public lifecycle boundary with a customer-readable invalid-state rejection,
+// leaves the interrupted session inspectable without a successful terminal
+// outcome, and does not hang or leak private JavaScript VM internals.
+func TestJavaScriptCorruptCheckpointFailsActionably(t *testing.T) {
+	const workflowName = "resumable-two-step-fake-children"
+	projectRoot := setupJavaScriptDurabilityResumeWorkflowFixture(t, workflowName)
+	provider := newJavaScriptDurabilityResumeBlockingProvider(workflowName)
+
+	seedServer := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir: projectRoot,
+		Edges:      serviceedges.Edges{ProviderOverride: provider},
+	})
+	seedURL := strings.TrimSuffix(seedServer.URL(), "/")
+	sessionID := startInterruptedJavaScriptDurabilitySession(t, seedURL, provider, workflowName)
+	waitForPersistedJavaScriptDurabilitySnapshot(t, projectRoot, sessionID)
+
+	before := readDurableJavaScriptSession(t, seedURL, sessionID)
+	if before.Status != factoryapi.FactorySessionDurableLifecycleStatusInterrupted {
+		t.Fatalf("pre-corruption status = %q, want INTERRUPTED", before.Status)
+	}
+	if before.Lifecycle == nil || before.Lifecycle.InterruptedAt == nil {
+		t.Fatalf("pre-corruption lifecycle = %#v, want interruptedAt", before.Lifecycle)
+	}
+	seedServer.Stop(t)
+
+	corruptJavaScriptDurableSessionCheckpointKind(t, projectRoot, sessionID)
+
+	resumeServer := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir: projectRoot,
+		Edges:      serviceedges.Edges{ProviderOverride: provider},
+	})
+	baseURL := strings.TrimSuffix(resumeServer.URL(), "/")
+
+	interrupted := readDurableJavaScriptSession(t, baseURL, sessionID)
+	if interrupted.Status != factoryapi.FactorySessionDurableLifecycleStatusInterrupted {
+		t.Fatalf("post-corruption status = %q, want INTERRUPTED", interrupted.Status)
+	}
+	if interrupted.Lifecycle == nil || interrupted.Lifecycle.InterruptedAt == nil {
+		t.Fatalf("post-corruption lifecycle = %#v, want interruptedAt", interrupted.Lifecycle)
+	}
+	callsBeforeResume := provider.callCount()
+
+	resumeResponse := resumeJavaScriptSessionExpectingInvalidState(t, baseURL, sessionID)
+	if resumeResponse.Operation != factoryapi.FactorySessionLifecycleControlKindResume {
+		t.Fatalf("resume operation = %q, want RESUME", resumeResponse.Operation)
+	}
+	if resumeResponse.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeInvalidState {
+		t.Fatalf("resume outcome = %q, want INVALID_STATE", resumeResponse.Outcome)
+	}
+	if resumeResponse.SessionId != sessionID {
+		t.Fatalf("resume sessionId = %q, want %q", resumeResponse.SessionId, sessionID)
+	}
+	if resumeResponse.Status != factoryapi.FactorySessionDurableLifecycleStatusInterrupted {
+		t.Fatalf("resume status = %q, want INTERRUPTED", resumeResponse.Status)
+	}
+	if resumeResponse.Detail == nil {
+		t.Fatal("resume detail unexpectedly missing")
+	}
+	detail := strings.ToLower(*resumeResponse.Detail)
+	if !strings.Contains(detail, "checkpoint") {
+		t.Fatalf("resume detail = %q, want customer-readable checkpoint diagnostic", *resumeResponse.Detail)
+	}
+	for _, leaked := range []string{"checkpointstate", "v8", "heap", "stack frame", "goroutine"} {
+		if strings.Contains(detail, leaked) {
+			t.Fatalf("resume detail leaked private internals: %q", *resumeResponse.Detail)
+		}
+	}
+
+	after := readDurableJavaScriptSession(t, baseURL, sessionID)
+	if after.Status != factoryapi.FactorySessionDurableLifecycleStatusInterrupted {
+		t.Fatalf("post-resume status = %q, want INTERRUPTED unchanged", after.Status)
+	}
+	if after.Lifecycle == nil || after.Lifecycle.InterruptedAt == nil {
+		t.Fatalf("post-resume lifecycle = %#v, want interruptedAt continuity", after.Lifecycle)
+	}
+	if after.Lifecycle.ResumedAt != nil {
+		t.Fatalf("resumedAt = %v, want nil after failed resume", after.Lifecycle.ResumedAt)
+	}
+	if after.ResultSummary != nil && after.ResultSummary.ResultStatus == factoryapi.FactorySessionResultStatusFinal {
+		t.Fatalf("post-resume resultSummary = %#v, want no successful terminal outcome", after.ResultSummary)
+	}
+	if provider.callCount() != callsBeforeResume {
+		t.Fatalf(
+			"provider infer calls = %d, want %d (no resume execution after corrupt checkpoint)",
+			provider.callCount(),
+			callsBeforeResume,
+		)
+	}
+}
+
 func setupJavaScriptDurabilityResumeWorkflowFixture(t *testing.T, workflowName string) string {
 	t.Helper()
 
@@ -313,6 +405,96 @@ func resumeJavaScriptSession(
 		baseURL+"/factory-sessions/"+sessionID+"/resume",
 		factoryapi.FactorySessionLifecycleControlRequest{},
 	)
+}
+
+func resumeJavaScriptSessionExpectingInvalidState(
+	t *testing.T,
+	baseURL string,
+	sessionID string,
+) factoryapi.FactorySessionLifecycleControlResponse {
+	t.Helper()
+
+	payload, err := json.Marshal(factoryapi.FactorySessionLifecycleControlRequest{})
+	if err != nil {
+		t.Fatalf("marshal resume request: %v", err)
+	}
+	endpoint := baseURL + "/factory-sessions/" + sessionID + "/resume"
+	response, err := http.Post(endpoint, "application/json", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("POST %s: %v", endpoint, err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read POST %s response: %v", endpoint, err)
+	}
+	if response.StatusCode != http.StatusConflict {
+		t.Fatalf("POST %s status = %d, want 409\n%s", endpoint, response.StatusCode, body)
+	}
+	var decoded factoryapi.FactorySessionLifecycleControlResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("decode POST %s response: %v\n%s", endpoint, err, body)
+	}
+	return decoded
+}
+
+func waitForPersistedJavaScriptDurabilitySnapshot(t *testing.T, projectRoot, sessionID string) {
+	t.Helper()
+
+	path := javaScriptDurableSessionPersistencePath(projectRoot, sessionID)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		raw, err := os.ReadFile(path)
+		if err == nil && len(raw) > 0 {
+			var probe struct {
+				CheckpointSummary *struct{} `json:"CheckpointSummary"`
+			}
+			if json.Unmarshal(raw, &probe) == nil && probe.CheckpointSummary != nil {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("persisted interrupted snapshot not ready at %s", path)
+}
+
+func javaScriptDurableSessionPersistencePath(projectRoot, sessionID string) string {
+	return filepath.Join(projectRoot, ".you-agent-factory", "durable-sessions", sessionID+".json")
+}
+
+func corruptJavaScriptDurableSessionCheckpointKind(t *testing.T, projectRoot, sessionID string) {
+	t.Helper()
+
+	path := javaScriptDurableSessionPersistencePath(projectRoot, sessionID)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read durable session snapshot %s: %v", path, err)
+	}
+	var snapshot map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &snapshot); err != nil {
+		t.Fatalf("unmarshal durable session snapshot: %v", err)
+	}
+	checkpointRaw, ok := snapshot["CheckpointSummary"]
+	if !ok {
+		t.Fatal("durable session snapshot missing CheckpointSummary")
+	}
+	var checkpointSummary map[string]any
+	if err := json.Unmarshal(checkpointRaw, &checkpointSummary); err != nil {
+		t.Fatalf("unmarshal checkpointSummary: %v", err)
+	}
+	checkpointSummary["kind"] = "invalid-checkpoint-kind"
+	encodedCheckpoint, err := json.Marshal(checkpointSummary)
+	if err != nil {
+		t.Fatalf("marshal checkpointSummary: %v", err)
+	}
+	snapshot["checkpointSummary"] = encodedCheckpoint
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("marshal durable session snapshot: %v", err)
+	}
+	if err := os.WriteFile(path, encoded, 0o600); err != nil {
+		t.Fatalf("write corrupt durable session snapshot %s: %v", path, err)
+	}
 }
 
 func listJavaScriptSessionDispatches(

--- a/tests/functional/orchestration/javascript/durability/resume_test.go
+++ b/tests/functional/orchestration/javascript/durability/resume_test.go
@@ -131,6 +131,76 @@ func TestJavaScriptInterruptedSessionResumesWithoutRepeatingCompletedChildren(t 
 	}
 }
 
+// TestJavaScriptResumeRestoresCheckpointAndFinalResult proves that a durable
+// JavaScript Factory Session interrupted after writing a workflow checkpoint
+// resumes through the public lifecycle boundary with restored durable progress
+// (latest checkpoint and dispatch counts preserved, not a blank restart) and
+// reaches the expected terminal primary result for the completed workflow.
+func TestJavaScriptResumeRestoresCheckpointAndFinalResult(t *testing.T) {
+	const workflowName = "resumable-two-step-fake-children"
+	projectRoot := setupJavaScriptDurabilityResumeWorkflowFixture(t, workflowName)
+	provider := newJavaScriptDurabilityResumeBlockingProvider(workflowName)
+
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir: projectRoot,
+		Edges:      serviceedges.Edges{ProviderOverride: provider},
+	})
+	baseURL := strings.TrimSuffix(server.URL(), "/")
+
+	sessionID := startInterruptedJavaScriptDurabilitySession(t, baseURL, provider, workflowName)
+
+	before := readDurableJavaScriptSession(t, baseURL, sessionID)
+	assertDurableProgressCounts(t, before.Progress, 1, 2, 0)
+	if before.Status != factoryapi.FactorySessionDurableLifecycleStatusInterrupted {
+		t.Fatalf("pre-resume status = %q, want INTERRUPTED", before.Status)
+	}
+	checkpointBefore := requireLatestCheckpointLabel(t, before, "after-step-one")
+
+	resumeResponse := resumeJavaScriptSession(t, baseURL, sessionID)
+	if resumeResponse.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
+		t.Fatalf("resume outcome = %q, want ACCEPTED", resumeResponse.Outcome)
+	}
+
+	after := waitForDurableJavaScriptSessionStatus(
+		t,
+		baseURL,
+		sessionID,
+		factoryapi.FactorySessionDurableLifecycleStatusSucceeded,
+		8*time.Second,
+	)
+	assertDurableProgressCounts(t, after.Progress, 2, 2, 0)
+	checkpointAfter := requireLatestCheckpointLabel(t, after, "after-step-one")
+	if checkpointAfter.Id != checkpointBefore.Id {
+		t.Fatalf(
+			"latestCheckpoint id changed across resume: before=%q after=%q",
+			checkpointBefore.Id,
+			checkpointAfter.Id,
+		)
+	}
+	if after.Lifecycle == nil || after.Lifecycle.InterruptedAt == nil || after.Lifecycle.ResumedAt == nil {
+		t.Fatalf("post-resume lifecycle = %#v, want interruptedAt and resumedAt continuity", after.Lifecycle)
+	}
+	if before.Lifecycle == nil || before.Lifecycle.InterruptedAt == nil {
+		t.Fatal("pre-resume lifecycle missing interruptedAt")
+	}
+	if !after.Lifecycle.InterruptedAt.Equal(*before.Lifecycle.InterruptedAt) {
+		t.Fatalf(
+			"interruptedAt changed across resume: before=%s after=%s",
+			before.Lifecycle.InterruptedAt,
+			after.Lifecycle.InterruptedAt,
+		)
+	}
+	if after.ResultSummary == nil || after.ResultSummary.ResultStatus != factoryapi.FactorySessionResultStatusFinal {
+		t.Fatalf("post-resume resultSummary = %#v, want FINAL", after.ResultSummary)
+	}
+
+	result := readJavaScriptSessionFinalResult(t, baseURL, sessionID)
+	if result.ResultStatus != factoryapi.FactorySessionResultStatusFinal {
+		t.Fatalf("terminal resultStatus = %q, want FINAL", result.ResultStatus)
+	}
+	assertResumableTwoStepFinalPrimaryResult(t, result, workflowName)
+}
+
 func setupJavaScriptDurabilityResumeWorkflowFixture(t *testing.T, workflowName string) string {
 	t.Helper()
 
@@ -337,6 +407,81 @@ func postJavaScriptDurabilityJSON[T any](t *testing.T, endpoint string, request 
 		t.Fatalf("decode POST %s response: %v\n%s", endpoint, err, body)
 	}
 	return decoded
+}
+
+func requireLatestCheckpointLabel(
+	t *testing.T,
+	session factoryapi.FactorySessionDurableReadModel,
+	wantLabel string,
+) factoryapi.FactorySessionCheckpointRef {
+	t.Helper()
+	if session.LatestCheckpoint == nil {
+		t.Fatalf("latestCheckpoint = nil, want label %q", wantLabel)
+	}
+	if session.LatestCheckpoint.Id == "" {
+		t.Fatal("latestCheckpoint.id unexpectedly empty")
+	}
+	if session.LatestCheckpoint.Label == nil || *session.LatestCheckpoint.Label != wantLabel {
+		t.Fatalf("latestCheckpoint.label = %#v, want %q", session.LatestCheckpoint.Label, wantLabel)
+	}
+	return *session.LatestCheckpoint
+}
+
+func readJavaScriptSessionFinalResult(
+	t *testing.T,
+	baseURL string,
+	sessionID string,
+) factoryapi.FactorySessionResult {
+	t.Helper()
+
+	result := support.GetJSON[factoryapi.FactorySessionResult](
+		t,
+		baseURL+"/factory-sessions/"+sessionID+"/results",
+	)
+	if result.SessionId != sessionID {
+		t.Fatalf("result sessionId = %q, want %q", result.SessionId, sessionID)
+	}
+	return result
+}
+
+func assertResumableTwoStepFinalPrimaryResult(
+	t *testing.T,
+	result factoryapi.FactorySessionResult,
+	workflowName string,
+) {
+	t.Helper()
+
+	if result.PrimaryResult == nil || len(*result.PrimaryResult) != 1 {
+		t.Fatalf("primaryResult = %#v, want exactly one content part", result.PrimaryResult)
+	}
+	part, err := (*result.PrimaryResult)[0].AsWorkJsonContentPart()
+	if err != nil {
+		t.Fatalf("decode primary result content part: %v", err)
+	}
+	payload, ok := part.Json.(map[string]any)
+	if !ok {
+		t.Fatalf("primary json payload = %#v, want object", part.Json)
+	}
+	if payload["label"] != workflowName {
+		t.Fatalf("result label = %#v, want %q", payload["label"], workflowName)
+	}
+	if payload["subject"] != "workflows" {
+		t.Fatalf("result subject = %#v, want workflows", payload["subject"])
+	}
+	first, ok := payload["first"].(map[string]any)
+	if !ok {
+		t.Fatalf("result first = %#v, want object with step-one label", payload["first"])
+	}
+	if first["label"] != "step-one" {
+		t.Fatalf("result first.label = %#v, want step-one", first["label"])
+	}
+	second, ok := payload["second"].(map[string]any)
+	if !ok {
+		t.Fatalf("result second = %#v, want object with step-two label", payload["second"])
+	}
+	if second["label"] != "step-two" {
+		t.Fatalf("result second.label = %#v, want step-two", second["label"])
+	}
 }
 
 func assertDurableProgressCounts(


### PR DESCRIPTION
{
  "project": "JavaScript Durable Resume Functional Coverage",
  "branchName": "ft-wave1-js-durability-resume",
  "description": "Implement only tests/functional/orchestration/javascript/durability/resume_test.go so an interrupted JavaScript session resumes without repeating completed children, restores checkpoint and final result correctly, and fails actionably on a corrupt checkpoint. Drive proofs through root.BuildProcess and public Factory Session/Dispatch/invocation surfaces; keep ownership inside durability/resume; add customer-readable Go docs; verify focused tests, functional-boundary-check, and metadata.",
  "context": {
    "customerAsk": "Implement only tests/functional/orchestration/javascript/durability/resume_test.go. Prove an interrupted JavaScript session resumes without repeating completed children, restore checkpoint and final result correctly, and fail actionably on a corrupt checkpoint. Keep ownership in durability/resume, add customer-readable Go doc comments, and verify focused tests, functional-boundary-check, and metadata.",
    "problem": "Sibling JavaScript Wave 1 cells own composition, policy, loading, and response-events, while CLI/MCP resume smoke maps elsewhere. The checklist destination tests/functional/orchestration/javascript/durability/resume_test.go does not exist yet, so maintainers lack a domain-owned proof that interrupted JavaScript resume avoids completed-child replay, restores checkpoint and final result, and fails actionably on a corrupt checkpoint.",
    "solution": "Implement TestJavaScriptInterruptedSessionResumesWithoutRepeatingCompletedChildren, TestJavaScriptResumeRestoresCheckpointAndFinalResult, and TestJavaScriptCorruptCheckpointFailsActionably in tests/functional/orchestration/javascript/durability/resume_test.go through root.BuildProcess and public Factory Session/Dispatch/invocation surfaces, with edges.Edges only for external effects. Keep ownership inside durability/resume, document every top-level Test, avoid private VM/service imports, and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks for this free destination."
  },
  "acceptanceCriteria": [
    "tests/functional/orchestration/javascript/durability/resume_test.go exists as the orchestration-owned functional cell and contains TestJavaScriptInterruptedSessionResumesWithoutRepeatingCompletedChildren, TestJavaScriptResumeRestoresCheckpointAndFinalResult, and TestJavaScriptCorruptCheckpointFailsActionably.",
    "Interrupted-resume coverage proves a JavaScript Factory Session interrupted after at least one completed child dispatch resumes through the public lifecycle/resume boundary without replaying those completed children (same completed Dispatch identities retained; no duplicate completed-child re-dispatch), while remaining work reaches a successful terminal outcome, after a root-built process run with external effects substituted only through edges.Edges.",
    "Checkpoint/final-result coverage proves that after resume, public checkpoint or durable progress facts and the terminal primary / invocation result correctly reflect restored durable state (not a blank restart and not a mismatched final).",
    "Corrupt-checkpoint coverage proves that a corrupt checkpoint produces a customer-readable public failure signal without private JavaScript VM internals or unresolved hangs.",
    "Coverage uses root.BuildProcess / approved public functional hosts and does not import private VM packages or service implementations.",
    "This cell does not modify or take ownership of adjacent composition, policy, loading, response-events, or sessions controls/restart destinations; specialty bindings remain none.",
    "Quality gate: typecheck, lint, and targeted verification pass — focused package tests for the new cell, make functional-boundary-check, and functional-test-viz-compatible metadata verification required for this cell."
  ],
  "userStories": [
    {
      "id": "ft-wave1-js-durability-resume-001",
      "title": "Prove interrupted resume does not repeat completed children",
      "description": "As a maintainer, I want an orchestration-owned functional test that interrupts a multi-child JavaScript Factory Session after at least one child completes, resumes it through the public boundary, and proves completed children are not re-dispatched, so customers can trust durable progress without inspecting private VM checkpoint bytes.",
      "acceptanceCriteria": [
        "Package path tests/functional/orchestration/javascript/durability/ exists and conforms to Wave 0 domain-layout rules for orchestration/javascript.",
        "Destination file tests/functional/orchestration/javascript/durability/resume_test.go includes TestJavaScriptInterruptedSessionResumesWithoutRepeatingCompletedChildren (checklist name).",
        "The scenario builds through root.BuildProcess / approved support harness and replaces only external effects via edges.Edges (mock workers and/or recording provider command runner so live provider execution does not occur).",
        "The workflow runs at least two child dispatches; the test interrupts after the first child is COMPLETED and while later work is still in-flight or pending, leaving the durable session INTERRUPTED.",
        "After a public resume is accepted, the session reaches a successful terminal outcome, completed-before-interrupt child Dispatch identities remain COMPLETED without replay (no extra completed-child re-dispatch for those children), and only remaining incomplete work is continued.",
        "Assertions observe public Factory Session / Dispatch / invocation / Factory Event contracts only; they do not import private VM packages or service implementations, and do not assert private checkpoint payload bytes or VM heap/stack details.",
        "The top-level test has a customer-readable Go doc comment describing the observable no-replay resume continuity behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-js-durability-resume-002",
      "title": "Prove resume restores checkpoint and final result",
      "description": "As a customer relying on durable JavaScript sessions, I want resume to restore checkpoint progress and produce the correct final result so operators can inspect continuity and trust the terminal outcome after interruption.",
      "acceptanceCriteria": [
        "The durability/resume cell includes TestJavaScriptResumeRestoresCheckpointAndFinalResult (checklist name).",
        "The scenario runs a JavaScript Factory that writes observable checkpoint / durable progress before interruption, interrupts, then resumes through the same public process/session boundary without live provider execution.",
        "After resume completes successfully, public session read / progress / checkpoint facts show restored durable progress (not a blank restart), and the terminal primary / invocation result matches the expected final outcome for the resumed workflow.",
        "Assertions stay on public Factory Session / result / Dispatch / Factory Event surfaces; they do not decode private VM checkpoint strategy records or import private runtime packages.",
        "The test does not claim ownership of generic pause/resume buffering (sessions/controls), logical-identity remap (sessions/restart), or composition/policy cells.",
        "The top-level test has a customer-readable Go doc comment describing the observable checkpoint restoration and final-result behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-js-durability-resume-003",
      "title": "Prove corrupt checkpoint fails actionably",
      "description": "As an operator recovering a durable JavaScript session, I want a corrupt checkpoint to fail with a customer-readable public diagnostic so I can distinguish recovery failure from a successful resume or a silent hang.",
      "acceptanceCriteria": [
        "The durability/resume cell includes TestJavaScriptCorruptCheckpointFailsActionably (checklist name).",
        "The scenario drives the public resume / restore path against a corrupt checkpoint (or an equivalently corrupt durable resume payload) through the approved functional boundary, without live provider execution.",
        "Observable outcome is a failed / rejected public result with a customer-readable corrupt-checkpoint (or equivalent actionable) diagnostic — not success, not an unresolved hang, and not private JavaScript VM stack frames or engine heap dumps.",
        "The test does not claim ownership of incompatible-checkpoint-only matrixing beyond what is required to prove actionable corrupt failure, and does not expand shared harness APIs.",
        "The top-level test has a customer-readable Go doc comment describing the observable corrupt-checkpoint failure behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-js-durability-resume-004",
      "title": "Preserve durability ownership and close verification gates",
      "description": "As a maintainer executing Wave 1 in parallel, I want this cell to stay inside durability/resume ownership, leave adjacent JavaScript and session cells untouched, and pass focused boundary/metadata gates so the destination is inventoriable without colliding with composition, policy, or session-controls lanes.",
      "acceptanceCriteria": [
        "Diff for this cell does not modify tests/functional/orchestration/javascript/composition/**, loading/**, policy/**, contracts/**, tests/functional/sessions/controls/**, tests/functional/sessions/restart/**, or historical cli/session_resume / cli/mcp_resume packages (or their mapped deletion-batch / ledger ownership metadata when those cells own them).",
        "Only narrowly coupled ownership, coverage, or catalog metadata required for tests/functional/orchestration/javascript/durability/resume_test.go are updated; specialty bindings remain none; no migration-ledger deletion batch is invented for this free destination.",
        "Focused package tests covering tests/functional/orchestration/javascript/durability pass for the three checklist resume scenarios (or the package subset that owns resume_test.go).",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as orchestration/javascript/durability).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)