### PR TITLE
ft-wave1-cli-stream-backpressure

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -240,6 +240,17 @@
   metadata infers domain `transport` and subsection `cli/parameters` from the
   path; every top-level `Test*` needs a customer-readable Go doc so
   `functionaltestmetadata` stays viz-compatible.
+  CLI response-stream backpressure functional coverage belongs in
+  `tests/functional/transport/cli/output/stream_backpressure_test.go`:
+  invoke `support.BuildProcess` with a gated or terminal-failing stdout writer
+  on `you --json run … --output response-stream`, prove NDJSON Factory Event
+  order and terminal `invocation_result` placement survive slow stdout drains,
+  and prove stdout writer failure ends the invocation unsuccessfully while
+  cancelling in-flight mock-worker external work through
+  `edges.Edges.ProviderCommandRunner`. Catalog metadata infers domain
+  `transport` and subsection `cli/output` from the path. Every top-level `Test*`
+  needs a customer-readable Go doc so `functionaltestmetadata` stays
+  viz-compatible.
   CLI docs command wiring functional coverage belongs in
   `tests/functional/transport/cli/commands/docs_wiring_test.go`: prove packaged
   topic discovery, index-driven non-empty topic rendering, and actionable

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -242,12 +242,16 @@
   `functionaltestmetadata` stays viz-compatible.
   CLI response-stream backpressure functional coverage belongs in
   `tests/functional/transport/cli/output/stream_backpressure_test.go`:
-  invoke `support.BuildProcess` with a gated or terminal-failing stdout writer
+  invoke `support.BuildProcess` with a gated or mid-stream-failing stdout writer
   on `you --json run … --output response-stream`, prove NDJSON Factory Event
   order and terminal `invocation_result` placement survive slow stdout drains,
   and prove stdout writer failure ends the invocation unsuccessfully while
   cancelling in-flight mock-worker external work through
-  `edges.Edges.ProviderCommandRunner`. Catalog metadata infers domain
+  `edges.Edges.ProviderCommandRunner` with a runner that blocks until its
+  context is cancelled. Response-stream stdout write failures cancel the
+  invocation through `pkg/transports/cli/run/factory_invocation_input.go`, and
+  worker-pool shutdown cancels in-flight executor contexts through
+  `pkg/services/factory_runtime/runtime/worker_pool.go`. Catalog metadata infers domain
   `transport` and subsection `cli/output` from the path. Every top-level `Test*`
   needs a customer-readable Go doc so `functionaltestmetadata` stays
   viz-compatible.

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -131,7 +131,7 @@ intentionally small enough to distribute across many agents.
   - `TestCLITextStreamDoesNotPrintStructuredEnvelopeNoise` covers human mode.
   - `TestCLITextStreamInterruptedRunDoesNotClaimCompletion` covers failure.
 
-- [ ] `tests/functional/transport/cli/output/stream_backpressure_test.go`
+- [x] `tests/functional/transport/cli/output/stream_backpressure_test.go`
   - `TestCLISlowWriterDoesNotReorderResponseEvents` uses a controlled blocking
     writer.
   - `TestCLIWriterFailureCancelsInvocation` verifies output failure cleanup.

--- a/pkg/services/factory_runtime/runtime/worker_pool.go
+++ b/pkg/services/factory_runtime/runtime/worker_pool.go
@@ -191,11 +191,13 @@ func validObservationScope(scope factory.ObservationScope) bool {
 }
 
 type workerPool struct {
-	runners  map[string]*workerRunner
-	resultCh chan workerexecution.WorkResult
-	logger   logging.Logger
-	mu       sync.RWMutex
-	clock    factory.Clock
+	runners   map[string]*workerRunner
+	resultCh  chan workerexecution.WorkResult
+	logger    logging.Logger
+	mu        sync.RWMutex
+	clock     factory.Clock
+	runCtx    context.Context
+	runCancel context.CancelFunc
 }
 
 func newWorkerPool(logger logging.Logger, clock factory.Clock) *workerPool {
@@ -239,17 +241,37 @@ func (p *workerPool) Dispatch(workerType string, dispatch work.WorkDispatch) boo
 func (p *workerPool) ResultCh() <-chan workerexecution.WorkResult { return p.resultCh }
 
 func (p *workerPool) Start() {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
+	p.mu.Lock()
+	if p.runCancel == nil {
+		p.runCtx, p.runCancel = context.WithCancel(context.Background())
+	}
+	runCtx := p.runCtx
+	runners := make([]*workerRunner, 0, len(p.runners))
 	for _, runner := range p.runners {
+		runner.runCtx = runCtx
+		runners = append(runners, runner)
+	}
+	p.mu.Unlock()
+	for _, runner := range runners {
 		runner.Start()
 	}
 }
 
 func (p *workerPool) Stop() {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
+	p.mu.Lock()
+	cancel := p.runCancel
+	p.runCancel = nil
+	p.runCtx = nil
+	runners := make([]*workerRunner, 0, len(p.runners))
 	for _, runner := range p.runners {
+		runner.runCtx = nil
+		runners = append(runners, runner)
+	}
+	p.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	for _, runner := range runners {
 		runner.Stop()
 	}
 }
@@ -262,6 +284,7 @@ type workerRunner struct {
 	resultCh   chan<- workerexecution.WorkResult
 	stopOnce   sync.Once
 	clock      factory.Clock
+	runCtx     context.Context
 }
 
 func newWorkerRunner(
@@ -329,7 +352,11 @@ func (r *workerRunner) execute(dispatch work.WorkDispatch) (result workerexecuti
 			"worker_type", r.workerType,
 			"transition_id", dispatch.TransitionID,
 			"dispatch_id", dispatch.DispatchID)...)
-	result, err := r.executor.Execute(context.Background(), dispatch)
+	execCtx := context.Background()
+	if r.runCtx != nil {
+		execCtx = r.runCtx
+	}
+	result, err := r.executor.Execute(execCtx, dispatch)
 	elapsed := r.clock.Now().Sub(start)
 	if err != nil {
 		r.logger.Error("runner: execution error",

--- a/pkg/transports/cli/run/factory_invocation_input.go
+++ b/pkg/transports/cli/run/factory_invocation_input.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
+	"sync"
 
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/transports/cli/climanifest"
@@ -273,7 +275,16 @@ func runFactoryInvocation(
 
 	logPackagedTTSInvocationStart(cfg)
 
-	streamRenderer := invocationFactoryEventRenderer(cfg, presentation)
+	invocationCfg := cfg
+	invokeCtx := ctx
+	if isResponseStreamOutputMode(cfg.InvocationOutputMode) && cfg.Output != nil {
+		var cancel context.CancelFunc
+		invokeCtx, cancel = context.WithCancel(ctx)
+		defer cancel()
+		invocationCfg.Output = responseStreamOutputCancelOnWriteError(cfg.Output, cancel)
+	}
+
+	streamRenderer := invocationFactoryEventRenderer(invocationCfg, presentation)
 	if streamRenderer != nil {
 		defer streamRenderer.stopProgressRendering()
 	}
@@ -289,15 +300,41 @@ func runFactoryInvocation(
 		invocationRequest.ContentProvided = false
 		invocationRequest.PreparedInvocationInput = cfg.PreparedInvocationInput.Clone()
 	}
-	outcome, err := invocation.InvokeFactory(ctx, target, invocationRequest, consume)
+	outcome, err := invocation.InvokeFactory(invokeCtx, target, invocationRequest, consume)
 	if err != nil {
 		return MapInvocationFailure(err)
 	}
 	result := outcome.Result
 	if result.Status != interfaces.InvocationTerminalStatusCompleted {
-		return writeInvocationFailure(cfg, result, streamRenderer)
+		return writeInvocationFailure(invocationCfg, result, streamRenderer)
 	}
-	return writeInvocationSuccess(cfg, result, streamRenderer)
+	return writeInvocationSuccess(invocationCfg, result, streamRenderer)
+}
+
+type responseStreamCancelOnWriteError struct {
+	writer  io.Writer
+	onError func()
+	once    sync.Once
+}
+
+func responseStreamOutputCancelOnWriteError(writer io.Writer, onError context.CancelFunc) io.Writer {
+	if writer == nil || onError == nil {
+		return writer
+	}
+	return &responseStreamCancelOnWriteError{
+		writer: writer,
+		onError: func() {
+			onError()
+		},
+	}
+}
+
+func (writer *responseStreamCancelOnWriteError) Write(payload []byte) (int, error) {
+	written, err := writer.writer.Write(payload)
+	if err != nil {
+		writer.once.Do(writer.onError)
+	}
+	return written, err
 }
 
 func invocationTarget(

--- a/pkg/transports/cli/run/factory_invocation_input_test.go
+++ b/pkg/transports/cli/run/factory_invocation_input_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/work"
@@ -326,4 +327,30 @@ func TestObserveInvocationRejection_AmbiguousInputRecordsStructuredLogAndMetrics
 	if got := snapshotCleanInvocationMetrics(); got != (CleanInvocationMetricsSnapshot{Attempts: 1, AmbiguityRejected: 1}) {
 		t.Fatalf("metrics = %#v", got)
 	}
+}
+
+func TestResponseStreamOutputCancelOnWriteErrorCancelsInvocationContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	writeErr := errors.New("broken stdout pipe")
+	writer := responseStreamOutputCancelOnWriteError(errorWriter{err: writeErr}, cancel)
+	if _, err := writer.Write([]byte("record")); !errors.Is(err, writeErr) {
+		t.Fatalf("Write() error = %v, want %v", err, writeErr)
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for invocation cancellation after stdout write failure")
+	}
+}
+
+type errorWriter struct {
+	err error
+}
+
+func (writer errorWriter) Write([]byte) (int, error) {
+	return 0, writer.err
 }

--- a/tests/functional/transport/cli/output/stream_backpressure_test.go
+++ b/tests/functional/transport/cli/output/stream_backpressure_test.go
@@ -134,16 +134,28 @@ func (writer *gatedStdoutWriter) release() {
 	})
 }
 
-func waitForStdoutWriteAttempt(t *testing.T, writer *gatedStdoutWriter) {
+func waitForStdoutWriteAttempt(t *testing.T, writer stdoutWriteObserver) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		if writer.attempts.Load() > 0 {
+		if writer.writeAttempts() > 0 {
 			return
 		}
 		time.Sleep(time.Millisecond)
 	}
 	t.Fatal("timed out waiting for stdout write under backpressure")
+}
+
+type stdoutWriteObserver interface {
+	writeAttempts() int64
+}
+
+func (writer *gatedStdoutWriter) writeAttempts() int64 {
+	return writer.attempts.Load()
+}
+
+func (writer *inFlightFailureStdoutWriter) writeAttempts() int64 {
+	return writer.attempts.Load()
 }
 
 func runGoalResponseStreamWithStdout(t *testing.T, stdout *gatedStdoutWriter) *gatedStdoutWriter {
@@ -193,10 +205,11 @@ func runGoalResponseStreamWithStdout(t *testing.T, stdout *gatedStdoutWriter) *g
 // external work so no orphaned subprocess remains after the CLI returns.
 func TestCLIWriterFailureCancelsInvocation(t *testing.T) {
 	externalWork := newCancellableExternalWorkRunner()
-	writer := newTerminalFailingStdoutWriter(errors.New(writerFailureStdoutError))
+	writer := newInFlightFailureStdoutWriter(errors.New(writerFailureStdoutError), externalWork)
 	runGoalResponseStreamWriterFailure(t, externalWork, writer)
 
 	waitForExternalWorkStart(t, externalWork)
+	waitForStdoutBufferedRecords(t, writer)
 
 	select {
 	case <-writer.done:
@@ -213,7 +226,7 @@ func TestCLIWriterFailureCancelsInvocation(t *testing.T) {
 	}
 
 	if err := externalWork.waitFinished(writerFailureScenarioTimeout); err != nil {
-		t.Fatalf("external mock-worker work still in flight after CLI returned: %v", err)
+		t.Fatalf("external mock-worker work teardown not observed after CLI returned: %v", err)
 	}
 	if !errors.Is(externalWork.runErr(), context.Canceled) {
 		t.Fatalf("external work cancellation error = %v, want context.Canceled", externalWork.runErr())
@@ -221,7 +234,7 @@ func TestCLIWriterFailureCancelsInvocation(t *testing.T) {
 
 	records := decodeNDJSONRecords(t, writer.String())
 	if len(records) == 0 {
-		t.Fatal("stdout empty, want Factory Event records before terminal writer failure")
+		t.Fatal("stdout empty, want Factory Event records before mid-stream writer failure")
 	}
 	for index, record := range records {
 		if record.RecordType == invocationResultType {
@@ -231,9 +244,10 @@ func TestCLIWriterFailureCancelsInvocation(t *testing.T) {
 }
 
 type cancellableExternalWorkRunner struct {
-	started   chan struct{}
-	finished  chan struct{}
-	finishOnce sync.Once
+	startedCh   chan struct{}
+	startedFlag atomic.Bool
+	finished    chan struct{}
+	finishOnce  sync.Once
 
 	mu  sync.Mutex
 	err error
@@ -241,29 +255,30 @@ type cancellableExternalWorkRunner struct {
 
 func newCancellableExternalWorkRunner() *cancellableExternalWorkRunner {
 	return &cancellableExternalWorkRunner{
-		started:  make(chan struct{}, 1),
-		finished: make(chan struct{}),
+		startedCh: make(chan struct{}, 1),
+		finished:  make(chan struct{}),
 	}
 }
 
 func (runner *cancellableExternalWorkRunner) Run(ctx context.Context, _ platformprocess.CommandRequest) (platformprocess.CommandResult, error) {
+	runner.startedFlag.Store(true)
 	select {
-	case runner.started <- struct{}{}:
+	case runner.startedCh <- struct{}{}:
 	default:
 	}
-	go func() {
-		<-ctx.Done()
-		runner.mu.Lock()
-		runner.err = ctx.Err()
-		runner.mu.Unlock()
-		runner.finishOnce.Do(func() {
-			close(runner.finished)
-		})
-	}()
-	return platformprocess.CommandResult{Stdout: []byte(writerFailureMockWorkerStdout)}, nil
+	<-ctx.Done()
+	runner.mu.Lock()
+	runner.err = ctx.Err()
+	runner.mu.Unlock()
+	runner.finishOnce.Do(func() {
+		close(runner.finished)
+	})
+	return platformprocess.CommandResult{}, ctx.Err()
 }
 
-const writerFailureMockWorkerStdout = "mock worker accepted\n<COMPLETE>"
+func (runner *cancellableExternalWorkRunner) started() bool {
+	return runner.startedFlag.Load()
+}
 
 func (runner *cancellableExternalWorkRunner) runErr() error {
 	runner.mu.Lock()
@@ -280,8 +295,14 @@ func (runner *cancellableExternalWorkRunner) waitFinished(timeout time.Duration)
 	}
 }
 
-type terminalFailingStdoutWriter struct {
-	failErr error
+type inFlightFailureStdoutWriter struct {
+	failErr      error
+	externalWork *cancellableExternalWorkRunner
+	gate         chan struct{}
+
+	attempts    atomic.Int64
+	failArmed   atomic.Bool
+	releaseOnce sync.Once
 
 	mu         sync.Mutex
 	buffer     bytes.Buffer
@@ -291,38 +312,82 @@ type terminalFailingStdoutWriter struct {
 	err  error
 }
 
-func newTerminalFailingStdoutWriter(failErr error) *terminalFailingStdoutWriter {
-	return &terminalFailingStdoutWriter{
-		failErr: failErr,
-		done:    make(chan struct{}),
+func newInFlightFailureStdoutWriter(
+	failErr error,
+	externalWork *cancellableExternalWorkRunner,
+) *inFlightFailureStdoutWriter {
+	writer := &inFlightFailureStdoutWriter{
+		failErr:      failErr,
+		externalWork: externalWork,
+		gate:         make(chan struct{}),
+		done:         make(chan struct{}),
 	}
+	go func() {
+		for externalWork != nil && !externalWork.started() {
+			time.Sleep(time.Millisecond)
+		}
+		writer.release()
+	}()
+	return writer
 }
 
-func (writer *terminalFailingStdoutWriter) Write(payload []byte) (int, error) {
-	if bytes.Contains(payload, []byte(`"recordType":"invocation_result"`)) {
+func (writer *inFlightFailureStdoutWriter) armFailure() {
+	writer.failArmed.Store(true)
+	writer.release()
+}
+
+func (writer *inFlightFailureStdoutWriter) release() {
+	writer.releaseOnce.Do(func() {
+		close(writer.gate)
+	})
+}
+
+func (writer *inFlightFailureStdoutWriter) Write(payload []byte) (int, error) {
+	writer.attempts.Add(1)
+	<-writer.gate
+	if writer.failArmed.Load() {
 		return 0, writer.failErr
 	}
 	writer.mu.Lock()
-	defer writer.mu.Unlock()
-	return writer.buffer.Write(payload)
+	written, err := writer.buffer.Write(payload)
+	writer.mu.Unlock()
+	if err != nil {
+		return written, err
+	}
+	if writer.externalWork != nil && writer.externalWork.started() {
+		writer.failArmed.Store(true)
+	}
+	return written, nil
 }
 
-func (writer *terminalFailingStdoutWriter) String() string {
+func (writer *inFlightFailureStdoutWriter) String() string {
 	writer.mu.Lock()
 	defer writer.mu.Unlock()
 	return writer.buffer.String()
 }
 
-func (writer *terminalFailingStdoutWriter) diagnosticText() string {
+func (writer *inFlightFailureStdoutWriter) diagnosticText() string {
 	writer.mu.Lock()
 	defer writer.mu.Unlock()
 	return writer.diagnostic.String()
 }
 
+func waitForStdoutBufferedRecords(t *testing.T, writer *inFlightFailureStdoutWriter) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.TrimSpace(writer.String()) != "" {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("timed out waiting for buffered stdout records before mid-stream writer failure")
+}
+
 func waitForExternalWorkStart(t *testing.T, runner *cancellableExternalWorkRunner) {
 	t.Helper()
 	select {
-	case <-runner.started:
+	case <-runner.startedCh:
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for mock-worker external work to start")
 	}
@@ -331,7 +396,7 @@ func waitForExternalWorkStart(t *testing.T, runner *cancellableExternalWorkRunne
 func runGoalResponseStreamWriterFailure(
 	t *testing.T,
 	externalWork *cancellableExternalWorkRunner,
-	stdout *terminalFailingStdoutWriter,
+	stdout *inFlightFailureStdoutWriter,
 ) {
 	t.Helper()
 
@@ -359,6 +424,7 @@ func runGoalResponseStreamWriterFailure(
 	}()
 
 	t.Cleanup(func() {
+		stdout.release()
 		select {
 		case <-stdout.done:
 		case <-time.After(writerFailureScenarioTimeout):

--- a/tests/functional/transport/cli/output/stream_backpressure_test.go
+++ b/tests/functional/transport/cli/output/stream_backpressure_test.go
@@ -331,11 +331,6 @@ func newInFlightFailureStdoutWriter(
 	return writer
 }
 
-func (writer *inFlightFailureStdoutWriter) armFailure() {
-	writer.failArmed.Store(true)
-	writer.release()
-}
-
 func (writer *inFlightFailureStdoutWriter) release() {
 	writer.releaseOnce.Do(func() {
 		close(writer.gate)

--- a/tests/functional/transport/cli/output/stream_backpressure_test.go
+++ b/tests/functional/transport/cli/output/stream_backpressure_test.go
@@ -1,0 +1,181 @@
+package output_test
+
+import (
+	"bytes"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const slowWriterScenarioTimeout = 30 * time.Second
+
+// TestCLISlowWriterDoesNotReorderResponseEvents proves CLI NDJSON
+// response-stream output preserves Factory Event and terminal InvocationResult
+// emission order when stdout is blocked by a slow consumer, so parsers never
+// observe reordered lifecycle or result records under backpressure.
+func TestCLISlowWriterDoesNotReorderResponseEvents(t *testing.T) {
+	writer := newGatedStdoutWriter()
+	stdout := runGoalResponseStreamWithStdout(t, writer)
+
+	waitForStdoutWriteAttempt(t, writer)
+	select {
+	case <-writer.done:
+		t.Fatal("invocation completed while stdout writer remained blocked")
+	default:
+	}
+	writer.release()
+
+	select {
+	case <-writer.done:
+	case <-time.After(slowWriterScenarioTimeout):
+		t.Fatalf("timed out waiting for invocation to finish after releasing slow stdout writer")
+	}
+	if err := writer.err; err != nil {
+		t.Fatalf("Process.Execute error = %v\nstdout:\n%s", err, stdout.String())
+	}
+	if writer.diagnosticText() != "" {
+		t.Fatalf("stderr = %q, want empty successful-run stderr", writer.diagnosticText())
+	}
+
+	records := decodeNDJSONRecords(t, stdout.String())
+	previousSequence := -1
+	previousSessionSequence := -1
+	factoryEventCount := 0
+	invocationResultSeen := false
+	for index, record := range records {
+		switch record.RecordType {
+		case factoryEventRecordType:
+			if invocationResultSeen {
+				t.Fatalf("Factory Event record %d follows terminal invocation result", index)
+			}
+			assertFactoryEventSequenceMonotonic(t, record, index, &previousSequence, &previousSessionSequence)
+			factoryEventCount++
+		case invocationResultType:
+			if invocationResultSeen {
+				t.Fatalf("second invocation_result at record %d", index)
+			}
+			invocationResultSeen = true
+			if index != len(records)-1 {
+				t.Fatalf("invocation_result record index = %d, want terminal index %d", index, len(records)-1)
+			}
+			assertInvocationResultRecord(t, record, index)
+		default:
+			t.Fatalf("record %d has unsupported recordType %q", index, record.RecordType)
+		}
+	}
+	if factoryEventCount == 0 {
+		t.Fatal("response stream contains no Factory Event records to order")
+	}
+	if previousSessionSequence < 0 {
+		t.Fatal("Factory Event records contain no public Factory Session sequence data")
+	}
+	if !invocationResultSeen {
+		t.Fatal("response stream missing terminal invocation_result")
+	}
+}
+
+type gatedStdoutWriter struct {
+	gate     chan struct{}
+	attempts atomic.Int64
+	releaseOnce sync.Once
+
+	mu         sync.Mutex
+	buffer     bytes.Buffer
+	diagnostic bytes.Buffer
+
+	done chan struct{}
+	err  error
+}
+
+func newGatedStdoutWriter() *gatedStdoutWriter {
+	return &gatedStdoutWriter{
+		gate: make(chan struct{}),
+		done: make(chan struct{}),
+	}
+}
+
+func (writer *gatedStdoutWriter) Write(payload []byte) (int, error) {
+	writer.attempts.Add(1)
+	<-writer.gate
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	return writer.buffer.Write(payload)
+}
+
+func (writer *gatedStdoutWriter) String() string {
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	return writer.buffer.String()
+}
+
+func (writer *gatedStdoutWriter) diagnosticText() string {
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	return writer.diagnostic.String()
+}
+
+func (writer *gatedStdoutWriter) release() {
+	writer.releaseOnce.Do(func() {
+		close(writer.gate)
+	})
+}
+
+func waitForStdoutWriteAttempt(t *testing.T, writer *gatedStdoutWriter) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if writer.attempts.Load() > 0 {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("timed out waiting for stdout write under backpressure")
+}
+
+func runGoalResponseStreamWithStdout(t *testing.T, stdout *gatedStdoutWriter) *gatedStdoutWriter {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	support.InstallPackagedFactory(t, homeDir, goalFactoryName)
+	mockWorkersPath := support.WriteMockWorkersConfig(t, &workers.MockWorkersConfig{
+		UnmatchedDispatchPolicy: workers.MockWorkerUnmatchedDispatchPolicyPassthrough,
+		MockWorkers: []workers.MockWorkerConfig{{
+			WorkerName:      "goal-executor",
+			WorkstationName: "execute-goal",
+			RunType:         workers.MockWorkerRunTypeAccept,
+		}},
+	})
+	args := []string{
+		"you", "--json", "run", "--named", goalFactoryName,
+		"--with-mock-workers", mockWorkersPath,
+		"--no-record", "--output", "response-stream",
+		"deterministic slow-writer ordering contract",
+	}
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	inputs.Input.WorkingDirectory = t.TempDir()
+	inputs.Input.Stdout = stdout
+	inputs.Input.Stderr = &stdout.diagnostic
+	process := support.BuildProcess(t, serviceedges.Edges{})
+
+	go func() {
+		stdout.err = process.Execute(inputs.Input)
+		close(stdout.done)
+	}()
+
+	t.Cleanup(func() {
+		stdout.release()
+		select {
+		case <-stdout.done:
+		case <-time.After(slowWriterScenarioTimeout):
+			t.Errorf("timed out waiting for invocation cleanup")
+		}
+	})
+	return stdout
+}

--- a/tests/functional/transport/cli/output/stream_backpressure_test.go
+++ b/tests/functional/transport/cli/output/stream_backpressure_test.go
@@ -2,18 +2,26 @@ package output_test
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
-const slowWriterScenarioTimeout = 30 * time.Second
+const (
+	slowWriterScenarioTimeout    = 30 * time.Second
+	writerFailureScenarioTimeout = 30 * time.Second
+	writerFailureStdoutError     = "broken stdout pipe"
+)
 
 // TestCLISlowWriterDoesNotReorderResponseEvents proves CLI NDJSON
 // response-stream output preserves Factory Event and terminal InvocationResult
@@ -179,3 +187,199 @@ func runGoalResponseStreamWithStdout(t *testing.T, stdout *gatedStdoutWriter) *g
 	})
 	return stdout
 }
+
+// TestCLIWriterFailureCancelsInvocation proves a broken stdout writer ends the
+// CLI response-stream invocation unsuccessfully and cancels in-flight mock-worker
+// external work so no orphaned subprocess remains after the CLI returns.
+func TestCLIWriterFailureCancelsInvocation(t *testing.T) {
+	externalWork := newCancellableExternalWorkRunner()
+	writer := newTerminalFailingStdoutWriter(errors.New(writerFailureStdoutError))
+	runGoalResponseStreamWriterFailure(t, externalWork, writer)
+
+	waitForExternalWorkStart(t, externalWork)
+
+	select {
+	case <-writer.done:
+	case <-time.After(writerFailureScenarioTimeout):
+		t.Fatalf("timed out waiting for invocation to finish after stdout writer failure")
+	}
+
+	if writer.err == nil {
+		t.Fatalf("Process.Execute error = nil, want stdout writer failure\nstdout:\n%s\nstderr:\n%s",
+			writer.String(), writer.diagnosticText())
+	}
+	if !errors.Is(writer.err, writer.failErr) && !strings.Contains(writer.err.Error(), writerFailureStdoutError) {
+		t.Fatalf("Process.Execute error = %v, want stdout writer failure", writer.err)
+	}
+
+	if err := externalWork.waitFinished(writerFailureScenarioTimeout); err != nil {
+		t.Fatalf("external mock-worker work still in flight after CLI returned: %v", err)
+	}
+	if !errors.Is(externalWork.runErr(), context.Canceled) {
+		t.Fatalf("external work cancellation error = %v, want context.Canceled", externalWork.runErr())
+	}
+
+	records := decodeNDJSONRecords(t, writer.String())
+	if len(records) == 0 {
+		t.Fatal("stdout empty, want Factory Event records before terminal writer failure")
+	}
+	for index, record := range records {
+		if record.RecordType == invocationResultType {
+			t.Fatalf("record %d is invocation_result, want writer failure before terminal record", index)
+		}
+	}
+}
+
+type cancellableExternalWorkRunner struct {
+	started   chan struct{}
+	finished  chan struct{}
+	finishOnce sync.Once
+
+	mu  sync.Mutex
+	err error
+}
+
+func newCancellableExternalWorkRunner() *cancellableExternalWorkRunner {
+	return &cancellableExternalWorkRunner{
+		started:  make(chan struct{}, 1),
+		finished: make(chan struct{}),
+	}
+}
+
+func (runner *cancellableExternalWorkRunner) Run(ctx context.Context, _ platformprocess.CommandRequest) (platformprocess.CommandResult, error) {
+	select {
+	case runner.started <- struct{}{}:
+	default:
+	}
+	go func() {
+		<-ctx.Done()
+		runner.mu.Lock()
+		runner.err = ctx.Err()
+		runner.mu.Unlock()
+		runner.finishOnce.Do(func() {
+			close(runner.finished)
+		})
+	}()
+	return platformprocess.CommandResult{Stdout: []byte(writerFailureMockWorkerStdout)}, nil
+}
+
+const writerFailureMockWorkerStdout = "mock worker accepted\n<COMPLETE>"
+
+func (runner *cancellableExternalWorkRunner) runErr() error {
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+	return runner.err
+}
+
+func (runner *cancellableExternalWorkRunner) waitFinished(timeout time.Duration) error {
+	select {
+	case <-runner.finished:
+		return nil
+	case <-time.After(timeout):
+		return errors.New("timed out waiting for external work teardown")
+	}
+}
+
+type terminalFailingStdoutWriter struct {
+	failErr error
+
+	mu         sync.Mutex
+	buffer     bytes.Buffer
+	diagnostic bytes.Buffer
+
+	done chan struct{}
+	err  error
+}
+
+func newTerminalFailingStdoutWriter(failErr error) *terminalFailingStdoutWriter {
+	return &terminalFailingStdoutWriter{
+		failErr: failErr,
+		done:    make(chan struct{}),
+	}
+}
+
+func (writer *terminalFailingStdoutWriter) Write(payload []byte) (int, error) {
+	if bytes.Contains(payload, []byte(`"recordType":"invocation_result"`)) {
+		return 0, writer.failErr
+	}
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	return writer.buffer.Write(payload)
+}
+
+func (writer *terminalFailingStdoutWriter) String() string {
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	return writer.buffer.String()
+}
+
+func (writer *terminalFailingStdoutWriter) diagnosticText() string {
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	return writer.diagnostic.String()
+}
+
+func waitForExternalWorkStart(t *testing.T, runner *cancellableExternalWorkRunner) {
+	t.Helper()
+	select {
+	case <-runner.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for mock-worker external work to start")
+	}
+}
+
+func runGoalResponseStreamWriterFailure(
+	t *testing.T,
+	externalWork *cancellableExternalWorkRunner,
+	stdout *terminalFailingStdoutWriter,
+) {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	support.InstallPackagedFactory(t, homeDir, goalFactoryName)
+	mockWorkersPath := support.WriteMockWorkersConfig(t, writerFailureGoalMockWorkers())
+	args := []string{
+		"you", "--json", "run", "--named", goalFactoryName,
+		"--with-mock-workers", mockWorkersPath,
+		"--no-record", "--output", "response-stream",
+		"deterministic writer-failure cancellation contract",
+	}
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	inputs.Input.WorkingDirectory = t.TempDir()
+	inputs.Input.Stdout = stdout
+	inputs.Input.Stderr = &stdout.diagnostic
+	process := support.BuildProcess(t, serviceedges.Edges{
+		ProviderCommandRunner: externalWork,
+	})
+
+	go func() {
+		stdout.err = process.Execute(inputs.Input)
+		close(stdout.done)
+	}()
+
+	t.Cleanup(func() {
+		select {
+		case <-stdout.done:
+		case <-time.After(writerFailureScenarioTimeout):
+			t.Errorf("timed out waiting for invocation cleanup")
+		}
+	})
+}
+
+func writerFailureGoalMockWorkers() *workers.MockWorkersConfig {
+	return &workers.MockWorkersConfig{
+		UnmatchedDispatchPolicy: workers.MockWorkerUnmatchedDispatchPolicyPassthrough,
+		MockWorkers: []workers.MockWorkerConfig{{
+			WorkerName:      "goal-executor",
+			WorkstationName: "execute-goal",
+			RunType:         workers.MockWorkerRunTypeScript,
+			ScriptConfig: &workers.MockWorkerScriptConfig{
+				Command: "you-writer-failure-external-work",
+				Args:    []string{"in-flight"},
+			},
+		}},
+	}
+}
+
+var _ platformprocess.CommandRunner = (*cancellableExternalWorkRunner)(nil)


### PR DESCRIPTION
{
  "project": "CLI Stream Backpressure and Writer Failure Functional Coverage",
  "branchName": "ft-wave1-cli-stream-backpressure",
  "description": "Implement the transport-owned functional cell at tests/functional/transport/cli/output/stream_backpressure_test.go so the public CLI proves slow stdout does not reorder response-stream events and stdout writer failure cancels the invocation while cleaning up external work, without implementing text_stream_test.go or inventing migration-ledger deletion work for this free destination.",
  "context": {
    "customerAsk": "Implement only tests/functional/transport/cli/output/stream_backpressure_test.go. Through the public CLI boundary with a controlled blocking writer edge, prove: (1) TestCLISlowWriterDoesNotReorderResponseEvents — slow stdout does not reorder response events; (2) TestCLIWriterFailureCancelsInvocation — writer failure cancels the invocation and cleans up external work. Do not implement text_stream_test.go. Avoid service/internal imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for CLI stream backpressure and writer-failure cleanup does not exist yet even though ndjson_stream and json_result cells have freed transport/cli/output. Maintainers lack a focused, catalogued transport proof that slow stdout preserves response-event order and that writer failure cancels the invocation and cleans up external work. No migration-ledger rows map here, so checklist behaviors are the authoritative scope; text_stream remains deferred.",
    "solution": "Implement the slow-writer non-reordering and writer-failure cancellation/cleanup scenarios in tests/functional/transport/cli/output/stream_backpressure_test.go through the public CLI/root.BuildProcess boundary with edges.Edges for a controlled blocking or failing stdout writer and mock-worker observation, with customer-readable Go docs on every top-level Test. Do not invent migration-ledger deletion consumption; apply only narrowly coupled ownership/coverage/catalog metadata; leave text_stream_test.go untouched; and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/transport/cli/output/stream_backpressure_test.go exists as the transport-owned functional cell and covers slow-writer non-reordering and writer-failure cancellation with external-work cleanup.",
    "Through the public CLI response-stream boundary with a controlled blocking/slow stdout writer edge, emitted public response-stream records retain emission order; when NDJSON automation mode is used, the terminal invocation_result remains the final line.",
    "Through the public CLI boundary with a failing stdout writer edge, the invocation is cancelled and external work started for that run is cleaned up, proven by observable approved external edges.",
    "Coverage uses root.BuildProcess/public CLI helpers and edges.Edges only for external effects; it does not import service implementations or internal Petri primitives, and does not assert Work/Session/Worker/Factory product semantics beyond transport stream-backpressure and cleanup evidence.",
    "Every top-level Test* has a customer-readable Go doc comment; specialty bindings remain none; only narrowly coupled ownership/coverage/catalog metadata for this cell are updated; no migration-ledger deletion batch is invented; text_stream_test.go is not implemented.",
    "Focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave1-cli-stream-backpressure-001",
      "title": "Prove slow stdout does not reorder response events",
      "description": "As an automation customer piping CLI response-stream output through a slow consumer, I want response events to retain emission order (including a final terminal record) so parsers never see reordered lifecycle or result records under backpressure.",
      "acceptanceCriteria": [
        "tests/functional/transport/cli/output/stream_backpressure_test.go includes TestCLISlowWriterDoesNotReorderResponseEvents (or equivalent top-level name matching the checklist intent).",
        "The test builds the customer process through root.BuildProcess / approved support helpers and substitutes external effects only through edges.Edges, including a controlled blocking / slow stdout writer edge that paces or delays writes while multiple response-stream records are produced.",
        "The public CLI is exercised in a documented response-stream mode that emits ordered public records (prefer NDJSON automation mode you --json run … --output response-stream so ordering is line-decodable).",
        "After the slow writer unblocks / completes, decoded stdout records match emission order: Factory Event / response-stream sequences are strictly monotonic where sequence is present, and the terminal invocation_result (when present) is the final record — matching the documented contract that the terminal record remains final even when stdout is slow.",
        "Assertions stay on transport ordering under backpressure and do not re-own NDJSON decodeability, single-JSON result shape, or human text-stream presentation proofs belonging to sibling cells.",
        "The top-level test has a customer-readable Go doc comment describing the observable slow-writer non-reordering behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-stream-backpressure-002",
      "title": "Prove writer failure cancels invocation and cleans up external work",
      "description": "As a CLI customer whose stdout pipe breaks mid-run, I want the invocation cancelled and external work cleaned up so a failed writer cannot leave orphaned workers or other external side effects running.",
      "acceptanceCriteria": [
        "The stream-backpressure cell includes TestCLIWriterFailureCancelsInvocation (or equivalent top-level name matching the checklist intent).",
        "The test injects a failing stdout writer edge through edges.Edges / approved support helpers while a public CLI response-stream invocation is in progress with deterministic mock-worker (or equivalent) external work.",
        "When the writer fails, the CLI invocation ends unsuccessfully (non-nil error and/or unsuccessful process outcome consistent with the public failure contract) and does not claim successful completion.",
        "External work started for that invocation is cleaned up: mock-worker / process / resource observation edges show cancellation or teardown (no orphaned in-flight external work left running after the CLI returns).",
        "Assertions prove cancellation and cleanup at approved external edges and do not import service implementations or internal Petri packages as the proof owner; they do not widen into Worker provider-fidelity or human text-stream cells.",
        "The top-level test has a customer-readable Go doc comment describing the observable writer-failure cancellation and cleanup behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-stream-backpressure-003",
      "title": "Close cell verification gates without inventing migration work",
      "description": "As a maintainer executing Wave 1 expansion, I want this cell catalogued with narrowly coupled metadata and passing focused boundary/viz gates, so the destination is reviewable without inventing deletion-batch work or implementing the deferred text-stream sibling.",
      "acceptanceCriteria": [
        "Checklist behaviors for tests/functional/transport/cli/output/stream_backpressure_test.go are treated as authoritative; no migration-ledger deletion batch is invented for this zero-row destination.",
        "text_stream_test.go remains unimplemented in this change set.",
        "Only narrowly coupled ownership, coverage, or catalog metadata required for this destination are updated; specialty bindings remain none.",
        "Neighboring NDJSON and JSON-result cells in the same package are not rewritten beyond what is required to leave the package compiling and sharing support helpers safely.",
        "Focused package tests for tests/functional/transport/cli/output pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as transport/cli/output).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)