### PR TITLE
structured-packages-implementation-rec-03-recording-lifecycle

### DIFF
--- a/pkg/services/factory_runtime/service/host/lifecycle_test.go
+++ b/pkg/services/factory_runtime/service/host/lifecycle_test.go
@@ -44,6 +44,12 @@ type terminalRecording struct {
 	finishedAt    time.Time
 }
 
+func (*terminalRecording) BindRecordingService(
+	recordings.Service,
+	recordings.CanonicalEventScope,
+) error {
+	return nil
+}
 func (*terminalRecording) Start(context.Context)               {}
 func (*terminalRecording) Stop()                               {}
 func (*terminalRecording) RecordEvent(interfaces.FactoryEvent) {}

--- a/pkg/services/factory_sessions/internal/runtimeopening/open.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/open.go
@@ -3,6 +3,7 @@ package runtimeopening
 import (
 	"context"
 	"fmt"
+	"time"
 
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
@@ -133,6 +134,20 @@ func openRuntime(
 	}
 	if runtimeRecorderFactory == nil {
 		return runtimeProducts{}, fmt.Errorf("construct runtime scope: Recordings runtime recorder factory is required")
+	}
+	var runtimeRecording recordings.RuntimeRecorder
+	sessionRecorderFactory := func(
+		flushInterval time.Duration,
+		loaded factorydefinitions.LoadedFactorySource,
+		now func() time.Time,
+		recordPath string,
+	) (recordings.RuntimeRecorder, error) {
+		recorder, err := runtimeRecorderFactory(flushInterval, loaded, now, recordPath)
+		if err != nil || recorder == nil {
+			return recorder, err
+		}
+		runtimeRecording = recorder
+		return recorder, nil
 	}
 	if durableExecutionFactory == nil {
 		return runtimeProducts{}, fmt.Errorf("construct runtime scope: durable execution operation is required")
@@ -277,7 +292,7 @@ func openRuntime(
 			mutationOwner.RecordPetriTokenMutations,
 			recordingProjections.ReconstructFactoryWorldState,
 			newRuntimeLedger,
-			runtimeRecorderFactory,
+			sessionRecorderFactory,
 			initialFactorySnapshotFactory,
 			configured.Definition.Directory,
 			root.FactoryRootDir,
@@ -346,6 +361,19 @@ func openRuntime(
 	recordingService := recordingsFactory(startupRuntime.RecordingLedger(), recordingProjections)
 	if recordingService == nil {
 		return runtimeProducts{}, fmt.Errorf("construct runtime scope: Recordings factory returned nil service")
+	}
+	if runtimeRecording != nil {
+		if err := runtimeRecording.BindRecordingService(
+			recordingService,
+			recordings.CanonicalEventScope{
+				FactorySessionID: factorysessions.DefaultSessionID,
+			},
+		); err != nil {
+			return runtimeProducts{}, fmt.Errorf(
+				"construct runtime scope: bind runtime recording: %w",
+				err,
+			)
+		}
 	}
 	if processRuntimeFactory == nil {
 		return runtimeProducts{}, fmt.Errorf("construct runtime scope: Factory Sessions process runtime factory is required")

--- a/pkg/services/recordings/contracts.go
+++ b/pkg/services/recordings/contracts.go
@@ -154,6 +154,8 @@ type CanonicalEvent struct {
 	RecordedAt  time.Time
 	Kind        CanonicalEventKind
 	Payload     string
+	// SourceContext preserves detached producer correlation metadata.
+	SourceContext string
 }
 
 // SubscriptionOutcomeKind identifies one deterministic observation from a
@@ -832,12 +834,10 @@ type WorkerEventRecorder interface {
 	RecordAgentRunEvent(workerexecution.AgentRunResponseEvent)
 }
 
-// RuntimeRecorder owns the lifecycle and durable flush behavior of one replay
-// recording without exposing the concrete replay artifact writer. Existing
-// Runtime callers may still consume this capability surface; peers should prefer
-// the plain recording-lifecycle methods on Service as the cross-service source
-// of truth rather than treating RuntimeRecorder construction as the peer seam.
+// RuntimeRecorder adapts Factory Runtime calls to the Recordings-owned
+// lifecycle and durable flush behavior of one recording.
 type RuntimeRecorder interface {
+	BindRecordingService(Service, CanonicalEventScope) error
 	Start(context.Context)
 	Stop()
 	RecordEvent(interfaces.FactoryEvent)

--- a/pkg/services/recordings/replay/recorder.go
+++ b/pkg/services/recordings/replay/recorder.go
@@ -9,6 +9,7 @@ import (
 
 	platformreplay "github.com/portpowered/infinite-you/pkg/platform/replay"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
 )
 
 const (
@@ -37,6 +38,15 @@ type Recorder struct {
 
 	finalizeOnce sync.Once
 	finalizeErr  error
+}
+
+// BindRecordingService rejects use of the legacy replay recorder as a
+// production lifecycle authority.
+func (*Recorder) BindRecordingService(
+	recordings.Service,
+	recordings.CanonicalEventScope,
+) error {
+	return fmt.Errorf("legacy replay recorder cannot bind the Recordings root")
 }
 
 // NewRecorder constructs a recorder for an existing artifact shell.

--- a/pkg/services/recordings/service/core.go
+++ b/pkg/services/recordings/service/core.go
@@ -74,25 +74,33 @@ func validAppendEvent(event recordings.CanonicalEvent) bool {
 		!event.RecordedAt.IsZero() &&
 		(event.Scope.FactorySessionID == "" ||
 			strings.TrimSpace(event.Scope.FactorySessionID) != "") &&
-		json.Valid([]byte(event.Payload))
+		json.Valid([]byte(event.Payload)) &&
+		(event.SourceContext == "" || json.Valid([]byte(event.SourceContext)))
 }
 
 func factoryEventFromCanonical(event recordings.CanonicalEvent) factorydefinitions.FactoryEvent {
+	context := factorydefinitions.FactoryEventContext{
+		EventTime: event.RecordedAt,
+		Sequence:  int(event.Sequence),
+		Tick:      event.FactoryTick,
+	}
+	hasSourceContext := json.Valid([]byte(event.SourceContext))
+	if hasSourceContext {
+		_ = json.Unmarshal([]byte(event.SourceContext), &context)
+	}
 	var sessionID *string
 	if event.Scope.FactorySessionID != "" {
 		value := event.Scope.FactorySessionID
 		sessionID = &value
 	}
 	legacy := factorydefinitions.FactoryEvent{
-		Context: factorydefinitions.FactoryEventContext{
-			EventTime: event.RecordedAt,
-			Sequence:  int(event.Sequence),
-			Tick:      event.FactoryTick,
-			SessionID: sessionID,
-		},
+		Context: context,
 		Id:      string(event.ID),
 		Payload: json.RawMessage(event.Payload),
 		Type:    factorydefinitions.FactoryEventType(event.Kind),
+	}
+	if !hasSourceContext && legacy.Context.SessionID == nil {
+		legacy.Context.SessionID = sessionID
 	}
 	legacy.SchemaVersion = factorydefinitions.FactoryEventSchemaVersionV1
 	return legacy
@@ -145,6 +153,7 @@ func canonicalEventFromFactory(
 	event factorydefinitions.FactoryEvent,
 	generationID string,
 ) recordings.CanonicalEvent {
+	sourceContext, _ := json.Marshal(event.Context)
 	scope := recordings.CanonicalEventScope{}
 	if event.Context.SessionID != nil {
 		scope.FactorySessionID = *event.Context.SessionID
@@ -159,9 +168,10 @@ func canonicalEventFromFactory(
 			StreamGenerationID: generationID,
 			Sequence:           sequence,
 		},
-		RecordedAt: event.Context.EventTime,
-		Kind:       recordings.CanonicalEventKind(event.Type),
-		Payload:    string(event.Payload),
+		RecordedAt:    event.Context.EventTime,
+		Kind:          recordings.CanonicalEventKind(event.Type),
+		Payload:       string(event.Payload),
+		SourceContext: string(sourceContext),
 	}
 }
 

--- a/pkg/services/recordings/service/lifecycle_effects.go
+++ b/pkg/services/recordings/service/lifecycle_effects.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"time"
 
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	recordings "github.com/portpowered/infinite-you/pkg/services/recordings"
+	"github.com/portpowered/infinite-you/pkg/services/recordings/replay"
 )
 
 // NewRecordingSnapshotWriter adapts policy-free byte persistence to the
@@ -21,6 +23,60 @@ func NewRecordingSnapshotWriter(
 		if err != nil {
 			return fmt.Errorf("%w: %w", recordings.ErrRecordingSnapshotEncoding, err)
 		}
+		if err := write(target, data); err != nil {
+			return fmt.Errorf(
+				"%w at %q: %w",
+				recordings.ErrRecordingSnapshotWrite,
+				target,
+				err,
+			)
+		}
+		return nil
+	}
+}
+
+// NewReplayRecordingSnapshotWriter persists lifecycle snapshots in the
+// replay-compatible artifact format consumed by existing recording readers.
+func NewReplayRecordingSnapshotWriter(
+	write func(string, []byte) error,
+) recordings.RecordingSnapshotWriter {
+	if write == nil {
+		return nil
+	}
+	return func(target string, snapshot recordings.RecordingSnapshot) error {
+		events := make([]factorydefinitions.FactoryEvent, len(snapshot.Events))
+		for index, event := range snapshot.Events {
+			events[index] = factoryEventFromCanonical(event)
+		}
+		recordedAt := time.Time{}
+		if len(events) > 0 {
+			recordedAt = events[0].Context.EventTime
+		}
+		wallClock := &factorydefinitions.ReplayWallClockMetadata{
+			StartedAt: recordedAt,
+		}
+		if snapshot.Status.FinalizedAt != nil {
+			wallClock.FinishedAt = snapshot.Status.FinalizedAt.UTC()
+		}
+		data, err := replay.MarshalArtifact(&factorydefinitions.ReplayArtifact{
+			SchemaVersion: replay.CurrentSchemaVersion,
+			RecordedAt:    recordedAt,
+			Events:        events,
+			WallClock:     wallClock,
+		})
+		if err != nil {
+			return fmt.Errorf("%w: %w", recordings.ErrRecordingSnapshotEncoding, err)
+		}
+		var persisted factorydefinitions.ReplayArtifact
+		if err := json.Unmarshal(data, &persisted); err != nil {
+			return fmt.Errorf("%w: %w", recordings.ErrRecordingSnapshotEncoding, err)
+		}
+		persisted.Events = events
+		data, err = json.MarshalIndent(&persisted, "", "  ")
+		if err != nil {
+			return fmt.Errorf("%w: %w", recordings.ErrRecordingSnapshotEncoding, err)
+		}
+		data = append(data, '\n')
 		if err := write(target, data); err != nil {
 			return fmt.Errorf(
 				"%w at %q: %w",

--- a/pkg/services/recordings/service/lifecycle_runtime_recorder.go
+++ b/pkg/services/recordings/service/lifecycle_runtime_recorder.go
@@ -1,0 +1,298 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	"github.com/portpowered/infinite-you/pkg/services/recordings/replay"
+)
+
+// lifecycleRuntimeRecorder adapts Factory Runtime's focused recording port to
+// the session's Recordings root without becoming a second lifecycle owner.
+type lifecycleRuntimeRecorder struct {
+	mu            sync.Mutex
+	service       recordings.Service
+	recordingID   recordings.RecordingID
+	scope         recordings.CanonicalEventScope
+	target        recordings.RecordingArtifactReference
+	flushInterval time.Duration
+	now           func() time.Time
+	startedAt     time.Time
+	initialEvent  factorydefinitions.FactoryEvent
+	seen          map[string]struct{}
+	nextSequence  recordings.CanonicalEventSequence
+	finalizeErr   error
+	pending       []pendingRuntimeRecording
+}
+
+type pendingRuntimeRecording struct {
+	event *factorydefinitions.FactoryEvent
+	err   error
+}
+
+var _ recordings.RuntimeRecorder = (*lifecycleRuntimeRecorder)(nil)
+
+// NewLifecycleRuntimeRecorder prepares a runtime recorder whose lifecycle is
+// activated only when Factory Sessions binds the composed Recordings root.
+func NewLifecycleRuntimeRecorder(
+	flushInterval time.Duration,
+	loaded factorydefinitions.LoadedFactorySource,
+	now func() time.Time,
+	recordPath string,
+	captureLoadedFactorySnapshot factorydefinitions.LoadedFactorySnapshotCapturer,
+) (recordings.RuntimeRecorder, error) {
+	if strings.TrimSpace(recordPath) == "" {
+		return nil, nil
+	}
+	if now == nil {
+		return nil, fmt.Errorf("recording clock is required")
+	}
+	if captureLoadedFactorySnapshot == nil {
+		return nil, fmt.Errorf("loaded Factory snapshot capturer is required")
+	}
+	recordedAt := now().UTC()
+	sourceDirectory := ""
+	if loaded != nil {
+		sourceDirectory = loaded.FactoryDir()
+	}
+	snapshot, err := captureLoadedFactorySnapshot(loaded, sourceDirectory, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build replay artifact config: %w", err)
+	}
+	artifact, err := replay.NewEventLogArtifact(
+		recordedAt,
+		snapshot,
+		&factorydefinitions.ReplayWallClockMetadata{StartedAt: recordedAt},
+		factorydefinitions.ReplayDiagnostics{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &lifecycleRuntimeRecorder{
+		target:        recordings.RecordingArtifactReference(recordPath),
+		flushInterval: flushInterval,
+		now:           now,
+		startedAt:     recordedAt,
+		initialEvent:  artifact.Events[0],
+		seen:          make(map[string]struct{}),
+	}, nil
+}
+
+func (recorder *lifecycleRuntimeRecorder) BindRecordingService(
+	service recordings.Service,
+	scope recordings.CanonicalEventScope,
+) error {
+	if recorder == nil {
+		return nil
+	}
+	if service == nil {
+		return fmt.Errorf("Recordings root service is required")
+	}
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	if recorder.service != nil {
+		if recorder.service == service && recorder.scope == scope {
+			return nil
+		}
+		return recordings.ErrRecordingBindingConflict
+	}
+	started, err := service.StartRecording(recordings.StartRecordingRequest{
+		Enabled: true,
+		Scope:   scope,
+		Target: recordings.RecordingTargetRequest{
+			Artifact: recorder.target,
+		},
+		FlushInterval: recorder.flushInterval,
+	})
+	if err != nil {
+		return err
+	}
+	recorder.service = service
+	recorder.recordingID = started.Status.RecordingID
+	recorder.scope = scope
+	if err := recorder.recordEventLocked(recorder.initialEvent); err != nil {
+		return fmt.Errorf("record initial Factory snapshot: %w", err)
+	}
+	for _, pending := range recorder.pending {
+		if pending.event != nil {
+			if err := recorder.recordEventLocked(*pending.event); err != nil {
+				recorder.recordErrorLocked("producer_boundary_failed", "accept Factory event", err)
+			}
+		} else {
+			recorder.recordErrorLocked(
+				"producer_boundary_failed",
+				"Factory event producer failed",
+				pending.err,
+			)
+		}
+	}
+	recorder.pending = nil
+	return nil
+}
+
+func (recorder *lifecycleRuntimeRecorder) Start(context.Context) {}
+
+func (recorder *lifecycleRuntimeRecorder) Stop() {
+	if recorder == nil {
+		return
+	}
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	if recorder.service == nil {
+		return
+	}
+	_, _ = recorder.service.StopRecording(recordings.StopRecordingRequest{
+		RecordingID: recorder.recordingID,
+	})
+}
+
+func (recorder *lifecycleRuntimeRecorder) RecordEvent(event factorydefinitions.FactoryEvent) {
+	if recorder == nil {
+		return
+	}
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	if recorder.service == nil {
+		event.Payload = append([]byte(nil), event.Payload...)
+		recorder.pending = append(recorder.pending, pendingRuntimeRecording{event: &event})
+		return
+	}
+	if err := recorder.recordEventLocked(event); err != nil {
+		recorder.recordErrorLocked("producer_boundary_failed", "accept Factory event", err)
+	}
+}
+
+func (recorder *lifecycleRuntimeRecorder) recordEventLocked(
+	event factorydefinitions.FactoryEvent,
+) error {
+	if recorder.service == nil {
+		return fmt.Errorf("Recordings root service is not bound")
+	}
+	if _, exists := recorder.seen[event.Id]; exists {
+		return nil
+	}
+	event.Context.Sequence = int(recorder.nextSequence)
+	canonical := canonicalEventFromFactory(event, string(recorder.recordingID))
+	canonical.Scope = recorder.scope
+	canonical.Sequence = recorder.nextSequence
+	canonical.Cursor.Sequence = recorder.nextSequence
+	result, err := recorder.service.RecordRecordingEvent(recordings.RecordRecordingEventRequest{
+		RecordingID: recorder.recordingID,
+		Event:       canonical,
+	})
+	if err != nil {
+		return err
+	}
+	recorder.seen[event.Id] = struct{}{}
+	recorder.nextSequence = recordings.CanonicalEventSequence(result.Status.AcceptedEvents)
+	return nil
+}
+
+func (recorder *lifecycleRuntimeRecorder) RecordError(err error) {
+	if recorder == nil || err == nil {
+		return
+	}
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	if recorder.service == nil {
+		recorder.pending = append(recorder.pending, pendingRuntimeRecording{err: err})
+		return
+	}
+	recorder.recordErrorLocked("producer_boundary_failed", "Factory event producer failed", err)
+}
+
+func (recorder *lifecycleRuntimeRecorder) recordErrorLocked(code, operation string, cause error) {
+	if recorder.service == nil || cause == nil {
+		return
+	}
+	_, _ = recorder.service.RecordRecordingError(recordings.RecordRecordingErrorRequest{
+		RecordingID: recorder.recordingID,
+		Failure: recordings.RecordingFailure{
+			Code:       code,
+			Message:    operation + ": " + cause.Error(),
+			RecordedAt: recorder.now().UTC(),
+		},
+		Cause: cause,
+	})
+}
+
+func (recorder *lifecycleRuntimeRecorder) Finish(finishedAt time.Time) {
+	_ = recorder.Finalize(finishedAt)
+}
+
+func (recorder *lifecycleRuntimeRecorder) Flush() error {
+	if recorder == nil {
+		return nil
+	}
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	if recorder.service == nil {
+		return fmt.Errorf("Recordings root service is not bound")
+	}
+	_, err := recorder.service.FlushRecording(recordings.FlushRecordingRequest{
+		RecordingID: recorder.recordingID,
+	})
+	return err
+}
+
+func (recorder *lifecycleRuntimeRecorder) Err() error {
+	if recorder == nil {
+		return nil
+	}
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	return recorder.finalizeErr
+}
+
+func (recorder *lifecycleRuntimeRecorder) Finalize(finishedAt time.Time) error {
+	if recorder == nil {
+		return nil
+	}
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	if recorder.service == nil {
+		return fmt.Errorf("Recordings root service is not bound")
+	}
+	if recorder.finalizeErr != nil {
+		return recorder.finalizeErr
+	}
+	if err := recorder.recordEventLocked(runtimeFinishedEvent(recorder.startedAt, finishedAt)); err != nil {
+		recorder.recordErrorLocked("terminal_metadata_failed", "record terminal Factory event", err)
+	}
+	_, recorder.finalizeErr = recorder.service.FinishRecording(recordings.FinishRecordingRequest{
+		RecordingID: recorder.recordingID,
+		FinishedAt:  finishedAt,
+	})
+	return recorder.finalizeErr
+}
+
+func runtimeFinishedEvent(startedAt, finishedAt time.Time) factorydefinitions.FactoryEvent {
+	state := factorydefinitions.FactoryStateCompleted
+	startedAtUTC := startedAt.UTC()
+	finishedAtUTC := finishedAt.UTC()
+	payload, err := json.Marshal(factorydefinitions.RunResponseEventPayload{
+		State: &state,
+		WallClock: &factorydefinitions.RunEventWallClock{
+			StartedAt:  &startedAtUTC,
+			FinishedAt: &finishedAtUTC,
+		},
+	})
+	if err != nil {
+		payload = json.RawMessage(`{}`)
+	}
+	return factorydefinitions.FactoryEvent{
+		Id:            "factory-event/run-finished",
+		SchemaVersion: factorydefinitions.FactoryEventSchemaVersionV1,
+		Type:          factorydefinitions.FactoryEventTypeRunResponse,
+		Context: factorydefinitions.FactoryEventContext{
+			EventTime: finishedAtUTC,
+		},
+		Payload: payload,
+	}
+}

--- a/pkg/services/recordings/service/lifecycle_runtime_recorder_test.go
+++ b/pkg/services/recordings/service/lifecycle_runtime_recorder_test.go
@@ -1,0 +1,179 @@
+package service
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	platformreplay "github.com/portpowered/infinite-you/pkg/platform/replay"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	"github.com/portpowered/infinite-you/pkg/services/recordings/replay"
+)
+
+type runtimeRecorderTestClock struct{ now time.Time }
+
+func (clock runtimeRecorderTestClock) Now() time.Time { return clock.now }
+
+func TestLifecycleRuntimeRecorderUsesComposedRootForBindingFailuresAndFinalization(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 27, 15, 0, 0, 0, time.UTC)
+	finishedAt := startedAt.Add(time.Minute)
+	producerErr := errors.New("producer failed")
+	finalWriteErr := errors.New("final write failed")
+	writeCount := 0
+	writer := func(string, recordings.RecordingSnapshot) error {
+		writeCount++
+		if writeCount == 2 {
+			return finalWriteErr
+		}
+		return nil
+	}
+	root := NewServiceWithLifecycleEffects(
+		NewRuntimeLedger(nil, func() time.Time { return startedAt }, "generation", nil),
+		NewProjectionService(),
+		nil,
+		writer,
+		nil,
+		runtimeRecorderTestClock{now: startedAt},
+	)
+	recorder := newLifecycleRecorderForTest(t, startedAt, "recording.json")
+	recorder.RecordError(producerErr)
+	recorder.RecordEvent(factorydefinitions.FactoryEvent{
+		Id:   "runtime-event",
+		Type: factorydefinitions.FactoryEventTypeWorkRequest,
+		Context: factorydefinitions.FactoryEventContext{
+			EventTime: startedAt.Add(time.Second),
+		},
+		Payload: []byte(`{"workId":"work-1"}`),
+	})
+	scope := recordings.CanonicalEventScope{FactorySessionID: "~default"}
+	if err := recorder.BindRecordingService(root, scope); err != nil {
+		t.Fatalf("BindRecordingService: %v", err)
+	}
+
+	if err := recorder.Flush(); err != nil {
+		t.Fatalf("initial Flush: %v", err)
+	}
+	err := recorder.Finalize(finishedAt)
+	if !errors.Is(err, producerErr) || !errors.Is(err, finalWriteErr) {
+		t.Fatalf("Finalize error = %v, want producer and final-write identities", err)
+	}
+
+	status, err := root.QueryRecordingStatus(recordings.RecordingStatusRequest{
+		RecordingID: recorder.recordingID,
+	})
+	if err != nil {
+		t.Fatalf("QueryRecordingStatus: %v", err)
+	}
+	assertFailedRuntimeRecordingStatus(t, status.Status, scope, finishedAt)
+}
+
+func assertFailedRuntimeRecordingStatus(
+	t *testing.T,
+	status recordings.RecordingStatusFacts,
+	scope recordings.CanonicalEventScope,
+	finishedAt time.Time,
+) {
+	t.Helper()
+	if status.Artifact != "recording.json" ||
+		status.Scope != scope ||
+		status.State != recordings.RecordingFailed ||
+		status.AcceptedEvents != 3 ||
+		len(status.Failures) != 2 ||
+		status.Failures[0].Code != "producer_boundary_failed" ||
+		status.Failures[1].Code != "final_flush_failed" ||
+		status.FinalizedAt == nil ||
+		!status.FinalizedAt.Equal(finishedAt) {
+		t.Fatalf("composed lifecycle status = %#v", status)
+	}
+}
+
+func TestReplayRecordingSnapshotWriterPreservesReplayCompatibility(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 27, 16, 0, 0, 0, time.UTC)
+	finishedAt := startedAt.Add(time.Minute)
+	path := filepath.Join(t.TempDir(), "recording.json")
+	storage := platformreplay.NewLocal(runtime.GOOS)
+	root := NewServiceWithLifecycleEffects(
+		NewRuntimeLedger(nil, func() time.Time { return startedAt }, "generation", nil),
+		NewProjectionService(),
+		nil,
+		NewReplayRecordingSnapshotWriter(storage.WriteFile),
+		nil,
+		runtimeRecorderTestClock{now: startedAt},
+	)
+	recorder := newLifecycleRecorderForTest(t, startedAt, path)
+	if err := recorder.BindRecordingService(root, recordings.CanonicalEventScope{
+		FactorySessionID: "~default",
+	}); err != nil {
+		t.Fatalf("BindRecordingService: %v", err)
+	}
+	if err := recorder.Finalize(finishedAt); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+
+	artifact, err := replay.Load(
+		storage,
+		path,
+		func(data []byte) (*factorydefinitions.FactorySnapshot, error) {
+			return factorydefinitions.NewFactorySnapshot(
+				map[string]any{"id": "factory-from-decoder"},
+			)
+		},
+	)
+	if err != nil {
+		payload, _ := os.ReadFile(path)
+		t.Fatalf("Load replay-compatible lifecycle recording: %v\n%s", err, payload)
+	}
+	if artifact.WallClock == nil ||
+		!artifact.WallClock.StartedAt.Equal(startedAt) ||
+		!artifact.WallClock.FinishedAt.Equal(finishedAt) ||
+		len(artifact.Events) != 2 {
+		t.Fatalf(
+			"replay artifact wall clock = %#v, events = %d",
+			artifact.WallClock,
+			len(artifact.Events),
+		)
+	}
+}
+
+func newLifecycleRecorderForTest(
+	t *testing.T,
+	startedAt time.Time,
+	path string,
+) *lifecycleRuntimeRecorder {
+	t.Helper()
+	snapshot, err := factorydefinitions.NewFactorySnapshot(map[string]any{
+		"id": "factory-1",
+	})
+	if err != nil {
+		t.Fatalf("NewFactorySnapshot: %v", err)
+	}
+	value, err := NewLifecycleRuntimeRecorder(
+		time.Hour,
+		nil,
+		func() time.Time { return startedAt },
+		path,
+		func(
+			factorydefinitions.FactorySnapshotSource,
+			string,
+			map[string]string,
+		) (*factorydefinitions.FactorySnapshot, error) {
+			return snapshot, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewLifecycleRuntimeRecorder: %v", err)
+	}
+	recorder, ok := value.(*lifecycleRuntimeRecorder)
+	if !ok {
+		t.Fatalf("recorder type = %T", value)
+	}
+	return recorder
+}

--- a/pkg/services/recordings/service/service.go
+++ b/pkg/services/recordings/service/service.go
@@ -2,63 +2,13 @@ package service
 
 import (
 	"fmt"
-	"time"
 
-	platformreplay "github.com/portpowered/infinite-you/pkg/platform/replay"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	recordings "github.com/portpowered/infinite-you/pkg/services/recordings"
 	"github.com/portpowered/infinite-you/pkg/services/recordings/replay"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	workerprovider "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
 )
-
-// NewRuntimeRecorder constructs the replay artifact and streaming recorder for
-// one runtime.
-func NewRuntimeRecorder(
-	storage platformreplay.Storage,
-	flushInterval time.Duration,
-	loaded factorydefinitions.LoadedFactorySource,
-	now func() time.Time,
-	recordPath string,
-	captureLoadedFactorySnapshot factorydefinitions.LoadedFactorySnapshotCapturer,
-) (recordings.RuntimeRecorder, error) {
-	if recordPath == "" {
-		return nil, nil
-	}
-	if now == nil {
-		return nil, fmt.Errorf("recording clock is required")
-	}
-	if captureLoadedFactorySnapshot == nil {
-		return nil, fmt.Errorf("loaded Factory snapshot capturer is required")
-	}
-	recordedAt := now().UTC()
-	sourceDirectory := ""
-	if loaded != nil {
-		sourceDirectory = loaded.FactoryDir()
-	}
-	snapshot, err := captureLoadedFactorySnapshot(
-		loaded,
-		sourceDirectory,
-		nil,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("build replay artifact config: %w", err)
-	}
-	artifact, err := replay.NewEventLogArtifact(
-		recordedAt,
-		snapshot,
-		&factorydefinitions.ReplayWallClockMetadata{StartedAt: recordedAt},
-		factorydefinitions.ReplayDiagnostics{},
-	)
-	if err != nil {
-		return nil, err
-	}
-	recorder, err := replay.NewRecorder(storage, recordPath, artifact, flushInterval)
-	if err != nil {
-		return nil, fmt.Errorf("create replay recorder: %w", err)
-	}
-	return recorder, nil
-}
 
 func NewReplayClock(artifact *factorydefinitions.ReplayArtifact) recordings.Clock {
 	if artifact == nil {

--- a/pkg/services/recordings/service/service_test.go
+++ b/pkg/services/recordings/service/service_test.go
@@ -3,20 +3,21 @@ package service
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
-func TestNewRuntimeRecorderRejectsMissingClockWhenRecordingEnabled(t *testing.T) {
+func TestNewLifecycleRuntimeRecorderRejectsMissingClockWhenRecordingEnabled(t *testing.T) {
 	t.Parallel()
-	recorder, err := NewRuntimeRecorder(nil, 0, nil, nil, "recording.json", nil)
+	recorder, err := NewLifecycleRuntimeRecorder(0, nil, nil, "recording.json", nil)
 	if recorder != nil || err == nil || !strings.Contains(err.Error(), "clock is required") {
-		t.Fatalf("NewRuntimeRecorder = (%#v, %v), want required clock error", recorder, err)
+		t.Fatalf("NewLifecycleRuntimeRecorder = (%#v, %v), want required clock error", recorder, err)
 	}
 }
 
-func TestNewRuntimeRecorderAllowsDisabledRecordingWithoutClock(t *testing.T) {
+func TestNewLifecycleRuntimeRecorderAllowsDisabledRecordingWithoutClock(t *testing.T) {
 	t.Parallel()
-	recorder, err := NewRuntimeRecorder(nil, 0, nil, nil, "", nil)
+	recorder, err := NewLifecycleRuntimeRecorder(time.Second, nil, nil, "", nil)
 	if recorder != nil || err != nil {
-		t.Fatalf("NewRuntimeRecorder disabled = (%#v, %v), want nil, nil", recorder, err)
+		t.Fatalf("NewLifecycleRuntimeRecorder disabled = (%#v, %v), want nil, nil", recorder, err)
 	}
 }

--- a/pkg/wire/recordings_providers.go
+++ b/pkg/wire/recordings_providers.go
@@ -12,7 +12,7 @@ func provideRecordingsFactory(
 	targets recordings.LiveRecordingTargetPlanner,
 	storage platformreplay.Storage,
 ) factorysessionwire.RecordingsFactory {
-	writer := recordingsservice.NewRecordingSnapshotWriter(storage.WriteFile)
+	writer := recordingsservice.NewReplayRecordingSnapshotWriter(storage.WriteFile)
 	tickers := recordingsservice.NewRecordingFlushTickerFactory()
 	return func(
 		ledger recordings.Ledger,

--- a/pkg/wire/session_runtime_providers.go
+++ b/pkg/wire/session_runtime_providers.go
@@ -16,7 +16,6 @@ import (
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	platformpty "github.com/portpowered/infinite-you/pkg/platform/pty"
 	platformrandom "github.com/portpowered/infinite-you/pkg/platform/random"
-	platformreplay "github.com/portpowered/infinite-you/pkg/platform/replay"
 	"github.com/portpowered/infinite-you/pkg/services/automations"
 	automationservice "github.com/portpowered/infinite-you/pkg/services/automations/service"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
@@ -567,7 +566,6 @@ func provideLoadedFactorySnapshotCapturer() factorydefinitions.LoadedFactorySnap
 }
 
 func provideRuntimeRecorderFactory(
-	storage platformreplay.Storage,
 	captureLoadedFactorySnapshot factorydefinitions.LoadedFactorySnapshotCapturer,
 ) recordings.RuntimeRecorderFactory {
 	return func(
@@ -576,8 +574,7 @@ func provideRuntimeRecorderFactory(
 		now func() time.Time,
 		recordPath string,
 	) (recordings.RuntimeRecorder, error) {
-		return recordingsservice.NewRuntimeRecorder(
-			storage,
+		return recordingsservice.NewLifecycleRuntimeRecorder(
 			flushInterval,
 			loaded,
 			now,

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -167,7 +167,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	v24 := provideRecordingsFactory(liveRecordingTargetPlanner, storage)
 	v25 := provideRuntimeLedgerFactory()
 	v26 := provideLoadedFactorySnapshotCapturer()
-	runtimeRecorderFactory := provideRuntimeRecorderFactory(storage, v26)
+	runtimeRecorderFactory := provideRuntimeRecorderFactory(v26)
 	v27 := provideReplayClockFactory()
 	replayExecutionFactory := provideReplayExecutionFactory()
 	decisionEnvelopeService := provideDecisionEnvelopeService()


### PR DESCRIPTION
{
  "project": "Converge Recording Target, Flush, and Finalize Lifecycle Ownership",
  "branchName": "structured-packages-implementation-rec-03-recording-lifecycle",
  "description": "Implement IMP-REC-03 as the parent-private Recordings recording-lifecycle capability so enabled Factory Session recordings use one explicit target, active flush and cancellation policy, deterministic final flush on normal close or crash, and accumulated failure semantics without absorbing ledger/projection, replay, or artifact/export ownership.",
  "context": {
    "customerAsk": "Converge recording target, flush, and finalize lifecycle ownership under the parent-private Recordings lifecycle service. Provide explicit target selection, flush, finalize, cancellation, and error-accumulation semantics; make final flush deterministic for normal close and crash paths; and continue delivery through review, required CI, conflict reconciliation, and actual PR merge.",
    "problem": "Recording target selection and runtime recorder construction are separate from the active and terminal lifecycle calls made by Factory Runtime. Periodic flush errors are retained differently from producer errors, and finalization ordering is encoded at call sites. A cancellation or crash can therefore exercise a different path from normal close, obscure more than one failure, or make it unclear whether the latest accepted events and terminal metadata received a final synchronous flush.",
    "solution": "Introduce one parent-private lifecycle owner behind the Recordings root contract. It will hold explicit per-recording state, consume exact injected clock, identity, storage, and scheduling effects, and serialize target binding, active flush, cancellation, and terminal close. Existing focused callers will invoke a single lifecycle path whose terminal ordering is deterministic: stop and join periodic activity, apply terminal metadata, attempt the final synchronous flush, and return detached accumulated failures. Canonical ledger/projection, replay, and artifact/export remain separate Recordings capabilities."
  },
  "acceptanceCriteria": [
    "An enabled recording selects and binds one deterministic target through Recordings, while a disabled recording remains inert and invalid or conflicting target inputs fail before recording work starts.",
    "Accepted canonical events can be flushed during an active run, and cancellation stops and joins periodic lifecycle work without an additional background write racing terminal close.",
    "Normal completion, cancellation, and crash all stop periodic work, apply terminal metadata, and attempt one final synchronous flush in a deterministic order before returning.",
    "Producer, periodic-flush, final-flush, and terminal-metadata failures are retained and returned without discarding earlier failures; terminal status distinguishes successful finalization from failed finalization.",
    "Canonical event ordering and projection ownership remain with Recordings' ledger/projection capabilities, and the lifecycle owner does not implement or absorb replay, artifact construction, or export behavior.",
    "Required typecheck/compile validation, formatting, lint, package-boundary checks, focused tests, and applicable race/repeat verification are terminal and passing.",
    "The implementation/review loop continues until required CI is terminal and passing, every blocking PR conversation comment is explicitly addressed, merge conflicts and shared coverage/ownership/package-target manifest churn are reconciled, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "structured-packages-implementation-rec-03-recording-lifecycle-001",
      "title": "Select and bind one recording target",
      "description": "As a Factory Session operator, I want an enabled recording to receive one stable Recordings-owned target so that its output location and lifecycle identity do not depend on runtime-host policy.",
      "acceptanceCriteria": [
        "Given valid target inputs, starting the same explicit recording identity with the same session scope and target is idempotent and reports the same active binding.",
        "Generated targets preserve the configured Recordings layout, use injected time and identity effects, and expose the session-safe reported target without granting callers a writer or storage handle.",
        "A disabled recording performs no target creation or storage write.",
        "Missing target inputs, invalid session scope, or rebinding an existing identity to different facts returns the applicable typed failure before an active lifecycle is created.",
        "Focused target-selection and binding tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented the parent-private recording_lifecycle owner, Recordings root StartRecording target selection/binding, inert disabled behavior, typed validation/conflict outcomes, stable generated binding reuse, and focused root/wire/race coverage."
    },
    {
      "id": "structured-packages-implementation-rec-03-recording-lifecycle-002",
      "title": "Flush active progress and honor cancellation",
      "description": "As a Factory Session operator, I want accepted recording progress flushed while a run is active and periodic work stopped on cancellation so that progress is durable without unsafe background activity.",
      "acceptanceCriteria": [
        "Starting an active recording schedules flush attempts at the configured cadence using injected scheduling effects; non-positive configuration uses the established default cadence.",
        "A flush persists a consistent snapshot through the latest accepted canonical position and reports that position only after the write succeeds.",
        "An unchanged recording does not perform redundant storage writes.",
        "Cancellation stops and joins periodic flush activity idempotently, and no periodic write begins after the lifecycle reports that periodic activity has stopped.",
        "Concurrent event acceptance, flush, and cancellation retain ordered events without data races or overlapping corruption.",
        "Focused cadence, dirty/clean flush, cancellation, and race/repeat tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented injected active-flush cadence with the established default, consistent dirty snapshot persistence, durable cursor advancement only after successful writes, idempotent cancellation that joins periodic work, and focused race/repeat coverage."
    },
    {
      "id": "structured-packages-implementation-rec-03-recording-lifecycle-003",
      "title": "Finalize deterministically on close or crash",
      "description": "As a Factory Session operator, I want normal completion, cancellation, and runtime crash to use the same final recording sequence so that the latest events and terminal metadata receive a deterministic final flush.",
      "acceptanceCriteria": [
        "Terminal close first stops and joins periodic flush activity, then applies terminal metadata, then attempts a synchronous final flush before returning.",
        "Normal completion, caller cancellation, and runtime crash all invoke that same terminal sequence and expose the same finalized-or-failed status model.",
        "The final synchronous flush is attempted even when an earlier producer or periodic flush failed, and includes every accepted event plus terminal metadata available at close time.",
        "Repeating stop or finalize is safe and does not append duplicate terminal facts or start an additional finalization sequence.",
        "Existing focused Runtime close/crash call sites delegate terminal recording behavior to Recordings while preserving their non-recording lifecycle outcomes.",
        "Focused normal-close, cancellation, crash, and final-flush ordering tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented single-flight deterministic finalization that stops and joins periodic work, applies terminal metadata, attempts one final synchronous flush, reports failed final writes, and delegates normal, canceled, and crashed Runtime shutdown through the Recordings-owned terminal operation."
    },
    {
      "id": "structured-packages-implementation-rec-03-recording-lifecycle-004",
      "title": "Accumulate and report lifecycle failures",
      "description": "As an operator diagnosing an incomplete recording, I want all recording lifecycle failures retained in occurrence order so that a later flush or finalization failure does not hide the original cause.",
      "acceptanceCriteria": [
        "Producer-boundary, snapshot/encoding, periodic-write, final-write, and terminal-metadata failures are captured as detached, actionable failure facts without retaining mutable implementation errors.",
        "Multiple distinct failures remain observable in occurrence order through recording status and the terminal returned error; an earlier failure is not replaced by a later one.",
        "A lifecycle with any accumulated failure reaches failed terminal status after finalization, while a lifecycle with no failure reaches finalized status.",
        "Failure reporting preserves cancellation and underlying error identity where callers use standard error matching, without panicking for operational failures.",
        "Query results are detached snapshots that callers cannot mutate to change lifecycle state or accumulated failures.",
        "Focused accumulated-error, detached-status, and terminal-result tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Implemented occurrence-ordered detached failure facts for producer, snapshot encoding, active/periodic/final write, and terminal-metadata failures; stable joined terminal errors preserve errors.Is identity; injected timestamps, failed terminal state, detached query results, and focused race/repeat coverage pass."
    }
  ]
}
