### PR TITLE
structured-packages-implementation-mod-04-runtime-host

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -927,6 +927,30 @@
       }
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/service",
+      "minimum": 0.00
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/wire",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/transports/cli",
       "minimum": 0.76
     },

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -897,6 +897,30 @@
       "minimum": 45.45
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/service",
+      "minimum": 0.00
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/wire",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes",
       "exception": {
         "kind": "measurement",
@@ -918,30 +942,6 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/service",
-      "minimum": 0.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/wire",
       "exception": {
         "kind": "measurement",
         "justification": "The active functional coverage profile contains no measurable statements for this package.",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -782,7 +782,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/host",
-      "minimum": 74.33
+      "minimum": 69.65
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/inference",
@@ -847,6 +847,24 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire",
       "minimum": 54.50
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active unit coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/service",
+      "minimum": 79.54
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/wire",
+      "minimum": 100.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes",

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -3408,6 +3408,24 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/models/internal/services/runtime_host",
+      "disposition": "retain",
+      "destination": "models",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/runtime_host/internal/service",
+      "disposition": "retain",
+      "destination": "models",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/runtime_host/wire",
+      "disposition": "retain",
+      "destination": "models",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/models/internal/services/runtime_scopes",
       "disposition": "retain",
       "destination": "models",

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -223,6 +223,9 @@
     "pkg/services/models/internal/services/catalog",
     "pkg/services/models/internal/services/catalog/internal/service",
     "pkg/services/models/internal/services/catalog/wire",
+    "pkg/services/models/internal/services/runtime_host",
+    "pkg/services/models/internal/services/runtime_host/internal/service",
+    "pkg/services/models/internal/services/runtime_host/wire",
     "pkg/services/models/internal/services/runtime_scopes",
     "pkg/services/models/internal/services/runtime_scopes/internal/service",
     "pkg/services/models/internal/services/runtime_scopes/wire",
@@ -1303,6 +1306,21 @@
       "packagePath": "pkg/services/models/internal/services/catalog/wire",
       "disposition": "retain",
       "destination": "models/internal/services/catalog"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/runtime_host",
+      "disposition": "retain",
+      "destination": "models/internal/services/runtime_host"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/runtime_host/internal/service",
+      "disposition": "retain",
+      "destination": "models/internal/services/runtime_host"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/runtime_host/wire",
+      "disposition": "retain",
+      "destination": "models/internal/services/runtime_host"
     },
     {
       "packagePath": "pkg/services/models/internal/services/runtime_scopes",

--- a/pkg/root/root_test.go
+++ b/pkg/root/root_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/portpowered/infinite-you/internal/testutil"
 	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	models "github.com/portpowered/infinite-you/pkg/services/models"
 	inference "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
 )
 
@@ -64,6 +65,36 @@ func TestBuildProcessConstructionFailureDoesNotStartExternalLifecycle(t *testing
 	if apiStarts != 0 {
 		t.Fatalf("construction failure started API lifecycle %d times, want zero", apiStarts)
 	}
+}
+
+func TestBuildProcessComposesInertModelsRuntimeHost(t *testing.T) {
+	t.Parallel()
+
+	launcher := &rootRecordingModelHostLauncher{}
+	process, err := BuildProcess(context.Background(), serviceedges.Edges{
+		ModelHostProcessLauncher: launcher,
+	})
+	if err != nil {
+		t.Fatalf("BuildProcess() error = %v", err)
+	}
+	if process == nil {
+		t.Fatal("BuildProcess() returned nil process")
+	}
+	if launcher.starts != 0 {
+		t.Fatalf("model host process starts during construction = %d, want 0", launcher.starts)
+	}
+}
+
+type rootRecordingModelHostLauncher struct {
+	starts int
+}
+
+func (launcher *rootRecordingModelHostLauncher) Start(
+	context.Context,
+	models.HostProcessStartSpec,
+) (models.HostManagedProcess, error) {
+	launcher.starts++
+	panic("model host process launcher called during inert construction")
 }
 
 func TestBuildProcessComposesDetachedExternalProviderWithBuiltInsInertly(t *testing.T) {

--- a/pkg/services/models/internal/host/scoped_compat_host.go
+++ b/pkg/services/models/internal/host/scoped_compat_host.go
@@ -310,9 +310,9 @@ func (h *ScopedCompatHost) issueLease(
 		h.diagnostics.logLeaseExhausted(snapshot.Identity)
 		return Lease{}, leaseCapacityError(modelName)
 	}
-	endpoint := strings.TrimSpace(snapshot.Diagnostics["endpoint"])
-	if requiresSupervisedBackend(snapshot.Identity) && endpoint == "" {
-		return Lease{}, ErrRuntimeNotReady
+	endpoint, err := h.supervisedLeaseEndpoint(runtimeCfg, modelName, snapshot.Identity, snapshot.Diagnostics)
+	if err != nil {
+		return Lease{}, err
 	}
 	h.seq++
 	leaseID := fmt.Sprintf("model-lease-%d", h.seq)
@@ -392,6 +392,50 @@ func (h *ScopedCompatHost) identityFromCatalog(
 		}
 	}
 	return identity
+}
+
+func (h *ScopedCompatHost) supervisedLeaseEndpoint(
+	runtimeCfg *models.RuntimeConfig,
+	modelName string,
+	identity Identity,
+	diagnostics map[string]string,
+) (string, error) {
+	if !requiresSupervisedBackend(identity) {
+		return "", nil
+	}
+	worker, err := localWorkerForModel(runtimeCfg, modelName)
+	if err != nil {
+		return "", err
+	}
+	if !workerDeclaresSupervisedHealthEndpoint(worker) {
+		return "", nil
+	}
+	endpoint := strings.TrimSpace(diagnostics["endpoint"])
+	if endpoint == "" {
+		return "", ErrRuntimeNotReady
+	}
+	return endpoint, nil
+}
+
+func localWorkerForModel(
+	runtimeCfg *models.RuntimeConfig,
+	modelName string,
+) (*models.RuntimeWorker, error) {
+	if runtimeCfg == nil {
+		return nil, fmt.Errorf("runtime config is not available")
+	}
+	target := canonicalModelKey(modelName)
+	for _, worker := range runtimeCfg.Workers {
+		if canonicalModelKey(worker.Model) != target {
+			continue
+		}
+		if strings.TrimSpace(worker.ModelLocality) != models.RuntimeModelLocalityLocal {
+			continue
+		}
+		copied := worker
+		return &copied, nil
+	}
+	return nil, fmt.Errorf("local model worker not found for %q", modelName)
 }
 
 func readinessFromModelHostSnapshot(host models.ModelHostSnapshot, identity Identity) ReadinessSnapshot {

--- a/pkg/services/models/internal/host/scoped_compat_host.go
+++ b/pkg/services/models/internal/host/scoped_compat_host.go
@@ -1,0 +1,411 @@
+package modelhost
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
+	localmodels "github.com/portpowered/infinite-you/pkg/services/models/internal/local"
+	managedruntime "github.com/portpowered/infinite-you/pkg/services/models/internal/managedruntime"
+)
+
+// ScopedCompatHost implements scoped runtime pull, readiness, and lease behavior
+// by delegating supervision to the packaged Runtime Host subservice instead of
+// constructing a per-scope CatalogHost supervisor.
+type ScopedCompatHost struct {
+	scope          models.RuntimeScopeRef
+	runtimeHost    runtimehost.Service
+	assetGateway   AssetGateway
+	sourceResolver SourceResolver
+	diagnostics    Diagnostics
+
+	mu      sync.Mutex
+	leases  map[string]*scopedTrackedLease
+	byModel map[string]map[string]struct{}
+	seq     uint64
+}
+
+type scopedTrackedLease struct {
+	lease      Lease
+	modelKey   string
+	runtimeCfg *models.RuntimeConfig
+	modelName  string
+}
+
+// NewScopedCompatHost constructs a scoped runtime host that routes supervise,
+// health, reuse, and unload through the packaged Runtime Host subservice.
+func NewScopedCompatHost(
+	scope models.RuntimeScopeRef,
+	runtimeHost runtimehost.Service,
+	assetGateway AssetGateway,
+	sourceResolver SourceResolver,
+	diagnostics Diagnostics,
+) (*ScopedCompatHost, error) {
+	if scope.IsZero() {
+		return nil, missingDependencyError("runtime scope")
+	}
+	if isNilDependency(runtimeHost) {
+		return nil, missingDependencyError("packaged runtime host")
+	}
+	if isNilDependency(assetGateway) {
+		return nil, missingDependencyError("asset gateway")
+	}
+	if sourceResolver == nil {
+		return nil, missingDependencyError("source resolver")
+	}
+	return &ScopedCompatHost{
+		scope:          scope,
+		runtimeHost:    runtimeHost,
+		assetGateway:   assetGateway,
+		sourceResolver: sourceResolver,
+		diagnostics:    diagnostics,
+		leases:         make(map[string]*scopedTrackedLease),
+		byModel:        make(map[string]map[string]struct{}),
+	}, nil
+}
+
+func (h *ScopedCompatHost) ResolveIdentity(
+	_ context.Context,
+	runtimeCfg *models.RuntimeConfig,
+	modelName string,
+) (Identity, error) {
+	entry, err := h.catalogEntry(runtimeCfg, modelName)
+	if err != nil {
+		return Identity{}, err
+	}
+	return h.identityFromCatalog(runtimeCfg, entry), nil
+}
+
+func (h *ScopedCompatHost) InspectReadiness(
+	ctx context.Context,
+	runtimeCfg *models.RuntimeConfig,
+	modelName string,
+) (ReadinessSnapshot, error) {
+	return h.inspectReadiness(ctx, runtimeCfg, modelName, true)
+}
+
+func (h *ScopedCompatHost) Pull(
+	ctx context.Context,
+	runtimeCfg *models.RuntimeConfig,
+	modelName string,
+) (PullSnapshot, error) {
+	if err := ctx.Err(); err != nil {
+		return PullSnapshot{}, cancelError(err)
+	}
+	entry, err := h.catalogEntry(runtimeCfg, modelName)
+	if err != nil {
+		return PullSnapshot{}, err
+	}
+	if string(entry.Summary.ProviderLocality) != models.RuntimeModelLocalityLocal {
+		identity := h.identityFromCatalog(runtimeCfg, entry)
+		snapshot := ClassifyReadiness(identity, CacheInspection{}, true)
+		pullSnapshot := PullSnapshot{
+			ReadinessSnapshot: snapshot,
+			PullOutcome:       managedruntime.PullOutcomeUnsupportedRuntime,
+		}
+		return pullSnapshot, &ReadinessError{Snapshot: snapshot, Cause: ErrUnsupportedRuntime}
+	}
+	pullResult, err := h.assetGateway.PullModel(ctx, runtimeCfg, modelName)
+	if err != nil {
+		readiness := pullResult.Snapshot
+		var pullErr *models.PullError
+		if errors.As(err, &pullErr) {
+			readiness = managedRuntimePullSnapshot(runtimeCfg, entry, pullErr.Result)
+		}
+		if readiness.Identity.Name == "" {
+			readiness = ClassifyReadiness(h.identityFromCatalog(runtimeCfg, entry), CacheInspection{}, false)
+		}
+		pullSnapshot := pullSnapshotFromAssetResult(pullResult, readiness)
+		return pullSnapshot, err
+	}
+	readiness := pullResult.Snapshot
+	if readiness.Identity.Name == "" {
+		inspected, inspectErr := h.assetGateway.InspectRuntimeCache(ctx, runtimeCfg, modelName)
+		if inspectErr != nil {
+			return PullSnapshot{}, inspectErr
+		}
+		readiness = ClassifyReadiness(h.identityFromCatalog(runtimeCfg, entry), inspected, false)
+	}
+	pullSnapshot := pullSnapshotFromAssetResult(pullResult, readiness)
+	return pullSnapshot, nil
+}
+
+func (h *ScopedCompatHost) AcquireLease(
+	ctx context.Context,
+	runtimeCfg *models.RuntimeConfig,
+	modelName string,
+	opts LeaseOptions,
+) (Lease, error) {
+	snapshot, inspection, modelKey, leaseCapacity, err := h.prepareAcquireLease(ctx, runtimeCfg, modelName)
+	if err != nil {
+		return Lease{}, err
+	}
+	if err := h.ensureSupervisedReadyForLease(ctx, modelName, inspection, &snapshot); err != nil {
+		return Lease{}, err
+	}
+	if snapshot.ReadinessState != managedruntime.ReadinessStateReady {
+		cause := readinessCause(snapshot)
+		return Lease{}, &ReadinessError{Snapshot: snapshot, Cause: cause}
+	}
+	return h.issueLease(runtimeCfg, modelName, modelKey, leaseCapacity, snapshot, opts)
+}
+
+func (h *ScopedCompatHost) ReleaseLease(_ context.Context, leaseID string) error {
+	h.mu.Lock()
+	tracked, ok := h.leases[leaseID]
+	if !ok {
+		h.mu.Unlock()
+		return ErrLeaseNotFound
+	}
+	delete(h.leases, leaseID)
+	modelKey := tracked.modelKey
+	identity := tracked.lease.Identity
+	if leases, ok := h.byModel[modelKey]; ok {
+		delete(leases, leaseID)
+		if len(leases) == 0 {
+			delete(h.byModel, modelKey)
+		}
+	}
+	h.mu.Unlock()
+
+	h.diagnostics.logLeaseReleased(identity, leaseID)
+	return nil
+}
+
+func (h *ScopedCompatHost) Unload(
+	ctx context.Context,
+	runtimeCfg *models.RuntimeConfig,
+	modelName string,
+) error {
+	modelKey := canonicalModelKey(modelName)
+	h.mu.Lock()
+	if leases := h.byModel[modelKey]; len(leases) > 0 {
+		h.mu.Unlock()
+		return &ReadinessError{
+			Snapshot: ReadinessSnapshot{
+				Identity:       Identity{Name: strings.TrimSpace(modelName)},
+				ReadinessState: managedruntime.ReadinessStateFailed,
+				LifecycleState: managedruntime.LifecycleStateLoaded,
+				FailureClass:   FailureClassCapacityExhausted,
+			},
+			Cause: ErrCapacityExhausted,
+		}
+	}
+	h.mu.Unlock()
+
+	_, err := h.runtimeHost.StopModelHost(ctx, models.StopModelHostRequest{
+		Scope: h.scope,
+		Name:  modelName,
+	})
+	return err
+}
+
+func (h *ScopedCompatHost) inspectReadiness(
+	ctx context.Context,
+	runtimeCfg *models.RuntimeConfig,
+	modelName string,
+	overlaySupervised bool,
+) (ReadinessSnapshot, error) {
+	if err := ctx.Err(); err != nil {
+		return ReadinessSnapshot{}, cancelError(err)
+	}
+	entry, err := h.catalogEntry(runtimeCfg, modelName)
+	if err != nil {
+		return ReadinessSnapshot{}, err
+	}
+	identity := h.identityFromCatalog(runtimeCfg, entry)
+	if string(entry.Summary.ProviderLocality) != models.RuntimeModelLocalityLocal {
+		return ClassifyReadiness(identity, CacheInspection{}, false), nil
+	}
+	inspection, err := h.assetGateway.InspectRuntimeCache(ctx, runtimeCfg, modelName)
+	if err != nil {
+		return ReadinessSnapshot{}, err
+	}
+	snapshot := ClassifyReadiness(identity, inspection, false)
+	if overlaySupervised {
+		inspected, inspectErr := h.runtimeHost.InspectModelHost(ctx, models.InspectModelHostRequest{
+			Scope: h.scope,
+			Name:  modelName,
+		})
+		if inspectErr != nil {
+			return ReadinessSnapshot{}, inspectErr
+		}
+		snapshot = readinessFromModelHostSnapshot(inspected.Host, identity)
+	}
+	return snapshot, nil
+}
+
+func (h *ScopedCompatHost) prepareAcquireLease(
+	ctx context.Context,
+	runtimeCfg *models.RuntimeConfig,
+	modelName string,
+) (ReadinessSnapshot, CacheInspection, string, int, error) {
+	if err := ctx.Err(); err != nil {
+		return ReadinessSnapshot{}, CacheInspection{}, "", 0, cancelError(err)
+	}
+	entry, err := h.catalogEntry(runtimeCfg, modelName)
+	if err != nil {
+		return ReadinessSnapshot{}, CacheInspection{}, "", 0, err
+	}
+	identity := h.identityFromCatalog(runtimeCfg, entry)
+	inspection, err := h.assetGateway.InspectRuntimeCache(ctx, runtimeCfg, modelName)
+	if err != nil {
+		return ReadinessSnapshot{}, CacheInspection{}, "", 0, err
+	}
+	snapshot, err := h.inspectReadiness(ctx, runtimeCfg, modelName, true)
+	if err != nil {
+		return ReadinessSnapshot{}, CacheInspection{}, "", 0, err
+	}
+	if snapshot.Identity.Name == "" {
+		snapshot.Identity = identity
+	}
+	modelKey := canonicalModelKey(modelName)
+	leaseCapacity := h.leaseCapacityForModel(runtimeCfg, modelName)
+	h.mu.Lock()
+	exhausted := h.leaseCapacityExhausted(modelKey, leaseCapacity)
+	h.mu.Unlock()
+	if exhausted {
+		h.diagnostics.logLeaseExhausted(identity)
+		return ReadinessSnapshot{}, CacheInspection{}, "", 0, leaseCapacityError(modelName)
+	}
+	return snapshot, inspection, modelKey, leaseCapacity, nil
+}
+
+func (h *ScopedCompatHost) ensureSupervisedReadyForLease(
+	ctx context.Context,
+	modelName string,
+	inspection CacheInspection,
+	snapshot *ReadinessSnapshot,
+) error {
+	if !requiresSupervisedBackend(snapshot.Identity) || !inspection.Installed {
+		return nil
+	}
+	ensureResult, err := h.runtimeHost.EnsureModelHost(ctx, models.EnsureModelHostRequest{
+		Scope: h.scope,
+		Name:  modelName,
+	})
+	if err != nil {
+		return err
+	}
+	updated := readinessFromModelHostSnapshot(ensureResult.Host, snapshot.Identity)
+	*snapshot = updated
+	return nil
+}
+
+func (h *ScopedCompatHost) issueLease(
+	runtimeCfg *models.RuntimeConfig,
+	modelName string,
+	modelKey string,
+	leaseCapacity int,
+	snapshot ReadinessSnapshot,
+	opts LeaseOptions,
+) (Lease, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.leaseCapacityExhausted(modelKey, leaseCapacity) {
+		h.diagnostics.logLeaseExhausted(snapshot.Identity)
+		return Lease{}, leaseCapacityError(modelName)
+	}
+	endpoint := strings.TrimSpace(snapshot.Diagnostics["endpoint"])
+	if requiresSupervisedBackend(snapshot.Identity) && endpoint == "" {
+		return Lease{}, ErrRuntimeNotReady
+	}
+	h.seq++
+	leaseID := fmt.Sprintf("model-lease-%d", h.seq)
+	lease := Lease{
+		ID:       leaseID,
+		Identity: snapshot.Identity,
+		Endpoint: endpoint,
+		Holder:   strings.TrimSpace(opts.Holder),
+	}
+	h.leases[leaseID] = &scopedTrackedLease{
+		lease:      lease,
+		modelKey:   modelKey,
+		runtimeCfg: runtimeCfg,
+		modelName:  modelName,
+	}
+	if h.byModel[modelKey] == nil {
+		h.byModel[modelKey] = make(map[string]struct{})
+	}
+	h.byModel[modelKey][leaseID] = struct{}{}
+	h.diagnostics.logLeaseAcquired(snapshot.Identity, leaseID)
+	return lease, nil
+}
+
+func (h *ScopedCompatHost) leaseCapacityForModel(runtimeCfg *models.RuntimeConfig, modelName string) int {
+	resource := modelScopedResource(runtimeCfg, modelName)
+	if resource == nil || resource.Capacity <= 0 {
+		return 0
+	}
+	return resource.Capacity
+}
+
+func (h *ScopedCompatHost) leaseCapacityExhausted(modelKey string, capacity int) bool {
+	if capacity <= 0 {
+		return false
+	}
+	return len(h.byModel[modelKey]) >= capacity
+}
+
+func (h *ScopedCompatHost) catalogEntry(runtimeCfg *models.RuntimeConfig, modelName string) (localmodels.CatalogEntry, error) {
+	if runtimeCfg == nil {
+		return localmodels.CatalogEntry{}, fmt.Errorf("runtime config is not available")
+	}
+	catalog := localmodels.BuildCatalog(runtimeCfg)
+	key := localmodels.CanonicalModelName(modelName)
+	if key == "" {
+		return localmodels.CatalogEntry{}, fmt.Errorf("%w: empty model name", managedruntime.ErrNotFound)
+	}
+	entry, ok := catalog[key]
+	if !ok {
+		return localmodels.CatalogEntry{}, fmt.Errorf("%w: %s", managedruntime.ErrNotFound, modelName)
+	}
+	return entry, nil
+}
+
+func (h *ScopedCompatHost) identityFromCatalog(
+	runtimeCfg *models.RuntimeConfig,
+	entry localmodels.CatalogEntry,
+) Identity {
+	identity := Identity{
+		Name:                entry.Summary.Name,
+		Locality:            managedruntime.Locality(entry.Summary.ProviderLocality),
+		SupportedOperations: operationsFromCatalog(entry),
+	}
+	if resource := modelScopedResource(runtimeCfg, entry.Summary.Name); resource != nil {
+		identity.Backend = strings.TrimSpace(resource.Backend)
+		identity.LoadPolicy = strings.TrimSpace(resource.LoadPolicy)
+		if h.sourceResolver != nil {
+			resolution := h.sourceResolver.Resolve(
+				entry.Summary.Name,
+				resource.Backend,
+				resource.LoadPolicy,
+				resource.Provider,
+			)
+			identity.SourceKind = resolution.SourceKind
+			identity.SourceID = resolution.SourceID
+			identity.ResolverNotes = resolution.ResolverNotes
+		}
+	}
+	return identity
+}
+
+func readinessFromModelHostSnapshot(host models.ModelHostSnapshot, identity Identity) ReadinessSnapshot {
+	readiness := managedruntime.ReadinessState(string(host.ReadinessState))
+	lifecycle := managedruntime.LifecycleState(string(host.LifecycleState))
+	snapshot := ReadinessSnapshot{
+		Identity:       identity,
+		ReadinessState: readiness,
+		LifecycleState: lifecycle,
+		FailureClass:   FailureClassForReadinessState(readiness),
+		Diagnostics:    managedDiagnostics(identity, readiness, lifecycle),
+	}
+	if len(host.Diagnostics) > 0 {
+		snapshot.Diagnostics = mergeDiagnostics(identity, readiness, lifecycle, host.Diagnostics)
+	}
+	return snapshot
+}

--- a/pkg/services/models/internal/host/scoped_compat_host_test.go
+++ b/pkg/services/models/internal/host/scoped_compat_host_test.go
@@ -1,0 +1,84 @@
+package modelhost
+
+import (
+	"context"
+	"testing"
+
+	apisurface "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+type stubPackagedRuntimeHost struct {
+	ensureHost apisurface.ModelHostSnapshot
+}
+
+func (s stubPackagedRuntimeHost) InspectModelHost(
+	_ context.Context,
+	request apisurface.InspectModelHostRequest,
+) (apisurface.InspectModelHostResult, error) {
+	return apisurface.InspectModelHostResult{Host: s.ensureHost.Clone()}, nil
+}
+
+func (s stubPackagedRuntimeHost) EnsureModelHost(
+	_ context.Context,
+	_ apisurface.EnsureModelHostRequest,
+) (apisurface.EnsureModelHostResult, error) {
+	return apisurface.EnsureModelHostResult{
+		Host:    s.ensureHost.Clone(),
+		Outcome: apisurface.HostEnsureAlreadyReady,
+	}, nil
+}
+
+func (s stubPackagedRuntimeHost) StopModelHost(
+	context.Context,
+	apisurface.StopModelHostRequest,
+) (apisurface.StopModelHostResult, error) {
+	return apisurface.StopModelHostResult{}, apisurface.ErrUnsupportedOperation
+}
+
+func TestScopedCompatHostAcquireLease_AllowsCLIPathWithoutSupervisedEndpoint(t *testing.T) {
+	loaded := mustLoadedCatalogConfig(t, llamaCppCatalogFactoryConfigWithoutHealthEndpoint())
+	scope, err := (apisurface.RuntimeScopeRef{}).Parse("factory-session:test-scope")
+	if err != nil {
+		t.Fatalf("Parse scope: %v", err)
+	}
+	host, err := NewScopedCompatHost(
+		scope,
+		stubPackagedRuntimeHost{
+			ensureHost: apisurface.ModelHostSnapshot{
+				Scope:          scope,
+				ModelName:      "OMNIVOICE_Q4_K_M",
+				ReadinessState: apisurface.ReadinessStateReady,
+				LifecycleState: apisurface.LifecycleStateInstalled,
+			},
+		},
+		stubAssetGateway{
+			byModel: map[string]CacheInspection{
+				"OMNIVOICE_Q4_K_M": {
+					Supported:          true,
+					Installed:          true,
+					InstalledFileCount: 2,
+				},
+			},
+		},
+		DefaultManagedRuntimeSourceResolverAdapter(),
+		Diagnostics{},
+	)
+	if err != nil {
+		t.Fatalf("NewScopedCompatHost: %v", err)
+	}
+
+	lease, err := host.AcquireLease(context.Background(), loaded, "OMNIVOICE_Q4_K_M", LeaseOptions{})
+	if err != nil {
+		t.Fatalf("AcquireLease: %v", err)
+	}
+	if lease.Endpoint != "" {
+		t.Fatalf("endpoint = %q, want empty CLI path without supervised health endpoint", lease.Endpoint)
+	}
+}
+
+func llamaCppCatalogFactoryConfigWithoutHealthEndpoint() *testFactoryConfig {
+	cfg := catalogFactoryConfig(true)
+	cfg.Resources[0].Backend = "LLAMACPP"
+	cfg.Workers[0].Command = "omnivoice-llamacpp"
+	return cfg
+}

--- a/pkg/services/models/internal/service/runtime_factory.go
+++ b/pkg/services/models/internal/service/runtime_factory.go
@@ -121,23 +121,23 @@ func (o *Root) ForRuntime(binding models.RuntimeBinding) (models.Service, error)
 	if err := models.ValidateRuntimeBinding(binding); err != nil {
 		return nil, err
 	}
-	assets, err := localmodels.NewDeferredScopedAssetPuller(o.assets, func() (models.RuntimeScopeRef, error) {
-		if binding.RuntimeConfig() == nil {
-			return models.RuntimeScopeRef{}, models.ErrUnavailable
-		}
-		privateScope, openErr := o.runtimeScopes.Open(binding)
-		if openErr != nil {
-			return models.RuntimeScopeRef{}, openErr
-		}
-		return (models.RuntimeScopeRef{}).Parse(string(privateScope))
-	})
+	privateScope, err := o.runtimeScopes.Open(binding)
 	if err != nil {
 		return nil, err
 	}
-	return o.runtimeForBindingWithAssets(binding, assets)
+	scope, err := (models.RuntimeScopeRef{}).Parse(string(privateScope))
+	if err != nil {
+		return nil, err
+	}
+	assets, err := localmodels.NewScopedAssetPuller(o.assets, scope)
+	if err != nil {
+		return nil, err
+	}
+	return o.runtimeForBindingWithAssets(scope, binding, assets)
 }
 
 func (o *Root) runtimeForBindingWithAssets(
+	scope models.RuntimeScopeRef,
 	binding models.RuntimeBinding,
 	assets localmodels.AssetPuller,
 ) (models.Service, error) {
@@ -147,11 +147,19 @@ func (o *Root) runtimeForBindingWithAssets(
 	if err != nil {
 		return nil, err
 	}
-	healthChecker := modelhost.HTTPHealthChecker{Client: o.hostHTTP, Path: modelhost.DefaultHealthCheckPath}
 	return newRuntimeWithHostEdges(
-		binding.CacheDirectory, binding.RuntimeConfig, o.process.Logger, o.process.Clock,
-		o.process.PullMetrics, o.process.HostLogger, o.process.HostMetrics, o.process.LocalHooks,
-		assets, localRuntime, o.processLauncher, healthChecker, o.hostClock, nil,
+		scope,
+		binding.RuntimeConfig,
+		o.process.Logger,
+		o.process.Clock,
+		o.process.PullMetrics,
+		o.process.HostLogger,
+		o.process.HostMetrics,
+		o.process.LocalHooks,
+		assets,
+		localRuntime,
+		o.runtimeHost,
+		nil,
 	)
 }
 
@@ -397,7 +405,7 @@ func (o *Root) scopedRuntime(scope models.RuntimeScopeRef) (models.Service, erro
 		if err != nil {
 			return nil, err
 		}
-		return o.runtimeForBindingWithAssets(binding, assets)
+		return o.runtimeForBindingWithAssets(scope, binding, assets)
 	})
 }
 
@@ -440,7 +448,7 @@ func (o *Root) scopedRuntimeWithBuilder(
 }
 
 func newRuntimeWithHostEdges(
-	cacheDir string,
+	scope models.RuntimeScopeRef,
 	runtimeConfig models.RuntimeConfigLoader,
 	logger *zap.Logger,
 	now func() time.Time,
@@ -450,9 +458,7 @@ func newRuntimeWithHostEdges(
 	hooks models.LocalRuntimeHooks,
 	assetPuller localmodels.AssetPuller,
 	localRuntime localmodels.Runtime,
-	processLauncher modelhost.ProcessLauncher,
-	healthChecker modelhost.HealthChecker,
-	hostClock modelhost.Clock,
+	runtimeHost runtimehost.Service,
 	host modelhost.Host,
 ) (models.Service, error) {
 	if assetPuller == nil {
@@ -472,20 +478,12 @@ func newRuntimeWithHostEdges(
 	modelHost := host
 	if modelHost == nil {
 		gateway := modelhost.NewLocalAssetGateway(assetPuller)
-		modelHost, err = modelhost.NewHost(
+		modelHost, err = modelhost.NewScopedCompatHost(
+			scope,
+			runtimeHost,
 			gateway,
-			gateway,
-			processLauncher,
 			modelhost.DefaultManagedRuntimeSourceResolverAdapter(),
-			modelhost.DefaultReadinessTimeout,
-			modelhost.DefaultHealthCheckInterval,
-			modelhost.DefaultHealthCheckPath,
-			healthChecker,
-			hostClock,
-			modelhost.DefaultServerStartBuilder,
 			modelhost.Diagnostics{Logger: hostLogger, Metrics: hostMetrics},
-			0,
-			0,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/services/models/internal/service/runtime_factory.go
+++ b/pkg/services/models/internal/service/runtime_factory.go
@@ -13,6 +13,7 @@ import (
 	localmodels "github.com/portpowered/infinite-you/pkg/services/models/internal/local"
 	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
 	modelcatalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
+	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
 	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
 	"go.uber.org/zap"
 )
@@ -30,6 +31,7 @@ type Root struct {
 	runtimeTempFile localmodels.CreateTempFile
 	runtimeScopes   runtimescopes.Service
 	assets          scopedassets.Service
+	runtimeHost     runtimehost.Service
 	runtimeMu       sync.RWMutex
 	runtimeByScope  map[models.RuntimeScopeRef]models.Service
 	catalog         modelcatalog.Service
@@ -51,6 +53,7 @@ func NewRoot(
 	runtimeScopes runtimescopes.Service,
 	catalogService modelcatalog.Service,
 	assetService scopedassets.Service,
+	runtimeHostService runtimehost.Service,
 	processDependencies ...models.ProcessDependencies,
 ) (*Root, error) {
 	if processLauncher == nil {
@@ -86,6 +89,9 @@ func NewRoot(
 	if assetService == nil {
 		return nil, missingDependencyError("Models Assets service")
 	}
+	if runtimeHostService == nil {
+		return nil, missingDependencyError("Models Runtime Host service")
+	}
 	process := models.ProcessDependencies{}
 	if len(processDependencies) > 0 {
 		process = processDependencies[0]
@@ -101,6 +107,7 @@ func NewRoot(
 		runtimeRunner: runtimeRunner, runtimeHTTP: runtimeHTTP,
 		runtimeInspect: runtimeInspect, runtimeTempDir: runtimeTempDir, runtimeTempFile: runtimeTempFile,
 		runtimeScopes: runtimeScopes, catalog: catalogService, assets: assetService,
+		runtimeHost: runtimeHostService,
 		runtimeByScope: make(map[models.RuntimeScopeRef]models.Service),
 		process:        process,
 	}, nil
@@ -285,24 +292,33 @@ func (o *Root) RemoveModelAssets(
 }
 
 func (o *Root) EnsureModelHost(
-	context.Context,
-	models.EnsureModelHostRequest,
+	ctx context.Context,
+	request models.EnsureModelHostRequest,
 ) (models.EnsureModelHostResult, error) {
-	return models.EnsureModelHostResult{}, models.ErrUnsupportedOperation
+	if o == nil || o.runtimeHost == nil {
+		return models.EnsureModelHostResult{}, models.ErrUnsupportedOperation
+	}
+	return o.runtimeHost.EnsureModelHost(ctx, request)
 }
 
 func (o *Root) InspectModelHost(
-	context.Context,
-	models.InspectModelHostRequest,
+	ctx context.Context,
+	request models.InspectModelHostRequest,
 ) (models.InspectModelHostResult, error) {
-	return models.InspectModelHostResult{}, models.ErrUnsupportedOperation
+	if o == nil || o.runtimeHost == nil {
+		return models.InspectModelHostResult{}, models.ErrUnsupportedOperation
+	}
+	return o.runtimeHost.InspectModelHost(ctx, request)
 }
 
 func (o *Root) StopModelHost(
-	context.Context,
-	models.StopModelHostRequest,
+	ctx context.Context,
+	request models.StopModelHostRequest,
 ) (models.StopModelHostResult, error) {
-	return models.StopModelHostResult{}, models.ErrUnsupportedOperation
+	if o == nil || o.runtimeHost == nil {
+		return models.StopModelHostResult{}, models.ErrUnsupportedOperation
+	}
+	return o.runtimeHost.StopModelHost(ctx, request)
 }
 
 func (o *Root) AcquireModelLease(

--- a/pkg/services/models/internal/services/runtime_host/internal/service/export_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/export_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"time"
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
@@ -16,6 +17,12 @@ type SupervisorTestConfig struct {
 	HealthChecker       healthChecker
 }
 
+// HostPolicyTestConfig overrides idle unload and loaded-runtime pressure policy for tests.
+type HostPolicyTestConfig struct {
+	IdleUnloadAfter   time.Duration
+	MaxLoadedRuntimes int
+}
+
 // NewWithSupervisorTestConfig constructs a Runtime Host with test-only supervisor overrides.
 func NewWithSupervisorTestConfig(
 	scopes runtimescopes.Service,
@@ -27,6 +34,31 @@ func NewWithSupervisorTestConfig(
 	hostMetrics models.HostMetricsRecorder,
 	cfg SupervisorTestConfig,
 ) runtimehost.Service {
+	return NewWithHostTestConfig(
+		scopes,
+		assets,
+		processLauncher,
+		hostHTTP,
+		hostClock,
+		hostLogger,
+		hostMetrics,
+		cfg,
+		HostPolicyTestConfig{},
+	)
+}
+
+// NewWithHostTestConfig constructs a Runtime Host with test-only supervisor and policy overrides.
+func NewWithHostTestConfig(
+	scopes runtimescopes.Service,
+	assets scopedassets.Service,
+	processLauncher models.HostProcessLauncher,
+	hostHTTP models.HostHTTPDoer,
+	hostClock models.HostClock,
+	hostLogger models.HostDiagnosticLogger,
+	hostMetrics models.HostMetricsRecorder,
+	supervisorCfg SupervisorTestConfig,
+	policyCfg HostPolicyTestConfig,
+) runtimehost.Service {
 	s := New(
 		scopes,
 		assets,
@@ -36,14 +68,43 @@ func NewWithSupervisorTestConfig(
 		hostLogger,
 		hostMetrics,
 	).(*service)
-	if cfg.ReadinessTimeout > 0 {
-		s.supervisor.ReadinessTimeout = cfg.ReadinessTimeout
+	if supervisorCfg.ReadinessTimeout > 0 {
+		s.supervisor.ReadinessTimeout = supervisorCfg.ReadinessTimeout
 	}
-	if cfg.HealthCheckInterval > 0 {
-		s.supervisor.HealthCheckInterval = cfg.HealthCheckInterval
+	if supervisorCfg.HealthCheckInterval > 0 {
+		s.supervisor.HealthCheckInterval = supervisorCfg.HealthCheckInterval
 	}
-	if cfg.HealthChecker != nil {
-		s.supervisor.HealthChecker = cfg.HealthChecker
+	if supervisorCfg.HealthChecker != nil {
+		s.supervisor.HealthChecker = supervisorCfg.HealthChecker
 	}
+	s.idleUnloadAfter, s.maxLoadedRuntimes = normalizeHostPolicy(
+		policyCfg.IdleUnloadAfter,
+		policyCfg.MaxLoadedRuntimes,
+	)
 	return s
+}
+
+// AcquireSlotCapacity simulates one active capacity holder for idle-unload tests.
+func AcquireSlotCapacity(s runtimehost.Service, scope models.RuntimeScopeRef, modelName string) {
+	host := s.(*service)
+	slotKey := runtimeSlotKey(scope, modelName)
+	host.mu.Lock()
+	host.acquireSlotCapacityLocked(slotKey)
+	host.mu.Unlock()
+}
+
+// ReleaseSlotCapacity releases one simulated capacity holder and may schedule idle unload.
+func ReleaseSlotCapacity(
+	s runtimehost.Service,
+	scope models.RuntimeScopeRef,
+	modelName string,
+	runtimeCfg *models.RuntimeConfig,
+) {
+	host := s.(*service)
+	host.releaseSlotCapacity(scope, modelName, runtimeCfg)
+}
+
+// ShutdownHost stops all supervised runtimes owned by the host.
+func ShutdownHost(ctx context.Context, s runtimehost.Service) error {
+	return s.(*service).Shutdown(ctx)
 }

--- a/pkg/services/models/internal/services/runtime_host/internal/service/export_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/export_test.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
+)
+
+// SupervisorTestConfig overrides supervisor timing and health probing for tests.
+type SupervisorTestConfig struct {
+	ReadinessTimeout    time.Duration
+	HealthCheckInterval time.Duration
+	HealthChecker       healthChecker
+}
+
+// NewWithSupervisorTestConfig constructs a Runtime Host with test-only supervisor overrides.
+func NewWithSupervisorTestConfig(
+	scopes runtimescopes.Service,
+	assets scopedassets.Service,
+	processLauncher models.HostProcessLauncher,
+	hostHTTP models.HostHTTPDoer,
+	hostClock models.HostClock,
+	hostLogger models.HostDiagnosticLogger,
+	hostMetrics models.HostMetricsRecorder,
+	cfg SupervisorTestConfig,
+) runtimehost.Service {
+	s := New(
+		scopes,
+		assets,
+		processLauncher,
+		hostHTTP,
+		hostClock,
+		hostLogger,
+		hostMetrics,
+	).(*service)
+	if cfg.ReadinessTimeout > 0 {
+		s.supervisor.ReadinessTimeout = cfg.ReadinessTimeout
+	}
+	if cfg.HealthCheckInterval > 0 {
+		s.supervisor.HealthCheckInterval = cfg.HealthCheckInterval
+	}
+	if cfg.HealthChecker != nil {
+		s.supervisor.HealthChecker = cfg.HealthChecker
+	}
+	return s
+}

--- a/pkg/services/models/internal/services/runtime_host/internal/service/failure_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/failure_test.go
@@ -1,0 +1,409 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/service"
+)
+
+func TestEnsureModelHostReadinessTimeoutReturnsTypedFailure(t *testing.T) {
+	t.Parallel()
+
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(healthServer.Close)
+
+	cacheDirectory := t.TempDir()
+	writeCacheFixture(t, cacheDirectory, true)
+	scopes := newScopes(t, "readiness-timeout")
+	ref := openScope(t, scopes, cacheDirectory, supervisedRuntimeConfig())
+	launcher := &fakeProcessLauncher{
+		newProcess: func(spec models.HostProcessStartSpec) *fakeManagedProcess {
+			return newFakeManagedProcess(healthServer.URL, nil)
+		},
+	}
+	service := internalservice.NewWithSupervisorTestConfig(
+		scopes,
+		mustAssetsService(t, scopes),
+		launcher,
+		http.DefaultClient,
+		realHostClock{},
+		nil,
+		nil,
+		internalservice.SupervisorTestConfig{
+			ReadinessTimeout:    75 * time.Millisecond,
+			HealthCheckInterval: 10 * time.Millisecond,
+		},
+	)
+
+	_, err := service.EnsureModelHost(context.Background(), models.EnsureModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if !errors.Is(err, models.ErrHostLoadingTimeout) {
+		t.Fatalf("error = %v, want ErrHostLoadingTimeout", err)
+	}
+
+	inspected, err := service.InspectModelHost(context.Background(), models.InspectModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("InspectModelHost: %v", err)
+	}
+	if inspected.Host.ReadinessState != models.ReadinessStateLoading {
+		t.Fatalf("readiness = %s, want LOADING after timeout", inspected.Host.ReadinessState)
+	}
+	if inspected.Host.Diagnostics["failureClass"] != "loading_timeout" {
+		t.Fatalf("failureClass = %q, want loading_timeout", inspected.Host.Diagnostics["failureClass"])
+	}
+}
+
+func TestEnsureModelHostPostStartCrashSurfacesFailedReadinessOnInspect(t *testing.T) {
+	t.Parallel()
+
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(healthServer.Close)
+
+	exitCh := make(chan error, 1)
+	cacheDirectory := t.TempDir()
+	writeCacheFixture(t, cacheDirectory, true)
+	scopes := newScopes(t, "post-start-crash")
+	ref := openScope(t, scopes, cacheDirectory, supervisedRuntimeConfig())
+	launcher := &fakeProcessLauncher{
+		newProcess: func(spec models.HostProcessStartSpec) *fakeManagedProcess {
+			return newFakeManagedProcess(healthServer.URL, exitCh)
+		},
+	}
+	service := newTestRuntimeHostWithScopesAndClock(t, scopes, launcher, realHostClock{})
+
+	_, err := service.EnsureModelHost(context.Background(), models.EnsureModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("EnsureModelHost: %v", err)
+	}
+	exitCh <- errors.New("unexpected exit")
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		inspected, inspectErr := service.InspectModelHost(context.Background(), models.InspectModelHostRequest{
+			Scope: ref,
+			Name:  "OMNIVOICE_Q4_K_M",
+		})
+		if inspectErr != nil {
+			t.Fatalf("InspectModelHost: %v", inspectErr)
+		}
+		if inspected.Host.ReadinessState == models.ReadinessStateFailed {
+			if inspected.Host.Diagnostics["failureClass"] != "process_crash" {
+				t.Fatalf("failureClass = %q, want process_crash", inspected.Host.Diagnostics["failureClass"])
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for crash readiness; last state = %s", inspected.Host.ReadinessState)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestEnsureModelHostCancellationStopsManagedProcess(t *testing.T) {
+	t.Parallel()
+
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(healthServer.Close)
+
+	var stopCount atomic.Int32
+	cacheDirectory := t.TempDir()
+	writeCacheFixture(t, cacheDirectory, true)
+	scopes := newScopes(t, "cancellation")
+	ref := openScope(t, scopes, cacheDirectory, supervisedRuntimeConfig())
+	launcher := &fakeProcessLauncher{
+		newProcess: func(spec models.HostProcessStartSpec) *fakeManagedProcess {
+			process := newFakeManagedProcess(healthServer.URL, nil)
+			process.stopFn = func() error {
+				stopCount.Add(1)
+				return process.defaultStop()
+			}
+			return process
+		},
+	}
+	service := internalservice.NewWithSupervisorTestConfig(
+		scopes,
+		mustAssetsService(t, scopes),
+		launcher,
+		http.DefaultClient,
+		realHostClock{},
+		nil,
+		nil,
+		internalservice.SupervisorTestConfig{
+			ReadinessTimeout:    time.Second,
+			HealthCheckInterval: 25 * time.Millisecond,
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := service.EnsureModelHost(ctx, models.EnsureModelHostRequest{
+			Scope: ref,
+			Name:  "OMNIVOICE_Q4_K_M",
+		})
+		errCh <- err
+	}()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	err := <-errCh
+	if !errors.Is(err, models.ErrHostCancelled) {
+		t.Fatalf("error = %v, want ErrHostCancelled", err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want underlying context.Canceled", err)
+	}
+	if stopCount.Load() != 1 {
+		t.Fatalf("stop count = %d, want 1", stopCount.Load())
+	}
+}
+
+func TestEnsureModelHostDiagnosticsReadinessTimeoutEmitsFailureLogAndMetric(t *testing.T) {
+	t.Parallel()
+
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(healthServer.Close)
+
+	logger := &capturingDiagnosticsLogger{}
+	metrics := &capturingMetricsRecorder{}
+	cacheDirectory := t.TempDir()
+	writeCacheFixture(t, cacheDirectory, true)
+	scopes := newScopes(t, "timeout-diagnostics")
+	ref := openScope(t, scopes, cacheDirectory, supervisedRuntimeConfig())
+	launcher := &fakeProcessLauncher{
+		newProcess: func(spec models.HostProcessStartSpec) *fakeManagedProcess {
+			return newFakeManagedProcess(healthServer.URL, nil)
+		},
+	}
+	service := internalservice.NewWithSupervisorTestConfig(
+		scopes,
+		mustAssetsService(t, scopes),
+		launcher,
+		http.DefaultClient,
+		realHostClock{},
+		logger,
+		metrics,
+		internalservice.SupervisorTestConfig{
+			ReadinessTimeout:    75 * time.Millisecond,
+			HealthCheckInterval: 10 * time.Millisecond,
+		},
+	)
+
+	_, err := service.EnsureModelHost(context.Background(), models.EnsureModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err == nil {
+		t.Fatal("expected readiness timeout failure")
+	}
+	if !errors.Is(err, models.ErrHostLoadingTimeout) {
+		t.Fatalf("error = %v, want ErrHostLoadingTimeout", err)
+	}
+
+	entry, ok := logger.findWarn("model host load failed")
+	if !ok {
+		t.Fatal("expected model host load failed warning log")
+	}
+	if entry.fields["managed_runtime_identity"] != "OMNIVOICE_Q4_K_M" {
+		t.Fatalf("identity = %q, want OMNIVOICE_Q4_K_M", entry.fields["managed_runtime_identity"])
+	}
+	if entry.fields["backend"] != "LLAMACPP" {
+		t.Fatalf("backend = %q, want LLAMACPP", entry.fields["backend"])
+	}
+	if entry.fields["failure_class"] != "loading_timeout" {
+		t.Fatalf("failure_class = %q, want loading_timeout", entry.fields["failure_class"])
+	}
+	if !metrics.contains("model_host.load.failure", map[string]string{
+		"managed_runtime_identity": "OMNIVOICE_Q4_K_M",
+		"failure_class":            "loading_timeout",
+	}) {
+		t.Fatalf("metrics = %#v, want load failure metric", metrics.metrics)
+	}
+	if !metrics.contains("model_host.readiness.timeout", map[string]string{
+		"managed_runtime_identity": "OMNIVOICE_Q4_K_M",
+	}) {
+		t.Fatalf("metrics = %#v, want readiness timeout metric", metrics.metrics)
+	}
+}
+
+func TestEnsureModelHostDiagnosticsProcessCrashEmitsFailureLogAndMetric(t *testing.T) {
+	t.Parallel()
+
+	exitCh := make(chan error, 1)
+	logger := &capturingDiagnosticsLogger{}
+	metrics := &capturingMetricsRecorder{}
+	cacheDirectory := t.TempDir()
+	writeCacheFixture(t, cacheDirectory, true)
+	scopes := newScopes(t, "crash-diagnostics")
+	ref := openScope(t, scopes, cacheDirectory, supervisedRuntimeConfig())
+	launcher := &fakeProcessLauncher{
+		newProcess: func(spec models.HostProcessStartSpec) *fakeManagedProcess {
+			return newFakeManagedProcess("http://127.0.0.1:1", exitCh)
+		},
+	}
+	service := internalservice.NewWithSupervisorTestConfig(
+		scopes,
+		mustAssetsService(t, scopes),
+		launcher,
+		http.DefaultClient,
+		realHostClock{},
+		logger,
+		metrics,
+		internalservice.SupervisorTestConfig{
+			HealthChecker: alwaysHealthyChecker{},
+		},
+	)
+
+	_, err := service.EnsureModelHost(context.Background(), models.EnsureModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("EnsureModelHost: %v", err)
+	}
+	exitCh <- errors.New("server exited")
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		entry, ok := logger.findWarn("model host process crashed")
+		if ok {
+			if entry.fields["failure_class"] != "process_crash" {
+				t.Fatalf("failure_class = %q, want process_crash", entry.fields["failure_class"])
+			}
+			if !metrics.contains("model_host.process.crash", map[string]string{
+				"managed_runtime_identity": "OMNIVOICE_Q4_K_M",
+			}) {
+				if time.Now().After(deadline) {
+					t.Fatalf("metrics = %#v, want process crash metric", metrics.metrics)
+				}
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for process crash diagnostics")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+type capturingDiagnosticsLogger struct {
+	mu   sync.Mutex
+	logs []diagnosticLogEntry
+}
+
+type diagnosticLogEntry struct {
+	level  string
+	msg    string
+	fields map[string]string
+}
+
+func (l *capturingDiagnosticsLogger) Info(msg string, fields map[string]string) {
+	l.record("info", msg, fields)
+}
+
+func (l *capturingDiagnosticsLogger) Warn(msg string, fields map[string]string) {
+	l.record("warn", msg, fields)
+}
+
+func (l *capturingDiagnosticsLogger) record(level, msg string, fields map[string]string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	cloned := make(map[string]string, len(fields))
+	for key, value := range fields {
+		cloned[key] = value
+	}
+	l.logs = append(l.logs, diagnosticLogEntry{
+		level:  level,
+		msg:    msg,
+		fields: cloned,
+	})
+}
+
+func (l *capturingDiagnosticsLogger) findWarn(msg string) (diagnosticLogEntry, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, entry := range l.logs {
+		if entry.level == "warn" && entry.msg == msg {
+			return entry, true
+		}
+	}
+	return diagnosticLogEntry{}, false
+}
+
+type capturingMetricsRecorder struct {
+	mu      sync.Mutex
+	metrics []recordedMetric
+}
+
+type recordedMetric struct {
+	name   string
+	labels map[string]string
+}
+
+func (r *capturingMetricsRecorder) RecordMetric(name string, labels map[string]string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cloned := make(map[string]string, len(labels))
+	for key, value := range labels {
+		cloned[key] = value
+	}
+	r.metrics = append(r.metrics, recordedMetric{
+		name:   name,
+		labels: cloned,
+	})
+}
+
+func (r *capturingMetricsRecorder) contains(name string, wantLabels map[string]string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, metric := range r.metrics {
+		if metric.name != name {
+			continue
+		}
+		if labelsMatch(metric.labels, wantLabels) {
+			return true
+		}
+	}
+	return false
+}
+
+func labelsMatch(got, want map[string]string) bool {
+	for key, value := range want {
+		if got[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+type alwaysHealthyChecker struct{}
+
+func (alwaysHealthyChecker) Check(context.Context, string) error {
+	return nil
+}

--- a/pkg/services/models/internal/services/runtime_host/internal/service/host_diagnostics.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/host_diagnostics.go
@@ -75,13 +75,12 @@ func (d hostDiagnostics) logLoadFailed(identity supervisedIdentity, class hostFa
 		fields["error"] = err.Error()
 	}
 	d.warn("model host load failed", fields)
+	d.record(metricLoadFailure, fields)
 	switch class {
 	case hostFailureClassLoadingTimeout:
 		d.record(metricReadinessTimeout, fields)
 	case hostFailureClassProcessCrash:
 		d.record(metricProcessCrash, fields)
-	default:
-		d.record(metricLoadFailure, fields)
 	}
 }
 

--- a/pkg/services/models/internal/services/runtime_host/internal/service/host_diagnostics.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/host_diagnostics.go
@@ -9,6 +9,7 @@ const (
 	metricLoadFailure      = "model_host.load.failure"
 	metricReadinessTimeout = "model_host.readiness.timeout"
 	metricProcessCrash     = "model_host.process.crash"
+	metricUnload           = "model_host.unload"
 )
 
 type hostDiagnostics struct {
@@ -92,6 +93,13 @@ func (d hostDiagnostics) logProcessCrash(identity supervisedIdentity, err error)
 	}
 	d.warn("model host process crashed", fields)
 	d.record(metricProcessCrash, fields)
+}
+
+func (d hostDiagnostics) logUnload(identity supervisedIdentity, reason string) {
+	fields := identityDiagnosticFields(identity)
+	fields["unload_reason"] = strings.TrimSpace(reason)
+	d.info("model host unload", fields)
+	d.record(metricUnload, fields)
 }
 
 func cloneDiagnosticLabels(fields map[string]string) map[string]string {

--- a/pkg/services/models/internal/services/runtime_host/internal/service/host_diagnostics.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/host_diagnostics.go
@@ -1,0 +1,107 @@
+package service
+
+import (
+	"strings"
+)
+
+const (
+	metricLoadSuccess      = "model_host.load.success"
+	metricLoadFailure      = "model_host.load.failure"
+	metricReadinessTimeout = "model_host.readiness.timeout"
+	metricProcessCrash     = "model_host.process.crash"
+)
+
+type hostDiagnostics struct {
+	logger  modelsHostDiagnosticLogger
+	metrics modelsHostMetricsRecorder
+}
+
+type modelsHostDiagnosticLogger interface {
+	Info(string, map[string]string)
+	Warn(string, map[string]string)
+}
+
+type modelsHostMetricsRecorder interface {
+	RecordMetric(string, map[string]string)
+}
+
+func (d hostDiagnostics) info(msg string, fields map[string]string) {
+	if d.logger == nil {
+		return
+	}
+	d.logger.Info(msg, cloneDiagnosticLabels(fields))
+}
+
+func (d hostDiagnostics) warn(msg string, fields map[string]string) {
+	if d.logger == nil {
+		return
+	}
+	d.logger.Warn(msg, cloneDiagnosticLabels(fields))
+}
+
+func (d hostDiagnostics) record(name string, fields map[string]string) {
+	if d.metrics == nil || strings.TrimSpace(name) == "" {
+		return
+	}
+	d.metrics.RecordMetric(name, cloneDiagnosticLabels(fields))
+}
+
+func identityDiagnosticFields(identity supervisedIdentity) map[string]string {
+	return map[string]string{
+		"managed_runtime_identity": strings.TrimSpace(identity.Name),
+		"backend":                  strings.TrimSpace(identity.Backend),
+	}
+}
+
+func (d hostDiagnostics) logLoadStarted(identity supervisedIdentity) {
+	fields := identityDiagnosticFields(identity)
+	fields["readiness_state"] = "LOADING"
+	fields["lifecycle_state"] = "LOADING"
+	d.info("model host load started", fields)
+}
+
+func (d hostDiagnostics) logLoadReady(identity supervisedIdentity) {
+	fields := identityDiagnosticFields(identity)
+	fields["readiness_state"] = "READY"
+	fields["lifecycle_state"] = "LOADED"
+	d.info("model host load ready", fields)
+	d.record(metricLoadSuccess, fields)
+}
+
+func (d hostDiagnostics) logLoadFailed(identity supervisedIdentity, class hostFailureClass, err error) {
+	fields := identityDiagnosticFields(identity)
+	fields["failure_class"] = string(class)
+	if err != nil {
+		fields["error"] = err.Error()
+	}
+	d.warn("model host load failed", fields)
+	switch class {
+	case hostFailureClassLoadingTimeout:
+		d.record(metricReadinessTimeout, fields)
+	case hostFailureClassProcessCrash:
+		d.record(metricProcessCrash, fields)
+	default:
+		d.record(metricLoadFailure, fields)
+	}
+}
+
+func (d hostDiagnostics) logProcessCrash(identity supervisedIdentity, err error) {
+	fields := identityDiagnosticFields(identity)
+	fields["failure_class"] = string(hostFailureClassProcessCrash)
+	if err != nil {
+		fields["error"] = err.Error()
+	}
+	d.warn("model host process crashed", fields)
+	d.record(metricProcessCrash, fields)
+}
+
+func cloneDiagnosticLabels(fields map[string]string) map[string]string {
+	if len(fields) == 0 {
+		return map[string]string{}
+	}
+	cloned := make(map[string]string, len(fields))
+	for key, value := range fields {
+		cloned[key] = value
+	}
+	return cloned
+}

--- a/pkg/services/models/internal/services/runtime_host/internal/service/lease_policy.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/lease_policy.go
@@ -1,0 +1,160 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+func normalizeHostPolicy(idleUnloadAfter time.Duration, maxLoadedRuntimes int) (time.Duration, int) {
+	if idleUnloadAfter < 0 {
+		idleUnloadAfter = 0
+	}
+	if maxLoadedRuntimes < 0 {
+		maxLoadedRuntimes = 0
+	}
+	return idleUnloadAfter, maxLoadedRuntimes
+}
+
+func (s *service) slotHasActiveHoldersLocked(slotKey string) bool {
+	return s.capacityHolders[slotKey] > 0
+}
+
+func (s *service) acquireSlotCapacityLocked(slotKey string) {
+	s.capacityHolders[slotKey]++
+	s.cancelIdleUnloadLocked(slotKey)
+}
+
+func (s *service) releaseSlotCapacityLocked(slotKey string) {
+	count := s.capacityHolders[slotKey]
+	if count <= 1 {
+		delete(s.capacityHolders, slotKey)
+		return
+	}
+	s.capacityHolders[slotKey] = count - 1
+}
+
+func (s *service) cancelIdleUnloadLocked(slotKey string) {
+	if timer, ok := s.idleUnloadTimers[slotKey]; ok {
+		timer.Stop()
+		delete(s.idleUnloadTimers, slotKey)
+	}
+}
+
+func (s *service) scheduleIdleUnloadIfIdle(
+	slotKey string,
+	identity supervisedIdentity,
+) {
+	if s.idleUnloadAfter <= 0 {
+		return
+	}
+	if s.slotHasActiveHoldersLocked(slotKey) {
+		return
+	}
+	s.cancelIdleUnloadLocked(slotKey)
+	identityCopy := identity
+	s.idleUnloadTimers[slotKey] = time.AfterFunc(s.idleUnloadAfter, func() {
+		s.runIdleUnload(identityCopy, slotKey)
+	})
+}
+
+func (s *service) runIdleUnload(identity supervisedIdentity, slotKey string) {
+	s.mu.Lock()
+	if s.slotHasActiveHoldersLocked(slotKey) {
+		s.mu.Unlock()
+		return
+	}
+	delete(s.idleUnloadTimers, slotKey)
+	s.mu.Unlock()
+
+	diagnostics := hostDiagnostics{logger: s.hostLogger, metrics: s.hostMetrics}
+	diagnostics.logUnload(identity, "idle")
+	_ = s.unloadRuntime(ctxWithoutCancel(), identity, slotKey)
+}
+
+func ctxWithoutCancel() context.Context {
+	return context.Background()
+}
+
+func (s *service) evictIdleRuntimesForCapacity(
+	ctx context.Context,
+	scope models.RuntimeScopeRef,
+	modelName string,
+	identity supervisedIdentity,
+) error {
+	if s.maxLoadedRuntimes <= 0 {
+		return nil
+	}
+	slotKey := runtimeSlotKey(scope, modelName)
+	s.mu.Lock()
+	if _, exists := s.runtimeSlots[slotKey]; exists {
+		s.mu.Unlock()
+		return nil
+	}
+	if len(s.runtimeSlots) < s.maxLoadedRuntimes {
+		s.mu.Unlock()
+		return nil
+	}
+	evictKey := ""
+	for key, slot := range s.runtimeSlots {
+		if s.slotHasActiveHoldersLocked(key) {
+			continue
+		}
+		if slot.isLoading() {
+			continue
+		}
+		if !slot.isResident() {
+			continue
+		}
+		evictKey = key
+		break
+	}
+	if evictKey == "" {
+		s.mu.Unlock()
+		return capacityExhaustedError(modelName)
+	}
+	slot := s.runtimeSlots[evictKey]
+	delete(s.runtimeSlots, evictKey)
+	s.cancelIdleUnloadLocked(evictKey)
+	s.mu.Unlock()
+
+	evictedModel := modelName
+	if parts := strings.SplitN(evictKey, "|", 2); len(parts) == 2 && strings.TrimSpace(parts[1]) != "" {
+		evictedModel = parts[1]
+	}
+	evictedIdentity := supervisedIdentity{
+		Name:    strings.TrimSpace(evictedModel),
+		Backend: identity.Backend,
+	}
+	diagnostics := hostDiagnostics{logger: s.hostLogger, metrics: s.hostMetrics}
+	diagnostics.logUnload(evictedIdentity, "pressure_eviction")
+	return slot.stop(ctx)
+}
+
+func capacityExhaustedError(modelName string) error {
+	name := strings.TrimSpace(modelName)
+	return &models.HostReadinessError{
+		Snapshot: models.HostReadinessSnapshot{
+			Identity:       models.HostIdentity{Name: name},
+			ReadinessState: models.ReadinessStateFailed,
+			LifecycleState: models.LifecycleStateLoaded,
+			FailureClass:   models.HostFailureClassCapacityExhausted,
+		},
+		Cause: models.ErrHostCapacityExhausted,
+	}
+}
+
+func loadingCapacityExhaustedError(modelName string) error {
+	name := strings.TrimSpace(modelName)
+	return &models.HostReadinessError{
+		Snapshot: models.HostReadinessSnapshot{
+			Identity:       models.HostIdentity{Name: name},
+			ReadinessState: models.ReadinessStateLoading,
+			LifecycleState: models.LifecycleStateLoading,
+			FailureClass:   models.HostFailureClassCapacityExhausted,
+		},
+		Cause: models.ErrHostCapacityExhausted,
+	}
+}

--- a/pkg/services/models/internal/services/runtime_host/internal/service/service.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
@@ -20,6 +21,9 @@ type service struct {
 	hostClock       models.HostClock
 	hostLogger      models.HostDiagnosticLogger
 	hostMetrics     models.HostMetricsRecorder
+	supervisor      supervisorSettings
+	mu              sync.Mutex
+	runtimeSlots    map[string]*supervisedRuntime
 }
 
 var _ runtimehost.Service = (*service)(nil)
@@ -35,6 +39,17 @@ func New(
 	hostLogger models.HostDiagnosticLogger,
 	hostMetrics models.HostMetricsRecorder,
 ) runtimehost.Service {
+	diagnostics := hostDiagnostics{logger: hostLogger, metrics: hostMetrics}
+	supervisor := supervisorSettings{
+		ReadinessTimeout:    DefaultReadinessTimeout,
+		HealthCheckInterval: DefaultHealthCheckInterval,
+		HealthCheckPath:     DefaultHealthCheckPath,
+		ProcessLauncher:     processLauncher,
+		HealthChecker:       HTTPHealthChecker{Client: hostHTTP, Path: DefaultHealthCheckPath},
+		Clock:               hostClock,
+		ServerStartBuilder:  defaultServerStartBuilder,
+		Diagnostics:         diagnostics,
+	}
 	return &service{
 		scopes:          scopes,
 		assets:          assets,
@@ -43,6 +58,8 @@ func New(
 		hostClock:       hostClock,
 		hostLogger:      hostLogger,
 		hostMetrics:     hostMetrics,
+		supervisor:      supervisor,
+		runtimeSlots:    make(map[string]*supervisedRuntime),
 	}
 }
 
@@ -59,7 +76,8 @@ func (s *service) InspectModelHost(
 	if s == nil || s.scopes == nil || s.assets == nil {
 		return models.InspectModelHostResult{}, models.ErrUnavailable
 	}
-	if _, err := s.scopes.Resolve(runtimescopes.Reference(request.Scope.String())); err != nil {
+	binding, err := s.scopes.Resolve(runtimescopes.Reference(request.Scope.String()))
+	if err != nil {
 		return models.InspectModelHostResult{}, scopeError(err)
 	}
 	inspection, err := s.assets.InspectRuntimeCache(ctx, models.InspectModelAssetsRequest{
@@ -69,16 +87,92 @@ func (s *service) InspectModelHost(
 	if err != nil {
 		return models.InspectModelHostResult{}, err
 	}
-	return models.InspectModelHostResult{
-		Host: hostSnapshotFromAssets(request.Scope, request.Name, inspection),
-	}, nil
+	snapshot := hostSnapshotFromAssets(request.Scope, request.Name, inspection)
+	snapshot = s.overlaySupervisedReadiness(
+		binding,
+		request.Scope,
+		request.Name,
+		inspection,
+		snapshot,
+	)
+	return models.InspectModelHostResult{Host: snapshot}, nil
 }
 
 func (s *service) EnsureModelHost(
-	context.Context,
-	models.EnsureModelHostRequest,
+	ctx context.Context,
+	request models.EnsureModelHostRequest,
 ) (models.EnsureModelHostResult, error) {
-	return models.EnsureModelHostResult{}, models.ErrUnsupportedOperation
+	if err := request.Validate(); err != nil {
+		return models.EnsureModelHostResult{}, err
+	}
+	if err := hostContextError(ctx); err != nil {
+		return models.EnsureModelHostResult{}, err
+	}
+	if s == nil || s.scopes == nil || s.assets == nil {
+		return models.EnsureModelHostResult{}, models.ErrUnavailable
+	}
+	binding, err := s.scopes.Resolve(runtimescopes.Reference(request.Scope.String()))
+	if err != nil {
+		return models.EnsureModelHostResult{}, scopeError(err)
+	}
+	inspection, err := s.assets.InspectRuntimeCache(ctx, models.InspectModelAssetsRequest{
+		Scope: request.Scope,
+		Name:  request.Name,
+	})
+	if err != nil {
+		return models.EnsureModelHostResult{}, err
+	}
+	cacheInspection := cacheInspectionFromAssets(inspection)
+	if !cacheInspection.Installed {
+		return models.EnsureModelHostResult{}, fmt.Errorf(
+			"%w: model assets are not installed",
+			models.ErrHostMissingAssets,
+		)
+	}
+
+	runtimeCfg := binding.RuntimeConfig()
+	identity := supervisedIdentityForModel(runtimeCfg, request.Name)
+	baseSnapshot := hostSnapshotFromAssets(request.Scope, request.Name, inspection)
+
+	if !requiresSupervisedBackend(identity.Backend) {
+		return models.EnsureModelHostResult{
+			Host:    baseSnapshot,
+			Outcome: models.HostEnsureAlreadyReady,
+		}, nil
+	}
+
+	worker, err := localWorkerForModel(runtimeCfg, request.Name)
+	if err != nil {
+		return models.EnsureModelHostResult{}, err
+	}
+	if !workerDeclaresSupervisedHealthEndpoint(worker) {
+		return models.EnsureModelHostResult{
+			Host:    baseSnapshot,
+			Outcome: models.HostEnsureAlreadyReady,
+		}, nil
+	}
+
+	spec, err := s.supervisor.ServerStartBuilder(identity, cacheInspection, worker)
+	if err != nil {
+		return models.EnsureModelHostResult{}, err
+	}
+
+	slotKey := runtimeSlotKey(request.Scope, request.Name)
+	slot := s.runtimeSlot(slotKey)
+	wasReady := slot.isReady()
+	if err := slot.ensureReady(ctx, identity, spec); err != nil {
+		return models.EnsureModelHostResult{}, err
+	}
+	if !slot.isReady() {
+		return models.EnsureModelHostResult{}, slot.failureOutcomeLocked()
+	}
+
+	snapshot := slot.hostSnapshotOverlay(request.Scope, request.Name, baseSnapshot)
+	outcome := models.HostEnsureBecameReady
+	if wasReady {
+		outcome = models.HostEnsureAlreadyReady
+	}
+	return models.EnsureModelHostResult{Host: snapshot, Outcome: outcome}, nil
 }
 
 func (s *service) StopModelHost(
@@ -86,6 +180,42 @@ func (s *service) StopModelHost(
 	models.StopModelHostRequest,
 ) (models.StopModelHostResult, error) {
 	return models.StopModelHostResult{}, models.ErrUnsupportedOperation
+}
+
+func (s *service) overlaySupervisedReadiness(
+	binding models.RuntimeBinding,
+	scope models.RuntimeScopeRef,
+	modelName string,
+	inspection scopedassets.RuntimeCacheInspection,
+	snapshot models.ModelHostSnapshot,
+) models.ModelHostSnapshot {
+	identity := supervisedIdentityForModel(binding.RuntimeConfig(), modelName)
+	if !requiresSupervisedBackend(identity.Backend) || !inspection.Installed {
+		return snapshot
+	}
+	slot := s.peekRuntimeSlot(runtimeSlotKey(scope, modelName))
+	if slot == nil {
+		return snapshot
+	}
+	return slot.hostSnapshotOverlay(scope, modelName, snapshot)
+}
+
+func (s *service) peekRuntimeSlot(slotKey string) *supervisedRuntime {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.runtimeSlots[slotKey]
+}
+
+func (s *service) runtimeSlot(slotKey string) *supervisedRuntime {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	slot, ok := s.runtimeSlots[slotKey]
+	if ok {
+		return slot
+	}
+	slot = &supervisedRuntime{cfg: s.supervisor}
+	s.runtimeSlots[slotKey] = slot
+	return slot
 }
 
 func hostSnapshotFromAssets(

--- a/pkg/services/models/internal/services/runtime_host/internal/service/service.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/service.go
@@ -1,0 +1,150 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
+)
+
+type service struct {
+	scopes          runtimescopes.Service
+	assets          scopedassets.Service
+	processLauncher models.HostProcessLauncher
+	hostHTTP        models.HostHTTPDoer
+	hostClock       models.HostClock
+	hostLogger      models.HostDiagnosticLogger
+	hostMetrics     models.HostMetricsRecorder
+}
+
+var _ runtimehost.Service = (*service)(nil)
+
+// New constructs an inert Runtime Host that validates and retains injected
+// supervision effects without launching subprocesses or starting lifecycle.
+func New(
+	scopes runtimescopes.Service,
+	assets scopedassets.Service,
+	processLauncher models.HostProcessLauncher,
+	hostHTTP models.HostHTTPDoer,
+	hostClock models.HostClock,
+	hostLogger models.HostDiagnosticLogger,
+	hostMetrics models.HostMetricsRecorder,
+) runtimehost.Service {
+	return &service{
+		scopes:          scopes,
+		assets:          assets,
+		processLauncher: processLauncher,
+		hostHTTP:        hostHTTP,
+		hostClock:       hostClock,
+		hostLogger:      hostLogger,
+		hostMetrics:     hostMetrics,
+	}
+}
+
+func (s *service) InspectModelHost(
+	ctx context.Context,
+	request models.InspectModelHostRequest,
+) (models.InspectModelHostResult, error) {
+	if err := request.Validate(); err != nil {
+		return models.InspectModelHostResult{}, err
+	}
+	if err := hostContextError(ctx); err != nil {
+		return models.InspectModelHostResult{}, err
+	}
+	if s == nil || s.scopes == nil || s.assets == nil {
+		return models.InspectModelHostResult{}, models.ErrUnavailable
+	}
+	if _, err := s.scopes.Resolve(runtimescopes.Reference(request.Scope.String())); err != nil {
+		return models.InspectModelHostResult{}, scopeError(err)
+	}
+	inspection, err := s.assets.InspectRuntimeCache(ctx, models.InspectModelAssetsRequest{
+		Scope: request.Scope,
+		Name:  request.Name,
+	})
+	if err != nil {
+		return models.InspectModelHostResult{}, err
+	}
+	return models.InspectModelHostResult{
+		Host: hostSnapshotFromAssets(request.Scope, request.Name, inspection),
+	}, nil
+}
+
+func (s *service) EnsureModelHost(
+	context.Context,
+	models.EnsureModelHostRequest,
+) (models.EnsureModelHostResult, error) {
+	return models.EnsureModelHostResult{}, models.ErrUnsupportedOperation
+}
+
+func (s *service) StopModelHost(
+	context.Context,
+	models.StopModelHostRequest,
+) (models.StopModelHostResult, error) {
+	return models.StopModelHostResult{}, models.ErrUnsupportedOperation
+}
+
+func hostSnapshotFromAssets(
+	scope models.RuntimeScopeRef,
+	modelName string,
+	inspection scopedassets.RuntimeCacheInspection,
+) models.ModelHostSnapshot {
+	snapshot := models.ModelHostSnapshot{
+		Scope:       scope,
+		ModelName:   modelName,
+		Diagnostics: map[string]string{},
+	}
+	if !inspection.Supported {
+		snapshot.ReadinessState = models.ReadinessStateUnsupported
+		snapshot.LifecycleState = models.LifecycleStateNotApplicable
+		return snapshot
+	}
+	if inspection.Installed {
+		snapshot.ReadinessState = models.ReadinessStateReady
+		snapshot.LifecycleState = models.LifecycleStateInstalled
+		if inspection.CachePath != "" {
+			snapshot.Diagnostics["cachePath"] = inspection.CachePath
+		}
+		if inspection.Revision != "" {
+			snapshot.Diagnostics["revision"] = inspection.Revision
+		}
+		if inspection.InstalledFileCount > 0 {
+			snapshot.Diagnostics["installedFileCount"] = fmt.Sprintf("%d", inspection.InstalledFileCount)
+		}
+		return snapshot
+	}
+	snapshot.ReadinessState = models.ReadinessStateMissing
+	snapshot.LifecycleState = models.LifecycleStateNotInstalled
+	if len(inspection.MissingAssets) > 0 {
+		snapshot.Diagnostics["missingAssets"] = strings.Join(inspection.MissingAssets, ",")
+	}
+	return snapshot
+}
+
+func scopeError(err error) error {
+	switch {
+	case errors.Is(err, runtimescopes.ErrScopeForeign):
+		return fmt.Errorf("%w: %v", models.ErrRuntimeScopeForeign, err)
+	case errors.Is(err, runtimescopes.ErrScopeClosed):
+		return fmt.Errorf("%w: %v", models.ErrRuntimeScopeClosed, err)
+	case errors.Is(err, runtimescopes.ErrScopeUnknown):
+		return fmt.Errorf("%w: %v", models.ErrRuntimeScopeStale, err)
+	default:
+		return models.ErrUnavailable
+	}
+}
+
+func hostContextError(ctx context.Context) error {
+	if ctx == nil || ctx.Err() == nil {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: %w",
+		models.ErrHostCancelled,
+		errors.Join(ctx.Err(), context.Cause(ctx)),
+	)
+}

--- a/pkg/services/models/internal/services/runtime_host/internal/service/service.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
@@ -24,6 +25,10 @@ type service struct {
 	supervisor      supervisorSettings
 	mu              sync.Mutex
 	runtimeSlots    map[string]*supervisedRuntime
+	capacityHolders map[string]int
+	idleUnloadTimers map[string]*time.Timer
+	idleUnloadAfter  time.Duration
+	maxLoadedRuntimes int
 }
 
 var _ runtimehost.Service = (*service)(nil)
@@ -51,15 +56,19 @@ func New(
 		Diagnostics:         diagnostics,
 	}
 	return &service{
-		scopes:          scopes,
-		assets:          assets,
-		processLauncher: processLauncher,
-		hostHTTP:        hostHTTP,
-		hostClock:       hostClock,
-		hostLogger:      hostLogger,
-		hostMetrics:     hostMetrics,
-		supervisor:      supervisor,
-		runtimeSlots:    make(map[string]*supervisedRuntime),
+		scopes:            scopes,
+		assets:            assets,
+		processLauncher:   processLauncher,
+		hostHTTP:          hostHTTP,
+		hostClock:         hostClock,
+		hostLogger:        hostLogger,
+		hostMetrics:       hostMetrics,
+		supervisor:        supervisor,
+		runtimeSlots:      make(map[string]*supervisedRuntime),
+		capacityHolders:   make(map[string]int),
+		idleUnloadTimers:  make(map[string]*time.Timer),
+		idleUnloadAfter:   0,
+		maxLoadedRuntimes: 0,
 	}
 }
 
@@ -157,7 +166,12 @@ func (s *service) EnsureModelHost(
 		return models.EnsureModelHostResult{}, err
 	}
 
+	if err := s.evictIdleRuntimesForCapacity(ctx, request.Scope, request.Name, identity); err != nil {
+		return models.EnsureModelHostResult{}, err
+	}
+
 	slotKey := runtimeSlotKey(request.Scope, request.Name)
+	s.cancelIdleUnload(slotKey)
 	slot := s.runtimeSlot(slotKey)
 	wasReady := slot.isReady()
 	if err := slot.ensureReady(ctx, identity, spec); err != nil {
@@ -176,10 +190,127 @@ func (s *service) EnsureModelHost(
 }
 
 func (s *service) StopModelHost(
-	context.Context,
-	models.StopModelHostRequest,
+	ctx context.Context,
+	request models.StopModelHostRequest,
 ) (models.StopModelHostResult, error) {
-	return models.StopModelHostResult{}, models.ErrUnsupportedOperation
+	if err := request.Validate(); err != nil {
+		return models.StopModelHostResult{}, err
+	}
+	if err := hostContextError(ctx); err != nil {
+		return models.StopModelHostResult{}, err
+	}
+	if s == nil || s.scopes == nil || s.assets == nil {
+		return models.StopModelHostResult{}, models.ErrUnavailable
+	}
+	binding, err := s.scopes.Resolve(runtimescopes.Reference(request.Scope.String()))
+	if err != nil {
+		return models.StopModelHostResult{}, scopeError(err)
+	}
+	inspection, err := s.assets.InspectRuntimeCache(ctx, models.InspectModelAssetsRequest{
+		Scope: request.Scope,
+		Name:  request.Name,
+	})
+	if err != nil {
+		return models.StopModelHostResult{}, err
+	}
+	baseSnapshot := hostSnapshotFromAssets(request.Scope, request.Name, inspection)
+	identity := supervisedIdentityForModel(binding.RuntimeConfig(), request.Name)
+
+	slotKey := runtimeSlotKey(request.Scope, request.Name)
+	s.mu.Lock()
+	if s.slotHasActiveHoldersLocked(slotKey) {
+		s.mu.Unlock()
+		return models.StopModelHostResult{}, capacityExhaustedError(request.Name)
+	}
+	slot := s.runtimeSlots[slotKey]
+	if slot != nil && slot.isLoading() {
+		s.mu.Unlock()
+		return models.StopModelHostResult{}, loadingCapacityExhaustedError(request.Name)
+	}
+	wasLoaded := slot != nil && slot.isReady()
+	s.cancelIdleUnloadLocked(slotKey)
+	s.mu.Unlock()
+
+	if wasLoaded {
+		s.supervisor.Diagnostics.logUnload(identity, "explicit")
+		if err := s.unloadRuntime(ctx, identity, slotKey); err != nil {
+			return models.StopModelHostResult{}, err
+		}
+		snapshot := baseSnapshot
+		snapshot.ReadinessState = models.ReadinessStateReady
+		snapshot.LifecycleState = models.LifecycleStateInstalled
+		return models.StopModelHostResult{
+			Host:    snapshot,
+			Outcome: models.HostStopStopped,
+		}, nil
+	}
+
+	return models.StopModelHostResult{
+		Host:    baseSnapshot,
+		Outcome: models.HostStopAlreadyStopped,
+	}, nil
+}
+
+// Shutdown stops all supervised runtimes and cancels outstanding idle-unload timers.
+func (s *service) Shutdown(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	for _, timer := range s.idleUnloadTimers {
+		timer.Stop()
+	}
+	s.idleUnloadTimers = make(map[string]*time.Timer)
+	slots := make([]*supervisedRuntime, 0, len(s.runtimeSlots))
+	for _, slot := range s.runtimeSlots {
+		slots = append(slots, slot)
+	}
+	s.runtimeSlots = make(map[string]*supervisedRuntime)
+	s.mu.Unlock()
+
+	var firstErr error
+	for _, slot := range slots {
+		if err := slot.stop(ctx); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (s *service) unloadRuntime(
+	ctx context.Context,
+	identity supervisedIdentity,
+	slotKey string,
+) error {
+	s.mu.Lock()
+	slot := s.runtimeSlots[slotKey]
+	delete(s.runtimeSlots, slotKey)
+	s.cancelIdleUnloadLocked(slotKey)
+	s.mu.Unlock()
+	if slot != nil {
+		return slot.stop(ctx)
+	}
+	return nil
+}
+
+func (s *service) cancelIdleUnload(slotKey string) {
+	s.mu.Lock()
+	s.cancelIdleUnloadLocked(slotKey)
+	s.mu.Unlock()
+}
+
+func (s *service) releaseSlotCapacity(
+	scope models.RuntimeScopeRef,
+	modelName string,
+	runtimeCfg *models.RuntimeConfig,
+) {
+	slotKey := runtimeSlotKey(scope, modelName)
+	identity := supervisedIdentityForModel(runtimeCfg, modelName)
+
+	s.mu.Lock()
+	s.releaseSlotCapacityLocked(slotKey)
+	s.scheduleIdleUnloadIfIdle(slotKey, identity)
+	s.mu.Unlock()
 }
 
 func (s *service) overlaySupervisedReadiness(

--- a/pkg/services/models/internal/services/runtime_host/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/service_test.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -127,6 +129,132 @@ func TestInspectModelHostRejectsForeignScope(t *testing.T) {
 	}
 }
 
+func TestEnsureModelHostHealthyStartupReturnsReadyWithEndpoint(t *testing.T) {
+	t.Parallel()
+
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(healthServer.Close)
+
+	cacheDirectory := t.TempDir()
+	writeCacheFixture(t, cacheDirectory, true)
+	scopes := newScopes(t, "healthy-startup")
+	ref := openScope(t, scopes, cacheDirectory, supervisedRuntimeConfig())
+	launcher := &fakeProcessLauncher{
+		newProcess: func(spec models.HostProcessStartSpec) *fakeManagedProcess {
+			return newFakeManagedProcess(healthServer.URL, nil)
+		},
+	}
+	service := newTestRuntimeHostWithScopesAndClock(t, scopes, launcher, realHostClock{})
+
+	result, err := service.EnsureModelHost(context.Background(), models.EnsureModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("EnsureModelHost: %v", err)
+	}
+	if result.Outcome != models.HostEnsureBecameReady ||
+		result.Host.ReadinessState != models.ReadinessStateReady ||
+		result.Host.LifecycleState != models.LifecycleStateLoaded {
+		t.Fatalf("ensure result = %#v, want became-ready/ready/loaded", result)
+	}
+	if result.Host.Diagnostics["endpoint"] != healthServer.URL {
+		t.Fatalf("endpoint = %q, want %q", result.Host.Diagnostics["endpoint"], healthServer.URL)
+	}
+	if launcher.startCount() != 1 {
+		t.Fatalf("process starts = %d, want 1", launcher.startCount())
+	}
+}
+
+func TestEnsureModelHostConcurrentReuseSharesOneSupervisedProcess(t *testing.T) {
+	t.Parallel()
+
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(healthServer.Close)
+
+	cacheDirectory := t.TempDir()
+	writeCacheFixture(t, cacheDirectory, true)
+	scopes := newScopes(t, "concurrent-reuse")
+	ref := openScope(t, scopes, cacheDirectory, supervisedRuntimeConfig())
+	launcher := &fakeProcessLauncher{
+		newProcess: func(spec models.HostProcessStartSpec) *fakeManagedProcess {
+			return newFakeManagedProcess(healthServer.URL, nil)
+		},
+	}
+	service := newTestRuntimeHostWithScopesAndClock(t, scopes, launcher, realHostClock{})
+
+	const workers = 8
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers)
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := service.EnsureModelHost(context.Background(), models.EnsureModelHostRequest{
+				Scope: ref,
+				Name:  "OMNIVOICE_Q4_K_M",
+			})
+			errCh <- err
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("EnsureModelHost: %v", err)
+		}
+	}
+	if launcher.startCount() != 1 {
+		t.Fatalf("process starts = %d, want 1 shared supervised process", launcher.startCount())
+	}
+}
+
+func TestEnsureModelHostReturnsDetachedSnapshotWithoutPrivateHandles(t *testing.T) {
+	t.Parallel()
+
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(healthServer.Close)
+
+	cacheDirectory := t.TempDir()
+	writeCacheFixture(t, cacheDirectory, true)
+	scopes := newScopes(t, "detached-snapshot")
+	ref := openScope(t, scopes, cacheDirectory, supervisedRuntimeConfig())
+	launcher := &fakeProcessLauncher{
+		newProcess: func(spec models.HostProcessStartSpec) *fakeManagedProcess {
+			return newFakeManagedProcess(healthServer.URL, nil)
+		},
+	}
+	service := newTestRuntimeHostWithScopesAndClock(t, scopes, launcher, realHostClock{})
+
+	result, err := service.EnsureModelHost(context.Background(), models.EnsureModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("EnsureModelHost: %v", err)
+	}
+	result.Host.Diagnostics["mutated"] = "peer"
+	inspected, err := service.InspectModelHost(context.Background(), models.InspectModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("InspectModelHost: %v", err)
+	}
+	if inspected.Host.Diagnostics["mutated"] != "" {
+		t.Fatal("peer mutation of ensure result changed retained host state")
+	}
+	if inspected.Host.Diagnostics["endpoint"] != healthServer.URL {
+		t.Fatalf("endpoint = %q, want %q", inspected.Host.Diagnostics["endpoint"], healthServer.URL)
+	}
+}
+
 func newTestRuntimeHost(t *testing.T, launcher *recordingProcessLauncher) runtimehost.Service {
 	t.Helper()
 	scopes := newScopes(t, t.Name())
@@ -136,7 +264,16 @@ func newTestRuntimeHost(t *testing.T, launcher *recordingProcessLauncher) runtim
 func newTestRuntimeHostWithScopes(
 	t *testing.T,
 	scopes runtimescopes.Service,
-	launcher *recordingProcessLauncher,
+	launcher models.HostProcessLauncher,
+) runtimehost.Service {
+	return newTestRuntimeHostWithScopesAndClock(t, scopes, launcher, testHostClock{})
+}
+
+func newTestRuntimeHostWithScopesAndClock(
+	t *testing.T,
+	scopes runtimescopes.Service,
+	launcher models.HostProcessLauncher,
+	clock models.HostClock,
 ) runtimehost.Service {
 	t.Helper()
 	assets, err := assetswire.NewService(
@@ -165,7 +302,7 @@ func newTestRuntimeHostWithScopes(
 		assets,
 		launcher,
 		http.DefaultClient,
-		testHostClock{},
+		clock,
 		nil,
 		nil,
 	)
@@ -236,6 +373,22 @@ func runtimeConfig() models.RuntimeConfig {
 	}
 }
 
+func supervisedRuntimeConfig() models.RuntimeConfig {
+	cfg := runtimeConfig()
+	cfg.Resources[0].Backend = "LLAMACPP"
+	cfg.Workers = []models.RuntimeWorker{{
+		Name:          "omnivoice-worker",
+		Model:         "OMNIVOICE_Q4_K_M",
+		ModelLocality: models.RuntimeModelLocalityLocal,
+		Command:       "fake-llamacpp-server",
+		Args: []string{
+			"--health-endpoint",
+			"http://127.0.0.1:1",
+		},
+	}}
+	return cfg
+}
+
 const metadataFileName = ".managed-cache.json"
 
 type cacheMetadata struct {
@@ -280,4 +433,94 @@ func writeCacheFixture(t *testing.T, cacheDirectory string, includeMetadata bool
 	if err := os.WriteFile(filepath.Join(root, metadataFileName), body, 0o644); err != nil {
 		t.Fatalf("write metadata: %v", err)
 	}
+}
+
+type fakeProcessLauncher struct {
+	mu         sync.Mutex
+	starts     int
+	newProcess func(spec models.HostProcessStartSpec) *fakeManagedProcess
+}
+
+func (f *fakeProcessLauncher) Start(
+	_ context.Context,
+	spec models.HostProcessStartSpec,
+) (models.HostManagedProcess, error) {
+	f.mu.Lock()
+	f.starts++
+	newProcess := f.newProcess
+	f.mu.Unlock()
+	if newProcess == nil {
+		return nil, errors.New("fake process launcher is not configured")
+	}
+	return newProcess(spec), nil
+}
+
+func (f *fakeProcessLauncher) startCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.starts
+}
+
+type fakeManagedProcess struct {
+	endpoint string
+	exitCh   chan error
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	stopFn   func() error
+}
+
+func newFakeManagedProcess(endpoint string, exitCh chan error) *fakeManagedProcess {
+	if exitCh == nil {
+		exitCh = make(chan error, 1)
+	}
+	return &fakeManagedProcess{
+		endpoint: endpoint,
+		exitCh:   exitCh,
+		stopCh:   make(chan struct{}),
+	}
+}
+
+func (p *fakeManagedProcess) HealthEndpoint() string {
+	return p.endpoint
+}
+
+func (p *fakeManagedProcess) Wait() error {
+	return <-p.exitCh
+}
+
+func (p *fakeManagedProcess) Stop(context.Context) error {
+	if p.stopFn != nil {
+		return p.stopFn()
+	}
+	return p.defaultStop()
+}
+
+func (p *fakeManagedProcess) defaultStop() error {
+	p.stopOnce.Do(func() {
+		close(p.stopCh)
+		p.exitCh <- errors.New("stopped")
+	})
+	return nil
+}
+
+type realHostClock struct{}
+
+func (realHostClock) Now() time.Time {
+	return time.Now()
+}
+
+func (realHostClock) NewTimer(duration time.Duration) models.HostTimer {
+	return realHostTimer{timer: time.NewTimer(duration)}
+}
+
+type realHostTimer struct {
+	timer *time.Timer
+}
+
+func (t realHostTimer) C() <-chan time.Time {
+	return t.timer.C
+}
+
+func (t realHostTimer) Stop() bool {
+	return t.timer.Stop()
 }

--- a/pkg/services/models/internal/services/runtime_host/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/service_test.go
@@ -1,0 +1,283 @@
+package service_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	assetswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets/wire"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/service"
+	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
+)
+
+func TestConstructionAllocatesHostStateWithoutLaunchingProcess(t *testing.T) {
+	t.Parallel()
+
+	launcher := &recordingProcessLauncher{}
+	service := newTestRuntimeHost(t, launcher)
+	if service == nil {
+		t.Fatal("New returned nil service")
+	}
+	if launcher.starts != 0 {
+		t.Fatalf("process starts during construction = %d, want 0", launcher.starts)
+	}
+}
+
+func TestInspectModelHostReportsMissingAssetsFromAcceptedAssetsFacts(t *testing.T) {
+	t.Parallel()
+
+	cacheDirectory := t.TempDir()
+	scopes := newScopes(t, "missing-assets")
+	ref := openScope(t, scopes, cacheDirectory, runtimeConfig())
+	service := newTestRuntimeHostWithScopes(t, scopes, &recordingProcessLauncher{})
+
+	result, err := service.InspectModelHost(context.Background(), models.InspectModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("InspectModelHost: %v", err)
+	}
+	if result.Host.ReadinessState != models.ReadinessStateMissing ||
+		result.Host.LifecycleState != models.LifecycleStateNotInstalled ||
+		result.Host.ModelName != "OMNIVOICE_Q4_K_M" {
+		t.Fatalf("host snapshot = %#v, want missing/not-installed", result.Host)
+	}
+}
+
+func TestInspectModelHostReportsInstalledAssetsWithoutSupervisedProcess(t *testing.T) {
+	t.Parallel()
+
+	cacheDirectory := t.TempDir()
+	writeCacheFixture(t, cacheDirectory, true)
+	scopes := newScopes(t, "installed-assets")
+	ref := openScope(t, scopes, cacheDirectory, runtimeConfig())
+	launcher := &recordingProcessLauncher{}
+	service := newTestRuntimeHostWithScopes(t, scopes, launcher)
+
+	result, err := service.InspectModelHost(context.Background(), models.InspectModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("InspectModelHost: %v", err)
+	}
+	if result.Host.ReadinessState != models.ReadinessStateReady ||
+		result.Host.LifecycleState != models.LifecycleStateInstalled {
+		t.Fatalf("host snapshot = %#v, want ready/installed from assets facts", result.Host)
+	}
+	if launcher.starts != 0 {
+		t.Fatalf("process starts during inspect = %d, want 0", launcher.starts)
+	}
+}
+
+func TestOpenRuntimeScopeDoesNotConstructAnotherRuntimeHost(t *testing.T) {
+	t.Parallel()
+
+	launcher := &recordingProcessLauncher{}
+	scopes := newScopes(t, "scope-binding")
+	service := newTestRuntimeHostWithScopes(t, scopes, launcher)
+	_, err := scopes.Open(models.RuntimeBinding{
+		CacheDirectory: t.TempDir(),
+		RuntimeConfig: func() *models.RuntimeConfig {
+			return &models.RuntimeConfig{FactoryDirectory: "factory"}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if service == nil {
+		t.Fatal("runtime host service is nil after scope open")
+	}
+	if launcher.starts != 0 {
+		t.Fatalf("process starts after scope open = %d, want 0", launcher.starts)
+	}
+}
+
+func TestInspectModelHostRejectsForeignScope(t *testing.T) {
+	t.Parallel()
+
+	left := newScopes(t, "left")
+	right := newScopes(t, "right")
+	ref, err := right.Open(models.RuntimeBinding{
+		CacheDirectory: t.TempDir(),
+		RuntimeConfig: func() *models.RuntimeConfig {
+			return &models.RuntimeConfig{FactoryDirectory: "factory"}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Open foreign scope: %v", err)
+	}
+	service := newTestRuntimeHostWithScopes(t, left, &recordingProcessLauncher{})
+	_, err = service.InspectModelHost(context.Background(), models.InspectModelHostRequest{
+		Scope: mustParseScope(t, ref),
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if !errors.Is(err, models.ErrRuntimeScopeForeign) {
+		t.Fatalf("InspectModelHost error = %v, want ErrRuntimeScopeForeign", err)
+	}
+}
+
+func newTestRuntimeHost(t *testing.T, launcher *recordingProcessLauncher) runtimehost.Service {
+	t.Helper()
+	scopes := newScopes(t, t.Name())
+	return newTestRuntimeHostWithScopes(t, scopes, launcher)
+}
+
+func newTestRuntimeHostWithScopes(
+	t *testing.T,
+	scopes runtimescopes.Service,
+	launcher *recordingProcessLauncher,
+) runtimehost.Service {
+	t.Helper()
+	assets, err := assetswire.NewService(
+		scopes,
+		models.AssetHostPlatform{OperatingSystem: "linux", Architecture: "amd64"},
+		http.DefaultClient,
+		models.RuntimeAssetEndpoints{
+			BaseURL: "https://assets.example.test", APIBaseURL: "https://api.example.test",
+		},
+		os.MkdirAll,
+		os.Stat,
+		os.UserHomeDir,
+		os.WriteFile,
+		os.Rename,
+		os.Remove,
+		os.ReadFile,
+		os.ReadDir,
+		func(path string) (io.WriteCloser, error) { return os.Create(path) },
+		func(path string) (io.ReadCloser, error) { return os.Open(path) },
+	)
+	if err != nil {
+		t.Fatalf("construct assets: %v", err)
+	}
+	return internalservice.New(
+		scopes,
+		assets,
+		launcher,
+		http.DefaultClient,
+		testHostClock{},
+		nil,
+		nil,
+	)
+}
+
+type recordingProcessLauncher struct {
+	starts int
+}
+
+func (launcher *recordingProcessLauncher) Start(
+	context.Context,
+	models.HostProcessStartSpec,
+) (models.HostManagedProcess, error) {
+	launcher.starts++
+	panic("process launcher called during inert runtime host")
+}
+
+type testHostClock struct{}
+
+func (testHostClock) Now() time.Time { return time.Unix(0, 0) }
+func (testHostClock) NewTimer(time.Duration) models.HostTimer {
+	panic("host timer created during inert runtime host")
+}
+
+func newScopes(t *testing.T, issuer string) runtimescopes.Service {
+	t.Helper()
+	scopes, err := runtimescopeswire.NewService(func() string { return issuer })
+	if err != nil {
+		t.Fatalf("construct runtime scopes: %v", err)
+	}
+	return scopes
+}
+
+func openScope(
+	t *testing.T,
+	scopes runtimescopes.Service,
+	cacheDirectory string,
+	config models.RuntimeConfig,
+) models.RuntimeScopeRef {
+	t.Helper()
+	ref, err := scopes.Open(models.RuntimeBinding{
+		CacheDirectory: cacheDirectory,
+		RuntimeConfig:  func() *models.RuntimeConfig { return &config },
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return mustParseScope(t, ref)
+}
+
+func mustParseScope(t *testing.T, ref runtimescopes.Reference) models.RuntimeScopeRef {
+	t.Helper()
+	scope, err := (models.RuntimeScopeRef{}).Parse(string(ref))
+	if err != nil {
+		t.Fatalf("Parse scope: %v", err)
+	}
+	return scope
+}
+
+func runtimeConfig() models.RuntimeConfig {
+	return models.RuntimeConfig{
+		Resources: []models.RuntimeResource{{
+			Name:     "omnivoice-cache",
+			Type:     models.RuntimeResourceTypeModel,
+			Model:    "OMNIVOICE_Q4_K_M",
+			Provider: "MODELSCOPE",
+		}},
+	}
+}
+
+const metadataFileName = ".managed-cache.json"
+
+type cacheMetadata struct {
+	ModelName string         `json:"modelName"`
+	Revision  string         `json:"revision"`
+	Files     []metadataFile `json:"files"`
+}
+
+type metadataFile struct {
+	Path   string `json:"path"`
+	SHA256 string `json:"sha256"`
+}
+
+func writeCacheFixture(t *testing.T, cacheDirectory string, includeMetadata bool) {
+	t.Helper()
+	root := filepath.Join(cacheDirectory, "OMNIVOICE_Q4_K_M")
+	revisionDirectory := filepath.Join(root, "rev-test")
+	if err := os.MkdirAll(revisionDirectory, 0o755); err != nil {
+		t.Fatalf("create cache fixture: %v", err)
+	}
+	files := []metadataFile{
+		{Path: "omnivoice-base-Q4_K_M.gguf", SHA256: "aaa"},
+		{Path: "omnivoice-tokenizer-Q4_K_M.gguf", SHA256: "bbb"},
+	}
+	for index, file := range files {
+		content := []byte{byte(index + 1), byte(index + 2)}
+		if err := os.WriteFile(filepath.Join(revisionDirectory, file.Path), content, 0o644); err != nil {
+			t.Fatalf("write cache artifact: %v", err)
+		}
+	}
+	if !includeMetadata {
+		return
+	}
+	body, err := json.Marshal(cacheMetadata{
+		ModelName: "OMNIVOICE_Q4_K_M",
+		Revision:  "rev-test",
+		Files:     files,
+	})
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, metadataFileName), body, 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+}

--- a/pkg/services/models/internal/services/runtime_host/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/service_test.go
@@ -15,6 +15,7 @@ import (
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 	assetswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets/wire"
+	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
 	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
 	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/service"
@@ -276,6 +277,19 @@ func newTestRuntimeHostWithScopesAndClock(
 	clock models.HostClock,
 ) runtimehost.Service {
 	t.Helper()
+	return internalservice.New(
+		scopes,
+		mustAssetsService(t, scopes),
+		launcher,
+		http.DefaultClient,
+		clock,
+		nil,
+		nil,
+	)
+}
+
+func mustAssetsService(t *testing.T, scopes runtimescopes.Service) scopedassets.Service {
+	t.Helper()
 	assets, err := assetswire.NewService(
 		scopes,
 		models.AssetHostPlatform{OperatingSystem: "linux", Architecture: "amd64"},
@@ -297,15 +311,7 @@ func newTestRuntimeHostWithScopesAndClock(
 	if err != nil {
 		t.Fatalf("construct assets: %v", err)
 	}
-	return internalservice.New(
-		scopes,
-		assets,
-		launcher,
-		http.DefaultClient,
-		clock,
-		nil,
-		nil,
-	)
+	return assets
 }
 
 type recordingProcessLauncher struct {

--- a/pkg/services/models/internal/services/runtime_host/internal/service/supervisor.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/supervisor.go
@@ -277,6 +277,39 @@ func (r *supervisedRuntime) isReady() bool {
 	return r.state == supervisedStateReady
 }
 
+func (r *supervisedRuntime) isLoading() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.state == supervisedStateLoading
+}
+
+func (r *supervisedRuntime) isResident() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	switch r.state {
+	case supervisedStateLoading, supervisedStateReady, supervisedStateFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *supervisedRuntime) stop(ctx context.Context) error {
+	r.mu.Lock()
+	process := r.process
+	r.process = nil
+	r.endpoint = ""
+	r.state = supervisedStateAbsent
+	r.failureClass = hostFailureClassNone
+	r.failureErr = nil
+	r.mu.Unlock()
+
+	if process == nil {
+		return nil
+	}
+	return process.Stop(ctx)
+}
+
 // HTTPHealthChecker probes readiness through HTTP GET on a health endpoint.
 type HTTPHealthChecker struct {
 	Client models.HostHTTPDoer

--- a/pkg/services/models/internal/services/runtime_host/internal/service/supervisor.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/supervisor.go
@@ -1,0 +1,325 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+const (
+	DefaultReadinessTimeout      = 30 * time.Second
+	DefaultHealthCheckInterval   = 100 * time.Millisecond
+	DefaultHealthCheckPath       = "/health"
+	supervisedHealthEndpointFlag = "--health-endpoint"
+)
+
+type supervisorSettings struct {
+	ReadinessTimeout    time.Duration
+	HealthCheckInterval time.Duration
+	HealthCheckPath     string
+	ProcessLauncher     models.HostProcessLauncher
+	HealthChecker       healthChecker
+	Clock               models.HostClock
+	ServerStartBuilder  func(
+		supervisedIdentity,
+		cacheInspection,
+		*models.RuntimeWorker,
+	) (models.HostProcessStartSpec, error)
+	Diagnostics hostDiagnostics
+}
+
+type healthChecker interface {
+	Check(ctx context.Context, healthEndpoint string) error
+}
+
+type supervisedState string
+
+const (
+	supervisedStateAbsent  supervisedState = "absent"
+	supervisedStateLoading supervisedState = "loading"
+	supervisedStateReady   supervisedState = "ready"
+	supervisedStateFailed  supervisedState = "failed"
+)
+
+type supervisedRuntime struct {
+	mu           sync.Mutex
+	state        supervisedState
+	failureClass hostFailureClass
+	failureErr   error
+	endpoint     string
+	process      models.HostManagedProcess
+	loadDone     chan struct{}
+	cfg          supervisorSettings
+	identity     supervisedIdentity
+}
+
+func (r *supervisedRuntime) hostSnapshotOverlay(
+	scope models.RuntimeScopeRef,
+	modelName string,
+	base models.ModelHostSnapshot,
+) models.ModelHostSnapshot {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	switch r.state {
+	case supervisedStateReady:
+		snapshot := base.Clone()
+		snapshot.Scope = scope
+		snapshot.ModelName = modelName
+		snapshot.ReadinessState = models.ReadinessStateReady
+		snapshot.LifecycleState = models.LifecycleStateLoaded
+		if r.endpoint != "" {
+			snapshot.Diagnostics["endpoint"] = r.endpoint
+		}
+		return snapshot
+	case supervisedStateLoading:
+		snapshot := base.Clone()
+		snapshot.Scope = scope
+		snapshot.ModelName = modelName
+		snapshot.ReadinessState = models.ReadinessStateLoading
+		snapshot.LifecycleState = models.LifecycleStateLoading
+		return snapshot
+	case supervisedStateFailed:
+		snapshot := base.Clone()
+		snapshot.Scope = scope
+		snapshot.ModelName = modelName
+		switch r.failureClass {
+		case hostFailureClassLoadingTimeout:
+			snapshot.ReadinessState = models.ReadinessStateLoading
+			snapshot.LifecycleState = models.LifecycleStateLoading
+		case hostFailureClassProcessCrash, hostFailureClassCancelled:
+			snapshot.ReadinessState = models.ReadinessStateFailed
+			snapshot.LifecycleState = models.LifecycleStateLoaded
+		default:
+			snapshot.ReadinessState = models.ReadinessStateFailed
+			snapshot.LifecycleState = models.LifecycleStateLoaded
+		}
+		if r.failureClass != hostFailureClassNone {
+			snapshot.Diagnostics["failureClass"] = string(r.failureClass)
+		}
+		return snapshot
+	default:
+		return base
+	}
+}
+
+func (r *supervisedRuntime) ensureReady(
+	ctx context.Context,
+	identity supervisedIdentity,
+	spec models.HostProcessStartSpec,
+) error {
+	if err := ctx.Err(); err != nil {
+		return cancelHostError(err)
+	}
+
+	if err := r.awaitExistingLoad(ctx); err != nil {
+		if errors.Is(err, errReadyAlready) {
+			return nil
+		}
+		return err
+	}
+
+	r.mu.Lock()
+	if r.state == supervisedStateReady {
+		r.mu.Unlock()
+		return nil
+	}
+	if r.state == supervisedStateFailed {
+		err := r.failureOutcomeLocked()
+		r.mu.Unlock()
+		return err
+	}
+	r.identity = identity
+	r.state = supervisedStateLoading
+	r.failureClass = hostFailureClassNone
+	r.failureErr = nil
+	r.loadDone = make(chan struct{})
+	loadDone := r.loadDone
+	r.mu.Unlock()
+	defer close(loadDone)
+
+	r.cfg.Diagnostics.logLoadStarted(identity)
+
+	process, err := r.cfg.ProcessLauncher.Start(ctx, spec)
+	if err != nil {
+		return r.markFailed(
+			identity,
+			hostFailureClassProcessCrash,
+			fmt.Errorf("%w: %v", models.ErrHostProcessCrash, err),
+		)
+	}
+
+	deadline := r.cfg.Clock.Now().Add(r.cfg.ReadinessTimeout)
+	for {
+		if err := ctx.Err(); err != nil {
+			_ = process.Stop(context.Background())
+			return r.markFailed(identity, hostFailureClassCancelled, cancelHostError(err))
+		}
+		if checkErr := r.cfg.HealthChecker.Check(ctx, process.HealthEndpoint()); checkErr == nil {
+			r.mu.Lock()
+			r.state = supervisedStateReady
+			r.endpoint = process.HealthEndpoint()
+			r.process = process
+			r.failureClass = hostFailureClassNone
+			r.failureErr = nil
+			r.mu.Unlock()
+			r.cfg.Diagnostics.logLoadReady(identity)
+			go r.watchProcessExit(identity, process)
+			return nil
+		}
+		if r.cfg.Clock.Now().After(deadline) {
+			_ = process.Stop(context.Background())
+			return r.markFailed(identity, hostFailureClassLoadingTimeout, models.ErrHostLoadingTimeout)
+		}
+		timer := r.cfg.Clock.NewTimer(r.cfg.HealthCheckInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			_ = process.Stop(context.Background())
+			return r.markFailed(identity, hostFailureClassCancelled, cancelHostError(ctx.Err()))
+		case <-timer.C():
+		}
+	}
+}
+
+var errReadyAlready = errors.New("model host runtime already ready")
+
+func (r *supervisedRuntime) awaitExistingLoad(ctx context.Context) error {
+	r.mu.Lock()
+	switch r.state {
+	case supervisedStateReady:
+		r.mu.Unlock()
+		return errReadyAlready
+	case supervisedStateLoading:
+		loadDone := r.loadDone
+		r.mu.Unlock()
+		return r.waitForLoad(ctx, loadDone)
+	case supervisedStateFailed:
+		err := r.failureOutcomeLocked()
+		r.mu.Unlock()
+		return err
+	default:
+		r.mu.Unlock()
+		return nil
+	}
+}
+
+func (r *supervisedRuntime) waitForLoad(ctx context.Context, loadDone chan struct{}) error {
+	select {
+	case <-loadDone:
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		switch r.state {
+		case supervisedStateReady:
+			return nil
+		case supervisedStateFailed:
+			return r.failureOutcomeLocked()
+		default:
+			return models.ErrHostRuntimeNotReady
+		}
+	case <-ctx.Done():
+		return cancelHostError(ctx.Err())
+	}
+}
+
+func (r *supervisedRuntime) markFailed(
+	identity supervisedIdentity,
+	class hostFailureClass,
+	err error,
+) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.state = supervisedStateFailed
+	r.failureClass = class
+	r.failureErr = err
+	r.endpoint = ""
+	r.process = nil
+	r.cfg.Diagnostics.logLoadFailed(identity, class, err)
+	return r.failureOutcomeLocked()
+}
+
+func (r *supervisedRuntime) failureOutcomeLocked() error {
+	if r.failureErr == nil {
+		return models.ErrHostRuntimeNotReady
+	}
+	return r.failureErr
+}
+
+func (r *supervisedRuntime) watchProcessExit(identity supervisedIdentity, process models.HostManagedProcess) {
+	waitErr := process.Wait()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.process != process || r.state != supervisedStateReady {
+		return
+	}
+	r.state = supervisedStateFailed
+	r.failureClass = hostFailureClassProcessCrash
+	if waitErr != nil {
+		r.failureErr = fmt.Errorf("%w: %v", models.ErrHostProcessCrash, waitErr)
+	} else {
+		r.failureErr = models.ErrHostProcessCrash
+	}
+	r.endpoint = ""
+	r.process = nil
+	r.cfg.Diagnostics.logProcessCrash(identity, r.failureErr)
+}
+
+func (r *supervisedRuntime) isReady() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.state == supervisedStateReady
+}
+
+// HTTPHealthChecker probes readiness through HTTP GET on a health endpoint.
+type HTTPHealthChecker struct {
+	Client models.HostHTTPDoer
+	Path   string
+}
+
+func (h HTTPHealthChecker) Check(ctx context.Context, healthEndpoint string) error {
+	url := healthEndpointURL(healthEndpoint, h.Path)
+	client := h.Client
+	if client == nil {
+		return fmt.Errorf("model host health HTTP client is required")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("health check returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func healthEndpointURL(endpoint string, path string) string {
+	trimmed := strings.TrimSpace(endpoint)
+	if strings.Contains(trimmed, "://") &&
+		(strings.HasSuffix(trimmed, "/health") || strings.Contains(trimmed, "/health?")) {
+		return trimmed
+	}
+	base := strings.TrimRight(trimmed, "/")
+	healthPath := strings.TrimSpace(path)
+	if healthPath == "" {
+		healthPath = DefaultHealthCheckPath
+	}
+	if !strings.HasPrefix(healthPath, "/") {
+		healthPath = "/" + healthPath
+	}
+	return base + healthPath
+}

--- a/pkg/services/models/internal/services/runtime_host/internal/service/supervisor_helpers.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/supervisor_helpers.go
@@ -1,0 +1,184 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	localmodels "github.com/portpowered/infinite-you/pkg/services/models/internal/local"
+	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
+)
+
+type supervisedIdentity struct {
+	Name    string
+	Backend string
+}
+
+type hostFailureClass string
+
+const (
+	hostFailureClassNone           hostFailureClass = ""
+	hostFailureClassLoadingTimeout hostFailureClass = "loading_timeout"
+	hostFailureClassProcessCrash   hostFailureClass = "process_crash"
+	hostFailureClassCancelled      hostFailureClass = "cancelled"
+)
+
+func canonicalModelKey(modelName string) string {
+	return strings.ToUpper(strings.TrimSpace(modelName))
+}
+
+func runtimeSlotKey(scope models.RuntimeScopeRef, modelName string) string {
+	return scope.String() + "|" + canonicalModelKey(modelName)
+}
+
+func requiresSupervisedBackend(backend string) bool {
+	return strings.ToUpper(strings.TrimSpace(backend)) == "LLAMACPP"
+}
+
+func localWorkerForModel(
+	runtimeCfg *models.RuntimeConfig,
+	modelName string,
+) (*models.RuntimeWorker, error) {
+	if runtimeCfg == nil {
+		return nil, fmt.Errorf("runtime config is not available")
+	}
+	target := canonicalModelKey(modelName)
+	for _, worker := range runtimeCfg.Workers {
+		if canonicalModelKey(worker.Model) != target {
+			continue
+		}
+		if strings.TrimSpace(worker.ModelLocality) != models.RuntimeModelLocalityLocal {
+			continue
+		}
+		copied := worker
+		return &copied, nil
+	}
+	return nil, fmt.Errorf("local model worker not found for %q", modelName)
+}
+
+func modelBackend(runtimeCfg *models.RuntimeConfig, modelName string) string {
+	resource := modelScopedResource(runtimeCfg, modelName)
+	if resource == nil {
+		return ""
+	}
+	return strings.TrimSpace(resource.Backend)
+}
+
+func modelScopedResource(factoryCfg *models.RuntimeConfig, modelName string) *models.RuntimeResource {
+	if factoryCfg == nil {
+		return nil
+	}
+	key := localmodels.CanonicalModelName(modelName)
+	for _, resource := range factoryCfg.Resources {
+		if strings.TrimSpace(resource.Type) != models.RuntimeResourceTypeModel {
+			continue
+		}
+		if localmodels.CanonicalModelName(resource.Model) != key {
+			continue
+		}
+		copied := resource
+		return &copied
+	}
+	return nil
+}
+
+func supervisedIdentityForModel(runtimeCfg *models.RuntimeConfig, modelName string) supervisedIdentity {
+	return supervisedIdentity{
+		Name:    strings.TrimSpace(modelName),
+		Backend: modelBackend(runtimeCfg, modelName),
+	}
+}
+
+func cacheInspectionFromAssets(inspection scopedassets.RuntimeCacheInspection) cacheInspection {
+	return cacheInspection{
+		Supported:          inspection.Supported,
+		Installed:          inspection.Installed,
+		Revision:           inspection.Revision,
+		CachePath:          inspection.CachePath,
+		InstalledFileCount: inspection.InstalledFileCount,
+		MissingAssets:      append([]string(nil), inspection.MissingAssets...),
+		PartialArtifacts:   inspection.PartialArtifacts,
+	}
+}
+
+type cacheInspection struct {
+	Supported          bool
+	Installed          bool
+	Revision           string
+	CachePath          string
+	InstalledFileCount int
+	MissingAssets      []string
+	PartialArtifacts   bool
+}
+
+func defaultServerStartBuilder(
+	identity supervisedIdentity,
+	inspection cacheInspection,
+	worker *models.RuntimeWorker,
+) (models.HostProcessStartSpec, error) {
+	if worker == nil {
+		return models.HostProcessStartSpec{}, fmt.Errorf(
+			"local model worker is required for supervised backend %q",
+			identity.Backend,
+		)
+	}
+	command := strings.TrimSpace(worker.Command)
+	if command == "" {
+		command = localmodels.DefaultOmniVoiceCommand
+	}
+	healthEndpoint, args, err := supervisedHealthEndpointAndArgs(worker.Args)
+	if err != nil {
+		return models.HostProcessStartSpec{}, err
+	}
+	if strings.TrimSpace(inspection.CachePath) == "" {
+		return models.HostProcessStartSpec{}, fmt.Errorf(
+			"%w: cache path is required for supervised runtime %q",
+			models.ErrHostMissingAssets,
+			identity.Name,
+		)
+	}
+	args = append([]string{"serve"}, args...)
+	args = append(args, "--cache-path", inspection.CachePath)
+	return models.HostProcessStartSpec{
+		Command:        command,
+		Args:           args,
+		HealthEndpoint: healthEndpoint,
+	}, nil
+}
+
+func supervisedHealthEndpointAndArgs(workerArgs []string) (string, []string, error) {
+	args := append([]string(nil), workerArgs...)
+	for i := 0; i < len(args); i++ {
+		if args[i] != supervisedHealthEndpointFlag {
+			continue
+		}
+		if i+1 >= len(args) {
+			return "", nil, fmt.Errorf("flag %q requires a value", supervisedHealthEndpointFlag)
+		}
+		endpoint := strings.TrimSpace(args[i+1])
+		remaining := append(append([]string(nil), args[:i]...), args[i+2:]...)
+		if endpoint == "" {
+			return "", nil, fmt.Errorf("flag %q requires a non-empty value", supervisedHealthEndpointFlag)
+		}
+		return endpoint, remaining, nil
+	}
+	return "", args, fmt.Errorf(
+		"supervised llama.cpp runtime requires worker arg %q",
+		supervisedHealthEndpointFlag,
+	)
+}
+
+func workerDeclaresSupervisedHealthEndpoint(worker *models.RuntimeWorker) bool {
+	if worker == nil {
+		return false
+	}
+	_, _, err := supervisedHealthEndpointAndArgs(worker.Args)
+	return err == nil
+}
+
+func cancelHostError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%w: %w", models.ErrHostCancelled, err)
+}

--- a/pkg/services/models/internal/services/runtime_host/internal/service/unload_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/unload_test.go
@@ -1,0 +1,411 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/service"
+	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
+)
+
+func TestStopModelHostStopsReadySupervisedProcess(t *testing.T) {
+	t.Parallel()
+
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(healthServer.Close)
+
+	var stopCount atomic.Int32
+	cacheDirectory := t.TempDir()
+	writeCacheFixture(t, cacheDirectory, true)
+	scopes := newScopes(t, "explicit-unload")
+	ref := openScope(t, scopes, cacheDirectory, supervisedRuntimeConfig())
+	launcher := &fakeProcessLauncher{
+		newProcess: func(spec models.HostProcessStartSpec) *fakeManagedProcess {
+			process := newFakeManagedProcess(healthServer.URL, nil)
+			process.stopFn = func() error {
+				stopCount.Add(1)
+				return process.defaultStop()
+			}
+			return process
+		},
+	}
+	service := newTestRuntimeHostWithScopesAndClock(t, scopes, launcher, realHostClock{})
+
+	_, err := service.EnsureModelHost(context.Background(), models.EnsureModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("EnsureModelHost: %v", err)
+	}
+
+	stopped, err := service.StopModelHost(context.Background(), models.StopModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("StopModelHost: %v", err)
+	}
+	if stopped.Outcome != models.HostStopStopped ||
+		stopped.Host.LifecycleState != models.LifecycleStateInstalled {
+		t.Fatalf("stop result = %#v, want stopped/installed", stopped)
+	}
+	if stopCount.Load() != 1 {
+		t.Fatalf("stop count = %d, want 1", stopCount.Load())
+	}
+	inspected, err := service.InspectModelHost(context.Background(), models.InspectModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("InspectModelHost: %v", err)
+	}
+	if inspected.Host.LifecycleState != models.LifecycleStateInstalled {
+		t.Fatalf("inspect after stop = %#v, want installed without live slot", inspected.Host)
+	}
+}
+
+func TestStopModelHostRejectsLoadingRuntime(t *testing.T) {
+	t.Parallel()
+
+	healthChecker := &blockingHealthChecker{started: make(chan struct{})}
+	cacheDirectory := t.TempDir()
+	writeCacheFixture(t, cacheDirectory, true)
+	scopes := newScopes(t, "unload-loading")
+	ref := openScope(t, scopes, cacheDirectory, supervisedRuntimeConfig())
+	service := internalservice.NewWithSupervisorTestConfig(
+		scopes,
+		mustAssetsService(t, scopes),
+		&fakeProcessLauncher{
+			newProcess: func(spec models.HostProcessStartSpec) *fakeManagedProcess {
+				return newFakeManagedProcess(spec.HealthEndpoint, nil)
+			},
+		},
+		http.DefaultClient,
+		realHostClock{},
+		nil,
+		nil,
+		internalservice.SupervisorTestConfig{
+			ReadinessTimeout:    time.Second,
+			HealthCheckInterval: 25 * time.Millisecond,
+			HealthChecker:       healthChecker,
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := service.EnsureModelHost(ctx, models.EnsureModelHostRequest{
+			Scope: ref,
+			Name:  "OMNIVOICE_Q4_K_M",
+		})
+		errCh <- err
+	}()
+	<-healthChecker.started
+
+	_, err := service.StopModelHost(context.Background(), models.StopModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	cancel()
+	<-errCh
+
+	var readinessErr *models.HostReadinessError
+	if !errors.As(err, &readinessErr) {
+		t.Fatalf("StopModelHost error = %v, want *HostReadinessError", err)
+	}
+	if !errors.Is(err, models.ErrHostCapacityExhausted) {
+		t.Fatalf("StopModelHost error = %v, want ErrHostCapacityExhausted", err)
+	}
+	if readinessErr.Snapshot.ReadinessState != models.ReadinessStateLoading {
+		t.Fatalf("readiness = %s, want LOADING", readinessErr.Snapshot.ReadinessState)
+	}
+}
+
+func TestStopModelHostRejectsActiveCapacityHolder(t *testing.T) {
+	t.Parallel()
+
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(healthServer.Close)
+
+	cacheDirectory := t.TempDir()
+	writeCacheFixture(t, cacheDirectory, true)
+	scopes := newScopes(t, "unload-active-holder")
+	ref := openScope(t, scopes, cacheDirectory, supervisedRuntimeConfig())
+	service := newTestRuntimeHostWithScopesAndClock(t, scopes, &fakeProcessLauncher{
+		newProcess: func(spec models.HostProcessStartSpec) *fakeManagedProcess {
+			return newFakeManagedProcess(healthServer.URL, nil)
+		},
+	}, realHostClock{})
+
+	_, err := service.EnsureModelHost(context.Background(), models.EnsureModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("EnsureModelHost: %v", err)
+	}
+	internalservice.AcquireSlotCapacity(service, ref, "OMNIVOICE_Q4_K_M")
+
+	_, err = service.StopModelHost(context.Background(), models.StopModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if !errors.Is(err, models.ErrHostCapacityExhausted) {
+		t.Fatalf("StopModelHost with active holder = %v, want capacity exhausted", err)
+	}
+
+	cfg := supervisedRuntimeConfig()
+	internalservice.ReleaseSlotCapacity(service, ref, "OMNIVOICE_Q4_K_M", &cfg)
+	_, err = service.StopModelHost(context.Background(), models.StopModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("StopModelHost after release: %v", err)
+	}
+}
+
+func TestIdleUnloadStopsRuntimeAfterLastCapacityReleased(t *testing.T) {
+	t.Parallel()
+
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(healthServer.Close)
+
+	var stopCount atomic.Int32
+	cacheDirectory := t.TempDir()
+	writeCacheFixture(t, cacheDirectory, true)
+	scopes := newScopes(t, "idle-unload")
+	ref := openScope(t, scopes, cacheDirectory, supervisedRuntimeConfig())
+	service := newRuntimeHostWithPolicy(
+		t,
+		scopes,
+		&fakeProcessLauncher{
+			newProcess: func(spec models.HostProcessStartSpec) *fakeManagedProcess {
+				process := newFakeManagedProcess(healthServer.URL, nil)
+				process.stopFn = func() error {
+					stopCount.Add(1)
+					return process.defaultStop()
+				}
+				return process
+			},
+		},
+		internalservice.HostPolicyTestConfig{IdleUnloadAfter: 40 * time.Millisecond},
+	)
+
+	_, err := service.EnsureModelHost(context.Background(), models.EnsureModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("EnsureModelHost: %v", err)
+	}
+	internalservice.AcquireSlotCapacity(service, ref, "OMNIVOICE_Q4_K_M")
+	cfg := supervisedRuntimeConfig()
+	internalservice.ReleaseSlotCapacity(service, ref, "OMNIVOICE_Q4_K_M", &cfg)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for stopCount.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for idle unload")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestIdleUnloadDoesNotStopActiveCapacityHolder(t *testing.T) {
+	t.Parallel()
+
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(healthServer.Close)
+
+	var stopCount atomic.Int32
+	cacheDirectory := t.TempDir()
+	writeCacheFixture(t, cacheDirectory, true)
+	scopes := newScopes(t, "idle-active-holder")
+	ref := openScope(t, scopes, cacheDirectory, supervisedRuntimeConfig())
+	service := newRuntimeHostWithPolicy(
+		t,
+		scopes,
+		&fakeProcessLauncher{
+			newProcess: func(spec models.HostProcessStartSpec) *fakeManagedProcess {
+				process := newFakeManagedProcess(healthServer.URL, nil)
+				process.stopFn = func() error {
+					stopCount.Add(1)
+					return process.defaultStop()
+				}
+				return process
+			},
+		},
+		internalservice.HostPolicyTestConfig{IdleUnloadAfter: 40 * time.Millisecond},
+	)
+
+	_, err := service.EnsureModelHost(context.Background(), models.EnsureModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("EnsureModelHost: %v", err)
+	}
+	internalservice.AcquireSlotCapacity(service, ref, "OMNIVOICE_Q4_K_M")
+
+	time.Sleep(120 * time.Millisecond)
+	if stopCount.Load() != 0 {
+		t.Fatalf("stop count = %d, want 0 while holder active", stopCount.Load())
+	}
+
+	inspected, err := service.InspectModelHost(context.Background(), models.InspectModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("InspectModelHost: %v", err)
+	}
+	if inspected.Host.ReadinessState != models.ReadinessStateReady {
+		t.Fatalf("readiness = %s, want READY", inspected.Host.ReadinessState)
+	}
+}
+
+func TestResourcePressureEvictsIdleRuntime(t *testing.T) {
+	t.Parallel()
+
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(healthServer.Close)
+
+	var stopCount atomic.Int32
+	cacheDirectoryA := t.TempDir()
+	writeCacheFixture(t, cacheDirectoryA, true)
+	cacheDirectoryB := t.TempDir()
+	writeCacheFixture(t, cacheDirectoryB, true)
+	scopes := newScopes(t, "pressure-eviction")
+	refA := openScope(t, scopes, cacheDirectoryA, supervisedRuntimeConfig())
+	refB := openScope(t, scopes, cacheDirectoryB, supervisedRuntimeConfig())
+	service := newRuntimeHostWithPolicy(
+		t,
+		scopes,
+		&fakeProcessLauncher{
+			newProcess: func(spec models.HostProcessStartSpec) *fakeManagedProcess {
+				process := newFakeManagedProcess(healthServer.URL, nil)
+				process.stopFn = func() error {
+					stopCount.Add(1)
+					return process.defaultStop()
+				}
+				return process
+			},
+		},
+		internalservice.HostPolicyTestConfig{MaxLoadedRuntimes: 1},
+	)
+
+	_, err := service.EnsureModelHost(context.Background(), models.EnsureModelHostRequest{
+		Scope: refA,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("EnsureModelHost A: %v", err)
+	}
+
+	_, err = service.EnsureModelHost(context.Background(), models.EnsureModelHostRequest{
+		Scope: refB,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("EnsureModelHost B: %v", err)
+	}
+	if stopCount.Load() != 1 {
+		t.Fatalf("stop count = %d, want eviction of idle prior runtime", stopCount.Load())
+	}
+}
+
+func TestShutdownStopsSupervisedRuntimesAndCancelsIdleTimers(t *testing.T) {
+	t.Parallel()
+
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(healthServer.Close)
+
+	var stopCount atomic.Int32
+	cacheDirectory := t.TempDir()
+	writeCacheFixture(t, cacheDirectory, true)
+	scopes := newScopes(t, "shutdown-cleanup")
+	ref := openScope(t, scopes, cacheDirectory, supervisedRuntimeConfig())
+	service := newRuntimeHostWithPolicy(
+		t,
+		scopes,
+		&fakeProcessLauncher{
+			newProcess: func(spec models.HostProcessStartSpec) *fakeManagedProcess {
+				process := newFakeManagedProcess(healthServer.URL, nil)
+				process.stopFn = func() error {
+					stopCount.Add(1)
+					return process.defaultStop()
+				}
+				return process
+			},
+		},
+		internalservice.HostPolicyTestConfig{IdleUnloadAfter: time.Minute},
+	)
+
+	_, err := service.EnsureModelHost(context.Background(), models.EnsureModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("EnsureModelHost: %v", err)
+	}
+
+	if err := internalservice.ShutdownHost(context.Background(), service); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if stopCount.Load() != 1 {
+		t.Fatalf("stop count = %d, want 1", stopCount.Load())
+	}
+}
+
+func newRuntimeHostWithPolicy(
+	t *testing.T,
+	scopes runtimescopes.Service,
+	launcher models.HostProcessLauncher,
+	policy internalservice.HostPolicyTestConfig,
+) runtimehost.Service {
+	t.Helper()
+	return internalservice.NewWithHostTestConfig(
+		scopes,
+		mustAssetsService(t, scopes),
+		launcher,
+		http.DefaultClient,
+		realHostClock{},
+		nil,
+		nil,
+		internalservice.SupervisorTestConfig{},
+		policy,
+	)
+}
+
+type blockingHealthChecker struct {
+	started chan struct{}
+	once    sync.Once
+}
+
+func (checker *blockingHealthChecker) Check(ctx context.Context, _ string) error {
+	checker.once.Do(func() { close(checker.started) })
+	<-ctx.Done()
+	return ctx.Err()
+}

--- a/pkg/services/models/internal/services/runtime_host/service.go
+++ b/pkg/services/models/internal/services/runtime_host/service.go
@@ -1,0 +1,26 @@
+// Package runtimehost defines the parent-private Models Runtime Host service.
+package runtimehost
+
+import (
+	"context"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+// Service supervises scoped model-host capacity behind the singular Models root.
+// Peers reach supervise, health, reuse, and unload behavior only through the
+// process-scoped Models service; this interface stays parent-private.
+type Service interface {
+	InspectModelHost(
+		context.Context,
+		models.InspectModelHostRequest,
+	) (models.InspectModelHostResult, error)
+	EnsureModelHost(
+		context.Context,
+		models.EnsureModelHostRequest,
+	) (models.EnsureModelHostResult, error)
+	StopModelHost(
+		context.Context,
+		models.StopModelHostRequest,
+	) (models.StopModelHostResult, error)
+}

--- a/pkg/services/models/internal/services/runtime_host/wire/wire.go
+++ b/pkg/services/models/internal/services/runtime_host/wire/wire.go
@@ -1,0 +1,64 @@
+// Package wire constructs the private Models Runtime Host subservice.
+package wire
+
+import (
+	"fmt"
+	"reflect"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/service"
+	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+)
+
+// NewService constructs an inert Runtime Host over accepted runtime-scope and
+// assets contracts. Construction validates injected supervision effects and
+// allocates host state only; it does not launch subprocesses.
+func NewService(
+	scopes runtimescopes.Service,
+	assets scopedassets.Service,
+	processLauncher models.HostProcessLauncher,
+	hostHTTP models.HostHTTPDoer,
+	hostClock models.HostClock,
+	hostLogger models.HostDiagnosticLogger,
+	hostMetrics models.HostMetricsRecorder,
+) (runtimehost.Service, error) {
+	if scopes == nil {
+		return nil, fmt.Errorf("%w: Models Runtime Scopes service is required", models.ErrInvalidHostDependencies)
+	}
+	if isNilDependency(assets) {
+		return nil, fmt.Errorf("%w: Models Assets service is required", models.ErrInvalidHostDependencies)
+	}
+	if isNilDependency(processLauncher) {
+		return nil, fmt.Errorf("%w: model host process launcher is required", models.ErrInvalidHostDependencies)
+	}
+	if isNilDependency(hostHTTP) {
+		return nil, fmt.Errorf("%w: model host HTTP client is required", models.ErrInvalidHostDependencies)
+	}
+	if isNilDependency(hostClock) {
+		return nil, fmt.Errorf("%w: model host clock is required", models.ErrInvalidHostDependencies)
+	}
+	return internalservice.New(
+		scopes,
+		assets,
+		processLauncher,
+		hostHTTP,
+		hostClock,
+		hostLogger,
+		hostMetrics,
+	), nil
+}
+
+func isNilDependency(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/pkg/services/models/internal/services/runtime_host/wire/wire_test.go
+++ b/pkg/services/models/internal/services/runtime_host/wire/wire_test.go
@@ -1,0 +1,158 @@
+package wire_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
+	runtimehostwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/wire"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
+)
+
+func TestNewServiceRequiresRuntimeHostDependencies(t *testing.T) {
+	t.Parallel()
+
+	scopes := testRuntimeScopes(t)
+	assets := &recordingAssetsService{}
+	launcher := &recordingProcessLauncher{}
+	clock := testHostClock{}
+
+	tests := []struct {
+		name            string
+		scopes          runtimescopes.Service
+		assets          *recordingAssetsService
+		launcher        *recordingProcessLauncher
+		hostHTTP        models.HostHTTPDoer
+		clock           models.HostClock
+		wantContains    string
+		wantInvalidDeps bool
+	}{
+		{
+			name: "valid", scopes: scopes, assets: assets, launcher: launcher,
+			hostHTTP: http.DefaultClient, clock: clock,
+		},
+		{
+			name: "scopes", assets: assets, launcher: launcher,
+			hostHTTP: http.DefaultClient, clock: clock, wantContains: "Runtime Scopes",
+			wantInvalidDeps: true,
+		},
+		{
+			name: "assets", scopes: scopes, launcher: launcher,
+			hostHTTP: http.DefaultClient, clock: clock, wantContains: "Assets",
+			wantInvalidDeps: true,
+		},
+		{
+			name: "process launcher", scopes: scopes, assets: assets,
+			hostHTTP: http.DefaultClient, clock: clock, wantContains: "process launcher",
+			wantInvalidDeps: true,
+		},
+		{
+			name: "host http", scopes: scopes, assets: assets, launcher: launcher,
+			clock: clock, wantContains: "HTTP client", wantInvalidDeps: true,
+		},
+		{
+			name: "host clock", scopes: scopes, assets: assets, launcher: launcher,
+			hostHTTP: http.DefaultClient, wantContains: "clock", wantInvalidDeps: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service, err := runtimehostwire.NewService(
+				test.scopes,
+				test.assets,
+				test.launcher,
+				test.hostHTTP,
+				test.clock,
+				nil,
+				nil,
+			)
+			if test.wantInvalidDeps {
+				if service != nil || err == nil {
+					t.Fatalf("NewService = (%#v, %v), want dependency error", service, err)
+				}
+				if !errors.Is(err, models.ErrInvalidHostDependencies) {
+					t.Fatalf("error = %v, want ErrInvalidHostDependencies", err)
+				}
+				if test.wantContains != "" && !strings.Contains(err.Error(), test.wantContains) {
+					t.Fatalf("error = %q, want substring %q", err.Error(), test.wantContains)
+				}
+				if launcher.starts != 0 {
+					t.Fatalf("process starts during validation = %d, want 0", launcher.starts)
+				}
+				return
+			}
+			if service == nil || err != nil {
+				t.Fatalf("NewService = (%#v, %v), want service", service, err)
+			}
+			if launcher.starts != 0 {
+				t.Fatalf("process starts during construction = %d, want 0", launcher.starts)
+			}
+		})
+	}
+}
+
+func testRuntimeScopes(t *testing.T) runtimescopes.Service {
+	t.Helper()
+	scopes, err := runtimescopeswire.NewService(func() string { return "runtime-host-wire-test" })
+	if err != nil {
+		t.Fatalf("construct runtime scopes: %v", err)
+	}
+	return scopes
+}
+
+type recordingProcessLauncher struct {
+	starts int
+}
+
+func (launcher *recordingProcessLauncher) Start(
+	context.Context,
+	models.HostProcessStartSpec,
+) (models.HostManagedProcess, error) {
+	launcher.starts++
+	panic("process launcher called during inert construction")
+}
+
+type testHostClock struct{}
+
+func (testHostClock) Now() time.Time { return time.Unix(0, 0) }
+func (testHostClock) NewTimer(time.Duration) models.HostTimer {
+	panic("host timer created during inert construction")
+}
+
+type recordingAssetsService struct{}
+
+var _ scopedassets.Service = recordingAssetsService{}
+
+func (recordingAssetsService) PrepareModelAssets(
+	context.Context,
+	models.PrepareModelAssetsRequest,
+) (models.PrepareModelAssetsResult, error) {
+	return models.PrepareModelAssetsResult{}, models.ErrUnsupportedOperation
+}
+
+func (recordingAssetsService) InspectModelAssets(
+	context.Context,
+	models.InspectModelAssetsRequest,
+) (models.InspectModelAssetsResult, error) {
+	return models.InspectModelAssetsResult{}, models.ErrUnsupportedOperation
+}
+
+func (recordingAssetsService) ResolveRuntimeCache(
+	context.Context,
+	models.InspectModelAssetsRequest,
+) (scopedassets.RuntimeCacheLayout, error) {
+	return scopedassets.RuntimeCacheLayout{}, models.ErrUnsupportedOperation
+}
+
+func (recordingAssetsService) InspectRuntimeCache(
+	context.Context,
+	models.InspectModelAssetsRequest,
+) (scopedassets.RuntimeCacheInspection, error) {
+	return scopedassets.RuntimeCacheInspection{}, models.ErrUnsupportedOperation
+}

--- a/pkg/services/models/wire/wire.go
+++ b/pkg/services/models/wire/wire.go
@@ -19,6 +19,7 @@ import (
 	assetswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets/wire"
 	catalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
 	catalogwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire"
+	runtimehostwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/wire"
 	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
 	"go.uber.org/zap"
 )
@@ -106,11 +107,23 @@ func NewService(
 	if err != nil {
 		return nil, err
 	}
+	runtimeHost, err := runtimehostwire.NewService(
+		runtimeScopes,
+		assetService,
+		processLauncher,
+		hostHTTP,
+		hostClock,
+		hostLogger,
+		hostMetrics,
+	)
+	if err != nil {
+		return nil, err
+	}
 	service, err := modelsservice.NewRoot(
 		launcher, hostHTTP, clock,
 		runtimeRunner, runtimeHTTP, localmodels.InspectFile(runtimeInspect),
 		localmodels.TempDirectory(runtimeTempDir), createTempFile,
-		runtimeScopes, catalogService, assetService,
+		runtimeScopes, catalogService, assetService, runtimeHost,
 		models.ProcessDependencies{
 			Logger: logger, Clock: now, PullMetrics: pullMetrics,
 			HostLogger: hostLogger, HostMetrics: hostMetrics, LocalHooks: localHooks,

--- a/pkg/services/models/wire/wire_test.go
+++ b/pkg/services/models/wire/wire_test.go
@@ -206,6 +206,78 @@ func TestProductionCompositionInspectsScopedAssetsThroughModelsRoot(t *testing.T
 	}
 }
 
+func TestProductionCompositionInspectsScopedHostThroughModelsRoot(t *testing.T) {
+	t.Parallel()
+
+	service := newProductionTestService(t)
+	cacheDirectory := t.TempDir()
+	config := models.RuntimeConfig{
+		Resources: []models.RuntimeResource{{
+			Name:     "omnivoice-cache",
+			Type:     models.RuntimeResourceTypeModel,
+			Model:    "OMNIVOICE_Q4_K_M",
+			Provider: "MODELSCOPE",
+		}},
+	}
+	opened, err := service.OpenRuntimeScope(context.Background(), models.OpenRuntimeScopeRequest{
+		Config: models.RuntimeScopeConfig{CacheDirectory: cacheDirectory, Runtime: config},
+	})
+	if err != nil {
+		t.Fatalf("OpenRuntimeScope: %v", err)
+	}
+
+	missing, err := service.InspectModelHost(context.Background(), models.InspectModelHostRequest{
+		Scope: opened.Scope,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("InspectModelHost before cache transition: %v", err)
+	}
+	if missing.Host.ReadinessState != models.ReadinessStateMissing {
+		t.Fatalf("initial host readiness = %s, want MISSING", missing.Host.ReadinessState)
+	}
+
+	root := filepath.Join(cacheDirectory, "OMNIVOICE_Q4_K_M")
+	revisionDirectory := filepath.Join(root, "rev-root")
+	if err := os.MkdirAll(revisionDirectory, 0o755); err != nil {
+		t.Fatalf("create revision directory: %v", err)
+	}
+	files := []string{"omnivoice-base-Q4_K_M.gguf", "omnivoice-tokenizer-Q4_K_M.gguf"}
+	assetBody := []byte("asset")
+	for _, name := range files {
+		if err := os.WriteFile(filepath.Join(revisionDirectory, name), assetBody, 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	assetChecksum := fmt.Sprintf("%x", sha256.Sum256(assetBody))
+	metadata, err := json.Marshal(map[string]any{
+		"modelName": "OMNIVOICE_Q4_K_M",
+		"revision":  "rev-root",
+		"files": []map[string]any{
+			{"path": files[0], "bytes": len(assetBody), "sha256": assetChecksum},
+			{"path": files[1], "bytes": len(assetBody), "sha256": assetChecksum},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".managed-cache.json"), metadata, 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	ready, err := service.InspectModelHost(context.Background(), models.InspectModelHostRequest{
+		Scope: opened.Scope,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("InspectModelHost after cache transition: %v", err)
+	}
+	if ready.Host.ReadinessState != models.ReadinessStateReady ||
+		ready.Host.LifecycleState != models.LifecycleStateInstalled {
+		t.Fatalf("ready host snapshot = %#v, want READY/INSTALLED from assets facts", ready.Host)
+	}
+}
+
 func TestProductionCompositionPreparesAssetsThroughModelsRoot(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "structured-packages-implementation-mod-04-runtime-host",
  "description": "Package Models Runtime Host supervision so supervise, health, reuse, and unload behavior is parent-private behind the singular process-scoped Models root, with inert construction, deterministic crash/eviction/reuse/cleanup outcomes, accepted runtime-scope and assets binding, and focused unit plus root.BuildProcess evidence through package-boundary verification, without reopening catalog/providers or editing OpenAPI, CLI root, Factory Runtime dispatch, or Workers runners.",
  "context": {
    "customerAsk": "After terminal IMP-MOD-03 assets, package Models internal/services/runtime_host so runtime supervise/health/reuse/unload behavior is parent-private behind the Models root. Construction remains inert; selected scopes bind through accepted runtime-scope contracts. Consume accepted runtime_scopes and assets contracts; do not reopen catalog ownership or provider adapters. Do not edit OpenAPI/generation, CLI root composition, Factory Runtime dispatch planning, or Workers runners. Continue the implementation and review loop until required CI is terminal and passing, blocking PR feedback is addressed, merge conflicts are resolved, and the PR is actually merged.",
    "problem": "Models runtime-host behavior still lives in a legacy host implementation that owns supervised process slots, readiness probing, handle reuse, idle unload, resource-pressure eviction, crash classification, and shutdown. That placement keeps supervision outside the packaged Models subservice layout, makes peer reachability of host internals easier, and leaves crash/eviction/reuse/cleanup harder to keep deterministic behind one parent-private owner for later leases and inference packets.",
    "solution": "Make the parent-private Models Runtime Host subservice the sole owner of supervise, health, reuse, and unload behavior behind the singular process-scoped Models root. Construction stays inert; selected scopes bind through accepted runtime-scope contracts; assets readiness is consumed without reopening catalog or providers. Preserve deterministic crash, eviction, reuse, and cleanup outcomes with bounded diagnostics; prove ownership with focused unit and root.BuildProcess evidence plus package-boundary gates; retire the legacy host seam after parity."
  },
  "acceptanceCriteria": [
    "AC-1: Runtime host supervision is owned by internal/services/runtime_host and reached by peers only through the singular process-scoped Models root.",
    "AC-2: Models Runtime Host construction is inert: validating and composing the host allocates state and accepts injected effects without launching a supervised subprocess or starting application lifecycle.",
    "AC-3: Crash, readiness-timeout, handle reuse, idle unload, resource-pressure eviction, cancellation, unload, and shutdown cleanup behave deterministically and emit only bounded Models-owned diagnostics.",
    "AC-4: Selected Factory/runtime scopes bind through accepted runtime-scope contracts; host work consumes accepted assets readiness facts and does not reopen catalog ownership, provider adapters, OpenAPI/generation, CLI root composition, Factory Runtime dispatch planning, or Workers runners.",
    "AC-5: Focused Runtime Host unit evidence and root.BuildProcess functional evidence pass together with package-boundary and verification gates for the moved ownership.",
    "AC-6: Quality gates pass: typecheck, lint, focused Models runtime-host tests, and the required repository test suite.",
    "AC-7: The implementation/review cycle continues until required CI is terminal and passing, every blocking PR conversation comment is explicitly addressed, merge conflicts and shared coverage/ownership/package-target manifest churn are reconciled, and the PR is actually merged; opening, approving, or making the PR merge-ready is not completion."
  ],
  "userStories": [
    {
      "id": "structured-packages-implementation-mod-04-runtime-host-001",
      "title": "Compose inert Runtime Host behind the Models root",
      "description": "As a maintainer, I want Runtime Host supervision constructed once behind the singular Models root so peers cannot reach host internals and Factory selection cannot reconstruct Models.",
      "acceptanceCriteria": [
        "The process-scoped Models root composes one parent-private Runtime Host capability and is the only peer-facing path to supervise/health/reuse/unload behavior.",
        "Constructing Models/Runtime Host with valid injected effects allocates host state without launching a supervised subprocess, opening network listeners, or starting application lifecycle.",
        "Missing or invalid required host dependencies fail synchronously at construction with the Models-owned invalid-dependencies classification and still launch no process.",
        "Opening or selecting a Factory/runtime scope binds through the accepted opaque runtime-scope contract and does not construct another Models service, host, puller, or deferred dependency bundle.",
        "Host readiness/missing-asset decisions consume accepted assets facts rather than reopening catalog ownership or provider adapters.",
        "Focused inert-construction and Models composition tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "structured-packages-implementation-mod-04-runtime-host-002",
      "title": "Supervise healthy startup and reuse one ready runtime",
      "description": "As a Models consumer, I want a managed runtime to start once, become ready through health probing, and be reused so concurrent demand shares one supervised slot instead of launching duplicate processes.",
      "acceptanceCriteria": [
        "For installed assets and a supported supervised backend, ensuring or acquiring host capacity starts one supervised process, waits for health readiness within the configured timeout, and returns a ready outcome with a usable endpoint.",
        "Concurrent requesters for the same ready model reuse the same supervised runtime slot/endpoint rather than launching additional processes while capacity remains available.",
        "Inspecting readiness for installed assets without a live supervised slot reports installed/missing readiness from assets facts and does not invent a live process.",
        "Successful readiness and reuse results are detached Models-owned values that do not expose private process handles, launcher types, or host implementation structs to peers.",
        "Focused healthy-startup and reuse tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "structured-packages-implementation-mod-04-runtime-host-003",
      "title": "Classify crash and readiness-timeout failures with bounded diagnostics",
      "description": "As a runtime operator, I want supervised startup failures and unexpected process exits to surface typed Models outcomes with bounded diagnostics so callers can recover without opaque host dumps.",
      "acceptanceCriteria": [
        "When health readiness does not complete before the configured timeout, Models returns the loading-timeout classification and does not report the runtime as ready.",
        "When a supervised process exits unexpectedly during or after startup, Models returns the process-crash classification and subsequent readiness inspection reports the failed supervised state.",
        "Cancellation during supervised startup stops the managed process and returns the Models-owned cancellation classification while preserving the underlying context cancellation cause.",
        "Failure diagnostics emit bounded model/runtime identity, failure-class, and phase facts (for example one failure log and metric) without unbounded process output dumps or private filesystem/implementation leakage through public contracts.",
        "Focused crash, readiness-timeout, cancellation, and diagnostics tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "structured-packages-implementation-mod-04-runtime-host-004",
      "title": "Evict idle runtimes and clean up supervised processes",
      "description": "As a runtime operator, I want idle and pressure-driven unload plus explicit shutdown to stop supervised processes deterministically so host capacity and process lifetime stay coherent.",
      "acceptanceCriteria": [
        "After the last active user of a supervised runtime releases capacity, idle unload stops the managed process within the configured idle window and leaves no live slot for that model.",
        "Idle unload does not stop a runtime that still has active capacity holders.",
        "When loaded-runtime capacity pressure requires another model, an idle supervised runtime is evicted/stopped so the new runtime can load; an actively held runtime is not evicted by that pressure path.",
        "Explicit unload of a ready supervised runtime stops the managed process; unload of a still-loading runtime is rejected with the existing typed non-ready/capacity classification rather than leaving an orphan process.",
        "Host/process shutdown stops all supervised runtimes and cancels outstanding idle-unload timers without relaunching processes.",
        "Focused idle-unload, pressure-eviction, unload, and shutdown-cleanup tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "structured-packages-implementation-mod-04-runtime-host-005",
      "title": "Cut over composition and prove package-boundary ownership",
      "description": "As a maintainer, I want Runtime Host owned only under internal/services/runtime_host, proven through Models composition and root.BuildProcess, so package-boundary gates and verification stay aligned.",
      "acceptanceCriteria": [
        "Models wire and the process composition graph construct Runtime Host only as a parent-private Models child; no peer package imports the Runtime Host implementation as a public service.",
        "The superseded legacy Models host implementation path is removed or reduced to zero callers after behavioral parity through the packaged Runtime Host path is proven.",
        "Package-boundary, ownership-inventory, and package-target-manifest verification gates record Runtime Host under models/internal/services/runtime_host and pass for the moved ownership.",
        "Focused root.BuildProcess functional evidence shows the process-scoped Models graph constructs successfully with inert Runtime Host composition and without deferred peer-service construction for host supervision.",
        "This story does not change OpenAPI/generation, CLI root composition, Factory Runtime dispatch planning, Workers runners, catalog ownership, or provider adapters.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}
