### PR TITLE
pss-imp-set-02-resolution

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1051,6 +1051,56 @@
       }
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/service",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/internal/service",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/wire",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions",
       "minimum": 81.81
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -979,6 +979,32 @@
       "minimum": 95.65
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/service",
+      "minimum": 66.66
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active unit coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/internal/service",
+      "minimum": 93.67
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/wire",
+      "minimum": 100.00
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire",
+      "minimum": 0.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions",
       "minimum": 90.90
     },

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -1378,6 +1378,12 @@
       "evidence": "pkg/services/operator_settings -\u003e pkg/services/factory_definitions"
     },
     {
+      "fromOwner": "operator_settings",
+      "toOwner": "providers",
+      "class": "query",
+      "evidence": "pkg/services/operator_settings/internal/services/resolution/internal/service -\u003e pkg/services/providers"
+    },
+    {
       "fromOwner": "platform",
       "toOwner": "work",
       "class": "command",
@@ -2796,12 +2802,6 @@
       "destinationKind": "owner"
     },
     {
-      "packagePath": "pkg/services/factory_runtime/ingest",
-      "disposition": "move",
-      "destination": "automations",
-      "destinationKind": "owner"
-    },
-    {
       "packagePath": "pkg/services/factory_runtime/internal/orchestrators/javascript/preview",
       "disposition": "retain",
       "destination": "factory_runtime",
@@ -3571,6 +3571,36 @@
     },
     {
       "packagePath": "pkg/services/operator_settings/identityinventory",
+      "disposition": "retain",
+      "destination": "operator_settings",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/internal/service",
+      "disposition": "retain",
+      "destination": "operator_settings",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/internal/services/resolution",
+      "disposition": "retain",
+      "destination": "operator_settings",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/internal/services/resolution/internal/service",
+      "disposition": "retain",
+      "destination": "operator_settings",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/internal/services/resolution/wire",
+      "disposition": "retain",
+      "destination": "operator_settings",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/wire",
       "disposition": "retain",
       "destination": "operator_settings",
       "destinationKind": "owner"

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -248,6 +248,11 @@
     "pkg/services/models/wire",
     "pkg/services/operator_settings",
     "pkg/services/operator_settings/identityinventory",
+    "pkg/services/operator_settings/internal/service",
+    "pkg/services/operator_settings/internal/services/resolution",
+    "pkg/services/operator_settings/internal/services/resolution/internal/service",
+    "pkg/services/operator_settings/internal/services/resolution/wire",
+    "pkg/services/operator_settings/wire",
     "pkg/services/provider_sessions",
     "pkg/services/provider_sessions/internal/services/codex_reader",
     "pkg/services/provider_sessions/internal/services/codex_reader/internal/service",
@@ -841,13 +846,6 @@
       "packagePath": "pkg/services/factory_runtime/engine",
       "disposition": "retain",
       "destination": "factory_runtime"
-    },
-    {
-      "packagePath": "pkg/services/factory_runtime/ingest",
-      "disposition": "move",
-      "destination": "automations/internal/services/filesystem_watchers",
-      "deletionSuccessor": "pkg/services/automations/internal/services/filesystem_watchers",
-      "deletionCondition": "Factory Runtime ingest ownership moved to Automations filesystem_watchers."
     },
     {
       "packagePath": "pkg/services/factory_runtime/internal/orchestrators/javascript/preview",
@@ -1466,6 +1464,31 @@
     },
     {
       "packagePath": "pkg/services/operator_settings/identityinventory",
+      "disposition": "retain",
+      "destination": "operator_settings"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/internal/service",
+      "disposition": "retain",
+      "destination": "operator_settings"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/internal/services/resolution",
+      "disposition": "retain",
+      "destination": "operator_settings/internal/services/resolution"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/internal/services/resolution/internal/service",
+      "disposition": "retain",
+      "destination": "operator_settings/internal/services/resolution"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/internal/services/resolution/wire",
+      "disposition": "retain",
+      "destination": "operator_settings/internal/services/resolution"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/wire",
       "disposition": "retain",
       "destination": "operator_settings"
     },

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -774,6 +774,12 @@ response-stream output.
   (`~/.you-agent-factory/recordings/...`) belongs in `pkg/config/defaultpaths`;
   `pkg/services/operator_settings` and `pkg/transports/cli/run` should keep only precedence,
   filename, and reporting behavior around those defaults.
+- Effective operator-settings resolution belongs in the parent-private owner at
+  `pkg/services/operator_settings/internal/services/resolution`; the published
+  `operatorsettings.Service` root delegates `ResolveEffective` through
+  `internal/service` and `wire` only. Query the accepted `providers.Service` root
+  for provider identity canonicalization at resolve time; do not cache availability
+  in settings state or add Providers→Operator Settings imports.
 - When global named-factory guidance changes, update its authored
   `contracts/cli/commands.json` records and the task-oriented guidance in
   `docs/reference/authoring-factories.md` plus `config.md`; do not restore

--- a/pkg/services/operator_settings/internal/service/service.go
+++ b/pkg/services/operator_settings/internal/service/service.go
@@ -1,0 +1,53 @@
+// Package service implements the published Operator Settings root Service by
+// delegating effective resolution to the parent-private resolution subservice.
+package service
+
+import (
+	"fmt"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	resolution "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution"
+)
+
+// Service fulfills the published Operator Settings root contract.
+type Service struct {
+	resolution resolution.Service
+}
+
+var _ operatorsettings.Service = (*Service)(nil)
+
+// New constructs an inert Operator Settings root facade over the private
+// resolution capability. Document operations remain outside this packet until
+// the document subservice is composed.
+func New(resolutionService resolution.Service) (operatorsettings.Service, error) {
+	if resolutionService == nil {
+		return nil, fmt.Errorf("construct Operator Settings: resolution is required")
+	}
+	return &Service{resolution: resolutionService}, nil
+}
+
+func (s *Service) LoadDocument(
+	request operatorsettings.LoadDocumentRequest,
+) (operatorsettings.LoadDocumentResult, error) {
+	return operatorsettings.LoadDocumentResult{}, operatorsettings.DocumentFailure{
+		Kind:    operatorsettings.DocumentFailureKindUnsupported,
+		Message: "document subservice is not composed",
+		Path:    request.Path,
+	}
+}
+
+func (s *Service) ApplyDocumentUpdate(
+	request operatorsettings.ApplyDocumentUpdateRequest,
+) (operatorsettings.ApplyDocumentUpdateResult, error) {
+	return operatorsettings.ApplyDocumentUpdateResult{}, operatorsettings.DocumentFailure{
+		Kind:    operatorsettings.DocumentFailureKindUnsupported,
+		Message: "document subservice is not composed",
+		Path:    request.Path,
+	}
+}
+
+func (s *Service) ResolveEffective(
+	request operatorsettings.ResolveEffectiveRequest,
+) (operatorsettings.ResolveEffectiveResult, error) {
+	return s.resolution.ResolveEffective(request)
+}

--- a/pkg/services/operator_settings/internal/service/service_test.go
+++ b/pkg/services/operator_settings/internal/service/service_test.go
@@ -6,12 +6,17 @@ import (
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	operatorservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/service"
 	resolutionwire "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/wire"
+	providerswire "github.com/portpowered/infinite-you/pkg/services/providers/wire"
 )
 
 func TestRootDelegatesResolveEffectiveToPrivateOwner(t *testing.T) {
 	t.Parallel()
 
-	resolutionService, err := resolutionwire.NewService()
+	providersRoot, err := providerswire.NewService()
+	if err != nil {
+		t.Fatalf("providerswire.NewService() = %v", err)
+	}
+	resolutionService, err := resolutionwire.NewService(providersRoot)
 	if err != nil {
 		t.Fatalf("resolutionwire.NewService() = %v", err)
 	}

--- a/pkg/services/operator_settings/internal/service/service_test.go
+++ b/pkg/services/operator_settings/internal/service/service_test.go
@@ -1,0 +1,53 @@
+package service_test
+
+import (
+	"testing"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	operatorservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/service"
+	resolutionwire "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/wire"
+)
+
+func TestRootDelegatesResolveEffectiveToPrivateOwner(t *testing.T) {
+	t.Parallel()
+
+	resolutionService, err := resolutionwire.NewService()
+	if err != nil {
+		t.Fatalf("resolutionwire.NewService() = %v", err)
+	}
+	root, err := operatorservice.New(resolutionService)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	configPath := "/home/operator/.you-agent-factory/config.json"
+	baseline := operatorsettings.DocumentDefaults{
+		WorkerModelProvider: "codex",
+		WorkerModel:         "gpt-5",
+	}
+	resolved, err := root.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: baseline,
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "gemini",
+			WorkerModel:         "flag-model",
+		},
+		ConfigPath: configPath,
+	})
+	if err != nil {
+		t.Fatalf("ResolveEffective() = %v", err)
+	}
+	if resolved.Selection.WorkerModelProvider != "GEMINI" ||
+		resolved.Selection.WorkerModel != "flag-model" ||
+		resolved.Selection.ConfigPath != configPath {
+		t.Fatalf("ResolveEffective() = %#v", resolved.Selection)
+	}
+}
+
+func TestNew_RejectsNilResolution(t *testing.T) {
+	t.Parallel()
+
+	service, err := operatorservice.New(nil)
+	if err == nil || service != nil {
+		t.Fatalf("New(nil) = (%v, %v), want error", service, err)
+	}
+}

--- a/pkg/services/operator_settings/internal/services/resolution/internal/service/ownership_boundary_test.go
+++ b/pkg/services/operator_settings/internal/services/resolution/internal/service/ownership_boundary_test.go
@@ -1,0 +1,91 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/internal/service"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+type countingProvidersRoot struct {
+	getProviderCalls int
+}
+
+var _ providers.Service = (*countingProvidersRoot)(nil)
+
+func (fake *countingProvidersRoot) ListProviders(
+	_ context.Context,
+	_ providers.ListProvidersRequest,
+) (providers.ListProvidersResult, error) {
+	return providers.ListProvidersResult{}, nil
+}
+
+func (fake *countingProvidersRoot) GetProvider(
+	_ context.Context,
+	request providers.GetProviderRequest,
+) (providers.GetProviderResult, error) {
+	fake.getProviderCalls++
+	return providers.GetProviderResult{
+		Provider: providers.Descriptor{
+			ID:           request.ID,
+			Availability: providers.AvailabilitySelectable,
+			Readiness:    providers.ReadinessReady,
+		},
+	}, nil
+}
+
+func (fake *countingProvidersRoot) Execute(
+	_ context.Context,
+	_ providers.ExecuteRequest,
+) (providers.ExecuteResult, error) {
+	return providers.ExecuteResult{}, errors.New("not implemented")
+}
+
+// TestResolutionOwnerConstructionDoesNotQueryProviders seals the ownership
+// fence: holding the private resolution owner performs no Providers catalog
+// work until a concrete provider identity is resolved.
+func TestResolutionOwnerConstructionDoesNotQueryProviders(t *testing.T) {
+	t.Parallel()
+
+	providersRoot := &countingProvidersRoot{}
+	service, err := internalservice.New(providersRoot)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+	if providersRoot.getProviderCalls != 0 {
+		t.Fatalf("providers GetProvider calls during construction = %d, want 0", providersRoot.getProviderCalls)
+	}
+	if service == nil {
+		t.Fatal("constructed resolution service is nil")
+	}
+}
+
+// TestResolutionOwnerDoesNotMutateDocumentBaseline seals document ownership
+// outside Resolution: resolve reads detached inputs without rewriting them.
+func TestResolutionOwnerDoesNotMutateDocumentBaseline(t *testing.T) {
+	t.Parallel()
+
+	service := newResolutionService(t)
+	baseline := operatorsettings.DocumentDefaults{
+		WorkerModelProvider: "codex",
+		WorkerModel:         "gpt-5",
+	}
+	clonedBaseline := baseline
+
+	_, err := service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: baseline,
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "gemini",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	if err != nil {
+		t.Fatalf("ResolveEffective() = %v", err)
+	}
+	if baseline != clonedBaseline {
+		t.Fatalf("document baseline mutated: got %#v, want %#v", baseline, clonedBaseline)
+	}
+}

--- a/pkg/services/operator_settings/internal/services/resolution/internal/service/provider_query.go
+++ b/pkg/services/operator_settings/internal/services/resolution/internal/service/provider_query.go
@@ -68,6 +68,10 @@ func mapProviderCatalogError(err error, raw string) error {
 			Field:   "workerModelProvider",
 		}
 	default:
-		return err
+		return operatorsettings.ResolutionFailure{
+			Kind:    operatorsettings.ResolutionFailureKindConflict,
+			Message: raw,
+			Field:   "workerModelProvider",
+		}
 	}
 }

--- a/pkg/services/operator_settings/internal/services/resolution/internal/service/provider_query.go
+++ b/pkg/services/operator_settings/internal/services/resolution/internal/service/provider_query.go
@@ -1,0 +1,73 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+// providerQuery canonicalizes provider identities through the accepted Providers
+// root vocabulary at resolve time without caching availability state.
+type providerQuery interface {
+	CanonicalizeConcreteProvider(raw string) (string, error)
+}
+
+type providersRootQuery struct {
+	providers providers.Service
+}
+
+func newProvidersRootQuery(root providers.Service) (providerQuery, error) {
+	if root == nil {
+		return nil, fmt.Errorf("providers root is required")
+	}
+	return providersRootQuery{providers: root}, nil
+}
+
+func (query providersRootQuery) CanonicalizeConcreteProvider(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", nil
+	}
+
+	result, err := query.providers.GetProvider(
+		context.Background(),
+		providers.GetProviderRequest{ID: providers.ID(trimmed)},
+	)
+	if err != nil {
+		return "", mapProviderCatalogError(err, trimmed)
+	}
+
+	canonical := interfaces.PublicWorkerModelProviderFromInternalRuntime(result.Provider.ID.String())
+	if canonical == "" {
+		return "", operatorsettings.ResolutionFailure{
+			Kind:    operatorsettings.ResolutionFailureKindUnsupportedOverride,
+			Message: trimmed,
+			Field:   "workerModelProvider",
+		}
+	}
+	return canonical, nil
+}
+
+func mapProviderCatalogError(err error, raw string) error {
+	switch {
+	case errors.Is(err, providers.ErrUnknownProvider), errors.Is(err, providers.ErrInvalidID):
+		return operatorsettings.ResolutionFailure{
+			Kind:    operatorsettings.ResolutionFailureKindUnsupportedOverride,
+			Message: raw,
+			Field:   "workerModelProvider",
+		}
+	case errors.Is(err, providers.ErrProviderUnavailable):
+		return operatorsettings.ResolutionFailure{
+			Kind:    operatorsettings.ResolutionFailureKindConflict,
+			Message: raw,
+			Field:   "workerModelProvider",
+		}
+	default:
+		return err
+	}
+}

--- a/pkg/services/operator_settings/internal/services/resolution/internal/service/service.go
+++ b/pkg/services/operator_settings/internal/services/resolution/internal/service/service.go
@@ -1,0 +1,138 @@
+package service
+
+import (
+	"strings"
+
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	resolution "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution"
+)
+
+type service struct{}
+
+var _ resolution.Service = (*service)(nil)
+
+// New constructs an inert effective-resolution owner.
+func New() (resolution.Service, error) {
+	return &service{}, nil
+}
+
+func (s *service) ResolveEffective(
+	request operatorsettings.ResolveEffectiveRequest,
+) (operatorsettings.ResolveEffectiveResult, error) {
+	if err := request.Validate(); err != nil {
+		return operatorsettings.ResolveEffectiveResult{}, err
+	}
+
+	providerRaw, providerSource := winningLayerValue(
+		request.DocumentBaseline.WorkerModelProvider,
+		request.EnvironmentOverrides.WorkerModelProvider,
+		request.InvocationOverrides.WorkerModelProvider,
+	)
+	modelRaw, modelSource := winningLayerValue(
+		request.DocumentBaseline.WorkerModel,
+		request.EnvironmentOverrides.WorkerModel,
+		request.InvocationOverrides.WorkerModel,
+	)
+
+	resolvedProvider, err := resolveWorkerModelProvider(providerRaw, providerSource, request)
+	if err != nil {
+		return operatorsettings.ResolveEffectiveResult{}, err
+	}
+
+	return operatorsettings.ResolveEffectiveResult{
+		Selection: operatorsettings.EffectiveSelection{
+			WorkerModelProvider:       resolvedProvider,
+			WorkerModel:               strings.TrimSpace(modelRaw),
+			WorkerModelProviderSource: providerSource,
+			WorkerModelSource:         modelSource,
+			ConfigPath:                strings.TrimSpace(request.ConfigPath),
+		},
+	}, nil
+}
+
+func winningLayerValue(
+	baselineValue, envValue, flagValue string,
+) (string, operatorsettings.EffectiveLayerSource) {
+	switch {
+	case strings.TrimSpace(flagValue) != "":
+		return strings.TrimSpace(flagValue), operatorsettings.EffectiveLayerSourceFlag
+	case strings.TrimSpace(envValue) != "":
+		return strings.TrimSpace(envValue), operatorsettings.EffectiveLayerSourceEnv
+	case strings.TrimSpace(baselineValue) != "":
+		return strings.TrimSpace(baselineValue), operatorsettings.EffectiveLayerSourceFile
+	default:
+		return "", ""
+	}
+}
+
+func resolveWorkerModelProvider(
+	raw string,
+	winningSource operatorsettings.EffectiveLayerSource,
+	request operatorsettings.ResolveEffectiveRequest,
+) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+
+	canonical, ok := interfaces.CanonicalizeOperatorWorkerModelProviderInput(raw)
+	if !ok {
+		return "", operatorsettings.ResolutionFailure{
+			Kind:    operatorsettings.ResolutionFailureKindUnsupportedOverride,
+			Message: raw,
+			Field:   "workerModelProvider",
+		}
+	}
+	if !interfaces.IsSymbolicWorkerModelProviderDefault(canonical) {
+		return canonical, nil
+	}
+
+	concreteRaw := concreteProviderBelowSource(winningSource, request)
+	if concreteRaw == "" {
+		return "", operatorsettings.ResolutionFailure{
+			Kind:    operatorsettings.ResolutionFailureKindInvalidInput,
+			Message: "symbolic DEFAULT requires a concrete provider from file or environment",
+			Field:   "workerModelProvider",
+		}
+	}
+	concreteCanonical, ok := interfaces.CanonicalizeOperatorWorkerModelProviderInput(concreteRaw)
+	if !ok || interfaces.IsSymbolicWorkerModelProviderDefault(concreteCanonical) {
+		return "", operatorsettings.ResolutionFailure{
+			Kind:    operatorsettings.ResolutionFailureKindInvalidInput,
+			Message: "symbolic DEFAULT requires a concrete provider from file or environment",
+			Field:   "workerModelProvider",
+		}
+	}
+	return concreteCanonical, nil
+}
+
+func concreteProviderBelowSource(
+	winningSource operatorsettings.EffectiveLayerSource,
+	request operatorsettings.ResolveEffectiveRequest,
+) string {
+	type layer struct {
+		source operatorsettings.EffectiveLayerSource
+		value  string
+	}
+	layers := []layer{
+		{source: operatorsettings.EffectiveLayerSourceFile, value: request.DocumentBaseline.WorkerModelProvider},
+		{source: operatorsettings.EffectiveLayerSourceEnv, value: request.EnvironmentOverrides.WorkerModelProvider},
+		{source: operatorsettings.EffectiveLayerSourceFlag, value: request.InvocationOverrides.WorkerModelProvider},
+	}
+
+	below := make([]layer, 0, 2)
+	for _, layer := range layers {
+		if layer.source == winningSource {
+			break
+		}
+		below = append(below, layer)
+	}
+	for i := len(below) - 1; i >= 0; i-- {
+		value := strings.TrimSpace(below[i].value)
+		if value == "" || interfaces.IsSymbolicWorkerModelProviderDefault(value) {
+			continue
+		}
+		return value
+	}
+	return ""
+}

--- a/pkg/services/operator_settings/internal/services/resolution/internal/service/service.go
+++ b/pkg/services/operator_settings/internal/services/resolution/internal/service/service.go
@@ -24,24 +24,31 @@ func (s *service) ResolveEffective(
 		return operatorsettings.ResolveEffectiveResult{}, err
 	}
 
+	invocationOverrides, err := expandInvocationOverrides(request)
+	if err != nil {
+		return operatorsettings.ResolveEffectiveResult{}, err
+	}
+
 	providerRaw, providerSource := winningLayerValue(
 		request.DocumentBaseline.WorkerModelProvider,
 		request.EnvironmentOverrides.WorkerModelProvider,
-		request.InvocationOverrides.WorkerModelProvider,
+		invocationOverrides.WorkerModelProvider,
 	)
 	modelRaw, modelSource := winningLayerValue(
 		request.DocumentBaseline.WorkerModel,
 		request.EnvironmentOverrides.WorkerModel,
-		request.InvocationOverrides.WorkerModel,
+		invocationOverrides.WorkerModel,
 	)
 
-	resolvedProvider, err := resolveWorkerModelProvider(providerRaw, providerSource, request)
+	resolvedProvider, err := resolveWorkerModelProvider(providerRaw, providerSource, request, invocationOverrides)
 	if err != nil {
 		return operatorsettings.ResolveEffectiveResult{}, err
 	}
 
 	return operatorsettings.ResolveEffectiveResult{
 		Selection: operatorsettings.EffectiveSelection{
+			BackendScopeID:            strings.TrimSpace(request.BackendScopeID),
+			WorkerPresets:             cloneWorkerPresets(request.WorkerPresets),
 			WorkerModelProvider:       resolvedProvider,
 			WorkerModel:               strings.TrimSpace(modelRaw),
 			WorkerModelProviderSource: providerSource,
@@ -49,6 +56,56 @@ func (s *service) ResolveEffective(
 			ConfigPath:                strings.TrimSpace(request.ConfigPath),
 		},
 	}, nil
+}
+
+func expandInvocationOverrides(
+	request operatorsettings.ResolveEffectiveRequest,
+) (operatorsettings.EffectiveOverrideFacts, error) {
+	overrides := request.InvocationOverrides.Clone()
+	presetID := strings.TrimSpace(overrides.WorkerPresetID)
+	if presetID == "" {
+		return overrides, nil
+	}
+
+	preset, ok := findWorkerPreset(request.WorkerPresets, presetID)
+	if !ok {
+		return operatorsettings.EffectiveOverrideFacts{}, operatorsettings.ResolutionFailure{
+			Kind:    operatorsettings.ResolutionFailureKindUnsupportedOverride,
+			Message: presetID,
+			Field:   "workerPresetID",
+		}
+	}
+
+	if strings.TrimSpace(overrides.WorkerModelProvider) == "" {
+		overrides.WorkerModelProvider = preset.ModelProvider
+	}
+	if strings.TrimSpace(overrides.WorkerModel) == "" {
+		overrides.WorkerModel = preset.Model
+	}
+	return overrides, nil
+}
+
+func findWorkerPreset(
+	presets []operatorsettings.DocumentWorkerPreset,
+	id string,
+) (operatorsettings.DocumentWorkerPreset, bool) {
+	for _, preset := range presets {
+		if strings.TrimSpace(preset.ID) == id {
+			return preset, true
+		}
+	}
+	return operatorsettings.DocumentWorkerPreset{}, false
+}
+
+func cloneWorkerPresets(
+	presets []operatorsettings.DocumentWorkerPreset,
+) []operatorsettings.DocumentWorkerPreset {
+	if presets == nil {
+		return nil
+	}
+	cloned := make([]operatorsettings.DocumentWorkerPreset, len(presets))
+	copy(cloned, presets)
+	return cloned
 }
 
 func winningLayerValue(
@@ -70,6 +127,7 @@ func resolveWorkerModelProvider(
 	raw string,
 	winningSource operatorsettings.EffectiveLayerSource,
 	request operatorsettings.ResolveEffectiveRequest,
+	invocationOverrides operatorsettings.EffectiveOverrideFacts,
 ) (string, error) {
 	if raw == "" {
 		return "", nil
@@ -87,7 +145,7 @@ func resolveWorkerModelProvider(
 		return canonical, nil
 	}
 
-	concreteRaw := concreteProviderBelowSource(winningSource, request)
+	concreteRaw := concreteProviderBelowSource(winningSource, request, invocationOverrides)
 	if concreteRaw == "" {
 		return "", operatorsettings.ResolutionFailure{
 			Kind:    operatorsettings.ResolutionFailureKindInvalidInput,
@@ -109,6 +167,7 @@ func resolveWorkerModelProvider(
 func concreteProviderBelowSource(
 	winningSource operatorsettings.EffectiveLayerSource,
 	request operatorsettings.ResolveEffectiveRequest,
+	invocationOverrides operatorsettings.EffectiveOverrideFacts,
 ) string {
 	type layer struct {
 		source operatorsettings.EffectiveLayerSource
@@ -117,7 +176,7 @@ func concreteProviderBelowSource(
 	layers := []layer{
 		{source: operatorsettings.EffectiveLayerSourceFile, value: request.DocumentBaseline.WorkerModelProvider},
 		{source: operatorsettings.EffectiveLayerSourceEnv, value: request.EnvironmentOverrides.WorkerModelProvider},
-		{source: operatorsettings.EffectiveLayerSourceFlag, value: request.InvocationOverrides.WorkerModelProvider},
+		{source: operatorsettings.EffectiveLayerSourceFlag, value: invocationOverrides.WorkerModelProvider},
 	}
 
 	below := make([]layer, 0, 2)

--- a/pkg/services/operator_settings/internal/services/resolution/internal/service/service.go
+++ b/pkg/services/operator_settings/internal/services/resolution/internal/service/service.go
@@ -6,15 +6,22 @@ import (
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	resolution "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
-type service struct{}
+type service struct {
+	providers providerQuery
+}
 
 var _ resolution.Service = (*service)(nil)
 
 // New constructs an inert effective-resolution owner.
-func New() (resolution.Service, error) {
-	return &service{}, nil
+func New(providersRoot providers.Service) (resolution.Service, error) {
+	providerQuery, err := newProvidersRootQuery(providersRoot)
+	if err != nil {
+		return nil, err
+	}
+	return &service{providers: providerQuery}, nil
 }
 
 func (s *service) ResolveEffective(
@@ -40,7 +47,7 @@ func (s *service) ResolveEffective(
 		invocationOverrides.WorkerModel,
 	)
 
-	resolvedProvider, err := resolveWorkerModelProvider(providerRaw, providerSource, request, invocationOverrides)
+	resolvedProvider, err := s.resolveWorkerModelProvider(providerRaw, providerSource, request, invocationOverrides)
 	if err != nil {
 		return operatorsettings.ResolveEffectiveResult{}, err
 	}
@@ -123,7 +130,7 @@ func winningLayerValue(
 	}
 }
 
-func resolveWorkerModelProvider(
+func (s *service) resolveWorkerModelProvider(
 	raw string,
 	winningSource operatorsettings.EffectiveLayerSource,
 	request operatorsettings.ResolveEffectiveRequest,
@@ -133,35 +140,19 @@ func resolveWorkerModelProvider(
 		return "", nil
 	}
 
-	canonical, ok := interfaces.CanonicalizeOperatorWorkerModelProviderInput(raw)
-	if !ok {
-		return "", operatorsettings.ResolutionFailure{
-			Kind:    operatorsettings.ResolutionFailureKindUnsupportedOverride,
-			Message: raw,
-			Field:   "workerModelProvider",
+	if interfaces.IsSymbolicWorkerModelProviderDefault(raw) {
+		concreteRaw := concreteProviderBelowSource(winningSource, request, invocationOverrides)
+		if concreteRaw == "" {
+			return "", operatorsettings.ResolutionFailure{
+				Kind:    operatorsettings.ResolutionFailureKindInvalidInput,
+				Message: "symbolic DEFAULT requires a concrete provider from file or environment",
+				Field:   "workerModelProvider",
+			}
 		}
-	}
-	if !interfaces.IsSymbolicWorkerModelProviderDefault(canonical) {
-		return canonical, nil
+		return s.providers.CanonicalizeConcreteProvider(concreteRaw)
 	}
 
-	concreteRaw := concreteProviderBelowSource(winningSource, request, invocationOverrides)
-	if concreteRaw == "" {
-		return "", operatorsettings.ResolutionFailure{
-			Kind:    operatorsettings.ResolutionFailureKindInvalidInput,
-			Message: "symbolic DEFAULT requires a concrete provider from file or environment",
-			Field:   "workerModelProvider",
-		}
-	}
-	concreteCanonical, ok := interfaces.CanonicalizeOperatorWorkerModelProviderInput(concreteRaw)
-	if !ok || interfaces.IsSymbolicWorkerModelProviderDefault(concreteCanonical) {
-		return "", operatorsettings.ResolutionFailure{
-			Kind:    operatorsettings.ResolutionFailureKindInvalidInput,
-			Message: "symbolic DEFAULT requires a concrete provider from file or environment",
-			Field:   "workerModelProvider",
-		}
-	}
-	return concreteCanonical, nil
+	return s.providers.CanonicalizeConcreteProvider(raw)
 }
 
 func concreteProviderBelowSource(

--- a/pkg/services/operator_settings/internal/services/resolution/internal/service/service_test.go
+++ b/pkg/services/operator_settings/internal/services/resolution/internal/service/service_test.go
@@ -423,3 +423,217 @@ func TestResolveEffective_UnknownProviderSurfacesUnsupportedOverride(t *testing.
 		t.Fatalf("ResolveEffective() error = %v, want ErrResolutionUnsupportedOverride", err)
 	}
 }
+
+func TestResolveEffective_SymbolicDefaultResolvesThroughLowerPrecedenceProvider(t *testing.T) {
+	t.Parallel()
+
+	service := newResolutionService(t)
+	resolved, err := service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "codex",
+			WorkerModel:         "file-model",
+		},
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "DEFAULT",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	if err != nil {
+		t.Fatalf("ResolveEffective() = %v", err)
+	}
+	if resolved.Selection.WorkerModelProvider != "CODEX" {
+		t.Fatalf("provider = %q, want CODEX", resolved.Selection.WorkerModelProvider)
+	}
+	if resolved.Selection.WorkerModelProviderSource != operatorsettings.EffectiveLayerSourceFlag {
+		t.Fatalf("provider source = %q, want flag", resolved.Selection.WorkerModelProviderSource)
+	}
+}
+
+func TestResolveEffective_UnresolvedSymbolicDefaultReturnsInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	service := newResolutionService(t)
+	_, err := service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "DEFAULT",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	assertResolutionFailure(
+		t,
+		err,
+		operatorsettings.ErrResolutionInvalidInput,
+		operatorsettings.ResolutionFailureKindInvalidInput,
+		"workerModelProvider",
+	)
+	if errors.Is(err, operatorsettings.ErrDocumentMalformed) ||
+		errors.Is(err, operatorsettings.ErrDocumentConflict) {
+		t.Fatalf("unresolved DEFAULT leaked document failure: %v", err)
+	}
+}
+
+func TestResolveEffective_TypedResolutionFailures(t *testing.T) {
+	t.Parallel()
+
+	service := newResolutionService(t)
+
+	_, err := service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "unsupported-provider",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	assertResolutionFailure(
+		t,
+		err,
+		operatorsettings.ErrResolutionUnsupportedOverride,
+		operatorsettings.ResolutionFailureKindUnsupportedOverride,
+		"workerModelProvider",
+	)
+	if errors.Is(err, providers.ErrUnknownProvider) {
+		t.Fatalf("unsupported override leaked providers error: %v", err)
+	}
+
+	_, err = service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		WorkerPresets: []operatorsettings.DocumentWorkerPreset{{
+			ID:            "research",
+			ModelProvider: "codex",
+		}},
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerPresetID: "missing-preset",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	assertResolutionFailure(
+		t,
+		err,
+		operatorsettings.ErrResolutionUnsupportedOverride,
+		operatorsettings.ResolutionFailureKindUnsupportedOverride,
+		"workerPresetID",
+	)
+
+	baseline := operatorsettings.DocumentDefaults{
+		WorkerModelProvider: "codex",
+		WorkerModel:         "gpt-5",
+	}
+	staleBaseline := operatorsettings.DocumentDefaults{
+		WorkerModelProvider: "claude",
+		WorkerModel:         "gpt-5",
+	}
+	_, err = service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: staleBaseline,
+		ExpectedDocumentBaseline: &operatorsettings.DocumentDefaults{
+			WorkerModelProvider: baseline.WorkerModelProvider,
+			WorkerModel:         baseline.WorkerModel,
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	assertResolutionFailure(
+		t,
+		err,
+		operatorsettings.ErrResolutionConflict,
+		operatorsettings.ResolutionFailureKindConflict,
+		"documentBaseline",
+	)
+}
+
+func TestResolveEffective_FailurePathsDoNotMutateDocumentBaseline(t *testing.T) {
+	t.Parallel()
+
+	baseline := operatorsettings.DocumentDefaults{
+		WorkerModelProvider: "codex",
+		WorkerModel:         "file-model",
+	}
+	request := operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: baseline,
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "not-a-real-provider",
+		},
+		ConfigPath: "/tmp/config.json",
+	}
+
+	service := newResolutionService(t)
+	_, err := service.ResolveEffective(request)
+	if err == nil {
+		t.Fatal("ResolveEffective() succeeded, want unsupported provider failure")
+	}
+	if request.DocumentBaseline != baseline {
+		t.Fatalf("document baseline mutated after unsupported provider: got %#v, want %#v", request.DocumentBaseline, baseline)
+	}
+}
+
+func TestResolveEffective_UnexpectedProviderErrorDoesNotLeakProvidersType(t *testing.T) {
+	t.Parallel()
+
+	service, err := internalservice.New(&unexpectedProviderErrorFake{})
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	_, err = service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "codex",
+			WorkerModel:         "file-model",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	assertResolutionFailure(
+		t,
+		err,
+		operatorsettings.ErrResolutionConflict,
+		operatorsettings.ResolutionFailureKindConflict,
+		"workerModelProvider",
+	)
+	if errors.Is(err, providers.ErrUnknownProvider) ||
+		errors.Is(err, providers.ErrProviderUnavailable) {
+		t.Fatalf("unexpected provider error leaked providers sentinel: %v", err)
+	}
+}
+
+type unexpectedProviderErrorFake struct{}
+
+var _ providers.Service = (*unexpectedProviderErrorFake)(nil)
+
+func (fake *unexpectedProviderErrorFake) ListProviders(
+	_ context.Context,
+	_ providers.ListProvidersRequest,
+) (providers.ListProvidersResult, error) {
+	return providers.ListProvidersResult{}, errors.New("unexpected list failure")
+}
+
+func (fake *unexpectedProviderErrorFake) GetProvider(
+	_ context.Context,
+	_ providers.GetProviderRequest,
+) (providers.GetProviderResult, error) {
+	return providers.GetProviderResult{}, errors.New("unexpected catalog failure")
+}
+
+func (fake *unexpectedProviderErrorFake) Execute(
+	_ context.Context,
+	_ providers.ExecuteRequest,
+) (providers.ExecuteResult, error) {
+	return providers.ExecuteResult{}, errors.New("not implemented")
+}
+
+func assertResolutionFailure(
+	t *testing.T,
+	err error,
+	sentinel error,
+	kind operatorsettings.ResolutionFailureKind,
+	field string,
+) {
+	t.Helper()
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error = %v, want %v", err, sentinel)
+	}
+	var failure operatorsettings.ResolutionFailure
+	if !errors.As(err, &failure) {
+		t.Fatalf("error = %T(%v), want operatorsettings.ResolutionFailure", err, err)
+	}
+	if failure.Kind != kind {
+		t.Fatalf("failure kind = %q, want %q", failure.Kind, kind)
+	}
+	if failure.Field != field {
+		t.Fatalf("failure field = %q, want %q", failure.Field, field)
+	}
+}

--- a/pkg/services/operator_settings/internal/services/resolution/internal/service/service_test.go
+++ b/pkg/services/operator_settings/internal/services/resolution/internal/service/service_test.go
@@ -1,20 +1,103 @@
 package service_test
 
 import (
+	"context"
+	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/internal/service"
 	resolution "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	providerswire "github.com/portpowered/infinite-you/pkg/services/providers/wire"
 )
 
 func newResolutionService(t *testing.T) resolution.Service {
-	service, err := internalservice.New()
+	t.Helper()
+	service, err := internalservice.New(mustProvidersRoot(t))
 	if err != nil {
 		t.Fatalf("New() = %v", err)
 	}
 	return service
+}
+
+func mustProvidersRoot(t *testing.T) providers.Service {
+	t.Helper()
+	root, err := providerswire.NewService()
+	if err != nil {
+		t.Fatalf("providerswire.NewService() = %v", err)
+	}
+	return root
+}
+
+type resolutionProvidersFake struct {
+	providers map[providers.ID]providers.Descriptor
+}
+
+var _ providers.Service = (*resolutionProvidersFake)(nil)
+
+func newResolutionProvidersFake(entries ...providers.Descriptor) *resolutionProvidersFake {
+	catalog := make(map[providers.ID]providers.Descriptor, len(entries))
+	for _, entry := range entries {
+		catalog[entry.ID] = entry.Clone()
+	}
+	return &resolutionProvidersFake{providers: catalog}
+}
+
+func (fake *resolutionProvidersFake) ListProviders(
+	_ context.Context,
+	_ providers.ListProvidersRequest,
+) (providers.ListProvidersResult, error) {
+	results := make([]providers.Descriptor, 0, len(fake.providers))
+	for _, descriptor := range fake.providers {
+		results = append(results, descriptor.Clone())
+	}
+	return providers.ListProvidersResult{Providers: results}, nil
+}
+
+func (fake *resolutionProvidersFake) GetProvider(
+	_ context.Context,
+	request providers.GetProviderRequest,
+) (providers.GetProviderResult, error) {
+	if err := request.Validate(); err != nil {
+		return providers.GetProviderResult{}, err
+	}
+	descriptor, ok := fake.lookup(request.ID)
+	if !ok {
+		return providers.GetProviderResult{}, providers.ErrUnknownProvider
+	}
+	if descriptor.Availability != providers.AvailabilitySelectable ||
+		descriptor.Readiness != providers.ReadinessReady {
+		return providers.GetProviderResult{}, providers.ErrProviderUnavailable
+	}
+	return providers.GetProviderResult{Provider: descriptor.Clone()}, nil
+}
+
+func (fake *resolutionProvidersFake) Execute(
+	_ context.Context,
+	_ providers.ExecuteRequest,
+) (providers.ExecuteResult, error) {
+	return providers.ExecuteResult{}, errors.New("not implemented")
+}
+
+func (fake *resolutionProvidersFake) lookup(id providers.ID) (providers.Descriptor, bool) {
+	if descriptor, ok := fake.providers[id]; ok {
+		return descriptor, true
+	}
+	normalized := strings.ToLower(strings.TrimSpace(id.String()))
+	for _, descriptor := range fake.providers {
+		if strings.ToLower(descriptor.ID.String()) == normalized {
+			return descriptor, true
+		}
+		for _, alias := range descriptor.Aliases {
+			if alias == normalized {
+				return descriptor, true
+			}
+		}
+	}
+	return providers.Descriptor{}, false
 }
 
 func TestResolveEffective_AppliesFlagPrecedence(t *testing.T) {
@@ -264,11 +347,79 @@ func TestResolveEffective_EquivalentInputsProduceIdenticalSelections(t *testing.
 func TestResolveEffective_ConstructionIsInert(t *testing.T) {
 	t.Parallel()
 
-	service, err := internalservice.New()
+	service, err := internalservice.New(mustProvidersRoot(t))
 	if err != nil {
 		t.Fatalf("New() = %v", err)
 	}
 	if service == nil {
 		t.Fatal("constructed resolution service is nil")
+	}
+}
+
+func TestResolveEffective_CanonicalizesProviderAliasThroughProvidersRoot(t *testing.T) {
+	t.Parallel()
+
+	service := newResolutionService(t)
+	resolved, err := service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "cursor",
+			WorkerModel:         "file-model",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	if err != nil {
+		t.Fatalf("ResolveEffective() = %v", err)
+	}
+	if resolved.Selection.WorkerModelProvider != "CURSOR" {
+		t.Fatalf("provider = %q, want CURSOR", resolved.Selection.WorkerModelProvider)
+	}
+}
+
+func TestResolveEffective_UnavailableProviderDoesNotMutateDocumentBaseline(t *testing.T) {
+	t.Parallel()
+
+	baseline := operatorsettings.DocumentDefaults{
+		WorkerModelProvider: "codex",
+		WorkerModel:         "file-model",
+	}
+	request := operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: baseline,
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "codex",
+		},
+		ConfigPath: "/tmp/config.json",
+	}
+
+	service, err := internalservice.New(newResolutionProvidersFake(providers.Descriptor{
+		ID:           providers.IDCodex,
+		Availability: providers.AvailabilitySelectable,
+		Readiness:    providers.ReadinessUnavailable,
+	}))
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	_, err = service.ResolveEffective(request)
+	if !errors.Is(err, operatorsettings.ErrResolutionConflict) {
+		t.Fatalf("ResolveEffective() error = %v, want ErrResolutionConflict", err)
+	}
+	if request.DocumentBaseline != baseline {
+		t.Fatalf("document baseline mutated: got %#v, want %#v", request.DocumentBaseline, baseline)
+	}
+}
+
+func TestResolveEffective_UnknownProviderSurfacesUnsupportedOverride(t *testing.T) {
+	t.Parallel()
+
+	service := newResolutionService(t)
+	_, err := service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "not-a-real-provider",
+			WorkerModel:         "file-model",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	if !errors.Is(err, operatorsettings.ErrResolutionUnsupportedOverride) {
+		t.Fatalf("ResolveEffective() error = %v, want ErrResolutionUnsupportedOverride", err)
 	}
 }

--- a/pkg/services/operator_settings/internal/services/resolution/internal/service/service_test.go
+++ b/pkg/services/operator_settings/internal/services/resolution/internal/service/service_test.go
@@ -1,0 +1,66 @@
+package service_test
+
+import (
+	"testing"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/internal/service"
+)
+
+func TestResolveEffective_AppliesFlagPrecedence(t *testing.T) {
+	t.Parallel()
+
+	service, err := internalservice.New()
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	configPath := "/home/operator/.you-agent-factory/config.json"
+	resolved, err := service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "claude",
+			WorkerModel:         "file-model",
+		},
+		EnvironmentOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "codex",
+			WorkerModel:         "env-model",
+		},
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "gemini",
+			WorkerModel:         "flag-model",
+		},
+		ConfigPath: configPath,
+	})
+	if err != nil {
+		t.Fatalf("ResolveEffective() = %v", err)
+	}
+
+	selection := resolved.Selection
+	if selection.WorkerModelProvider != "GEMINI" {
+		t.Fatalf("provider = %q, want GEMINI", selection.WorkerModelProvider)
+	}
+	if selection.WorkerModel != "flag-model" {
+		t.Fatalf("model = %q, want flag-model", selection.WorkerModel)
+	}
+	if selection.WorkerModelProviderSource != operatorsettings.EffectiveLayerSourceFlag {
+		t.Fatalf("provider source = %q, want flag", selection.WorkerModelProviderSource)
+	}
+	if selection.WorkerModelSource != operatorsettings.EffectiveLayerSourceFlag {
+		t.Fatalf("model source = %q, want flag", selection.WorkerModelSource)
+	}
+	if selection.ConfigPath != configPath {
+		t.Fatalf("config path = %q, want %q", selection.ConfigPath, configPath)
+	}
+}
+
+func TestResolveEffective_ConstructionIsInert(t *testing.T) {
+	t.Parallel()
+
+	service, err := internalservice.New()
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+	if service == nil {
+		t.Fatal("constructed resolution service is nil")
+	}
+}

--- a/pkg/services/operator_settings/internal/services/resolution/internal/service/service_test.go
+++ b/pkg/services/operator_settings/internal/services/resolution/internal/service/service_test.go
@@ -1,20 +1,26 @@
 package service_test
 
 import (
+	"reflect"
 	"testing"
 
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/internal/service"
+	resolution "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution"
 )
 
-func TestResolveEffective_AppliesFlagPrecedence(t *testing.T) {
-	t.Parallel()
-
+func newResolutionService(t *testing.T) resolution.Service {
 	service, err := internalservice.New()
 	if err != nil {
 		t.Fatalf("New() = %v", err)
 	}
+	return service
+}
 
+func TestResolveEffective_AppliesFlagPrecedence(t *testing.T) {
+	t.Parallel()
+
+	service := newResolutionService(t)
 	configPath := "/home/operator/.you-agent-factory/config.json"
 	resolved, err := service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
 		DocumentBaseline: operatorsettings.DocumentDefaults{
@@ -50,6 +56,208 @@ func TestResolveEffective_AppliesFlagPrecedence(t *testing.T) {
 	}
 	if selection.ConfigPath != configPath {
 		t.Fatalf("config path = %q, want %q", selection.ConfigPath, configPath)
+	}
+}
+
+func TestResolveEffective_EnvOverridesFileWhenFlagsUnset(t *testing.T) {
+	t.Parallel()
+
+	service := newResolutionService(t)
+	resolved, err := service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "claude",
+			WorkerModel:         "file-model",
+		},
+		EnvironmentOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "codex",
+			WorkerModel:         "env-model",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	if err != nil {
+		t.Fatalf("ResolveEffective() = %v", err)
+	}
+
+	selection := resolved.Selection
+	if selection.WorkerModelProvider != "CODEX" {
+		t.Fatalf("provider = %q, want CODEX", selection.WorkerModelProvider)
+	}
+	if selection.WorkerModel != "env-model" {
+		t.Fatalf("model = %q, want env-model", selection.WorkerModel)
+	}
+	if selection.WorkerModelProviderSource != operatorsettings.EffectiveLayerSourceEnv {
+		t.Fatalf("provider source = %q, want env", selection.WorkerModelProviderSource)
+	}
+	if selection.WorkerModelSource != operatorsettings.EffectiveLayerSourceEnv {
+		t.Fatalf("model source = %q, want env", selection.WorkerModelSource)
+	}
+}
+
+func TestResolveEffective_PrecedenceIsIndependentPerField(t *testing.T) {
+	t.Parallel()
+
+	service := newResolutionService(t)
+	resolved, err := service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "claude",
+			WorkerModel:         "file-model",
+		},
+		EnvironmentOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "codex",
+			WorkerModel:         "env-model",
+		},
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "gemini",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	if err != nil {
+		t.Fatalf("ResolveEffective() = %v", err)
+	}
+
+	selection := resolved.Selection
+	if selection.WorkerModelProvider != "GEMINI" {
+		t.Fatalf("provider = %q, want GEMINI", selection.WorkerModelProvider)
+	}
+	if selection.WorkerModel != "env-model" {
+		t.Fatalf("model = %q, want env-model", selection.WorkerModel)
+	}
+	if selection.WorkerModelProviderSource != operatorsettings.EffectiveLayerSourceFlag {
+		t.Fatalf("provider source = %q, want flag", selection.WorkerModelProviderSource)
+	}
+	if selection.WorkerModelSource != operatorsettings.EffectiveLayerSourceEnv {
+		t.Fatalf("model source = %q, want env", selection.WorkerModelSource)
+	}
+}
+
+func TestResolveEffective_IncludesBackendScopeFromDocumentBaseline(t *testing.T) {
+	t.Parallel()
+
+	service := newResolutionService(t)
+	scopeID := "local-11111111-1111-4111-8111-111111111111"
+	resolved, err := service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		BackendScopeID: scopeID,
+		DocumentBaseline: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "codex",
+			WorkerModel:         "file-model",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	if err != nil {
+		t.Fatalf("ResolveEffective() = %v", err)
+	}
+	if resolved.Selection.BackendScopeID != scopeID {
+		t.Fatalf("backend scope = %q, want %q", resolved.Selection.BackendScopeID, scopeID)
+	}
+}
+
+func TestResolveEffective_PresetInfluencesInvocationLayerWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	service := newResolutionService(t)
+	presets := []operatorsettings.DocumentWorkerPreset{{
+		ID:            "careful-review",
+		ModelProvider: "codex",
+		Model:         "preset-model",
+		ReasoningEffort: "high",
+	}}
+	resolved, err := service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "claude",
+			WorkerModel:         "file-model",
+		},
+		WorkerPresets: presets,
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerPresetID: "careful-review",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	if err != nil {
+		t.Fatalf("ResolveEffective() = %v", err)
+	}
+
+	selection := resolved.Selection
+	if selection.WorkerModelProvider != "CODEX" {
+		t.Fatalf("provider = %q, want CODEX", selection.WorkerModelProvider)
+	}
+	if selection.WorkerModel != "preset-model" {
+		t.Fatalf("model = %q, want preset-model", selection.WorkerModel)
+	}
+	if selection.WorkerModelProviderSource != operatorsettings.EffectiveLayerSourceFlag {
+		t.Fatalf("provider source = %q, want flag", selection.WorkerModelProviderSource)
+	}
+	if selection.WorkerModelSource != operatorsettings.EffectiveLayerSourceFlag {
+		t.Fatalf("model source = %q, want flag", selection.WorkerModelSource)
+	}
+	if !reflect.DeepEqual(selection.WorkerPresets, presets) {
+		t.Fatalf("worker presets = %#v, want %#v", selection.WorkerPresets, presets)
+	}
+}
+
+func TestResolveEffective_ExplicitInvocationOverridesWinOverPreset(t *testing.T) {
+	t.Parallel()
+
+	service := newResolutionService(t)
+	resolved, err := service.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "claude",
+			WorkerModel:         "file-model",
+		},
+		WorkerPresets: []operatorsettings.DocumentWorkerPreset{{
+			ID:            "careful-review",
+			ModelProvider: "codex",
+			Model:         "preset-model",
+		}},
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerPresetID:      "careful-review",
+			WorkerModelProvider: "gemini",
+		},
+		ConfigPath: "/tmp/config.json",
+	})
+	if err != nil {
+		t.Fatalf("ResolveEffective() = %v", err)
+	}
+
+	selection := resolved.Selection
+	if selection.WorkerModelProvider != "GEMINI" {
+		t.Fatalf("provider = %q, want GEMINI", selection.WorkerModelProvider)
+	}
+	if selection.WorkerModel != "preset-model" {
+		t.Fatalf("model = %q, want preset-model from preset", selection.WorkerModel)
+	}
+}
+
+func TestResolveEffective_EquivalentInputsProduceIdenticalSelections(t *testing.T) {
+	t.Parallel()
+
+	service := newResolutionService(t)
+	request := operatorsettings.ResolveEffectiveRequest{
+		BackendScopeID: "local-22222222-2222-4222-8222-222222222222",
+		DocumentBaseline: operatorsettings.DocumentDefaults{
+			WorkerModelProvider: "claude",
+			WorkerModel:         "file-model",
+		},
+		EnvironmentOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "codex",
+		},
+		WorkerPresets: []operatorsettings.DocumentWorkerPreset{{
+			ID:            "research",
+			ModelProvider: "CODEX",
+			Model:         "preset-model",
+		}},
+		ConfigPath: "/tmp/config.json",
+	}
+
+	first, err := service.ResolveEffective(request)
+	if err != nil {
+		t.Fatalf("first ResolveEffective() = %v", err)
+	}
+	second, err := service.ResolveEffective(request)
+	if err != nil {
+		t.Fatalf("second ResolveEffective() = %v", err)
+	}
+	if !reflect.DeepEqual(first.Selection, second.Selection) {
+		t.Fatalf("selections differ: first = %#v, second = %#v", first.Selection, second.Selection)
 	}
 }
 

--- a/pkg/services/operator_settings/internal/services/resolution/service.go
+++ b/pkg/services/operator_settings/internal/services/resolution/service.go
@@ -1,0 +1,13 @@
+// Package resolution defines the parent-private Operator Settings effective
+// resolution capability.
+package resolution
+
+import (
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
+
+// Service fulfills the accepted CTR-SET effective-resolution root slice as a
+// parent-private owner. Resolution does not mutate the operator document.
+type Service interface {
+	ResolveEffective(operatorsettings.ResolveEffectiveRequest) (operatorsettings.ResolveEffectiveResult, error)
+}

--- a/pkg/services/operator_settings/internal/services/resolution/wire/wire.go
+++ b/pkg/services/operator_settings/internal/services/resolution/wire/wire.go
@@ -1,0 +1,13 @@
+// Package wire constructs the parent-private Operator Settings resolution
+// subservice.
+package wire
+
+import (
+	resolution "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution"
+	resolutionservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/internal/service"
+)
+
+// NewService constructs an inert effective-resolution owner.
+func NewService() (resolution.Service, error) {
+	return resolutionservice.New()
+}

--- a/pkg/services/operator_settings/internal/services/resolution/wire/wire.go
+++ b/pkg/services/operator_settings/internal/services/resolution/wire/wire.go
@@ -5,9 +5,11 @@ package wire
 import (
 	resolution "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution"
 	resolutionservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/internal/service"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
-// NewService constructs an inert effective-resolution owner.
-func NewService() (resolution.Service, error) {
-	return resolutionservice.New()
+// NewService constructs an inert effective-resolution owner backed by the
+// accepted Providers root for semantic validation and canonicalization.
+func NewService(providersRoot providers.Service) (resolution.Service, error) {
+	return resolutionservice.New(providersRoot)
 }

--- a/pkg/services/operator_settings/resolution_contract.go
+++ b/pkg/services/operator_settings/resolution_contract.go
@@ -87,6 +87,7 @@ const (
 type EffectiveOverrideFacts struct {
 	WorkerModelProvider string
 	WorkerModel         string
+	WorkerPresetID      string
 }
 
 // Clone returns a detached override-facts copy.
@@ -97,6 +98,8 @@ func (facts EffectiveOverrideFacts) Clone() EffectiveOverrideFacts {
 // EffectiveSelection is the immutable effective operator default selection
 // peers consume from effective resolution without owning precedence rules.
 type EffectiveSelection struct {
+	BackendScopeID            string
+	WorkerPresets             []DocumentWorkerPreset
 	WorkerModelProvider       string
 	WorkerModel               string
 	WorkerModelProviderSource EffectiveLayerSource
@@ -106,7 +109,11 @@ type EffectiveSelection struct {
 
 // Clone returns a detached effective-selection copy.
 func (selection EffectiveSelection) Clone() EffectiveSelection {
-	return selection
+	cloned := selection
+	if selection.WorkerPresets != nil {
+		cloned.WorkerPresets = cloneDocumentWorkerPresets(selection.WorkerPresets)
+	}
+	return cloned
 }
 
 // ResolveEffectiveRequest asks for an effective selection from detached
@@ -114,6 +121,8 @@ func (selection EffectiveSelection) Clone() EffectiveSelection {
 // document; document mutation remains on document operations.
 type ResolveEffectiveRequest struct {
 	DocumentBaseline         DocumentDefaults
+	BackendScopeID           string
+	WorkerPresets            []DocumentWorkerPreset
 	ExpectedDocumentBaseline *DocumentDefaults
 	EnvironmentOverrides     EffectiveOverrideFacts
 	InvocationOverrides      EffectiveOverrideFacts

--- a/pkg/services/operator_settings/service_root_contract_invariants_test.go
+++ b/pkg/services/operator_settings/service_root_contract_invariants_test.go
@@ -160,6 +160,8 @@ func TestRootContract_ContractValuesStayInertWhenHeld(t *testing.T) {
 	}
 
 	selection := operatorsettings.EffectiveSelection{
+		BackendScopeID:            "local-00000000-0000-4000-8000-000000000010",
+		WorkerPresets:             []operatorsettings.DocumentWorkerPreset{{ID: "research", ModelProvider: "CODEX"}},
 		WorkerModelProvider:       "CODEX",
 		WorkerModel:               "gpt-5",
 		WorkerModelProviderSource: operatorsettings.EffectiveLayerSourceFlag,
@@ -170,6 +172,10 @@ func TestRootContract_ContractValuesStayInertWhenHeld(t *testing.T) {
 	selection.WorkerModel = "mutated"
 	if clonedSelection.WorkerModel == "mutated" {
 		t.Fatal("EffectiveSelection.Clone() shares mutable model state")
+	}
+	selection.WorkerPresets[0].ID = "mutated"
+	if clonedSelection.WorkerPresets[0].ID == "mutated" {
+		t.Fatal("EffectiveSelection.Clone() shares mutable worker preset state")
 	}
 
 	overrides := operatorsettings.EffectiveOverrideFacts{

--- a/pkg/services/operator_settings/wire/wire.go
+++ b/pkg/services/operator_settings/wire/wire.go
@@ -6,12 +6,13 @@ import (
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	operatorservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/service"
 	resolutionwire "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/wire"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
 // NewService constructs one inert Operator Settings root over the private
-// resolution capability.
-func NewService() (operatorsettings.Service, error) {
-	resolutionService, err := resolutionwire.NewService()
+// resolution capability backed by the accepted Providers root.
+func NewService(providersRoot providers.Service) (operatorsettings.Service, error) {
+	resolutionService, err := resolutionwire.NewService(providersRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/operator_settings/wire/wire.go
+++ b/pkg/services/operator_settings/wire/wire.go
@@ -1,0 +1,19 @@
+// Package wire constructs the published Operator Settings root Service from the
+// parent-private resolution subservice.
+package wire
+
+import (
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	operatorservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/service"
+	resolutionwire "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/wire"
+)
+
+// NewService constructs one inert Operator Settings root over the private
+// resolution capability.
+func NewService() (operatorsettings.Service, error) {
+	resolutionService, err := resolutionwire.NewService()
+	if err != nil {
+		return nil, err
+	}
+	return operatorservice.New(resolutionService)
+}


### PR DESCRIPTION
{
  "project": "PSS IMP-SET-02 — Package Operator Settings Resolution",
  "branchName": "pss-imp-set-02-resolution",
  "description": "Implement IMP-SET-02 as the parent-private Operator Settings resolution owner under pkg/services/operator_settings/internal/services/resolution. Provide deterministic scopes/env/presets/overrides precedence into an immutable effective selection through the accepted CTR-SET root, query Providers only for semantic validation/canonicalization without caching availability, leave Document persist and Clean CLI UX alone, and forbid a reverse Providers-to-Settings dependency.",
  "context": {
    "customerAsk": "Implement IMP-SET-02 as the parent-private Operator Settings resolution owner. Provide deterministic scopes/env/presets/overrides precedence without caching Providers availability, querying Providers only for semantic validation/canonicalization. Do not absorb document load/update/persist ownership, redesign Clean CLI init UX, or introduce a reverse Providers-to-Settings dependency. Shared coverage, ownership, and package-target manifest edits are allowed. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "CTR-SET published the Operator Settings root for document operations and effective resolution, and CTR-PROV published Providers catalog facts, but resolution behavior still lives as loose Operator Settings helpers rather than a parent-private resolution owner. Peers lack one inert root-fulfilled authority that applies scopes/env/defaults/presets/overrides into an immutable effective selection while querying Providers only for semantic validation/canonicalization and never caching volatile availability into settings state.",
    "solution": "Create the parent-private Operator Settings Resolution subservice that fulfills the accepted CTR-SET effective-resolution root slice. Move/adapt existing deterministic precedence and effective-selection behavior into that private owner, inject Providers root queries only for semantic validation/canonicalization, keep construction inert, leave Document load/update/persist ownership alone, and prove outcomes with focused resolution tests without redesigning Clean CLI init UX or introducing Providers→Settings imports."
  },
  "acceptanceCriteria": [
    "The accepted Operator Settings root effective-resolution operation is fulfilled by one parent-private resolution owner under pkg/services/operator_settings/internal/services/resolution rather than by a second peer-facing Settings authority.",
    "Given equivalent detached document baseline, environment, defaults, presets, and invocation override inputs, resolution returns a detached immutable effective selection with deterministic field values and source/precedence facts already owned by Operator Settings.",
    "Resolution may query the accepted Providers root only for semantic validation/canonicalization of provider identities/capabilities; it does not persist, cache, or fork Providers availability into the operator document or resolution results as a second registry.",
    "Invalid resolution input, unsupported override/preset, unresolved symbolic DEFAULT, and conflict classes retain distinct Operator-Settings-owned typed failures; resolution never mutates the operator document.",
    "Diff does not absorb Document load/update/atomic-persist ownership, redesign Clean CLI init UX, regenerate CLI manifests, edit OpenAPI/generated clients, cut over pkg/root/pkg/wire/pkg/initializer, add UI work, or introduce a Providers→Operator Settings dependency.",
    "Quality checks pass (typecheck, lint, focused Operator Settings resolution tests, architecture/ownership checks for changed paths, and make verify-fast).",
    "Delivery loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file churn are reconciled, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "pss-imp-set-02-resolution-001",
      "title": "Fulfill root effective resolution through a parent-private owner",
      "description": "As a Workers, Models, Sessions, or Bootstrap maintainer, I want the accepted Operator Settings effective-resolution root operation to be fulfilled by one parent-private resolution owner so I depend on a single Settings authority for immutable effective selection.",
      "acceptanceCriteria": [
        "A parent-private Resolution capability exists under pkg/services/operator_settings/internal/services/resolution and is composed only through the Operator Settings parent / accepted service-local construction boundary.",
        "The accepted CTR-SET effective-resolution root operation returns an immutable effective selection produced by that private owner for valid detached inputs.",
        "Resolution does not mutate the operator document; document writes remain outside this packet's ownership.",
        "Holding or constructing the resolution owner performs no filesystem persist, process start, Wire, or Initializer work; construction remains inert.",
        "Focused tests exercise at least one successful root effective-resolution path through the private owner.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-set-02-resolution-002",
      "title": "Apply deterministic scopes, env, defaults, presets, and override precedence",
      "description": "As a Settings consumer, I want effective selection to apply backend scope, environment, file defaults, worker/provider presets, and explicit invocation overrides with deterministic precedence so the same inputs always yield the same effective values and source facts.",
      "acceptanceCriteria": [
        "For each resolved field, higher-precedence layers win according to the accepted Operator Settings precedence chain (file < env < flag/invocation override, with presets applied as already owned by Settings behavior).",
        "Backend scope identity from the document baseline participates in effective selection without inventing a second identity store.",
        "Effective selection reports source/precedence facts already owned by Operator Settings when those facts are part of the accepted resolution result.",
        "Equivalent inputs produce identical effective selections independent of map iteration or call repetition.",
        "Focused tests cover independent per-field precedence, env-over-file, flag/override-over-env, and at least one preset-influenced effective selection path.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-set-02-resolution-003",
      "title": "Canonicalize and validate through Providers without caching availability",
      "description": "As a Settings maintainer, I want resolution to query Providers only for semantic validation and identity/capability canonicalization so Settings never becomes a second provider registry and never imports a reverse Providers→Settings dependency.",
      "acceptanceCriteria": [
        "Provider identity values in defaults/presets/overrides are canonicalized/validated through the accepted Providers root catalog vocabulary rather than forked Settings-owned provider constant tables where those tables are being replaced by this packet.",
        "Resolution does not persist or cache Providers availability/readiness into the operator document or as durable Settings state.",
        "A temporarily unavailable provider does not rewrite settings storage; any unavailable/unsupported outcome surfaces as a typed resolution or already-owned validation fact at resolve time rather than as cached catalog state.",
        "Providers packages do not import Operator Settings; dependency direction remains Settings → Providers only.",
        "Focused tests prove canonicalization/alias acceptance for at least one provider identity and prove that an injected unavailable/unsupported Providers response does not mutate document inputs and surfaces as a typed resolve-time outcome.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-set-02-resolution-004",
      "title": "Preserve typed resolution failures and symbolic DEFAULT behavior",
      "description": "As a peer consumer, I want invalid inputs, unsupported overrides/presets, unresolved symbolic DEFAULT, and conflict cases to remain distinct Operator-Settings-owned typed failures so I can branch with errors.Is / errors.As without parsing free-form strings.",
      "acceptanceCriteria": [
        "Invalid resolution input returns a typed Operator Settings invalid-input failure distinct from document-persist failures.",
        "Unsupported override/preset/provider values return typed unsupported/conflict-class Operator Settings failures already owned by the resolution contract.",
        "Symbolic DEFAULT provider continues to resolve through a lower-precedence concrete provider when one exists, and fails with the accepted unresolved-DEFAULT typed/actionable outcome when none exists.",
        "Failure paths do not mutate caller-supplied document baselines or leak Providers implementation types, filesystem handles, or Wire/Initializer types.",
        "Focused tests assert each failure class with errors.Is / errors.As and cover successful DEFAULT resolution plus unresolved DEFAULT.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-set-02-resolution-005",
      "title": "Seal ownership fence, lease-minimal manifests, and verify-fast",
      "description": "As a Packaged Service Structure steward, I want Resolution packaged with lease-minimal shared registration and an explicit ownership fence so Document, Clean CLI UX, and reverse Providers dependencies stay out of this packet while quality gates pass.",
      "acceptanceCriteria": [
        "Changed exclusive implementation paths stay focused on pkg/services/operator_settings/internal/services/resolution/** plus focused precedence/Providers-validation proof paths and any required Operator Settings parent adaptation to delegate resolution.",
        "Diff does not absorb Document load/update/atomic-persist ownership, redesign Clean CLI init UX, regenerate CLI manifests, edit OpenAPI/generated clients, cut over pkg/root/pkg/wire/pkg/initializer, or add UI behavior.",
        "If coverage, ownership-inventory, or package-target-manifest updates are required, they register only Resolution package ownership needs and stay lease-minimal.",
        "Focused Operator Settings resolution tests pass; gofmt and vet/lint are clean for changed Go files; applicable architecture/ownership checks pass.",
        "make verify-fast passes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}
