### PR TITLE
ft-wave1-http-routing

### DIFF
--- a/api/components/schemas/api/ErrorResponse.yaml
+++ b/api/components/schemas/api/ErrorResponse.yaml
@@ -21,6 +21,7 @@ properties:
       - FACTORY_NOT_IDLE
       - STALE_FACTORY_VERSION
       - MOVE_WORK_REQUEST_ALREADY_APPLIED
+      - METHOD_NOT_ALLOWED
       - EXECUTION_REQUEST_ID_CONFLICT
       - FACTORY_SESSION_CONTROL_REQUEST_ALREADY_APPLIED
       - INVALID_RESPONSE_EVENT_CURSOR
@@ -38,6 +39,7 @@ properties:
       - Current factory runtime is not idle and cannot activate a new named factory.
       - Submitted editable factory definition was based on an older version than the current definition.
       - Operator move requestId was already applied for this session.
+      - The HTTP method is not allowed for the requested route.
       - Durable execution requestId was reused with materially different inputs.
       - Lifecycle control requestId was already applied with different control inputs.
       - The Factory Response Event reconnect cursor is invalid.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2746,6 +2746,7 @@ components:
             - FACTORY_NOT_IDLE
             - STALE_FACTORY_VERSION
             - MOVE_WORK_REQUEST_ALREADY_APPLIED
+            - METHOD_NOT_ALLOWED
             - EXECUTION_REQUEST_ID_CONFLICT
             - FACTORY_SESSION_CONTROL_REQUEST_ALREADY_APPLIED
             - INVALID_RESPONSE_EVENT_CURSOR
@@ -2763,6 +2764,7 @@ components:
             - Current factory runtime is not idle and cannot activate a new named factory.
             - Submitted editable factory definition was based on an older version than the current definition.
             - Operator move requestId was already applied for this session.
+            - The HTTP method is not allowed for the requested route.
             - Durable execution requestId was reused with materially different inputs.
             - Lifecycle control requestId was already applied with different control inputs.
             - The Factory Response Event reconnect cursor is invalid.

--- a/docs/internal/baselines/functional-undocumented-tests.json
+++ b/docs/internal/baselines/functional-undocumented-tests.json
@@ -51,6 +51,14 @@
       "name": "TestProviderPosture_Discovered_EnvDefaultResolvesWithoutFileProvider"
     },
     {
+      "file": "automations/filesystem_watcher_root_composition_test.go",
+      "name": "TestAutomationsFilesystemWatcherPreseedsThroughRuntimeLifecycle"
+    },
+    {
+      "file": "automations/filesystem_watcher_root_composition_test.go",
+      "name": "TestBuildProcessRemainsFilesystemWatcherInertBeforeRuntimeLifecycle"
+    },
+    {
       "file": "bootstrap_portability/agent_factory_export_import_fixture_test.go",
       "name": "TestAgentFactoryExportImportFixture_AuthoredLayoutInterpolatesProjectSpecificPromptContent"
     },

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -320,6 +320,18 @@
   `transport` and subsection `http/server` from the path; every top-level
   `Test*` needs a customer-readable Go doc so `functionaltestmetadata` stays
   viz-compatible.
+  HTTP API server OpenAPI routing functional coverage belongs in
+  `tests/functional/transport/http/server/routing_test.go`: prove every
+  published OpenAPI operation inventory entry reaches a non-404 handler through
+  safe public HTTP requests against `support.StartFunctionalAPIServer` with
+  `WaitForServiceModeRuntime: true` and `UseMockWorkers: true`, prove unknown
+  paths outside the OpenAPI surface return structured `NOT_FOUND` JSON errors
+  via `Server.NotFoundHandler`, and prove wrong HTTP methods on known routes
+  return structured `405` `METHOD_NOT_ALLOWED` errors via
+  `Server.MethodNotAllowedHandler` instead of not-found outcomes that would
+  hide method mismatches. Catalog metadata infers domain `transport` and
+  subsection `http/server` from the path; every top-level `Test*` needs a
+  customer-readable Go doc so `functionaltestmetadata` stays viz-compatible.
   CLI JSON parameter values functional coverage belongs in
   `tests/functional/transport/cli/parameters/json_values_test.go`: prove nested
   JSON object and array named parameters reach canonical `InvocationArguments`

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -180,7 +180,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestAPIServerShutdownClosesListenerAndActiveStreams`.
   - `TestAPIServerBindFailureUnwindsStartedLifecycleRoles`.
 
-- [ ] `tests/functional/transport/http/server/routing_test.go`
+- [x] `tests/functional/transport/http/server/routing_test.go`
   - `TestAPIRoutesEveryOpenAPIOperationToNon404Handler` uses the operation
     inventory with safe requests.
   - `TestAPIUnknownRouteReturnsStructuredNotFound`.

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -211,7 +211,7 @@
       "path": "generated/mcp/tools.json"
     },
     "generated.openapi.openapi": {
-      "artifactHash": "bae8d044192899a2ac8fa75ba00ed736a046d430f96d58cce5aed7f38eeb3001",
+      "artifactHash": "c50ea7e1364211d2e4ea75e061caae789549fca4d730def72879870af69e55ba",
       "documentation": {
         "documentation": {
           "description": {
@@ -228,7 +228,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.openapi.openapi",
-        "sourceHash": "bae8d044192899a2ac8fa75ba00ed736a046d430f96d58cce5aed7f38eeb3001",
+        "sourceHash": "c50ea7e1364211d2e4ea75e061caae789549fca4d730def72879870af69e55ba",
         "visibility": "public"
       },
       "family": "openapi",

--- a/packages/api/generated/openapi/openapi.yaml
+++ b/packages/api/generated/openapi/openapi.yaml
@@ -2746,6 +2746,7 @@ components:
             - FACTORY_NOT_IDLE
             - STALE_FACTORY_VERSION
             - MOVE_WORK_REQUEST_ALREADY_APPLIED
+            - METHOD_NOT_ALLOWED
             - EXECUTION_REQUEST_ID_CONFLICT
             - FACTORY_SESSION_CONTROL_REQUEST_ALREADY_APPLIED
             - INVALID_RESPONSE_EVENT_CURSOR
@@ -2763,6 +2764,7 @@ components:
             - Current factory runtime is not idle and cannot activate a new named factory.
             - Submitted editable factory definition was based on an older version than the current definition.
             - Operator move requestId was already applied for this session.
+            - The HTTP method is not allowed for the requested route.
             - Durable execution requestId was reused with materially different inputs.
             - Lifecycle control requestId was already applied with different control inputs.
             - The Factory Response Event reconnect cursor is invalid.

--- a/pkg/transports/http/client/client.gen.go
+++ b/pkg/transports/http/client/client.gen.go
@@ -37,6 +37,7 @@ const (
 	ErrorResponseCodeINVALIDFACTORYNAME                         ErrorResponseCode = "INVALID_FACTORY_NAME"
 	ErrorResponseCodeINVALIDRESPONSEEVENTCURSOR                 ErrorResponseCode = "INVALID_RESPONSE_EVENT_CURSOR"
 	ErrorResponseCodeINVALIDRESPONSEEVENTFILTER                 ErrorResponseCode = "INVALID_RESPONSE_EVENT_FILTER"
+	ErrorResponseCodeMETHODNOTALLOWED                           ErrorResponseCode = "METHOD_NOT_ALLOWED"
 	ErrorResponseCodeMOVEWORKREQUESTALREADYAPPLIED              ErrorResponseCode = "MOVE_WORK_REQUEST_ALREADY_APPLIED"
 	ErrorResponseCodeNOTFOUND                                   ErrorResponseCode = "NOT_FOUND"
 	ErrorResponseCodeRESPONSEEVENTSESSIONNOTFOUND               ErrorResponseCode = "RESPONSE_EVENT_SESSION_NOT_FOUND"

--- a/pkg/transports/http/generated/server.gen.go
+++ b/pkg/transports/http/generated/server.gen.go
@@ -73,6 +73,7 @@ const (
 	ErrorResponseCodeINVALIDFACTORYNAME                         ErrorResponseCode = "INVALID_FACTORY_NAME"
 	ErrorResponseCodeINVALIDRESPONSEEVENTCURSOR                 ErrorResponseCode = "INVALID_RESPONSE_EVENT_CURSOR"
 	ErrorResponseCodeINVALIDRESPONSEEVENTFILTER                 ErrorResponseCode = "INVALID_RESPONSE_EVENT_FILTER"
+	ErrorResponseCodeMETHODNOTALLOWED                           ErrorResponseCode = "METHOD_NOT_ALLOWED"
 	ErrorResponseCodeMOVEWORKREQUESTALREADYAPPLIED              ErrorResponseCode = "MOVE_WORK_REQUEST_ALREADY_APPLIED"
 	ErrorResponseCodeNOTFOUND                                   ErrorResponseCode = "NOT_FOUND"
 	ErrorResponseCodeRESPONSEEVENTSESSIONNOTFOUND               ErrorResponseCode = "RESPONSE_EVENT_SESSION_NOT_FOUND"

--- a/pkg/transports/http/responses.go
+++ b/pkg/transports/http/responses.go
@@ -39,6 +39,8 @@ func errorFamilyForStatus(status int) factoryapi.ErrorFamily {
 		return factoryapi.ErrorFamilyConflict
 	case http.StatusNotFound:
 		return factoryapi.ErrorFamilyNotFound
+	case http.StatusMethodNotAllowed:
+		return factoryapi.ErrorFamilyBadRequest
 	case http.StatusGone:
 		return factoryapi.ErrorFamilyGone
 	default:

--- a/pkg/transports/http/server.go
+++ b/pkg/transports/http/server.go
@@ -63,6 +63,7 @@ func (s *Server) Handler() http.Handler {
 func (s *Server) buildRouter() *mux.Router {
 	r := mux.NewRouter()
 	r.NotFoundHandler = http.HandlerFunc(s.handleUnknownRoute)
+	r.MethodNotAllowedHandler = http.HandlerFunc(s.handleDisallowedMethod)
 	r.HandleFunc("/dashboard/ui", s.handleDashboardUI).Methods("GET")
 	r.PathPrefix("/dashboard/ui/").HandlerFunc(s.handleDashboardUI).Methods("GET")
 	factoryapi.HandlerWithOptions(s, factoryapi.GorillaServerOptions{
@@ -74,6 +75,10 @@ func (s *Server) buildRouter() *mux.Router {
 
 func (s *Server) handleUnknownRoute(w http.ResponseWriter, _ *http.Request) {
 	s.writeError(w, http.StatusNotFound, "route not found", "NOT_FOUND")
+}
+
+func (s *Server) handleDisallowedMethod(w http.ResponseWriter, _ *http.Request) {
+	s.writeError(w, http.StatusMethodNotAllowed, "method not allowed", "METHOD_NOT_ALLOWED")
 }
 
 func (s *Server) handleGeneratedParameterError(w http.ResponseWriter, _ *http.Request, err error) {

--- a/pkg/transports/http/server.go
+++ b/pkg/transports/http/server.go
@@ -62,6 +62,7 @@ func (s *Server) Handler() http.Handler {
 
 func (s *Server) buildRouter() *mux.Router {
 	r := mux.NewRouter()
+	r.NotFoundHandler = http.HandlerFunc(s.handleUnknownRoute)
 	r.HandleFunc("/dashboard/ui", s.handleDashboardUI).Methods("GET")
 	r.PathPrefix("/dashboard/ui/").HandlerFunc(s.handleDashboardUI).Methods("GET")
 	factoryapi.HandlerWithOptions(s, factoryapi.GorillaServerOptions{
@@ -69,6 +70,10 @@ func (s *Server) buildRouter() *mux.Router {
 		ErrorHandlerFunc: s.handleGeneratedParameterError,
 	})
 	return r
+}
+
+func (s *Server) handleUnknownRoute(w http.ResponseWriter, _ *http.Request) {
+	s.writeError(w, http.StatusNotFound, "route not found", "NOT_FOUND")
 }
 
 func (s *Server) handleGeneratedParameterError(w http.ResponseWriter, _ *http.Request, err error) {

--- a/pkg/transports/http/server_routing_test.go
+++ b/pkg/transports/http/server_routing_test.go
@@ -13,3 +13,11 @@ func TestUnknownRouteReturnsStructuredNotFound(t *testing.T) {
 	srv.Handler().ServeHTTP(rec, req)
 	assertJSONError(t, rec, http.StatusNotFound, "NOT_FOUND", "route not found")
 }
+
+func TestWrongMethodReturnsDocumentedMethodError(t *testing.T) {
+	srv := newFactoryDefinitionTestServer(nil, nil)
+	req := httptest.NewRequest(http.MethodPost, "/status", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	assertJSONError(t, rec, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+}

--- a/pkg/transports/http/server_routing_test.go
+++ b/pkg/transports/http/server_routing_test.go
@@ -1,0 +1,15 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUnknownRouteReturnsStructuredNotFound(t *testing.T) {
+	srv := newFactoryDefinitionTestServer(nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/functional-routing-unknown-route", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	assertJSONError(t, rec, http.StatusNotFound, "NOT_FOUND", "route not found")
+}

--- a/tests/functional/transport/http/server/routing_safe_requests_test.go
+++ b/tests/functional/transport/http/server/routing_safe_requests_test.go
@@ -28,6 +28,11 @@ const (
 	routingReachabilityWorkstation    = "process"
 )
 
+const routingLiveJavaScriptWorkflowSource = `phase("plan");
+workflow.checkpoint({ label: "routing-reachability-plan", state: { ready: true } });
+phase("execute");
+return "routing-reachability-live-result";`
+
 const routingArtifactWorkflowSource = `return (async function () {
   const artifactRef = workflow.artifact({
     kind: "log",
@@ -42,14 +47,15 @@ const routingArtifactWorkflowSource = `return (async function () {
 })();`
 
 type routingReachabilityContext struct {
-	t          *testing.T
-	server     *support.FunctionalAPIServer
-	baseURL    string
-	factoryDir string
-	jsLive     string
-	durable    routingDurableSessionContext
-	opened     string
-	workID     string
+	t                       *testing.T
+	server                  *support.FunctionalAPIServer
+	baseURL                 string
+	factoryDir              string
+	liveJavaScriptFactoryDir string
+	jsLive                  string
+	durable                 routingDurableSessionContext
+	opened                  string
+	workID                  string
 }
 
 type routingDurableSessionContext struct {
@@ -63,7 +69,7 @@ func (ctx *routingReachabilityContext) prepareSessions() {
 
 	ctx.durable = startRoutingArtifactDurableSession(ctx.t, ctx.baseURL)
 	ctx.opened = openRoutingFactorySession(ctx.t, ctx.baseURL, ctx.factoryDir)
-	ctx.jsLive = startRoutingBusyLoopJavaScriptSession(ctx.t, ctx.baseURL)
+	ctx.jsLive = openRoutingLiveJavaScriptFactorySession(ctx.t, ctx.baseURL, ctx.liveJavaScriptFactoryDir)
 }
 
 func (ctx *routingReachabilityContext) prepareWork() {
@@ -311,26 +317,19 @@ func startRoutingArtifactDurableSession(t *testing.T, baseURL string) routingDur
 	}
 }
 
-func startRoutingBusyLoopJavaScriptSession(t *testing.T, baseURL string) string {
+func openRoutingLiveJavaScriptFactorySession(t *testing.T, baseURL, factoryDir string) string {
 	t.Helper()
 
-	workflowName := "busy-loop"
-	started := postRoutingJSON[factoryapi.FactorySessionExecutionResponse](
+	response := postRoutingJSON[factoryapi.OpenFactorySessionResponse](
 		t,
-		baseURL+"/factory-sessions/async",
-		factoryapi.FactorySessionExecutionRequest{
-			RequestId: "routing-reachability-busy-loop",
-			Source: factoryapi.FactorySessionExecutionSource{
-				Kind:         factoryapi.FactorySessionExecutionSourceKindWorkflowName,
-				WorkflowName: &workflowName,
-			},
-		},
-		"start routing busy-loop JavaScript session",
+		baseURL+"/factory-sessions",
+		factoryapi.OpenFactorySessionRequest{FolderPath: factoryDir},
+		"open routing live JavaScript factory session",
 	)
-	if strings.TrimSpace(started.SessionId) == "" {
-		t.Fatalf("async JavaScript session id is empty: %#v", started)
+	if response.Session == nil || strings.TrimSpace(response.Session.Id) == "" {
+		t.Fatalf("open live JavaScript factory session response = %#v, want session id", response)
 	}
-	return started.SessionId
+	return response.Session.Id
 }
 
 func openRoutingFactorySession(t *testing.T, baseURL, factoryDir string) string {
@@ -374,6 +373,35 @@ func postRoutingJSON[T any](t *testing.T, endpoint string, body any, label strin
 	return decoded
 }
 
+func scaffoldRoutingLiveJavaScriptFactory(t *testing.T) string {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, map[string]any{
+		"name": "routing-reachability-live-javascript",
+		"orchestrator": map[string]any{
+			"kind": "JAVASCRIPT",
+			"javascript": map[string]any{
+				"sourceRef": "workflow.js",
+			},
+		},
+	})
+	if err := os.WriteFile(
+		filepath.Join(dir, "workflow.js"),
+		[]byte(routingLiveJavaScriptWorkflowSource),
+		0o600,
+	); err != nil {
+		t.Fatalf("write live JavaScript routing workflow: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "mock-workers.json"),
+		[]byte(`{"mockWorkers":[]}`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write live JavaScript mock-workers config: %v", err)
+	}
+	return dir
+}
+
 func scaffoldRoutingReachabilityFactory(t *testing.T) string {
 	t.Helper()
 
@@ -403,7 +431,6 @@ func scaffoldRoutingReachabilityFactory(t *testing.T) string {
 	); err != nil {
 		t.Fatalf("write routing javascript workflow: %v", err)
 	}
-	installRoutingBusyLoopWorkflow(t, dir)
 	installRoutingReachabilityModelWorker(t, dir)
 	support.WriteAgentConfig(t, dir, "worker-a", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"))
 	return dir
@@ -451,26 +478,6 @@ func installRoutingReachabilityModelWorker(t *testing.T, dir string) {
 		t.Fatalf("write factory.json: %v", err)
 	}
 	support.WriteAgentConfig(t, dir, "tts-worker", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, routingReachabilityModelName))
-}
-
-func installRoutingBusyLoopWorkflow(t *testing.T, dir string) {
-	t.Helper()
-
-	workflowDir := filepath.Join(dir, ".claude", "workflows")
-	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
-		t.Fatalf("mkdir workflows: %v", err)
-	}
-	fixturePath := support.AgentFactoryPath(
-		t,
-		filepath.Join("tests", "fixtures", "javascript_runtime", "busy-loop.workflow.js"),
-	)
-	raw, err := os.ReadFile(fixturePath)
-	if err != nil {
-		t.Fatalf("read busy-loop workflow fixture: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workflowDir, "busy-loop.js"), raw, 0o600); err != nil {
-		t.Fatalf("write busy-loop workflow: %v", err)
-	}
 }
 
 func stringPtr(value string) *string {

--- a/tests/functional/transport/http/server/routing_safe_requests_test.go
+++ b/tests/functional/transport/http/server/routing_safe_requests_test.go
@@ -1,0 +1,494 @@
+package server_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/contractinventory"
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	routingReachabilityRequestTimeout = 15 * time.Second
+	routingReachabilityModelName      = "OMNIVOICE_Q4_K_M"
+	routingReachabilityWorkstation    = "process"
+)
+
+const routingArtifactWorkflowSource = `return (async function () {
+  const artifactRef = workflow.artifact({
+    kind: "log",
+    label: "routing-reachability-artifact",
+    content: { message: "routing reachability" },
+  });
+  const child = await agent.run({
+    prompt: "routing reachability child",
+    label: "routing-reachability-child",
+  });
+  return { artifactRef, child };
+})();`
+
+type routingReachabilityContext struct {
+	t          *testing.T
+	server     *support.FunctionalAPIServer
+	baseURL    string
+	factoryDir string
+	jsLive     string
+	durable    routingDurableSessionContext
+	opened     string
+	workID     string
+}
+
+type routingDurableSessionContext struct {
+	sessionID  string
+	dispatchID string
+	artifactID string
+}
+
+func (ctx *routingReachabilityContext) prepareSessions() {
+	ctx.t.Helper()
+
+	ctx.durable = startRoutingArtifactDurableSession(ctx.t, ctx.baseURL)
+	ctx.opened = openRoutingFactorySession(ctx.t, ctx.baseURL, ctx.factoryDir)
+	ctx.jsLive = startRoutingBusyLoopJavaScriptSession(ctx.t, ctx.baseURL)
+}
+
+func (ctx *routingReachabilityContext) prepareWork() {
+	ctx.t.Helper()
+
+	submitted := support.SubmitDefaultSessionWork(ctx.t, ctx.baseURL, factoryapi.SubmitWorkRequest{
+		Name:         stringPtr("routing-reachability-work"),
+		WorkTypeName: "task",
+		Payload:      map[string]string{"title": "routing reachability"},
+	})
+	workID := ""
+	if submitted.WorkId != nil {
+		workID = strings.TrimSpace(*submitted.WorkId)
+	}
+	if workID == "" {
+		ctx.t.Fatalf("submit work returned empty workId: %#v", submitted)
+	}
+	ctx.workID = workID
+}
+
+func (ctx *routingReachabilityContext) safeRequest(operation contractinventory.Operation) (*http.Request, error) {
+	path, err := ctx.resolveOperationPath(operation)
+	if err != nil {
+		return nil, err
+	}
+	endpoint := strings.TrimSuffix(ctx.baseURL, "/") + path
+
+	switch operation.OperationID {
+	case "previewFactory":
+		return newJSONRequest(http.MethodPost, endpoint, map[string]any{})
+	case "validateFactory":
+		return newJSONRequest(http.MethodPost, endpoint, map[string]any{})
+	case "openFactorySession":
+		return newJSONRequest(http.MethodPost, endpoint, factoryapi.OpenFactorySessionRequest{
+			FolderPath: ctx.factoryDir,
+		})
+	case "startDurableFactorySessionAsync", "startDurableFactorySessionSync":
+		return newJSONRequest(http.MethodPost, endpoint, map[string]any{})
+	case "closeFactorySession":
+		return http.NewRequest(http.MethodDelete, sessionEndpoint(ctx.baseURL, ctx.opened), nil)
+	case "submitWorkBySessionId":
+		return newJSONRequest(http.MethodPost, sessionEndpoint(ctx.baseURL, factorysessions.DefaultSessionID)+"/work", factoryapi.SubmitWorkRequest{
+			Name:         stringPtr("routing-reachability-submit"),
+			WorkTypeName: "task",
+			Payload:      map[string]string{"title": "routing reachability submit"},
+		})
+	case "upsertWorkRequestBySessionId":
+		return newJSONRequest(
+			http.MethodPut,
+			sessionEndpoint(ctx.baseURL, factorysessions.DefaultSessionID)+"/work-requests/routing-reachability",
+			map[string]any{},
+		)
+	case "stageSubmitWorkFileBySessionId":
+		return newJSONRequest(http.MethodPost, sessionEndpoint(ctx.baseURL, factorysessions.DefaultSessionID)+"/work/staged-files", map[string]any{})
+	case "moveWorkBySessionId":
+		return newJSONRequest(
+			http.MethodPost,
+			sessionEndpoint(ctx.baseURL, factorysessions.DefaultSessionID)+"/work/"+url.PathEscape(ctx.workID)+"/move",
+			map[string]any{},
+		)
+	case "saveCurrentFactoryBySessionId":
+		return newJSONRequest(http.MethodPut, sessionEndpoint(ctx.baseURL, factorysessions.DefaultSessionID)+"/factory", map[string]any{})
+	case "invokeFactorySessionBySessionId":
+		return newJSONRequest(http.MethodPost, sessionEndpoint(ctx.baseURL, factorysessions.DefaultSessionID)+"/invocations", map[string]any{})
+	case "pauseFactorySession", "resumeFactorySession", "terminateFactorySession", "cancelFactorySession", "approveFactorySession",
+		"interruptFactorySessionDispatch", "retryFactorySessionDispatch":
+		endpoint, err := sessionScopedEndpoint(ctx, operation)
+		if err != nil {
+			return nil, err
+		}
+		return newJSONRequest(http.MethodPost, endpoint, map[string]any{})
+	case "validateCurrentFactoryWorkstationPromptTemplateBySessionId":
+		return newJSONRequest(
+			http.MethodPost,
+			sessionEndpoint(ctx.baseURL, factorysessions.DefaultSessionID)+"/factory/workstations/"+routingReachabilityWorkstation+"/prompt-template-validation",
+			map[string]any{},
+		)
+	case "invokeModel":
+		return newJSONRequest(
+			http.MethodPost,
+			strings.TrimSuffix(ctx.baseURL, "/")+"/models/"+routingReachabilityModelName+"/invocations",
+			factoryapi.ModelInvocationRequest{Operation: "EMBED"},
+		)
+	case "pullModel":
+		return newJSONRequest(
+			http.MethodPost,
+			strings.TrimSuffix(ctx.baseURL, "/")+"/models/"+routingReachabilityModelName+"/pull",
+			nil,
+		)
+	case "getProviderSessionDetails":
+		return http.NewRequest(
+			http.MethodGet,
+			strings.TrimSuffix(ctx.baseURL, "/")+"/provider-sessions/detail?provider=openai&kind=session_id&id=routing-reachability",
+			nil,
+		)
+	case "getEventsBySessionId", "getFactoryResponseEventsBySessionId":
+		request, err := http.NewRequest(http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, err
+		}
+		request.Header.Set("Accept", "text/event-stream")
+		return request, nil
+	default:
+		request, err := http.NewRequest(operation.Method, endpoint, nil)
+		if err != nil {
+			return nil, err
+		}
+		if len(operation.RequestMediaTypes) > 0 {
+			request.Header.Set("Content-Type", operation.RequestMediaTypes[0])
+		}
+		return request, nil
+	}
+}
+
+func (ctx *routingReachabilityContext) resolveOperationPath(operation contractinventory.Operation) (string, error) {
+	replacements := map[string]string{
+		"{session_id}":       ctx.sessionIDFor(operation),
+		"{model_name}":       routingReachabilityModelName,
+		"{workstation_name}": routingReachabilityWorkstation,
+		"{request_id}":       "routing-reachability",
+		"{id}":               ctx.workID,
+		"{dispatch_id}":      ctx.durable.dispatchID,
+		"{artifact_id}":      ctx.durable.artifactID,
+	}
+	path := operation.Path
+	for placeholder, value := range replacements {
+		if !strings.Contains(path, placeholder) {
+			continue
+		}
+		if strings.TrimSpace(value) == "" {
+			return "", fmt.Errorf("missing path value for %s in %s", placeholder, operation.OperationID)
+		}
+		path = strings.ReplaceAll(path, placeholder, value)
+	}
+	if strings.Contains(path, "{") {
+		return "", fmt.Errorf("unresolved path placeholders remain in %q", path)
+	}
+	return path, nil
+}
+
+func (ctx *routingReachabilityContext) sessionIDFor(operation contractinventory.Operation) string {
+	switch operation.OperationID {
+	case "closeFactorySession", "terminateFactorySession", "cancelFactorySession":
+		if ctx.opened != "" {
+			return ctx.opened
+		}
+	case "getFactorySessionResult", "getFactorySessionPartialResult":
+		if ctx.jsLive != "" {
+			return ctx.jsLive
+		}
+	case "getFactorySessionResults":
+		if ctx.durable.sessionID != "" {
+			return ctx.durable.sessionID
+		}
+	case "listFactorySessionArtifacts", "getFactorySessionArtifact",
+		"listFactorySessionDispatches", "getFactorySessionDispatch",
+		"approveFactorySession", "interruptFactorySessionDispatch", "retryFactorySessionDispatch":
+		if ctx.durable.sessionID != "" {
+			return ctx.durable.sessionID
+		}
+	}
+	return factorysessions.DefaultSessionID
+}
+
+func sessionScopedEndpoint(ctx *routingReachabilityContext, operation contractinventory.Operation) (string, error) {
+	path, err := ctx.resolveOperationPath(operation)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(ctx.baseURL, "/") + path, nil
+}
+
+func sessionEndpoint(baseURL, sessionID string) string {
+	return strings.TrimSuffix(baseURL, "/") + "/factory-sessions/" + url.PathEscape(sessionID)
+}
+
+func newJSONRequest(method, endpoint string, body any) (*http.Request, error) {
+	var reader io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("marshal request body: %w", err)
+		}
+		reader = bytes.NewReader(payload)
+	}
+	request, err := http.NewRequest(method, endpoint, reader)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	return request, nil
+}
+
+func startRoutingArtifactDurableSession(t *testing.T, baseURL string) routingDurableSessionContext {
+	t.Helper()
+
+	dialect := "you-workflow-v1"
+	response := postRoutingJSON[factoryapi.FactorySessionSyncExecutionResponse](
+		t,
+		baseURL+"/factory-sessions/sync",
+		factoryapi.FactorySessionExecutionRequest{
+			RequestId: "routing-reachability-durable",
+			Source: factoryapi.FactorySessionExecutionSource{
+				Kind: factoryapi.FactorySessionExecutionSourceKindInlineWorkflow,
+				InlineWorkflow: &factoryapi.FactorySessionExecutionInlineWorkflow{
+					Dialect: &dialect,
+					InlineSource: factoryapi.FactoryOrchestratorJavaScriptInlineSource{
+						Encoding: factoryapi.FactoryOrchestratorJavaScriptInlineSourceEncodingUtf8,
+						Inline:   routingArtifactWorkflowSource,
+					},
+				},
+			},
+		},
+		"start routing durable session",
+	)
+	if response.Status != factoryapi.FactorySessionDurableLifecycleStatusSucceeded {
+		t.Fatalf("durable session status = %q, want SUCCEEDED", response.Status)
+	}
+	if strings.TrimSpace(response.SessionId) == "" {
+		t.Fatal("durable session id is empty")
+	}
+
+	dispatches := support.GetJSON[factoryapi.ListFactorySessionDispatchesResponse](
+		t,
+		sessionEndpoint(baseURL, response.SessionId)+"/dispatches",
+	)
+	if len(dispatches.Dispatches) == 0 {
+		t.Fatalf("durable session dispatches = %#v, want at least one dispatch", dispatches)
+	}
+
+	artifacts := support.GetJSON[factoryapi.ListFactorySessionArtifactsResponse](
+		t,
+		sessionEndpoint(baseURL, response.SessionId)+"/artifacts",
+	)
+	if len(artifacts.Artifacts) == 0 {
+		t.Fatalf("durable session artifacts = %#v, want at least one artifact", artifacts)
+	}
+
+	return routingDurableSessionContext{
+		sessionID:  response.SessionId,
+		dispatchID: dispatches.Dispatches[0].Id,
+		artifactID: artifacts.Artifacts[0].Id,
+	}
+}
+
+func startRoutingBusyLoopJavaScriptSession(t *testing.T, baseURL string) string {
+	t.Helper()
+
+	workflowName := "busy-loop"
+	started := postRoutingJSON[factoryapi.FactorySessionExecutionResponse](
+		t,
+		baseURL+"/factory-sessions/async",
+		factoryapi.FactorySessionExecutionRequest{
+			RequestId: "routing-reachability-busy-loop",
+			Source: factoryapi.FactorySessionExecutionSource{
+				Kind:         factoryapi.FactorySessionExecutionSourceKindWorkflowName,
+				WorkflowName: &workflowName,
+			},
+		},
+		"start routing busy-loop JavaScript session",
+	)
+	if strings.TrimSpace(started.SessionId) == "" {
+		t.Fatalf("async JavaScript session id is empty: %#v", started)
+	}
+	return started.SessionId
+}
+
+func openRoutingFactorySession(t *testing.T, baseURL, factoryDir string) string {
+	t.Helper()
+
+	response := postRoutingJSON[factoryapi.OpenFactorySessionResponse](
+		t,
+		baseURL+"/factory-sessions",
+		factoryapi.OpenFactorySessionRequest{FolderPath: factoryDir},
+		"open routing factory session",
+	)
+	if response.Session == nil || strings.TrimSpace(response.Session.Id) == "" {
+		t.Fatalf("open factory session response = %#v, want session id", response)
+	}
+	return response.Session.Id
+}
+
+func postRoutingJSON[T any](t *testing.T, endpoint string, body any, label string) T {
+	t.Helper()
+
+	request, err := newJSONRequest(http.MethodPost, endpoint, body)
+	if err != nil {
+		t.Fatalf("%s: build request: %v", label, err)
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("%s: %v", label, err)
+	}
+	defer response.Body.Close()
+	payload, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("%s: read body: %v", label, err)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		t.Fatalf("%s status = %d, want success: %s", label, response.StatusCode, strings.TrimSpace(string(payload)))
+	}
+	var decoded T
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("%s: decode response: %v\n%s", label, err, string(payload))
+	}
+	return decoded
+}
+
+func scaffoldRoutingReachabilityFactory(t *testing.T) string {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, map[string]any{
+		"name": "routing-reachability",
+		"workTypes": []map[string]any{{
+			"name": "task",
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "complete", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []map[string]string{{"name": "worker-a"}},
+		"workstations": []map[string]any{{
+			"name":      routingReachabilityWorkstation,
+			"worker":    "worker-a",
+			"inputs":    []map[string]string{{"workType": "task", "state": "init"}},
+			"outputs":   []map[string]string{{"workType": "task", "state": "complete"}},
+			"onFailure": []map[string]string{{"workType": "task", "state": "failed"}},
+		}},
+	})
+	if err := os.WriteFile(
+		filepath.Join(dir, "workflow.js"),
+		[]byte(`return { ok: true };`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write routing javascript workflow: %v", err)
+	}
+	installRoutingBusyLoopWorkflow(t, dir)
+	installRoutingReachabilityModelWorker(t, dir)
+	support.WriteAgentConfig(t, dir, "worker-a", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"))
+	return dir
+}
+
+func installRoutingReachabilityModelWorker(t *testing.T, dir string) {
+	t.Helper()
+
+	factoryPath := filepath.Join(dir, "factory.json")
+	raw, err := os.ReadFile(factoryPath)
+	if err != nil {
+		t.Fatalf("read factory.json: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("decode factory.json: %v", err)
+	}
+	cfg["workers"] = []map[string]any{
+		{"name": "worker-a"},
+		{
+			"name":          "tts-worker",
+			"type":          interfaces.WorkerTypeModel,
+			"model":         routingReachabilityModelName,
+			"modelProvider": "CODEX",
+			"modelLocality": interfaces.ModelLocalityCloud,
+			"operations": []map[string]any{{
+				"name": "TTS",
+				"inputs": []map[string]any{{
+					"name":         "text",
+					"contentTypes": []string{interfaces.ModelOperationContentTypeText},
+					"required":     true,
+				}},
+				"outputs": []map[string]any{{
+					"name":         "audio",
+					"contentTypes": []string{interfaces.ModelOperationContentTypeAudio},
+				}},
+			}},
+		},
+	}
+	encoded, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("encode factory.json: %v", err)
+	}
+	if err := os.WriteFile(factoryPath, encoded, 0o600); err != nil {
+		t.Fatalf("write factory.json: %v", err)
+	}
+	support.WriteAgentConfig(t, dir, "tts-worker", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, routingReachabilityModelName))
+}
+
+func installRoutingBusyLoopWorkflow(t *testing.T, dir string) {
+	t.Helper()
+
+	workflowDir := filepath.Join(dir, ".claude", "workflows")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("mkdir workflows: %v", err)
+	}
+	fixturePath := support.AgentFactoryPath(
+		t,
+		filepath.Join("tests", "fixtures", "javascript_runtime", "busy-loop.workflow.js"),
+	)
+	raw, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("read busy-loop workflow fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "busy-loop.js"), raw, 0o600); err != nil {
+		t.Fatalf("write busy-loop workflow: %v", err)
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func routingPackageDirectory() string {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return ""
+	}
+	return filepath.Dir(filename)
+}
+
+func loadRESTOperationInventoryFromFile(path string) (*contractinventory.Inventory, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read openapi file: %w", err)
+	}
+	return contractinventory.ExtractFromOpenAPIYAML(data)
+}

--- a/tests/functional/transport/http/server/routing_test.go
+++ b/tests/functional/transport/http/server/routing_test.go
@@ -23,11 +23,6 @@ func TestAPIRoutesEveryOpenAPIOperationToNon404Handler(t *testing.T) {
 	for _, operation := range inventory.Operations {
 		operation := operation
 		t.Run(operation.OperationID, func(t *testing.T) {
-			if operation.OperationID == "getFactorySessionResult" ||
-				operation.OperationID == "getFactorySessionPartialResult" {
-				t.Skip("live JavaScript /result and /partial-result reads return NOT_FOUND for functional-server sessions until a reachable live JS projection fixture exists")
-			}
-
 			request, err := ctx.safeRequest(operation)
 			if err != nil {
 				t.Fatalf("build safe request for %s %s (%s): %v", operation.Method, operation.Path, operation.OperationID, err)
@@ -82,16 +77,18 @@ func newRoutingReachabilityContext(t *testing.T) *routingReachabilityContext {
 	t.Helper()
 
 	dir := scaffoldRoutingReachabilityFactory(t)
+	liveJavaScriptFactoryDir := scaffoldRoutingLiveJavaScriptFactory(t)
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:                dir,
 		UseMockWorkers:            true,
 		WaitForServiceModeRuntime: true,
 	})
 	ctx := &routingReachabilityContext{
-		t:          t,
-		server:     server,
-		baseURL:    server.URL(),
-		factoryDir: dir,
+		t:                        t,
+		server:                   server,
+		baseURL:                  server.URL(),
+		factoryDir:               dir,
+		liveJavaScriptFactoryDir: liveJavaScriptFactoryDir,
 	}
 	ctx.prepareSessions()
 	ctx.prepareWork()

--- a/tests/functional/transport/http/server/routing_test.go
+++ b/tests/functional/transport/http/server/routing_test.go
@@ -1,0 +1,99 @@
+package server_test
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/contractinventory"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+// TestAPIRoutesEveryOpenAPIOperationToNon404Handler proves every published OpenAPI
+// REST operation inventory entry is wired to a real handler by issuing a safe
+// public HTTP request that reaches a non-404 response on the live functional API
+// server.
+func TestAPIRoutesEveryOpenAPIOperationToNon404Handler(t *testing.T) {
+	inventory := loadRESTOperationInventory(t)
+	ctx := newRoutingReachabilityContext(t)
+	defer ctx.server.Stop(t)
+
+	client := &http.Client{Timeout: routingReachabilityRequestTimeout}
+	for _, operation := range inventory.Operations {
+		operation := operation
+		t.Run(operation.OperationID, func(t *testing.T) {
+			if operation.OperationID == "getFactorySessionResult" ||
+				operation.OperationID == "getFactorySessionPartialResult" {
+				t.Skip("live JavaScript /result and /partial-result reads return NOT_FOUND for functional-server sessions until a reachable live JS projection fixture exists")
+			}
+
+			request, err := ctx.safeRequest(operation)
+			if err != nil {
+				t.Fatalf("build safe request for %s %s (%s): %v", operation.Method, operation.Path, operation.OperationID, err)
+			}
+
+			response, err := client.Do(request)
+			if err != nil {
+				t.Fatalf("%s %s (%s): %v", operation.Method, request.URL.String(), operation.OperationID, err)
+			}
+			defer response.Body.Close()
+
+			if response.StatusCode == http.StatusNotFound {
+				t.Fatalf(
+					"%s %s (%s) status = %d, want any non-404 handler response",
+					operation.Method,
+					request.URL.String(),
+					operation.OperationID,
+					response.StatusCode,
+				)
+			}
+		})
+	}
+
+	if len(inventory.Operations) == 0 {
+		t.Fatal("OpenAPI operation inventory is empty")
+	}
+}
+
+func loadRESTOperationInventory(t *testing.T) *contractinventory.Inventory {
+	t.Helper()
+
+	repositoryRoot := routingPackageDirectory()
+	for {
+		if _, err := os.Stat(filepath.Join(repositoryRoot, "go.mod")); err == nil {
+			break
+		}
+		parent := filepath.Dir(repositoryRoot)
+		if parent == repositoryRoot {
+			t.Fatal("find repository root from routing test package")
+		}
+		repositoryRoot = parent
+	}
+	openAPIPath := filepath.Join(repositoryRoot, "api", "openapi.yaml")
+	inventory, err := loadRESTOperationInventoryFromFile(openAPIPath)
+	if err != nil {
+		t.Fatalf("load OpenAPI operation inventory from %s: %v", openAPIPath, err)
+	}
+	return inventory
+}
+
+func newRoutingReachabilityContext(t *testing.T) *routingReachabilityContext {
+	t.Helper()
+
+	dir := scaffoldRoutingReachabilityFactory(t)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		UseMockWorkers:            true,
+		WaitForServiceModeRuntime: true,
+	})
+	ctx := &routingReachabilityContext{
+		t:          t,
+		server:     server,
+		baseURL:    server.URL(),
+		factoryDir: dir,
+	}
+	ctx.prepareSessions()
+	ctx.prepareWork()
+	return ctx
+}

--- a/tests/functional/transport/http/server/routing_test.go
+++ b/tests/functional/transport/http/server/routing_test.go
@@ -1,12 +1,16 @@
 package server_test
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/portpowered/infinite-you/internal/contractinventory"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
@@ -48,6 +52,58 @@ func TestAPIRoutesEveryOpenAPIOperationToNon404Handler(t *testing.T) {
 
 	if len(inventory.Operations) == 0 {
 		t.Fatal("OpenAPI operation inventory is empty")
+	}
+}
+
+// TestAPIUnknownRouteReturnsStructuredNotFound proves requests to paths outside the
+// published OpenAPI surface return a structured not-found response at the public
+// HTTP contract boundary.
+func TestAPIUnknownRouteReturnsStructuredNotFound(t *testing.T) {
+	dir := support.ScaffoldFactory(t, startupShutdownTestFactoryConfig())
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		UseMockWorkers:            true,
+		WaitForServiceModeRuntime: true,
+	})
+	defer server.Stop(t)
+
+	unknownPath := "/functional-routing-unknown-route"
+	response, err := http.Get(server.URL() + unknownPath)
+	if err != nil {
+		t.Fatalf("GET %s: %v", unknownPath, err)
+	}
+	defer response.Body.Close()
+
+	assertStructuredNotFoundHTTPResponse(t, response)
+}
+
+func assertStructuredNotFoundHTTPResponse(t *testing.T, response *http.Response) {
+	t.Helper()
+
+	if response.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("status = %d, want %d: %s", response.StatusCode, http.StatusNotFound, strings.TrimSpace(string(body)))
+	}
+
+	contentType := response.Header.Get("Content-Type")
+	if !strings.Contains(contentType, "application/json") {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("Content-Type = %q, want application/json structured error body: %s", contentType, strings.TrimSpace(string(body)))
+	}
+
+	var errResp factoryapi.ErrorResponse
+	if err := json.NewDecoder(response.Body).Decode(&errResp); err != nil {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("decode structured not-found response: %v\nbody: %s", err, strings.TrimSpace(string(body)))
+	}
+	if errResp.Family != factoryapi.ErrorFamilyNotFound {
+		t.Fatalf("error family = %q, want %q", errResp.Family, factoryapi.ErrorFamilyNotFound)
+	}
+	if errResp.Code != factoryapi.ErrorResponseCodeNOTFOUND {
+		t.Fatalf("error code = %q, want %q", errResp.Code, factoryapi.ErrorResponseCodeNOTFOUND)
+	}
+	if strings.TrimSpace(errResp.Message) == "" {
+		t.Fatal("error message is empty, want a customer-readable not-found message")
 	}
 }
 

--- a/tests/functional/transport/http/server/routing_test.go
+++ b/tests/functional/transport/http/server/routing_test.go
@@ -77,6 +77,33 @@ func TestAPIUnknownRouteReturnsStructuredNotFound(t *testing.T) {
 	assertStructuredNotFoundHTTPResponse(t, response)
 }
 
+// TestAPIWrongMethodReturnsDocumentedMethodError proves wrong HTTP methods on known
+// OpenAPI routes return the documented method-error response at the public HTTP
+// contract boundary instead of a not-found outcome that would hide the mismatch.
+func TestAPIWrongMethodReturnsDocumentedMethodError(t *testing.T) {
+	dir := support.ScaffoldFactory(t, startupShutdownTestFactoryConfig())
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		UseMockWorkers:            true,
+		WaitForServiceModeRuntime: true,
+	})
+	defer server.Stop(t)
+
+	knownPath := "/status"
+	request, err := http.NewRequest(http.MethodPost, server.URL()+knownPath, nil)
+	if err != nil {
+		t.Fatalf("build POST %s: %v", knownPath, err)
+	}
+
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("POST %s: %v", knownPath, err)
+	}
+	defer response.Body.Close()
+
+	assertStructuredMethodNotAllowedHTTPResponse(t, response)
+}
+
 func assertStructuredNotFoundHTTPResponse(t *testing.T, response *http.Response) {
 	t.Helper()
 
@@ -104,6 +131,45 @@ func assertStructuredNotFoundHTTPResponse(t *testing.T, response *http.Response)
 	}
 	if strings.TrimSpace(errResp.Message) == "" {
 		t.Fatal("error message is empty, want a customer-readable not-found message")
+	}
+}
+
+func assertStructuredMethodNotAllowedHTTPResponse(t *testing.T, response *http.Response) {
+	t.Helper()
+
+	if response.StatusCode != http.StatusMethodNotAllowed {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("status = %d, want %d: %s", response.StatusCode, http.StatusMethodNotAllowed, strings.TrimSpace(string(body)))
+	}
+	if response.StatusCode == http.StatusNotFound {
+		t.Fatal("wrong-method probe returned not-found, want documented method-error status")
+	}
+
+	contentType := response.Header.Get("Content-Type")
+	if !strings.Contains(contentType, "application/json") {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("Content-Type = %q, want application/json structured error body: %s", contentType, strings.TrimSpace(string(body)))
+	}
+
+	var errResp factoryapi.ErrorResponse
+	if err := json.NewDecoder(response.Body).Decode(&errResp); err != nil {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("decode structured method-error response: %v\nbody: %s", err, strings.TrimSpace(string(body)))
+	}
+	if errResp.Family == factoryapi.ErrorFamilyNotFound {
+		t.Fatalf("error family = %q, want method-error family distinct from not-found", errResp.Family)
+	}
+	if errResp.Code == factoryapi.ErrorResponseCodeNOTFOUND {
+		t.Fatalf("error code = %q, want method-error code distinct from not-found", errResp.Code)
+	}
+	if errResp.Family != factoryapi.ErrorFamilyBadRequest {
+		t.Fatalf("error family = %q, want %q", errResp.Family, factoryapi.ErrorFamilyBadRequest)
+	}
+	if errResp.Code != "METHOD_NOT_ALLOWED" {
+		t.Fatalf("error code = %q, want %q", errResp.Code, "METHOD_NOT_ALLOWED")
+	}
+	if strings.TrimSpace(errResp.Message) == "" {
+		t.Fatal("error message is empty, want a customer-readable method-error message")
 	}
 }
 

--- a/ui/src/api/generated/openapi.ts
+++ b/ui/src/api/generated/openapi.ts
@@ -7215,6 +7215,8 @@ export const ErrorResponseCode = {
   STALE_FACTORY_VERSION: "STALE_FACTORY_VERSION",
   // Operator move requestId was already applied for this session.
   MOVE_WORK_REQUEST_ALREADY_APPLIED: "MOVE_WORK_REQUEST_ALREADY_APPLIED",
+  // The HTTP method is not allowed for the requested route.
+  METHOD_NOT_ALLOWED: "METHOD_NOT_ALLOWED",
   // Durable execution requestId was reused with materially different inputs.
   EXECUTION_REQUEST_ID_CONFLICT: "EXECUTION_REQUEST_ID_CONFLICT",
   // Lifecycle control requestId was already applied with different control inputs.


### PR DESCRIPTION
{
  "project": "HTTP Server OpenAPI Routing Functional Coverage",
  "branchName": "ft-wave1-http-routing",
  "description": "Implement the transport-owned functional cell at tests/functional/transport/http/server/routing_test.go so every OpenAPI operation inventory entry reaches a non-404 handler with a safe request, unknown routes return a structured not-found response, and wrong HTTP methods return the documented method error. Checklist behaviors are authoritative (no mapped migration-ledger rows); do not invent runtime_api-delete-01-transport-http deletion ownership or implement sibling content_negotiation/generated_client cells. Freeing follows startup_shutdown_test.go terminal-complete (PR #1437).",
  "context": {
    "customerAsk": "Implement only tests/functional/transport/http/server/routing_test.go. Through the public HTTP/server boundary, prove: (1) TestAPIRoutesEveryOpenAPIOperationToNon404Handler — every OpenAPI operation inventory entry reaches a non-404 handler with a safe request; (2) TestAPIUnknownRouteReturnsStructuredNotFound — unknown routes return a structured not-found response; (3) TestAPIWrongMethodReturnsDocumentedMethodError — wrong HTTP methods return the documented method error. Do not implement content_negotiation_test.go or generated_client_test.go. Avoid service/internal imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled ownership/coverage/catalog/migration metadata required for this cell; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist cell for HTTP server OpenAPI routing does not exist yet even though transport/http/server is freed by startup_shutdown (PR #1437). Maintainers lack a focused, catalogued transport proof that every published OpenAPI operation is wired to a non-404 handler, that unknown paths return a structured not-found contract, and that wrong methods return the documented method error at the public HTTP edge. Without this cell, Wave 1 cannot inventory routing ownership under transport/http/server, and sibling content_negotiation/generated_client cells remain blocked on the shared package.",
    "solution": "Implement the three checklist scenarios in tests/functional/transport/http/server/routing_test.go through the public HTTP/server and root.BuildProcess / support.StartFunctionalAPIServer boundary, with customer-readable Go docs on every top-level Test. Assert every OpenAPI operation inventory entry reaches a non-404 handler via a safe request, unknown routes return structured not-found, and wrong methods return the documented method error. Treat checklist behaviors as authoritative scope with no mapped migration-ledger rows; do not invent runtime_api-delete-01-transport-http deletions still owned by siblings; apply narrowly coupled metadata updates; leave content_negotiation/generated_client unimplemented; verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/transport/http/server/routing_test.go exists as the transport-owned functional cell and covers OpenAPI operation routing to non-404 handlers, structured unknown-route not-found, and documented wrong-method errors.",
    "For every OpenAPI operation inventory entry, a safe public HTTP request against the live functional server reaches a non-404 handler (status is not 404).",
    "An unknown route returns a structured not-found response at the public HTTP contract surface (documented status and structured error body/code family consistent with not-found).",
    "A wrong HTTP method on a known route returns the documented method error (documented method-not-allowed/method-error status and structured or otherwise documented method-error shape), not a not-found that hides method mismatch.",
    "Coverage uses root.BuildProcess/public HTTP functional hosts; it does not import service implementations or internal Petri primitives, and assertions stay at the public HTTP routing/error-contract surface.",
    "Every top-level Test* has a customer-readable Go doc comment whose first sentence describes the observable behavior; no migration-ledger deletion ownership is invented for this destination; only narrowly coupled metadata required for this cell are updated; sibling content_negotiation and generated_client cells remain unimplemented and untouched.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave1-http-routing-001",
      "title": "Prove every OpenAPI operation reaches a non-404 handler",
      "description": "As a maintainer, I want a transport-owned functional test that issues a safe request for every OpenAPI operation inventory entry against the public API server, so customers can trust published operations are wired to real handlers rather than silently 404ing.",
      "acceptanceCriteria": [
        "tests/functional/transport/http/server/routing_test.go includes TestAPIRoutesEveryOpenAPIOperationToNon404Handler.",
        "The test starts the process through the public functional boundary (root.BuildProcess / support.StartFunctionalAPIServer or equivalent public HTTP host helpers).",
        "The test uses the OpenAPI operation inventory (the customer/contract operation catalog for the public REST surface) as the authoritative set of operations to exercise.",
        "For each inventory operation, the test issues a safe request (minimal method/path/body that proves handler reachability without requiring destructive or live-provider side effects) and asserts the response status is not 404.",
        "Assertions stay at the public HTTP routing surface and do not inspect private router tables, service internals, or Petri markings.",
        "The top-level test has a customer-readable Go doc comment describing the every-operation-reaches-a-handler behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-http-routing-002",
      "title": "Prove unknown routes return structured not-found",
      "description": "As a customer integrating with the HTTP API, I want unknown routes to return a structured not-found response, so clients can distinguish missing paths from other failures using the documented public error shape.",
      "acceptanceCriteria": [
        "The routing cell includes TestAPIUnknownRouteReturnsStructuredNotFound.",
        "The test issues a public HTTP request to a path that is not part of the documented OpenAPI surface against a reachable functional API server.",
        "The response is a structured not-found outcome at the public contract surface (documented not-found status and structured error body/code family consistent with not-found).",
        "The outcome is distinguishable from a successful handler response and from an unstructured empty/plain failure body.",
        "Assertions use public HTTP status and structured error observations and do not inspect private router internals.",
        "The top-level test has a customer-readable Go doc comment describing the unknown-route structured not-found behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-http-routing-003",
      "title": "Prove wrong methods return documented method error",
      "description": "As a customer integrating with the HTTP API, I want wrong HTTP methods on known routes to return the documented method error, so clients can detect method mismatches without treating them as missing routes.",
      "acceptanceCriteria": [
        "The routing cell includes TestAPIWrongMethodReturnsDocumentedMethodError.",
        "The test selects at least one known OpenAPI route/path and issues an HTTP method that is not allowed for that route against a reachable functional API server.",
        "The response matches the documented method-error contract (documented method-not-allowed / method-error status and structured or otherwise documented method-error shape), not a not-found that hides the method mismatch.",
        "Assertions stay at the public HTTP method-error contract surface and do not invent content-negotiation or generated-client schema coverage.",
        "The top-level test has a customer-readable Go doc comment describing the wrong-method documented error behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-http-routing-004",
      "title": "Keep ledger scope clean and close verification gates",
      "description": "As a maintainer executing Wave 1 migration, I want this cell to remain checklist-authoritative (no invented ledger deletions), leave sibling HTTP cells untouched, and pass focused boundary/metadata gates, so routing ownership is catalogued correctly under transport/http/server.",
      "acceptanceCriteria": [
        "Planning confirms no migration-ledger inventory rows currently map to tests/functional/transport/http/server/routing_test.go; the cell does not invent deletion batches or claim runtime_api-delete-01-transport-http rows still owned by sibling destinations.",
        "Only narrowly coupled ownership, coverage, catalog, or migration metadata required for this cell are updated; neighboring HTTP server cells (content_negotiation, generated_client) remain unimplemented and untouched.",
        "Focused package tests for tests/functional/transport/http/server pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as transport/http/server).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)