### PR TITLE
pss-lwr-pses-service-wire

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1085,6 +1085,16 @@
       "minimum": 28.57
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/wire",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers",
       "exception": {
         "kind": "measurement",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1007,6 +1007,10 @@
       "minimum": 94.11
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/wire",
+      "minimum": 100.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers",
       "minimum": 59.32
     },

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -3582,6 +3582,12 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/provider_sessions/wire",
+      "disposition": "retain",
+      "destination": "provider_sessions",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/providers",
       "disposition": "retain",
       "destination": "providers",

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -252,6 +252,7 @@
     "pkg/services/provider_sessions/internal/services/cursor_reader/internal/service",
     "pkg/services/provider_sessions/internal/services/cursor_reader/wire",
     "pkg/services/provider_sessions/service",
+    "pkg/services/provider_sessions/wire",
     "pkg/services/providers",
     "pkg/services/providers/internal/service",
     "pkg/services/providers/internal/services/catalog",
@@ -1434,14 +1435,19 @@
       "destination": "provider_sessions"
     },
     {
-      "packagePath": "pkg/services/provider_sessions/codex",
-      "disposition": "move",
+      "packagePath": "pkg/services/provider_sessions/internal/services/codex_reader",
+      "disposition": "retain",
       "destination": "provider_sessions/internal/services/codex_reader"
     },
     {
-      "packagePath": "pkg/services/provider_sessions/cursor",
-      "disposition": "move",
-      "destination": "provider_sessions/internal/services/cursor_reader"
+      "packagePath": "pkg/services/provider_sessions/internal/services/codex_reader/internal/service",
+      "disposition": "retain",
+      "destination": "provider_sessions/internal/services/codex_reader"
+    },
+    {
+      "packagePath": "pkg/services/provider_sessions/internal/services/codex_reader/wire",
+      "disposition": "retain",
+      "destination": "provider_sessions/internal/services/codex_reader"
     },
     {
       "packagePath": "pkg/services/provider_sessions/internal/services/cursor_reader",
@@ -1464,22 +1470,12 @@
       "destination": "provider_sessions/internal/services/cursor_reader"
     },
     {
-      "packagePath": "pkg/services/provider_sessions/internal/services/codex_reader",
-      "disposition": "retain",
-      "destination": "provider_sessions/internal/services/codex_reader"
-    },
-    {
-      "packagePath": "pkg/services/provider_sessions/internal/services/codex_reader/internal/service",
-      "disposition": "retain",
-      "destination": "provider_sessions/internal/services/codex_reader"
-    },
-    {
-      "packagePath": "pkg/services/provider_sessions/internal/services/codex_reader/wire",
-      "disposition": "retain",
-      "destination": "provider_sessions/internal/services/codex_reader"
-    },
-    {
       "packagePath": "pkg/services/provider_sessions/service",
+      "disposition": "retain",
+      "destination": "provider_sessions"
+    },
+    {
+      "packagePath": "pkg/services/provider_sessions/wire",
       "disposition": "retain",
       "destination": "provider_sessions"
     },
@@ -1526,7 +1522,7 @@
     {
       "packagePath": "pkg/services/providers/internal/testutil/execution",
       "disposition": "retain",
-      "destination": "providers/internal/services/execution"
+      "destination": "providers"
     },
     {
       "packagePath": "pkg/services/providers/wire",

--- a/pkg/services/provider_sessions/wire/wire.go
+++ b/pkg/services/provider_sessions/wire/wire.go
@@ -1,0 +1,62 @@
+// Package wire is the Provider Sessions service composition boundary.
+//
+// Wire performs construction only, returns the singular providersessions.Service
+// root interface, and starts no lifecycle components. Parent-private Codex and
+// Cursor reader wiring stays inside the owner service assembly path; peers
+// depend on Service rather than reader internals or construction ports.
+package wire
+
+import (
+	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+	providersessionsservice "github.com/portpowered/infinite-you/pkg/services/provider_sessions/service"
+)
+
+// NewService constructs an inert Provider Sessions root from construction and
+// process-edge ports. It composes the accepted root through parent-private
+// Codex/Cursor reader construction without publishing reader types on the
+// returned peer surface.
+func NewService(
+	files providersessions.FileSystem,
+	resolveHome providersessions.ResolveHomeDirectory,
+	codexWalkDirectory providersessions.CodexWalkDirectory,
+	codexResolveSymlinks providersessions.CodexResolveSymlinks,
+	cursorWalkDirectory providersessions.CursorWalkDirectory,
+	cursorResolveSymlinks providersessions.CursorResolveSymlinks,
+	cursorOpenDatabase providersessions.CursorOpenSQLDatabase,
+	cursorOperatingSystem providersessions.OperatingSystem,
+) (providersessions.Service, error) {
+	return providersessionsservice.New(
+		files,
+		resolveHome,
+		codexWalkDirectory,
+		codexResolveSymlinks,
+		cursorWalkDirectory,
+		cursorResolveSymlinks,
+		cursorOpenDatabase,
+		cursorOperatingSystem,
+	)
+}
+
+// NewForRoots constructs Provider Sessions with explicit Codex and Cursor
+// storage roots. Missing required construction ports fail with a deterministic
+// construction error and a nil service.
+func NewForRoots(
+	files providersessions.FileSystem,
+	codexWalkDirectory providersessions.CodexWalkDirectory,
+	codexResolveSymlinks providersessions.CodexResolveSymlinks,
+	cursorWalkDirectory providersessions.CursorWalkDirectory,
+	cursorResolveSymlinks providersessions.CursorResolveSymlinks,
+	cursorOpenDatabase providersessions.CursorOpenSQLDatabase,
+	codexRoot, cursorRoot string,
+) (providersessions.Service, error) {
+	return providersessionsservice.NewForRoots(
+		files,
+		codexWalkDirectory,
+		codexResolveSymlinks,
+		cursorWalkDirectory,
+		cursorResolveSymlinks,
+		cursorOpenDatabase,
+		codexRoot,
+		cursorRoot,
+	)
+}

--- a/pkg/services/provider_sessions/wire/wire_test.go
+++ b/pkg/services/provider_sessions/wire/wire_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
@@ -225,6 +226,84 @@ func TestNewServiceConstructsPublishedRoot(t *testing.T) {
 	}}); !errors.Is(err, providersessions.ErrSessionNotFound) {
 		t.Fatalf("Inspect() = %v, want ErrSessionNotFound", err)
 	}
+}
+
+func TestNewForRootsServesPublishedInspectPeerBehavior(t *testing.T) {
+	t.Parallel()
+
+	codexRoot := writeCodexSessionFixture(t, "wire-inspect-1")
+	service, err := NewForRoots(
+		platformfilesystem.Local{},
+		filepath.WalkDir,
+		filepath.EvalSymlinks,
+		filepath.WalkDir,
+		filepath.EvalSymlinks,
+		sql.Open,
+		codexRoot,
+		t.TempDir(),
+	)
+	if err != nil {
+		t.Fatalf("NewForRoots() error = %v", err)
+	}
+	var root providersessions.Service = service
+	ref := providers.SessionRef{
+		Provider: providers.IDCodex,
+		Kind:     providersessions.SessionIDKind,
+		ID:       "wire-inspect-1",
+	}
+
+	result, err := root.Inspect(providersessions.InspectRequest{Session: ref})
+	if err != nil {
+		t.Fatalf("Inspect() = %v", err)
+	}
+	if result.Session != ref {
+		t.Fatalf("InspectResult.Session = %#v, want %#v", result.Session, ref)
+	}
+	if strings.TrimSpace(result.Source.RelativePath) == "" {
+		t.Fatalf("InspectResult.Source.RelativePath empty")
+	}
+}
+
+func TestNewForRootsReturnsUnsupportedProviderForUnknownProvider(t *testing.T) {
+	t.Parallel()
+
+	service, err := NewForRoots(
+		platformfilesystem.Local{},
+		filepath.WalkDir,
+		filepath.EvalSymlinks,
+		filepath.WalkDir,
+		filepath.EvalSymlinks,
+		sql.Open,
+		t.TempDir(),
+		t.TempDir(),
+	)
+	if err != nil {
+		t.Fatalf("NewForRoots() error = %v", err)
+	}
+	var root providersessions.Service = service
+
+	_, err = root.Inspect(providersessions.InspectRequest{Session: providers.SessionRef{
+		Provider: "openai",
+		Kind:     providersessions.SessionIDKind,
+		ID:       "session-1",
+	}})
+	if !errors.Is(err, providersessions.ErrUnsupportedProvider) {
+		t.Fatalf("Inspect() = %v, want ErrUnsupportedProvider", err)
+	}
+}
+
+func writeCodexSessionFixture(t *testing.T, sessionID string) string {
+	t.Helper()
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "2026", "07", "16")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir session fixture: %v", err)
+	}
+	path := filepath.Join(sessionDir, "rollout-"+sessionID+".jsonl")
+	if err := os.WriteFile(path, []byte("{\"type\":\"session_meta\"}\n"), 0o600); err != nil {
+		t.Fatalf("write session fixture: %v", err)
+	}
+	return root
 }
 
 func TestNewForRootsRejectsMissingProcessEdges(t *testing.T) {

--- a/pkg/services/provider_sessions/wire/wire_test.go
+++ b/pkg/services/provider_sessions/wire/wire_test.go
@@ -1,0 +1,114 @@
+package wire
+
+import (
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+func TestNewServiceRejectsMissingRequiredDependencies(t *testing.T) {
+	t.Parallel()
+
+	resolveHome := providersessions.ResolveHomeDirectory(func() (string, error) { return t.TempDir(), nil })
+	tests := []struct {
+		name                  string
+		files                 providersessions.FileSystem
+		home                  providersessions.ResolveHomeDirectory
+		codexWalk             providersessions.CodexWalkDirectory
+		codexSymlinks         providersessions.CodexResolveSymlinks
+		cursorWalk            providersessions.CursorWalkDirectory
+		cursorSymlinks        providersessions.CursorResolveSymlinks
+		cursorDatabase        providersessions.CursorOpenSQLDatabase
+		cursorOperatingSystem providersessions.OperatingSystem
+	}{
+		{name: "filesystem", home: resolveHome, codexWalk: filepath.WalkDir, codexSymlinks: filepath.EvalSymlinks, cursorWalk: filepath.WalkDir, cursorSymlinks: filepath.EvalSymlinks, cursorDatabase: sql.Open, cursorOperatingSystem: providersessions.OperatingSystem(runtime.GOOS)},
+		{name: "home resolver", files: platformfilesystem.Local{}, codexWalk: filepath.WalkDir, codexSymlinks: filepath.EvalSymlinks, cursorWalk: filepath.WalkDir, cursorSymlinks: filepath.EvalSymlinks, cursorDatabase: sql.Open, cursorOperatingSystem: providersessions.OperatingSystem(runtime.GOOS)},
+		{name: "Codex walker", files: platformfilesystem.Local{}, home: resolveHome, codexSymlinks: filepath.EvalSymlinks, cursorWalk: filepath.WalkDir, cursorSymlinks: filepath.EvalSymlinks, cursorDatabase: sql.Open, cursorOperatingSystem: providersessions.OperatingSystem(runtime.GOOS)},
+		{name: "Codex symlink resolver", files: platformfilesystem.Local{}, home: resolveHome, codexWalk: filepath.WalkDir, cursorWalk: filepath.WalkDir, cursorSymlinks: filepath.EvalSymlinks, cursorDatabase: sql.Open, cursorOperatingSystem: providersessions.OperatingSystem(runtime.GOOS)},
+		{name: "Cursor walker", files: platformfilesystem.Local{}, home: resolveHome, codexWalk: filepath.WalkDir, codexSymlinks: filepath.EvalSymlinks, cursorSymlinks: filepath.EvalSymlinks, cursorDatabase: sql.Open, cursorOperatingSystem: providersessions.OperatingSystem(runtime.GOOS)},
+		{name: "Cursor symlink resolver", files: platformfilesystem.Local{}, home: resolveHome, codexWalk: filepath.WalkDir, codexSymlinks: filepath.EvalSymlinks, cursorWalk: filepath.WalkDir, cursorDatabase: sql.Open, cursorOperatingSystem: providersessions.OperatingSystem(runtime.GOOS)},
+		{name: "Cursor database opener", files: platformfilesystem.Local{}, home: resolveHome, codexWalk: filepath.WalkDir, codexSymlinks: filepath.EvalSymlinks, cursorWalk: filepath.WalkDir, cursorSymlinks: filepath.EvalSymlinks, cursorOperatingSystem: providersessions.OperatingSystem(runtime.GOOS)},
+		{name: "operating system", files: platformfilesystem.Local{}, home: resolveHome, codexWalk: filepath.WalkDir, codexSymlinks: filepath.EvalSymlinks, cursorWalk: filepath.WalkDir, cursorSymlinks: filepath.EvalSymlinks, cursorDatabase: sql.Open},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service, err := NewService(
+				test.files,
+				test.home,
+				test.codexWalk,
+				test.codexSymlinks,
+				test.cursorWalk,
+				test.cursorSymlinks,
+				test.cursorDatabase,
+				test.cursorOperatingSystem,
+			)
+			if err == nil {
+				t.Fatalf("NewService() error = nil, want missing %s dependency", test.name)
+			}
+			if service != nil {
+				t.Fatalf("NewService() = %#v, want nil service", service)
+			}
+		})
+	}
+}
+
+func TestNewServiceConstructsPublishedRoot(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".cursor", "chats"), 0o755); err != nil {
+		t.Fatalf("mkdir cursor chats: %v", err)
+	}
+	service, err := NewService(
+		platformfilesystem.Local{},
+		func() (string, error) { return home, nil },
+		filepath.WalkDir,
+		filepath.EvalSymlinks,
+		filepath.WalkDir,
+		filepath.EvalSymlinks,
+		sql.Open,
+		providersessions.OperatingSystem(runtime.GOOS),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+	var root providersessions.Service = service
+	if _, err := root.Inspect(providersessions.InspectRequest{Session: providers.SessionRef{
+		Provider: providers.IDCodex,
+		Kind:     providersessions.SessionIDKind,
+		ID:       "missing-from-default-root",
+	}}); !errors.Is(err, providersessions.ErrSessionNotFound) {
+		t.Fatalf("Inspect() = %v, want ErrSessionNotFound", err)
+	}
+}
+
+func TestNewForRootsRejectsMissingProcessEdges(t *testing.T) {
+	t.Parallel()
+
+	service, err := NewForRoots(
+		nil,
+		filepath.WalkDir,
+		filepath.EvalSymlinks,
+		filepath.WalkDir,
+		filepath.EvalSymlinks,
+		sql.Open,
+		t.TempDir(),
+		t.TempDir(),
+	)
+	if err == nil {
+		t.Fatal("NewForRoots() error = nil, want missing filesystem dependency")
+	}
+	if service != nil {
+		t.Fatalf("NewForRoots() = %#v, want nil service", service)
+	}
+}

--- a/pkg/services/provider_sessions/wire/wire_test.go
+++ b/pkg/services/provider_sessions/wire/wire_test.go
@@ -3,6 +3,7 @@ package wire
 import (
 	"database/sql"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -12,6 +13,140 @@ import (
 	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
+
+func TestNewForRootsConstructsInertRoot(t *testing.T) {
+	t.Parallel()
+
+	codexWalk := &recordingCodexWalkDirectory{}
+	codexSymlinks := &recordingCodexResolveSymlinks{}
+	cursorWalk := &recordingCursorWalkDirectory{}
+	cursorSymlinks := &recordingCursorResolveSymlinks{}
+	cursorDatabase := &recordingCursorOpenDatabase{}
+
+	service, err := NewForRoots(
+		platformfilesystem.Local{},
+		codexWalk.walk,
+		codexSymlinks.resolve,
+		cursorWalk.walk,
+		cursorSymlinks.resolve,
+		cursorDatabase.open,
+		t.TempDir(),
+		t.TempDir(),
+	)
+	if err != nil {
+		t.Fatalf("NewForRoots() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewForRoots() returned nil service")
+	}
+	var root providersessions.Service = service
+	if codexWalk.calls != 0 {
+		t.Fatalf("construction invoked Codex walk %d times, want no session discovery", codexWalk.calls)
+	}
+	if codexSymlinks.calls != 0 {
+		t.Fatalf("construction invoked Codex symlink resolution %d times, want no filesystem activity", codexSymlinks.calls)
+	}
+	if cursorWalk.calls != 0 {
+		t.Fatalf("construction invoked Cursor walk %d times, want no session discovery", cursorWalk.calls)
+	}
+	if cursorSymlinks.calls != 0 {
+		t.Fatalf("construction invoked Cursor symlink resolution %d times, want no filesystem activity", cursorSymlinks.calls)
+	}
+	if cursorDatabase.calls != 0 {
+		t.Fatalf("construction opened Cursor SQL %d times, want no database activity", cursorDatabase.calls)
+	}
+	if _, err := root.Inspect(providersessions.InspectRequest{Session: providers.SessionRef{
+		Provider: providers.IDCodex,
+		Kind:     providersessions.SessionIDKind,
+		ID:       "missing-session",
+	}}); !errors.Is(err, providersessions.ErrSessionNotFound) {
+		t.Fatalf("Inspect() = %v, want ErrSessionNotFound after inert construction", err)
+	}
+	if codexWalk.calls == 0 {
+		t.Fatal("Inspect() did not invoke Codex walk, want runtime session lookup")
+	}
+}
+
+func TestNewServiceConstructsInertRoot(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".cursor", "chats"), 0o755); err != nil {
+		t.Fatalf("mkdir cursor chats: %v", err)
+	}
+	codexWalk := &recordingCodexWalkDirectory{}
+	codexSymlinks := &recordingCodexResolveSymlinks{}
+	cursorWalk := &recordingCursorWalkDirectory{}
+	cursorSymlinks := &recordingCursorResolveSymlinks{}
+	cursorDatabase := &recordingCursorOpenDatabase{}
+
+	service, err := NewService(
+		platformfilesystem.Local{},
+		func() (string, error) { return home, nil },
+		codexWalk.walk,
+		codexSymlinks.resolve,
+		cursorWalk.walk,
+		cursorSymlinks.resolve,
+		cursorDatabase.open,
+		providersessions.OperatingSystem(runtime.GOOS),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+	var root providersessions.Service = service
+	if codexWalk.calls != 0 || codexSymlinks.calls != 0 ||
+		cursorWalk.calls != 0 || cursorSymlinks.calls != 0 || cursorDatabase.calls != 0 {
+		t.Fatalf(
+			"construction invoked walk/symlink/sql stubs (codex walk=%d symlinks=%d cursor walk=%d symlinks=%d sql=%d), want inert construction",
+			codexWalk.calls, codexSymlinks.calls, cursorWalk.calls, cursorSymlinks.calls, cursorDatabase.calls,
+		)
+	}
+	if _, err := root.Inspect(providersessions.InspectRequest{Session: providers.SessionRef{
+		Provider: providers.IDCodex,
+		Kind:     providersessions.SessionIDKind,
+		ID:       "missing-from-default-root",
+	}}); !errors.Is(err, providersessions.ErrSessionNotFound) {
+		t.Fatalf("Inspect() = %v, want ErrSessionNotFound", err)
+	}
+}
+
+type recordingCodexWalkDirectory struct{ calls int }
+
+func (r *recordingCodexWalkDirectory) walk(string, fs.WalkDirFunc) error {
+	r.calls++
+	return nil
+}
+
+type recordingCodexResolveSymlinks struct{ calls int }
+
+func (r *recordingCodexResolveSymlinks) resolve(string) (string, error) {
+	r.calls++
+	return "", nil
+}
+
+type recordingCursorWalkDirectory struct{ calls int }
+
+func (r *recordingCursorWalkDirectory) walk(string, fs.WalkDirFunc) error {
+	r.calls++
+	return nil
+}
+
+type recordingCursorResolveSymlinks struct{ calls int }
+
+func (r *recordingCursorResolveSymlinks) resolve(string) (string, error) {
+	r.calls++
+	return "", nil
+}
+
+type recordingCursorOpenDatabase struct{ calls int }
+
+func (r *recordingCursorOpenDatabase) open(string, string) (*sql.DB, error) {
+	r.calls++
+	return nil, errors.New("database open during construction")
+}
 
 func TestNewServiceRejectsMissingRequiredDependencies(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
{
  "project": "LWR-PSES: Package Provider Sessions service-local Wire",
  "branchName": "pss-lwr-pses-service-wire",
  "description": "Implement LWR-PSES as the Provider Sessions service-local Wire packet: compose the accepted Provider Sessions root from parent-private Codex/Cursor readers through an inert Wire path that returns only providersessions.Service and starts no lifecycle; prove inert construction and published peer behavior; register shared manifests as required; leave pkg/wire, pkg/root, pkg/initializer, OpenAPI, CLI composition, other-service Wire, and HTTP/CLI/MCP adapters untouched; finish only after the PR is merged.",
  "context": {
    "customerAsk": "Implement LWR-PSES as the Provider Sessions service-local Wire packet. Compose the accepted Provider Sessions root from parent-private readers through an inert Wire path that returns only the root interface and starts no lifecycle. Do not edit pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, or other services' Wire. Do not expand into HTTP/CLI/MCP adapters. Shared coverage, ownership, and package-target manifest edits are allowed. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Provider Sessions already has an accepted singular root, parent-private Codex/Cursor readers with Wire packages, and an owner constructor, but Packaged Service Structure still lacks the owner-local inert Wire composition path that returns only providersessions.Service. Application composition reaches the constructor directly from root Wire, so later shared Wire cutover cannot depend on a Provider Sessions-owned construction boundary without importing service internals.",
    "solution": "Add pkg/services/provider_sessions/wire that composes the accepted root from parent-private reader construction, returns only providersessions.Service, and starts no lifecycle. Prove inert construction and at least one published peer API outcome with focused tests, register the package in shared manifests as required, leave root Wire/initializer/OpenAPI/CLI/other-service Wire and transport adapters untouched, then finish verification and merge the packet PR."
  },
  "acceptanceCriteria": [
    "AC-1: pkg/services/provider_sessions/wire (or owner-local equivalent) exposes a focused constructor that returns only the published providersessions.Service root and composes it from the accepted parent-private Codex/Cursor reader path",
    "AC-2: Focused inert construction proof shows Wire construction returns a usable root interface without starting lifecycle components and without invoking session walk/open/symlink effects during construction when those ports are panic/recording stubs with explicit storage roots",
    "AC-3: Wire-constructed root exercises at least one published peer behavior (Details, Inspect, or Project) successfully against a fixture and returns a typed Provider Sessions failure for an unsupported provider path",
    "AC-4: Diff stays inside Provider Sessions Wire composition/tests plus accepted shared coverage/ownership/package-target manifest reconciliation; no edits to pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, other services' Wire, or HTTP/CLI/MCP adapters",
    "AC-5: Quality checks pass (typecheck, lint, focused Provider Sessions Wire tests, and repository verification gates such as make verify-fast)",
    "AC-6: Delivery loop completes: required CI is terminal and passing, blocking PR conversation feedback is addressed, merge conflicts and shared-file churn are reconciled, and the PR is merged (opening, green CI, or approval alone is not completion)"
  ],
  "userStories": [
    {
      "id": "pss-lwr-pses-service-wire-001",
      "title": "Publish Provider Sessions service-local Wire constructor",
      "description": "As an application composition maintainer, I want a Provider Sessions owner-local Wire constructor that returns only providersessions.Service so later root Wire cutover can compose Provider Sessions without importing reader internals or the concrete service package from outside the owner boundary.",
      "acceptanceCriteria": [
        "pkg/services/provider_sessions/wire (or the owner-local Provider Sessions Wire composition path) publishes a constructor such as NewService that accepts Provider Sessions construction/process-edge ports and returns (providersessions.Service, error)",
        "The Wire path composes the accepted root through parent-private Codex/Cursor reader construction (via the existing owner service assembly), without publishing Codex/Cursor reader types or filesystem/SQL/OS ports on the returned peer surface",
        "Missing required construction ports fail with a deterministic construction error and a nil service",
        "Package documentation states that Wire performs construction only, returns the singular root interface, and starts no lifecycle",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-pses-service-wire-002",
      "title": "Prove inert Wire construction",
      "description": "As a Packaged Service Structure reviewer, I want focused proof that Provider Sessions Wire construction is inert so process composition can hold a constructed root without starting session discovery, SQL opens, or other lifecycle activity.",
      "acceptanceCriteria": [
        "Focused Wire tests construct the root with explicit storage roots and panic or recording stubs for Codex/Cursor walk, symlink resolution, and Cursor SQL open ports",
        "Construction completes without invoking those walk/symlink/SQL stubs and without starting background lifecycle goroutines or host processes",
        "The constructed value is usable only through providersessions.Service (compile-time assignment and/or focused assertion that the returned peer is non-nil and typed as the root interface)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-pses-service-wire-003",
      "title": "Prove Wire-built root serves published peer behavior",
      "description": "As a peer-service consumer, I want the Wire-constructed Provider Sessions root to perform published Details/Inspect/Project behavior so the composition path is proven by observable session inspection outcomes, not by package shape alone.",
      "acceptanceCriteria": [
        "A focused Wire (or Wire-driven) test constructs the root through the service-local Wire path and successfully loads at least one Codex or Cursor fixture via Details, Inspect, or Project",
        "The same Wire-built root returns a typed Provider Sessions failure (for example ErrUnsupportedProvider) for an unsupported provider identity without panicking",
        "The success path returns Provider Sessions-owned detached values (session identity / source / detail facts as applicable) without requiring the test to import Codex/Cursor reader packages as the peer API",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-pses-service-wire-004",
      "title": "Register Wire package and pass focused verification",
      "description": "As a Packaged Service Structure steward, I want the new Provider Sessions Wire package registered in shared coverage/ownership/package-target manifests as required, with focused verification green, so the packet is merge-safe without expanding into root Wire cutover or transports.",
      "acceptanceCriteria": [
        "pkg/services/provider_sessions/wire is registered in the package-target manifest (and coverage/ownership manifests only as required by Wire package registration)",
        "Focused Provider Sessions Wire tests pass",
        "Changed Go files are gofmt-clean; vet/lint and applicable ownership/package-target checks for changed paths pass",
        "make verify-fast (or the repository’s equivalent required short verification gate) passes",
        "Diff does not edit pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, other services' Wire, or HTTP/CLI/MCP adapters",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-pses-service-wire-005",
      "title": "Open, land, and merge the LWR-PSES PR",
      "description": "As a Factory delivery owner, I want the LWR-PSES branch reviewed and merged so Provider Sessions service-local Wire is actually landed, not merely implemented on a long-lived branch.",
      "acceptanceCriteria": [
        "Branch pss-lwr-pses-service-wire is pushed and a PR is opened or updated against the integration base",
        "Required CI checks on the PR reach a terminal passing state",
        "Every blocking PR conversation comment is explicitly addressed (fix, follow-up commit, or recorded resolution)",
        "Merge conflicts and shared-file churn are rebased/reconciled as needed",
        "The PR is merged; work is not marked complete while the PR is only open, green, approved, or ready to merge",
        "Typecheck passes"
      ],
      "priority": 5,
      "passes": false,
      "notes": ""
    }
  ]
}
