### PR TITLE
ft-wave1-js-worker-overrides

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -163,8 +163,24 @@
   blocking `Provider.Infer` until public `inFlightDispatches` reaches the fan-out
   size, release children to assert declared input-order results and documented
   partial-failure shaping on `/factory-sessions/{id}/results?mode=final` and
-  `/dispatches` without wall-clock sleeps. Mock-worker replacement functional
-  coverage belongs in
+  `/dispatches` without wall-clock sleeps. Catalog metadata infers domain
+  `orchestration` and subsection `javascript/composition` from the path; every
+  top-level `Test*` needs a customer-readable Go doc so `functionaltestmetadata`
+  stays viz-compatible.
+  JavaScript per-child worker override functional coverage belongs in
+  `tests/functional/orchestration/javascript/workers/overrides_test.go`:
+  drive sync or async Factory Session execution through
+  `tests/functional/internal/support.StartFunctionalAPIServer` with
+  `WaitForServiceModeRuntime: true`, assert per-child `modelProvider`/`model`
+  selections on `/factory-sessions/{id}/dispatches` and injected
+  `edges.Edges.ProviderOverride` inference requests, prove partial
+  `workers.MockWorkersConfig` behavior with `UseMockWorkers: true` via
+  `javascript.executionMode` and public child results, and surface invalid
+  per-child overrides on durable session `failureDetail` with synchronous
+  inline workflows when override validation fails before dispatch. Catalog
+  metadata infers domain `orchestration` and subsection `javascript/workers`
+  from the path.
+  Mock-worker replacement functional coverage belongs in
   `tests/functional/workers/mock/replacement_test.go`: prove named-only
   `--with-mock-workers` replacement through
   `tests/functional/internal/support.StartFunctionalAPIServer` with

--- a/pkg/services/factory_sessions/internal/execution/livechild/provider.go
+++ b/pkg/services/factory_sessions/internal/execution/livechild/provider.go
@@ -220,9 +220,11 @@ func providerInferenceRequestFromChild(
 			outputSchema = string(encoded)
 		}
 	}
+	preset := strings.TrimSpace(req.Preset)
 	inferReq := workerexecution.ProviderInferenceRequest{
 		Dispatch: work.WorkDispatch{
 			DispatchID: dispatchID,
+			WorkerType: preset,
 		},
 		UserMessage:   req.Prompt,
 		Model:         req.Model,
@@ -230,6 +232,7 @@ func providerInferenceRequestFromChild(
 		OutputSchema:  outputSchema,
 		SessionID:     sessionID,
 		RunnerID:      strings.TrimSpace(req.Command),
+		WorkerType:    preset,
 	}
 	return inferReq
 }

--- a/pkg/services/factory_sessions/internal/execution/livechild/provider_test.go
+++ b/pkg/services/factory_sessions/internal/execution/livechild/provider_test.go
@@ -502,3 +502,18 @@ func (m *blockingInvocationExecutor) invocationContextsHonored() int {
 }
 
 var _ workerexecution.InvocationExecutor = (*blockingInvocationExecutor)(nil)
+
+func TestProviderInferenceRequestFromChild_PropagatesPresetAsWorkerType(t *testing.T) {
+	t.Parallel()
+
+	req := providerInferenceRequestFromChild("session-1", "dispatch-1", factory.JavaScriptChildExecutionRequest{
+		Prompt: "mocked child prompt",
+		Preset: "worker-a",
+	})
+	if req.WorkerType != "worker-a" {
+		t.Fatalf("WorkerType = %q, want worker-a", req.WorkerType)
+	}
+	if req.Dispatch.WorkerType != "worker-a" {
+		t.Fatalf("Dispatch.WorkerType = %q, want worker-a", req.Dispatch.WorkerType)
+	}
+}

--- a/pkg/services/factory_sessions/internal/runtimeopening/durable_provider.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/durable_provider.go
@@ -26,7 +26,10 @@ func resolveDurableExecutionProvider(
 	if providerOverride != nil {
 		return providerOverride, nil
 	}
-	if mockWorkers == nil || platformRunner == nil || buildProvider == nil {
+	if mockWorkers == nil ||
+		!mockWorkers.UnmatchedDispatchPolicy.PassthroughUnmatched() ||
+		platformRunner == nil ||
+		buildProvider == nil {
 		return nil, nil
 	}
 	runner := adaptRunner(platformRunner)

--- a/pkg/services/factory_sessions/internal/runtimeopening/durable_provider.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/durable_provider.go
@@ -1,0 +1,45 @@
+package runtimeopening
+
+import (
+	"fmt"
+
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	workerprovider "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+)
+
+// ProviderFromCommandRunnerFactory constructs one provider-backed worker from a
+// Workers command runner using the same production edges as direct invocation.
+type ProviderFromCommandRunnerFactory func(workers.CommandRunner) (workerprovider.Provider, error)
+
+func resolveDurableExecutionProvider(
+	providerOverride workerprovider.Provider,
+	mockWorkers *workers.MockWorkersConfig,
+	runtimeCfg interfaces.RuntimeDefinitionLookup,
+	platformRunner platformprocess.CommandRunner,
+	adaptRunner WorkerCommandRunnerAdapter,
+	mockRunnerFactory factoryruntime.WorkersMockCommandRunnerFactory,
+	buildProvider ProviderFromCommandRunnerFactory,
+) (workerprovider.Provider, error) {
+	if providerOverride != nil {
+		return providerOverride, nil
+	}
+	if mockWorkers == nil || platformRunner == nil || buildProvider == nil {
+		return nil, nil
+	}
+	runner := adaptRunner(platformRunner)
+	if runner == nil {
+		return nil, nil
+	}
+	wrapped := mockRunnerFactory(mockWorkers, runtimeCfg, runner)
+	if wrapped == nil {
+		return nil, nil
+	}
+	provider, err := buildProvider(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("compose durable session provider: %w", err)
+	}
+	return provider, nil
+}

--- a/pkg/services/factory_sessions/internal/runtimeopening/durable_provider_test.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/durable_provider_test.go
@@ -1,0 +1,106 @@
+package runtimeopening
+
+import (
+	"context"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	workerprovider "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+	workersservice "github.com/portpowered/infinite-you/pkg/services/workers/service"
+)
+
+type stubWorkersCommandRunner struct{}
+
+func (stubWorkersCommandRunner) Run(context.Context, workers.CommandRequest) (workers.CommandResult, error) {
+	return workers.CommandResult{}, nil
+}
+
+func TestResolveDurableExecutionProvider_PrefersOverride(t *testing.T) {
+	t.Parallel()
+
+	override := testutil.NewMockProvider(workers.InferenceResponse{Content: "override"})
+	provider, err := resolveDurableExecutionProvider(
+		override,
+		&workers.MockWorkersConfig{},
+		nil,
+		testutil.NewProviderCommandRunner(),
+		func(platformprocess.CommandRunner) workers.CommandRunner { return stubWorkersCommandRunner{} },
+		workersservice.NewMockCommandRunner,
+		func(workers.CommandRunner) (workerprovider.Provider, error) {
+			t.Fatal("build provider should not run when override is present")
+			return nil, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("resolveDurableExecutionProvider: %v", err)
+	}
+	if provider != override {
+		t.Fatalf("provider = %#v, want override %#v", provider, override)
+	}
+}
+
+func TestResolveDurableExecutionProvider_BuildsFromMockWrappedRunner(t *testing.T) {
+	t.Parallel()
+
+	baseRunner := stubWorkersCommandRunner{}
+	cfg := &workers.MockWorkersConfig{
+		UnmatchedDispatchPolicy: workers.MockWorkerUnmatchedDispatchPolicyPassthrough,
+		MockWorkers: []workers.MockWorkerConfig{{
+			WorkerName: "worker-a",
+			RunType:    workers.MockWorkerRunTypeAccept,
+		}},
+	}
+	var builtRunner workers.CommandRunner
+	provider, err := resolveDurableExecutionProvider(
+		nil,
+		cfg,
+		nil,
+		testutil.NewProviderCommandRunner(),
+		func(platformprocess.CommandRunner) workers.CommandRunner { return baseRunner },
+		func(mockCfg *workers.MockWorkersConfig, _ interfaces.RuntimeDefinitionLookup, next workers.CommandRunner) workers.CommandRunner {
+			if next != baseRunner {
+				t.Fatalf("next runner = %#v, want base runner %#v", next, baseRunner)
+			}
+			builtRunner = workersservice.NewMockCommandRunner(mockCfg, nil, next)
+			return builtRunner
+		},
+		func(runner workers.CommandRunner) (workerprovider.Provider, error) {
+			if runner != builtRunner {
+				t.Fatalf("build provider runner = %#v, want wrapped %#v", runner, builtRunner)
+			}
+			return testutil.NewMockProvider(workers.InferenceResponse{Content: "built"}), nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("resolveDurableExecutionProvider: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("provider = nil, want built provider")
+	}
+}
+
+func TestResolveDurableExecutionProvider_ReturnsNilWithoutMockWorkers(t *testing.T) {
+	t.Parallel()
+
+	provider, err := resolveDurableExecutionProvider(
+		nil,
+		nil,
+		nil,
+		testutil.NewProviderCommandRunner(),
+		func(platformprocess.CommandRunner) workers.CommandRunner { return stubWorkersCommandRunner{} },
+		workersservice.NewMockCommandRunner,
+		func(workers.CommandRunner) (workerprovider.Provider, error) {
+			t.Fatal("build provider should not run without mock workers")
+			return nil, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("resolveDurableExecutionProvider: %v", err)
+	}
+	if provider != nil {
+		t.Fatalf("provider = %#v, want nil", provider)
+	}
+}

--- a/pkg/services/factory_sessions/internal/runtimeopening/durable_provider_test.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/durable_provider_test.go
@@ -82,6 +82,29 @@ func TestResolveDurableExecutionProvider_BuildsFromMockWrappedRunner(t *testing.
 	}
 }
 
+func TestResolveDurableExecutionProvider_ReturnsNilWithoutPassthroughPolicy(t *testing.T) {
+	t.Parallel()
+
+	provider, err := resolveDurableExecutionProvider(
+		nil,
+		workers.NewEmptyMockWorkersConfig(),
+		nil,
+		testutil.NewProviderCommandRunner(),
+		func(platformprocess.CommandRunner) workers.CommandRunner { return stubWorkersCommandRunner{} },
+		workersservice.NewMockCommandRunner,
+		func(workers.CommandRunner) (workerprovider.Provider, error) {
+			t.Fatal("build provider should not run without passthrough unmatched policy")
+			return nil, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("resolveDurableExecutionProvider: %v", err)
+	}
+	if provider != nil {
+		t.Fatalf("provider = %#v, want nil", provider)
+	}
+}
+
 func TestResolveDurableExecutionProvider_ReturnsNilWithoutMockWorkers(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_sessions/internal/runtimeopening/factory.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/factory.go
@@ -64,6 +64,7 @@ type Factory struct {
 	resolveClock                    factoryruntime.ClockResolver
 	newSessionLogger                factoryruntime.SessionLoggerFactory
 	adaptWorkerCommandRunner        WorkerCommandRunnerAdapter
+	providerFromCommandRunnerFactory ProviderFromCommandRunnerFactory
 	processRuntimeFactory           roles.ProcessRuntimeFactory
 	ensureOperatorBackendScope      operatorsettings.BackendScopeEnsurer
 	generateRuntimeInstanceID       factorysessions.RuntimeInstanceIDGenerator
@@ -112,6 +113,7 @@ func NewFactory(
 	resolveClock factoryruntime.ClockResolver,
 	newSessionLogger factoryruntime.SessionLoggerFactory,
 	adaptWorkerCommandRunner WorkerCommandRunnerAdapter,
+	providerFromCommandRunnerFactory ProviderFromCommandRunnerFactory,
 	processRuntimeFactory roles.ProcessRuntimeFactory,
 	ensureOperatorBackendScope operatorsettings.BackendScopeEnsurer,
 	generateRuntimeInstanceID factorysessions.RuntimeInstanceIDGenerator,
@@ -192,8 +194,9 @@ func NewFactory(
 		captureLoadedFactorySnapshot:    captureLoadedFactorySnapshot,
 		resolveClock:                    resolveClock,
 		newSessionLogger:                newSessionLogger,
-		adaptWorkerCommandRunner:        adaptWorkerCommandRunner,
-		processRuntimeFactory:           processRuntimeFactory,
+		adaptWorkerCommandRunner:         adaptWorkerCommandRunner,
+		providerFromCommandRunnerFactory: providerFromCommandRunnerFactory,
+		processRuntimeFactory:            processRuntimeFactory,
 		ensureOperatorBackendScope:      ensureOperatorBackendScope,
 		generateRuntimeInstanceID:       generateRuntimeInstanceID,
 		resolveHome:                     resolveHome,
@@ -247,6 +250,7 @@ func (f *Factory) openRuntime(
 		f.resolveClock,
 		f.newSessionLogger,
 		f.adaptWorkerCommandRunner,
+		f.providerFromCommandRunnerFactory,
 		f.processRuntimeFactory,
 		f.ensureOperatorBackendScope,
 		f.generateRuntimeInstanceID,

--- a/pkg/services/factory_sessions/internal/runtimeopening/open.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/open.go
@@ -65,6 +65,7 @@ func openRuntime(
 	resolveClock factoryruntime.ClockResolver,
 	newSessionLogger factoryruntime.SessionLoggerFactory,
 	adaptWorkerCommandRunner WorkerCommandRunnerAdapter,
+	providerFromCommandRunnerFactory ProviderFromCommandRunnerFactory,
 	processRuntimeFactory roles.ProcessRuntimeFactory,
 	ensureOperatorBackendScope operatorsettings.BackendScopeEnsurer,
 	generateRuntimeInstanceID factorysessions.RuntimeInstanceIDGenerator,
@@ -152,12 +153,24 @@ func openRuntime(
 	if durableExecutionFactory == nil {
 		return runtimeProducts{}, fmt.Errorf("construct runtime scope: durable execution operation is required")
 	}
+	providerForDurable, err := resolveDurableExecutionProvider(
+		edges.ProviderOverride,
+		configured.Workers.MockWorkers,
+		load.LoadedFactoryCfg,
+		edges.ProviderCommandRunner,
+		adaptWorkerCommandRunner,
+		workersMockCommandRunnerFactory,
+		providerFromCommandRunnerFactory,
+	)
+	if err != nil {
+		return runtimeProducts{}, err
+	}
 	factorysessionexecutionService, err := durableExecutionFactory(
 		configured.Definition,
 		configured.Session,
 		root,
 		clock,
-		edges.ProviderOverride,
+		providerForDurable,
 		factorySessionExecutionFactory,
 		providerIdentities,
 	)

--- a/pkg/services/factory_sessions/wire/application_graph.go
+++ b/pkg/services/factory_sessions/wire/application_graph.go
@@ -106,8 +106,9 @@ type (
 	FactoryDefinitionsFactory       = runtimeopening.FactoryDefinitionsFactory
 	DurableExecutionFactory         = runtimeopening.DurableExecutionFactory
 	WorkerExecutionFactory          = runtimeopening.WorkerExecutionFactory
-	WorkerCommandRunnerAdapter      = runtimeopening.WorkerCommandRunnerAdapter
-	FactoryRuntimeAssembler         = runtimeopening.FactoryRuntimeAssembler
+	WorkerCommandRunnerAdapter           = runtimeopening.WorkerCommandRunnerAdapter
+	ProviderFromCommandRunnerFactory     = runtimeopening.ProviderFromCommandRunnerFactory
+	FactoryRuntimeAssembler              = runtimeopening.FactoryRuntimeAssembler
 	RuntimeOpeningFactory           = runtimeopening.Factory
 	RuntimeRoot                     = runtimeopening.RuntimeRoot
 
@@ -166,8 +167,9 @@ type RuntimeOpeningDependencies struct {
 	CaptureLoadedFactorySnapshot    factorydefinitions.LoadedFactorySnapshotCapturer
 	ResolveClock                    factoryruntime.ClockResolver
 	NewSessionLogger                factoryruntime.SessionLoggerFactory
-	AdaptWorkerCommandRunner        WorkerCommandRunnerAdapter
-	ProcessRuntimeFactory           ProcessRuntimeFactory
+	AdaptWorkerCommandRunner            WorkerCommandRunnerAdapter
+	ProviderFromCommandRunnerFactory    ProviderFromCommandRunnerFactory
+	ProcessRuntimeFactory               ProcessRuntimeFactory
 	EnsureOperatorBackendScope      operatorsettings.BackendScopeEnsurer
 	GenerateRuntimeInstanceID       factorysessions.RuntimeInstanceIDGenerator
 	ResolveHome                     factorysessions.HomeDirectoryResolver
@@ -190,7 +192,8 @@ func NewRuntimeOpeningFactory(deps RuntimeOpeningDependencies) (*RuntimeOpeningF
 		deps.InitialFactorySnapshotFactory, deps.FactoryRuntimeAssembler, deps.ContentMaterializer,
 		deps.LoadFactory, deps.NewLoadedFactory, deps.DecodeReplayConfig, deps.LoadReplay,
 		deps.CaptureLoadedFactorySnapshot, deps.ResolveClock, deps.NewSessionLogger,
-		deps.AdaptWorkerCommandRunner, deps.ProcessRuntimeFactory, deps.EnsureOperatorBackendScope,
+		deps.AdaptWorkerCommandRunner, deps.ProviderFromCommandRunnerFactory, deps.ProcessRuntimeFactory,
+		deps.EnsureOperatorBackendScope,
 		deps.GenerateRuntimeInstanceID, deps.ResolveHome, deps.ReplayFiles,
 		deps.ProviderIdentities,
 	)

--- a/pkg/services/workers/service/provider.go
+++ b/pkg/services/workers/service/provider.go
@@ -7,13 +7,14 @@ import (
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	"github.com/portpowered/infinite-you/pkg/services/workers/agypty"
-	workerinvocation "github.com/portpowered/infinite-you/pkg/services/workers/invocation"
 	workerprocess "github.com/portpowered/infinite-you/pkg/services/workers/process"
+	workerprovider "github.com/portpowered/infinite-you/pkg/services/workers/provider"
+	workerprovidercontract "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
 )
 
-// NewInvocation constructs the narrow direct-invocation role used by
-// standalone Factory Session execution.
-func NewInvocation(
+// NewProviderFromCommandRunner constructs one provider-backed worker from the
+// supplied command runner using the same production edges as direct invocation.
+func NewProviderFromCommandRunner(
 	commandRunner workers.CommandRunner,
 	commandClock workerprocess.Clock,
 	allocator agypty.PTYAllocator,
@@ -23,23 +24,27 @@ func NewInvocation(
 	executableFiles platformfilesystem.ReadOpener,
 	operatingSystem workers.OperatingSystem,
 	temporaryFileSystems ...platformfilesystem.TemporaryFileSystem,
-) (workers.InvocationExecutor, error) {
+) (workerprovidercontract.Provider, error) {
 	if commandRunner == nil {
-		return nil, fmt.Errorf("construct Worker invocation: command runner is required")
+		return nil, fmt.Errorf("construct provider-backed worker: command runner is required")
 	}
 	if commandClock == nil {
-		return nil, fmt.Errorf("construct Worker invocation: command clock is required")
+		return nil, fmt.Errorf("construct provider-backed worker: command clock is required")
 	}
 	if allocator == nil {
-		return nil, fmt.Errorf("construct Worker invocation: PTY allocator is required")
+		return nil, fmt.Errorf("construct provider-backed worker: PTY allocator is required")
 	}
-	provider, err := NewProviderFromCommandRunner(
+	factory, err := workerprovider.NewFactory(
 		commandRunner, commandClock, allocator, resolveSymlinks,
 		executableLocator, executableInspector, executableFiles, operatingSystem,
 		temporaryFileSystems...,
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("construct provider-backed worker: %w", err)
 	}
-	return workerinvocation.NewExecutor(provider), nil
+	provider, err := factory.New(false, nil, nil, nil, nil, "")
+	if err != nil {
+		return nil, fmt.Errorf("construct provider-backed worker: %w", err)
+	}
+	return provider, nil
 }

--- a/pkg/wire/session_runtime_providers.go
+++ b/pkg/wire/session_runtime_providers.go
@@ -850,6 +850,40 @@ func provideWorkerInvocationFactory(edges serviceedges.Edges) factorysessionwire
 	}
 }
 
+func provideProviderFromCommandRunnerFactory(
+	edges serviceedges.Edges,
+	allocator agypty.PTYAllocator,
+) factorysessionwire.ProviderFromCommandRunnerFactory {
+	commandClock := edges.Clock
+	if commandClock == nil {
+		commandClock = platformclock.Real{}
+	}
+	resolveSymlinks := edges.WorkersResolveSymlinks
+	if resolveSymlinks == nil {
+		resolveSymlinks = filepath.EvalSymlinks
+	}
+	executableLocator := edges.WorkersExecutableLocator
+	if executableLocator == nil {
+		executableLocator = platformprocess.HostExecutableLocator{}
+	}
+	executableInspector := edges.WorkersExecutablePathInspector
+	if executableInspector == nil {
+		executableInspector = platformfilesystem.Local{}
+	}
+	executableFiles := edges.WorkersExecutableFileReader
+	if executableFiles == nil {
+		executableFiles = platformfilesystem.Local{}
+	}
+	operatingSystem := resolveWorkersOperatingSystem(edges)
+	temporaryFiles := provideWorkersProviderTemporaryFileSystem(edges)
+	return func(runner workers.CommandRunner) (workerprovider.Provider, error) {
+		return workersservice.NewProviderFromCommandRunner(
+			runner, commandClock, allocator, resolveSymlinks,
+			executableLocator, executableInspector, executableFiles, operatingSystem, temporaryFiles,
+		)
+	}
+}
+
 func provideSessionExecutionOpeningFactory(
 	runtimes *factorysessionwire.RuntimeOpeningFactory,
 	edges serviceedges.Edges,

--- a/pkg/wire/wire.go
+++ b/pkg/wire/wire.go
@@ -225,6 +225,7 @@ var factoryDefinitionsServicesSet = wire.NewSet(
 
 var workerServiceSet = wire.NewSet(
 	provideWorkerInvocationFactory,
+	provideProviderFromCommandRunnerFactory,
 	provideWorkerProcessEnvironment,
 	provideWorkerCurrentWorkingDirectory,
 )

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -257,12 +257,13 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	clockResolver := provideFactoryRuntimeClockResolver()
 	sessionLoggerFactory := provideFactoryRuntimeSessionLoggerFactory()
 	v42 := provideWorkerCommandRunnerAdapter()
+	v43 := provideProviderFromCommandRunnerFactory(edges2, ptyAllocator)
 	starter, err := provideAPIServerStarter(edges2)
 	if err != nil {
 		return nil, err
 	}
-	v43 := provideRuntimeHostOperation(starter)
-	v44, err := provideProcessRuntimeFactory(v43)
+	v44 := provideRuntimeHostOperation(starter)
+	v45, err := provideProcessRuntimeFactory(v44)
 	if err != nil {
 		return nil, err
 	}
@@ -271,72 +272,73 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	configEncoder := provideOperatorConfigEncoder()
 	backendScopeEnsurer := provideOperatorBackendScopeEnsurer(fileSystem, createTemporaryFile, operatorsettingsIDGenerator, configDecoder, configEncoder)
 	runtimeInstanceIDGenerator := provideFactorySessionRuntimeInstanceIDGenerator(edges2)
-	v45 := provideFactorySessionReplayRecordingReader(edges2)
+	v46 := provideFactorySessionReplayRecordingReader(edges2)
 	providerIdentityResolver := provideFactorySessionProviderIdentityResolver(registry)
 	runtimeOpeningDependencies := wire.RuntimeOpeningDependencies{
-		ProviderSessions:                providersessionsService,
-		FactoryWorkflows:                javaScriptWorkflowDefinitions,
-		WorkflowPreview:                 workflowPreviewOperation,
-		FactoryDefinitionValidator:      v10,
-		NamedPaths:                      namedPathResolver,
-		DurableExecutionFactory:         v11,
-		WorkerExecutionFactory:          v12,
-		ModelService:                    modelsService,
-		WorkFactory:                     v13,
-		AutomationFactory:               v14,
-		FactorySessionsService:          factorysessionsService,
-		FactorySessionExecutionFactory:  v22,
-		RecordingsProjectionFactory:     v23,
-		RecordingsFactory:               v24,
-		RuntimeLedgerFactory:            v25,
-		RuntimeRecorderFactory:          runtimeRecorderFactory,
-		ReplayClockFactory:              v27,
-		ReplayExecutionFactory:          replayExecutionFactory,
-		WorkersRuntimeFactory:           v30,
-		WorkersRuntimeExecutorsFactory:  workersRuntimeExecutorsFactory,
-		WorkersMockCommandRunnerFactory: workersMockCommandRunnerFactory,
-		WorkerHostedPollersFactory:      v31,
-		WorkersLocalRuntimeHooksFactory: v32,
-		FactoryDefinitionsFactory:       v37,
-		FactoryScaffoldInitializer:      factoryScaffoldInitializer,
-		EditableFactoryValidator:        editableFactoryValidator,
-		InitialFactorySnapshotFactory:   initialFactorySnapshotFactory,
-		FactoryRuntimeAssembler:         assembly,
-		ContentMaterializer:             contentMaterializer,
-		LoadFactory:                     v40,
-		NewLoadedFactory:                v41,
-		DecodeReplayConfig:              replayRuntimeConfigDecoder,
-		LoadReplay:                      replayArtifactLoader,
-		CaptureLoadedFactorySnapshot:    v26,
-		ResolveClock:                    clockResolver,
-		NewSessionLogger:                sessionLoggerFactory,
-		AdaptWorkerCommandRunner:        v42,
-		ProcessRuntimeFactory:           v44,
-		EnsureOperatorBackendScope:      backendScopeEnsurer,
-		GenerateRuntimeInstanceID:       runtimeInstanceIDGenerator,
-		ResolveHome:                     homeDirectoryResolver,
-		ReplayFiles:                     v45,
-		ProviderIdentities:              providerIdentityResolver,
+		ProviderSessions:                 providersessionsService,
+		FactoryWorkflows:                 javaScriptWorkflowDefinitions,
+		WorkflowPreview:                  workflowPreviewOperation,
+		FactoryDefinitionValidator:       v10,
+		NamedPaths:                       namedPathResolver,
+		DurableExecutionFactory:          v11,
+		WorkerExecutionFactory:           v12,
+		ModelService:                     modelsService,
+		WorkFactory:                      v13,
+		AutomationFactory:                v14,
+		FactorySessionsService:           factorysessionsService,
+		FactorySessionExecutionFactory:   v22,
+		RecordingsProjectionFactory:      v23,
+		RecordingsFactory:                v24,
+		RuntimeLedgerFactory:             v25,
+		RuntimeRecorderFactory:           runtimeRecorderFactory,
+		ReplayClockFactory:               v27,
+		ReplayExecutionFactory:           replayExecutionFactory,
+		WorkersRuntimeFactory:            v30,
+		WorkersRuntimeExecutorsFactory:   workersRuntimeExecutorsFactory,
+		WorkersMockCommandRunnerFactory:  workersMockCommandRunnerFactory,
+		WorkerHostedPollersFactory:       v31,
+		WorkersLocalRuntimeHooksFactory:  v32,
+		FactoryDefinitionsFactory:        v37,
+		FactoryScaffoldInitializer:       factoryScaffoldInitializer,
+		EditableFactoryValidator:         editableFactoryValidator,
+		InitialFactorySnapshotFactory:    initialFactorySnapshotFactory,
+		FactoryRuntimeAssembler:          assembly,
+		ContentMaterializer:              contentMaterializer,
+		LoadFactory:                      v40,
+		NewLoadedFactory:                 v41,
+		DecodeReplayConfig:               replayRuntimeConfigDecoder,
+		LoadReplay:                       replayArtifactLoader,
+		CaptureLoadedFactorySnapshot:     v26,
+		ResolveClock:                     clockResolver,
+		NewSessionLogger:                 sessionLoggerFactory,
+		AdaptWorkerCommandRunner:         v42,
+		ProviderFromCommandRunnerFactory: v43,
+		ProcessRuntimeFactory:            v45,
+		EnsureOperatorBackendScope:       backendScopeEnsurer,
+		GenerateRuntimeInstanceID:        runtimeInstanceIDGenerator,
+		ResolveHome:                      homeDirectoryResolver,
+		ReplayFiles:                      v46,
+		ProviderIdentities:               providerIdentityResolver,
 	}
-	v46, err := wire.NewRuntimeOpeningFactory(runtimeOpeningDependencies)
+	v47, err := wire.NewRuntimeOpeningFactory(runtimeOpeningDependencies)
 	if err != nil {
 		return nil, err
 	}
-	v47 := provideFactorySessionContractFixtureReader(edges2)
-	v48 := provideStandaloneSessionExecutionFactory(javaScriptWorkflows, writer, v20, v21, v15, v47)
-	v49 := provideWorkerInvocationFactory(edges2)
+	v48 := provideFactorySessionContractFixtureReader(edges2)
+	v49 := provideStandaloneSessionExecutionFactory(javaScriptWorkflows, writer, v20, v21, v15, v48)
+	v50 := provideWorkerInvocationFactory(edges2)
 	runtimeArtifactRootResolver := provideRuntimeArtifactRootResolver()
-	v50 := provideFactorySessionExecutionOpeningFileSystem(edges2)
+	v51 := provideFactorySessionExecutionOpeningFileSystem(edges2)
 	logger, err := logging.NewDefaultLogger()
 	if err != nil {
 		return nil, err
 	}
-	v51, err := provideSessionExecutionOpeningFactory(v46, edges2, v48, v49, clockResolver, runtimeArtifactRootResolver, v42, v50, ptyAllocator, logger)
+	v52, err := provideSessionExecutionOpeningFactory(v47, edges2, v49, v50, clockResolver, runtimeArtifactRootResolver, v42, v51, ptyAllocator, logger)
 	if err != nil {
 		return nil, err
 	}
-	v52 := wire.NewExecutionServiceBuilder(v51)
-	executionServiceBuilder := provideCLIExecutionServiceBuilder(v52)
+	v53 := wire.NewExecutionServiceBuilder(v52)
+	executionServiceBuilder := provideCLIExecutionServiceBuilder(v53)
 	wireStandardCLIHTTPProtocol, err := provideStandardCLIHTTPProtocol()
 	if err != nil {
 		return nil, err
@@ -347,11 +349,11 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		return nil, err
 	}
 	modelInvocationTimeout := provideModelInvocationTimeout()
-	v53, err := provideInvocationOperation(v46, edges2, workingDirectory, v3, invocationArtifactExporter, modelInvocationTimeout, runtimeArtifactRootResolver, v15)
+	v54, err := provideInvocationOperation(v47, edges2, workingDirectory, v3, invocationArtifactExporter, modelInvocationTimeout, runtimeArtifactRootResolver, v15)
 	if err != nil {
 		return nil, err
 	}
-	invocationOperation := provideModelsCLIInvocationOperation(v53)
+	invocationOperation := provideModelsCLIInvocationOperation(v54)
 	cliService := provideModelsCLIService(wireStandardCLIHTTPProtocol, invocationOperation)
 	payloadFileReader := provideSubmitPayloadReader()
 	wireExtendedCLIHTTPProtocol, err := provideExtendedCLIHTTPProtocol()
@@ -361,8 +363,8 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	submitWorkOperation := provideSubmitWorkOperation(payloadFileReader, wireExtendedCLIHTTPProtocol)
 	factoryRequestBatchPreparation := work.NewFactoryRequestBatchPreparation()
 	submitBatchOperation := provideSubmitBatchOperation(wireExtendedCLIHTTPProtocol, factoryRequestBatchPreparation)
-	v54 := wire.NewRequestPreparation()
-	listSessionsOperation := provideListSessionsOperation(wireStandardCLIHTTPProtocol, v54)
+	v55 := wire.NewRequestPreparation()
+	listSessionsOperation := provideListSessionsOperation(wireStandardCLIHTTPProtocol, v55)
 	showSessionOperation := provideShowSessionOperation(wireStandardCLIHTTPProtocol)
 	pauseSessionOperation := providePauseSessionOperation(wireStandardCLIHTTPProtocol)
 	resumeSessionOperation := provideResumeSessionOperation(wireStandardCLIHTTPProtocol)
@@ -375,14 +377,14 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	configDocumentService := provideOperatorConfigDocumentService(fileSystem, createTemporaryFile, providerCatalog, configDecoder, configEncoder)
 	configureInitOperation := provideConfigureInitOperation(configDocumentService)
 	queryFactoryOperation := provideQueryFactoryOperation(wireStandardCLIHTTPProtocol)
-	v55 := provideCurrentFactoryPointerReader(namedPathResolver)
-	listFactoriesOperation := provideListFactoriesOperation(effectiveCatalogService, v55)
-	v56 := provideSubmittedDefinitionValidationOperation(validationService)
-	validateFactoryOperation := provideValidateFactoryOperation(v56, authoredFactorySourceLoader)
-	v57 := provideNamedFactoryPersistenceOperation(v36)
-	createFactoryFromFileOperation := provideCreateFactoryFromFileOperation(v57, authoredFactorySourceLoader)
+	v56 := provideCurrentFactoryPointerReader(namedPathResolver)
+	listFactoriesOperation := provideListFactoriesOperation(effectiveCatalogService, v56)
+	v57 := provideSubmittedDefinitionValidationOperation(validationService)
+	validateFactoryOperation := provideValidateFactoryOperation(v57, authoredFactorySourceLoader)
+	v58 := provideNamedFactoryPersistenceOperation(v36)
+	createFactoryFromFileOperation := provideCreateFactoryFromFileOperation(v58, authoredFactorySourceLoader)
 	replaceFactoryCurrentOperation := provideReplaceFactoryCurrentOperation(wireStandardCLIHTTPProtocol)
-	updateFactoryFromFileOperation := provideUpdateFactoryFromFileOperation(v57, authoredFactorySourceLoader)
+	updateFactoryFromFileOperation := provideUpdateFactoryFromFileOperation(v58, authoredFactorySourceLoader)
 	deleteFactoryOperation := provideDeleteFactoryOperation(v)
 	listRequestPreparation := work.NewListRequestPreparation()
 	listWorkOperation := provideListWorkOperation(wireStandardCLIHTTPProtocol, listRequestPreparation)
@@ -403,8 +405,8 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	v58 := provideRuntimeInputResolver(edges2, clockResolver)
-	v59 := provideRuntimeOpener(v46)
+	v59 := provideRuntimeInputResolver(edges2, clockResolver)
+	v60 := provideRuntimeOpener(v47)
 	factory_visualizationRuntimeFactory := provideFactoryVisualizationFactory()
 	factoryStatusProjector := factory.NewFactoryStatusProjector()
 	contentPreparation := work.NewContentPreparation()
@@ -416,36 +418,36 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	requestPreparation := provideFactorySessionHTTPRequestPreparation(v54)
-	handler, err := application2.NewHandler(httpBinder, contentPreparation, v56, contentStagingService, requestPreparationService, requestPreparation)
+	requestPreparation := provideFactorySessionHTTPRequestPreparation(v55)
+	handler, err := application2.NewHandler(httpBinder, contentPreparation, v57, contentStagingService, requestPreparationService, requestPreparation)
 	if err != nil {
 		return nil, err
 	}
 	runnerFactory := provideLifecycleRunnerFactory()
-	v60, err := provideApplicationRuntimeAdapter(factory_visualizationRuntimeFactory, handler, runnerFactory)
+	v61, err := provideApplicationRuntimeAdapter(factory_visualizationRuntimeFactory, handler, runnerFactory)
 	if err != nil {
 		return nil, err
 	}
-	v61 := wire.NewLifecyclePlanOperation()
-	v62, err := wire.NewApplicationService(v58, v59, v60, v61)
+	v62 := wire.NewLifecyclePlanOperation()
+	v63, err := wire.NewApplicationService(v59, v60, v61, v62)
 	if err != nil {
 		return nil, err
 	}
-	runRuntimeRunnerBuilder, err := provideRunRuntimeRunnerBuilder(runtimeRunnerBuilder, v62)
+	runRuntimeRunnerBuilder, err := provideRunRuntimeRunnerBuilder(runtimeRunnerBuilder, v63)
 	if err != nil {
 		return nil, err
 	}
 	responsePresentation := provideResponsePresentation()
-	v63 := provideDirectJavaScriptSyncRunner()
+	v64 := provideDirectJavaScriptSyncRunner()
 	directJavaScriptHostAdapter, err := provideDirectJavaScriptHostAdapter(handler, starter, runnerFactory)
 	if err != nil {
 		return nil, err
 	}
-	v64, err := wire.NewDirectJavaScriptRunOperation(v52, v63, v15, directJavaScriptHostAdapter)
+	v65, err := wire.NewDirectJavaScriptRunOperation(v53, v64, v15, directJavaScriptHostAdapter)
 	if err != nil {
 		return nil, err
 	}
-	selectionFactory, err := provideRunSelectionFactory(runOpener, runRuntimeRunnerBuilder, v53, responsePresentation, v64, runtimeRunnerBuilder)
+	selectionFactory, err := provideRunSelectionFactory(runOpener, runRuntimeRunnerBuilder, v54, responsePresentation, v65, runtimeRunnerBuilder)
 	if err != nil {
 		return nil, err
 	}
@@ -502,17 +504,17 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		return nil, err
 	}
 	stdioOpener := stdio.NewOpener()
-	v65 := provideFixtureStdioApplicationBuilder(stdioRunnerBuilder, runnerFactory, stdioOpener, v54, workflowPreviewOperation)
+	v66 := provideFixtureStdioApplicationBuilder(stdioRunnerBuilder, runnerFactory, stdioOpener, v55, workflowPreviewOperation)
 	openedStdioRunnerBuilder, err := application.NewOpenedStdioRunnerBuilder(managedRunnerFactory)
 	if err != nil {
 		return nil, err
 	}
-	v66 := provideRuntimeStdioApplicationBuilder(openedStdioRunnerBuilder, runnerFactory, stdioOpener, v54)
-	v67, err := wire.NewStdioOpeningService(v51, v65, v66)
+	v67 := provideRuntimeStdioApplicationBuilder(openedStdioRunnerBuilder, runnerFactory, stdioOpener, v55)
+	v68, err := wire.NewStdioOpeningService(v52, v66, v67)
 	if err != nil {
 		return nil, err
 	}
-	processStdioApplicationOpener, err := provideStdioApplicationOpener(v67)
+	processStdioApplicationOpener, err := provideStdioApplicationOpener(v68)
 	if err != nil {
 		return nil, err
 	}
@@ -694,6 +696,7 @@ var factoryDefinitionsServicesSet = wire2.NewSet(
 
 var workerServiceSet = wire2.NewSet(
 	provideWorkerInvocationFactory,
+	provideProviderFromCommandRunnerFactory,
 	provideWorkerProcessEnvironment,
 	provideWorkerCurrentWorkingDirectory,
 )

--- a/tests/functional/orchestration/javascript/workers/overrides_test.go
+++ b/tests/functional/orchestration/javascript/workers/overrides_test.go
@@ -6,6 +6,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -23,8 +25,9 @@ const (
 	childPassthroughLabel = "child-passthrough"
 	unknownOverrideChildLabel = "child-unknown-override"
 
-	mockedChildPrompt      = "mocked child prompt"
-	passthroughChildPrompt = "passthrough child prompt"
+	mockedWorkerPresetName   = "worker-a"
+	mockedChildPrompt        = "mocked child prompt"
+	passthroughChildPrompt   = "passthrough child prompt"
 	unknownOverrideModelProvider = "Not_A_Provider"
 
 	perChildProviderModelWorkflow = `return (async function () {
@@ -47,6 +50,7 @@ const (
   const mocked = await agent.run({
     prompt: "` + mockedChildPrompt + `",
     label: "` + childMockedLabel + `",
+    preset: "` + mockedWorkerPresetName + `",
   });
   const passthrough = await agent.run({
     prompt: "` + passthroughChildPrompt + `",
@@ -103,87 +107,51 @@ func TestJavaScriptChildrenSelectDifferentProvidersAndModels(t *testing.T) {
 }
 
 // TestJavaScriptMockWorkersReplaceOnlyNamedChildren proves a partial
-// --with-mock-workers configuration serves named workstation workers through
-// the mock-worker accept path while unmatched JavaScript child dispatches keep
-// the live-provider path when unmatchedDispatchPolicy is passthrough and a
-// provider edge is injected at the public process boundary.
+// --with-mock-workers configuration serves a named preset worker through the
+// mock-worker accept path while an unmatched JavaScript child without that
+// preset keeps the live-provider passthrough path when
+// unmatchedDispatchPolicy is passthrough and a provider command edge is
+// injected at the public process boundary.
 func TestJavaScriptMockWorkersReplaceOnlyNamedChildren(t *testing.T) {
 	t.Parallel()
 
-	t.Run("namedMockWorkerAcceptsConfiguredWorker", func(t *testing.T) {
-		t.Parallel()
+	dir := support.ScaffoldFactory(t, overridesFactoryConfig())
+	support.WriteAgentConfig(t, dir, mockedWorkerPresetName, "---\ntype: MODEL_WORKER\n---\n")
+	homeDir := writePartialMockWorkersGlobalConfig(t)
 
-		dir := support.ScaffoldFactory(t, overridesFactoryConfig())
-		support.WriteAgentConfig(t, dir, "worker-a", "---\ntype: MODEL_WORKER\n---\n")
-
-		runner := support.NewRecordingCommandRunner("unexpected live provider execution")
-		server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
-			FactoryDir:                dir,
-			WaitForServiceModeRuntime: true,
-			UseMockWorkers:            true,
-			MockWorkersConfig:         partialNamedJavaScriptMockWorkersConfig(),
-			Edges:                     serviceedges.Edges{ProviderCommandRunner: runner},
-		})
-		t.Cleanup(func() { server.Stop(t) })
-
-		started := startOverridesWorkflow(
-			t,
-			server.URL(),
-			"javascript-partial-mock-workers-fake",
-			partialMockWorkersWorkflow,
-		)
-		if started.Status != factoryapi.FactorySessionDurableLifecycleStatusSucceeded {
-			t.Fatalf("session status = %q, want SUCCEEDED", started.Status)
-		}
-		if runner.CallCount() != 0 {
-			t.Fatalf("provider command runner call count = %d, want 0 for fake child execution", runner.CallCount())
-		}
-
-		dispatches := support.GetJSON[factoryapi.ListFactorySessionDispatchesResponse](
-			t,
-			strings.TrimSuffix(server.URL(), "/")+"/factory-sessions/"+started.SessionId+"/dispatches",
-		)
-		assertPartialMockFakeChildDispatches(t, dispatches.Dispatches)
-		assertPartialMockFakeChildPrimaryResult(t, started.Result)
+	runner := support.NewRecordingCommandRunner(livePassthroughChildText)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		WaitForServiceModeRuntime: true,
+		UseMockWorkers:            true,
+		MockWorkersConfig:         partialNamedJavaScriptMockWorkersConfig(),
+		Edges:                     serviceedges.Edges{ProviderCommandRunner: runner},
+		Env: append(os.Environ(),
+			"HOME="+homeDir,
+			"USERPROFILE="+homeDir,
+		),
 	})
+	t.Cleanup(func() { server.Stop(t) })
 
-	t.Run("passthroughChildUsesLiveProvider", func(t *testing.T) {
-		t.Parallel()
+	started := startOverridesWorkflow(
+		t,
+		server.URL(),
+		"javascript-partial-mock-workers-mixed",
+		partialMockWorkersWorkflow,
+	)
+	if started.Status != factoryapi.FactorySessionDurableLifecycleStatusSucceeded {
+		t.Fatalf("session status = %q, want SUCCEEDED", started.Status)
+	}
+	if runner.CallCount() != 1 {
+		t.Fatalf("provider command runner call count = %d, want 1 passthrough child dispatch", runner.CallCount())
+	}
 
-		dir := support.ScaffoldFactory(t, overridesFactoryConfig())
-		support.WriteAgentConfig(t, dir, "worker-a", "---\ntype: MODEL_WORKER\n---\n")
-
-		provider := testutil.NewMockProvider(
-			workers.InferenceResponse{Content: `{"text":"` + livePassthroughChildText + `"}`},
-			workers.InferenceResponse{Content: `{"text":"` + livePassthroughChildText + `"}`},
-		)
-		server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
-			FactoryDir:                dir,
-			WaitForServiceModeRuntime: true,
-			UseMockWorkers:            true,
-			MockWorkersConfig:         partialNamedJavaScriptMockWorkersConfig(),
-			Edges:                     serviceedges.Edges{ProviderOverride: provider},
-		})
-		t.Cleanup(func() { server.Stop(t) })
-
-		started := startOverridesWorkflow(
-			t,
-			server.URL(),
-			"javascript-partial-mock-workers-passthrough",
-			partialMockWorkersWorkflow,
-		)
-		if started.Status != factoryapi.FactorySessionDurableLifecycleStatusSucceeded {
-			t.Fatalf("session status = %q, want SUCCEEDED", started.Status)
-		}
-
-		dispatches := support.GetJSON[factoryapi.ListFactorySessionDispatchesResponse](
-			t,
-			strings.TrimSuffix(server.URL(), "/")+"/factory-sessions/"+started.SessionId+"/dispatches",
-		)
-		assertPartialMockPassthroughChildDispatches(t, dispatches.Dispatches)
-		assertPartialMockPassthroughProviderRequests(t, provider.Calls())
-		assertPartialMockPassthroughPrimaryResult(t, started.Result)
-	})
+	dispatches := support.GetJSON[factoryapi.ListFactorySessionDispatchesResponse](
+		t,
+		strings.TrimSuffix(server.URL(), "/")+"/factory-sessions/"+started.SessionId+"/dispatches",
+	)
+	assertPartialMockMixedChildDispatches(t, dispatches.Dispatches)
+	assertPartialMockMixedPrimaryResult(t, started.Result)
 }
 
 // TestJavaScriptUnknownWorkerOverrideFailsActionably proves configuring an
@@ -234,14 +202,35 @@ func partialNamedJavaScriptMockWorkersConfig() *workers.MockWorkersConfig {
 	return &workers.MockWorkersConfig{
 		UnmatchedDispatchPolicy: workers.MockWorkerUnmatchedDispatchPolicyPassthrough,
 		MockWorkers: []workers.MockWorkerConfig{{
-			WorkerName:      "worker-a",
-			WorkstationName: "process",
-			RunType:         workers.MockWorkerRunTypeAccept,
+			WorkerName: mockedWorkerPresetName,
+			RunType:    workers.MockWorkerRunTypeAccept,
 		}},
 	}
 }
 
-func assertPartialMockFakeChildDispatches(
+func writePartialMockWorkersGlobalConfig(t *testing.T) string {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	configDir := filepath.Join(homeDir, ".you-agent-factory")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatalf("mkdir global config directory: %v", err)
+	}
+	config := []byte(`{
+  "defaults": {"workerModelProvider": "codex", "workerModel": "default-model"},
+  "workerPresets": [{
+    "id": "` + mockedWorkerPresetName + `",
+    "modelProvider": "codex",
+    "model": "mocked-child-model"
+  }]
+}`)
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), config, 0o600); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+	return homeDir
+}
+
+func assertPartialMockMixedChildDispatches(
 	t *testing.T,
 	dispatches []factoryapi.FactorySessionDispatchSummary,
 ) {
@@ -260,27 +249,58 @@ func assertPartialMockFakeChildDispatches(
 		}
 		byLabel[*dispatch.Label] = dispatch
 	}
-	assertPartialMockFakeChildDispatch(t, byLabel[childMockedLabel], childMockedLabel, mockedChildPrompt)
-	assertPartialMockFakeChildDispatch(t, byLabel[childPassthroughLabel], childPassthroughLabel, passthroughChildPrompt)
+	assertPartialMockNamedChildDispatch(t, byLabel[childMockedLabel], childMockedLabel, mockedWorkerPresetName)
+	assertPartialMockPassthroughChildDispatch(t, byLabel[childPassthroughLabel], childPassthroughLabel)
 }
 
-func assertPartialMockFakeChildDispatch(
+func assertPartialMockNamedChildDispatch(
 	t *testing.T,
 	dispatch factoryapi.FactorySessionDispatchSummary,
-	wantLabel, wantPrompt string,
+	wantLabel, wantPreset string,
 ) {
 	t.Helper()
 
 	if dispatch.Label == nil || *dispatch.Label != wantLabel {
 		t.Fatalf("dispatch label = %#v, want %q", dispatch.Label, wantLabel)
 	}
+	gotPreset := dereferenceOverridesValue(dispatch.PresetId)
+	if gotPreset != wantPreset {
+		t.Fatalf("dispatch preset = %q, want %q", gotPreset, wantPreset)
+	}
 	if dispatch.Javascript == nil || dispatch.Javascript.ExecutionMode == nil ||
-		*dispatch.Javascript.ExecutionMode != "fake" {
-		t.Fatalf("dispatch %s javascript projection = %#v, want fake execution mode", dispatch.Id, dispatch.Javascript)
+		*dispatch.Javascript.ExecutionMode != "live-provider" {
+		t.Fatalf(
+			"dispatch %s javascript projection = %#v, want live-provider execution mode",
+			dispatch.Id,
+			dispatch.Javascript,
+		)
 	}
 }
 
-func assertPartialMockFakeChildPrimaryResult(t *testing.T, result *factoryapi.FactorySessionResult) {
+func assertPartialMockPassthroughChildDispatch(
+	t *testing.T,
+	dispatch factoryapi.FactorySessionDispatchSummary,
+	wantLabel string,
+) {
+	t.Helper()
+
+	if dispatch.Label == nil || *dispatch.Label != wantLabel {
+		t.Fatalf("dispatch label = %#v, want %q", dispatch.Label, wantLabel)
+	}
+	if dispatch.PresetId != nil && strings.TrimSpace(*dispatch.PresetId) != "" {
+		t.Fatalf("dispatch preset = %#v, want empty preset for unmatched child", dispatch.PresetId)
+	}
+	if dispatch.Javascript == nil || dispatch.Javascript.ExecutionMode == nil ||
+		*dispatch.Javascript.ExecutionMode != "live-provider" {
+		t.Fatalf(
+			"dispatch %s javascript projection = %#v, want live-provider execution mode",
+			dispatch.Id,
+			dispatch.Javascript,
+		)
+	}
+}
+
+func assertPartialMockMixedPrimaryResult(t *testing.T, result *factoryapi.FactorySessionResult) {
 	t.Helper()
 
 	if result == nil || result.ResultStatus != factoryapi.FactorySessionResultStatusFinal {
@@ -304,14 +324,14 @@ func assertPartialMockFakeChildPrimaryResult(t *testing.T, result *factoryapi.Fa
 	if err := json.Unmarshal(encoded, &evidence); err != nil {
 		t.Fatalf("decode partial mock primary result: %v", err)
 	}
-	assertPartialMockFakeChildResult(t, evidence.Mocked, childMockedLabel, mockedChildPrompt)
-	assertPartialMockFakeChildResult(t, evidence.Passthrough, childPassthroughLabel, passthroughChildPrompt)
+	assertPartialMockNamedChildResult(t, evidence.Mocked, childMockedLabel)
+	assertPartialMockPassthroughChildResult(t, evidence.Passthrough, childPassthroughLabel)
 }
 
-func assertPartialMockFakeChildResult(
+func assertPartialMockNamedChildResult(
 	t *testing.T,
 	child map[string]any,
-	wantLabel, wantPrompt string,
+	wantLabel string,
 ) {
 	t.Helper()
 
@@ -321,104 +341,20 @@ func assertPartialMockFakeChildResult(
 	if label, _ := child["label"].(string); label != wantLabel {
 		t.Fatalf("child label = %#v, want %q", child["label"], wantLabel)
 	}
-	if mode, _ := child["executionMode"].(string); mode != "fake" {
-		t.Fatalf("child executionMode = %#v, want fake", child["executionMode"])
+	if mode, _ := child["executionMode"].(string); mode != "live-provider" {
+		t.Fatalf("child executionMode = %#v, want live-provider", child["executionMode"])
 	}
 	output, ok := child["output"].(map[string]any)
 	if !ok || output == nil {
 		t.Fatalf("child output = %#v, want structured output object", child["output"])
 	}
 	text, _ := output["text"].(string)
-	if !strings.Contains(text, wantPrompt) {
-		t.Fatalf("child output text = %#v, want deterministic fake output containing prompt %q", output["text"], wantPrompt)
+	if !strings.Contains(text, mockWorkerAcceptedOutput) {
+		t.Fatalf("child output text = %#v, want mock-worker accept output", output["text"])
 	}
-}
-
-func assertPartialMockPassthroughChildDispatches(
-	t *testing.T,
-	dispatches []factoryapi.FactorySessionDispatchSummary,
-) {
-	t.Helper()
-
-	if len(dispatches) != 2 {
-		t.Fatalf("dispatch count = %d, want 2 child dispatches", len(dispatches))
+	if strings.Contains(text, livePassthroughChildText) {
+		t.Fatalf("child output text = %#v, want mock-worker output not passthrough provider text", output["text"])
 	}
-	byLabel := make(map[string]factoryapi.FactorySessionDispatchSummary, len(dispatches))
-	for _, dispatch := range dispatches {
-		if dispatch.Label == nil || strings.TrimSpace(*dispatch.Label) == "" {
-			t.Fatalf("dispatch %s missing label, want labeled child dispatches", dispatch.Id)
-		}
-		if dispatch.Status != factoryapi.FactoryDispatchStatusCOMPLETED {
-			t.Fatalf("dispatch %s status = %q, want COMPLETED", dispatch.Id, dispatch.Status)
-		}
-		byLabel[*dispatch.Label] = dispatch
-	}
-	assertPartialMockPassthroughChildDispatch(t, byLabel[childMockedLabel], childMockedLabel)
-	assertPartialMockPassthroughChildDispatch(t, byLabel[childPassthroughLabel], childPassthroughLabel)
-}
-
-func assertPartialMockPassthroughChildDispatch(
-	t *testing.T,
-	dispatch factoryapi.FactorySessionDispatchSummary,
-	wantLabel string,
-) {
-	t.Helper()
-
-	if dispatch.Label == nil || *dispatch.Label != wantLabel {
-		t.Fatalf("dispatch label = %#v, want %q", dispatch.Label, wantLabel)
-	}
-	if dispatch.Javascript == nil || dispatch.Javascript.ExecutionMode == nil ||
-		*dispatch.Javascript.ExecutionMode != "live-provider" {
-		t.Fatalf(
-			"dispatch %s javascript projection = %#v, want live-provider execution mode",
-			dispatch.Id,
-			dispatch.Javascript,
-		)
-	}
-}
-
-func assertPartialMockPassthroughProviderRequests(
-	t *testing.T,
-	calls []workers.ProviderInferenceRequest,
-) {
-	t.Helper()
-
-	if len(calls) != 2 {
-		t.Fatalf("provider call count = %d, want 2 passthrough child dispatches", len(calls))
-	}
-	for index, call := range calls {
-		if !strings.Contains(call.UserMessage, "child prompt") {
-			t.Fatalf("provider call[%d] prompt = %q, want child prompt text", index, call.UserMessage)
-		}
-	}
-}
-
-func assertPartialMockPassthroughPrimaryResult(t *testing.T, result *factoryapi.FactorySessionResult) {
-	t.Helper()
-
-	if result == nil || result.ResultStatus != factoryapi.FactorySessionResultStatusFinal {
-		t.Fatalf("result = %#v, want FINAL Factory Session result", result)
-	}
-	if result.PrimaryResult == nil || len(*result.PrimaryResult) != 1 {
-		t.Fatalf("primary result = %#v, want exactly one content part", result.PrimaryResult)
-	}
-	part, err := (*result.PrimaryResult)[0].AsWorkJsonContentPart()
-	if err != nil {
-		t.Fatalf("decode primary result content part: %v", err)
-	}
-	encoded, err := json.Marshal(part.Json)
-	if err != nil {
-		t.Fatalf("encode primary result JSON: %v", err)
-	}
-	var evidence struct {
-		Mocked      map[string]any `json:"mocked"`
-		Passthrough map[string]any `json:"passthrough"`
-	}
-	if err := json.Unmarshal(encoded, &evidence); err != nil {
-		t.Fatalf("decode partial mock passthrough primary result: %v", err)
-	}
-	assertPartialMockPassthroughChildResult(t, evidence.Mocked, childMockedLabel)
-	assertPartialMockPassthroughChildResult(t, evidence.Passthrough, childPassthroughLabel)
 }
 
 func assertPartialMockPassthroughChildResult(

--- a/tests/functional/orchestration/javascript/workers/overrides_test.go
+++ b/tests/functional/orchestration/javascript/workers/overrides_test.go
@@ -1,0 +1,236 @@
+// Package workers holds customer functional scenarios for JavaScript per-child
+// worker override behavior through the public process and invocation boundary.
+package workers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	childCodexLabel  = "child-codex"
+	childClaudeLabel = "child-claude"
+
+	perChildProviderModelWorkflow = `return (async function () {
+  const codexChild = await agent.run({
+    prompt: "use codex provider and model",
+    label: "` + childCodexLabel + `",
+    modelProvider: "codex",
+    model: "codex-child-model",
+  });
+  const claudeChild = await agent.run({
+    prompt: "use claude provider and model",
+    label: "` + childClaudeLabel + `",
+    modelProvider: "claude",
+    model: "claude-child-model",
+  });
+  return { codexChild, claudeChild };
+})();`
+)
+
+// TestJavaScriptChildrenSelectDifferentProvidersAndModels proves a JavaScript
+// Factory with multiple child dispatches can select distinct per-child provider
+// and model overrides so each child completes with public dispatch and provider
+// evidence matching its configured worker selection rather than a shared default.
+func TestJavaScriptChildrenSelectDifferentProvidersAndModels(t *testing.T) {
+	t.Parallel()
+
+	dir := support.ScaffoldFactory(t, overridesFactoryConfig())
+	support.WriteAgentConfig(t, dir, "worker-a", "---\ntype: MODEL_WORKER\n---\n")
+
+	provider := testutil.NewMockProvider(
+		workerexecution.InferenceResponse{Content: `{"text":"codex child complete"}`},
+		workerexecution.InferenceResponse{Content: `{"text":"claude child complete"}`},
+	)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		WaitForServiceModeRuntime: true,
+		Edges:                     serviceedges.Edges{ProviderOverride: provider},
+	})
+	t.Cleanup(func() { server.Stop(t) })
+
+	started := startOverridesWorkflow(t, server.URL(), "javascript-per-child-provider-model", perChildProviderModelWorkflow)
+	if started.Status != factoryapi.FactorySessionDurableLifecycleStatusSucceeded {
+		t.Fatalf("session status = %q, want SUCCEEDED", started.Status)
+	}
+
+	dispatches := support.GetJSON[factoryapi.ListFactorySessionDispatchesResponse](
+		t,
+		strings.TrimSuffix(server.URL(), "/")+"/factory-sessions/"+started.SessionId+"/dispatches",
+	)
+	assertPerChildProviderModelDispatches(t, dispatches.Dispatches)
+	assertPerChildProviderModelRequests(t, provider.Calls())
+}
+
+func overridesFactoryConfig() map[string]any {
+	return map[string]any{
+		"workTypes": []map[string]any{
+			{
+				"name": "task",
+				"states": []map[string]string{
+					{"name": "init", "type": "INITIAL"},
+					{"name": "complete", "type": "TERMINAL"},
+					{"name": "failed", "type": "FAILED"},
+				},
+			},
+		},
+		"workers": []map[string]string{
+			{"name": "worker-a"},
+		},
+		"workstations": []map[string]any{
+			{
+				"name":      "process",
+				"worker":    "worker-a",
+				"inputs":    []map[string]string{{"workType": "task", "state": "init"}},
+				"outputs":   []map[string]string{{"workType": "task", "state": "complete"}},
+				"onFailure": []map[string]string{{"workType": "task", "state": "failed"}},
+			},
+		},
+	}
+}
+
+func startOverridesWorkflow(
+	t *testing.T,
+	serverURL, requestID, workflowSource string,
+) factoryapi.FactorySessionSyncExecutionResponse {
+	t.Helper()
+
+	dialect := "you-workflow-v1"
+	payload, err := json.Marshal(factoryapi.FactorySessionExecutionRequest{
+		RequestId: requestID,
+		Source: factoryapi.FactorySessionExecutionSource{
+			Kind: factoryapi.FactorySessionExecutionSourceKindInlineWorkflow,
+			InlineWorkflow: &factoryapi.FactorySessionExecutionInlineWorkflow{
+				Dialect: &dialect,
+				InlineSource: factoryapi.FactoryOrchestratorJavaScriptInlineSource{
+					Encoding: factoryapi.FactoryOrchestratorJavaScriptInlineSourceEncodingUtf8,
+					Inline:   workflowSource,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal overrides workflow request: %v", err)
+	}
+	endpoint := strings.TrimSuffix(serverURL, "/") + "/factory-sessions/sync"
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("build overrides workflow request: %v", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("start overrides workflow: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		var body bytes.Buffer
+		_, _ = body.ReadFrom(response.Body)
+		t.Fatalf("start overrides workflow status = %d: %s", response.StatusCode, body.String())
+	}
+	var started factoryapi.FactorySessionSyncExecutionResponse
+	if err := json.NewDecoder(response.Body).Decode(&started); err != nil {
+		t.Fatalf("decode overrides workflow response: %v", err)
+	}
+	return started
+}
+
+func assertPerChildProviderModelDispatches(
+	t *testing.T,
+	dispatches []factoryapi.FactorySessionDispatchSummary,
+) {
+	t.Helper()
+
+	if len(dispatches) != 2 {
+		t.Fatalf("dispatch count = %d, want 2 child dispatches", len(dispatches))
+	}
+	byLabel := make(map[string]factoryapi.FactorySessionDispatchSummary, len(dispatches))
+	for _, dispatch := range dispatches {
+		if dispatch.Label == nil || strings.TrimSpace(*dispatch.Label) == "" {
+			t.Fatalf("dispatch %s missing label, want labeled child dispatches", dispatch.Id)
+		}
+		if dispatch.Status != factoryapi.FactoryDispatchStatusCOMPLETED {
+			t.Fatalf("dispatch %s status = %q, want COMPLETED", dispatch.Id, dispatch.Status)
+		}
+		byLabel[*dispatch.Label] = dispatch
+	}
+	assertOverridesDispatchSelection(
+		t,
+		byLabel[childCodexLabel],
+		childCodexLabel,
+		"codex",
+		"codex-child-model",
+	)
+	assertOverridesDispatchSelection(
+		t,
+		byLabel[childClaudeLabel],
+		childClaudeLabel,
+		"claude",
+		"claude-child-model",
+	)
+}
+
+func assertOverridesDispatchSelection(
+	t *testing.T,
+	dispatch factoryapi.FactorySessionDispatchSummary,
+	wantLabel, wantProvider, wantModel string,
+) {
+	t.Helper()
+
+	if dispatch.Label == nil || *dispatch.Label != wantLabel {
+		t.Fatalf("dispatch label = %#v, want %q", dispatch.Label, wantLabel)
+	}
+	gotProvider := dereferenceOverridesValue(dispatch.ModelProvider)
+	gotModel := dereferenceOverridesValue(dispatch.Model)
+	if gotProvider != wantProvider || gotModel != wantModel {
+		t.Fatalf(
+			"dispatch %s selection = provider=%q model=%q, want provider=%q model=%q",
+			dispatch.Id,
+			gotProvider,
+			gotModel,
+			wantProvider,
+			wantModel,
+		)
+	}
+}
+
+func assertPerChildProviderModelRequests(
+	t *testing.T,
+	calls []workerexecution.ProviderInferenceRequest,
+) {
+	t.Helper()
+
+	if len(calls) != 2 {
+		t.Fatalf("provider call count = %d, want 2", len(calls))
+	}
+	if calls[0].ModelProvider != "codex" || calls[0].Model != "codex-child-model" {
+		t.Fatalf(
+			"first provider request = provider %q model %q, want codex/codex-child-model",
+			calls[0].ModelProvider,
+			calls[0].Model,
+		)
+	}
+	if calls[1].ModelProvider != "claude" || calls[1].Model != "claude-child-model" {
+		t.Fatalf(
+			"second provider request = provider %q model %q, want claude/claude-child-model",
+			calls[1].ModelProvider,
+			calls[1].Model,
+		)
+	}
+}
+
+func dereferenceOverridesValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/tests/functional/orchestration/javascript/workers/overrides_test.go
+++ b/tests/functional/orchestration/javascript/workers/overrides_test.go
@@ -21,9 +21,11 @@ const (
 	childClaudeLabel   = "child-claude"
 	childMockedLabel   = "child-mocked"
 	childPassthroughLabel = "child-passthrough"
+	unknownOverrideChildLabel = "child-unknown-override"
 
 	mockedChildPrompt      = "mocked child prompt"
 	passthroughChildPrompt = "passthrough child prompt"
+	unknownOverrideModelProvider = "Not_A_Provider"
 
 	perChildProviderModelWorkflow = `return (async function () {
   const codexChild = await agent.run({
@@ -51,6 +53,15 @@ const (
     label: "` + childPassthroughLabel + `",
   });
   return { mocked, passthrough };
+})();`
+
+	unknownWorkerOverrideWorkflow = `return (function () {
+  agent.run({
+    prompt: "use unknown worker provider override",
+    label: "` + unknownOverrideChildLabel + `",
+    modelProvider: "` + unknownOverrideModelProvider + `",
+  });
+  return { ok: true };
 })();`
 
 	mockWorkerAcceptedOutput = "mock worker accepted"
@@ -173,6 +184,50 @@ func TestJavaScriptMockWorkersReplaceOnlyNamedChildren(t *testing.T) {
 		assertPartialMockPassthroughProviderRequests(t, provider.Calls())
 		assertPartialMockPassthroughPrimaryResult(t, started.Result)
 	})
+}
+
+// TestJavaScriptUnknownWorkerOverrideFailsActionably proves configuring an
+// invalid per-child worker override on agent.run fails at the public JavaScript
+// boundary with a customer-readable diagnostic that identifies the bad override,
+// does not emit a successful child dispatch, and does not leak private runtime
+// internals as the primary failure signal.
+func TestJavaScriptUnknownWorkerOverrideFailsActionably(t *testing.T) {
+	t.Parallel()
+
+	dir := support.ScaffoldFactory(t, overridesFactoryConfig())
+	support.WriteAgentConfig(t, dir, "worker-a", "---\ntype: MODEL_WORKER\n---\n")
+
+	runner := support.NewRecordingCommandRunner("unexpected live provider execution")
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		WaitForServiceModeRuntime: true,
+		UseMockWorkers:            true,
+		Edges:                     serviceedges.Edges{ProviderCommandRunner: runner},
+	})
+	t.Cleanup(func() { server.Stop(t) })
+
+	started := startOverridesWorkflow(
+		t,
+		server.URL(),
+		"javascript-unknown-worker-override",
+		unknownWorkerOverrideWorkflow,
+	)
+	if started.Status != factoryapi.FactorySessionDurableLifecycleStatusFailed {
+		t.Fatalf("session status = %q, want FAILED", started.Status)
+	}
+	if runner.CallCount() != 0 {
+		t.Fatalf("provider command runner call count = %d, want 0 before override validation", runner.CallCount())
+	}
+
+	dispatches := support.GetJSON[factoryapi.ListFactorySessionDispatchesResponse](
+		t,
+		strings.TrimSuffix(server.URL(), "/")+"/factory-sessions/"+started.SessionId+"/dispatches",
+	)
+	if len(dispatches.Dispatches) != 0 {
+		t.Fatalf("dispatch count = %d, want 0 for invalid worker override", len(dispatches.Dispatches))
+	}
+
+	assertUnknownWorkerOverrideFailureRecord(t, server.URL(), started.SessionId, started.Result)
 }
 
 func partialNamedJavaScriptMockWorkersConfig() *workers.MockWorkersConfig {
@@ -393,6 +448,66 @@ func assertPartialMockPassthroughChildResult(
 	if strings.Contains(text, mockWorkerAcceptedOutput) {
 		t.Fatalf("child output text = %#v, want provider output not mock-worker accept text", output["text"])
 	}
+}
+
+func assertUnknownWorkerOverrideFailureRecord(
+	t *testing.T,
+	serverURL, sessionID string,
+	result *factoryapi.FactorySessionResult,
+) {
+	t.Helper()
+
+	if result == nil {
+		t.Fatal("result = nil, want failed Factory Session result")
+	}
+	if result.SessionStatus == nil ||
+		*result.SessionStatus != factoryapi.FactorySessionDurableLifecycleStatusFailed {
+		t.Fatalf("result sessionStatus = %#v, want FAILED", result.SessionStatus)
+	}
+	if result.ResultStatus != factoryapi.FactorySessionResultStatusUnavailable {
+		t.Fatalf("result status = %q, want UNAVAILABLE on invalid worker override", result.ResultStatus)
+	}
+	if result.PrimaryResult != nil {
+		t.Fatalf("primary result = %#v, want nil on invalid worker override", result.PrimaryResult)
+	}
+
+	session := readOverridesDurableSession(t, serverURL, sessionID)
+	if session.FailureDetail == nil || strings.TrimSpace(session.FailureDetail.Message) == "" {
+		t.Fatalf("session failureDetail = %#v, want actionable public failure record", session.FailureDetail)
+	}
+	message := session.FailureDetail.Message
+	if !strings.Contains(message, "unsupported effective modelProvider") {
+		t.Fatalf("session failure message = %#v, want unsupported modelProvider diagnostic", message)
+	}
+	if !strings.Contains(message, unknownOverrideModelProvider) {
+		t.Fatalf(
+			"session failure message = %#v, want override value %q",
+			message,
+			unknownOverrideModelProvider,
+		)
+	}
+	for _, leaked := range []string{"stack", "heap", "goja", "VM"} {
+		if strings.Contains(message, leaked) {
+			t.Fatalf("session failure message leaked non-customer detail %q: %q", leaked, message)
+		}
+	}
+}
+
+func readOverridesDurableSession(
+	t *testing.T,
+	serverURL, sessionID string,
+) factoryapi.FactorySessionDurableReadModel {
+	t.Helper()
+
+	response := support.GetJSON[factoryapi.FactorySessionGetResponse](
+		t,
+		strings.TrimSuffix(serverURL, "/")+"/factory-sessions/"+sessionID,
+	)
+	session, err := response.AsFactorySessionDurableReadModel()
+	if err != nil {
+		t.Fatalf("decode durable session read model: %v", err)
+	}
+	return session
 }
 
 func overridesFactoryConfig() map[string]any {

--- a/tests/functional/orchestration/javascript/workers/overrides_test.go
+++ b/tests/functional/orchestration/javascript/workers/overrides_test.go
@@ -11,14 +11,19 @@ import (
 
 	"github.com/portpowered/infinite-you/internal/testutil"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
-	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
 const (
-	childCodexLabel  = "child-codex"
-	childClaudeLabel = "child-claude"
+	childCodexLabel    = "child-codex"
+	childClaudeLabel   = "child-claude"
+	childMockedLabel   = "child-mocked"
+	childPassthroughLabel = "child-passthrough"
+
+	mockedChildPrompt      = "mocked child prompt"
+	passthroughChildPrompt = "passthrough child prompt"
 
 	perChildProviderModelWorkflow = `return (async function () {
   const codexChild = await agent.run({
@@ -35,6 +40,21 @@ const (
   });
   return { codexChild, claudeChild };
 })();`
+
+	partialMockWorkersWorkflow = `return (async function () {
+  const mocked = await agent.run({
+    prompt: "` + mockedChildPrompt + `",
+    label: "` + childMockedLabel + `",
+  });
+  const passthrough = await agent.run({
+    prompt: "` + passthroughChildPrompt + `",
+    label: "` + childPassthroughLabel + `",
+  });
+  return { mocked, passthrough };
+})();`
+
+	mockWorkerAcceptedOutput = "mock worker accepted"
+	livePassthroughChildText = "passthrough child provider output"
 )
 
 // TestJavaScriptChildrenSelectDifferentProvidersAndModels proves a JavaScript
@@ -48,8 +68,8 @@ func TestJavaScriptChildrenSelectDifferentProvidersAndModels(t *testing.T) {
 	support.WriteAgentConfig(t, dir, "worker-a", "---\ntype: MODEL_WORKER\n---\n")
 
 	provider := testutil.NewMockProvider(
-		workerexecution.InferenceResponse{Content: `{"text":"codex child complete"}`},
-		workerexecution.InferenceResponse{Content: `{"text":"claude child complete"}`},
+		workers.InferenceResponse{Content: `{"text":"codex child complete"}`},
+		workers.InferenceResponse{Content: `{"text":"claude child complete"}`},
 	)
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:                dir,
@@ -69,6 +89,310 @@ func TestJavaScriptChildrenSelectDifferentProvidersAndModels(t *testing.T) {
 	)
 	assertPerChildProviderModelDispatches(t, dispatches.Dispatches)
 	assertPerChildProviderModelRequests(t, provider.Calls())
+}
+
+// TestJavaScriptMockWorkersReplaceOnlyNamedChildren proves a partial
+// --with-mock-workers configuration serves named workstation workers through
+// the mock-worker accept path while unmatched JavaScript child dispatches keep
+// the live-provider path when unmatchedDispatchPolicy is passthrough and a
+// provider edge is injected at the public process boundary.
+func TestJavaScriptMockWorkersReplaceOnlyNamedChildren(t *testing.T) {
+	t.Parallel()
+
+	t.Run("namedMockWorkerAcceptsConfiguredWorker", func(t *testing.T) {
+		t.Parallel()
+
+		dir := support.ScaffoldFactory(t, overridesFactoryConfig())
+		support.WriteAgentConfig(t, dir, "worker-a", "---\ntype: MODEL_WORKER\n---\n")
+
+		runner := support.NewRecordingCommandRunner("unexpected live provider execution")
+		server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+			FactoryDir:                dir,
+			WaitForServiceModeRuntime: true,
+			UseMockWorkers:            true,
+			MockWorkersConfig:         partialNamedJavaScriptMockWorkersConfig(),
+			Edges:                     serviceedges.Edges{ProviderCommandRunner: runner},
+		})
+		t.Cleanup(func() { server.Stop(t) })
+
+		started := startOverridesWorkflow(
+			t,
+			server.URL(),
+			"javascript-partial-mock-workers-fake",
+			partialMockWorkersWorkflow,
+		)
+		if started.Status != factoryapi.FactorySessionDurableLifecycleStatusSucceeded {
+			t.Fatalf("session status = %q, want SUCCEEDED", started.Status)
+		}
+		if runner.CallCount() != 0 {
+			t.Fatalf("provider command runner call count = %d, want 0 for fake child execution", runner.CallCount())
+		}
+
+		dispatches := support.GetJSON[factoryapi.ListFactorySessionDispatchesResponse](
+			t,
+			strings.TrimSuffix(server.URL(), "/")+"/factory-sessions/"+started.SessionId+"/dispatches",
+		)
+		assertPartialMockFakeChildDispatches(t, dispatches.Dispatches)
+		assertPartialMockFakeChildPrimaryResult(t, started.Result)
+	})
+
+	t.Run("passthroughChildUsesLiveProvider", func(t *testing.T) {
+		t.Parallel()
+
+		dir := support.ScaffoldFactory(t, overridesFactoryConfig())
+		support.WriteAgentConfig(t, dir, "worker-a", "---\ntype: MODEL_WORKER\n---\n")
+
+		provider := testutil.NewMockProvider(
+			workers.InferenceResponse{Content: `{"text":"` + livePassthroughChildText + `"}`},
+			workers.InferenceResponse{Content: `{"text":"` + livePassthroughChildText + `"}`},
+		)
+		server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+			FactoryDir:                dir,
+			WaitForServiceModeRuntime: true,
+			UseMockWorkers:            true,
+			MockWorkersConfig:         partialNamedJavaScriptMockWorkersConfig(),
+			Edges:                     serviceedges.Edges{ProviderOverride: provider},
+		})
+		t.Cleanup(func() { server.Stop(t) })
+
+		started := startOverridesWorkflow(
+			t,
+			server.URL(),
+			"javascript-partial-mock-workers-passthrough",
+			partialMockWorkersWorkflow,
+		)
+		if started.Status != factoryapi.FactorySessionDurableLifecycleStatusSucceeded {
+			t.Fatalf("session status = %q, want SUCCEEDED", started.Status)
+		}
+
+		dispatches := support.GetJSON[factoryapi.ListFactorySessionDispatchesResponse](
+			t,
+			strings.TrimSuffix(server.URL(), "/")+"/factory-sessions/"+started.SessionId+"/dispatches",
+		)
+		assertPartialMockPassthroughChildDispatches(t, dispatches.Dispatches)
+		assertPartialMockPassthroughProviderRequests(t, provider.Calls())
+		assertPartialMockPassthroughPrimaryResult(t, started.Result)
+	})
+}
+
+func partialNamedJavaScriptMockWorkersConfig() *workers.MockWorkersConfig {
+	return &workers.MockWorkersConfig{
+		UnmatchedDispatchPolicy: workers.MockWorkerUnmatchedDispatchPolicyPassthrough,
+		MockWorkers: []workers.MockWorkerConfig{{
+			WorkerName:      "worker-a",
+			WorkstationName: "process",
+			RunType:         workers.MockWorkerRunTypeAccept,
+		}},
+	}
+}
+
+func assertPartialMockFakeChildDispatches(
+	t *testing.T,
+	dispatches []factoryapi.FactorySessionDispatchSummary,
+) {
+	t.Helper()
+
+	if len(dispatches) != 2 {
+		t.Fatalf("dispatch count = %d, want 2 child dispatches", len(dispatches))
+	}
+	byLabel := make(map[string]factoryapi.FactorySessionDispatchSummary, len(dispatches))
+	for _, dispatch := range dispatches {
+		if dispatch.Label == nil || strings.TrimSpace(*dispatch.Label) == "" {
+			t.Fatalf("dispatch %s missing label, want labeled child dispatches", dispatch.Id)
+		}
+		if dispatch.Status != factoryapi.FactoryDispatchStatusCOMPLETED {
+			t.Fatalf("dispatch %s status = %q, want COMPLETED", dispatch.Id, dispatch.Status)
+		}
+		byLabel[*dispatch.Label] = dispatch
+	}
+	assertPartialMockFakeChildDispatch(t, byLabel[childMockedLabel], childMockedLabel, mockedChildPrompt)
+	assertPartialMockFakeChildDispatch(t, byLabel[childPassthroughLabel], childPassthroughLabel, passthroughChildPrompt)
+}
+
+func assertPartialMockFakeChildDispatch(
+	t *testing.T,
+	dispatch factoryapi.FactorySessionDispatchSummary,
+	wantLabel, wantPrompt string,
+) {
+	t.Helper()
+
+	if dispatch.Label == nil || *dispatch.Label != wantLabel {
+		t.Fatalf("dispatch label = %#v, want %q", dispatch.Label, wantLabel)
+	}
+	if dispatch.Javascript == nil || dispatch.Javascript.ExecutionMode == nil ||
+		*dispatch.Javascript.ExecutionMode != "fake" {
+		t.Fatalf("dispatch %s javascript projection = %#v, want fake execution mode", dispatch.Id, dispatch.Javascript)
+	}
+}
+
+func assertPartialMockFakeChildPrimaryResult(t *testing.T, result *factoryapi.FactorySessionResult) {
+	t.Helper()
+
+	if result == nil || result.ResultStatus != factoryapi.FactorySessionResultStatusFinal {
+		t.Fatalf("result = %#v, want FINAL Factory Session result", result)
+	}
+	if result.PrimaryResult == nil || len(*result.PrimaryResult) != 1 {
+		t.Fatalf("primary result = %#v, want exactly one content part", result.PrimaryResult)
+	}
+	part, err := (*result.PrimaryResult)[0].AsWorkJsonContentPart()
+	if err != nil {
+		t.Fatalf("decode primary result content part: %v", err)
+	}
+	encoded, err := json.Marshal(part.Json)
+	if err != nil {
+		t.Fatalf("encode primary result JSON: %v", err)
+	}
+	var evidence struct {
+		Mocked      map[string]any `json:"mocked"`
+		Passthrough map[string]any `json:"passthrough"`
+	}
+	if err := json.Unmarshal(encoded, &evidence); err != nil {
+		t.Fatalf("decode partial mock primary result: %v", err)
+	}
+	assertPartialMockFakeChildResult(t, evidence.Mocked, childMockedLabel, mockedChildPrompt)
+	assertPartialMockFakeChildResult(t, evidence.Passthrough, childPassthroughLabel, passthroughChildPrompt)
+}
+
+func assertPartialMockFakeChildResult(
+	t *testing.T,
+	child map[string]any,
+	wantLabel, wantPrompt string,
+) {
+	t.Helper()
+
+	if child == nil {
+		t.Fatalf("child result = nil, want structured child object")
+	}
+	if label, _ := child["label"].(string); label != wantLabel {
+		t.Fatalf("child label = %#v, want %q", child["label"], wantLabel)
+	}
+	if mode, _ := child["executionMode"].(string); mode != "fake" {
+		t.Fatalf("child executionMode = %#v, want fake", child["executionMode"])
+	}
+	output, ok := child["output"].(map[string]any)
+	if !ok || output == nil {
+		t.Fatalf("child output = %#v, want structured output object", child["output"])
+	}
+	text, _ := output["text"].(string)
+	if !strings.Contains(text, wantPrompt) {
+		t.Fatalf("child output text = %#v, want deterministic fake output containing prompt %q", output["text"], wantPrompt)
+	}
+}
+
+func assertPartialMockPassthroughChildDispatches(
+	t *testing.T,
+	dispatches []factoryapi.FactorySessionDispatchSummary,
+) {
+	t.Helper()
+
+	if len(dispatches) != 2 {
+		t.Fatalf("dispatch count = %d, want 2 child dispatches", len(dispatches))
+	}
+	byLabel := make(map[string]factoryapi.FactorySessionDispatchSummary, len(dispatches))
+	for _, dispatch := range dispatches {
+		if dispatch.Label == nil || strings.TrimSpace(*dispatch.Label) == "" {
+			t.Fatalf("dispatch %s missing label, want labeled child dispatches", dispatch.Id)
+		}
+		if dispatch.Status != factoryapi.FactoryDispatchStatusCOMPLETED {
+			t.Fatalf("dispatch %s status = %q, want COMPLETED", dispatch.Id, dispatch.Status)
+		}
+		byLabel[*dispatch.Label] = dispatch
+	}
+	assertPartialMockPassthroughChildDispatch(t, byLabel[childMockedLabel], childMockedLabel)
+	assertPartialMockPassthroughChildDispatch(t, byLabel[childPassthroughLabel], childPassthroughLabel)
+}
+
+func assertPartialMockPassthroughChildDispatch(
+	t *testing.T,
+	dispatch factoryapi.FactorySessionDispatchSummary,
+	wantLabel string,
+) {
+	t.Helper()
+
+	if dispatch.Label == nil || *dispatch.Label != wantLabel {
+		t.Fatalf("dispatch label = %#v, want %q", dispatch.Label, wantLabel)
+	}
+	if dispatch.Javascript == nil || dispatch.Javascript.ExecutionMode == nil ||
+		*dispatch.Javascript.ExecutionMode != "live-provider" {
+		t.Fatalf(
+			"dispatch %s javascript projection = %#v, want live-provider execution mode",
+			dispatch.Id,
+			dispatch.Javascript,
+		)
+	}
+}
+
+func assertPartialMockPassthroughProviderRequests(
+	t *testing.T,
+	calls []workers.ProviderInferenceRequest,
+) {
+	t.Helper()
+
+	if len(calls) != 2 {
+		t.Fatalf("provider call count = %d, want 2 passthrough child dispatches", len(calls))
+	}
+	for index, call := range calls {
+		if !strings.Contains(call.UserMessage, "child prompt") {
+			t.Fatalf("provider call[%d] prompt = %q, want child prompt text", index, call.UserMessage)
+		}
+	}
+}
+
+func assertPartialMockPassthroughPrimaryResult(t *testing.T, result *factoryapi.FactorySessionResult) {
+	t.Helper()
+
+	if result == nil || result.ResultStatus != factoryapi.FactorySessionResultStatusFinal {
+		t.Fatalf("result = %#v, want FINAL Factory Session result", result)
+	}
+	if result.PrimaryResult == nil || len(*result.PrimaryResult) != 1 {
+		t.Fatalf("primary result = %#v, want exactly one content part", result.PrimaryResult)
+	}
+	part, err := (*result.PrimaryResult)[0].AsWorkJsonContentPart()
+	if err != nil {
+		t.Fatalf("decode primary result content part: %v", err)
+	}
+	encoded, err := json.Marshal(part.Json)
+	if err != nil {
+		t.Fatalf("encode primary result JSON: %v", err)
+	}
+	var evidence struct {
+		Mocked      map[string]any `json:"mocked"`
+		Passthrough map[string]any `json:"passthrough"`
+	}
+	if err := json.Unmarshal(encoded, &evidence); err != nil {
+		t.Fatalf("decode partial mock passthrough primary result: %v", err)
+	}
+	assertPartialMockPassthroughChildResult(t, evidence.Mocked, childMockedLabel)
+	assertPartialMockPassthroughChildResult(t, evidence.Passthrough, childPassthroughLabel)
+}
+
+func assertPartialMockPassthroughChildResult(
+	t *testing.T,
+	child map[string]any,
+	wantLabel string,
+) {
+	t.Helper()
+
+	if child == nil {
+		t.Fatalf("child result = nil, want structured child object")
+	}
+	if label, _ := child["label"].(string); label != wantLabel {
+		t.Fatalf("child label = %#v, want %q", child["label"], wantLabel)
+	}
+	if mode, _ := child["executionMode"].(string); mode != "live-provider" {
+		t.Fatalf("child executionMode = %#v, want live-provider", child["executionMode"])
+	}
+	output, ok := child["output"].(map[string]any)
+	if !ok || output == nil {
+		t.Fatalf("child output = %#v, want structured output object", child["output"])
+	}
+	text, _ := output["text"].(string)
+	if !strings.Contains(text, livePassthroughChildText) {
+		t.Fatalf("child output text = %#v, want injected provider output %q", output["text"], livePassthroughChildText)
+	}
+	if strings.Contains(text, mockWorkerAcceptedOutput) {
+		t.Fatalf("child output text = %#v, want provider output not mock-worker accept text", output["text"])
+	}
 }
 
 func overridesFactoryConfig() map[string]any {
@@ -205,7 +529,7 @@ func assertOverridesDispatchSelection(
 
 func assertPerChildProviderModelRequests(
 	t *testing.T,
-	calls []workerexecution.ProviderInferenceRequest,
+	calls []workers.ProviderInferenceRequest,
 ) {
 	t.Helper()
 


### PR DESCRIPTION
{
  "project": "JavaScript Per-Child Worker Overrides Functional Coverage",
  "branchName": "ft-wave1-js-worker-overrides",
  "description": "Add customer-level functional coverage in tests/functional/orchestration/javascript/workers/overrides_test.go proving JavaScript children can select different providers/models, partial mock workers replace only named children, and unknown worker overrides fail actionably—without owning adjacent JS loading/composition/contracts/policy/durability cells.",
  "context": {
    "customerAsk": "Implement only tests/functional/orchestration/javascript/workers/overrides_test.go. Prove children can select different providers/models, partial mock workers replace only named children, and unknown worker overrides fail actionably. Do not take ownership of loading, composition, contracts, policy, or durability cells. Add customer-readable Go doc comments and verify focused tests, functional-boundary-check, and metadata.",
    "problem": "Wave 1 JS orchestration already owns loading/contracts/composition/policy/durability packages, but maintainers lack a domain-owned black-box proof under orchestration/javascript/workers that per-child provider/model selection, partial mock replacement, and unknown override failures behave correctly on public surfaces.",
    "solution": "Land three focused functional scenarios in the free workers/overrides destination package, exercised through public/root-built process edges only, with customer-readable Go doc comments and standard functional quality gates (focused tests, functional-boundary-check, metadata)."
  },
  "acceptanceCriteria": [
    "Destination file tests/functional/orchestration/javascript/workers/overrides_test.go exists and owns the three checklist scenarios",
    "A multi-child JavaScript run with distinct per-child provider/model selections completes with public evidence that each child used its selected provider and model",
    "A partial mock-worker config replaces only named children; unnamed children are not replaced by those mocks",
    "An unknown worker override fails with an actionable public diagnostic and does not proceed as a successful override",
    "Every top-level Test* has a customer-readable Go doc comment describing the observable behavior under test",
    "No edits claim ownership of JS loading, composition, contracts, policy, or durability destination packages",
    "Focused destination-package tests pass, make functional-boundary-check passes for the touched surface, generated functional catalog/metadata stays consistent, and typecheck/lint/tests required for the change pass"
  ],
  "userStories": [
    {
      "id": "ft-wave1-js-worker-overrides-001",
      "title": "Prove per-child provider and model selection",
      "description": "As a maintainer, I want a functional test that runs a JavaScript Factory with multiple child dispatches selecting different providers and models so I can detect regressions in per-child worker override selection.",
      "acceptanceCriteria": [
        "TestJavaScriptChildrenSelectDifferentProvidersAndModels exists in tests/functional/orchestration/javascript/workers/overrides_test.go",
        "The scenario exercises a public/root-built process boundary (not internal Petri or private JS VM packages)",
        "After a successful multi-child run, public dispatch or result evidence shows at least two children with different provider and/or model selections matching the configured overrides",
        "The top-level test has a customer-readable Go doc comment",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-js-worker-overrides-002",
      "title": "Prove partial mock workers replace only named children",
      "description": "As a maintainer, I want a functional test that applies mock workers to only some JavaScript children so I can confirm partial overrides do not silently replace unmatched children.",
      "acceptanceCriteria": [
        "TestJavaScriptMockWorkersReplaceOnlyNamedChildren exists in the same destination file",
        "A mock-worker config names a subset of children; those named children are served by the mock path",
        "At least one unmatched child is observably not replaced by the named mocks (passthrough/default path remains)",
        "The scenario uses public mock-worker configuration edges already available to root-built processes",
        "The top-level test has a customer-readable Go doc comment",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-js-worker-overrides-003",
      "title": "Prove unknown worker overrides fail actionably",
      "description": "As a maintainer, I want a functional test that supplies an unknown worker override so customers get a stable, actionable failure instead of a silent mis-dispatch or opaque internal error.",
      "acceptanceCriteria": [
        "TestJavaScriptUnknownWorkerOverrideFailsActionably exists in the same destination file",
        "Configuring an override for an unknown/nonexistent worker name fails at the public boundary",
        "The failure diagnostic is actionable (names the unknown worker or otherwise identifies the bad override) and customer-safe (no private runtime/stack dump as the primary signal)",
        "The run does not report a successful override/dispatch for the unknown worker",
        "The top-level test has a customer-readable Go doc comment",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-js-worker-overrides-004",
      "title": "Verify cell quality gates and package isolation",
      "description": "As a maintainer, I want the completed overrides cell to pass focused verification and remain isolated from adjacent JS ownership so Wave 1 parallelism stays collision-safe.",
      "acceptanceCriteria": [
        "Focused tests for the destination package pass",
        "make functional-boundary-check passes for the touched functional surface",
        "Functional catalog/metadata reflects the new package/tests as required by the functional-test-viz pipeline",
        "Diff does not add or rewrite destination files under JS loading, composition, contracts, policy, or durability cells",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)