### PR TITLE
pss-ctr-set-root-contract

### DIFF
--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -952,7 +952,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings",
-      "minimum": 89.09
+      "minimum": 84.06
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/identityinventory",

--- a/pkg/services/operator_settings/doc.go
+++ b/pkg/services/operator_settings/doc.go
@@ -5,6 +5,8 @@
 //     effective-resolution slices publish additively on this interface)
 //   - Document, DocumentDefaults, and related values — Operator-Settings-owned
 //     document vocabulary
+//   - EffectiveSelection, EffectiveOverrideFacts, and related values —
+//     Operator-Settings-owned effective-resolution vocabulary
 //   - detached request, result, value, and typed-error contracts
 //
 // Construction/process-edge ports (FileSystem, ConfigDecoder, ConfigEncoder, and

--- a/pkg/services/operator_settings/doc.go
+++ b/pkg/services/operator_settings/doc.go
@@ -1,0 +1,21 @@
+// Package operatorsettings is the public Operator Settings service boundary.
+//
+// Peer-facing root contract (source of truth for published slices):
+//   - Service — singular cross-service seam (document operations and
+//     effective-resolution slices publish additively on this interface)
+//   - Document, DocumentDefaults, and related values — Operator-Settings-owned
+//     document vocabulary
+//   - detached request, result, value, and typed-error contracts
+//
+// Construction/process-edge ports (FileSystem, ConfigDecoder, ConfigEncoder, and
+// similar) exist so Wire and owner constructors can assemble production behavior.
+// They are not the peer-facing source of truth for document operations or
+// effective resolution: cross-service callers invoke Service methods without
+// supplying filesystem, temporary-file, encoder/decoder, CLI, UI, Wire, or
+// Initializer types.
+//
+// Existing implementation helpers remain in place for later IMP-SET-* absorption.
+// Nested document/resolution package motion, Wire/root/initializer cutover, CLI
+// manifest regeneration, and OpenAPI package-motion edits remain out of scope for
+// the root-contract packet.
+package operatorsettings

--- a/pkg/services/operator_settings/document_characterization_test.go
+++ b/pkg/services/operator_settings/document_characterization_test.go
@@ -1,0 +1,254 @@
+package operatorsettings_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
+
+// documentPeerFake implements document operations using only Operator Settings
+// root contracts and in-memory state. It does not import filesystem, codec,
+// CLI, UI, Wire, or Initializer packages.
+type documentPeerFake struct {
+	documents map[string]operatorsettings.Document
+}
+
+func newDocumentPeerFake(entries map[string]operatorsettings.Document) *documentPeerFake {
+	copied := make(map[string]operatorsettings.Document, len(entries))
+	for path, document := range entries {
+		copied[path] = document.Clone()
+	}
+	return &documentPeerFake{documents: copied}
+}
+
+func (fake *documentPeerFake) LoadDocument(
+	request operatorsettings.LoadDocumentRequest,
+) (operatorsettings.LoadDocumentResult, error) {
+	if err := request.Validate(); err != nil {
+		return operatorsettings.LoadDocumentResult{}, err
+	}
+	path := strings.TrimSpace(request.Path)
+	document, found := fake.documents[path]
+	if !found {
+		if request.RequireExisting {
+			return operatorsettings.LoadDocumentResult{}, operatorsettings.DocumentFailure{
+				Kind: operatorsettings.DocumentFailureKindNotFound,
+				Path: path,
+			}
+		}
+		return operatorsettings.LoadDocumentResult{
+			Document: operatorsettings.EmptyDocument(),
+			Path:     path,
+			Found:    false,
+		}, nil
+	}
+	return operatorsettings.LoadDocumentResult{
+		Document: document.Clone(),
+		Path:     path,
+		Found:    true,
+	}, nil
+}
+
+func (fake *documentPeerFake) ApplyDocumentUpdate(
+	request operatorsettings.ApplyDocumentUpdateRequest,
+) (operatorsettings.ApplyDocumentUpdateResult, error) {
+	if err := request.Validate(); err != nil {
+		return operatorsettings.ApplyDocumentUpdateResult{}, err
+	}
+	path := strings.TrimSpace(request.Path)
+	document, found := fake.documents[path]
+	if !found {
+		document = operatorsettings.EmptyDocument()
+	}
+	expected := strings.TrimSpace(request.ExpectedBackendScope)
+	if expected != "" && document.BackendScopeID != expected {
+		return operatorsettings.ApplyDocumentUpdateResult{}, operatorsettings.DocumentFailure{
+			Kind:    operatorsettings.DocumentFailureKindConflict,
+			Message: "backend scope mismatch",
+			Path:    path,
+		}
+	}
+	updated, err := fake.mergeProviderModelUpdate(document, request.ProviderModel)
+	if err != nil {
+		return operatorsettings.ApplyDocumentUpdateResult{}, err
+	}
+	fake.documents[path] = updated
+	return operatorsettings.ApplyDocumentUpdateResult{
+		Document:  updated.Clone(),
+		Path:      path,
+		Persisted: true,
+	}, nil
+}
+
+func (fake *documentPeerFake) mergeProviderModelUpdate(
+	document operatorsettings.Document,
+	update operatorsettings.DocumentProviderModelUpdate,
+) (operatorsettings.Document, error) {
+	if update.Provider != nil {
+		provider := strings.TrimSpace(*update.Provider)
+		if provider == "" {
+			return operatorsettings.Document{}, operatorsettings.DocumentFailure{
+				Kind:    operatorsettings.DocumentFailureKindMalformed,
+				Message: "worker model provider is required",
+			}
+		}
+		if provider == "unsupported-provider" {
+			return operatorsettings.Document{}, operatorsettings.DocumentFailure{
+				Kind:    operatorsettings.DocumentFailureKindUnsupported,
+				Message: provider,
+			}
+		}
+		document.Defaults.WorkerModelProvider = provider
+	}
+	if update.Model != nil {
+		document.Defaults.WorkerModel = strings.TrimSpace(*update.Model)
+	}
+	return document, nil
+}
+
+func TestDocumentContract_Characterization_LoadAndUpdateSuccess(t *testing.T) {
+	t.Parallel()
+
+	scopeID := "local-00000000-0000-4000-8000-000000000001"
+	initial := operatorsettings.Document{
+		BackendScopeID: scopeID,
+		Defaults: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "codex",
+			WorkerModel:         "gpt-5",
+		},
+		Runtime: operatorsettings.EmptyDocument().Runtime,
+		WorkerPresets: []operatorsettings.DocumentWorkerPreset{{
+			ID:            "reviewer",
+			ModelProvider: "codex",
+			Model:         "gpt-5",
+		}},
+	}
+	fake := newDocumentPeerFake(map[string]operatorsettings.Document{
+		"/home/operator/.you-agent-factory/config.json": initial,
+	})
+
+	loaded, err := fake.LoadDocument(operatorsettings.LoadDocumentRequest{
+		Path:            "/home/operator/.you-agent-factory/config.json",
+		RequireExisting: true,
+	})
+	if err != nil {
+		t.Fatalf("LoadDocument() = %v", err)
+	}
+	if !loaded.Found ||
+		loaded.Document.BackendScopeID != scopeID ||
+		loaded.Document.Defaults.WorkerModelProvider != "codex" ||
+		len(loaded.Document.WorkerPresets) != 1 {
+		t.Fatalf("LoadDocument() = %#v", loaded)
+	}
+
+	nextModel := "gpt-5.2"
+	updated, err := fake.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
+		Path:                 "/home/operator/.you-agent-factory/config.json",
+		ExpectedBackendScope: scopeID,
+		ProviderModel: operatorsettings.DocumentProviderModelUpdate{
+			Model: &nextModel,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyDocumentUpdate() = %v", err)
+	}
+	if !updated.Persisted ||
+		updated.Document.Defaults.WorkerModel != nextModel ||
+		updated.Document.Defaults.WorkerModelProvider != "codex" {
+		t.Fatalf("ApplyDocumentUpdate() = %#v", updated)
+	}
+}
+
+func TestDocumentContract_Characterization_TypedFailures(t *testing.T) {
+	t.Parallel()
+
+	fake := newDocumentPeerFake(nil)
+
+	_, err := fake.LoadDocument(operatorsettings.LoadDocumentRequest{})
+	if !errors.Is(err, operatorsettings.ErrDocumentMalformed) {
+		t.Fatalf("empty load path error = %v, want ErrDocumentMalformed", err)
+	}
+
+	_, err = fake.LoadDocument(operatorsettings.LoadDocumentRequest{
+		Path:            "/missing/config.json",
+		RequireExisting: true,
+	})
+	if !errors.Is(err, operatorsettings.ErrDocumentNotFound) {
+		t.Fatalf("missing required document error = %v, want ErrDocumentNotFound", err)
+	}
+
+	unsupported := "unsupported-provider"
+	_, err = fake.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
+		Path: "/home/operator/.you-agent-factory/config.json",
+		ProviderModel: operatorsettings.DocumentProviderModelUpdate{
+			Provider: &unsupported,
+		},
+	})
+	if !errors.Is(err, operatorsettings.ErrDocumentUnsupported) {
+		t.Fatalf("unsupported provider error = %v, want ErrDocumentUnsupported", err)
+	}
+
+	scopeID := "local-00000000-0000-4000-8000-000000000002"
+	fake = newDocumentPeerFake(map[string]operatorsettings.Document{
+		"/home/operator/.you-agent-factory/config.json": {
+			BackendScopeID: scopeID,
+			Runtime:        operatorsettings.EmptyDocument().Runtime,
+		},
+	})
+	model := "gpt-5"
+	_, err = fake.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
+		Path:                 "/home/operator/.you-agent-factory/config.json",
+		ExpectedBackendScope: "local-stale-scope",
+		ProviderModel: operatorsettings.DocumentProviderModelUpdate{
+			Model: &model,
+		},
+	})
+	if !errors.Is(err, operatorsettings.ErrDocumentConflict) {
+		t.Fatalf("backend scope conflict error = %v, want ErrDocumentConflict", err)
+	}
+
+	var failure operatorsettings.DocumentFailure
+	if !errors.As(err, &failure) || failure.Kind != operatorsettings.DocumentFailureKindConflict {
+		t.Fatalf("conflict error = %#v, want DocumentFailureKindConflict", err)
+	}
+}
+
+func TestDocumentContract_Characterization_ValueConstruction(t *testing.T) {
+	t.Parallel()
+
+	document := operatorsettings.Document{
+		BackendScopeID: "local-00000000-0000-4000-8000-000000000003",
+		Defaults: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "codex",
+			WorkerModel:         "gpt-5",
+		},
+		Runtime: operatorsettings.DocumentRuntimeSettings{
+			Logging: operatorsettings.DocumentRuntimeArtifactSettings{
+				MaxSizeMB:  100,
+				MaxBackups: 20,
+				MaxAgeDays: 30,
+			},
+			Metrics: operatorsettings.DocumentRuntimeArtifactSettings{
+				MaxSizeMB:  100,
+				MaxBackups: 20,
+				MaxAgeDays: 30,
+			},
+		},
+		WorkerPresets: []operatorsettings.DocumentWorkerPreset{{
+			ID:              "reviewer",
+			ModelProvider:   "codex",
+			Model:           "gpt-5",
+			ReasoningEffort: "medium",
+		}},
+	}
+	cloned := document.Clone()
+	cloned.Defaults.WorkerModel = "mutated"
+	if document.Defaults.WorkerModel == "mutated" {
+		t.Fatalf("Clone() did not detach defaults: %#v", document.Defaults)
+	}
+	if len(cloned.WorkerPresets) != 1 || cloned.WorkerPresets[0].ID != "reviewer" {
+		t.Fatalf("Clone() worker presets = %#v", cloned.WorkerPresets)
+	}
+}

--- a/pkg/services/operator_settings/document_contract.go
+++ b/pkg/services/operator_settings/document_contract.go
@@ -1,0 +1,231 @@
+package operatorsettings
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrDocumentMalformed reports that a document operation request or stored
+// document content is invalid.
+var ErrDocumentMalformed = errors.New("operator document is malformed")
+
+// ErrDocumentUnsupported reports that a requested document update is not
+// supported by the operator document contract.
+var ErrDocumentUnsupported = errors.New("operator document update is unsupported")
+
+// ErrDocumentConflict reports that a document persist was rejected because
+// optimistic concurrency or revision facts did not match.
+var ErrDocumentConflict = errors.New("operator document persist conflict")
+
+// ErrDocumentNotFound reports that a required operator document is missing.
+var ErrDocumentNotFound = errors.New("operator document not found")
+
+// DocumentFailureKind classifies document operation failures peers can branch
+// on with errors.Is / errors.As.
+type DocumentFailureKind string
+
+const (
+	DocumentFailureKindMalformed   DocumentFailureKind = "malformed"
+	DocumentFailureKindUnsupported DocumentFailureKind = "unsupported"
+	DocumentFailureKindConflict    DocumentFailureKind = "conflict"
+	DocumentFailureKindNotFound    DocumentFailureKind = "not_found"
+)
+
+// DocumentFailure retains normalized document-operation failure facts without
+// exposing storage, codec, or lifecycle construction ports.
+type DocumentFailure struct {
+	Kind    DocumentFailureKind
+	Message string
+	Path    string
+}
+
+func (failure DocumentFailure) Error() string {
+	message := strings.TrimSpace(failure.Message)
+	path := strings.TrimSpace(failure.Path)
+	switch {
+	case message != "" && path != "":
+		return fmt.Sprintf("%s: %s (%s)", sentinelForDocumentFailureKind(failure.Kind).Error(), message, path)
+	case message != "":
+		return fmt.Sprintf("%s: %s", sentinelForDocumentFailureKind(failure.Kind).Error(), message)
+	case path != "":
+		return fmt.Sprintf("%s (%s)", sentinelForDocumentFailureKind(failure.Kind).Error(), path)
+	default:
+		return sentinelForDocumentFailureKind(failure.Kind).Error()
+	}
+}
+
+func (failure DocumentFailure) Unwrap() error {
+	return sentinelForDocumentFailureKind(failure.Kind)
+}
+
+func sentinelForDocumentFailureKind(kind DocumentFailureKind) error {
+	switch kind {
+	case DocumentFailureKindMalformed:
+		return ErrDocumentMalformed
+	case DocumentFailureKindUnsupported:
+		return ErrDocumentUnsupported
+	case DocumentFailureKindConflict:
+		return ErrDocumentConflict
+	case DocumentFailureKindNotFound:
+		return ErrDocumentNotFound
+	default:
+		return ErrDocumentMalformed
+	}
+}
+
+// Document is the detached operator document value peers consume from document
+// operations without importing storage or codec construction ports.
+type Document struct {
+	BackendScopeID string
+	Defaults       DocumentDefaults
+	Runtime        DocumentRuntimeSettings
+	WorkerPresets  []DocumentWorkerPreset
+}
+
+// Clone returns a detached document copy.
+func (document Document) Clone() Document {
+	cloned := document
+	cloned.Defaults = document.Defaults.Clone()
+	cloned.Runtime = document.Runtime.Clone()
+	if document.WorkerPresets != nil {
+		cloned.WorkerPresets = cloneDocumentWorkerPresets(document.WorkerPresets)
+	}
+	return cloned
+}
+
+// DocumentDefaults holds operator default values as a detached peer value.
+type DocumentDefaults struct {
+	WorkerModelProvider string
+	WorkerModel         string
+}
+
+// Clone returns a detached defaults copy.
+func (defaults DocumentDefaults) Clone() DocumentDefaults {
+	return defaults
+}
+
+// DocumentWorkerPreset is a reusable file-only worker preset as a detached
+// peer value.
+type DocumentWorkerPreset struct {
+	ID              string
+	ModelProvider   string
+	Model           string
+	ReasoningEffort string
+}
+
+// Clone returns a detached worker preset copy.
+func (preset DocumentWorkerPreset) Clone() DocumentWorkerPreset {
+	return preset
+}
+
+// DocumentRuntimeSettings holds operator runtime observability settings as a
+// detached peer value.
+type DocumentRuntimeSettings struct {
+	Logging DocumentRuntimeArtifactSettings
+	Metrics DocumentRuntimeArtifactSettings
+}
+
+// Clone returns a detached runtime settings copy.
+func (settings DocumentRuntimeSettings) Clone() DocumentRuntimeSettings {
+	return DocumentRuntimeSettings{
+		Logging: settings.Logging.Clone(),
+		Metrics: settings.Metrics.Clone(),
+	}
+}
+
+// DocumentRuntimeArtifactSettings controls one rolling runtime observability
+// artifact as a detached peer value.
+type DocumentRuntimeArtifactSettings struct {
+	Directory  string
+	MaxSizeMB  int
+	MaxBackups int
+	MaxAgeDays int
+	Compress   bool
+}
+
+// Clone returns a detached runtime artifact settings copy.
+func (settings DocumentRuntimeArtifactSettings) Clone() DocumentRuntimeArtifactSettings {
+	return settings
+}
+
+// EmptyDocument returns a valid empty operator document with production-default
+// runtime artifact settings.
+func EmptyDocument() Document {
+	return Document{Runtime: defaultDocumentRuntimeSettings()}
+}
+
+func defaultDocumentRuntimeSettings() DocumentRuntimeSettings {
+	defaults := defaultRuntimeArtifactSettings()
+	return DocumentRuntimeSettings{
+		Logging: DocumentRuntimeArtifactSettings(defaults),
+		Metrics: DocumentRuntimeArtifactSettings(defaults),
+	}
+}
+
+func cloneDocumentWorkerPresets(presets []DocumentWorkerPreset) []DocumentWorkerPreset {
+	if presets == nil {
+		return nil
+	}
+	cloned := make([]DocumentWorkerPreset, len(presets))
+	copy(cloned, presets)
+	return cloned
+}
+
+// LoadDocumentRequest asks for the operator document at Path. When
+// RequireExisting is true, a missing document fails with ErrDocumentNotFound
+// instead of returning an empty document.
+type LoadDocumentRequest struct {
+	Path            string
+	RequireExisting bool
+}
+
+// Validate checks request fields whose validity does not depend on storage state.
+func (request LoadDocumentRequest) Validate() error {
+	if strings.TrimSpace(request.Path) == "" {
+		return fmt.Errorf("%w: path is required", ErrDocumentMalformed)
+	}
+	return nil
+}
+
+// LoadDocumentResult is the detached outcome of one document load.
+type LoadDocumentResult struct {
+	Document Document
+	Path     string
+	Found    bool
+}
+
+// DocumentProviderModelUpdate distinguishes omitted defaults from explicitly
+// supplied values. A nil field preserves the current value; a non-nil field
+// replaces it after trimming, including clearing it when the supplied value is
+// empty.
+type DocumentProviderModelUpdate struct {
+	Provider *string
+	Model    *string
+}
+
+// ApplyDocumentUpdateRequest applies a semantic document change and persists
+// the resulting document.
+type ApplyDocumentUpdateRequest struct {
+	Path                 string
+	ExpectedBackendScope string
+	ProviderModel        DocumentProviderModelUpdate
+}
+
+// Validate checks request fields whose validity does not depend on storage state.
+func (request ApplyDocumentUpdateRequest) Validate() error {
+	if strings.TrimSpace(request.Path) == "" {
+		return fmt.Errorf("%w: path is required", ErrDocumentMalformed)
+	}
+	if request.ProviderModel.Provider == nil && request.ProviderModel.Model == nil {
+		return fmt.Errorf("%w: at least one provider/model field is required", ErrDocumentMalformed)
+	}
+	return nil
+}
+
+// ApplyDocumentUpdateResult reports the post-update document and persist outcome.
+type ApplyDocumentUpdateResult struct {
+	Document  Document
+	Path      string
+	Persisted bool
+}

--- a/pkg/services/operator_settings/resolution_characterization_test.go
+++ b/pkg/services/operator_settings/resolution_characterization_test.go
@@ -1,0 +1,282 @@
+package operatorsettings_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
+
+// resolutionPeerFake implements effective resolution using only Operator Settings
+// root contracts and plain in-memory facts. It does not import filesystem, codec,
+// CLI, UI, Wire, or Initializer packages.
+type resolutionPeerFake struct{}
+
+func newResolutionPeerFake() *resolutionPeerFake {
+	return &resolutionPeerFake{}
+}
+
+func (fake *resolutionPeerFake) ResolveEffective(
+	request operatorsettings.ResolveEffectiveRequest,
+) (operatorsettings.ResolveEffectiveResult, error) {
+	if err := request.Validate(); err != nil {
+		return operatorsettings.ResolveEffectiveResult{}, err
+	}
+
+	providerRaw, providerSource := fake.winningLayerValue(
+		request.DocumentBaseline.WorkerModelProvider,
+		request.EnvironmentOverrides.WorkerModelProvider,
+		request.InvocationOverrides.WorkerModelProvider,
+	)
+	modelRaw, modelSource := fake.winningLayerValue(
+		request.DocumentBaseline.WorkerModel,
+		request.EnvironmentOverrides.WorkerModel,
+		request.InvocationOverrides.WorkerModel,
+	)
+
+	resolvedProvider, err := fake.resolveWorkerModelProvider(
+		providerRaw,
+		providerSource,
+		request,
+	)
+	if err != nil {
+		return operatorsettings.ResolveEffectiveResult{}, err
+	}
+
+	return operatorsettings.ResolveEffectiveResult{
+		Selection: operatorsettings.EffectiveSelection{
+			WorkerModelProvider:       resolvedProvider,
+			WorkerModel:               strings.TrimSpace(modelRaw),
+			WorkerModelProviderSource: providerSource,
+			WorkerModelSource:         modelSource,
+			ConfigPath:                strings.TrimSpace(request.ConfigPath),
+		},
+	}, nil
+}
+
+func (fake *resolutionPeerFake) winningLayerValue(
+	baselineValue, envValue, flagValue string,
+) (string, operatorsettings.EffectiveLayerSource) {
+	switch {
+	case strings.TrimSpace(flagValue) != "":
+		return strings.TrimSpace(flagValue), operatorsettings.EffectiveLayerSourceFlag
+	case strings.TrimSpace(envValue) != "":
+		return strings.TrimSpace(envValue), operatorsettings.EffectiveLayerSourceEnv
+	case strings.TrimSpace(baselineValue) != "":
+		return strings.TrimSpace(baselineValue), operatorsettings.EffectiveLayerSourceFile
+	default:
+		return "", ""
+	}
+}
+
+func (fake *resolutionPeerFake) resolveWorkerModelProvider(
+	raw string,
+	winningSource operatorsettings.EffectiveLayerSource,
+	request operatorsettings.ResolveEffectiveRequest,
+) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+
+	canonical, ok := fake.canonicalizeProvider(raw)
+	if !ok {
+		return "", operatorsettings.ResolutionFailure{
+			Kind:    operatorsettings.ResolutionFailureKindUnsupportedOverride,
+			Message: raw,
+			Field:   "workerModelProvider",
+		}
+	}
+	if canonical != "DEFAULT" {
+		return canonical, nil
+	}
+
+	concreteRaw := fake.concreteProviderBelowSource(winningSource, request)
+	if concreteRaw == "" {
+		return "", operatorsettings.ResolutionFailure{
+			Kind:    operatorsettings.ResolutionFailureKindInvalidInput,
+			Message: "symbolic DEFAULT requires a concrete provider from file or environment",
+			Field:   "workerModelProvider",
+		}
+	}
+	concreteCanonical, ok := fake.canonicalizeProvider(concreteRaw)
+	if !ok || concreteCanonical == "DEFAULT" {
+		return "", operatorsettings.ResolutionFailure{
+			Kind:    operatorsettings.ResolutionFailureKindInvalidInput,
+			Message: "symbolic DEFAULT requires a concrete provider from file or environment",
+			Field:   "workerModelProvider",
+		}
+	}
+	return concreteCanonical, nil
+}
+
+func (fake *resolutionPeerFake) concreteProviderBelowSource(
+	winningSource operatorsettings.EffectiveLayerSource,
+	request operatorsettings.ResolveEffectiveRequest,
+) string {
+	type layer struct {
+		source operatorsettings.EffectiveLayerSource
+		value  string
+	}
+	layers := []layer{
+		{source: operatorsettings.EffectiveLayerSourceFile, value: request.DocumentBaseline.WorkerModelProvider},
+		{source: operatorsettings.EffectiveLayerSourceEnv, value: request.EnvironmentOverrides.WorkerModelProvider},
+		{source: operatorsettings.EffectiveLayerSourceFlag, value: request.InvocationOverrides.WorkerModelProvider},
+	}
+
+	below := make([]layer, 0, 2)
+	for _, layer := range layers {
+		if layer.source == winningSource {
+			break
+		}
+		below = append(below, layer)
+	}
+	for i := len(below) - 1; i >= 0; i-- {
+		value := strings.TrimSpace(below[i].value)
+		if value == "" || strings.EqualFold(value, "DEFAULT") {
+			continue
+		}
+		return value
+	}
+	return ""
+}
+
+func (fake *resolutionPeerFake) canonicalizeProvider(raw string) (string, bool) {
+	value := strings.TrimSpace(raw)
+	switch strings.ToLower(value) {
+	case "", "default":
+		return "DEFAULT", true
+	case "codex", "openai":
+		return "CODEX", true
+	case "claude", "anthropic":
+		return "CLAUDE", true
+	case "gemini":
+		return "GEMINI", true
+	default:
+		if strings.Contains(value, ".") {
+			return value, true
+		}
+		return "", false
+	}
+}
+
+func TestResolutionContract_Characterization_EffectiveSelectionSuccess(t *testing.T) {
+	t.Parallel()
+
+	fake := newResolutionPeerFake()
+	configPath := "/home/operator/.you-agent-factory/config.json"
+
+	resolved, err := fake.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "claude",
+			WorkerModel:         "file-model",
+		},
+		EnvironmentOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "codex",
+			WorkerModel:         "env-model",
+		},
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "gemini",
+			WorkerModel:         "flag-model",
+		},
+		ConfigPath: configPath,
+	})
+	if err != nil {
+		t.Fatalf("ResolveEffective() = %v", err)
+	}
+
+	selection := resolved.Selection
+	if selection.WorkerModelProvider != "GEMINI" {
+		t.Fatalf("provider = %q, want GEMINI", selection.WorkerModelProvider)
+	}
+	if selection.WorkerModel != "flag-model" {
+		t.Fatalf("model = %q, want flag-model", selection.WorkerModel)
+	}
+	if selection.WorkerModelProviderSource != operatorsettings.EffectiveLayerSourceFlag {
+		t.Fatalf("provider source = %q, want flag", selection.WorkerModelProviderSource)
+	}
+	if selection.WorkerModelSource != operatorsettings.EffectiveLayerSourceFlag {
+		t.Fatalf("model source = %q, want flag", selection.WorkerModelSource)
+	}
+	if selection.ConfigPath != configPath {
+		t.Fatalf("config path = %q, want %q", selection.ConfigPath, configPath)
+	}
+
+	cloned := selection.Clone()
+	cloned.WorkerModel = "mutated"
+	if selection.WorkerModel == "mutated" {
+		t.Fatalf("Clone() did not detach model: %#v", selection)
+	}
+}
+
+func TestResolutionContract_Characterization_SymbolicDefaultResolvesThroughFileBaseline(t *testing.T) {
+	t.Parallel()
+
+	fake := newResolutionPeerFake()
+	resolved, err := fake.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "codex",
+		},
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "DEFAULT",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	if err != nil {
+		t.Fatalf("ResolveEffective() = %v", err)
+	}
+	if resolved.Selection.WorkerModelProvider != "CODEX" {
+		t.Fatalf("provider = %q, want CODEX", resolved.Selection.WorkerModelProvider)
+	}
+	if resolved.Selection.WorkerModelProviderSource != operatorsettings.EffectiveLayerSourceFlag {
+		t.Fatalf("provider source = %q, want flag", resolved.Selection.WorkerModelProviderSource)
+	}
+}
+
+func TestResolutionContract_Characterization_TypedFailures(t *testing.T) {
+	t.Parallel()
+
+	fake := newResolutionPeerFake()
+
+	_, err := fake.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "unsupported-provider",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	if !errors.Is(err, operatorsettings.ErrResolutionUnsupportedOverride) {
+		t.Fatalf("unsupported override error = %v, want ErrResolutionUnsupportedOverride", err)
+	}
+	var unsupported operatorsettings.ResolutionFailure
+	if !errors.As(err, &unsupported) ||
+		unsupported.Kind != operatorsettings.ResolutionFailureKindUnsupportedOverride {
+		t.Fatalf("unsupported override failure = %#v", err)
+	}
+
+	_, err = fake.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "DEFAULT",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	if !errors.Is(err, operatorsettings.ErrResolutionInvalidInput) {
+		t.Fatalf("unresolved DEFAULT error = %v, want ErrResolutionInvalidInput", err)
+	}
+
+	expected := operatorsettings.DocumentDefaults{
+		WorkerModelProvider: "codex",
+		WorkerModel:         "gpt-5",
+	}
+	stale := operatorsettings.DocumentDefaults{
+		WorkerModelProvider: "claude",
+		WorkerModel:         "gpt-5",
+	}
+	_, err = fake.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline:         stale,
+		ExpectedDocumentBaseline: &expected,
+		ConfigPath:               "/tmp/config.json",
+	})
+	if !errors.Is(err, operatorsettings.ErrResolutionConflict) {
+		t.Fatalf("baseline conflict error = %v, want ErrResolutionConflict", err)
+	}
+}

--- a/pkg/services/operator_settings/resolution_contract.go
+++ b/pkg/services/operator_settings/resolution_contract.go
@@ -1,0 +1,146 @@
+package operatorsettings
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrResolutionInvalidInput reports that effective-resolution inputs are
+// incomplete or cannot be resolved (for example unresolved symbolic DEFAULT).
+var ErrResolutionInvalidInput = errors.New("operator effective resolution input is invalid")
+
+// ErrResolutionUnsupportedOverride reports that an override layer supplied a
+// value the operator settings contract does not support.
+var ErrResolutionUnsupportedOverride = errors.New("operator effective resolution override is unsupported")
+
+// ErrResolutionConflict reports that supplied baseline or override facts
+// conflict and cannot be reconciled without mutating the operator document.
+var ErrResolutionConflict = errors.New("operator effective resolution conflict")
+
+// ResolutionFailureKind classifies effective-resolution failures peers can
+// branch on with errors.Is / errors.As.
+type ResolutionFailureKind string
+
+const (
+	ResolutionFailureKindInvalidInput          ResolutionFailureKind = "invalid_input"
+	ResolutionFailureKindUnsupportedOverride   ResolutionFailureKind = "unsupported_override"
+	ResolutionFailureKindConflict              ResolutionFailureKind = "conflict"
+)
+
+// ResolutionFailure retains normalized effective-resolution failure facts
+// without exposing storage, codec, or lifecycle construction ports.
+type ResolutionFailure struct {
+	Kind    ResolutionFailureKind
+	Message string
+	Field   string
+}
+
+func (failure ResolutionFailure) Error() string {
+	message := strings.TrimSpace(failure.Message)
+	field := strings.TrimSpace(failure.Field)
+	switch {
+	case message != "" && field != "":
+		return fmt.Sprintf("%s: %s (%s)", sentinelForResolutionFailureKind(failure.Kind).Error(), message, field)
+	case message != "":
+		return fmt.Sprintf("%s: %s", sentinelForResolutionFailureKind(failure.Kind).Error(), message)
+	case field != "":
+		return fmt.Sprintf("%s (%s)", sentinelForResolutionFailureKind(failure.Kind).Error(), field)
+	default:
+		return sentinelForResolutionFailureKind(failure.Kind).Error()
+	}
+}
+
+func (failure ResolutionFailure) Unwrap() error {
+	return sentinelForResolutionFailureKind(failure.Kind)
+}
+
+func sentinelForResolutionFailureKind(kind ResolutionFailureKind) error {
+	switch kind {
+	case ResolutionFailureKindInvalidInput:
+		return ErrResolutionInvalidInput
+	case ResolutionFailureKindUnsupportedOverride:
+		return ErrResolutionUnsupportedOverride
+	case ResolutionFailureKindConflict:
+		return ErrResolutionConflict
+	default:
+		return ErrResolutionInvalidInput
+	}
+}
+
+// EffectivePrecedenceChain describes the operator default precedence order
+// for diagnostics on effective selections.
+const EffectivePrecedenceChain = "file < env < flag"
+
+// EffectiveLayerSource identifies which precedence layer supplied one effective
+// default field after resolution.
+type EffectiveLayerSource string
+
+const (
+	EffectiveLayerSourceFile EffectiveLayerSource = "file"
+	EffectiveLayerSourceEnv  EffectiveLayerSource = "env"
+	EffectiveLayerSourceFlag EffectiveLayerSource = "flag"
+)
+
+// EffectiveOverrideFacts carries invocation or environment override values as
+// detached plain facts. Empty fields are treated as unset overrides.
+type EffectiveOverrideFacts struct {
+	WorkerModelProvider string
+	WorkerModel         string
+}
+
+// Clone returns a detached override-facts copy.
+func (facts EffectiveOverrideFacts) Clone() EffectiveOverrideFacts {
+	return facts
+}
+
+// EffectiveSelection is the immutable effective operator default selection
+// peers consume from effective resolution without owning precedence rules.
+type EffectiveSelection struct {
+	WorkerModelProvider       string
+	WorkerModel               string
+	WorkerModelProviderSource EffectiveLayerSource
+	WorkerModelSource         EffectiveLayerSource
+	ConfigPath                string
+}
+
+// Clone returns a detached effective-selection copy.
+func (selection EffectiveSelection) Clone() EffectiveSelection {
+	return selection
+}
+
+// ResolveEffectiveRequest asks for an effective selection from detached
+// document baseline and override facts. Resolution does not mutate the operator
+// document; document mutation remains on document operations.
+type ResolveEffectiveRequest struct {
+	DocumentBaseline         DocumentDefaults
+	ExpectedDocumentBaseline *DocumentDefaults
+	EnvironmentOverrides     EffectiveOverrideFacts
+	InvocationOverrides      EffectiveOverrideFacts
+	ConfigPath                 string
+}
+
+// Validate checks request fields whose validity does not depend on resolution
+// state. Baseline mismatch against ExpectedDocumentBaseline fails before
+// precedence resolution.
+func (request ResolveEffectiveRequest) Validate() error {
+	if request.ExpectedDocumentBaseline == nil {
+		return nil
+	}
+	expected := request.ExpectedDocumentBaseline
+	if expected.WorkerModelProvider != request.DocumentBaseline.WorkerModelProvider ||
+		expected.WorkerModel != request.DocumentBaseline.WorkerModel {
+		return ResolutionFailure{
+			Kind:    ResolutionFailureKindConflict,
+			Message: "document baseline mismatch",
+			Field:   "documentBaseline",
+		}
+	}
+	return nil
+}
+
+// ResolveEffectiveResult is the detached outcome of one effective-resolution
+// operation.
+type ResolveEffectiveResult struct {
+	Selection EffectiveSelection
+}

--- a/pkg/services/operator_settings/resolution_contract.go
+++ b/pkg/services/operator_settings/resolution_contract.go
@@ -23,9 +23,9 @@ var ErrResolutionConflict = errors.New("operator effective resolution conflict")
 type ResolutionFailureKind string
 
 const (
-	ResolutionFailureKindInvalidInput          ResolutionFailureKind = "invalid_input"
-	ResolutionFailureKindUnsupportedOverride   ResolutionFailureKind = "unsupported_override"
-	ResolutionFailureKindConflict              ResolutionFailureKind = "conflict"
+	ResolutionFailureKindInvalidInput        ResolutionFailureKind = "invalid_input"
+	ResolutionFailureKindUnsupportedOverride ResolutionFailureKind = "unsupported_override"
+	ResolutionFailureKindConflict            ResolutionFailureKind = "conflict"
 )
 
 // ResolutionFailure retains normalized effective-resolution failure facts
@@ -117,7 +117,7 @@ type ResolveEffectiveRequest struct {
 	ExpectedDocumentBaseline *DocumentDefaults
 	EnvironmentOverrides     EffectiveOverrideFacts
 	InvocationOverrides      EffectiveOverrideFacts
-	ConfigPath                 string
+	ConfigPath               string
 }
 
 // Validate checks request fields whose validity does not depend on resolution

--- a/pkg/services/operator_settings/root_contract_legacy_preservation_test.go
+++ b/pkg/services/operator_settings/root_contract_legacy_preservation_test.go
@@ -1,0 +1,24 @@
+package operatorsettings
+
+import "testing"
+
+// TestImplementationConstructionPortsRemainOwnerLocal proves existing Operator
+// Settings implementation and construction ports remain in place for later
+// IMP-SET-* absorption while the published Service seam stays peer-facing.
+func TestImplementationConstructionPortsRemainOwnerLocal(t *testing.T) {
+	t.Parallel()
+
+	// Construction ports remain owner-local; peer Service method signatures do
+	// not accept them as caller parameters.
+	var (
+		_ FileSystem
+		_ CreateTemporaryFile
+		_ ConfigDecoder
+		_ ConfigEncoder
+		_ ConfigLoader
+		_ IDGenerator
+		_ ProviderCatalog
+		_ Config
+		_ ConfigDocument
+	)
+}

--- a/pkg/services/operator_settings/service_characterization_test.go
+++ b/pkg/services/operator_settings/service_characterization_test.go
@@ -1,0 +1,148 @@
+package operatorsettings_test
+
+import (
+	"errors"
+	"testing"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
+
+// servicePeerFake implements the full Operator Settings Service using only root
+// contracts and in-memory state. It does not import filesystem, codec, CLI, UI,
+// Wire, or Initializer packages.
+type servicePeerFake struct {
+	document   *documentPeerFake
+	resolution *resolutionPeerFake
+}
+
+var _ operatorsettings.Service = (*servicePeerFake)(nil)
+
+func newServicePeerFake(entries map[string]operatorsettings.Document) *servicePeerFake {
+	return &servicePeerFake{
+		document:   newDocumentPeerFake(entries),
+		resolution: newResolutionPeerFake(),
+	}
+}
+
+func (fake *servicePeerFake) LoadDocument(
+	request operatorsettings.LoadDocumentRequest,
+) (operatorsettings.LoadDocumentResult, error) {
+	return fake.document.LoadDocument(request)
+}
+
+func (fake *servicePeerFake) ApplyDocumentUpdate(
+	request operatorsettings.ApplyDocumentUpdateRequest,
+) (operatorsettings.ApplyDocumentUpdateResult, error) {
+	return fake.document.ApplyDocumentUpdate(request)
+}
+
+func (fake *servicePeerFake) ResolveEffective(
+	request operatorsettings.ResolveEffectiveRequest,
+) (operatorsettings.ResolveEffectiveResult, error) {
+	return fake.resolution.ResolveEffective(request)
+}
+
+func TestService_Characterization_FakeImplementsSingularSeam(t *testing.T) {
+	t.Parallel()
+
+	scopeID := "local-00000000-0000-4000-8000-000000000010"
+	configPath := "/home/operator/.you-agent-factory/config.json"
+	initial := operatorsettings.Document{
+		BackendScopeID: scopeID,
+		Defaults: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "codex",
+			WorkerModel:         "gpt-5",
+		},
+		Runtime: operatorsettings.EmptyDocument().Runtime,
+	}
+	fake := newServicePeerFake(map[string]operatorsettings.Document{
+		configPath: initial,
+	})
+	var svc operatorsettings.Service = fake
+
+	loaded, err := svc.LoadDocument(operatorsettings.LoadDocumentRequest{
+		Path:            configPath,
+		RequireExisting: true,
+	})
+	if err != nil {
+		t.Fatalf("LoadDocument() = %v", err)
+	}
+	if !loaded.Found || loaded.Document.BackendScopeID != scopeID {
+		t.Fatalf("LoadDocument() = %#v", loaded)
+	}
+
+	nextModel := "gpt-5.2"
+	updated, err := svc.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
+		Path:                 configPath,
+		ExpectedBackendScope: scopeID,
+		ProviderModel: operatorsettings.DocumentProviderModelUpdate{
+			Model: &nextModel,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyDocumentUpdate() = %v", err)
+	}
+	if !updated.Persisted || updated.Document.Defaults.WorkerModel != nextModel {
+		t.Fatalf("ApplyDocumentUpdate() = %#v", updated)
+	}
+
+	resolved, err := svc.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: loaded.Document.Defaults,
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "gemini",
+			WorkerModel:         "flag-model",
+		},
+		ConfigPath: configPath,
+	})
+	if err != nil {
+		t.Fatalf("ResolveEffective() = %v", err)
+	}
+	if resolved.Selection.WorkerModelProvider != "GEMINI" ||
+		resolved.Selection.WorkerModel != "flag-model" ||
+		resolved.Selection.ConfigPath != configPath {
+		t.Fatalf("ResolveEffective() = %#v", resolved.Selection)
+	}
+}
+
+func TestService_Characterization_TypedFailures(t *testing.T) {
+	t.Parallel()
+
+	fake := newServicePeerFake(nil)
+	var svc operatorsettings.Service = fake
+
+	_, err := svc.LoadDocument(operatorsettings.LoadDocumentRequest{})
+	if !errors.Is(err, operatorsettings.ErrDocumentMalformed) {
+		t.Fatalf("empty load path error = %v, want ErrDocumentMalformed", err)
+	}
+
+	unsupported := "unsupported-provider"
+	_, err = svc.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
+		Path: "/home/operator/.you-agent-factory/config.json",
+		ProviderModel: operatorsettings.DocumentProviderModelUpdate{
+			Provider: &unsupported,
+		},
+	})
+	if !errors.Is(err, operatorsettings.ErrDocumentUnsupported) {
+		t.Fatalf("unsupported provider error = %v, want ErrDocumentUnsupported", err)
+	}
+
+	_, err = svc.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "unsupported-provider",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	if !errors.Is(err, operatorsettings.ErrResolutionUnsupportedOverride) {
+		t.Fatalf("unsupported override error = %v, want ErrResolutionUnsupportedOverride", err)
+	}
+
+	_, err = svc.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "DEFAULT",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	if !errors.Is(err, operatorsettings.ErrResolutionInvalidInput) {
+		t.Fatalf("unresolved DEFAULT error = %v, want ErrResolutionInvalidInput", err)
+	}
+}

--- a/pkg/services/operator_settings/service_contract.go
+++ b/pkg/services/operator_settings/service_contract.go
@@ -1,0 +1,26 @@
+package operatorsettings
+
+// Service is the singular cross-service Operator Settings root authority.
+// Peer packages depend on this one named interface for document operations
+// and effective resolution rather than nested document/resolution implementation
+// packages or construction ports such as filesystem, encoder/decoder, or
+// lifecycle collaborators.
+type Service interface {
+	// LoadDocument loads the operator document at the requested path. Missing
+	// documents return EmptyDocument unless RequireExisting is true, which fails
+	// with ErrDocumentNotFound. Malformed requests fail with ErrDocumentMalformed.
+	LoadDocument(LoadDocumentRequest) (LoadDocumentResult, error)
+
+	// ApplyDocumentUpdate applies a semantic document change and persists the
+	// resulting document. Conflicts fail with ErrDocumentConflict, unsupported
+	// updates fail with ErrDocumentUnsupported, and malformed requests fail
+	// with ErrDocumentMalformed.
+	ApplyDocumentUpdate(ApplyDocumentUpdateRequest) (ApplyDocumentUpdateResult, error)
+
+	// ResolveEffective resolves an immutable effective selection from detached
+	// document baseline and override facts. Resolution does not mutate the
+	// operator document. Invalid inputs fail with ErrResolutionInvalidInput,
+	// unsupported overrides fail with ErrResolutionUnsupportedOverride, and
+	// baseline conflicts fail with ErrResolutionConflict.
+	ResolveEffective(ResolveEffectiveRequest) (ResolveEffectiveResult, error)
+}

--- a/pkg/services/operator_settings/service_root_contract_invariants_test.go
+++ b/pkg/services/operator_settings/service_root_contract_invariants_test.go
@@ -1,0 +1,258 @@
+package operatorsettings_test
+
+import (
+	"errors"
+	"testing"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
+
+// TestRootContractInvariants_AllSlicesThroughSingularService seals the
+// Operator Settings root-contract packet: document operations and effective
+// resolution are reachable through one named operatorsettings.Service, a
+// peer-shaped fake exercises success and typed-failure paths using only the
+// root package, and no second peer-facing Operator Settings authority is
+// required.
+func TestRootContractInvariants_AllSlicesThroughSingularService(t *testing.T) {
+	t.Parallel()
+
+	scopeID := "local-00000000-0000-4000-8000-000000000010"
+	configPath := "/home/operator/.you-agent-factory/config.json"
+	initial := operatorsettings.Document{
+		BackendScopeID: scopeID,
+		Defaults: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "codex",
+			WorkerModel:         "gpt-5",
+		},
+		Runtime: operatorsettings.EmptyDocument().Runtime,
+	}
+	service := newServicePeerFake(map[string]operatorsettings.Document{
+		configPath: initial,
+	})
+	var root operatorsettings.Service = service
+
+	assertSealDocumentSuccess(t, root, configPath, scopeID)
+	assertSealDocumentFailures(t, root, configPath)
+	assertSealResolutionSuccess(t, root, initial.Defaults, configPath)
+	assertSealResolutionFailures(t, root)
+}
+
+func assertSealDocumentSuccess(
+	t *testing.T,
+	service operatorsettings.Service,
+	configPath string,
+	scopeID string,
+) {
+	t.Helper()
+
+	loaded, err := service.LoadDocument(operatorsettings.LoadDocumentRequest{
+		Path:            configPath,
+		RequireExisting: true,
+	})
+	if err != nil {
+		t.Fatalf("LoadDocument() = %v", err)
+	}
+	if !loaded.Found || loaded.Document.BackendScopeID != scopeID {
+		t.Fatalf("LoadDocument() = %#v", loaded)
+	}
+
+	nextModel := "gpt-5.2"
+	updated, err := service.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
+		Path:                 configPath,
+		ExpectedBackendScope: scopeID,
+		ProviderModel: operatorsettings.DocumentProviderModelUpdate{
+			Model: &nextModel,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyDocumentUpdate() = %v", err)
+	}
+	if !updated.Persisted || updated.Document.Defaults.WorkerModel != nextModel {
+		t.Fatalf("ApplyDocumentUpdate() = %#v", updated)
+	}
+}
+
+func assertSealDocumentFailures(t *testing.T, service operatorsettings.Service, configPath string) {
+	t.Helper()
+
+	_, err := service.LoadDocument(operatorsettings.LoadDocumentRequest{})
+	if !errors.Is(err, operatorsettings.ErrDocumentMalformed) {
+		t.Fatalf("empty load path error = %v, want ErrDocumentMalformed", err)
+	}
+
+	unsupported := "unsupported-provider"
+	_, err = service.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
+		Path: configPath,
+		ProviderModel: operatorsettings.DocumentProviderModelUpdate{
+			Provider: &unsupported,
+		},
+	})
+	if !errors.Is(err, operatorsettings.ErrDocumentUnsupported) {
+		t.Fatalf("unsupported provider error = %v, want ErrDocumentUnsupported", err)
+	}
+}
+
+func assertSealResolutionSuccess(
+	t *testing.T,
+	service operatorsettings.Service,
+	baseline operatorsettings.DocumentDefaults,
+	configPath string,
+) {
+	t.Helper()
+
+	resolved, err := service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: baseline,
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "gemini",
+			WorkerModel:         "flag-model",
+		},
+		ConfigPath: configPath,
+	})
+	if err != nil {
+		t.Fatalf("ResolveEffective() = %v", err)
+	}
+	if resolved.Selection.WorkerModelProvider != "GEMINI" ||
+		resolved.Selection.WorkerModel != "flag-model" ||
+		resolved.Selection.ConfigPath != configPath {
+		t.Fatalf("ResolveEffective() = %#v", resolved.Selection)
+	}
+}
+
+func assertSealResolutionFailures(t *testing.T, service operatorsettings.Service) {
+	t.Helper()
+
+	_, err := service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "unsupported-provider",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	if !errors.Is(err, operatorsettings.ErrResolutionUnsupportedOverride) {
+		t.Fatalf("unsupported override error = %v, want ErrResolutionUnsupportedOverride", err)
+	}
+
+	_, err = service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "DEFAULT",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	if !errors.Is(err, operatorsettings.ErrResolutionInvalidInput) {
+		t.Fatalf("unresolved DEFAULT error = %v, want ErrResolutionInvalidInput", err)
+	}
+}
+
+func TestRootContract_ContractValuesStayInertWhenHeld(t *testing.T) {
+	t.Parallel()
+
+	document := operatorsettings.Document{
+		BackendScopeID: "scope-inert",
+		Defaults: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "codex",
+			WorkerModel:         "gpt-5",
+		},
+		Runtime: operatorsettings.EmptyDocument().Runtime,
+	}
+	clonedDocument := document.Clone()
+	document.Defaults.WorkerModel = "mutated"
+	if clonedDocument.Defaults.WorkerModel == "mutated" {
+		t.Fatal("Document.Clone() shares mutable defaults state")
+	}
+
+	selection := operatorsettings.EffectiveSelection{
+		WorkerModelProvider:       "CODEX",
+		WorkerModel:               "gpt-5",
+		WorkerModelProviderSource: operatorsettings.EffectiveLayerSourceFlag,
+		WorkerModelSource:         operatorsettings.EffectiveLayerSourceFile,
+		ConfigPath:                "/tmp/config.json",
+	}
+	clonedSelection := selection.Clone()
+	selection.WorkerModel = "mutated"
+	if clonedSelection.WorkerModel == "mutated" {
+		t.Fatal("EffectiveSelection.Clone() shares mutable model state")
+	}
+
+	overrides := operatorsettings.EffectiveOverrideFacts{
+		WorkerModelProvider: "gemini",
+		WorkerModel:         "gemini-pro",
+	}
+	clonedOverrides := overrides.Clone()
+	overrides.WorkerModel = "mutated"
+	if clonedOverrides.WorkerModel == "mutated" {
+		t.Fatal("EffectiveOverrideFacts.Clone() shares mutable override state")
+	}
+
+	loadRequest := operatorsettings.LoadDocumentRequest{Path: "/tmp/config.json"}
+	if err := loadRequest.Validate(); err != nil {
+		t.Fatalf("LoadDocumentRequest.Validate() = %v", err)
+	}
+	loadRequest.Path = "mutated"
+	if err := (operatorsettings.LoadDocumentRequest{Path: ""}).Validate(); !errors.Is(
+		err, operatorsettings.ErrDocumentMalformed,
+	) {
+		t.Fatalf("empty LoadDocumentRequest.Validate() = %v, want ErrDocumentMalformed", err)
+	}
+
+	model := "gpt-5"
+	updateRequest := operatorsettings.ApplyDocumentUpdateRequest{
+		Path: "/tmp/config.json",
+		ProviderModel: operatorsettings.DocumentProviderModelUpdate{
+			Model: &model,
+		},
+	}
+	if err := updateRequest.Validate(); err != nil {
+		t.Fatalf("ApplyDocumentUpdateRequest.Validate() = %v", err)
+	}
+
+	baseline := operatorsettings.DocumentDefaults{
+		WorkerModelProvider: "codex",
+		WorkerModel:         "gpt-5",
+	}
+	resolutionRequest := operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: baseline,
+		ExpectedDocumentBaseline: &operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "mutated",
+			WorkerModel:         "gpt-5",
+		},
+	}
+	if err := resolutionRequest.Validate(); !errors.Is(err, operatorsettings.ErrResolutionConflict) {
+		t.Fatalf("baseline mismatch Validate() = %v, want ErrResolutionConflict", err)
+	}
+
+	// Holding contract values must not require a Service implementation or
+	// perform filesystem, atomic persist, Wire, or Initializer work.
+	var (
+		_ operatorsettings.Document
+		_ operatorsettings.DocumentDefaults
+		_ operatorsettings.EffectiveSelection
+		_ operatorsettings.EffectiveOverrideFacts
+		_ operatorsettings.LoadDocumentRequest
+		_ operatorsettings.LoadDocumentResult
+		_ operatorsettings.ApplyDocumentUpdateRequest
+		_ operatorsettings.ApplyDocumentUpdateResult
+		_ operatorsettings.ResolveEffectiveRequest
+		_ operatorsettings.ResolveEffectiveResult
+		_ operatorsettings.DocumentFailure
+		_ operatorsettings.ResolutionFailure
+	)
+}
+
+func TestRootContract_FakePeerConstructionIsInert(t *testing.T) {
+	t.Parallel()
+
+	fake := newServicePeerFake(nil)
+	if fake.document == nil || fake.resolution == nil {
+		t.Fatal("fake peer construction returned nil slice collaborators")
+	}
+	if fake.document.documents == nil {
+		t.Fatal("fake peer construction returned nil document store")
+	}
+	if len(fake.document.documents) != 0 {
+		t.Fatalf("fake peer construction initialized documents = %d, want 0", len(fake.document.documents))
+	}
+
+	var service operatorsettings.Service = fake
+	if service == nil {
+		t.Fatal("constructed Service is nil")
+	}
+}


### PR DESCRIPTION
{
  "project": "CTR-SET: Publish the Operator Settings root contract",
  "branchName": "pss-ctr-set-root-contract",
  "description": "Publish an inert, contract-first Operator Settings root at pkg/services/operator_settings with one named Service covering document operations and effective resolution through detached request/result/value/typed-error contracts, characterized so a fake peer can implement the seam without storage/lifecycle construction ports, Clean CLI redesign, CLI manifest regeneration, Wire/root/initializer cutover, or IMP-SET-* package relocation.",
  "context": {
    "customerAsk": "Publish the singular Operator Settings root contract covering document operations and effective resolution without relocating implementation packages yet. Characterize the slice, prove a fake peer can implement it, and keep implementation/storage/lifecycle types out of the root surface. Do not admit IMP-SET-* in this packet. Do not redesign Clean CLI UX or regenerate CLI manifests merely because Settings contracts appear. Shared coverage, ownership, and package-target manifest edits are allowed. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Operator Settings already owns configuration, identity, defaults, presets, and precedence under pkg/services/operator_settings, but peers cannot depend on one named, inert root Service for document operations and effective resolution. Cross-service consumers still risk coupling to filesystem/atomic-write ports, encoder/decoder construction seams, or mixed implementation types instead of detached request/result/value/error contracts. Later IMP-SET-* absorption and IMP-SET-02 Providers consumption are gated on a published peer-facing root that does not yet exist as a characterized, fake-peer-proven seam.",
    "solution": "Publish an inert, contract-first Operator Settings root at pkg/services/operator_settings that exposes one named Service covering document operations and effective resolution through plain Operator-Settings-owned request/result/value/typed-error types. Prove the seam with fake-peer characterization tests. Keep storage, atomic-write, encoder/decoder, and lifecycle construction ports out of the peer-facing root surface. Leave existing implementation in place for later IMP-SET-* packets; do not redesign Clean CLI UX or regenerate CLI manifests in this packet."
  },
  "acceptanceCriteria": [
    "AC-1: pkg/services/operator_settings publishes one named peer-facing Service whose public root surface covers document operations and effective resolution through detached request, result, value, and typed-error contracts",
    "AC-2: A fake peer implements the full published Service using only Operator Settings root types and exercises success and typed-failure paths for document operations and effective resolution without importing peer implementation packages, OpenAPI-generated transport codecs, CLI/UI packages, Wire/root/initializer, or filesystem/atomic-write construction ports as peer method parameters",
    "AC-3: Holding or using the published root contract types performs no filesystem, atomic persist, process, Wire, or Initializer work; existing Operator Settings implementation remains in place and is not relocated into nested IMP-SET-* package motion in this packet",
    "AC-4: Peer-facing root surface excludes storage/lifecycle construction types (FileSystem, temporary-file factories, encoder/decoder ports, and similar) as caller-supplied peer method parameters; those remain owner-local construction concerns",
    "AC-5: Changed paths stay inside Operator Settings root contracts/characterization tests plus lease-minimal shared coverage/ownership/package-target manifest registration; no Clean CLI UX redesign, CLI manifest regeneration, OpenAPI/generated client edits, pkg/root/pkg/wire/pkg/initializer cutover, UI, or IMP-SET-* implementation moves",
    "AC-6: Quality checks pass (typecheck, lint, focused Operator Settings root-contract tests, and make verify-fast)",
    "AC-7: Delivery loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file churn are reconciled, and the PR is actually merged"
  ],
  "userStories": [
    {
      "id": "pss-ctr-set-root-contract-001",
      "title": "Publish document value and document-operation contracts",
      "description": "As a peer-service maintainer, I want Operator-Settings-owned document values and detached document operation request/result/error contracts so I can load and update the operator document without importing filesystem or atomic-write construction ports.",
      "acceptanceCriteria": [
        "pkg/services/operator_settings publishes plain document/value vocabulary needed for peer document operations (for example backend scope identity, defaults, runtime settings, and worker presets as detached values)",
        "Singular root contracts expose document operations that read/load the operator document and apply a semantic update/persist outcome through detached request/result types",
        "Malformed, unsupported, conflict, and not-found/missing-document classes return typed Operator-Settings-owned errors that peers can branch with errors.Is / errors.As",
        "Published document contracts do not embed filesystem handles, temporary-file factories, OpenAPI codec types, CLI/UI types, or Wire/root/initializer types",
        "A focused characterization test constructs document values and exercises at least one document success path and one typed document failure path through root types only",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-ctr-set-root-contract-002",
      "title": "Publish effective resolution request/result/error contracts",
      "description": "As a Workers, Models, Sessions, or Bootstrap maintainer, I want an effective-resolution slice that returns an immutable effective selection so I can consume resolved defaults/presets/overrides without owning Operator Settings precedence rules.",
      "acceptanceCriteria": [
        "Singular Operator Settings root contracts expose an effective-resolution operation that accepts detached resolution inputs (document baseline and/or invocation/environment override facts as plain values) and returns an immutable effective selection",
        "Resolution does not mutate the operator document through the resolution method; document mutation remains on document operations",
        "Conflict/unsupported-override and invalid-resolution-input cases return typed Operator-Settings-owned errors distinct from document-persist failures where applicable",
        "Published resolution contracts do not require callers to supply filesystem, atomic-write, encoder/decoder, CLI, UI, Wire, or Initializer types",
        "A focused characterization test asserts one successful effective-selection outcome (including source/precedence facts when published) and at least one typed resolution failure path using only root types",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-ctr-set-root-contract-003",
      "title": "Publish singular Service and prove fake-peer implementability",
      "description": "As a peer-service maintainer, I want one named Operator Settings Service that combines document operations and effective resolution so I depend on a single root authority instead of nested document/resolution implementation packages.",
      "acceptanceCriteria": [
        "One named Service interface is the only peer-facing Operator Settings authority for the published document and resolution slices",
        "A fake peer implements the full published Service using only Operator Settings root contracts",
        "Characterization tests exercise document success/failure and resolution success/failure through that singular Service without a second peer-facing Settings authority",
        "Method signatures do not require peer callers to supply storage/lifecycle construction ports",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-ctr-set-root-contract-004",
      "title": "Seal inert construction and exclude storage/lifecycle from the root surface",
      "description": "As a reviewer, I want proof that the published root stays inert for peers, keeps storage/lifecycle types off the peer surface, and leaves existing implementation in place so CTR-SET unlocks IMP-SET-* without starting those packets.",
      "acceptanceCriteria": [
        "Characterization suite seals the full published Service through a fake peer covering document and resolution outcomes already published",
        "Fake-peer and root-contract tests import only the Operator Settings root package plus stdlib/test helpers; they do not import peer service implementation packages, CLI/UI packages, OpenAPI-generated transport packages as peer dependencies, or pkg/root/pkg/wire/pkg/initializer",
        "Holding/using published contract types performs no filesystem/atomic-persist/process work; no production Wire/root/initializer wiring cutover for Operator Settings is added in this packet",
        "Existing Operator Settings implementation remains present for later IMP-SET-* absorption; this packet does not relocate nested document/resolution packages or admit IMP-SET-* behavior",
        "Diff does not redesign Clean CLI UX or regenerate CLI manifests merely because Settings contracts appear",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-ctr-set-root-contract-005",
      "title": "Lease-minimal ownership registration and verify-fast gate",
      "description": "As a Packaged Service Structure steward, I want the Operator Settings root registered only where coverage/ownership/package-target manifests require it, then verified with the narrow quality gate so later IMP-SET-* packets can lease against a known root.",
      "acceptanceCriteria": [
        "If coverage, ownership-inventory, or package-target-manifest updates are required for the new/updated root surface to pass architecture/ownership checks, they register only Operator Settings root contract ownership needs and stay lease-minimal",
        "Focused Operator Settings root-contract characterization tests pass; gofmt and vet/lint are clean for changed Go files",
        "Architecture/ownership checks that apply to the changed paths pass",
        "make verify-fast passes",
        "Diff stays inside Operator Settings root contracts/tests plus any lease-minimal shared manifest registration; no OpenAPI, Clean CLI UX redesign, CLI manifest regeneration, Wire/root/initializer cutover, UI, or IMP-SET-* package moves",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}
