### PR TITLE
pss-imp-mod-05-runtime-host-leases

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -973,6 +973,18 @@
       "minimum": 0.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases",
+      "minimum": 66.66
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service",
+      "minimum": 83.72
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire",
+      "minimum": 90.90
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/wire",
       "exception": {
         "kind": "measurement",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -138,7 +138,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/filesystem_watchers/internal/service",
-      "minimum": 42.44
+      "minimum": 42.22
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/filesystem_watchers/wire",
@@ -978,11 +978,11 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service",
-      "minimum": 83.72
+      "minimum": 1.55
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire",
-      "minimum": 90.90
+      "minimum": 72.72
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/wire",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -922,7 +922,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/service",
-      "minimum": 79.54
+      "minimum": 79.31
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -925,6 +925,18 @@
       "minimum": 79.54
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases",
+      "minimum": 66.66
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service",
+      "minimum": 83.72
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire",
+      "minimum": 90.90
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/wire",
       "minimum": 100.00
     },

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -3504,6 +3504,24 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/models/internal/services/runtime_host/internal/services/leases",
+      "disposition": "retain",
+      "destination": "models",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service",
+      "disposition": "retain",
+      "destination": "models",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/runtime_host/internal/services/leases/wire",
+      "disposition": "retain",
+      "destination": "models",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/models/internal/services/runtime_host/wire",
       "disposition": "retain",
       "destination": "models",

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -236,6 +236,9 @@
     "pkg/services/models/internal/services/catalog/wire",
     "pkg/services/models/internal/services/runtime_host",
     "pkg/services/models/internal/services/runtime_host/internal/service",
+    "pkg/services/models/internal/services/runtime_host/internal/services/leases",
+    "pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service",
+    "pkg/services/models/internal/services/runtime_host/internal/services/leases/wire",
     "pkg/services/models/internal/services/runtime_host/wire",
     "pkg/services/models/internal/services/runtime_scopes",
     "pkg/services/models/internal/services/runtime_scopes/internal/service",
@@ -1402,6 +1405,21 @@
     },
     {
       "packagePath": "pkg/services/models/internal/services/runtime_host/internal/service",
+      "disposition": "retain",
+      "destination": "models/internal/services/runtime_host"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/runtime_host/internal/services/leases",
+      "disposition": "retain",
+      "destination": "models/internal/services/runtime_host"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service",
+      "disposition": "retain",
+      "destination": "models/internal/services/runtime_host"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/runtime_host/internal/services/leases/wire",
       "disposition": "retain",
       "destination": "models/internal/services/runtime_host"
     },

--- a/pkg/services/models/internal/host/scoped_compat_host_test.go
+++ b/pkg/services/models/internal/host/scoped_compat_host_test.go
@@ -35,6 +35,27 @@ func (s stubPackagedRuntimeHost) StopModelHost(
 	return apisurface.StopModelHostResult{}, apisurface.ErrUnsupportedOperation
 }
 
+func (stubPackagedRuntimeHost) AcquireModelLease(
+	context.Context,
+	apisurface.AcquireModelLeaseRequest,
+) (apisurface.AcquireModelLeaseResult, error) {
+	return apisurface.AcquireModelLeaseResult{}, apisurface.ErrUnsupportedOperation
+}
+
+func (stubPackagedRuntimeHost) GetModelLease(
+	context.Context,
+	apisurface.GetModelLeaseRequest,
+) (apisurface.GetModelLeaseResult, error) {
+	return apisurface.GetModelLeaseResult{}, apisurface.ErrUnsupportedOperation
+}
+
+func (stubPackagedRuntimeHost) ReleaseModelLease(
+	context.Context,
+	apisurface.ReleaseModelLeaseRequest,
+) (apisurface.ReleaseModelLeaseResult, error) {
+	return apisurface.ReleaseModelLeaseResult{}, apisurface.ErrUnsupportedOperation
+}
+
 func TestScopedCompatHostAcquireLease_AllowsCLIPathWithoutSupervisedEndpoint(t *testing.T) {
 	loaded := mustLoadedCatalogConfig(t, llamaCppCatalogFactoryConfigWithoutHealthEndpoint())
 	scope, err := (apisurface.RuntimeScopeRef{}).Parse("factory-session:test-scope")

--- a/pkg/services/models/internal/service/runtime_factory.go
+++ b/pkg/services/models/internal/service/runtime_factory.go
@@ -330,24 +330,33 @@ func (o *Root) StopModelHost(
 }
 
 func (o *Root) AcquireModelLease(
-	context.Context,
-	models.AcquireModelLeaseRequest,
+	ctx context.Context,
+	request models.AcquireModelLeaseRequest,
 ) (models.AcquireModelLeaseResult, error) {
-	return models.AcquireModelLeaseResult{}, models.ErrUnsupportedOperation
+	if o == nil || o.runtimeHost == nil {
+		return models.AcquireModelLeaseResult{}, models.ErrUnsupportedOperation
+	}
+	return o.runtimeHost.AcquireModelLease(ctx, request)
 }
 
 func (o *Root) GetModelLease(
-	context.Context,
-	models.GetModelLeaseRequest,
+	ctx context.Context,
+	request models.GetModelLeaseRequest,
 ) (models.GetModelLeaseResult, error) {
-	return models.GetModelLeaseResult{}, models.ErrUnsupportedOperation
+	if o == nil || o.runtimeHost == nil {
+		return models.GetModelLeaseResult{}, models.ErrUnsupportedOperation
+	}
+	return o.runtimeHost.GetModelLease(ctx, request)
 }
 
 func (o *Root) ReleaseModelLease(
-	context.Context,
-	models.ReleaseModelLeaseRequest,
+	ctx context.Context,
+	request models.ReleaseModelLeaseRequest,
 ) (models.ReleaseModelLeaseResult, error) {
-	return models.ReleaseModelLeaseResult{}, models.ErrUnsupportedOperation
+	if o == nil || o.runtimeHost == nil {
+		return models.ReleaseModelLeaseResult{}, models.ErrUnsupportedOperation
+	}
+	return o.runtimeHost.ReleaseModelLease(ctx, request)
 }
 
 func (o *Root) InvokeModelWithLease(

--- a/pkg/services/models/internal/services/runtime_host/internal/service/export_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/export_test.go
@@ -87,6 +87,45 @@ func NewWithHostTestConfig(
 	return s
 }
 
+// LeasesService returns the nested leases owner for focused integration tests.
+func LeasesService(s runtimehost.Service) hostleases.Service {
+	return s.(*service).leases
+}
+
+// NewWithLeasesFacts constructs a Runtime Host whose nested leases owner uses
+// the supplied slot facts and binds holder-aware cleanup to the host.
+func NewWithLeasesFacts(
+	scopes runtimescopes.Service,
+	assets scopedassets.Service,
+	processLauncher models.HostProcessLauncher,
+	hostHTTP models.HostHTTPDoer,
+	hostClock models.HostClock,
+	hostLogger models.HostDiagnosticLogger,
+	hostMetrics models.HostMetricsRecorder,
+	slotFacts hostleases.SlotFactsProvider,
+	policyCfg HostPolicyTestConfig,
+) runtimehost.Service {
+	leases, err := leaseswire.NewService(hostClock, slotFacts)
+	if err != nil {
+		panic(err)
+	}
+	s := New(
+		scopes,
+		assets,
+		leases,
+		processLauncher,
+		hostHTTP,
+		hostClock,
+		hostLogger,
+		hostMetrics,
+	).(*service)
+	s.idleUnloadAfter, s.maxLoadedRuntimes = normalizeHostPolicy(
+		policyCfg.IdleUnloadAfter,
+		policyCfg.MaxLoadedRuntimes,
+	)
+	return s
+}
+
 // AcquireSlotCapacity simulates one active capacity holder for idle-unload tests.
 func AcquireSlotCapacity(s runtimehost.Service, scope models.RuntimeScopeRef, modelName string) {
 	host := s.(*service)

--- a/pkg/services/models/internal/services/runtime_host/internal/service/export_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/export_test.go
@@ -6,6 +6,8 @@ import (
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
+	hostleases "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases"
+	leaseswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire"
 	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
 	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
 )
@@ -62,6 +64,7 @@ func NewWithHostTestConfig(
 	s := New(
 		scopes,
 		assets,
+		mustLeasesService(hostClock),
 		processLauncher,
 		hostHTTP,
 		hostClock,
@@ -107,4 +110,12 @@ func ReleaseSlotCapacity(
 // ShutdownHost stops all supervised runtimes owned by the host.
 func ShutdownHost(ctx context.Context, s runtimehost.Service) error {
 	return s.(*service).Shutdown(ctx)
+}
+
+func mustLeasesService(hostClock models.HostClock) hostleases.Service {
+	leases, err := leaseswire.NewService(hostClock)
+	if err != nil {
+		panic(err)
+	}
+	return leases
 }

--- a/pkg/services/models/internal/services/runtime_host/internal/service/export_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/export_test.go
@@ -113,7 +113,7 @@ func ShutdownHost(ctx context.Context, s runtimehost.Service) error {
 }
 
 func mustLeasesService(hostClock models.HostClock) hostleases.Service {
-	leases, err := leaseswire.NewService(hostClock)
+	leases, err := leaseswire.NewService(hostClock, hostleases.UnconfiguredSlotFacts{})
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/services/models/internal/services/runtime_host/internal/service/lease_cutover_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/lease_cutover_test.go
@@ -1,0 +1,116 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/service"
+	runtimehostwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/wire"
+)
+
+func TestWiredHostDelegatesLeaseOperationsToNestedOwner(t *testing.T) {
+	t.Parallel()
+
+	cacheDirectory := t.TempDir()
+	writeCacheFixture(t, cacheDirectory, true)
+	scopes := newScopes(t, "lease-cutover-delegate")
+	cfg := runtimeConfig()
+	cfg.Resources[0].Capacity = 2
+	ref := openScope(t, scopes, cacheDirectory, cfg)
+	launcher := &recordingProcessLauncher{}
+	service, err := runtimehostwire.NewService(
+		scopes,
+		mustAssetsService(t, scopes),
+		launcher,
+		http.DefaultClient,
+		testHostClock{},
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	acquired, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  ref,
+		Name:   "OMNIVOICE_Q4_K_M",
+		Holder: "worker-a",
+	})
+	if err != nil {
+		t.Fatalf("AcquireModelLease: %v", err)
+	}
+	if acquired.Lease.Lease.IsZero() || acquired.Lease.Holder != "worker-a" {
+		t.Fatalf("AcquireModelLease = %#v, want active lease facts", acquired)
+	}
+
+	got, err := service.GetModelLease(context.Background(), models.GetModelLeaseRequest{
+		Scope: ref,
+		Lease: acquired.Lease.Lease,
+	})
+	if err != nil {
+		t.Fatalf("GetModelLease: %v", err)
+	}
+	if got.Lease.Status != models.ModelLeaseStatusActive {
+		t.Fatalf("GetModelLease = %#v, want active lease", got)
+	}
+
+	released, err := service.ReleaseModelLease(context.Background(), models.ReleaseModelLeaseRequest{
+		Scope: ref,
+		Lease: acquired.Lease.Lease,
+	})
+	if err != nil || released.Outcome != models.ModelLeaseReleased {
+		t.Fatalf("ReleaseModelLease = (%#v, %v), want released", released, err)
+	}
+
+	leases := internalservice.LeasesService(service)
+	if leases == nil {
+		t.Fatal("LeasesService returned nil nested owner")
+	}
+}
+
+func TestWiredHostSlotFactsRejectMissingAssetsWithoutConsumingCapacity(t *testing.T) {
+	t.Parallel()
+
+	cacheDirectory := t.TempDir()
+	scopes := newScopes(t, "lease-cutover-missing")
+	cfg := runtimeConfig()
+	cfg.Resources[0].Capacity = 1
+	ref := openScope(t, scopes, cacheDirectory, cfg)
+	service, err := runtimehostwire.NewService(
+		scopes,
+		mustAssetsService(t, scopes),
+		&recordingProcessLauncher{},
+		http.DefaultClient,
+		testHostClock{},
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	_, err = service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  ref,
+		Name:   "OMNIVOICE_Q4_K_M",
+		Holder: "worker-a",
+	})
+	if !errors.Is(err, models.ErrHostRuntimeNotReady) {
+		t.Fatalf("AcquireModelLease missing assets = %v, want ErrHostRuntimeNotReady", err)
+	}
+
+	writeCacheFixture(t, cacheDirectory, true)
+	acquired, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  ref,
+		Name:   "OMNIVOICE_Q4_K_M",
+		Holder: "worker-b",
+	})
+	if err != nil {
+		t.Fatalf("second AcquireModelLease after not-ready = %v, want success once assets installed", err)
+	}
+	if acquired.Lease.Lease.IsZero() {
+		t.Fatal("expected lease after not-ready did not consume capacity")
+	}
+}

--- a/pkg/services/models/internal/services/runtime_host/internal/service/lease_delegate.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/lease_delegate.go
@@ -1,0 +1,37 @@
+package service
+
+import (
+	"context"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+func (s *service) AcquireModelLease(
+	ctx context.Context,
+	request models.AcquireModelLeaseRequest,
+) (models.AcquireModelLeaseResult, error) {
+	if s == nil || s.leases == nil {
+		return models.AcquireModelLeaseResult{}, models.ErrUnsupportedOperation
+	}
+	return s.leases.AcquireModelLease(ctx, request)
+}
+
+func (s *service) GetModelLease(
+	ctx context.Context,
+	request models.GetModelLeaseRequest,
+) (models.GetModelLeaseResult, error) {
+	if s == nil || s.leases == nil {
+		return models.GetModelLeaseResult{}, models.ErrUnsupportedOperation
+	}
+	return s.leases.GetModelLease(ctx, request)
+}
+
+func (s *service) ReleaseModelLease(
+	ctx context.Context,
+	request models.ReleaseModelLeaseRequest,
+) (models.ReleaseModelLeaseResult, error) {
+	if s == nil || s.leases == nil {
+		return models.ReleaseModelLeaseResult{}, models.ErrUnsupportedOperation
+	}
+	return s.leases.ReleaseModelLease(ctx, request)
+}

--- a/pkg/services/models/internal/services/runtime_host/internal/service/service.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/service.go
@@ -34,6 +34,7 @@ type service struct {
 }
 
 var _ runtimehost.Service = (*service)(nil)
+var _ hostleases.SlotCapacityCoordinator = (*service)(nil)
 
 // New constructs an inert Runtime Host that validates and retains injected
 // supervision effects without launching subprocesses or starting lifecycle.
@@ -58,7 +59,7 @@ func New(
 		ServerStartBuilder:  defaultServerStartBuilder,
 		Diagnostics:         diagnostics,
 	}
-	return &service{
+	s := &service{
 		scopes:            scopes,
 		assets:            assets,
 		leases:            leases,
@@ -74,6 +75,8 @@ func New(
 		idleUnloadAfter:   0,
 		maxLoadedRuntimes: 0,
 	}
+	hostleases.BindCoordinator(leases, s)
+	return s
 }
 
 func (s *service) InspectModelHost(
@@ -301,6 +304,29 @@ func (s *service) cancelIdleUnload(slotKey string) {
 	s.mu.Lock()
 	s.cancelIdleUnloadLocked(slotKey)
 	s.mu.Unlock()
+}
+
+// OnLeaseCapacityAcquired records one active holder for idle-unload policy.
+func (s *service) OnLeaseCapacityAcquired(
+	scope models.RuntimeScopeRef,
+	modelName string,
+) {
+	slotKey := runtimeSlotKey(scope, modelName)
+	s.mu.Lock()
+	s.acquireSlotCapacityLocked(slotKey)
+	s.mu.Unlock()
+}
+
+// OnLeaseCapacityReleased frees one holder and may schedule idle unload.
+func (s *service) OnLeaseCapacityReleased(
+	scope models.RuntimeScopeRef,
+	modelName string,
+) {
+	binding, err := s.scopes.Resolve(runtimescopes.Reference(scope.String()))
+	if err != nil {
+		return
+	}
+	s.releaseSlotCapacity(scope, modelName, binding.RuntimeConfig())
 }
 
 func (s *service) releaseSlotCapacity(

--- a/pkg/services/models/internal/services/runtime_host/internal/service/service.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/service.go
@@ -10,6 +10,7 @@ import (
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
+	hostleases "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases"
 	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
 	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
 )
@@ -17,6 +18,7 @@ import (
 type service struct {
 	scopes          runtimescopes.Service
 	assets          scopedassets.Service
+	leases          hostleases.Service
 	processLauncher models.HostProcessLauncher
 	hostHTTP        models.HostHTTPDoer
 	hostClock       models.HostClock
@@ -38,6 +40,7 @@ var _ runtimehost.Service = (*service)(nil)
 func New(
 	scopes runtimescopes.Service,
 	assets scopedassets.Service,
+	leases hostleases.Service,
 	processLauncher models.HostProcessLauncher,
 	hostHTTP models.HostHTTPDoer,
 	hostClock models.HostClock,
@@ -58,6 +61,7 @@ func New(
 	return &service{
 		scopes:            scopes,
 		assets:            assets,
+		leases:            leases,
 		processLauncher:   processLauncher,
 		hostHTTP:          hostHTTP,
 		hostClock:         hostClock,

--- a/pkg/services/models/internal/services/runtime_host/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/service_test.go
@@ -332,7 +332,7 @@ func newTestRuntimeHostWithScopesAndClock(
 
 func mustLeasesService(t *testing.T, clock models.HostClock) hostleases.Service {
 	t.Helper()
-	leases, err := leaseswire.NewService(clock)
+	leases, err := leaseswire.NewService(clock, hostleases.UnconfiguredSlotFacts{})
 	if err != nil {
 		t.Fatalf("construct leases: %v", err)
 	}

--- a/pkg/services/models/internal/services/runtime_host/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/service_test.go
@@ -19,6 +19,8 @@ import (
 	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
 	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/service"
+	hostleases "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases"
+	leaseswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire"
 	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
 )
 
@@ -104,6 +106,45 @@ func TestOpenRuntimeScopeDoesNotConstructAnotherRuntimeHost(t *testing.T) {
 	if launcher.starts != 0 {
 		t.Fatalf("process starts after scope open = %d, want 0", launcher.starts)
 	}
+}
+
+func TestRuntimeHostCompositionIncludesInertLeasesOwner(t *testing.T) {
+	t.Parallel()
+
+	clock := &recordingHostClock{}
+	scopes := newScopes(t, "leases-composition")
+	service := newTestRuntimeHostWithScopesAndClock(t, scopes, &recordingProcessLauncher{}, clock)
+	if service == nil {
+		t.Fatal("runtime host service is nil")
+	}
+	if clock.timerCreates != 0 {
+		t.Fatalf("timer creates during runtime host construction = %d, want 0", clock.timerCreates)
+	}
+	_, err := scopes.Open(models.RuntimeBinding{
+		CacheDirectory: t.TempDir(),
+		RuntimeConfig: func() *models.RuntimeConfig {
+			return &models.RuntimeConfig{FactoryDirectory: "factory"}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if clock.timerCreates != 0 {
+		t.Fatalf("timer creates after scope open = %d, want 0", clock.timerCreates)
+	}
+}
+
+type recordingHostClock struct {
+	timerCreates int
+}
+
+func (clock *recordingHostClock) Now() time.Time {
+	return time.Unix(0, 0)
+}
+
+func (clock *recordingHostClock) NewTimer(time.Duration) models.HostTimer {
+	clock.timerCreates++
+	panic("host timer created during inert runtime host composition")
 }
 
 func TestInspectModelHostRejectsForeignScope(t *testing.T) {
@@ -280,12 +321,22 @@ func newTestRuntimeHostWithScopesAndClock(
 	return internalservice.New(
 		scopes,
 		mustAssetsService(t, scopes),
+		mustLeasesService(t, clock),
 		launcher,
 		http.DefaultClient,
 		clock,
 		nil,
 		nil,
 	)
+}
+
+func mustLeasesService(t *testing.T, clock models.HostClock) hostleases.Service {
+	t.Helper()
+	leases, err := leaseswire.NewService(clock)
+	if err != nil {
+		t.Fatalf("construct leases: %v", err)
+	}
+	return leases
 }
 
 func mustAssetsService(t *testing.T, scopes runtimescopes.Service) scopedassets.Service {

--- a/pkg/services/models/internal/services/runtime_host/internal/service/slot_facts.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/slot_facts.go
@@ -1,0 +1,78 @@
+package service
+
+import (
+	"context"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	hostleases "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+)
+
+type slotFactsAdapter struct {
+	host *service
+}
+
+func (adapter *slotFactsAdapter) SlotFacts(
+	ctx context.Context,
+	scope models.RuntimeScopeRef,
+	modelName string,
+) (hostleases.SlotFacts, error) {
+	if adapter == nil || adapter.host == nil {
+		return hostleases.SlotFacts{}, models.ErrHostRuntimeNotReady
+	}
+	return adapter.host.slotFacts(ctx, scope, modelName)
+}
+
+func (s *service) slotFacts(
+	ctx context.Context,
+	scope models.RuntimeScopeRef,
+	modelName string,
+) (hostleases.SlotFacts, error) {
+	if s == nil || s.scopes == nil || s.assets == nil {
+		return hostleases.SlotFacts{}, models.ErrUnavailable
+	}
+	if err := hostContextError(ctx); err != nil {
+		return hostleases.SlotFacts{}, err
+	}
+	binding, err := s.scopes.Resolve(runtimescopes.Reference(scope.String()))
+	if err != nil {
+		return hostleases.SlotFacts{}, scopeError(err)
+	}
+	inspection, err := s.assets.InspectRuntimeCache(ctx, models.InspectModelAssetsRequest{
+		Scope: scope,
+		Name:  modelName,
+	})
+	if err != nil {
+		return hostleases.SlotFacts{}, err
+	}
+	snapshot := hostSnapshotFromAssets(scope, modelName, inspection)
+	snapshot = s.overlaySupervisedReadiness(
+		binding,
+		scope,
+		modelName,
+		inspection,
+		snapshot,
+	)
+
+	capacity := 0
+	if resource := modelScopedResource(binding.RuntimeConfig(), modelName); resource != nil &&
+		resource.Capacity > 0 {
+		capacity = resource.Capacity
+	}
+
+	contendedHolder := ""
+	slotKey := runtimeSlotKey(scope, modelName)
+	s.mu.Lock()
+	if slot := s.runtimeSlots[slotKey]; slot != nil && slot.isLoading() {
+		contendedHolder = slotContendedLoadingHolder
+	}
+	s.mu.Unlock()
+
+	return hostleases.SlotFacts{
+		Readiness:       snapshot.ReadinessState,
+		Capacity:        capacity,
+		ContendedHolder: contendedHolder,
+	}, nil
+}
+
+const slotContendedLoadingHolder = "__runtime_host_loading__"

--- a/pkg/services/models/internal/services/runtime_host/internal/service/unload_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/unload_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
+	hostleases "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases"
 	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/service"
 	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
@@ -377,6 +378,148 @@ func TestShutdownStopsSupervisedRuntimesAndCancelsIdleTimers(t *testing.T) {
 	if stopCount.Load() != 1 {
 		t.Fatalf("stop count = %d, want 1", stopCount.Load())
 	}
+}
+
+func TestIdleUnloadStopsRuntimeAfterLeaseRelease(t *testing.T) {
+	t.Parallel()
+
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(healthServer.Close)
+
+	var stopCount atomic.Int32
+	cacheDirectory := t.TempDir()
+	writeCacheFixture(t, cacheDirectory, true)
+	scopes := newScopes(t, "idle-unload-lease-release")
+	ref := openScope(t, scopes, cacheDirectory, supervisedRuntimeConfig())
+	service := internalservice.NewWithLeasesFacts(
+		scopes,
+		mustAssetsService(t, scopes),
+		&fakeProcessLauncher{
+			newProcess: func(spec models.HostProcessStartSpec) *fakeManagedProcess {
+				process := newFakeManagedProcess(healthServer.URL, nil)
+				process.stopFn = func() error {
+					stopCount.Add(1)
+					return process.defaultStop()
+				}
+				return process
+			},
+		},
+		http.DefaultClient,
+		realHostClock{},
+		nil,
+		nil,
+		leaseReadySlotFacts{capacity: 1},
+		internalservice.HostPolicyTestConfig{IdleUnloadAfter: 40 * time.Millisecond},
+	)
+
+	_, err := service.EnsureModelHost(context.Background(), models.EnsureModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("EnsureModelHost: %v", err)
+	}
+
+	leases := internalservice.LeasesService(service)
+	acquired, err := leases.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  ref,
+		Name:   "OMNIVOICE_Q4_K_M",
+		Holder: "worker-a",
+	})
+	if err != nil {
+		t.Fatalf("AcquireModelLease: %v", err)
+	}
+	if _, err := leases.ReleaseModelLease(context.Background(), models.ReleaseModelLeaseRequest{
+		Scope: ref,
+		Lease: acquired.Lease.Lease,
+	}); err != nil {
+		t.Fatalf("ReleaseModelLease: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for stopCount.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for idle unload after lease release")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestIdleUnloadDoesNotStopActiveLeaseHolder(t *testing.T) {
+	t.Parallel()
+
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(healthServer.Close)
+
+	var stopCount atomic.Int32
+	cacheDirectory := t.TempDir()
+	writeCacheFixture(t, cacheDirectory, true)
+	scopes := newScopes(t, "idle-active-lease-holder")
+	ref := openScope(t, scopes, cacheDirectory, supervisedRuntimeConfig())
+	service := internalservice.NewWithLeasesFacts(
+		scopes,
+		mustAssetsService(t, scopes),
+		&fakeProcessLauncher{
+			newProcess: func(spec models.HostProcessStartSpec) *fakeManagedProcess {
+				process := newFakeManagedProcess(healthServer.URL, nil)
+				process.stopFn = func() error {
+					stopCount.Add(1)
+					return process.defaultStop()
+				}
+				return process
+			},
+		},
+		http.DefaultClient,
+		realHostClock{},
+		nil,
+		nil,
+		leaseReadySlotFacts{capacity: 2},
+		internalservice.HostPolicyTestConfig{IdleUnloadAfter: 40 * time.Millisecond},
+	)
+
+	_, err := service.EnsureModelHost(context.Background(), models.EnsureModelHostRequest{
+		Scope: ref,
+		Name:  "OMNIVOICE_Q4_K_M",
+	})
+	if err != nil {
+		t.Fatalf("EnsureModelHost: %v", err)
+	}
+
+	leases := internalservice.LeasesService(service)
+	if _, err := leases.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  ref,
+		Name:   "OMNIVOICE_Q4_K_M",
+		Holder: "worker-a",
+	}); err != nil {
+		t.Fatalf("AcquireModelLease: %v", err)
+	}
+
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if stopCount.Load() != 0 {
+		t.Fatalf("stop count = %d, want 0 while lease holder active", stopCount.Load())
+	}
+}
+
+type leaseReadySlotFacts struct {
+	capacity int
+}
+
+func (facts leaseReadySlotFacts) SlotFacts(
+	context.Context,
+	models.RuntimeScopeRef,
+	string,
+) (hostleases.SlotFacts, error) {
+	return hostleases.SlotFacts{
+		Readiness: models.ReadinessStateReady,
+		Capacity:  facts.capacity,
+	}, nil
 }
 
 func newRuntimeHostWithPolicy(

--- a/pkg/services/models/internal/services/runtime_host/internal/service/wired.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/wired.go
@@ -1,0 +1,46 @@
+package service
+
+import (
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
+	hostleases "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases"
+	leaseswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire"
+	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+)
+
+// NewWired constructs Runtime Host with a host-backed SlotFactsProvider bound to
+// the nested leases owner. Construction remains inert and does not launch
+// subprocesses or start application lifecycle.
+func NewWired(
+	scopes runtimescopes.Service,
+	assets scopedassets.Service,
+	processLauncher models.HostProcessLauncher,
+	hostHTTP models.HostHTTPDoer,
+	hostClock models.HostClock,
+	hostLogger models.HostDiagnosticLogger,
+	hostMetrics models.HostMetricsRecorder,
+) (runtimehost.Service, error) {
+	adapter := &slotFactsAdapter{}
+	leases, err := leaseswire.NewService(hostClock, adapter)
+	if err != nil {
+		return nil, err
+	}
+	host := New(
+		scopes,
+		assets,
+		leases,
+		processLauncher,
+		hostHTTP,
+		hostClock,
+		hostLogger,
+		hostMetrics,
+	).(*service)
+	adapter.host = host
+	return host, nil
+}
+
+// LeasesOwner returns the nested leases capability for focused integration tests.
+func LeasesOwner(host runtimehost.Service) hostleases.Service {
+	return host.(*service).leases
+}

--- a/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/concurrency_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/concurrency_test.go
@@ -1,0 +1,501 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	hostleases "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service"
+)
+
+func TestConcurrentAcquireBarrierRespectsConfiguredCapacity(t *testing.T) {
+	t.Parallel()
+
+	const capacity = 4
+
+	scope := mustRuntimeScopeRef(t, "leases-race-barrier")
+	service := internalservice.New(fixedHostClock{}, readySlotFacts{capacity: capacity})
+	request := models.AcquireModelLeaseRequest{
+		Scope: scope,
+		Name:  "local-model",
+	}
+
+	const contenders = capacity + 4
+	start := make(chan struct{})
+	results := make(chan error, contenders)
+	var wg sync.WaitGroup
+
+	for worker := 0; worker < contenders; worker++ {
+		wg.Add(1)
+		holder := fmt.Sprintf("barrier-%d", worker)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+				Scope:  request.Scope,
+				Name:   request.Name,
+				Holder: holder,
+			})
+			results <- err
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+
+	successes := 0
+	for err := range results {
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, models.ErrHostCapacityExhausted):
+		default:
+			t.Fatalf("unexpected acquire error: %v", err)
+		}
+	}
+	if successes != capacity {
+		t.Fatalf("successful barrier acquires = %d, want %d", successes, capacity)
+	}
+	if observed := internalservice.ActiveCapacityForTest(service, scope, request.Name); observed != capacity {
+		t.Fatalf("service active capacity = %d, want %d", observed, capacity)
+	}
+}
+
+func TestConcurrentAcquireReleasePreservesCapacityAndUniqueIdentities(t *testing.T) {
+	t.Parallel()
+
+	const (
+		capacity   = 4
+		workers    = 16
+		iterations = 50
+	)
+
+	scope := mustRuntimeScopeRef(t, "leases-race-acquire-release")
+	service := internalservice.New(fixedHostClock{}, readySlotFacts{capacity: capacity})
+	request := models.AcquireModelLeaseRequest{
+		Scope: scope,
+		Name:  "local-model",
+	}
+
+	var (
+		seenIDs sync.Map
+		errCh   = make(chan error, workers*iterations)
+		wg      sync.WaitGroup
+	)
+
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		holder := fmt.Sprintf("worker-%d", worker)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				acquired, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+					Scope:  request.Scope,
+					Name:   request.Name,
+					Holder: holder,
+				})
+				if err != nil {
+					if errors.Is(err, models.ErrHostCapacityExhausted) {
+						continue
+					}
+					errCh <- fmt.Errorf("AcquireModelLease: %w", err)
+					return
+				}
+
+				leaseID := acquired.Lease.Lease.String()
+				if leaseID == "" {
+					errCh <- errors.New("successful acquire returned empty lease identity")
+					return
+				}
+				if _, loaded := seenIDs.LoadOrStore(leaseID, struct{}{}); loaded {
+					errCh <- fmt.Errorf("duplicate active lease identity %q", leaseID)
+					return
+				}
+				if observed := internalservice.ActiveCapacityForTest(service, scope, request.Name); observed > capacity {
+					errCh <- fmt.Errorf(
+						"service active capacity %d exceeded limit %d at acquire boundary",
+						observed,
+						capacity,
+					)
+					return
+				}
+
+				_, err = service.ReleaseModelLease(context.Background(), models.ReleaseModelLeaseRequest{
+					Scope: scope,
+					Lease: acquired.Lease.Lease,
+				})
+				if err != nil {
+					errCh <- fmt.Errorf("ReleaseModelLease: %w", err)
+					return
+				}
+
+				seenIDs.Delete(leaseID)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatal(err)
+	}
+
+	fillCapacity(t, service, request, capacity)
+}
+
+func TestConcurrentAcquireReleaseDoesNotStrandCapacity(t *testing.T) {
+	t.Parallel()
+
+	const (
+		capacity   = 3
+		workers    = 12
+		iterations = 40
+	)
+
+	scope := mustRuntimeScopeRef(t, "leases-race-no-strand")
+	service := internalservice.New(fixedHostClock{}, readySlotFacts{capacity: capacity})
+	request := models.AcquireModelLeaseRequest{
+		Scope: scope,
+		Name:  "local-model",
+	}
+
+	var (
+		issuedMu sync.Mutex
+		issued   []models.ModelLeaseRef
+		errCh    = make(chan error, workers*iterations)
+		wg       sync.WaitGroup
+	)
+
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		holder := fmt.Sprintf("holder-%d", worker)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				acquired, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+					Scope:  request.Scope,
+					Name:   request.Name,
+					Holder: holder,
+				})
+				if err != nil {
+					if errors.Is(err, models.ErrHostCapacityExhausted) {
+						continue
+					}
+					errCh <- fmt.Errorf("AcquireModelLease: %w", err)
+					return
+				}
+
+				issuedMu.Lock()
+				issued = append(issued, acquired.Lease.Lease)
+				issuedMu.Unlock()
+
+				if _, err := service.ReleaseModelLease(context.Background(), models.ReleaseModelLeaseRequest{
+					Scope: scope,
+					Lease: acquired.Lease.Lease,
+				}); err != nil {
+					errCh <- fmt.Errorf("ReleaseModelLease: %w", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatal(err)
+	}
+
+	fillCapacity(t, service, request, capacity)
+}
+
+func TestConcurrentCancelDuringAcquireDoesNotConsumeCapacity(t *testing.T) {
+	t.Parallel()
+
+	const (
+		capacity   = 2
+		workers    = 24
+		iterations = 30
+	)
+
+	scope := mustRuntimeScopeRef(t, "leases-race-cancel")
+	service := internalservice.New(fixedHostClock{}, readySlotFacts{capacity: capacity})
+	request := models.AcquireModelLeaseRequest{
+		Scope: scope,
+		Name:  "local-model",
+	}
+
+	var (
+		cancelledAttempts atomic.Int64
+		successfulLeases  sync.Map
+		errCh             = make(chan error, workers*iterations)
+		wg                sync.WaitGroup
+	)
+
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		holder := fmt.Sprintf("cancel-worker-%d", worker)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				ctx, cancel := context.WithCancel(context.Background())
+				if i%2 == 0 {
+					cancel()
+				}
+
+				acquired, err := service.AcquireModelLease(ctx, models.AcquireModelLeaseRequest{
+					Scope:  request.Scope,
+					Name:   request.Name,
+					Holder: holder,
+				})
+				cancel()
+
+				if err != nil {
+					if errors.Is(err, models.ErrHostCancelled) {
+						cancelledAttempts.Add(1)
+						continue
+					}
+					if errors.Is(err, models.ErrHostCapacityExhausted) {
+						continue
+					}
+					errCh <- fmt.Errorf("AcquireModelLease: %w", err)
+					return
+				}
+
+				leaseID := acquired.Lease.Lease.String()
+				if leaseID == "" {
+					errCh <- errors.New("cancelled acquire path returned lease without identity")
+					return
+				}
+				if _, loaded := successfulLeases.LoadOrStore(leaseID, struct{}{}); loaded {
+					errCh <- fmt.Errorf("duplicate lease identity %q from concurrent acquire", leaseID)
+					return
+				}
+
+				_, err = service.ReleaseModelLease(context.Background(), models.ReleaseModelLeaseRequest{
+					Scope: scope,
+					Lease: acquired.Lease.Lease,
+				})
+				if err != nil {
+					errCh <- fmt.Errorf("ReleaseModelLease: %w", err)
+					return
+				}
+				successfulLeases.Delete(leaseID)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatal(err)
+	}
+	if cancelledAttempts.Load() == 0 {
+		t.Fatal("expected cancelled acquire attempts during concurrent stress")
+	}
+
+	fillCapacity(t, service, request, capacity)
+}
+
+func TestConcurrentExpiryGetAndAcquireReclaimsCapacity(t *testing.T) {
+	t.Parallel()
+
+	const capacity = 3
+
+	start := time.Date(2026, time.July, 27, 14, 0, 0, 0, time.UTC)
+	clock := &mutexAdvanceableHostClock{now: start}
+	scope := mustRuntimeScopeRef(t, "leases-race-expiry")
+	service := internalservice.New(clock, readySlotFacts{capacity: capacity})
+	request := models.AcquireModelLeaseRequest{
+		Scope: scope,
+		Name:  "local-model",
+	}
+
+	held := make([]models.ModelLeaseRef, 0, capacity)
+	for holder := 0; holder < capacity; holder++ {
+		acquired, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+			Scope:  request.Scope,
+			Name:   request.Name,
+			Holder: fmt.Sprintf("seed-%d", holder),
+		})
+		if err != nil {
+			t.Fatalf("seed acquire %d: %v", holder, err)
+		}
+		held = append(held, acquired.Lease.Lease)
+	}
+
+	clock.advance(hostleases.DefaultLeaseTTL)
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, capacity*2)
+	for _, lease := range held {
+		wg.Add(1)
+		go func(lease models.ModelLeaseRef) {
+			defer wg.Done()
+			_, err := service.GetModelLease(context.Background(), models.GetModelLeaseRequest{
+				Scope: scope,
+				Lease: lease,
+			})
+			if !errors.Is(err, models.ErrHostLeaseExpired) {
+				errCh <- fmt.Errorf("GetModelLease %s = %v, want ErrHostLeaseExpired", lease, err)
+			}
+		}(lease)
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		fillCapacity(t, service, request, capacity)
+	}()
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatal(err)
+	}
+}
+
+func TestConcurrentAcquireDuringLazyExpiryHonoursCapacity(t *testing.T) {
+	t.Parallel()
+
+	const (
+		capacity   = 2
+		workers    = 10
+		iterations = 30
+	)
+
+	start := time.Date(2026, time.July, 27, 15, 0, 0, 0, time.UTC)
+	clock := &mutexAdvanceableHostClock{now: start}
+	scope := mustRuntimeScopeRef(t, "leases-race-lazy-expiry")
+	service := internalservice.New(clock, readySlotFacts{capacity: capacity})
+	request := models.AcquireModelLeaseRequest{
+		Scope: scope,
+		Name:  "local-model",
+	}
+
+	var (
+		seenIDs sync.Map
+		errCh   = make(chan error, workers*iterations)
+		wg      sync.WaitGroup
+	)
+
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		holder := fmt.Sprintf("lazy-expiry-%d", worker)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				if i%5 == 0 {
+					clock.advance(hostleases.DefaultLeaseTTL / 2)
+				}
+
+				acquired, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+					Scope:  request.Scope,
+					Name:   request.Name,
+					Holder: holder,
+				})
+				if err != nil {
+					if errors.Is(err, models.ErrHostCapacityExhausted) {
+						continue
+					}
+					errCh <- fmt.Errorf("AcquireModelLease: %w", err)
+					return
+				}
+
+				leaseID := acquired.Lease.Lease.String()
+				if _, loaded := seenIDs.LoadOrStore(leaseID, struct{}{}); loaded {
+					errCh <- fmt.Errorf("duplicate lease identity %q", leaseID)
+					return
+				}
+
+				if i%3 == 0 {
+					clock.advance(hostleases.DefaultLeaseTTL)
+				}
+
+				_, err = service.ReleaseModelLease(context.Background(), models.ReleaseModelLeaseRequest{
+					Scope: scope,
+					Lease: acquired.Lease.Lease,
+				})
+				if err != nil &&
+					!errors.Is(err, models.ErrHostLeaseExpired) {
+					errCh <- fmt.Errorf("ReleaseModelLease: %w", err)
+					return
+				}
+
+				seenIDs.Delete(leaseID)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatal(err)
+	}
+
+	fillCapacity(t, service, request, capacity)
+}
+
+func fillCapacity(
+	t *testing.T,
+	service hostleases.Service,
+	request models.AcquireModelLeaseRequest,
+	capacity int,
+) {
+	t.Helper()
+
+	acquired := make([]models.ModelLeaseRef, 0, capacity)
+	for holder := 0; holder < capacity; holder++ {
+		result, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+			Scope:  request.Scope,
+			Name:   request.Name,
+			Holder: fmt.Sprintf("fill-%d", holder),
+		})
+		if err != nil {
+			t.Fatalf("fill capacity slot %d/%d: %v", holder+1, capacity, err)
+		}
+		acquired = append(acquired, result.Lease.Lease)
+	}
+
+	_, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  request.Scope,
+		Name:   request.Name,
+		Holder: "fill-overflow",
+	})
+	if !errors.Is(err, models.ErrHostCapacityExhausted) {
+		t.Fatalf("overflow acquire = %v, want ErrHostCapacityExhausted", err)
+	}
+
+	for _, lease := range acquired {
+		if _, err := service.ReleaseModelLease(context.Background(), models.ReleaseModelLeaseRequest{
+			Scope: request.Scope,
+			Lease: lease,
+		}); err != nil {
+			t.Fatalf("release fill lease: %v", err)
+		}
+	}
+}
+
+type mutexAdvanceableHostClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (clock *mutexAdvanceableHostClock) Now() time.Time {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	return clock.now
+}
+
+func (clock *mutexAdvanceableHostClock) NewTimer(time.Duration) models.HostTimer {
+	panic("host timer created during leases concurrency tests")
+}
+
+func (clock *mutexAdvanceableHostClock) advance(delta time.Duration) {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	clock.now = clock.now.Add(delta)
+}

--- a/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/export_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/export_test.go
@@ -1,0 +1,22 @@
+package service
+
+import (
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	hostleases "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases"
+)
+
+// ActiveCapacityForTest reports the nested leases owner capacity holder count.
+func ActiveCapacityForTest(
+	leases hostleases.Service,
+	scope models.RuntimeScopeRef,
+	modelName string,
+) int {
+	svc, ok := leases.(*service)
+	if !ok {
+		return -1
+	}
+	slotKey := leaseSlotKey(scope, modelName)
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	return svc.capacityHolders[slotKey]
+}

--- a/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/service.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/service.go
@@ -14,6 +14,7 @@ import (
 type service struct {
 	hostClock       models.HostClock
 	slotFacts       hostleases.SlotFactsProvider
+	coordinator     hostleases.SlotCapacityCoordinator
 	mu              sync.Mutex
 	leases          map[string]leaseRecord
 	capacityHolders map[string]int
@@ -25,6 +26,7 @@ type leaseRecord struct {
 }
 
 var _ hostleases.Service = (*service)(nil)
+var _ hostleases.CoordinatorBindable = (*service)(nil)
 
 // New constructs an inert leases owner that retains injected effects and
 // allocates lease/capacity state without launching subprocesses or timers.
@@ -38,6 +40,12 @@ func New(
 		leases:          make(map[string]leaseRecord),
 		capacityHolders: make(map[string]int),
 	}
+}
+
+func (s *service) BindSlotCapacityCoordinator(
+	coordinator hostleases.SlotCapacityCoordinator,
+) {
+	s.coordinator = coordinator
 }
 
 func (s *service) AcquireModelLease(
@@ -60,14 +68,15 @@ func (s *service) AcquireModelLease(
 
 	slotKey := leaseSlotKey(request.Scope, request.Name)
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if leaseCapacityExhausted(s.capacityHolders[slotKey], facts.Capacity) {
+		s.mu.Unlock()
 		return models.AcquireModelLeaseResult{}, models.ErrHostCapacityExhausted
 	}
 
 	s.nextLease++
 	ref, err := (models.ModelLeaseRef{}).Parse(fmt.Sprintf("model-lease-%d", s.nextLease))
 	if err != nil {
+		s.mu.Unlock()
 		return models.AcquireModelLeaseResult{}, err
 	}
 	now := s.hostClock.Now()
@@ -82,6 +91,11 @@ func (s *service) AcquireModelLease(
 	}
 	s.leases[ref.String()] = leaseRecord{lease: lease}
 	s.capacityHolders[slotKey]++
+	s.mu.Unlock()
+
+	if s.coordinator != nil {
+		s.coordinator.OnLeaseCapacityAcquired(request.Scope, request.Name)
+	}
 
 	return models.AcquireModelLeaseResult{Lease: lease}, nil
 }
@@ -94,10 +108,52 @@ func (s *service) GetModelLease(
 }
 
 func (s *service) ReleaseModelLease(
-	context.Context,
-	models.ReleaseModelLeaseRequest,
+	ctx context.Context,
+	request models.ReleaseModelLeaseRequest,
 ) (models.ReleaseModelLeaseResult, error) {
-	return models.ReleaseModelLeaseResult{}, models.ErrUnsupportedOperation
+	if err := request.Validate(); err != nil {
+		return models.ReleaseModelLeaseResult{}, err
+	}
+	if err := hostContextError(ctx); err != nil {
+		return models.ReleaseModelLeaseResult{}, err
+	}
+
+	leaseKey := request.Lease.String()
+	s.mu.Lock()
+	record, ok := s.leases[leaseKey]
+	if !ok || record.lease.Scope != request.Scope {
+		s.mu.Unlock()
+		return models.ReleaseModelLeaseResult{}, models.ErrHostLeaseNotFound
+	}
+	if record.lease.Status != models.ModelLeaseStatusActive {
+		s.mu.Unlock()
+		return models.ReleaseModelLeaseResult{}, models.ErrHostLeaseNotFound
+	}
+
+	record.lease.Status = models.ModelLeaseStatusReleased
+	s.leases[leaseKey] = record
+	slotKey := leaseSlotKey(request.Scope, record.lease.ModelName)
+	modelName := record.lease.ModelName
+	s.releaseCapacityCountLocked(slotKey)
+	s.mu.Unlock()
+
+	if s.coordinator != nil {
+		s.coordinator.OnLeaseCapacityReleased(request.Scope, modelName)
+	}
+
+	return models.ReleaseModelLeaseResult{
+		Lease:   record.lease,
+		Outcome: models.ModelLeaseReleased,
+	}, nil
+}
+
+func (s *service) releaseCapacityCountLocked(slotKey string) {
+	count := s.capacityHolders[slotKey]
+	if count <= 1 {
+		delete(s.capacityHolders, slotKey)
+		return
+	}
+	s.capacityHolders[slotKey] = count - 1
 }
 
 func leaseSlotKey(scope models.RuntimeScopeRef, modelName string) string {

--- a/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/service.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/service.go
@@ -1,0 +1,53 @@
+package service
+
+import (
+	"context"
+	"sync"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	hostleases "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases"
+)
+
+type service struct {
+	hostClock       models.HostClock
+	mu              sync.Mutex
+	leases          map[string]leaseRecord
+	capacityHolders map[string]int
+}
+
+type leaseRecord struct {
+	lease models.ModelLease
+}
+
+var _ hostleases.Service = (*service)(nil)
+
+// New constructs an inert leases owner that retains injected effects and
+// allocates lease/capacity state without launching subprocesses or timers.
+func New(hostClock models.HostClock) hostleases.Service {
+	return &service{
+		hostClock:       hostClock,
+		leases:          make(map[string]leaseRecord),
+		capacityHolders: make(map[string]int),
+	}
+}
+
+func (s *service) AcquireModelLease(
+	context.Context,
+	models.AcquireModelLeaseRequest,
+) (models.AcquireModelLeaseResult, error) {
+	return models.AcquireModelLeaseResult{}, models.ErrUnsupportedOperation
+}
+
+func (s *service) GetModelLease(
+	context.Context,
+	models.GetModelLeaseRequest,
+) (models.GetModelLeaseResult, error) {
+	return models.GetModelLeaseResult{}, models.ErrUnsupportedOperation
+}
+
+func (s *service) ReleaseModelLease(
+	context.Context,
+	models.ReleaseModelLeaseRequest,
+) (models.ReleaseModelLeaseResult, error) {
+	return models.ReleaseModelLeaseResult{}, models.ErrUnsupportedOperation
+}

--- a/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/service.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/service.go
@@ -2,6 +2,9 @@ package service
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 	"sync"
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
@@ -10,9 +13,11 @@ import (
 
 type service struct {
 	hostClock       models.HostClock
+	slotFacts       hostleases.SlotFactsProvider
 	mu              sync.Mutex
 	leases          map[string]leaseRecord
 	capacityHolders map[string]int
+	nextLease       int
 }
 
 type leaseRecord struct {
@@ -23,19 +28,62 @@ var _ hostleases.Service = (*service)(nil)
 
 // New constructs an inert leases owner that retains injected effects and
 // allocates lease/capacity state without launching subprocesses or timers.
-func New(hostClock models.HostClock) hostleases.Service {
+func New(
+	hostClock models.HostClock,
+	slotFacts hostleases.SlotFactsProvider,
+) hostleases.Service {
 	return &service{
 		hostClock:       hostClock,
+		slotFacts:       slotFacts,
 		leases:          make(map[string]leaseRecord),
 		capacityHolders: make(map[string]int),
 	}
 }
 
 func (s *service) AcquireModelLease(
-	context.Context,
-	models.AcquireModelLeaseRequest,
+	ctx context.Context,
+	request models.AcquireModelLeaseRequest,
 ) (models.AcquireModelLeaseResult, error) {
-	return models.AcquireModelLeaseResult{}, models.ErrUnsupportedOperation
+	if err := request.Validate(); err != nil {
+		return models.AcquireModelLeaseResult{}, err
+	}
+	if err := hostContextError(ctx); err != nil {
+		return models.AcquireModelLeaseResult{}, err
+	}
+	facts, err := s.slotFacts.SlotFacts(ctx, request.Scope, request.Name)
+	if err != nil {
+		return models.AcquireModelLeaseResult{}, err
+	}
+	if facts.Readiness != models.ReadinessStateReady {
+		return models.AcquireModelLeaseResult{}, models.ErrHostRuntimeNotReady
+	}
+
+	slotKey := leaseSlotKey(request.Scope, request.Name)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if leaseCapacityExhausted(s.capacityHolders[slotKey], facts.Capacity) {
+		return models.AcquireModelLeaseResult{}, models.ErrHostCapacityExhausted
+	}
+
+	s.nextLease++
+	ref, err := (models.ModelLeaseRef{}).Parse(fmt.Sprintf("model-lease-%d", s.nextLease))
+	if err != nil {
+		return models.AcquireModelLeaseResult{}, err
+	}
+	now := s.hostClock.Now()
+	lease := models.ModelLease{
+		Lease:         ref,
+		Scope:         request.Scope,
+		ModelName:     request.Name,
+		Holder:        strings.TrimSpace(request.Holder),
+		ExpiresAt:     now.Add(hostleases.DefaultLeaseTTL),
+		Status:        models.ModelLeaseStatusActive,
+		HostReadiness: facts.Readiness,
+	}
+	s.leases[ref.String()] = leaseRecord{lease: lease}
+	s.capacityHolders[slotKey]++
+
+	return models.AcquireModelLeaseResult{Lease: lease}, nil
 }
 
 func (s *service) GetModelLease(
@@ -50,4 +98,26 @@ func (s *service) ReleaseModelLease(
 	models.ReleaseModelLeaseRequest,
 ) (models.ReleaseModelLeaseResult, error) {
 	return models.ReleaseModelLeaseResult{}, models.ErrUnsupportedOperation
+}
+
+func leaseSlotKey(scope models.RuntimeScopeRef, modelName string) string {
+	return scope.String() + "|" + strings.ToUpper(strings.TrimSpace(modelName))
+}
+
+func leaseCapacityExhausted(activeCount int, capacity int) bool {
+	if capacity <= 0 {
+		return false
+	}
+	return activeCount >= capacity
+}
+
+func hostContextError(ctx context.Context) error {
+	if ctx == nil || ctx.Err() == nil {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: %w",
+		models.ErrHostCancelled,
+		errors.Join(ctx.Err(), context.Cause(ctx)),
+	)
 }

--- a/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/service.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 	hostleases "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases"
@@ -68,9 +69,19 @@ func (s *service) AcquireModelLease(
 
 	slotKey := leaseSlotKey(request.Scope, request.Name)
 	s.mu.Lock()
+	now := s.hostClock.Now()
+	expiredReleases := s.expireStaleLeasesLocked(slotKey, now)
 	if leaseCapacityExhausted(s.capacityHolders[slotKey], facts.Capacity) {
 		s.mu.Unlock()
+		s.notifyCapacityReleased(expiredReleases)
 		return models.AcquireModelLeaseResult{}, models.ErrHostCapacityExhausted
+	}
+	requestHolder := strings.TrimSpace(request.Holder)
+	if contended := strings.TrimSpace(facts.ContendedHolder); contended != "" &&
+		!strings.EqualFold(contended, requestHolder) {
+		s.mu.Unlock()
+		s.notifyCapacityReleased(expiredReleases)
+		return models.AcquireModelLeaseResult{}, models.ErrHostCapacityContended
 	}
 
 	s.nextLease++
@@ -79,7 +90,6 @@ func (s *service) AcquireModelLease(
 		s.mu.Unlock()
 		return models.AcquireModelLeaseResult{}, err
 	}
-	now := s.hostClock.Now()
 	lease := models.ModelLease{
 		Lease:         ref,
 		Scope:         request.Scope,
@@ -93,6 +103,7 @@ func (s *service) AcquireModelLease(
 	s.capacityHolders[slotKey]++
 	s.mu.Unlock()
 
+	s.notifyCapacityReleased(expiredReleases)
 	if s.coordinator != nil {
 		s.coordinator.OnLeaseCapacityAcquired(request.Scope, request.Name)
 	}
@@ -101,10 +112,44 @@ func (s *service) AcquireModelLease(
 }
 
 func (s *service) GetModelLease(
-	context.Context,
-	models.GetModelLeaseRequest,
+	ctx context.Context,
+	request models.GetModelLeaseRequest,
 ) (models.GetModelLeaseResult, error) {
-	return models.GetModelLeaseResult{}, models.ErrUnsupportedOperation
+	if err := request.Validate(); err != nil {
+		return models.GetModelLeaseResult{}, err
+	}
+	if err := hostContextError(ctx); err != nil {
+		return models.GetModelLeaseResult{}, err
+	}
+
+	leaseKey := request.Lease.String()
+	s.mu.Lock()
+	record, ok := s.leases[leaseKey]
+	if !ok || record.lease.Scope != request.Scope {
+		s.mu.Unlock()
+		return models.GetModelLeaseResult{}, models.ErrHostLeaseNotFound
+	}
+	slotKey := leaseSlotKey(request.Scope, record.lease.ModelName)
+	now := s.hostClock.Now()
+	expiredReleases := s.expireStaleLeasesLocked(slotKey, now)
+	record = s.leases[leaseKey]
+	if record.lease.Status == models.ModelLeaseStatusActive && leaseExpired(record.lease, now) {
+		record = s.expireLeaseRecordLocked(leaseKey, record, slotKey)
+		s.mu.Unlock()
+		s.notifyCapacityReleased(append(expiredReleases, capacityRelease{
+			scope:     request.Scope,
+			modelName: record.lease.ModelName,
+		}))
+		return models.GetModelLeaseResult{Lease: record.lease}, models.ErrHostLeaseExpired
+	}
+	if record.lease.Status == models.ModelLeaseStatusExpired {
+		s.mu.Unlock()
+		s.notifyCapacityReleased(expiredReleases)
+		return models.GetModelLeaseResult{Lease: record.lease}, models.ErrHostLeaseExpired
+	}
+	s.mu.Unlock()
+	s.notifyCapacityReleased(expiredReleases)
+	return models.GetModelLeaseResult{Lease: record.lease}, nil
 }
 
 func (s *service) ReleaseModelLease(
@@ -125,18 +170,37 @@ func (s *service) ReleaseModelLease(
 		s.mu.Unlock()
 		return models.ReleaseModelLeaseResult{}, models.ErrHostLeaseNotFound
 	}
+	slotKey := leaseSlotKey(request.Scope, record.lease.ModelName)
+	now := s.hostClock.Now()
+	expiredReleases := s.expireStaleLeasesLocked(slotKey, now)
+	record = s.leases[leaseKey]
+	if record.lease.Status == models.ModelLeaseStatusActive && leaseExpired(record.lease, now) {
+		record = s.expireLeaseRecordLocked(leaseKey, record, slotKey)
+		s.mu.Unlock()
+		s.notifyCapacityReleased(append(expiredReleases, capacityRelease{
+			scope:     request.Scope,
+			modelName: record.lease.ModelName,
+		}))
+		return models.ReleaseModelLeaseResult{Lease: record.lease}, models.ErrHostLeaseExpired
+	}
+	if record.lease.Status == models.ModelLeaseStatusExpired {
+		s.mu.Unlock()
+		s.notifyCapacityReleased(expiredReleases)
+		return models.ReleaseModelLeaseResult{Lease: record.lease}, models.ErrHostLeaseExpired
+	}
 	if record.lease.Status != models.ModelLeaseStatusActive {
 		s.mu.Unlock()
+		s.notifyCapacityReleased(expiredReleases)
 		return models.ReleaseModelLeaseResult{}, models.ErrHostLeaseNotFound
 	}
 
 	record.lease.Status = models.ModelLeaseStatusReleased
 	s.leases[leaseKey] = record
-	slotKey := leaseSlotKey(request.Scope, record.lease.ModelName)
 	modelName := record.lease.ModelName
 	s.releaseCapacityCountLocked(slotKey)
 	s.mu.Unlock()
 
+	s.notifyCapacityReleased(expiredReleases)
 	if s.coordinator != nil {
 		s.coordinator.OnLeaseCapacityReleased(request.Scope, modelName)
 	}
@@ -165,6 +229,56 @@ func leaseCapacityExhausted(activeCount int, capacity int) bool {
 		return false
 	}
 	return activeCount >= capacity
+}
+
+type capacityRelease struct {
+	scope     models.RuntimeScopeRef
+	modelName string
+}
+
+func (s *service) notifyCapacityReleased(releases []capacityRelease) {
+	if s.coordinator == nil {
+		return
+	}
+	for _, release := range releases {
+		s.coordinator.OnLeaseCapacityReleased(release.scope, release.modelName)
+	}
+}
+
+func leaseExpired(lease models.ModelLease, now time.Time) bool {
+	return lease.Status == models.ModelLeaseStatusActive && !now.Before(lease.ExpiresAt)
+}
+
+func (s *service) expireStaleLeasesLocked(
+	slotKey string,
+	now time.Time,
+) []capacityRelease {
+	releases := make([]capacityRelease, 0)
+	for leaseKey, record := range s.leases {
+		if leaseSlotKey(record.lease.Scope, record.lease.ModelName) != slotKey {
+			continue
+		}
+		if record.lease.Status != models.ModelLeaseStatusActive || !leaseExpired(record.lease, now) {
+			continue
+		}
+		record = s.expireLeaseRecordLocked(leaseKey, record, slotKey)
+		releases = append(releases, capacityRelease{
+			scope:     record.lease.Scope,
+			modelName: record.lease.ModelName,
+		})
+	}
+	return releases
+}
+
+func (s *service) expireLeaseRecordLocked(
+	leaseKey string,
+	record leaseRecord,
+	slotKey string,
+) leaseRecord {
+	record.lease.Status = models.ModelLeaseStatusExpired
+	s.leases[leaseKey] = record
+	s.releaseCapacityCountLocked(slotKey)
+	return record
 }
 
 func hostContextError(ctx context.Context) error {

--- a/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/service_test.go
@@ -162,7 +162,7 @@ func TestAcquireModelLeaseRejectsRuntimeNotReady(t *testing.T) {
 	}
 }
 
-func TestGetAndReleaseModelLeaseRemainContractOnlyUntilReleasePacket(t *testing.T) {
+func TestGetModelLeaseRemainsContractOnlyUntilExpiryPacket(t *testing.T) {
 	t.Parallel()
 
 	service := internalservice.New(fixedHostClock{}, readySlotFacts{capacity: 1})
@@ -171,10 +171,179 @@ func TestGetAndReleaseModelLeaseRemainContractOnlyUntilReleasePacket(t *testing.
 	if !errors.Is(err, models.ErrUnsupportedOperation) {
 		t.Fatalf("GetModelLease error = %v, want ErrUnsupportedOperation", err)
 	}
-	_, err = service.ReleaseModelLease(ctx, models.ReleaseModelLeaseRequest{})
-	if !errors.Is(err, models.ErrUnsupportedOperation) {
-		t.Fatalf("ReleaseModelLease error = %v, want ErrUnsupportedOperation", err)
+}
+
+func TestReleaseModelLeaseFreesCapacityForSubsequentAcquire(t *testing.T) {
+	t.Parallel()
+
+	scope := mustRuntimeScopeRef(t, "leases-release-free")
+	service := internalservice.New(fixedHostClock{}, readySlotFacts{capacity: 1})
+	request := models.AcquireModelLeaseRequest{
+		Scope:  scope,
+		Name:   "local-model",
+		Holder: "worker-a",
 	}
+
+	first, err := service.AcquireModelLease(context.Background(), request)
+	if err != nil {
+		t.Fatalf("first AcquireModelLease: %v", err)
+	}
+	_, err = service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  request.Scope,
+		Name:   request.Name,
+		Holder: "worker-b",
+	})
+	if !errors.Is(err, models.ErrHostCapacityExhausted) {
+		t.Fatalf("second AcquireModelLease = %v, want ErrHostCapacityExhausted", err)
+	}
+
+	released, err := service.ReleaseModelLease(context.Background(), models.ReleaseModelLeaseRequest{
+		Scope: scope,
+		Lease: first.Lease.Lease,
+	})
+	if err != nil {
+		t.Fatalf("ReleaseModelLease: %v", err)
+	}
+	if released.Outcome != models.ModelLeaseReleased ||
+		released.Lease.Status != models.ModelLeaseStatusReleased {
+		t.Fatalf("ReleaseModelLease = %#v, want released lease", released)
+	}
+
+	third, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  request.Scope,
+		Name:   request.Name,
+		Holder: "worker-c",
+	})
+	if err != nil {
+		t.Fatalf("AcquireModelLease after release: %v", err)
+	}
+	if third.Lease.Lease.IsZero() {
+		t.Fatal("expected lease after release freed capacity")
+	}
+}
+
+func TestReleaseModelLeaseRejectsUnknownAndAlreadyReleased(t *testing.T) {
+	t.Parallel()
+
+	scope := mustRuntimeScopeRef(t, "leases-release-not-found")
+	service := internalservice.New(fixedHostClock{}, readySlotFacts{capacity: 2})
+	unknown, err := (models.ModelLeaseRef{}).Parse("model-lease-unknown")
+	if err != nil {
+		t.Fatalf("parse lease ref: %v", err)
+	}
+	_, err = service.ReleaseModelLease(context.Background(), models.ReleaseModelLeaseRequest{
+		Scope: scope,
+		Lease: unknown,
+	})
+	if !errors.Is(err, models.ErrHostLeaseNotFound) {
+		t.Fatalf("ReleaseModelLease unknown = %v, want ErrHostLeaseNotFound", err)
+	}
+
+	acquired, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  scope,
+		Name:   "local-model",
+		Holder: "worker-a",
+	})
+	if err != nil {
+		t.Fatalf("AcquireModelLease: %v", err)
+	}
+	_, err = service.ReleaseModelLease(context.Background(), models.ReleaseModelLeaseRequest{
+		Scope: scope,
+		Lease: acquired.Lease.Lease,
+	})
+	if err != nil {
+		t.Fatalf("first ReleaseModelLease: %v", err)
+	}
+	_, err = service.ReleaseModelLease(context.Background(), models.ReleaseModelLeaseRequest{
+		Scope: scope,
+		Lease: acquired.Lease.Lease,
+	})
+	if !errors.Is(err, models.ErrHostLeaseNotFound) {
+		t.Fatalf("ReleaseModelLease already released = %v, want ErrHostLeaseNotFound", err)
+	}
+}
+
+func TestAcquireModelLeaseHonoursCancelledContextWithoutConsumingCapacity(t *testing.T) {
+	t.Parallel()
+
+	scope := mustRuntimeScopeRef(t, "leases-acquire-cancel")
+	service := internalservice.New(fixedHostClock{}, readySlotFacts{capacity: 1})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := service.AcquireModelLease(ctx, models.AcquireModelLeaseRequest{
+		Scope:  scope,
+		Name:   "local-model",
+		Holder: "worker-a",
+	})
+	if !errors.Is(err, models.ErrHostCancelled) {
+		t.Fatalf("AcquireModelLease cancelled = %v, want ErrHostCancelled", err)
+	}
+
+	acquired, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  scope,
+		Name:   "local-model",
+		Holder: "worker-b",
+	})
+	if err != nil {
+		t.Fatalf("AcquireModelLease after cancel = %v, want success", err)
+	}
+	if acquired.Lease.Lease.IsZero() {
+		t.Fatal("cancelled acquire should not consume capacity")
+	}
+}
+
+func TestReleaseModelLeaseNotifiesCapacityCoordinator(t *testing.T) {
+	t.Parallel()
+
+	scope := mustRuntimeScopeRef(t, "leases-coordinator")
+	coordinator := &recordingSlotCapacityCoordinator{}
+	leasesSvc := internalservice.New(fixedHostClock{}, readySlotFacts{capacity: 1})
+	hostleases.BindCoordinator(leasesSvc, coordinator)
+
+	acquired, err := leasesSvc.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  scope,
+		Name:   "local-model",
+		Holder: "worker-a",
+	})
+	if err != nil {
+		t.Fatalf("AcquireModelLease: %v", err)
+	}
+	if coordinator.acquired != 1 || coordinator.released != 0 {
+		t.Fatalf("coordinator after acquire = (%d, %d), want (1, 0)",
+			coordinator.acquired, coordinator.released)
+	}
+
+	_, err = leasesSvc.ReleaseModelLease(context.Background(), models.ReleaseModelLeaseRequest{
+		Scope: scope,
+		Lease: acquired.Lease.Lease,
+	})
+	if err != nil {
+		t.Fatalf("ReleaseModelLease: %v", err)
+	}
+	if coordinator.acquired != 1 || coordinator.released != 1 {
+		t.Fatalf("coordinator after release = (%d, %d), want (1, 1)",
+			coordinator.acquired, coordinator.released)
+	}
+}
+
+type recordingSlotCapacityCoordinator struct {
+	acquired int
+	released int
+}
+
+func (coordinator *recordingSlotCapacityCoordinator) OnLeaseCapacityAcquired(
+	models.RuntimeScopeRef,
+	string,
+) {
+	coordinator.acquired++
+}
+
+func (coordinator *recordingSlotCapacityCoordinator) OnLeaseCapacityReleased(
+	models.RuntimeScopeRef,
+	string,
+) {
+	coordinator.released++
 }
 
 func TestOpenRuntimeScopeDoesNotConstructAnotherLeasesOwner(t *testing.T) {

--- a/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/service_test.go
@@ -1,0 +1,83 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service"
+	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
+)
+
+func TestConstructionAllocatesLeaseStateWithoutStartingLifecycle(t *testing.T) {
+	t.Parallel()
+
+	clock := &recordingHostClock{}
+	service := internalservice.New(clock)
+	if service == nil {
+		t.Fatal("New returned nil service")
+	}
+	if clock.timerCreates != 0 {
+		t.Fatalf("timer creates during construction = %d, want 0", clock.timerCreates)
+	}
+}
+
+func TestLeaseOperationsAreContractOnlyUntilBehaviorPacket(t *testing.T) {
+	t.Parallel()
+
+	service := internalservice.New(&recordingHostClock{})
+	ctx := context.Background()
+	_, err := service.AcquireModelLease(ctx, models.AcquireModelLeaseRequest{})
+	if !errors.Is(err, models.ErrUnsupportedOperation) {
+		t.Fatalf("AcquireModelLease error = %v, want ErrUnsupportedOperation", err)
+	}
+	_, err = service.GetModelLease(ctx, models.GetModelLeaseRequest{})
+	if !errors.Is(err, models.ErrUnsupportedOperation) {
+		t.Fatalf("GetModelLease error = %v, want ErrUnsupportedOperation", err)
+	}
+	_, err = service.ReleaseModelLease(ctx, models.ReleaseModelLeaseRequest{})
+	if !errors.Is(err, models.ErrUnsupportedOperation) {
+		t.Fatalf("ReleaseModelLease error = %v, want ErrUnsupportedOperation", err)
+	}
+}
+
+func TestOpenRuntimeScopeDoesNotConstructAnotherLeasesOwner(t *testing.T) {
+	t.Parallel()
+
+	clock := &recordingHostClock{}
+	service := internalservice.New(clock)
+	scopes, err := runtimescopeswire.NewService(func() string { return "leases-scope-binding" })
+	if err != nil {
+		t.Fatalf("construct runtime scopes: %v", err)
+	}
+	_, err = scopes.Open(models.RuntimeBinding{
+		CacheDirectory: t.TempDir(),
+		RuntimeConfig: func() *models.RuntimeConfig {
+			return &models.RuntimeConfig{FactoryDirectory: "factory"}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if service == nil {
+		t.Fatal("leases service is nil after scope open")
+	}
+	if clock.timerCreates != 0 {
+		t.Fatalf("timer creates after scope open = %d, want 0", clock.timerCreates)
+	}
+}
+
+type recordingHostClock struct {
+	timerCreates int
+}
+
+func (clock *recordingHostClock) Now() time.Time {
+	return time.Unix(0, 0)
+}
+
+func (clock *recordingHostClock) NewTimer(time.Duration) models.HostTimer {
+	clock.timerCreates++
+	panic("host timer created during inert leases owner")
+}

--- a/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/service_test.go
@@ -162,14 +162,226 @@ func TestAcquireModelLeaseRejectsRuntimeNotReady(t *testing.T) {
 	}
 }
 
-func TestGetModelLeaseRemainsContractOnlyUntilExpiryPacket(t *testing.T) {
+func TestGetModelLeaseReportsExpiredLeaseAndFreesCapacity(t *testing.T) {
 	t.Parallel()
 
-	service := internalservice.New(fixedHostClock{}, readySlotFacts{capacity: 1})
-	ctx := context.Background()
-	_, err := service.GetModelLease(ctx, models.GetModelLeaseRequest{})
-	if !errors.Is(err, models.ErrUnsupportedOperation) {
-		t.Fatalf("GetModelLease error = %v, want ErrUnsupportedOperation", err)
+	start := time.Date(2026, time.July, 27, 12, 0, 0, 0, time.UTC)
+	clock := &advanceableHostClock{now: start}
+	scope := mustRuntimeScopeRef(t, "leases-get-expired")
+	service := internalservice.New(clock, readySlotFacts{capacity: 1})
+	request := models.AcquireModelLeaseRequest{
+		Scope:  scope,
+		Name:   "local-model",
+		Holder: "worker-a",
+	}
+
+	acquired, err := service.AcquireModelLease(context.Background(), request)
+	if err != nil {
+		t.Fatalf("AcquireModelLease: %v", err)
+	}
+	_, err = service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  request.Scope,
+		Name:   request.Name,
+		Holder: "worker-b",
+	})
+	if !errors.Is(err, models.ErrHostCapacityExhausted) {
+		t.Fatalf("AcquireModelLease before expiry = %v, want ErrHostCapacityExhausted", err)
+	}
+
+	clock.now = start.Add(hostleases.DefaultLeaseTTL)
+	expired, err := service.GetModelLease(context.Background(), models.GetModelLeaseRequest{
+		Scope: scope,
+		Lease: acquired.Lease.Lease,
+	})
+	if !errors.Is(err, models.ErrHostLeaseExpired) {
+		t.Fatalf("GetModelLease expired = %v, want ErrHostLeaseExpired", err)
+	}
+	if expired.Lease.Status != models.ModelLeaseStatusExpired {
+		t.Fatalf("expired lease status = %q, want EXPIRED", expired.Lease.Status)
+	}
+
+	afterExpiry, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  request.Scope,
+		Name:   request.Name,
+		Holder: "worker-c",
+	})
+	if err != nil {
+		t.Fatalf("AcquireModelLease after expiry freed capacity: %v", err)
+	}
+	if afterExpiry.Lease.Lease.IsZero() {
+		t.Fatal("expected lease after expiry freed capacity")
+	}
+}
+
+func TestReleaseModelLeaseRejectsExpiredWithoutDoubleFree(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.July, 27, 12, 0, 0, 0, time.UTC)
+	clock := &advanceableHostClock{now: start}
+	scope := mustRuntimeScopeRef(t, "leases-release-expired")
+	service := internalservice.New(clock, readySlotFacts{capacity: 1})
+
+	acquired, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  scope,
+		Name:   "local-model",
+		Holder: "worker-a",
+	})
+	if err != nil {
+		t.Fatalf("AcquireModelLease: %v", err)
+	}
+
+	clock.now = start.Add(hostleases.DefaultLeaseTTL)
+	_, err = service.ReleaseModelLease(context.Background(), models.ReleaseModelLeaseRequest{
+		Scope: scope,
+		Lease: acquired.Lease.Lease,
+	})
+	if !errors.Is(err, models.ErrHostLeaseExpired) {
+		t.Fatalf("ReleaseModelLease expired = %v, want ErrHostLeaseExpired", err)
+	}
+
+	_, err = service.ReleaseModelLease(context.Background(), models.ReleaseModelLeaseRequest{
+		Scope: scope,
+		Lease: acquired.Lease.Lease,
+	})
+	if !errors.Is(err, models.ErrHostLeaseExpired) {
+		t.Fatalf("ReleaseModelLease already expired = %v, want ErrHostLeaseExpired", err)
+	}
+
+	reacquired, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  scope,
+		Name:   "local-model",
+		Holder: "worker-b",
+	})
+	if err != nil {
+		t.Fatalf("AcquireModelLease after expired release did not double-free: %v", err)
+	}
+	if reacquired.Lease.Lease.IsZero() {
+		t.Fatal("capacity should remain available exactly once after expiry")
+	}
+}
+
+func TestAcquireModelLeaseRejectsContendedCapacity(t *testing.T) {
+	t.Parallel()
+
+	scope := mustRuntimeScopeRef(t, "leases-acquire-contended")
+	service := internalservice.New(
+		fixedHostClock{},
+		readySlotFacts{capacity: 2, contendedHolder: "worker-a"},
+	)
+
+	_, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  scope,
+		Name:   "local-model",
+		Holder: "worker-b",
+	})
+	if !errors.Is(err, models.ErrHostCapacityContended) {
+		t.Fatalf("AcquireModelLease contended = %v, want ErrHostCapacityContended", err)
+	}
+
+	acquired, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  scope,
+		Name:   "local-model",
+		Holder: "worker-a",
+	})
+	if err != nil {
+		t.Fatalf("AcquireModelLease contending holder = %v, want success", err)
+	}
+	if acquired.Lease.Lease.IsZero() {
+		t.Fatal("contending holder should acquire when capacity is available")
+	}
+}
+
+func TestHostLeaseFailureClassificationsRemainDistinct(t *testing.T) {
+	t.Parallel()
+
+	scope := mustRuntimeScopeRef(t, "leases-failure-distinct")
+	start := time.Date(2026, time.July, 27, 12, 0, 0, 0, time.UTC)
+	clock := &advanceableHostClock{now: start}
+	service := internalservice.New(clock, readySlotFacts{capacity: 1})
+
+	assertHostLeaseFailureIsOnly(t, "invalid holder", mustAcquireErr(service, models.AcquireModelLeaseRequest{
+		Scope: scope, Name: "local-model", Holder: "",
+	}), models.ErrHostInvalidHolder)
+	assertHostLeaseFailureIsOnly(t, "runtime not ready", mustAcquireErr(service, models.AcquireModelLeaseRequest{
+		Scope: scope, Name: "not-ready", Holder: "worker",
+	}), models.ErrHostRuntimeNotReady)
+
+	exhaustedService := internalservice.New(
+		fixedHostClock{},
+		readySlotFacts{capacity: 1},
+	)
+	_, err := exhaustedService.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope: scope, Name: "local-model", Holder: "worker-a",
+	})
+	if err != nil {
+		t.Fatalf("seed exhausted capacity: %v", err)
+	}
+	assertHostLeaseFailureIsOnly(t, "capacity exhausted", mustAcquireErr(exhaustedService, models.AcquireModelLeaseRequest{
+		Scope: scope, Name: "local-model", Holder: "worker-b",
+	}), models.ErrHostCapacityExhausted)
+
+	contendedService := internalservice.New(
+		fixedHostClock{},
+		readySlotFacts{capacity: 2, contendedHolder: "holder-a"},
+	)
+	assertHostLeaseFailureIsOnly(t, "capacity contended", mustAcquireErr(contendedService, models.AcquireModelLeaseRequest{
+		Scope: scope, Name: "local-model", Holder: "holder-b",
+	}), models.ErrHostCapacityContended)
+
+	unknown, parseErr := (models.ModelLeaseRef{}).Parse("model-lease-unknown")
+	if parseErr != nil {
+		t.Fatalf("parse unknown lease: %v", parseErr)
+	}
+	_, err = service.GetModelLease(context.Background(), models.GetModelLeaseRequest{
+		Scope: scope, Lease: unknown,
+	})
+	assertHostLeaseFailureIsOnly(t, "lease not found", err, models.ErrHostLeaseNotFound)
+
+	acquired, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope: scope, Name: "expiring", Holder: "worker",
+	})
+	if err != nil {
+		t.Fatalf("AcquireModelLease expiring: %v", err)
+	}
+	clock.now = start.Add(hostleases.DefaultLeaseTTL)
+	_, err = service.GetModelLease(context.Background(), models.GetModelLeaseRequest{
+		Scope: scope, Lease: acquired.Lease.Lease,
+	})
+	assertHostLeaseFailureIsOnly(t, "lease expired", err, models.ErrHostLeaseExpired)
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = service.AcquireModelLease(cancelled, models.AcquireModelLeaseRequest{
+		Scope: scope, Name: "local-model", Holder: "worker",
+	})
+	assertHostLeaseFailureIsOnly(t, "cancelled acquire", err, models.ErrHostCancelled)
+}
+
+func mustAcquireErr(
+	service hostleases.Service,
+	request models.AcquireModelLeaseRequest,
+) error {
+	_, err := service.AcquireModelLease(context.Background(), request)
+	return err
+}
+
+func assertHostLeaseFailureIsOnly(t *testing.T, label string, err, want error) {
+	t.Helper()
+	if !errors.Is(err, want) {
+		t.Fatalf("%s = %v, want %v", label, err, want)
+	}
+	for _, other := range []error{
+		models.ErrHostCapacityExhausted,
+		models.ErrHostCapacityContended,
+		models.ErrHostLeaseExpired,
+		models.ErrHostLeaseNotFound,
+		models.ErrHostInvalidHolder,
+		models.ErrHostRuntimeNotReady,
+		models.ErrHostCancelled,
+	} {
+		if other != want && errors.Is(err, other) {
+			t.Fatalf("%s must keep %v distinct from %v: %v", label, want, other, err)
+		}
 	}
 }
 
@@ -400,23 +612,43 @@ func (clock fixedHostClock) NewTimer(time.Duration) models.HostTimer {
 	panic("host timer created during leases acquire tests")
 }
 
+type advanceableHostClock struct {
+	now time.Time
+}
+
+func (clock *advanceableHostClock) Now() time.Time {
+	return clock.now
+}
+
+func (clock *advanceableHostClock) NewTimer(time.Duration) models.HostTimer {
+	panic("host timer created during leases expiry tests")
+}
+
 type readySlotFacts struct {
-	readiness models.ReadinessState
-	capacity  int
+	readiness       models.ReadinessState
+	capacity        int
+	contendedHolder string
 }
 
 func (facts readySlotFacts) SlotFacts(
-	context.Context,
-	models.RuntimeScopeRef,
-	string,
+	ctx context.Context,
+	scope models.RuntimeScopeRef,
+	name string,
 ) (hostleases.SlotFacts, error) {
+	if name == "not-ready" {
+		return hostleases.SlotFacts{
+			Readiness: models.ReadinessStateLoading,
+			Capacity:  facts.capacity,
+		}, nil
+	}
 	readiness := facts.readiness
 	if readiness == "" {
 		readiness = models.ReadinessStateReady
 	}
 	return hostleases.SlotFacts{
-		Readiness: readiness,
-		Capacity:  facts.capacity,
+		Readiness:       readiness,
+		Capacity:        facts.capacity,
+		ContendedHolder: facts.contendedHolder,
 	}, nil
 }
 

--- a/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service/service_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
+	hostleases "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service"
 	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
 )
@@ -15,7 +16,7 @@ func TestConstructionAllocatesLeaseStateWithoutStartingLifecycle(t *testing.T) {
 	t.Parallel()
 
 	clock := &recordingHostClock{}
-	service := internalservice.New(clock)
+	service := internalservice.New(clock, readySlotFacts{capacity: 1})
 	if service == nil {
 		t.Fatal("New returned nil service")
 	}
@@ -24,16 +25,149 @@ func TestConstructionAllocatesLeaseStateWithoutStartingLifecycle(t *testing.T) {
 	}
 }
 
-func TestLeaseOperationsAreContractOnlyUntilBehaviorPacket(t *testing.T) {
+func TestAcquireModelLeaseReturnsDetachedActiveLeaseFacts(t *testing.T) {
 	t.Parallel()
 
-	service := internalservice.New(&recordingHostClock{})
-	ctx := context.Background()
-	_, err := service.AcquireModelLease(ctx, models.AcquireModelLeaseRequest{})
-	if !errors.Is(err, models.ErrUnsupportedOperation) {
-		t.Fatalf("AcquireModelLease error = %v, want ErrUnsupportedOperation", err)
+	now := time.Date(2026, time.July, 27, 12, 0, 0, 0, time.UTC)
+	scope := mustRuntimeScopeRef(t, "leases-acquire-ready")
+	service := internalservice.New(
+		fixedHostClock{now: now},
+		readySlotFacts{capacity: 2},
+	)
+
+	acquired, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  scope,
+		Name:   "local-model",
+		Holder: "worker-a",
+	})
+	if err != nil {
+		t.Fatalf("AcquireModelLease: %v", err)
 	}
-	_, err = service.GetModelLease(ctx, models.GetModelLeaseRequest{})
+	if acquired.Lease.Lease.IsZero() ||
+		acquired.Lease.Scope != scope ||
+		acquired.Lease.ModelName != "local-model" ||
+		acquired.Lease.Holder != "worker-a" ||
+		acquired.Lease.Status != models.ModelLeaseStatusActive ||
+		acquired.Lease.HostReadiness != models.ReadinessStateReady ||
+		acquired.Lease.ExpiresAt != now.Add(hostleases.DefaultLeaseTTL) {
+		t.Fatalf("AcquireModelLease = %#v, want opaque active lease facts", acquired)
+	}
+}
+
+func TestAcquireModelLeaseRejectsBlankHolderWithoutConsumingCapacity(t *testing.T) {
+	t.Parallel()
+
+	scope := mustRuntimeScopeRef(t, "leases-acquire-holder")
+	facts := readySlotFacts{capacity: 1}
+	service := internalservice.New(fixedHostClock{}, facts)
+
+	_, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  scope,
+		Name:   "local-model",
+		Holder: " ",
+	})
+	if !errors.Is(err, models.ErrHostInvalidHolder) {
+		t.Fatalf("AcquireModelLease blank holder = %v, want ErrHostInvalidHolder", err)
+	}
+
+	acquired, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  scope,
+		Name:   "local-model",
+		Holder: "worker-a",
+	})
+	if err != nil {
+		t.Fatalf("AcquireModelLease after invalid holder = %v, want success", err)
+	}
+	if acquired.Lease.Lease.IsZero() {
+		t.Fatal("expected lease after invalid holder did not consume capacity")
+	}
+}
+
+func TestAcquireModelLeaseIssuesUniqueLeaseIdentities(t *testing.T) {
+	t.Parallel()
+
+	scope := mustRuntimeScopeRef(t, "leases-acquire-unique")
+	service := internalservice.New(fixedHostClock{}, readySlotFacts{capacity: 2})
+	request := models.AcquireModelLeaseRequest{
+		Scope: scope,
+		Name:  "local-model",
+	}
+
+	first, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  request.Scope,
+		Name:   request.Name,
+		Holder: "caller-1",
+	})
+	if err != nil {
+		t.Fatalf("first AcquireModelLease: %v", err)
+	}
+	second, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  request.Scope,
+		Name:   request.Name,
+		Holder: "caller-2",
+	})
+	if err != nil {
+		t.Fatalf("second AcquireModelLease: %v", err)
+	}
+	if first.Lease.Lease.String() == second.Lease.Lease.String() {
+		t.Fatalf("lease identities must be unique: %q", first.Lease.Lease.String())
+	}
+}
+
+func TestAcquireModelLeaseRejectsCapacityExhaustion(t *testing.T) {
+	t.Parallel()
+
+	scope := mustRuntimeScopeRef(t, "leases-acquire-exhausted")
+	service := internalservice.New(fixedHostClock{}, readySlotFacts{capacity: 1})
+	request := models.AcquireModelLeaseRequest{
+		Scope:  scope,
+		Name:   "local-model",
+		Holder: "worker-a",
+	}
+
+	first, err := service.AcquireModelLease(context.Background(), request)
+	if err != nil {
+		t.Fatalf("first AcquireModelLease: %v", err)
+	}
+	if first.Lease.Lease.IsZero() {
+		t.Fatal("first lease identity is zero")
+	}
+
+	_, err = service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  request.Scope,
+		Name:   request.Name,
+		Holder: "worker-b",
+	})
+	if !errors.Is(err, models.ErrHostCapacityExhausted) {
+		t.Fatalf("second AcquireModelLease = %v, want ErrHostCapacityExhausted", err)
+	}
+}
+
+func TestAcquireModelLeaseRejectsRuntimeNotReady(t *testing.T) {
+	t.Parallel()
+
+	scope := mustRuntimeScopeRef(t, "leases-acquire-not-ready")
+	service := internalservice.New(
+		fixedHostClock{},
+		readySlotFacts{readiness: models.ReadinessStateLoading, capacity: 1},
+	)
+
+	_, err := service.AcquireModelLease(context.Background(), models.AcquireModelLeaseRequest{
+		Scope:  scope,
+		Name:   "local-model",
+		Holder: "worker-a",
+	})
+	if !errors.Is(err, models.ErrHostRuntimeNotReady) {
+		t.Fatalf("AcquireModelLease not ready = %v, want ErrHostRuntimeNotReady", err)
+	}
+}
+
+func TestGetAndReleaseModelLeaseRemainContractOnlyUntilReleasePacket(t *testing.T) {
+	t.Parallel()
+
+	service := internalservice.New(fixedHostClock{}, readySlotFacts{capacity: 1})
+	ctx := context.Background()
+	_, err := service.GetModelLease(ctx, models.GetModelLeaseRequest{})
 	if !errors.Is(err, models.ErrUnsupportedOperation) {
 		t.Fatalf("GetModelLease error = %v, want ErrUnsupportedOperation", err)
 	}
@@ -47,7 +181,7 @@ func TestOpenRuntimeScopeDoesNotConstructAnotherLeasesOwner(t *testing.T) {
 	t.Parallel()
 
 	clock := &recordingHostClock{}
-	service := internalservice.New(clock)
+	service := internalservice.New(clock, readySlotFacts{capacity: 1})
 	scopes, err := runtimescopeswire.NewService(func() string { return "leases-scope-binding" })
 	if err != nil {
 		t.Fatalf("construct runtime scopes: %v", err)
@@ -80,4 +214,48 @@ func (clock *recordingHostClock) Now() time.Time {
 func (clock *recordingHostClock) NewTimer(time.Duration) models.HostTimer {
 	clock.timerCreates++
 	panic("host timer created during inert leases owner")
+}
+
+type fixedHostClock struct {
+	now time.Time
+}
+
+func (clock fixedHostClock) Now() time.Time {
+	if clock.now.IsZero() {
+		return time.Unix(0, 0)
+	}
+	return clock.now
+}
+
+func (clock fixedHostClock) NewTimer(time.Duration) models.HostTimer {
+	panic("host timer created during leases acquire tests")
+}
+
+type readySlotFacts struct {
+	readiness models.ReadinessState
+	capacity  int
+}
+
+func (facts readySlotFacts) SlotFacts(
+	context.Context,
+	models.RuntimeScopeRef,
+	string,
+) (hostleases.SlotFacts, error) {
+	readiness := facts.readiness
+	if readiness == "" {
+		readiness = models.ReadinessStateReady
+	}
+	return hostleases.SlotFacts{
+		Readiness: readiness,
+		Capacity:  facts.capacity,
+	}, nil
+}
+
+func mustRuntimeScopeRef(t *testing.T, value string) models.RuntimeScopeRef {
+	t.Helper()
+	ref, err := models.RuntimeScopeRef{}.Parse(value)
+	if err != nil {
+		t.Fatalf("parse runtime scope ref: %v", err)
+	}
+	return ref
 }

--- a/pkg/services/models/internal/services/runtime_host/internal/services/leases/service.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/services/leases/service.go
@@ -1,0 +1,26 @@
+// Package leases defines the parent-private Models Runtime Host leases owner.
+package leases
+
+import (
+	"context"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+// Service owns capacity reservation and holder lifecycle over Runtime Host slots.
+// Peers reach acquire, release, and get lease behavior only through the singular
+// process-scoped Models root; this interface stays parent-private.
+type Service interface {
+	AcquireModelLease(
+		context.Context,
+		models.AcquireModelLeaseRequest,
+	) (models.AcquireModelLeaseResult, error)
+	GetModelLease(
+		context.Context,
+		models.GetModelLeaseRequest,
+	) (models.GetModelLeaseResult, error)
+	ReleaseModelLease(
+		context.Context,
+		models.ReleaseModelLeaseRequest,
+	) (models.ReleaseModelLeaseResult, error)
+}

--- a/pkg/services/models/internal/services/runtime_host/internal/services/leases/service.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/services/leases/service.go
@@ -16,6 +16,10 @@ const DefaultLeaseTTL = time.Minute
 type SlotFacts struct {
 	Readiness models.ReadinessState
 	Capacity  int
+	// ContendedHolder names the holder currently contending for otherwise
+	// available capacity. Acquisition by a different holder fails with
+	// ErrHostCapacityContended until the contention clears.
+	ContendedHolder string
 }
 
 // SlotFactsProvider supplies host-owned readiness and capacity facts for lease

--- a/pkg/services/models/internal/services/runtime_host/internal/services/leases/service.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/services/leases/service.go
@@ -3,9 +3,39 @@ package leases
 
 import (
 	"context"
+	"time"
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 )
+
+// DefaultLeaseTTL is the detached lease lifetime issued on successful acquire.
+const DefaultLeaseTTL = time.Minute
+
+// SlotFacts captures Runtime Host readiness and configured capacity for one
+// scoped model slot without exposing private host internals.
+type SlotFacts struct {
+	Readiness models.ReadinessState
+	Capacity  int
+}
+
+// SlotFactsProvider supplies host-owned readiness and capacity facts for lease
+// acquisition. Runtime Host implements this port; leases construction requires
+// a non-nil provider but does not start supervision from it.
+type SlotFactsProvider interface {
+	SlotFacts(context.Context, models.RuntimeScopeRef, string) (SlotFacts, error)
+}
+
+// UnconfiguredSlotFacts reports runtime-not-ready for every slot until Runtime
+// Host wires a live facts adapter during lease call-site cutover.
+type UnconfiguredSlotFacts struct{}
+
+func (UnconfiguredSlotFacts) SlotFacts(
+	context.Context,
+	models.RuntimeScopeRef,
+	string,
+) (SlotFacts, error) {
+	return SlotFacts{}, models.ErrHostRuntimeNotReady
+}
 
 // Service owns capacity reservation and holder lifecycle over Runtime Host slots.
 // Peers reach acquire, release, and get lease behavior only through the singular

--- a/pkg/services/models/internal/services/runtime_host/internal/services/leases/service.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/services/leases/service.go
@@ -25,6 +25,26 @@ type SlotFactsProvider interface {
 	SlotFacts(context.Context, models.RuntimeScopeRef, string) (SlotFacts, error)
 }
 
+// SlotCapacityCoordinator notifies Runtime Host when nested lease capacity
+// holders change so idle-unload and holder-aware eviction stay coherent.
+type SlotCapacityCoordinator interface {
+	OnLeaseCapacityAcquired(models.RuntimeScopeRef, string)
+	OnLeaseCapacityReleased(models.RuntimeScopeRef, string)
+}
+
+// CoordinatorBindable leases owners accept a Runtime Host coordinator after
+// construction so wire can bind holder-aware cleanup without circular imports.
+type CoordinatorBindable interface {
+	BindSlotCapacityCoordinator(SlotCapacityCoordinator)
+}
+
+// BindCoordinator attaches holder-aware Runtime Host cleanup when supported.
+func BindCoordinator(leases Service, coordinator SlotCapacityCoordinator) {
+	if bindable, ok := leases.(CoordinatorBindable); ok {
+		bindable.BindSlotCapacityCoordinator(coordinator)
+	}
+}
+
 // UnconfiguredSlotFacts reports runtime-not-ready for every slot until Runtime
 // Host wires a live facts adapter during lease call-site cutover.
 type UnconfiguredSlotFacts struct{}

--- a/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire/wire.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire/wire.go
@@ -1,0 +1,34 @@
+// Package wire constructs the parent-private Models Runtime Host leases owner.
+package wire
+
+import (
+	"fmt"
+	"reflect"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	hostleases "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service"
+)
+
+// NewService constructs an inert leases owner over injected host effects.
+// Construction validates required dependencies and allocates lease/capacity
+// state only; it does not launch subprocesses or start application lifecycle.
+func NewService(hostClock models.HostClock) (hostleases.Service, error) {
+	if isNilDependency(hostClock) {
+		return nil, fmt.Errorf("%w: model host clock is required", models.ErrInvalidHostDependencies)
+	}
+	return internalservice.New(hostClock), nil
+}
+
+func isNilDependency(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire/wire.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire/wire.go
@@ -13,11 +13,17 @@ import (
 // NewService constructs an inert leases owner over injected host effects.
 // Construction validates required dependencies and allocates lease/capacity
 // state only; it does not launch subprocesses or start application lifecycle.
-func NewService(hostClock models.HostClock) (hostleases.Service, error) {
+func NewService(
+	hostClock models.HostClock,
+	slotFacts hostleases.SlotFactsProvider,
+) (hostleases.Service, error) {
 	if isNilDependency(hostClock) {
 		return nil, fmt.Errorf("%w: model host clock is required", models.ErrInvalidHostDependencies)
 	}
-	return internalservice.New(hostClock), nil
+	if isNilDependency(slotFacts) {
+		return nil, fmt.Errorf("%w: model host slot facts provider is required", models.ErrInvalidHostDependencies)
+	}
+	return internalservice.New(hostClock, slotFacts), nil
 }
 
 func isNilDependency(value any) bool {

--- a/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire/wire_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire/wire_test.go
@@ -1,0 +1,57 @@
+package wire_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	leaseswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire"
+)
+
+func TestNewServiceRequiresLeaseDependencies(t *testing.T) {
+	t.Parallel()
+
+	clock := testHostClock{}
+
+	tests := []struct {
+		name            string
+		clock           models.HostClock
+		wantContains    string
+		wantInvalidDeps bool
+	}{
+		{name: "valid", clock: clock},
+		{
+			name: "host clock", wantContains: "clock",
+			wantInvalidDeps: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service, err := leaseswire.NewService(test.clock)
+			if test.wantInvalidDeps {
+				if service != nil || err == nil {
+					t.Fatalf("NewService = (%#v, %v), want dependency error", service, err)
+				}
+				if !errors.Is(err, models.ErrInvalidHostDependencies) {
+					t.Fatalf("error = %v, want ErrInvalidHostDependencies", err)
+				}
+				if test.wantContains != "" && !strings.Contains(err.Error(), test.wantContains) {
+					t.Fatalf("error = %q, want substring %q", err.Error(), test.wantContains)
+				}
+				return
+			}
+			if service == nil || err != nil {
+				t.Fatalf("NewService = (%#v, %v), want service", service, err)
+			}
+		})
+	}
+}
+
+type testHostClock struct{}
+
+func (testHostClock) Now() time.Time { return time.Unix(0, 0) }
+func (testHostClock) NewTimer(time.Duration) models.HostTimer {
+	panic("host timer created during inert leases construction")
+}

--- a/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire/wire_test.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire/wire_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
+	hostleases "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases"
 	leaseswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire"
 )
 
@@ -14,22 +15,28 @@ func TestNewServiceRequiresLeaseDependencies(t *testing.T) {
 	t.Parallel()
 
 	clock := testHostClock{}
+	slotFacts := hostleases.UnconfiguredSlotFacts{}
 
 	tests := []struct {
 		name            string
 		clock           models.HostClock
+		slotFacts       hostleases.SlotFactsProvider
 		wantContains    string
 		wantInvalidDeps bool
 	}{
-		{name: "valid", clock: clock},
+		{name: "valid", clock: clock, slotFacts: slotFacts},
 		{
 			name: "host clock", wantContains: "clock",
-			wantInvalidDeps: true,
+			slotFacts: slotFacts, wantInvalidDeps: true,
+		},
+		{
+			name: "slot facts", wantContains: "slot facts",
+			clock: clock, wantInvalidDeps: true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			service, err := leaseswire.NewService(test.clock)
+			service, err := leaseswire.NewService(test.clock, test.slotFacts)
 			if test.wantInvalidDeps {
 				if service != nil || err == nil {
 					t.Fatalf("NewService = (%#v, %v), want dependency error", service, err)

--- a/pkg/services/models/internal/services/runtime_host/service.go
+++ b/pkg/services/models/internal/services/runtime_host/service.go
@@ -23,4 +23,16 @@ type Service interface {
 		context.Context,
 		models.StopModelHostRequest,
 	) (models.StopModelHostResult, error)
+	AcquireModelLease(
+		context.Context,
+		models.AcquireModelLeaseRequest,
+	) (models.AcquireModelLeaseResult, error)
+	GetModelLease(
+		context.Context,
+		models.GetModelLeaseRequest,
+	) (models.GetModelLeaseResult, error)
+	ReleaseModelLease(
+		context.Context,
+		models.ReleaseModelLeaseRequest,
+	) (models.ReleaseModelLeaseResult, error)
 }

--- a/pkg/services/models/internal/services/runtime_host/wire/wire.go
+++ b/pkg/services/models/internal/services/runtime_host/wire/wire.go
@@ -7,6 +7,7 @@ import (
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
+	leaseswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/service"
 	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
 	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
@@ -39,9 +40,14 @@ func NewService(
 	if isNilDependency(hostClock) {
 		return nil, fmt.Errorf("%w: model host clock is required", models.ErrInvalidHostDependencies)
 	}
+	leases, err := leaseswire.NewService(hostClock)
+	if err != nil {
+		return nil, err
+	}
 	return internalservice.New(
 		scopes,
 		assets,
+		leases,
 		processLauncher,
 		hostHTTP,
 		hostClock,

--- a/pkg/services/models/internal/services/runtime_host/wire/wire.go
+++ b/pkg/services/models/internal/services/runtime_host/wire/wire.go
@@ -7,6 +7,7 @@ import (
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
+	hostleases "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases"
 	leaseswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/service"
 	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
@@ -40,7 +41,7 @@ func NewService(
 	if isNilDependency(hostClock) {
 		return nil, fmt.Errorf("%w: model host clock is required", models.ErrInvalidHostDependencies)
 	}
-	leases, err := leaseswire.NewService(hostClock)
+	leases, err := leaseswire.NewService(hostClock, hostleases.UnconfiguredSlotFacts{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/models/internal/services/runtime_host/wire/wire.go
+++ b/pkg/services/models/internal/services/runtime_host/wire/wire.go
@@ -45,7 +45,7 @@ func NewService(
 	if err != nil {
 		return nil, err
 	}
-	return internalservice.New(
+	host := internalservice.New(
 		scopes,
 		assets,
 		leases,
@@ -54,7 +54,8 @@ func NewService(
 		hostClock,
 		hostLogger,
 		hostMetrics,
-	), nil
+	)
+	return host, nil
 }
 
 func isNilDependency(value any) bool {

--- a/pkg/services/models/internal/services/runtime_host/wire/wire.go
+++ b/pkg/services/models/internal/services/runtime_host/wire/wire.go
@@ -7,8 +7,6 @@ import (
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
-	hostleases "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases"
-	leaseswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/wire"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/service"
 	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
 	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
@@ -41,21 +39,15 @@ func NewService(
 	if isNilDependency(hostClock) {
 		return nil, fmt.Errorf("%w: model host clock is required", models.ErrInvalidHostDependencies)
 	}
-	leases, err := leaseswire.NewService(hostClock, hostleases.UnconfiguredSlotFacts{})
-	if err != nil {
-		return nil, err
-	}
-	host := internalservice.New(
+	return internalservice.NewWired(
 		scopes,
 		assets,
-		leases,
 		processLauncher,
 		hostHTTP,
 		hostClock,
 		hostLogger,
 		hostMetrics,
 	)
-	return host, nil
 }
 
 func isNilDependency(value any) bool {


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "pss-imp-mod-05-runtime-host-leases",
  "description": "Package Models runtime-host capacity leases and holders as a parent-private nested owner under Runtime Host, with inert construction, injected effects, and deterministic contention, expiry, release, cancel, and race-safe capacity accounting, without absorbing runtime_scopes, catalog, assets, host supervision, or inference.",
  "context": {
    "customerAsk": "Implement IMP-MOD-05 as the parent-private Models runtime_host leases owner. Provide capacity and holder semantics with deterministic contention, expiry, release, cancel, and race proof while keeping construction inert and effects injected. Do not absorb runtime_scopes, catalog, assets, runtime_host supervision itself, or inference ownership. Shared coverage, ownership, and package-target manifest edits are allowed. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Capacity reservation, holder identity, acquisition, release, expiry, and contention still live inside the broader Models runtime-host/legacy host implementation rather than a nested parent-private leases owner under runtime_host. That entanglement makes concurrent acquire/release races, capacity exhaustion, holder validation, expiry, and cancellation harder to prove as one coherent capacity authority for later inference work.",
    "solution": "Create the parent-private Models Runtime Host leases subservice as the sole owner of capacity reservation and holder lifecycle over Host-owned slots. Keep construction inert with injected effects, preserve distinct Models-owned acquire/release/expiry/cancel/contention outcomes, prove race-safe capacity accounting, adapt focused Runtime Host call sites, and update shared ownership/package-target/coverage manifests without absorbing runtime_scopes, catalog, assets, supervision, or inference."
  },
  "acceptanceCriteria": [
    "AC-1: Capacity reservation and holder lifecycle are owned by runtime_host/internal/services/leases and reached by peers only through the singular process-scoped Models root / Runtime Host composition path.",
    "AC-2: Leases construction is inert: validating and composing the leases owner allocates state and accepts injected effects (including clock) without launching supervised processes or starting application lifecycle.",
    "AC-3: Acquire, release, expiry, cancel, capacity exhaustion, and holder/contention failures behave deterministically with distinct Models-owned classifications and do not expose private lease tables, timers, or host internals to peers.",
    "AC-4: Concurrent acquire/release/cancel races never oversubscribe configured capacity, never return duplicate active lease identities for the same issued capacity unit, and never leave released or expired capacity permanently stranded.",
    "AC-5: This packet does not absorb runtime_scopes, catalog, assets, Runtime Host supervision itself, or inference ownership; shared coverage, ownership-inventory, and package-target manifest edits remain limited to proving the leases ownership move.",
    "AC-6: Quality gates pass: typecheck, lint, focused Models runtime-host leases tests, and the required repository test suite.",
    "AC-7: The implementation/review cycle continues until required CI is terminal and passing, every blocking PR conversation comment is explicitly addressed, merge conflicts and shared coverage/ownership/package-target manifest churn are reconciled, and the PR is actually merged; opening, approving, or making the PR merge-ready is not completion."
  ],
  "userStories": [
    {
      "id": "pss-imp-mod-05-runtime-host-leases-001",
      "title": "Compose an inert leases owner under Runtime Host",
      "description": "As a maintainer, I want capacity-lease ownership constructed once as a parent-private child of Runtime Host so peers cannot reach lease internals and Factory selection cannot reconstruct Models.",
      "acceptanceCriteria": [
        "Runtime Host composes one parent-private leases capability under internal/services/leases, and peer callers reach acquire/release/get lease behavior only through the singular process-scoped Models root.",
        "Constructing Models/Runtime Host/leases with valid injected effects (including clock) allocates lease/capacity state without launching a supervised subprocess, opening network listeners, or starting application lifecycle.",
        "Missing or invalid required lease dependencies fail synchronously at construction with the Models-owned invalid-dependencies classification and still launch no process.",
        "Constructing or selecting a Factory/runtime scope does not construct another Models service, host, leases owner, puller, or deferred dependency bundle for lease capacity.",
        "Focused inert-construction and composition tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-mod-05-runtime-host-leases-002",
      "title": "Acquire capacity with stable holder identity",
      "description": "As a Models consumer, I want to reserve disposable runtime capacity for a named holder so later release and contention decisions can attribute ownership correctly.",
      "acceptanceCriteria": [
        "Acquiring a lease for a ready model with a non-empty holder returns a detached active lease containing opaque lease identity, model association, holder, expiry, and readiness facts without exposing private lease tables or host internals.",
        "Acquiring a lease with a missing/blank holder fails with ErrHostInvalidHolder and does not consume capacity.",
        "Each successful acquisition returns a unique lease identity while capacity remains available; concurrent successful acquisitions for the same model may share a supervised endpoint/slot when Runtime Host reuse allows it, but each issued lease identity remains distinct.",
        "When configured capacity for the model is already fully held, acquisition fails with ErrHostCapacityExhausted and does not issue another active lease.",
        "Focused acquire, holder-validation, and capacity-exhaustion tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-mod-05-runtime-host-leases-003",
      "title": "Release capacity and honor cancel during acquire",
      "description": "As a Models consumer, I want release and cancel to free or abort capacity deterministically so holders cannot strand runtime slots.",
      "acceptanceCriteria": [
        "Releasing an active lease by opaque identity frees that capacity so a subsequent acquire can succeed when capacity was previously exhausted.",
        "Releasing an unknown or already-released lease identity fails with ErrHostLeaseNotFound and does not mutate other holders' capacity.",
        "Cancelling the acquire context before a lease is issued returns the Models-owned host cancellation classification, issues no lease, and leaves capacity unchanged.",
        "After the last active lease for a supervised runtime is released, Runtime Host idle-unload/holder-aware cleanup remains coherent (idle unload may proceed; actively held capacity still blocks eviction).",
        "Focused release and cancel tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-mod-05-runtime-host-leases-004",
      "title": "Expire leases and surface contention outcomes",
      "description": "As a runtime operator, I want expired and contended capacity to surface distinct Models-owned outcomes so callers can recover without guessing which capacity fault occurred.",
      "acceptanceCriteria": [
        "When an issued lease's expiry time has passed (via injected clock), get/use of that lease reports ErrHostLeaseExpired with expired status and the expired lease no longer consumes capacity against the configured limit.",
        "Explicit release of an already-expired lease does not double-free capacity or succeed as if the lease were still active; the observable outcome remains lease-not-found or expired according to the accepted Models host/lease classifications.",
        "When another holder currently contends for otherwise available model capacity, acquisition fails with ErrHostCapacityContended rather than silently sharing or stealing that holder's reservation.",
        "Capacity-exhausted, capacity-contended, lease-not-found, lease-expired, invalid-holder, runtime-not-ready, and cancellation outcomes remain distinct under errors.Is.",
        "Focused expiry and contention tests pass using injected clock/effects.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-mod-05-runtime-host-leases-005",
      "title": "Prove concurrent race safety for capacity accounting",
      "description": "As a maintainer, I want concurrent acquire, release, and cancel traffic to preserve capacity invariants so races cannot oversubscribe or permanently strand leases.",
      "acceptanceCriteria": [
        "Under concurrent acquire/release workers for one model, active lease count never exceeds configured capacity at any observed successful-acquire boundary.",
        "Concurrent workers never observe two active leases with the same lease identity.",
        "After all workers finish and every successfully issued lease is released or expired, subsequent acquires can again fill capacity up to the configured limit (no stranded capacity).",
        "Concurrent cancel during acquire never leaves a peer-visible active lease without a returned identity, and cancelled attempts do not permanently reduce available capacity.",
        "Focused race/stress evidence for contention, expiry, release, cancel, and capacity accounting passes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-mod-05-runtime-host-leases-006",
      "title": "Cut over Runtime Host call sites and prove package ownership through merge",
      "description": "As a maintainer, I want focused Runtime Host lease call sites and package-boundary gates aligned to the nested leases owner, then delivered through actual PR merge.",
      "acceptanceCriteria": [
        "Focused Models Runtime Host lease capacity/holder call sites delegate to the nested leases owner; superseded in-host lease tables/accounting are removed or reduced to zero callers after behavioral parity is proven.",
        "Package-boundary, ownership-inventory, and package-target-manifest verification gates record models/runtime_host/leases under pkg/services/models/internal/services/runtime_host/internal/services/leases and pass for the moved ownership.",
        "This story does not absorb runtime_scopes, catalog, assets, Runtime Host supervision packaging itself, or inference ownership; shared coverage/ownership/package-target edits stay limited to this packet.",
        "Required CI is terminal and passing, every blocking PR conversation comment is explicitly addressed, merge conflicts and shared-file churn are reconciled, and the PR is actually merged.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": false,
      "notes": ""
    }
  ]
}
