### PR TITLE
ft-wave1-inference-stream-fidelity

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -616,6 +616,21 @@ Wave 0 functional-tests-expansion planning authority lives under
   plus public Work outcomes only. Catalog metadata infers domain `workers` and
   subsection `inference` from the path; every top-level `Test*` needs a
   customer-readable Go doc so `functionaltestmetadata` stays viz-compatible.
+- Workers inference provider stream-fidelity functional coverage belongs in
+  `tests/functional/workers/inference/stream_fidelity_test.go`: prove full-stream
+  providers publish truthful message deltas and completed snapshots (native-stream
+  delivery, no final-only fabrication), partial-stream providers do not fabricate
+  missing message deltas, snapshot-only providers emit completed snapshots only
+  (zero deltas, no final-only), and final-only providers emit only the terminal
+  completed message (`FINAL_ONLY` / `NATIVE_FINAL`, zero message deltas). Drive
+  proofs through `support.RunFactoryToCompletionWithEdgesAndResponseEvents` with
+  sanitized FND-006 provider-session goldens replayed via
+  `serviceedges.Edges{ProviderCommandRunner: ...}` (and OpenCode snapshot-only
+  executable-locator edges when required) and assert on public
+  `FactoryResponseEvent` provenance plus terminal Work outcomes only. Catalog
+  metadata infers domain `workers` and subsection `inference` from the path;
+  every top-level `Test*` needs a customer-readable Go doc so
+  `functionaltestmetadata` stays viz-compatible.
 
 - `tests/functional/automations/` owns root.BuildProcess evidence for packaged
   Automations cron scheduling. Keep cron workstation factories explicit with

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -427,7 +427,16 @@ primary-result behavior.
   `tests/functional/workers/inference/flags_test.go`; drive proofs through
   `support.RunFactoryToCompletionWithEdgesAndObservations` with
   `serviceedges.Edges{ProviderCommandRunner: ...}` and assert on provider-process
-  command args plus public Work outcomes only. Script execution-environment
+  command args plus public Work outcomes only. Provider stream fidelity
+  (full-stream truthful deltas and snapshots, partial-stream non-fabrication of
+  missing deltas, snapshot-only completed snapshots without deltas, and final-only
+  terminal messages without native-stream claims) belongs in
+  `tests/functional/workers/inference/stream_fidelity_test.go`; drive proofs
+  through `support.RunFactoryToCompletionWithEdgesAndResponseEvents` with
+  sanitized FND-006 provider-session goldens replayed via
+  `serviceedges.Edges{ProviderCommandRunner: ...}` (and OpenCode snapshot-only
+  executable-locator edges when required) and assert on public Factory response
+  events and Work outcomes only. Script execution-environment
   boundary proofs (declared env filtering, missing-executable public failure,
   resource-token template resolution, multi-input ordering, and worktree
   passthrough) belong in

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -249,7 +249,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestProviderAuthRateLimitAndTimeoutRemainDistinct` covers error classes.
   - `TestProviderFailureRedactsPromptEnvironmentAndCredentials` covers safety.
 
-- [ ] `tests/functional/workers/inference/stream_fidelity_test.go`
+- [x] `tests/functional/workers/inference/stream_fidelity_test.go`
   - `TestProviderFullStreamClaimsDeltasAndSnapshotsTruthfully`.
   - `TestProviderPartialStreamDoesNotFabricateMissingDeltas`.
   - `TestProviderSnapshotOnlyEmitsCompletedSnapshotsOnly`.

--- a/tests/functional/workers/inference/stream_fidelity_test.go
+++ b/tests/functional/workers/inference/stream_fidelity_test.go
@@ -14,7 +14,10 @@ import (
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
-const claudeFullStreamGoldenCase = "full-stream-text-success"
+const (
+	claudeFullStreamGoldenCase   = "full-stream-text-success"
+	codexPartialStreamGoldenCase = "success"
+)
 
 // TestProviderFullStreamClaimsDeltasAndSnapshotsTruthfully replays a sanitized
 // full-stream provider transcript through root.BuildProcess and proves published
@@ -68,6 +71,55 @@ func TestProviderFullStreamClaimsDeltasAndSnapshotsTruthfully(t *testing.T) {
 	}
 
 	assertFullStreamPublicResponseEvents(t, responseEvents, "Parity hello world COMPLETE")
+}
+
+// TestProviderPartialStreamDoesNotFabricateMissingDeltas replays a sanitized
+// partial-stream provider transcript through root.BuildProcess and proves
+// published Factory response events expose native streaming with completed
+// message snapshots only—no fabricated message deltas and no final-only fidelity
+// on those snapshots.
+func TestProviderPartialStreamDoesNotFabricateMissingDeltas(t *testing.T) {
+	loaded := loadStreamFidelityGoldenCase(t, modelprovider.ProviderCodex, codexPartialStreamGoldenCase)
+	if loaded.Manifest.FidelityClass != support.ProviderSessionFidelityPartialStream {
+		t.Fatalf(
+			"manifest.fidelityClass = %q, want %q",
+			loaded.Manifest.FidelityClass,
+			support.ProviderSessionFidelityPartialStream,
+		)
+	}
+
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
+	support.WriteAgentConfig(t, dir, "worker", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, loaded.Process.Model))
+	testutil.WriteSeedFile(t, dir, "task", []byte(`{"title":"provider partial stream fidelity"}`))
+
+	exitCode := 0
+	if loaded.Process.ExitCode != nil {
+		exitCode = *loaded.Process.ExitCode
+	}
+	runner := testutil.NewProviderCommandRunner(platformprocess.CommandResult{
+		Stdout:   append([]byte(nil), loaded.Stdout.Raw...),
+		Stderr:   []byte(loaded.Stderr),
+		ExitCode: exitCode,
+	})
+
+	_, listed, factoryEvents, responseEvents := support.RunFactoryToCompletionWithEdgesAndResponseEvents(
+		t,
+		dir,
+		serviceedges.Edges{ProviderCommandRunner: runner},
+		20*time.Second,
+	)
+
+	if got := support.CountWorkAtCustomerState(listed, "task:done"); got != 1 {
+		t.Fatalf("completed work = %d, want 1; listed=%#v", got, listed)
+	}
+	if got := support.CountWorkAtCustomerState(listed, "task:failed"); got != 0 {
+		t.Fatalf("failed work = %d, want 0", got)
+	}
+	if runner.CallCount() != 1 {
+		t.Fatalf("provider command runner calls = %d, want exactly one provider-process edge", runner.CallCount())
+	}
+
+	assertPartialStreamPublicResponseEvents(t, responseEvents, factoryEvents, "Codex fixture answer COMPLETE")
 }
 
 func loadStreamFidelityGoldenCase(
@@ -185,6 +237,97 @@ func assertFullStreamPublicResponseEvents(
 	if completedText != wantCompletedText {
 		t.Fatalf("completed message snapshot = %q, want %q", completedText, wantCompletedText)
 	}
+}
+
+func assertPartialStreamPublicResponseEvents(
+	t *testing.T,
+	responseEvents []factoryapi.FactoryResponseEvent,
+	factoryEvents []factoryapi.FactoryEvent,
+	wantCompletedText string,
+) {
+	t.Helper()
+
+	var (
+		snapshotCount   int
+		terminalMatched bool
+	)
+
+	for _, event := range responseEvents {
+		if event.Kind != factoryapi.FactoryResponseEventKindMessage {
+			continue
+		}
+
+		switch event.Phase {
+		case factoryapi.FactoryResponseEventPhaseDelta:
+			t.Fatalf("partial-stream replay fabricated message delta: %#v", event)
+
+		case factoryapi.FactoryResponseEventPhaseCompleted:
+			if event.Provenance.Fidelity == factoryapi.FactoryResponseEventProvenanceFidelityFinalOnly {
+				t.Fatalf("partial-stream replay claimed final-only fidelity on completed message: %#v", event)
+			}
+			if event.Provenance.Delivery != factoryapi.FactoryResponseEventProvenanceDeliveryNativeStream {
+				t.Fatalf(
+					"partial-stream completed message delivery = %q, want %q: %#v",
+					event.Provenance.Delivery,
+					factoryapi.FactoryResponseEventProvenanceDeliveryNativeStream,
+					event,
+				)
+			}
+			if event.Provenance.Representation != factoryapi.FactoryResponseEventProvenanceRepresentationSnapshot {
+				t.Fatalf(
+					"partial-stream completed message representation = %q, want %q: %#v",
+					event.Provenance.Representation,
+					factoryapi.FactoryResponseEventProvenanceRepresentationSnapshot,
+					event,
+				)
+			}
+
+			payload, err := event.Payload.AsFactoryResponseEventMessagePayload()
+			if err != nil {
+				t.Fatalf("decode completed message response event: %v", err)
+			}
+			text := streamFidelityMessageText(payload)
+			if text == "" {
+				t.Fatalf("partial-stream completed message missing text: %#v", event)
+			}
+			snapshotCount++
+			if text == wantCompletedText {
+				terminalMatched = true
+			}
+		}
+	}
+
+	if snapshotCount == 0 {
+		terminalMatched = streamFidelityInferenceResponseContains(t, factoryEvents, wantCompletedText)
+	}
+	if !terminalMatched {
+		t.Fatalf("partial-stream replay missing terminal message %q", wantCompletedText)
+	}
+}
+
+func streamFidelityInferenceResponseContains(
+	t *testing.T,
+	factoryEvents []factoryapi.FactoryEvent,
+	wantText string,
+) bool {
+	t.Helper()
+
+	for _, event := range factoryEvents {
+		if event.Type != factoryapi.FactoryEventTypeInferenceResponse {
+			continue
+		}
+		payload, err := event.Payload.AsInferenceResponseEventPayload()
+		if err != nil {
+			t.Fatalf("decode inference response event: %v", err)
+		}
+		if payload.Outcome != factoryapi.InferenceOutcomeSucceeded {
+			continue
+		}
+		if payload.Response != nil && strings.Contains(*payload.Response, wantText) {
+			return true
+		}
+	}
+	return false
 }
 
 func streamFidelityMessageText(message factoryapi.FactoryResponseEventMessagePayload) string {

--- a/tests/functional/workers/inference/stream_fidelity_test.go
+++ b/tests/functional/workers/inference/stream_fidelity_test.go
@@ -1,6 +1,8 @@
 package inference_test
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -15,8 +17,9 @@ import (
 )
 
 const (
-	claudeFullStreamGoldenCase   = "full-stream-text-success"
-	codexPartialStreamGoldenCase = "success"
+	claudeFullStreamGoldenCase      = "full-stream-text-success"
+	codexPartialStreamGoldenCase    = "success"
+	openCodeSnapshotOnlyGoldenCase  = "structured-snapshot-success"
 )
 
 // TestProviderFullStreamClaimsDeltasAndSnapshotsTruthfully replays a sanitized
@@ -120,6 +123,68 @@ func TestProviderPartialStreamDoesNotFabricateMissingDeltas(t *testing.T) {
 	}
 
 	assertPartialStreamPublicResponseEvents(t, responseEvents, factoryEvents, "Codex fixture answer COMPLETE")
+}
+
+// TestProviderSnapshotOnlyEmitsCompletedSnapshotsOnly replays a sanitized
+// snapshot-only provider transcript through root.BuildProcess and proves
+// published Factory response events expose native streaming with completed
+// message snapshots only—zero message deltas and no final-only fidelity claims.
+func TestProviderSnapshotOnlyEmitsCompletedSnapshotsOnly(t *testing.T) {
+	loaded := loadStreamFidelityGoldenCase(t, modelprovider.ProviderOpenCode, openCodeSnapshotOnlyGoldenCase)
+	if loaded.Manifest.FidelityClass != support.ProviderSessionFidelitySnapshotOnly {
+		t.Fatalf(
+			"manifest.fidelityClass = %q, want %q",
+			loaded.Manifest.FidelityClass,
+			support.ProviderSessionFidelitySnapshotOnly,
+		)
+	}
+
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
+	support.WriteAgentConfig(t, dir, "worker", strings.Replace(
+		support.BuildModelWorkerConfig(modelprovider.ProviderOpenCode, loaded.Process.Model),
+		"stopToken: COMPLETE",
+		"skipPermissions: true\nstopToken: COMPLETE",
+		1,
+	))
+	testutil.WriteSeedFile(t, dir, "task", []byte(`{"title":"provider snapshot-only fidelity"}`))
+
+	exitCode := 0
+	if loaded.Process.ExitCode != nil {
+		exitCode = *loaded.Process.ExitCode
+	}
+	executablePath := writeStreamFidelityOpenCodeExecutable(t)
+	runner := testutil.NewProviderCommandRunner(
+		platformprocess.CommandResult{Stdout: []byte("1.2.3\n")},
+		platformprocess.CommandResult{ExitCode: 0},
+		platformprocess.CommandResult{
+			Stdout:   append([]byte(nil), loaded.Stdout.Raw...),
+			Stderr:   []byte(loaded.Stderr),
+			ExitCode: exitCode,
+		},
+	)
+
+	_, listed, _, responseEvents := support.RunFactoryToCompletionWithEdgesAndResponseEvents(
+		t,
+		dir,
+		serviceedges.Edges{
+			ProviderCommandRunner:    runner,
+			WorkersExecutableLocator: streamFidelityOpenCodeExecutableLocator{path: executablePath},
+			WorkersResolveSymlinks:   streamFidelityIdentityResolveSymlinks,
+		},
+		30*time.Second,
+	)
+
+	if got := support.CountWorkAtCustomerState(listed, "task:done"); got != 1 {
+		t.Fatalf("completed work = %d, want 1; listed=%#v", got, listed)
+	}
+	if got := support.CountWorkAtCustomerState(listed, "task:failed"); got != 0 {
+		t.Fatalf("failed work = %d, want 0", got)
+	}
+	if runner.CallCount() != 3 {
+		t.Fatalf("provider command runner calls = %d, want discovery probes plus one invocation", runner.CallCount())
+	}
+
+	assertSnapshotOnlyPublicResponseEvents(t, responseEvents, "Hello world COMPLETE")
 }
 
 func loadStreamFidelityGoldenCase(
@@ -303,6 +368,96 @@ func assertPartialStreamPublicResponseEvents(
 	if !terminalMatched {
 		t.Fatalf("partial-stream replay missing terminal message %q", wantCompletedText)
 	}
+}
+
+func assertSnapshotOnlyPublicResponseEvents(
+	t *testing.T,
+	events []factoryapi.FactoryResponseEvent,
+	wantCompletedText string,
+) {
+	t.Helper()
+
+	var (
+		snapshotCount int
+		terminalSeen  bool
+	)
+
+	for _, event := range events {
+		if event.Kind != factoryapi.FactoryResponseEventKindMessage {
+			continue
+		}
+
+		switch event.Phase {
+		case factoryapi.FactoryResponseEventPhaseDelta:
+			t.Fatalf("snapshot-only replay fabricated message delta: %#v", event)
+
+		case factoryapi.FactoryResponseEventPhaseCompleted:
+			if event.Provenance.Fidelity == factoryapi.FactoryResponseEventProvenanceFidelityFinalOnly {
+				t.Fatalf("snapshot-only replay claimed final-only fidelity on completed message: %#v", event)
+			}
+			if event.Provenance.Delivery != factoryapi.FactoryResponseEventProvenanceDeliveryNativeStream {
+				t.Fatalf(
+					"snapshot-only completed message delivery = %q, want %q: %#v",
+					event.Provenance.Delivery,
+					factoryapi.FactoryResponseEventProvenanceDeliveryNativeStream,
+					event,
+				)
+			}
+			if event.Provenance.Representation != factoryapi.FactoryResponseEventProvenanceRepresentationSnapshot {
+				t.Fatalf(
+					"snapshot-only completed message representation = %q, want %q: %#v",
+					event.Provenance.Representation,
+					factoryapi.FactoryResponseEventProvenanceRepresentationSnapshot,
+					event,
+				)
+			}
+
+			payload, err := event.Payload.AsFactoryResponseEventMessagePayload()
+			if err != nil {
+				t.Fatalf("decode completed message response event: %v", err)
+			}
+			text := streamFidelityMessageText(payload)
+			if text == "" {
+				t.Fatalf("snapshot-only completed message missing text: %#v", event)
+			}
+			snapshotCount++
+			if text == wantCompletedText {
+				terminalSeen = true
+			}
+		}
+	}
+
+	if snapshotCount == 0 {
+		t.Fatal("snapshot-only replay missing completed message snapshots")
+	}
+	if !terminalSeen {
+		t.Fatalf("snapshot-only replay missing terminal completed message %q", wantCompletedText)
+	}
+}
+
+type streamFidelityOpenCodeExecutableLocator struct {
+	path string
+}
+
+func (l streamFidelityOpenCodeExecutableLocator) LookPath(file string) (string, error) {
+	if file == "opencode" {
+		return l.path, nil
+	}
+	return "", fmt.Errorf("executable %q not found", file)
+}
+
+func streamFidelityIdentityResolveSymlinks(path string) (string, error) {
+	return path, nil
+}
+
+func writeStreamFidelityOpenCodeExecutable(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "opencode")
+	if err := os.WriteFile(path, []byte("opencode-fixture-executable\n"), 0o755); err != nil {
+		t.Fatalf("write opencode fixture executable: %v", err)
+	}
+	return path
 }
 
 func streamFidelityInferenceResponseContains(

--- a/tests/functional/workers/inference/stream_fidelity_test.go
+++ b/tests/functional/workers/inference/stream_fidelity_test.go
@@ -1,0 +1,201 @@
+package inference_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const claudeFullStreamGoldenCase = "full-stream-text-success"
+
+// TestProviderFullStreamClaimsDeltasAndSnapshotsTruthfully replays a sanitized
+// full-stream provider transcript through root.BuildProcess and proves published
+// Factory response events claim native streaming with truthful message deltas and
+// a matching completed snapshot, without final-only fidelity or synthesized
+// message-delta fabrication.
+func TestProviderFullStreamClaimsDeltasAndSnapshotsTruthfully(t *testing.T) {
+	loaded := loadStreamFidelityGoldenCase(t, modelprovider.ProviderClaude, claudeFullStreamGoldenCase)
+	if loaded.Manifest.FidelityClass != support.ProviderSessionFidelityFullStream {
+		t.Fatalf(
+			"manifest.fidelityClass = %q, want %q",
+			loaded.Manifest.FidelityClass,
+			support.ProviderSessionFidelityFullStream,
+		)
+	}
+
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
+	support.WriteAgentConfig(t, dir, "worker", strings.Replace(
+		support.BuildModelWorkerConfig(modelprovider.ProviderClaude, loaded.Process.Model),
+		"stopToken: COMPLETE",
+		"skipPermissions: true\nstopToken: COMPLETE",
+		1,
+	))
+	testutil.WriteSeedFile(t, dir, "task", []byte(`{"title":"provider full stream fidelity"}`))
+
+	exitCode := 0
+	if loaded.Process.ExitCode != nil {
+		exitCode = *loaded.Process.ExitCode
+	}
+	runner := testutil.NewProviderCommandRunner(platformprocess.CommandResult{
+		Stdout:   append([]byte(nil), loaded.Stdout.Raw...),
+		Stderr:   []byte(loaded.Stderr),
+		ExitCode: exitCode,
+	})
+
+	_, listed, _, responseEvents := support.RunFactoryToCompletionWithEdgesAndResponseEvents(
+		t,
+		dir,
+		serviceedges.Edges{ProviderCommandRunner: runner},
+		20*time.Second,
+	)
+
+	if got := support.CountWorkAtCustomerState(listed, "task:done"); got != 1 {
+		t.Fatalf("completed work = %d, want 1; listed=%#v", got, listed)
+	}
+	if got := support.CountWorkAtCustomerState(listed, "task:failed"); got != 0 {
+		t.Fatalf("failed work = %d, want 0", got)
+	}
+	if runner.CallCount() != 1 {
+		t.Fatalf("provider command runner calls = %d, want exactly one provider-process edge", runner.CallCount())
+	}
+
+	assertFullStreamPublicResponseEvents(t, responseEvents, "Parity hello world COMPLETE")
+}
+
+func loadStreamFidelityGoldenCase(
+	t *testing.T,
+	provider modelprovider.Provider,
+	caseName string,
+) support.ProviderSessionCase {
+	t.Helper()
+
+	repoRoot := testutil.MustRepoRoot(t)
+	caseDir := filepath.Join(
+		repoRoot,
+		filepath.FromSlash(support.ProviderSessionFixturePath(string(provider), caseName)),
+	)
+	loaded, err := support.LoadProviderSessionCase(caseDir)
+	if err != nil {
+		t.Fatalf("LoadProviderSessionCase(%q): %v", caseName, err)
+	}
+	return loaded
+}
+
+func assertFullStreamPublicResponseEvents(
+	t *testing.T,
+	events []factoryapi.FactoryResponseEvent,
+	wantCompletedText string,
+) {
+	t.Helper()
+
+	var (
+		deltaCount      int
+		deltaText       strings.Builder
+		completedText   string
+		completedSeen   bool
+	)
+
+	for _, event := range events {
+		if event.Kind != factoryapi.FactoryResponseEventKindMessage {
+			continue
+		}
+
+		switch event.Phase {
+		case factoryapi.FactoryResponseEventPhaseDelta:
+			if event.Provenance.Fidelity == factoryapi.FactoryResponseEventProvenanceFidelityFinalOnly {
+				t.Fatalf("full-stream replay claimed final-only fidelity on message delta: %#v", event)
+			}
+			if event.Provenance.Delivery != factoryapi.FactoryResponseEventProvenanceDeliveryNativeStream {
+				t.Fatalf(
+					"full-stream message delta delivery = %q, want %q: %#v",
+					event.Provenance.Delivery,
+					factoryapi.FactoryResponseEventProvenanceDeliveryNativeStream,
+					event,
+				)
+			}
+			if event.Provenance.Representation != factoryapi.FactoryResponseEventProvenanceRepresentationDelta {
+				t.Fatalf(
+					"full-stream message delta representation = %q, want %q: %#v",
+					event.Provenance.Representation,
+					factoryapi.FactoryResponseEventProvenanceRepresentationDelta,
+					event,
+				)
+			}
+
+			payload, err := event.Payload.AsFactoryResponseEventMessageDeltaPayload()
+			if err != nil {
+				t.Fatalf("decode message delta response event: %v", err)
+			}
+			if payload.TextDelta == nil || strings.TrimSpace(*payload.TextDelta) == "" {
+				t.Fatalf("full-stream message delta missing text: %#v", event)
+			}
+			deltaCount++
+			deltaText.WriteString(*payload.TextDelta)
+
+		case factoryapi.FactoryResponseEventPhaseCompleted:
+			if event.Provenance.Fidelity == factoryapi.FactoryResponseEventProvenanceFidelityFinalOnly {
+				t.Fatalf("full-stream replay claimed final-only fidelity on completed message: %#v", event)
+			}
+			if event.Provenance.Delivery != factoryapi.FactoryResponseEventProvenanceDeliveryNativeStream {
+				t.Fatalf(
+					"full-stream completed message delivery = %q, want %q: %#v",
+					event.Provenance.Delivery,
+					factoryapi.FactoryResponseEventProvenanceDeliveryNativeStream,
+					event,
+				)
+			}
+			if event.Provenance.Representation != factoryapi.FactoryResponseEventProvenanceRepresentationSnapshot {
+				t.Fatalf(
+					"full-stream completed message representation = %q, want %q: %#v",
+					event.Provenance.Representation,
+					factoryapi.FactoryResponseEventProvenanceRepresentationSnapshot,
+					event,
+				)
+			}
+
+			payload, err := event.Payload.AsFactoryResponseEventMessagePayload()
+			if err != nil {
+				t.Fatalf("decode completed message response event: %v", err)
+			}
+			completedText = streamFidelityMessageText(payload)
+			if completedText == "" {
+				t.Fatalf("full-stream completed message missing text: %#v", event)
+			}
+			completedSeen = true
+		}
+	}
+
+	if deltaCount == 0 {
+		t.Fatal("full-stream replay missing native message deltas")
+	}
+	if !completedSeen {
+		t.Fatal("full-stream replay missing completed message snapshot")
+	}
+	if got := strings.TrimSpace(deltaText.String()); got != wantCompletedText {
+		t.Fatalf("concatenated message deltas = %q, want %q", got, wantCompletedText)
+	}
+	if completedText != wantCompletedText {
+		t.Fatalf("completed message snapshot = %q, want %q", completedText, wantCompletedText)
+	}
+}
+
+func streamFidelityMessageText(message factoryapi.FactoryResponseEventMessagePayload) string {
+	for _, block := range message.ContentBlocks {
+		text, err := block.AsFactoryResponseEventTextContentBlock()
+		if err != nil {
+			continue
+		}
+		if text.Text != "" {
+			return text.Text
+		}
+	}
+	return ""
+}

--- a/tests/functional/workers/inference/stream_fidelity_test.go
+++ b/tests/functional/workers/inference/stream_fidelity_test.go
@@ -17,9 +17,10 @@ import (
 )
 
 const (
-	claudeFullStreamGoldenCase      = "full-stream-text-success"
-	codexPartialStreamGoldenCase    = "success"
-	openCodeSnapshotOnlyGoldenCase  = "structured-snapshot-success"
+	claudeFullStreamGoldenCase     = "full-stream-text-success"
+	codexPartialStreamGoldenCase   = "success"
+	openCodeSnapshotOnlyGoldenCase = "structured-snapshot-success"
+	geminiFinalOnlyGoldenCase        = "text-success"
 )
 
 // TestProviderFullStreamClaimsDeltasAndSnapshotsTruthfully replays a sanitized
@@ -185,6 +186,55 @@ func TestProviderSnapshotOnlyEmitsCompletedSnapshotsOnly(t *testing.T) {
 	}
 
 	assertSnapshotOnlyPublicResponseEvents(t, responseEvents, "Hello world COMPLETE")
+}
+
+// TestProviderFinalOnlyEmitsTerminalMessageOnly replays a sanitized final-only
+// provider transcript through root.BuildProcess and proves published Factory
+// response events expose only the terminal completed message with final-only
+// fidelity and native-final delivery—zero fabricated message deltas or native
+// streaming claims.
+func TestProviderFinalOnlyEmitsTerminalMessageOnly(t *testing.T) {
+	loaded := loadStreamFidelityGoldenCase(t, modelprovider.ProviderGemini, geminiFinalOnlyGoldenCase)
+	if loaded.Manifest.FidelityClass != support.ProviderSessionFidelityFinalOnly {
+		t.Fatalf(
+			"manifest.fidelityClass = %q, want %q",
+			loaded.Manifest.FidelityClass,
+			support.ProviderSessionFidelityFinalOnly,
+		)
+	}
+
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
+	support.WriteAgentConfig(t, dir, "worker", support.BuildModelWorkerConfig(modelprovider.ProviderGemini, loaded.Process.Model))
+	testutil.WriteSeedFile(t, dir, "task", []byte(`{"title":"provider final-only fidelity"}`))
+
+	exitCode := 0
+	if loaded.Process.ExitCode != nil {
+		exitCode = *loaded.Process.ExitCode
+	}
+	runner := testutil.NewProviderCommandRunner(platformprocess.CommandResult{
+		Stdout:   append([]byte(nil), loaded.Stdout.Raw...),
+		Stderr:   []byte(loaded.Stderr),
+		ExitCode: exitCode,
+	})
+
+	_, listed, _, responseEvents := support.RunFactoryToCompletionWithEdgesAndResponseEvents(
+		t,
+		dir,
+		serviceedges.Edges{ProviderCommandRunner: runner},
+		20*time.Second,
+	)
+
+	if got := support.CountWorkAtCustomerState(listed, "task:done"); got != 1 {
+		t.Fatalf("completed work = %d, want 1; listed=%#v", got, listed)
+	}
+	if got := support.CountWorkAtCustomerState(listed, "task:failed"); got != 0 {
+		t.Fatalf("failed work = %d, want 0", got)
+	}
+	if runner.CallCount() != 1 {
+		t.Fatalf("provider command runner calls = %d, want exactly one provider-process edge", runner.CallCount())
+	}
+
+	assertFinalOnlyPublicResponseEvents(t, responseEvents, "gemini functional answer COMPLETE")
 }
 
 func loadStreamFidelityGoldenCase(
@@ -432,6 +482,81 @@ func assertSnapshotOnlyPublicResponseEvents(
 	}
 	if !terminalSeen {
 		t.Fatalf("snapshot-only replay missing terminal completed message %q", wantCompletedText)
+	}
+}
+
+func assertFinalOnlyPublicResponseEvents(
+	t *testing.T,
+	events []factoryapi.FactoryResponseEvent,
+	wantCompletedText string,
+) {
+	t.Helper()
+
+	var (
+		completedCount int
+		terminalSeen   bool
+	)
+
+	for _, event := range events {
+		switch event.Kind {
+		case factoryapi.FactoryResponseEventKindMessage:
+			switch event.Phase {
+			case factoryapi.FactoryResponseEventPhaseDelta:
+				t.Fatalf("final-only replay fabricated message delta: %#v", event)
+
+			case factoryapi.FactoryResponseEventPhaseCompleted:
+				if event.Provenance.Fidelity != factoryapi.FactoryResponseEventProvenanceFidelityFinalOnly {
+					t.Fatalf(
+						"final-only completed message fidelity = %q, want %q: %#v",
+						event.Provenance.Fidelity,
+						factoryapi.FactoryResponseEventProvenanceFidelityFinalOnly,
+						event,
+					)
+				}
+				if event.Provenance.Delivery != factoryapi.FactoryResponseEventProvenanceDeliveryNativeFinal {
+					t.Fatalf(
+						"final-only completed message delivery = %q, want %q: %#v",
+						event.Provenance.Delivery,
+						factoryapi.FactoryResponseEventProvenanceDeliveryNativeFinal,
+						event,
+					)
+				}
+				if event.Provenance.Representation != factoryapi.FactoryResponseEventProvenanceRepresentationSnapshot {
+					t.Fatalf(
+						"final-only completed message representation = %q, want %q: %#v",
+						event.Provenance.Representation,
+						factoryapi.FactoryResponseEventProvenanceRepresentationSnapshot,
+						event,
+					)
+				}
+
+				payload, err := event.Payload.AsFactoryResponseEventMessagePayload()
+				if err != nil {
+					t.Fatalf("decode completed message response event: %v", err)
+				}
+				text := streamFidelityMessageText(payload)
+				if text == "" {
+					t.Fatalf("final-only completed message missing text: %#v", event)
+				}
+				completedCount++
+				if strings.Contains(text, wantCompletedText) {
+					terminalSeen = true
+				}
+			}
+
+		case factoryapi.FactoryResponseEventKindTool:
+			t.Fatalf("final-only replay fabricated tool lifecycle: %#v", event)
+
+		case factoryapi.FactoryResponseEventKindUsage:
+			t.Fatalf("final-only replay fabricated usage lifecycle: %#v", event)
+		}
+	}
+
+	if completedCount == 0 {
+		t.Fatal("final-only replay missing authoritative completed message")
+	}
+	if !terminalSeen {
+		t.Fatalf("final-only replay missing terminal completed message %q", wantCompletedText)
 	}
 }
 


### PR DESCRIPTION
{
  "project": "Inference Provider Stream Fidelity Functional Coverage",
  "branchName": "ft-wave1-inference-stream-fidelity",
  "description": "Add customer-facing functional coverage in tests/functional/workers/inference/stream_fidelity_test.go that proves, through root.BuildProcess and exact provider-process / response-event edges (not wall-clock sleeps), that full streams claim deltas and snapshots truthfully, partial streams do not fabricate missing deltas, snapshot-only providers emit completed snapshots only, and final-only providers emit only the terminal message—reusing FND-006 sanitized/golden harness patterns without inventing provider metadata or migration-ledger rows.",
  "context": {
    "customerAsk": "Implement only tests/functional/workers/inference/stream_fidelity_test.go. Through root.BuildProcess and exact provider-process / response-event edges (not wall-clock sleeps), prove: (1) TestProviderFullStreamClaimsDeltasAndSnapshotsTruthfully — full stream claims deltas and snapshots truthfully; (2) TestProviderPartialStreamDoesNotFabricateMissingDeltas — partial streams do not fabricate missing deltas; (3) TestProviderSnapshotOnlyEmitsCompletedSnapshotsOnly — snapshot-only providers emit completed snapshots only; (4) TestProviderFinalOnlyEmitsTerminalMessageOnly — final-only providers emit only the terminal message. Do not invent provider metadata; use sanitized provider edges or golden harness patterns already landed by FND-006. Avoid service/internal imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled ownership/coverage/catalog/migration metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "Stream fidelity claims for inference providers are still proven mainly in unit/parity layers and provider-variant goldens, not as one worker-owned functional cell that customers and maintainers can point to. Without that cell, reviewers cannot separately verify that full-stream, partial-stream, snapshot-only, and final-only providers publish truthful response-event / capability outcomes through root.BuildProcess rather than fabricating richer streams than the provider edge produced. flags_test.go is terminal-complete and has freed workers/inference; the checklist destination remains unimplemented; no ledger rows map here, so the gap is coverage clarity under checklist-authoritative scope.",
    "solution": "Author one worker-domain functional cell that drives the four fidelity classes through root.BuildProcess and exact provider-process / response-event edges (approved support helpers and FND-006 sanitized/golden harness patterns, replacing only external provider/process effects). Synchronize on process and event-edge completion rather than wall-clock sleeps. Cover the four checklist scenarios as top-level Tests with customer-readable Go doc comments, treat checklist behaviors as authoritative because no ledger rows map here, avoid pkg/**/internal and service-internal imports, do not invent provider metadata, and update only the narrowly coupled ownership, coverage, catalog, and migration metadata required for this cell."
  },
  "acceptanceCriteria": [
    "tests/functional/workers/inference/stream_fidelity_test.go exists as the sole new functional cell for this work and is owned by the workers/inference domain, not CLI or HTTP transport packages.",
    "Through root.BuildProcess and exact provider-process / response-event edges (not wall-clock sleeps), the four checklist fidelity scenarios are proven as top-level Tests: TestProviderFullStreamClaimsDeltasAndSnapshotsTruthfully, TestProviderPartialStreamDoesNotFabricateMissingDeltas, TestProviderSnapshotOnlyEmitsCompletedSnapshotsOnly, and TestProviderFinalOnlyEmitsTerminalMessageOnly.",
    "Observable outcomes assert truthful streaming claims only: full-stream publishes native message deltas (and truthful snapshot/capability claims consistent with full stream); partial-stream does not emit fabricated message deltas; snapshot-only emits completed snapshots without deltas; final-only emits only the terminal completed message with final-only provenance/delivery semantics.",
    "Checklist behaviors are treated as authoritative scope; no migration-ledger inventory rows are invented for this destination; no provider metadata is invented under assertion; FND-006 sanitized provider edges or golden harness patterns are reused rather than inventing a new harness contract.",
    "Every top-level Test* function has a customer-readable Go doc comment; tests avoid service/internal imports; only narrowly coupled ownership/coverage/catalog/migration metadata for this cell are updated; deferred neighboring Wave 1 cells remain untouched.",
    "Quality gate passes: focused package tests for the new cell, make functional-boundary-check, functional-test metadata / viz-compatible verification for the touched catalog surfaces, plus typecheck, lint, and tests for touched surfaces."
  ],
  "userStories": [
    {
      "id": "ft-wave1-inference-stream-fidelity-001",
      "title": "Prove full stream claims deltas and snapshots truthfully",
      "description": "As a customer or maintainer, I want a worker-domain functional test that shows a full-stream provider claims message deltas and snapshots truthfully through root.BuildProcess, so I can trust that published response-event fidelity matches what the provider process edge actually produced.",
      "acceptanceCriteria": [
        "tests/functional/workers/inference/stream_fidelity_test.go is created under workers/inference ownership and does not import CLI or HTTP transport packages as the proof owner.",
        "The scenario runs through root.BuildProcess with exact provider-process / response-event edges (approved support helpers and/or FND-006 sanitized / golden harness patterns), replacing only external provider/process effects, and synchronizing on edge completion rather than wall-clock sleeps.",
        "TestProviderFullStreamClaimsDeltasAndSnapshotsTruthfully exists with a customer-readable Go doc comment describing the observable full-stream fidelity behavior.",
        "When a full-stream provider edge produces streaming output, published capabilities/events claim native streaming with truthful message deltas (and do not claim final-only), and message-delta events use native-stream delivery rather than fabricated richer-than-source fidelity.",
        "The test does not invent expected provider metadata beyond sanitized / golden harness contracts already landed by FND-006, and avoids service/internal imports.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-inference-stream-fidelity-002",
      "title": "Prove partial streams do not fabricate missing deltas",
      "description": "As a customer or maintainer, I want a partial-stream provider to publish only the stream shape it actually produced, so missing deltas are never fabricated into the public response-event stream.",
      "acceptanceCriteria": [
        "TestProviderPartialStreamDoesNotFabricateMissingDeltas exists with a customer-readable Go doc comment describing the observable partial-stream non-fabrication behavior.",
        "Through root.BuildProcess and exact provider-process / response-event edges, a partial-stream provider edge that does not produce message deltas results in published capabilities/events that do not claim or emit fabricated message deltas.",
        "Observable outcomes show native streaming without message-delta fabrication (for example completed snapshots when that is what the edge produced) and do not claim final-only fidelity for those snapshots.",
        "Expected outcomes assert observable fidelity honesty only; they do not invent provider metadata or change the shared golden harness contract beyond reuse of FND-006 patterns; service/internal imports are avoided; synchronization uses exact edges, not wall-clock sleeps.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-inference-stream-fidelity-003",
      "title": "Prove snapshot-only providers emit completed snapshots only",
      "description": "As a customer or maintainer, I want a snapshot-only provider to emit completed message snapshots only, so consumers never observe invented message deltas or final-only claims for that fidelity class.",
      "acceptanceCriteria": [
        "TestProviderSnapshotOnlyEmitsCompletedSnapshotsOnly exists with a customer-readable Go doc comment describing the observable snapshot-only fidelity behavior.",
        "Through root.BuildProcess and exact provider-process / response-event edges, a snapshot-only provider edge results in completed message snapshot events and zero message-delta events.",
        "Published capabilities claim native streaming with message snapshots and do not claim message deltas or final-only.",
        "The test reuses sanitized provider edges or FND-006 golden harness patterns, does not invent provider metadata, avoids service/internal imports, and does not rely on wall-clock sleeps.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-inference-stream-fidelity-004",
      "title": "Prove final-only providers emit only the terminal message",
      "description": "As a customer or maintainer, I want a final-only provider to emit only the terminal completed message, so consumers never observe fabricated native stream deltas for providers that only produce a final result.",
      "acceptanceCriteria": [
        "TestProviderFinalOnlyEmitsTerminalMessageOnly exists with a customer-readable Go doc comment describing the observable final-only fidelity behavior.",
        "Through root.BuildProcess and exact provider-process / response-event edges, a final-only provider edge results in terminal completed message event(s) only—no message-delta events.",
        "Published capabilities/events claim final-only semantics (no native streaming / message-delta claims), and the terminal completed message uses final-only fidelity with native-final delivery.",
        "The test reuses sanitized provider edges or FND-006 golden harness patterns, does not invent provider metadata, avoids service/internal imports, and does not rely on wall-clock sleeps.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-inference-stream-fidelity-005",
      "title": "Close out ownership metadata and verification gates",
      "description": "As a maintainer, I want narrowly coupled ownership, coverage, catalog, and migration metadata updated and verified so this cell is discoverable and boundary-safe without unrelated cleanup or deferred neighboring cell work.",
      "acceptanceCriteria": [
        "Only narrowly coupled ownership, coverage, catalog, and migration metadata required for tests/functional/workers/inference/stream_fidelity_test.go are updated.",
        "No new migration-ledger inventory rows are invented for this destination; checklist behaviors remain the authoritative scope for the four top-level Tests.",
        "Checklist / catalog visibility for this cell reflects the four top-level Tests and workers/inference ownership; deferred neighboring Wave 1 cells (text_stream, process siblings, HTTP server siblings, loading typescript) remain untouched.",
        "Focused tests for the new package / cell pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test metadata verification (viz-compatible catalog/metadata checks) accepts the cell without requiring broad unrelated inventory cleanup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)