### PR TITLE
ft-wave1-cli-environment-precedence

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -290,6 +290,19 @@
   `transport` and subsection `cli/parameters` from the path; every top-level
   `Test*` needs a customer-readable Go doc so `functionaltestmetadata` stays
   viz-compatible.
+  CLI operator-default environment precedence functional coverage belongs in
+  `tests/functional/transport/cli/parameters/environment_precedence_test.go`:
+  prove explicit `--default-worker-model-provider` and `--default-worker-model`
+  flags override conflicting `YOU_DEFAULT_WORKER_MODEL_PROVIDER` and
+  `YOU_DEFAULT_WORKER_MODEL` environment values with `SourceCLIFlag` provenance
+  on `CLIObserver` resolved inputs, prove environment overrides conflicting
+  `~/.you-agent-factory/config.json` defaults with `SourceEnvironment` when no
+  overriding flag is present, and prove unset operator-default environment
+  variables fall back to global config with `SourceOperatorConfig` without
+  fabricating `SourceEnvironment` overrides at the public
+  `support.BuildProcess` boundary. Catalog metadata infers domain `transport`
+  and subsection `cli/parameters` from the path; every top-level `Test*` needs a
+  customer-readable Go doc so `functionaltestmetadata` stays viz-compatible.
   CLI response-stream backpressure functional coverage belongs in
   `tests/functional/transport/cli/output/stream_backpressure_test.go`:
   invoke `support.BuildProcess` with a gated or mid-stream-failing stdout writer

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -98,7 +98,7 @@ intentionally small enough to distribute across many agents.
     output.
   - `TestCLIJSONNullAndEmptyValuesRemainDistinct` prevents normalization loss.
 
-- [ ] `tests/functional/transport/cli/parameters/environment_precedence_test.go`
+- [x] `tests/functional/transport/cli/parameters/environment_precedence_test.go`
   - `TestCLIExplicitFlagOverridesEnvironmentDefault` verifies precedence.
   - `TestCLIEnvironmentOverridesGlobalConfig` verifies documented precedence.
   - `TestCLIUnsetEnvironmentFallsBackWithoutFabricatingValue` covers absence.

--- a/tests/functional/transport/cli/parameters/environment_precedence_test.go
+++ b/tests/functional/transport/cli/parameters/environment_precedence_test.go
@@ -2,6 +2,7 @@ package parameters_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
@@ -67,6 +68,78 @@ func TestCLIExplicitFlagOverridesEnvironmentDefault(t *testing.T) {
 		resolvedinput.SourceEnvironment,
 		"environment-model",
 	)
+}
+
+// TestCLIEnvironmentOverridesGlobalConfig proves environment variables override
+// conflicting global operator config for the same documented operator setting,
+// with the environment-resolved value observable at the CLI resolution edge and
+// the file value not selected.
+func TestCLIEnvironmentOverridesGlobalConfig(t *testing.T) {
+	home := t.TempDir()
+	writeOperatorConfig(t, home, []byte(
+		`{"defaults":{"workerModelProvider":"codex","workerModel":"file-model"}}`,
+	))
+
+	var observation cliobservation.Result
+	process := support.BuildProcess(t, serviceedges.Edges{
+		CLIObserver: cliobservation.Capture(&observation),
+	})
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you",
+		"docs", "agents",
+	})
+	inputs.Input.Env = append(os.Environ(),
+		"HOME="+home,
+		"USERPROFILE="+home,
+		operatorsettings.EnvDefaultWorkerModelProvider+"=gemini",
+		operatorsettings.EnvDefaultWorkerModel+"=environment-model",
+	)
+	inputs.Input.WorkingDirectory = home
+
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf("Process.Execute(docs agents with operator defaults) error = %v", err)
+	}
+
+	assertResolvedOperatorDefault(
+		t,
+		observation.ResolvedInputs,
+		"you.flag.default-worker-model-provider",
+		"gemini",
+		resolvedinput.SourceEnvironment,
+	)
+	assertResolvedOperatorDefault(
+		t,
+		observation.ResolvedInputs,
+		"you.flag.default-worker-model",
+		"environment-model",
+		resolvedinput.SourceEnvironment,
+	)
+	assertOperatorDefaultNotFromSource(
+		t,
+		observation.ResolvedInputs,
+		"you.flag.default-worker-model-provider",
+		resolvedinput.SourceOperatorConfig,
+		"codex",
+	)
+	assertOperatorDefaultNotFromSource(
+		t,
+		observation.ResolvedInputs,
+		"you.flag.default-worker-model",
+		resolvedinput.SourceOperatorConfig,
+		"file-model",
+	)
+}
+
+func writeOperatorConfig(t *testing.T, homeDir string, payload []byte) {
+	t.Helper()
+	configDir := filepath.Join(homeDir, ".you-agent-factory")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatalf("mkdir operator config directory: %v", err)
+	}
+	configPath := filepath.Join(configDir, "config.json")
+	if err := os.WriteFile(configPath, payload, 0o600); err != nil {
+		t.Fatalf("write operator config: %v", err)
+	}
 }
 
 func assertResolvedOperatorDefault(

--- a/tests/functional/transport/cli/parameters/environment_precedence_test.go
+++ b/tests/functional/transport/cli/parameters/environment_precedence_test.go
@@ -3,6 +3,7 @@ package parameters_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
@@ -130,6 +131,77 @@ func TestCLIEnvironmentOverridesGlobalConfig(t *testing.T) {
 	)
 }
 
+// TestCLIUnsetEnvironmentFallsBackWithoutFabricatingValue proves an unset
+// documented environment variable falls back to the next precedence source
+// (global operator config) without fabricating an environment-derived override.
+func TestCLIUnsetEnvironmentFallsBackWithoutFabricatingValue(t *testing.T) {
+	home := t.TempDir()
+	writeOperatorConfig(t, home, []byte(
+		`{"defaults":{"workerModelProvider":"codex","workerModel":"file-model"}}`,
+	))
+
+	var observation cliobservation.Result
+	process := support.BuildProcess(t, serviceedges.Edges{
+		CLIObserver: cliobservation.Capture(&observation),
+	})
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you",
+		"docs", "agents",
+	})
+	inputs.Input.Env = environmentWithoutOperatorDefaults(append(os.Environ(),
+		"HOME="+home,
+		"USERPROFILE="+home,
+	))
+	inputs.Input.WorkingDirectory = home
+
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf("Process.Execute(docs agents with operator defaults) error = %v", err)
+	}
+
+	assertResolvedOperatorDefault(
+		t,
+		observation.ResolvedInputs,
+		"you.flag.default-worker-model-provider",
+		"codex",
+		resolvedinput.SourceOperatorConfig,
+	)
+	assertResolvedOperatorDefault(
+		t,
+		observation.ResolvedInputs,
+		"you.flag.default-worker-model",
+		"file-model",
+		resolvedinput.SourceOperatorConfig,
+	)
+	assertOperatorDefaultSourceIsNot(
+		t,
+		observation.ResolvedInputs,
+		"you.flag.default-worker-model-provider",
+		resolvedinput.SourceEnvironment,
+	)
+	assertOperatorDefaultSourceIsNot(
+		t,
+		observation.ResolvedInputs,
+		"you.flag.default-worker-model",
+		resolvedinput.SourceEnvironment,
+	)
+}
+
+func environmentWithoutOperatorDefaults(environment []string) []string {
+	filtered := make([]string, 0, len(environment))
+	for _, entry := range environment {
+		name, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		switch name {
+		case operatorsettings.EnvDefaultWorkerModelProvider, operatorsettings.EnvDefaultWorkerModel:
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
 func writeOperatorConfig(t *testing.T, homeDir string, payload []byte) {
 	t.Helper()
 	configDir := filepath.Join(homeDir, ".you-agent-factory")
@@ -187,6 +259,27 @@ func assertOperatorDefaultNotFromSource(
 			observation,
 			rejectedSource,
 			rejectedValue,
+		)
+	}
+}
+
+func assertOperatorDefaultSourceIsNot(
+	t *testing.T,
+	observations []resolvedinput.Observation,
+	inputID string,
+	rejectedSource resolvedinput.Source,
+) {
+	t.Helper()
+	observation, found := resolvedOperatorDefaultObservation(observations, inputID)
+	if !found {
+		t.Fatalf("%s observation is missing", inputID)
+	}
+	if observation.Provenance == rejectedSource {
+		t.Fatalf(
+			"%s observation = %#v, want source other than %q",
+			inputID,
+			observation,
+			rejectedSource,
 		)
 	}
 }

--- a/tests/functional/transport/cli/parameters/environment_precedence_test.go
+++ b/tests/functional/transport/cli/parameters/environment_precedence_test.go
@@ -1,0 +1,131 @@
+package parameters_test
+
+import (
+	"os"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	cliobservation "github.com/portpowered/infinite-you/pkg/transports/cli/observation"
+	"github.com/portpowered/infinite-you/pkg/transports/cli/resolvedinput"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+// TestCLIExplicitFlagOverridesEnvironmentDefault proves an explicit CLI flag
+// wins over a conflicting environment default for the same documented operator
+// setting, with the flag-resolved value observable at the CLI resolution edge
+// and the environment value not selected.
+func TestCLIExplicitFlagOverridesEnvironmentDefault(t *testing.T) {
+	home := t.TempDir()
+	var observation cliobservation.Result
+	process := support.BuildProcess(t, serviceedges.Edges{
+		CLIObserver: cliobservation.Capture(&observation),
+	})
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you",
+		"--default-worker-model-provider", "gemini",
+		"--default-worker-model", "flag-gemini-model",
+		"docs", "agents",
+	})
+	inputs.Input.Env = append(os.Environ(),
+		"HOME="+home,
+		"USERPROFILE="+home,
+		operatorsettings.EnvDefaultWorkerModelProvider+"=codex",
+		operatorsettings.EnvDefaultWorkerModel+"=environment-model",
+	)
+	inputs.Input.WorkingDirectory = home
+
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf("Process.Execute(docs agents with operator defaults) error = %v", err)
+	}
+
+	assertResolvedOperatorDefault(
+		t,
+		observation.ResolvedInputs,
+		"you.flag.default-worker-model-provider",
+		"gemini",
+		resolvedinput.SourceCLIFlag,
+	)
+	assertResolvedOperatorDefault(
+		t,
+		observation.ResolvedInputs,
+		"you.flag.default-worker-model",
+		"flag-gemini-model",
+		resolvedinput.SourceCLIFlag,
+	)
+	assertOperatorDefaultNotFromSource(
+		t,
+		observation.ResolvedInputs,
+		"you.flag.default-worker-model-provider",
+		resolvedinput.SourceEnvironment,
+		"codex",
+	)
+	assertOperatorDefaultNotFromSource(
+		t,
+		observation.ResolvedInputs,
+		"you.flag.default-worker-model",
+		resolvedinput.SourceEnvironment,
+		"environment-model",
+	)
+}
+
+func assertResolvedOperatorDefault(
+	t *testing.T,
+	observations []resolvedinput.Observation,
+	inputID string,
+	wantValue string,
+	wantSource resolvedinput.Source,
+) {
+	t.Helper()
+	observation, found := resolvedOperatorDefaultObservation(observations, inputID)
+	if !found {
+		t.Fatalf("%s observation is missing", inputID)
+	}
+	if observation.Value != wantValue ||
+		observation.Provenance != wantSource ||
+		!observation.Changed ||
+		observation.Default {
+		t.Fatalf(
+			"%s observation = %#v, want value %q changed non-default source %q",
+			inputID,
+			observation,
+			wantValue,
+			wantSource,
+		)
+	}
+}
+
+func assertOperatorDefaultNotFromSource(
+	t *testing.T,
+	observations []resolvedinput.Observation,
+	inputID string,
+	rejectedSource resolvedinput.Source,
+	rejectedValue string,
+) {
+	t.Helper()
+	observation, found := resolvedOperatorDefaultObservation(observations, inputID)
+	if !found {
+		t.Fatalf("%s observation is missing", inputID)
+	}
+	if observation.Provenance == rejectedSource && observation.Value == rejectedValue {
+		t.Fatalf(
+			"%s observation = %#v, want source other than %q with value other than %q",
+			inputID,
+			observation,
+			rejectedSource,
+			rejectedValue,
+		)
+	}
+}
+
+func resolvedOperatorDefaultObservation(
+	observations []resolvedinput.Observation,
+	inputID string,
+) (resolvedinput.Observation, bool) {
+	for _, observation := range observations {
+		if observation.InputID == inputID {
+			return observation, true
+		}
+	}
+	return resolvedinput.Observation{}, false
+}


### PR DESCRIPTION
{
  "project": "CLI Environment Precedence Functional Coverage",
  "branchName": "ft-wave1-cli-environment-precedence",
  "description": "Implement the transport-owned functional cell at tests/functional/transport/cli/parameters/environment_precedence_test.go so the public CLI proves explicit flags override environment defaults, environment overrides global config per documented file < env < flag precedence, and an unset environment falls back without fabricating values, without implementing other CLI parameter cells or inventing migration-ledger deletion work for this free destination.",
  "context": {
    "customerAsk": "Implement only tests/functional/transport/cli/parameters/environment_precedence_test.go. Through the public CLI boundary, prove: (1) TestCLIExplicitFlagOverridesEnvironmentDefault — explicit flags override environment defaults; (2) TestCLIEnvironmentOverridesGlobalConfig — environment overrides global config per documented precedence; (3) TestCLIUnsetEnvironmentFallsBackWithoutFabricatingValue — unset environment falls back without fabricating values. Do not implement other CLI parameter cells. Avoid service/internal imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled ownership/coverage/catalog/migration metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for CLI environment precedence does not exist yet even though json_values_test.go has freed transport/cli/parameters. Maintainers lack a focused, catalogued transport proof that explicit flags override environment defaults, that environment overrides global config per documented precedence, and that an unset environment falls back without fabricating values. No migration-ledger rows map here, so checklist behaviors are the authoritative scope.",
    "solution": "Implement the flag-over-env, env-over-global-config, and unset-env fallback scenarios in tests/functional/transport/cli/parameters/environment_precedence_test.go through the public CLI/root.BuildProcess boundary with edges.Edges for observation and controlled environment/config fixtures, with customer-readable Go docs on every top-level Test. Do not invent migration-ledger deletion consumption; apply only narrowly coupled ownership/coverage/catalog metadata; leave other CLI parameter cells untouched; and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/transport/cli/parameters/environment_precedence_test.go exists as the transport-owned functional cell and covers flag-over-env, env-over-global-config, and unset-env fallback without fabricated values.",
    "Through the public CLI boundary, when an environment default and an explicit flag both supply the same documented operator setting, the flag-resolved value is observable at the invocation / CLI observation edge and the environment value is not selected.",
    "When global config and environment disagree for the same documented operator setting, the environment-resolved value is observable and the file value is not selected, matching documented file < env < flag precedence.",
    "When the relevant environment variable is unset, the CLI falls back to the next documented source without fabricating an environment-derived value; the fallback outcome is observable at an approved external edge.",
    "Coverage uses root.BuildProcess/public CLI helpers and edges.Edges only for external effects; it does not import service implementations or internal Petri primitives, and does not assert Work/Session/Worker/Factory product semantics beyond transport precedence evidence; every top-level Test* has a customer-readable Go doc comment; specialty bindings remain none; only narrowly coupled ownership/coverage/catalog metadata for this cell are updated; no migration-ledger deletion batch is invented; other CLI parameter cells are not implemented.",
    "Focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave1-cli-environment-precedence-001",
      "title": "Prove explicit flags override environment defaults",
      "description": "As a CLI customer, I want an explicit flag to win when both a flag and an environment default are set for the same operator setting, so I can override a shell environment for a single invocation without changing my session exports.",
      "acceptanceCriteria": [
        "tests/functional/transport/cli/parameters/environment_precedence_test.go includes TestCLIExplicitFlagOverridesEnvironmentDefault (or equivalent top-level name matching the checklist intent).",
        "The test builds the customer process through root.BuildProcess / approved support helpers and substitutes external effects only through edges.Edges (for example CLI observation and/or process environment injection).",
        "Executing a public CLI invocation with both a documented environment default (for example YOU_DEFAULT_WORKER_MODEL_PROVIDER / YOU_DEFAULT_WORKER_MODEL) and a conflicting explicit flag (for example --default-worker-model-provider / --default-worker-model) succeeds far enough for the resolved default to be observed.",
        "The observed invocation / CLI observation edge records the flag-supplied value as the selected default; the environment value is not selected.",
        "Evidence is an approved external edge, not private config-merge or env parser internals.",
        "Assertions stay on transport precedence and do not assert Work completion, Worker provider semantics, or Factory orchestration outcomes beyond what is required to observe the resolved default.",
        "The top-level test has a customer-readable Go doc comment describing the observable flag-over-env behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-environment-precedence-002",
      "title": "Prove environment overrides global config",
      "description": "As a CLI customer, I want environment variables to override global operator config for the same setting, so I can temporarily change defaults without rewriting ~/.you-agent-factory/config.json.",
      "acceptanceCriteria": [
        "The environment-precedence cell includes TestCLIEnvironmentOverridesGlobalConfig (or equivalent top-level name matching the checklist intent).",
        "The test supplies a global config default and a conflicting environment default for the same documented operator setting, then invokes a public CLI surface far enough for the resolved default to be observed.",
        "The observed invocation / CLI observation edge records the environment-supplied value as the selected default; the file value is not selected.",
        "The outcome matches documented public precedence file < env < flag (environment wins over file when no overriding flag is present).",
        "Evidence is an approved external edge, not private config loader internals.",
        "Assertions remain transport precedence-focused and do not prove Worker execution or Factory orchestration semantics beyond observing the resolved default.",
        "The top-level test has a customer-readable Go doc comment describing the observable env-over-file behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-environment-precedence-003",
      "title": "Prove unset environment falls back without fabricating a value",
      "description": "As a CLI customer, I want an unset environment variable to fall back to the next documented source without inventing a value, so absence is not silently treated as an empty or placeholder override.",
      "acceptanceCriteria": [
        "The environment-precedence cell includes TestCLIUnsetEnvironmentFallsBackWithoutFabricatingValue (or equivalent top-level name matching the checklist intent).",
        "The test leaves the relevant documented environment variable unset while a next-source default is available (global config and/or product default as appropriate to the public surface), then invokes a public CLI surface far enough for the resolved default to be observed.",
        "The observed outcome falls back to the next documented source; the CLI does not fabricate an environment-derived value for the unset variable.",
        "Evidence is an approved external edge, not private env-lookup or default materialization internals.",
        "Assertions remain transport fallback-contract focused and do not prove domain payload or Factory orchestration semantics beyond observing the fallback.",
        "The top-level test has a customer-readable Go doc comment describing the observable unset-env fallback behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-environment-precedence-004",
      "title": "Close cell verification gates without sibling widening",
      "description": "As a maintainer executing Wave 1 expansion, I want this free destination catalogued and verified without inventing migration-ledger deletion work or implementing other CLI parameter cells, so the parameters package remains collision-safe and checklist-scoped.",
      "acceptanceCriteria": [
        "No migration-ledger deletion batch is invented or claimed for this destination; checklist behaviors remain the authoritative scope.",
        "Specialty bindings for this cell remain none; only narrowly coupled ownership, coverage, or catalog metadata required for tests/functional/transport/cli/parameters/environment_precedence_test.go are updated.",
        "Other CLI parameter cells are not created or modified by this work.",
        "Focused package tests for tests/functional/transport/cli/parameters pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as transport/cli/parameters).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)