### PR TITLE
pss-lwr-ses-service-wire

### DIFF
--- a/pkg/services/factory_sessions/internal/service/root.go
+++ b/pkg/services/factory_sessions/internal/service/root.go
@@ -107,7 +107,10 @@ func (r *Root) ForRuntime(binding factorysessions.RuntimeBinding) (factorysessio
 		return nil, fmt.Errorf("construct Factory Sessions runtime: service is required")
 	}
 	if binding.Clock == nil {
-		return nil, fmt.Errorf("construct Factory Sessions runtime: clock is required")
+		return nil, &factorysessions.OpeningBindingError{
+			Field:   "clock",
+			Message: "clock is required",
+		}
 	}
 	assembly := legacyservice.NewAssembly(
 		r.newJavaScriptCheckpointStore,

--- a/pkg/services/factory_sessions/wire/wire.go
+++ b/pkg/services/factory_sessions/wire/wire.go
@@ -1,6 +1,9 @@
 // Package wire is the Factory Sessions service composition boundary.
-// Application Wire uses these providers without importing the service's
-// concrete implementation package.
+//
+// Wire performs construction only, returns the singular factorysessions.Service
+// root interface, and starts no lifecycle components. Parent-private identity
+// and response-stream owner wiring stays inside the owner service assembly path;
+// peers depend on Service rather than owner internals or construction ports.
 package wire
 
 import (
@@ -40,8 +43,11 @@ func NewWorkStopSummaryProjector() factorysessions.WorkStopSummaryProjector {
 	}
 }
 
-// NewService constructs the inert, process-scoped Factory Sessions service.
-// Runtime-specific values are supplied later through Service.ForRuntime.
+// NewService constructs an inert Factory Sessions root from construction and
+// process-edge ports. It composes the accepted root through parent-private
+// identity and response-stream owner construction without publishing owner types
+// on the returned peer surface. Missing required construction ports fail with a
+// deterministic construction error and a nil service.
 func NewService(
 	newJavaScriptCheckpointStore factoryruntime.JavaScriptCheckpointStoreFactory,
 	sessionResultProjection factoryruntime.SessionResultProjectionOperation,

--- a/pkg/services/factory_sessions/wire/wire_test.go
+++ b/pkg/services/factory_sessions/wire/wire_test.go
@@ -1,6 +1,7 @@
 package wire
 
 import (
+	"errors"
 	"io/fs"
 	"runtime"
 	"testing"
@@ -136,7 +137,9 @@ func TestNewServiceConstructsInertRoot(t *testing.T) {
 	}
 }
 
-func TestNewServiceIsInertAndRequiresRuntimeClockBinding(t *testing.T) {
+func TestNewServiceServesPublishedForRuntimePeerBehavior(t *testing.T) {
+	t.Parallel()
+
 	clock := &recordingClock{}
 	directories := &recordingDirectoryInspection{}
 	symlinkCalls := 0
@@ -150,12 +153,36 @@ func TestNewServiceIsInertAndRequiresRuntimeClockBinding(t *testing.T) {
 	if service == nil {
 		t.Fatal("NewService() returned nil service")
 	}
-	if assembly, bindErr := service.ForRuntime(factorysessions.RuntimeBinding{}); bindErr == nil || assembly != nil {
-		t.Fatalf("ForRuntime() without clock = %#v, %v; want deterministic error", assembly, bindErr)
+
+	bound, bindErr := service.ForRuntime(factorysessions.RuntimeBinding{})
+	if bound != nil {
+		t.Fatalf("ForRuntime() without clock = %#v, want nil Service on missing binding input", bound)
 	}
-	assembly, err := service.ForRuntime(factorysessions.RuntimeBinding{Clock: clock})
-	if err != nil || assembly == nil {
-		t.Fatalf("ForRuntime() = %#v, %v; want bound assembly", assembly, err)
+	var openingErr *factorysessions.OpeningBindingError
+	if !errors.As(bindErr, &openingErr) {
+		t.Fatalf("ForRuntime() error = %v, want *OpeningBindingError", bindErr)
+	}
+	if openingErr.Field != "clock" {
+		t.Fatalf("OpeningBindingError.Field = %q, want clock", openingErr.Field)
+	}
+	if !errors.Is(bindErr, factorysessions.ErrOpeningBindingInvalid) {
+		t.Fatalf("ForRuntime() error = %v, want errors.Is ErrOpeningBindingInvalid", bindErr)
+	}
+
+	bound, err = service.ForRuntime(factorysessions.RuntimeBinding{Clock: clock})
+	if err != nil {
+		t.Fatalf("ForRuntime() error = %v, want nil", err)
+	}
+	if bound == nil {
+		t.Fatal("ForRuntime() returned nil Service view")
+	}
+	var runtimeView factorysessions.Service = bound
+	if runtimeView == nil {
+		t.Fatal("bound runtime view is nil")
+	}
+	result := factorysessions.OpeningBindingResult{Service: bound}
+	if result.Service == nil {
+		t.Fatal("OpeningBindingResult must carry the usable root Service view")
 	}
 	if clock.calls != 0 {
 		t.Fatalf("runtime binding read clock %d times, want no runtime activity", clock.calls)

--- a/pkg/services/factory_sessions/wire/wire_test.go
+++ b/pkg/services/factory_sessions/wire/wire_test.go
@@ -2,7 +2,6 @@ package wire
 
 import (
 	"io/fs"
-	"strings"
 	"testing"
 	"time"
 
@@ -13,14 +12,51 @@ import (
 )
 
 func TestNewServiceRejectsMissingRequiredDependencies(t *testing.T) {
-	service, err := NewService(
-		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-	)
-	if err == nil || !strings.Contains(err.Error(), "session result projection is required") {
-		t.Fatalf("NewService() error = %v, want deterministic required dependency error", err)
+	t.Parallel()
+
+	valid := validNewServiceInputs()
+	tests := []struct {
+		name   string
+		mutate func(*newServiceInputs)
+	}{
+		{name: "session result projection", mutate: func(in *newServiceInputs) { in.sessionResultProjection = nil }},
+		{name: "response event ID generator", mutate: func(in *newServiceInputs) { in.eventIDs = nil }},
+		{name: "session ID generator", mutate: func(in *newServiceInputs) { in.sessionIDs = nil }},
+		{name: "home directory resolver", mutate: func(in *newServiceInputs) { in.resolveHome = nil }},
+		{name: "directory inspection", mutate: func(in *newServiceInputs) { in.directoryInspection = nil }},
+		{name: "named path resolver", mutate: func(in *newServiceInputs) { in.namedPaths = nil }},
+		{name: "invocation input reader", mutate: func(in *newServiceInputs) { in.invocationInputFiles = nil }},
+		{name: "initial Work reader", mutate: func(in *newServiceInputs) { in.initialWorkFiles = nil }},
+		{name: "symlink resolver", mutate: func(in *newServiceInputs) { in.resolveSymlinks = nil }},
 	}
-	if service != nil {
-		t.Fatalf("NewService() = %#v, want nil service", service)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			inputs := valid
+			test.mutate(&inputs)
+			service, err := inputs.callNewService()
+			if err == nil {
+				t.Fatalf("NewService() error = nil, want missing %s dependency", test.name)
+			}
+			if service != nil {
+				t.Fatalf("NewService() = %#v, want nil service", service)
+			}
+		})
+	}
+}
+
+func TestNewServiceConstructsPublishedRoot(t *testing.T) {
+	t.Parallel()
+
+	service, err := validNewServiceInputs().callNewService()
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+	var root factorysessions.Service = service
+	if root == nil {
+		t.Fatal("constructed root is nil")
 	}
 }
 
@@ -28,21 +64,10 @@ func TestNewServiceIsInertAndRequiresRuntimeClockBinding(t *testing.T) {
 	clock := &recordingClock{}
 	directories := &recordingDirectoryInspection{}
 	symlinkCalls := 0
-	service, err := NewService(
-		nil,
-		resultProjector{},
-		nil,
-		nil,
-		nil,
-		func() string { return "response-event-id" },
-		func() string { return "session-id" },
-		func() (string, error) { return "home", nil },
-		directories,
-		namedPathResolver{},
-		fileeffects.InvocationInputReader(func(string) ([]byte, error) { return nil, nil }),
-		fileeffects.InitialWorkReader(func(string) ([]byte, error) { return nil, nil }),
-		func(path string) (string, error) { symlinkCalls++; return path, nil },
-	)
+	inputs := validNewServiceInputs()
+	inputs.directoryInspection = directories
+	inputs.resolveSymlinks = func(path string) (string, error) { symlinkCalls++; return path, nil }
+	service, err := inputs.callNewService()
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
 	}
@@ -80,6 +105,54 @@ type resultProjector struct{}
 
 func (resultProjector) ProjectSessionResults(factoryruntime.SessionResultInput) factoryruntime.SessionResultProjection {
 	return factoryruntime.SessionResultProjection{}
+}
+
+type newServiceInputs struct {
+	newJavaScriptCheckpointStore factoryruntime.JavaScriptCheckpointStoreFactory
+	sessionResultProjection      factoryruntime.SessionResultProjectionOperation
+	interpolation                factorydefinitions.InvocationInterpolationService
+	invocationWorkTypes          factorydefinitions.InvocationWorkTypeService
+	ttsObservability             factorydefinitions.TTSObservabilityService
+	eventIDs                     factorysessions.ResponseEventIDGenerator
+	sessionIDs                   factorysessions.SessionIDGenerator
+	resolveHome                  factorysessions.HomeDirectoryResolver
+	directoryInspection          DirectoryInspection
+	namedPaths                   factorydefinitions.NamedPathResolver
+	invocationInputFiles         fileeffects.InvocationInputReader
+	initialWorkFiles             fileeffects.InitialWorkReader
+	resolveSymlinks              factorysessions.LogicalTargetResolveSymlinks
+}
+
+func validNewServiceInputs() newServiceInputs {
+	return newServiceInputs{
+		sessionResultProjection: resultProjector{},
+		eventIDs:                func() string { return "response-event-id" },
+		sessionIDs:              func() string { return "session-id" },
+		resolveHome:             func() (string, error) { return "home", nil },
+		directoryInspection:     &recordingDirectoryInspection{},
+		namedPaths:              namedPathResolver{},
+		invocationInputFiles:    fileeffects.InvocationInputReader(func(string) ([]byte, error) { return nil, nil }),
+		initialWorkFiles:        fileeffects.InitialWorkReader(func(string) ([]byte, error) { return nil, nil }),
+		resolveSymlinks:         func(path string) (string, error) { return path, nil },
+	}
+}
+
+func (in newServiceInputs) callNewService() (factorysessions.Service, error) {
+	return NewService(
+		in.newJavaScriptCheckpointStore,
+		in.sessionResultProjection,
+		in.interpolation,
+		in.invocationWorkTypes,
+		in.ttsObservability,
+		in.eventIDs,
+		in.sessionIDs,
+		in.resolveHome,
+		in.directoryInspection,
+		in.namedPaths,
+		in.invocationInputFiles,
+		in.initialWorkFiles,
+		in.resolveSymlinks,
+	)
 }
 
 type recordingClock struct{ calls int }

--- a/pkg/services/factory_sessions/wire/wire_test.go
+++ b/pkg/services/factory_sessions/wire/wire_test.go
@@ -2,6 +2,7 @@ package wire
 
 import (
 	"io/fs"
+	"runtime"
 	"testing"
 	"time"
 
@@ -60,6 +61,81 @@ func TestNewServiceConstructsPublishedRoot(t *testing.T) {
 	}
 }
 
+func TestNewServiceConstructsInertRoot(t *testing.T) {
+	t.Parallel()
+
+	directories := &recordingDirectoryInspection{}
+	homeCalls := 0
+	symlinkCalls := 0
+	invocationInputCalls := 0
+	initialWorkCalls := 0
+	eventIDCalls := 0
+	sessionIDCalls := 0
+	inputs := validNewServiceInputs()
+	inputs.directoryInspection = directories
+	inputs.resolveHome = func() (string, error) {
+		homeCalls++
+		panic("home directory resolved during inert construction")
+	}
+	inputs.resolveSymlinks = func(path string) (string, error) {
+		symlinkCalls++
+		panic("symlink resolved during inert construction")
+	}
+	inputs.invocationInputFiles = fileeffects.InvocationInputReader(func(string) ([]byte, error) {
+		invocationInputCalls++
+		panic("invocation input read during inert construction")
+	})
+	inputs.initialWorkFiles = fileeffects.InitialWorkReader(func(string) ([]byte, error) {
+		initialWorkCalls++
+		panic("initial Work read during inert construction")
+	})
+	inputs.eventIDs = func() string {
+		eventIDCalls++
+		return "response-event-id"
+	}
+	inputs.sessionIDs = func() string {
+		sessionIDCalls++
+		return "session-id"
+	}
+
+	runtime.GC()
+	time.Sleep(20 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	service, err := inputs.callNewService()
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+	var root factorysessions.Service = service
+	if root == nil {
+		t.Fatal("constructed root is nil")
+	}
+	if directories.calls != 0 {
+		t.Fatalf("construction inspected filesystem %d times, want no runtime activity", directories.calls)
+	}
+	if homeCalls != 0 || symlinkCalls != 0 || invocationInputCalls != 0 || initialWorkCalls != 0 {
+		t.Fatalf(
+			"construction invoked effect stubs (home=%d symlinks=%d invocation input=%d initial Work=%d), want inert construction",
+			homeCalls, symlinkCalls, invocationInputCalls, initialWorkCalls,
+		)
+	}
+	if eventIDCalls != 0 || sessionIDCalls != 0 {
+		t.Fatalf(
+			"construction invoked generators (event IDs=%d session IDs=%d), want inert construction",
+			eventIDCalls, sessionIDCalls,
+		)
+	}
+
+	runtime.GC()
+	time.Sleep(20 * time.Millisecond)
+	if leaked := runtime.NumGoroutine() - baseline; leaked > 4 {
+		t.Fatalf("goroutine leak after construction: baseline=%d current=%d delta=%d", baseline, runtime.NumGoroutine(), leaked)
+	}
+}
+
 func TestNewServiceIsInertAndRequiresRuntimeClockBinding(t *testing.T) {
 	clock := &recordingClock{}
 	directories := &recordingDirectoryInspection{}
@@ -73,15 +149,6 @@ func TestNewServiceIsInertAndRequiresRuntimeClockBinding(t *testing.T) {
 	}
 	if service == nil {
 		t.Fatal("NewService() returned nil service")
-	}
-	if clock.calls != 0 {
-		t.Fatalf("construction read clock %d times, want no runtime activity", clock.calls)
-	}
-	if directories.calls != 0 {
-		t.Fatalf("construction inspected filesystem %d times, want no runtime activity", directories.calls)
-	}
-	if symlinkCalls != 0 {
-		t.Fatalf("construction resolved symlinks %d times, want no filesystem activity", symlinkCalls)
 	}
 	if assembly, bindErr := service.ForRuntime(factorysessions.RuntimeBinding{}); bindErr == nil || assembly != nil {
 		t.Fatalf("ForRuntime() without clock = %#v, %v; want deterministic error", assembly, bindErr)


### PR DESCRIPTION
{
  "project": "LWR-SES: Package Factory Sessions service-local Wire",
  "branchName": "pss-lwr-ses-service-wire",
  "description": "Implement LWR-SES as the Factory Sessions service-local Wire packet: compose the accepted Sessions root from parent-private Session owners through an inert Wire path that returns only factorysessions.Service and starts no lifecycle; prove inert construction and published ForRuntime peer behavior; register shared manifests as required; leave pkg/wire, pkg/root, pkg/initializer, OpenAPI, CLI composition, other-service Wire, HTTP/CLI/MCP adapters, and IMP-SES ownership interiors untouched beyond Wire composition; finish only after the PR is merged.",
  "context": {
    "customerAsk": "Implement LWR-SES as the Factory Sessions service-local Wire packet. Compose the accepted Sessions root from parent-private Session owners through an inert Wire path that returns only the root interface and starts no lifecycle. Do not edit pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, or other services' Wire. Do not expand into HTTP/CLI/MCP adapters or reopen IMP-SES ownership. Shared coverage, ownership, and package-target manifest edits are allowed. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Factory Sessions already has an accepted singular root, terminal owner-local IMP Session packets, and a service Wire package, but Packaged Service Structure still lacks the LWR-SES packet outcome: an owner-local inert Wire composition path that returns only factorysessions.Service and is proven the same way LWR-PSES proved Provider Sessions Wire. Later shared Wire cutover cannot depend on a Factory Sessions-owned construction boundary without that packet landing.",
    "solution": "Deliver LWR-SES by publishing or tightening pkg/services/factory_sessions/wire so it composes the accepted root from parent-private Session owners, returns only factorysessions.Service, starts no lifecycle, proves inert construction and ForRuntime peer behavior with focused tests, registers shared manifests as required, leaves root Wire/initializer/OpenAPI/CLI/other-service Wire and transport adapters untouched, then finishes verification and merges the packet PR."
  },
  "acceptanceCriteria": [
    "AC-1: pkg/services/factory_sessions/wire (or owner-local equivalent) exposes a focused constructor that returns only the published factorysessions.Service root and composes it from accepted parent-private Session owners",
    "AC-2: Focused inert construction proof shows Wire construction returns a usable root interface without starting lifecycle components and without invoking filesystem/symlink/runtime effect ports during construction when those ports are panic/recording stubs",
    "AC-3: Wire-constructed root exercises at least one published peer behavior successfully (runtime binding via ForRuntime with required inputs) and returns a typed Sessions failure for invalid/missing binding inputs",
    "AC-4: Diff stays inside Factory Sessions Wire composition/tests plus accepted shared coverage/ownership/package-target manifest reconciliation; no edits to pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, other services' Wire, HTTP/CLI/MCP adapters, or IMP-SES ownership interiors beyond Wire composition consumption",
    "AC-5: Quality checks pass (typecheck, lint, focused Factory Sessions Wire tests, and repository verification gates such as make verify-fast)",
    "AC-6: Delivery loop completes: required CI is terminal and passing, blocking PR conversation feedback is addressed, merge conflicts and shared-file churn are reconciled, and the PR is merged (opening, green CI, or approval alone is not completion)"
  ],
  "userStories": [
    {
      "id": "pss-lwr-ses-service-wire-001",
      "title": "Publish Factory Sessions service-local Wire constructor",
      "description": "As an application composition maintainer, I want a Factory Sessions owner-local Wire constructor that returns only factorysessions.Service so later root Wire cutover can compose Factory Sessions without importing parent-private Session owner internals or the concrete root implementation package from outside the owner boundary.",
      "acceptanceCriteria": [
        "pkg/services/factory_sessions/wire (or the owner-local Factory Sessions Wire composition path) publishes a constructor such as NewService that accepts Factory Sessions construction/process-edge ports and returns (factorysessions.Service, error)",
        "The Wire path composes the accepted root through parent-private Session owner construction (for example identity and response-stream owner Wire/assembly already consumed by Sessions), without publishing those owner types or filesystem/OS ports on the returned peer surface",
        "Missing required construction ports fail with a deterministic construction error and a nil service",
        "Package documentation states that Wire performs construction only, returns the singular root interface, and starts no lifecycle",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-ses-service-wire-002",
      "title": "Prove inert Wire construction",
      "description": "As a Packaged Service Structure reviewer, I want focused proof that Factory Sessions Wire construction is inert so process composition can hold a constructed root without starting session runtime, filesystem inspection, or other lifecycle activity.",
      "acceptanceCriteria": [
        "Focused Wire tests construct the root with panic or recording stubs for required effect ports (for example directory inspection and symlink resolution) and required generators/resolvers",
        "Construction completes without invoking those effect stubs and without starting background lifecycle goroutines or host processes",
        "The constructed value is usable only through factorysessions.Service (compile-time assignment and/or focused assertion that the returned peer is non-nil and typed as the root interface)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-ses-service-wire-003",
      "title": "Prove Wire-built root serves published peer behavior",
      "description": "As a peer-service consumer, I want the Wire-constructed Factory Sessions root to perform published runtime-binding behavior so the composition path is proven by observable Sessions outcomes, not by package shape alone.",
      "acceptanceCriteria": [
        "A focused Wire (or Wire-driven) test constructs the root through the service-local Wire path and successfully binds a runtime view via ForRuntime when required binding inputs (for example a clock) are supplied",
        "The same Wire-built root returns a typed Factory Sessions binding failure (for example ErrOpeningBindingInvalid / opening-binding error) when required binding inputs are missing, without panicking",
        "Successful binding returns a usable factorysessions.Service view without requiring the test to import parent-private Session owner packages as the peer API",
        "Binding itself remains inert with respect to the same recording effect stubs used at construction (no filesystem/runtime side effects solely from ForRuntime with a clock)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-ses-service-wire-004",
      "title": "Register Wire package and pass focused verification",
      "description": "As a Packaged Service Structure steward, I want the Factory Sessions Wire package registered in shared coverage/ownership/package-target manifests as required, with focused verification green, so the packet is merge-safe without expanding into root Wire cutover, transports, or IMP-SES ownership rewrites.",
      "acceptanceCriteria": [
        "pkg/services/factory_sessions/wire is registered in the package-target manifest (and coverage/ownership manifests only as required by Wire package registration)",
        "Focused Factory Sessions Wire tests pass",
        "Changed Go files are gofmt-clean; vet/lint and applicable ownership/package-target checks for changed paths pass",
        "make verify-fast (or the repository’s equivalent required short verification gate) passes",
        "Diff does not edit pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, other services' Wire, HTTP/CLI/MCP adapters, or reopen IMP-SES ownership interiors beyond Wire composition consumption",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-ses-service-wire-005",
      "title": "Open, land, and merge the LWR-SES PR",
      "description": "As a Factory delivery owner, I want the LWR-SES branch reviewed and merged so Factory Sessions service-local Wire is actually landed, not merely implemented on a long-lived branch.",
      "acceptanceCriteria": [
        "Branch pss-lwr-ses-service-wire is pushed and a PR is opened or updated against the integration base",
        "Required CI checks on the PR reach a terminal passing state",
        "Every blocking PR conversation comment is explicitly addressed (fix, follow-up commit, or recorded resolution)",
        "Merge conflicts and shared-file churn are rebased/reconciled as needed",
        "The PR is merged; work is not marked complete while the PR is only open, green, approved, or ready to merge",
        "Typecheck passes"
      ],
      "priority": 5,
      "passes": false,
      "notes": ""
    }
  ]
}


Made with [Cursor](https://cursor.com)