### PR TITLE
pss-imp-pses-01-codex-reader

### DIFF
--- a/cmd/pkgboundarycheck/main.go
+++ b/cmd/pkgboundarycheck/main.go
@@ -160,7 +160,6 @@ var convergedServiceSubpackageRoots = map[string]string{
 	"pkg/services/factory_definitions/editable":                 "factory_definitions",
 	"pkg/services/factory_definitions/packages":                 "factory_definitions",
 	"pkg/services/factory_definitions/scaffold":                 "factory_definitions",
-	"pkg/services/provider_sessions/codex":                      "provider_sessions",
 	"pkg/services/provider_sessions/cursor":                     "provider_sessions",
 	"pkg/services/recordings/events":                            "recordings",
 	"pkg/services/recordings/projections/dashboard":             "recordings",

--- a/cmd/pkgboundarycheck/test_behavior_boundary.go
+++ b/cmd/pkgboundarycheck/test_behavior_boundary.go
@@ -44,7 +44,6 @@ const (
 	factorySessionsImportPath    = repositoryImportPrefix + "pkg/services/factory_sessions"
 	providerSessionsImportPath   = repositoryImportPrefix + "pkg/services/provider_sessions"
 	providerSessionServicePath   = repositoryImportPrefix + "pkg/services/provider_sessions/service"
-	providerSessionCodexPath     = repositoryImportPrefix + "pkg/services/provider_sessions/codex"
 	providerSessionCursorPath    = repositoryImportPrefix + "pkg/services/provider_sessions/cursor"
 	modelsImportPath             = repositoryImportPrefix + "pkg/services/models"
 	workImportPath               = repositoryImportPrefix + "pkg/services/work"
@@ -112,10 +111,6 @@ var prohibitedTransportTestPolicyOperations = map[string]map[string]string{
 	providerSessionServicePath: {
 		"New":         "provider_sessions",
 		"NewForRoots": "provider_sessions",
-	},
-	providerSessionCodexPath: {
-		"DefaultSessionsRoot": "provider_sessions",
-		"LoadDetails":         "provider_sessions",
 	},
 	providerSessionCursorPath: {
 		"DefaultAgentStorageRoot":   "provider_sessions",

--- a/cmd/pkgboundarycheck/test_behavior_boundary_test.go
+++ b/cmd/pkgboundarycheck/test_behavior_boundary_test.go
@@ -268,13 +268,12 @@ func TestScanTestBehaviorBoundariesRejectsProviderSessionPolicyInTransportSuppor
 	writeGoSourceFile(t, repoRoot, "pkg/transports/http/server_test_helpers_test.go", `package http
 import (
   sessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
-  codex "github.com/portpowered/infinite-you/pkg/services/provider_sessions/codex"
   cursor "github.com/portpowered/infinite-you/pkg/services/provider_sessions/cursor"
   service "github.com/portpowered/infinite-you/pkg/services/provider_sessions/service"
   workers "github.com/portpowered/infinite-you/pkg/services/workers"
 )
 type testProviderSessionService struct{}
-func newTestProviderSessionService() { sessions.CanonicalProvider("agent"); service.NewForRoots(); codex.LoadDetails(); cursor.LoadDetails(); workers.CanonicalProviderSessionProvider("agent") }
+func newTestProviderSessionService() { sessions.CanonicalProvider("agent"); service.NewForRoots(); cursor.LoadDetails(); workers.CanonicalProviderSessionProvider("agent") }
 func scriptedProviderSessionDetail() {}
 `)
 

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -925,12 +925,32 @@
       "minimum": 81.81
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/cursor",
+      "minimum": 0.92
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader/internal/service",
       "minimum": 1.17
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/cursor",
-      "minimum": 0.92
+      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader/wire",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/service",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -925,7 +925,7 @@
       "minimum": 81.81
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/codex",
+      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader/internal/service",
       "minimum": 1.17
     },
     {

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -859,7 +859,7 @@
       "minimum": 90.90
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/codex",
+      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader/internal/service",
       "minimum": 79.11
     },
     {

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -859,12 +859,26 @@
       "minimum": 90.90
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader/internal/service",
-      "minimum": 79.11
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/cursor",
       "minimum": 43.36
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active unit coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader/internal/service",
+      "minimum": 83.91
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader/wire",
+      "minimum": 100.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/service",

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -1378,6 +1378,12 @@
       "evidence": "pkg/platform/contentstaging -\u003e pkg/services/work"
     },
     {
+      "fromOwner": "provider_sessions",
+      "toOwner": "providers",
+      "class": "command",
+      "evidence": "pkg/services/provider_sessions -\u003e pkg/services/providers"
+    },
+    {
       "fromOwner": "providers",
       "toOwner": "models",
       "class": "command",
@@ -3432,13 +3438,25 @@
       "destinationKind": "owner"
     },
     {
-      "packagePath": "pkg/services/provider_sessions/codex",
+      "packagePath": "pkg/services/provider_sessions/cursor",
       "disposition": "retain",
       "destination": "provider_sessions",
       "destinationKind": "owner"
     },
     {
-      "packagePath": "pkg/services/provider_sessions/cursor",
+      "packagePath": "pkg/services/provider_sessions/internal/services/codex_reader",
+      "disposition": "retain",
+      "destination": "provider_sessions",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/provider_sessions/internal/services/codex_reader/internal/service",
+      "disposition": "retain",
+      "destination": "provider_sessions",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/provider_sessions/internal/services/codex_reader/wire",
       "disposition": "retain",
       "destination": "provider_sessions",
       "destinationKind": "owner"

--- a/docs/internal/baselines/package-structure-baseline.json
+++ b/docs/internal/baselines/package-structure-baseline.json
@@ -2829,11 +2829,6 @@
     },
     {
       "rule": "service-root-unexpected-directory",
-      "filePath": "pkg/services/provider_sessions/codex",
-      "target": "pkg/services/provider_sessions"
-    },
-    {
-      "rule": "service-root-unexpected-directory",
       "filePath": "pkg/services/provider_sessions/cursor",
       "target": "pkg/services/provider_sessions"
     },

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -227,8 +227,10 @@
     "pkg/services/operator_settings",
     "pkg/services/operator_settings/identityinventory",
     "pkg/services/provider_sessions",
-    "pkg/services/provider_sessions/codex",
     "pkg/services/provider_sessions/cursor",
+    "pkg/services/provider_sessions/internal/services/codex_reader",
+    "pkg/services/provider_sessions/internal/services/codex_reader/internal/service",
+    "pkg/services/provider_sessions/internal/services/codex_reader/wire",
     "pkg/services/provider_sessions/service",
     "pkg/services/providers",
     "pkg/services/providers/internal/service",
@@ -1320,14 +1322,24 @@
       "destination": "provider_sessions"
     },
     {
-      "packagePath": "pkg/services/provider_sessions/codex",
-      "disposition": "move",
-      "destination": "provider_sessions/internal/services/codex_reader"
-    },
-    {
       "packagePath": "pkg/services/provider_sessions/cursor",
       "disposition": "move",
       "destination": "provider_sessions/internal/services/cursor_reader"
+    },
+    {
+      "packagePath": "pkg/services/provider_sessions/internal/services/codex_reader",
+      "disposition": "retain",
+      "destination": "provider_sessions/internal/services/codex_reader"
+    },
+    {
+      "packagePath": "pkg/services/provider_sessions/internal/services/codex_reader/internal/service",
+      "disposition": "retain",
+      "destination": "provider_sessions/internal/services/codex_reader"
+    },
+    {
+      "packagePath": "pkg/services/provider_sessions/internal/services/codex_reader/wire",
+      "disposition": "retain",
+      "destination": "provider_sessions/internal/services/codex_reader"
     },
     {
       "packagePath": "pkg/services/provider_sessions/service",

--- a/pkg/services/provider_sessions/contracts.go
+++ b/pkg/services/provider_sessions/contracts.go
@@ -24,7 +24,9 @@ type Service interface {
 	// receive a detached Detail value (transcript, parse, usage, and related
 	// normalized facts) or a typed Provider Sessions failure such as
 	// ErrUnsupportedProvider, ErrUnsupportedKind, ErrInvalidIdentifier,
-	// ErrSessionNotFound, ErrAmbiguousSessionFile, and/or LookupError. Callers do
+	// ErrSessionNotFound, ErrAmbiguousSessionFile, ErrSessionOutsideRoot,
+	// ErrSessionSourceNotRegularFile, ErrSessionStorageUnavailable, and/or
+	// LookupError. Callers do
 	// not supply filesystem/SQL/OS effect ports or Codex/Cursor reader types to
 	// invoke this peer API. Additive typed SessionRef slices (Inspect, Project)
 	// share this singular root without replacing Details.
@@ -34,7 +36,9 @@ type Service interface {
 	// providers.SessionRef vocabulary (provider + kind + id). Peers receive a
 	// detached InspectResult or a typed Provider Sessions failure such as
 	// ErrUnsupportedProvider, ErrUnsupportedKind, ErrInvalidIdentifier,
-	// ErrSessionNotFound, ErrAmbiguousSessionFile, and/or LookupError. This slice
+	// ErrSessionNotFound, ErrAmbiguousSessionFile, ErrSessionOutsideRoot,
+	// ErrSessionSourceNotRegularFile, ErrSessionStorageUnavailable, and/or
+	// LookupError. This slice
 	// does not import Providers catalog/execution, enumeration, availability,
 	// capability, or Workers selection-policy types.
 	Inspect(InspectRequest) (InspectResult, error)
@@ -44,7 +48,9 @@ type Service interface {
 	// whose Detail covers transcript entries, reasoning summaries,
 	// tool/function-call facts, parse summary, and token usage, or a typed
 	// Provider Sessions failure such as ErrUnsupportedProvider,
-	// ErrUnsupportedKind, ErrSessionNotFound, and/or LookupError. Method
+	// ErrUnsupportedKind, ErrSessionNotFound, ErrSessionOutsideRoot,
+	// ErrSessionSourceNotRegularFile, ErrSessionStorageUnavailable, and/or
+	// LookupError. Method
 	// signatures and published values do not name private Codex/Cursor reader
 	// types, filesystem/SQL/OS effect ports, or Providers execution types.
 	Project(ProjectRequest) (ProjectResult, error)
@@ -234,15 +240,19 @@ type UnknownEvent struct {
 }
 
 var (
-	ErrAmbiguousSessionFile = errors.New("ambiguous provider session file")
-	ErrInvalidIdentifier    = errors.New("invalid provider session identifier")
-	ErrSessionNotFound      = errors.New("provider session not found")
-	ErrUnsupportedKind      = errors.New("unsupported provider session kind")
-	ErrUnsupportedProvider  = errors.New("unsupported provider session provider")
+	ErrAmbiguousSessionFile        = errors.New("ambiguous provider session file")
+	ErrInvalidIdentifier           = errors.New("invalid provider session identifier")
+	ErrSessionNotFound             = errors.New("provider session not found")
+	ErrSessionOutsideRoot          = errors.New("provider session resolves outside configured storage")
+	ErrSessionSourceNotRegularFile = errors.New("provider session source is not a regular file")
+	ErrSessionStorageUnavailable   = errors.New("provider session storage is unavailable")
+	ErrUnsupportedKind             = errors.New("unsupported provider session kind")
+	ErrUnsupportedProvider         = errors.New("unsupported provider session provider")
 )
 
-// LookupError retains normalized provider and root context without exposing
-// provider-specific storage details through the service API.
+// LookupError retains normalized provider context. Root is optional legacy
+// diagnostic context; Codex lookups omit it so configured host paths do not
+// cross the Provider Sessions boundary.
 type LookupError struct {
 	Provider Provider
 	Root     string

--- a/pkg/services/provider_sessions/contracts.go
+++ b/pkg/services/provider_sessions/contracts.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
 // Service is the singular Provider Sessions root contract for cross-service
@@ -48,28 +50,17 @@ type Service interface {
 	Project(ProjectRequest) (ProjectResult, error)
 }
 
-// SessionRef is the detached typed provider-session identity in the
-// providers.SessionRef vocabulary (provider + kind + id). Until CTR-PROV
-// publishes the canonical Providers type, this Provider Sessions-owned value is
-// the peer identity accepted by additive root slices. It does not carry
-// Providers catalog/execution or Workers selection-policy fields.
-type SessionRef struct {
-	Provider Provider
-	Kind     string
-	ID       string
-}
-
 // InspectRequest asks the root Service to validate and inspect one detached
 // SessionRef without requiring filesystem/SQL/OS effect ports from the caller.
 type InspectRequest struct {
-	Session SessionRef
+	Session providers.SessionRef
 }
 
 // InspectResult is the detached success outcome for typed SessionRef
 // validation/inspection. Normalized transcript/detail projection is published
 // as the additive Project companion slice on the same root Service.
 type InspectResult struct {
-	Session SessionRef
+	Session providers.SessionRef
 	Source  SourceMetadata
 }
 
@@ -77,16 +68,20 @@ type InspectResult struct {
 // projection for one detached SessionRef without requiring filesystem/SQL/OS
 // effect ports from the caller.
 type ProjectRequest struct {
-	Session SessionRef
+	Session providers.SessionRef
 }
 
 // ProjectResult is the detached Detail-shaped projection peers consume for
 // transcript, reasoning, tool/function-call, parse, and usage facts through
 // Provider Sessions root contracts only.
 type ProjectResult struct {
-	Session SessionRef
+	Session providers.SessionRef
 	Detail  Detail
 }
+
+// SessionRef remains as a source-compatible alias while Providers owns the
+// canonical identity and all root request/result fields use that exact type.
+type SessionRef = providers.SessionRef
 
 type Provider string
 
@@ -94,7 +89,7 @@ const (
 	ProviderCodex  Provider = "codex"
 	ProviderCursor Provider = "cursor"
 
-	SessionIDKind = "session_id"
+	SessionIDKind = providers.SessionIDKind
 )
 
 type Detail struct {

--- a/pkg/services/provider_sessions/doc.go
+++ b/pkg/services/provider_sessions/doc.go
@@ -2,7 +2,8 @@
 //
 // Peer-facing root contract (source of truth for published slices):
 //   - Service — singular cross-service seam
-//   - SessionRef, InspectRequest/InspectResult, ProjectRequest/ProjectResult
+//   - InspectRequest/InspectResult and ProjectRequest/ProjectResult using the
+//     canonical providers.SessionRef identity
 //   - Detail and related normalized transcript/parse/usage value types
 //   - typed errors (ErrUnsupportedProvider, ErrUnsupportedKind,
 //     ErrInvalidIdentifier, ErrSessionNotFound, ErrAmbiguousSessionFile, LookupError)

--- a/pkg/services/provider_sessions/doc.go
+++ b/pkg/services/provider_sessions/doc.go
@@ -6,7 +6,9 @@
 //     canonical providers.SessionRef identity
 //   - Detail and related normalized transcript/parse/usage value types
 //   - typed errors (ErrUnsupportedProvider, ErrUnsupportedKind,
-//     ErrInvalidIdentifier, ErrSessionNotFound, ErrAmbiguousSessionFile, LookupError)
+//     ErrInvalidIdentifier, ErrSessionNotFound, ErrAmbiguousSessionFile,
+//     ErrSessionOutsideRoot, ErrSessionSourceNotRegularFile,
+//     ErrSessionStorageUnavailable, LookupError)
 //
 // Construction/process-edge ports (FileSystem, home/OS resolution, Codex/Cursor
 // walk/symlink/SQL helpers) exist so Wire and owner constructors can assemble a

--- a/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/adverse_handling_test.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/adverse_handling_test.go
@@ -1,0 +1,283 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+)
+
+func TestParseDetailsTruncatedJSONLReportsBoundedDiagnostic(t *testing.T) {
+	parsed, err := ParseDetails(strings.NewReader(`{"type":"turn_context"}` + "\n" + `{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"partial`))
+	if err != nil {
+		t.Fatalf("ParseDetails: %v", err)
+	}
+	if parsed.Summary.MalformedLineCount != 1 || len(parsed.Summary.ParseErrors) != 1 {
+		t.Fatalf("summary = %#v, want one truncated diagnostic", parsed.Summary)
+	}
+	if parsed.Summary.ParseErrors[0].Message != diagnosticTruncatedJSONEvent {
+		t.Fatalf("parse error = %#v, want truncated JSON diagnostic", parsed.Summary.ParseErrors[0])
+	}
+	if len(parsed.Transcript) != 0 {
+		t.Fatalf("transcript = %#v, want no fabricated entries", parsed.Transcript)
+	}
+}
+
+func TestParseDetailsKeepsValidLinesWhenLaterLineIsMalformed(t *testing.T) {
+	parsed, err := ParseDetails(strings.NewReader(strings.Join([]string{
+		`{"type":"event_msg","payload":{"type":"agent_message","message":"kept"}}`,
+		`{bad json`,
+	}, "\n")))
+	if err != nil {
+		t.Fatalf("ParseDetails: %v", err)
+	}
+	if len(parsed.Transcript) != 1 || parsed.Summary.MalformedLineCount != 1 {
+		t.Fatalf("parsed = %#v, want one transcript entry and one malformed diagnostic", parsed)
+	}
+}
+
+func TestParseDetailsSanitizesUnknownEventLabels(t *testing.T) {
+	parsed, err := ParseDetails(strings.NewReader(`{"type":"C:\\private\\rollout.jsonl","payload":{"type":"api_key-secret-token"}}` + "\n"))
+	if err != nil {
+		t.Fatalf("ParseDetails: %v", err)
+	}
+	if len(parsed.Summary.UnknownEvents) != 1 {
+		t.Fatalf("unknown events = %#v, want one sanitized event", parsed.Summary.UnknownEvents)
+	}
+	event := parsed.Summary.UnknownEvents[0]
+	if stringValue(event.Type) != "redacted" || stringValue(event.PayloadType) != "redacted" {
+		t.Fatalf("unknown event = %#v, want redacted labels", event)
+	}
+	encoded := strings.Join([]string{stringValue(event.Type), stringValue(event.PayloadType)}, " ")
+	if strings.Contains(encoded, "private") || strings.Contains(encoded, "api_key") {
+		t.Fatalf("unknown event leaked sensitive labels: %s", encoded)
+	}
+}
+
+func TestParseDetailsUnreadableStreamFailsSafely(t *testing.T) {
+	_, err := ParseDetails(errorReader{err: errors.New("permission denied reading C:\\secret\\rollout.jsonl")})
+	if !errors.Is(err, providersessions.ErrSessionStorageUnavailable) {
+		t.Fatalf("err = %v, want ErrSessionStorageUnavailable", err)
+	}
+}
+
+func TestParseDetailsEnforcesLineAndByteLimitsDeterministically(t *testing.T) {
+	t.Run("line limit", func(t *testing.T) {
+		restore := overrideCodexInspectionLimits(3, 1<<20, 10, 10)
+		t.Cleanup(restore)
+
+		lines := strings.Join([]string{
+			`{"type":"event_msg","payload":{"type":"agent_message","message":"one"}}`,
+			`{"type":"event_msg","payload":{"type":"agent_message","message":"two"}}`,
+			`{"type":"event_msg","payload":{"type":"agent_message","message":"three"}}`,
+			`{"type":"event_msg","payload":{"type":"agent_message","message":"four"}}`,
+		}, "\n")
+		first, err := ParseDetails(strings.NewReader(lines))
+		if err != nil {
+			t.Fatalf("first ParseDetails: %v", err)
+		}
+		second, err := ParseDetails(strings.NewReader(lines))
+		if err != nil {
+			t.Fatalf("second ParseDetails: %v", err)
+		}
+		if !reflect.DeepEqual(first, second) {
+			t.Fatalf("limit handling differed across runs:\nfirst=%#v\nsecond=%#v", first, second)
+		}
+		if len(first.Transcript) != 3 {
+			t.Fatalf("transcript = %#v, want three retained entries before line limit", first.Transcript)
+		}
+		if first.Summary.ParseErrors[len(first.Summary.ParseErrors)-1].Message != diagnosticInspectionLineLimit {
+			t.Fatalf("parse errors = %#v, want line-limit diagnostic", first.Summary.ParseErrors)
+		}
+	})
+
+	t.Run("byte limit", func(t *testing.T) {
+		restore := overrideCodexInspectionLimits(100, 64, 10, 10)
+		t.Cleanup(restore)
+
+		oversized := strings.Repeat("x", 80) + "\n"
+		limited, err := ParseDetails(strings.NewReader(oversized))
+		if err != nil {
+			t.Fatalf("byte-limited ParseDetails: %v", err)
+		}
+		if limited.Summary.ParseErrors[len(limited.Summary.ParseErrors)-1].Message != diagnosticInspectionByteLimit {
+			t.Fatalf("parse errors = %#v, want byte-limit diagnostic", limited.Summary.ParseErrors)
+		}
+	})
+}
+
+func TestParseDetailsEnforcesTranscriptAndDiagnosticLimits(t *testing.T) {
+	restore := overrideCodexInspectionLimits(100, 1<<20, 1, 1)
+	t.Cleanup(restore)
+
+	lines := make([]string, 0, 4)
+	for i := 0; i < 4; i++ {
+		lines = append(lines, `{"type":"event_msg","payload":{"type":"agent_message","message":"msg-`+fmt.Sprint(i)+`"}}`)
+	}
+	parsed, err := ParseDetails(strings.NewReader(strings.Join(lines, "\n")))
+	if err != nil {
+		t.Fatalf("ParseDetails: %v", err)
+	}
+	if len(parsed.Transcript) != 1 {
+		t.Fatalf("transcript = %#v, want one retained entry", parsed.Transcript)
+	}
+	if parsed.Summary.ParseErrors[len(parsed.Summary.ParseErrors)-1].Message != diagnosticInspectionTranscriptLimit {
+		t.Fatalf("parse errors = %#v, want transcript-limit diagnostic", parsed.Summary.ParseErrors)
+	}
+
+	unknownLines := make([]string, 0, 4)
+	for i := 0; i < 4; i++ {
+		unknownLines = append(unknownLines, `{"type":"future_event_`+fmt.Sprint(i)+`"}`)
+	}
+	unknownParsed, err := ParseDetails(strings.NewReader(strings.Join(unknownLines, "\n")))
+	if err != nil {
+		t.Fatalf("unknown ParseDetails: %v", err)
+	}
+	if len(unknownParsed.Summary.UnknownEvents) != 1 {
+		t.Fatalf("unknown events = %#v, want one retained diagnostic", unknownParsed.Summary.UnknownEvents)
+	}
+	if unknownParsed.Summary.UnknownEventCount != 4 {
+		t.Fatalf("UnknownEventCount = %d, want counted omissions", unknownParsed.Summary.UnknownEventCount)
+	}
+}
+
+func TestParseCancellationDuringJSONLLoopReturnsContextError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	release := make(chan struct{})
+	reader := &blockAfterLineReader{
+		content: []byte(strings.Join([]string{
+			`{"type":"event_msg","payload":{"type":"agent_message","message":"first"}}`,
+			`{"type":"event_msg","payload":{"type":"agent_message","message":"second"}}`,
+			`{"type":"event_msg","payload":{"type":"agent_message","message":"third"}}`,
+		}, "\n") + "\n"),
+		linesBeforeBlock: 1,
+		block:            release,
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := parseCodexSessionDetails(ctx, reader)
+		done <- err
+	}()
+	cancel()
+	close(release)
+	err := <-done
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
+
+func TestDiscoveryRejectsExcessiveWalkCandidates(t *testing.T) {
+	root := t.TempDir()
+	for i := 0; i < maxCodexWalkCandidates+1; i++ {
+		writeCodexFixtureAt(t, root, fmt.Sprintf("2026/05/%02d", i), "rollout-session-limit.jsonl")
+	}
+	_, err := LoadDetails(testFiles, testWalkDirectory, testResolveSymlinks, root, "session-limit")
+	if !errors.Is(err, providersessions.ErrSessionStorageUnavailable) {
+		t.Fatalf("err = %v, want ErrSessionStorageUnavailable", err)
+	}
+	if strings.Contains(err.Error(), root) {
+		t.Fatalf("public error exposed host path: %v", err)
+	}
+}
+
+func TestLoadDetailsUnreadableFileFailsWithoutHostPathLeakage(t *testing.T) {
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "2026", "05", "18", "rollout-session-read.jsonl")
+	if err := os.MkdirAll(filepath.Dir(hostPath), 0o755); err != nil {
+		t.Fatalf("mkdir fixture: %v", err)
+	}
+	if err := os.WriteFile(hostPath, []byte(`{"type":"session_meta"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	files := &errorOpenFileSystem{
+		base:      platformfilesystem.Local{},
+		openError: errors.New("permission denied reading " + hostPath),
+	}
+	_, err := LoadDetails(files, testWalkDirectory, testResolveSymlinks, root, "session-read")
+	if !errors.Is(err, providersessions.ErrSessionStorageUnavailable) {
+		t.Fatalf("err = %v, want ErrSessionStorageUnavailable", err)
+	}
+	if strings.Contains(err.Error(), hostPath) || strings.Contains(err.Error(), root) {
+		t.Fatalf("public error exposed host path: %v", err)
+	}
+}
+
+type blockAfterLineReader struct {
+	content          []byte
+	offset           int
+	linesDelivered   int
+	linesBeforeBlock int
+	block            <-chan struct{}
+}
+
+func (r *blockAfterLineReader) Read(p []byte) (int, error) {
+	if r.offset >= len(r.content) {
+		return 0, io.EOF
+	}
+	end := r.offset
+	for end < len(r.content) && r.content[end] != '\n' {
+		end++
+	}
+	if end < len(r.content) {
+		end++
+	}
+	if r.linesDelivered >= r.linesBeforeBlock {
+		<-r.block
+	}
+	chunk := r.content[r.offset:end]
+	r.offset = end
+	r.linesDelivered++
+	n := copy(p, chunk)
+	return n, nil
+}
+
+type errorReader struct {
+	err error
+}
+
+func (r errorReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+type errorOpenFileSystem struct {
+	base      providersessions.FileSystem
+	openError error
+}
+
+func (f *errorOpenFileSystem) Open(path string) (io.ReadCloser, error) {
+	if f.openError != nil {
+		return nil, f.openError
+	}
+	return f.base.Open(path)
+}
+
+func (f *errorOpenFileSystem) Stat(path string) (fs.FileInfo, error) {
+	return f.base.Stat(path)
+}
+
+func overrideCodexInspectionLimits(lines int, bytes int64, transcript int, diagnostics int) func() {
+	previousLines := maxCodexJSONLLinesPerInspection
+	previousBytes := maxCodexJSONLBytesPerInspection
+	previousTranscript := maxCodexTranscriptEntries
+	previousDiagnostics := maxCodexDiagnosticRecords
+	maxCodexJSONLLinesPerInspection = lines
+	maxCodexJSONLBytesPerInspection = bytes
+	maxCodexTranscriptEntries = transcript
+	maxCodexDiagnosticRecords = diagnostics
+	return func() {
+		maxCodexJSONLLinesPerInspection = previousLines
+		maxCodexJSONLBytesPerInspection = previousBytes
+		maxCodexTranscriptEntries = previousTranscript
+		maxCodexDiagnosticRecords = previousDiagnostics
+	}
+}

--- a/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/dependencies_test.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/dependencies_test.go
@@ -1,4 +1,4 @@
-package codex
+package service
 
 import (
 	"path/filepath"

--- a/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/detach.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/detach.go
@@ -1,0 +1,204 @@
+package service
+
+import (
+	"time"
+
+	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+)
+
+func detachDetail(detail providersessions.Detail) providersessions.Detail {
+	return providersessions.Detail{
+		ProviderSession: detail.ProviderSession,
+		Source:          detachSourceMetadata(detail.Source),
+		Parse:           detachParseSummary(detail.Parse),
+		Transcript:      detachTranscript(detail.Transcript),
+	}
+}
+
+func detachParsedDetails(parsed ParsedDetails) ParsedDetails {
+	return ParsedDetails{
+		Summary:    detachParseSummary(parsed.Summary),
+		Transcript: detachTranscript(parsed.Transcript),
+	}
+}
+
+func detachSourceMetadata(source providersessions.SourceMetadata) providersessions.SourceMetadata {
+	return providersessions.SourceMetadata{
+		ModifiedAt:   cloneTimePtr(source.ModifiedAt),
+		RelativePath: source.RelativePath,
+		SizeBytes:    source.SizeBytes,
+	}
+}
+
+func detachParseSummary(summary providersessions.ParseSummary) providersessions.ParseSummary {
+	return providersessions.ParseSummary{
+		EventCount:         summary.EventCount,
+		FunctionCalls:      detachFunctionCalls(summary.FunctionCalls),
+		LineCount:          summary.LineCount,
+		MalformedLineCount: summary.MalformedLineCount,
+		ParseErrors:        detachLineErrors(summary.ParseErrors),
+		Reasoning:          detachReasoningSummaries(summary.Reasoning),
+		TokenUsage:         detachTokenUsage(summary.TokenUsage),
+		Turns:              detachTurnSummaries(summary.Turns),
+		UnknownEventCount:  summary.UnknownEventCount,
+		UnknownEvents:      detachUnknownEvents(summary.UnknownEvents),
+	}
+}
+
+func detachTranscript(entries []providersessions.TranscriptEntry) []providersessions.TranscriptEntry {
+	if len(entries) == 0 {
+		return []providersessions.TranscriptEntry{}
+	}
+	cloned := make([]providersessions.TranscriptEntry, len(entries))
+	for i := range entries {
+		cloned[i] = detachTranscriptEntry(entries[i])
+	}
+	return cloned
+}
+
+func detachTranscriptEntry(entry providersessions.TranscriptEntry) providersessions.TranscriptEntry {
+	return providersessions.TranscriptEntry{
+		Arguments:        cloneStringPtr(entry.Arguments),
+		CallID:           cloneStringPtr(entry.CallID),
+		Encrypted:        cloneBoolPtr(entry.Encrypted),
+		EncryptedContent: cloneStringPtr(entry.EncryptedContent),
+		LineNumber:       cloneIntPtr(entry.LineNumber),
+		Name:             cloneStringPtr(entry.Name),
+		Order:            entry.Order,
+		Output:           cloneStringPtr(entry.Output),
+		SourceType:       cloneStringPtr(entry.SourceType),
+		Status:           cloneStringPtr(entry.Status),
+		Summary:          cloneStringPtr(entry.Summary),
+		Text:             cloneStringPtr(entry.Text),
+		Timestamp:        cloneTimePtr(entry.Timestamp),
+		TurnIndex:        cloneIntPtr(entry.TurnIndex),
+		Type:             entry.Type,
+	}
+}
+
+func detachFunctionCalls(calls []providersessions.FunctionCallSummary) []providersessions.FunctionCallSummary {
+	if len(calls) == 0 {
+		return []providersessions.FunctionCallSummary{}
+	}
+	cloned := make([]providersessions.FunctionCallSummary, len(calls))
+	for i := range calls {
+		cloned[i] = providersessions.FunctionCallSummary{
+			Arguments: cloneStringPtr(calls[i].Arguments),
+			CallID:    cloneStringPtr(calls[i].CallID),
+			Name:      cloneStringPtr(calls[i].Name),
+			Order:     calls[i].Order,
+			Output:    cloneStringPtr(calls[i].Output),
+			Status:    cloneStringPtr(calls[i].Status),
+			TurnIndex: cloneIntPtr(calls[i].TurnIndex),
+			Type:      calls[i].Type,
+		}
+	}
+	return cloned
+}
+
+func detachReasoningSummaries(reasoning []providersessions.ReasoningSummary) []providersessions.ReasoningSummary {
+	if len(reasoning) == 0 {
+		return []providersessions.ReasoningSummary{}
+	}
+	cloned := make([]providersessions.ReasoningSummary, len(reasoning))
+	for i := range reasoning {
+		cloned[i] = providersessions.ReasoningSummary{
+			Encrypted:        cloneBoolPtr(reasoning[i].Encrypted),
+			EncryptedContent: cloneStringPtr(reasoning[i].EncryptedContent),
+			Order:            reasoning[i].Order,
+			SourceType:       reasoning[i].SourceType,
+			Summary:          cloneStringPtr(reasoning[i].Summary),
+			Text:             cloneStringPtr(reasoning[i].Text),
+			TurnIndex:        cloneIntPtr(reasoning[i].TurnIndex),
+		}
+	}
+	return cloned
+}
+
+func detachTurnSummaries(turns []providersessions.TurnSummary) []providersessions.TurnSummary {
+	if len(turns) == 0 {
+		return []providersessions.TurnSummary{}
+	}
+	cloned := make([]providersessions.TurnSummary, len(turns))
+	for i := range turns {
+		cloned[i] = providersessions.TurnSummary{
+			EventCount:        turns[i].EventCount,
+			FunctionCallCount: turns[i].FunctionCallCount,
+			Index:             turns[i].Index,
+			ReasoningCount:    turns[i].ReasoningCount,
+			ResponseItemCount: turns[i].ResponseItemCount,
+			StartedAt:         cloneTimePtr(turns[i].StartedAt),
+		}
+	}
+	return cloned
+}
+
+func detachLineErrors(errors []providersessions.LineError) []providersessions.LineError {
+	if len(errors) == 0 {
+		return []providersessions.LineError{}
+	}
+	cloned := make([]providersessions.LineError, len(errors))
+	copy(cloned, errors)
+	return cloned
+}
+
+func detachUnknownEvents(events []providersessions.UnknownEvent) []providersessions.UnknownEvent {
+	if len(events) == 0 {
+		return []providersessions.UnknownEvent{}
+	}
+	cloned := make([]providersessions.UnknownEvent, len(events))
+	for i := range events {
+		cloned[i] = providersessions.UnknownEvent{
+			LineNumber:  events[i].LineNumber,
+			PayloadType: cloneStringPtr(events[i].PayloadType),
+			Type:        cloneStringPtr(events[i].Type),
+		}
+	}
+	return cloned
+}
+
+func detachTokenUsage(usage *providersessions.TokenUsage) *providersessions.TokenUsage {
+	if usage == nil {
+		return nil
+	}
+	return &providersessions.TokenUsage{
+		CacheWriteTokens:      cloneIntPtr(usage.CacheWriteTokens),
+		CachedInputTokens:     cloneIntPtr(usage.CachedInputTokens),
+		InputTokens:           cloneIntPtr(usage.InputTokens),
+		OutputTokens:          cloneIntPtr(usage.OutputTokens),
+		ReasoningOutputTokens: cloneIntPtr(usage.ReasoningOutputTokens),
+		TotalTokens:           cloneIntPtr(usage.TotalTokens),
+	}
+}
+
+func cloneStringPtr(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneIntPtr(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneBoolPtr(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneTimePtr(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}

--- a/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/detail.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/detail.go
@@ -1,4 +1,4 @@
-package codex
+package service
 
 import (
 	"bufio"
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
 var safeProviderSessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
@@ -60,7 +61,7 @@ func LoadDetails(files providersessions.FileSystem, walkDirectory providersessio
 	return providersessions.Detail{
 		ProviderSession: providersessions.Ref{
 			Provider: providersessions.ProviderCodex,
-			Kind:     providersessions.SessionIDKind,
+			Kind:     providers.SessionIDKind,
 			ID:       normalizedID,
 		},
 		Source: providersessions.SourceMetadata{

--- a/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/detail.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/detail.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -34,13 +35,23 @@ func DefaultSessionsRoot(resolveHome providersessions.ResolveHomeDirectory) (str
 
 // LoadDetails resolves and parses one Codex session from the configured root.
 func LoadDetails(files providersessions.FileSystem, walkDirectory providersessions.CodexWalkDirectory, resolveSymlinks providersessions.CodexResolveSymlinks, root, id string) (providersessions.Detail, error) {
+	return loadDetails(context.Background(), files, walkDirectory, resolveSymlinks, root, id)
+}
+
+func loadDetails(ctx context.Context, files providersessions.FileSystem, walkDirectory providersessions.CodexWalkDirectory, resolveSymlinks providersessions.CodexResolveSymlinks, root, id string) (providersessions.Detail, error) {
+	if err := ctx.Err(); err != nil {
+		return providersessions.Detail{}, err
+	}
 	normalizedID := strings.TrimSpace(id)
 	if !safeProviderSessionIDPattern.MatchString(normalizedID) {
 		return providersessions.Detail{}, providersessions.ErrInvalidIdentifier
 	}
 
-	resolved, err := resolveCodexSessionFile(files, walkDirectory, resolveSymlinks, root, normalizedID)
+	resolved, err := resolveCodexSessionFile(ctx, files, walkDirectory, resolveSymlinks, root, normalizedID)
 	if err != nil {
+		return providersessions.Detail{}, err
+	}
+	if err := ctx.Err(); err != nil {
 		return providersessions.Detail{}, err
 	}
 
@@ -49,9 +60,12 @@ func LoadDetails(files providersessions.FileSystem, walkDirectory providersessio
 		if errors.Is(err, fs.ErrNotExist) {
 			return providersessions.Detail{}, providersessions.ErrSessionNotFound
 		}
-		return providersessions.Detail{}, fmt.Errorf("open provider session file: %w", err)
+		return providersessions.Detail{}, providersessions.ErrSessionStorageUnavailable
 	}
 	defer file.Close()
+	if err := ctx.Err(); err != nil {
+		return providersessions.Detail{}, err
+	}
 
 	parsed, err := parseCodexSessionDetails(file)
 	if err != nil {
@@ -89,20 +103,23 @@ const (
 	codexSessionFileLayoutTimestampPrefixed
 )
 
-func resolveCodexSessionFile(files providersessions.FileSystem, walkDirectory providersessions.CodexWalkDirectory, resolveSymlinks providersessions.CodexResolveSymlinks, root, id string) (resolvedCodexSessionFile, error) {
+func resolveCodexSessionFile(ctx context.Context, files providersessions.FileSystem, walkDirectory providersessions.CodexWalkDirectory, resolveSymlinks providersessions.CodexResolveSymlinks, root, id string) (resolvedCodexSessionFile, error) {
 	if walkDirectory == nil {
 		return resolvedCodexSessionFile{}, fmt.Errorf("codex session directory walker is required")
 	}
 	if resolveSymlinks == nil {
 		return resolvedCodexSessionFile{}, fmt.Errorf("codex session symlink resolver is required")
 	}
-	cleanRoot, resolvedRoot, err := resolveCodexSessionsRoot(files, resolveSymlinks, root)
+	if err := ctx.Err(); err != nil {
+		return resolvedCodexSessionFile{}, err
+	}
+	cleanRoot, resolvedRoot, err := resolveCodexSessionsRoot(ctx, files, resolveSymlinks, root)
 	if err != nil {
 		return resolvedCodexSessionFile{}, err
 	}
 
 	targetName := "rollout-" + id + ".jsonl"
-	matches, err := collectCodexSessionMatches(walkDirectory, cleanRoot, id, targetName)
+	matches, err := collectCodexSessionMatches(ctx, walkDirectory, cleanRoot, id, targetName)
 	if err != nil {
 		return resolvedCodexSessionFile{}, err
 	}
@@ -110,12 +127,12 @@ func resolveCodexSessionFile(files providersessions.FileSystem, walkDirectory pr
 		return resolvedCodexSessionFile{}, providersessions.ErrSessionNotFound
 	}
 	sort.Strings(matches)
-	return buildResolvedCodexSessionCandidates(files, resolveSymlinks, cleanRoot, resolvedRoot, matches, targetName)
+	return buildResolvedCodexSessionCandidates(ctx, files, resolveSymlinks, cleanRoot, resolvedRoot, matches, targetName)
 }
 
 // Resolve locates one Codex rollout without opening or parsing it.
 func Resolve(files providersessions.FileSystem, walkDirectory providersessions.CodexWalkDirectory, resolveSymlinks providersessions.CodexResolveSymlinks, root, id string) (providersessions.SourceMetadata, error) {
-	resolved, err := resolveCodexSessionFile(files, walkDirectory, resolveSymlinks, root, id)
+	resolved, err := resolveCodexSessionFile(context.Background(), files, walkDirectory, resolveSymlinks, root, id)
 	if err != nil {
 		return providersessions.SourceMetadata{}, err
 	}
@@ -126,33 +143,55 @@ func Resolve(files providersessions.FileSystem, walkDirectory providersessions.C
 	}, nil
 }
 
-func resolveCodexSessionsRoot(files providersessions.FileSystem, resolveSymlinks providersessions.CodexResolveSymlinks, root string) (string, string, error) {
+func resolveCodexSessionsRoot(ctx context.Context, files providersessions.FileSystem, resolveSymlinks providersessions.CodexResolveSymlinks, root string) (string, string, error) {
+	if strings.TrimSpace(root) == "" {
+		return "", "", providersessions.ErrSessionStorageUnavailable
+	}
 	cleanRoot, err := filepath.Abs(filepath.Clean(root))
 	if err != nil {
-		return "", "", fmt.Errorf("resolve codex sessions root: %w", err)
+		return "", "", providersessions.ErrSessionStorageUnavailable
+	}
+	if err := ctx.Err(); err != nil {
+		return "", "", err
 	}
 	rootInfo, err := files.Stat(cleanRoot)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return "", "", providersessions.ErrSessionNotFound
 		}
-		return "", "", fmt.Errorf("stat codex sessions root: %w", err)
+		return "", "", providersessions.ErrSessionStorageUnavailable
 	}
 	if !rootInfo.IsDir() {
-		return "", "", fmt.Errorf("codex sessions root is not a directory: %s", cleanRoot)
+		return "", "", providersessions.ErrSessionStorageUnavailable
+	}
+	if err := ctx.Err(); err != nil {
+		return "", "", err
 	}
 	resolvedRoot, err := resolveSymlinks(cleanRoot)
 	if err != nil {
-		return "", "", fmt.Errorf("resolve codex sessions root symlinks: %w", err)
+		return "", "", providersessions.ErrSessionStorageUnavailable
+	}
+	if err := ctx.Err(); err != nil {
+		return "", "", err
 	}
 	return cleanRoot, resolvedRoot, nil
 }
 
-func collectCodexSessionMatches(walkDirectory providersessions.CodexWalkDirectory, cleanRoot, id, targetName string) ([]string, error) {
+func collectCodexSessionMatches(ctx context.Context, walkDirectory providersessions.CodexWalkDirectory, cleanRoot, id, targetName string) ([]string, error) {
 	matches := make([]string, 0, 1)
 	err := walkDirectory(cleanRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if walkErr != nil {
 			return walkErr
+		}
+		if path != cleanRoot && matchesCodexSessionBaseName(filepath.Base(path), id, targetName) {
+			matches = append(matches, path)
+			if entry.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
 		}
 		if entry.IsDir() {
 			return nil
@@ -160,44 +199,62 @@ func collectCodexSessionMatches(walkDirectory providersessions.CodexWalkDirector
 		if entry.Type()&fs.ModeType != 0 && entry.Type()&fs.ModeSymlink == 0 {
 			return nil
 		}
-		if matchesCodexSessionBaseName(filepath.Base(path), id, targetName) {
-			matches = append(matches, path)
-		}
 		return nil
 	})
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, ctxErr
+	}
 	if err != nil {
-		return nil, fmt.Errorf("walk codex sessions root: %w", err)
+		return nil, providersessions.ErrSessionStorageUnavailable
 	}
 	return matches, nil
 }
 
-func buildResolvedCodexSessionCandidates(files providersessions.FileSystem, resolveSymlinks providersessions.CodexResolveSymlinks, cleanRoot, resolvedRoot string, matches []string, targetName string) (resolvedCodexSessionFile, error) {
+func buildResolvedCodexSessionCandidates(ctx context.Context, files providersessions.FileSystem, resolveSymlinks providersessions.CodexResolveSymlinks, cleanRoot, resolvedRoot string, matches []string, targetName string) (resolvedCodexSessionFile, error) {
 	candidates := make([]resolvedCodexSessionFile, 0, len(matches))
 	for _, match := range matches {
-		candidate, err := resolvedCodexSessionCandidate(files, resolveSymlinks, cleanRoot, resolvedRoot, match, targetName)
+		if err := ctx.Err(); err != nil {
+			return resolvedCodexSessionFile{}, err
+		}
+		candidate, err := resolvedCodexSessionCandidate(ctx, files, resolveSymlinks, cleanRoot, resolvedRoot, match, targetName)
 		if err != nil {
 			return resolvedCodexSessionFile{}, err
 		}
 		candidates = append(candidates, candidate)
 	}
+	if err := ctx.Err(); err != nil {
+		return resolvedCodexSessionFile{}, err
+	}
 	return selectResolvedCodexSessionFile(candidates)
 }
 
-func resolvedCodexSessionCandidate(files providersessions.FileSystem, resolveSymlinks providersessions.CodexResolveSymlinks, cleanRoot, resolvedRoot, match, targetName string) (resolvedCodexSessionFile, error) {
+func resolvedCodexSessionCandidate(ctx context.Context, files providersessions.FileSystem, resolveSymlinks providersessions.CodexResolveSymlinks, cleanRoot, resolvedRoot, match, targetName string) (resolvedCodexSessionFile, error) {
 	resolvedMatch, err := resolveSymlinks(match)
 	if err != nil {
-		return resolvedCodexSessionFile{}, fmt.Errorf("resolve provider session symlink: %w", err)
+		return resolvedCodexSessionFile{}, providersessions.ErrSessionStorageUnavailable
 	}
 	if !pathInsideRoot(resolvedRoot, resolvedMatch) {
-		return resolvedCodexSessionFile{}, providersessions.ErrInvalidIdentifier
+		return resolvedCodexSessionFile{}, providersessions.ErrSessionOutsideRoot
+	}
+	if err := ctx.Err(); err != nil {
+		return resolvedCodexSessionFile{}, err
 	}
 	info, err := files.Stat(resolvedMatch)
 	if err != nil {
-		return resolvedCodexSessionFile{}, fmt.Errorf("stat provider session file: %w", err)
+		if errors.Is(err, fs.ErrNotExist) {
+			return resolvedCodexSessionFile{}, providersessions.ErrSessionNotFound
+		}
+		return resolvedCodexSessionFile{}, providersessions.ErrSessionStorageUnavailable
+	}
+	if !info.Mode().IsRegular() {
+		return resolvedCodexSessionFile{}, providersessions.ErrSessionSourceNotRegularFile
+	}
+	if err := ctx.Err(); err != nil {
+		return resolvedCodexSessionFile{}, err
 	}
 	rel, err := filepath.Rel(cleanRoot, match)
 	if err != nil {
-		return resolvedCodexSessionFile{}, fmt.Errorf("rel provider session file: %w", err)
+		return resolvedCodexSessionFile{}, providersessions.ErrSessionStorageUnavailable
 	}
 	modifiedAt := info.ModTime().UTC()
 	return resolvedCodexSessionFile{

--- a/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/detail.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/detail.go
@@ -67,7 +67,7 @@ func loadDetails(ctx context.Context, files providersessions.FileSystem, walkDir
 		return providersessions.Detail{}, err
 	}
 
-	parsed, err := parseCodexSessionDetails(file)
+	parsed, err := parseCodexSessionDetails(ctx, file)
 	if err != nil {
 		return providersessions.Detail{}, err
 	}
@@ -187,6 +187,9 @@ func collectCodexSessionMatches(ctx context.Context, walkDirectory providersessi
 			return walkErr
 		}
 		if path != cleanRoot && matchesCodexSessionBaseName(filepath.Base(path), id, targetName) {
+			if len(matches) >= maxCodexWalkCandidates {
+				return errCodexWalkCandidateLimit
+			}
 			matches = append(matches, path)
 			if entry.IsDir() {
 				return fs.SkipDir
@@ -204,11 +207,16 @@ func collectCodexSessionMatches(ctx context.Context, walkDirectory providersessi
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return nil, ctxErr
 	}
+	if errors.Is(err, errCodexWalkCandidateLimit) {
+		return nil, providersessions.ErrSessionStorageUnavailable
+	}
 	if err != nil {
 		return nil, providersessions.ErrSessionStorageUnavailable
 	}
 	return matches, nil
 }
+
+var errCodexWalkCandidateLimit = errors.New("codex session walk candidate limit reached")
 
 func buildResolvedCodexSessionCandidates(ctx context.Context, files providersessions.FileSystem, resolveSymlinks providersessions.CodexResolveSymlinks, cleanRoot, resolvedRoot string, matches []string, targetName string) (resolvedCodexSessionFile, error) {
 	candidates := make([]resolvedCodexSessionFile, 0, len(matches))
@@ -333,7 +341,7 @@ type ParsedDetails struct {
 
 // ParseSummary parses a Codex JSONL stream into its inspection summary.
 func ParseSummary(reader io.Reader) (providersessions.ParseSummary, error) {
-	parsed, err := parseCodexSessionDetails(reader)
+	parsed, err := parseCodexSessionDetails(context.Background(), reader)
 	if err != nil {
 		return providersessions.ParseSummary{}, err
 	}
@@ -342,7 +350,7 @@ func ParseSummary(reader io.Reader) (providersessions.ParseSummary, error) {
 
 // ParseDetails parses a Codex JSONL stream into summary and transcript data.
 func ParseDetails(reader io.Reader) (ParsedDetails, error) {
-	parsed, err := parseCodexSessionDetails(reader)
+	parsed, err := parseCodexSessionDetails(context.Background(), reader)
 	if err != nil {
 		return ParsedDetails{}, err
 	}
@@ -356,7 +364,7 @@ func ParseDetails(reader io.Reader) (ParsedDetails, error) {
 // Mirrored user/assistant messages emitted as both event_msg and response_item
 // message records are deduplicated. Function outputs attach to the earliest
 // matching call_id within the reconstructed stream.
-func parseCodexSessionDetails(reader io.Reader) (ParsedDetails, error) {
+func parseCodexSessionDetails(ctx context.Context, reader io.Reader) (ParsedDetails, error) {
 	parser := codexSessionParser{
 		summary: providersessions.ParseSummary{
 			Turns:         []providersessions.TurnSummary{},
@@ -370,35 +378,53 @@ func parseCodexSessionDetails(reader io.Reader) (ParsedDetails, error) {
 	bufferedReader := bufio.NewReader(reader)
 	lineNumber := 0
 	for {
-		lineBytes, err := bufferedReader.ReadBytes('\n')
-		if errors.Is(err, io.EOF) && len(lineBytes) == 0 {
+		if err := ctx.Err(); err != nil {
+			return ParsedDetails{}, err
+		}
+		lineBytes, readErr := bufferedReader.ReadBytes('\n')
+		if readErr != nil && !errors.Is(readErr, io.EOF) {
+			return ParsedDetails{}, providersessions.ErrSessionStorageUnavailable
+		}
+		if !parser.budget.recordBytes(int64(len(lineBytes))) {
+			parser.recordInspectionLimit(lineNumber, diagnosticInspectionByteLimit)
 			break
 		}
-		if err != nil && !errors.Is(err, io.EOF) {
-			return ParsedDetails{}, fmt.Errorf("read provider session stream: %w", err)
+		atEOF := errors.Is(readErr, io.EOF)
+		if atEOF && len(lineBytes) == 0 {
+			break
 		}
 
 		lineNumber++
+		if !parser.budget.beginLine() {
+			parser.recordInspectionLimit(lineNumber, diagnosticInspectionLineLimit)
+			break
+		}
 		line := strings.TrimSpace(string(lineBytes))
 		if line == "" {
-			if errors.Is(err, io.EOF) {
+			if atEOF {
 				break
 			}
 			continue
 		}
 		parser.summary.LineCount++
 		var event map[string]any
-		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			parser.summary.MalformedLineCount++
-			parser.summary.ParseErrors = append(parser.summary.ParseErrors, providersessions.LineError{
-				LineNumber: lineNumber,
-				Message:    "invalid JSON event record",
-			})
+		if jsonErr := json.Unmarshal([]byte(line), &event); jsonErr != nil {
+			message := diagnosticInvalidJSONEvent
+			if atEOF {
+				message = diagnosticTruncatedJSONEvent
+			}
+			parser.recordMalformedLine(lineNumber, message)
+			if atEOF {
+				break
+			}
 			continue
 		}
 		parser.summary.EventCount++
 		parser.recordEvent(lineNumber, event)
-		if errors.Is(err, io.EOF) {
+		if parser.budget.stopParsing {
+			break
+		}
+		if atEOF {
 			break
 		}
 	}
@@ -412,6 +438,46 @@ type codexSessionParser struct {
 	summary          providersessions.ParseSummary
 	transcript       []providersessions.TranscriptEntry
 	currentTurnIndex int
+	budget           parseBudget
+}
+
+func (p *codexSessionParser) recordMalformedLine(lineNumber int, message string) {
+	p.summary.MalformedLineCount++
+	p.appendDiagnostic(lineNumber, message)
+}
+
+func (p *codexSessionParser) recordTranscriptLimit(lineNumber int) {
+	if p.budget.transcriptLimitReported {
+		return
+	}
+	if lineNumber <= 0 {
+		lineNumber = max(1, p.summary.LineCount)
+	}
+	p.budget.transcriptLimitReported = true
+	p.recordMalformedLine(lineNumber, diagnosticInspectionTranscriptLimit)
+}
+
+func (p *codexSessionParser) recordInspectionLimit(lineNumber int, message string) {
+	if lineNumber <= 0 {
+		if p.summary.LineCount > 0 {
+			lineNumber = p.summary.LineCount
+		} else {
+			lineNumber = 1
+		}
+	}
+	p.budget.stopParsing = true
+	p.recordMalformedLine(lineNumber, message)
+}
+
+func (p *codexSessionParser) appendDiagnostic(lineNumber int, message string) {
+	if p.budget.diagnosticsFull {
+		return
+	}
+	p.summary.ParseErrors = append(p.summary.ParseErrors, providersessions.LineError{
+		LineNumber: lineNumber,
+		Message:    sanitizeDiagnosticMessage(message),
+	})
+	p.budget.recordedDiagnostic()
 }
 
 func (p *codexSessionParser) recordEvent(lineNumber int, event map[string]any) {
@@ -660,11 +726,16 @@ func (p *codexSessionParser) appendToolOutputTranscript(
 }
 
 func (p *codexSessionParser) appendTranscriptEntry(entry providersessions.TranscriptEntry) {
+	if !p.budget.canRetainTranscript() {
+		p.recordTranscriptLimit(intValue(entry.LineNumber))
+		return
+	}
 	if len(p.transcript) > 0 && isDuplicateTranscriptMessage(p.transcript[len(p.transcript)-1], entry) {
 		return
 	}
 	entry.Order = len(p.transcript) + 1
 	p.transcript = append(p.transcript, entry)
+	p.budget.retainedTranscript()
 }
 
 func isDuplicateTranscriptMessage(previous, next providersessions.TranscriptEntry) bool {
@@ -712,11 +783,17 @@ func (p *codexSessionParser) recordTokenUsage(payload map[string]any) {
 
 func (p *codexSessionParser) recordUnknownEvent(lineNumber int, eventType string, payloadType string) {
 	p.summary.UnknownEventCount++
+	if p.budget.diagnosticsFull {
+		return
+	}
+	sanitizedEventType := sanitizeUnknownEventLabel(eventType)
+	sanitizedPayloadType := sanitizeUnknownEventLabel(payloadType)
 	p.summary.UnknownEvents = append(p.summary.UnknownEvents, providersessions.UnknownEvent{
 		LineNumber:  lineNumber,
-		Type:        stringPtrIfNotEmpty(eventType),
-		PayloadType: stringPtrIfNotEmpty(payloadType),
+		Type:        stringPtrIfNotEmpty(sanitizedEventType),
+		PayloadType: stringPtrIfNotEmpty(sanitizedPayloadType),
 	})
+	p.budget.recordedDiagnostic()
 }
 
 func nestedPayloadType(event map[string]any) string {

--- a/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/detail.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/detail.go
@@ -72,7 +72,7 @@ func loadDetails(ctx context.Context, files providersessions.FileSystem, walkDir
 		return providersessions.Detail{}, err
 	}
 
-	return providersessions.Detail{
+	return detachDetail(providersessions.Detail{
 		ProviderSession: providersessions.Ref{
 			Provider: providersessions.ProviderCodex,
 			Kind:     providers.SessionIDKind,
@@ -85,7 +85,7 @@ func loadDetails(ctx context.Context, files providersessions.FileSystem, walkDir
 		},
 		Parse:      parsed.Summary,
 		Transcript: parsed.Transcript,
-	}, nil
+	}), nil
 }
 
 type resolvedCodexSessionFile struct {
@@ -342,9 +342,20 @@ func ParseSummary(reader io.Reader) (providersessions.ParseSummary, error) {
 
 // ParseDetails parses a Codex JSONL stream into summary and transcript data.
 func ParseDetails(reader io.Reader) (ParsedDetails, error) {
-	return parseCodexSessionDetails(reader)
+	parsed, err := parseCodexSessionDetails(reader)
+	if err != nil {
+		return ParsedDetails{}, err
+	}
+	return detachParsedDetails(parsed), nil
 }
 
+// Codex JSONL reconstruction preserves source line order for transcript,
+// parse-summary, and turn facts. turn_context opens a new turn; later events
+// without an explicit turn inherit the current turn until the next turn_context.
+// When timestamps are absent, ordering follows JSONL line order only.
+// Mirrored user/assistant messages emitted as both event_msg and response_item
+// message records are deduplicated. Function outputs attach to the earliest
+// matching call_id within the reconstructed stream.
 func parseCodexSessionDetails(reader io.Reader) (ParsedDetails, error) {
 	parser := codexSessionParser{
 		summary: providersessions.ParseSummary{

--- a/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/detail_reconstruction_test.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/detail_reconstruction_test.go
@@ -1,0 +1,143 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+)
+
+func representativeCodexJSONL() string {
+	return strings.Join([]string{
+		`{"timestamp":"2026-05-18T10:00:00Z","type":"turn_context"}`,
+		`{"timestamp":"2026-05-18T10:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Inspect the failing run."}]}}`,
+		`{"timestamp":"2026-05-18T10:00:02Z","type":"response_item","payload":{"type":"reasoning","summary":["Checking tool output"]}}`,
+		`{"timestamp":"2026-05-18T10:00:03Z","type":"response_item","payload":{"type":"function_call","call_id":"call-1","name":"exec_command","arguments":"go test ./pkg/api"}}`,
+		`{"timestamp":"2026-05-18T10:00:04Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-1","output":"ok"}}`,
+		`{"timestamp":"2026-05-18T10:00:05Z","type":"event_msg","payload":{"type":"agent_message","message":"The package tests passed."}}`,
+		`{"timestamp":"2026-05-18T10:00:06Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":25,"reasoning_output_tokens":5,"total_tokens":130}}}}`,
+	}, "\n")
+}
+
+func TestParseDetailsRepeatedRunsAreStructurallyEquivalent(t *testing.T) {
+	session := representativeCodexJSONL()
+	first, err := ParseDetails(strings.NewReader(session))
+	if err != nil {
+		t.Fatalf("first ParseDetails: %v", err)
+	}
+	second, err := ParseDetails(strings.NewReader(session))
+	if err != nil {
+		t.Fatalf("second ParseDetails: %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("repeated parse results differ:\nfirst = %#v\nsecond = %#v", first, second)
+	}
+}
+
+func TestParseDetailsDetachesNestedPointerFields(t *testing.T) {
+	parsed, err := ParseDetails(strings.NewReader(strings.Join([]string{
+		`{"type":"response_item","payload":{"type":"function_call","call_id":"call-1","name":"exec_command","arguments":"go test"}}`,
+		`{"type":"response_item","payload":{"type":"function_call_output","call_id":"call-1","output":"ok"}}`,
+	}, "\n")))
+	if err != nil {
+		t.Fatalf("ParseDetails: %v", err)
+	}
+	if len(parsed.Summary.FunctionCalls) != 1 || len(parsed.Transcript) != 2 {
+		t.Fatalf("parsed = %#v, want one call and two transcript entries", parsed)
+	}
+	if parsed.Transcript[0].Arguments == parsed.Summary.FunctionCalls[0].Arguments {
+		t.Fatal("tool_call transcript arguments alias function-call summary arguments")
+	}
+	*parsed.Transcript[0].Arguments = "mutated"
+	if *parsed.Summary.FunctionCalls[0].Arguments == "mutated" {
+		t.Fatalf("mutating transcript arguments changed summary arguments = %#v", parsed.Summary.FunctionCalls[0])
+	}
+}
+
+func TestLoadDetailsReturnsDetachedResultsAcrossInspections(t *testing.T) {
+	root, sessionID := writeCodexJSONLFixture(t, representativeCodexJSONL())
+	first, err := LoadDetails(testFiles, testWalkDirectory, testResolveSymlinks, root, sessionID)
+	if err != nil {
+		t.Fatalf("first LoadDetails: %v", err)
+	}
+	second, err := LoadDetails(testFiles, testWalkDirectory, testResolveSymlinks, root, sessionID)
+	if err != nil {
+		t.Fatalf("second LoadDetails: %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("repeated inspections differ before mutation:\nfirst = %#v\nsecond = %#v", first, second)
+	}
+	if len(first.Transcript) == 0 || first.Transcript[0].Text == nil {
+		t.Fatalf("first detail missing transcript text: %#v", first)
+	}
+	*first.Transcript[0].Text = "mutated transcript"
+	if reflect.DeepEqual(first, second) {
+		t.Fatal("mutating first inspection transcript also changed second inspection")
+	}
+}
+
+func TestParseDetailsAttachesToolOutputToMatchingCallOnly(t *testing.T) {
+	parsed, err := ParseDetails(strings.NewReader(strings.Join([]string{
+		`{"type":"response_item","payload":{"type":"function_call","call_id":"call-1","name":"first_tool","arguments":"a"}}`,
+		`{"type":"response_item","payload":{"type":"function_call","call_id":"call-2","name":"second_tool","arguments":"b"}}`,
+		`{"type":"response_item","payload":{"type":"function_call_output","call_id":"call-2","output":"second-output"}}`,
+		`{"type":"response_item","payload":{"type":"function_call_output","call_id":"call-1","output":"first-output"}}`,
+	}, "\n")))
+	if err != nil {
+		t.Fatalf("ParseDetails: %v", err)
+	}
+	if len(parsed.Summary.FunctionCalls) != 2 {
+		t.Fatalf("function calls = %#v, want two calls", parsed.Summary.FunctionCalls)
+	}
+	first := parsed.Summary.FunctionCalls[0]
+	second := parsed.Summary.FunctionCalls[1]
+	if stringValue(first.CallID) != "call-1" || stringValue(first.Output) != "first-output" {
+		t.Fatalf("first call = %#v, want call-1 with first-output", first)
+	}
+	if stringValue(second.CallID) != "call-2" || stringValue(second.Output) != "second-output" {
+		t.Fatalf("second call = %#v, want call-2 with second-output", second)
+	}
+}
+
+func TestParseDetailsPreservesLineOrderWhenTimestampsAreAbsent(t *testing.T) {
+	parsed, err := ParseDetails(strings.NewReader(strings.Join([]string{
+		`{"type":"turn_context"}`,
+		`{"type":"event_msg","payload":{"type":"user_message","message":"first"}}`,
+		`{"type":"event_msg","payload":{"type":"agent_message","message":"second"}}`,
+	}, "\n")))
+	if err != nil {
+		t.Fatalf("ParseDetails: %v", err)
+	}
+	want := []providersessions.TranscriptEntryType{
+		providersessions.TranscriptUserMessage,
+		providersessions.TranscriptAssistantMessage,
+	}
+	if len(parsed.Transcript) != len(want) {
+		t.Fatalf("transcript = %#v, want %d entries", parsed.Transcript, len(want))
+	}
+	for index, wantType := range want {
+		if parsed.Transcript[index].Type != wantType {
+			t.Fatalf("transcript[%d].Type = %q, want %q", index, parsed.Transcript[index].Type, wantType)
+		}
+	}
+	if len(parsed.Summary.Turns) != 1 || parsed.Summary.Turns[0].EventCount != 3 {
+		t.Fatalf("turns = %#v, want one turn with three counted events", parsed.Summary.Turns)
+	}
+}
+
+func writeCodexJSONLFixture(t *testing.T, content string) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	sessionID := "session-reconstruct-1"
+	dir := filepath.Join(root, "2026", "07", "27")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "rollout-"+sessionID+".jsonl"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return root, sessionID
+}

--- a/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/detail_test.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/detail_test.go
@@ -1,4 +1,4 @@
-package codex
+package service
 
 import (
 	"errors"

--- a/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/discovery_test.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/discovery_test.go
@@ -1,0 +1,251 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+	codexreader "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+type trackingFileSystem struct {
+	base       providersessions.FileSystem
+	cancel     context.CancelFunc
+	cancelStat int
+	openCalls  int
+	statCalls  int
+}
+
+func (f *trackingFileSystem) Open(path string) (io.ReadCloser, error) {
+	f.openCalls++
+	return f.base.Open(path)
+}
+
+func (f *trackingFileSystem) Stat(path string) (fs.FileInfo, error) {
+	f.statCalls++
+	info, err := f.base.Stat(path)
+	if f.cancel != nil && f.statCalls == f.cancelStat {
+		f.cancel()
+	}
+	return info, err
+}
+
+func TestReaderDetailsCancellationStopsDiscoveryEffects(t *testing.T) {
+	t.Run("before discovery", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		files := &trackingFileSystem{base: platformfilesystem.Local{}}
+		walkCalls, resolveCalls := 0, 0
+		reader := newTestReader(t, files,
+			func(string, fs.WalkDirFunc) error {
+				walkCalls++
+				return nil
+			},
+			func(path string) (string, error) {
+				resolveCalls++
+				return path, nil
+			},
+			t.TempDir(),
+		)
+
+		_, err := reader.Details(ctx, codexSessionRef("canceled"))
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Details error = %v, want context.Canceled", err)
+		}
+		if files.statCalls != 0 || files.openCalls != 0 || walkCalls != 0 || resolveCalls != 0 {
+			t.Fatalf("effects after cancellation: stat=%d open=%d walk=%d resolve=%d", files.statCalls, files.openCalls, walkCalls, resolveCalls)
+		}
+	})
+
+	t.Run("during walk", func(t *testing.T) {
+		root := t.TempDir()
+		writeCodexFixture(t, root, "rollout-canceled.jsonl")
+		ctx, cancel := context.WithCancel(context.Background())
+		files := &trackingFileSystem{base: platformfilesystem.Local{}}
+		resolveCalls := 0
+		reader := newTestReader(t, files,
+			func(path string, fn fs.WalkDirFunc) error {
+				return filepath.WalkDir(path, func(path string, entry fs.DirEntry, walkErr error) error {
+					cancel()
+					return fn(path, entry, walkErr)
+				})
+			},
+			func(path string) (string, error) {
+				resolveCalls++
+				return filepath.EvalSymlinks(path)
+			},
+			root,
+		)
+
+		_, err := reader.Details(ctx, codexSessionRef("canceled"))
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Details error = %v, want context.Canceled", err)
+		}
+		if files.statCalls != 1 || files.openCalls != 0 || resolveCalls != 1 {
+			t.Fatalf("effects after walk cancellation: stat=%d open=%d resolve=%d", files.statCalls, files.openCalls, resolveCalls)
+		}
+	})
+
+	t.Run("after candidate stat", func(t *testing.T) {
+		root := t.TempDir()
+		writeCodexFixture(t, root, "rollout-canceled.jsonl")
+		ctx, cancel := context.WithCancel(context.Background())
+		files := &trackingFileSystem{
+			base:       platformfilesystem.Local{},
+			cancel:     cancel,
+			cancelStat: 2,
+		}
+		reader := newTestReader(t, files, filepath.WalkDir, filepath.EvalSymlinks, root)
+
+		_, err := reader.Details(ctx, codexSessionRef("canceled"))
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Details error = %v, want context.Canceled", err)
+		}
+		if files.statCalls != 2 || files.openCalls != 0 {
+			t.Fatalf("effects after stat cancellation: stat=%d open=%d", files.statCalls, files.openCalls)
+		}
+	})
+}
+
+func TestReaderDetailsCancellationDuringSymlinkResolutionStopsStatAndOpen(t *testing.T) {
+	root := t.TempDir()
+	writeCodexFixture(t, root, "rollout-canceled.jsonl")
+	ctx, cancel := context.WithCancel(context.Background())
+	files := &trackingFileSystem{base: platformfilesystem.Local{}}
+	resolveCalls := 0
+	reader := newTestReader(t, files, filepath.WalkDir,
+		func(path string) (string, error) {
+			resolveCalls++
+			resolved, err := filepath.EvalSymlinks(path)
+			if resolveCalls == 2 {
+				cancel()
+			}
+			return resolved, err
+		},
+		root,
+	)
+
+	_, err := reader.Details(ctx, codexSessionRef("canceled"))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Details error = %v, want context.Canceled", err)
+	}
+	if resolveCalls != 2 || files.statCalls != 1 || files.openCalls != 0 {
+		t.Fatalf("effects after resolve cancellation: resolve=%d stat=%d open=%d", resolveCalls, files.statCalls, files.openCalls)
+	}
+}
+
+func TestDiscoveryRejectsNonRegularCandidate(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "rollout-directory.jsonl"), 0o755); err != nil {
+		t.Fatalf("mkdir candidate: %v", err)
+	}
+
+	_, err := LoadDetails(testFiles, testWalkDirectory, testResolveSymlinks, root, "directory")
+	if !errors.Is(err, providersessions.ErrSessionSourceNotRegularFile) {
+		t.Fatalf("LoadDetails error = %v, want ErrSessionSourceNotRegularFile", err)
+	}
+}
+
+func TestDiscoveryRejectsEmptyConfiguredRoot(t *testing.T) {
+	_, err := LoadDetails(testFiles, testWalkDirectory, testResolveSymlinks, "", "session")
+	if !errors.Is(err, providersessions.ErrSessionStorageUnavailable) {
+		t.Fatalf("LoadDetails error = %v, want ErrSessionStorageUnavailable", err)
+	}
+}
+
+func TestDiscoveryReturnsSafeStorageFailure(t *testing.T) {
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "private", "credentials")
+	_, err := LoadDetails(
+		testFiles,
+		func(string, fs.WalkDirFunc) error {
+			return fmt.Errorf("permission denied reading %s", hostPath)
+		},
+		testResolveSymlinks,
+		root,
+		"session",
+	)
+	if !errors.Is(err, providersessions.ErrSessionStorageUnavailable) {
+		t.Fatalf("LoadDetails error = %v, want ErrSessionStorageUnavailable", err)
+	}
+	if strings.Contains(err.Error(), root) || strings.Contains(err.Error(), hostPath) {
+		t.Fatalf("public error exposed host path: %v", err)
+	}
+}
+
+func TestSelectionIsDeterministicAndExactWins(t *testing.T) {
+	exact := resolvedCodexSessionFile{relativePath: "z/rollout-session.jsonl", layout: codexSessionFileLayoutExact}
+	timestamp := resolvedCodexSessionFile{relativePath: "a/rollout-2026-01-01T00-00-00-session.jsonl", layout: codexSessionFileLayoutTimestampPrefixed}
+	for _, candidates := range [][]resolvedCodexSessionFile{
+		{exact, timestamp},
+		{timestamp, exact},
+	} {
+		got, err := selectResolvedCodexSessionFile(candidates)
+		if err != nil {
+			t.Fatalf("selectResolvedCodexSessionFile: %v", err)
+		}
+		if got.relativePath != exact.relativePath {
+			t.Fatalf("selected %q, want exact %q", got.relativePath, exact.relativePath)
+		}
+	}
+}
+
+func TestDiscoveryMetadataIsContainedNormalizedAndUTC(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "2026", "07", "27", "rollout-session.jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir fixture: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{\"type\":\"session_meta\"}\n"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	modifiedAt := time.Date(2026, time.July, 27, 9, 30, 0, 0, time.FixedZone("fixture", 5*60*60))
+	if err := os.Chtimes(path, modifiedAt, modifiedAt); err != nil {
+		t.Fatalf("set fixture time: %v", err)
+	}
+
+	source, err := Resolve(testFiles, testWalkDirectory, testResolveSymlinks, root, "session")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if source.RelativePath != "2026/07/27/rollout-session.jsonl" {
+		t.Fatalf("RelativePath = %q, want normalized contained path", source.RelativePath)
+	}
+	if source.ModifiedAt == nil || source.ModifiedAt.Location() != time.UTC || !source.ModifiedAt.Equal(modifiedAt) {
+		t.Fatalf("ModifiedAt = %v, want %v in UTC", source.ModifiedAt, modifiedAt)
+	}
+}
+
+func newTestReader(
+	t *testing.T,
+	files providersessions.FileSystem,
+	walk providersessions.CodexWalkDirectory,
+	resolve providersessions.CodexResolveSymlinks,
+	root string,
+) codexreader.Service {
+	t.Helper()
+	reader, err := New(codexreader.Dependencies{
+		Files:           files,
+		WalkDirectory:   walk,
+		ResolveSymlinks: resolve,
+		SessionsRoot:    root,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return reader
+}
+
+func codexSessionRef(id string) providers.SessionRef {
+	return providers.SessionRef{Provider: providers.IDCodex, Kind: providers.SessionIDKind, ID: id}
+}

--- a/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/limits.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/limits.go
@@ -1,0 +1,76 @@
+package service
+
+const (
+	maxCodexWalkCandidates          = 64
+	maxCodexDiagnosticMessageLength = 200
+	maxCodexUnknownEventLabelLength = 64
+)
+
+var (
+	maxCodexJSONLLinesPerInspection = 500_000
+	maxCodexJSONLBytesPerInspection = int64(128 << 20)
+	maxCodexTranscriptEntries       = 50_000
+	maxCodexDiagnosticRecords       = 256
+)
+
+const (
+	diagnosticInvalidJSONEvent        = "invalid JSON event record"
+	diagnosticTruncatedJSONEvent      = "truncated JSON event record"
+	diagnosticInspectionLineLimit     = "inspection line limit reached"
+	diagnosticInspectionByteLimit     = "inspection byte limit reached"
+	diagnosticInspectionTranscriptLimit = "inspection transcript limit reached"
+	diagnosticInspectionDiagnosticLimit = "inspection diagnostic limit reached"
+)
+
+type parseBudget struct {
+	linesRead                 int
+	bytesRead                 int64
+	transcriptEntries         int
+	diagnosticRecords         int
+	stopParsing               bool
+	transcriptFull            bool
+	diagnosticsFull           bool
+	transcriptLimitReported   bool
+}
+
+func (b *parseBudget) recordBytes(n int64) bool {
+	if b.stopParsing {
+		return false
+	}
+	b.bytesRead += n
+	if b.bytesRead > maxCodexJSONLBytesPerInspection {
+		b.stopParsing = true
+		return false
+	}
+	return true
+}
+
+func (b *parseBudget) beginLine() bool {
+	if b.stopParsing {
+		return false
+	}
+	if b.linesRead >= maxCodexJSONLLinesPerInspection {
+		b.stopParsing = true
+		return false
+	}
+	b.linesRead++
+	return true
+}
+
+func (b *parseBudget) canRetainTranscript() bool {
+	return !b.transcriptFull && b.transcriptEntries < maxCodexTranscriptEntries
+}
+
+func (b *parseBudget) retainedTranscript() {
+	b.transcriptEntries++
+	if b.transcriptEntries >= maxCodexTranscriptEntries {
+		b.transcriptFull = true
+	}
+}
+
+func (b *parseBudget) recordedDiagnostic() {
+	b.diagnosticRecords++
+	if b.diagnosticRecords >= maxCodexDiagnosticRecords {
+		b.diagnosticsFull = true
+	}
+}

--- a/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/sanitize.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/sanitize.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+var (
+	unsafeDiagnosticPathPattern = regexp.MustCompile(`(?i)(?:[a-z]:\\|\\\\|/|\\|\.\./)`)
+	unsafeDiagnosticTokenPattern = regexp.MustCompile(`(?i)(?:api[_-]?key|authorization|bearer\s+|password|secret|token)`)
+)
+
+func sanitizeDiagnosticMessage(message string) string {
+	trimmed := strings.TrimSpace(message)
+	if trimmed == "" {
+		return diagnosticInvalidJSONEvent
+	}
+	if !isAllowlistedDiagnosticMessage(trimmed) {
+		return diagnosticInvalidJSONEvent
+	}
+	return truncateDiagnosticMessage(trimmed)
+}
+
+func isAllowlistedDiagnosticMessage(message string) bool {
+	switch message {
+	case diagnosticInvalidJSONEvent,
+		diagnosticTruncatedJSONEvent,
+		diagnosticInspectionLineLimit,
+		diagnosticInspectionByteLimit,
+		diagnosticInspectionTranscriptLimit,
+		diagnosticInspectionDiagnosticLimit:
+		return true
+	default:
+		return false
+	}
+}
+
+func truncateDiagnosticMessage(message string) string {
+	if len(message) <= maxCodexDiagnosticMessageLength {
+		return message
+	}
+	return message[:maxCodexDiagnosticMessageLength]
+}
+
+func sanitizeUnknownEventLabel(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	if unsafeDiagnosticPathPattern.MatchString(trimmed) ||
+		unsafeDiagnosticTokenPattern.MatchString(trimmed) ||
+		strings.Contains(trimmed, string(filepath.Separator)) {
+		return "redacted"
+	}
+	builder := strings.Builder{}
+	for _, r := range trimmed {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' || r == '.' {
+			builder.WriteRune(r)
+		}
+		if builder.Len() >= maxCodexUnknownEventLabelLength {
+			break
+		}
+	}
+	sanitized := builder.String()
+	if sanitized == "" {
+		return "redacted"
+	}
+	return sanitized
+}

--- a/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/service.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/service.go
@@ -44,7 +44,8 @@ func (r *reader) Details(
 	if session.Kind != providers.SessionIDKind {
 		return providersessions.Detail{}, providersessions.ErrUnsupportedKind
 	}
-	return LoadDetails(
+	return loadDetails(
+		ctx,
 		r.dependencies.Files,
 		r.dependencies.WalkDirectory,
 		r.dependencies.ResolveSymlinks,

--- a/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/service.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/service.go
@@ -1,0 +1,54 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+	codexreader "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+type reader struct {
+	dependencies codexreader.Dependencies
+}
+
+var _ codexreader.Service = (*reader)(nil)
+
+// New constructs the parent-private Codex reader from fixed storage effects.
+func New(dependencies codexreader.Dependencies) (codexreader.Service, error) {
+	if dependencies.Files == nil {
+		return nil, fmt.Errorf("provider-session filesystem is required")
+	}
+	if dependencies.WalkDirectory == nil {
+		return nil, fmt.Errorf("provider-session Codex directory walker is required")
+	}
+	if dependencies.ResolveSymlinks == nil {
+		return nil, fmt.Errorf("provider-session Codex symlink resolver is required")
+	}
+	dependencies.SessionsRoot = filepath.Clean(dependencies.SessionsRoot)
+	return &reader{dependencies: dependencies}, nil
+}
+
+func (r *reader) Details(
+	ctx context.Context,
+	session providers.SessionRef,
+) (providersessions.Detail, error) {
+	if err := ctx.Err(); err != nil {
+		return providersessions.Detail{}, err
+	}
+	if session.Provider != providers.IDCodex {
+		return providersessions.Detail{}, providersessions.ErrUnsupportedProvider
+	}
+	if session.Kind != providers.SessionIDKind {
+		return providersessions.Detail{}, providersessions.ErrUnsupportedKind
+	}
+	return LoadDetails(
+		r.dependencies.Files,
+		r.dependencies.WalkDirectory,
+		r.dependencies.ResolveSymlinks,
+		r.dependencies.SessionsRoot,
+		session.ID,
+	)
+}

--- a/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/transport_migration_test.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/transport_migration_test.go
@@ -239,8 +239,8 @@ func TestGetProviderSessionDetails_RejectsSessionSymlinkOutsideConfiguredRoot(t 
 		t.Fatalf("create symlink: %v", err)
 	}
 	_, err := LoadDetails(testFiles, testWalkDirectory, testResolveSymlinks, root, "sess-outside")
-	if !errors.Is(err, providersessions.ErrInvalidIdentifier) {
-		t.Fatalf("err = %v, want ErrInvalidIdentifier", err)
+	if !errors.Is(err, providersessions.ErrSessionOutsideRoot) {
+		t.Fatalf("err = %v, want ErrSessionOutsideRoot", err)
 	}
 }
 
@@ -262,8 +262,8 @@ func TestGetProviderSessionDetails_RejectsSessionSymlinkOutsideConfiguredRootEve
 		t.Fatalf("create symlink: %v", err)
 	}
 	_, err := LoadDetails(testFiles, testWalkDirectory, testResolveSymlinks, root, "sess-shared")
-	if !errors.Is(err, providersessions.ErrInvalidIdentifier) {
-		t.Fatalf("err = %v, want ErrInvalidIdentifier", err)
+	if !errors.Is(err, providersessions.ErrSessionOutsideRoot) {
+		t.Fatalf("err = %v, want ErrSessionOutsideRoot", err)
 	}
 }
 

--- a/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/transport_migration_test.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/transport_migration_test.go
@@ -1,4 +1,4 @@
-package codex
+package service
 
 import (
 	"errors"

--- a/pkg/services/provider_sessions/internal/services/codex_reader/service.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/service.go
@@ -1,0 +1,26 @@
+// Package codexreader defines the parent-private Codex historical-session
+// reader owned by Provider Sessions.
+package codexreader
+
+import (
+	"context"
+
+	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+// Service resolves and projects Codex-native history into Provider
+// Sessions-owned values. Only the Provider Sessions implementation consumes
+// this parent-private contract.
+type Service interface {
+	Details(context.Context, providers.SessionRef) (providersessions.Detail, error)
+}
+
+// Dependencies are fixed when Provider Sessions is composed. They never cross
+// the peer-facing Provider Sessions invocation boundary.
+type Dependencies struct {
+	Files           providersessions.FileSystem
+	WalkDirectory   providersessions.CodexWalkDirectory
+	ResolveSymlinks providersessions.CodexResolveSymlinks
+	SessionsRoot    string
+}

--- a/pkg/services/provider_sessions/internal/services/codex_reader/wire/wire.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/wire/wire.go
@@ -1,0 +1,17 @@
+// Package wire constructs the parent-private Codex Provider Session reader.
+package wire
+
+import (
+	codexreader "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader"
+	codexreaderservice "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader/internal/service"
+)
+
+// NewService constructs the inert Codex reader used by Provider Sessions.
+func NewService(dependencies codexreader.Dependencies) (codexreader.Service, error) {
+	return codexreaderservice.New(dependencies)
+}
+
+// DefaultSessionsRoot returns the conventional Codex session storage root.
+func DefaultSessionsRoot(resolveHome func() (string, error)) (string, error) {
+	return codexreaderservice.DefaultSessionsRoot(resolveHome)
+}

--- a/pkg/services/provider_sessions/service/service.go
+++ b/pkg/services/provider_sessions/service/service.go
@@ -2,19 +2,21 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
 
 	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
-	"github.com/portpowered/infinite-you/pkg/services/provider_sessions/codex"
 	"github.com/portpowered/infinite-you/pkg/services/provider_sessions/cursor"
+	codexreader "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader"
+	codexreaderwire "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader/wire"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
 type inspectionService struct {
+	codex                 codexreader.Service
 	codexRoot             string
-	codexWalkDirectory    providersessions.CodexWalkDirectory
-	codexResolveSymlinks  providersessions.CodexResolveSymlinks
 	cursorRoot            cursor.AgentStorageRoot
 	cursorWalkDirectory   providersessions.CursorWalkDirectory
 	cursorResolveSymlinks providersessions.CursorResolveSymlinks
@@ -42,7 +44,7 @@ func New(
 	if err := validateDependencies(files, resolveHome, codexWalkDirectory, codexResolveSymlinks, cursorWalkDirectory, cursorResolveSymlinks, cursorOpenDatabase, cursorOperatingSystem); err != nil {
 		return nil, err
 	}
-	codexRoot, err := codex.DefaultSessionsRoot(resolveHome)
+	codexRoot, err := codexreaderwire.DefaultSessionsRoot(resolveHome)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +52,7 @@ func New(
 	if err != nil {
 		return nil, err
 	}
-	return newForRoots(files, codexWalkDirectory, codexResolveSymlinks, cursorWalkDirectory, cursorResolveSymlinks, cursorOpenDatabase, codexRoot, string(cursorRoot)), nil
+	return newForRoots(files, codexWalkDirectory, codexResolveSymlinks, cursorWalkDirectory, cursorResolveSymlinks, cursorOpenDatabase, codexRoot, string(cursorRoot))
 }
 
 // NewForRoots constructs Provider Sessions with explicit storage roots.
@@ -66,21 +68,29 @@ func NewForRoots(
 	if err := validateStorageDependencies(files, codexWalkDirectory, codexResolveSymlinks, cursorWalkDirectory, cursorResolveSymlinks, cursorOpenDatabase); err != nil {
 		return nil, err
 	}
-	return newForRoots(files, codexWalkDirectory, codexResolveSymlinks, cursorWalkDirectory, cursorResolveSymlinks, cursorOpenDatabase, codexRoot, cursorRoot), nil
+	return newForRoots(files, codexWalkDirectory, codexResolveSymlinks, cursorWalkDirectory, cursorResolveSymlinks, cursorOpenDatabase, codexRoot, cursorRoot)
 }
 
-func newForRoots(files providersessions.FileSystem, codexWalkDirectory providersessions.CodexWalkDirectory, codexResolveSymlinks providersessions.CodexResolveSymlinks, cursorWalkDirectory providersessions.CursorWalkDirectory, cursorResolveSymlinks providersessions.CursorResolveSymlinks, cursorOpenDatabase providersessions.CursorOpenSQLDatabase, codexRoot, cursorRoot string) *inspectionService {
+func newForRoots(files providersessions.FileSystem, codexWalkDirectory providersessions.CodexWalkDirectory, codexResolveSymlinks providersessions.CodexResolveSymlinks, cursorWalkDirectory providersessions.CursorWalkDirectory, cursorResolveSymlinks providersessions.CursorResolveSymlinks, cursorOpenDatabase providersessions.CursorOpenSQLDatabase, codexRoot, cursorRoot string) (providersessions.Service, error) {
 	codexRoot = filepath.Clean(codexRoot)
+	codexService, err := codexreaderwire.NewService(codexreader.Dependencies{
+		Files:           files,
+		WalkDirectory:   codexWalkDirectory,
+		ResolveSymlinks: codexResolveSymlinks,
+		SessionsRoot:    codexRoot,
+	})
+	if err != nil {
+		return nil, err
+	}
 	return &inspectionService{
+		codex:                 codexService,
 		codexRoot:             codexRoot,
-		codexWalkDirectory:    codexWalkDirectory,
-		codexResolveSymlinks:  codexResolveSymlinks,
 		cursorRoot:            cursor.AgentStorageRoot(cursorRoot),
 		cursorWalkDirectory:   cursorWalkDirectory,
 		cursorResolveSymlinks: cursorResolveSymlinks,
 		cursorOpenDatabase:    cursorOpenDatabase,
 		files:                 files,
-	}
+	}, nil
 }
 
 func validateDependencies(files providersessions.FileSystem, resolveHome providersessions.ResolveHomeDirectory, codexWalkDirectory providersessions.CodexWalkDirectory, codexResolveSymlinks providersessions.CodexResolveSymlinks, cursorWalkDirectory providersessions.CursorWalkDirectory, cursorResolveSymlinks providersessions.CursorResolveSymlinks, cursorOpenDatabase providersessions.CursorOpenSQLDatabase, cursorOperatingSystem providersessions.OperatingSystem) error {
@@ -129,7 +139,11 @@ func (s *inspectionService) Details(provider, kind, id string) (providersessions
 	var detail providersessions.Detail
 	switch normalizedProvider {
 	case providersessions.ProviderCodex:
-		detail, err = codex.LoadDetails(s.files, s.codexWalkDirectory, s.codexResolveSymlinks, s.codexRoot, id)
+		detail, err = s.codex.Details(context.Background(), providers.SessionRef{
+			Provider: providers.IDCodex,
+			Kind:     kind,
+			ID:       id,
+		})
 	case providersessions.ProviderCursor:
 		detail, err = cursor.LoadDetails(s.files, s.cursorWalkDirectory, s.cursorResolveSymlinks, s.cursorOpenDatabase, s.cursorRoot, id)
 	}
@@ -146,16 +160,16 @@ func (s *inspectionService) Details(provider, kind, id string) (providersessions
 // Inspect validates and inspects a detached typed SessionRef through the same
 // storage-backed lookup path as Details, returning a plain InspectResult.
 func (s *inspectionService) Inspect(req providersessions.InspectRequest) (providersessions.InspectResult, error) {
-	if strings.TrimSpace(req.Session.ID) == "" {
-		return providersessions.InspectResult{}, providersessions.ErrInvalidIdentifier
+	if err := validateSessionRef(req.Session); err != nil {
+		return providersessions.InspectResult{}, err
 	}
-	detail, err := s.Details(string(req.Session.Provider), req.Session.Kind, req.Session.ID)
+	detail, err := s.Details(req.Session.Provider.String(), req.Session.Kind, req.Session.ID)
 	if err != nil {
 		return providersessions.InspectResult{}, err
 	}
 	return providersessions.InspectResult{
-		Session: providersessions.SessionRef{
-			Provider: detail.ProviderSession.Provider,
+		Session: providers.SessionRef{
+			Provider: canonicalProviderID(detail.ProviderSession.Provider),
 			Kind:     detail.ProviderSession.Kind,
 			ID:       detail.ProviderSession.ID,
 		},
@@ -166,16 +180,16 @@ func (s *inspectionService) Inspect(req providersessions.InspectRequest) (provid
 // Project projects provider-independent transcript/detail facts for a detached
 // typed SessionRef through the same storage-backed lookup path as Details.
 func (s *inspectionService) Project(req providersessions.ProjectRequest) (providersessions.ProjectResult, error) {
-	if strings.TrimSpace(req.Session.ID) == "" {
-		return providersessions.ProjectResult{}, providersessions.ErrInvalidIdentifier
+	if err := validateSessionRef(req.Session); err != nil {
+		return providersessions.ProjectResult{}, err
 	}
-	detail, err := s.Details(string(req.Session.Provider), req.Session.Kind, req.Session.ID)
+	detail, err := s.Details(req.Session.Provider.String(), req.Session.Kind, req.Session.ID)
 	if err != nil {
 		return providersessions.ProjectResult{}, err
 	}
 	return providersessions.ProjectResult{
-		Session: providersessions.SessionRef{
-			Provider: detail.ProviderSession.Provider,
+		Session: providers.SessionRef{
+			Provider: canonicalProviderID(detail.ProviderSession.Provider),
 			Kind:     detail.ProviderSession.Kind,
 			ID:       detail.ProviderSession.ID,
 		},
@@ -192,6 +206,28 @@ func normalizeProvider(provider string) (providersessions.Provider, error) {
 	default:
 		return "", providersessions.ErrUnsupportedProvider
 	}
+}
+
+func validateSessionRef(session providers.SessionRef) error {
+	if strings.TrimSpace(session.ID) == "" {
+		return providersessions.ErrInvalidIdentifier
+	}
+	switch session.Provider {
+	case providers.IDCodex, providers.IDCursor:
+	default:
+		return providersessions.ErrUnsupportedProvider
+	}
+	if strings.TrimSpace(session.Kind) != providers.SessionIDKind {
+		return providersessions.ErrUnsupportedKind
+	}
+	return nil
+}
+
+func canonicalProviderID(provider providersessions.Provider) providers.ID {
+	if provider == providersessions.ProviderCursor {
+		return providers.IDCursor
+	}
+	return providers.IDCodex
 }
 
 func (s *inspectionService) rootFor(provider providersessions.Provider) string {

--- a/pkg/services/provider_sessions/service/service.go
+++ b/pkg/services/provider_sessions/service/service.go
@@ -16,7 +16,6 @@ import (
 
 type inspectionService struct {
 	codex                 codexreader.Service
-	codexRoot             string
 	cursorRoot            cursor.AgentStorageRoot
 	cursorWalkDirectory   providersessions.CursorWalkDirectory
 	cursorResolveSymlinks providersessions.CursorResolveSymlinks
@@ -84,7 +83,6 @@ func newForRoots(files providersessions.FileSystem, codexWalkDirectory providers
 	}
 	return &inspectionService{
 		codex:                 codexService,
-		codexRoot:             codexRoot,
 		cursorRoot:            cursor.AgentStorageRoot(cursorRoot),
 		cursorWalkDirectory:   cursorWalkDirectory,
 		cursorResolveSymlinks: cursorResolveSymlinks,
@@ -235,6 +233,6 @@ func (s *inspectionService) rootFor(provider providersessions.Provider) string {
 	case providersessions.ProviderCursor:
 		return string(s.cursorRoot)
 	default:
-		return s.codexRoot
+		return ""
 	}
 }

--- a/pkg/services/provider_sessions/service_root_contract_test.go
+++ b/pkg/services/provider_sessions/service_root_contract_test.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
 // rootServiceFake is a peer-shaped Provider Sessions root Service that uses
-// only Provider Sessions root contracts. It never imports Codex/Cursor reader
-// packages, filesystem/SQL/OS effect ports, Providers catalog/execution types,
-// or Workers selection-policy types.
+// only Provider Sessions and canonical Providers identity contracts. It never
+// imports Codex/Cursor reader packages, filesystem/SQL/OS effect ports,
+// Providers catalog/execution services, or Workers selection-policy types.
 type rootServiceFake struct {
 	detail    providersessions.Detail
 	detailErr error
@@ -181,7 +182,7 @@ func TestRootService_Characterization_TypedFailures(t *testing.T) {
 func TestRootService_Inspect_Characterization_TypedSessionRefSuccess(t *testing.T) {
 	modifiedAt := time.Date(2026, 7, 24, 3, 0, 0, 0, time.UTC)
 	ref := providersessions.SessionRef{
-		Provider: providersessions.ProviderCodex,
+		Provider: providers.IDCodex,
 		Kind:     providersessions.SessionIDKind,
 		ID:       "session-inspect-1",
 	}
@@ -214,7 +215,7 @@ func TestRootService_Inspect_Characterization_TypedSessionRefSuccess(t *testing.
 
 func TestRootService_Inspect_Characterization_TypedFailures(t *testing.T) {
 	ref := providersessions.SessionRef{
-		Provider: providersessions.ProviderCursor,
+		Provider: providers.IDCursor,
 		Kind:     providersessions.SessionIDKind,
 		ID:       "missing-session",
 	}
@@ -285,7 +286,7 @@ func newProjectSuccessFixture() projectSuccessFixture {
 	outputTokens := 7
 	totalTokens := 18
 	ref := providersessions.SessionRef{
-		Provider: providersessions.ProviderCodex,
+		Provider: providers.IDCodex,
 		Kind:     providersessions.SessionIDKind,
 		ID:       "session-project-1",
 	}
@@ -298,7 +299,7 @@ func newProjectSuccessFixture() projectSuccessFixture {
 		outputTokens:  outputTokens,
 		totalTokens:   totalTokens,
 		detail: providersessions.Detail{
-			ProviderSession: providersessions.Ref{Provider: ref.Provider, Kind: ref.Kind, ID: ref.ID},
+			ProviderSession: providersessions.Ref{Provider: providersessions.Provider(ref.Provider), Kind: ref.Kind, ID: ref.ID},
 			Source: providersessions.SourceMetadata{
 				ModifiedAt:   &modifiedAt,
 				RelativePath: "2026/07/24/rollout-session-project-1.jsonl",
@@ -413,7 +414,7 @@ func TestRootService_Project_Characterization_NormalizedDetailSuccess(t *testing
 		t.Fatalf("ProjectResult.Session = %#v, want %#v", result.Session, fx.ref)
 	}
 	detail := result.Detail
-	if detail.ProviderSession.Provider != fx.ref.Provider ||
+	if detail.ProviderSession.Provider != providersessions.Provider(fx.ref.Provider) ||
 		detail.ProviderSession.Kind != fx.ref.Kind ||
 		detail.ProviderSession.ID != fx.ref.ID {
 		t.Fatalf("Detail.ProviderSession = %#v", detail.ProviderSession)
@@ -424,7 +425,7 @@ func TestRootService_Project_Characterization_NormalizedDetailSuccess(t *testing
 
 func TestRootService_Project_Characterization_TypedFailures(t *testing.T) {
 	ref := providersessions.SessionRef{
-		Provider: providersessions.ProviderCursor,
+		Provider: providers.IDCursor,
 		Kind:     providersessions.SessionIDKind,
 		ID:       "missing-project-session",
 	}
@@ -483,7 +484,7 @@ func sealRootFake(ref providersessions.SessionRef, assistantText string, inputTo
 		project: providersessions.ProjectResult{
 			Session: ref,
 			Detail: providersessions.Detail{
-				ProviderSession: providersessions.Ref{Provider: ref.Provider, Kind: ref.Kind, ID: ref.ID},
+				ProviderSession: providersessions.Ref{Provider: providersessions.Provider(ref.Provider), Kind: ref.Kind, ID: ref.ID},
 				Source: providersessions.SourceMetadata{
 					ModifiedAt:   &modifiedAt,
 					RelativePath: "2026/07/24/rollout-session-seal-1.jsonl",
@@ -550,7 +551,7 @@ func TestRootService_Seal_PublishedSlicesOnSingularRoot(t *testing.T) {
 	assistantText := "sealed assistant reply"
 	inputTokens := 5
 	ref := providersessions.SessionRef{
-		Provider: providersessions.ProviderCodex,
+		Provider: providers.IDCodex,
 		Kind:     providersessions.SessionIDKind,
 		ID:       "session-seal-1",
 	}

--- a/pkg/services/provider_sessions/service_root_contract_test.go
+++ b/pkg/services/provider_sessions/service_root_contract_test.go
@@ -144,6 +144,9 @@ func TestRootService_Characterization_TypedFailures(t *testing.T) {
 		{name: "invalid identifier", err: providersessions.ErrInvalidIdentifier},
 		{name: "session not found", err: providersessions.ErrSessionNotFound},
 		{name: "ambiguous session", err: providersessions.ErrAmbiguousSessionFile},
+		{name: "outside root", err: providersessions.ErrSessionOutsideRoot},
+		{name: "non-regular source", err: providersessions.ErrSessionSourceNotRegularFile},
+		{name: "storage unavailable", err: providersessions.ErrSessionStorageUnavailable},
 		{
 			name: "lookup wraps session not found",
 			err: &providersessions.LookupError{
@@ -228,6 +231,9 @@ func TestRootService_Inspect_Characterization_TypedFailures(t *testing.T) {
 		{name: "invalid identifier", err: providersessions.ErrInvalidIdentifier},
 		{name: "session not found", err: providersessions.ErrSessionNotFound},
 		{name: "ambiguous session", err: providersessions.ErrAmbiguousSessionFile},
+		{name: "outside root", err: providersessions.ErrSessionOutsideRoot},
+		{name: "non-regular source", err: providersessions.ErrSessionSourceNotRegularFile},
+		{name: "storage unavailable", err: providersessions.ErrSessionStorageUnavailable},
 		{
 			name: "lookup wraps session not found",
 			err: &providersessions.LookupError{
@@ -436,6 +442,9 @@ func TestRootService_Project_Characterization_TypedFailures(t *testing.T) {
 		{name: "unsupported provider", err: providersessions.ErrUnsupportedProvider},
 		{name: "unsupported kind", err: providersessions.ErrUnsupportedKind},
 		{name: "session not found", err: providersessions.ErrSessionNotFound},
+		{name: "outside root", err: providersessions.ErrSessionOutsideRoot},
+		{name: "non-regular source", err: providersessions.ErrSessionSourceNotRegularFile},
+		{name: "storage unavailable", err: providersessions.ErrSessionStorageUnavailable},
 		{
 			name: "lookup wraps session not found",
 			err: &providersessions.LookupError{

--- a/pkg/services/provider_sessions/service_test.go
+++ b/pkg/services/provider_sessions/service_test.go
@@ -3,6 +3,8 @@ package providersessions_test
 import (
 	"database/sql"
 	"errors"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -14,6 +16,7 @@ import (
 	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
 	providercursor "github.com/portpowered/infinite-you/pkg/services/provider_sessions/cursor"
 	providersessionsservice "github.com/portpowered/infinite-you/pkg/services/provider_sessions/service"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
 func TestDetailsLoadsCodexSessionThroughService(t *testing.T) {
@@ -33,7 +36,7 @@ func TestInspectLoadsTypedSessionRefThroughService(t *testing.T) {
 	root := writeCodexSessionFixture(t, "session-inspect-1")
 	svc := newServiceForRoots(t, root, "")
 	ref := providersessions.SessionRef{
-		Provider: providersessions.ProviderCodex,
+		Provider: providers.IDCodex,
 		Kind:     providersessions.SessionIDKind,
 		ID:       "session-inspect-1",
 	}
@@ -50,10 +53,60 @@ func TestInspectLoadsTypedSessionRefThroughService(t *testing.T) {
 	}
 }
 
+func TestInspectValidatesCanonicalProviderSessionRefBeforeOpeningNativeContent(t *testing.T) {
+	files := &openRecordingFileSystem{base: platformfilesystem.Local{}}
+	svc, err := providersessionsservice.NewForRoots(
+		files,
+		filepath.WalkDir,
+		filepath.EvalSymlinks,
+		filepath.WalkDir,
+		filepath.EvalSymlinks,
+		sql.Open,
+		t.TempDir(),
+		t.TempDir(),
+	)
+	if err != nil {
+		t.Fatalf("NewForRoots: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		ref  providers.SessionRef
+		want error
+	}{
+		{
+			name: "provider",
+			ref:  providers.SessionRef{Provider: "openai", Kind: providers.SessionIDKind, ID: "session-1"},
+			want: providersessions.ErrUnsupportedProvider,
+		},
+		{
+			name: "kind",
+			ref:  providers.SessionRef{Provider: providers.IDCodex, Kind: "path", ID: "session-1"},
+			want: providersessions.ErrUnsupportedKind,
+		},
+		{
+			name: "identifier",
+			ref:  providers.SessionRef{Provider: providers.IDCodex, Kind: providers.SessionIDKind, ID: "../secret"},
+			want: providersessions.ErrInvalidIdentifier,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, inspectErr := svc.Inspect(providersessions.InspectRequest{Session: test.ref})
+			if !errors.Is(inspectErr, test.want) {
+				t.Fatalf("Inspect error = %v, want %v", inspectErr, test.want)
+			}
+		})
+	}
+	if files.opens != 0 {
+		t.Fatalf("native file opens = %d, want 0", files.opens)
+	}
+}
+
 func TestInspectRejectsInvalidIdentifierAndPropagatesTypedFailures(t *testing.T) {
 	svc := newServiceForRoots(t, t.TempDir(), "")
 	if _, err := svc.Inspect(providersessions.InspectRequest{Session: providersessions.SessionRef{
-		Provider: providersessions.ProviderCodex,
+		Provider: providers.IDCodex,
 		Kind:     providersessions.SessionIDKind,
 		ID:       "   ",
 	}}); !errors.Is(err, providersessions.ErrInvalidIdentifier) {
@@ -67,7 +120,7 @@ func TestInspectRejectsInvalidIdentifierAndPropagatesTypedFailures(t *testing.T)
 		t.Fatalf("provider err = %v, want ErrUnsupportedProvider", err)
 	}
 	if _, err := svc.Inspect(providersessions.InspectRequest{Session: providersessions.SessionRef{
-		Provider: providersessions.ProviderCodex,
+		Provider: providers.IDCodex,
 		Kind:     "path",
 		ID:       "session-1",
 	}}); !errors.Is(err, providersessions.ErrUnsupportedKind) {
@@ -79,7 +132,7 @@ func TestProjectLoadsNormalizedDetailThroughService(t *testing.T) {
 	root := writeCodexSessionFixture(t, "session-project-1")
 	svc := newServiceForRoots(t, root, "")
 	ref := providersessions.SessionRef{
-		Provider: providersessions.ProviderCodex,
+		Provider: providers.IDCodex,
 		Kind:     providersessions.SessionIDKind,
 		ID:       "session-project-1",
 	}
@@ -100,14 +153,14 @@ func TestProjectLoadsNormalizedDetailThroughService(t *testing.T) {
 func TestProjectRejectsInvalidIdentifierAndPropagatesTypedFailures(t *testing.T) {
 	svc := newServiceForRoots(t, t.TempDir(), "")
 	if _, err := svc.Project(providersessions.ProjectRequest{Session: providersessions.SessionRef{
-		Provider: providersessions.ProviderCodex,
+		Provider: providers.IDCodex,
 		Kind:     providersessions.SessionIDKind,
 		ID:       "",
 	}}); !errors.Is(err, providersessions.ErrInvalidIdentifier) {
 		t.Fatalf("empty id err = %v, want ErrInvalidIdentifier", err)
 	}
 	if _, err := svc.Project(providersessions.ProjectRequest{Session: providersessions.SessionRef{
-		Provider: providersessions.ProviderCodex,
+		Provider: providers.IDCodex,
 		Kind:     providersessions.SessionIDKind,
 		ID:       "missing-session",
 	}}); !errors.Is(err, providersessions.ErrSessionNotFound) {
@@ -274,7 +327,7 @@ func TestNewConstructsServiceWithValidDependencies(t *testing.T) {
 		t.Fatal("New returned nil Service")
 	}
 	if _, err := svc.Inspect(providersessions.InspectRequest{Session: providersessions.SessionRef{
-		Provider: providersessions.ProviderCodex,
+		Provider: providers.IDCodex,
 		Kind:     providersessions.SessionIDKind,
 		ID:       "missing-from-default-root",
 	}}); !errors.Is(err, providersessions.ErrSessionNotFound) {
@@ -328,4 +381,18 @@ func newServiceForRoots(t *testing.T, codexRoot, cursorRoot string) providersess
 		t.Fatalf("NewForRoots: %v", err)
 	}
 	return service
+}
+
+type openRecordingFileSystem struct {
+	base  providersessions.FileSystem
+	opens int
+}
+
+func (f *openRecordingFileSystem) Open(path string) (io.ReadCloser, error) {
+	f.opens++
+	return f.base.Open(path)
+}
+
+func (f *openRecordingFileSystem) Stat(path string) (fs.FileInfo, error) {
+	return f.base.Stat(path)
 }

--- a/pkg/services/provider_sessions/service_test.go
+++ b/pkg/services/provider_sessions/service_test.go
@@ -32,6 +32,38 @@ func TestDetailsLoadsCodexSessionThroughService(t *testing.T) {
 	}
 }
 
+func TestDetailsReconstructsNormalizedCodexJSONLThroughRoot(t *testing.T) {
+	root := writeRichCodexSessionFixture(t, "session-reconstruct-root")
+	svc := newServiceForRoots(t, root, "")
+
+	first, err := svc.Details("codex", providersessions.SessionIDKind, "session-reconstruct-root")
+	if err != nil {
+		t.Fatalf("Details: %v", err)
+	}
+	second, err := svc.Details("codex", providersessions.SessionIDKind, "session-reconstruct-root")
+	if err != nil {
+		t.Fatalf("Details repeat: %v", err)
+	}
+	if first.ProviderSession.ID != "session-reconstruct-root" ||
+		first.Source.RelativePath != "2026/07/27/rollout-session-reconstruct-root.jsonl" {
+		t.Fatalf("detail identity = %#v, want normalized codex session and source", first)
+	}
+	if len(first.Transcript) < 4 || len(first.Parse.FunctionCalls) != 1 || len(first.Parse.Reasoning) != 1 {
+		t.Fatalf("detail = %#v, want transcript, tool, and reasoning facts", first)
+	}
+	if first.Parse.TokenUsage == nil || first.Parse.TokenUsage.TotalTokens == nil ||
+		*first.Parse.TokenUsage.TotalTokens != 130 {
+		t.Fatalf("token usage = %#v, want total 130", first.Parse.TokenUsage)
+	}
+	if first.Transcript[0].Text == nil || !strings.Contains(*first.Transcript[0].Text, "Inspect the failing run") {
+		t.Fatalf("transcript = %#v, want user message text", first.Transcript)
+	}
+	*first.Transcript[0].Text = "mutated"
+	if *second.Transcript[0].Text == "mutated" {
+		t.Fatalf("mutating first inspection affected second inspection transcript")
+	}
+}
+
 func TestInspectLoadsTypedSessionRefThroughService(t *testing.T) {
 	root := writeCodexSessionFixture(t, "session-inspect-1")
 	svc := newServiceForRoots(t, root, "")
@@ -360,6 +392,29 @@ func writeCodexSessionFixture(t *testing.T, sessionID string) string {
 	}
 	path := filepath.Join(sessionDir, "rollout-"+sessionID+".jsonl")
 	if err := os.WriteFile(path, []byte("{\"type\":\"session_meta\"}\n"), 0o600); err != nil {
+		t.Fatalf("write session fixture: %v", err)
+	}
+	return root
+}
+
+func writeRichCodexSessionFixture(t *testing.T, sessionID string) string {
+	t.Helper()
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "2026", "07", "27")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir session fixture: %v", err)
+	}
+	content := strings.Join([]string{
+		`{"timestamp":"2026-05-18T10:00:00Z","type":"turn_context"}`,
+		`{"timestamp":"2026-05-18T10:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Inspect the failing run."}]}}`,
+		`{"timestamp":"2026-05-18T10:00:02Z","type":"response_item","payload":{"type":"reasoning","summary":["Checking tool output"]}}`,
+		`{"timestamp":"2026-05-18T10:00:03Z","type":"response_item","payload":{"type":"function_call","call_id":"call-1","name":"exec_command","arguments":"go test ./pkg/api"}}`,
+		`{"timestamp":"2026-05-18T10:00:04Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-1","output":"ok"}}`,
+		`{"timestamp":"2026-05-18T10:00:05Z","type":"event_msg","payload":{"type":"agent_message","message":"The package tests passed."}}`,
+		`{"timestamp":"2026-05-18T10:00:06Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":25,"reasoning_output_tokens":5,"total_tokens":130}}}}`,
+	}, "\n") + "\n"
+	path := filepath.Join(sessionDir, "rollout-"+sessionID+".jsonl")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("write session fixture: %v", err)
 	}
 	return root

--- a/pkg/services/provider_sessions/service_test.go
+++ b/pkg/services/provider_sessions/service_test.go
@@ -223,7 +223,7 @@ func TestGetProviderSessionDetails_RegressionLoadsCodexAndCursorFromConfiguredRo
 	codexRoot, cursorRoot := t.TempDir(), t.TempDir()
 	service := newServiceForRoots(t, codexRoot, cursorRoot)
 	_, codexErr := service.Details("codex", "session_id", "missing-session")
-	assertLookupContext(t, codexErr, providersessions.ProviderCodex, codexRoot)
+	assertLookupContext(t, codexErr, providersessions.ProviderCodex, "")
 	_, cursorErr := service.Details("cursor", "session_id", "missing-session")
 	assertCursorLookupContext(t, cursorErr, cursorRoot)
 }
@@ -236,7 +236,7 @@ func TestGetProviderSessionDetails_EventRefRoundTripLoadsCursorAndCodex(t *testi
 		want     providersessions.Provider
 		root     string
 	}{
-		{"codex", providersessions.ProviderCodex, codexRoot},
+		{"codex", providersessions.ProviderCodex, ""},
 		{"cursor", providersessions.ProviderCursor, cursorRoot},
 		{"agent", providersessions.ProviderCursor, cursorRoot},
 	} {

--- a/tests/functional/providers/codex/process_harness_test.go
+++ b/tests/functional/providers/codex/process_harness_test.go
@@ -1,0 +1,339 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	codexFunctionalSessionID          = "session-functional-root"
+	codexFunctionalMissingSessionID     = "session-missing-root"
+	codexFunctionalMalformedSessionID   = "session-malformed-root"
+	codexFunctionalBoundedWalkSessionID = "session-bounded-root"
+	codexFunctionalCanceledSessionID    = "session-canceled-root"
+	codexFunctionalOutsideSessionID     = "session-outside-root"
+)
+
+// TestCodexHistoricalInspectionSuccessThroughRootBuildProcess proves a stored
+// Codex rollout is readable through the public provider-session detail surface
+// composed from root.BuildProcess.
+func TestCodexHistoricalInspectionSuccessThroughRootBuildProcess(t *testing.T) {
+	homeDir := t.TempDir()
+	writeCodexRolloutFixture(t, codexSessionsRoot(homeDir), codexFunctionalSessionID, representativeCodexJSONL())
+
+	server := startCodexHistoricalInspectionServer(t, homeDir, serviceedges.Edges{})
+	defer server.Stop(t)
+
+	detail := getCodexProviderSessionDetail(t, server.URL(), codexFunctionalSessionID)
+	if detail.ProviderSession.Id != codexFunctionalSessionID ||
+		detail.ProviderSession.Provider != factoryapi.Codex ||
+		detail.ProviderSession.Kind != factoryapi.LoadableProviderSessionKindSessionID {
+		t.Fatalf("provider session = %#v, want codex session_id %s", detail.ProviderSession, codexFunctionalSessionID)
+	}
+	if detail.Source.RelativePath != "2026/07/27/rollout-"+codexFunctionalSessionID+".jsonl" {
+		t.Fatalf("source path = %q, want contained rollout path", detail.Source.RelativePath)
+	}
+	if len(detail.Transcript) < 4 || len(detail.Parse.FunctionCalls) != 1 || len(detail.Parse.Reasoning) != 1 {
+		t.Fatalf("detail = %#v, want transcript, tool, and reasoning facts", detail)
+	}
+	if detail.Parse.TokenUsage == nil || detail.Parse.TokenUsage.TotalTokens == nil ||
+		*detail.Parse.TokenUsage.TotalTokens != 130 {
+		t.Fatalf("token usage = %#v, want total 130", detail.Parse.TokenUsage)
+	}
+	if detail.Transcript[0].Text == nil || !strings.Contains(*detail.Transcript[0].Text, "Inspect the failing run") {
+		t.Fatalf("transcript = %#v, want user message text", detail.Transcript)
+	}
+}
+
+// TestCodexHistoricalInspectionDetachedRepeatedRunsThroughRootBuildProcess proves
+// repeated root-built inspections return detached equivalent detail.
+func TestCodexHistoricalInspectionDetachedRepeatedRunsThroughRootBuildProcess(t *testing.T) {
+	homeDir := t.TempDir()
+	writeCodexRolloutFixture(t, codexSessionsRoot(homeDir), codexFunctionalSessionID, representativeCodexJSONL())
+
+	server := startCodexHistoricalInspectionServer(t, homeDir, serviceedges.Edges{})
+	defer server.Stop(t)
+
+	first := getCodexProviderSessionDetail(t, server.URL(), codexFunctionalSessionID)
+	second := getCodexProviderSessionDetail(t, server.URL(), codexFunctionalSessionID)
+	if first.Transcript[0].Text == nil || second.Transcript[0].Text == nil {
+		t.Fatal("expected transcript text in both inspections")
+	}
+	if *first.Transcript[0].Text != *second.Transcript[0].Text {
+		t.Fatalf("repeated inspections differ: %#v vs %#v", first.Transcript[0], second.Transcript[0])
+	}
+	mutated := "mutated transcript"
+	first.Transcript[0].Text = &mutated
+	if *second.Transcript[0].Text == mutated {
+		t.Fatal("mutating first inspection affected second inspection transcript")
+	}
+}
+
+// TestCodexHistoricalInspectionMissingSessionThroughRootBuildProcess proves a
+// missing Codex session returns the accepted not-found outcome without leaking
+// configured host storage paths.
+func TestCodexHistoricalInspectionMissingSessionThroughRootBuildProcess(t *testing.T) {
+	homeDir := t.TempDir()
+	server := startCodexHistoricalInspectionServer(t, homeDir, serviceedges.Edges{})
+	defer server.Stop(t)
+
+	body := getCodexProviderSessionDetailErrorBody(
+		t,
+		server.URL(),
+		codexFunctionalMissingSessionID,
+		http.StatusNotFound,
+	)
+	if !strings.Contains(body, "provider session not found") {
+		t.Fatalf("error body = %q, want not-found message", body)
+	}
+	assertCodexProviderSessionErrorBodySafe(t, "missing-session", body, homeDir)
+}
+
+// TestCodexHistoricalInspectionMalformedJSONLThroughRootBuildProcess proves
+// truncated JSONL returns bounded parse diagnostics without fabricating
+// transcript content or leaking host paths.
+func TestCodexHistoricalInspectionMalformedJSONLThroughRootBuildProcess(t *testing.T) {
+	homeDir := t.TempDir()
+	content := `{"type":"turn_context"}` + "\n" +
+		`{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"partial`
+	writeCodexRolloutFixture(t, codexSessionsRoot(homeDir), codexFunctionalMalformedSessionID, content)
+
+	server := startCodexHistoricalInspectionServer(t, homeDir, serviceedges.Edges{})
+	defer server.Stop(t)
+
+	detail := getCodexProviderSessionDetail(t, server.URL(), codexFunctionalMalformedSessionID)
+	if detail.Parse.MalformedLineCount != 1 || len(detail.Parse.ParseErrors) != 1 {
+		t.Fatalf("parse summary = %#v, want one malformed-line diagnostic", detail.Parse)
+	}
+	if detail.Parse.ParseErrors[0].Message != "truncated JSON event record" {
+		t.Fatalf("parse error = %#v, want truncated JSON diagnostic", detail.Parse.ParseErrors[0])
+	}
+	if len(detail.Transcript) != 0 {
+		t.Fatalf("transcript = %#v, want no fabricated entries", detail.Transcript)
+	}
+	encoded, err := json.Marshal(detail)
+	if err != nil {
+		t.Fatalf("marshal detail: %v", err)
+	}
+	assertCodexProviderSessionErrorBodySafe(t, "malformed-jsonl", string(encoded), homeDir)
+}
+
+// TestCodexHistoricalInspectionContainmentRejectionThroughRootBuildProcess proves
+// symlink escapes fail safely through the root-composed detail surface.
+func TestCodexHistoricalInspectionContainmentRejectionThroughRootBuildProcess(t *testing.T) {
+	homeDir := t.TempDir()
+	root := codexSessionsRoot(homeDir)
+	outsideDir := t.TempDir()
+	outsidePath := filepath.Join(outsideDir, "rollout-"+codexFunctionalOutsideSessionID+".jsonl")
+	if err := os.WriteFile(outsidePath, []byte(`{"type":"session_meta"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write outside fixture: %v", err)
+	}
+	linkDir := filepath.Join(root, "2026", "07", "27")
+	if err := os.MkdirAll(linkDir, 0o755); err != nil {
+		t.Fatalf("mkdir link dir: %v", err)
+	}
+	if err := os.Symlink(outsidePath, filepath.Join(linkDir, "rollout-"+codexFunctionalOutsideSessionID+".jsonl")); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf("symlink capability unavailable: %v", err)
+		}
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	server := startCodexHistoricalInspectionServer(t, homeDir, serviceedges.Edges{})
+	defer server.Stop(t)
+
+	body := getCodexProviderSessionDetailErrorBody(
+		t,
+		server.URL(),
+		codexFunctionalOutsideSessionID,
+		http.StatusInternalServerError,
+	)
+	if !strings.Contains(body, "failed to load provider session details") {
+		t.Fatalf("error body = %q, want safe load failure", body)
+	}
+	assertCodexProviderSessionErrorBodySafe(t, "containment-rejection", body, homeDir)
+}
+
+// TestCodexHistoricalInspectionBoundedWalkThroughRootBuildProcess proves
+// excessive discovery candidates terminate with a safe root outcome.
+func TestCodexHistoricalInspectionBoundedWalkThroughRootBuildProcess(t *testing.T) {
+	homeDir := t.TempDir()
+	root := codexSessionsRoot(homeDir)
+	for i := 0; i < 65; i++ {
+		writeCodexRolloutFixtureAt(
+			t,
+			root,
+			fmt.Sprintf("2026/05/%02d", i),
+			codexFunctionalBoundedWalkSessionID,
+			`{"type":"session_meta"}`+"\n",
+		)
+	}
+
+	server := startCodexHistoricalInspectionServer(t, homeDir, serviceedges.Edges{})
+	defer server.Stop(t)
+
+	body := getCodexProviderSessionDetailErrorBody(
+		t,
+		server.URL(),
+		codexFunctionalBoundedWalkSessionID,
+		http.StatusInternalServerError,
+	)
+	if !strings.Contains(body, "failed to load provider session details") {
+		t.Fatalf("error body = %q, want safe load failure", body)
+	}
+	assertCodexProviderSessionErrorBodySafe(t, "bounded-walk", body, homeDir)
+}
+
+// TestCodexHistoricalInspectionCancelledDiscoveryThroughRootBuildProcess proves
+// injected discovery cancellation surfaces a safe root outcome without host-path
+// leakage when reached only through root.BuildProcess and public contracts.
+func TestCodexHistoricalInspectionCancelledDiscoveryThroughRootBuildProcess(t *testing.T) {
+	homeDir := t.TempDir()
+	writeCodexRolloutFixture(
+		t,
+		codexSessionsRoot(homeDir),
+		codexFunctionalCanceledSessionID,
+		`{"type":"session_meta"}`+"\n",
+	)
+
+	server := startCodexHistoricalInspectionServer(t, homeDir, serviceedges.Edges{
+		ProviderSessionCodexWalkDirectory: func(string, fs.WalkDirFunc) error {
+			return context.Canceled
+		},
+	})
+	defer server.Stop(t)
+
+	body := getCodexProviderSessionDetailErrorBody(
+		t,
+		server.URL(),
+		codexFunctionalCanceledSessionID,
+		http.StatusInternalServerError,
+	)
+	if !strings.Contains(body, "failed to load provider session details") {
+		t.Fatalf("error body = %q, want safe load failure", body)
+	}
+	assertCodexProviderSessionErrorBodySafe(t, "canceled-discovery", body, homeDir)
+}
+
+func startCodexHistoricalInspectionServer(
+	t *testing.T,
+	homeDir string,
+	edges serviceedges.Edges,
+) *support.FunctionalAPIServer {
+	t.Helper()
+
+	if edges.ProviderSessionResolveHomeDirectory == nil {
+		edges.ProviderSessionResolveHomeDirectory = func() (string, error) { return homeDir, nil }
+	}
+	dir := support.ScaffoldSingleStepFactory(t, "codex-historical-inspection")
+	return support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		UseMockWorkers:            true,
+		WaitForServiceModeRuntime: true,
+		Edges:                     edges,
+		Env:                       []string{"HOME=" + homeDir, "USERPROFILE=" + homeDir},
+	})
+}
+
+func codexSessionsRoot(homeDir string) string {
+	return filepath.Join(homeDir, ".codex", "sessions")
+}
+
+func codexProviderSessionDetailURL(baseURL, sessionID string) string {
+	query := url.Values{}
+	query.Set("provider", string(factoryapi.Codex))
+	query.Set("kind", string(factoryapi.LoadableProviderSessionKindSessionID))
+	query.Set("id", sessionID)
+	return strings.TrimSuffix(baseURL, "/") + "/provider-sessions/detail?" + query.Encode()
+}
+
+func getCodexProviderSessionDetail(
+	t *testing.T,
+	baseURL, sessionID string,
+) factoryapi.ProviderSessionDetailResponse {
+	t.Helper()
+	return support.GetJSON[factoryapi.ProviderSessionDetailResponse](
+		t,
+		codexProviderSessionDetailURL(baseURL, sessionID),
+	)
+}
+
+func getCodexProviderSessionDetailErrorBody(
+	t *testing.T,
+	baseURL, sessionID string,
+	wantStatus int,
+) string {
+	t.Helper()
+
+	response, err := http.Get(codexProviderSessionDetailURL(baseURL, sessionID))
+	if err != nil {
+		t.Fatalf("GET provider session detail: %v", err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read provider session detail body: %v", err)
+	}
+	if response.StatusCode != wantStatus {
+		t.Fatalf(
+			"GET provider session detail status = %d, want %d: %s",
+			response.StatusCode,
+			wantStatus,
+			strings.TrimSpace(string(body)),
+		)
+	}
+	return string(body)
+}
+
+func assertCodexProviderSessionErrorBodySafe(t *testing.T, caseID, body, homeDir string) {
+	t.Helper()
+	if err := support.ValidateProviderSessionFixtureContent(caseID, "provider-session-detail", []byte(body)); err != nil {
+		t.Fatalf("provider session response leaked forbidden material: %v\nbody=%s", err, body)
+	}
+	if strings.Contains(body, homeDir) || strings.Contains(body, codexSessionsRoot(homeDir)) {
+		t.Fatalf("provider session response leaked configured host path: %s", body)
+	}
+}
+
+func writeCodexRolloutFixture(t *testing.T, root, sessionID, content string) {
+	t.Helper()
+	writeCodexRolloutFixtureAt(t, root, "2026/07/27", sessionID, content)
+}
+
+func writeCodexRolloutFixtureAt(t *testing.T, root, relativeDir, sessionID, content string) {
+	t.Helper()
+	dir := filepath.Join(root, filepath.FromSlash(relativeDir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir codex rollout fixture: %v", err)
+	}
+	path := filepath.Join(dir, "rollout-"+sessionID+".jsonl")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write codex rollout fixture: %v", err)
+	}
+}
+
+func representativeCodexJSONL() string {
+	return strings.Join([]string{
+		`{"timestamp":"2026-05-18T10:00:00Z","type":"turn_context"}`,
+		`{"timestamp":"2026-05-18T10:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Inspect the failing run."}]}}`,
+		`{"timestamp":"2026-05-18T10:00:02Z","type":"response_item","payload":{"type":"reasoning","summary":["Checking tool output"]}}`,
+		`{"timestamp":"2026-05-18T10:00:03Z","type":"response_item","payload":{"type":"function_call","call_id":"call-1","name":"exec_command","arguments":"go test ./pkg/api"}}`,
+		`{"timestamp":"2026-05-18T10:00:04Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-1","output":"ok"}}`,
+		`{"timestamp":"2026-05-18T10:00:05Z","type":"event_msg","payload":{"type":"agent_message","message":"The package tests passed."}}`,
+		`{"timestamp":"2026-05-18T10:00:06Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":25,"reasoning_output_tokens":5,"total_tokens":130}}}}`,
+	}, "\n") + "\n"
+}


### PR DESCRIPTION
{
  "project": "PSS IMP-PSES-01 — Package the Codex Provider Session Reader",
  "branchName": "pss-imp-pses-01-codex-reader",
  "description": "Move Codex historical Provider Session discovery and normalized JSONL detail inspection behind the Provider Sessions-owned parent-private codex_reader, preserving accepted Providers and Provider Sessions behavior while containing rollout layout, JSONL grammar, and host-path handling and proving bounded safe behavior through the production root. Resume from existing branch head 19b41d17c; do not recreate landed stories 001 and 002.",
  "context": {
    "customerAsk": "Package Codex Provider Session discovery and detail behavior under pkg/services/provider_sessions/internal/services/codex_reader, compose it through the singular Provider Sessions root using accepted Provider Sessions and Providers contracts, preserve normalized customer-visible session discovery and detail, read only contained validated session references, normalize Codex JSONL into detached public Provider Session values with bounded safe diagnostics, prove malformed/truncated JSONL, missing sessions, cancellation, containment violations, stable ordering, and mutation detachment through focused unit and root.BuildProcess functional evidence, and leave Codex live execution, top-level CLI/Cobra, Factory Runtime dispatch planning, Models assets, OpenAPI generation, and Cursor reader paths unchanged.",
    "problem": "Codex historical inspection previously lived in a transitional provider-specific package whose filesystem traversal, symlink resolution, and JSONL parsing participated directly in Provider Sessions construction. That shape does not provide the planned parent-private reader boundary and increases the risk that Codex-native rollout layout, JSONL grammar, and host-path handling leak into root contracts, composition, tests, or peer callers. The untrusted host-owned data path also needs an explicit end-to-end contract for containment, cancellation, deterministic ordering, detachment, safe malformed/truncated handling, cleanup, and diagnostic redaction.",
    "solution": "Introduce one parent-private Codex Reader service owned by Provider Sessions. The root validates the accepted Providers-owned SessionRef, selects the reader by canonical provider identity, and delegates once. The reader securely resolves and contains Codex rollout references under the configured sessions root, performs cancellation-aware read-only JSONL inspection, deterministically reconstructs session facts, and returns fresh Provider Sessions-owned normalized values. Structural and containment failures fail safely, line-local corruption yields only bounded sanitized parse facts when partial detail remains trustworthy, all resources close on terminal paths, and production composition is proven through root.BuildProcess. Continue from existing branch head 19b41d17c without recreating landed stories 001 and 002."
  },
  "acceptanceCriteria": [
    "Codex Provider Session discovery and detail behavior is owned by internal/services/codex_reader and reached through the Provider Sessions root using accepted Providers SessionRef and Provider Sessions result/error contracts.",
    "Containment and malformed-input cases fail safely without exposing prompts, credentials, raw environment values, or arbitrary host paths in public errors or parse diagnostics.",
    "Returned values are normalized, detached, deterministic, and cancellation-aware; repeated inspections of equivalent Codex JSONL return structurally equivalent detail, and mutating one result cannot affect a later inspection or reader state.",
    "Focused unit and public functional evidence proves behavior through root.BuildProcess without constructing a peer service graph or the private Codex reader directly.",
    "Relevant package boundaries, maintainability, ownership/coverage manifests, and verification gates pass.",
    "Typecheck, gofmt, focused unit and Provider Sessions integration/functional tests, applicable repeat or race checks, package boundary/structure checks, lint, and required fast/PR verification pass.",
    "The implementation/review loop continues until required CI is terminal and passing, every blocking PR conversation comment is explicitly addressed, merge conflicts and shared-file churn are reconciled, and the PR is actually merged; an opened, green, approved, or ready-to-merge PR is not complete."
  ],
  "userStories": [
    {
      "id": "pss-imp-pses-01-codex-reader-001",
      "title": "Route Codex inspection through the Provider Sessions root",
      "description": "As a Provider Sessions consumer, I want Codex historical inspection reached only through the singular Provider Sessions root so that peers never depend on a transitional Codex package or construct a private reader themselves.",
      "acceptanceCriteria": [
        "Codex historical discovery/detail ownership lives under pkg/services/provider_sessions/internal/services/codex_reader with a parent-private service interface consumed only by the Provider Sessions implementation.",
        "The Provider Sessions root accepts the canonical Codex provider identity and session-id kind from the accepted Providers contract, validates the reference, and delegates once to the private Codex reader.",
        "Peer-facing Provider Sessions contracts and method signatures expose only accepted Providers/Provider Sessions values and do not name private Codex reader types.",
        "The transitional public pkg/services/provider_sessions/codex production path is removed or no longer callable after equivalent root behavior is wired; ownership, coverage, and package-target manifests are reconciled for the move.",
        "Focused composition and contract tests prove root-only delegation and absence of private reader types from accepted contracts.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Already implemented on branch pss-imp-pses-01-codex-reader at/before 19b41d17c. Do not recreate this commit; mark passes after verifying existing work still satisfies criteria."
    },
    {
      "id": "pss-imp-pses-01-codex-reader-002",
      "title": "Resolve only contained Codex rollout references",
      "description": "As a Provider Sessions consumer, I want a canonical Codex session reference to resolve exactly one contained rollout file so that missing, ambiguous, or unsafe identities cannot read another host session.",
      "acceptanceCriteria": [
        "A valid configured fixture resolves exactly one read-only Codex rollout beneath the configured sessions root and reports only accepted normalized source metadata; no absolute host path crosses the reader boundary as a public value.",
        "Empty, malformed, path-like, wrong-kind, and unsupported-provider references fail with the accepted typed validation outcome before rollout open.",
        "Missing sessions, non-regular candidates, escaped paths, symlink escapes, empty configured roots, and unsafe storage failures return deterministic typed not-found, invalid, or containment/storage failures and never open an out-of-root file.",
        "When multiple candidates match, selection is deterministic and exact matches win according to one documented policy.",
        "Focused tests prove valid discovery, missing/unsafe candidates, identifier rejection, containment after symlink resolution, deterministic selection, and cancellation stopping discovery effects before open.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Already implemented on branch pss-imp-pses-01-codex-reader at 19b41d17c. Do not recreate this commit; mark passes after verifying existing work still satisfies criteria."
    },
    {
      "id": "pss-imp-pses-01-codex-reader-003",
      "title": "Reconstruct deterministic normalized Codex detail from JSONL",
      "description": "As a customer inspecting a Codex Provider Session, I want supported JSONL events reconstructed into stable provider-independent detail so repeated inspection shows the same conversation, tools, reasoning, and usage without exposing Codex's native grammar.",
      "acceptanceCriteria": [
        "Supported Codex JSONL event and response-item forms map into accepted Provider Sessions transcript, reasoning, function/tool-call, parse-summary, source, turn, timestamp, and token-usage values.",
        "Reconstruction preserves native or event order when available and applies one documented deterministic fallback and tie-break policy when timestamps or pairing facts are incomplete.",
        "Equivalent JSONL content returns structurally equivalent normalized detail across repeated reads regardless of filesystem walk candidate order.",
        "Duplicate mirrored message representations do not duplicate customer-visible transcript entries, and tool results attach only to the intended call.",
        "Returned maps, slices, pointers, and nested summaries are detached; mutating one result cannot affect a later inspection or reader state.",
        "Fixture-driven unit and root integration tests prove representative messages, reasoning, tools, usage, duplicates, stable ordering, repeated-run determinism, and detached results.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-pses-01-codex-reader-004",
      "title": "Bound and sanitize adverse Codex JSONL handling",
      "description": "As an operator, I want corrupt, truncated, or hostile Codex history to terminate safely with useful bounded outcomes so inspection cannot exhaust the process or leak sensitive host/session data.",
      "acceptanceCriteria": [
        "Named limits bound walk or candidate work, bytes or lines read per inspection, retained transcript facts, diagnostic count, and diagnostic message length where material; limit exhaustion returns a deterministic normalized failure or parse fact and performs no further unbounded work.",
        "Malformed lines, truncated JSONL, unknown event types, and unreadable files fail or degrade according to one deterministic policy without fabricating transcript content or discarding otherwise valid lines when partial detail remains trustworthy.",
        "Public errors and parse diagnostics identify only an allowlisted normalized failure class and bounded position or count facts; they exclude absolute host paths, prompts, credentials, raw environment values, tool arguments or output payloads beyond accepted normalized fields, and unrelated session IDs.",
        "Cancellation already carried by the accepted operation is checked during discovery, symlink resolution, open, and JSONL parse loops; it stops further work promptly and returns the accepted cancellation outcome.",
        "Opened readers and walk resources close exactly once on success, malformed data, limit exhaustion, cancellation, and dependency failure, with no background work or post-terminal result.",
        "Focused failure-injection tests cover malformed and truncated JSONL, unknown events, unreadable files, material resource limits, cancellation at multiple phases, cleanup, redaction, and repeat determinism.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-pses-01-codex-reader-005",
      "title": "Prove Codex inspection through the production process root",
      "description": "As a customer-scale verifier, I want Codex Provider Session inspection exercised through the production process graph so the shipped root composition demonstrably preserves normalized detail and safe failure behavior.",
      "acceptanceCriteria": [
        "Functional scenarios construct the reusable application only through root.BuildProcess, provide ordinary process inputs, and replace only exact external effects through edges.Edges; they do not construct the Codex reader, Provider Sessions implementation, or a second application graph.",
        "A representative valid Codex rollout inspected through the accepted public or peer observation surface returns the expected canonical session identity and normalized source, transcript, reasoning or tool, parse, and usage facts in deterministic order.",
        "Representative missing-session, containment-rejection, malformed or truncated JSONL, bounded-read, and cancellation scenarios expose the accepted safe root outcomes with no sensitive diagnostic leakage.",
        "Repeated root-built inspections return detached equivalent results, and mutating one observed result cannot affect the next inspection.",
        "Functional assertions use public Provider Sessions and Providers contracts or observations made by injected exact effects rather than internal reader, JSONL grammar, registration-inventory, or source-topology assertions.",
        "Scope remains limited to Codex historical inspection and required ownership or coverage manifest reconciliation; Codex live execution, top-level CLI/Cobra, Factory Runtime dispatch planning, Models assets, OpenAPI/generated clients, UI, and Cursor reader behavior remain unchanged.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}
