### PR TITLE
packaged-factories-first-party-definition-guard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ BACKEND_DEPENDENCY_GRAPH_DOT ?= $(BACKEND_DEPENDENCY_GRAPH_DIR)/backend-dependen
 BACKEND_DEPENDENCY_GRAPH_SVG ?= $(BACKEND_DEPENDENCY_GRAPH_DIR)/backend-dependency-graph.svg
 COMPATIBILITY_ALIAS_CHECK_ROOT ?= .
 RETIRED_SURFACE_CHECK_ROOT ?= .
-LINT_TARGETS ?= ui-lint ui-deadcode vet backend-size pkg-maint pkg-file-count pkg-boundary pkg-structure package-target-manifest-check packaged-factory-source-check packaged-factory-catalog-check provider-catalog-check model-provider-package-check durable-runtime-construction-check logging-boundary-check compatibility-alias-check retired-surface-check ownership-inventory-check deadcode
+LINT_TARGETS ?= ui-lint ui-deadcode vet backend-size pkg-maint pkg-file-count pkg-boundary pkg-structure package-target-manifest-check packaged-factory-source-check packaged-factory-consumption-check packaged-factory-catalog-check provider-catalog-check model-provider-package-check durable-runtime-construction-check logging-boundary-check compatibility-alias-check retired-surface-check ownership-inventory-check deadcode
 
 define run_verification_step
 	@printf '%s\n' "==> $(2) [make $(1)]"
@@ -143,7 +143,7 @@ endef
 .PHONY: docs-reference-check docs-reference-smoke
 
 .PHONY: script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke provider-parity-smoke javascript-contract-smoke config-contract-smoke
-.PHONY: backend-size pkg-maint pkg-file-count pkg-boundary pkg-structure package-target-manifest-check packaged-factory-source-check packaged-factory-catalog-generate packaged-factory-catalog-check provider-catalog-generate provider-catalog-check model-provider-package-generate model-provider-package-check durable-runtime-construction-check logging-boundary-check ownership-inventory-check
+.PHONY: backend-size pkg-maint pkg-file-count pkg-boundary pkg-structure package-target-manifest-check packaged-factory-source-check packaged-factory-consumption-check packaged-factory-catalog-generate packaged-factory-catalog-check provider-catalog-generate provider-catalog-check model-provider-package-generate model-provider-package-check durable-runtime-construction-check logging-boundary-check ownership-inventory-check
 .PHONY: response-stream-stress-smoke release-surface-smoke artifact-contract-closeout
 .PHONY: compatibility-alias-check retired-surface-check readme-check deadcode dashboard-verify
 
@@ -539,6 +539,9 @@ package-target-manifest-check:
 
 packaged-factory-source-check:
 	$(GO) run ./cmd/packagedfactorysourcecheck -root .
+
+packaged-factory-consumption-check:
+	$(GO) run ./cmd/packagedfactoryconsumptioncheck -root .
 
 packaged-factory-catalog-generate:
 	$(GO) run ./cmd/packagedfactorycataloggenerate -root .

--- a/cmd/packagedfactoryconsumptioncheck/main.go
+++ b/cmd/packagedfactoryconsumptioncheck/main.go
@@ -1,0 +1,214 @@
+// Command packagedfactoryconsumptioncheck enforces that shipped first-party
+// Factory definition bytes are consumed only through the packaged publication
+// and catalog loader surfaces.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	modulePath                          = "github.com/portpowered/infinite-you"
+	packagedFactoriesImport             = modulePath + "/packages/packaged-factories"
+	packagedFactoryCatalogImport        = modulePath + "/internal/packagedfactorycatalog"
+	diagnosticPrefix                    = "[agent-factory:packaged-factory-consumption]"
+	catalogLoaderSymbol                 = "LoadPublishedDefinitionCatalog"
+	packagedFactoriesPublicationSurface = "packages/packaged-factories"
+)
+
+var excludedDirectoryNames = map[string]struct{}{
+	".git":         {},
+	".artifacts":   {},
+	"coverage":     {},
+	"dist":         {},
+	"examples":     {},
+	"fixtures":     {},
+	"node_modules": {},
+	"testdata":     {},
+	"tests":        {},
+	"vendor":       {},
+}
+
+var allowedPackagedFactoriesImporters = map[string]struct{}{
+	"packages/packaged-factories":     {},
+	"internal/packagedfactorycatalog": {},
+}
+
+var allowedCatalogLoaderFiles = map[string]struct{}{
+	"pkg/wire/profiles.go": {},
+	"pkg/transports/http/handlers_models.go": {},
+	"pkg/services/factory_definitions/packages/goal/prompt_drift.go": {},
+}
+
+type config struct {
+	root string
+}
+
+func main() {
+	cfg := config{}
+	flag.StringVar(&cfg.root, "root", ".", "repository root to scan")
+	flag.Parse()
+	if err := run(cfg, os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(cfg config, stdout io.Writer) error {
+	repoRoot, err := filepath.Abs(cfg.root)
+	if err != nil {
+		return fmt.Errorf("%s resolve repository root: %w", diagnosticPrefix, err)
+	}
+	violations, err := inspectConsumptionBoundary(repoRoot)
+	if err != nil {
+		return err
+	}
+	sort.Strings(violations)
+	if len(violations) > 0 {
+		return fmt.Errorf("%s consumption boundary failed:\n- %s", diagnosticPrefix, strings.Join(violations, "\n- "))
+	}
+	fmt.Fprintf(
+		stdout,
+		"%s packaged Factory consumption is constrained to the embedded catalog surface\n",
+		diagnosticPrefix,
+	)
+	return nil
+}
+
+func inspectConsumptionBoundary(repoRoot string) ([]string, error) {
+	var violations []string
+	err := filepath.WalkDir(repoRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if path != repoRoot && excludedDirectory(path, entry.Name(), repoRoot) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		relative, err := filepath.Rel(repoRoot, path)
+		if err != nil {
+			return err
+		}
+		relative = filepath.ToSlash(relative)
+		if !isProductionGoFile(relative) {
+			return nil
+		}
+		fileViolations, err := inspectGoFile(path, relative)
+		if err != nil {
+			return fmt.Errorf("inspect %s: %w", relative, err)
+		}
+		violations = append(violations, fileViolations...)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s scan repository: %w", diagnosticPrefix, err)
+	}
+	return violations, nil
+}
+
+func inspectGoFile(path, relative string) ([]string, error) {
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, path, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+	if ast.IsGenerated(file) {
+		return nil, nil
+	}
+	packagePath := filepath.ToSlash(filepath.Dir(relative))
+	var violations []string
+	for _, importSpec := range file.Imports {
+		importPath, err := strconvUnquote(importSpec.Path.Value)
+		if err != nil {
+			return nil, err
+		}
+		switch importPath {
+		case packagedFactoriesImport:
+			if _, allowed := allowedPackagedFactoriesImporters[packagePath]; !allowed {
+				violations = append(violations, directEmbedImportViolation(relative, importPath))
+			}
+		case packagedFactoryCatalogImport:
+			if usesCatalogLoader(file) {
+				if _, allowed := allowedCatalogLoaderFiles[relative]; !allowed {
+					violations = append(violations, directCatalogLoaderViolation(relative))
+				}
+			}
+		}
+	}
+	return violations, nil
+}
+
+func usesCatalogLoader(file *ast.File) bool {
+	found := false
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || selector.Sel == nil || selector.Sel.Name != catalogLoaderSymbol {
+			return true
+		}
+		ident, ok := selector.X.(*ast.Ident)
+		if !ok || ident.Name != "packagedfactorycatalog" {
+			return true
+		}
+		found = true
+		return false
+	})
+	return found
+}
+
+func directEmbedImportViolation(relative, importPath string) string {
+	return fmt.Sprintf(
+		"%s imports %s directly; load shipped first-party Factory bytes only through %s and Factory Definitions catalog resolve/install",
+		relative,
+		importPath,
+		packagedFactoriesPublicationSurface,
+	)
+}
+
+func directCatalogLoaderViolation(relative string) string {
+	return fmt.Sprintf(
+		"%s calls packagedfactorycatalog.%s outside the approved catalog-consumption surface; route built-in packaged Factory list/resolve/install through Factory Definitions catalog operations",
+		relative,
+		catalogLoaderSymbol,
+	)
+}
+
+func isProductionGoFile(relative string) bool {
+	lowerName := strings.ToLower(filepath.Base(relative))
+	if !strings.HasSuffix(lowerName, ".go") || strings.HasSuffix(lowerName, "_test.go") {
+		return false
+	}
+	return true
+}
+
+func excludedDirectory(path, name, repoRoot string) bool {
+	if _, excluded := excludedDirectoryNames[strings.ToLower(name)]; excluded {
+		return true
+	}
+	relative, err := filepath.Rel(repoRoot, path)
+	if err != nil {
+		return false
+	}
+	return filepath.ToSlash(relative) == "factory"
+}
+
+func strconvUnquote(value string) (string, error) {
+	if len(value) < 2 {
+		return "", fmt.Errorf("invalid quoted import path %q", value)
+	}
+	return value[1 : len(value)-1], nil
+}

--- a/cmd/packagedfactoryconsumptioncheck/main_test.go
+++ b/cmd/packagedfactoryconsumptioncheck/main_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunAcceptsApprovedCatalogConsumptionSurface(t *testing.T) {
+	root := fixtureRepository(t)
+
+	var stdout bytes.Buffer
+	if err := run(config{root: root}, &stdout); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "consumption is constrained") {
+		t.Fatalf("stdout = %q, want success diagnostic", stdout.String())
+	}
+}
+
+func TestRunRejectsDirectPackagedFactoriesImportOutsideCatalogLoader(t *testing.T) {
+	root := fixtureRepository(t)
+	writeFixture(
+		t,
+		root,
+		"pkg/services/factory_definitions/bypass.go",
+		`package factorydefinitions
+
+import packagedfactories "github.com/portpowered/infinite-you/packages/packaged-factories"
+
+func bypass() packagedfactories.Source {
+	return packagedfactories.Source()
+}
+`,
+	)
+
+	err := run(config{root: root}, &bytes.Buffer{})
+	assertErrorContains(
+		t,
+		err,
+		"pkg/services/factory_definitions/bypass.go imports",
+		"packages/packaged-factories",
+	)
+}
+
+func TestRunRejectsDirectCatalogLoaderOutsideApprovedFiles(t *testing.T) {
+	root := fixtureRepository(t)
+	writeFixture(
+		t,
+		root,
+		"pkg/services/factory_definitions/bypass.go",
+		`package factorydefinitions
+
+import "github.com/portpowered/infinite-you/internal/packagedfactorycatalog"
+
+func bypass() error {
+	_, err := packagedfactorycatalog.LoadPublishedDefinitionCatalog()
+	return err
+}
+`,
+	)
+
+	err := run(config{root: root}, &bytes.Buffer{})
+	assertErrorContains(
+		t,
+		err,
+		"pkg/services/factory_definitions/bypass.go calls packagedfactorycatalog.LoadPublishedDefinitionCatalog",
+	)
+}
+
+func fixtureRepository(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, relative := range []string{
+		"pkg/wire",
+		"pkg/transports/http",
+		"pkg/services/factory_definitions/packages/goal",
+		"internal/packagedfactorycatalog",
+		"packages/packaged-factories",
+	} {
+		if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(relative)), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", relative, err)
+		}
+	}
+	writeFixture(t, root, "pkg/wire/profiles.go", `package wire
+
+import "github.com/portpowered/infinite-you/internal/packagedfactorycatalog"
+
+func profiles() error {
+	_, err := packagedfactorycatalog.LoadPublishedDefinitionCatalog()
+	return err
+}
+`)
+	writeFixture(t, root, "pkg/transports/http/handlers_models.go", `package http
+
+import "github.com/portpowered/infinite-you/internal/packagedfactorycatalog"
+
+func handlers() error {
+	_, err := packagedfactorycatalog.LoadPublishedDefinitionCatalog()
+	return err
+}
+`)
+	writeFixture(t, root, "pkg/services/factory_definitions/packages/goal/prompt_drift.go", `package goal
+
+import "github.com/portpowered/infinite-you/internal/packagedfactorycatalog"
+
+func promptDrift() error {
+	_, err := packagedfactorycatalog.LoadPublishedDefinitionCatalog()
+	return err
+}
+`)
+	writeFixture(t, root, "internal/packagedfactorycatalog/definition_catalog.go", `package packagedfactorycatalog
+
+import packagedfactories "github.com/portpowered/infinite-you/packages/packaged-factories"
+
+func LoadPublishedDefinitionCatalog() error {
+	_ = packagedfactories.Published()
+	return nil
+}
+`)
+	writeFixture(t, root, "packages/packaged-factories/embed.go", `package packagedfactories
+
+func Source() string { return "" }
+`)
+	return root
+}
+
+func writeFixture(t *testing.T, root, relative, contents string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(relative))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}
+
+func assertErrorContains(t *testing.T, err error, parts ...string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	message := err.Error()
+	for _, part := range parts {
+		if !strings.Contains(message, part) {
+			t.Fatalf("error = %q, want substring %q", message, part)
+		}
+	}
+}

--- a/cmd/packagedfactorysourcecheck/guard_failure_behavior_test.go
+++ b/cmd/packagedfactorysourcecheck/guard_failure_behavior_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPackagedFactorySourceGuardCommandFailsOnOffBoundaryRootDocument(t *testing.T) {
+	root := fixtureRepository(t)
+	writeFixture(t, root, "pkg/services/factory_definitions/packages/new/factory.yml", "name: '@you/new'\n")
+
+	exitCode, stderr := runSourceGuardCommand(t, root)
+	if exitCode == 0 {
+		t.Fatalf("source guard exit code = 0, want non-zero failure; stderr = %q", stderr)
+	}
+	for _, want := range []string{
+		diagnosticPrefix,
+		"source boundary failed",
+		"pkg/services/factory_definitions/packages/new/factory.yml",
+		`declares shipped first-party Factory "@you/new"`,
+		authoredBoundary,
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("stderr = %q, want substring %q", stderr, want)
+		}
+	}
+}
+
+func TestPackagedFactorySourceGuardCommandFailsOnOffBoundaryGoLiteral(t *testing.T) {
+	root := fixtureRepository(t)
+	writeFixture(
+		t,
+		root,
+		"pkg/services/factory_definitions/packages/new/builtin.go",
+		"package new\nvar definition = []byte(`{\"name\":\"@you/new-literal\"}`)\n",
+	)
+
+	exitCode, stderr := runSourceGuardCommand(t, root)
+	if exitCode == 0 {
+		t.Fatalf("source guard exit code = 0, want non-zero failure; stderr = %q", stderr)
+	}
+	for _, want := range []string{
+		diagnosticPrefix,
+		"pkg/services/factory_definitions/packages/new/builtin.go",
+		`declares shipped first-party Factory "@you/new-literal"`,
+		authoredBoundary,
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("stderr = %q, want substring %q", stderr, want)
+		}
+	}
+}
+
+func runSourceGuardCommand(t *testing.T, root string) (int, string) {
+	t.Helper()
+	repoRoot := repositoryRoot(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	command := exec.CommandContext(
+		ctx,
+		"go",
+		"run",
+		"./cmd/packagedfactorysourcecheck",
+		"-root",
+		root,
+	)
+	command.Dir = repoRoot
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	err := command.Run()
+	if err == nil {
+		return 0, stderr.String()
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("go run packagedfactorysourcecheck: %v", err)
+	}
+	return exitErr.ExitCode(), stderr.String()
+}
+
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("repository root: %v", err)
+	}
+	return root
+}

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -496,6 +496,18 @@ Wave 0 functional-tests-expansion planning authority lives under
   The package's passive embedded-filesystem tests run in `make test-maintenance`,
   matching the repository-boundary checker that protects its authored data
   ownership.
+- `cmd/packagedfactoryconsumptioncheck` owns the static consumption gate for
+  shipped first-party Factory definition bytes. Keep it in the default
+  `make lint` aggregation: production Go may import
+  `packages/packaged-factories` only from the embed package itself and
+  `internal/packagedfactorycatalog`, and may call
+  `packagedfactorycatalog.LoadPublishedDefinitionCatalog` only from the
+  approved wiring and catalog-projection files
+  (`pkg/wire/profiles.go`, `pkg/transports/http/handlers_models.go`,
+  `pkg/services/factory_definitions/packages/goal/prompt_drift.go`). Factory
+  Definitions list/resolve/install must continue to consume detached catalog
+  bytes through `PackagedFactoryCatalogOperations` rather than alternate embed
+  or filesystem paths.
   Public Go packages under `packages/` are not selected by the default unit
   lane. Classify passive publication boundaries explicitly in
   `internal/testlanes` and list them in `make test-maintenance`; the

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -508,9 +508,16 @@ Wave 0 functional-tests-expansion planning authority lives under
   `pkg/services/factory_definitions/packages/goal/prompt_drift.go`). Factory
   Definitions list/resolve/install must continue to consume detached catalog
   bytes through `PackagedFactoryCatalogOperations` rather than alternate embed
-  or filesystem paths. Focused unknown-identity resolve/install rejection
+  or filesystem paths.   Focused unknown-identity resolve/install rejection
   evidence lives in `pkg/wire/packaged_factory_guard_failure_test.go` and
   `tests/functional/product/packaged_factory_guard_failure/`.
+  First-party definition guard closeout verification runs, in order,
+  `make packaged-factory-source-check`, `make packaged-factory-consumption-check`,
+  `make packaged-factory-catalog-check`, and `make packaged-factory-package-verify`
+  (or the focused `packaged-factory-package-consumer-smoke` subset for
+  clean-consumer proof). No additional coverage, ownership, or package-target
+  manifest edits are required when those gates already register the new cmd
+  surfaces through default `make lint`.
   Public Go packages under `packages/` are not selected by the default unit
   lane. Classify passive publication boundaries explicitly in
   `internal/testlanes` and list them in `make test-maintenance`; the

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -495,7 +495,8 @@ Wave 0 functional-tests-expansion planning authority lives under
   repository `factory/` scaffold remain outside that classification.
   The package's passive embedded-filesystem tests run in `make test-maintenance`,
   matching the repository-boundary checker that protects its authored data
-  ownership.
+  ownership. Focused command-exit failure evidence lives in
+  `cmd/packagedfactorysourcecheck/guard_failure_behavior_test.go`.
 - `cmd/packagedfactoryconsumptioncheck` owns the static consumption gate for
   shipped first-party Factory definition bytes. Keep it in the default
   `make lint` aggregation: production Go may import
@@ -507,7 +508,9 @@ Wave 0 functional-tests-expansion planning authority lives under
   `pkg/services/factory_definitions/packages/goal/prompt_drift.go`). Factory
   Definitions list/resolve/install must continue to consume detached catalog
   bytes through `PackagedFactoryCatalogOperations` rather than alternate embed
-  or filesystem paths.
+  or filesystem paths. Focused unknown-identity resolve/install rejection
+  evidence lives in `pkg/wire/packaged_factory_guard_failure_test.go` and
+  `tests/functional/product/packaged_factory_guard_failure/`.
   Public Go packages under `packages/` are not selected by the default unit
   lane. Classify passive publication boundaries explicitly in
   `internal/testlanes` and list them in `make test-maintenance`; the

--- a/pkg/services/factory_definitions/install_packaged_factory_operation_test.go
+++ b/pkg/services/factory_definitions/install_packaged_factory_operation_test.go
@@ -1,0 +1,102 @@
+package factorydefinitions_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/packagedfactorycatalog"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorydefinitionsservice "github.com/portpowered/infinite-you/pkg/services/factory_definitions/service"
+)
+
+func TestInstallPackagedFactoryOperation_UsesEmbeddedCatalogForKnownIdentity(t *testing.T) {
+	t.Parallel()
+
+	catalog, err := newPublishedPackagedFactoryCatalog(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var installedName string
+	install := factorydefinitions.NewInstallPackagedFactoryOperation(
+		catalog,
+		factorydefinitions.PackagedFactoryInstallationOperations{
+			Install: func(
+				_ context.Context,
+				params factorydefinitions.PackagedFactoryInstallParams,
+			) (factorydefinitions.PackagedFactoryInstallResult, error) {
+				installedName = params.Definition.Name
+				return factorydefinitions.PackagedFactoryInstallResult{
+					Name:       params.Definition.Name,
+					FactoryDir: "/customer/factories/@you/review",
+					Outcome:    factorydefinitions.PackagedFactoryInstallCreated,
+					Format:     params.Format,
+				}, nil
+			},
+		},
+	)
+
+	result, err := install(
+		t.Context(),
+		factorydefinitions.InstallPackagedFactoryRequest{
+			RootDir: "/customer/factories",
+			Name:    "@you/review",
+			Format:  factorydefinitions.PackagedFactoryFormatJSON,
+		},
+	)
+	if err != nil {
+		t.Fatalf("InstallPackagedFactory() error = %v", err)
+	}
+	if installedName != "@you/review" || result.Definition.Name != "@you/review" {
+		t.Fatalf("install result = %#v, installedName = %q", result, installedName)
+	}
+}
+
+func TestInstallPackagedFactoryOperation_UnknownIdentityFailsClosedWithInventory(t *testing.T) {
+	t.Parallel()
+
+	catalog, err := newPublishedPackagedFactoryCatalog(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	install := factorydefinitions.NewInstallPackagedFactoryOperation(
+		catalog,
+		factorydefinitions.PackagedFactoryInstallationOperations{
+			Install: func(
+				context.Context,
+				factorydefinitions.PackagedFactoryInstallParams,
+			) (factorydefinitions.PackagedFactoryInstallResult, error) {
+				t.Fatal("installer should not run for unknown packaged identity")
+				return factorydefinitions.PackagedFactoryInstallResult{}, nil
+			},
+		},
+	)
+
+	_, err = install(
+		t.Context(),
+		factorydefinitions.InstallPackagedFactoryRequest{
+			RootDir: "/customer/factories",
+			Name:    "@you/missing",
+		},
+	)
+	if !errors.Is(err, factorydefinitions.ErrUnknownPackagedFactoryIdentity) {
+		t.Fatalf("InstallPackagedFactory() error = %v", err)
+	}
+	if !strings.Contains(err.Error(), "@you/goal") ||
+		!strings.Contains(err.Error(), "@you/review") ||
+		strings.Contains(err.Error(), "generated/") {
+		t.Fatalf("install error = %q, want stable public inventory", err.Error())
+	}
+}
+
+func newPublishedPackagedFactoryCatalog(
+	t *testing.T,
+) (factorydefinitions.PackagedFactoryCatalogOperations, error) {
+	t.Helper()
+	published, err := packagedfactorycatalog.LoadPublishedDefinitionCatalog()
+	if err != nil {
+		return factorydefinitions.PackagedFactoryCatalogOperations{}, err
+	}
+	return factorydefinitionsservice.NewPackagedFactoryCatalog(published.All())
+}

--- a/pkg/wire/packaged_factory_catalog_consumption_test.go
+++ b/pkg/wire/packaged_factory_catalog_consumption_test.go
@@ -1,0 +1,123 @@
+package wire
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+)
+
+func TestPackagedFactoryCatalogConsumption_ListResolveInstallUsesPublishedCatalog(t *testing.T) {
+	definitions, err := providePackagedFactoryDefinitions()
+	if err != nil {
+		t.Fatalf("providePackagedFactoryDefinitions() error = %v", err)
+	}
+	catalog, err := providePackagedFactoryCatalog(definitions)
+	if err != nil {
+		t.Fatalf("providePackagedFactoryCatalog() error = %v", err)
+	}
+
+	listed, err := catalog.ListBuiltInPackagedFactories(
+		t.Context(),
+		factorydefinitions.ListBuiltInPackagedFactoriesRequest{},
+	)
+	if err != nil {
+		t.Fatalf("ListBuiltInPackagedFactories() error = %v", err)
+	}
+	gotNames := make([]string, len(listed.Entries))
+	for index, entry := range listed.Entries {
+		gotNames[index] = entry.Name
+	}
+	wantNames := []string{
+		"@you/deep-research",
+		"@you/fusion",
+		"@you/goal",
+		"@you/quorum",
+		"@you/review",
+		"@you/subagent",
+		"@you/tts",
+	}
+	if len(gotNames) != len(wantNames) {
+		t.Fatalf("listed count = %d, want %d", len(gotNames), len(wantNames))
+	}
+	for index, wantName := range wantNames {
+		if gotNames[index] != wantName {
+			t.Fatalf("listed[%d] = %q, want %q", index, gotNames[index], wantName)
+		}
+	}
+
+	resolved, err := catalog.ResolveBuiltInPackagedFactory(
+		t.Context(),
+		factorydefinitions.ResolveBuiltInPackagedFactoryRequest{Name: "@you/goal"},
+	)
+	if err != nil {
+		t.Fatalf("ResolveBuiltInPackagedFactory(@you/goal) error = %v", err)
+	}
+	if resolved.Definition.Name != "@you/goal" || len(resolved.Definition.JSON) == 0 {
+		t.Fatalf("resolved goal = %#v, want published goal definition bytes", resolved.Definition)
+	}
+
+	_, err = catalog.ResolveBuiltInPackagedFactory(
+		t.Context(),
+		factorydefinitions.ResolveBuiltInPackagedFactoryRequest{Name: "@you/missing"},
+	)
+	if !errors.Is(err, factorydefinitions.ErrUnknownPackagedFactoryIdentity) {
+		t.Fatalf("ResolveBuiltInPackagedFactory(@you/missing) error = %v", err)
+	}
+	if !strings.Contains(err.Error(), "@you/deep-research") ||
+		!strings.Contains(err.Error(), "@you/tts") ||
+		strings.Contains(err.Error(), "generated/") {
+		t.Fatalf("unknown resolve error = %q, want stable public inventory", err.Error())
+	}
+
+	var installed factorydefinitions.PackagedDefinition
+	install := factorydefinitions.NewInstallPackagedFactoryOperation(
+		catalog,
+		factorydefinitions.PackagedFactoryInstallationOperations{
+			Install: func(
+				_ context.Context,
+				params factorydefinitions.PackagedFactoryInstallParams,
+			) (factorydefinitions.PackagedFactoryInstallResult, error) {
+				installed = params.Definition
+				return factorydefinitions.PackagedFactoryInstallResult{
+					Name:       params.Definition.Name,
+					FactoryDir: "/customer/factories/@you/goal",
+					Outcome:    factorydefinitions.PackagedFactoryInstallCreated,
+					Format:     params.Format,
+				}, nil
+			},
+		},
+	)
+	result, err := install(
+		t.Context(),
+		factorydefinitions.InstallPackagedFactoryRequest{
+			RootDir: "/customer/factories",
+			Name:    "@you/goal",
+			Format:  factorydefinitions.PackagedFactoryFormatJSON,
+		},
+	)
+	if err != nil {
+		t.Fatalf("InstallPackagedFactory(@you/goal) error = %v", err)
+	}
+	if !bytes.Equal(installed.JSON, resolved.Definition.JSON) {
+		t.Fatal("install received definition bytes that differ from catalog resolve")
+	}
+	if result.Definition.Name != "@you/goal" ||
+		result.Outcome != factorydefinitions.PackagedFactoryInstallCreated {
+		t.Fatalf("install result = %#v, want created goal install", result)
+	}
+
+	_, err = install(
+		t.Context(),
+		factorydefinitions.InstallPackagedFactoryRequest{
+			RootDir: "/customer/factories",
+			Name:    "@you/missing",
+		},
+	)
+	if !errors.Is(err, factorydefinitions.ErrUnknownPackagedFactoryIdentity) {
+		t.Fatalf("InstallPackagedFactory(@you/missing) error = %v", err)
+	}
+}

--- a/pkg/wire/packaged_factory_guard_failure_test.go
+++ b/pkg/wire/packaged_factory_guard_failure_test.go
@@ -1,0 +1,62 @@
+package wire
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+)
+
+func TestPackagedFactoryGuardFailure_UnknownResolveAndInstallRejectWithCatalogInventory(t *testing.T) {
+	definitions, err := providePackagedFactoryDefinitions()
+	if err != nil {
+		t.Fatalf("providePackagedFactoryDefinitions() error = %v", err)
+	}
+	catalog, err := providePackagedFactoryCatalog(definitions)
+	if err != nil {
+		t.Fatalf("providePackagedFactoryCatalog() error = %v", err)
+	}
+
+	_, err = catalog.ResolveBuiltInPackagedFactory(
+		t.Context(),
+		factorydefinitions.ResolveBuiltInPackagedFactoryRequest{Name: "@you/missing"},
+	)
+	if !errors.Is(err, factorydefinitions.ErrUnknownPackagedFactoryIdentity) {
+		t.Fatalf("ResolveBuiltInPackagedFactory(@you/missing) error = %v", err)
+	}
+	if !strings.Contains(err.Error(), "@you/goal") ||
+		!strings.Contains(err.Error(), "@you/tts") ||
+		strings.Contains(err.Error(), "generated/") {
+		t.Fatalf("resolve error = %q, want stable public inventory", err.Error())
+	}
+
+	install := factorydefinitions.NewInstallPackagedFactoryOperation(
+		catalog,
+		factorydefinitions.PackagedFactoryInstallationOperations{
+			Install: func(
+				_ context.Context,
+				_ factorydefinitions.PackagedFactoryInstallParams,
+			) (factorydefinitions.PackagedFactoryInstallResult, error) {
+				t.Fatal("installer should not run for unknown packaged identity")
+				return factorydefinitions.PackagedFactoryInstallResult{}, nil
+			},
+		},
+	)
+	_, err = install(
+		t.Context(),
+		factorydefinitions.InstallPackagedFactoryRequest{
+			RootDir: "/customer/factories",
+			Name:    "@you/missing",
+		},
+	)
+	if !errors.Is(err, factorydefinitions.ErrUnknownPackagedFactoryIdentity) {
+		t.Fatalf("InstallPackagedFactory(@you/missing) error = %v", err)
+	}
+	if !strings.Contains(err.Error(), "@you/deep-research") ||
+		!strings.Contains(err.Error(), "@you/review") ||
+		strings.Contains(err.Error(), "generated/") {
+		t.Fatalf("install error = %q, want stable public inventory", err.Error())
+	}
+}

--- a/tests/functional/product/packaged_factory_guard_failure/packaged_factory_guard_failure_test.go
+++ b/tests/functional/product/packaged_factory_guard_failure/packaged_factory_guard_failure_test.go
@@ -1,0 +1,92 @@
+package packaged_factory_guard_failure
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/root"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+)
+
+const existingOperatorConfig = `{
+  "backendScopeId": "scope-existing",
+  "defaults": {
+    "workerModelProvider": "claude",
+    "workerModel": "old-model"
+  },
+  "runtime": {
+    "logging": {
+      "directory": "custom-logs",
+      "maxSizeMB": 12,
+      "maxBackups": 3,
+      "maxAgeDays": 7,
+      "compress": true
+    },
+    "metrics": {
+      "directory": "custom-metrics",
+      "maxSizeMB": 14,
+      "maxBackups": 4,
+      "maxAgeDays": 8,
+      "compress": false
+    }
+  },
+  "workerPresets": [
+    {
+      "id": "review",
+      "modelProvider": "codex",
+      "model": "preset-model"
+    }
+  ]
+}`
+
+// TestInitUnknownPackagedFactoryFailsClosedWithCatalogInventory proves the public
+// init command rejects unknown first-party packaged identities before install.
+func TestInitUnknownPackagedFactoryFailsClosedWithCatalogInventory(t *testing.T) {
+	homeDir := t.TempDir()
+	workingDir := t.TempDir()
+	configPath := filepath.Join(homeDir, ".you-agent-factory", "config.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(config directory): %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(existingOperatorConfig), 0o600); err != nil {
+		t.Fatalf("WriteFile(config): %v", err)
+	}
+
+	process, err := root.BuildProcess(t.Context(), serviceedges.Edges{})
+	if err != nil {
+		t.Fatalf("BuildProcess() error = %v", err)
+	}
+	err = process.Execute(root.Input{
+		Args: []string{
+			"you", "init",
+			"--package", "@you/missing",
+			"--dir", filepath.Join(workingDir, "packaged-factories"),
+		},
+		Env: append(
+			os.Environ(),
+			"HOME="+homeDir,
+			"USERPROFILE="+homeDir,
+		),
+		Stdin:            strings.NewReader(""),
+		Stdout:           io.Discard,
+		Stderr:           io.Discard,
+		Context:          t.Context(),
+		WorkingDirectory: workingDir,
+	})
+	if !errors.Is(err, factorydefinitions.ErrUnknownPackagedFactoryIdentity) {
+		t.Fatalf("Process.Execute() error = %v, want ErrUnknownPackagedFactoryIdentity", err)
+	}
+	if !strings.Contains(err.Error(), "@you/goal") ||
+		!strings.Contains(err.Error(), "@you/review") ||
+		strings.Contains(err.Error(), "generated/") {
+		t.Fatalf("init error = %q, want stable public inventory", err.Error())
+	}
+	if _, statErr := os.Stat(filepath.Join(workingDir, "packaged-factories", "@you", "missing")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("unknown packaged factory directory exists or returned unexpected error: %v", statErr)
+	}
+}


### PR DESCRIPTION
{
  "project": "Packaged Factories First-Party Definition Guard",
  "branchName": "packaged-factories-first-party-definition-guard",
  "description": "Close Packaged Factories by guarding shipped first-party Factory definitions to the packaged catalog/package and running remaining final gates, including clean-consumer proof, without reopening embedded initialization, npm publication, or website inventory work.",
  "context": {
    "customerAsk": "Implement the Packaged Factories closeout guard so first-party Factory definitions are constrained to the packaged catalog/package and run the remaining final gates/proofs without reopening embedded initialization, npm publication, or website inventory work. Preserve accepted Clean CLI and Schema-Driven CLI contracts. Do not redesign customer-facing initialization command ownership beyond what the guard requires. Do not edit OpenAPI generation or top-level CLI composition unless a proven contract gap blocks the guard. Shared coverage, ownership, and package-target manifest edits are allowed. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Packaged Factories already ships an embedded catalog, npm publication, and website manifest consumption, but the remaining closeout item is incomplete: first-party (@you/*) Factory definitions are not yet proven to be permanently constrained to packages/packaged-factories plus the Factory Definitions packaged-catalog consumption path. Without that guard and the remaining final-gate evidence (including clean-consumer proof), maintainers can reintroduce handwritten or off-boundary first-party definitions, and the Packaged Factories program cannot close.",
    "solution": "Close the first-party definition ownership loop with a fail-closed source and consumption guard: authored/@you/* shipped definitions must live under the packaged-factories tree, Factory Definitions built-in catalog resolve/install must serve only identities from that packaged catalog, prove focused failure and clean-consumer final-gate outcomes, then deliver through merge without reopening accepted init, npm, website, Clean CLI, or Schema-Driven CLI work."
  },
  "acceptanceCriteria": [
    "AC-1: Shipped first-party Factory definitions (@you/*) cannot be authored or embedded outside packages/packaged-factories/factories; off-boundary attempts fail the packaged-factory source guard with actionable diagnostics",
    "AC-2: Factory Definitions built-in list/resolve/install for first-party packaged identities succeeds only for identities present in the embedded packaged catalog; unknown first-party package names fail closed and report available catalog names",
    "AC-3: Focused behavioral evidence covers both guard failure (off-boundary ownership / non-catalog first-party resolve-install) and clean-consumer final-gate success",
    "AC-4: Final Packaged Factories gates required for closeout pass (packaged-factory-source-check, packaged-factory-catalog-check, and packaged-factory package consumer/smoke proofs as applicable) without reopening embedded initialization, npm publication design, or website inventory work",
    "AC-5: Shared coverage, ownership, and package-target manifests change only when required by the guard",
    "AC-6: Quality checks pass (typecheck, lint, tests)",
    "AC-7: Implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is addressed, merge conflicts and shared-file churn are reconciled, and the PR is merged"
  ],
  "userStories": [
    {
      "id": "packaged-factories-first-party-definition-guard-001",
      "title": "Enforce authored first-party source boundary",
      "description": "As a maintainer, I want shipped first-party Factory definitions rejected outside the packaged-factories authored tree so there is only one place to change product-owned Factory documents.",
      "acceptanceCriteria": [
        "Adding a root Factory document named @you/* outside packages/packaged-factories/factories causes the packaged-factory source guard to fail with a diagnostic that names the offending path and required boundary",
        "Production Go string literals that embed a complete @you/* Factory definition outside the packaged-factories boundary cause the same guard to fail",
        "Examples, fixtures, test data, generated outputs, and the customer-authored repository factory/ scaffold remain outside that failure classification",
        "Canonical authored inventory under packages/packaged-factories/factories continues to pass the source guard",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Verified on main via cmd/packagedfactorysourcecheck (PRs #1232, #1246); no branch code changes required."
    },
    {
      "id": "packaged-factories-first-party-definition-guard-002",
      "title": "Constrain Factory Definitions packaged-catalog consumption",
      "description": "As a Factory Definitions consumer, I want built-in packaged Factory list/resolve/install to serve only identities from the embedded packaged catalog so first-party definitions cannot be introduced through an alternate consumption path.",
      "acceptanceCriteria": [
        "Listing built-in packaged Factories returns exactly the identities present in the embedded packaged catalog, in stable order",
        "Resolving or installing a first-party packaged Factory succeeds only when that identity exists in the embedded packaged catalog",
        "Resolving or installing an unknown first-party packaged identity fails closed and reports the available catalog names",
        "No alternate production path loads shipped @you/* Factory definition bytes from outside the packaged-factories publication/catalog surface",
        "Accepted Clean CLI and Schema-Driven CLI contracts remain unchanged unless a proven contract gap blocks the guard",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added cmd/packagedfactoryconsumptioncheck (make packaged-factory-consumption-check), wire catalog consumption integration test, and install operation tests against the published embedded catalog."
    },
    {
      "id": "packaged-factories-first-party-definition-guard-003",
      "title": "Prove focused guard failure behavior",
      "description": "As a reviewer, I want direct behavioral evidence that the guard fails closed on off-boundary ownership and non-catalog first-party consumption so closeout does not rely on inventory scanning or documentation topology checks.",
      "acceptanceCriteria": [
        "Focused tests demonstrate source-guard failure when a first-party definition is placed outside the packaged-factories authored boundary",
        "Focused tests demonstrate Factory Definitions resolve/install failure for an unknown first-party packaged identity, including available-name reporting",
        "Evidence asserts observable failure outcomes (non-zero guard/command result, structured error identity, or equivalent runtime rejection), not source-file inventories or docs-link topology",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added exec-based source-guard command failure tests, wire catalog unknown resolve/install rejection tests, and functional init unknown-package failure test."
    },
    {
      "id": "packaged-factories-first-party-definition-guard-004",
      "title": "Run Packaged Factories final gates and clean-consumer proof",
      "description": "As a maintainer, I want the remaining Packaged Factories final gates and clean-consumer proof to pass so the program can close without reopening accepted publication or website work.",
      "acceptanceCriteria": [
        "make packaged-factory-source-check passes against the guarded tree",
        "make packaged-factory-catalog-check passes against the published packaged-factories artifacts",
        "Packaged-factories clean-consumer / package smoke proof succeeds using only public package exports (no repository-relative consumption)",
        "Shared coverage, ownership, and package-target manifests are updated only when required by the guard registration or verification policy",
        "Embedded initialization, npm publication design, and website inventory/manifest consumption work are not reopened or redesigned",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Verified packaged-factory-source-check, packaged-factory-consumption-check, packaged-factory-catalog-check, packaged-factory-package-consumer-smoke, and packaged-factory-package-smoke; no manifest updates required."
    },
    {
      "id": "packaged-factories-first-party-definition-guard-005",
      "title": "Deliver through review, CI, and merge",
      "description": "As the program owner, I want the guard closeout carried through review and required CI until the PR is merged so the Packaged Factories checklist item is actually complete.",
      "acceptanceCriteria": [
        "A pull request containing the guard and final-gate evidence is opened against the integration branch",
        "Required CI reaches a terminal green state",
        "Every blocking PR conversation comment is explicitly addressed",
        "Merge conflicts and shared-file churn (including allowed coverage/ownership/package-target manifests) are reconciled",
        "The PR is merged; opened/green/approved/ready-to-merge alone does not satisfy completion",
        "Typecheck passes"
      ],
      "priority": 5,
      "passes": false,
      "notes": ""
    }
  ]
}
