### PR TITLE
ft-wave1-cli-json-values

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -263,6 +263,17 @@
   metadata infers domain `transport` and subsection `cli/parameters` from the
   path; every top-level `Test*` needs a customer-readable Go doc so
   `functionaltestmetadata` stays viz-compatible.
+  CLI JSON parameter values functional coverage belongs in
+  `tests/functional/transport/cli/parameters/json_values_test.go`: prove nested
+  JSON object and array named parameters reach canonical `InvocationArguments`
+  intact through `SubmissionRecorder`, prove invalid JSON for a `typeHint: "JSON"`
+  parameter fails with a named-parameter diagnostic and zero provider dispatch
+  through `ProviderCommandRunner`, and prove JSON `null`, empty string, empty
+  object, and empty array remain observably distinct without normalization loss
+  at the public `support.BuildProcess` boundary. Catalog metadata infers domain
+  `transport` and subsection `cli/parameters` from the path; every top-level
+  `Test*` needs a customer-readable Go doc so `functionaltestmetadata` stays
+  viz-compatible.
   CLI response-stream backpressure functional coverage belongs in
   `tests/functional/transport/cli/output/stream_backpressure_test.go`:
   invoke `support.BuildProcess` with a gated or mid-stream-failing stdout writer

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -91,7 +91,7 @@ intentionally small enough to distribute across many agents.
   - `TestRunDuplicateKeyUsesDocumentedPrecedence` covers duplicate input.
   - `TestRunMalformedKeyValueFailsWithoutDispatch` covers missing key/value.
 
-- [ ] `tests/functional/transport/cli/parameters/json_values_test.go`
+- [x] `tests/functional/transport/cli/parameters/json_values_test.go`
   - `TestCLIJSONParameterPreservesNestedObjectAndArray` verifies typed payload
     mapping.
   - `TestCLIInvalidJSONParameterNamesTheParameter` verifies actionable error

--- a/pkg/services/factory_definitions/contracts/factory_config.go
+++ b/pkg/services/factory_definitions/contracts/factory_config.go
@@ -337,6 +337,7 @@ const (
 	InvocationParameterTypeHintDirectoryPath = work.InvocationParameterTypeHintDirectoryPath
 	InvocationParameterTypeHintNumberString  = work.InvocationParameterTypeHintNumberString
 	InvocationParameterTypeHintBooleanString = work.InvocationParameterTypeHintBooleanString
+	InvocationParameterTypeHintJSON          = work.InvocationParameterTypeHintJSON
 
 	InvocationParameterValueModeExact        = work.InvocationParameterValueModeExact
 	InvocationParameterValueModeRepeated     = work.InvocationParameterValueModeRepeated

--- a/pkg/services/factory_definitions/validation/codes.go
+++ b/pkg/services/factory_definitions/validation/codes.go
@@ -89,6 +89,7 @@ var supportedInvocationTypeHints = []string{
 	interfaces.InvocationParameterTypeHintDirectoryPath,
 	interfaces.InvocationParameterTypeHintNumberString,
 	interfaces.InvocationParameterTypeHintBooleanString,
+	interfaces.InvocationParameterTypeHintJSON,
 }
 
 var supportedInvocationValueModes = []string{

--- a/pkg/services/work/arguments.go
+++ b/pkg/services/work/arguments.go
@@ -80,6 +80,7 @@ const (
 	typeHintDirectoryPath = "DIRECTORY_PATH"
 	typeHintNumberString  = "NUMBER_STRING"
 	typeHintBooleanString = "BOOLEAN_STRING"
+	typeHintJSON          = "JSON"
 )
 
 type ArgumentSourceKind string
@@ -676,6 +677,14 @@ func validateArgumentValue(def parameterDefinition, value string) error {
 			return &ArgumentError{
 				Code:      ArgumentErrorCodeStringValidationMismatch,
 				Message:   fmt.Sprintf("parameter %q value %s is not a valid NUMBER_STRING", def.name, argumentValueDiagnostic(def, value)),
+				Parameter: def.name,
+			}
+		}
+	case typeHintJSON:
+		if !json.Valid([]byte(value)) {
+			return &ArgumentError{
+				Code:      ArgumentErrorCodeStringValidationMismatch,
+				Message:   fmt.Sprintf("parameter %q value %s is not valid JSON", def.name, argumentValueDiagnostic(def, value)),
 				Parameter: def.name,
 			}
 		}

--- a/pkg/services/work/arguments_test.go
+++ b/pkg/services/work/arguments_test.go
@@ -175,6 +175,21 @@ func TestNormalizeArguments_SignatureRejectsStringValidationMismatch(t *testing.
 	assertArgumentErrorCode(t, err, ArgumentErrorCodeStringValidationMismatch)
 }
 
+func TestNormalizeArguments_SignatureRejectsInvalidJSONTypeHint(t *testing.T) {
+	_, err := NormalizeArguments(NormalizeArgumentsInput{
+		Signature: signatureConfig(namedParameter("metadata", "", nil, false, typeHintJSON, "")),
+		NamedArgs: []NamedArgumentInput{{Key: "metadata", Values: []string{`{not-json`}}},
+	})
+
+	assertArgumentErrorCode(t, err, ArgumentErrorCodeStringValidationMismatch)
+	if !strings.Contains(err.Error(), `parameter "metadata"`) {
+		t.Fatalf("error = %v, want parameter name in diagnostic", err)
+	}
+	if !strings.Contains(err.Error(), "is not valid JSON") {
+		t.Fatalf("error = %v, want JSON validation detail", err)
+	}
+}
+
 func TestNormalizeArguments_SignatureRejectsUnroutableStdin(t *testing.T) {
 	stdin := "content"
 	_, err := NormalizeArguments(NormalizeArgumentsInput{

--- a/pkg/services/work/contracts.go
+++ b/pkg/services/work/contracts.go
@@ -30,6 +30,7 @@ const (
 	InvocationParameterTypeHintDirectoryPath = "DIRECTORY_PATH"
 	InvocationParameterTypeHintNumberString  = "NUMBER_STRING"
 	InvocationParameterTypeHintBooleanString = "BOOLEAN_STRING"
+	InvocationParameterTypeHintJSON          = "JSON"
 
 	InvocationParameterValueModeExact        = "EXACT"
 	InvocationParameterValueModeRepeated     = "REPEATED"

--- a/pkg/transports/cli/climanifest/composition_test.go
+++ b/pkg/transports/cli/climanifest/composition_test.go
@@ -80,6 +80,7 @@ func TestComposeRunInputsPreservesSupportedTypeHints(t *testing.T) {
 		work.InvocationParameterTypeHintDirectoryPath,
 		work.InvocationParameterTypeHintNumberString,
 		work.InvocationParameterTypeHintBooleanString,
+		work.InvocationParameterTypeHintJSON,
 	}
 	for _, typeHint := range supported {
 		t.Run(typeHint, func(t *testing.T) {

--- a/tests/functional/transport/cli/parameters/json_values_test.go
+++ b/tests/functional/transport/cli/parameters/json_values_test.go
@@ -304,21 +304,25 @@ func scaffoldJSONNullAndEmptyInvocationFactory(t *testing.T) string {
 				},
 				map[string]any{
 					"name":     "nullable",
+					"typeHint": work.InvocationParameterTypeHintJSON,
 					"required": true,
 					"bindings": []any{map[string]any{"kind": "NAMED"}},
 				},
 				map[string]any{
 					"name":     "emptyString",
+					"typeHint": work.InvocationParameterTypeHintJSON,
 					"required": true,
 					"bindings": []any{map[string]any{"kind": "NAMED"}},
 				},
 				map[string]any{
 					"name":     "emptyObject",
+					"typeHint": work.InvocationParameterTypeHintJSON,
 					"required": true,
 					"bindings": []any{map[string]any{"kind": "NAMED"}},
 				},
 				map[string]any{
 					"name":     "emptyArray",
+					"typeHint": work.InvocationParameterTypeHintJSON,
 					"required": true,
 					"bindings": []any{map[string]any{"kind": "NAMED"}},
 				},
@@ -358,11 +362,13 @@ func scaffoldJSONInvocationFactory(t *testing.T) string {
 				},
 				map[string]any{
 					"name":     "metadata",
+					"typeHint": work.InvocationParameterTypeHintJSON,
 					"required": true,
 					"bindings": []any{map[string]any{"kind": "NAMED"}},
 				},
 				map[string]any{
 					"name":     "items",
+					"typeHint": work.InvocationParameterTypeHintJSON,
 					"required": true,
 					"bindings": []any{map[string]any{"kind": "NAMED"}},
 				},

--- a/tests/functional/transport/cli/parameters/json_values_test.go
+++ b/tests/functional/transport/cli/parameters/json_values_test.go
@@ -1,0 +1,166 @@
+package parameters_test
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+// TestCLIJSONParameterPreservesNestedObjectAndArray proves typed nested JSON
+// object and array parameters on you run reach the factory invocation with
+// structure and typed values intact, observed through the canonical submission
+// edge rather than private decoder internals.
+func TestCLIJSONParameterPreservesNestedObjectAndArray(t *testing.T) {
+	metadataValue := `{"user":{"name":"alice","roles":["admin","editor"]},"version":2}`
+	itemsValue := `[{"id":1,"label":"alpha"},{"id":2,"label":"beta"}]`
+
+	factoryDir := scaffoldJSONInvocationFactory(t)
+	factoryPath := filepath.Join(factoryDir, interfaces.FactoryConfigFile)
+	mockWorkersPath := support.WriteMockWorkersConfig(t, &workers.MockWorkersConfig{
+		UnmatchedDispatchPolicy: workers.MockWorkerUnmatchedDispatchPolicyPassthrough,
+		MockWorkers: []workers.MockWorkerConfig{{
+			WorkerName:      "processor",
+			WorkstationName: "process",
+			RunType:         workers.MockWorkerRunTypeAccept,
+		}},
+	})
+
+	submissions := &invocationSubmissionObservation{}
+	process := support.BuildProcess(t, serviceedges.Edges{
+		SubmissionRecorder: submissions.observe,
+	})
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "run",
+		"--factory", factoryPath,
+		"--no-record",
+		"--with-mock-workers", mockWorkersPath,
+		"invoke marker",
+		"--metadata=" + metadataValue,
+		"--items=" + itemsValue,
+	})
+	inputs.WorkingDirectory = t.TempDir()
+
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(JSON parameter invocation) error = %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+
+	records := submissions.snapshot()
+	if len(records) != 1 {
+		t.Fatalf("canonical submissions = %d, want 1; records=%#v", len(records), records)
+	}
+	arguments := records[0].Request.InvocationArguments
+	if arguments == nil {
+		t.Fatal("submitted invocation arguments = nil")
+	}
+	assertInvocationArgumentJSON(t, arguments, "metadata", metadataValue)
+	assertInvocationArgumentJSON(t, arguments, "items", itemsValue)
+}
+
+func assertInvocationArgumentJSON(
+	t *testing.T,
+	arguments *work.InvocationArguments,
+	name string,
+	wantJSON string,
+) {
+	t.Helper()
+
+	got, ok := arguments.Arguments[name]
+	if !ok {
+		t.Fatalf("invocation argument %q missing from %#v", name, arguments.Arguments)
+	}
+	if len(got.Values) != 1 {
+		t.Fatalf("invocation argument %q values = %#v, want one value", name, got.Values)
+	}
+	if got.Values[0] != wantJSON {
+		t.Fatalf("invocation argument %q value = %q, want %q", name, got.Values[0], wantJSON)
+	}
+	if !json.Valid([]byte(got.Values[0])) {
+		t.Fatalf("invocation argument %q value is not valid JSON: %q", name, got.Values[0])
+	}
+	var gotValue any
+	if err := json.Unmarshal([]byte(got.Values[0]), &gotValue); err != nil {
+		t.Fatalf("unmarshal invocation argument %q: %v", name, err)
+	}
+	var wantValue any
+	if err := json.Unmarshal([]byte(wantJSON), &wantValue); err != nil {
+		t.Fatalf("unmarshal want JSON for %q: %v", name, err)
+	}
+	if !jsonValuesEqual(gotValue, wantValue) {
+		t.Fatalf("invocation argument %q decoded = %#v, want %#v", name, gotValue, wantValue)
+	}
+	if got.Sources[0].Kind != string(work.ArgumentSourceKindNamed) {
+		t.Fatalf(
+			"invocation argument %q source kind = %q, want %q",
+			name,
+			got.Sources[0].Kind,
+			work.ArgumentSourceKindNamed,
+		)
+	}
+}
+
+func jsonValuesEqual(left, right any) bool {
+	leftJSON, err := json.Marshal(left)
+	if err != nil {
+		return false
+	}
+	rightJSON, err := json.Marshal(right)
+	if err != nil {
+		return false
+	}
+	return string(leftJSON) == string(rightJSON)
+}
+
+func scaffoldJSONInvocationFactory(t *testing.T) string {
+	t.Helper()
+
+	return support.ScaffoldFactory(t, map[string]any{
+		"name": "json-params",
+		"invocationSignature": map[string]any{
+			"parameters": []any{
+				map[string]any{
+					"name":     "input",
+					"required": true,
+					"bindings": []any{map[string]any{"kind": "POSITIONAL", "position": 1}},
+				},
+				map[string]any{
+					"name":     "metadata",
+					"required": true,
+					"bindings": []any{map[string]any{"kind": "NAMED"}},
+				},
+				map[string]any{
+					"name":     "items",
+					"required": true,
+					"bindings": []any{map[string]any{"kind": "NAMED"}},
+				},
+			},
+		},
+		"workTypes": []any{map[string]any{
+			"name":             "task",
+			"handlingBehavior": []any{"DEFAULT"},
+			"states": []any{
+				map[string]any{"name": "init", "type": "INITIAL"},
+				map[string]any{"name": "complete", "type": "TERMINAL"},
+				map[string]any{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []any{map[string]any{"name": "processor"}},
+		"workstations": []map[string]any{{
+			"name":      "process",
+			"worker":    "processor",
+			"inputs":    []any{map[string]any{"workType": "task", "state": "init"}},
+			"outputs":   []any{map[string]any{"workType": "task", "state": "complete"}},
+			"onFailure": []any{map[string]any{"workType": "task", "state": "failed"}},
+		}},
+	})
+}

--- a/tests/functional/transport/cli/parameters/json_values_test.go
+++ b/tests/functional/transport/cli/parameters/json_values_test.go
@@ -152,6 +152,90 @@ func TestCLIInvalidJSONParameterNamesTheParameter(t *testing.T) {
 	}
 }
 
+// TestCLIJSONNullAndEmptyValuesRemainDistinct proves JSON null and empty value
+// shapes (empty string, empty object, and empty array) remain observably distinct
+// through CLI parameter mapping to the factory invocation, without silent
+// normalization into one another.
+func TestCLIJSONNullAndEmptyValuesRemainDistinct(t *testing.T) {
+	nullValue := "null"
+	emptyStringValue := `""`
+	emptyObjectValue := `{}`
+	emptyArrayValue := `[]`
+
+	factoryDir := scaffoldJSONNullAndEmptyInvocationFactory(t)
+	factoryPath := filepath.Join(factoryDir, interfaces.FactoryConfigFile)
+	mockWorkersPath := support.WriteMockWorkersConfig(t, &workers.MockWorkersConfig{
+		UnmatchedDispatchPolicy: workers.MockWorkerUnmatchedDispatchPolicyPassthrough,
+		MockWorkers: []workers.MockWorkerConfig{{
+			WorkerName:      "processor",
+			WorkstationName: "process",
+			RunType:         workers.MockWorkerRunTypeAccept,
+		}},
+	})
+
+	submissions := &invocationSubmissionObservation{}
+	process := support.BuildProcess(t, serviceedges.Edges{
+		SubmissionRecorder: submissions.observe,
+	})
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "run",
+		"--factory", factoryPath,
+		"--no-record",
+		"--with-mock-workers", mockWorkersPath,
+		"invoke marker",
+		"--nullable=" + nullValue,
+		"--emptyString=" + emptyStringValue,
+		"--emptyObject=" + emptyObjectValue,
+		"--emptyArray=" + emptyArrayValue,
+	})
+	inputs.WorkingDirectory = t.TempDir()
+
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(null and empty JSON parameter invocation) error = %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+
+	records := submissions.snapshot()
+	if len(records) != 1 {
+		t.Fatalf("canonical submissions = %d, want 1; records=%#v", len(records), records)
+	}
+	arguments := records[0].Request.InvocationArguments
+	if arguments == nil {
+		t.Fatal("submitted invocation arguments = nil")
+	}
+
+	assertInvocationArgumentJSON(t, arguments, "nullable", nullValue)
+	assertInvocationArgumentJSON(t, arguments, "emptyString", emptyStringValue)
+	assertInvocationArgumentJSON(t, arguments, "emptyObject", emptyObjectValue)
+	assertInvocationArgumentJSON(t, arguments, "emptyArray", emptyArrayValue)
+
+	observed := map[string]string{
+		"nullable":    arguments.Arguments["nullable"].Values[0],
+		"emptyString": arguments.Arguments["emptyString"].Values[0],
+		"emptyObject": arguments.Arguments["emptyObject"].Values[0],
+		"emptyArray":  arguments.Arguments["emptyArray"].Values[0],
+	}
+	for name, value := range observed {
+		for otherName, otherValue := range observed {
+			if name == otherName {
+				continue
+			}
+			if value == otherValue {
+				t.Fatalf(
+					"invocation arguments %q and %q normalized to the same value %q",
+					name,
+					otherName,
+					value,
+				)
+			}
+		}
+	}
+}
+
 func assertInvocationArgumentJSON(
 	t *testing.T,
 	arguments *work.InvocationArguments,
@@ -204,6 +288,60 @@ func jsonValuesEqual(left, right any) bool {
 		return false
 	}
 	return string(leftJSON) == string(rightJSON)
+}
+
+func scaffoldJSONNullAndEmptyInvocationFactory(t *testing.T) string {
+	t.Helper()
+
+	return support.ScaffoldFactory(t, map[string]any{
+		"name": "json-null-empty-params",
+		"invocationSignature": map[string]any{
+			"parameters": []any{
+				map[string]any{
+					"name":     "input",
+					"required": true,
+					"bindings": []any{map[string]any{"kind": "POSITIONAL", "position": 1}},
+				},
+				map[string]any{
+					"name":     "nullable",
+					"required": true,
+					"bindings": []any{map[string]any{"kind": "NAMED"}},
+				},
+				map[string]any{
+					"name":     "emptyString",
+					"required": true,
+					"bindings": []any{map[string]any{"kind": "NAMED"}},
+				},
+				map[string]any{
+					"name":     "emptyObject",
+					"required": true,
+					"bindings": []any{map[string]any{"kind": "NAMED"}},
+				},
+				map[string]any{
+					"name":     "emptyArray",
+					"required": true,
+					"bindings": []any{map[string]any{"kind": "NAMED"}},
+				},
+			},
+		},
+		"workTypes": []any{map[string]any{
+			"name":             "task",
+			"handlingBehavior": []any{"DEFAULT"},
+			"states": []any{
+				map[string]any{"name": "init", "type": "INITIAL"},
+				map[string]any{"name": "complete", "type": "TERMINAL"},
+				map[string]any{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []any{map[string]any{"name": "processor"}},
+		"workstations": []map[string]any{{
+			"name":      "process",
+			"worker":    "processor",
+			"inputs":    []any{map[string]any{"workType": "task", "state": "init"}},
+			"outputs":   []any{map[string]any{"workType": "task", "state": "complete"}},
+			"onFailure": []any{map[string]any{"workType": "task", "state": "failed"}},
+		}},
+	})
 }
 
 func scaffoldJSONInvocationFactory(t *testing.T) string {

--- a/tests/functional/transport/cli/parameters/json_values_test.go
+++ b/tests/functional/transport/cli/parameters/json_values_test.go
@@ -3,8 +3,10 @@ package parameters_test
 import (
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/portpowered/infinite-you/internal/testutil"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	"github.com/portpowered/infinite-you/pkg/services/work"
@@ -65,6 +67,89 @@ func TestCLIJSONParameterPreservesNestedObjectAndArray(t *testing.T) {
 	}
 	assertInvocationArgumentJSON(t, arguments, "metadata", metadataValue)
 	assertInvocationArgumentJSON(t, arguments, "items", itemsValue)
+}
+
+// TestCLIInvalidJSONParameterNamesTheParameter proves invalid JSON for a named
+// factory parameter is rejected with an actionable diagnostic that names the
+// parameter before any worker provider dispatch can start.
+func TestCLIInvalidJSONParameterNamesTheParameter(t *testing.T) {
+	validItemsValue := `[{"id":1,"label":"alpha"}]`
+	invalidMetadataValue := `{not-json`
+
+	factoryDir := scaffoldJSONInvocationFactory(t)
+	factoryPath := filepath.Join(factoryDir, interfaces.FactoryConfigFile)
+	mockWorkersPath := support.WriteMockWorkersConfig(t, &workers.MockWorkersConfig{
+		UnmatchedDispatchPolicy: workers.MockWorkerUnmatchedDispatchPolicyPassthrough,
+		MockWorkers: []workers.MockWorkerConfig{{
+			WorkerName:      "processor",
+			WorkstationName: "process",
+			RunType:         workers.MockWorkerRunTypeAccept,
+		}},
+	})
+
+	support.UpdateFactoryConfig(t, factoryDir, func(cfg map[string]any) {
+		signature, ok := cfg["invocationSignature"].(map[string]any)
+		if !ok {
+			t.Fatal("factory config missing invocationSignature")
+		}
+		parameters, ok := signature["parameters"].([]any)
+		if !ok {
+			t.Fatal("factory config missing invocationSignature.parameters")
+		}
+		for _, raw := range parameters {
+			parameter, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			switch parameter["name"] {
+			case "metadata", "items":
+				parameter["typeHint"] = work.InvocationParameterTypeHintJSON
+			}
+		}
+	})
+
+	submissions := &invocationSubmissionObservation{}
+	providerRunner := testutil.NewProviderCommandRunner()
+	process := support.BuildProcess(t, serviceedges.Edges{
+		SubmissionRecorder:    submissions.observe,
+		ProviderCommandRunner: providerRunner,
+	})
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "run",
+		"--factory", factoryPath,
+		"--no-record",
+		"--with-mock-workers", mockWorkersPath,
+		"invoke marker",
+		"--metadata=" + invalidMetadataValue,
+		"--items=" + validItemsValue,
+	})
+	inputs.WorkingDirectory = t.TempDir()
+
+	executeErr := process.Execute(inputs.Input)
+	if executeErr == nil {
+		t.Fatalf(
+			"Process.Execute(invalid JSON parameter) succeeded; stdout:\n%s\nstderr:\n%s",
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+
+	diagnostic := executeErr.Error() + "\n" + inputs.Stderr()
+	for _, want := range []string{
+		string(work.ArgumentErrorCodeStringValidationMismatch),
+		`parameter "metadata"`,
+		"is not valid JSON",
+	} {
+		if !strings.Contains(diagnostic, want) {
+			t.Fatalf("invalid JSON diagnostic missing %q:\n%s", want, diagnostic)
+		}
+	}
+	if records := submissions.snapshot(); len(records) != 0 {
+		t.Fatalf("canonical submissions = %d, want 0; records=%#v", len(records), records)
+	}
+	if providerRunner.CallCount() != 0 {
+		t.Fatalf("provider dispatch calls = %d, want 0", providerRunner.CallCount())
+	}
 }
 
 func assertInvocationArgumentJSON(


### PR DESCRIPTION
{
  "project": "CLI JSON Parameter Values Functional Coverage",
  "branchName": "ft-wave1-cli-json-values",
  "description": "Implement the transport-owned functional cell at tests/functional/transport/cli/parameters/json_values_test.go so the public CLI proves typed nested object/array JSON parameters reach the invocation intact, invalid JSON fails with an actionable diagnostic that names the parameter without worker dispatch, and JSON null versus empty values remain distinct without normalization loss, without implementing sibling environment_precedence or inventing migration-ledger deletion work for this free destination.",
  "context": {
    "customerAsk": "Implement only tests/functional/transport/cli/parameters/json_values_test.go. Through the public CLI boundary, prove: (1) TestCLIJSONParameterPreservesNestedObjectAndArray — typed nested object/array JSON parameters reach the invocation intact; (2) TestCLIInvalidJSONParameterNamesTheParameter — invalid JSON fails with an actionable diagnostic that names the parameter and without worker dispatch; (3) TestCLIJSONNullAndEmptyValuesRemainDistinct — JSON null and empty values remain distinct without normalization loss. Do not implement environment_precedence_test.go. Avoid service/internal imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled ownership/coverage/catalog/migration metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for CLI JSON parameter values does not exist yet even though key_value_test.go has freed transport/cli/parameters. Maintainers lack a focused, catalogued transport proof that nested object/array JSON values reach the invocation intact, that invalid JSON names the parameter and rejects without worker dispatch, and that null versus empty remain distinct. No migration-ledger rows map here, so checklist behaviors are the authoritative scope.",
    "solution": "Implement the nested object/array preservation, invalid-JSON named diagnostic with no-dispatch rejection, and null-versus-empty distinction scenarios in tests/functional/transport/cli/parameters/json_values_test.go through the public CLI/root.BuildProcess boundary with edges.Edges for observation and dispatch-tracking edges, with customer-readable Go docs on every top-level Test. Do not invent migration-ledger deletion consumption; apply only narrowly coupled ownership/coverage/catalog metadata; leave sibling environment_precedence untouched; and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/transport/cli/parameters/json_values_test.go exists as the transport-owned functional cell and covers nested object/array JSON preservation, invalid JSON naming the parameter without worker dispatch, and null-versus-empty distinction.",
    "Through the public CLI boundary, a nested JSON object and a nested JSON array parameter reach the invocation input / CLI observation edge with structure and typed values intact (not stringified-away or flattened).",
    "Invalid JSON for a named parameter fails with a stable, actionable diagnostic that includes the parameter name, and does not dispatch a worker.",
    "JSON null and empty values remain observably distinct at the invocation / observation edge without silent normalization loss.",
    "Coverage uses root.BuildProcess/public CLI helpers and edges.Edges only for external effects; it does not import service implementations or internal Petri primitives, and does not assert Work/Session/Worker/Factory product semantics beyond transport parameter and dispatch-gate evidence; every top-level Test* has a customer-readable Go doc comment; specialty bindings remain none; only narrowly coupled ownership/coverage/catalog metadata for this cell are updated; no migration-ledger deletion batch is invented; sibling environment_precedence is not implemented.",
    "Focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave1-cli-json-values-001",
      "title": "Prove nested object and array JSON parameters reach the invocation intact",
      "description": "As a CLI customer, I want typed nested object and array JSON parameters on a public run invocation to reach the factory invocation with structure intact, so I can pass complex payloads without silent stringification or flattening.",
      "acceptanceCriteria": [
        "tests/functional/transport/cli/parameters/json_values_test.go includes TestCLIJSONParameterPreservesNestedObjectAndArray (or equivalent top-level name matching the checklist intent).",
        "The test builds the customer process through root.BuildProcess / approved support helpers and substitutes external effects only through edges.Edges (for example CLI observation and/or mock workers).",
        "Executing a public you run (or equivalent documented one-shot invocation surface) with at least one nested JSON object parameter and one nested JSON array parameter succeeds far enough for the invocation parameters to be observed.",
        "The observed invocation input / CLI observation edge records the nested object and array with structure and typed values intact; evidence is an approved external edge, not private JSON decoder internals.",
        "Assertions stay on transport JSON parameter mapping and do not assert Work completion, Worker provider semantics, or Factory orchestration outcomes beyond what is required to observe the parameters.",
        "The top-level test has a customer-readable Go doc comment describing the observable nested object/array JSON preservation behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-json-values-002",
      "title": "Prove invalid JSON names the parameter and skips worker dispatch",
      "description": "As a CLI customer, I want invalid JSON parameter input rejected before any worker runs, with a diagnostic that names the parameter, so I can fix the command line without partial execution.",
      "acceptanceCriteria": [
        "The JSON-values cell includes TestCLIInvalidJSONParameterNamesTheParameter (or equivalent top-level name matching the checklist intent).",
        "Executing a public CLI invocation with invalid JSON for a named parameter fails with a stable, actionable diagnostic that includes the parameter name.",
        "No worker dispatch occurs: mock-worker / dispatch-tracking edges record zero worker starts (or equivalent zero dispatch observations).",
        "The test does not widen into Worker execution success paths, Session lifecycle controls, or Work completion semantics beyond proving pre-dispatch rejection with a named-parameter diagnostic.",
        "The top-level test has a customer-readable Go doc comment describing the invalid-JSON naming and no-dispatch behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-json-values-003",
      "title": "Prove JSON null and empty values remain distinct",
      "description": "As a CLI customer, I want JSON null and empty values to remain distinct through CLI parameter mapping, so intentional absence is not silently collapsed into empty payloads (or the reverse).",
      "acceptanceCriteria": [
        "The JSON-values cell includes TestCLIJSONNullAndEmptyValuesRemainDistinct (or equivalent top-level name matching the checklist intent).",
        "Executing public CLI invocations that supply JSON null and at least one empty value shape supported by the public surface (for example empty string, empty object, and/or empty array) succeeds far enough for the parameters to be observed.",
        "The observed invocation input / CLI observation edge shows null and the empty value(s) as distinct; neither is silently normalized into the other.",
        "Evidence is an approved external edge, not private decoder or normalization internals.",
        "Assertions remain transport parameter-contract focused and do not prove domain payload or Factory orchestration semantics beyond observing the distinct values.",
        "The top-level test has a customer-readable Go doc comment describing the null-versus-empty distinction behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-json-values-004",
      "title": "Close cell verification gates without sibling widening",
      "description": "As a maintainer executing Wave 1 expansion, I want this free destination catalogued and verified without inventing migration-ledger deletion work or implementing the sibling environment-precedence cell, so the parameters package stays collision-safe for held neighbors.",
      "acceptanceCriteria": [
        "No migration-ledger deletion batch is invented or claimed for this destination; checklist behaviors remain the authoritative scope.",
        "Specialty bindings for this cell remain none; only narrowly coupled ownership, coverage, or catalog metadata required for tests/functional/transport/cli/parameters/json_values_test.go are updated.",
        "Sibling cell environment_precedence_test.go is not created or modified by this work.",
        "Focused package tests for tests/functional/transport/cli/parameters pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as transport/cli/parameters).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)