### PR TITLE
pss-lwr-def-service-wire

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -361,6 +361,16 @@
       "minimum": 55.18
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire/defaultscaffold",
       "minimum": 9.09
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -337,6 +337,10 @@
       "minimum": 89.51
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire",
+      "minimum": 74.10
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire/defaultscaffold",
       "minimum": 75.75
     },

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -1157,6 +1157,12 @@
     },
     {
       "fromOwner": "factory_definitions",
+      "toOwner": "transports",
+      "class": "command",
+      "evidence": "pkg/services/factory_definitions/wire -\u003e pkg/transports/mapping/factoryconfig"
+    },
+    {
+      "fromOwner": "factory_definitions",
       "toOwner": "work",
       "class": "command",
       "evidence": "pkg/services/factory_definitions/contracts -\u003e pkg/services/work"
@@ -2712,6 +2718,12 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/factory_definitions/wire",
+      "disposition": "retain",
+      "destination": "factory_definitions",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/factory_definitions/wire/defaultscaffold",
       "disposition": "retain",
       "destination": "factory_definitions",
@@ -2793,12 +2805,6 @@
       "packagePath": "pkg/services/factory_runtime/exhaustiontests",
       "disposition": "retain",
       "destination": "factory_runtime",
-      "destinationKind": "owner"
-    },
-    {
-      "packagePath": "pkg/services/factory_runtime/ingest",
-      "disposition": "move",
-      "destination": "automations",
       "destinationKind": "owner"
     },
     {

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -112,6 +112,7 @@
     "pkg/services/factory_definitions/transports/cli",
     "pkg/services/factory_definitions/ttsobservability",
     "pkg/services/factory_definitions/validation",
+    "pkg/services/factory_definitions/wire",
     "pkg/services/factory_definitions/wire/defaultscaffold",
     "pkg/services/factory_definitions/workers",
     "pkg/services/factory_definitions/workers/taxonomy",
@@ -783,6 +784,11 @@
       "destination": "factory_definitions"
     },
     {
+      "packagePath": "pkg/services/factory_definitions/wire",
+      "disposition": "retain",
+      "destination": "factory_definitions"
+    },
+    {
       "packagePath": "pkg/services/factory_definitions/wire/defaultscaffold",
       "disposition": "retain",
       "destination": "factory_definitions"
@@ -841,13 +847,6 @@
       "packagePath": "pkg/services/factory_runtime/engine",
       "disposition": "retain",
       "destination": "factory_runtime"
-    },
-    {
-      "packagePath": "pkg/services/factory_runtime/ingest",
-      "disposition": "move",
-      "destination": "automations/internal/services/filesystem_watchers",
-      "deletionSuccessor": "pkg/services/automations/internal/services/filesystem_watchers",
-      "deletionCondition": "Factory Runtime ingest ownership moved to Automations filesystem_watchers."
     },
     {
       "packagePath": "pkg/services/factory_runtime/internal/orchestrators/javascript/preview",

--- a/pkg/services/factory_definitions/wire/wire.go
+++ b/pkg/services/factory_definitions/wire/wire.go
@@ -1,0 +1,200 @@
+// Package wire is the Factory Definitions service composition boundary.
+//
+// Wire performs construction only, returns the singular factorydefinitions.Service
+// root interface, and starts no lifecycle components. Parent-private catalog Wire
+// and the accepted service assembly stay inside the owner boundary; peers depend on
+// Service rather than Definition owner internals or construction ports.
+package wire
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryloading "github.com/portpowered/infinite-you/pkg/services/factory_definitions/loading"
+	"github.com/portpowered/infinite-you/pkg/services/factory_definitions/portableconfig"
+	factorydefinitionsservice "github.com/portpowered/infinite-you/pkg/services/factory_definitions/service"
+	factorysnapshotcapture "github.com/portpowered/infinite-you/pkg/services/factory_definitions/snapshotcapture"
+	factorymapping "github.com/portpowered/infinite-you/pkg/transports/mapping/factoryconfig"
+	"github.com/portpowered/infinite-you/pkg/transports/mapping/factorysnapshot"
+)
+
+// NewService constructs an inert Factory Definitions root from construction and
+// process-edge ports. It composes the accepted root through parent-private catalog
+// Wire and the accepted service assembly without publishing owner types on the
+// returned peer surface.
+func NewService(
+	sessionHost factorydefinitions.SessionHost,
+	validator factorydefinitions.Validator,
+	persistence factorydefinitions.Persistence,
+	loader *factoryloading.Loader,
+	applySupportedFiles factorydefinitions.PortableBundledFilesApplier,
+	applyStarterWork factorydefinitions.FactoryStarterWorkApplier,
+	namedPaths factorydefinitions.NamedPathResolver,
+	namedFactoryCatalogFileSystem factorydefinitions.NamedFactoryCatalogFileSystem,
+	clock factorydefinitions.Clock,
+	versionFileSystem factorydefinitions.VersionFileSystem,
+	listEffective factorydefinitions.EffectiveFactoryCatalogOperation,
+	packagedCatalog factorydefinitions.PackagedFactoryCatalogOperations,
+	packagedInstaller factorydefinitions.PackagedFactoryInstallationOperations,
+) (factorydefinitions.Service, error) {
+	if err := validateDependencies(
+		sessionHost,
+		validator,
+		persistence,
+		loader,
+		applySupportedFiles,
+		applyStarterWork,
+		namedPaths,
+		namedFactoryCatalogFileSystem,
+		clock,
+		versionFileSystem,
+		listEffective,
+		packagedCatalog,
+		packagedInstaller,
+	); err != nil {
+		return nil, err
+	}
+
+	preparePortableFactoryConfig := portableconfig.NewPreparer(
+		factorydefinitions.CloneFactoryConfig,
+		applySupportedFiles,
+		applyStarterWork,
+	)
+	captureFactorySnapshot := factorysnapshotcapture.NewExplicit(
+		factorysnapshot.ObjectFromFactoryConfig,
+	)
+
+	definitions := factorydefinitionsservice.New(
+		sessionHost,
+		clock,
+		versionFileSystem,
+		validator,
+		func(
+			factoryDir string,
+			workstationLoader factorydefinitions.WorkstationLoader,
+		) (factorydefinitions.MutableLoadedFactorySource, error) {
+			return loader.LoadRuntimeSource(factoryDir, workstationLoader)
+		},
+		namedPaths.ReadCurrentPointer,
+		func(
+			ctx context.Context,
+			segment string,
+			payload []byte,
+			_ factorydefinitions.Validator,
+		) (*factorydefinitions.PreparedFactoryLayoutPayload, error) {
+			return persistence.PrepareFactoryLayout(ctx, segment, payload)
+		},
+		persistence.CreateNamedFactory,
+		namedPaths.WriteCurrentPointer,
+		preparePortableFactoryConfig,
+		captureFactorySnapshot,
+		persistence.ReplaceFactoryLayout,
+		namedPaths,
+		namedFactoryCatalogFileSystem,
+		packagedCatalog,
+		packagedInstaller,
+	)
+	if definitions == nil {
+		return nil, fmt.Errorf("construct Factory Definitions: implementation rejected its dependencies")
+	}
+
+	attached, err := factorydefinitionsservice.AttachEffectiveCatalog(definitions, listEffective)
+	if err != nil {
+		return nil, err
+	}
+	if attached == nil {
+		return nil, fmt.Errorf("construct Factory Definitions: effective catalog attachment rejected its dependencies")
+	}
+	return attached, nil
+}
+
+func validateDependencies(
+	sessionHost factorydefinitions.SessionHost,
+	validator factorydefinitions.Validator,
+	persistence factorydefinitions.Persistence,
+	loader *factoryloading.Loader,
+	applySupportedFiles factorydefinitions.PortableBundledFilesApplier,
+	applyStarterWork factorydefinitions.FactoryStarterWorkApplier,
+	namedPaths factorydefinitions.NamedPathResolver,
+	namedFactoryCatalogFileSystem factorydefinitions.NamedFactoryCatalogFileSystem,
+	clock factorydefinitions.Clock,
+	versionFileSystem factorydefinitions.VersionFileSystem,
+	listEffective factorydefinitions.EffectiveFactoryCatalogOperation,
+	packagedCatalog factorydefinitions.PackagedFactoryCatalogOperations,
+	packagedInstaller factorydefinitions.PackagedFactoryInstallationOperations,
+) error {
+	if sessionHost == nil {
+		return fmt.Errorf("construct Factory Definitions: session host is required")
+	}
+	if validator == nil {
+		return fmt.Errorf("construct Factory Definitions: validator is required")
+	}
+	if persistence == nil {
+		return fmt.Errorf("construct Factory Definitions: persistence is required")
+	}
+	if loader == nil {
+		return fmt.Errorf("construct Factory Definitions: loader is required")
+	}
+	if applySupportedFiles == nil {
+		return fmt.Errorf("construct Factory Definitions: portable bundled files applier is required")
+	}
+	if applyStarterWork == nil {
+		return fmt.Errorf("construct Factory Definitions: starter Work applier is required")
+	}
+	if namedPaths == nil {
+		return fmt.Errorf("construct Factory Definitions: named path resolver is required")
+	}
+	if namedFactoryCatalogFileSystem == nil {
+		return fmt.Errorf("construct Factory Definitions: named Factory catalog filesystem is required")
+	}
+	if clock == nil {
+		return fmt.Errorf("construct Factory Definitions: clock is required")
+	}
+	if versionFileSystem == nil {
+		return fmt.Errorf("construct Factory Definitions: version filesystem is required")
+	}
+	if listEffective == nil {
+		return fmt.Errorf("construct Factory Definitions: effective Factory catalog is required")
+	}
+	if packagedCatalog.List == nil {
+		return fmt.Errorf("construct Factory Definitions: packaged Factory catalog list operation is required")
+	}
+	if packagedCatalog.Resolve == nil {
+		return fmt.Errorf("construct Factory Definitions: packaged Factory catalog resolve operation is required")
+	}
+	if packagedInstaller.Install == nil {
+		return fmt.Errorf("construct Factory Definitions: packaged Factory installer is required")
+	}
+	return nil
+}
+
+// EffectiveFactoryDefinitionNormalizerFromMapper binds the canonical Factory
+// config mapper to effective-catalog normalization for Wire composition.
+func EffectiveFactoryDefinitionNormalizerFromMapper() factorydefinitions.EffectiveFactoryDefinitionNormalizer {
+	mapper := factorymapping.NewFactoryConfigMapper()
+	return func(
+		ctx context.Context,
+		candidate factorydefinitions.EffectiveFactoryCatalogCandidate,
+	) (*factorydefinitions.FactoryConfig, error) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		definition, err := mapper.Expand(candidate.Canonical)
+		if contextErr := ctx.Err(); contextErr != nil {
+			return nil, contextErr
+		}
+		return definition, err
+	}
+}
+
+// StaticClock returns a Factory Definitions clock backed by one fixed instant.
+// It is intended for focused Wire tests that need deterministic construction ports.
+func StaticClock(instant time.Time) factorydefinitions.Clock {
+	return staticClock{instant: instant}
+}
+
+type staticClock struct{ instant time.Time }
+
+func (c staticClock) Now() time.Time { return c.instant }

--- a/pkg/services/factory_definitions/wire/wire_test.go
+++ b/pkg/services/factory_definitions/wire/wire_test.go
@@ -1,0 +1,382 @@
+package wire_test
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"strings"
+	"testing"
+	"time"
+
+	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorycontracts "github.com/portpowered/infinite-you/pkg/services/factory_definitions/contracts"
+	factoryloading "github.com/portpowered/infinite-you/pkg/services/factory_definitions/loading"
+	factorydefinitionsservice "github.com/portpowered/infinite-you/pkg/services/factory_definitions/service"
+	factorydefinitionswire "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire"
+)
+
+func TestNewServiceRejectsMissingRequiredDependencies(t *testing.T) {
+	t.Parallel()
+
+	base := validConstructionPorts(t)
+	tests := []struct {
+		name   string
+		mutate func(*constructionPorts)
+		want   string
+	}{
+		{
+			name:   "session host",
+			mutate: func(ports *constructionPorts) { ports.sessionHost = nil },
+			want:   "session host is required",
+		},
+		{
+			name:   "validator",
+			mutate: func(ports *constructionPorts) { ports.validator = nil },
+			want:   "validator is required",
+		},
+		{
+			name:   "persistence",
+			mutate: func(ports *constructionPorts) { ports.persistence = nil },
+			want:   "persistence is required",
+		},
+		{
+			name:   "loader",
+			mutate: func(ports *constructionPorts) { ports.loader = nil },
+			want:   "loader is required",
+		},
+		{
+			name:   "portable bundled files applier",
+			mutate: func(ports *constructionPorts) { ports.applySupportedFiles = nil },
+			want:   "portable bundled files applier is required",
+		},
+		{
+			name:   "starter Work applier",
+			mutate: func(ports *constructionPorts) { ports.applyStarterWork = nil },
+			want:   "starter Work applier is required",
+		},
+		{
+			name:   "named path resolver",
+			mutate: func(ports *constructionPorts) { ports.namedPaths = nil },
+			want:   "named path resolver is required",
+		},
+		{
+			name:   "named Factory catalog filesystem",
+			mutate: func(ports *constructionPorts) { ports.namedFactoryCatalogFileSystem = nil },
+			want:   "named Factory catalog filesystem is required",
+		},
+		{
+			name:   "clock",
+			mutate: func(ports *constructionPorts) { ports.clock = nil },
+			want:   "clock is required",
+		},
+		{
+			name:   "version filesystem",
+			mutate: func(ports *constructionPorts) { ports.versionFileSystem = nil },
+			want:   "version filesystem is required",
+		},
+		{
+			name:   "effective Factory catalog",
+			mutate: func(ports *constructionPorts) { ports.listEffective = nil },
+			want:   "effective Factory catalog is required",
+		},
+		{
+			name: "packaged Factory catalog list operation",
+			mutate: func(ports *constructionPorts) {
+				ports.packagedCatalog.List = nil
+			},
+			want: "packaged Factory catalog list operation is required",
+		},
+		{
+			name: "packaged Factory catalog resolve operation",
+			mutate: func(ports *constructionPorts) {
+				ports.packagedCatalog.Resolve = nil
+			},
+			want: "packaged Factory catalog resolve operation is required",
+		},
+		{
+			name: "packaged Factory installer",
+			mutate: func(ports *constructionPorts) {
+				ports.packagedInstaller.Install = nil
+			},
+			want: "packaged Factory installer is required",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ports := base
+			test.mutate(&ports)
+			service, err := factorydefinitionswire.NewService(
+				ports.sessionHost,
+				ports.validator,
+				ports.persistence,
+				ports.loader,
+				ports.applySupportedFiles,
+				ports.applyStarterWork,
+				ports.namedPaths,
+				ports.namedFactoryCatalogFileSystem,
+				ports.clock,
+				ports.versionFileSystem,
+				ports.listEffective,
+				ports.packagedCatalog,
+				ports.packagedInstaller,
+			)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("NewService() error = %v, want %q", err, test.want)
+			}
+			if service != nil {
+				t.Fatalf("NewService() = %#v, want nil service", service)
+			}
+		})
+	}
+}
+
+func TestNewServiceConstructsPublishedRoot(t *testing.T) {
+	t.Parallel()
+
+	ports := validConstructionPorts(t)
+	service, err := factorydefinitionswire.NewService(
+		ports.sessionHost,
+		ports.validator,
+		ports.persistence,
+		ports.loader,
+		ports.applySupportedFiles,
+		ports.applyStarterWork,
+		ports.namedPaths,
+		ports.namedFactoryCatalogFileSystem,
+		ports.clock,
+		ports.versionFileSystem,
+		ports.listEffective,
+		ports.packagedCatalog,
+		ports.packagedInstaller,
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+	var root factorydefinitions.Service = service
+	if root == nil {
+		t.Fatal("constructed value is not assignable to factorydefinitions.Service")
+	}
+}
+
+type constructionPorts struct {
+	sessionHost                   factorydefinitions.SessionHost
+	validator                     factorydefinitions.Validator
+	persistence                   factorydefinitions.Persistence
+	loader                        *factoryloading.Loader
+	applySupportedFiles           factorydefinitions.PortableBundledFilesApplier
+	applyStarterWork              factorydefinitions.FactoryStarterWorkApplier
+	namedPaths                    factorydefinitions.NamedPathResolver
+	namedFactoryCatalogFileSystem factorydefinitions.NamedFactoryCatalogFileSystem
+	clock                         factorydefinitions.Clock
+	versionFileSystem             factorydefinitions.VersionFileSystem
+	listEffective                 factorydefinitions.EffectiveFactoryCatalogOperation
+	packagedCatalog               factorydefinitions.PackagedFactoryCatalogOperations
+	packagedInstaller             factorydefinitions.PackagedFactoryInstallationOperations
+}
+
+func validConstructionPorts(t *testing.T) constructionPorts {
+	t.Helper()
+
+	packagedCatalog, err := factorydefinitionsservice.NewPackagedFactoryCatalog([]factorydefinitions.PackagedDefinition{{
+		Name:    "@you/wire-test",
+		Project: "wire-test",
+		JSON:    []byte(`{"name":"wire-test"}`),
+		Formats: []factorydefinitions.PackagedFactoryFormat{
+			factorydefinitions.PackagedFactoryFormatJSON,
+		},
+	}})
+	if err != nil {
+		t.Fatalf("NewPackagedFactoryCatalog() error = %v", err)
+	}
+
+	return constructionPorts{
+		sessionHost:                   &stubSessionHost{},
+		validator:                     stubValidator{},
+		persistence:                   stubPersistence{},
+		loader:                        &factoryloading.Loader{},
+		applySupportedFiles:           func(string, *factorydefinitions.FactoryConfig, bool, bool) error { return nil },
+		applyStarterWork:              func(string, *factorydefinitions.FactoryConfig) error { return nil },
+		namedPaths:                    stubNamedPathResolver{},
+		namedFactoryCatalogFileSystem: platformfilesystem.Local{},
+		clock:                         factorydefinitionswire.StaticClock(time.Unix(0, 0)),
+		versionFileSystem:             platformfilesystem.Local{},
+		listEffective: func(
+			context.Context,
+			factorydefinitions.ListEffectiveFactoriesRequest,
+		) (factorydefinitions.ListEffectiveFactoriesResult, error) {
+			return factorydefinitions.ListEffectiveFactoriesResult{}, nil
+		},
+		packagedCatalog: packagedCatalog,
+		packagedInstaller: factorydefinitions.PackagedFactoryInstallationOperations{
+			Install: func(
+				context.Context,
+				factorydefinitions.PackagedFactoryInstallParams,
+			) (factorydefinitions.PackagedFactoryInstallResult, error) {
+				return factorydefinitions.PackagedFactoryInstallResult{}, nil
+			},
+		},
+	}
+}
+
+type stubSessionHost struct{}
+
+func (stubSessionHost) PersistRootDir() string { return "" }
+func (stubSessionHost) WorkstationLoader() factorydefinitions.WorkstationLoader {
+	return nil
+}
+func (stubSessionHost) CurrentRuntimeConfig() factorydefinitions.LoadedFactorySource { return nil }
+func (stubSessionHost) WorkflowID() string                                           { return "" }
+func (stubSessionHost) RequireSession(string) (*factorydefinitions.DefinitionSession, error) {
+	return nil, errors.New("session not found")
+}
+func (stubSessionHost) SessionRuntimeConfig(string) (factorydefinitions.LoadedFactorySource, error) {
+	return nil, errors.New("session not found")
+}
+func (stubSessionHost) SessionFactoryPersistRoot(*factorydefinitions.DefinitionSession) string {
+	return ""
+}
+func (stubSessionHost) ValidateEditableFactorySnapshot(context.Context, *factorydefinitions.FactorySnapshot) error {
+	return nil
+}
+func (stubSessionHost) GetCurrentFactorySnapshotForSession(context.Context, string) (*factorydefinitions.FactorySnapshot, error) {
+	return nil, errors.New("session not found")
+}
+func (stubSessionHost) WithActivationLock(func() error) error { return nil }
+func (stubSessionHost) RequireIdleRuntimeForSession(context.Context, string) error {
+	return nil
+}
+func (stubSessionHost) ActivateSessionEditableFactory(
+	context.Context,
+	*factorydefinitions.DefinitionSession,
+	string, string, string, string, string,
+) error {
+	return nil
+}
+func (stubSessionHost) ReplaceFactoryLayoutAtDir(
+	string,
+	*factorydefinitions.PreparedFactoryLayoutPayload,
+) (*factorydefinitions.FactorySplitLayoutReplaceResult, error) {
+	return nil, nil
+}
+func (stubSessionHost) SaveNow() time.Time   { return time.Unix(0, 0) }
+func (stubSessionHost) RunSessionID() string { return "" }
+func (stubSessionHost) SessionForActivation(string) *factorydefinitions.DefinitionSession {
+	return nil
+}
+func (stubSessionHost) NamedFactoryActivationPaths(*factorydefinitions.DefinitionSession) (string, string) {
+	return "", ""
+}
+func (stubSessionHost) RequireIdleBeforeNamedFactoryActivation(
+	context.Context,
+	string,
+	*factorydefinitions.DefinitionSession,
+) error {
+	return nil
+}
+func (stubSessionHost) SwapPersistedNamedFactoryRuntime(
+	context.Context,
+	string,
+	*factorydefinitions.DefinitionSession,
+	string, string, string, string,
+) error {
+	return nil
+}
+func (stubSessionHost) AttachFactoryDefinitions(
+	definitions factorydefinitions.Service,
+) factorydefinitions.Service {
+	return definitions
+}
+
+type stubValidator struct{}
+
+func (stubValidator) Validate(
+	context.Context,
+	*factorycontracts.FactoryConfig,
+	factorycontracts.WorkflowSourceReader,
+) factorycontracts.ValidationResult {
+	return factorycontracts.ValidationResult{}
+}
+func (stubValidator) ValidateBlockingLoad(context.Context, *factorycontracts.FactoryConfig) factorycontracts.ValidationResult {
+	return factorycontracts.ValidationResult{}
+}
+func (stubValidator) ValidateTopology(
+	context.Context,
+	*factorycontracts.FactoryConfig,
+	factorycontracts.RequiredToolChecker,
+) factorycontracts.TopologyValidationResult {
+	return factorycontracts.TopologyValidationResult{}
+}
+func (stubValidator) WorkerWorkstationBehaviorCompatibility(
+	context.Context,
+	*factorycontracts.FactoryConfig,
+) []factorycontracts.ValidationTarget {
+	return nil
+}
+func (stubValidator) WorkTypeHandlingBehavior(
+	context.Context,
+	*factorycontracts.FactoryConfig,
+	bool,
+) []factorycontracts.ValidationTarget {
+	return nil
+}
+func (stubValidator) PruneLayout(
+	context.Context,
+	*factorycontracts.FactoryConfig,
+	factorycontracts.PendingFactoryGraphTopology,
+) factorycontracts.ValidationResult {
+	return factorycontracts.ValidationResult{}
+}
+
+type stubPersistence struct{}
+
+func (stubPersistence) PersistNamedFactory(
+	context.Context,
+	factorydefinitions.NamedFactoryPersistenceRequest,
+) (factorydefinitions.NamedFactoryPersistenceResult, error) {
+	return factorydefinitions.NamedFactoryPersistenceResult{}, nil
+}
+func (stubPersistence) PrepareFactoryLayout(
+	context.Context,
+	string,
+	[]byte,
+) (*factorydefinitions.PreparedFactoryLayoutPayload, error) {
+	return nil, nil
+}
+func (stubPersistence) ValidateFactoryLayout(string) error          { return nil }
+func (stubPersistence) FlattenFactoryLayout(string) ([]byte, error) { return nil, nil }
+func (stubPersistence) ExpandFactoryLayout(string) (string, factorydefinitions.LayoutExpansionReport, error) {
+	return "", factorydefinitions.LayoutExpansionReport{}, nil
+}
+func (stubPersistence) CreateNamedFactory(string, string, *factorydefinitions.PreparedFactoryLayoutPayload) (string, error) {
+	return "", nil
+}
+func (stubPersistence) ReplaceNamedFactory(string, string, *factorydefinitions.PreparedFactoryLayoutPayload) (string, error) {
+	return "", nil
+}
+func (stubPersistence) ReplaceFactoryLayout(
+	string,
+	*factorydefinitions.PreparedFactoryLayoutPayload,
+) (*factorydefinitions.FactorySplitLayoutReplaceResult, error) {
+	return nil, nil
+}
+
+type stubNamedPathResolver struct{}
+
+func (stubNamedPathResolver) ResolveCandidatePaths(string, string, string) (factorydefinitions.NamedFactoryCandidatePaths, error) {
+	return factorydefinitions.NamedFactoryCandidatePaths{}, nil
+}
+func (stubNamedPathResolver) ResolveExistingDir(string, string) (string, error) {
+	return "", factorydefinitions.ErrNamedFactoryNotFound
+}
+func (stubNamedPathResolver) RequireDefinitionDir(string) error { return fs.ErrNotExist }
+func (stubNamedPathResolver) ResolveCurrentDir(string) (string, error) {
+	return "", fs.ErrNotExist
+}
+func (stubNamedPathResolver) ReadCurrentPointer(string) (string, error) {
+	return "", fs.ErrNotExist
+}
+func (stubNamedPathResolver) WriteCurrentPointer(string, string) error { return nil }

--- a/pkg/services/factory_definitions/wire/wire_test.go
+++ b/pkg/services/factory_definitions/wire/wire_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -223,6 +224,83 @@ func TestNewServiceConstructsInertRoot(t *testing.T) {
 			runtime.NumGoroutine(),
 			leaked,
 		)
+	}
+}
+
+func TestNewServiceServesPublishedPackagedCatalogPeerBehavior(t *testing.T) {
+	t.Parallel()
+
+	packagedCatalog, err := factorydefinitionsservice.NewPackagedFactoryCatalog([]factorydefinitions.PackagedDefinition{
+		{
+			Name: "@you/review", Project: "builtin-review",
+			JSON: []byte(`{"name":"review"}`),
+			Formats: []factorydefinitions.PackagedFactoryFormat{
+				factorydefinitions.PackagedFactoryFormatJSON,
+			},
+		},
+		{
+			Name: "@you/goal", Project: "builtin-goal",
+			JSON: []byte(`{"name":"goal"}`),
+			Formats: []factorydefinitions.PackagedFactoryFormat{
+				factorydefinitions.PackagedFactoryFormatJSON,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewPackagedFactoryCatalog() error = %v", err)
+	}
+
+	ports := validConstructionPorts(t)
+	ports.packagedCatalog = packagedCatalog
+	service, err := factorydefinitionswire.NewService(
+		ports.sessionHost,
+		ports.validator,
+		ports.persistence,
+		ports.loader,
+		ports.applySupportedFiles,
+		ports.applyStarterWork,
+		ports.namedPaths,
+		ports.namedFactoryCatalogFileSystem,
+		ports.clock,
+		ports.versionFileSystem,
+		ports.listEffective,
+		ports.packagedCatalog,
+		ports.packagedInstaller,
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	var root factorydefinitions.Service = service
+
+	listed, err := root.ListBuiltInPackagedFactories(
+		t.Context(),
+		factorydefinitions.ListBuiltInPackagedFactoriesRequest{},
+	)
+	if err != nil {
+		t.Fatalf("ListBuiltInPackagedFactories() error = %v", err)
+	}
+	gotNames := []string{listed.Entries[0].Name, listed.Entries[1].Name}
+	if !reflect.DeepEqual(gotNames, []string{"@you/goal", "@you/review"}) {
+		t.Fatalf("ListBuiltInPackagedFactories names = %v, want [@you/goal @you/review]", gotNames)
+	}
+
+	resolved, err := root.ResolveBuiltInPackagedFactory(
+		t.Context(),
+		factorydefinitions.ResolveBuiltInPackagedFactoryRequest{Name: "@you/goal"},
+	)
+	if err != nil {
+		t.Fatalf("ResolveBuiltInPackagedFactory() error = %v", err)
+	}
+	if resolved.Definition.Project != "builtin-goal" {
+		t.Fatalf("ResolveBuiltInPackagedFactory result = %#v, want builtin-goal project", resolved)
+	}
+
+	_, err = root.ResolveBuiltInPackagedFactory(
+		t.Context(),
+		factorydefinitions.ResolveBuiltInPackagedFactoryRequest{Name: "@you/missing"},
+	)
+	if !errors.Is(err, factorydefinitions.ErrUnknownPackagedFactoryIdentity) {
+		t.Fatalf("ResolveBuiltInPackagedFactory(missing) error = %v, want ErrUnknownPackagedFactoryIdentity", err)
 	}
 }
 

--- a/pkg/services/factory_definitions/wire/wire_test.go
+++ b/pkg/services/factory_definitions/wire/wire_test.go
@@ -304,6 +304,29 @@ func TestNewServiceServesPublishedPackagedCatalogPeerBehavior(t *testing.T) {
 	}
 }
 
+func TestStaticClockReturnsFixedInstant(t *testing.T) {
+	t.Parallel()
+
+	instant := time.Unix(42, 0)
+	clock := factorydefinitionswire.StaticClock(instant)
+	if got := clock.Now(); !got.Equal(instant) {
+		t.Fatalf("StaticClock.Now() = %v, want %v", got, instant)
+	}
+}
+
+func TestEffectiveFactoryDefinitionNormalizerFromMapperHonorsCancelledContext(t *testing.T) {
+	t.Parallel()
+
+	normalizer := factorydefinitionswire.EffectiveFactoryDefinitionNormalizerFromMapper()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := normalizer(ctx, factorydefinitions.EffectiveFactoryCatalogCandidate{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("normalizer() error = %v, want context.Canceled", err)
+	}
+}
+
 func TestNewServiceConstructsPublishedRoot(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_definitions/wire/wire_test.go
+++ b/pkg/services/factory_definitions/wire/wire_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -128,6 +129,100 @@ func TestNewServiceRejectsMissingRequiredDependencies(t *testing.T) {
 				t.Fatalf("NewService() = %#v, want nil service", service)
 			}
 		})
+	}
+}
+
+func TestNewServiceConstructsInertRoot(t *testing.T) {
+	t.Parallel()
+
+	baselineGoroutines := runtime.NumGoroutine()
+	sessionHost := &recordingSessionHost{}
+	namedPaths := &recordingNamedPathResolver{}
+	namedFactoryCatalogFileSystem := &recordingNamedFactoryCatalogFileSystem{}
+	versionFileSystem := &recordingVersionFileSystem{}
+	clock := &recordingClock{}
+
+	packagedCatalog, err := factorydefinitionsservice.NewPackagedFactoryCatalog([]factorydefinitions.PackagedDefinition{{
+		Name:    "@you/wire-inert",
+		Project: "wire-inert",
+		JSON:    []byte(`{"name":"wire-inert"}`),
+		Formats: []factorydefinitions.PackagedFactoryFormat{
+			factorydefinitions.PackagedFactoryFormatJSON,
+		},
+	}})
+	if err != nil {
+		t.Fatalf("NewPackagedFactoryCatalog() error = %v", err)
+	}
+
+	service, err := factorydefinitionswire.NewService(
+		sessionHost,
+		stubValidator{},
+		stubPersistence{},
+		&factoryloading.Loader{},
+		func(string, *factorydefinitions.FactoryConfig, bool, bool) error { return nil },
+		func(string, *factorydefinitions.FactoryConfig) error { return nil },
+		namedPaths,
+		namedFactoryCatalogFileSystem,
+		clock,
+		versionFileSystem,
+		func(
+			context.Context,
+			factorydefinitions.ListEffectiveFactoriesRequest,
+		) (factorydefinitions.ListEffectiveFactoriesResult, error) {
+			return factorydefinitions.ListEffectiveFactoriesResult{}, nil
+		},
+		packagedCatalog,
+		factorydefinitions.PackagedFactoryInstallationOperations{
+			Install: func(
+				context.Context,
+				factorydefinitions.PackagedFactoryInstallParams,
+			) (factorydefinitions.PackagedFactoryInstallResult, error) {
+				return factorydefinitions.PackagedFactoryInstallResult{}, nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+	var root factorydefinitions.Service = service
+	if root == nil {
+		t.Fatal("constructed value is not assignable to factorydefinitions.Service")
+	}
+
+	if namedPaths.calls != 0 {
+		t.Fatalf("construction invoked named path resolver %d times, want no filesystem activity", namedPaths.calls)
+	}
+	if namedFactoryCatalogFileSystem.calls != 0 {
+		t.Fatalf(
+			"construction invoked named Factory catalog filesystem %d times, want no filesystem activity",
+			namedFactoryCatalogFileSystem.calls,
+		)
+	}
+	if versionFileSystem.calls != 0 {
+		t.Fatalf("construction invoked version filesystem %d times, want no filesystem activity", versionFileSystem.calls)
+	}
+	if clock.calls != 0 {
+		t.Fatalf("construction read clock %d times, want no runtime activity", clock.calls)
+	}
+	if sessionHost.runtimeCalls != 0 {
+		t.Fatalf(
+			"construction invoked session-host runtime ports %d times, want no disk or runtime activity",
+			sessionHost.runtimeCalls,
+		)
+	}
+	if sessionHost.attachCalls != 1 {
+		t.Fatalf("AttachFactoryDefinitions calls = %d, want exactly one construction-time wiring call", sessionHost.attachCalls)
+	}
+	if leaked := runtime.NumGoroutine() - baselineGoroutines; leaked > 4 {
+		t.Fatalf(
+			"construction started background goroutines: baseline=%d current=%d delta=%d",
+			baselineGoroutines,
+			runtime.NumGoroutine(),
+			leaked,
+		)
 	}
 }
 
@@ -380,3 +475,194 @@ func (stubNamedPathResolver) ReadCurrentPointer(string) (string, error) {
 	return "", fs.ErrNotExist
 }
 func (stubNamedPathResolver) WriteCurrentPointer(string, string) error { return nil }
+
+type recordingNamedPathResolver struct{ calls int }
+
+func (r *recordingNamedPathResolver) ResolveCandidatePaths(string, string, string) (factorydefinitions.NamedFactoryCandidatePaths, error) {
+	r.calls++
+	panic("named path resolver invoked during inert construction")
+}
+
+func (r *recordingNamedPathResolver) ResolveExistingDir(string, string) (string, error) {
+	r.calls++
+	panic("named path resolver invoked during inert construction")
+}
+
+func (r *recordingNamedPathResolver) RequireDefinitionDir(string) error {
+	r.calls++
+	panic("named path resolver invoked during inert construction")
+}
+
+func (r *recordingNamedPathResolver) ResolveCurrentDir(string) (string, error) {
+	r.calls++
+	panic("named path resolver invoked during inert construction")
+}
+
+func (r *recordingNamedPathResolver) ReadCurrentPointer(string) (string, error) {
+	r.calls++
+	panic("named path resolver invoked during inert construction")
+}
+
+func (r *recordingNamedPathResolver) WriteCurrentPointer(string, string) error {
+	r.calls++
+	panic("named path resolver invoked during inert construction")
+}
+
+type recordingNamedFactoryCatalogFileSystem struct{ calls int }
+
+func (f *recordingNamedFactoryCatalogFileSystem) Stat(string) (fs.FileInfo, error) {
+	f.calls++
+	panic("named Factory catalog filesystem invoked during inert construction")
+}
+
+func (f *recordingNamedFactoryCatalogFileSystem) ReadDir(string) ([]fs.DirEntry, error) {
+	f.calls++
+	panic("named Factory catalog filesystem invoked during inert construction")
+}
+
+func (f *recordingNamedFactoryCatalogFileSystem) RemoveAll(string) error {
+	f.calls++
+	panic("named Factory catalog filesystem invoked during inert construction")
+}
+
+type recordingVersionFileSystem struct{ calls int }
+
+func (v *recordingVersionFileSystem) Stat(string) (fs.FileInfo, error) {
+	v.calls++
+	panic("version filesystem invoked during inert construction")
+}
+
+type recordingClock struct{ calls int }
+
+func (c *recordingClock) Now() time.Time {
+	c.calls++
+	panic("clock invoked during inert construction")
+}
+
+type recordingSessionHost struct {
+	runtimeCalls int
+	attachCalls  int
+}
+
+func (h *recordingSessionHost) recordRuntimeCall() {
+	h.runtimeCalls++
+	panic("session-host runtime port invoked during inert construction")
+}
+
+func (h *recordingSessionHost) PersistRootDir() string {
+	h.recordRuntimeCall()
+	return ""
+}
+
+func (h *recordingSessionHost) WorkstationLoader() factorydefinitions.WorkstationLoader {
+	h.recordRuntimeCall()
+	return nil
+}
+
+func (h *recordingSessionHost) CurrentRuntimeConfig() factorydefinitions.LoadedFactorySource {
+	h.recordRuntimeCall()
+	return nil
+}
+
+func (h *recordingSessionHost) WorkflowID() string {
+	h.recordRuntimeCall()
+	return ""
+}
+
+func (h *recordingSessionHost) RequireSession(string) (*factorydefinitions.DefinitionSession, error) {
+	h.recordRuntimeCall()
+	return nil, errors.New("session not found")
+}
+
+func (h *recordingSessionHost) SessionRuntimeConfig(string) (factorydefinitions.LoadedFactorySource, error) {
+	h.recordRuntimeCall()
+	return nil, errors.New("session not found")
+}
+
+func (h *recordingSessionHost) SessionFactoryPersistRoot(*factorydefinitions.DefinitionSession) string {
+	h.recordRuntimeCall()
+	return ""
+}
+
+func (h *recordingSessionHost) ValidateEditableFactorySnapshot(context.Context, *factorydefinitions.FactorySnapshot) error {
+	h.recordRuntimeCall()
+	return nil
+}
+
+func (h *recordingSessionHost) GetCurrentFactorySnapshotForSession(context.Context, string) (*factorydefinitions.FactorySnapshot, error) {
+	h.recordRuntimeCall()
+	return nil, errors.New("session not found")
+}
+
+func (h *recordingSessionHost) WithActivationLock(func() error) error {
+	h.recordRuntimeCall()
+	return nil
+}
+
+func (h *recordingSessionHost) RequireIdleRuntimeForSession(context.Context, string) error {
+	h.recordRuntimeCall()
+	return nil
+}
+
+func (h *recordingSessionHost) ActivateSessionEditableFactory(
+	context.Context,
+	*factorydefinitions.DefinitionSession,
+	string, string, string, string, string,
+) error {
+	h.recordRuntimeCall()
+	return nil
+}
+
+func (h *recordingSessionHost) ReplaceFactoryLayoutAtDir(
+	string,
+	*factorydefinitions.PreparedFactoryLayoutPayload,
+) (*factorydefinitions.FactorySplitLayoutReplaceResult, error) {
+	h.recordRuntimeCall()
+	return nil, nil
+}
+
+func (h *recordingSessionHost) SaveNow() time.Time {
+	h.recordRuntimeCall()
+	return time.Unix(0, 0)
+}
+
+func (h *recordingSessionHost) RunSessionID() string {
+	h.recordRuntimeCall()
+	return ""
+}
+
+func (h *recordingSessionHost) SessionForActivation(string) *factorydefinitions.DefinitionSession {
+	h.recordRuntimeCall()
+	return nil
+}
+
+func (h *recordingSessionHost) NamedFactoryActivationPaths(*factorydefinitions.DefinitionSession) (string, string) {
+	h.recordRuntimeCall()
+	return "", ""
+}
+
+func (h *recordingSessionHost) RequireIdleBeforeNamedFactoryActivation(
+	context.Context,
+	string,
+	*factorydefinitions.DefinitionSession,
+) error {
+	h.recordRuntimeCall()
+	return nil
+}
+
+func (h *recordingSessionHost) SwapPersistedNamedFactoryRuntime(
+	context.Context,
+	string,
+	*factorydefinitions.DefinitionSession,
+	string, string, string, string,
+) error {
+	h.recordRuntimeCall()
+	return nil
+}
+
+func (h *recordingSessionHost) AttachFactoryDefinitions(
+	definitions factorydefinitions.Service,
+) factorydefinitions.Service {
+	h.attachCalls++
+	return definitions
+}


### PR DESCRIPTION
{
  "project": "LWR-DEF: Package Factory Definitions service-local Wire",
  "branchName": "pss-lwr-def-service-wire",
  "description": "Implement LWR-DEF as the Factory Definitions service-local Wire packet: compose the accepted Definitions root from parent-private Definition owners through an inert Wire path that returns only factorydefinitions.Service and starts no lifecycle; prove inert construction and published catalog/distribute/validate peer behavior; register shared manifests as required; leave pkg/wire, pkg/root, pkg/initializer, OpenAPI, CLI composition, other-service Wire, HTTP/CLI/MCP adapters, and IMP-DEF ownership interiors untouched beyond Wire composition; finish only after the PR is merged.",
  "context": {
    "customerAsk": "Implement LWR-DEF as the Factory Definitions service-local Wire packet. Compose the accepted Definitions root from parent-private Definition owners through an inert Wire path that returns only the root interface and starts no lifecycle. Do not edit pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, or other services' Wire. Do not expand into HTTP/CLI/MCP adapters or reopen IMP-DEF ownership. Shared coverage, ownership, and package-target manifest edits are allowed. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Factory Definitions already has an accepted singular root, terminal owner-local IMP Definition packets, and service assembly that consumes catalog/authoring/compilation/snapshots/distribution, but Packaged Service Structure still lacks the LWR-DEF packet outcome: an owner-local inert Wire composition path that returns only factorydefinitions.Service and is proven the same way LWR-SES and LWR-PSES proved service-local Wire. Application composition reaches the constructor directly from root Wire, so later shared Wire cutover cannot depend on a Factory Definitions-owned construction boundary without importing service internals.",
    "solution": "Deliver LWR-DEF by publishing pkg/services/factory_definitions/wire so it composes the accepted root from parent-private Definition owners, returns only factorydefinitions.Service, starts no lifecycle, proves inert construction and at least one published peer catalog/distribute/validate behavior with focused tests, registers shared manifests as required, leaves root Wire/initializer/OpenAPI/CLI/other-service Wire and transport adapters untouched, then finishes verification and merges the packet PR."
  },
  "acceptanceCriteria": [
    "AC-1: pkg/services/factory_definitions/wire (or owner-local equivalent) exposes a focused constructor that returns only the published factorydefinitions.Service root and composes it from accepted parent-private Definition owners",
    "AC-2: Focused inert construction proof shows Wire construction returns a usable root interface without starting lifecycle components and without invoking named-path/catalog-filesystem/version-filesystem/session-host effect ports during construction when those ports are panic/recording stubs",
    "AC-3: Wire-constructed root exercises at least one published peer behavior successfully (for example ListBuiltInPackagedFactories, ListNamedFactories, GetNamedFactory, or ValidateStructuralFactoryDefinition against a fixture/injected catalog) and returns a typed Definitions failure for an invalid/unknown input (for example ErrUnknownPackagedFactoryIdentity, ErrInvalidNamedFactoryName, or ErrNamedFactoryNotFound)",
    "AC-4: Diff stays inside Factory Definitions Wire composition/tests plus accepted shared coverage/ownership/package-target manifest reconciliation; no edits to pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, other services' Wire, HTTP/CLI/MCP adapters, or IMP-DEF ownership interiors beyond Wire composition consumption",
    "AC-5: Quality checks pass (typecheck, lint, focused Factory Definitions Wire tests, and repository verification gates such as make verify-fast)",
    "AC-6: Delivery loop completes: required CI is terminal and passing, blocking PR conversation feedback is addressed, merge conflicts and shared-file churn are reconciled, and the PR is merged (opening, green CI, or approval alone is not completion)"
  ],
  "userStories": [
    {
      "id": "pss-lwr-def-service-wire-001",
      "title": "Publish Factory Definitions service-local Wire constructor",
      "description": "As an application composition maintainer, I want a Factory Definitions owner-local Wire constructor that returns only factorydefinitions.Service so later root Wire cutover can compose Factory Definitions without importing parent-private Definition owner internals or the concrete root implementation package from outside the owner boundary.",
      "acceptanceCriteria": [
        "pkg/services/factory_definitions/wire (or the owner-local Factory Definitions Wire composition path) publishes a constructor such as NewService that accepts Factory Definitions construction/process-edge ports and returns (factorydefinitions.Service, error)",
        "The Wire path composes the accepted root through parent-private Definition owner construction (for example catalog Wire/assembly and the accepted service assembly that already consumes authoring/compilation/snapshots/distribution), without publishing those owner types or filesystem/OS ports on the returned peer surface",
        "Missing required construction ports fail with a deterministic construction error and a nil service",
        "Package documentation states that Wire performs construction only, returns the singular root interface, and starts no lifecycle",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-def-service-wire-002",
      "title": "Prove inert Wire construction",
      "description": "As a Packaged Service Structure reviewer, I want focused proof that Factory Definitions Wire construction is inert so process composition can hold a constructed root without starting definition discovery, persistence I/O, or other lifecycle activity.",
      "acceptanceCriteria": [
        "Focused Wire tests construct the root with panic or recording stubs for required effect ports (for example named-path resolution, named-factory catalog filesystem, version filesystem, and session-host ports that would otherwise touch disk or runtime)",
        "Construction completes without invoking those effect stubs and without starting background lifecycle goroutines or host processes",
        "The constructed value is usable only through factorydefinitions.Service (compile-time assignment and/or focused assertion that the returned peer is non-nil and typed as the root interface)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-def-service-wire-003",
      "title": "Prove Wire-built root serves published peer behavior",
      "description": "As a peer-service consumer, I want the Wire-constructed Factory Definitions root to perform published catalog, distribute, or validate behavior so the composition path is proven by observable Definitions outcomes, not by package shape alone.",
      "acceptanceCriteria": [
        "A focused Wire (or Wire-driven) test constructs the root through the service-local Wire path and successfully exercises at least one published peer method (ListBuiltInPackagedFactories, ResolveBuiltInPackagedFactory, ListNamedFactories, GetNamedFactory, or ValidateStructuralFactoryDefinition) against an injected catalog and/or fixture",
        "The same Wire-built root returns a typed Factory Definitions failure (for example ErrUnknownPackagedFactoryIdentity, ErrInvalidNamedFactoryName, or ErrNamedFactoryNotFound) for an invalid/unknown input without panicking",
        "Successful peer calls return Definitions-owned detached values without requiring the test to import parent-private catalog/authoring/compilation/snapshots/distribution packages as the peer API",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-def-service-wire-004",
      "title": "Register Wire package and pass focused verification",
      "description": "As a Packaged Service Structure steward, I want the Factory Definitions Wire package registered in shared coverage/ownership/package-target manifests as required, with focused verification green, so the packet is merge-safe without expanding into root Wire cutover, transports, or IMP-DEF ownership rewrites.",
      "acceptanceCriteria": [
        "pkg/services/factory_definitions/wire is registered in the package-target manifest (and coverage/ownership manifests only as required by Wire package registration)",
        "Focused Factory Definitions Wire tests pass",
        "Changed Go files are gofmt-clean; vet/lint and applicable ownership/package-target checks for changed paths pass",
        "make verify-fast (or the repository’s equivalent required short verification gate) passes",
        "Diff does not edit pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, other services' Wire, HTTP/CLI/MCP adapters, or reopen IMP-DEF ownership interiors beyond Wire composition consumption",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-def-service-wire-005",
      "title": "Open, land, and merge the LWR-DEF PR",
      "description": "As a Factory delivery owner, I want the LWR-DEF branch reviewed and merged so Factory Definitions service-local Wire is actually landed, not merely implemented on a long-lived branch.",
      "acceptanceCriteria": [
        "Branch pss-lwr-def-service-wire is pushed and a PR is opened or updated against the integration base",
        "Required CI checks on the PR reach a terminal passing state",
        "Every blocking PR conversation comment is explicitly addressed (fix, follow-up commit, or recorded resolution)",
        "Merge conflicts and shared-file churn are rebased/reconciled as needed",
        "The PR is merged; work is not marked complete while the PR is only open, green, approved, or ready to merge",
        "Typecheck passes"
      ],
      "priority": 5,
      "passes": false,
      "notes": ""
    }
  ]
}
