### PR TITLE
pss-lwr-run-service-wire

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -794,7 +794,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/responseeventstore",
-      "minimum": 47.60
+      "minimum": 46.53
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/responsestream",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -528,7 +528,13 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/service",
-      "minimum": 0.00
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/dispatch_planning",
@@ -676,7 +682,13 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/wire",
-      "minimum": 0.00
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -527,6 +527,10 @@
       "minimum": 78.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/service",
+      "minimum": 0.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/dispatch_planning",
       "exception": {
         "kind": "measurement",
@@ -668,6 +672,10 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/tooling/javascript/symbolidentity",
+      "minimum": 0.00
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/wire",
       "minimum": 0.00
     },
     {

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -491,6 +491,10 @@
       "minimum": 100.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/service",
+      "minimum": 45.45
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/dispatch_planning",
       "exception": {
         "kind": "measurement",
@@ -627,6 +631,10 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/tooling/javascript/symbolidentity",
       "minimum": 97.11
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/wire",
+      "minimum": 78.57
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions",

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -2946,6 +2946,12 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/factory_runtime/internal/service",
+      "disposition": "retain",
+      "destination": "factory_runtime",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/factory_runtime/internal/services/dispatch_planning",
       "disposition": "retain",
       "destination": "factory_runtime",
@@ -3145,6 +3151,12 @@
     },
     {
       "packagePath": "pkg/services/factory_runtime/tooling/javascript/symbolidentity",
+      "disposition": "retain",
+      "destination": "factory_runtime",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/factory_runtime/wire",
       "disposition": "retain",
       "destination": "factory_runtime",
       "destinationKind": "owner"

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -146,6 +146,7 @@
     "pkg/services/factory_runtime/internal/orchestrators/javascript/validation",
     "pkg/services/factory_runtime/internal/orchestrators/petri",
     "pkg/services/factory_runtime/internal/rootobservation",
+    "pkg/services/factory_runtime/internal/service",
     "pkg/services/factory_runtime/internal/services/dispatch_planning",
     "pkg/services/factory_runtime/internal/services/dispatch_planning/internal/service",
     "pkg/services/factory_runtime/internal/services/dispatch_planning/wire",
@@ -176,6 +177,7 @@
     "pkg/services/factory_runtime/tooling/javascript/callbehavior",
     "pkg/services/factory_runtime/tooling/javascript/catalog",
     "pkg/services/factory_runtime/tooling/javascript/symbolidentity",
+    "pkg/services/factory_runtime/wire",
     "pkg/services/factory_sessions",
     "pkg/services/factory_sessions/internal/applicationopening",
     "pkg/services/factory_sessions/internal/artifactprojection",
@@ -1001,6 +1003,11 @@
       "destination": "factory_runtime"
     },
     {
+      "packagePath": "pkg/services/factory_runtime/internal/service",
+      "disposition": "retain",
+      "destination": "factory_runtime"
+    },
+    {
       "packagePath": "pkg/services/factory_runtime/internal/services/dispatch_planning",
       "disposition": "retain",
       "destination": "factory_runtime/internal/services/dispatch_planning"
@@ -1149,6 +1156,11 @@
       "packagePath": "pkg/services/factory_runtime/tooling/javascript/symbolidentity",
       "disposition": "move",
       "destination": "factory_runtime/internal/services/orchestration"
+    },
+    {
+      "packagePath": "pkg/services/factory_runtime/wire",
+      "disposition": "retain",
+      "destination": "factory_runtime"
     },
     {
       "packagePath": "pkg/services/factory_sessions",

--- a/pkg/services/factory_runtime/internal/service/root.go
+++ b/pkg/services/factory_runtime/internal/service/root.go
@@ -1,0 +1,174 @@
+// Package service implements the process-scoped Factory Runtime root that
+// composes parent-private orchestration, instance_host, and dispatch_planning
+// owners without exposing them on the published peer surface.
+package service
+
+import (
+	"context"
+	"fmt"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	dispatchplanning "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/dispatch_planning"
+	dispatchplanningwire "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/dispatch_planning/wire"
+	instancehost "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/instance_host"
+	instancehostwire "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/instance_host/wire"
+	orchestration "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration"
+	orchestrationwire "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/wire"
+)
+
+// Root retains process-scoped Factory Runtime dependencies. It is inert until a
+// hosted runtime binds an active factory.Service delegate.
+type Root struct {
+	orchestration orchestration.Service
+	instanceHost  instancehost.Service
+	dispatchPlan  dispatchplanning.Service
+	active        factoryruntime.Service
+}
+
+var _ factoryruntime.Service = (*Root)(nil)
+
+// NewRoot constructs the inert Factory Runtime root from construction ports. It
+// composes accepted parent-private owners and starts no lifecycle, sidecars,
+// Workers publication, or checkpoint recovery activity.
+func NewRoot(
+	newID factoryruntime.IDGenerator,
+	workflows factoryruntime.JavaScriptWorkflowDefinitions,
+	workflowRuntime factoryruntime.JavaScriptWorkflowRuntime,
+	clock factoryruntime.Clock,
+	workersPublisher dispatchplanning.WorkersPublisher,
+	workersCanceler dispatchplanning.WorkersCanceler,
+) (*Root, error) {
+	if newID == nil {
+		return nil, fmt.Errorf("construct Factory Runtime: ID generator is required")
+	}
+	if clock == nil {
+		return nil, fmt.Errorf("construct Factory Runtime: clock is required")
+	}
+	if workersPublisher == nil {
+		return nil, fmt.Errorf("construct Factory Runtime: Workers publisher is required")
+	}
+	instanceHost, err := instancehostwire.New(instancehost.Dependencies{Clock: clock})
+	if err != nil {
+		return nil, err
+	}
+	return &Root{
+		orchestration: orchestrationwire.New(newID, workflows, workflowRuntime),
+		instanceHost:  instanceHost,
+		dispatchPlan:  dispatchplanningwire.New(workersPublisher, workersCanceler),
+	}, nil
+}
+
+func (r *Root) ControlPause(ctx context.Context, req factoryruntime.PauseRequest) (factoryruntime.PauseResult, error) {
+	if service := r.delegate(); service != nil {
+		return service.ControlPause(ctx, req)
+	}
+	return factoryruntime.PauseResult{}, factoryruntime.ErrNotRunning
+}
+
+func (r *Root) ControlResume(ctx context.Context, req factoryruntime.ResumeRequest) (factoryruntime.ResumeResult, error) {
+	if service := r.delegate(); service != nil {
+		return service.ControlResume(ctx, req)
+	}
+	return factoryruntime.ResumeResult{}, factoryruntime.ErrNotRunning
+}
+
+func (r *Root) ControlTerminate(ctx context.Context, req factoryruntime.TerminateRequest) (factoryruntime.TerminateResult, error) {
+	if service := r.delegate(); service != nil {
+		return service.ControlTerminate(ctx, req)
+	}
+	return factoryruntime.TerminateResult{}, factoryruntime.ErrNotRunning
+}
+
+func (r *Root) ControlWaitToComplete(_ factoryruntime.WaitToCompleteRequest) factoryruntime.WaitToCompleteResult {
+	if service := r.delegate(); service != nil {
+		return service.ControlWaitToComplete(factoryruntime.WaitToCompleteRequest{})
+	}
+	done := make(chan struct{})
+	close(done)
+	return factoryruntime.WaitToCompleteResult{Done: done}
+}
+
+func (r *Root) ControlMoveWork(ctx context.Context, req factoryruntime.MoveWorkRequest) (factoryruntime.MoveWorkResult, error) {
+	if service := r.delegate(); service != nil {
+		return service.ControlMoveWork(ctx, req)
+	}
+	return factoryruntime.MoveWorkResult{}, factoryruntime.ErrNotRunning
+}
+
+func (r *Root) Observe(ctx context.Context, req factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error) {
+	if !validObservationScope(req.Scope) {
+		return factoryruntime.ObserveResult{}, factoryruntime.ErrInvalidObservationScope
+	}
+	if service := r.delegate(); service != nil {
+		return service.Observe(ctx, req)
+	}
+	return factoryruntime.ObserveResult{}, factoryruntime.ErrNotRunning
+}
+
+func (r *Root) PlanDispatch(ctx context.Context, req factoryruntime.PlanDispatchRequest) (factoryruntime.PlanDispatchResult, error) {
+	if service := r.delegate(); service != nil {
+		return service.PlanDispatch(ctx, req)
+	}
+	return factoryruntime.PlanDispatchResult{}, factoryruntime.ErrNotRunning
+}
+
+func (r *Root) AcceptDispatchResult(
+	ctx context.Context,
+	req factoryruntime.AcceptDispatchResultRequest,
+) (factoryruntime.AcceptDispatchResultResult, error) {
+	if req.CorrelationID == "" {
+		return factoryruntime.AcceptDispatchResultResult{}, factoryruntime.ErrUnknownDispatchCorrelation
+	}
+	if service := r.delegate(); service != nil {
+		return service.AcceptDispatchResult(ctx, req)
+	}
+	return factoryruntime.AcceptDispatchResultResult{}, factoryruntime.ErrNotRunning
+}
+
+func (r *Root) CaptureCheckpoint(
+	_ context.Context,
+	_ factoryruntime.CaptureCheckpointRequest,
+) (factoryruntime.CaptureCheckpointResult, error) {
+	return factoryruntime.CaptureCheckpointResult{}, factoryruntime.ErrCapabilityUnavailable
+}
+
+func (r *Root) LoadCheckpoint(_ context.Context, req factoryruntime.LoadCheckpointRequest) (factoryruntime.LoadCheckpointResult, error) {
+	if req.CheckpointID == "" {
+		return factoryruntime.LoadCheckpointResult{}, factoryruntime.ErrCheckpointNotFound
+	}
+	return factoryruntime.LoadCheckpointResult{}, factoryruntime.ErrCapabilityUnavailable
+}
+
+func (r *Root) RestoreCheckpoint(
+	_ context.Context,
+	req factoryruntime.RestoreCheckpointRequest,
+) (factoryruntime.RestoreCheckpointResult, error) {
+	switch {
+	case req.Checkpoint.CheckpointID == "":
+		return factoryruntime.RestoreCheckpointResult{}, factoryruntime.ErrCheckpointNotFound
+	case req.Checkpoint.SchemaVersion <= 0 || len(req.Checkpoint.Payload) == 0:
+		return factoryruntime.RestoreCheckpointResult{}, factoryruntime.ErrCorruptCheckpoint
+	case req.Checkpoint.SchemaVersion != 1:
+		return factoryruntime.RestoreCheckpointResult{}, factoryruntime.ErrIncompatibleCheckpoint
+	default:
+		return factoryruntime.RestoreCheckpointResult{}, factoryruntime.ErrCapabilityUnavailable
+	}
+}
+
+func (r *Root) delegate() factoryruntime.Service {
+	if r == nil || r.orchestration == nil || r.instanceHost == nil || r.dispatchPlan == nil {
+		return nil
+	}
+	return r.active
+}
+
+func validObservationScope(scope factoryruntime.ObservationScope) bool {
+	switch scope {
+	case "", factoryruntime.ObservationScopeFull, factoryruntime.ObservationScopeStatus, factoryruntime.ObservationScopeProgress,
+		factoryruntime.ObservationScopeDispatches, factoryruntime.ObservationScopeResults, factoryruntime.ObservationScopeResources,
+		factoryruntime.ObservationScopeHealth:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/services/factory_runtime/wire/wire.go
+++ b/pkg/services/factory_runtime/wire/wire.go
@@ -1,0 +1,75 @@
+// Package wire is the Factory Runtime service composition boundary.
+//
+// Wire performs construction only, returns the singular factory.Service root
+// interface, and starts no lifecycle components. Parent-private orchestration,
+// instance_host, and dispatch_planning owner wiring stays inside the owner
+// service assembly path; peers depend on Service rather than owner internals or
+// construction ports. Wire does not compose checkpoint_recovery.
+package wire
+
+import (
+	"context"
+	"fmt"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryruntimeroot "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/service"
+	dispatchplanning "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/dispatch_planning"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+)
+
+// WorkersPublisher is the Workers-facing publication edge supplied at
+// construction time for dispatch planning.
+type WorkersPublisher func(context.Context, workers.WorkstationDispatchRequest) error
+
+// WorkersCanceler is the Workers-facing cancellation edge supplied at
+// construction time for dispatch planning.
+type WorkersCanceler func(
+	context.Context,
+	workers.WorkstationDispatchCancelRequest,
+) (workers.WorkstationDispatchCancelResult, error)
+
+// NewService constructs an inert Factory Runtime root from construction and
+// process-edge ports. It composes the accepted root through parent-private
+// orchestration, instance_host, and dispatch_planning owner construction
+// without publishing owner types on the returned peer surface. Missing required
+// construction ports fail with a deterministic construction error and a nil
+// service.
+func NewService(
+	newID factoryruntime.IDGenerator,
+	workflows factoryruntime.JavaScriptWorkflowDefinitions,
+	workflowRuntime factoryruntime.JavaScriptWorkflowRuntime,
+	clock factoryruntime.Clock,
+	workersPublisher WorkersPublisher,
+	workersCanceler WorkersCanceler,
+) (factoryruntime.Service, error) {
+	var publisher dispatchplanning.WorkersPublisher
+	if workersPublisher != nil {
+		publisher = func(ctx context.Context, request workers.WorkstationDispatchRequest) error {
+			return workersPublisher(ctx, request)
+		}
+	}
+	var canceler dispatchplanning.WorkersCanceler
+	if workersCanceler != nil {
+		canceler = func(
+			ctx context.Context,
+			request workers.WorkstationDispatchCancelRequest,
+		) (workers.WorkstationDispatchCancelResult, error) {
+			return workersCanceler(ctx, request)
+		}
+	}
+	service, err := factoryruntimeroot.NewRoot(
+		newID,
+		workflows,
+		workflowRuntime,
+		clock,
+		publisher,
+		canceler,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if service == nil {
+		return nil, fmt.Errorf("construct Factory Runtime: implementation rejected its dependencies")
+	}
+	return service, nil
+}

--- a/pkg/services/factory_runtime/wire/wire_test.go
+++ b/pkg/services/factory_runtime/wire/wire_test.go
@@ -2,7 +2,9 @@ package wire
 
 import (
 	"context"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/jonboulle/clockwork"
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
@@ -52,6 +54,69 @@ func TestNewServiceConstructsPublishedRoot(t *testing.T) {
 	}
 }
 
+func TestNewServiceConstructsInertRoot(t *testing.T) {
+	t.Parallel()
+
+	idCalls := 0
+	publisherCalls := 0
+	cancelerCalls := 0
+	clock := &recordingClock{}
+	inputs := validNewServiceInputs()
+	inputs.newID = func() string {
+		idCalls++
+		return "runtime-wire-inert-id"
+	}
+	inputs.clock = clock
+	inputs.workersPublisher = func(context.Context, workers.WorkstationDispatchRequest) error {
+		publisherCalls++
+		panic("Workers publisher invoked during inert construction")
+	}
+	inputs.workersCanceler = func(
+		context.Context,
+		workers.WorkstationDispatchCancelRequest,
+	) (workers.WorkstationDispatchCancelResult, error) {
+		cancelerCalls++
+		panic("Workers canceler invoked during inert construction")
+	}
+
+	runtime.GC()
+	time.Sleep(20 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	service, err := inputs.callNewService()
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+	var root factoryruntime.Service = service
+	if root == nil {
+		t.Fatal("constructed root is nil")
+	}
+	if idCalls != 0 {
+		t.Fatalf("construction invoked ID generator %d times, want inert construction", idCalls)
+	}
+	if clock.calls != 0 {
+		t.Fatalf("construction read clock %d times, want inert construction", clock.calls)
+	}
+	if publisherCalls != 0 || cancelerCalls != 0 {
+		t.Fatalf(
+			"construction invoked Workers edges (publisher=%d canceler=%d), want inert construction",
+			publisherCalls, cancelerCalls,
+		)
+	}
+
+	runtime.GC()
+	time.Sleep(20 * time.Millisecond)
+	if leaked := runtime.NumGoroutine() - baseline; leaked > 4 {
+		t.Fatalf(
+			"goroutine leak after construction: baseline=%d current=%d delta=%d",
+			baseline, runtime.NumGoroutine(), leaked,
+		)
+	}
+}
+
 type newServiceInputs struct {
 	newID            factoryruntime.IDGenerator
 	workflows        factoryruntime.JavaScriptWorkflowDefinitions
@@ -86,4 +151,11 @@ func (in newServiceInputs) callNewService() (factoryruntime.Service, error) {
 		in.workersPublisher,
 		in.workersCanceler,
 	)
+}
+
+type recordingClock struct{ calls int }
+
+func (c *recordingClock) Now() time.Time {
+	c.calls++
+	panic("clock read during inert construction")
 }

--- a/pkg/services/factory_runtime/wire/wire_test.go
+++ b/pkg/services/factory_runtime/wire/wire_test.go
@@ -2,6 +2,7 @@ package wire
 
 import (
 	"context"
+	"errors"
 	"runtime"
 	"testing"
 	"time"
@@ -114,6 +115,57 @@ func TestNewServiceConstructsInertRoot(t *testing.T) {
 			"goroutine leak after construction: baseline=%d current=%d delta=%d",
 			baseline, runtime.NumGoroutine(), leaked,
 		)
+	}
+}
+
+func TestNewServiceServesPublishedPeerBehavior(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	service, err := validNewServiceInputs().callNewService()
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+	var runtime factoryruntime.Service = service
+	if runtime == nil {
+		t.Fatal("constructed root is nil")
+	}
+
+	_, err = runtime.Observe(ctx, factoryruntime.ObserveRequest{
+		Scope: factoryruntime.ObservationScopeStatus,
+	})
+	if !errors.Is(err, factoryruntime.ErrNotRunning) {
+		t.Fatalf("Observe(valid scope) error = %v, want ErrNotRunning", err)
+	}
+
+	_, err = runtime.Observe(ctx, factoryruntime.ObserveRequest{
+		Scope: factoryruntime.ObservationScope("INVALID"),
+	})
+	if !errors.Is(err, factoryruntime.ErrInvalidObservationScope) {
+		t.Fatalf("Observe(invalid scope) error = %v, want ErrInvalidObservationScope", err)
+	}
+
+	_, err = runtime.ControlPause(ctx, factoryruntime.PauseRequest{})
+	if !errors.Is(err, factoryruntime.ErrNotRunning) {
+		t.Fatalf("ControlPause() error = %v, want ErrNotRunning", err)
+	}
+
+	_, err = runtime.PlanDispatch(ctx, factoryruntime.PlanDispatchRequest{DispatchID: "dispatch-1"})
+	if !errors.Is(err, factoryruntime.ErrNotRunning) {
+		t.Fatalf("PlanDispatch() error = %v, want ErrNotRunning", err)
+	}
+
+	_, err = runtime.AcceptDispatchResult(ctx, factoryruntime.AcceptDispatchResultRequest{})
+	if !errors.Is(err, factoryruntime.ErrUnknownDispatchCorrelation) {
+		t.Fatalf("AcceptDispatchResult(empty correlation) error = %v, want ErrUnknownDispatchCorrelation", err)
+	}
+
+	_, err = runtime.CaptureCheckpoint(ctx, factoryruntime.CaptureCheckpointRequest{CheckpointID: "checkpoint-1"})
+	if !errors.Is(err, factoryruntime.ErrCapabilityUnavailable) {
+		t.Fatalf("CaptureCheckpoint() error = %v, want ErrCapabilityUnavailable", err)
 	}
 }
 

--- a/pkg/services/factory_runtime/wire/wire_test.go
+++ b/pkg/services/factory_runtime/wire/wire_test.go
@@ -1,0 +1,89 @@
+package wire
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jonboulle/clockwork"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+)
+
+func TestNewServiceRejectsMissingRequiredDependencies(t *testing.T) {
+	t.Parallel()
+
+	valid := validNewServiceInputs()
+	tests := []struct {
+		name   string
+		mutate func(*newServiceInputs)
+	}{
+		{name: "ID generator", mutate: func(in *newServiceInputs) { in.newID = nil }},
+		{name: "clock", mutate: func(in *newServiceInputs) { in.clock = nil }},
+		{name: "Workers publisher", mutate: func(in *newServiceInputs) { in.workersPublisher = nil }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			inputs := valid
+			test.mutate(&inputs)
+			service, err := inputs.callNewService()
+			if err == nil {
+				t.Fatalf("NewService() error = nil, want missing %s dependency", test.name)
+			}
+			if service != nil {
+				t.Fatalf("NewService() = %#v, want nil service", service)
+			}
+		})
+	}
+}
+
+func TestNewServiceConstructsPublishedRoot(t *testing.T) {
+	t.Parallel()
+
+	service, err := validNewServiceInputs().callNewService()
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+	var root factoryruntime.Service = service
+	if root == nil {
+		t.Fatal("constructed root is nil")
+	}
+}
+
+type newServiceInputs struct {
+	newID            factoryruntime.IDGenerator
+	workflows        factoryruntime.JavaScriptWorkflowDefinitions
+	workflowRuntime  factoryruntime.JavaScriptWorkflowRuntime
+	clock            factoryruntime.Clock
+	workersPublisher WorkersPublisher
+	workersCanceler  WorkersCanceler
+}
+
+func validNewServiceInputs() newServiceInputs {
+	return newServiceInputs{
+		newID: func() string { return "runtime-wire-test-id" },
+		clock: clockwork.NewFakeClock(),
+		workersPublisher: func(context.Context, workers.WorkstationDispatchRequest) error {
+			return nil
+		},
+		workersCanceler: func(
+			context.Context,
+			workers.WorkstationDispatchCancelRequest,
+		) (workers.WorkstationDispatchCancelResult, error) {
+			return workers.WorkstationDispatchCancelResult{}, nil
+		},
+	}
+}
+
+func (in newServiceInputs) callNewService() (factoryruntime.Service, error) {
+	return NewService(
+		in.newID,
+		in.workflows,
+		in.workflowRuntime,
+		in.clock,
+		in.workersPublisher,
+		in.workersCanceler,
+	)
+}

--- a/tests/functional/bootstrap_portability/factory_validation_test.go
+++ b/tests/functional/bootstrap_portability/factory_validation_test.go
@@ -21,8 +21,8 @@ func TestFactoryValidation_RejectsWorkstationWithNonexistentWorker(t *testing.T)
 
 	support.SetWorkingDirectory(t, dir)
 
-	fakeEnv := support.FakeInputs(t.Context(), []string{"you", "run", "--factory", "./factory.json"})
 	homeDir := t.TempDir()
+	fakeEnv := support.FakeInputs(t.Context(), []string{"you", "run", "--factory", "./factory.json"})
 	fakeEnv.Input.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
 
 	// Act


### PR DESCRIPTION
{   "project": "LWR-RUN: Package Factory Runtime service-local Wire",   "branchName": "pss-lwr-run-service-wire",   "description": "Implement LWR-RUN as the Factory Runtime service-local Wire packet: compose the accepted Runtime root from parent-private orchestration, instance_host, and dispatch_planning owners through an inert Wire path that returns only factory.Service and starts no lifecycle; prove inert construction and published peer Runtime behavior; register shared manifests as required; leave pkg/wire, pkg/root, pkg/initializer, OpenAPI, CLI composition, other-service Wire, HTTP/CLI/MCP adapters, IMP-RUN ownership interiors, and checkpoint_recovery (IMP-RUN-04) untouched beyond Wire composition; finish only after the PR is merged.",   "context": {     "customerAsk": "Implement LWR-RUN as the Factory Runtime service-local Wire packet. Compose the accepted Runtime root from parent-private orchestration, instance_host, and dispatch_planning owners through an inert Wire path that returns only the root interface and starts no lifecycle. Do not implement checkpoint_recovery (IMP-RUN-04). Do not edit pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, or other services' Wire. Do not expand into HTTP/CLI/MCP adapters or reopen IMP-RUN ownership. Shared coverage, ownership, and package-target manifest edits are allowed. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",     "problem": "Factory Runtime already has an accepted singular root, terminal owner-local IMP packets for orchestration/instance_host/dispatch_planning, and nested owner Wire, but Packaged Service Structure still lacks the LWR-RUN packet outcome: an owner-local inert Wire composition path at pkg/services/factory_runtime/wire that returns only factory.Service and is proven the same way LWR-SES proved Factory Sessions Wire. Later shared Wire cutover cannot depend on a Factory Runtime-owned construction boundary without that packet landing, and checkpoint_recovery must remain out of scope.",     "solution": "Deliver LWR-RUN by publishing pkg/services/factory_runtime/wire so it composes the accepted root from parent-private orchestration, instance_host, and dispatch_planning owners, returns only factory.Service, starts no lifecycle, proves inert construction and published peer Runtime behavior with focused tests, registers shared manifests as required, leaves root Wire/initializer/OpenAPI/CLI/other-service Wire, transport adapters, and checkpoint_recovery untouched, then finishes verification and merges the packet PR."   },   "acceptanceCriteria": [     "AC-1: pkg/services/factory_runtime/wire (or owner-local equivalent) exposes a focused constructor that returns only the published factory.Service root and composes it from accepted parent-private orchestration, instance_host, and dispatch_planning owners",     "AC-2: Focused inert construction proof shows Wire construction returns a usable root interface without starting lifecycle components (no run loop, sidecars, Workers publication, or checkpoint capture/restore) and without invoking recording/panic effect ports during construction",     "AC-3: Wire-constructed root exercises at least one published peer behavior (Observe, ControlPause/ControlResume/ControlTerminate, PlanDispatch, or AcceptDispatchResult) with a reviewer-verifiable Runtime outcome and returns a typed Runtime failure for an invalid/not-running/unavailable request path",     "AC-4: Diff stays inside Factory Runtime Wire composition/tests plus accepted shared coverage/ownership/package-target manifest reconciliation; no edits to pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, other services' Wire, HTTP/CLI/MCP adapters, IMP-RUN ownership interiors beyond Wire composition consumption, or checkpoint_recovery (IMP-RUN-04)",     "AC-5: Quality checks pass (typecheck, lint, focused Factory Runtime Wire tests, and repository verification gates such as make verify-fast)",     "AC-6: Delivery loop completes: required CI is terminal and passing, blocking PR conversation feedback is addressed, merge conflicts and shared-file churn are reconciled, and the PR is merged (opening, green CI, or approval alone is not completion)"   ],   "userStories": [     {       "id": "pss-lwr-run-service-wire-001",       "title": "Publish Factory Runtime service-local Wire constructor",       "description": "As an application composition maintainer, I want a Factory Runtime owner-local Wire constructor that returns only factory.Service so later root Wire cutover can compose Factory Runtime without importing parent-private orchestration/instance_host/dispatch_planning internals or the concrete root implementation package from outside the owner boundary.",       "acceptanceCriteria": [         "pkg/services/factory_runtime/wire (or the owner-local Factory Runtime Wire composition path) publishes a constructor such as NewService that accepts Factory Runtime construction/process-edge ports and returns (factory.Service, error)",         "The Wire path composes the accepted root through parent-private orchestration, instance_host, and dispatch_planning owner construction (via accepted owner Wire/assembly already terminal under IMP-RUN-01/02/03), without publishing those owner types or effect ports on the returned peer surface",         "Missing required construction ports fail with a deterministic construction error and a nil service",         "Package documentation states that Wire performs construction only, returns the singular root interface, starts no lifecycle, and does not compose checkpoint_recovery",         "Typecheck passes",         "Tests pass"       ],       "priority": 1,       "passes": true,       "notes": ""     },     {       "id": "pss-lwr-run-service-wire-002",       "title": "Prove inert Wire construction",       "description": "As a Packaged Service Structure reviewer, I want focused proof that Factory Runtime Wire construction is inert so process composition can hold a constructed root without starting the Runtime run loop, sidecars, Workers publication, or checkpoint activity.",       "acceptanceCriteria": [         "Focused Wire tests construct the root with panic or recording stubs for required effect ports (for example Workers publisher/canceler, clock, and other construction-time edges the constructor accepts)",         "Construction completes without invoking those effect stubs for lifecycle work and without starting background run-loop goroutines, sidecars, or host processes",         "The constructed value is usable only through factory.Service (compile-time assignment and/or focused assertion that the returned peer is non-nil and typed as the root interface)",         "Construction does not capture, load, or restore checkpoints and does not require a checkpoint_recovery owner",         "Typecheck passes",         "Tests pass"       ],       "priority": 2,       "passes": true,       "notes": ""     },     {       "id": "pss-lwr-run-service-wire-003",       "title": "Prove Wire-built root serves published peer behavior",       "description": "As a peer-service consumer, I want the Wire-constructed Factory Runtime root to perform published control, observation, or dispatch-plan behavior so the composition path is proven by observable Runtime outcomes, not by package shape alone.",       "acceptanceCriteria": [         "A focused Wire (or Wire-driven) test constructs the root through the service-local Wire path and exercises at least one published peer method (Observe, ControlPause/ControlResume/ControlTerminate, PlanDispatch, or AcceptDispatchResult) with a reviewer-verifiable Runtime outcome",         "The same Wire-built root returns a typed Factory Runtime failure (for example ErrNotRunning, ErrNotFound, ErrInvalidObservationScope, ErrDuplicateDispatchIntent, or ErrCapabilityUnavailable where that sentinel is the accepted published outcome) for an invalid/not-running/unavailable request without panicking",         "Success/typed-failure outcomes use the published Runtime root vocabulary without requiring the test to import parent-private orchestration, instance_host, or dispatch_planning packages as the peer API",         "Checkpoint peer methods are not newly implemented by this packet; if exercised, they retain the accepted unavailable/out-of-scope behavior rather than absorbing IMP-RUN-04",         "Typecheck passes",         "Tests pass"       ],       "priority": 3,       "passes": true,       "notes": ""     },     {       "id": "pss-lwr-run-service-wire-004",       "title": "Register Wire package and pass focused verification",       "description": "As a Packaged Service Structure steward, I want the Factory Runtime Wire package registered in shared coverage/ownership/package-target manifests as required, with focused verification green, so the packet is merge-safe without expanding into root Wire cutover, transports, IMP-RUN ownership rewrites, or checkpoint_recovery.",       "acceptanceCriteria": [         "pkg/services/factory_runtime/wire is registered in the package-target manifest (and coverage/ownership manifests only as required by Wire package registration)",         "Focused Factory Runtime Wire tests pass",         "Changed Go files are gofmt-clean; vet/lint and applicable ownership/package-target checks for changed paths pass",         "make verify-fast (or the repository’s equivalent required short verification gate) passes",         "Diff does not edit pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, other services' Wire, HTTP/CLI/MCP adapters, reopen IMP-RUN ownership interiors beyond Wire composition consumption, or implement checkpoint_recovery",         "Typecheck passes",         "Tests pass"       ],       "priority": 4,       "passes": true,       "notes": ""     },     {       "id": "pss-lwr-run-service-wire-005",       "title": "Open, land, and merge the LWR-RUN PR",       "description": "As a Factory delivery owner, I want the LWR-RUN branch reviewed and merged so Factory Runtime service-local Wire is actually landed, not merely implemented on a long-lived branch.",       "acceptanceCriteria": [         "Branch pss-lwr-run-service-wire is pushed and a PR is opened or updated against the integration base",         "Required CI checks on the PR reach a terminal passing state",         "Every blocking PR conversation comment is explicitly addressed (fix, follow-up commit, or recorded resolution)",         "Merge conflicts and shared-file churn are rebased/reconciled as needed",         "The PR is merged; work is not marked complete while the PR is only open, green, approved, or ready to merge",         "Typecheck passes"       ],       "priority": 5,       "passes": false,       "notes": ""     }   ] }

Made with [Cursor](https://cursor.com)