### PR TITLE
factory-bug-batch-ingress-starvation

### DIFF
--- a/pkg/services/factory_runtime/engine/engine.go
+++ b/pkg/services/factory_runtime/engine/engine.go
@@ -508,6 +508,11 @@ func (e *FactoryEngine) waitForEngineSignal(ctx context.Context, dispatchWait <-
 
 func (e *FactoryEngine) runUntilQuiescent(ctx context.Context) (bool, error) {
 	for {
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		default:
+		}
 		mutated, shouldTerminate, err := e.tickOnce(ctx)
 		if err != nil {
 			return false, err
@@ -518,11 +523,12 @@ func (e *FactoryEngine) runUntilQuiescent(ctx context.Context) (bool, error) {
 		if !mutated {
 			e.mu.Lock()
 			stillBuffered := e.hasBufferedInputs()
-			if stillBuffered {
+			paused := e.automaticTicksPaused != nil && e.automaticTicksPaused()
+			if stillBuffered && !paused {
 				e.wakeForPendingProcessing()
 			}
 			e.mu.Unlock()
-			if stillBuffered {
+			if stillBuffered && !paused {
 				continue
 			}
 			return false, nil

--- a/pkg/services/factory_runtime/engine/engine.go
+++ b/pkg/services/factory_runtime/engine/engine.go
@@ -333,6 +333,10 @@ func (e *FactoryEngine) submitNormalizedWorkRequest(context context.Context, req
 		existing.Accepted = false
 		return existing, nil
 	}
+	if e.conflictingMaterializedWorkID(work) != "" {
+		e.mu.Unlock()
+		return workdomain.WorkRequestSubmitResultFromNormalized(requestID, work, false), nil
+	}
 	e.workRequests[requestID] = result
 	e.submissionHook.enqueue(work)
 	awaitProjection := e.shouldAwaitObservableProjection()
@@ -356,6 +360,28 @@ func (e *FactoryEngine) submitNormalizedWorkRequest(context context.Context, req
 	}
 
 	return result, nil
+}
+
+func (e *FactoryEngine) conflictingMaterializedWorkID(work []workdomain.SubmitRequest) string {
+	for _, req := range work {
+		if req.WorkID == "" {
+			continue
+		}
+		if e.visibleWorkIDAlreadyMaterialized(req.WorkID) {
+			return req.WorkID
+		}
+	}
+	return ""
+}
+
+func (e *FactoryEngine) visibleWorkIDAlreadyMaterialized(workID string) bool {
+	if workID == "" {
+		return false
+	}
+	if _, ok := findWorkTokenByID(e.runtimeState.Marking.Tokens, workID); ok {
+		return true
+	}
+	return workIDInActiveDispatches(e.runtimeState.Dispatches, workID)
 }
 
 func (e *FactoryEngine) shouldAwaitObservableProjection() bool {

--- a/pkg/services/factory_runtime/engine/engine.go
+++ b/pkg/services/factory_runtime/engine/engine.go
@@ -37,6 +37,8 @@ type FactoryEngine struct {
 	submissionHooks       []factory.SubmissionHook
 	submissionState       map[string]map[string]string
 	workRequests          map[string]workdomain.WorkRequestSubmitResult
+	projectionWaiters     map[string]chan struct{}
+	runLoopActive         bool
 	recordSubmission      func(work.FactorySubmissionRecord)
 	recordWorkRequest     func(int, work.WorkRequestRecord)
 	recordWorkInput       func(int, workdomain.SubmitRequest, factorytoken.Token)
@@ -114,6 +116,7 @@ func NewFactoryEngine(
 		submissionHooks:       append([]factory.SubmissionHook(nil), submissionHooks...),
 		submissionState:       make(map[string]map[string]string),
 		workRequests:          make(map[string]workdomain.WorkRequestSubmitResult),
+		projectionWaiters:     make(map[string]chan struct{}),
 		recordSubmission:      recordSubmission,
 		recordWorkRequest:     recordWorkRequest,
 		recordWorkInput:       recordWorkInput,
@@ -332,6 +335,13 @@ func (e *FactoryEngine) submitNormalizedWorkRequest(context context.Context, req
 	}
 	e.workRequests[requestID] = result
 	e.submissionHook.enqueue(work)
+	awaitProjection := e.shouldAwaitObservableProjection()
+	var projectionWait <-chan struct{}
+	if awaitProjection {
+		waitCh := make(chan struct{}, 1)
+		e.projectionWaiters[requestID] = waitCh
+		projectionWait = waitCh
+	}
 	e.mu.Unlock()
 
 	select {
@@ -339,7 +349,54 @@ func (e *FactoryEngine) submitNormalizedWorkRequest(context context.Context, req
 	default:
 	}
 
+	if awaitProjection {
+		if err := e.awaitObservableProjection(context, requestID, projectionWait); err != nil {
+			return workdomain.WorkRequestSubmitResult{}, err
+		}
+	}
+
 	return result, nil
+}
+
+func (e *FactoryEngine) shouldAwaitObservableProjection() bool {
+	if !e.runLoopActive {
+		return false
+	}
+	if e.automaticTicksPaused != nil && e.automaticTicksPaused() {
+		return false
+	}
+	return true
+}
+
+func (e *FactoryEngine) awaitObservableProjection(
+	ctx context.Context,
+	requestID string,
+	waitCh <-chan struct{},
+) error {
+	select {
+	case <-waitCh:
+		return nil
+	case <-ctx.Done():
+		e.mu.Lock()
+		delete(e.projectionWaiters, requestID)
+		e.mu.Unlock()
+		return ctx.Err()
+	}
+}
+
+func (e *FactoryEngine) signalObservableProjection(requestID string) {
+	if requestID == "" {
+		return
+	}
+	waitCh, ok := e.projectionWaiters[requestID]
+	if !ok {
+		return
+	}
+	delete(e.projectionWaiters, requestID)
+	select {
+	case waitCh <- struct{}{}:
+	default:
+	}
 }
 
 func (e *FactoryEngine) validWorkTypes() map[string]bool {
@@ -354,8 +411,12 @@ func (e *FactoryEngine) validWorkTypes() map[string]bool {
 // ctx is cancelled or the marking has no more actionable tokens.
 func (e *FactoryEngine) Run(ctx context.Context) error {
 	e.logger.Info("engine started")
+	e.mu.Lock()
+	e.runLoopActive = true
+	e.mu.Unlock()
 	defer func() {
 		e.mu.Lock()
+		e.runLoopActive = false
 		e.acceptingSubmits = false
 		e.mu.Unlock()
 	}()
@@ -867,6 +928,9 @@ func (e *FactoryEngine) processGeneratedSubmissionBatches(batches []work.Generat
 		}
 		e.recordGeneratedSubmissionRequest(requestID, source, batch, normalized)
 		e.recordGeneratedSubmissionTokens(source, normalized, tokens)
+		if source == externalSubmissionHookName {
+			e.signalObservableProjection(requestID)
+		}
 		total += len(tokens)
 	}
 	return total, nil

--- a/pkg/services/factory_runtime/engine/engine.go
+++ b/pkg/services/factory_runtime/engine/engine.go
@@ -429,6 +429,15 @@ func (e *FactoryEngine) runUntilQuiescent(ctx context.Context) (bool, error) {
 			return e.finishTerminationDrain()
 		}
 		if !mutated {
+			e.mu.Lock()
+			stillBuffered := e.hasBufferedInputs()
+			if stillBuffered {
+				e.wakeForPendingProcessing()
+			}
+			e.mu.Unlock()
+			if stillBuffered {
+				continue
+			}
 			return false, nil
 		}
 	}

--- a/pkg/services/factory_runtime/engine/engine_submit_test.go
+++ b/pkg/services/factory_runtime/engine/engine_submit_test.go
@@ -497,3 +497,55 @@ func TestSubmitWorkRequest_WithRunLoopActiveReturnsAfterObservableProjection(t *
 		t.Fatalf("Run: %v", err)
 	}
 }
+
+func TestSubmitWorkRequest_RejectsDifferentRequestIDWhenWorkIDAlreadyMaterialized(t *testing.T) {
+	n := buildTestNet()
+	marking := petri.NewMarking("test-wf")
+	eng := newTestFactoryEngine(n, marking, nil)
+
+	first := work.WorkRequest{
+		RequestID: "request-materialized-first",
+		Type:      work.WorkRequestTypeFactoryRequestBatch,
+		Works: []work.Work{{
+			Name:       "materialized",
+			WorkID:     "work-materialized",
+			WorkTypeID: "task",
+			TraceID:    "trace-materialized",
+		}},
+	}
+	firstResult, err := eng.SubmitWorkRequest(context.Background(), first)
+	if err != nil {
+		t.Fatalf("first SubmitWorkRequest: %v", err)
+	}
+	if !firstResult.Accepted {
+		t.Fatalf("first submit accepted = false, want true")
+	}
+	if err := eng.Tick(context.Background()); err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+
+	second := work.WorkRequest{
+		RequestID: "request-materialized-retry",
+		Type:      work.WorkRequestTypeFactoryRequestBatch,
+		Works: []work.Work{{
+			Name:       "materialized-retry",
+			WorkID:     "work-materialized",
+			WorkTypeID: "task",
+			TraceID:    "trace-materialized-retry",
+		}},
+	}
+	secondResult, err := eng.SubmitWorkRequest(context.Background(), second)
+	if err != nil {
+		t.Fatalf("retry SubmitWorkRequest: %v", err)
+	}
+	if secondResult.Accepted {
+		t.Fatalf("retry accepted = true, want rejection when work ID is already materialized")
+	}
+	if err := eng.Tick(context.Background()); err != nil {
+		t.Fatalf("Tick after retry: %v", err)
+	}
+	snap := eng.GetMarking()
+	if tokens := snap.TokensInPlace("task:init"); len(tokens) != 1 {
+		t.Fatalf("tokens in task:init = %d, want 1 after rejected retry", len(tokens))
+	}
+}

--- a/pkg/services/factory_runtime/engine/engine_submit_test.go
+++ b/pkg/services/factory_runtime/engine/engine_submit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/petri"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/subsystems"
@@ -414,5 +415,85 @@ func assertNoTokensInPlace(t *testing.T, engine *FactoryEngine, placeID string) 
 	snap := engine.GetMarking()
 	if got := len((&snap).TokensInPlace(placeID)); got != 0 {
 		t.Fatalf("tokens in %s = %d, want 0 while paused", placeID, got)
+	}
+}
+
+func TestSubmitWorkRequest_WithoutRunLoopReturnsBeforeProjection(t *testing.T) {
+	n := buildTestNet()
+	marking := petri.NewMarking("test-wf")
+	eng := newTestFactoryEngine(n, marking, nil)
+	request := work.WorkRequest{
+		RequestID: "request-no-run-loop",
+		Type:      work.WorkRequestTypeFactoryRequestBatch,
+		Works: []work.Work{{
+			Name:       "no-run-loop",
+			WorkTypeID: "task",
+			TraceID:    "trace-no-run-loop",
+		}},
+	}
+
+	result, err := eng.SubmitWorkRequest(context.Background(), request)
+	if err != nil {
+		t.Fatalf("SubmitWorkRequest: %v", err)
+	}
+	if !result.Accepted || result.RequestID != request.RequestID {
+		t.Fatalf("submit result = %#v, want accepted request metadata", result)
+	}
+	assertNoTokensInPlace(t, eng, "task:init")
+}
+
+func TestSubmitWorkRequest_WithRunLoopActiveReturnsAfterObservableProjection(t *testing.T) {
+	n := buildTestNet()
+	marking := petri.NewMarking("test-wf")
+	sub := &mockSubsystem{group: subsystems.Scheduler}
+	var recordedRequestIDs []string
+	eng := newTestFactoryEngine(
+		n,
+		marking,
+		[]subsystems.Subsystem{sub},
+		WithWorkRequestRecorder(func(_ int, record work.WorkRequestRecord) {
+			recordedRequestIDs = append(recordedRequestIDs, record.RequestID)
+		}),
+	)
+	request := work.WorkRequest{
+		RequestID: "request-run-loop-await",
+		Type:      work.WorkRequestTypeFactoryRequestBatch,
+		Works: []work.Work{{
+			Name:       "run-loop-await",
+			WorkTypeID: "task",
+			TraceID:    "trace-run-loop-await",
+		}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- eng.Run(ctx)
+	}()
+	waitForEngineRunLoopActive(t, eng, time.Second)
+
+	result, err := eng.SubmitWorkRequest(context.Background(), request)
+	if err != nil {
+		t.Fatalf("SubmitWorkRequest: %v", err)
+	}
+	if !result.Accepted || result.RequestID != request.RequestID {
+		t.Fatalf("submit result = %#v, want accepted request metadata", result)
+	}
+	if len(recordedRequestIDs) != 1 || recordedRequestIDs[0] != request.RequestID {
+		t.Fatalf("recorded WORK_REQUEST ids = %#v, want [%q] before submit returned", recordedRequestIDs, request.RequestID)
+	}
+	snap := eng.GetMarking()
+	tokens := (&snap).TokensInPlace("task:init")
+	if len(tokens) != 1 {
+		t.Fatalf("tokens in task:init = %d, want 1 when submit returned", len(tokens))
+	}
+	if tokens[0].Color.TraceID != "trace-run-loop-await" {
+		t.Fatalf("token traceID = %q, want trace-run-loop-await", tokens[0].Color.TraceID)
+	}
+
+	cancel()
+	if err := <-errCh; err != nil && err != context.Canceled {
+		t.Fatalf("Run: %v", err)
 	}
 }

--- a/pkg/services/factory_runtime/engine/engine_submit_test.go
+++ b/pkg/services/factory_runtime/engine/engine_submit_test.go
@@ -498,6 +498,40 @@ func TestSubmitWorkRequest_WithRunLoopActiveReturnsAfterObservableProjection(t *
 	}
 }
 
+func TestRunLoopCancelsWhilePausedWithBufferedSubmission(t *testing.T) {
+	n := buildTestNet()
+	marking := petri.NewMarking("test-wf")
+	paused := true
+	eng := newTestFactoryEngine(n, marking, nil, WithAutomaticTicksPaused(func() bool {
+		return paused
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- eng.Run(ctx)
+	}()
+	waitForEngineRunLoopActive(t, eng, time.Second)
+
+	if _, err := submitWorkRequests(context.Background(), eng, []work.SubmitRequest{{
+		WorkTypeID: "task",
+		TraceID:    "trace-paused-buffered-shutdown",
+	}}); err != nil {
+		t.Fatalf("SubmitWorkRequest while paused: %v", err)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil && err != context.Canceled {
+			t.Fatalf("Run: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Run to stop while paused with buffered submission")
+	}
+}
+
 func TestSubmitWorkRequest_RejectsDifferentRequestIDWhenWorkIDAlreadyMaterialized(t *testing.T) {
 	n := buildTestNet()
 	marking := petri.NewMarking("test-wf")

--- a/pkg/services/factory_runtime/engine/engine_test_helpers_test.go
+++ b/pkg/services/factory_runtime/engine/engine_test_helpers_test.go
@@ -2,6 +2,8 @@ package engine
 
 import (
 	"context"
+	"testing"
+	"time"
 
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/petri"
@@ -32,6 +34,21 @@ func (m *mockSubsystem) Execute(ctx context.Context, snap *interfaces.EngineStat
 
 func submitWorkRequests(ctx context.Context, engine *FactoryEngine, reqs []work.SubmitRequest) (work.WorkRequestSubmitResult, error) {
 	return engine.SubmitWorkRequest(ctx, work.WorkRequestFromSubmitRequests(reqs))
+}
+
+func waitForEngineRunLoopActive(t *testing.T, engine *FactoryEngine, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		engine.mu.Lock()
+		active := engine.runLoopActive
+		engine.mu.Unlock()
+		if active {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for engine run loop to become active")
 }
 
 type testSubmissionHook struct {

--- a/pkg/services/factory_runtime/runtime/factory_batch_ingress_idempotency_test.go
+++ b/pkg/services/factory_runtime/runtime/factory_batch_ingress_idempotency_test.go
@@ -1,0 +1,234 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil/recordingfixtures"
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/petri"
+	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/state"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
+)
+
+func TestConcurrentBatchIngressSameRequestIDReplayIsIdempotent_ServiceModeWorkerPool(t *testing.T) {
+	t.Helper()
+
+	executor, history, h := startBlockedDispatchIngressHarness(t)
+
+	batchRequest := ingressBatchRequest(
+		"request-idempotent-replay",
+		"work-idempotent-replay",
+		"trace-idempotent-replay",
+	)
+
+	first, err := h.Factory.SubmitWorkRequest(context.Background(), batchRequest)
+	if err != nil {
+		t.Fatalf("first SubmitWorkRequest: %v", err)
+	}
+	if !first.Accepted {
+		t.Fatalf("first submit accepted = false, want true")
+	}
+	assertIngressObservable(t, history, h.Factory, batchRequest.RequestID, "work-idempotent-replay")
+
+	replayed, err := h.Factory.SubmitWorkRequest(context.Background(), batchRequest)
+	if err != nil {
+		t.Fatalf("replay SubmitWorkRequest: %v", err)
+	}
+	if replayed.Accepted {
+		t.Fatalf("replay accepted = true, want idempotent no-op")
+	}
+	if replayed.RequestID != first.RequestID || replayed.WorkID != first.WorkID {
+		t.Fatalf("replay identity = %#v, want preserved %#v", replayed, first)
+	}
+	if countWorkRequestRecords(history, batchRequest.RequestID) != 1 {
+		t.Fatalf("WORK_REQUEST count for %q = %d, want 1", batchRequest.RequestID, countWorkRequestRecords(history, batchRequest.RequestID))
+	}
+	snap, err := h.Factory.GetEngineStateSnapshot(context.Background())
+	if err != nil {
+		t.Fatalf("GetEngineStateSnapshot: %v", err)
+	}
+	if countObservedWorkMaterializations(snap, "work-idempotent-replay") != 1 {
+		t.Fatalf("observed work materializations for work-idempotent-replay = %d, want 1", countObservedWorkMaterializations(snap, "work-idempotent-replay"))
+	}
+
+	releaseBlockedDispatchHarness(t, executor, h)
+}
+
+func TestConcurrentBatchIngressDifferentRequestIDAfterVisibleAcceptanceDoesNotDuplicateWork_ServiceModeWorkerPool(t *testing.T) {
+	t.Helper()
+
+	executor, history, h := startBlockedDispatchIngressHarness(t)
+
+	const workID = "work-visible-retry"
+	firstRequest := ingressBatchRequest("request-visible-first", workID, "trace-visible-first")
+	secondRequest := ingressBatchRequest("request-visible-retry", workID, "trace-visible-retry")
+
+	first, err := h.Factory.SubmitWorkRequest(context.Background(), firstRequest)
+	if err != nil {
+		t.Fatalf("first SubmitWorkRequest: %v", err)
+	}
+	if !first.Accepted {
+		t.Fatalf("first submit accepted = false, want true")
+	}
+	assertIngressObservable(t, history, h.Factory, firstRequest.RequestID, workID)
+
+	second, err := h.Factory.SubmitWorkRequest(context.Background(), secondRequest)
+	if err != nil {
+		t.Fatalf("retry SubmitWorkRequest: %v", err)
+	}
+	if second.Accepted {
+		t.Fatalf("different-request-ID retry accepted = true, want rejection after visible acceptance")
+	}
+	if countWorkRequestRecords(history, secondRequest.RequestID) != 0 {
+		t.Fatalf("WORK_REQUEST count for retry request %q = %d, want 0", secondRequest.RequestID, countWorkRequestRecords(history, secondRequest.RequestID))
+	}
+	snap, err := h.Factory.GetEngineStateSnapshot(context.Background())
+	if err != nil {
+		t.Fatalf("GetEngineStateSnapshot: %v", err)
+	}
+	if countObservedWorkMaterializations(snap, workID) != 1 {
+		t.Fatalf("observed work materializations for %q = %d, want 1 durable materialization", workID, countObservedWorkMaterializations(snap, workID))
+	}
+
+	releaseBlockedDispatchHarness(t, executor, h)
+}
+
+func startBlockedDispatchIngressHarness(t *testing.T) (*ingressBlockingExecutor, *recordingfixtures.ScriptedRuntimeLedger, *serviceModeRunHarness) {
+	t.Helper()
+
+	executor := &ingressBlockingExecutor{
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	history := &recordingfixtures.ScriptedRuntimeLedger{}
+	h := startServiceModeRunHarness(t,
+		withNet(buildSimpleNet()),
+		withServiceMode(),
+		withWorkerExecutor("mock", executor),
+		withFactoryEventHistory(history),
+		withLogger(logging.NoopLogger{}),
+	)
+
+	if _, err := submitWorkRequests(context.Background(), h.Factory, []work.SubmitRequest{{
+		WorkID:     "work-blocked-dispatch",
+		WorkTypeID: "task",
+		TraceID:    "trace-blocked-dispatch",
+	}}); err != nil {
+		t.Fatalf("submit initial work: %v", err)
+	}
+
+	waitForAggregateSnapshot(t, h.Factory, func(snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) bool {
+		return snapshot.InFlightCount > 0
+	})
+
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for blocking dispatch to start")
+	}
+
+	return executor, history, h
+}
+
+func releaseBlockedDispatchHarness(t *testing.T, executor *ingressBlockingExecutor, h *serviceModeRunHarness) {
+	t.Helper()
+	close(executor.release)
+	h.cancel()
+	select {
+	case <-h.errCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for service-mode runtime to stop")
+	}
+}
+
+func ingressBatchRequest(requestID, workID, traceID string) work.WorkRequest {
+	return work.WorkRequest{
+		RequestID: requestID,
+		Type:      work.WorkRequestTypeFactoryRequestBatch,
+		Works: []work.Work{{
+			Name:       "ingress-batch",
+			WorkID:     workID,
+			WorkTypeID: "task",
+			TraceID:    traceID,
+		}},
+	}
+}
+
+func assertIngressObservable(
+	t *testing.T,
+	history *recordingfixtures.ScriptedRuntimeLedger,
+	factoryInstance factory.Factory,
+	requestID string,
+	workID string,
+) {
+	t.Helper()
+	if !workRequestRecorded(history, requestID) {
+		t.Fatalf("WORK_REQUEST not recorded for %q; work requests=%#v", requestID, history.WorkRequests)
+	}
+	snap, err := factoryInstance.GetEngineStateSnapshot(context.Background())
+	if err != nil {
+		t.Fatalf("GetEngineStateSnapshot: %v", err)
+	}
+	if !snapshotObservesWork(snap, workID) {
+		t.Fatalf("work %q not observable before retry; marking=%#v", workID, snap.Marking.Tokens)
+	}
+}
+
+func countWorkRequestRecords(history *recordingfixtures.ScriptedRuntimeLedger, requestID string) int {
+	count := 0
+	for _, record := range history.WorkRequests {
+		if record.RequestID == requestID {
+			count++
+		}
+	}
+	return count
+}
+
+func countMarkingTokensForWorkID(marking *petri.MarkingSnapshot, workID string) int {
+	count := 0
+	for _, token := range marking.Tokens {
+		if token != nil && token.Color.WorkID == workID {
+			count++
+		}
+	}
+	return count
+}
+
+func countObservedWorkMaterializations(snap *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], workID string) int {
+	if snap == nil {
+		return 0
+	}
+	count := countMarkingTokensForWorkID(&snap.Marking, workID)
+	for _, entry := range snap.Dispatches {
+		for _, token := range entry.ConsumedTokens {
+			if token.Color.WorkID == workID {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+type ingressBlockingExecutor struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (e *ingressBlockingExecutor) Execute(_ context.Context, dispatch work.WorkDispatch) (workerexecution.WorkResult, error) {
+	select {
+	case e.started <- struct{}{}:
+	default:
+	}
+	<-e.release
+	return workerexecution.WorkResult{
+		DispatchID:   dispatch.DispatchID,
+		TransitionID: dispatch.TransitionID,
+		Outcome:      workerexecution.OutcomeAccepted,
+		Output:       "done",
+	}, nil
+}

--- a/pkg/services/factory_runtime/runtime/factory_batch_ingress_regression_test.go
+++ b/pkg/services/factory_runtime/runtime/factory_batch_ingress_regression_test.go
@@ -1,0 +1,64 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+)
+
+// TestBlockedDispatchConcurrentBatchIngressRegression_ServiceModeWorkerPool is the
+// deterministic regression for issue #1352. It blocks one unrelated dispatch,
+// submits a concurrent batch, and asserts observable acceptance (WORK_REQUEST plus
+// marking visibility) and same-request-ID replay idempotency before the blocker
+// completes. It fails on the pre-fix starvation path where submit returned while
+// WORK_REQUEST and marking visibility were still missing.
+func TestBlockedDispatchConcurrentBatchIngressRegression_ServiceModeWorkerPool(t *testing.T) {
+	t.Helper()
+
+	executor, history, h := startBlockedDispatchIngressHarness(t)
+
+	const (
+		requestID = "request-batch-ingress-regression"
+		workID    = "work-batch-ingress-regression"
+		traceID   = "trace-batch-ingress-regression"
+	)
+
+	batchRequest := ingressBatchRequest(requestID, workID, traceID)
+
+	first, err := h.Factory.SubmitWorkRequest(context.Background(), batchRequest)
+	if err != nil {
+		t.Fatalf("first SubmitWorkRequest: %v", err)
+	}
+	if !first.Accepted {
+		t.Fatalf("first submit accepted = false, want true before blocked dispatch completes")
+	}
+	if first.RequestID != requestID {
+		t.Fatalf("first submit request_id = %q, want %q", first.RequestID, requestID)
+	}
+	assertIngressObservable(t, history, h.Factory, requestID, workID)
+
+	replayed, err := h.Factory.SubmitWorkRequest(context.Background(), batchRequest)
+	if err != nil {
+		t.Fatalf("replay SubmitWorkRequest: %v", err)
+	}
+	if replayed.Accepted {
+		t.Fatalf("replay accepted = true, want idempotent no-op")
+	}
+	if replayed.RequestID != first.RequestID || replayed.WorkID != first.WorkID {
+		t.Fatalf("replay identity = %#v, want preserved %#v", replayed, first)
+	}
+	if countWorkRequestRecords(history, requestID) != 1 {
+		t.Fatalf(
+			"WORK_REQUEST count for %q = %d, want 1 before blocked dispatch completes",
+			requestID,
+			countWorkRequestRecords(history, requestID),
+		)
+	}
+
+	select {
+	case <-executor.release:
+		t.Fatal("blocked dispatch completed before ingress regression assertions finished")
+	default:
+	}
+
+	releaseBlockedDispatchHarness(t, executor, h)
+}

--- a/pkg/services/factory_runtime/runtime/factory_batch_ingress_starvation_test.go
+++ b/pkg/services/factory_runtime/runtime/factory_batch_ingress_starvation_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
-	factory "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/petri"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/state"
 	"github.com/portpowered/infinite-you/internal/testutil/recordingfixtures"
@@ -65,7 +64,20 @@ func TestConcurrentBatchIngressProjectsWhileDispatchBlocked_ServiceModeWorkerPoo
 		t.Fatalf("SubmitWorkRequest concurrent batch: %v", err)
 	}
 
-	waitForConcurrentBatchProjection(t, h.Factory, history, batchRequest.RequestID, "work-concurrent-ingress")
+	if !workRequestRecorded(history, batchRequest.RequestID) {
+		t.Fatalf("WORK_REQUEST not recorded before submit returned; work requests=%#v", history.WorkRequests)
+	}
+	snap, err := h.Factory.GetEngineStateSnapshot(context.Background())
+	if err != nil {
+		t.Fatalf("GetEngineStateSnapshot: %v", err)
+	}
+	if !snapshotObservesWork(snap, "work-concurrent-ingress") {
+		t.Fatalf(
+			"submit returned before work became observable; work requests=%#v marking tokens=%#v",
+			history.WorkRequests,
+			snap.Marking.Tokens,
+		)
+	}
 
 	close(executor.release)
 	h.cancel()
@@ -73,44 +85,6 @@ func TestConcurrentBatchIngressProjectsWhileDispatchBlocked_ServiceModeWorkerPoo
 	case <-h.errCh:
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for service-mode runtime to stop")
-	}
-}
-
-func waitForConcurrentBatchProjection(
-	t *testing.T,
-	f factory.Factory,
-	history *recordingfixtures.ScriptedRuntimeLedger,
-	requestID string,
-	workID string,
-) {
-	t.Helper()
-
-	deadline := time.After(2 * time.Second)
-	for {
-		if workRequestRecorded(history, requestID) {
-			snap, err := f.GetEngineStateSnapshot(context.Background())
-			if err != nil {
-				t.Fatalf("GetEngineStateSnapshot: %v", err)
-			}
-			if snapshotObservesWork(snap, workID) {
-				return
-			}
-		}
-
-		select {
-		case <-deadline:
-			snap, err := f.GetEngineStateSnapshot(context.Background())
-			if err != nil {
-				t.Fatalf("GetEngineStateSnapshot: %v", err)
-			}
-			t.Fatalf(
-				"timed out waiting for concurrent batch projection while dispatch blocked; work requests=%#v marking tokens=%#v",
-				history.WorkRequests,
-				snap.Marking.Tokens,
-			)
-		default:
-			time.Sleep(10 * time.Millisecond)
-		}
 	}
 }
 

--- a/pkg/services/factory_runtime/runtime/factory_batch_ingress_starvation_test.go
+++ b/pkg/services/factory_runtime/runtime/factory_batch_ingress_starvation_test.go
@@ -1,0 +1,141 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factory "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/petri"
+	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/state"
+	"github.com/portpowered/infinite-you/internal/testutil/recordingfixtures"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+)
+
+func TestConcurrentBatchIngressProjectsWhileDispatchBlocked_ServiceModeWorkerPool(t *testing.T) {
+	t.Helper()
+
+	executor := &blockingExecutor{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	history := &recordingfixtures.ScriptedRuntimeLedger{}
+
+	opts := []testFactoryOption{
+		withNet(buildSimpleNet()),
+		withServiceMode(),
+		withWorkerExecutor("mock", executor),
+		withFactoryEventHistory(history),
+		withLogger(logging.NoopLogger{}),
+	}
+
+	h := startServiceModeRunHarness(t, opts...)
+
+	if _, err := submitWorkRequests(context.Background(), h.Factory, []work.SubmitRequest{{
+		WorkID:     "work-blocked-dispatch",
+		WorkTypeID: "task",
+		TraceID:    "trace-blocked-dispatch",
+	}}); err != nil {
+		t.Fatalf("submit initial work: %v", err)
+	}
+
+	waitForAggregateSnapshot(t, h.Factory, func(snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) bool {
+		return snapshot.InFlightCount > 0
+	})
+
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for blocking dispatch to start")
+	}
+
+	batchRequest := work.WorkRequest{
+		RequestID: "request-concurrent-ingress",
+		Type:      work.WorkRequestTypeFactoryRequestBatch,
+		Works: []work.Work{{
+			Name:       "concurrent-ingress",
+			WorkID:     "work-concurrent-ingress",
+			WorkTypeID: "task",
+			TraceID:    "trace-concurrent-ingress",
+		}},
+	}
+	if _, err := h.Factory.SubmitWorkRequest(context.Background(), batchRequest); err != nil {
+		t.Fatalf("SubmitWorkRequest concurrent batch: %v", err)
+	}
+
+	waitForConcurrentBatchProjection(t, h.Factory, history, batchRequest.RequestID, "work-concurrent-ingress")
+
+	close(executor.release)
+	h.cancel()
+	select {
+	case <-h.errCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for service-mode runtime to stop")
+	}
+}
+
+func waitForConcurrentBatchProjection(
+	t *testing.T,
+	f factory.Factory,
+	history *recordingfixtures.ScriptedRuntimeLedger,
+	requestID string,
+	workID string,
+) {
+	t.Helper()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if workRequestRecorded(history, requestID) {
+			snap, err := f.GetEngineStateSnapshot(context.Background())
+			if err != nil {
+				t.Fatalf("GetEngineStateSnapshot: %v", err)
+			}
+			if snapshotObservesWork(snap, workID) {
+				return
+			}
+		}
+
+		select {
+		case <-deadline:
+			snap, err := f.GetEngineStateSnapshot(context.Background())
+			if err != nil {
+				t.Fatalf("GetEngineStateSnapshot: %v", err)
+			}
+			t.Fatalf(
+				"timed out waiting for concurrent batch projection while dispatch blocked; work requests=%#v marking tokens=%#v",
+				history.WorkRequests,
+				snap.Marking.Tokens,
+			)
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}
+
+func workRequestRecorded(history *recordingfixtures.ScriptedRuntimeLedger, requestID string) bool {
+	for _, record := range history.WorkRequests {
+		if record.RequestID == requestID {
+			return true
+		}
+	}
+	return false
+}
+
+func snapshotObservesWork(snap *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], workID string) bool {
+	if snap == nil {
+		return false
+	}
+	if markingContainsWorkAtPlace(&snap.Marking, workID, "task:init") {
+		return true
+	}
+	for _, entry := range snap.Dispatches {
+		for _, token := range entry.ConsumedTokens {
+			if token.Color.WorkID == workID {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/tests/functional/runtime_api/api_batch_ingress_starvation_regression_test.go
+++ b/tests/functional/runtime_api/api_batch_ingress_starvation_regression_test.go
@@ -1,0 +1,110 @@
+package runtime_api_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+// TestBlockedDispatchConcurrentBatchIngressRegression proves accepted batch ingress
+// stays HTTP-observable (WORK_REQUEST plus Work list/get) while an unrelated
+// dispatch remains blocked, and same-request-ID replay stays idempotent.
+func TestBlockedDispatchConcurrentBatchIngressRegression(t *testing.T) {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, simplePipelineConfig())
+	dispatchRelease := make(chan struct{})
+	server := StartFunctionalServer(
+		t,
+		dir,
+		false,
+		withProvider(&serviceModeBlockingProvider{release: dispatchRelease}),
+	)
+
+	traceID := server.SubmitWork(t, "task", []byte(`{"title":"blocked dispatch for batch ingress regression"}`))
+	if traceID == "" {
+		t.Fatal("POST /work returned an empty trace ID")
+	}
+	waitForPublicFactorySession(t, server, 10*time.Second, serviceModeSessionActive)
+
+	const (
+		requestID = "request-http-batch-ingress-regression"
+		workID    = "work-http-batch-ingress-regression"
+	)
+	workTypeName := "task"
+	workIDPtr := workID
+	traceIDPtr := "trace-http-batch-ingress-regression"
+	batchRequest := factoryapi.WorkRequest{
+		RequestId: requestID,
+		Type:      factoryapi.WorkRequestTypeFactoryRequestBatch,
+		Works: &[]factoryapi.Work{{
+			Name:         "http-ingress-regression",
+			WorkId:       &workIDPtr,
+			WorkTypeName: &workTypeName,
+			TraceId:      &traceIDPtr,
+			Payload:      map[string]string{"title": "concurrent batch ingress regression"},
+		}},
+	}
+
+	first := support.UpsertDefaultSessionWorkRequest(t, server.URL(), batchRequest)
+	if first.RequestId != requestID {
+		t.Fatalf("PUT /work-requests request_id = %q, want %q", first.RequestId, requestID)
+	}
+	if len(first.Works) != 1 || first.Works[0].WorkId != workID {
+		t.Fatalf("PUT /work-requests works = %#v, want one work with id %q", first.Works, workID)
+	}
+
+	support.AssertSingleWorkRequestEvent(t, server.GetFactoryEvents(t), requestID, workID, workTypeName)
+	assertPublicWorkListAndGetVisible(t, server, workID)
+
+	replayed := support.UpsertDefaultSessionWorkRequest(t, server.URL(), batchRequest)
+	if replayed.RequestId != first.RequestId || replayed.TraceId != first.TraceId {
+		t.Fatalf("idempotent PUT identity changed: first=%#v replay=%#v", first, replayed)
+	}
+	support.AssertSingleWorkRequestEvent(t, server.GetFactoryEvents(t), requestID, workID, workTypeName)
+
+	select {
+	case <-dispatchRelease:
+		t.Fatal("blocked dispatch released before ingress regression assertions finished")
+	default:
+	}
+
+	close(dispatchRelease)
+	server.Stop(t)
+}
+
+func assertPublicWorkListAndGetVisible(t *testing.T, server *FunctionalServer, workID string) {
+	t.Helper()
+
+	listed := server.ListWork(t)
+	if !publicWorkListingContainsID(listed, workID) {
+		t.Fatalf("work %q missing from public Work list before blocked dispatch completed; listed=%#v", workID, listed.Results)
+	}
+
+	endpoint := support.DefaultSessionWorkURL(server.URL(), "/work/"+workID)
+	response, err := http.Get(endpoint)
+	if err != nil {
+		t.Fatalf("GET %s: %v", endpoint, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s status = %d, want 200 while blocked dispatch continues", endpoint, response.StatusCode)
+	}
+
+	work := support.GetJSON[factoryapi.Work](t, endpoint)
+	if support.StringPointerValue(work.WorkId) != workID {
+		t.Fatalf("GET /work/%s workId = %q, want %q", workID, support.StringPointerValue(work.WorkId), workID)
+	}
+}
+
+func publicWorkListingContainsID(listed factoryapi.ListWorkResponse, workID string) bool {
+	for _, item := range listed.Results {
+		if support.StringPointerValue(item.WorkId) == workID {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/functional/runtime_api/external_support_test.go
+++ b/tests/functional/runtime_api/external_support_test.go
@@ -1,5 +1,33 @@
 package runtime_api_test
 
+func simplePipelineConfig() map[string]any {
+	return map[string]any{
+		"workTypes": []map[string]any{{
+			"name": "task",
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "complete", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []map[string]string{{
+			"name":          "worker-a",
+			"type":          "MODEL_WORKER",
+			"model":         "functional-model",
+			"modelProvider": "CODEX",
+		}},
+		"workstations": []map[string]any{{
+			"name":      "process",
+			"worker":    "worker-a",
+			"type":      "MODEL_WORKSTATION",
+			"behavior":  "STANDARD",
+			"inputs":    []map[string]string{{"workType": "task", "state": "init"}},
+			"outputs":   []map[string]string{{"workType": "task", "state": "complete"}},
+			"onFailure": []map[string]string{{"workType": "task", "state": "failed"}},
+		}},
+	}
+}
+
 func twoStagePipelineConfig() map[string]any {
 	return map[string]any{
 		"name": "factory",


### PR DESCRIPTION
{
  "project": "Fix Acknowledged Batch Submissions Remaining Invisible During Long-Running Dispatches",
  "branchName": "factory-bug-batch-ingress-starvation",
  "description": "Diagnose and fix GitHub issue #1352 so an accepted Factory Session batch submission becomes durable and event-observable through WORK_REQUEST plus Work list/get promptly while unrelated long-running agent dispatches continue, without starving ingress behind a blocking dispatch/tick path, while preserving same-request-ID idempotency and preventing latent duplicate semantic work from different-request-ID retries after invisible acknowledgements.",
  "context": {
    "customerAsk": "Diagnose and fix GitHub issue #1352. An accepted batch submission must become durable/event-observable and visible through work list/get promptly while unrelated long-running agent dispatches continue; the engine must not starve ingress processing behind a blocking dispatch/tick path. Preserve same-request-ID idempotency and prevent invisible acknowledged requests from encouraging different-request-ID retries that later materialize duplicate semantic work. Add a deterministic regression with a blocked long-running dispatch plus concurrent batch ingress, covering HTTP acknowledgement, WORK_REQUEST emission, marking visibility, retry behavior, and restart durability where applicable. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Valid batch PUTs can return HTTP 201 with generated work IDs while live Work list omits those IDs, direct Work GET returns 404, and the Factory Event stream contains no WORK_REQUEST for the acknowledged request. This occurs while unrelated long-running agent dispatches are active even with free executor-slot capacity. Callers treat success as real acceptance, retry with a new request ID, and risk later materializing duplicate semantic work from multiple latent acknowledgements.",
    "solution": "Restore the ingress acceptance contract so concurrent batch submissions project WORK_REQUEST and become Work list/get visible without waiting for unrelated blocked/long-running dispatches to finish; return success with work IDs only after durable event-observable acceptance (or expose an explicit queryable pending status instead of pretending acceptance); preserve same-request-ID idempotency; prevent different-request-ID retries from creating latent duplicates from the invisible-ack path; and lock the behavior with a deterministic regression plus delivery through actual PR merge."
  },
  "acceptanceCriteria": [
    "While at least one unrelated long-running or deliberately blocked dispatch remains active, a concurrent valid batch work-request submission becomes visible through Work list and Work GET and emits its canonical WORK_REQUEST Factory Event without waiting for that dispatch to finish.",
    "HTTP success that returns generated work IDs is issued only after the request has crossed a durable, event-observable acceptance boundary; if the runtime cannot complete that boundary, the API does not pretend the batch was accepted with work IDs (failure or an explicit queryable pending status only).",
    "Repeating the same request ID remains idempotent and does not create a second set of work IDs or a second WORK_REQUEST for the same acceptance.",
    "After an acknowledgement that previously would have been invisible, submitting the same semantic batch under a different request ID cannot later materialize duplicate latent work from the earlier invisible acceptance path.",
    "A deterministic regression covers blocked/long-running dispatch plus concurrent batch ingress for HTTP acknowledgement, WORK_REQUEST emission, marking/list/get visibility, same-ID retry, different-ID retry behavior, and restart durability where the chosen acceptance boundary requires it.",
    "Quality checks pass (typecheck, lint, tests).",
    "The implementation/review loop continues until required CI is terminal and passing, every blocking PR conversation comment is explicitly addressed, merge conflicts and shared-file churn are reconciled, and the PR is actually merged; an opened, green, approved, or ready-to-merge PR is not complete."
  ],
  "userStories": [
    {
      "id": "factory-bug-batch-ingress-starvation-001",
      "title": "Concurrent batch ingress projects while a dispatch is blocked",
      "description": "As a Factory Session operator, I want a valid batch submitted during an unrelated long-running dispatch to become event-observable and list/get-visible promptly so I can trust that accepted work actually entered the session without waiting for other agents to finish.",
      "acceptanceCriteria": [
        "With at least one unrelated dispatch held in a long-running/blocked state and free capacity remaining for other work, a concurrent valid batch work-request submission emits a canonical WORK_REQUEST Factory Event for that request ID.",
        "Every work ID returned for that submission becomes visible through live Work list and succeeds on direct Work GET before the blocked dispatch completes.",
        "Ingress projection does not wait for the blocked/long-running dispatch to release; unrelated in-flight dispatches continue independently.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-bug-batch-ingress-starvation-002",
      "title": "Success acknowledgement matches durable observable acceptance",
      "description": "As a CLI/API caller, I want HTTP/CLI success with generated work IDs only when the batch has crossed a durable event-observable acceptance boundary so I do not treat buffered-but-invisible requests as complete acceptance.",
      "acceptanceCriteria": [
        "A successful batch upsert response that returns generated work IDs corresponds to a request that already has (or immediately has) a durable WORK_REQUEST event and Work GET visibility for those IDs, or the transport instead returns a non-success / explicit pending outcome that does not claim accepted work IDs prematurely.",
        "If the runtime cannot durably accept or project the request, the caller does not receive HTTP 201 (or equivalent success) containing generated work IDs for that invisible request.",
        "Existing successful batch clients continue to observe success only for requests that satisfy the observable acceptance boundary above.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-bug-batch-ingress-starvation-003",
      "title": "Preserve idempotency and block latent duplicate retries",
      "description": "As an automation author, I want same-request-ID retries to remain idempotent and different-request-ID retries not to create latent duplicate semantic work after an earlier acknowledgement so repeated submits cannot silently double the batch later.",
      "acceptanceCriteria": [
        "Replaying the same request ID after a successful acceptance returns the prior accepted identity/result and does not emit a second WORK_REQUEST or create a second set of work tokens for that request.",
        "When a caller retries the same semantic batch under a new request ID after an earlier acknowledgement, the system does not later materialize both as duplicate latent work from the old invisible-ack path; either the first acceptance remains the only durable materialization, or the second request is rejected/handled according to an explicit observable policy covered by tests.",
        "Focused tests cover same-ID replay and different-ID retry behavior under the concurrent blocked-dispatch ingress condition.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-bug-batch-ingress-starvation-004",
      "title": "Deterministic regression for blocked dispatch plus concurrent ingress",
      "description": "As a maintainer, I want a deterministic regression that blocks a long-running dispatch and submits a concurrent batch so this starvation cannot return unnoticed.",
      "acceptanceCriteria": [
        "The regression deterministically establishes an active long-running or blocked dispatch, then performs a concurrent valid batch work-request submission without waiting for that dispatch to finish.",
        "The regression asserts HTTP/submit acknowledgement behavior, canonical WORK_REQUEST emission for the request ID, live marking/list/get visibility for returned work IDs, and same-request-ID retry idempotency.",
        "Where the chosen acceptance boundary claims durability across process restart, the regression also asserts the acknowledged request remains recoverable/visible after restart; otherwise it asserts that not-yet-durable requests are never reported as successful accepted work IDs.",
        "The regression fails on the pre-fix starvation behavior (acknowledged success with missing WORK_REQUEST / 404 Work GET while the blocked dispatch continues) and passes after the fix.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-bug-batch-ingress-starvation-005",
      "title": "Drive the fix through review, CI, and merge",
      "description": "As the Factory delivery owner, I want the implementation and review loop to continue until the PR is actually merged so the starvation fix is landed, not merely opened or approved.",
      "acceptanceCriteria": [
        "A PR for branch factory-bug-batch-ingress-starvation contains the behavioral fix and regression evidence for issue #1352.",
        "Required CI is terminal and passing.",
        "Every blocking PR conversation comment is explicitly addressed.",
        "Merge conflicts and shared-file churn are reconciled with the target branch.",
        "The PR is actually merged; opened, green, approved, or ready-to-merge states are not treated as completion.",
        "Typecheck passes"
      ],
      "priority": 5,
      "passes": false,
      "notes": ""
    }
  ]
}
