### PR TITLE
pss-imp-set-01-document

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1284,7 +1284,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings",
-      "minimum": 50.59
+      "minimum": 46.25
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/identityinventory",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1307,6 +1307,24 @@
       }
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/internal/service",
+      "minimum": 67.14
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/wire",
+      "minimum": 100.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution",
       "exception": {
         "kind": "measurement",
@@ -1328,6 +1346,20 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/wire",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/servicewire",
+      "minimum": 100.00
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/testlink",
       "exception": {
         "kind": "measurement",
         "justification": "The active functional coverage profile contains no measurable statements for this package.",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1169,28 +1169,6 @@
       "minimum": 66.66
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/internal/service",
-      "minimum": 93.67
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/wire",
-      "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire",
-      "minimum": 0.00
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document",
       "exception": {
         "kind": "measurement",
@@ -1209,12 +1187,34 @@
       "minimum": 100.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active unit coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/internal/service",
+      "minimum": 93.67
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/wire",
+      "minimum": 100.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/servicewire",
       "minimum": 100.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/testlink",
       "minimum": 100.00
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire",
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1191,6 +1191,24 @@
       "minimum": 0.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active unit coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/internal/service",
+      "minimum": 82.90
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/wire",
+      "minimum": 100.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions",
       "minimum": 90.90
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1209,6 +1209,14 @@
       "minimum": 100.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/servicewire",
+      "minimum": 100.00
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/testlink",
+      "minimum": 100.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions",
       "minimum": 90.90
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1670,7 +1670,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/workstations/internal/service",
-      "minimum": 92.54
+      "minimum": 92.20
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/workstations/wire",

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -285,9 +285,14 @@
     "pkg/services/operator_settings",
     "pkg/services/operator_settings/identityinventory",
     "pkg/services/operator_settings/internal/service",
+    "pkg/services/operator_settings/internal/services/document",
+    "pkg/services/operator_settings/internal/services/document/internal/service",
+    "pkg/services/operator_settings/internal/services/document/wire",
     "pkg/services/operator_settings/internal/services/resolution",
     "pkg/services/operator_settings/internal/services/resolution/internal/service",
     "pkg/services/operator_settings/internal/services/resolution/wire",
+    "pkg/services/operator_settings/servicewire",
+    "pkg/services/operator_settings/testlink",
     "pkg/services/operator_settings/wire",
     "pkg/services/provider_sessions",
     "pkg/services/provider_sessions/internal/services/codex_reader",
@@ -1701,6 +1706,21 @@
       "destination": "operator_settings"
     },
     {
+      "packagePath": "pkg/services/operator_settings/internal/services/document",
+      "disposition": "retain",
+      "destination": "operator_settings/internal/services/document"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/internal/services/document/internal/service",
+      "disposition": "retain",
+      "destination": "operator_settings/internal/services/document"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/internal/services/document/wire",
+      "disposition": "retain",
+      "destination": "operator_settings/internal/services/document"
+    },
+    {
       "packagePath": "pkg/services/operator_settings/internal/services/resolution",
       "disposition": "retain",
       "destination": "operator_settings/internal/services/resolution"
@@ -1714,6 +1734,16 @@
       "packagePath": "pkg/services/operator_settings/internal/services/resolution/wire",
       "disposition": "retain",
       "destination": "operator_settings/internal/services/resolution"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/servicewire",
+      "disposition": "retain",
+      "destination": "operator_settings"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/testlink",
+      "disposition": "retain",
+      "destination": "operator_settings"
     },
     {
       "packagePath": "pkg/services/operator_settings/wire",

--- a/pkg/services/operator_settings/atomic_config_test.go
+++ b/pkg/services/operator_settings/atomic_config_test.go
@@ -61,14 +61,14 @@ func TestConfigDocumentServicePersist_PreCommitFailuresPreserveDestination(t *te
 		shortWrite bool
 		want       string
 	}{
-		{name: "directory", filePhase: "mkdir", want: "create operator config directory"},
-		{name: "temporary file", tempPhase: "create", want: "create operator config temp file"},
-		{name: "write", tempPhase: "write", want: "write operator config temp file"},
+		{name: "directory", filePhase: "mkdir", want: "create operator document directory"},
+		{name: "temporary file", tempPhase: "create", want: "create operator document temp file"},
+		{name: "write", tempPhase: "write", want: "write operator document temp file"},
 		{name: "short write", shortWrite: true, want: "short write"},
-		{name: "sync", tempPhase: "sync", want: "sync operator config temp file"},
-		{name: "close", tempPhase: "close", want: "close operator config temp file"},
-		{name: "permissions", filePhase: "chmod", want: "set operator config temp file permissions"},
-		{name: "replacement", filePhase: "rename", want: "replace operator config with temp file"},
+		{name: "sync", tempPhase: "sync", want: "sync operator document temp file"},
+		{name: "close", tempPhase: "close", want: "close operator document temp file"},
+		{name: "permissions", filePhase: "chmod", want: "set operator document temp file permissions"},
+		{name: "replacement", filePhase: "rename", want: "replace operator document with temp file"},
 	}
 	for _, phase := range phases {
 		phase := phase

--- a/pkg/services/operator_settings/document_bridge.go
+++ b/pkg/services/operator_settings/document_bridge.go
@@ -1,0 +1,70 @@
+package operatorsettings
+
+func documentFromConfigDocument(document ConfigDocument) Document {
+	return documentFromConfig(document.FileConfig())
+}
+
+func configDocumentFromDocument(document Document) ConfigDocument {
+	return ConfigDocument{config: configFromDocument(document)}
+}
+
+func documentFromConfig(config Config) Document {
+	document := Document{
+		BackendScopeID: config.BackendScopeID,
+		Defaults: DocumentDefaults{
+			WorkerModelProvider: config.Defaults.WorkerModelProvider,
+			WorkerModel:         config.Defaults.WorkerModel,
+		},
+		Runtime: DocumentRuntimeSettings{
+			Logging: DocumentRuntimeArtifactSettings(config.Runtime.Logging),
+			Metrics: DocumentRuntimeArtifactSettings(config.Runtime.Metrics),
+		},
+	}
+	if config.WorkerPresets != nil {
+		document.WorkerPresets = make([]DocumentWorkerPreset, len(config.WorkerPresets))
+		for i, preset := range config.WorkerPresets {
+			document.WorkerPresets[i] = DocumentWorkerPreset{
+				ID:              preset.ID,
+				ModelProvider:   preset.ModelProvider,
+				Model:           preset.Model,
+				ReasoningEffort: preset.ReasoningEffort,
+			}
+		}
+	}
+	return document
+}
+
+func configFromDocument(document Document) Config {
+	config := Config{
+		BackendScopeID: document.BackendScopeID,
+		Defaults: Defaults{
+			WorkerModelProvider: document.Defaults.WorkerModelProvider,
+			WorkerModel:         document.Defaults.WorkerModel,
+		},
+		Runtime: RuntimeSettings{
+			Logging: RuntimeArtifactSettings(document.Runtime.Logging),
+			Metrics: RuntimeArtifactSettings(document.Runtime.Metrics),
+		},
+	}
+	if document.WorkerPresets != nil {
+		config.WorkerPresets = make([]WorkerPreset, len(document.WorkerPresets))
+		for i, preset := range document.WorkerPresets {
+			config.WorkerPresets[i] = WorkerPreset{
+				ID:              preset.ID,
+				ModelProvider:   preset.ModelProvider,
+				Model:           preset.Model,
+				ReasoningEffort: preset.ReasoningEffort,
+			}
+		}
+	}
+	return config
+}
+
+func documentProviderModelUpdateFromProviderModelUpdate(
+	update ProviderModelUpdate,
+) DocumentProviderModelUpdate {
+	return DocumentProviderModelUpdate{
+		Provider: update.Provider,
+		Model:    update.Model,
+	}
+}

--- a/pkg/services/operator_settings/document_contract.go
+++ b/pkg/services/operator_settings/document_contract.go
@@ -1,6 +1,7 @@
 package operatorsettings
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -235,6 +236,15 @@ type ApplyDocumentUpdateResult struct {
 type PersistDocumentRequest struct {
 	Path     string
 	Document Document
+}
+
+// DocumentOwner is the parent-private document capability consumed by
+// ConfigDocumentService. Wire injects the nested document owner implementation.
+type DocumentOwner interface {
+	LoadDocument(LoadDocumentRequest) (LoadDocumentResult, error)
+	MergeDocumentProviderModel(Document, DocumentProviderModelUpdate) (Document, error)
+	ApplyDocumentUpdate(ApplyDocumentUpdateRequest) (ApplyDocumentUpdateResult, error)
+	PersistDocument(context.Context, PersistDocumentRequest) error
 }
 
 // Validate checks request fields whose validity does not depend on storage state.

--- a/pkg/services/operator_settings/document_contract.go
+++ b/pkg/services/operator_settings/document_contract.go
@@ -229,3 +229,18 @@ type ApplyDocumentUpdateResult struct {
 	Path      string
 	Persisted bool
 }
+
+// PersistDocumentRequest atomically publishes one complete validated operator
+// document at Path.
+type PersistDocumentRequest struct {
+	Path     string
+	Document Document
+}
+
+// Validate checks request fields whose validity does not depend on storage state.
+func (request PersistDocumentRequest) Validate() error {
+	if strings.TrimSpace(request.Path) == "" {
+		return fmt.Errorf("%w: path is required", ErrDocumentMalformed)
+	}
+	return nil
+}

--- a/pkg/services/operator_settings/document_owner_construct.go
+++ b/pkg/services/operator_settings/document_owner_construct.go
@@ -1,0 +1,35 @@
+package operatorsettings
+
+import "fmt"
+
+// DocumentOwnerConstructor builds the parent-private document owner from
+// injected Operator Settings ports.
+type DocumentOwnerConstructor func(
+	FileSystem,
+	CreateTemporaryFile,
+	ConfigDecoder,
+	ConfigEncoder,
+	ProviderCatalog,
+) DocumentOwner
+
+var documentOwnerConstructor DocumentOwnerConstructor
+
+// ConfigureDocumentOwnerConstructor registers the nested document owner
+// constructor used when ConfigDocumentService.DocumentOwner is unset.
+// Wire and servicewire call this during process composition.
+func ConfigureDocumentOwnerConstructor(constructor DocumentOwnerConstructor) {
+	documentOwnerConstructor = constructor
+}
+
+func newDocumentOwnerFromConstructor(service ConfigDocumentService) (DocumentOwner, error) {
+	if documentOwnerConstructor == nil {
+		return nil, fmt.Errorf("operator settings document owner is required")
+	}
+	return documentOwnerConstructor(
+		service.Files,
+		service.CreateTemp,
+		service.Decoder,
+		service.Encoder,
+		service.Providers,
+	), nil
+}

--- a/pkg/services/operator_settings/document_routing_test.go
+++ b/pkg/services/operator_settings/document_routing_test.go
@@ -1,0 +1,97 @@
+package operatorsettings
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestConfigDocumentServiceRoutesLoadUpdatePersistThroughNestedDocumentOwner(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	service := persistedConfigService(testFiles, testCreateTemp)
+
+	loaded, err := service.Load(path)
+	if err != nil {
+		t.Fatalf("Load() = %v", err)
+	}
+	if loaded.BackendScopeID() != "" || loaded.FileConfig().Defaults != (Defaults{}) {
+		t.Fatalf("missing load = %#v, want empty valid document", loaded.FileConfig())
+	}
+
+	provider, model := "codex", "routed-model"
+	updated, err := service.ConfigureProviderModel(context.Background(), path, ProviderModelUpdate{
+		Provider: &provider,
+		Model:    &model,
+	})
+	if err != nil {
+		t.Fatalf("ConfigureProviderModel() = %v", err)
+	}
+	if got := updated.FileConfig().Defaults; got != (Defaults{WorkerModelProvider: "CODEX", WorkerModel: "routed-model"}) {
+		t.Fatalf("updated defaults = %#v", got)
+	}
+
+	reloaded, err := service.Load(path)
+	if err != nil {
+		t.Fatalf("Load() after persist = %v", err)
+	}
+	if reloaded.FileConfig().Defaults != updated.FileConfig().Defaults {
+		t.Fatalf("reloaded defaults = %#v, want %#v", reloaded.FileConfig().Defaults, updated.FileConfig().Defaults)
+	}
+}
+
+func TestConfigDocumentServiceRoutesMalformedConflictAndUnsupportedThroughNestedOwner(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	service := ConfigDocumentService{
+		Files:           testFiles,
+		CreateTemp:      testCreateTemp,
+		Providers:       controlledProviderCatalog,
+		Decoder:         decodeTestConfig,
+		Encoder:         encodeTestConfig,
+		PersistenceLock: &sync.Mutex{},
+	}
+
+	if writeErr := os.WriteFile(filepath.Join(dir, "malformed.json"), []byte(`{"defaults":`), 0o600); writeErr != nil {
+		t.Fatalf("WriteFile() = %v", writeErr)
+	}
+	_, err := service.Load(filepath.Join(dir, "malformed.json"))
+	if !errors.Is(err, ErrDocumentMalformed) {
+		t.Fatalf("Load(malformed) = %v, want ErrDocumentMalformed", err)
+	}
+
+	scope := "local-11111111-1111-4111-8111-111111111111"
+	if writeErr := os.WriteFile(path, []byte(`{"backendScopeID":"`+scope+`","defaults":{"workerModelProvider":"CODEX"}}`), 0o600); writeErr != nil {
+		t.Fatalf("WriteFile() = %v", writeErr)
+	}
+	unsupported := "unsupported-provider"
+	_, err = service.ConfigureProviderModel(context.Background(), path, ProviderModelUpdate{Provider: &unsupported})
+	if !errors.Is(err, ErrDocumentUnsupported) {
+		t.Fatalf("ConfigureProviderModel(unsupported) = %v, want ErrDocumentUnsupported", err)
+	}
+
+	wrongScope := "local-22222222-2222-4222-8222-222222222222"
+	owner, ownerErr := service.resolvedDocumentOwner()
+	if ownerErr != nil {
+		t.Fatalf("resolvedDocumentOwner() = %v", ownerErr)
+	}
+	_, err = owner.ApplyDocumentUpdate(ApplyDocumentUpdateRequest{
+		Path:                 path,
+		ExpectedBackendScope: wrongScope,
+		ProviderModel:        DocumentProviderModelUpdate{Model: strPtr("next")},
+	})
+	if !errors.Is(err, ErrDocumentConflict) {
+		t.Fatalf("ApplyDocumentUpdate(conflict) = %v, want ErrDocumentConflict", err)
+	}
+}
+
+func strPtr(value string) *string {
+	return &value
+}

--- a/pkg/services/operator_settings/encode.go
+++ b/pkg/services/operator_settings/encode.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
-	"path/filepath"
 	"strings"
 	"sync"
 )
@@ -35,7 +33,15 @@ type ConfigDocumentService struct {
 	Providers       ProviderCatalog
 	Decoder         ConfigDecoder
 	Encoder         ConfigEncoder
+	DocumentOwner   DocumentOwner
 	PersistenceLock sync.Locker
+}
+
+func (service ConfigDocumentService) resolvedDocumentOwner() (DocumentOwner, error) {
+	if service.DocumentOwner != nil {
+		return service.DocumentOwner, nil
+	}
+	return newDocumentOwnerFromConstructor(service)
 }
 
 // ErrProviderModelInputCanceled is returned by a prompt when the operator
@@ -54,21 +60,15 @@ func (service ConfigDocumentService) Load(path string) (ConfigDocument, error) {
 }
 
 func (service ConfigDocumentService) load(path string) (ConfigDocument, error) {
-	if service.Files == nil {
-		return ConfigDocument{}, fmt.Errorf("operator config filesystem is required")
-	}
-	data, err := service.Files.ReadFile(path)
+	owner, err := service.resolvedDocumentOwner()
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return emptyConfigDocument(), nil
-		}
-		return ConfigDocument{}, fmt.Errorf("read operator config %s: %w", path, err)
+		return ConfigDocument{}, err
 	}
-	document, err := service.Parse(data)
+	result, err := owner.LoadDocument(LoadDocumentRequest{Path: path})
 	if err != nil {
-		return ConfigDocument{}, fmt.Errorf("parse operator config %s: %w", path, err)
+		return ConfigDocument{}, err
 	}
-	return document, nil
+	return configDocumentFromDocument(result.Document), nil
 }
 
 // Parse validates bytes through the injected canonical global-config codec.
@@ -103,22 +103,18 @@ func (service ConfigDocumentService) MergeProviderModelDefaults(
 	document ConfigDocument,
 	update ProviderModelUpdate,
 ) (ConfigDocument, error) {
-	validatedUpdate, err := service.validateProviderModelUpdate(update)
+	owner, err := service.resolvedDocumentOwner()
 	if err != nil {
 		return ConfigDocument{}, err
 	}
-	config := document.FileConfig()
-	if validatedUpdate.Provider != nil {
-		config.Defaults.WorkerModelProvider = *validatedUpdate.Provider
-	}
-	if validatedUpdate.Model != nil {
-		config.Defaults.WorkerModel = strings.TrimSpace(*validatedUpdate.Model)
-	}
-	config, err = config.Normalize()
+	merged, err := owner.MergeDocumentProviderModel(
+		documentFromConfigDocument(document),
+		documentProviderModelUpdateFromProviderModelUpdate(update),
+	)
 	if err != nil {
 		return ConfigDocument{}, err
 	}
-	return ConfigDocument{config: config}, nil
+	return configDocumentFromDocument(merged), nil
 }
 
 // ConfigureProviderModel applies pre-supplied values through the complete
@@ -137,24 +133,24 @@ func (service ConfigDocumentService) ConfigureProviderModel(
 	service.PersistenceLock.Lock()
 	defer service.PersistenceLock.Unlock()
 
-	document, err := service.load(path)
+	if err := operationContextError(ctx); err != nil {
+		return ConfigDocument{}, err
+	}
+	owner, err := service.resolvedDocumentOwner()
+	if err != nil {
+		return ConfigDocument{}, err
+	}
+	result, err := owner.ApplyDocumentUpdate(ApplyDocumentUpdateRequest{
+		Path:          path,
+		ProviderModel: documentProviderModelUpdateFromProviderModelUpdate(update),
+	})
 	if err != nil {
 		return ConfigDocument{}, err
 	}
 	if err := operationContextError(ctx); err != nil {
 		return ConfigDocument{}, err
 	}
-	candidate, err := service.MergeProviderModelDefaults(document, update)
-	if err != nil {
-		return ConfigDocument{}, err
-	}
-	if err := operationContextError(ctx); err != nil {
-		return ConfigDocument{}, err
-	}
-	if err := service.persistLocked(ctx, path, candidate); err != nil {
-		return ConfigDocument{}, err
-	}
-	return candidate, nil
+	return configDocumentFromDocument(result.Document), nil
 }
 
 // ConfigureProviderModelPrompted acquires values through a write-free prompt,
@@ -201,26 +197,6 @@ func operationContextError(ctx context.Context) error {
 	return nil
 }
 
-func (service ConfigDocumentService) validateProviderModelUpdate(update ProviderModelUpdate) (ProviderModelUpdate, error) {
-	if update.Provider == nil {
-		return update, nil
-	}
-	provider := strings.TrimSpace(*update.Provider)
-	if provider == "" {
-		return ProviderModelUpdate{}, fmt.Errorf("worker model provider is required")
-	}
-	if service.Providers == nil {
-		return ProviderModelUpdate{}, fmt.Errorf("operator provider catalog is required")
-	}
-	canonical, ok := service.Providers(provider)
-	canonical = strings.TrimSpace(canonical)
-	if !ok || canonical == "" {
-		return ProviderModelUpdate{}, fmt.Errorf("unsupported worker model provider %q", provider)
-	}
-	update.Provider = &canonical
-	return update, nil
-}
-
 // Marshal encodes the complete validated document as JSON.
 func (service ConfigDocumentService) Marshal(document ConfigDocument) ([]byte, error) {
 	if service.Encoder == nil {
@@ -251,85 +227,14 @@ func (service ConfigDocumentService) Persist(ctx context.Context, path string, d
 	}
 	service.PersistenceLock.Lock()
 	defer service.PersistenceLock.Unlock()
-	return service.persistLocked(ctx, path, document)
-}
-
-func (service ConfigDocumentService) persistLocked(ctx context.Context, path string, document ConfigDocument) error {
-	if ctx == nil {
-		return fmt.Errorf("operator config context is required")
-	}
-	if service.Files == nil {
-		return fmt.Errorf("operator config filesystem is required")
-	}
-	if service.CreateTemp == nil {
-		return fmt.Errorf("operator config temporary-file creator is required")
-	}
-	path = strings.TrimSpace(path)
-	if path == "" {
-		return fmt.Errorf("operator config path is required")
-	}
-	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("persist operator config: %w", err)
-	}
-	data, err := service.Marshal(document)
+	owner, err := service.resolvedDocumentOwner()
 	if err != nil {
 		return err
 	}
-	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("persist operator config: %w", err)
-	}
-
-	dir := filepath.Dir(path)
-	if err := service.Files.MkdirAll(dir, 0o755); err != nil {
-		return fmt.Errorf("create operator config directory %q: %w", dir, err)
-	}
-	tmp, err := service.CreateTemp(dir, filepath.Base(path)+".*.tmp")
-	if err != nil {
-		return fmt.Errorf("create operator config temp file: %w", err)
-	}
-	return service.commitTemporaryFile(ctx, tmp, path, data)
-}
-
-func (service ConfigDocumentService) commitTemporaryFile(
-	ctx context.Context,
-	tmp TemporaryFile,
-	path string,
-	data []byte,
-) error {
-	tmpPath := tmp.Name()
-	committed := false
-	defer func() {
-		if !committed {
-			_ = service.Files.Remove(tmpPath)
-		}
-	}()
-
-	written, err := tmp.Write(data)
-	if err == nil && written != len(data) {
-		err = io.ErrShortWrite
-	}
-	if err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("write operator config temp file: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("sync operator config temp file: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close operator config temp file: %w", err)
-	}
-	if err := service.Files.Chmod(tmpPath, 0o600); err != nil {
-		return fmt.Errorf("set operator config temp file permissions: %w", err)
-	}
-	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("persist operator config before commit: %w", err)
-	}
-	if err := service.Files.Rename(tmpPath, path); err != nil {
-		return fmt.Errorf("replace operator config with temp file: %w", err)
-	}
-	committed = true
-	return nil
+	return owner.PersistDocument(ctx, PersistDocumentRequest{
+		Path:     path,
+		Document: documentFromConfigDocument(document),
+	})
 }
 
 func emptyConfigDocument() ConfigDocument {

--- a/pkg/services/operator_settings/internal/services/document/internal/service/document_map.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/document_map.go
@@ -1,0 +1,37 @@
+package service
+
+import (
+	"strings"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
+
+func documentFromConfig(config operatorsettings.Config) operatorsettings.Document {
+	document := operatorsettings.Document{
+		BackendScopeID: strings.TrimSpace(config.BackendScopeID),
+		Defaults: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: config.Defaults.WorkerModelProvider,
+			WorkerModel:         config.Defaults.WorkerModel,
+		},
+		Runtime: documentRuntimeFromConfig(config.Runtime),
+	}
+	if config.WorkerPresets != nil {
+		document.WorkerPresets = make([]operatorsettings.DocumentWorkerPreset, len(config.WorkerPresets))
+		for i, preset := range config.WorkerPresets {
+			document.WorkerPresets[i] = operatorsettings.DocumentWorkerPreset{
+				ID:              preset.ID,
+				ModelProvider:   preset.ModelProvider,
+				Model:           preset.Model,
+				ReasoningEffort: preset.ReasoningEffort,
+			}
+		}
+	}
+	return document
+}
+
+func documentRuntimeFromConfig(runtime operatorsettings.RuntimeSettings) operatorsettings.DocumentRuntimeSettings {
+	return operatorsettings.DocumentRuntimeSettings{
+		Logging: operatorsettings.DocumentRuntimeArtifactSettings(runtime.Logging),
+		Metrics: operatorsettings.DocumentRuntimeArtifactSettings(runtime.Metrics),
+	}
+}

--- a/pkg/services/operator_settings/internal/services/document/internal/service/document_map.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/document_map.go
@@ -35,3 +35,29 @@ func documentRuntimeFromConfig(runtime operatorsettings.RuntimeSettings) operato
 		Metrics: operatorsettings.DocumentRuntimeArtifactSettings(runtime.Metrics),
 	}
 }
+
+func configFromDocument(document operatorsettings.Document) operatorsettings.Config {
+	config := operatorsettings.Config{
+		BackendScopeID: document.BackendScopeID,
+		Defaults: operatorsettings.Defaults{
+			WorkerModelProvider: document.Defaults.WorkerModelProvider,
+			WorkerModel:         document.Defaults.WorkerModel,
+		},
+		Runtime: operatorsettings.RuntimeSettings{
+			Logging: operatorsettings.RuntimeArtifactSettings(document.Runtime.Logging),
+			Metrics: operatorsettings.RuntimeArtifactSettings(document.Runtime.Metrics),
+		},
+	}
+	if document.WorkerPresets != nil {
+		config.WorkerPresets = make([]operatorsettings.WorkerPreset, len(document.WorkerPresets))
+		for i, preset := range document.WorkerPresets {
+			config.WorkerPresets[i] = operatorsettings.WorkerPreset{
+				ID:              preset.ID,
+				ModelProvider:   preset.ModelProvider,
+				Model:           preset.Model,
+				ReasoningEffort: preset.ReasoningEffort,
+			}
+		}
+	}
+	return config
+}

--- a/pkg/services/operator_settings/internal/services/document/internal/service/load.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/load.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"strings"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
+
+func (service *Service) loadDocument(
+	request operatorsettings.LoadDocumentRequest,
+) (operatorsettings.LoadDocumentResult, error) {
+	if service.files == nil {
+		return operatorsettings.LoadDocumentResult{}, fmt.Errorf("operator document filesystem is required")
+	}
+	if service.decoder == nil {
+		return operatorsettings.LoadDocumentResult{}, fmt.Errorf("operator document decoder is required")
+	}
+
+	path := strings.TrimSpace(request.Path)
+	data, err := service.files.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			if request.RequireExisting {
+				return operatorsettings.LoadDocumentResult{}, operatorsettings.DocumentFailure{
+					Kind: operatorsettings.DocumentFailureKindNotFound,
+					Path: path,
+				}
+			}
+			return operatorsettings.LoadDocumentResult{
+				Document: operatorsettings.EmptyDocument(),
+				Path:     path,
+				Found:    false,
+			}, nil
+		}
+		return operatorsettings.LoadDocumentResult{}, operatorsettings.DocumentFailure{
+			Kind:    operatorsettings.DocumentFailureKindMalformed,
+			Message: fmt.Sprintf("read operator document: %v", err),
+			Path:    path,
+		}
+	}
+
+	config, err := service.decoder(data)
+	if err != nil {
+		return operatorsettings.LoadDocumentResult{}, operatorsettings.DocumentFailure{
+			Kind:    operatorsettings.DocumentFailureKindMalformed,
+			Message: err.Error(),
+			Path:    path,
+		}
+	}
+	return operatorsettings.LoadDocumentResult{
+		Document: documentFromConfig(config),
+		Path:     path,
+		Found:    true,
+	}, nil
+}

--- a/pkg/services/operator_settings/internal/services/document/internal/service/load_test.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/load_test.go
@@ -1,0 +1,216 @@
+package service_test
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/internal/service"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+)
+
+const fixturesRelativeDir = "pkg/services/operator_settings/testdata/fixtures"
+
+func TestLoadDocument_MissingDestinationReturnsEmptyValidDocument(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "missing-config.json")
+	service := newDocumentLoadService(t, map[string][]byte{})
+
+	loaded, err := service.LoadDocument(operatorsettings.LoadDocumentRequest{Path: path})
+	if err != nil {
+		t.Fatalf("LoadDocument() = %v", err)
+	}
+	if loaded.Found {
+		t.Fatalf("Found = true, want false for missing destination")
+	}
+	if loaded.Path != path {
+		t.Fatalf("Path = %q, want %q", loaded.Path, path)
+	}
+	want := operatorsettings.EmptyDocument()
+	if !reflect.DeepEqual(loaded.Document, want) {
+		t.Fatalf("Document = %#v, want empty valid document %#v", loaded.Document, want)
+	}
+}
+
+func TestLoadDocument_RequireExistingMissingFailsWithNotFound(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "missing-config.json")
+	service := newDocumentLoadService(t, map[string][]byte{})
+
+	_, err := service.LoadDocument(operatorsettings.LoadDocumentRequest{
+		Path:            path,
+		RequireExisting: true,
+	})
+	if !errors.Is(err, operatorsettings.ErrDocumentNotFound) {
+		t.Fatalf("LoadDocument() = %v, want ErrDocumentNotFound", err)
+	}
+}
+
+func TestLoadDocument_MalformedBytesFailClosedWithoutPartialDocument(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		data string
+	}{
+		{name: "malformed-json", data: `{"defaults":`},
+		{name: "trailing-json", data: `{} {}`},
+		{name: "unknown-top-level", data: `{"unexpected":true}`},
+		{name: "null-document", data: `null`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "config.json")
+			service := newDocumentLoadService(t, map[string][]byte{
+				path: []byte(test.data),
+			})
+
+			loaded, err := service.LoadDocument(operatorsettings.LoadDocumentRequest{Path: path})
+			if !errors.Is(err, operatorsettings.ErrDocumentMalformed) {
+				t.Fatalf("LoadDocument() = %v, want ErrDocumentMalformed", err)
+			}
+			if loaded.Found || loaded.Path != "" || !reflect.DeepEqual(loaded.Document, operatorsettings.Document{}) {
+				t.Fatalf("LoadDocument() = %#v, want zero result on malformed load", loaded)
+			}
+		})
+	}
+}
+
+func TestLoadDocument_ValidOnDiskDocumentReturnsCompleteValidatedDocument(t *testing.T) {
+	t.Parallel()
+
+	path := writeFixtureToTemp(t, "valid/load-defaults.json")
+	service := newDocumentLoadService(t, map[string][]byte{
+		path: readFixture(t, "valid/load-defaults.json"),
+	})
+
+	loaded, err := service.LoadDocument(operatorsettings.LoadDocumentRequest{Path: path})
+	if err != nil {
+		t.Fatalf("LoadDocument() = %v", err)
+	}
+	if !loaded.Found {
+		t.Fatal("Found = false, want true for existing valid document")
+	}
+	if loaded.Path != path {
+		t.Fatalf("Path = %q, want %q", loaded.Path, path)
+	}
+	if loaded.Document.Defaults != (operatorsettings.DocumentDefaults{
+		WorkerModelProvider: "claude",
+		WorkerModel:         "claude-sonnet",
+	}) {
+		t.Fatalf("Defaults = %#v, want validated load-defaults values", loaded.Document.Defaults)
+	}
+	if loaded.Document.Runtime != operatorsettings.EmptyDocument().Runtime {
+		t.Fatalf("Runtime = %#v, want production defaults", loaded.Document.Runtime)
+	}
+}
+
+func TestLoadDocument_ValidDocumentIncludesBackendScopeAndPresets(t *testing.T) {
+	t.Parallel()
+
+	path := writeFixtureToTemp(t, "valid/backend-scope-sibling.json")
+	service := newDocumentLoadService(t, map[string][]byte{
+		path: readFixture(t, "valid/backend-scope-sibling.json"),
+	})
+
+	loaded, err := service.LoadDocument(operatorsettings.LoadDocumentRequest{Path: path})
+	if err != nil {
+		t.Fatalf("LoadDocument() = %v", err)
+	}
+	if loaded.Document.BackendScopeID != "local-11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("BackendScopeID = %q, want persisted scope id", loaded.Document.BackendScopeID)
+	}
+}
+
+func newDocumentLoadService(t *testing.T, files map[string][]byte) *internalservice.Service {
+	t.Helper()
+
+	return internalservice.New(
+		&mapFileSystem{files: files},
+		func(string, string) (operatorsettings.TemporaryFile, error) {
+			t.Fatal("temp-file creation is unexpected during load")
+			return nil, errors.New("unexpected temp-file creation")
+		},
+		globalconfigmapping.Decode,
+		globalconfigmapping.Encode,
+		func(string) (string, bool) {
+			t.Fatal("provider catalog is unexpected during load")
+			return "", false
+		},
+	)
+}
+
+type mapFileSystem struct {
+	files map[string][]byte
+}
+
+func (filesystem *mapFileSystem) ReadFile(path string) ([]byte, error) {
+	data, ok := filesystem.files[path]
+	if !ok {
+		return nil, fs.ErrNotExist
+	}
+	return data, nil
+}
+
+func (filesystem *mapFileSystem) MkdirAll(string, fs.FileMode) error {
+	panic("unexpected mkdir during load")
+}
+
+func (filesystem *mapFileSystem) Remove(string) error {
+	panic("unexpected remove during load")
+}
+
+func (filesystem *mapFileSystem) Chmod(string, fs.FileMode) error {
+	panic("unexpected chmod during load")
+}
+
+func (filesystem *mapFileSystem) Rename(string, string) error {
+	panic("unexpected rename during load")
+}
+
+func readFixture(t *testing.T, relativePath string) []byte {
+	t.Helper()
+
+	path := testutil.MustRepoPath(t, filepath.ToSlash(filepath.Join(fixturesRelativeDir, relativePath)))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) = %v", path, err)
+	}
+	return data
+}
+
+func writeFixtureToTemp(t *testing.T, relativePath string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), filepath.Base(relativePath))
+	if err := os.WriteFile(path, readFixture(t, relativePath), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) = %v", path, err)
+	}
+	return path
+}
+
+func TestLoadDocument_MalformedFixtureFromInventoryFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	path := writeFixtureToTemp(t, "invalid/load-malformed.json")
+	service := newDocumentLoadService(t, map[string][]byte{
+		path: readFixture(t, "invalid/load-malformed.json"),
+	})
+
+	_, err := service.LoadDocument(operatorsettings.LoadDocumentRequest{Path: path})
+	if !errors.Is(err, operatorsettings.ErrDocumentMalformed) {
+		t.Fatalf("LoadDocument() = %v, want ErrDocumentMalformed", err)
+	}
+	if failure, ok := err.(operatorsettings.DocumentFailure); !ok || !strings.Contains(failure.Path, filepath.Base(path)) {
+		t.Fatalf("LoadDocument() = %v, want malformed failure naming path", err)
+	}
+}

--- a/pkg/services/operator_settings/internal/services/document/internal/service/load_test.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/load_test.go
@@ -198,6 +198,16 @@ func writeFixtureToTemp(t *testing.T, relativePath string) string {
 	return path
 }
 
+func readFixtureFromPath(t *testing.T, path string) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) = %v", path, err)
+	}
+	return data
+}
+
 func TestLoadDocument_MalformedFixtureFromInventoryFailsClosed(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/operator_settings/internal/services/document/internal/service/persist.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/persist.go
@@ -1,0 +1,105 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
+
+func (service *Service) persistDocument(
+	ctx context.Context,
+	request operatorsettings.PersistDocumentRequest,
+) error {
+	if ctx == nil {
+		return fmt.Errorf("operator document context is required")
+	}
+	if service.files == nil {
+		return fmt.Errorf("operator document filesystem is required")
+	}
+	if service.createTemp == nil {
+		return fmt.Errorf("operator document temporary-file creator is required")
+	}
+
+	path := strings.TrimSpace(request.Path)
+	if path == "" {
+		return fmt.Errorf("operator document path is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("persist operator document: %w", err)
+	}
+
+	data, err := service.marshalDocument(request.Document)
+	if err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("persist operator document: %w", err)
+	}
+
+	dir := filepath.Dir(path)
+	if err := service.files.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create operator document directory %q: %w", dir, err)
+	}
+	tmp, err := service.createTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create operator document temp file: %w", err)
+	}
+	return service.commitTemporaryFile(ctx, tmp, path, data)
+}
+
+func (service *Service) marshalDocument(document operatorsettings.Document) ([]byte, error) {
+	if service.encoder == nil {
+		return nil, fmt.Errorf("operator document encoder is required")
+	}
+	config, err := configFromDocument(document).Normalize()
+	if err != nil {
+		return nil, err
+	}
+	return service.encoder(config)
+}
+
+func (service *Service) commitTemporaryFile(
+	ctx context.Context,
+	tmp operatorsettings.TemporaryFile,
+	path string,
+	data []byte,
+) error {
+	tmpPath := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = service.files.Remove(tmpPath)
+		}
+	}()
+
+	written, err := tmp.Write(data)
+	if err == nil && written != len(data) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write operator document temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync operator document temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close operator document temp file: %w", err)
+	}
+	if err := service.files.Chmod(tmpPath, 0o600); err != nil {
+		return fmt.Errorf("set operator document temp file permissions: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("persist operator document before commit: %w", err)
+	}
+	if err := service.files.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replace operator document with temp file: %w", err)
+	}
+	committed = true
+	return nil
+}

--- a/pkg/services/operator_settings/internal/services/document/internal/service/persist_test.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/persist_test.go
@@ -1,0 +1,416 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/internal/service"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+)
+
+func TestPersistDocument_AtomicallyPublishesCompleteDocument(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "config.json")
+	service := newDocumentPersistService(t, testLocalFilesystem, testCreateTemp)
+
+	loaded, err := service.LoadDocument(operatorsettings.LoadDocumentRequest{Path: path})
+	if err != nil {
+		t.Fatalf("LoadDocument() = %v", err)
+	}
+	document := loaded.Document
+	document.Defaults.WorkerModel = "provider/model@next"
+	document.Defaults.WorkerModelProvider = "claude"
+	document.WorkerPresets = nil
+
+	if err := service.PersistDocument(context.Background(), operatorsettings.PersistDocumentRequest{
+		Path:     path,
+		Document: document,
+	}); err != nil {
+		t.Fatalf("PersistDocument() = %v", err)
+	}
+
+	reloaded, err := service.LoadDocument(operatorsettings.LoadDocumentRequest{Path: path})
+	if err != nil {
+		t.Fatalf("LoadDocument() after persist = %v", err)
+	}
+	if reloaded.Document.Defaults != document.Defaults ||
+		reloaded.Document.BackendScopeID != document.BackendScopeID ||
+		reloaded.Document.Runtime != document.Runtime ||
+		len(reloaded.Document.WorkerPresets) != len(document.WorkerPresets) {
+		t.Fatalf("reloaded document = %#v, want %#v", reloaded.Document, document)
+	}
+	if runtime.GOOS != "windows" {
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			t.Fatalf("Stat() = %v", statErr)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Fatalf("destination mode = %v, want 0600", info.Mode().Perm())
+		}
+	}
+}
+
+func TestPersistDocument_PreCommitFailuresPreserveDestination(t *testing.T) {
+	t.Parallel()
+
+	phases := []struct {
+		name       string
+		filePhase  string
+		tempPhase  string
+		shortWrite bool
+		want       string
+	}{
+		{name: "directory", filePhase: "mkdir", want: "create operator document directory"},
+		{name: "temporary file", tempPhase: "create", want: "create operator document temp file"},
+		{name: "write", tempPhase: "write", want: "write operator document temp file"},
+		{name: "short write", shortWrite: true, want: "short write"},
+		{name: "sync", tempPhase: "sync", want: "sync operator document temp file"},
+		{name: "close", tempPhase: "close", want: "close operator document temp file"},
+		{name: "permissions", filePhase: "chmod", want: "set operator document temp file permissions"},
+		{name: "replacement", filePhase: "rename", want: "replace operator document with temp file"},
+	}
+	for _, phase := range phases {
+		phase := phase
+		t.Run(phase.name, func(t *testing.T) {
+			t.Parallel()
+			path, original, document := persistedDocumentFixture(t)
+			files := &faultFileSystem{FileSystem: testLocalFilesystem, failPhase: phase.filePhase}
+			create := faultTemporaryFileCreator(phase.tempPhase, phase.shortWrite)
+			service := newDocumentPersistService(t, files, create)
+			err := service.PersistDocument(context.Background(), operatorsettings.PersistDocumentRequest{
+				Path:     path,
+				Document: document,
+			})
+			if err == nil || !strings.Contains(err.Error(), phase.want) {
+				t.Fatalf("PersistDocument() = %v, want %q", err, phase.want)
+			}
+			assertDocumentBytesUnchanged(t, path, original)
+			assertNoTemporaryArtifacts(t, filepath.Dir(path))
+		})
+	}
+}
+
+func TestPersistDocument_DeniedDirectoryPermissionsPreserveDestination(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not enforce Unix directory permission bits")
+	}
+	path, original, document := persistedDocumentFixture(t)
+	dir := filepath.Dir(path)
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Skipf("cannot establish restrictive directory permissions: %v", err)
+	}
+	defer func() {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			t.Errorf("restore directory permissions: %v", err)
+		}
+	}()
+
+	probe, probeErr := os.CreateTemp(dir, "permission-probe-*.tmp")
+	if probeErr == nil {
+		probePath := probe.Name()
+		_ = probe.Close()
+		_ = os.Remove(probePath)
+		t.Skip("environment does not enforce denied writes for the restrictive directory")
+	}
+	if !errors.Is(probeErr, fs.ErrPermission) {
+		t.Skipf("cannot establish permission-denied behavior: %v", probeErr)
+	}
+
+	service := newDocumentPersistService(t, testLocalFilesystem, testCreateTemp)
+	err := service.PersistDocument(context.Background(), operatorsettings.PersistDocumentRequest{
+		Path:     path,
+		Document: document,
+	})
+	if err == nil || !errors.Is(err, fs.ErrPermission) {
+		t.Fatalf("PersistDocument() = %v, want permission denied", err)
+	}
+	assertDocumentSemanticallyUnchanged(t, service, path, original)
+	assertNoTemporaryArtifacts(t, dir)
+}
+
+func TestPersistDocument_RejectsBeforeFilesystemSideEffects(t *testing.T) {
+	t.Parallel()
+
+	files := &faultFileSystem{FileSystem: testLocalFilesystem}
+	service := newDocumentPersistService(t, files, testCreateTemp)
+	invalid := operatorsettings.Document{
+		WorkerPresets: []operatorsettings.DocumentWorkerPreset{{
+			ID:            "invalid",
+			ModelProvider: "DEFAULT",
+		}},
+	}
+	if err := service.PersistDocument(context.Background(), operatorsettings.PersistDocumentRequest{
+		Path:     "config.json",
+		Document: invalid,
+	}); err == nil {
+		t.Fatal("PersistDocument() = nil, want invalid candidate")
+	}
+	if files.calls != 0 {
+		t.Fatalf("filesystem calls = %d, want zero", files.calls)
+	}
+
+	document := operatorsettings.EmptyDocument()
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := service.PersistDocument(cancelled, operatorsettings.PersistDocumentRequest{
+		Path:     "config.json",
+		Document: document,
+	}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("PersistDocument(cancelled) = %v, want context canceled", err)
+	}
+	if files.calls != 0 {
+		t.Fatalf("filesystem calls after cancellation = %d, want zero", files.calls)
+	}
+}
+
+func TestPersistDocument_CancellationAtCommitBoundaryPreservesDestination(t *testing.T) {
+	t.Parallel()
+
+	path, original, document := persistedDocumentFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	files := &faultFileSystem{FileSystem: testLocalFilesystem, cancelOnChmod: cancel}
+	service := newDocumentPersistService(t, files, testCreateTemp)
+	if err := service.PersistDocument(ctx, operatorsettings.PersistDocumentRequest{
+		Path:     path,
+		Document: document,
+	}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("PersistDocument() = %v, want context canceled", err)
+	}
+	assertDocumentBytesUnchanged(t, path, original)
+	assertNoTemporaryArtifacts(t, filepath.Dir(path))
+}
+
+func TestPersistDocument_CancellationDuringSuccessfulCommitReportsSuccess(t *testing.T) {
+	t.Parallel()
+
+	path, original, document := persistedDocumentFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	files := &faultFileSystem{FileSystem: testLocalFilesystem, cancelOnRename: cancel}
+	service := newDocumentPersistService(t, files, testCreateTemp)
+	if err := service.PersistDocument(ctx, operatorsettings.PersistDocumentRequest{
+		Path:     path,
+		Document: document,
+	}); err != nil {
+		t.Fatalf("PersistDocument() = %v, want committed success", err)
+	}
+	if ctx.Err() != context.Canceled {
+		t.Fatalf("context error = %v, want cancellation observed during replacement", ctx.Err())
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() = %v", err)
+	}
+	if string(got) == string(original) {
+		t.Fatal("destination retained original bytes after successful commit")
+	}
+	if _, err := globalconfigmapping.Decode(got); err != nil {
+		t.Fatalf("committed document is invalid: %v", err)
+	}
+}
+
+func newDocumentPersistService(
+	t *testing.T,
+	files operatorsettings.FileSystem,
+	create operatorsettings.CreateTemporaryFile,
+) *internalservice.Service {
+	t.Helper()
+
+	return internalservice.New(
+		files,
+		create,
+		globalconfigmapping.Decode,
+		globalconfigmapping.Encode,
+		controlledProviderCatalog,
+	)
+}
+
+var testLocalFilesystem platformfilesystem.Local
+
+func testCreateTemp(dir, pattern string) (operatorsettings.TemporaryFile, error) {
+	return os.CreateTemp(dir, pattern)
+}
+
+type faultFileSystem struct {
+	operatorsettings.FileSystem
+	failPhase      string
+	cancelOnChmod  context.CancelFunc
+	cancelOnRename context.CancelFunc
+	calls          int
+}
+
+func (files *faultFileSystem) fail(phase string) error {
+	files.calls++
+	if files.failPhase == phase {
+		return errors.New("injected " + phase + " failure")
+	}
+	return nil
+}
+
+func (files *faultFileSystem) MkdirAll(path string, mode fs.FileMode) error {
+	if err := files.fail("mkdir"); err != nil {
+		return err
+	}
+	return files.FileSystem.MkdirAll(path, mode)
+}
+
+func (files *faultFileSystem) Remove(path string) error {
+	files.calls++
+	return files.FileSystem.Remove(path)
+}
+
+func (files *faultFileSystem) Chmod(path string, mode fs.FileMode) error {
+	if err := files.fail("chmod"); err != nil {
+		return err
+	}
+	if files.cancelOnChmod != nil {
+		files.cancelOnChmod()
+	}
+	return files.FileSystem.Chmod(path, mode)
+}
+
+func (files *faultFileSystem) Rename(oldPath, newPath string) error {
+	if err := files.fail("rename"); err != nil {
+		return err
+	}
+	if files.cancelOnRename != nil {
+		files.cancelOnRename()
+	}
+	return files.FileSystem.Rename(oldPath, newPath)
+}
+
+type faultTemporaryFile struct {
+	operatorsettings.TemporaryFile
+	failPhase  string
+	shortWrite bool
+}
+
+func (file *faultTemporaryFile) Write(data []byte) (int, error) {
+	if file.failPhase == "write" {
+		return 0, errors.New("injected write failure")
+	}
+	if file.shortWrite {
+		return len(data) / 2, nil
+	}
+	return file.TemporaryFile.Write(data)
+}
+
+func (file *faultTemporaryFile) Sync() error {
+	if file.failPhase == "sync" {
+		return errors.New("injected sync failure")
+	}
+	return file.TemporaryFile.Sync()
+}
+
+func (file *faultTemporaryFile) Close() error {
+	if file.failPhase == "close" {
+		_ = file.TemporaryFile.Close()
+		return errors.New("injected close failure")
+	}
+	return file.TemporaryFile.Close()
+}
+
+func faultTemporaryFileCreator(failPhase string, shortWrite bool) operatorsettings.CreateTemporaryFile {
+	return func(dir, pattern string) (operatorsettings.TemporaryFile, error) {
+		if failPhase == "create" {
+			return nil, errors.New("injected create failure")
+		}
+		file, err := os.CreateTemp(dir, pattern)
+		if err != nil {
+			return nil, err
+		}
+		return &faultTemporaryFile{TemporaryFile: file, failPhase: failPhase, shortWrite: shortWrite}, nil
+	}
+}
+
+func persistedDocumentFixture(t *testing.T) (string, []byte, operatorsettings.Document) {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	original := readFixture(t, "valid/load-defaults.json")
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatalf("WriteFile() = %v", err)
+	}
+	service := newDocumentPersistService(t, testLocalFilesystem, testCreateTemp)
+	loaded, err := service.LoadDocument(operatorsettings.LoadDocumentRequest{Path: path})
+	if err != nil {
+		t.Fatalf("LoadDocument() = %v", err)
+	}
+	document := loaded.Document
+	document.Defaults.WorkerModel = "replacement-model"
+	return path, original, document
+}
+
+func assertDocumentBytesUnchanged(t *testing.T, path string, want []byte) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() = %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("destination changed: got %q want %q", got, want)
+	}
+}
+
+func assertDocumentSemanticallyUnchanged(
+	t *testing.T,
+	service *internalservice.Service,
+	path string,
+	want []byte,
+) {
+	t.Helper()
+	wantConfig, err := globalconfigmapping.Decode(want)
+	if err != nil {
+		t.Fatalf("Decode(original) = %v", err)
+	}
+	wantDocument := documentFromConfigForTest(wantConfig)
+	got, err := service.LoadDocument(operatorsettings.LoadDocumentRequest{Path: path})
+	if err != nil {
+		t.Fatalf("LoadDocument(destination) = %v", err)
+	}
+	if !reflect.DeepEqual(got.Document, wantDocument) {
+		t.Fatalf("destination changed semantically: got %#v want %#v", got.Document, wantDocument)
+	}
+}
+
+func assertNoTemporaryArtifacts(t *testing.T, dir string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "config.json.*.tmp"))
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("temporary artifacts = %v, error = %v", matches, err)
+	}
+}
+
+func documentFromConfigForTest(config operatorsettings.Config) operatorsettings.Document {
+	document := operatorsettings.Document{
+		BackendScopeID: strings.TrimSpace(config.BackendScopeID),
+		Defaults: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: config.Defaults.WorkerModelProvider,
+			WorkerModel:         config.Defaults.WorkerModel,
+		},
+		Runtime: operatorsettings.EmptyDocument().Runtime,
+	}
+	if config.WorkerPresets != nil {
+		document.WorkerPresets = make([]operatorsettings.DocumentWorkerPreset, len(config.WorkerPresets))
+		for i, preset := range config.WorkerPresets {
+			document.WorkerPresets[i] = operatorsettings.DocumentWorkerPreset{
+				ID:              preset.ID,
+				ModelProvider:   preset.ModelProvider,
+				Model:           preset.Model,
+				ReasoningEffort: preset.ReasoningEffort,
+			}
+		}
+	}
+	return document
+}

--- a/pkg/services/operator_settings/internal/services/document/internal/service/service.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/service.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"errors"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	settingsdocument "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document"
+)
+
+var errDocumentOwnerUnavailable = errors.New("operator settings document owner is unavailable")
+
+// Service keeps document load/update/persist behavior behind the
+// Operator Settings-owned document capability.
+type Service struct {
+	files      operatorsettings.FileSystem
+	createTemp operatorsettings.CreateTemporaryFile
+	decoder    operatorsettings.ConfigDecoder
+	encoder    operatorsettings.ConfigEncoder
+	providers  operatorsettings.ProviderCatalog
+}
+
+var _ settingsdocument.Service = (*Service)(nil)
+
+// New constructs the private document owner from injected filesystem, codec, and
+// provider-catalog ports. Construction performs no filesystem, temp-file, or
+// codec work.
+func New(
+	files operatorsettings.FileSystem,
+	createTemp operatorsettings.CreateTemporaryFile,
+	decoder operatorsettings.ConfigDecoder,
+	encoder operatorsettings.ConfigEncoder,
+	providers operatorsettings.ProviderCatalog,
+) *Service {
+	return &Service{
+		files:      files,
+		createTemp: createTemp,
+		decoder:    decoder,
+		encoder:    encoder,
+		providers:  providers,
+	}
+}
+
+func (service *Service) LoadDocument(
+	request operatorsettings.LoadDocumentRequest,
+) (operatorsettings.LoadDocumentResult, error) {
+	if service == nil {
+		return operatorsettings.LoadDocumentResult{}, errDocumentOwnerUnavailable
+	}
+	if err := request.Validate(); err != nil {
+		return operatorsettings.LoadDocumentResult{}, err
+	}
+	return operatorsettings.LoadDocumentResult{}, errDocumentOwnerUnavailable
+}
+
+func (service *Service) ApplyDocumentUpdate(
+	request operatorsettings.ApplyDocumentUpdateRequest,
+) (operatorsettings.ApplyDocumentUpdateResult, error) {
+	if service == nil {
+		return operatorsettings.ApplyDocumentUpdateResult{}, errDocumentOwnerUnavailable
+	}
+	if err := request.Validate(); err != nil {
+		return operatorsettings.ApplyDocumentUpdateResult{}, err
+	}
+	return operatorsettings.ApplyDocumentUpdateResult{}, errDocumentOwnerUnavailable
+}

--- a/pkg/services/operator_settings/internal/services/document/internal/service/service.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/service.go
@@ -53,6 +53,16 @@ func (service *Service) LoadDocument(
 	return service.loadDocument(request)
 }
 
+func (service *Service) MergeDocumentProviderModel(
+	document operatorsettings.Document,
+	update operatorsettings.DocumentProviderModelUpdate,
+) (operatorsettings.Document, error) {
+	if service == nil {
+		return operatorsettings.Document{}, errDocumentOwnerUnavailable
+	}
+	return service.mergeProviderModelUpdate(document, update)
+}
+
 func (service *Service) ApplyDocumentUpdate(
 	request operatorsettings.ApplyDocumentUpdateRequest,
 ) (operatorsettings.ApplyDocumentUpdateResult, error) {

--- a/pkg/services/operator_settings/internal/services/document/internal/service/service.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/service.go
@@ -61,5 +61,5 @@ func (service *Service) ApplyDocumentUpdate(
 	if err := request.Validate(); err != nil {
 		return operatorsettings.ApplyDocumentUpdateResult{}, err
 	}
-	return operatorsettings.ApplyDocumentUpdateResult{}, errDocumentOwnerUnavailable
+	return service.applyDocumentUpdate(request)
 }

--- a/pkg/services/operator_settings/internal/services/document/internal/service/service.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/service.go
@@ -49,7 +49,7 @@ func (service *Service) LoadDocument(
 	if err := request.Validate(); err != nil {
 		return operatorsettings.LoadDocumentResult{}, err
 	}
-	return operatorsettings.LoadDocumentResult{}, errDocumentOwnerUnavailable
+	return service.loadDocument(request)
 }
 
 func (service *Service) ApplyDocumentUpdate(

--- a/pkg/services/operator_settings/internal/services/document/internal/service/service.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
@@ -62,4 +63,17 @@ func (service *Service) ApplyDocumentUpdate(
 		return operatorsettings.ApplyDocumentUpdateResult{}, err
 	}
 	return service.applyDocumentUpdate(request)
+}
+
+func (service *Service) PersistDocument(
+	ctx context.Context,
+	request operatorsettings.PersistDocumentRequest,
+) error {
+	if service == nil {
+		return errDocumentOwnerUnavailable
+	}
+	if err := request.Validate(); err != nil {
+		return err
+	}
+	return service.persistDocument(ctx, request)
 }

--- a/pkg/services/operator_settings/internal/services/document/internal/service/update.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/update.go
@@ -1,0 +1,98 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
+
+func (service *Service) applyDocumentUpdate(
+	request operatorsettings.ApplyDocumentUpdateRequest,
+) (operatorsettings.ApplyDocumentUpdateResult, error) {
+	loaded, err := service.loadDocument(operatorsettings.LoadDocumentRequest{Path: request.Path})
+	if err != nil {
+		return operatorsettings.ApplyDocumentUpdateResult{}, err
+	}
+
+	path := loaded.Path
+	document := loaded.Document
+
+	expected := strings.TrimSpace(request.ExpectedBackendScope)
+	if expected != "" && document.BackendScopeID != expected {
+		return operatorsettings.ApplyDocumentUpdateResult{}, operatorsettings.DocumentFailure{
+			Kind:    operatorsettings.DocumentFailureKindConflict,
+			Message: "backend scope mismatch",
+			Path:    path,
+		}
+	}
+
+	updated, err := service.mergeProviderModelUpdate(document, request.ProviderModel)
+	if err != nil {
+		return operatorsettings.ApplyDocumentUpdateResult{}, err
+	}
+
+	return operatorsettings.ApplyDocumentUpdateResult{
+		Document:  updated,
+		Path:      path,
+		Persisted: false,
+	}, nil
+}
+
+func (service *Service) mergeProviderModelUpdate(
+	document operatorsettings.Document,
+	update operatorsettings.DocumentProviderModelUpdate,
+) (operatorsettings.Document, error) {
+	validated, err := service.validateProviderModelUpdate(update)
+	if err != nil {
+		return operatorsettings.Document{}, err
+	}
+
+	config := configFromDocument(document)
+	if validated.Provider != nil {
+		config.Defaults.WorkerModelProvider = *validated.Provider
+	}
+	if validated.Model != nil {
+		config.Defaults.WorkerModel = strings.TrimSpace(*validated.Model)
+	}
+
+	normalized, err := config.Normalize()
+	if err != nil {
+		return operatorsettings.Document{}, operatorsettings.DocumentFailure{
+			Kind:    operatorsettings.DocumentFailureKindMalformed,
+			Message: err.Error(),
+		}
+	}
+	return documentFromConfig(normalized), nil
+}
+
+func (service *Service) validateProviderModelUpdate(
+	update operatorsettings.DocumentProviderModelUpdate,
+) (operatorsettings.DocumentProviderModelUpdate, error) {
+	if update.Provider == nil {
+		return update, nil
+	}
+	provider := strings.TrimSpace(*update.Provider)
+	if provider == "" {
+		return operatorsettings.DocumentProviderModelUpdate{}, operatorsettings.DocumentFailure{
+			Kind:    operatorsettings.DocumentFailureKindMalformed,
+			Message: "worker model provider is required",
+		}
+	}
+	if service.providers == nil {
+		return operatorsettings.DocumentProviderModelUpdate{}, operatorsettings.DocumentFailure{
+			Kind:    operatorsettings.DocumentFailureKindMalformed,
+			Message: "operator provider catalog is required",
+		}
+	}
+	canonical, ok := service.providers(provider)
+	canonical = strings.TrimSpace(canonical)
+	if !ok || canonical == "" {
+		return operatorsettings.DocumentProviderModelUpdate{}, operatorsettings.DocumentFailure{
+			Kind:    operatorsettings.DocumentFailureKindUnsupported,
+			Message: fmt.Sprintf("unsupported worker model provider %q", provider),
+		}
+	}
+	update.Provider = &canonical
+	return update, nil
+}

--- a/pkg/services/operator_settings/internal/services/document/internal/service/update.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/update.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -32,10 +33,17 @@ func (service *Service) applyDocumentUpdate(
 		return operatorsettings.ApplyDocumentUpdateResult{}, err
 	}
 
+	if err := service.persistDocument(context.Background(), operatorsettings.PersistDocumentRequest{
+		Path:     path,
+		Document: updated,
+	}); err != nil {
+		return operatorsettings.ApplyDocumentUpdateResult{}, err
+	}
+
 	return operatorsettings.ApplyDocumentUpdateResult{
 		Document:  updated,
 		Path:      path,
-		Persisted: false,
+		Persisted: true,
 	}, nil
 }
 

--- a/pkg/services/operator_settings/internal/services/document/internal/service/update_test.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/update_test.go
@@ -8,16 +8,13 @@ import (
 
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/internal/service"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
 )
 
 func TestApplyDocumentUpdate_ModelOnlyUpdatePreservesProviderAndReturnsValidatedDocument(t *testing.T) {
 	t.Parallel()
 
 	path := writeFixtureToTemp(t, "valid/load-defaults.json")
-	initialBytes := readFixture(t, "valid/load-defaults.json")
-	files := map[string][]byte{path: initialBytes}
-	service := newDocumentUpdateService(t, files)
+	service := newDocumentUpdateService(t)
 
 	nextModel := "claude-opus"
 	updated, err := service.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
@@ -29,8 +26,8 @@ func TestApplyDocumentUpdate_ModelOnlyUpdatePreservesProviderAndReturnsValidated
 	if err != nil {
 		t.Fatalf("ApplyDocumentUpdate() = %v", err)
 	}
-	if updated.Persisted {
-		t.Fatal("Persisted = true, want false before atomic persist story")
+	if !updated.Persisted {
+		t.Fatal("Persisted = false, want true after atomic persist")
 	}
 	if updated.Path != path {
 		t.Fatalf("Path = %q, want %q", updated.Path, path)
@@ -44,8 +41,13 @@ func TestApplyDocumentUpdate_ModelOnlyUpdatePreservesProviderAndReturnsValidated
 	if updated.Document.Runtime != operatorsettings.EmptyDocument().Runtime {
 		t.Fatalf("Runtime = %#v, want production defaults", updated.Document.Runtime)
 	}
-	if !reflect.DeepEqual(files[path], initialBytes) {
-		t.Fatal("destination bytes changed after semantic-only update")
+
+	reloaded, err := service.LoadDocument(operatorsettings.LoadDocumentRequest{Path: path})
+	if err != nil {
+		t.Fatalf("LoadDocument() after persist = %v", err)
+	}
+	if reloaded.Document.Defaults.WorkerModel != nextModel {
+		t.Fatalf("reloaded WorkerModel = %q, want %q", reloaded.Document.Defaults.WorkerModel, nextModel)
 	}
 }
 
@@ -54,8 +56,7 @@ func TestApplyDocumentUpdate_UnsupportedProviderPreservesDocumentAndDestinationB
 
 	path := writeFixtureToTemp(t, "valid/load-defaults.json")
 	initialBytes := readFixture(t, "valid/load-defaults.json")
-	files := map[string][]byte{path: append([]byte(nil), initialBytes...)}
-	service := newDocumentUpdateService(t, files)
+	service := newDocumentUpdateService(t)
 
 	unsupported := "other"
 	_, err := service.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
@@ -71,7 +72,7 @@ func TestApplyDocumentUpdate_UnsupportedProviderPreservesDocumentAndDestinationB
 		failure.Kind != operatorsettings.DocumentFailureKindUnsupported {
 		t.Fatalf("ApplyDocumentUpdate() = %#v, want unsupported DocumentFailure", err)
 	}
-	if !reflect.DeepEqual(files[path], initialBytes) {
+	if !reflect.DeepEqual(readFixtureFromPath(t, path), initialBytes) {
 		t.Fatal("destination bytes changed after unsupported provider update")
 	}
 
@@ -92,8 +93,7 @@ func TestApplyDocumentUpdate_BackendScopeConflictPreservesDocumentAndDestination
 
 	path := writeFixtureToTemp(t, "valid/backend-scope-sibling.json")
 	initialBytes := readFixture(t, "valid/backend-scope-sibling.json")
-	files := map[string][]byte{path: append([]byte(nil), initialBytes...)}
-	service := newDocumentUpdateService(t, files)
+	service := newDocumentUpdateService(t)
 
 	model := "gpt-5"
 	_, err := service.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
@@ -111,7 +111,7 @@ func TestApplyDocumentUpdate_BackendScopeConflictPreservesDocumentAndDestination
 		!strings.Contains(failure.Message, "backend scope mismatch") {
 		t.Fatalf("ApplyDocumentUpdate() = %#v, want backend scope conflict", err)
 	}
-	if !reflect.DeepEqual(files[path], initialBytes) {
+	if !reflect.DeepEqual(readFixtureFromPath(t, path), initialBytes) {
 		t.Fatal("destination bytes changed after backend scope conflict")
 	}
 
@@ -128,8 +128,7 @@ func TestApplyDocumentUpdate_ProviderUpdateCanonicalizesThroughCatalog(t *testin
 	t.Parallel()
 
 	path := writeFixtureToTemp(t, "valid/load-defaults.json")
-	files := map[string][]byte{path: readFixture(t, "valid/load-defaults.json")}
-	service := newDocumentUpdateService(t, files)
+	service := newDocumentUpdateService(t)
 
 	alias := " openai "
 	updated, err := service.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
@@ -149,19 +148,10 @@ func TestApplyDocumentUpdate_ProviderUpdateCanonicalizesThroughCatalog(t *testin
 	}
 }
 
-func newDocumentUpdateService(t *testing.T, files map[string][]byte) *internalservice.Service {
+func newDocumentUpdateService(t *testing.T) *internalservice.Service {
 	t.Helper()
 
-	return internalservice.New(
-		&mapFileSystem{files: files},
-		func(string, string) (operatorsettings.TemporaryFile, error) {
-			t.Fatal("temp-file creation is unexpected during semantic update")
-			return nil, errors.New("unexpected temp-file creation")
-		},
-		globalconfigmapping.Decode,
-		globalconfigmapping.Encode,
-		controlledProviderCatalog,
-	)
+	return newDocumentPersistService(t, testLocalFilesystem, testCreateTemp)
 }
 
 func controlledProviderCatalog(value string) (string, bool) {

--- a/pkg/services/operator_settings/internal/services/document/internal/service/update_test.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/update_test.go
@@ -1,0 +1,178 @@
+package service_test
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/internal/service"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+)
+
+func TestApplyDocumentUpdate_ModelOnlyUpdatePreservesProviderAndReturnsValidatedDocument(t *testing.T) {
+	t.Parallel()
+
+	path := writeFixtureToTemp(t, "valid/load-defaults.json")
+	initialBytes := readFixture(t, "valid/load-defaults.json")
+	files := map[string][]byte{path: initialBytes}
+	service := newDocumentUpdateService(t, files)
+
+	nextModel := "claude-opus"
+	updated, err := service.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
+		Path: path,
+		ProviderModel: operatorsettings.DocumentProviderModelUpdate{
+			Model: &nextModel,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyDocumentUpdate() = %v", err)
+	}
+	if updated.Persisted {
+		t.Fatal("Persisted = true, want false before atomic persist story")
+	}
+	if updated.Path != path {
+		t.Fatalf("Path = %q, want %q", updated.Path, path)
+	}
+	if updated.Document.Defaults.WorkerModel != nextModel {
+		t.Fatalf("WorkerModel = %q, want %q", updated.Document.Defaults.WorkerModel, nextModel)
+	}
+	if updated.Document.Defaults.WorkerModelProvider != "claude" {
+		t.Fatalf("WorkerModelProvider = %q, want unchanged claude", updated.Document.Defaults.WorkerModelProvider)
+	}
+	if updated.Document.Runtime != operatorsettings.EmptyDocument().Runtime {
+		t.Fatalf("Runtime = %#v, want production defaults", updated.Document.Runtime)
+	}
+	if !reflect.DeepEqual(files[path], initialBytes) {
+		t.Fatal("destination bytes changed after semantic-only update")
+	}
+}
+
+func TestApplyDocumentUpdate_UnsupportedProviderPreservesDocumentAndDestinationBytes(t *testing.T) {
+	t.Parallel()
+
+	path := writeFixtureToTemp(t, "valid/load-defaults.json")
+	initialBytes := readFixture(t, "valid/load-defaults.json")
+	files := map[string][]byte{path: append([]byte(nil), initialBytes...)}
+	service := newDocumentUpdateService(t, files)
+
+	unsupported := "other"
+	_, err := service.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
+		Path: path,
+		ProviderModel: operatorsettings.DocumentProviderModelUpdate{
+			Provider: &unsupported,
+		},
+	})
+	if !errors.Is(err, operatorsettings.ErrDocumentUnsupported) {
+		t.Fatalf("ApplyDocumentUpdate() = %v, want ErrDocumentUnsupported", err)
+	}
+	if failure, ok := err.(operatorsettings.DocumentFailure); !ok ||
+		failure.Kind != operatorsettings.DocumentFailureKindUnsupported {
+		t.Fatalf("ApplyDocumentUpdate() = %#v, want unsupported DocumentFailure", err)
+	}
+	if !reflect.DeepEqual(files[path], initialBytes) {
+		t.Fatal("destination bytes changed after unsupported provider update")
+	}
+
+	reloaded, loadErr := service.LoadDocument(operatorsettings.LoadDocumentRequest{Path: path})
+	if loadErr != nil {
+		t.Fatalf("LoadDocument() after failed update = %v", loadErr)
+	}
+	if reloaded.Document.Defaults != (operatorsettings.DocumentDefaults{
+		WorkerModelProvider: "claude",
+		WorkerModel:         "claude-sonnet",
+	}) {
+		t.Fatalf("reloaded defaults = %#v, want unchanged fixture defaults", reloaded.Document.Defaults)
+	}
+}
+
+func TestApplyDocumentUpdate_BackendScopeConflictPreservesDocumentAndDestinationBytes(t *testing.T) {
+	t.Parallel()
+
+	path := writeFixtureToTemp(t, "valid/backend-scope-sibling.json")
+	initialBytes := readFixture(t, "valid/backend-scope-sibling.json")
+	files := map[string][]byte{path: append([]byte(nil), initialBytes...)}
+	service := newDocumentUpdateService(t, files)
+
+	model := "gpt-5"
+	_, err := service.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
+		Path:                 path,
+		ExpectedBackendScope: "local-stale-scope",
+		ProviderModel: operatorsettings.DocumentProviderModelUpdate{
+			Model: &model,
+		},
+	})
+	if !errors.Is(err, operatorsettings.ErrDocumentConflict) {
+		t.Fatalf("ApplyDocumentUpdate() = %v, want ErrDocumentConflict", err)
+	}
+	if failure, ok := err.(operatorsettings.DocumentFailure); !ok ||
+		failure.Kind != operatorsettings.DocumentFailureKindConflict ||
+		!strings.Contains(failure.Message, "backend scope mismatch") {
+		t.Fatalf("ApplyDocumentUpdate() = %#v, want backend scope conflict", err)
+	}
+	if !reflect.DeepEqual(files[path], initialBytes) {
+		t.Fatal("destination bytes changed after backend scope conflict")
+	}
+
+	reloaded, loadErr := service.LoadDocument(operatorsettings.LoadDocumentRequest{Path: path})
+	if loadErr != nil {
+		t.Fatalf("LoadDocument() after conflict = %v", loadErr)
+	}
+	if reloaded.Document.BackendScopeID != "local-11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("BackendScopeID = %q, want unchanged persisted scope", reloaded.Document.BackendScopeID)
+	}
+}
+
+func TestApplyDocumentUpdate_ProviderUpdateCanonicalizesThroughCatalog(t *testing.T) {
+	t.Parallel()
+
+	path := writeFixtureToTemp(t, "valid/load-defaults.json")
+	files := map[string][]byte{path: readFixture(t, "valid/load-defaults.json")}
+	service := newDocumentUpdateService(t, files)
+
+	alias := " openai "
+	updated, err := service.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
+		Path: path,
+		ProviderModel: operatorsettings.DocumentProviderModelUpdate{
+			Provider: &alias,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyDocumentUpdate() = %v", err)
+	}
+	if updated.Document.Defaults.WorkerModelProvider != "CODEX" {
+		t.Fatalf("WorkerModelProvider = %q, want catalog canonical CODEX", updated.Document.Defaults.WorkerModelProvider)
+	}
+	if updated.Document.Defaults.WorkerModel != "claude-sonnet" {
+		t.Fatalf("WorkerModel = %q, want unchanged claude-sonnet", updated.Document.Defaults.WorkerModel)
+	}
+}
+
+func newDocumentUpdateService(t *testing.T, files map[string][]byte) *internalservice.Service {
+	t.Helper()
+
+	return internalservice.New(
+		&mapFileSystem{files: files},
+		func(string, string) (operatorsettings.TemporaryFile, error) {
+			t.Fatal("temp-file creation is unexpected during semantic update")
+			return nil, errors.New("unexpected temp-file creation")
+		},
+		globalconfigmapping.Decode,
+		globalconfigmapping.Encode,
+		controlledProviderCatalog,
+	)
+}
+
+func controlledProviderCatalog(value string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "codex", "openai":
+		return "CODEX", true
+	case "claude", "anthropic":
+		return "CLAUDE", true
+	case "gemini":
+		return "GEMINI", true
+	default:
+		return "", false
+	}
+}

--- a/pkg/services/operator_settings/internal/services/document/service.go
+++ b/pkg/services/operator_settings/internal/services/document/service.go
@@ -3,7 +3,11 @@
 // service instead of this parent-private subservice contract.
 package settingsdocument
 
-import operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+import (
+	"context"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
 
 // Service is the singular document subservice contract for the Operator
 // Settings root. It owns strict load, semantic update, and atomic persist of
@@ -13,4 +17,5 @@ type Service interface {
 	ApplyDocumentUpdate(
 		operatorsettings.ApplyDocumentUpdateRequest,
 	) (operatorsettings.ApplyDocumentUpdateResult, error)
+	PersistDocument(context.Context, operatorsettings.PersistDocumentRequest) error
 }

--- a/pkg/services/operator_settings/internal/services/document/service.go
+++ b/pkg/services/operator_settings/internal/services/document/service.go
@@ -1,0 +1,16 @@
+// Package settingsdocument defines the Operator Settings-owned document
+// capability. Consumers outside Operator Settings use the Operator Settings root
+// service instead of this parent-private subservice contract.
+package settingsdocument
+
+import operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+
+// Service is the singular document subservice contract for the Operator
+// Settings root. It owns strict load, semantic update, and atomic persist of
+// the operator document behind the parent-private boundary.
+type Service interface {
+	LoadDocument(operatorsettings.LoadDocumentRequest) (operatorsettings.LoadDocumentResult, error)
+	ApplyDocumentUpdate(
+		operatorsettings.ApplyDocumentUpdateRequest,
+	) (operatorsettings.ApplyDocumentUpdateResult, error)
+}

--- a/pkg/services/operator_settings/internal/services/document/service.go
+++ b/pkg/services/operator_settings/internal/services/document/service.go
@@ -14,6 +14,10 @@ import (
 // the operator document behind the parent-private boundary.
 type Service interface {
 	LoadDocument(operatorsettings.LoadDocumentRequest) (operatorsettings.LoadDocumentResult, error)
+	MergeDocumentProviderModel(
+		operatorsettings.Document,
+		operatorsettings.DocumentProviderModelUpdate,
+	) (operatorsettings.Document, error)
 	ApplyDocumentUpdate(
 		operatorsettings.ApplyDocumentUpdateRequest,
 	) (operatorsettings.ApplyDocumentUpdateResult, error)

--- a/pkg/services/operator_settings/internal/services/document/wire/wire.go
+++ b/pkg/services/operator_settings/internal/services/document/wire/wire.go
@@ -1,0 +1,22 @@
+// Package wire constructs the Operator Settings document subservice.
+package wire
+
+import (
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	settingsdocument "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/internal/service"
+)
+
+// NewService constructs the private document owner from injected filesystem,
+// temporary-file, decoder, encoder, and provider-catalog ports selected by the
+// Operator Settings root. Construction performs no filesystem, temp-file, or
+// codec work.
+func NewService(
+	files operatorsettings.FileSystem,
+	createTemp operatorsettings.CreateTemporaryFile,
+	decoder operatorsettings.ConfigDecoder,
+	encoder operatorsettings.ConfigEncoder,
+	providers operatorsettings.ProviderCatalog,
+) settingsdocument.Service {
+	return internalservice.New(files, createTemp, decoder, encoder, providers)
+}

--- a/pkg/services/operator_settings/internal/services/document/wire/wire_test.go
+++ b/pkg/services/operator_settings/internal/services/document/wire/wire_test.go
@@ -52,19 +52,6 @@ func TestNewServiceConstructsInertDocumentOwner(t *testing.T) {
 	if providers.calls != 0 {
 		t.Fatalf("construction invoked provider catalog %d times, want inert construction", providers.calls)
 	}
-
-	_, err := service.LoadDocument(operatorsettings.LoadDocumentRequest{
-		Path: "/home/operator/.you-agent-factory/config.json",
-	})
-	if err == nil {
-		t.Fatal("LoadDocument() = nil, want error before document load is implemented")
-	}
-	if files.readCalls != 0 {
-		t.Fatalf("LoadDocument() invoked ReadFile during unavailable load, want no filesystem read yet")
-	}
-	if decoder.calls != 0 {
-		t.Fatalf("LoadDocument() invoked decoder during unavailable load, want no codec decode yet")
-	}
 }
 
 func TestNewServiceRejectsMalformedLoadWithoutFilesystemOrCodecEffects(t *testing.T) {

--- a/pkg/services/operator_settings/internal/services/document/wire/wire_test.go
+++ b/pkg/services/operator_settings/internal/services/document/wire/wire_test.go
@@ -1,0 +1,173 @@
+package wire_test
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	settingsdocumentwire "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/wire"
+)
+
+func TestNewServiceConstructsInertDocumentOwner(t *testing.T) {
+	t.Parallel()
+
+	files := &recordingFileSystem{}
+	createTemp := newRecordingCreateTemporaryFile()
+	decoder := newRecordingConfigDecoder()
+	encoder := newRecordingConfigEncoder()
+	providers := newRecordingProviderCatalog()
+
+	service := settingsdocumentwire.NewService(
+		files,
+		createTemp.fn,
+		decoder.fn,
+		encoder.fn,
+		providers.fn,
+	)
+	if service == nil {
+		t.Fatal("NewService() = nil")
+	}
+	if files.readCalls != 0 {
+		t.Fatalf("construction invoked ReadFile %d times, want inert construction", files.readCalls)
+	}
+	if files.mkdirCalls != 0 || files.removeCalls != 0 || files.chmodCalls != 0 || files.renameCalls != 0 {
+		t.Fatalf(
+			"construction invoked filesystem mutations (mkdir=%d remove=%d chmod=%d rename=%d), want inert construction",
+			files.mkdirCalls,
+			files.removeCalls,
+			files.chmodCalls,
+			files.renameCalls,
+		)
+	}
+	if createTemp.calls != 0 {
+		t.Fatalf("construction invoked temp-file creation %d times, want inert construction", createTemp.calls)
+	}
+	if decoder.calls != 0 {
+		t.Fatalf("construction invoked decoder %d times, want inert construction", decoder.calls)
+	}
+	if encoder.calls != 0 {
+		t.Fatalf("construction invoked encoder %d times, want inert construction", encoder.calls)
+	}
+	if providers.calls != 0 {
+		t.Fatalf("construction invoked provider catalog %d times, want inert construction", providers.calls)
+	}
+
+	_, err := service.LoadDocument(operatorsettings.LoadDocumentRequest{
+		Path: "/home/operator/.you-agent-factory/config.json",
+	})
+	if err == nil {
+		t.Fatal("LoadDocument() = nil, want error before document load is implemented")
+	}
+	if files.readCalls != 0 {
+		t.Fatalf("LoadDocument() invoked ReadFile during unavailable load, want no filesystem read yet")
+	}
+	if decoder.calls != 0 {
+		t.Fatalf("LoadDocument() invoked decoder during unavailable load, want no codec decode yet")
+	}
+}
+
+func TestNewServiceRejectsMalformedLoadWithoutFilesystemOrCodecEffects(t *testing.T) {
+	t.Parallel()
+
+	service := settingsdocumentwire.NewService(
+		&recordingFileSystem{},
+		newRecordingCreateTemporaryFile().fn,
+		newRecordingConfigDecoder().fn,
+		newRecordingConfigEncoder().fn,
+		newRecordingProviderCatalog().fn,
+	)
+	_, err := service.LoadDocument(operatorsettings.LoadDocumentRequest{})
+	if !errors.Is(err, operatorsettings.ErrDocumentMalformed) {
+		t.Fatalf("LoadDocument() = %v, want ErrDocumentMalformed", err)
+	}
+}
+
+type recordingFileSystem struct {
+	readCalls   int
+	mkdirCalls  int
+	removeCalls int
+	chmodCalls  int
+	renameCalls int
+}
+
+func (files *recordingFileSystem) ReadFile(string) ([]byte, error) {
+	files.readCalls++
+	panic("filesystem read during inert construction")
+}
+
+func (files *recordingFileSystem) MkdirAll(string, fs.FileMode) error {
+	files.mkdirCalls++
+	panic("filesystem mkdir during inert construction")
+}
+
+func (files *recordingFileSystem) Remove(string) error {
+	files.removeCalls++
+	panic("filesystem remove during inert construction")
+}
+
+func (files *recordingFileSystem) Chmod(string, fs.FileMode) error {
+	files.chmodCalls++
+	panic("filesystem chmod during inert construction")
+}
+
+func (files *recordingFileSystem) Rename(string, string) error {
+	files.renameCalls++
+	panic("filesystem rename during inert construction")
+}
+
+type recordingCreateTemporaryFile struct {
+	calls int
+	fn    operatorsettings.CreateTemporaryFile
+}
+
+func newRecordingCreateTemporaryFile() *recordingCreateTemporaryFile {
+	recorder := &recordingCreateTemporaryFile{}
+	recorder.fn = func(string, string) (operatorsettings.TemporaryFile, error) {
+		recorder.calls++
+		panic("temp-file creation during inert construction")
+	}
+	return recorder
+}
+
+type recordingConfigDecoder struct {
+	calls int
+	fn    operatorsettings.ConfigDecoder
+}
+
+func newRecordingConfigDecoder() *recordingConfigDecoder {
+	recorder := &recordingConfigDecoder{}
+	recorder.fn = func([]byte) (operatorsettings.Config, error) {
+		recorder.calls++
+		panic("config decode during inert construction")
+	}
+	return recorder
+}
+
+type recordingConfigEncoder struct {
+	calls int
+	fn    operatorsettings.ConfigEncoder
+}
+
+func newRecordingConfigEncoder() *recordingConfigEncoder {
+	recorder := &recordingConfigEncoder{}
+	recorder.fn = func(operatorsettings.Config) ([]byte, error) {
+		recorder.calls++
+		panic("config encode during inert construction")
+	}
+	return recorder
+}
+
+type recordingProviderCatalog struct {
+	calls int
+	fn    operatorsettings.ProviderCatalog
+}
+
+func newRecordingProviderCatalog() *recordingProviderCatalog {
+	recorder := &recordingProviderCatalog{}
+	recorder.fn = func(string) (string, bool) {
+		recorder.calls++
+		panic("provider catalog during inert construction")
+	}
+	return recorder
+}

--- a/pkg/services/operator_settings/servicewire/document_owner.go
+++ b/pkg/services/operator_settings/servicewire/document_owner.go
@@ -1,0 +1,42 @@
+// Package operatorsettingsservicewire links the Operator Settings root to the
+// parent-private document owner without creating an import cycle.
+package operatorsettingsservicewire
+
+import (
+	"sync"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	settingsdocumentwire "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/wire"
+)
+
+// NewDocumentOwner constructs the nested document owner from injected ports.
+func NewDocumentOwner(
+	files operatorsettings.FileSystem,
+	createTemp operatorsettings.CreateTemporaryFile,
+	decoder operatorsettings.ConfigDecoder,
+	encoder operatorsettings.ConfigEncoder,
+	providers operatorsettings.ProviderCatalog,
+) operatorsettings.DocumentOwner {
+	return settingsdocumentwire.NewService(files, createTemp, decoder, encoder, providers)
+}
+
+// NewConfigDocumentService constructs a root ConfigDocumentService whose load,
+// update, and persist operations delegate to the nested document owner.
+func NewConfigDocumentService(
+	files operatorsettings.FileSystem,
+	createTemp operatorsettings.CreateTemporaryFile,
+	decoder operatorsettings.ConfigDecoder,
+	encoder operatorsettings.ConfigEncoder,
+	providers operatorsettings.ProviderCatalog,
+	persistenceLock sync.Locker,
+) operatorsettings.ConfigDocumentService {
+	return operatorsettings.ConfigDocumentService{
+		Files:           files,
+		CreateTemp:      createTemp,
+		Providers:       providers,
+		Decoder:         decoder,
+		Encoder:         encoder,
+		DocumentOwner:   NewDocumentOwner(files, createTemp, decoder, encoder, providers),
+		PersistenceLock: persistenceLock,
+	}
+}

--- a/pkg/services/operator_settings/servicewire/register.go
+++ b/pkg/services/operator_settings/servicewire/register.go
@@ -1,0 +1,7 @@
+package operatorsettingsservicewire
+
+import operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+
+func init() {
+	operatorsettings.ConfigureDocumentOwnerConstructor(NewDocumentOwner)
+}

--- a/pkg/services/operator_settings/testlink/register.go
+++ b/pkg/services/operator_settings/testlink/register.go
@@ -1,0 +1,14 @@
+// Package testlink registers the nested document owner constructor for
+// Operator Settings unit tests without creating an import cycle.
+package testlink
+
+import (
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	operatorsettingsservicewire "github.com/portpowered/infinite-you/pkg/services/operator_settings/servicewire"
+)
+
+// RegisterDocumentOwner wires the nested document owner into Operator Settings
+// unit tests.
+func RegisterDocumentOwner() {
+	operatorsettings.ConfigureDocumentOwnerConstructor(operatorsettingsservicewire.NewDocumentOwner)
+}

--- a/pkg/services/operator_settings/testmain_test.go
+++ b/pkg/services/operator_settings/testmain_test.go
@@ -1,0 +1,12 @@
+package operatorsettings_test
+
+import (
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/operator_settings/testlink"
+)
+
+func TestMain(m *testing.M) {
+	testlink.RegisterDocumentOwner()
+	m.Run()
+}

--- a/pkg/transports/cli/initsetup/init_test.go
+++ b/pkg/transports/cli/initsetup/init_test.go
@@ -14,6 +14,7 @@ import (
 
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	operatorsettingsservicewire "github.com/portpowered/infinite-you/pkg/services/operator_settings/servicewire"
 	"github.com/portpowered/infinite-you/pkg/transports/cli/initsetup"
 	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
 )
@@ -54,16 +55,7 @@ func TestConfigurerRejectsEmptySuppliedModelBeforePersistence(t *testing.T) {
 func TestConfigurerReportsCanonicalPersistedDefaults(t *testing.T) {
 	var output bytes.Buffer
 	model := "  free-form/model:v1  "
-	service := operatorsettings.ConfigDocumentService{
-		Files: platformfilesystem.Local{},
-		CreateTemp: func(dir, pattern string) (operatorsettings.TemporaryFile, error) {
-			return os.CreateTemp(dir, pattern)
-		},
-		Providers:       testProviderCatalog,
-		Decoder:         globalconfigmapping.Decode,
-		Encoder:         globalconfigmapping.Encode,
-		PersistenceLock: &sync.Mutex{},
-	}
+	service := testConfigService()
 	homeDir := t.TempDir()
 	err := initsetup.NewConfigurer(service, testLineReaderFactory)(initsetup.Config{
 		Context:  context.Background(),
@@ -202,16 +194,16 @@ func TestConfigurerRejectsPromptedInvalidProviderWithoutPersisting(t *testing.T)
 }
 
 func testConfigService() operatorsettings.ConfigDocumentService {
-	return operatorsettings.ConfigDocumentService{
-		Files: platformfilesystem.Local{},
-		CreateTemp: func(dir, pattern string) (operatorsettings.TemporaryFile, error) {
+	return operatorsettingsservicewire.NewConfigDocumentService(
+		platformfilesystem.Local{},
+		func(dir, pattern string) (operatorsettings.TemporaryFile, error) {
 			return os.CreateTemp(dir, pattern)
 		},
-		Providers:       testProviderCatalog,
-		Decoder:         globalconfigmapping.Decode,
-		Encoder:         globalconfigmapping.Encode,
-		PersistenceLock: &sync.Mutex{},
-	}
+		globalconfigmapping.Decode,
+		globalconfigmapping.Encode,
+		testProviderCatalog,
+		&sync.Mutex{},
+	)
 }
 
 type testLineReader struct {

--- a/pkg/transports/mapping/globalconfig/decode_test.go
+++ b/pkg/transports/mapping/globalconfig/decode_test.go
@@ -9,6 +9,7 @@ import (
 
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	operatorsettingsservicewire "github.com/portpowered/infinite-you/pkg/services/operator_settings/servicewire"
 	"github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
 )
 
@@ -251,10 +252,14 @@ func TestGeneratedLoaderAndConfigDocumentServiceAgreeOnEffectiveConfig(t *testin
 			if err != nil {
 				t.Fatalf("LoadFileConfig() error = %v", err)
 			}
-			document, err := (operatorsettings.ConfigDocumentService{
-				Files:   files,
-				Decoder: globalconfig.Decode,
-			}).Load(path)
+			document, err := operatorsettingsservicewire.NewConfigDocumentService(
+				files,
+				nil,
+				globalconfig.Decode,
+				nil,
+				nil,
+				nil,
+			).Load(path)
 			if err != nil {
 				t.Fatalf("ConfigDocumentService.Load() error = %v", err)
 			}

--- a/pkg/wire/profiles.go
+++ b/pkg/wire/profiles.go
@@ -44,6 +44,7 @@ import (
 	modelscli "github.com/portpowered/infinite-you/pkg/services/models/transports/cli"
 	modelswire "github.com/portpowered/infinite-you/pkg/services/models/wire"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	operatorsettingsservicewire "github.com/portpowered/infinite-you/pkg/services/operator_settings/servicewire"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
 	systeminitialization "github.com/portpowered/infinite-you/pkg/services/system_initialization"
 	systeminitializationwire "github.com/portpowered/infinite-you/pkg/services/system_initialization/wire"
@@ -253,14 +254,14 @@ func provideOperatorConfigDocumentService(
 	decode operatorsettings.ConfigDecoder,
 	encode operatorsettings.ConfigEncoder,
 ) operatorsettings.ConfigDocumentService {
-	return operatorsettings.ConfigDocumentService{
-		Files:           files,
-		CreateTemp:      createTemp,
-		Providers:       providers,
-		Decoder:         decode,
-		Encoder:         encode,
-		PersistenceLock: &sync.Mutex{},
-	}
+	return operatorsettingsservicewire.NewConfigDocumentService(
+		files,
+		createTemp,
+		decode,
+		encode,
+		providers,
+		&sync.Mutex{},
+	)
 }
 
 func provideOperatorSettingsIDGenerator(edges serviceedges.Edges) operatorsettings.IDGenerator {

--- a/tests/functional/operator_settings/configcore/operator_config_core_test.go
+++ b/tests/functional/operator_settings/configcore/operator_config_core_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	operatorsettingsservicewire "github.com/portpowered/infinite-you/pkg/services/operator_settings/servicewire"
 	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
 )
 
@@ -133,12 +134,14 @@ func assertRuntimePreserved(t *testing.T, got operatorsettings.RuntimeSettings) 
 }
 
 func operatorConfigService() operatorsettings.ConfigDocumentService {
-	return operatorsettings.ConfigDocumentService{
-		Files: operatorConfigOS{},
-		CreateTemp: func(dir, pattern string) (operatorsettings.TemporaryFile, error) {
+	return operatorsettingsservicewire.NewConfigDocumentService(
+		operatorConfigOS{},
+		func(dir, pattern string) (operatorsettings.TemporaryFile, error) {
 			return os.CreateTemp(dir, pattern)
 		},
-		Providers: func(value string) (string, bool) {
+		globalconfigmapping.Decode,
+		globalconfigmapping.Encode,
+		func(value string) (string, bool) {
 			switch strings.ToLower(strings.TrimSpace(value)) {
 			case "codex", "openai":
 				return "CODEX", true
@@ -148,10 +151,8 @@ func operatorConfigService() operatorsettings.ConfigDocumentService {
 				return "", false
 			}
 		},
-		Decoder:         globalconfigmapping.Decode,
-		Encoder:         globalconfigmapping.Encode,
-		PersistenceLock: &sync.Mutex{},
-	}
+		&sync.Mutex{},
+	)
 }
 
 func assertOperatorConfig(t *testing.T, document operatorsettings.ConfigDocument, provider, model string) {

--- a/tests/functional/product/init_setup/init_setup_test.go
+++ b/tests/functional/product/init_setup/init_setup_test.go
@@ -255,7 +255,7 @@ func TestInitSuppliedInputsPreserveConfigWhenAtomicWriteCannotStart(t *testing.T
 		},
 	}
 	err := fixture.execute(edges, io.Discard, "you", "init", "--provider", "codex", "--model", "new-model")
-	if err == nil || !strings.Contains(err.Error(), "create operator config temp file") ||
+	if err == nil || !strings.Contains(err.Error(), "create operator document temp file") ||
 		!errors.Is(err, tempFailure) {
 		t.Fatalf("Process.Execute() error = %v, want temporary-file failure", err)
 	}


### PR DESCRIPTION
{
  "project": "PSS IMP-SET-01 — Operator Settings Document Load/Update/Atomic Persist",
  "branchName": "pss-imp-set-01-document",
  "description": "Implement the parent-private Operator Settings document owner with strict load/update/atomic persist, deterministic malformed/conflict/failed-write preservation, inert construction, and injected codecs/filesystem effects; complete only after the PR is merged.",
  "context": {
    "customerAsk": "Implement IMP-SET-01 as the parent-private Operator Settings document owner. Provide strict load/update/atomic persist with deterministic malformed, conflict, and failed-write preservation while keeping construction inert and codecs/filesystem effects injected. Do not absorb resolution/precedence ownership, Providers catalog facts, CLI root/manifest composition, or System Bootstrap workflow. Shared coverage, ownership, and package-target manifest edits are allowed. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Operator Settings already has document load, semantic merge, and atomic persist behavior at the service root, but that ownership is not yet packaged as the parent-private nested document subservice required by Packaged Service Structure. Without a nested owner that strictly loads, semantically updates with conflict preservation, and atomically persists with failed-write preservation under inert injected construction, IMP-SET-02 and later Settings packets lack a stable document transaction boundary.",
    "solution": "Package Operator Settings document operations under pkg/services/operator_settings/internal/services/document as the parent-private nested owner, route focused load/update/atomic-persist call sites through it, prove malformed/conflict/failed-write preservation with focused tests, keep resolution/Providers/CLI/Bootstrap out of scope, and complete only after the PR is actually merged."
  },
  "acceptanceCriteria": [
    "AC-1: Parent-private nested owner exists at pkg/services/operator_settings/internal/services/document and owns load, decode/normalize/validate, semantic update, and atomic persist of the operator document",
    "AC-2: Strict load returns an empty valid document for a missing destination and fails closed on malformed/unsupported decode without publishing a partial document",
    "AC-3: Semantic updates that conflict or are unsupported leave the prior document unchanged; successful updates produce a complete validated document",
    "AC-4: Atomic persist commits only on successful replacement; pre-commit and failed-write phases leave the destination bytes unchanged",
    "AC-5: Construction of the document owner is inert; codecs and filesystem/temp-file effects are injected and unused until an operation runs",
    "AC-6: Quality checks pass (typecheck, lint, tests)",
    "AC-7: Delivery loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file churn are reconciled, and the PR is actually merged"
  ],
  "userStories": [
    {
      "id": "pss-imp-set-01-document-001",
      "title": "Nest document owner with inert injected construction",
      "description": "As an Operator Settings maintainer, I need the document capability nested as a parent-private owner whose construction is inert and whose filesystem/codec effects are injected so peers consume Settings through the root while document persistence stays privately owned.",
      "acceptanceCriteria": [
        "Parent-private package pkg/services/operator_settings/internal/services/document declares one nested document owner interface and keeps implementation under that subservice's own internal",
        "Constructing the document owner with injected filesystem, temporary-file, decoder, and encoder ports performs no filesystem read/write, temp-file creation, or codec encode/decode work",
        "Peers and transports do not import the nested document package as a cross-service dependency; Operator Settings root remains the peer-facing authority",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-set-01-document-002",
      "title": "Strict load for missing and malformed documents",
      "description": "As an Operator Settings caller, I want strict document load so a missing config path yields an empty valid document and malformed bytes fail closed without a half-decoded document.",
      "acceptanceCriteria": [
        "Loading a missing destination returns an empty valid operator document (no error that blocks default/empty use)",
        "Loading or parsing malformed document bytes fails closed and does not return a usable partial document",
        "Successful load of a valid on-disk document returns the complete validated semantic document (backend scope, defaults, runtime settings, presets as owned by document)",
        "Focused tests exercise missing, malformed, and valid-load outcomes through the document owner (or Operator Settings root seam that delegates to it)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-set-01-document-003",
      "title": "Semantic update with conflict and unsupported preservation",
      "description": "As an operator or Settings caller, I want semantic document updates so valid merges publish a new complete document while conflict and unsupported inputs preserve the prior document unchanged.",
      "acceptanceCriteria": [
        "A valid semantic update (for example provider/model default merge) returns a new complete validated document reflecting only the explicitly supplied changes",
        "Unsupported or conflicting update inputs fail with a typed Operator Settings document failure class and leave the prior document contents unchanged",
        "Omitted update fields preserve existing document values; explicit empty supplied values clear only when that is the existing semantic rule",
        "Focused tests assert at least one successful update and one conflict/unsupported preservation outcome",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-set-01-document-004",
      "title": "Atomic persist with failed-write destination preservation",
      "description": "As an Operator Settings maintainer, I need atomic persist so a successful replace publishes the complete document and every pre-commit failure leaves the destination bytes unchanged.",
      "acceptanceCriteria": [
        "Successful Persist writes a complete validated document that a subsequent Load reads back identically for the persisted semantic fields",
        "Pre-commit failures (directory create, temp create, write/short-write, sync, close, permissions, rename/replace) leave the existing destination file contents unchanged",
        "Cancellation observed before the rename/replace commit boundary prevents destination replacement",
        "Focused failed-write preservation tests inject filesystem/temp faults and assert destination byte identity after each failure phase",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-set-01-document-005",
      "title": "Route focused call sites and seal preservation proofs",
      "description": "As a Packaged Service Structure steward, I want focused Operator Settings load/update/atomic-persist call sites to use the nested document owner and I want malformed/conflict/failed-write preservation proved so IMP-SET-01 can be accepted without absorbing resolution or Bootstrap.",
      "acceptanceCriteria": [
        "Focused Operator Settings load/update/atomic-persist call sites delegate to the nested document owner rather than retaining a parallel root-only document implementation path for those operations",
        "Focused malformed, conflict/unsupported, and failed-write preservation proofs pass against the nested owner (and root seam where call sites were cut over)",
        "Diff does not absorb resolution/precedence ownership, Providers catalog facts, CLI root/manifest composition, or System Bootstrap workflow",
        "Shared coverage, ownership-inventory, and package-target manifest edits required for the document path are lease-minimal and reconciled",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-set-01-document-006",
      "title": "Complete delivery through merged PR",
      "description": "As the Factory program owner, I need the IMP-SET-01 implementation/review loop to continue until the PR is actually merged so the packet is not left merely opened, green, or approved.",
      "acceptanceCriteria": [
        "PR for branch pss-imp-set-01-document is opened or updated against the integration base with a summary of document ownership, strict load/update/persist behavior, and preservation proofs",
        "Required CI is terminal and passing",
        "Every blocking PR conversation comment is explicitly addressed",
        "Merge conflicts and shared-file churn (including allowed coverage/ownership/package-target edits) are reconciled",
        "PR is merged; work is not marked complete while merely approved or ready to merge",
        "Typecheck passes"
      ],
      "priority": 6,
      "passes": false,
      "notes": ""
    }
  ]
}
