### PR TITLE
ft-wave1-js-policy-denied

### DIFF
--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -631,6 +631,8 @@ response-stream output.
   must retain the stable error code and parameter identity while replacing the
   rejected value with the Work-owned redaction marker.
 - JavaScript named-factory lookup carries the authored `argsSchema` and `defaultPolicy` through `pkg/orchestrators/javascript/source/` into `pkg/factory/sessions/execution/PrepareStart`. Validate resolved arguments before runtime execution and resolve policy with that default; `workflowruntime.Request.ArgsSchema` preserves the same no-side-effect guard for direct runtime callers.
+- `WORKFLOW_FILE` JavaScript factories with authored `defaultPolicy` also attach an `InlineWorkflow` overlay in `pkg/services/factory_sessions/internal/runtimeopening/invocation/operation.go` so durable execution receives the same policy defaults as inline workflows.
+- JavaScript one-shot invocation maps terminal failures in `javaScriptInvocationResult` (`pkg/services/factory_sessions/internal/runtimeopening/invocation/operation.go`). When `GetResult` final-mode projection returns `UNAVAILABLE` without `Failure`, fall back to `GetSession().Failure` so policy/runtime denials surface the actionable message on CLI/API invocation responses instead of the generic "did not produce a final result" placeholder.
 - `pkg/work/invocation/interpolation.go` owns runtime `${parameter}` interpolation
   for signature-backed worker and workstation fields plus pre-dispatch
   interpolation validation. Keep file-contents substitution, omitted-exact-field

--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -1881,6 +1881,26 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/orchestration/javascript/policy/denied_operations_test.go",
+      "package": "you-agent-factory/tests/functional/orchestration/javascript/policy",
+      "scenario": "TestJavaScriptDeniedChildOperationReturnsStablePolicyDiagnostic",
+      "lane": "short",
+      "destination": "tests/functional/orchestration/javascript/policy/denied_operations_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/orchestration/javascript/policy/denied_operations_test.go",
+      "package": "you-agent-factory/tests/functional/orchestration/javascript/policy",
+      "scenario": "TestJavaScriptPolicyFailureDoesNotDispatchExternalWork",
+      "lane": "short",
+      "destination": "tests/functional/orchestration/javascript/policy/denied_operations_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/orchestration/petri/dispatch/concurrent_workers_test.go",
       "package": "you-agent-factory/tests/functional/orchestration/petri/dispatch",
       "scenario": "TestPetriConcurrentFailureDoesNotDuplicateDispatch",
@@ -6345,14 +6365,14 @@
       "workflow": 64,
       "workstations": 7
     },
-    "customer_top_level_Test_scenarios": 612,
+    "customer_top_level_Test_scenarios": 614,
     "files_with_customer_Test": 200,
     "functional_test_go_files": 251,
     "helper_only_non_customer_files": 51,
     "internal_harness_Test_functions": 15,
     "internal_harness_test_files": 5,
     "lane_functionallong": 118,
-    "lane_short": 494,
+    "lane_short": 496,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 14,
       "you-agent-factory/tests/functional/bootstrap_portability": 25,
@@ -6488,15 +6508,15 @@
     }
   },
   "completeness_audit": {
-    "audited_at_utc": "2026-07-27T16:30:00Z",
-    "story": "ft-wave1-mock-replacement-mergeability",
-    "live_customer_scenarios": 612,
-    "ledger_rows": 612,
+    "audited_at_utc": "2026-07-27T15:40:00Z",
+    "story": "ft-wave1-js-policy-denied-mergeability",
+    "live_customer_scenarios": 614,
+    "ledger_rows": 614,
     "unmapped_scenarios": 0,
     "checklist_destinations": 435,
     "wrong_layer_destinations": 69,
     "invalid_destinations": 0,
-    "lane_short": 494,
+    "lane_short": 496,
     "lane_functionallong": 118,
     "specialty_targets_documented": 11,
     "deletion_only_batches": 52,

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -409,7 +409,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestJavaScriptMockWorkersReplaceOnlyNamedChildren` covers partial mocks.
   - `TestJavaScriptUnknownWorkerOverrideFailsActionably` covers error.
 
-- [ ] `tests/functional/orchestration/javascript/policy/denied_operations_test.go`
+- [x] `tests/functional/orchestration/javascript/policy/denied_operations_test.go`
   - `TestJavaScriptDeniedChildOperationReturnsStablePolicyDiagnostic` covers
     policy failure.
   - `TestJavaScriptPolicyFailureDoesNotDispatchExternalWork` covers safety.

--- a/pkg/services/factory_sessions/internal/execution/fake_service_runtime_test.go
+++ b/pkg/services/factory_sessions/internal/execution/fake_service_runtime_test.go
@@ -20,6 +20,7 @@ import (
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryruntimejavascript "github.com/portpowered/infinite-you/pkg/services/factory_runtime/javascript"
 	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/execution/runtimepersist"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
 	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
@@ -3772,4 +3773,94 @@ func TestJavaScriptRuntimeServiceWriteRecordingUsesCanonicalSnapshotAndCorrelate
 	if readErr != nil || read.Status != LifecycleStatusSucceeded {
 		t.Fatalf("live session changed after recording failure: read=%#v err=%v", read, readErr)
 	}
+}
+
+func TestJavaScriptRuntimeService_StartSync_WorkflowFilePolicyDeniesDisallowedModel(t *testing.T) {
+	t.Parallel()
+
+	projectRoot := t.TempDir()
+	workflowPath := filepath.Join(projectRoot, "workflow.js")
+	workflowSource := `agent.run({
+  prompt: "summarize workflows",
+  label: "denied-model",
+  model: "gpt-denied",
+});
+return { ok: true };`
+	if err := os.WriteFile(workflowPath, []byte(workflowSource), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	defaultPolicy := json.RawMessage(`{
+  "mode":"READ_ONLY",
+  "maxAgents":4,
+  "concurrency":2,
+  "allowedModels":["gpt-allowed"],
+  "allowedReasoningEfforts":["low"]
+}`)
+	var requestedPolicy map[string]any
+	if err := json.Unmarshal(defaultPolicy, &requestedPolicy); err != nil {
+		t.Fatalf("unmarshal default policy: %v", err)
+	}
+
+	workflows := realJavaScriptWorkflowsForExecutionTest(t)
+	service := newConfiguredJavaScriptRuntimeService(javaScriptRuntimeServiceConfig{
+		ProjectRoot:       projectRoot,
+		ChildExecutorMode: ChildExecutorModeFake,
+		Workflows:         workflows,
+	})
+
+	started, err := service.StartSync(context.Background(), StartRequest{
+		RequestID: "req-policy-denied-model",
+		Source: Source{
+			Kind:         factory.WorkflowSourceKindWorkflowFile,
+			WorkflowFile: workflowPath,
+			InlineWorkflow: &InlineWorkflowSource{
+				DefaultPolicy: defaultPolicy,
+			},
+		},
+		Args:            map[string]any{"prompt": "hello"},
+		RequestedPolicy: requestedPolicy,
+		Runtime:         &RuntimeOptions{ChildExecutorMode: ChildExecutorModeFake},
+	})
+	if err != nil {
+		t.Fatalf("StartSync: %v", err)
+	}
+	if started.Status != string(LifecycleStatusFailed) {
+		t.Fatalf("status = %q, want FAILED; outcome = %#v", started.Status, started)
+	}
+
+	session, err := service.GetSession(context.Background(), started.SessionID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	result, err := service.GetResult(context.Background(), started.SessionID, ResultRequest{Mode: ResultModeFinal})
+	if err != nil {
+		t.Fatalf("GetResult: %v", err)
+	}
+	failureMessage := ""
+	if result.Failure != nil {
+		failureMessage = result.Failure.Message
+	} else if session.Failure != nil {
+		failureMessage = session.Failure.Message
+	}
+	if !strings.Contains(failureMessage, `policy denied: model "gpt-denied" is not listed in allowedModels`) {
+		t.Fatalf("session failure = %#v result failure = %#v, want stable policy diagnostic", session.Failure, result.Failure)
+	}
+}
+
+func realJavaScriptWorkflowsForExecutionTest(t *testing.T) factory.JavaScriptWorkflows {
+	t.Helper()
+	return factoryruntimejavascript.New(localWorkflowSourceFilesForExecutionTest{}, os.UserHomeDir, filepath.EvalSymlinks)
+}
+
+type localWorkflowSourceFilesForExecutionTest struct{}
+
+func (localWorkflowSourceFilesForExecutionTest) ReadDir(path string) ([]os.DirEntry, error) {
+	return os.ReadDir(path)
+}
+func (localWorkflowSourceFilesForExecutionTest) ReadFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+func (localWorkflowSourceFilesForExecutionTest) Stat(path string) (os.FileInfo, error) {
+	return os.Stat(path)
 }

--- a/pkg/services/factory_sessions/internal/execution/prepare_start.go
+++ b/pkg/services/factory_sessions/internal/execution/prepare_start.go
@@ -184,16 +184,29 @@ func resolveStartSourceWithResolution(
 }
 
 func applyInlineFactoryDeclaration(resolution *factory.WorkflowSourceResolution, source Source) {
-	if resolution == nil || source.Kind != factory.WorkflowSourceKindInlineWorkflow || source.InlineWorkflow == nil {
+	if resolution == nil || source.InlineWorkflow == nil {
 		return
 	}
 	inline := source.InlineWorkflow
-	if sourceRef := strings.TrimSpace(inline.Metadata["sourceRef"]); sourceRef != "" {
-		resolution.SourceRef = sourceRef
+	switch source.Kind {
+	case factory.WorkflowSourceKindInlineWorkflow:
+		if sourceRef := strings.TrimSpace(inline.Metadata["sourceRef"]); sourceRef != "" {
+			resolution.SourceRef = sourceRef
+		}
+		resolution.Agents = cloneJavaScriptAgents(inline.Agents)
+		resolution.ArgsSchema = append(json.RawMessage(nil), inline.ArgsSchema...)
+		resolution.DefaultPolicy = append(json.RawMessage(nil), inline.DefaultPolicy...)
+	case factory.WorkflowSourceKindWorkflowFile:
+		if len(inline.Agents) > 0 {
+			resolution.Agents = cloneJavaScriptAgents(inline.Agents)
+		}
+		if len(inline.ArgsSchema) > 0 {
+			resolution.ArgsSchema = append(json.RawMessage(nil), inline.ArgsSchema...)
+		}
+		if len(inline.DefaultPolicy) > 0 {
+			resolution.DefaultPolicy = append(json.RawMessage(nil), inline.DefaultPolicy...)
+		}
 	}
-	resolution.Agents = cloneJavaScriptAgents(inline.Agents)
-	resolution.ArgsSchema = append(json.RawMessage(nil), inline.ArgsSchema...)
-	resolution.DefaultPolicy = append(json.RawMessage(nil), inline.DefaultPolicy...)
 }
 
 func validateResolvedSourceContent(

--- a/pkg/services/factory_sessions/internal/execution/prepare_start_policy_test.go
+++ b/pkg/services/factory_sessions/internal/execution/prepare_start_policy_test.go
@@ -1,0 +1,25 @@
+package factorysessionexecution
+
+import (
+	"encoding/json"
+	"testing"
+
+	factory "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+func TestApplyInlineFactoryDeclarationPreservesWorkflowFileDefaultPolicy(t *testing.T) {
+	t.Parallel()
+
+	defaultPolicy := json.RawMessage(`{"allowedModels":["gpt-allowed"],"mode":"READ_ONLY"}`)
+	resolution := factory.WorkflowSourceResolution{Found: true}
+	applyInlineFactoryDeclaration(&resolution, Source{
+		Kind:         factory.WorkflowSourceKindWorkflowFile,
+		WorkflowFile: "/tmp/workflow.js",
+		InlineWorkflow: &InlineWorkflowSource{
+			DefaultPolicy: defaultPolicy,
+		},
+	})
+	if string(resolution.DefaultPolicy) != string(defaultPolicy) {
+		t.Fatalf("resolution defaultPolicy = %s, want %s", resolution.DefaultPolicy, defaultPolicy)
+	}
+}

--- a/pkg/services/factory_sessions/internal/runtimeopening/invocation/operation.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/invocation/operation.go
@@ -333,7 +333,19 @@ func invokeJavaScriptFactory(
 	if err != nil {
 		return factorydefinitions.FactoryInvocationResult{}, err
 	}
-	return javaScriptInvocationResult(startRequest.RequestID, result), nil
+	var sessionFailure *factorysessions.FailureSummary
+	if result.Failure == nil && !javaScriptInvocationSucceeded(result) {
+		session, sessionErr := opened.Execution.GetSession(ctx, started.SessionID)
+		if sessionErr == nil {
+			sessionFailure = session.Failure
+		}
+	}
+	return javaScriptInvocationResult(startRequest.RequestID, result, sessionFailure), nil
+}
+
+func javaScriptInvocationSucceeded(result factorysessions.ResultReadResult) bool {
+	return result.SessionStatus == factorysessions.LifecycleStatusSucceeded &&
+		result.ResultStatus == factorysessions.ResultStatusFinal
 }
 
 func javaScriptStartRequest(
@@ -369,6 +381,13 @@ func javaScriptStartRequest(
 			}
 			source.WorkflowFile = filepath.Join(factoryDir, source.WorkflowFile)
 		}
+		if len(js.DefaultPolicy) > 0 || len(js.ArgsSchema) > 0 || len(js.Agents) > 0 {
+			source.InlineWorkflow = &factorysessions.InlineWorkflowSource{
+				Agents:        cloneJavaScriptAgents(js.Agents),
+				ArgsSchema:    append(json.RawMessage(nil), js.ArgsSchema...),
+				DefaultPolicy: append(json.RawMessage(nil), js.DefaultPolicy...),
+			}
+		}
 	}
 	args, err := javaScriptInvocationArgs(projection.FactoryCfg, request, js.ArgsSchema, resolver)
 	if err != nil {
@@ -389,12 +408,24 @@ func javaScriptStartRequest(
 		childMode = factorysessions.ChildExecutorModeFake
 	}
 	return factorysessions.StartRequest{
-		RequestID: requestID,
-		Source:    source,
-		Args:      args,
-		Runtime:   &factorysessions.RuntimeOptions{ChildExecutorMode: childMode},
-		Wait:      &factorysessions.WaitOptions{TimeoutMillis: request.TimeoutMillis},
+		RequestID:       requestID,
+		Source:          source,
+		Args:            args,
+		RequestedPolicy: factoryDefaultPolicyMap(js.DefaultPolicy),
+		Runtime:         &factorysessions.RuntimeOptions{ChildExecutorMode: childMode},
+		Wait:            &factorysessions.WaitOptions{TimeoutMillis: request.TimeoutMillis},
 	}, nil
+}
+
+func factoryDefaultPolicyMap(raw json.RawMessage) map[string]any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var policy map[string]any
+	if err := json.Unmarshal(raw, &policy); err != nil || len(policy) == 0 {
+		return nil
+	}
+	return policy
 }
 
 func javaScriptInvocationArgs(
@@ -466,6 +497,7 @@ func coerceJavaScriptArgument(value, valueType string) any {
 func javaScriptInvocationResult(
 	requestID string,
 	result factorysessions.ResultReadResult,
+	sessionFailure *factorysessions.FailureSummary,
 ) factorydefinitions.FactoryInvocationResult {
 	out := factorydefinitions.FactoryInvocationResult{
 		RequestID: requestID,
@@ -473,7 +505,7 @@ func javaScriptInvocationResult(
 		Status:    factorydefinitions.InvocationTerminalStatusFailed,
 		ErrorCode: string(factorydefinitions.InvocationErrorCodeRuntimeFailure),
 	}
-	if result.SessionStatus == factorysessions.LifecycleStatusSucceeded && result.ResultStatus == factorysessions.ResultStatusFinal {
+	if javaScriptInvocationSucceeded(result) {
 		out.Status = factorydefinitions.InvocationTerminalStatusCompleted
 		out.ErrorCode = ""
 		if len(result.PrimaryResult) > 0 {
@@ -485,10 +517,14 @@ func javaScriptInvocationResult(
 		}
 		return out
 	}
-	if result.Failure != nil {
-		out.Message = strings.TrimSpace(result.Failure.Message)
+	failure := result.Failure
+	if failure == nil {
+		failure = sessionFailure
+	}
+	if failure != nil {
+		out.Message = strings.TrimSpace(failure.Message)
 		if out.Message == "" {
-			out.Message = strings.TrimSpace(result.Failure.Reason)
+			out.Message = strings.TrimSpace(failure.Reason)
 		}
 	}
 	if out.Message == "" && result.Availability != nil {

--- a/pkg/services/factory_sessions/internal/runtimeopening/invocation/operation_test.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/invocation/operation_test.go
@@ -13,6 +13,36 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 )
 
+func TestJavaScriptStartRequestPreservesWorkflowFileDefaultPolicy(t *testing.T) {
+	factoryDir := t.TempDir()
+	defaultPolicy := json.RawMessage(`{"allowedModels":["gpt-allowed"],"mode":"READ_ONLY"}`)
+	cfg := &factorydefinitions.FactoryConfig{
+		Orchestrator: &factorydefinitions.FactoryOrchestratorConfig{
+			Kind: factorydefinitions.OrchestratorKindJavaScript,
+			JavaScript: &factorydefinitions.FactoryOrchestratorJavaScriptConfig{
+				SourceRef:     "workflow.js",
+				DefaultPolicy: defaultPolicy,
+			},
+		},
+	}
+	projection := factorysessions.ProjectionContext{
+		FactoryCfg: cfg,
+		Session:    &factorysessions.ScopedLiveSessionSummary{FactoryDir: factoryDir},
+	}
+	started, err := javaScriptStartRequest(projection, roles.InvocationTarget{
+		FactoryDir: factoryDir,
+	}, factorysessions.InvocationRequest{}, invocationInputResolver{}, func() string { return "session-policy-test" })
+	if err != nil {
+		t.Fatalf("javaScriptStartRequest: %v", err)
+	}
+	if started.Source.Kind != factoryruntime.WorkflowSourceKindWorkflowFile {
+		t.Fatalf("source kind = %q, want WORKFLOW_FILE", started.Source.Kind)
+	}
+	if started.Source.InlineWorkflow == nil || string(started.Source.InlineWorkflow.DefaultPolicy) != string(defaultPolicy) {
+		t.Fatalf("inline workflow overlay = %#v, want factory defaultPolicy preserved", started.Source.InlineWorkflow)
+	}
+}
+
 func TestJavaScriptStartRequestUsesDefinitionAndNormalizedArguments(t *testing.T) {
 	factoryDir := t.TempDir()
 	requestID := "request-deep-research"
@@ -89,11 +119,29 @@ func TestJavaScriptInvocationResultDecodesCanonicalWorkContent(t *testing.T) {
 	result := javaScriptInvocationResult("request-1", factorysessions.ResultReadResult{
 		SessionID: "session-1", SessionStatus: factorysessions.LifecycleStatusSucceeded,
 		ResultStatus: factorysessions.ResultStatusFinal, PrimaryResult: primary,
-	})
+	}, nil)
 	if result.Status != factorydefinitions.InvocationTerminalStatusCompleted || result.ErrorCode != "" {
 		t.Fatalf("result = %#v, want completed", result)
 	}
 	if len(result.PrimaryResult) != 1 || result.PrimaryResult[0].Text != "research complete" {
 		t.Fatalf("primary result = %#v", result.PrimaryResult)
+	}
+}
+
+func TestJavaScriptInvocationResultFallsBackToSessionFailureWhenResultUnavailable(t *testing.T) {
+	policyMessage := `policy denied: model "gpt-denied" is not listed in allowedModels (label="denied-model")`
+	result := javaScriptInvocationResult("request-1", factorysessions.ResultReadResult{
+		SessionID:     "session-1",
+		SessionStatus: factorysessions.LifecycleStatusFailed,
+		ResultStatus:  factorysessions.ResultStatusUnavailable,
+	}, &factorysessions.FailureSummary{
+		Reason:  "POLICY_DENIED",
+		Message: policyMessage,
+	})
+	if result.Status != factorydefinitions.InvocationTerminalStatusFailed {
+		t.Fatalf("status = %q, want FAILED", result.Status)
+	}
+	if result.Message != policyMessage {
+		t.Fatalf("message = %q, want %q", result.Message, policyMessage)
 	}
 }

--- a/tests/functional/orchestration/javascript/policy/denied_operations_test.go
+++ b/tests/functional/orchestration/javascript/policy/denied_operations_test.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/portpowered/infinite-you/internal/testutil"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
@@ -35,15 +37,46 @@ func TestJavaScriptDeniedChildOperationReturnsStablePolicyDiagnostic(t *testing.
 	first := runPolicyDeniedJavaScriptInvocation(t, dir)
 	second := runPolicyDeniedJavaScriptInvocation(t, dir)
 
-	assertPolicyDeniedInvocationOutcome(t, first)
-	assertPolicyDeniedInvocationOutcome(t, second)
-	if first.policyDiagnostic != second.policyDiagnostic {
+	assertPolicyDeniedInvocationOutcome(t, first.outcome)
+	assertPolicyDeniedInvocationOutcome(t, second.outcome)
+	if first.outcome.policyDiagnostic != second.outcome.policyDiagnostic {
 		t.Fatalf(
 			"policy diagnostic = %q then %q, want identical stable denial across repeated runs",
-			first.policyDiagnostic,
-			second.policyDiagnostic,
+			first.outcome.policyDiagnostic,
+			second.outcome.policyDiagnostic,
 		)
 	}
+}
+
+// TestJavaScriptPolicyFailureDoesNotDispatchExternalWork proves a denied child
+// operation fails through the public invocation boundary before any external
+// worker or provider work is dispatched when external effects are substituted
+// only through edges.Edges.
+func TestJavaScriptPolicyFailureDoesNotDispatchExternalWork(t *testing.T) {
+	t.Parallel()
+
+	dir := scaffoldPolicyDeniedJavaScriptFactory(t)
+	run := runPolicyDeniedJavaScriptInvocation(t, dir)
+
+	assertPolicyDeniedInvocationOutcome(t, run.outcome)
+	if run.providerRunner.CallCount() != 0 {
+		t.Fatalf(
+			"provider command runner call count = %d, want 0 before policy-denied child dispatch",
+			run.providerRunner.CallCount(),
+		)
+	}
+	if run.workerProvider.CallCount() != 0 {
+		t.Fatalf(
+			"worker provider inference call count = %d, want 0 before policy-denied child dispatch",
+			run.workerProvider.CallCount(),
+		)
+	}
+}
+
+type policyDeniedInvocationRun struct {
+	providerRunner *support.RecordingCommandRunner
+	workerProvider *testutil.MockProvider
+	outcome        policyDeniedInvocationOutcome
 }
 
 type policyDeniedInvocationOutcome struct {
@@ -92,10 +125,13 @@ func scaffoldPolicyDeniedJavaScriptFactory(t *testing.T) string {
 	return dir
 }
 
-func runPolicyDeniedJavaScriptInvocation(t *testing.T, dir string) policyDeniedInvocationOutcome {
+func runPolicyDeniedJavaScriptInvocation(t *testing.T, dir string) policyDeniedInvocationRun {
 	t.Helper()
 
 	runner := support.NewRecordingCommandRunner("unexpected live provider execution")
+	workerProvider := testutil.NewMockProvider(
+		workerexecution.InferenceResponse{Content: `{"text":"should not run"}`},
+	)
 	inputs := support.FakeInputs(t.Context(), []string{
 		"you", "--json", "run",
 		"--factory", filepath.Join(dir, "factory.json"),
@@ -109,25 +145,30 @@ func runPolicyDeniedJavaScriptInvocation(t *testing.T, dir string) policyDeniedI
 
 	err := support.BuildProcess(t, serviceedges.Edges{
 		ProviderCommandRunner: runner,
+		ProviderOverride:      workerProvider,
 	}).Execute(inputs.Input)
 	if err == nil {
 		t.Fatalf("Process.Execute() error = nil; stdout:\n%s\nstderr:\n%s", inputs.Stdout(), inputs.Stderr())
 	}
 
-	outcome := policyDeniedInvocationOutcome{
+	runOutcome := policyDeniedInvocationOutcome{
 		policyDiagnostic: extractPolicyDiagnostic(t, inputs.Stdout(), inputs.Stderr(), err.Error()),
 	}
 	if stdout := strings.TrimSpace(inputs.Stdout()); stdout != "" {
-		if decodeErr := json.Unmarshal([]byte(stdout), &outcome.response); decodeErr != nil {
+		if decodeErr := json.Unmarshal([]byte(stdout), &runOutcome.response); decodeErr != nil {
 			t.Fatalf("decode InvocationResponse: %v\nstdout:\n%s", decodeErr, stdout)
 		}
 	}
 	if stderr := strings.TrimSpace(inputs.Stderr()); stderr != "" {
-		if decodeErr := json.Unmarshal([]byte(stderr), &outcome.errorResponse); decodeErr != nil {
+		if decodeErr := json.Unmarshal([]byte(stderr), &runOutcome.errorResponse); decodeErr != nil {
 			t.Fatalf("decode ErrorResponse: %v\nstderr:\n%s", decodeErr, stderr)
 		}
 	}
-	return outcome
+	return policyDeniedInvocationRun{
+		providerRunner: runner,
+		workerProvider: workerProvider,
+		outcome:        runOutcome,
+	}
 }
 
 func assertPolicyDeniedInvocationOutcome(t *testing.T, outcome policyDeniedInvocationOutcome) {

--- a/tests/functional/orchestration/javascript/policy/denied_operations_test.go
+++ b/tests/functional/orchestration/javascript/policy/denied_operations_test.go
@@ -1,0 +1,174 @@
+package policy
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	policyDeniedModelWorkflow = `agent.run({
+  prompt: "summarize workflows",
+  label: "denied-model",
+  model: "gpt-denied",
+});
+return { ok: true };`
+
+	stablePolicyDeniedModelDiagnostic = `policy denied: model "gpt-denied" is not listed in allowedModels`
+)
+
+// TestJavaScriptDeniedChildOperationReturnsStablePolicyDiagnostic proves a
+// JavaScript Factory whose child request violates effective policy fails through
+// the public invocation boundary with a stable customer-readable policy denial
+// diagnostic after a root-built process run with external effects substituted
+// only through edges.Edges.
+func TestJavaScriptDeniedChildOperationReturnsStablePolicyDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	dir := scaffoldPolicyDeniedJavaScriptFactory(t)
+	first := runPolicyDeniedJavaScriptInvocation(t, dir)
+	second := runPolicyDeniedJavaScriptInvocation(t, dir)
+
+	assertPolicyDeniedInvocationOutcome(t, first)
+	assertPolicyDeniedInvocationOutcome(t, second)
+	if first.policyDiagnostic != second.policyDiagnostic {
+		t.Fatalf(
+			"policy diagnostic = %q then %q, want identical stable denial across repeated runs",
+			first.policyDiagnostic,
+			second.policyDiagnostic,
+		)
+	}
+}
+
+type policyDeniedInvocationOutcome struct {
+	response         factoryapi.InvocationResponse
+	errorResponse    factoryapi.ErrorResponse
+	policyDiagnostic string
+}
+
+func scaffoldPolicyDeniedJavaScriptFactory(t *testing.T) string {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, map[string]any{
+		"name": "javascript-policy-denied",
+		"invocationSignature": map[string]any{
+			"parameters": []any{map[string]any{
+				"name": "prompt", "required": true,
+				"bindings": []any{map[string]any{"kind": "POSITIONAL", "position": 1}},
+			}},
+		},
+		"orchestrator": map[string]any{
+			"kind": "JAVASCRIPT",
+			"javascript": map[string]any{
+				"sourceRef": "workflow.js",
+				"argsSchema": map[string]any{
+					"type": "object", "required": []any{"prompt"},
+					"properties":           map[string]any{"prompt": map[string]any{"type": "string"}},
+					"additionalProperties": false,
+				},
+				"defaultPolicy": map[string]any{
+					"mode":                    "READ_ONLY",
+					"maxAgents":               4,
+					"concurrency":             2,
+					"allowNetwork":            false,
+					"allowedModels":           []any{"gpt-allowed"},
+					"allowedReasoningEfforts": []any{"low"},
+				},
+			},
+		},
+	})
+	if err := os.WriteFile(filepath.Join(dir, "workflow.js"), []byte(policyDeniedModelWorkflow), 0o600); err != nil {
+		t.Fatalf("write JavaScript workflow: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "mock-workers.json"), []byte(`{"mockWorkers":[]}`), 0o600); err != nil {
+		t.Fatalf("write mock-workers config: %v", err)
+	}
+	return dir
+}
+
+func runPolicyDeniedJavaScriptInvocation(t *testing.T, dir string) policyDeniedInvocationOutcome {
+	t.Helper()
+
+	runner := support.NewRecordingCommandRunner("unexpected live provider execution")
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "--json", "run",
+		"--factory", filepath.Join(dir, "factory.json"),
+		"--no-record",
+		"--with-mock-workers", filepath.Join(dir, "mock-workers.json"),
+		"hello",
+	})
+	inputs.Input.WorkingDirectory = dir
+	home := t.TempDir()
+	inputs.Input.Env = append(inputs.Input.Env, "HOME="+home, "USERPROFILE="+home)
+
+	err := support.BuildProcess(t, serviceedges.Edges{
+		ProviderCommandRunner: runner,
+	}).Execute(inputs.Input)
+	if err == nil {
+		t.Fatalf("Process.Execute() error = nil; stdout:\n%s\nstderr:\n%s", inputs.Stdout(), inputs.Stderr())
+	}
+
+	outcome := policyDeniedInvocationOutcome{
+		policyDiagnostic: extractPolicyDiagnostic(t, inputs.Stdout(), inputs.Stderr(), err.Error()),
+	}
+	if stdout := strings.TrimSpace(inputs.Stdout()); stdout != "" {
+		if decodeErr := json.Unmarshal([]byte(stdout), &outcome.response); decodeErr != nil {
+			t.Fatalf("decode InvocationResponse: %v\nstdout:\n%s", decodeErr, stdout)
+		}
+	}
+	if stderr := strings.TrimSpace(inputs.Stderr()); stderr != "" {
+		if decodeErr := json.Unmarshal([]byte(stderr), &outcome.errorResponse); decodeErr != nil {
+			t.Fatalf("decode ErrorResponse: %v\nstderr:\n%s", decodeErr, stderr)
+		}
+	}
+	return outcome
+}
+
+func assertPolicyDeniedInvocationOutcome(t *testing.T, outcome policyDeniedInvocationOutcome) {
+	t.Helper()
+
+	if outcome.response.Status != factoryapi.InvocationTerminalStatusFailed {
+		t.Fatalf("invocation status = %q, want FAILED", outcome.response.Status)
+	}
+	if outcome.response.ErrorCode == nil ||
+		*outcome.response.ErrorCode != factoryapi.InvocationResponseErrorCode("INVOCATION_RUNTIME_FAILURE") {
+		t.Fatalf("invocation errorCode = %#v, want INVOCATION_RUNTIME_FAILURE", outcome.response.ErrorCode)
+	}
+	if outcome.response.PrimaryResult != nil {
+		t.Fatalf("primaryResult = %#v, want nil on policy denial", outcome.response.PrimaryResult)
+	}
+	if !strings.Contains(outcome.policyDiagnostic, stablePolicyDeniedModelDiagnostic) {
+		t.Fatalf("policy diagnostic = %q, want substring %q", outcome.policyDiagnostic, stablePolicyDeniedModelDiagnostic)
+	}
+	if !strings.Contains(outcome.policyDiagnostic, `label="denied-model"`) {
+		t.Fatalf("policy diagnostic = %q, want actionable child label context", outcome.policyDiagnostic)
+	}
+	if outcome.errorResponse.Code != factoryapi.ErrorResponseCode("INVOCATION_RUNTIME_FAILURE") {
+		t.Fatalf("ErrorResponse code = %q, want INVOCATION_RUNTIME_FAILURE", outcome.errorResponse.Code)
+	}
+	if !strings.Contains(outcome.errorResponse.Message, stablePolicyDeniedModelDiagnostic) {
+		t.Fatalf("ErrorResponse message = %q, want policy denial diagnostic", outcome.errorResponse.Message)
+	}
+}
+
+func extractPolicyDiagnostic(t *testing.T, stdout, stderr, executeError string) string {
+	t.Helper()
+
+	diagnostic := strings.Join([]string{executeError, stdout, stderr}, "\n")
+	for _, fragment := range []string{
+		`policy denied: model "gpt-denied" is not listed in allowedModels (label="denied-model")`,
+		stablePolicyDeniedModelDiagnostic,
+	} {
+		if strings.Contains(diagnostic, fragment) {
+			return fragment
+		}
+	}
+	t.Fatalf("diagnostic %q does not contain stable policy denial", diagnostic)
+	return ""
+}


### PR DESCRIPTION
{
  "project": "JavaScript Denied-Operations Policy Functional Coverage",
  "branchName": "ft-wave1-js-policy-denied",
  "description": "Implement only tests/functional/orchestration/javascript/policy/denied_operations_test.go so a denied JavaScript child operation returns a stable policy diagnostic and the policy failure does not dispatch external work. Drive proofs through root.BuildProcess and public invocation/failure surfaces; add customer-readable Go docs; avoid private runtime imports; verify focused tests, functional-boundary-check, and metadata.",
  "context": {
    "customerAsk": "Implement only tests/functional/orchestration/javascript/policy/denied_operations_test.go. Prove a denied child operation returns a stable policy diagnostic and that the policy failure does not dispatch external work. Add customer-readable Go doc comments, avoid private runtime imports, and verify focused tests, functional-boundary-check, and metadata.",
    "problem": "Sibling JavaScript Wave 1 cells own loading, response-events, composition, and durability, but the checklist destination tests/functional/orchestration/javascript/policy/denied_operations_test.go does not exist yet. Maintainers lack a domain-owned proof that a denied child operation surfaces a stable public policy diagnostic and that policy denial prevents external worker/provider dispatch, leaving denied-operations policy uninventoried under orchestration/javascript/policy.",
    "solution": "Implement TestJavaScriptDeniedChildOperationReturnsStablePolicyDiagnostic and TestJavaScriptPolicyFailureDoesNotDispatchExternalWork in tests/functional/orchestration/javascript/policy/denied_operations_test.go through root.BuildProcess and public invocation/failure surfaces, with edges.Edges only for external effects (mock workers / recording provider runner). Leave composition, loading, and durability ownership untouched, document every top-level Test, avoid private runtime imports, and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks for this free destination."
  },
  "acceptanceCriteria": [
    "tests/functional/orchestration/javascript/policy/denied_operations_test.go exists as the orchestration-owned functional cell and contains TestJavaScriptDeniedChildOperationReturnsStablePolicyDiagnostic and TestJavaScriptPolicyFailureDoesNotDispatchExternalWork.",
    "Stable-diagnostic coverage proves a JavaScript Factory whose child request violates effective policy fails with a stable public policy diagnostic (customer-readable policy denial signal such as a documented policy code/class and actionable message) after a root-built process run with external effects substituted only through edges.Edges.",
    "No-dispatch coverage proves that when policy denies the child operation, the substituted external edge records zero external worker / provider dispatches, and the public outcome is a policy failure rather than a completed child.",
    "Coverage uses root.BuildProcess / approved public functional hosts and does not import private JavaScript runtime packages or service implementations.",
    "This cell does not modify or take ownership of adjacent JavaScript cells (composition/**, loading/**, durability/**, contracts/response_events*).",
    "Every top-level Test* has a customer-readable Go doc comment whose first sentence describes the observable behavior; specialty bindings for this cell remain none.",
    "Quality gate: typecheck, lint, and targeted verification pass — focused package tests for the new cell, make functional-boundary-check, and functional-test-viz-compatible metadata verification required for this cell."
  ],
  "userStories": [
    {
      "id": "ft-wave1-js-policy-denied-001",
      "title": "Prove denied child returns stable policy diagnostic",
      "description": "As a maintainer, I want an orchestration-owned functional test that runs a JavaScript Factory whose child request violates effective policy through the public process boundary and proves the failure surfaces as a stable policy diagnostic, so customers can trust deny outcomes without inspecting private runtime state.",
      "acceptanceCriteria": [
        "Package path tests/functional/orchestration/javascript/policy/ exists and conforms to Wave 0 domain-layout rules for orchestration/javascript.",
        "Destination file tests/functional/orchestration/javascript/policy/denied_operations_test.go includes TestJavaScriptDeniedChildOperationReturnsStablePolicyDiagnostic (checklist name).",
        "The scenario builds through root.BuildProcess / approved support harness and replaces only external effects via edges.Edges (mock workers and/or recording provider command runner so live provider execution does not occur).",
        "The JavaScript workflow attempts a child operation that the effective Factory / workflow policy denies (for example a disallowed model or other documented child-request constraint reachable through the public Factory definition / invocation path).",
        "After the run, the public invocation / failure surface exposes a stable policy diagnostic: a customer-readable policy denial signal (documented policy code/class and/or actionable \"policy denied\" message) that is stable across repeated runs of the same fixture.",
        "Assertions observe public invocation / Dispatch / Factory Event contracts only; they do not import private JavaScript runtime packages or service implementations, and do not assert private VM heap/stack details.",
        "The top-level test has a customer-readable Go doc comment describing the observable stable policy-diagnostic behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-js-policy-denied-002",
      "title": "Prove policy failure does not dispatch external work",
      "description": "As a customer relying on JavaScript workflow policy, I want a denied child operation to fail before any external worker or provider work is dispatched so operators do not incur side effects or observe spurious child completions after a policy denial.",
      "acceptanceCriteria": [
        "The policy/denied_operations cell includes TestJavaScriptPolicyFailureDoesNotDispatchExternalWork (checklist name).",
        "The scenario runs a JavaScript Factory through the same public process/invocation boundary with a recording / mock external edge that can count worker or provider dispatches, without live provider execution.",
        "The workflow attempts a child operation that effective policy denies.",
        "Observable outcome proves zero external dispatches occurred on the substituted edge (no completed external child call / provider run attributed to the denied operation).",
        "Public outcome remains a policy failure (not a successful child result), without private JavaScript VM stack frames, engine heap dumps, or unresolved hangs.",
        "The test does not claim ownership of agent unary failure records, pipeline stop-on-failure, parallel partial-failure policy, load-time diagnostics, or durable resume (those remain other cells).",
        "The top-level test has a customer-readable Go doc comment describing the observable no-external-dispatch safety behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-js-policy-denied-003",
      "title": "Preserve policy ownership and close verification gates",
      "description": "As a maintainer executing Wave 1 in parallel, I want this cell to stay inside policy/denied_operations ownership, leave adjacent JavaScript cells untouched, and pass focused boundary/metadata gates so the free destination is inventoriable without colliding with composition, loading, or durability lanes.",
      "acceptanceCriteria": [
        "Diff for this cell does not modify tests/functional/orchestration/javascript/composition/**, loading/**, durability/**, or contracts/response_events* (or their mapped deletion-batch / ledger ownership metadata when those cells own them).",
        "Only narrowly coupled ownership, coverage, or catalog metadata required for tests/functional/orchestration/javascript/policy/denied_operations_test.go are updated; specialty bindings remain none; no migration-ledger deletion batch is invented for this free destination.",
        "Focused package tests for tests/functional/orchestration/javascript/policy pass for the two checklist scenarios.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as orchestration/javascript/policy).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)