### PR TITLE
ft-wave1-cli-docs-wiring

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -190,7 +190,9 @@
   configured mock rejection with stable public `WorkOutcomeFailed` /
   `WorkFailureTypeUnknown` dispatch responses without live provider credentials
   or leaking configured reject stdout/stderr on customer-visible surfaces.
-  Catalog metadata infers domain `workers` and subsection `mock` from the path.
+  Catalog metadata infers domain `workers` and subsection `mock` from the path;
+  every top-level `Test*` needs a customer-readable Go doc so
+  `functionaltestmetadata` stays viz-compatible.
   CLI single-JSON result functional coverage belongs in
   `tests/functional/transport/cli/output/json_result_test.go`: invoke
   `support.BuildProcess(t, serviceedges.Edges{}).Execute` with global `--json`
@@ -202,6 +204,17 @@
   `transport` and subsection `cli/output` from the path. Every top-level `Test*`
   needs a customer-readable Go doc so `functionaltestmetadata` stays
   viz-compatible.
+  CLI docs command wiring functional coverage belongs in
+  `tests/functional/transport/cli/commands/docs_wiring_test.go`: prove packaged
+  topic discovery, index-driven non-empty topic rendering, and actionable
+  unknown-topic failure through `support.BuildProcess` + `support.FakeInputs`
+  from an isolated temp working directory without a local `docs/` tree; derive
+  topics from the customer-visible packaged docs index stdout rather than
+  scanning repository files or embedded registries; assert only transport
+  discovery, render-wiring, and failure diagnostics without product/docs content
+  contracts. Catalog metadata infers domain `transport` and subsection
+  `cli/commands` from the path; every top-level `Test*` needs a
+  customer-readable Go doc so `functionaltestmetadata` stays viz-compatible.
   Prove default
   `functional-test-viz` wiring (boundary first, single coverage with profile
   + JSON under `.artifacts/functional-test-viz/`, Markdown generator) with

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -168,7 +168,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestCLIFactoryFlattenExpandPreservesMeaning` covers portability.
   - `TestCLIFactoryReplaceCurrentChangesSessionFactory` covers current Factory.
 
-- [ ] `tests/functional/transport/cli/commands/docs_wiring_test.go`
+- [x] `tests/functional/transport/cli/commands/docs_wiring_test.go`
   - `TestCLIDocsListsPackagedTopics` covers discovery.
   - `TestCLIDocsEveryTopicRendersNonEmptyContent` iterates the packaged index.
   - `TestCLIDocsUnknownTopicReturnsActionableFailure` covers errors.

--- a/tests/functional/transport/cli/commands/docs_wiring_test.go
+++ b/tests/functional/transport/cli/commands/docs_wiring_test.go
@@ -1,0 +1,81 @@
+package commands_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+var packagedDocsIndexTopicPattern = regexp.MustCompile(`(?m)^- ` + "`" + `([a-z][a-z0-9-]*)` + "`" + ` - `)
+
+// TestCLIDocsListsPackagedTopics proves you docs with no topic prints a
+// non-empty packaged-topic index through the public CLI boundary so customers
+// can discover reference topics without reading repository source trees.
+func TestCLIDocsListsPackagedTopics(t *testing.T) {
+	workingDir := isolatedWorkingDirectoryWithoutDocsTree(t)
+
+	output := executeDocsWiringCommand(t, workingDir, "docs")
+	if strings.TrimSpace(output) == "" {
+		t.Fatal("you docs index stdout is empty")
+	}
+
+	for _, marker := range []string{
+		"# Docs",
+		"Packaged reference topics:",
+	} {
+		if !strings.Contains(output, marker) {
+			t.Fatalf("docs index missing packaged discovery marker %q:\n%s", marker, output)
+		}
+	}
+
+	topics := parsePackagedDocsIndexTopics(output)
+	if len(topics) == 0 {
+		t.Fatalf("docs index did not expose any discoverable packaged topics:\n%s", output)
+	}
+
+	for _, topic := range topics {
+		if !strings.Contains(output, "you docs "+topic) {
+			t.Fatalf("docs index missing customer-visible retrieval hint for topic %q:\n%s", topic, output)
+		}
+	}
+}
+
+func isolatedWorkingDirectoryWithoutDocsTree(t *testing.T) string {
+	t.Helper()
+
+	workingDir := t.TempDir()
+	docsTree := filepath.Join(workingDir, "docs")
+	if _, err := os.Stat(docsTree); !os.IsNotExist(err) {
+		t.Fatalf("working directory unexpectedly contains docs tree %q", docsTree)
+	}
+	return workingDir
+}
+
+func executeDocsWiringCommand(t *testing.T, workingDir string, args ...string) string {
+	t.Helper()
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	inputs := support.FakeInputs(t.Context(), append([]string{"you"}, args...))
+	inputs.WorkingDirectory = workingDir
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf("execute root command %v: %v\nstdout:\n%s\nstderr:\n%s", args, err, inputs.Stdout(), inputs.Stderr())
+	}
+	return inputs.Stdout()
+}
+
+func parsePackagedDocsIndexTopics(index string) []string {
+	matches := packagedDocsIndexTopicPattern.FindAllStringSubmatch(index, -1)
+	topics := make([]string, 0, len(matches))
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		topics = append(topics, match[1])
+	}
+	return topics
+}

--- a/tests/functional/transport/cli/commands/docs_wiring_test.go
+++ b/tests/functional/transport/cli/commands/docs_wiring_test.go
@@ -68,6 +68,25 @@ func TestCLIDocsEveryTopicRendersNonEmptyContent(t *testing.T) {
 	}
 }
 
+// TestCLIDocsUnknownTopicReturnsActionableFailure proves you docs with an
+// unsupported topic fails with a clear diagnostic naming the topic and does not
+// write misleading success content to stdout.
+func TestCLIDocsUnknownTopicReturnsActionableFailure(t *testing.T) {
+	workingDir := isolatedWorkingDirectoryWithoutDocsTree(t)
+	const unknownTopic = "unknown"
+
+	stdout, err := executeDocsWiringCommandResult(t, workingDir, "docs", unknownTopic)
+	if err == nil {
+		t.Fatal("expected unknown docs topic to fail")
+	}
+	if !strings.Contains(err.Error(), `unsupported docs topic "`+unknownTopic+`"`) {
+		t.Fatalf("unexpected unsupported topic error %q", err.Error())
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Fatalf("unsupported docs topic should not write stdout, got %q", stdout)
+	}
+}
+
 func isolatedWorkingDirectoryWithoutDocsTree(t *testing.T) string {
 	t.Helper()
 
@@ -82,13 +101,21 @@ func isolatedWorkingDirectoryWithoutDocsTree(t *testing.T) string {
 func executeDocsWiringCommand(t *testing.T, workingDir string, args ...string) string {
 	t.Helper()
 
+	stdout, err := executeDocsWiringCommandResult(t, workingDir, args...)
+	if err != nil {
+		t.Fatalf("execute root command %v: %v\nstdout:\n%s", args, err, stdout)
+	}
+	return stdout
+}
+
+func executeDocsWiringCommandResult(t *testing.T, workingDir string, args ...string) (stdout string, err error) {
+	t.Helper()
+
 	process := support.BuildProcess(t, serviceedges.Edges{})
 	inputs := support.FakeInputs(t.Context(), append([]string{"you"}, args...))
 	inputs.WorkingDirectory = workingDir
-	if err := process.Execute(inputs.Input); err != nil {
-		t.Fatalf("execute root command %v: %v\nstdout:\n%s\nstderr:\n%s", args, err, inputs.Stdout(), inputs.Stderr())
-	}
-	return inputs.Stdout()
+	err = process.Execute(inputs.Input)
+	return inputs.Stdout(), err
 }
 
 func parsePackagedDocsIndexTopics(index string) []string {

--- a/tests/functional/transport/cli/commands/docs_wiring_test.go
+++ b/tests/functional/transport/cli/commands/docs_wiring_test.go
@@ -45,6 +45,29 @@ func TestCLIDocsListsPackagedTopics(t *testing.T) {
 	}
 }
 
+// TestCLIDocsEveryTopicRendersNonEmptyContent proves every topic named by the
+// packaged docs index renders non-empty content through the public CLI boundary
+// so discovery and retrieval stay consistent for customers.
+func TestCLIDocsEveryTopicRendersNonEmptyContent(t *testing.T) {
+	workingDir := isolatedWorkingDirectoryWithoutDocsTree(t)
+
+	index := executeDocsWiringCommand(t, workingDir, "docs")
+	topics := parsePackagedDocsIndexTopics(index)
+	if len(topics) == 0 {
+		t.Fatalf("docs index did not expose any discoverable packaged topics:\n%s", index)
+	}
+
+	for _, topic := range topics {
+		topic := topic
+		t.Run(topic, func(t *testing.T) {
+			output := executeDocsWiringCommand(t, workingDir, "docs", topic)
+			if strings.TrimSpace(output) == "" {
+				t.Fatalf("you docs %s stdout is empty", topic)
+			}
+		})
+	}
+}
+
 func isolatedWorkingDirectoryWithoutDocsTree(t *testing.T) string {
 	t.Helper()
 


### PR DESCRIPTION
{
  "project": "CLI Docs Command Wiring Functional Coverage",
  "branchName": "ft-wave1-cli-docs-wiring",
  "description": "Implement the transport-owned functional cell at tests/functional/transport/cli/commands/docs_wiring_test.go so the public you docs CLI proves packaged topic discovery, every indexed topic renders non-empty content, and unknown topics fail actionably, without taking product/docs content-contract ownership.",
  "context": {
    "customerAsk": "Implement only tests/functional/transport/cli/commands/docs_wiring_test.go. Prove packaged topic discovery, every indexed topic renders non-empty content, and unknown topics fail actionably. Keep product/docs domain ownership out of this transport wiring cell. Add customer-readable Go doc comments and verify focused tests, functional-boundary-check, and metadata.",
    "problem": "The checklist destination for thin CLI docs command wiring does not exist yet, while deep docs coverage remains under smoke/product/docs content contracts. Maintainers lack a focused, catalogued transport proof that you docs discovers packaged topics, renders non-empty content for every indexed topic, and fails actionably for unknown topics without absorbing product/docs ownership.",
    "solution": "Implement TestCLIDocsListsPackagedTopics, TestCLIDocsEveryTopicRendersNonEmptyContent, and TestCLIDocsUnknownTopicReturnsActionableFailure in tests/functional/transport/cli/commands/docs_wiring_test.go through the public CLI/root.BuildProcess boundary, deriving the topic set from the customer-visible docs index, asserting non-empty rendered content and actionable unknown-topic failure, adding customer-readable Go docs on every top-level Test, keeping product/docs content contracts out of this cell, and verifying focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/transport/cli/commands/docs_wiring_test.go exists as the transport-owned functional cell and covers packaged topic discovery, every indexed topic rendering non-empty content, and unknown-topic actionable failure.",
    "Through the public CLI boundary, you docs with no topic succeeds and prints a non-empty packaged-topic index that names discoverable topics in customer-visible output.",
    "For every topic discovered from that public index, you docs <topic> succeeds and writes non-empty rendered content to stdout.",
    "you docs with an unknown topic fails with a stable, actionable diagnostic that identifies the unsupported topic and does not write success topic content to stdout.",
    "Coverage uses root.BuildProcess/public CLI helpers and edges.Edges only for external effects; it does not import service implementations or internal Petri primitives, and does not assert product/docs content markers, link topology, asset-bundle internals, or docs-reference domain contracts.",
    "Every top-level Test* has a customer-readable Go doc comment; only narrowly coupled ownership/coverage/catalog metadata updates for this cell are applied, and product/docs ownership remains outside this transport wiring cell.",
    "Focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave1-cli-docs-wiring-001",
      "title": "Prove packaged docs topic discovery via the public index",
      "description": "As a CLI customer, I want you docs with no topic to print a packaged-topic index, so I can discover which reference topics are available without reading repository source trees.",
      "acceptanceCriteria": [
        "tests/functional/transport/cli/commands/docs_wiring_test.go includes TestCLIDocsListsPackagedTopics (or equivalent top-level name matching the checklist intent).",
        "The test builds the customer process through root.BuildProcess / approved support helpers and executes the public CLI as you docs with no topic argument, preferably from a working directory that does not contain a local docs/ tree so packaging/wiring is what is proven.",
        "The command succeeds and stdout contains a non-empty packaged docs index that exposes discoverable topic names in customer-visible form.",
        "Assertions stay on transport discovery / index wiring outcomes and do not assert topic body markers, retired wording absence, markdown link topology, or product/docs content contracts.",
        "The top-level test has a customer-readable Go doc comment describing the packaged-topic discovery behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-docs-wiring-002",
      "title": "Prove every indexed topic renders non-empty content",
      "description": "As a CLI customer, I want every topic named by the public docs index to render non-empty content when I run you docs <topic>, so discovery and retrieval stay consistent through the CLI wiring.",
      "acceptanceCriteria": [
        "The docs-wiring cell includes TestCLIDocsEveryTopicRendersNonEmptyContent (or equivalent top-level name matching the checklist intent).",
        "The test derives the topic set from the customer-visible packaged docs index produced by you docs, not by scanning repository files, asset-bundle internals, or command-registration inventories as the product behavior under test.",
        "For each discovered topic, you docs <topic> succeeds and stdout is non-empty rendered content suitable as a docs page, without asserting specific product markers or link graphs.",
        "Assertions remain transport render-wiring focused and do not take ownership of product/docs content contracts.",
        "The top-level test has a customer-readable Go doc comment describing index-driven non-empty topic rendering.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-docs-wiring-003",
      "title": "Prove unknown docs topics fail actionably",
      "description": "As a CLI customer, I want an unknown docs topic to fail with a clear diagnostic naming the unsupported topic, so I can correct the topic name without receiving empty or misleading success output.",
      "acceptanceCriteria": [
        "The docs-wiring cell includes TestCLIDocsUnknownTopicReturnsActionableFailure (or equivalent top-level name matching the checklist intent).",
        "Executing you docs with a topic that is not supported fails with a stable, actionable diagnostic that identifies the unsupported topic in customer-readable terms.",
        "Success stdout for the unknown-topic invocation remains empty.",
        "The test does not widen into product/docs content contracts, retired-topic inventories as a separate ownership surface, or docs-reference smoke marker suites beyond proving actionable unknown-topic wiring failure.",
        "The top-level test has a customer-readable Go doc comment describing the unknown-topic failure behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-docs-wiring-004",
      "title": "Close cell verification gates without product/docs ownership",
      "description": "As a maintainer executing Wave 1 transport coverage, I want this cell to pass focused boundary/metadata gates while leaving product/docs content ownership elsewhere, so the destination is catalogued as thin CLI wiring only.",
      "acceptanceCriteria": [
        "The cell remains owned under tests/functional/transport/cli/commands/docs_wiring_test.go and does not claim or migrate product/docs content-contract ownership.",
        "Only narrowly coupled ownership, coverage, or catalog metadata required for this cell are updated; neighboring CLI command-wiring cells and product/docs destinations are left alone.",
        "Focused package tests for tests/functional/transport/cli/commands covering this cell pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as transport/cli/commands).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)