### PR TITLE
ft-wave1-js-file-javascript

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -140,6 +140,22 @@
   `functional-boundary-check` stays unavoidable through the nested
   `test-functional-coverage` call, and the lane uploads Markdown, coverage
   JSON, profile, and command log on success and failure.
+  JavaScript file-backed loading functional coverage belongs in
+  `tests/functional/orchestration/javascript/loading/file_javascript_test.go`:
+  drive sync Factory Session execution through `support.BuildProcess` +
+  `support.FakeInputs` with `you --json run`, `--factory`, and
+  `--with-mock-workers`; scaffold file-backed factories with
+  `orchestrator.javascript.sourceRef` and workflow modules beside
+  `factory.json`; prove factory-relative ES module imports resolve under the
+  Factory root with a terminal `COMPLETED` primary result that reflects the
+  imported module contribution and zero provider dispatch; prove missing
+  factory-relative imports fail before work starts with customer-stable
+  `workflow.source.notFound` diagnostics that name the missing path without
+  private VM stack frames or live provider execution. Substitute external
+  effects only through `edges.Edges`. Catalog metadata infers domain
+  `orchestration` and subsection `javascript/loading` from the path; every
+  top-level `Test*` needs a customer-readable Go doc so `functionaltestmetadata`
+  stays viz-compatible.
   JavaScript agent composition functional coverage belongs in
   `tests/functional/orchestration/javascript/composition/agent_test.go`:
   drive sync Factory Session execution through

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -341,7 +341,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestInlineJavaScriptFactoryRunsFromCLI` covers an inline definition.
   - `TestInlineJavaScriptSyntaxErrorReturnsSourceLocation` covers load failure.
 
-- [ ] `tests/functional/orchestration/javascript/loading/file_javascript_test.go`
+- [x] `tests/functional/orchestration/javascript/loading/file_javascript_test.go`
   - `TestJavaScriptFactoryFileRunsRelativeImportsFromFactoryRoot` covers path
     resolution.
   - `TestJavaScriptFactoryMissingImportFailsActionably` covers load failure.

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle.go
@@ -68,12 +68,25 @@ func BundleFactoryRelativeImports(
 	}
 
 	modules := make(map[string]bundledModule)
+	visiting := make(map[string]struct{})
 	var walk func(sourceRef, source string) []Issue
 	walk = func(sourceRef, source string) []Issue {
 		sourceRef = normalizeFactorySourceRef(sourceRef)
 		if _, seen := modules[sourceRef]; seen {
 			return nil
 		}
+		if _, inProgress := visiting[sourceRef]; inProgress {
+			return []Issue{{
+				Code: CodeUnsupportedLoader,
+				Message: fmt.Sprintf(
+					"circular factory-relative import detected involving %q",
+					sourceRef,
+				),
+				Path: sourceRef,
+			}}
+		}
+		visiting[sourceRef] = struct{}{}
+		defer delete(visiting, sourceRef)
 
 		ast, err := js.Parse(parse.NewInputString(source), js.Options{})
 		if err != nil {

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle.go
@@ -165,12 +165,16 @@ func emitBundledExecutable(modules map[string]bundledModule, entrySourceRef stri
 		}
 		out.WriteString("__modules[")
 		out.WriteString(jsStringLiteral(sourceRef))
-		out.WriteString("]=(function(exports){\n")
+		out.WriteString("]=(function(exports, __factoryRequire){\n")
+		for _, imp := range module.imports {
+			out.WriteString(importBindingLine(imp))
+			out.WriteString("\n")
+		}
 		out.WriteString(module.body)
 		if module.body != "" {
 			out.WriteString("\n")
 		}
-		out.WriteString("return exports;\n})({});\n")
+		out.WriteString("return exports;\n})({}, __factoryRequire);\n")
 	}
 	emitDependencies(entrySourceRef)
 

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle.go
@@ -265,6 +265,7 @@ func transformExportStatement(stmt *js.ExportStmt) (string, *Issue) {
 	}
 	switch decl := stmt.Decl.(type) {
 	case *js.VarDecl:
+		keyword := varDeclKeyword(decl)
 		lines := make([]string, 0, len(decl.List))
 		for _, binding := range decl.List {
 			name := bindingName(binding.Binding)
@@ -272,10 +273,17 @@ func transformExportStatement(stmt *js.ExportStmt) (string, *Issue) {
 				continue
 			}
 			if binding.Default != nil {
-				lines = append(lines, fmt.Sprintf("exports.%s = %s;", name, exprString(binding.Default)))
+				lines = append(lines, fmt.Sprintf(
+					"%s %s = %s; exports.%s = %s;",
+					keyword,
+					name,
+					exprString(binding.Default),
+					name,
+					name,
+				))
 				continue
 			}
-			lines = append(lines, fmt.Sprintf("var %s; exports.%s = %s;", name, name, name))
+			lines = append(lines, fmt.Sprintf("%s %s; exports.%s = %s;", keyword, name, name, name))
 		}
 		return strings.Join(lines, "\n"), nil
 	case *js.FuncDecl:
@@ -289,7 +297,7 @@ func transformExportStatement(stmt *js.ExportStmt) (string, *Issue) {
 				Message: "anonymous export functions are not supported in factory-relative workflow modules",
 			}
 		}
-		return fmt.Sprintf("exports.%s = %s;", name, declString(decl)), nil
+		return fmt.Sprintf("%s; exports.%s = %s;", declString(decl), name, name), nil
 	default:
 		return "", &Issue{
 			Code:    CodeUnsupportedLoader,
@@ -368,6 +376,17 @@ func declExpressionString(decl js.IExpr) string {
 		return declString(node)
 	default:
 		return exprString(decl)
+	}
+}
+
+func varDeclKeyword(decl *js.VarDecl) string {
+	switch decl.TokenType {
+	case js.ConstToken:
+		return "const"
+	case js.LetToken:
+		return "let"
+	default:
+		return "var"
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle.go
@@ -271,7 +271,7 @@ func transformExportStatement(stmt *js.ExportStmt) ([]string, []exportAssignment
 		}
 	}
 	if stmt.Default {
-		return []string{fmt.Sprintf("exports.default = %s;", declExpressionString(stmt.Decl))}, nil, nil
+		return transformDefaultExportDecl(stmt.Decl)
 	}
 	switch decl := stmt.Decl.(type) {
 	case *js.VarDecl:
@@ -293,6 +293,31 @@ func transformExportStatement(stmt *js.ExportStmt) ([]string, []exportAssignment
 			Code:    CodeUnsupportedLoader,
 			Message: "unsupported export declaration in factory-relative workflow module",
 		}
+	}
+}
+
+func transformDefaultExportDecl(decl js.IExpr) ([]string, []exportAssignment, *Issue) {
+	switch node := decl.(type) {
+	case *js.FuncDecl:
+		name := ""
+		if node.Name != nil {
+			name = string(node.Name.Name())
+		}
+		if name != "" {
+			return []string{fmt.Sprintf("%s; exports.default = %s;", declString(node), name)}, nil, nil
+		}
+		return []string{fmt.Sprintf("exports.default = %s;", declString(node))}, nil, nil
+	case *js.ClassDecl:
+		name := ""
+		if node.Name != nil {
+			name = string(node.Name.Data)
+		}
+		if name != "" {
+			return []string{fmt.Sprintf("%s; exports.default = %s;", classDeclString(node), name)}, nil, nil
+		}
+		return []string{fmt.Sprintf("exports.default = %s;", classDeclString(node))}, nil, nil
+	default:
+		return []string{fmt.Sprintf("exports.default = %s;", declExpressionString(decl))}, nil, nil
 	}
 }
 
@@ -455,6 +480,12 @@ func stmtString(stmt js.IStmt) string {
 }
 
 func declString(decl *js.FuncDecl) string {
+	var buf strings.Builder
+	decl.JS(&buf)
+	return strings.TrimSpace(buf.String())
+}
+
+func classDeclString(decl *js.ClassDecl) string {
 	var buf strings.Builder
 	decl.JS(&buf)
 	return strings.TrimSpace(buf.String())

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle.go
@@ -18,10 +18,16 @@ type importBinding struct {
 	importedAs string
 }
 
+type exportAssignment struct {
+	exportName string
+	localName  string
+}
+
 type bundledModule struct {
-	sourceRef string
-	body      string
-	imports   []resolvedImport
+	sourceRef         string
+	body              string
+	imports           []resolvedImport
+	deferredExports   []exportAssignment
 }
 
 type resolvedImport struct {
@@ -131,12 +137,13 @@ func BundleFactoryRelativeImports(
 					defaultAs: string(node.Default),
 				})
 			case *js.ExportStmt:
-				transformed, issue := transformExportStatement(node)
+				lines, deferred, issue := transformExportStatement(node)
 				if issue != nil {
 					issue.Path = sourceRef
 					return []Issue{*issue}
 				}
-				bodyLines = append(bodyLines, transformed)
+				bodyLines = append(bodyLines, lines...)
+				module.deferredExports = append(module.deferredExports, deferred...)
 			default:
 				bodyLines = append(bodyLines, stmtString(stmt))
 			}
@@ -186,6 +193,9 @@ func emitBundledExecutable(modules map[string]bundledModule, entrySourceRef stri
 		out.WriteString(module.body)
 		if module.body != "" {
 			out.WriteString("\n")
+		}
+		for _, assignment := range module.deferredExports {
+			out.WriteString(fmt.Sprintf("exports.%s = %s;\n", assignment.exportName, assignment.localName))
 		}
 		out.WriteString("return exports;\n})({}, __factoryRequire);\n")
 	}
@@ -253,56 +263,142 @@ func importBindingsFromStmt(stmt *js.ImportStmt) []importBinding {
 	return bindings
 }
 
-func transformExportStatement(stmt *js.ExportStmt) (string, *Issue) {
+func transformExportStatement(stmt *js.ExportStmt) ([]string, []exportAssignment, *Issue) {
 	if stmt.Decl == nil {
-		return "", &Issue{
+		return nil, nil, &Issue{
 			Code:    CodeUnsupportedLoader,
 			Message: "re-export statements are not supported in MVP factory-relative imports",
 		}
 	}
 	if stmt.Default {
-		return fmt.Sprintf("exports.default = %s;", declExpressionString(stmt.Decl)), nil
+		return []string{fmt.Sprintf("exports.default = %s;", declExpressionString(stmt.Decl))}, nil, nil
 	}
 	switch decl := stmt.Decl.(type) {
 	case *js.VarDecl:
-		keyword := varDeclKeyword(decl)
-		lines := make([]string, 0, len(decl.List))
-		for _, binding := range decl.List {
-			name := bindingName(binding.Binding)
-			if name == "" {
-				continue
-			}
-			if binding.Default != nil {
-				lines = append(lines, fmt.Sprintf(
-					"%s %s = %s; exports.%s = %s;",
-					keyword,
-					name,
-					exprString(binding.Default),
-					name,
-					name,
-				))
-				continue
-			}
-			lines = append(lines, fmt.Sprintf("%s %s; exports.%s = %s;", keyword, name, name, name))
-		}
-		return strings.Join(lines, "\n"), nil
+		return transformVarExportDecl(decl)
 	case *js.FuncDecl:
 		name := ""
 		if decl.Name != nil {
 			name = string(decl.Name.Name())
 		}
 		if name == "" {
-			return "", &Issue{
+			return nil, nil, &Issue{
 				Code:    CodeUnsupportedLoader,
 				Message: "anonymous export functions are not supported in factory-relative workflow modules",
 			}
 		}
-		return fmt.Sprintf("%s; exports.%s = %s;", declString(decl), name, name), nil
+		return []string{fmt.Sprintf("%s; exports.%s = %s;", declString(decl), name, name)}, nil, nil
 	default:
-		return "", &Issue{
+		return nil, nil, &Issue{
 			Code:    CodeUnsupportedLoader,
 			Message: "unsupported export declaration in factory-relative workflow module",
 		}
+	}
+}
+
+func transformVarExportDecl(decl *js.VarDecl) ([]string, []exportAssignment, *Issue) {
+	keyword := varDeclKeyword(decl)
+	deferExports := keyword == "let" || keyword == "var"
+
+	lines := make([]string, 0, len(decl.List))
+	var deferred []exportAssignment
+	for _, binding := range decl.List {
+		pattern := bindingPatternString(binding.Binding)
+		if pattern == "" {
+			continue
+		}
+		assignments, issue := collectExportAssignments(binding.Binding)
+		if issue != nil {
+			return nil, nil, issue
+		}
+		if binding.Default != nil {
+			lines = append(lines, fmt.Sprintf("%s %s = %s;", keyword, pattern, exprString(binding.Default)))
+		} else {
+			lines = append(lines, fmt.Sprintf("%s %s;", keyword, pattern))
+		}
+		for _, assignment := range assignments {
+			if deferExports {
+				deferred = append(deferred, assignment)
+				continue
+			}
+			lines = append(lines, fmt.Sprintf(
+				"exports.%s = %s;",
+				assignment.exportName,
+				assignment.localName,
+			))
+		}
+	}
+	return lines, deferred, nil
+}
+
+func collectExportAssignments(binding js.IBinding) ([]exportAssignment, *Issue) {
+	switch node := binding.(type) {
+	case *js.Var:
+		name := string(node.Name())
+		if name == "" {
+			return nil, unsupportedExportBindingIssue()
+		}
+		return []exportAssignment{{exportName: name, localName: name}}, nil
+	case *js.BindingObject:
+		if node.Rest != nil {
+			return nil, unsupportedExportBindingIssue()
+		}
+		assignments := make([]exportAssignment, 0, len(node.List))
+		for _, item := range node.List {
+			itemAssignments, issue := exportAssignmentsFromObjectItem(item)
+			if issue != nil {
+				return nil, issue
+			}
+			assignments = append(assignments, itemAssignments...)
+		}
+		return assignments, nil
+	case *js.BindingArray:
+		if node.Rest != nil {
+			return nil, unsupportedExportBindingIssue()
+		}
+		assignments := make([]exportAssignment, 0, len(node.List))
+		for _, item := range node.List {
+			if item.Binding == nil {
+				continue
+			}
+			itemAssignments, issue := collectExportAssignments(item.Binding)
+			if issue != nil {
+				return nil, issue
+			}
+			assignments = append(assignments, itemAssignments...)
+		}
+		return assignments, nil
+	default:
+		return nil, unsupportedExportBindingIssue()
+	}
+}
+
+func exportAssignmentsFromObjectItem(item js.BindingObjectItem) ([]exportAssignment, *Issue) {
+	if item.Key == nil || item.Key.IsComputed() {
+		return nil, unsupportedExportBindingIssue()
+	}
+	exportName := string(item.Key.Literal.Data)
+	if exportName == "" {
+		return nil, unsupportedExportBindingIssue()
+	}
+	switch binding := item.Value.Binding.(type) {
+	case *js.Var:
+		localName := string(binding.Name())
+		if localName == "" {
+			return nil, unsupportedExportBindingIssue()
+		}
+		return []exportAssignment{{exportName: exportName, localName: localName}}, nil
+	case *js.BindingObject, *js.BindingArray:
+		return nil, unsupportedExportBindingIssue()
+	default:
+		return nil, unsupportedExportBindingIssue()
+	}
+}
+
+func unsupportedExportBindingIssue() *Issue {
+	return &Issue{
+		Code:    CodeUnsupportedLoader,
+		Message: "unsupported export binding pattern in factory-relative workflow module",
 	}
 }
 
@@ -390,7 +486,7 @@ func varDeclKeyword(decl *js.VarDecl) string {
 	}
 }
 
-func bindingName(binding js.IBinding) string {
+func bindingPatternString(binding js.IBinding) string {
 	if binding == nil {
 		return ""
 	}

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle.go
@@ -1,0 +1,344 @@
+package workflowvalidation
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/tdewolff/parse/v2"
+	"github.com/tdewolff/parse/v2/js"
+)
+
+const (
+	CodeImportNotFound = "workflow.source.notFound"
+)
+
+type importBinding struct {
+	localName  string
+	importedAs string
+}
+
+type bundledModule struct {
+	sourceRef string
+	body      string
+	imports   []resolvedImport
+}
+
+type resolvedImport struct {
+	spec       string
+	resolved   string
+	bindings   []importBinding
+	isDefault  bool
+	defaultAs  string
+}
+
+// BundleFactoryRelativeImports resolves factory-relative ES module imports and
+// returns one executable JavaScript source for the workflow runtime.
+func BundleFactoryRelativeImports(
+	entrySourceRef string,
+	content string,
+	reader SourceReader,
+) (string, []Issue) {
+	entrySourceRef = normalizeFactorySourceRef(entrySourceRef)
+	if reader == nil {
+		return "", []Issue{{
+			Code:    CodeSourceUnreadable,
+			Message: "workflow source reader is required to resolve factory-relative imports",
+			Path:    entrySourceRef,
+		}}
+	}
+
+	modules := make(map[string]bundledModule)
+	var walk func(sourceRef, source string) []Issue
+	walk = func(sourceRef, source string) []Issue {
+		sourceRef = normalizeFactorySourceRef(sourceRef)
+		if _, seen := modules[sourceRef]; seen {
+			return nil
+		}
+
+		ast, err := js.Parse(parse.NewInputString(source), js.Options{})
+		if err != nil {
+			issue := syntaxIssue(err, Request{SourceRef: sourceRef})
+			return []Issue{issue}
+		}
+
+		module := bundledModule{sourceRef: sourceRef}
+		var bodyLines []string
+
+		for _, stmt := range ast.BlockStmt.List {
+			switch node := stmt.(type) {
+			case *js.ImportStmt:
+				spec := unquoteJSModuleSpecifier(string(node.Module))
+				if !isFactoryRelativeImportSpecifier(spec) {
+					return []Issue{{
+						Code:    CodeForbiddenHostAccess,
+						Message: "ES module import is not supported in MVP workflows",
+						Path:    sourceRef,
+					}}
+				}
+				resolved, issue := resolveFactoryRelativeImport(sourceRef, spec)
+				if issue != nil {
+					return []Issue{*issue}
+				}
+				imported, err := reader.ReadWorkflowSource(resolved)
+				if err != nil {
+					return []Issue{{
+						Code:    CodeImportNotFound,
+						Message: fmt.Sprintf("workflow import %q could not be resolved under the factory root: %v", spec, err),
+						Path:    sourceRef,
+					}}
+				}
+				if childIssues := walk(resolved, imported); len(childIssues) > 0 {
+					return childIssues
+				}
+				module.imports = append(module.imports, resolvedImport{
+					spec:     spec,
+					resolved: resolved,
+					bindings: importBindingsFromStmt(node),
+					isDefault: len(node.Default) > 0,
+					defaultAs: string(node.Default),
+				})
+			case *js.ExportStmt:
+				transformed, issue := transformExportStatement(node)
+				if issue != nil {
+					issue.Path = sourceRef
+					return []Issue{*issue}
+				}
+				bodyLines = append(bodyLines, transformed)
+			default:
+				bodyLines = append(bodyLines, stmtString(stmt))
+			}
+		}
+
+		module.body = strings.TrimSpace(strings.Join(bodyLines, "\n"))
+		modules[sourceRef] = module
+		return nil
+	}
+
+	if issues := walk(entrySourceRef, content); len(issues) > 0 {
+		return "", issues
+	}
+	return emitBundledExecutable(modules, entrySourceRef), nil
+}
+
+func emitBundledExecutable(modules map[string]bundledModule, entrySourceRef string) string {
+	var out strings.Builder
+	out.WriteString("const __modules = {};\n")
+	out.WriteString("function __factoryRequire(ref){\n")
+	out.WriteString("if(__modules[ref]===undefined){\n")
+	out.WriteString("throw new Error(\"missing workflow module \"+ref);\n")
+	out.WriteString("}\nreturn __modules[ref];\n}\n")
+
+	visited := make(map[string]struct{})
+	var emitDependencies func(sourceRef string)
+	emitDependencies = func(sourceRef string) {
+		sourceRef = normalizeFactorySourceRef(sourceRef)
+		if _, ok := visited[sourceRef]; ok {
+			return
+		}
+		visited[sourceRef] = struct{}{}
+		module := modules[sourceRef]
+		for _, imp := range module.imports {
+			emitDependencies(imp.resolved)
+		}
+		if sourceRef == normalizeFactorySourceRef(entrySourceRef) {
+			return
+		}
+		out.WriteString("__modules[")
+		out.WriteString(jsStringLiteral(sourceRef))
+		out.WriteString("]=(function(exports){\n")
+		out.WriteString(module.body)
+		if module.body != "" {
+			out.WriteString("\n")
+		}
+		out.WriteString("return exports;\n})({});\n")
+	}
+	emitDependencies(entrySourceRef)
+
+	entry := modules[entrySourceRef]
+	for _, imp := range entry.imports {
+		out.WriteString(importBindingLine(imp))
+		out.WriteString("\n")
+	}
+	out.WriteString(entry.body)
+	if entry.body != "" {
+		out.WriteString("\n")
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func importBindingLine(imp resolvedImport) string {
+	moduleRef := jsStringLiteral(imp.resolved)
+	if imp.isDefault {
+		name := strings.TrimSpace(imp.defaultAs)
+		if name == "" {
+			name = "default"
+		}
+		return fmt.Sprintf("const %s = __factoryRequire(%s);", name, moduleRef)
+	}
+	if len(imp.bindings) == 1 && imp.bindings[0].localName == "*" {
+		return fmt.Sprintf("const %s = __factoryRequire(%s);", imp.bindings[0].importedAs, moduleRef)
+	}
+	parts := make([]string, 0, len(imp.bindings))
+	for _, binding := range imp.bindings {
+		if binding.localName == binding.importedAs {
+			parts = append(parts, binding.localName)
+		} else {
+			parts = append(parts, binding.importedAs+": "+binding.localName)
+		}
+	}
+	return fmt.Sprintf("const {%s} = __factoryRequire(%s);", strings.Join(parts, ", "), moduleRef)
+}
+
+func importBindingsFromStmt(stmt *js.ImportStmt) []importBinding {
+	if len(stmt.Default) > 0 {
+		return nil
+	}
+	bindings := make([]importBinding, 0, len(stmt.List))
+	for _, alias := range stmt.List {
+		localName := string(alias.Binding)
+		importedAs := string(alias.Name)
+		if importedAs == "" {
+			importedAs = localName
+		}
+		if localName == "" && len(alias.Name) == 1 && alias.Name[0] == '*' {
+			localName = "*"
+			importedAs = "*"
+		}
+		bindings = append(bindings, importBinding{
+			localName:  localName,
+			importedAs: importedAs,
+		})
+	}
+	return bindings
+}
+
+func transformExportStatement(stmt *js.ExportStmt) (string, *Issue) {
+	if stmt.Decl == nil {
+		return "", &Issue{
+			Code:    CodeUnsupportedLoader,
+			Message: "re-export statements are not supported in MVP factory-relative imports",
+		}
+	}
+	if stmt.Default {
+		return fmt.Sprintf("exports.default = %s;", declExpressionString(stmt.Decl)), nil
+	}
+	switch decl := stmt.Decl.(type) {
+	case *js.VarDecl:
+		lines := make([]string, 0, len(decl.List))
+		for _, binding := range decl.List {
+			name := bindingName(binding.Binding)
+			if name == "" {
+				continue
+			}
+			if binding.Default != nil {
+				lines = append(lines, fmt.Sprintf("exports.%s = %s;", name, exprString(binding.Default)))
+				continue
+			}
+			lines = append(lines, fmt.Sprintf("var %s; exports.%s = %s;", name, name, name))
+		}
+		return strings.Join(lines, "\n"), nil
+	case *js.FuncDecl:
+		name := ""
+		if decl.Name != nil {
+			name = string(decl.Name.Name())
+		}
+		if name == "" {
+			return "", &Issue{
+				Code:    CodeUnsupportedLoader,
+				Message: "anonymous export functions are not supported in factory-relative workflow modules",
+			}
+		}
+		return fmt.Sprintf("exports.%s = %s;", name, declString(decl)), nil
+	default:
+		return "", &Issue{
+			Code:    CodeUnsupportedLoader,
+			Message: "unsupported export declaration in factory-relative workflow module",
+		}
+	}
+}
+
+func resolveFactoryRelativeImport(importerRef, spec string) (string, *Issue) {
+	spec = strings.TrimSpace(spec)
+	if !isFactoryRelativeImportSpecifier(spec) {
+		return "", &Issue{
+			Code:    CodeForbiddenHostAccess,
+			Message: "ES module import is not supported in MVP workflows",
+			Path:    importerRef,
+		}
+	}
+	importerDir := filepath.Dir(filepath.FromSlash(importerRef))
+	joined := filepath.ToSlash(filepath.Clean(filepath.Join(importerDir, spec)))
+	if joined == ".." || strings.HasPrefix(joined, "../") {
+		return "", &Issue{
+			Code:    CodeImportNotFound,
+			Message: fmt.Sprintf("workflow import %q escapes the factory root", spec),
+			Path:    importerRef,
+		}
+	}
+	return normalizeFactorySourceRef(joined), nil
+}
+
+func isFactoryRelativeImportSpecifier(spec string) bool {
+	spec = strings.TrimSpace(spec)
+	return strings.HasPrefix(spec, "./") || strings.HasPrefix(spec, "../")
+}
+
+func normalizeFactorySourceRef(sourceRef string) string {
+	ref := filepath.ToSlash(strings.TrimSpace(sourceRef))
+	ref = strings.TrimPrefix(ref, "./")
+	return ref
+}
+
+func unquoteJSModuleSpecifier(spec string) string {
+	spec = strings.TrimSpace(spec)
+	if len(spec) >= 2 {
+		if (spec[0] == '"' && spec[len(spec)-1] == '"') || (spec[0] == '\'' && spec[len(spec)-1] == '\'') {
+			return spec[1 : len(spec)-1]
+		}
+	}
+	return spec
+}
+
+func jsStringLiteral(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `\"`) + `"`
+}
+
+func stmtString(stmt js.IStmt) string {
+	var buf strings.Builder
+	stmt.JS(&buf)
+	return strings.TrimSpace(buf.String())
+}
+
+func declString(decl *js.FuncDecl) string {
+	var buf strings.Builder
+	decl.JS(&buf)
+	return strings.TrimSpace(buf.String())
+}
+
+func exprString(expr js.IExpr) string {
+	var buf strings.Builder
+	expr.JS(&buf)
+	return strings.TrimSpace(buf.String())
+}
+
+func declExpressionString(decl js.IExpr) string {
+	switch node := decl.(type) {
+	case *js.FuncDecl:
+		return declString(node)
+	default:
+		return exprString(decl)
+	}
+}
+
+func bindingName(binding js.IBinding) string {
+	if binding == nil {
+		return ""
+	}
+	if variable, ok := binding.(*js.Var); ok {
+		return string(variable.Name())
+	}
+	var buf strings.Builder
+	binding.JS(&buf)
+	return strings.TrimSpace(buf.String())
+}

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle.go
@@ -188,31 +188,34 @@ func emitBundledExecutable(modules map[string]bundledModule, entrySourceRef stri
 
 func importBindingLine(imp resolvedImport) string {
 	moduleRef := jsStringLiteral(imp.resolved)
+	var lines []string
 	if imp.isDefault {
 		name := strings.TrimSpace(imp.defaultAs)
 		if name == "" {
 			name = "default"
 		}
-		return fmt.Sprintf("const %s = __factoryRequire(%s);", name, moduleRef)
+		lines = append(lines, fmt.Sprintf("const %s = __factoryRequire(%s).default;", name, moduleRef))
 	}
-	if len(imp.bindings) == 1 && imp.bindings[0].localName == "*" {
-		return fmt.Sprintf("const %s = __factoryRequire(%s);", imp.bindings[0].importedAs, moduleRef)
-	}
-	parts := make([]string, 0, len(imp.bindings))
-	for _, binding := range imp.bindings {
-		if binding.localName == binding.importedAs {
-			parts = append(parts, binding.localName)
-		} else {
-			parts = append(parts, binding.importedAs+": "+binding.localName)
+	if len(imp.bindings) == 1 && imp.bindings[0].importedAs == "*" {
+		lines = append(lines, fmt.Sprintf("const %s = __factoryRequire(%s);", imp.bindings[0].localName, moduleRef))
+	} else if len(imp.bindings) > 0 {
+		parts := make([]string, 0, len(imp.bindings))
+		for _, binding := range imp.bindings {
+			if binding.localName == binding.importedAs {
+				parts = append(parts, binding.localName)
+			} else {
+				parts = append(parts, binding.importedAs+": "+binding.localName)
+			}
 		}
+		lines = append(lines, fmt.Sprintf("const {%s} = __factoryRequire(%s);", strings.Join(parts, ", "), moduleRef))
 	}
-	return fmt.Sprintf("const {%s} = __factoryRequire(%s);", strings.Join(parts, ", "), moduleRef)
+	if len(lines) == 0 {
+		return fmt.Sprintf("__factoryRequire(%s);", moduleRef)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func importBindingsFromStmt(stmt *js.ImportStmt) []importBinding {
-	if len(stmt.Default) > 0 {
-		return nil
-	}
 	bindings := make([]importBinding, 0, len(stmt.List))
 	for _, alias := range stmt.List {
 		localName := string(alias.Binding)
@@ -220,9 +223,10 @@ func importBindingsFromStmt(stmt *js.ImportStmt) []importBinding {
 		if importedAs == "" {
 			importedAs = localName
 		}
-		if localName == "" && len(alias.Name) == 1 && alias.Name[0] == '*' {
-			localName = "*"
-			importedAs = "*"
+		if len(importedAs) == 1 && importedAs[0] == '*' {
+			if localName == "" {
+				localName = "namespace"
+			}
 		}
 		bindings = append(bindings, importBinding{
 			localName:  localName,

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle.go
@@ -32,6 +32,25 @@ type resolvedImport struct {
 	defaultAs  string
 }
 
+// ContainsFactoryRelativeImports reports whether source includes factory-relative
+// ES module import statements that require bundling before validation or execution.
+func ContainsFactoryRelativeImports(source string) bool {
+	ast, err := js.Parse(parse.NewInputString(source), js.Options{})
+	if err != nil {
+		return false
+	}
+	for _, stmt := range ast.BlockStmt.List {
+		importStmt, ok := stmt.(*js.ImportStmt)
+		if !ok {
+			continue
+		}
+		if isFactoryRelativeImportSpecifier(unquoteJSModuleSpecifier(string(importStmt.Module))) {
+			return true
+		}
+	}
+	return false
+}
+
 // BundleFactoryRelativeImports resolves factory-relative ES module imports and
 // returns one executable JavaScript source for the workflow runtime.
 func BundleFactoryRelativeImports(

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/dop251/goja"
 )
 
 type bundleTestFileSystem struct{}
@@ -46,10 +48,36 @@ workflow.final(successResult);`
 	if result.HasIssues() {
 		t.Fatalf("validate bundled source issues = %#v", result.Issues)
 	}
+	finalValue, err := executeBundledWorkflowFinalForTest(t, bundled)
+	if err != nil {
+		t.Fatalf("execute bundled source: %v", err)
+	}
+	if finalValue != "ok" {
+		t.Fatalf("workflow.final value = %q, want ok", finalValue)
+	}
 }
 
 func wrapWorkflowSourceForBundleTest(source string) string {
 	return "(function(){\n" + source + "\n})()"
+}
+
+func executeBundledWorkflowFinalForTest(t *testing.T, bundled string) (string, error) {
+	t.Helper()
+
+	vm := goja.New()
+	var captured string
+	workflow := vm.NewObject()
+	if err := workflow.Set("final", func(call goja.FunctionCall) goja.Value {
+		captured = call.Argument(0).String()
+		return goja.Undefined()
+	}); err != nil {
+		t.Fatalf("set workflow.final: %v", err)
+	}
+	if err := vm.Set("workflow", workflow); err != nil {
+		t.Fatalf("set workflow: %v", err)
+	}
+	_, err := vm.RunString(wrapWorkflowSourceForBundleTest(bundled))
+	return captured, err
 }
 
 func TestContainsFactoryRelativeImports(t *testing.T) {
@@ -129,7 +157,73 @@ func TestContainsFactoryRelativeImportsIgnoresNonRelativeImports(t *testing.T) {
 	}
 }
 
-func TestBundleFactoryRelativeImportsNamedExportFunctionAndAliasBindings(t *testing.T) {
+func TestBundleFactoryRelativeImportsNamespaceImportExecutes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "constants.js"),
+		[]byte(`export const successResult = "namespace-ok";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write constants module: %v", err)
+	}
+	entry := `import * as constants from "./lib/constants.js";
+workflow.final(constants.successResult);`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	bundled, issues := BundleFactoryRelativeImports("workflow.js", entry, reader)
+	if len(issues) > 0 {
+		t.Fatalf("bundle issues = %#v, want none", issues)
+	}
+	finalValue, err := executeBundledWorkflowFinalForTest(t, bundled)
+	if err != nil {
+		t.Fatalf("execute bundled source: %v", err)
+	}
+	if finalValue != "namespace-ok" {
+		t.Fatalf("workflow.final value = %q, want namespace-ok", finalValue)
+	}
+}
+
+func TestBundleFactoryRelativeImportsSideEffectImportExecutes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "constants.js"),
+		[]byte(`export const successResult = "side-effect-ok";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write constants module: %v", err)
+	}
+	entry := `import "./lib/constants.js";
+import { successResult } from "./lib/constants.js";
+workflow.final(successResult);`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	bundled, issues := BundleFactoryRelativeImports("workflow.js", entry, reader)
+	if len(issues) > 0 {
+		t.Fatalf("bundle issues = %#v, want none", issues)
+	}
+	if !strings.Contains(bundled, "__factoryRequire(\"lib/constants.js\");") {
+		t.Fatalf("bundled source = %q, want side-effect import invocation", bundled)
+	}
+	finalValue, err := executeBundledWorkflowFinalForTest(t, bundled)
+	if err != nil {
+		t.Fatalf("execute bundled source: %v", err)
+	}
+	if finalValue != "side-effect-ok" {
+		t.Fatalf("workflow.final value = %q, want side-effect-ok", finalValue)
+	}
+}
+
+func TestBundleFactoryRelativeImportsNamedAliasBindingExecutes(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -138,7 +232,41 @@ func TestBundleFactoryRelativeImportsNamedExportFunctionAndAliasBindings(t *test
 	}
 	if err := os.WriteFile(
 		filepath.Join(dir, "lib", "helpers.js"),
-		[]byte(`export function helper() { return "helper"; }
+		[]byte(`export const aliasValue = "alias-only";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write helpers module: %v", err)
+	}
+	entry := `import { aliasValue as importedAlias } from "./lib/helpers.js";
+workflow.final(importedAlias);`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	bundled, issues := BundleFactoryRelativeImports("workflow.js", entry, reader)
+	if len(issues) > 0 {
+		t.Fatalf("bundle issues = %#v, want none", issues)
+	}
+	if !strings.Contains(bundled, "aliasValue: importedAlias") {
+		t.Fatalf("bundled source = %q, want named alias binding", bundled)
+	}
+	finalValue, err := executeBundledWorkflowFinalForTest(t, bundled)
+	if err != nil {
+		t.Fatalf("execute bundled source: %v", err)
+	}
+	if finalValue != "alias-only" {
+		t.Fatalf("workflow.final value = %q, want alias-only", finalValue)
+	}
+}
+
+func TestBundleFactoryRelativeImportsDefaultAndNamedBindingsExecute(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "helpers.js"),
+		[]byte(`export default function helper() { return "helper"; }
 export const aliasValue = "alias";`),
 		0o600,
 	); err != nil {
@@ -152,12 +280,49 @@ workflow.final(helper() + ":" + importedAlias);`
 	if len(issues) > 0 {
 		t.Fatalf("bundle issues = %#v, want none", issues)
 	}
-	result := Validate(Request{
-		Source:    wrapWorkflowSourceForBundleTest(bundled),
-		SourceRef: "workflow.js",
-	})
-	if result.HasIssues() {
-		t.Fatalf("validate bundled source issues = %#v", result.Issues)
+	if !strings.Contains(bundled, "__factoryRequire(\"lib/helpers.js\").default") {
+		t.Fatalf("bundled source = %q, want default import bound from module.default", bundled)
+	}
+	if !strings.Contains(bundled, "aliasValue: importedAlias") {
+		t.Fatalf("bundled source = %q, want named alias binding preserved alongside default import", bundled)
+	}
+	finalValue, err := executeBundledWorkflowFinalForTest(t, bundled)
+	if err != nil {
+		t.Fatalf("execute bundled source: %v", err)
+	}
+	if finalValue != "helper:alias" {
+		t.Fatalf("workflow.final value = %q, want helper:alias", finalValue)
+	}
+}
+
+func TestBundleFactoryRelativeImportsDefaultExportOnlyExecutes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "default-only.js"),
+		[]byte(`export default "default-export";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write default-only module: %v", err)
+	}
+	entry := `import importedDefault from "./lib/default-only.js";
+workflow.final(importedDefault);`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	bundled, issues := BundleFactoryRelativeImports("workflow.js", entry, reader)
+	if len(issues) > 0 {
+		t.Fatalf("bundle issues = %#v, want none", issues)
+	}
+	finalValue, err := executeBundledWorkflowFinalForTest(t, bundled)
+	if err != nil {
+		t.Fatalf("execute bundled source: %v", err)
+	}
+	if finalValue != "default-export" {
+		t.Fatalf("workflow.final value = %q, want default-export", finalValue)
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dop251/goja"
 )
@@ -412,6 +413,97 @@ workflow.final(mid);`
 	}
 	if finalValue != "LEAF-MID" {
 		t.Fatalf("workflow.final value = %q, want LEAF-MID", finalValue)
+	}
+}
+
+func TestBundleFactoryRelativeImportsCircularImportReturnsUnsupportedLoader(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "a.js"),
+		[]byte(`import { b } from "./b.js";
+export const a = b;`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write a module: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "b.js"),
+		[]byte(`import { a } from "./a.js";
+export const b = a;`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write b module: %v", err)
+	}
+	entry := `import { a } from "./lib/a.js";
+workflow.final(a);`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	done := make(chan struct{})
+	var issues []Issue
+	go func() {
+		_, issues = BundleFactoryRelativeImports("workflow.js", entry, reader)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("BundleFactoryRelativeImports hung, want circular import failure")
+	}
+	if len(issues) == 0 {
+		t.Fatal("bundle issues = nil, want circular import failure")
+	}
+	if issues[0].Code != CodeUnsupportedLoader {
+		t.Fatalf("issue code = %q, want %q", issues[0].Code, CodeUnsupportedLoader)
+	}
+	if !strings.Contains(issues[0].Message, "circular factory-relative import") {
+		t.Fatalf("issue message = %q, want circular import diagnostic", issues[0].Message)
+	}
+}
+
+func TestLoadBundlesCircularRelativeImportReturnsUnsupportedLoader(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "a.js"),
+		[]byte(`import { b } from "./b.js";
+export const a = b;`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write a module: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "b.js"),
+		[]byte(`import { a } from "./a.js";
+export const b = a;`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write b module: %v", err)
+	}
+	entry := `import { a } from "./lib/a.js";
+workflow.final(a);`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	_, issues := Load(LoadRequest{
+		SourceRef:    "workflow.js",
+		Content:      entry,
+		FactoryRoot:  dir,
+		BundleReader: reader,
+	})
+	if len(issues) == 0 {
+		t.Fatal("load issues = nil, want circular import failure")
+	}
+	if issues[0].Code != CodeUnsupportedLoader {
+		t.Fatalf("issue code = %q, want %q", issues[0].Code, CodeUnsupportedLoader)
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle_test.go
@@ -327,6 +327,82 @@ workflow.final(importedDefault);`
 	}
 }
 
+func TestBundleFactoryRelativeImportsNamedDefaultFunctionLocalBindingExecutes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "default-fn.js"),
+		[]byte(`export default function helper() { return "OK"; }
+export const tag = typeof helper;`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write default-fn module: %v", err)
+	}
+	entry := `import helper, { tag } from "./lib/default-fn.js";
+workflow.final(helper() + ":" + tag);`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	bundled, issues := BundleFactoryRelativeImports("workflow.js", entry, reader)
+	if len(issues) > 0 {
+		t.Fatalf("bundle issues = %#v, want none", issues)
+	}
+	if strings.Contains(bundled, "exports.default = function helper") {
+		t.Fatalf("bundled source = %q, want local function declaration before exports.default assignment", bundled)
+	}
+	if !strings.Contains(bundled, "function helper()") || !strings.Contains(bundled, "exports.default = helper;") {
+		t.Fatalf("bundled source = %q, want function helper declaration and exports.default = helper", bundled)
+	}
+	finalValue, err := executeBundledWorkflowFinalForTest(t, bundled)
+	if err != nil {
+		t.Fatalf("execute bundled source: %v", err)
+	}
+	if finalValue != "OK:function" {
+		t.Fatalf("workflow.final value = %q, want OK:function", finalValue)
+	}
+}
+
+func TestBundleFactoryRelativeImportsNamedDefaultClassLocalBindingExecutes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "default-class.js"),
+		[]byte(`export default class Widget { static tag() { return "widget"; } }
+export const tag = Widget.tag();`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write default-class module: %v", err)
+	}
+	entry := `import Widget, { tag } from "./lib/default-class.js";
+workflow.final(new Widget().constructor.tag() + ":" + tag);`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	bundled, issues := BundleFactoryRelativeImports("workflow.js", entry, reader)
+	if len(issues) > 0 {
+		t.Fatalf("bundle issues = %#v, want none", issues)
+	}
+	if strings.Contains(bundled, "exports.default = class Widget") {
+		t.Fatalf("bundled source = %q, want local class declaration before exports.default assignment", bundled)
+	}
+	if !strings.Contains(bundled, "class Widget") || !strings.Contains(bundled, "exports.default = Widget;") {
+		t.Fatalf("bundled source = %q, want class Widget declaration and exports.default = Widget", bundled)
+	}
+	finalValue, err := executeBundledWorkflowFinalForTest(t, bundled)
+	if err != nil {
+		t.Fatalf("execute bundled source: %v", err)
+	}
+	if finalValue != "widget:widget" {
+		t.Fatalf("workflow.final value = %q, want widget:widget", finalValue)
+	}
+}
+
 func TestLoadBundlesNestedRelativeImportChainExecutes(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle_test.go
@@ -416,6 +416,82 @@ workflow.final(mid);`
 	}
 }
 
+func TestBundleFactoryRelativeImportsSameModuleExportReferencesExecute(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "helpers.js"),
+		[]byte(`export const leaf = "LEAF";
+export const doubled = leaf + "-X";
+export function suffix(value) { return value + "-FN"; }`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write helpers module: %v", err)
+	}
+	entry := `import { doubled, suffix } from "./lib/helpers.js";
+workflow.final(suffix(doubled));`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	bundled, issues := BundleFactoryRelativeImports("workflow.js", entry, reader)
+	if len(issues) > 0 {
+		t.Fatalf("bundle issues = %#v, want none", issues)
+	}
+	if !strings.Contains(bundled, `const leaf = "LEAF"; exports.leaf = leaf;`) {
+		t.Fatalf("bundled source = %q, want local binding for same-module export const", bundled)
+	}
+	if !strings.Contains(bundled, `exports.doubled = doubled;`) {
+		t.Fatalf("bundled source = %q, want local binding for export referencing prior export", bundled)
+	}
+	finalValue, err := executeBundledWorkflowFinalForTest(t, bundled)
+	if err != nil {
+		t.Fatalf("execute bundled source: %v", err)
+	}
+	if finalValue != "LEAF-X-FN" {
+		t.Fatalf("workflow.final value = %q, want LEAF-X-FN", finalValue)
+	}
+}
+
+func TestLoadBundlesSameModuleExportReferencesExecute(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "helpers.js"),
+		[]byte(`export const leaf = "LEAF";
+export const doubled = leaf + "-X";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write helpers module: %v", err)
+	}
+	entry := `import { doubled } from "./lib/helpers.js";
+workflow.final(doubled);`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	loaded, issues := Load(LoadRequest{
+		SourceRef:    "workflow.js",
+		Content:      entry,
+		FactoryRoot:  dir,
+		BundleReader: reader,
+	})
+	if len(issues) > 0 {
+		t.Fatalf("load issues = %#v, want none", issues)
+	}
+	finalValue, err := executeBundledWorkflowFinalForTest(t, loaded.ExecutableSource)
+	if err != nil {
+		t.Fatalf("execute bundled source: %v", err)
+	}
+	if finalValue != "LEAF-X" {
+		t.Fatalf("workflow.final value = %q, want LEAF-X", finalValue)
+	}
+}
+
 func TestBundleFactoryRelativeImportsCircularImportReturnsUnsupportedLoader(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle_test.go
@@ -440,7 +440,7 @@ workflow.final(suffix(doubled));`
 	if len(issues) > 0 {
 		t.Fatalf("bundle issues = %#v, want none", issues)
 	}
-	if !strings.Contains(bundled, `const leaf = "LEAF"; exports.leaf = leaf;`) {
+	if !strings.Contains(bundled, `const leaf = "LEAF";`) || !strings.Contains(bundled, `exports.leaf = leaf;`) {
 		t.Fatalf("bundled source = %q, want local binding for same-module export const", bundled)
 	}
 	if !strings.Contains(bundled, `exports.doubled = doubled;`) {
@@ -489,6 +489,160 @@ workflow.final(doubled);`
 	}
 	if finalValue != "LEAF-X" {
 		t.Fatalf("workflow.final value = %q, want LEAF-X", finalValue)
+	}
+}
+
+func TestBundleFactoryRelativeImportsDestructuredExportBindingsExecute(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "pairs.js"),
+		[]byte(`export const { a, b } = { a: "A", b: "B" };`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write pairs module: %v", err)
+	}
+	entry := `import { a, b } from "./lib/pairs.js";
+workflow.final(a + b);`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	bundled, issues := BundleFactoryRelativeImports("workflow.js", entry, reader)
+	if len(issues) > 0 {
+		t.Fatalf("bundle issues = %#v, want none", issues)
+	}
+	if !strings.Contains(bundled, `const {a, b} = {a: "A", b: "B"}`) {
+		t.Fatalf("bundled source = %q, want destructured local binding", bundled)
+	}
+	if strings.Contains(bundled, `exports.{a, b}`) {
+		t.Fatalf("bundled source = %q, want per-name export assignments", bundled)
+	}
+	if !strings.Contains(bundled, `exports.a = a;`) || !strings.Contains(bundled, `exports.b = b;`) {
+		t.Fatalf("bundled source = %q, want exports.a and exports.b assignments", bundled)
+	}
+	finalValue, err := executeBundledWorkflowFinalForTest(t, bundled)
+	if err != nil {
+		t.Fatalf("execute bundled source: %v", err)
+	}
+	if finalValue != "AB" {
+		t.Fatalf("workflow.final value = %q, want AB", finalValue)
+	}
+}
+
+func TestBundleFactoryRelativeImportsMutableLetExportSnapshotsFinalValue(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "mutable.js"),
+		[]byte(`export let value = "initial";
+value = "updated";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write mutable module: %v", err)
+	}
+	entry := `import { value } from "./lib/mutable.js";
+workflow.final(value);`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	bundled, issues := BundleFactoryRelativeImports("workflow.js", entry, reader)
+	if len(issues) > 0 {
+		t.Fatalf("bundle issues = %#v, want none", issues)
+	}
+	if strings.Contains(bundled, `exports.value = value; value = "updated"`) {
+		t.Fatalf("bundled source = %q, want deferred let export assignment after module evaluation", bundled)
+	}
+	if !strings.Contains(bundled, `let value = "initial";`) {
+		t.Fatalf("bundled source = %q, want let binding initializer", bundled)
+	}
+	if !strings.Contains(bundled, `value = "updated";`) {
+		t.Fatalf("bundled source = %q, want module evaluation mutation", bundled)
+	}
+	finalValue, err := executeBundledWorkflowFinalForTest(t, bundled)
+	if err != nil {
+		t.Fatalf("execute bundled source: %v", err)
+	}
+	if finalValue != "updated" {
+		t.Fatalf("workflow.final value = %q, want updated", finalValue)
+	}
+}
+
+func TestLoadBundlesDestructuredExportBindingsExecute(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "pairs.js"),
+		[]byte(`export const { a, b } = { a: "A", b: "B" };`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write pairs module: %v", err)
+	}
+	entry := `import { a, b } from "./lib/pairs.js";
+workflow.final(a + b);`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	loaded, issues := Load(LoadRequest{
+		SourceRef:    "workflow.js",
+		Content:      entry,
+		FactoryRoot:  dir,
+		BundleReader: reader,
+	})
+	if len(issues) > 0 {
+		t.Fatalf("load issues = %#v, want none", issues)
+	}
+	finalValue, err := executeBundledWorkflowFinalForTest(t, loaded.ExecutableSource)
+	if err != nil {
+		t.Fatalf("execute bundled source: %v", err)
+	}
+	if finalValue != "AB" {
+		t.Fatalf("workflow.final value = %q, want AB", finalValue)
+	}
+}
+
+func TestLoadBundlesMutableLetExportSnapshotsFinalValue(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "mutable.js"),
+		[]byte(`export let value = "initial";
+value = "updated";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write mutable module: %v", err)
+	}
+	entry := `import { value } from "./lib/mutable.js";
+workflow.final(value);`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	loaded, issues := Load(LoadRequest{
+		SourceRef:    "workflow.js",
+		Content:      entry,
+		FactoryRoot:  dir,
+		BundleReader: reader,
+	})
+	if len(issues) > 0 {
+		t.Fatalf("load issues = %#v, want none", issues)
+	}
+	finalValue, err := executeBundledWorkflowFinalForTest(t, loaded.ExecutableSource)
+	if err != nil {
+		t.Fatalf("execute bundled source: %v", err)
+	}
+	if finalValue != "updated" {
+		t.Fatalf("workflow.final value = %q, want updated", finalValue)
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle_test.go
@@ -1,0 +1,70 @@
+package workflowvalidation
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type bundleTestFileSystem struct{}
+
+func (bundleTestFileSystem) ReadDir(path string) ([]fs.DirEntry, error) { return os.ReadDir(path) }
+func (bundleTestFileSystem) ReadFile(path string) ([]byte, error)       { return os.ReadFile(path) }
+func (bundleTestFileSystem) Stat(path string) (fs.FileInfo, error)      { return os.Stat(path) }
+
+func TestBundleFactoryRelativeImportsResolvesDependencyExports(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "constants.js"),
+		[]byte(`export const successResult = "ok";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write constants module: %v", err)
+	}
+	entry := `import { successResult } from "./lib/constants.js";
+workflow.final(successResult);`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	bundled, issues := BundleFactoryRelativeImports("workflow.js", entry, reader)
+	if len(issues) > 0 {
+		t.Fatalf("bundle issues = %#v, want none", issues)
+	}
+	if bundled == "" {
+		t.Fatal("bundled source = empty, want executable JavaScript")
+	}
+	result := Validate(Request{
+		Source:    wrapWorkflowSourceForBundleTest(bundled),
+		SourceRef: "workflow.js",
+	})
+	if result.HasIssues() {
+		t.Fatalf("validate bundled source issues = %#v", result.Issues)
+	}
+}
+
+func wrapWorkflowSourceForBundleTest(source string) string {
+	return "(function(){\n" + source + "\n})()"
+}
+
+func TestBundleFactoryRelativeImportsMissingModuleReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+	_, issues := BundleFactoryRelativeImports(
+		"workflow.js",
+		`import { missing } from "./lib/missing.js"; workflow.final(missing);`,
+		reader,
+	)
+	if len(issues) == 0 {
+		t.Fatal("bundle issues = nil, want missing import failure")
+	}
+	if issues[0].Code != CodeImportNotFound {
+		t.Fatalf("issue code = %q, want %q", issues[0].Code, CodeImportNotFound)
+	}
+}

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle_test.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -49,6 +50,115 @@ workflow.final(successResult);`
 
 func wrapWorkflowSourceForBundleTest(source string) string {
 	return "(function(){\n" + source + "\n})()"
+}
+
+func TestContainsFactoryRelativeImports(t *testing.T) {
+	t.Parallel()
+
+	if ContainsFactoryRelativeImports(`return (async function () { workflow.final("ok"); })();`) {
+		t.Fatal("ContainsFactoryRelativeImports = true, want false for workflow without imports")
+	}
+	if !ContainsFactoryRelativeImports(`import { ok } from "./lib/constants.js"; workflow.final(ok);`) {
+		t.Fatal("ContainsFactoryRelativeImports = false, want true for factory-relative import")
+	}
+}
+
+func TestLoadSkipsBundlingWithoutFactoryRelativeImports(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+	source := `return (async function () { workflow.final("ok"); })();`
+	loaded, issues := Load(LoadRequest{
+		SourceRef:    "workflow.js",
+		Content:      source,
+		FactoryRoot:  dir,
+		BundleReader: reader,
+	})
+	if len(issues) > 0 {
+		t.Fatalf("load issues = %#v, want none", issues)
+	}
+	if loaded.ExecutableSource != source {
+		t.Fatalf("executable source = %q, want authored source without bundler preamble", loaded.ExecutableSource)
+	}
+}
+
+func TestLoadBundlesFactoryRelativeImports(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "constants.js"),
+		[]byte(`export const successResult = "ok";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write constants module: %v", err)
+	}
+	entry := `import { successResult } from "./lib/constants.js";
+workflow.final(successResult);`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	loaded, issues := Load(LoadRequest{
+		SourceRef:    "workflow.js",
+		Content:      entry,
+		FactoryRoot:  dir,
+		BundleReader: reader,
+	})
+	if len(issues) > 0 {
+		t.Fatalf("load issues = %#v, want none", issues)
+	}
+	if loaded.ExecutableSource == entry {
+		t.Fatal("executable source = authored entry, want bundled executable")
+	}
+	if !strings.Contains(loaded.ExecutableSource, "__factoryRequire") {
+		t.Fatalf("executable source = %q, want bundled factory-relative import helper", loaded.ExecutableSource)
+	}
+}
+
+func TestContainsFactoryRelativeImportsIgnoresNonRelativeImports(t *testing.T) {
+	t.Parallel()
+
+	if ContainsFactoryRelativeImports(`import fs from "node:fs"; workflow.final("ok");`) {
+		t.Fatal("ContainsFactoryRelativeImports = true, want false for non-factory-relative import")
+	}
+	if ContainsFactoryRelativeImports(`import { broken`) {
+		t.Fatal("ContainsFactoryRelativeImports = true, want false for unparseable source")
+	}
+}
+
+func TestBundleFactoryRelativeImportsNamedExportFunctionAndAliasBindings(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "helpers.js"),
+		[]byte(`export function helper() { return "helper"; }
+export const aliasValue = "alias";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write helpers module: %v", err)
+	}
+	entry := `import helper, { aliasValue as importedAlias } from "./lib/helpers.js";
+workflow.final(helper() + ":" + importedAlias);`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	bundled, issues := BundleFactoryRelativeImports("workflow.js", entry, reader)
+	if len(issues) > 0 {
+		t.Fatalf("bundle issues = %#v, want none", issues)
+	}
+	result := Validate(Request{
+		Source:    wrapWorkflowSourceForBundleTest(bundled),
+		SourceRef: "workflow.js",
+	})
+	if result.HasIssues() {
+		t.Fatalf("validate bundled source issues = %#v", result.Issues)
+	}
 }
 
 func TestBundleFactoryRelativeImportsMissingModuleReturnsNotFound(t *testing.T) {

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/bundle_test.go
@@ -326,6 +326,95 @@ workflow.final(importedDefault);`
 	}
 }
 
+func TestLoadBundlesNestedRelativeImportChainExecutes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "leaf.js"),
+		[]byte(`export const leaf = "LEAF";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write leaf module: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "mid.js"),
+		[]byte(`import { leaf } from "./leaf.js";
+export const mid = leaf + "-MID";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write mid module: %v", err)
+	}
+	entry := `import { mid } from "./lib/mid.js";
+workflow.final(mid);`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	loaded, issues := Load(LoadRequest{
+		SourceRef:    "workflow.js",
+		Content:      entry,
+		FactoryRoot:  dir,
+		BundleReader: reader,
+	})
+	if len(issues) > 0 {
+		t.Fatalf("load issues = %#v, want none", issues)
+	}
+	if !strings.Contains(loaded.ExecutableSource, "const {leaf} = __factoryRequire(\"lib/leaf.js\");") {
+		t.Fatalf("executable source = %q, want nested import bindings inside mid module wrapper", loaded.ExecutableSource)
+	}
+	finalValue, err := executeBundledWorkflowFinalForTest(t, loaded.ExecutableSource)
+	if err != nil {
+		t.Fatalf("execute bundled source: %v", err)
+	}
+	if finalValue != "LEAF-MID" {
+		t.Fatalf("workflow.final value = %q, want LEAF-MID", finalValue)
+	}
+}
+
+func TestBundleFactoryRelativeImportsNestedImportChainExecutes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "leaf.js"),
+		[]byte(`export const leaf = "LEAF";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write leaf module: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "mid.js"),
+		[]byte(`import { leaf } from "./leaf.js";
+export const mid = leaf + "-MID";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write mid module: %v", err)
+	}
+	entry := `import { mid } from "./lib/mid.js";
+workflow.final(mid);`
+	reader := FileSourceReader(dir, bundleTestFileSystem{})
+
+	bundled, issues := BundleFactoryRelativeImports("workflow.js", entry, reader)
+	if len(issues) > 0 {
+		t.Fatalf("bundle issues = %#v, want none", issues)
+	}
+	if !strings.Contains(bundled, "const {leaf} = __factoryRequire(\"lib/leaf.js\");") {
+		t.Fatalf("bundled source = %q, want nested import bindings inside mid module wrapper", bundled)
+	}
+	finalValue, err := executeBundledWorkflowFinalForTest(t, bundled)
+	if err != nil {
+		t.Fatalf("execute bundled source: %v", err)
+	}
+	if finalValue != "LEAF-MID" {
+		t.Fatalf("workflow.final value = %q, want LEAF-MID", finalValue)
+	}
+}
+
 func TestBundleFactoryRelativeImportsMissingModuleReturnsNotFound(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/loader.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/loader.go
@@ -56,7 +56,7 @@ func Load(req LoadRequest) (LoadedSource, []Issue) {
 	switch format {
 	case FormatJavaScript:
 		executable := content
-		if strings.TrimSpace(req.FactoryRoot) != "" && req.BundleReader != nil {
+		if strings.TrimSpace(req.FactoryRoot) != "" && req.BundleReader != nil && ContainsFactoryRelativeImports(content) {
 			bundled, bundleIssues := BundleFactoryRelativeImports(sourceRef, content, req.BundleReader)
 			if len(bundleIssues) > 0 {
 				return loaded, bundleIssues

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/loader.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/loader.go
@@ -12,8 +12,10 @@ const (
 
 // LoadRequest carries file-backed workflow source to load for validation.
 type LoadRequest struct {
-	SourceRef string
-	Content   string
+	SourceRef    string
+	Content      string
+	FactoryRoot  string
+	BundleReader SourceReader
 }
 
 // LoadedSource is the resolved workflow source metadata for validation or preview.
@@ -53,7 +55,15 @@ func Load(req LoadRequest) (LoadedSource, []Issue) {
 
 	switch format {
 	case FormatJavaScript:
-		loaded.ExecutableSource = content
+		executable := content
+		if strings.TrimSpace(req.FactoryRoot) != "" && req.BundleReader != nil {
+			bundled, bundleIssues := BundleFactoryRelativeImports(sourceRef, content, req.BundleReader)
+			if len(bundleIssues) > 0 {
+				return loaded, bundleIssues
+			}
+			executable = bundled
+		}
+		loaded.ExecutableSource = executable
 	case FormatTypeScript:
 		executable, lineMap, stripIssues := stripTypeScript(content)
 		if len(stripIssues) > 0 {

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/reader.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/validation/reader.go
@@ -34,6 +34,11 @@ type fileSourceReader struct {
 	files   SourceFileSystem
 }
 
+// FactoryRoot returns the factory-relative workflow source root for this reader.
+func (r fileSourceReader) FactoryRoot() string {
+	return r.rootDir
+}
+
 func (r fileSourceReader) ReadWorkflowSource(sourceRef string) (string, error) {
 	ref := strings.TrimSpace(sourceRef)
 	if ref == "" {

--- a/pkg/services/factory_runtime/javascript_bundler_loader_test.go
+++ b/pkg/services/factory_runtime/javascript_bundler_loader_test.go
@@ -1,0 +1,157 @@
+package factory_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	factory "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	workflowpolicy "github.com/portpowered/infinite-you/pkg/services/factory_runtime/orchestratorcontract"
+)
+
+func TestLoad_BundlesDefaultAndNamedRelativeImportsExecutes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "helpers.js"),
+		[]byte(`export default function helper() { return "helper"; }
+export const aliasValue = "alias";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write helpers module: %v", err)
+	}
+	entry := `import helper, { aliasValue as importedAlias } from "./lib/helpers.js";
+workflow.final(helper() + ":" + importedAlias);`
+	reader := factory.NewWorkflowSourceReader(dir, localWorkflowSourceFiles{})
+
+	loaded, issues := validationLoaderWorkflows.LoadSource(factory.WorkflowValidationLoadRequest{
+		SourceRef:    "workflow.js",
+		Content:      entry,
+		FactoryRoot:  dir,
+		BundleReader: reader,
+	})
+	if len(issues) > 0 {
+		t.Fatalf("load issues = %#v, want none", issues)
+	}
+	if !strings.Contains(loaded.ExecutableSource, "__factoryRequire(\"lib/helpers.js\").default") {
+		t.Fatalf("executable source = %q, want default import bound from module.default", loaded.ExecutableSource)
+	}
+	if !strings.Contains(loaded.ExecutableSource, "aliasValue: importedAlias") {
+		t.Fatalf("executable source = %q, want named alias binding preserved alongside default import", loaded.ExecutableSource)
+	}
+
+	outcome, err := validationLoaderWorkflows.Run(t.Context(), factory.JavaScriptRuntimeRequest{
+		Source:    loaded.ExecutableSource,
+		SourceRef: "workflow.js",
+		SessionID: "session-default-named-import",
+		Args:      json.RawMessage(`{}`),
+		Policy:    workflowpolicy.DefaultEffectivePolicy(),
+	}, factory.JavaScriptRuntimeHooks{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !outcome.OK {
+		t.Fatalf("Run() failure = %#v", outcome.Failure)
+	}
+	if string(outcome.Value.JSON) != `"helper:alias"` {
+		t.Fatalf("primary result = %s, want \"helper:alias\"", outcome.Value.JSON)
+	}
+}
+
+func TestLoad_BundlesNamespaceRelativeImportExecutes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "constants.js"),
+		[]byte(`export const successResult = "namespace-ok";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write constants module: %v", err)
+	}
+	entry := `import * as constants from "./lib/constants.js";
+workflow.final(constants.successResult);`
+	reader := factory.NewWorkflowSourceReader(dir, localWorkflowSourceFiles{})
+
+	loaded, issues := validationLoaderWorkflows.LoadSource(factory.WorkflowValidationLoadRequest{
+		SourceRef:    "workflow.js",
+		Content:      entry,
+		FactoryRoot:  dir,
+		BundleReader: reader,
+	})
+	if len(issues) > 0 {
+		t.Fatalf("load issues = %#v, want none", issues)
+	}
+
+	outcome, err := validationLoaderWorkflows.Run(t.Context(), factory.JavaScriptRuntimeRequest{
+		Source:    loaded.ExecutableSource,
+		SourceRef: "workflow.js",
+		SessionID: "session-namespace-import",
+		Args:      json.RawMessage(`{}`),
+		Policy:    workflowpolicy.DefaultEffectivePolicy(),
+	}, factory.JavaScriptRuntimeHooks{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !outcome.OK {
+		t.Fatalf("Run() failure = %#v", outcome.Failure)
+	}
+	if string(outcome.Value.JSON) != `"namespace-ok"` {
+		t.Fatalf("primary result = %s, want \"namespace-ok\"", outcome.Value.JSON)
+	}
+}
+
+func TestLoad_BundlesDefaultExportRelativeImportExecutes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "default-only.js"),
+		[]byte(`export default "default-export";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write default-only module: %v", err)
+	}
+	entry := `import importedDefault from "./lib/default-only.js";
+workflow.final(importedDefault);`
+	reader := factory.NewWorkflowSourceReader(dir, localWorkflowSourceFiles{})
+
+	loaded, issues := validationLoaderWorkflows.LoadSource(factory.WorkflowValidationLoadRequest{
+		SourceRef:    "workflow.js",
+		Content:      entry,
+		FactoryRoot:  dir,
+		BundleReader: reader,
+	})
+	if len(issues) > 0 {
+		t.Fatalf("load issues = %#v, want none", issues)
+	}
+
+	outcome, err := validationLoaderWorkflows.Run(t.Context(), factory.JavaScriptRuntimeRequest{
+		Source:    loaded.ExecutableSource,
+		SourceRef: "workflow.js",
+		SessionID: "session-default-import",
+		Args:      json.RawMessage(`{}`),
+		Policy:    workflowpolicy.DefaultEffectivePolicy(),
+	}, factory.JavaScriptRuntimeHooks{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !outcome.OK {
+		t.Fatalf("Run() failure = %#v", outcome.Failure)
+	}
+	if string(outcome.Value.JSON) != `"default-export"` {
+		t.Fatalf("primary result = %s, want \"default-export\"", outcome.Value.JSON)
+	}
+}

--- a/pkg/services/factory_runtime/javascript_bundler_loader_test.go
+++ b/pkg/services/factory_runtime/javascript_bundler_loader_test.go
@@ -354,6 +354,56 @@ workflow.final(importedDefault);`
 	}
 }
 
+func TestLoad_BundlesNamedDefaultFunctionLocalBindingExecutes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "default-fn.js"),
+		[]byte(`export default function helper() { return "OK"; }
+export const tag = typeof helper;`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write default-fn module: %v", err)
+	}
+	entry := `import helper, { tag } from "./lib/default-fn.js";
+workflow.final(helper() + ":" + tag);`
+	reader := factory.NewWorkflowSourceReader(dir, localWorkflowSourceFiles{})
+
+	loaded, issues := validationLoaderWorkflows.LoadSource(factory.WorkflowValidationLoadRequest{
+		SourceRef:    "workflow.js",
+		Content:      entry,
+		FactoryRoot:  dir,
+		BundleReader: reader,
+	})
+	if len(issues) > 0 {
+		t.Fatalf("load issues = %#v, want none", issues)
+	}
+	if strings.Contains(loaded.ExecutableSource, "exports.default = function helper") {
+		t.Fatalf("executable source = %q, want local function declaration before exports.default assignment", loaded.ExecutableSource)
+	}
+
+	outcome, err := validationLoaderWorkflows.Run(t.Context(), factory.JavaScriptRuntimeRequest{
+		Source:    loaded.ExecutableSource,
+		SourceRef: "workflow.js",
+		SessionID: "session-named-default-function",
+		Args:      json.RawMessage(`{}`),
+		Policy:    workflowpolicy.DefaultEffectivePolicy(),
+	}, factory.JavaScriptRuntimeHooks{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !outcome.OK {
+		t.Fatalf("Run() failure = %#v", outcome.Failure)
+	}
+	if string(outcome.Value.JSON) != `"OK:function"` {
+		t.Fatalf("primary result = %s, want \"OK:function\"", outcome.Value.JSON)
+	}
+}
+
 func TestLoad_BundlesCircularRelativeImportReturnsUnsupportedLoader(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_runtime/javascript_bundler_loader_test.go
+++ b/pkg/services/factory_runtime/javascript_bundler_loader_test.go
@@ -110,6 +110,63 @@ workflow.final(constants.successResult);`
 	}
 }
 
+func TestLoad_BundlesNestedRelativeImportChainExecutes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "leaf.js"),
+		[]byte(`export const leaf = "LEAF";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write leaf module: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "mid.js"),
+		[]byte(`import { leaf } from "./leaf.js";
+export const mid = leaf + "-MID";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write mid module: %v", err)
+	}
+	entry := `import { mid } from "./lib/mid.js";
+workflow.final(mid);`
+	reader := factory.NewWorkflowSourceReader(dir, localWorkflowSourceFiles{})
+
+	loaded, issues := validationLoaderWorkflows.LoadSource(factory.WorkflowValidationLoadRequest{
+		SourceRef:    "workflow.js",
+		Content:      entry,
+		FactoryRoot:  dir,
+		BundleReader: reader,
+	})
+	if len(issues) > 0 {
+		t.Fatalf("load issues = %#v, want none", issues)
+	}
+	if !strings.Contains(loaded.ExecutableSource, "const {leaf} = __factoryRequire(\"lib/leaf.js\");") {
+		t.Fatalf("executable source = %q, want nested import bindings inside mid module wrapper", loaded.ExecutableSource)
+	}
+
+	outcome, err := validationLoaderWorkflows.Run(t.Context(), factory.JavaScriptRuntimeRequest{
+		Source:    loaded.ExecutableSource,
+		SourceRef: "workflow.js",
+		SessionID: "session-nested-import-chain",
+		Args:      json.RawMessage(`{}`),
+		Policy:    workflowpolicy.DefaultEffectivePolicy(),
+	}, factory.JavaScriptRuntimeHooks{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !outcome.OK {
+		t.Fatalf("Run() failure = %#v", outcome.Failure)
+	}
+	if string(outcome.Value.JSON) != `"LEAF-MID"` {
+		t.Fatalf("primary result = %s, want \"LEAF-MID\"", outcome.Value.JSON)
+	}
+}
+
 func TestLoad_BundlesDefaultExportRelativeImportExecutes(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_runtime/javascript_bundler_loader_test.go
+++ b/pkg/services/factory_runtime/javascript_bundler_loader_test.go
@@ -212,3 +212,47 @@ workflow.final(importedDefault);`
 		t.Fatalf("primary result = %s, want \"default-export\"", outcome.Value.JSON)
 	}
 }
+
+func TestLoad_BundlesCircularRelativeImportReturnsUnsupportedLoader(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "a.js"),
+		[]byte(`import { b } from "./b.js";
+export const a = b;`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write a module: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "b.js"),
+		[]byte(`import { a } from "./a.js";
+export const b = a;`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write b module: %v", err)
+	}
+	entry := `import { a } from "./lib/a.js";
+workflow.final(a);`
+	reader := factory.NewWorkflowSourceReader(dir, localWorkflowSourceFiles{})
+
+	_, issues := validationLoaderWorkflows.LoadSource(factory.WorkflowValidationLoadRequest{
+		SourceRef:    "workflow.js",
+		Content:      entry,
+		FactoryRoot:  dir,
+		BundleReader: reader,
+	})
+	if len(issues) == 0 {
+		t.Fatal("load issues = nil, want circular import failure")
+	}
+	if issues[0].Code != "workflow.source.unsupportedLoader" {
+		t.Fatalf("issue code = %q, want workflow.source.unsupportedLoader", issues[0].Code)
+	}
+	if !strings.Contains(issues[0].Message, "circular factory-relative import") {
+		t.Fatalf("issue message = %q, want circular import diagnostic", issues[0].Message)
+	}
+}

--- a/pkg/services/factory_runtime/javascript_bundler_loader_test.go
+++ b/pkg/services/factory_runtime/javascript_bundler_loader_test.go
@@ -167,6 +167,54 @@ workflow.final(mid);`
 	}
 }
 
+func TestLoad_BundlesSameModuleExportReferencesExecute(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "helpers.js"),
+		[]byte(`export const leaf = "LEAF";
+export const doubled = leaf + "-X";
+export function suffix(value) { return value + "-FN"; }`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write helpers module: %v", err)
+	}
+	entry := `import { doubled, suffix } from "./lib/helpers.js";
+workflow.final(suffix(doubled));`
+	reader := factory.NewWorkflowSourceReader(dir, localWorkflowSourceFiles{})
+
+	loaded, issues := validationLoaderWorkflows.LoadSource(factory.WorkflowValidationLoadRequest{
+		SourceRef:    "workflow.js",
+		Content:      entry,
+		FactoryRoot:  dir,
+		BundleReader: reader,
+	})
+	if len(issues) > 0 {
+		t.Fatalf("load issues = %#v, want none", issues)
+	}
+
+	outcome, err := validationLoaderWorkflows.Run(t.Context(), factory.JavaScriptRuntimeRequest{
+		Source:    loaded.ExecutableSource,
+		SourceRef: "workflow.js",
+		SessionID: "session-same-module-export-refs",
+		Args:      json.RawMessage(`{}`),
+		Policy:    workflowpolicy.DefaultEffectivePolicy(),
+	}, factory.JavaScriptRuntimeHooks{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !outcome.OK {
+		t.Fatalf("Run() failure = %#v", outcome.Failure)
+	}
+	if string(outcome.Value.JSON) != `"LEAF-X-FN"` {
+		t.Fatalf("primary result = %s, want \"LEAF-X-FN\"", outcome.Value.JSON)
+	}
+}
+
 func TestLoad_BundlesDefaultExportRelativeImportExecutes(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_runtime/javascript_bundler_loader_test.go
+++ b/pkg/services/factory_runtime/javascript_bundler_loader_test.go
@@ -215,6 +215,99 @@ workflow.final(suffix(doubled));`
 	}
 }
 
+func TestLoad_BundlesDestructuredExportBindingsExecute(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "pairs.js"),
+		[]byte(`export const { a, b } = { a: "A", b: "B" };`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write pairs module: %v", err)
+	}
+	entry := `import { a, b } from "./lib/pairs.js";
+workflow.final(a + b);`
+	reader := factory.NewWorkflowSourceReader(dir, localWorkflowSourceFiles{})
+
+	loaded, issues := validationLoaderWorkflows.LoadSource(factory.WorkflowValidationLoadRequest{
+		SourceRef:    "workflow.js",
+		Content:      entry,
+		FactoryRoot:  dir,
+		BundleReader: reader,
+	})
+	if len(issues) > 0 {
+		t.Fatalf("load issues = %#v, want none", issues)
+	}
+
+	outcome, err := validationLoaderWorkflows.Run(t.Context(), factory.JavaScriptRuntimeRequest{
+		Source:    loaded.ExecutableSource,
+		SourceRef: "workflow.js",
+		SessionID: "session-destructured-export",
+		Args:      json.RawMessage(`{}`),
+		Policy:    workflowpolicy.DefaultEffectivePolicy(),
+	}, factory.JavaScriptRuntimeHooks{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !outcome.OK {
+		t.Fatalf("Run() failure = %#v", outcome.Failure)
+	}
+	if string(outcome.Value.JSON) != `"AB"` {
+		t.Fatalf("primary result = %s, want \"AB\"", outcome.Value.JSON)
+	}
+}
+
+func TestLoad_BundlesMutableLetExportSnapshotsFinalValue(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir lib: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "lib", "mutable.js"),
+		[]byte(`export let value = "initial";
+value = "updated";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write mutable module: %v", err)
+	}
+	entry := `import { value } from "./lib/mutable.js";
+workflow.final(value);`
+	reader := factory.NewWorkflowSourceReader(dir, localWorkflowSourceFiles{})
+
+	loaded, issues := validationLoaderWorkflows.LoadSource(factory.WorkflowValidationLoadRequest{
+		SourceRef:    "workflow.js",
+		Content:      entry,
+		FactoryRoot:  dir,
+		BundleReader: reader,
+	})
+	if len(issues) > 0 {
+		t.Fatalf("load issues = %#v, want none", issues)
+	}
+
+	outcome, err := validationLoaderWorkflows.Run(t.Context(), factory.JavaScriptRuntimeRequest{
+		Source:    loaded.ExecutableSource,
+		SourceRef: "workflow.js",
+		SessionID: "session-mutable-let-export",
+		Args:      json.RawMessage(`{}`),
+		Policy:    workflowpolicy.DefaultEffectivePolicy(),
+	}, factory.JavaScriptRuntimeHooks{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !outcome.OK {
+		t.Fatalf("Run() failure = %#v", outcome.Failure)
+	}
+	if string(outcome.Value.JSON) != `"updated"` {
+		t.Fatalf("primary result = %s, want \"updated\"", outcome.Value.JSON)
+	}
+}
+
 func TestLoad_BundlesDefaultExportRelativeImportExecutes(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_runtime/javascript_validation_contract.go
+++ b/pkg/services/factory_runtime/javascript_validation_contract.go
@@ -24,4 +24,5 @@ const (
 	WorkflowValidationCodeSourceUnreadable     = workflowvalidation.CodeSourceUnreadable
 	WorkflowValidationCodeUnsupportedLoader    = workflowvalidation.CodeUnsupportedLoader
 	WorkflowValidationCodeSourceHashMismatch   = workflowvalidation.CodeSourceHashMismatch
+	WorkflowValidationCodeImportNotFound       = workflowvalidation.CodeImportNotFound
 )

--- a/pkg/services/factory_runtime/service/orchestrator_definition_validation.go
+++ b/pkg/services/factory_runtime/service/orchestrator_definition_validation.go
@@ -135,10 +135,7 @@ func javascriptWorkflowSourceTargets(
 			},
 		)}
 	}
-	loaded, loadIssues := workflows.LoadSource(factoryruntime.WorkflowValidationLoadRequest{
-		SourceRef: sourceRef,
-		Content:   content,
-	})
+	loaded, loadIssues := workflows.LoadSource(workflowValidationLoadRequestFromReader(sourceRef, content, reader))
 	if len(loadIssues) > 0 {
 		return workflowIssuesToDefinitionTargets(loadIssues)
 	}
@@ -195,6 +192,26 @@ func workflowIssueToDefinitionTarget(
 			Location: factorydefinitions.ValidationSubjectLocationDefinition,
 		},
 	}
+}
+
+type factoryRootWorkflowSourceReader interface {
+	FactoryRoot() string
+}
+
+func workflowValidationLoadRequestFromReader(
+	sourceRef string,
+	content string,
+	reader factorydefinitions.WorkflowSourceReader,
+) factoryruntime.WorkflowValidationLoadRequest {
+	request := factoryruntime.WorkflowValidationLoadRequest{
+		SourceRef: sourceRef,
+		Content:   content,
+	}
+	if rootReader, ok := reader.(factoryRootWorkflowSourceReader); ok {
+		request.FactoryRoot = rootReader.FactoryRoot()
+		request.BundleReader = reader
+	}
+	return request
 }
 
 var _ factorydefinitions.OrchestratorDefinitionValidator = OrchestratorDefinitionValidation{}

--- a/pkg/services/factory_runtime/workflow_source_reader.go
+++ b/pkg/services/factory_runtime/workflow_source_reader.go
@@ -1,0 +1,9 @@
+package factory
+
+import workflowvalidation "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/javascript/validation"
+
+// NewWorkflowSourceReader returns a reader that resolves workflow source refs
+// relative to one factory root directory.
+func NewWorkflowSourceReader(rootDir string, files WorkflowSourceFileSystem) WorkflowSourceReader {
+	return workflowvalidation.FileSourceReader(rootDir, files)
+}

--- a/pkg/services/factory_sessions/internal/execution/fake_service_runtime_test.go
+++ b/pkg/services/factory_sessions/internal/execution/fake_service_runtime_test.go
@@ -2132,6 +2132,11 @@ func testRuntimeMetadataAndSourceValidationBranches(t *testing.T) {
 	if err := validationErrorFromSourceIssues([]factory.WorkflowValidationIssue{{Message: "bad source", Line: 3, Column: 5}}); err == nil || err.Error() != "bad source (line 3, column 5)" {
 		t.Fatalf("validationErrorFromSourceIssues(location) = %v", err)
 	}
+	if err := validationErrorFromSourceIssues([]factory.WorkflowValidationIssue{
+		{Code: factory.WorkflowValidationCodeImportNotFound, Message: "missing module"},
+	}); err == nil || err.Error() != "[workflow.source.notFound] missing module" {
+		t.Fatalf("validationErrorFromSourceIssues(code) = %v", err)
+	}
 	if err := validationErrorFromSourceIssues([]factory.WorkflowValidationIssue{{}}); err == nil || err.Error() != "workflow source validation failed" {
 		t.Fatalf("validationErrorFromSourceIssues(default message) = %v", err)
 	}

--- a/pkg/services/factory_sessions/internal/execution/prepare_start.go
+++ b/pkg/services/factory_sessions/internal/execution/prepare_start.go
@@ -271,6 +271,9 @@ func validationErrorFromSourceIssues(issues []factory.WorkflowValidationIssue) e
 		message = "workflow source validation failed"
 	}
 	message += issue.LocationSuffix()
+	if code := strings.TrimSpace(issue.Code); code != "" {
+		message = fmt.Sprintf("[%s] %s", code, message)
+	}
 	return NewValidationError("source", message)
 }
 

--- a/pkg/services/factory_sessions/internal/execution/prepare_start.go
+++ b/pkg/services/factory_sessions/internal/execution/prepare_start.go
@@ -75,7 +75,7 @@ func PrepareStart(
 	if err != nil {
 		return PreparedStart{}, err
 	}
-	if err := validateResolvedSourceContent(resolution, workflows); err != nil {
+	if err := validateResolvedSourceContent(normalized.Source, resolution, workflows); err != nil {
 		return PreparedStart{}, err
 	}
 	if err := workflows.ValidateArgs(resolution.ArgsSchema, normalized.Args); err != nil {
@@ -104,10 +104,7 @@ func PrepareStart(
 	}
 
 	executableSource := strings.TrimSpace(resolution.Content)
-	loaded, loadIssues := workflows.LoadSource(factory.WorkflowValidationLoadRequest{
-		SourceRef: resolution.SourceRef,
-		Content:   executableSource,
-	})
+	loaded, loadIssues := workflows.LoadSource(workflowValidationLoadRequest(normalized.Source, resolution, executableSource))
 	if len(loadIssues) > 0 {
 		return PreparedStart{}, validationErrorFromSourceIssues(loadIssues)
 	}
@@ -210,6 +207,7 @@ func applyInlineFactoryDeclaration(resolution *factory.WorkflowSourceResolution,
 }
 
 func validateResolvedSourceContent(
+	source Source,
 	resolution factory.WorkflowSourceResolution,
 	workflows factory.JavaScriptWorkflowDefinitions,
 ) error {
@@ -218,10 +216,7 @@ func validateResolvedSourceContent(
 		return NewValidationError("source", "workflow source content is empty")
 	}
 
-	loaded, loadIssues := workflows.LoadSource(factory.WorkflowValidationLoadRequest{
-		SourceRef: resolution.SourceRef,
-		Content:   content,
-	})
+	loaded, loadIssues := workflows.LoadSource(workflowValidationLoadRequest(source, resolution, content))
 	if len(loadIssues) > 0 {
 		return validationErrorFromSourceIssues(loadIssues)
 	}

--- a/pkg/services/factory_sessions/internal/execution/prepare_start_bundle.go
+++ b/pkg/services/factory_sessions/internal/execution/prepare_start_bundle.go
@@ -1,0 +1,82 @@
+package factorysessionexecution
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factory "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+type workflowBundleFileSystem struct{}
+
+func (workflowBundleFileSystem) ReadDir(path string) ([]fs.DirEntry, error) {
+	return os.ReadDir(path)
+}
+
+func (workflowBundleFileSystem) ReadFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+func (workflowBundleFileSystem) Stat(path string) (fs.FileInfo, error) {
+	return os.Stat(path)
+}
+
+func workflowValidationLoadRequest(
+	source Source,
+	resolution factory.WorkflowSourceResolution,
+	content string,
+) factory.WorkflowValidationLoadRequest {
+	request := factory.WorkflowValidationLoadRequest{
+		SourceRef: resolution.SourceRef,
+		Content:   content,
+	}
+	factoryRoot, entrySourceRef := factoryRootForWorkflowSource(source, resolution.SourceRef)
+	if factoryRoot == "" {
+		return request
+	}
+	if entrySourceRef != "" {
+		request.SourceRef = entrySourceRef
+	}
+	request.FactoryRoot = factoryRoot
+	request.BundleReader = factory.NewWorkflowSourceReader(factoryRoot, workflowBundleFileSystem{})
+	return request
+}
+
+func factoryRootForWorkflowSource(source Source, resolvedSourceRef string) (string, string) {
+	if source.Kind != factory.WorkflowSourceKindWorkflowFile {
+		return "", ""
+	}
+	workflowFile := strings.TrimSpace(source.WorkflowFile)
+	if workflowFile == "" {
+		return "", ""
+	}
+	if !filepath.IsAbs(workflowFile) {
+		return "", ""
+	}
+	factoryRoot := findFactoryRoot(filepath.Dir(workflowFile))
+	if factoryRoot == "" {
+		return "", ""
+	}
+	entrySourceRef, err := filepath.Rel(factoryRoot, workflowFile)
+	if err != nil {
+		return factoryRoot, filepath.ToSlash(strings.TrimSpace(resolvedSourceRef))
+	}
+	return factoryRoot, filepath.ToSlash(entrySourceRef)
+}
+
+func findFactoryRoot(startDir string) string {
+	dir := filepath.Clean(startDir)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, interfaces.FactoryConfigFile)); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}

--- a/tests/functional/orchestration/javascript/loading/file_javascript_test.go
+++ b/tests/functional/orchestration/javascript/loading/file_javascript_test.go
@@ -1,0 +1,3 @@
+// file_javascript_test.go holds customer functional scenarios for file-backed
+// JavaScript Factory loading through the public CLI and customer process boundary.
+package loading_test

--- a/tests/functional/orchestration/javascript/loading/file_javascript_test.go
+++ b/tests/functional/orchestration/javascript/loading/file_javascript_test.go
@@ -1,3 +1,118 @@
 // file_javascript_test.go holds customer functional scenarios for file-backed
 // JavaScript Factory loading through the public CLI and customer process boundary.
 package loading_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const fileJavaScriptImportedSuccessResult = "<FILE_IMPORT_SUCCESS>"
+
+// TestJavaScriptFactoryFileRunsRelativeImportsFromFactoryRoot proves a
+// file-backed JavaScript Factory resolves a factory-relative import through
+// the public you run customer process boundary with a terminal COMPLETED
+// primary outcome that reflects the imported module contribution.
+func TestJavaScriptFactoryFileRunsRelativeImportsFromFactoryRoot(t *testing.T) {
+	t.Parallel()
+
+	dir := scaffoldFileBackedJavaScriptFactoryWithRelativeImport(t)
+	mockWorkersPath := writeEmptyMockWorkersConfig(t, dir)
+
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "--json", "run",
+		"--factory", filepath.Join(dir, "factory.json"),
+		"--with-mock-workers", mockWorkersPath,
+		"--output", "primary",
+		"--no-record",
+		"hello",
+	})
+	homeDir := t.TempDir()
+	inputs.Input.Env = append(inputs.Input.Env, "HOME="+homeDir, "USERPROFILE="+homeDir)
+	inputs.Input.WorkingDirectory = dir
+
+	runner := support.NewRecordingCommandRunner("unexpected live provider execution")
+	if err := support.BuildProcess(t, serviceedges.Edges{
+		ProviderCommandRunner: runner,
+	}).Execute(inputs.Input); err != nil {
+		t.Fatalf("Process.Execute() error = %v\nstdout:\n%s\nstderr:\n%s", err, inputs.Stdout(), inputs.Stderr())
+	}
+	if inputs.Stderr() != "" {
+		t.Fatalf("stderr = %q, want empty stderr on successful JSON invocation", inputs.Stderr())
+	}
+	if runner.CallCount() != 0 {
+		t.Fatalf("provider command runner call count = %d, want 0 for file-backed factory without child dispatch", runner.CallCount())
+	}
+
+	result := decodeSingleInvocationResponse(t, inputs.Stdout())
+	assertFileJavaScriptImportedSuccessOutcome(t, result)
+	assertNoPrivateJavaScriptVMDiagnostics(t, inputs.Stdout(), inputs.Stderr())
+}
+
+func scaffoldFileBackedJavaScriptFactoryWithRelativeImport(t *testing.T) string {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, map[string]any{
+		"name": "file-javascript-relative-import",
+		"invocationSignature": map[string]any{
+			"parameters": []any{map[string]any{
+				"name": "prompt", "required": false,
+				"bindings": []any{map[string]any{"kind": "POSITIONAL", "position": 1}},
+			}},
+		},
+		"orchestrator": map[string]any{
+			"kind": "JAVASCRIPT",
+			"javascript": map[string]any{
+				"sourceRef": "workflow.js",
+				"argsSchema": map[string]any{
+					"type":                 "object",
+					"properties":           map[string]any{"prompt": map[string]any{"type": "string"}},
+					"additionalProperties": false,
+				},
+			},
+		},
+	})
+	libDir := filepath.Join(dir, "lib")
+	if err := os.MkdirAll(libDir, 0o700); err != nil {
+		t.Fatalf("create lib directory: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(libDir, "constants.js"),
+		[]byte(`export const successResult = "`+fileJavaScriptImportedSuccessResult+`";`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write imported module: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "workflow.js"),
+		[]byte(`import { successResult } from "./lib/constants.js";
+workflow.final(successResult);`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write workflow entry: %v", err)
+	}
+	return dir
+}
+
+func assertFileJavaScriptImportedSuccessOutcome(t *testing.T, result factoryapi.InvocationResponse) {
+	t.Helper()
+
+	if result.Status != factoryapi.InvocationTerminalStatusCompleted {
+		t.Fatalf("terminal outcome = %s, want COMPLETED", result.Status)
+	}
+	if result.PrimaryResult == nil || len(*result.PrimaryResult) != 1 {
+		t.Fatalf("primary result = %#v, want exactly one content part", result.PrimaryResult)
+	}
+	part, err := (*result.PrimaryResult)[0].AsWorkJsonContentPart()
+	if err != nil {
+		t.Fatalf("decode primary result content part: %v", err)
+	}
+	if got, ok := part.Json.(string); !ok || got != fileJavaScriptImportedSuccessResult {
+		t.Fatalf("primary result = %#v, want exact imported string %q", part.Json, fileJavaScriptImportedSuccessResult)
+	}
+}

--- a/tests/functional/orchestration/javascript/loading/file_javascript_test.go
+++ b/tests/functional/orchestration/javascript/loading/file_javascript_test.go
@@ -3,8 +3,10 @@
 package loading_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
@@ -12,7 +14,11 @@ import (
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
-const fileJavaScriptImportedSuccessResult = "<FILE_IMPORT_SUCCESS>"
+const (
+	fileJavaScriptImportedSuccessResult = "<FILE_IMPORT_SUCCESS>"
+	fileJavaScriptMissingImportPath     = "./lib/missing.js"
+	workflowSourceNotFoundCode          = "workflow.source.notFound"
+)
 
 // TestJavaScriptFactoryFileRunsRelativeImportsFromFactoryRoot proves a
 // file-backed JavaScript Factory resolves a factory-relative import through
@@ -51,6 +57,46 @@ func TestJavaScriptFactoryFileRunsRelativeImportsFromFactoryRoot(t *testing.T) {
 
 	result := decodeSingleInvocationResponse(t, inputs.Stdout())
 	assertFileJavaScriptImportedSuccessOutcome(t, result)
+	assertNoPrivateJavaScriptVMDiagnostics(t, inputs.Stdout(), inputs.Stderr())
+}
+
+// TestJavaScriptFactoryMissingImportFailsActionably proves a file-backed
+// JavaScript Factory with a missing factory-relative import fails before work
+// starts through the public you run customer process boundary with an
+// actionable load diagnostic and without private VM internals or external
+// worker dispatch.
+func TestJavaScriptFactoryMissingImportFailsActionably(t *testing.T) {
+	t.Parallel()
+
+	dir := scaffoldFileBackedJavaScriptFactoryWithMissingImport(t)
+	mockWorkersPath := writeEmptyMockWorkersConfig(t, dir)
+
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "--json", "run",
+		"--factory", filepath.Join(dir, "factory.json"),
+		"--with-mock-workers", mockWorkersPath,
+		"--output", "primary",
+		"--no-record",
+		"hello",
+	})
+	homeDir := t.TempDir()
+	inputs.Input.Env = append(inputs.Input.Env, "HOME="+homeDir, "USERPROFILE="+homeDir)
+	inputs.Input.WorkingDirectory = dir
+
+	runner := support.NewRecordingCommandRunner("unexpected live provider execution")
+	err := support.BuildProcess(t, serviceedges.Edges{
+		ProviderCommandRunner: runner,
+	}).Execute(inputs.Input)
+	assertFileJavaScriptMissingImportFailureOutcome(
+		t,
+		err,
+		inputs.Stdout(),
+		inputs.Stderr(),
+		fileJavaScriptMissingImportPath,
+	)
+	if runner.CallCount() != 0 {
+		t.Fatalf("provider command runner call count = %d, want 0 for missing import before dispatch", runner.CallCount())
+	}
 	assertNoPrivateJavaScriptVMDiagnostics(t, inputs.Stdout(), inputs.Stderr())
 }
 
@@ -97,6 +143,65 @@ workflow.final(successResult);`),
 		t.Fatalf("write workflow entry: %v", err)
 	}
 	return dir
+}
+
+func scaffoldFileBackedJavaScriptFactoryWithMissingImport(t *testing.T) string {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, map[string]any{
+		"name": "file-javascript-missing-import",
+		"invocationSignature": map[string]any{
+			"parameters": []any{map[string]any{
+				"name": "prompt", "required": false,
+				"bindings": []any{map[string]any{"kind": "POSITIONAL", "position": 1}},
+			}},
+		},
+		"orchestrator": map[string]any{
+			"kind": "JAVASCRIPT",
+			"javascript": map[string]any{
+				"sourceRef": "workflow.js",
+				"argsSchema": map[string]any{
+					"type":                 "object",
+					"properties":           map[string]any{"prompt": map[string]any{"type": "string"}},
+					"additionalProperties": false,
+				},
+			},
+		},
+	})
+	if err := os.WriteFile(
+		filepath.Join(dir, "workflow.js"),
+		[]byte(fmt.Sprintf(`import { missing } from %q;
+workflow.final(missing);`, fileJavaScriptMissingImportPath)),
+		0o600,
+	); err != nil {
+		t.Fatalf("write workflow entry: %v", err)
+	}
+	return dir
+}
+
+func assertFileJavaScriptMissingImportFailureOutcome(
+	t *testing.T,
+	runErr error,
+	stdout string,
+	stderr string,
+	wantImportPath string,
+) {
+	t.Helper()
+
+	if runErr == nil {
+		t.Fatalf("Process.Execute() error = nil, want missing import failure before invocation\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty stdout before terminal invocation on missing import failure", stdout)
+	}
+
+	failureText := strings.Join([]string{runErr.Error(), stderr}, "\n")
+	if !strings.Contains(failureText, workflowSourceNotFoundCode) {
+		t.Fatalf("failure output = %q, want customer-stable code %q", failureText, workflowSourceNotFoundCode)
+	}
+	if !strings.Contains(failureText, wantImportPath) {
+		t.Fatalf("failure output = %q, want missing import path %q", failureText, wantImportPath)
+	}
 }
 
 func assertFileJavaScriptImportedSuccessOutcome(t *testing.T, result factoryapi.InvocationResponse) {


### PR DESCRIPTION
{
  "project": "File-Based JavaScript Factory Loading Functional Coverage",
  "branchName": "ft-wave1-js-file-javascript",
  "description": "Add customer functional coverage at tests/functional/orchestration/javascript/loading/file_javascript_test.go proving a file-backed JavaScript Factory resolves relative imports from the Factory root through the public CLI/customer process boundary and that a missing import fails with an actionable customer diagnostic without private VM details or external dispatch. Do not implement named_factory_test.go or typescript_test.go; this destination has no owned migration-ledger rows.",
  "context": {
    "customerAsk": "Implement only tests/functional/orchestration/javascript/loading/file_javascript_test.go. Prove that a file-backed JavaScript Factory resolves relative imports from the Factory root through the public CLI/customer process boundary, and that a missing import fails with an actionable customer diagnostic without private VM details or external dispatch. Do not implement named_factory_test.go or typescript_test.go in this cell. Avoid service/internal Petri imports; add customer-readable Go doc comments on every top-level Test; update only narrowly coupled ownership/coverage/catalog/migration metadata required for this cell; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "Inline loading proves inline definitions but not file-backed Factory-root relative import resolution. The checklist destination file_javascript_test.go does not exist yet, so maintainers lack domain-owned proof that a file-backed JavaScript Factory resolves relative imports successfully and that a missing import fails actionably without private VM details or external dispatch, while named_factory and typescript siblings remain held on the same package.",
    "solution": "Deliver the orchestration-owned file-backed loading cell with TestJavaScriptFactoryFileRunsRelativeImportsFromFactoryRoot and TestJavaScriptFactoryMissingImportFailsActionably through the public CLI/customer process boundary. Do not invent migration-ledger deletion ownership (none mapped here) or implement named/TypeScript siblings; update only narrowly coupled ownership/coverage/catalog/migration metadata; verify focused package plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "Destination file tests/functional/orchestration/javascript/loading/file_javascript_test.go exists and is the only new customer functional scenario file owned by this cell.",
    "TestJavaScriptFactoryFileRunsRelativeImportsFromFactoryRoot proves a file-backed JavaScript Factory whose relative import resolves under the Factory root completes successfully through the public CLI/customer process boundary with a customer-visible primary/terminal outcome and without private VM internals on success.",
    "TestJavaScriptFactoryMissingImportFailsActionably proves a missing relative import returns an actionable customer diagnostic, does not leak private VM details, and performs no external dispatch.",
    "Planning confirmed no owned migration-ledger inventory rows for this destination; the cell does not invent deletion batches or claim ledger rows owned by inline, named_factory, or other cells.",
    "Every top-level Test* in the destination file has a customer-readable Go doc comment, the cell uses only public/root-built boundaries with no direct service or internal Petri imports, and named_factory_test.go / typescript_test.go are not implemented.",
    "Quality gate: focused destination package tests pass; make functional-boundary-check passes for the touched tree; required functional-test-viz-compatible catalog/metadata checks pass; typecheck, lint, and tests required by the changed surface pass."
  ],
  "userStories": [
    {
      "id": "ft-wave1-js-file-javascript-001",
      "title": "Place the file-backed JavaScript loading cell",
      "description": "As a maintainer expanding Wave 1 functional coverage, I need the destination file to exist under the domain-mirrored orchestration loading package so file-backed JavaScript loading has a durable owner beside any already-merged inline sibling.",
      "acceptanceCriteria": [
        "Package path tests/functional/orchestration/javascript/loading/ exists and conforms to the Wave 0 domain-layout rules for orchestration/javascript (create the package only if the merged inline sibling has not already placed it).",
        "Destination file tests/functional/orchestration/javascript/loading/file_javascript_test.go exists as the sole customer scenario file added for this cell.",
        "The package compiles under the short functional lane conventions used by neighboring Wave 1 cells (no accidental functionallong-only binding for these scenarios).",
        "No direct imports of service implementations or internal Petri packages appear in the new file.",
        "The cell does not add named_factory_test.go or typescript_test.go.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-js-file-javascript-002",
      "title": "Prove file-backed Factory resolves relative imports from Factory root",
      "description": "As a customer operator, I want a file-backed JavaScript Factory to resolve relative imports from the Factory root through the public you CLI / customer process boundary so multi-file Factory layouts load and complete without private runtime wiring.",
      "acceptanceCriteria": [
        "Top-level test TestJavaScriptFactoryFileRunsRelativeImportsFromFactoryRoot exists in the destination file.",
        "The test exercises a file-backed (not inline-only) JavaScript Factory definition whose runnable source depends on at least one relative import that resolves under the Factory root.",
        "The scenario runs through the public CLI or equivalent customer process boundary (for example root.BuildProcess / public run entry with --dir / Factory root), not through internal orchestrator constructors.",
        "On success, the process exits successfully and exposes a customer-visible completed/terminal primary outcome consistent with a successful Factory Session sync run.",
        "Success proves the relative import was resolved from the Factory root (for example the imported module’s observable contribution appears in the primary/terminal result or other public customer-visible outcome).",
        "Success diagnostics do not include private JavaScript VM internals.",
        "External effects are substituted only through edges.Edges / approved functional support (no live provider execution required for this proof).",
        "The test has a customer-readable Go doc comment whose first sentence states the observable CLI/customer behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-js-file-javascript-003",
      "title": "Prove missing relative import fails actionably",
      "description": "As a customer author, I want a missing relative import in a file-backed JavaScript Factory to fail before work starts with an actionable diagnostic so I can fix the path without reading VM internals.",
      "acceptanceCriteria": [
        "Top-level test TestJavaScriptFactoryMissingImportFailsActionably exists in the destination file.",
        "Feeding a file-backed JavaScript Factory that references a missing relative import yields a non-success customer-visible outcome.",
        "The failure diagnostic is actionable: it identifies the missing import/path (or equivalent customer-stable load failure signal) so an author can correct the Factory layout without inspecting private runtime state.",
        "Failure output/diagnostics do not expose private VM stack frames, engine heap dumps, or other non-customer VM internals.",
        "The failure occurs with no external worker/provider dispatch (no mock or live child invocation side effect for the rejected load).",
        "The public failure surface aligns with documented load/validation failure behavior (for example a workflow.source.* or equivalent customer-stable signal when one is emitted on this boundary).",
        "The test has a customer-readable Go doc comment whose first sentence states the observable failure behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-js-file-javascript-004",
      "title": "Preserve adjacent ownership and narrow metadata only",
      "description": "As a maintainer executing Wave 1 in parallel, I need this cell to stay inside file-javascript loading ownership, leave named/TypeScript siblings and other ledger batches untouched, and update only narrowly coupled metadata required for inventoriability.",
      "acceptanceCriteria": [
        "Planning found no owned migration-ledger inventory rows for file_javascript_test.go; this cell does not invent a deletion batch and does not claim rows destined to inline_javascript_test.go, named_factory_test.go, or typescript_test.go.",
        "Diff for this cell does not implement or modify named_factory_test.go or typescript_test.go.",
        "Only narrowly coupled ownership / coverage / catalog / migration metadata required for tests/functional/orchestration/javascript/loading/file_javascript_test.go are updated; specialty bindings remain none unless an existing binding already requires a minimal update.",
        "If any applicable ledger mapping is discovered during implementation that already destinations this exact checklist path, consume it without widening ownership to unrelated scenarios or sibling cells.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-js-file-javascript-005",
      "title": "Verify focused package, boundary, and metadata gates",
      "description": "As a reviewer, I want focused verification evidence that the file-backed JavaScript loading cell meets functional boundary and viz-compatible metadata rules without running unrelated suites as the primary proof.",
      "acceptanceCriteria": [
        "Focused tests for the destination package tests/functional/orchestration/javascript/loading pass for the two checklist scenarios owned by this cell.",
        "make functional-boundary-check passes for the touched functional tree.",
        "Functional-test-viz-compatible catalog/metadata checks required for this cell pass (including Go doc presence for every top-level Test* in the destination file).",
        "Checklist item for tests/functional/orchestration/javascript/loading/file_javascript_test.go can be marked complete against the two named scenarios.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)