### PR TITLE
ft-wave1-js-input-mapping

### DIFF
--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -1839,26 +1839,6 @@
       "deletion_only_batch": "n/a"
     },
     {
-      "source_path": "tests/functional/orchestration/javascript/contracts/input_mapping_test.go",
-      "package": "you-agent-factory/tests/functional/orchestration/javascript/contracts",
-      "scenario": "TestJavaScriptInvocationReceivesStringNumberBooleanObjectAndArrayInputs",
-      "lane": "short",
-      "destination": "tests/functional/orchestration/javascript/contracts/input_mapping_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/orchestration/javascript/contracts/input_mapping_test.go",
-      "package": "you-agent-factory/tests/functional/orchestration/javascript/contracts",
-      "scenario": "TestJavaScriptMissingRequiredInputFailsBeforeChildDispatch",
-      "lane": "short",
-      "destination": "tests/functional/orchestration/javascript/contracts/input_mapping_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
       "source_path": "tests/functional/orchestration/javascript/durability/resume_test.go",
       "package": "you-agent-factory/tests/functional/orchestration/javascript/durability",
       "scenario": "TestJavaScriptCorruptCheckpointFailsActionably",
@@ -6627,6 +6607,26 @@
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/orchestration/javascript/contracts/input_mapping_test.go",
+      "package": "you-agent-factory/tests/functional/orchestration/javascript/contracts",
+      "scenario": "TestJavaScriptInvocationReceivesStringNumberBooleanObjectAndArrayInputs",
+      "lane": "short",
+      "destination": "tests/functional/orchestration/javascript/contracts/input_mapping_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/orchestration/javascript/contracts/input_mapping_test.go",
+      "package": "you-agent-factory/tests/functional/orchestration/javascript/contracts",
+      "scenario": "TestJavaScriptMissingRequiredInputFailsBeforeChildDispatch",
+      "lane": "short",
+      "destination": "tests/functional/orchestration/javascript/contracts/input_mapping_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
     }
   ],
   "scanned_at_utc": "2026-07-27T20:00:00Z",
@@ -6634,11 +6634,7 @@
     "by_catch_all": {
       "bootstrap_portability": 21,
       "guards_batch": 27,
-<<<<<<< HEAD
-      "none": 341,
-=======
-      "none": 342,
->>>>>>> aecd88cff (feat: ft-wave1-js-input-mapping-004 - Preserve adjacent ownership and narrow metadata only)
+      "none": 343,
       "replay_contracts": 23,
       "runtime_api": 106,
       "smoke": 84,
@@ -6668,23 +6664,14 @@
       "workflow": 44,
       "workstations": 29
     },
-<<<<<<< HEAD
-    "customer_top_level_Test_scenarios": 641,
-    "files_with_customer_Test": 219,
-=======
-    "customer_top_level_Test_scenarios": 642,
+    "customer_top_level_Test_scenarios": 643,
     "files_with_customer_Test": 220,
->>>>>>> aecd88cff (feat: ft-wave1-js-input-mapping-004 - Preserve adjacent ownership and narrow metadata only)
     "functional_test_go_files": 251,
     "helper_only_non_customer_files": 51,
     "internal_harness_Test_functions": 15,
     "internal_harness_test_files": 5,
     "lane_functionallong": 95,
-<<<<<<< HEAD
-    "lane_short": 546,
-=======
-    "lane_short": 547,
->>>>>>> aecd88cff (feat: ft-wave1-js-input-mapping-004 - Preserve adjacent ownership and narrow metadata only)
+    "lane_short": 548,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 14,
       "you-agent-factory/tests/functional/automations": 4,
@@ -6827,26 +6814,15 @@
     }
   },
   "completeness_audit": {
-<<<<<<< HEAD
-    "audited_at_utc": "2026-07-27T21:15:00Z",
-    "story": "ft-wave1-inference-selection",
-    "live_customer_scenarios": 641,
-    "ledger_rows": 641,
-=======
-    "audited_at_utc": "2026-07-27T20:18:00Z",
+    "audited_at_utc": "2026-07-27T20:26:00Z",
     "story": "ft-wave1-js-input-mapping-mergeability",
-    "live_customer_scenarios": 642,
-    "ledger_rows": 642,
->>>>>>> aecd88cff (feat: ft-wave1-js-input-mapping-004 - Preserve adjacent ownership and narrow metadata only)
+    "live_customer_scenarios": 643,
+    "ledger_rows": 643,
     "unmapped_scenarios": 0,
     "checklist_destinations": 437,
     "wrong_layer_destinations": 69,
     "invalid_destinations": 0,
-<<<<<<< HEAD
-    "lane_short": 546,
-=======
-    "lane_short": 547,
->>>>>>> aecd88cff (feat: ft-wave1-js-input-mapping-004 - Preserve adjacent ownership and narrow metadata only)
+    "lane_short": 548,
     "lane_functionallong": 95,
     "specialty_targets_documented": 11,
     "deletion_only_batches": 52,

--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -1839,6 +1839,26 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/orchestration/javascript/contracts/input_mapping_test.go",
+      "package": "you-agent-factory/tests/functional/orchestration/javascript/contracts",
+      "scenario": "TestJavaScriptInvocationReceivesStringNumberBooleanObjectAndArrayInputs",
+      "lane": "short",
+      "destination": "tests/functional/orchestration/javascript/contracts/input_mapping_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/orchestration/javascript/contracts/input_mapping_test.go",
+      "package": "you-agent-factory/tests/functional/orchestration/javascript/contracts",
+      "scenario": "TestJavaScriptMissingRequiredInputFailsBeforeChildDispatch",
+      "lane": "short",
+      "destination": "tests/functional/orchestration/javascript/contracts/input_mapping_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/orchestration/javascript/durability/resume_test.go",
       "package": "you-agent-factory/tests/functional/orchestration/javascript/durability",
       "scenario": "TestJavaScriptCorruptCheckpointFailsActionably",
@@ -6614,7 +6634,11 @@
     "by_catch_all": {
       "bootstrap_portability": 21,
       "guards_batch": 27,
+<<<<<<< HEAD
       "none": 341,
+=======
+      "none": 342,
+>>>>>>> aecd88cff (feat: ft-wave1-js-input-mapping-004 - Preserve adjacent ownership and narrow metadata only)
       "replay_contracts": 23,
       "runtime_api": 106,
       "smoke": 84,
@@ -6630,7 +6654,7 @@
       "models": 5,
       "observability": 9,
       "operator_settings": 1,
-      "orchestration": 32,
+      "orchestration": 34,
       "product": 10,
       "providers": 53,
       "replay_contracts": 24,
@@ -6644,14 +6668,23 @@
       "workflow": 44,
       "workstations": 29
     },
+<<<<<<< HEAD
     "customer_top_level_Test_scenarios": 641,
     "files_with_customer_Test": 219,
+=======
+    "customer_top_level_Test_scenarios": 642,
+    "files_with_customer_Test": 220,
+>>>>>>> aecd88cff (feat: ft-wave1-js-input-mapping-004 - Preserve adjacent ownership and narrow metadata only)
     "functional_test_go_files": 251,
     "helper_only_non_customer_files": 51,
     "internal_harness_Test_functions": 15,
     "internal_harness_test_files": 5,
     "lane_functionallong": 95,
+<<<<<<< HEAD
     "lane_short": 546,
+=======
+    "lane_short": 547,
+>>>>>>> aecd88cff (feat: ft-wave1-js-input-mapping-004 - Preserve adjacent ownership and narrow metadata only)
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 14,
       "you-agent-factory/tests/functional/automations": 4,
@@ -6675,7 +6708,7 @@
       "you-agent-factory/tests/functional/observability/coverage": 9,
       "you-agent-factory/tests/functional/operator_settings/configcore": 1,
       "you-agent-factory/tests/functional/orchestration/javascript/composition": 14,
-      "you-agent-factory/tests/functional/orchestration/javascript/contracts": 3,
+      "you-agent-factory/tests/functional/orchestration/javascript/contracts": 5,
       "you-agent-factory/tests/functional/orchestration/javascript/durability": 3,
       "you-agent-factory/tests/functional/orchestration/petri/cross": 2,
       "you-agent-factory/tests/functional/orchestration/petri/dispatch": 3,
@@ -6794,15 +6827,26 @@
     }
   },
   "completeness_audit": {
+<<<<<<< HEAD
     "audited_at_utc": "2026-07-27T21:15:00Z",
     "story": "ft-wave1-inference-selection",
     "live_customer_scenarios": 641,
     "ledger_rows": 641,
+=======
+    "audited_at_utc": "2026-07-27T20:18:00Z",
+    "story": "ft-wave1-js-input-mapping-mergeability",
+    "live_customer_scenarios": 642,
+    "ledger_rows": 642,
+>>>>>>> aecd88cff (feat: ft-wave1-js-input-mapping-004 - Preserve adjacent ownership and narrow metadata only)
     "unmapped_scenarios": 0,
     "checklist_destinations": 437,
     "wrong_layer_destinations": 69,
     "invalid_destinations": 0,
+<<<<<<< HEAD
     "lane_short": 546,
+=======
+    "lane_short": 547,
+>>>>>>> aecd88cff (feat: ft-wave1-js-input-mapping-004 - Preserve adjacent ownership and narrow metadata only)
     "lane_functionallong": 95,
     "specialty_targets_documented": 11,
     "deletion_only_batches": 52,

--- a/docs/temp/functional-tests-expansion/migration-ledger.md
+++ b/docs/temp/functional-tests-expansion/migration-ledger.md
@@ -343,12 +343,14 @@ batch ids (FND-007-003…005). Remaining non-catch-all packages use `n/a` for
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | tests/functional/operator_settings/configcore/operator_config_core_test.go | you-agent-factory/tests/functional/operator_settings/configcore | TestOperatorConfigCore_PromptedAndPresuppliedUpdatesShareAtomicBehavior | short | wrong-layer: package-integration — direct operator_settings service calls without root.BuildProcess / public CLI boundary. Replacement evidence owner: pkg/services/operator_settings package-integration tests. | none | none | n/a |
 
-#### `orchestration` (2 scenarios, catch_all=`none`)
+#### `orchestration` (4 scenarios, catch_all=`none`)
 
 | source_path | package | scenario | lane | destination | catch_all | specialty_targets | deletion_only_batch |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | tests/functional/orchestration/javascript/contracts/response_events_test.go | you-agent-factory/tests/functional/orchestration/javascript/contracts | TestJavaScriptChildProgressPublishesCanonicalResponseEvents | short | tests/functional/orchestration/javascript/contracts/response_events_test.go | none | none | workflow-delete-09-orchestration-javascript |
 | tests/functional/orchestration/javascript/contracts/response_events_test.go | you-agent-factory/tests/functional/orchestration/javascript/contracts | TestJavaScriptTerminalResultFollowsFinalResponseEvent | short | tests/functional/orchestration/javascript/contracts/response_events_test.go | none | none | n/a |
+| tests/functional/orchestration/javascript/contracts/input_mapping_test.go | you-agent-factory/tests/functional/orchestration/javascript/contracts | TestJavaScriptInvocationReceivesStringNumberBooleanObjectAndArrayInputs | short | tests/functional/orchestration/javascript/contracts/input_mapping_test.go | none | none | n/a |
+| tests/functional/orchestration/javascript/contracts/input_mapping_test.go | you-agent-factory/tests/functional/orchestration/javascript/contracts | TestJavaScriptMissingRequiredInputFailsBeforeChildDispatch | short | tests/functional/orchestration/javascript/contracts/input_mapping_test.go | none | none | n/a |
 
 #### `providers` (45 scenarios, catch_all=`none`)
 

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -389,7 +389,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
 
 ### JavaScript contracts, policy, and durability
 
-- [ ] `tests/functional/orchestration/javascript/contracts/input_mapping_test.go`
+- [x] `tests/functional/orchestration/javascript/contracts/input_mapping_test.go`
   - `TestJavaScriptInvocationReceivesStringNumberBooleanObjectAndArrayInputs`
     covers typed request mapping.
   - `TestJavaScriptMissingRequiredInputFailsBeforeChildDispatch` covers error.

--- a/tests/functional/orchestration/javascript/contracts/input_mapping_test.go
+++ b/tests/functional/orchestration/javascript/contracts/input_mapping_test.go
@@ -1,0 +1,1 @@
+package contracts

--- a/tests/functional/orchestration/javascript/contracts/input_mapping_test.go
+++ b/tests/functional/orchestration/javascript/contracts/input_mapping_test.go
@@ -1,1 +1,229 @@
 package contracts
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	typedInputWorkflowFileName = "typed-input.workflow.js"
+	typedInputWorkflowSource   = `return {
+  label: args.label,
+  count: args.count,
+  enabled: args.enabled,
+  metadata: args.metadata,
+  tags: args.tags,
+};`
+
+	typedInputLabelValue    = "hello"
+	typedInputRegionValue   = "us-west"
+	typedInputTagAlphaValue = "alpha"
+	typedInputTagBetaValue  = "beta"
+)
+
+var privateJavaScriptVMDiagnosticMarkers = []string{
+	"goja",
+	"goja.",
+	"stack frame",
+	"heap dump",
+}
+
+// TestJavaScriptInvocationReceivesStringNumberBooleanObjectAndArrayInputs proves
+// string, number, boolean, object, and array Work Request inputs reach a
+// JavaScript Factory invocation with preserved types on the public primary
+// Factory Session result surface after a root-built process run.
+func TestJavaScriptInvocationReceivesStringNumberBooleanObjectAndArrayInputs(t *testing.T) {
+	t.Parallel()
+
+	dir := scaffoldTypedInputMappingWorkflow(t)
+	runner := support.NewRecordingCommandRunner("unexpected live provider execution")
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		WaitForServiceModeRuntime: true,
+		UseMockWorkers:            true,
+		Edges:                     serviceedges.Edges{ProviderCommandRunner: runner},
+	})
+	t.Cleanup(func() { server.Stop(t) })
+
+	started := startTypedInputMappingWorkflow(t, server.URL(), dir)
+	if started.Status != factoryapi.FactorySessionDurableLifecycleStatusSucceeded {
+		t.Fatalf("session status = %q, want SUCCEEDED", started.Status)
+	}
+	if runner.CallCount() != 0 {
+		t.Fatalf("provider command runner call count = %d, want 0 for typed-input echo workflow", runner.CallCount())
+	}
+
+	assertTypedInputMappingPrimaryResult(t, started.Result)
+	assertNoPrivateJavaScriptVMDiagnostics(t, marshalPrimaryResultForDiagnostics(t, started.Result))
+}
+
+func scaffoldTypedInputMappingWorkflow(t *testing.T) string {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, map[string]any{
+		"name": "javascript-input-mapping",
+		"orchestrator": map[string]any{
+			"kind": "JAVASCRIPT",
+			"javascript": map[string]any{
+				"sourceRef": typedInputWorkflowFileName,
+				"argsSchema": map[string]any{
+					"type":     "object",
+					"required": []any{"label", "count", "enabled", "metadata", "tags"},
+					"properties": map[string]any{
+						"label":    map[string]any{"type": "string"},
+						"count":    map[string]any{"type": "number"},
+						"enabled":  map[string]any{"type": "boolean"},
+						"metadata": map[string]any{"type": "object"},
+						"tags": map[string]any{
+							"type":  "array",
+							"items": map[string]any{"type": "string"},
+						},
+					},
+					"additionalProperties": false,
+				},
+			},
+		},
+	})
+	if err := os.WriteFile(
+		filepath.Join(dir, typedInputWorkflowFileName),
+		[]byte(typedInputWorkflowSource),
+		0o600,
+	); err != nil {
+		t.Fatalf("write typed input workflow: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "mock-workers.json"),
+		[]byte(`{"mockWorkers":[]}`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write mock-workers config: %v", err)
+	}
+	return dir
+}
+
+func startTypedInputMappingWorkflow(
+	t *testing.T,
+	serverURL, dir string,
+) factoryapi.FactorySessionSyncExecutionResponse {
+	t.Helper()
+
+	workflowPath := filepath.Join(dir, typedInputWorkflowFileName)
+	args := map[string]any{
+		"label":    typedInputLabelValue,
+		"count":    42,
+		"enabled":  true,
+		"metadata": map[string]any{"region": typedInputRegionValue},
+		"tags":     []any{typedInputTagAlphaValue, typedInputTagBetaValue},
+	}
+	payload, err := json.Marshal(factoryapi.FactorySessionExecutionRequest{
+		RequestId: "javascript-typed-input-mapping",
+		Source: factoryapi.FactorySessionExecutionSource{
+			Kind:         factoryapi.FactorySessionExecutionSourceKindWorkflowFile,
+			WorkflowFile: &workflowPath,
+		},
+		Args: &args,
+	})
+	if err != nil {
+		t.Fatalf("marshal typed input workflow request: %v", err)
+	}
+	endpoint := strings.TrimSuffix(serverURL, "/") + "/factory-sessions/sync"
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("build typed input workflow request: %v", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("start typed input workflow: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		var body bytes.Buffer
+		_, _ = body.ReadFrom(response.Body)
+		t.Fatalf("start typed input workflow status = %d: %s", response.StatusCode, body.String())
+	}
+	var started factoryapi.FactorySessionSyncExecutionResponse
+	if err := json.NewDecoder(response.Body).Decode(&started); err != nil {
+		t.Fatalf("decode typed input workflow response: %v", err)
+	}
+	return started
+}
+
+func assertTypedInputMappingPrimaryResult(t *testing.T, result *factoryapi.FactorySessionResult) {
+	t.Helper()
+
+	if result == nil || result.ResultStatus != factoryapi.FactorySessionResultStatusFinal {
+		t.Fatalf("result = %#v, want FINAL Factory Session result", result)
+	}
+	if result.PrimaryResult == nil || len(*result.PrimaryResult) != 1 {
+		t.Fatalf("primary result = %#v, want exactly one content part", result.PrimaryResult)
+	}
+	part, err := (*result.PrimaryResult)[0].AsWorkJsonContentPart()
+	if err != nil {
+		t.Fatalf("decode primary result content part: %v", err)
+	}
+	encoded, err := json.Marshal(part.Json)
+	if err != nil {
+		t.Fatalf("encode primary result JSON: %v", err)
+	}
+	var evidence struct {
+		Label    string         `json:"label"`
+		Count    float64        `json:"count"`
+		Enabled  bool           `json:"enabled"`
+		Metadata map[string]any `json:"metadata"`
+		Tags     []string       `json:"tags"`
+	}
+	if err := json.Unmarshal(encoded, &evidence); err != nil {
+		t.Fatalf("decode typed input primary result: %v", err)
+	}
+	if evidence.Label != typedInputLabelValue {
+		t.Fatalf("mapped label = %q, want %q", evidence.Label, typedInputLabelValue)
+	}
+	if evidence.Count != 42 {
+		t.Fatalf("mapped count = %v, want 42", evidence.Count)
+	}
+	if !evidence.Enabled {
+		t.Fatalf("mapped enabled = %v, want true", evidence.Enabled)
+	}
+	if evidence.Metadata == nil || evidence.Metadata["region"] != typedInputRegionValue {
+		t.Fatalf("mapped metadata = %#v, want region %q", evidence.Metadata, typedInputRegionValue)
+	}
+	if len(evidence.Tags) != 2 ||
+		evidence.Tags[0] != typedInputTagAlphaValue ||
+		evidence.Tags[1] != typedInputTagBetaValue {
+		t.Fatalf("mapped tags = %#v, want [%q, %q]", evidence.Tags, typedInputTagAlphaValue, typedInputTagBetaValue)
+	}
+}
+
+func marshalPrimaryResultForDiagnostics(t *testing.T, result *factoryapi.FactorySessionResult) string {
+	t.Helper()
+
+	if result == nil || result.PrimaryResult == nil {
+		return ""
+	}
+	encoded, err := json.Marshal(result.PrimaryResult)
+	if err != nil {
+		t.Fatalf("marshal primary result for diagnostics: %v", err)
+	}
+	return string(encoded)
+}
+
+func assertNoPrivateJavaScriptVMDiagnostics(t *testing.T, outputs ...string) {
+	t.Helper()
+
+	combined := strings.ToLower(strings.Join(outputs, "\n"))
+	for _, marker := range privateJavaScriptVMDiagnosticMarkers {
+		if strings.Contains(combined, strings.ToLower(marker)) {
+			t.Fatalf("diagnostics exposed private VM detail %q in %q", marker, strings.Join(outputs, "\n---\n"))
+		}
+	}
+}

--- a/tests/functional/orchestration/javascript/contracts/input_mapping_test.go
+++ b/tests/functional/orchestration/javascript/contracts/input_mapping_test.go
@@ -28,6 +28,24 @@ const (
 	typedInputRegionValue   = "us-west"
 	typedInputTagAlphaValue = "alpha"
 	typedInputTagBetaValue  = "beta"
+
+	missingRequiredInputWorkflowSource = `return (async function () {
+  const child = await agent.run({
+    prompt: "typed-input-child",
+    label: "missing-required-child",
+    model: "gpt-allowed",
+  });
+  return {
+    label: args.label,
+    count: args.count,
+    enabled: args.enabled,
+    metadata: args.metadata,
+    tags: args.tags,
+    child: child,
+  };
+})();`
+
+	stableMissingRequiredInputDiagnostic = `required invocation parameter "label" is missing`
 )
 
 var privateJavaScriptVMDiagnosticMarkers = []string{
@@ -64,6 +82,187 @@ func TestJavaScriptInvocationReceivesStringNumberBooleanObjectAndArrayInputs(t *
 
 	assertTypedInputMappingPrimaryResult(t, started.Result)
 	assertNoPrivateJavaScriptVMDiagnostics(t, marshalPrimaryResultForDiagnostics(t, started.Result))
+}
+
+// TestJavaScriptMissingRequiredInputFailsBeforeChildDispatch proves omitting a
+// required JavaScript Factory request input fails with an actionable customer
+// diagnostic before any child worker or provider dispatch when invoked through
+// the public you run customer process boundary after a root-built process run.
+func TestJavaScriptMissingRequiredInputFailsBeforeChildDispatch(t *testing.T) {
+	t.Parallel()
+
+	dir := scaffoldMissingRequiredInputMappingFactory(t)
+	run := runMissingRequiredInputJavaScriptInvocation(t, dir)
+
+	assertMissingRequiredInputInvocationOutcome(t, run.outcome)
+	if run.providerRunner.CallCount() != 0 {
+		t.Fatalf(
+			"provider command runner call count = %d, want 0 before missing-required-input validation",
+			run.providerRunner.CallCount(),
+		)
+	}
+	assertNoPrivateJavaScriptVMDiagnostics(t, run.outcome.diagnostic)
+}
+
+type missingRequiredInputInvocationRun struct {
+	providerRunner *support.RecordingCommandRunner
+	outcome        missingRequiredInputInvocationOutcome
+}
+
+type missingRequiredInputInvocationOutcome struct {
+	response      factoryapi.InvocationResponse
+	errorResponse factoryapi.ErrorResponse
+	diagnostic    string
+}
+
+func scaffoldMissingRequiredInputMappingFactory(t *testing.T) string {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, map[string]any{
+		"name": "javascript-input-mapping-missing-required",
+		"invocationSignature": map[string]any{
+			"parameters": []any{map[string]any{
+				"name": "label", "required": true,
+				"bindings": []any{map[string]any{"kind": "POSITIONAL", "position": 1}},
+			}},
+		},
+		"orchestrator": map[string]any{
+			"kind": "JAVASCRIPT",
+			"javascript": map[string]any{
+				"sourceRef": typedInputWorkflowFileName,
+				"argsSchema": map[string]any{
+					"type":     "object",
+					"required": []any{"label", "count", "enabled", "metadata", "tags"},
+					"properties": map[string]any{
+						"label":    map[string]any{"type": "string"},
+						"count":    map[string]any{"type": "number"},
+						"enabled":  map[string]any{"type": "boolean"},
+						"metadata": map[string]any{"type": "object"},
+						"tags": map[string]any{
+							"type":  "array",
+							"items": map[string]any{"type": "string"},
+						},
+					},
+					"additionalProperties": false,
+				},
+				"defaultPolicy": map[string]any{
+					"mode":          "READ_ONLY",
+					"maxAgents":     4,
+					"concurrency":   2,
+					"allowNetwork":  false,
+					"allowedModels": []any{"gpt-allowed"},
+				},
+			},
+		},
+	})
+	if err := os.WriteFile(
+		filepath.Join(dir, typedInputWorkflowFileName),
+		[]byte(missingRequiredInputWorkflowSource),
+		0o600,
+	); err != nil {
+		t.Fatalf("write missing required input workflow: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "mock-workers.json"),
+		[]byte(`{"mockWorkers":[]}`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write mock-workers config: %v", err)
+	}
+	return dir
+}
+
+func runMissingRequiredInputJavaScriptInvocation(
+	t *testing.T,
+	dir string,
+) missingRequiredInputInvocationRun {
+	t.Helper()
+
+	runner := support.NewRecordingCommandRunner("unexpected live provider execution")
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "--json", "run",
+		"--factory", filepath.Join(dir, "factory.json"),
+		"--no-record",
+		"--with-mock-workers", filepath.Join(dir, "mock-workers.json"),
+		"--output", "primary",
+	})
+	homeDir := t.TempDir()
+	inputs.Input.Env = append(inputs.Input.Env, "HOME="+homeDir, "USERPROFILE="+homeDir)
+	inputs.Input.WorkingDirectory = dir
+
+	err := support.BuildProcess(t, serviceedges.Edges{
+		ProviderCommandRunner: runner,
+	}).Execute(inputs.Input)
+	if err == nil {
+		t.Fatalf(
+			"Process.Execute() error = nil, want missing required input failure before child dispatch\nstdout:\n%s\nstderr:\n%s",
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+	outcome := missingRequiredInputInvocationOutcome{
+		diagnostic: extractMissingRequiredInputDiagnostic(t, inputs.Stdout(), inputs.Stderr(), err.Error()),
+	}
+	if stdout := strings.TrimSpace(inputs.Stdout()); stdout != "" {
+		if decodeErr := json.Unmarshal([]byte(stdout), &outcome.response); decodeErr != nil {
+			t.Fatalf("decode InvocationResponse: %v\nstdout:\n%s", decodeErr, stdout)
+		}
+	}
+	if stderr := strings.TrimSpace(inputs.Stderr()); stderr != "" {
+		if decodeErr := json.Unmarshal([]byte(stderr), &outcome.errorResponse); decodeErr != nil {
+			t.Fatalf("decode ErrorResponse: %v\nstderr:\n%s", decodeErr, stderr)
+		}
+	}
+	return missingRequiredInputInvocationRun{
+		providerRunner: runner,
+		outcome:        outcome,
+	}
+}
+
+func assertMissingRequiredInputInvocationOutcome(
+	t *testing.T,
+	outcome missingRequiredInputInvocationOutcome,
+) {
+	t.Helper()
+
+	if outcome.response.Status != "" &&
+		outcome.response.Status != factoryapi.InvocationTerminalStatusFailed {
+		t.Fatalf("invocation status = %q, want FAILED or empty before terminal invocation", outcome.response.Status)
+	}
+	if outcome.response.PrimaryResult != nil {
+		t.Fatalf("primaryResult = %#v, want nil before missing-required-input validation", outcome.response.PrimaryResult)
+	}
+	if outcome.errorResponse.Code != factoryapi.ErrorResponseCode("INVOCATION_ARGUMENT_MISSING_REQUIRED_INPUT") {
+		t.Fatalf(
+			"ErrorResponse code = %q, want INVOCATION_ARGUMENT_MISSING_REQUIRED_INPUT",
+			outcome.errorResponse.Code,
+		)
+	}
+	if !strings.Contains(outcome.errorResponse.Message, stableMissingRequiredInputDiagnostic) {
+		t.Fatalf(
+			"ErrorResponse message = %q, want missing required input diagnostic %q",
+			outcome.errorResponse.Message,
+			stableMissingRequiredInputDiagnostic,
+		)
+	}
+	if !strings.Contains(outcome.diagnostic, `"label"`) {
+		t.Fatalf(
+			"failure diagnostic = %q, want actionable missing required input field name %q",
+			outcome.diagnostic,
+			"label",
+		)
+	}
+}
+
+func extractMissingRequiredInputDiagnostic(t *testing.T, stdout, stderr, executeError string) string {
+	t.Helper()
+
+	diagnostic := strings.Join([]string{executeError, stdout, stderr}, "\n")
+	if strings.Contains(diagnostic, stableMissingRequiredInputDiagnostic) {
+		return diagnostic
+	}
+	t.Fatalf("diagnostic %q does not contain missing required input detail %q", diagnostic, stableMissingRequiredInputDiagnostic)
+	return ""
 }
 
 func scaffoldTypedInputMappingWorkflow(t *testing.T) string {


### PR DESCRIPTION
{
  "project": "JavaScript Invocation Input Mapping Functional Coverage",
  "branchName": "ft-wave1-js-input-mapping",
  "description": "Add customer functional coverage at tests/functional/orchestration/javascript/contracts/input_mapping_test.go proving typed Work Request inputs (string, number, boolean, object, array) reach a JavaScript invocation through root.BuildProcess and public Work/events/projections, and that a missing required input fails before child dispatch without private VM details. Do not implement output_mapping_test.go; this destination has no owned migration-ledger rows.",
  "context": {
    "customerAsk": "Implement only tests/functional/orchestration/javascript/contracts/input_mapping_test.go. Through root.BuildProcess and public Work/events/projections, prove: (1) TestJavaScriptInvocationReceivesStringNumberBooleanObjectAndArrayInputs — typed request mapping reaches the JavaScript invocation; (2) TestJavaScriptMissingRequiredInputFailsBeforeChildDispatch — missing required input fails before child dispatch without private VM details. Do not implement output_mapping_test.go. Avoid internal Petri/service imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "Response-event contracts prove child progress publishing, not typed request input mapping into a JavaScript invocation. The checklist destination input_mapping_test.go does not exist yet, so maintainers lack domain-owned proof that string/number/boolean/object/array Work Request inputs reach the JavaScript invocation on public Work/events/projections, and that omitting a required input fails before child dispatch without private VM details, while output_mapping remains held on the same package.",
    "solution": "Deliver the orchestration-owned input-mapping contracts cell with TestJavaScriptInvocationReceivesStringNumberBooleanObjectAndArrayInputs and TestJavaScriptMissingRequiredInputFailsBeforeChildDispatch through root.BuildProcess and public Work/events/projections. Do not invent migration-ledger deletion ownership (none mapped here) or implement output_mapping_test.go; update only narrowly coupled ownership/coverage/catalog/migration metadata; verify focused package plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "Destination file tests/functional/orchestration/javascript/contracts/input_mapping_test.go exists and is the only new customer functional scenario file owned by this cell.",
    "TestJavaScriptInvocationReceivesStringNumberBooleanObjectAndArrayInputs proves a JavaScript Factory run through root.BuildProcess receives string, number, boolean, object, and array request inputs at the invocation, with those typed values observable on public Work/Factory Event/projection surfaces.",
    "TestJavaScriptMissingRequiredInputFailsBeforeChildDispatch proves omitting a required input yields a non-success customer-visible outcome before any child dispatch, with an actionable diagnostic and without private VM details.",
    "Planning confirmed no owned migration-ledger inventory rows for this destination; the cell does not invent deletion batches or claim ledger rows owned by response-events, output-mapping, or other cells.",
    "Every top-level Test* in the destination file has a customer-readable Go doc comment, the cell uses only public/root-built boundaries with no direct service or internal Petri imports, and output_mapping_test.go is not implemented.",
    "Quality gate: focused destination package tests pass; make functional-boundary-check passes for the touched tree; required functional-test-viz-compatible catalog/metadata checks pass; typecheck, lint, and tests required by the changed surface pass."
  ],
  "userStories": [
    {
      "id": "ft-wave1-js-input-mapping-001",
      "title": "Place the JavaScript input mapping cell",
      "description": "As a maintainer expanding Wave 1 functional coverage, I need the destination file to exist under the domain-mirrored orchestration contracts package so JavaScript input mapping has a durable owner beside any already-merged response-events sibling.",
      "acceptanceCriteria": [
        "Package path tests/functional/orchestration/javascript/contracts/ exists and conforms to the Wave 0 domain-layout rules for orchestration/javascript (create the package only if the merged response-events sibling has not already placed it).",
        "Destination file tests/functional/orchestration/javascript/contracts/input_mapping_test.go exists as the sole customer scenario file added for this cell.",
        "The package compiles under the short functional lane conventions used by neighboring Wave 1 cells (no accidental functionallong-only binding for these scenarios).",
        "No direct imports of service implementations or internal Petri packages appear in the new file.",
        "The cell does not add or modify output_mapping_test.go.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-js-input-mapping-002",
      "title": "Prove typed request inputs reach the JavaScript invocation",
      "description": "As a customer authoring Work Requests for a JavaScript Factory, I want string, number, boolean, object, and array inputs to reach the invocation with their types preserved so orchestration can rely on typed request mapping without private runtime wiring.",
      "acceptanceCriteria": [
        "Top-level test TestJavaScriptInvocationReceivesStringNumberBooleanObjectAndArrayInputs exists in the destination file.",
        "The scenario submits a Work Request / invocation that includes at least one string, one number, one boolean, one object, and one array input value through the public customer process boundary.",
        "The scenario builds through root.BuildProcess / approved support harness and replaces only external effects via edges.Edges (mock workers and/or recording provider command runner so live provider execution does not occur).",
        "After completion, public Work / Factory Event / projection observations prove those typed values reached the JavaScript invocation (for example they appear in the customer-visible primary/terminal result, or in publicly projected Work / dispatch payload evidence that reflects the mapped inputs).",
        "Success diagnostics do not include private JavaScript VM internals.",
        "Assertions observe public Work / events / projections only; they do not import service implementations or internal Petri primitives.",
        "The test has a customer-readable Go doc comment whose first sentence states the observable typed input-mapping behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-js-input-mapping-003",
      "title": "Prove missing required input fails before child dispatch",
      "description": "As a customer operator, I want omitting a required JavaScript Factory input to fail before any child work starts with an actionable diagnostic so I can correct the request without reading VM internals or observing spurious child dispatches.",
      "acceptanceCriteria": [
        "Top-level test TestJavaScriptMissingRequiredInputFailsBeforeChildDispatch exists in the destination file.",
        "Feeding a JavaScript Factory invocation that omits a required input yields a non-success customer-visible outcome.",
        "The failure occurs before any child dispatch: public Work / Factory Event / projection observations show no child worker/provider dispatch for the rejected invocation.",
        "The failure diagnostic is actionable: it identifies the missing required input (or equivalent customer-stable validation signal) so an operator can correct the request without inspecting private runtime state.",
        "Failure output/diagnostics do not expose private VM stack frames, engine heap dumps, or other non-customer VM internals.",
        "The test has a customer-readable Go doc comment whose first sentence states the observable missing-required-input failure behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-js-input-mapping-004",
      "title": "Preserve adjacent ownership and narrow metadata only",
      "description": "As a maintainer executing Wave 1 in parallel, I need this cell to stay inside input-mapping contracts ownership, leave output-mapping and other ledger batches untouched, and update only narrowly coupled metadata required for inventoriability.",
      "acceptanceCriteria": [
        "Planning found no owned migration-ledger inventory rows for input_mapping_test.go; this cell does not invent a deletion batch and does not claim rows destined to response_events_test.go, output_mapping_test.go, or unrelated cells.",
        "Diff for this cell does not implement or modify output_mapping_test.go.",
        "Only narrowly coupled ownership / coverage / catalog / migration metadata required for tests/functional/orchestration/javascript/contracts/input_mapping_test.go are updated; specialty bindings remain none unless an existing binding already requires a minimal update.",
        "If any applicable ledger mapping is discovered during implementation that already destinations this exact checklist path, consume it without widening ownership to unrelated scenarios or sibling cells.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-js-input-mapping-005",
      "title": "Verify focused package, boundary, and metadata gates",
      "description": "As a reviewer, I want focused verification evidence that the JavaScript input mapping cell meets functional boundary and viz-compatible metadata rules without running unrelated suites as the primary proof.",
      "acceptanceCriteria": [
        "Focused tests for the destination package tests/functional/orchestration/javascript/contracts pass for the two checklist scenarios owned by this cell.",
        "make functional-boundary-check passes for the touched functional tree.",
        "Functional-test-viz-compatible catalog/metadata checks required for this cell pass (including Go doc presence for every top-level Test* in the destination file).",
        "Checklist item for tests/functional/orchestration/javascript/contracts/input_mapping_test.go can be marked complete against the two named scenarios.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)