### PR TITLE
ft-wave1-inference-flags

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -580,6 +580,17 @@ Wave 0 functional-tests-expansion planning authority lives under
   metadata infers domain `workers` and subsection `inference` from the path;
   every top-level `Test*` needs a customer-readable Go doc so
   `functionaltestmetadata` stays viz-compatible.
+- Workers inference provider command-flag functional coverage belongs in
+  `tests/functional/workers/inference/flags_test.go`: prove skip-permissions
+  policy, resolved worktree names, and explicit model values map onto the
+  selected provider-process command args, and prove unsupported provider flags
+  (for example workstation `outputSchema` on Gemini) fail with a capability
+  error before any `ProviderCommandRunner` call. Drive proofs through
+  `support.RunFactoryToCompletionWithEdgesAndObservations` with
+  `serviceedges.Edges{ProviderCommandRunner: ...}` and assert on command args
+  plus public Work outcomes only. Catalog metadata infers domain `workers` and
+  subsection `inference` from the path; every top-level `Test*` needs a
+  customer-readable Go doc so `functionaltestmetadata` stays viz-compatible.
 
 - `tests/functional/automations/` owns root.BuildProcess evidence for packaged
   Automations cron scheduling. Keep cron workstation factories explicit with

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -419,7 +419,15 @@ primary-result behavior.
   belongs in `tests/functional/workers/inference/selection_test.go`; drive
   proofs through `support.RunFactoryToCompletionWithEdgesAndObservations` or
   `support.BuildProcess` with `serviceedges.Edges{ProviderRegistrations: ...}`
-  and assert on registered integration stats plus public Work outcomes only. Script execution-environment
+  and assert on registered integration stats plus public Work outcomes only.
+  Provider command-flag mapping and unsupported-flag capability rejection
+  (skip-permissions policy, resolved worktree names, explicit model values, and
+  pre-start unsupported-capability failures such as workstation `outputSchema`
+  on Gemini) belongs in
+  `tests/functional/workers/inference/flags_test.go`; drive proofs through
+  `support.RunFactoryToCompletionWithEdgesAndObservations` with
+  `serviceedges.Edges{ProviderCommandRunner: ...}` and assert on provider-process
+  command args plus public Work outcomes only. Script execution-environment
   boundary proofs (declared env filtering, missing-executable public failure,
   resource-token template resolution, multi-input ordering, and worktree
   passthrough) belong in

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -239,7 +239,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestWorkerProviderOverridesGlobalDefault` covers precedence.
   - `TestUnknownProviderFailsBeforeProcessStart` covers validation.
 
-- [ ] `tests/functional/workers/inference/flags_test.go`
+- [x] `tests/functional/workers/inference/flags_test.go`
   - `TestProviderPermissionWorktreeAndModelFlagsMapToCommand` covers shared
     command metadata.
   - `TestUnsupportedProviderFlagReturnsCapabilityError` covers mismatch.

--- a/tests/functional/workers/inference/flags_test.go
+++ b/tests/functional/workers/inference/flags_test.go
@@ -72,6 +72,51 @@ func TestProviderPermissionWorktreeAndModelFlagsMapToCommand(t *testing.T) {
 	support.AssertArgsContainSequence(t, call.Args, []string{"--model", flagsTestModel})
 }
 
+// TestUnsupportedProviderFlagReturnsCapabilityError proves that when a
+// worker/workstation configuration requests a provider flag the selected
+// provider does not support, root.BuildProcess rejects the dispatch with a
+// capability error before starting a provider command instead of launching a
+// live provider-process edge for that work.
+func TestUnsupportedProviderFlagReturnsCapabilityError(t *testing.T) {
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
+
+	support.WriteAgentConfig(t, dir, "worker", support.BuildModelWorkerConfig(
+		modelprovider.ProviderGemini,
+		"gemini-2.5-flash",
+	))
+	support.WriteWorkstationConfig(t, dir, "process", `---
+type: MODEL_WORKSTATION
+outputSchema: '{}'
+---
+Test workstation.
+`)
+	testutil.WriteSeedFile(t, dir, "task", []byte(`{"title":"unsupported provider flag"}`))
+
+	runner := testutil.NewProviderCommandRunner(platformprocess.CommandResult{
+		Stdout: []byte("provider must not run"),
+	})
+
+	_, listed, _ := support.RunFactoryToCompletionWithEdgesAndObservations(
+		t,
+		dir,
+		serviceedges.Edges{ProviderCommandRunner: runner},
+		20*time.Second,
+	)
+
+	if got := support.CountWorkAtCustomerState(listed, "task:failed"); got != 1 {
+		t.Fatalf("failed work tokens = %d, want 1 unsupported-capability failure; listed=%#v", got, listed)
+	}
+	if got := support.CountWorkAtCustomerState(listed, "task:done"); got != 0 {
+		t.Fatalf("completed work tokens = %d, want 0", got)
+	}
+	if runner.CallCount() != 0 {
+		t.Fatalf(
+			"provider command runner calls = %d, want no provider-process edge before capability rejection",
+			runner.CallCount(),
+		)
+	}
+}
+
 const claudeFlagsSuccessStdout = `{"type":"stream_event","session_id":"session-flags-map","event":{"type":"message_start","message":{"id":"msg-flags-map","role":"assistant","content":[]}}}` + "\n" +
 	`{"type":"stream_event","session_id":"session-flags-map","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}}` + "\n" +
 	`{"type":"stream_event","session_id":"session-flags-map","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Done. COMPLETE"}}}` + "\n" +

--- a/tests/functional/workers/inference/flags_test.go
+++ b/tests/functional/workers/inference/flags_test.go
@@ -1,0 +1,81 @@
+package inference_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	flagsTestWorktreeName = "flags-feature-branch"
+	flagsTestModel        = "claude-flags-test-model"
+)
+
+// TestProviderPermissionWorktreeAndModelFlagsMapToCommand proves that when a
+// worker/workstation configuration supplies skip-permissions policy, a resolved
+// worktree name, and an explicit model for a selected provider, root.BuildProcess
+// dispatch maps those settings onto the provider-process command args for that
+// provider instead of silently dropping them or routing through a different edge.
+func TestProviderPermissionWorktreeAndModelFlagsMapToCommand(t *testing.T) {
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "worktree_passthrough"))
+
+	testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+		Name:       flagsTestWorktreeName,
+		WorkID:     "work-flags-map",
+		WorkTypeID: "task",
+		TraceID:    "trace-flags-map",
+		Payload:    []byte(`{"title":"provider permission worktree model flags"}`),
+	})
+
+	workerConfig := strings.Replace(
+		support.BuildModelWorkerConfig(modelprovider.ProviderClaude, flagsTestModel),
+		"stopToken: COMPLETE",
+		"skipPermissions: true\nstopToken: COMPLETE",
+		1,
+	)
+	support.WriteAgentConfig(t, dir, "worker-a", workerConfig)
+
+	runner := testutil.NewProviderCommandRunner(
+		platformprocess.CommandResult{Stdout: []byte(claudeFlagsSuccessStdout)},
+	)
+
+	_, listed, _ := support.RunFactoryToCompletionWithEdgesAndObservations(
+		t,
+		dir,
+		serviceedges.Edges{ProviderCommandRunner: runner},
+		20*time.Second,
+	)
+
+	if got := support.CountWorkAtCustomerState(listed, "task:complete"); got != 1 {
+		t.Fatalf("completed work tokens = %d, want 1; listed=%#v", got, listed)
+	}
+	if got := support.CountWorkAtCustomerState(listed, "task:failed"); got != 0 {
+		t.Fatalf("failed work tokens = %d, want 0", got)
+	}
+	if runner.CallCount() != 1 {
+		t.Fatalf("provider command runner calls = %d, want exactly one provider-process edge", runner.CallCount())
+	}
+
+	call := runner.LastRequest()
+	if call.Command != string(modelprovider.ProviderClaude) {
+		t.Fatalf("command = %q, want selected provider %q", call.Command, modelprovider.ProviderClaude)
+	}
+	support.AssertArgsContainSequence(t, call.Args, []string{"--dangerously-skip-permissions"})
+	support.AssertArgsContainSequence(t, call.Args, []string{"--worktree", flagsTestWorktreeName})
+	support.AssertArgsContainSequence(t, call.Args, []string{"--model", flagsTestModel})
+}
+
+const claudeFlagsSuccessStdout = `{"type":"stream_event","session_id":"session-flags-map","event":{"type":"message_start","message":{"id":"msg-flags-map","role":"assistant","content":[]}}}` + "\n" +
+	`{"type":"stream_event","session_id":"session-flags-map","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}}` + "\n" +
+	`{"type":"stream_event","session_id":"session-flags-map","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Done. COMPLETE"}}}` + "\n" +
+	`{"type":"stream_event","session_id":"session-flags-map","event":{"type":"content_block_stop","index":0}}` + "\n" +
+	`{"type":"stream_event","session_id":"session-flags-map","event":{"type":"message_stop"}}` + "\n" +
+	`{"type":"assistant","session_id":"session-flags-map","message":{"id":"msg-flags-map","role":"assistant","content":[{"type":"text","text":"Done. COMPLETE"}]}}` + "\n" +
+	`{"type":"result","subtype":"success","is_error":false,"result":"Done. COMPLETE","session_id":"session-flags-map"}` + "\n"


### PR DESCRIPTION
{
  "project": "Inference Provider Command Flags Functional Coverage",
  "branchName": "ft-wave1-inference-flags",
  "description": "Add customer-facing functional coverage in tests/functional/workers/inference/flags_test.go that proves, through root.BuildProcess and exact provider-process edges, permission/worktree/model flags map onto the selected provider command and unsupported provider flags return a capability error before process start—without inventing migration-ledger rows, changing the shared golden harness, or implementing stream_fidelity_test.go.",
  "context": {
    "customerAsk": "Implement only tests/functional/workers/inference/flags_test.go. Through root.BuildProcess and exact provider-process edges, prove: (1) TestProviderPermissionWorktreeAndModelFlagsMapToCommand — permission/worktree/model flags map onto the selected provider command; (2) TestUnsupportedProviderFlagReturnsCapabilityError — unsupported provider flags return a capability error before process start. Do not implement stream_fidelity_test.go. Avoid service/internal imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "Permission, worktree, and model flag mapping for inference providers is still scattered across legacy provider harnesses and unit-level command builders. Customers and maintainers cannot point to one worker-owned flags cell that answers: whether configured permission, worktree, and model settings appear on the selected provider command at the process edge, and whether an unsupported provider flag fails with a capability error before the process starts rather than launching a command. selection_test.go is complete and has freed this package, while stream_fidelity_test.go must stay held until this cell completes, so the gap is coverage clarity without package collisions.",
    "solution": "Author one worker-domain functional cell that drives provider command-flag behavior through root.BuildProcess and exact provider-process edges (approved support helpers, replacing only external provider/process effects). Cover the two checklist scenarios as top-level Tests with customer-readable Go doc comments, treat checklist behaviors as authoritative because no ledger rows map here, avoid pkg/**/internal and service-internal imports, leave the shared golden harness unchanged, and update only the narrowly coupled ownership, coverage, catalog, and migration metadata required for this cell."
  },
  "acceptanceCriteria": [
    "tests/functional/workers/inference/flags_test.go exists as the sole new functional cell for this work and is owned by the workers/inference domain, not CLI or HTTP transport packages.",
    "Through root.BuildProcess and exact provider-process edges, configured permission, worktree, and model flags appear on the selected provider command (observable command args / process-edge request), not as silent drops or alternate-provider command shapes.",
    "An unsupported provider flag returns a capability error before process start with no provider command runner call (or equivalent process-start side effect) for that attempt.",
    "Checklist behaviors are treated as authoritative scope; no migration-ledger inventory rows are invented for this destination; the shared golden harness is unchanged; no provider metadata is invented under assertion.",
    "Every top-level Test* function has a customer-readable Go doc comment; tests avoid service/internal imports; only narrowly coupled ownership/coverage/catalog/migration metadata for this cell are updated; stream_fidelity_test.go is not implemented.",
    "Quality gate passes: focused package tests for the new cell, make functional-boundary-check, functional-test metadata / viz-compatible verification for the touched catalog surfaces, plus typecheck, lint, and tests for touched surfaces."
  ],
  "userStories": [
    {
      "id": "ft-wave1-inference-flags-001",
      "title": "Prove permission, worktree, and model flags map onto the selected provider command",
      "description": "As a customer or maintainer, I want a worker-domain functional test that shows configured permission, worktree, and model flags map onto the selected provider command through root.BuildProcess so I can trust shared command metadata without transport-package ownership.",
      "acceptanceCriteria": [
        "tests/functional/workers/inference/flags_test.go is created under workers/inference ownership and does not import CLI or HTTP transport packages as the proof owner.",
        "The scenario runs through root.BuildProcess with exact provider-process edges (approved support helpers), replacing only external provider/process effects.",
        "TestProviderPermissionWorktreeAndModelFlagsMapToCommand exists with a customer-readable Go doc comment describing the observable command-metadata behavior.",
        "When a worker/workstation configuration supplies permission, worktree, and model settings for a selected provider, the provider-process edge receives those flags on the selected provider command (observable args / command request), matching the provider's documented shared command metadata.",
        "The test does not invent expected provider metadata, does not change the shared golden harness, and avoids service/internal imports.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-inference-flags-002",
      "title": "Prove unsupported provider flags return a capability error before process start",
      "description": "As a customer or maintainer, I want an unsupported provider flag to fail with a capability error before process start so invalid command metadata never launches a live provider command for that work.",
      "acceptanceCriteria": [
        "TestUnsupportedProviderFlagReturnsCapabilityError exists with a customer-readable Go doc comment describing the observable mismatch / capability-rejection behavior.",
        "Through root.BuildProcess and exact provider-process edges, a configuration that requests a flag or capability the selected provider does not support fails before process start.",
        "No provider command runner call (or equivalent process-start side effect) occurs for that attempt; the public failure is a capability error (or equivalent customer-readable unsupported-capability outcome), not a post-launch process failure.",
        "Expected outcomes assert observable pre-start rejection only; they do not invent provider metadata or change the shared golden harness; service/internal imports are avoided.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-inference-flags-003",
      "title": "Close out ownership metadata and verification gates",
      "description": "As a maintainer, I want narrowly coupled ownership, coverage, catalog, and migration metadata updated and verified so this cell is discoverable and boundary-safe without unrelated cleanup or sibling-cell work.",
      "acceptanceCriteria": [
        "Only narrowly coupled ownership, coverage, catalog, and migration metadata required for tests/functional/workers/inference/flags_test.go are updated.",
        "No new migration-ledger inventory rows are invented for this destination; checklist behaviors remain the authoritative scope for the two top-level Tests.",
        "Checklist / catalog visibility for this cell reflects the two top-level Tests and workers/inference ownership; stream_fidelity_test.go remains unimplemented.",
        "Focused tests for the new package / cell pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test metadata verification (viz-compatible catalog/metadata checks) accepts the cell without requiring broad unrelated inventory cleanup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)