### PR TITLE
pss-http-ses-adapter

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -456,7 +456,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/engine",
-      "minimum": 74.39
+      "minimum": 73.78
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/javascript/preview",
@@ -558,7 +558,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/runtime",
-      "minimum": 65.21
+      "minimum": 65.07
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/runtime/buffers",
@@ -786,7 +786,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/scopedlisting",
-      "minimum": 76.59
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/service",

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -8,6 +8,16 @@ Use this map when changing the public REST contract.
   `pkg/transports/http` server only composes that injected adapter with other
   service-owned handlers and registers the generated routes; runtime binding
   occurs in `pkg/transports/http/application`.
+- The Sessions HTTP adapter package must stay registered in the allowed shared
+  manifests only: retain `pkg/services/factory_sessions/transports/http` under
+  destination `factory_sessions` in
+  `docs/internal/packaged-service-structure/package-target-manifest.json` and
+  `docs/internal/baselines/ownership-inventory.json`, and keep measured floors in
+  both `docs/internal/baselines/go-unit-coverage-package-minimums.json` and
+  `docs/internal/baselines/go-functional-coverage-package-minimums.json`.
+  Prove registration with `manifest_registration_test.go`; do not edit
+  `pkg/wire`, `pkg/root`, `pkg/initializer`, top-level CLI composition, or
+  other services' HTTP adapters when reconciling manifest churn.
 - Factory Session CLI request construction, rendering, diagnostics, and
   operation handlers live under
   `pkg/services/factory_sessions/transports/cli`; Factory Session MCP tool

--- a/pkg/services/factory_sessions/transports/http/export_test.go
+++ b/pkg/services/factory_sessions/transports/http/export_test.go
@@ -1,3 +1,4 @@
 package http
 
 var SessionsRootErrorResponseForTest = sessionsRootErrorResponse
+var SessionsRequestContextErrorResponseForTest = sessionsRequestContextErrorResponse

--- a/pkg/services/factory_sessions/transports/http/export_test.go
+++ b/pkg/services/factory_sessions/transports/http/export_test.go
@@ -1,0 +1,3 @@
+package http
+
+var SessionsRootErrorResponseForTest = sessionsRootErrorResponse

--- a/pkg/services/factory_sessions/transports/http/handler.go
+++ b/pkg/services/factory_sessions/transports/http/handler.go
@@ -19,6 +19,7 @@ import (
 // Handler owns the generated HTTP operation implementations for Factory
 // Sessions and their session-scoped Factory and Work resources.
 type Adapter struct {
+	sessionsRoot       factorysessions.Service
 	runtime            apisurface.RuntimeAPI
 	factoryStatus      apisurface.FactoryStatusAPI
 	sessions           apisurface.LiveSessionAPI
@@ -44,6 +45,7 @@ type Adapter struct {
 // Dependencies are the exact injected roles used by the Factory Sessions HTTP
 // adapter. They are supplied by the already-opened runtime composition.
 type Dependencies struct {
+	SessionsRoot       factorysessions.Service
 	Runtime            apisurface.RuntimeAPI
 	FactoryStatus      apisurface.FactoryStatusAPI
 	Sessions           apisurface.LiveSessionAPI
@@ -82,6 +84,7 @@ func NewHandler(deps Dependencies, logger *zap.Logger) *Adapter {
 		logger = zap.NewNop()
 	}
 	return &Adapter{
+		sessionsRoot: deps.SessionsRoot,
 		runtime: deps.Runtime, factoryStatus: deps.FactoryStatus,
 		sessions: deps.Sessions, work: deps.Work, workRead: deps.WorkRead,
 		invocation:         deps.Invocation,

--- a/pkg/services/factory_sessions/transports/http/handlers_common.go
+++ b/pkg/services/factory_sessions/transports/http/handlers_common.go
@@ -398,12 +398,7 @@ func (s *Server) handleDurableLifecycleControl(
 		return
 	}
 
-	lifecycle, ok := s.requireDurableSessionLifecycleAPI(w)
-	if !ok {
-		return
-	}
-
-	req, err := decodeOptionalLifecycleControlRequest(r.Body)
+	control, err := decodeLifecycleControlRequest(r.Body, s.sessionRequests)
 	if err != nil {
 		if message, ok := requestFieldValidationMessage(err); ok {
 			s.writeError(w, http.StatusBadRequest, message, "BAD_REQUEST")
@@ -412,12 +407,14 @@ func (s *Server) handleDurableLifecycleControl(
 		s.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
 		return
 	}
-	control, err := factorysession.ControlRequestFromAPI(req)
-	if err == nil {
-		control, err = s.sessionRequests.PrepareControl(control)
+
+	if s.sessionsRoot != nil {
+		s.invokeRootDurableLifecycleControl(w, r.Context(), sessionID, operation, control)
+		return
 	}
-	if err != nil {
-		s.writeError(w, http.StatusBadRequest, err.Error(), "BAD_REQUEST")
+
+	lifecycle, ok := s.requireDurableSessionLifecycleAPI(w)
+	if !ok {
 		return
 	}
 
@@ -445,12 +442,7 @@ func (s *Server) handleLiveLifecycleControl(
 	operation string,
 	invoke func(apisurface.LiveSessionAPI, factorysessionexecution.ControlRequest) (factoryapi.FactorySessionLifecycleControlResponse, error),
 ) {
-	sessionRuntime, ok := s.requireSessionRuntime(w)
-	if !ok {
-		return
-	}
-
-	req, err := decodeOptionalLifecycleControlRequest(r.Body)
+	control, err := decodeLifecycleControlRequest(r.Body, s.sessionRequests)
 	if err != nil {
 		if message, ok := requestFieldValidationMessage(err); ok {
 			s.writeError(w, http.StatusBadRequest, message, "BAD_REQUEST")
@@ -459,12 +451,14 @@ func (s *Server) handleLiveLifecycleControl(
 		s.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
 		return
 	}
-	control, err := factorysession.ControlRequestFromAPI(req)
-	if err == nil {
-		control, err = s.sessionRequests.PrepareControl(control)
+
+	if s.sessionsRoot != nil {
+		s.invokeRootLiveLifecycleControl(w, r.Context(), sessionID, operation, control)
+		return
 	}
-	if err != nil {
-		s.writeError(w, http.StatusBadRequest, err.Error(), "BAD_REQUEST")
+
+	sessionRuntime, ok := s.requireSessionRuntime(w)
+	if !ok {
 		return
 	}
 
@@ -541,12 +535,7 @@ func (s *Server) handleDurableApproveControl(
 		return
 	}
 
-	lifecycle, ok := s.requireDurableSessionLifecycleAPI(w)
-	if !ok {
-		return
-	}
-
-	req, err := decodeOptionalApproveRequest(r.Body)
+	approve, err := decodeApproveFactorySessionRequest(r.Body, s.sessionRequests)
 	if err != nil {
 		if message, ok := requestFieldValidationMessage(err); ok {
 			s.writeError(w, http.StatusBadRequest, message, "BAD_REQUEST")
@@ -555,12 +544,15 @@ func (s *Server) handleDurableApproveControl(
 		s.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
 		return
 	}
-	approve, err := factorysession.ApproveRequestFromAPI(req)
-	if err == nil {
-		approve, err = s.sessionRequests.PrepareApprove(approve)
+
+	if s.sessionsRoot != nil {
+		result, invokeErr := s.sessionsRoot.ApproveDurableFactorySession(r.Context(), string(sessionID), approve)
+		s.finishRootLifecycleControl(w, string(sessionID), "approve", result, invokeErr)
+		return
 	}
-	if err != nil {
-		s.writeError(w, http.StatusBadRequest, err.Error(), "BAD_REQUEST")
+
+	lifecycle, ok := s.requireDurableSessionLifecycleAPI(w)
+	if !ok {
 		return
 	}
 
@@ -591,12 +583,7 @@ func (s *Server) handleDurableRetryDispatchControl(
 		return
 	}
 
-	lifecycle, ok := s.requireDurableSessionLifecycleAPI(w)
-	if !ok {
-		return
-	}
-
-	req, err := decodeOptionalRetryDispatchRequest(r.Body)
+	retry, err := decodeRetryDispatchRequest(r.Body, s.sessionRequests)
 	if err != nil {
 		if message, ok := requestFieldValidationMessage(err); ok {
 			s.writeError(w, http.StatusBadRequest, message, "BAD_REQUEST")
@@ -605,12 +592,15 @@ func (s *Server) handleDurableRetryDispatchControl(
 		s.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
 		return
 	}
-	retry, err := factorysession.RetryDispatchRequestFromAPI(req)
-	if err == nil {
-		retry, err = s.sessionRequests.PrepareRetryDispatch(retry)
+
+	if s.sessionsRoot != nil {
+		result, invokeErr := s.sessionsRoot.RetryDurableFactorySessionDispatch(r.Context(), string(sessionID), retry)
+		s.finishRootLifecycleControl(w, string(sessionID), "retry-dispatch", result, invokeErr)
+		return
 	}
-	if err != nil {
-		s.writeError(w, http.StatusBadRequest, err.Error(), "BAD_REQUEST")
+
+	lifecycle, ok := s.requireDurableSessionLifecycleAPI(w)
+	if !ok {
 		return
 	}
 
@@ -713,12 +703,7 @@ func (s *Server) handleDurableInterruptDispatchControl(
 		return
 	}
 
-	lifecycle, ok := s.requireDurableSessionLifecycleAPI(w)
-	if !ok {
-		return
-	}
-
-	req, err := decodeOptionalInterruptDispatchRequest(r.Body)
+	interrupt, err := decodeInterruptDispatchRequest(r.Body, s.sessionRequests)
 	if err != nil {
 		if message, ok := requestFieldValidationMessage(err); ok {
 			s.writeError(w, http.StatusBadRequest, message, "BAD_REQUEST")
@@ -727,12 +712,15 @@ func (s *Server) handleDurableInterruptDispatchControl(
 		s.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
 		return
 	}
-	interrupt, err := factorysession.InterruptDispatchRequestFromAPI(req)
-	if err == nil {
-		interrupt, err = s.sessionRequests.PrepareInterruptDispatch(interrupt)
+
+	if s.sessionsRoot != nil {
+		result, invokeErr := s.sessionsRoot.InterruptDurableFactorySessionDispatch(r.Context(), string(sessionID), interrupt)
+		s.finishRootLifecycleControl(w, string(sessionID), "interrupt-dispatch", result, invokeErr)
+		return
 	}
-	if err != nil {
-		s.writeError(w, http.StatusBadRequest, err.Error(), "BAD_REQUEST")
+
+	lifecycle, ok := s.requireDurableSessionLifecycleAPI(w)
+	if !ok {
 		return
 	}
 

--- a/pkg/services/factory_sessions/transports/http/handlers_factory.go
+++ b/pkg/services/factory_sessions/transports/http/handlers_factory.go
@@ -116,10 +116,7 @@ func (s *Server) requireFactoryDefinitionAPI(w http.ResponseWriter) (apisurface.
 }
 
 func (s *Server) ListFactorySessions(w http.ResponseWriter, r *http.Request, params factoryapi.ListFactorySessionsParams) {
-	raw, err := factorysession.ListSessionsRequestFromAPI(params)
-	if err == nil {
-		raw, err = s.sessionRequests.PrepareListSessions(raw)
-	}
+	raw, err := decodeListFactorySessionsRequest(params, s.sessionRequests)
 	if err != nil {
 		s.writeError(w, http.StatusBadRequest, err.Error(), "BAD_REQUEST")
 		return
@@ -157,7 +154,7 @@ func (s *Server) GetFactorySession(w http.ResponseWriter, r *http.Request, sessi
 	}
 
 	if s.sessionsRoot != nil {
-		projection, err := s.sessionsRoot.GetFactorySession(r.Context(), string(sessionID))
+		projection, err := s.sessionsRoot.GetFactorySession(r.Context(), decodeGetFactorySessionRequest(sessionID))
 		if err != nil {
 			if errors.Is(err, factorysessionexecution.ErrSessionNotFound) {
 				s.writeError(w, http.StatusNotFound, "factory session not found", "NOT_FOUND")

--- a/pkg/services/factory_sessions/transports/http/handlers_factory.go
+++ b/pkg/services/factory_sessions/transports/http/handlers_factory.go
@@ -156,12 +156,11 @@ func (s *Server) GetFactorySession(w http.ResponseWriter, r *http.Request, sessi
 	if s.sessionsRoot != nil {
 		projection, err := s.sessionsRoot.GetFactorySession(r.Context(), decodeGetFactorySessionRequest(sessionID))
 		if err != nil {
-			if errors.Is(err, factorysessionexecution.ErrSessionNotFound) {
-				s.writeError(w, http.StatusNotFound, "factory session not found", "NOT_FOUND")
+			if s.writeSessionsRootError(w, string(sessionID), err) {
 				return
 			}
 			s.logger.Error("get factory session failed", zap.Error(err))
-			s.writeError(w, http.StatusInternalServerError, "failed to get factory session", "INTERNAL_ERROR")
+			s.writeSessionsRootErrorOrInternal(w, string(sessionID), err, "failed to get factory session")
 			return
 		}
 		s.writeJSON(w, http.StatusOK, factorysession.SessionResponseToAPI(projection))
@@ -440,12 +439,11 @@ func (s *Server) writeOpenFactorySessionRejected(w http.ResponseWriter, err erro
 func (s *Server) CloseFactorySession(w http.ResponseWriter, r *http.Request, sessionID string) {
 	if s.sessionsRoot != nil {
 		if err := s.sessionsRoot.CloseFactorySession(r.Context(), sessionID); err != nil {
-			if errors.Is(err, factorysessionexecution.ErrSessionNotFound) {
-				s.writeError(w, http.StatusNotFound, "factory session not found", "NOT_FOUND")
+			if s.writeSessionsRootError(w, sessionID, err) {
 				return
 			}
 			s.logger.Error("close factory session failed", zap.Error(err), zap.String("session_id", sessionID))
-			s.writeError(w, http.StatusInternalServerError, "failed to close factory session", "INTERNAL_ERROR")
+			s.writeSessionsRootErrorOrInternal(w, sessionID, err, "failed to close factory session")
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
@@ -839,10 +837,11 @@ func (s *Server) StartDurableFactorySessionAsync(w http.ResponseWriter, r *http.
 	if s.sessionsRoot != nil {
 		result, err := s.sessionsRoot.StartAsync(r.Context(), raw)
 		if err != nil {
-			if s.writeDurableExecutionError(w, err) {
+			if s.writeSessionsRootError(w, "", err) {
 				return
 			}
-			s.writeError(w, http.StatusInternalServerError, "durable factory session execution failed", "INTERNAL_ERROR")
+			s.logger.Error("durable factory session async start failed", zap.Error(err))
+			s.writeSessionsRootErrorOrInternal(w, "", err, "durable factory session execution failed")
 			return
 		}
 		s.writeJSON(w, http.StatusOK, factorysession.AsyncStartResponseToAPI(result))
@@ -881,10 +880,11 @@ func (s *Server) StartDurableFactorySessionSync(w http.ResponseWriter, r *http.R
 	if s.sessionsRoot != nil {
 		result, err := s.sessionsRoot.StartSync(r.Context(), raw)
 		if err != nil {
-			if s.writeDurableExecutionError(w, err) {
+			if s.writeSessionsRootError(w, "", err) {
 				return
 			}
-			s.writeError(w, http.StatusInternalServerError, "durable factory session execution failed", "INTERNAL_ERROR")
+			s.logger.Error("durable factory session sync start failed", zap.Error(err))
+			s.writeSessionsRootErrorOrInternal(w, "", err, "durable factory session execution failed")
 			return
 		}
 		s.writeJSON(w, http.StatusOK, factorysession.SyncStartResponseToAPI(result))
@@ -1004,24 +1004,7 @@ func (s *Server) mergeScopedFactorySessionList(
 }
 
 func (s *Server) writeDurableSessionReadError(w http.ResponseWriter, err error) bool {
-	if errors.Is(err, factorysessionexecution.ErrDurableSessionNotFound) {
-		s.writeError(w, http.StatusNotFound, "factory session not found", "NOT_FOUND")
-		return true
-	}
-	if errors.Is(err, factorysessionexecution.ErrDispatchNotFound) {
-		s.writeError(w, http.StatusNotFound, "factory session dispatch not found", "NOT_FOUND")
-		return true
-	}
-	if errors.Is(err, factorysessionexecution.ErrArtifactNotFound) {
-		s.writeError(w, http.StatusNotFound, "factory session artifact not found", "NOT_FOUND")
-		return true
-	}
-	var validationErr *factorysessionexecution.ExecutionValidationError
-	if errors.As(err, &validationErr) {
-		s.writeError(w, http.StatusBadRequest, validationErr.Message, "BAD_REQUEST")
-		return true
-	}
-	return false
+	return s.writeSessionsRootError(w, "", err)
 }
 
 func (s *Server) writeDurableSessionListError(w http.ResponseWriter, err error) {

--- a/pkg/services/factory_sessions/transports/http/handlers_factory.go
+++ b/pkg/services/factory_sessions/transports/http/handlers_factory.go
@@ -121,6 +121,9 @@ func (s *Server) ListFactorySessions(w http.ResponseWriter, r *http.Request, par
 		s.writeError(w, http.StatusBadRequest, err.Error(), "BAD_REQUEST")
 		return
 	}
+	if s.sessionsRoot != nil && s.guardSessionsRequestContext(w, r) {
+		return
+	}
 
 	response, err := s.mergeScopedFactorySessionList(r.Context(), raw)
 	if err != nil {
@@ -154,6 +157,9 @@ func (s *Server) GetFactorySession(w http.ResponseWriter, r *http.Request, sessi
 	}
 
 	if s.sessionsRoot != nil {
+		if s.guardSessionsRequestContext(w, r) {
+			return
+		}
 		projection, err := s.sessionsRoot.GetFactorySession(r.Context(), decodeGetFactorySessionRequest(sessionID))
 		if err != nil {
 			if s.writeSessionsRootError(w, string(sessionID), err) {
@@ -381,6 +387,9 @@ func (s *Server) OpenFactorySession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if s.sessionsRoot != nil {
+		if s.guardSessionsRequestContext(w, r) {
+			return
+		}
 		result, err := s.sessionsRoot.OpenFactorySession(r.Context(), factorysession.OpenRequestFromAPI(req))
 		if err != nil {
 			s.writeOpenFactorySessionRejected(w, err)
@@ -403,6 +412,9 @@ func (s *Server) OpenFactorySession(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) writeOpenFactorySessionRejected(w http.ResponseWriter, err error) {
+	if s.writeSessionsRequestContextOutcome(w, err) {
+		return
+	}
 	s.logger.Debug("open factory session rejected", zap.Error(err))
 	var domainTargetedErr interface {
 		error
@@ -438,6 +450,9 @@ func (s *Server) writeOpenFactorySessionRejected(w http.ResponseWriter, err erro
 
 func (s *Server) CloseFactorySession(w http.ResponseWriter, r *http.Request, sessionID string) {
 	if s.sessionsRoot != nil {
+		if s.guardSessionsRequestContext(w, r) {
+			return
+		}
 		if err := s.sessionsRoot.CloseFactorySession(r.Context(), sessionID); err != nil {
 			if s.writeSessionsRootError(w, sessionID, err) {
 				return
@@ -835,6 +850,9 @@ func (s *Server) StartDurableFactorySessionAsync(w http.ResponseWriter, r *http.
 	}
 
 	if s.sessionsRoot != nil {
+		if s.guardSessionsRequestContext(w, r) {
+			return
+		}
 		result, err := s.sessionsRoot.StartAsync(r.Context(), raw)
 		if err != nil {
 			if s.writeSessionsRootError(w, "", err) {
@@ -878,6 +896,9 @@ func (s *Server) StartDurableFactorySessionSync(w http.ResponseWriter, r *http.R
 	}
 
 	if s.sessionsRoot != nil {
+		if s.guardSessionsRequestContext(w, r) {
+			return
+		}
 		result, err := s.sessionsRoot.StartSync(r.Context(), raw)
 		if err != nil {
 			if s.writeSessionsRootError(w, "", err) {

--- a/pkg/services/factory_sessions/transports/http/handlers_factory.go
+++ b/pkg/services/factory_sessions/transports/http/handlers_factory.go
@@ -361,15 +361,11 @@ func (s *Server) InterruptFactorySessionDispatch(w http.ResponseWriter, r *http.
 }
 
 func (s *Server) OpenFactorySession(w http.ResponseWriter, r *http.Request) {
-	sessionRuntime, ok := s.requireSessionRuntime(w)
-	if !ok {
-		return
-	}
 	if !requestAcceptsJSONContentType(r.Header.Get("Content-Type")) {
 		s.writeUnsupportedMediaTypeError(w)
 		return
 	}
-	req, err := decodeOpenFactorySessionBody(r.Body)
+	req, err := decodeOpenFactorySessionRequest(r.Body)
 	if err != nil {
 		if message, ok := requestFieldValidationMessage(err); ok {
 			s.writeError(w, http.StatusBadRequest, message, "BAD_REQUEST")
@@ -384,45 +380,78 @@ func (s *Server) OpenFactorySession(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+
+	if s.sessionsRoot != nil {
+		result, err := s.sessionsRoot.OpenFactorySession(r.Context(), factorysession.OpenRequestFromAPI(req))
+		if err != nil {
+			s.writeOpenFactorySessionRejected(w, err)
+			return
+		}
+		s.writeJSON(w, http.StatusOK, factorysession.OpenResultToAPI(result))
+		return
+	}
+
+	sessionRuntime, ok := s.requireSessionRuntime(w)
+	if !ok {
+		return
+	}
 	response, err := sessionRuntime.OpenFactorySession(r.Context(), req)
 	if err != nil {
-		s.logger.Debug("open factory session rejected", zap.Error(err))
-		var domainTargetedErr interface {
-			error
-			ErrorTargets() []interfaces.ValidationTarget
-		}
-		var targetedErr interface {
-			error
-			ErrorTargets() []factoryapi.FactoryValidationTarget
-		}
-		code := "BAD_REQUEST"
-		var codedErr interface {
-			ErrorCode() string
-		}
-		if errors.As(err, &codedErr) {
-			code = codedErr.ErrorCode()
-		}
-		if errors.As(err, &domainTargetedErr) {
-			s.writeErrorWithTargets(
-				w,
-				http.StatusBadRequest,
-				err.Error(),
-				code,
-				apisurface.FactoryValidationTargetsToAPI(domainTargetedErr.ErrorTargets()),
-			)
-			return
-		}
-		if errors.As(err, &targetedErr) {
-			s.writeErrorWithTargets(w, http.StatusBadRequest, err.Error(), code, targetedErr.ErrorTargets())
-			return
-		}
-		s.writeError(w, http.StatusBadRequest, err.Error(), code)
+		s.writeOpenFactorySessionRejected(w, err)
 		return
 	}
 	s.writeJSON(w, http.StatusOK, response)
 }
 
+func (s *Server) writeOpenFactorySessionRejected(w http.ResponseWriter, err error) {
+	s.logger.Debug("open factory session rejected", zap.Error(err))
+	var domainTargetedErr interface {
+		error
+		ErrorTargets() []interfaces.ValidationTarget
+	}
+	var targetedErr interface {
+		error
+		ErrorTargets() []factoryapi.FactoryValidationTarget
+	}
+	code := "BAD_REQUEST"
+	var codedErr interface {
+		ErrorCode() string
+	}
+	if errors.As(err, &codedErr) {
+		code = codedErr.ErrorCode()
+	}
+	if errors.As(err, &domainTargetedErr) {
+		s.writeErrorWithTargets(
+			w,
+			http.StatusBadRequest,
+			err.Error(),
+			code,
+			apisurface.FactoryValidationTargetsToAPI(domainTargetedErr.ErrorTargets()),
+		)
+		return
+	}
+	if errors.As(err, &targetedErr) {
+		s.writeErrorWithTargets(w, http.StatusBadRequest, err.Error(), code, targetedErr.ErrorTargets())
+		return
+	}
+	s.writeError(w, http.StatusBadRequest, err.Error(), code)
+}
+
 func (s *Server) CloseFactorySession(w http.ResponseWriter, r *http.Request, sessionID string) {
+	if s.sessionsRoot != nil {
+		if err := s.sessionsRoot.CloseFactorySession(r.Context(), sessionID); err != nil {
+			if errors.Is(err, factorysessionexecution.ErrSessionNotFound) {
+				s.writeError(w, http.StatusNotFound, "factory session not found", "NOT_FOUND")
+				return
+			}
+			s.logger.Error("close factory session failed", zap.Error(err), zap.String("session_id", sessionID))
+			s.writeError(w, http.StatusInternalServerError, "failed to close factory session", "INTERNAL_ERROR")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	sessionRuntime, ok := s.requireSessionRuntime(w)
 	if !ok {
 		return
@@ -794,30 +823,34 @@ func (s *Server) writeDurableExecutionError(w http.ResponseWriter, err error) bo
 }
 
 func (s *Server) StartDurableFactorySessionAsync(w http.ResponseWriter, r *http.Request) {
-	execution, ok := s.requireDurableExecutionAPI(w)
-	if !ok {
-		return
-	}
-
-	req, err := decodeStrictJSON[factoryapi.FactorySessionExecutionRequest](r.Body)
+	raw, err := decodeStartFactorySessionRequest(r.Body, s.sessionRequests)
 	if err != nil {
 		if message, ok := requestFieldValidationMessage(err); ok {
 			s.writeError(w, http.StatusBadRequest, message, "BAD_REQUEST")
 			return
 		}
-		s.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
-		return
-	}
-
-	raw, err := factorysession.StartRequestFromAPI(req)
-	if err == nil {
-		raw, err = s.sessionRequests.PrepareStart(raw)
-	}
-	if err != nil {
 		if s.writeDurableExecutionError(w, err) {
 			return
 		}
 		s.writeError(w, http.StatusBadRequest, err.Error(), "BAD_REQUEST")
+		return
+	}
+
+	if s.sessionsRoot != nil {
+		result, err := s.sessionsRoot.StartAsync(r.Context(), raw)
+		if err != nil {
+			if s.writeDurableExecutionError(w, err) {
+				return
+			}
+			s.writeError(w, http.StatusInternalServerError, "durable factory session execution failed", "INTERNAL_ERROR")
+			return
+		}
+		s.writeJSON(w, http.StatusOK, factorysession.AsyncStartResponseToAPI(result))
+		return
+	}
+
+	execution, ok := s.requireDurableExecutionAPI(w)
+	if !ok {
 		return
 	}
 	response, err := execution.StartDurableFactorySessionAsync(r.Context(), raw)
@@ -832,30 +865,34 @@ func (s *Server) StartDurableFactorySessionAsync(w http.ResponseWriter, r *http.
 }
 
 func (s *Server) StartDurableFactorySessionSync(w http.ResponseWriter, r *http.Request) {
-	execution, ok := s.requireDurableExecutionAPI(w)
-	if !ok {
-		return
-	}
-
-	req, err := decodeStrictJSON[factoryapi.FactorySessionExecutionRequest](r.Body)
+	raw, err := decodeStartFactorySessionRequest(r.Body, s.sessionRequests)
 	if err != nil {
 		if message, ok := requestFieldValidationMessage(err); ok {
 			s.writeError(w, http.StatusBadRequest, message, "BAD_REQUEST")
 			return
 		}
-		s.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
-		return
-	}
-
-	raw, err := factorysession.StartRequestFromAPI(req)
-	if err == nil {
-		raw, err = s.sessionRequests.PrepareStart(raw)
-	}
-	if err != nil {
 		if s.writeDurableExecutionError(w, err) {
 			return
 		}
 		s.writeError(w, http.StatusBadRequest, err.Error(), "BAD_REQUEST")
+		return
+	}
+
+	if s.sessionsRoot != nil {
+		result, err := s.sessionsRoot.StartSync(r.Context(), raw)
+		if err != nil {
+			if s.writeDurableExecutionError(w, err) {
+				return
+			}
+			s.writeError(w, http.StatusInternalServerError, "durable factory session execution failed", "INTERNAL_ERROR")
+			return
+		}
+		s.writeJSON(w, http.StatusOK, factorysession.SyncStartResponseToAPI(result))
+		return
+	}
+
+	execution, ok := s.requireDurableExecutionAPI(w)
+	if !ok {
 		return
 	}
 	response, err := execution.StartDurableFactorySessionSync(r.Context(), raw)

--- a/pkg/services/factory_sessions/transports/http/handlers_factory.go
+++ b/pkg/services/factory_sessions/transports/http/handlers_factory.go
@@ -9,7 +9,6 @@ import (
 
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factorysessionexecution "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
-	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/scopedlisting"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	apisurface "github.com/portpowered/infinite-you/pkg/transports/mapping"
@@ -128,7 +127,7 @@ func (s *Server) ListFactorySessions(w http.ResponseWriter, r *http.Request, par
 
 	response, err := s.mergeScopedFactorySessionList(r.Context(), raw)
 	if err != nil {
-		if errors.Is(err, scopedlisting.ErrDurableReaderRequired) {
+		if errors.Is(err, ErrDurableReaderRequired) {
 			s.writeError(w, http.StatusNotImplemented, "durable factory session listing is not implemented", "INTERNAL_ERROR")
 			return
 		}
@@ -154,6 +153,21 @@ func (s *Server) GetFactorySession(w http.ResponseWriter, r *http.Request, sessi
 			return
 		}
 		s.writeJSON(w, http.StatusOK, response)
+		return
+	}
+
+	if s.sessionsRoot != nil {
+		projection, err := s.sessionsRoot.GetFactorySession(r.Context(), string(sessionID))
+		if err != nil {
+			if errors.Is(err, factorysessionexecution.ErrSessionNotFound) {
+				s.writeError(w, http.StatusNotFound, "factory session not found", "NOT_FOUND")
+				return
+			}
+			s.logger.Error("get factory session failed", zap.Error(err))
+			s.writeError(w, http.StatusInternalServerError, "failed to get factory session", "INTERNAL_ERROR")
+			return
+		}
+		s.writeJSON(w, http.StatusOK, factorysession.SessionResponseToAPI(projection))
 		return
 	}
 
@@ -937,9 +951,18 @@ func (s *Server) mergeScopedFactorySessionList(
 	ctx context.Context,
 	normalized factorysessionexecution.ListSessionsRequest,
 ) (factoryapi.ListFactorySessionsResponse, error) {
-	result, err := scopedlisting.List(
-		ctx, normalized, s.liveSessionLister, s.durableLister,
-	)
+	var live scopedLiveReader
+	var durable scopedDurableReader
+
+	if s.sessionsRoot != nil {
+		live = ReadProjectionSessionListReader{Reader: s.sessionsRoot}
+		durable = s.sessionsRoot
+	} else {
+		live = s.liveSessionLister
+		durable = s.durableLister
+	}
+
+	result, err := mergeScopedSessionList(ctx, normalized, live, durable)
 	if err != nil {
 		return factoryapi.ListFactorySessionsResponse{}, err
 	}

--- a/pkg/services/factory_sessions/transports/http/handlers_response_events_test.go
+++ b/pkg/services/factory_sessions/transports/http/handlers_response_events_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
@@ -44,6 +45,85 @@ func (s *staticResponseEventSubscription) Next(context.Context) ([]apisurface.Fa
 }
 
 func (s *staticResponseEventSubscription) Detach() {}
+
+func TestGetFactoryResponseEventsBySessionId_CanceledStreamCompletesWithoutHang(t *testing.T) {
+	t.Parallel()
+
+	handler := NewHandler(Dependencies{
+		DurableProjection: durableResponseEventsProjectionFake{
+			subscribe: func(ctx context.Context, request factorysessions.ResponseEventSubscriptionRequest) (apisurface.FactoryResponseEventSubscription, error) {
+				return &blockingResponseEventSubscription{}, nil
+			},
+		},
+	}, zap.NewNop())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/factory-sessions/dur-sess-1/response-events", nil).WithContext(ctx)
+	recorder := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		handler.GetFactoryResponseEventsBySessionId(recorder, req, "dur-sess-1", factoryapi.GetFactoryResponseEventsBySessionIdParams{})
+		close(done)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetFactoryResponseEventsBySessionId hung after request cancellation")
+	}
+	if body := recorder.Body.String(); body != "" {
+		t.Fatalf("response body = %q, want empty cancel-oriented stream outcome", body)
+	}
+}
+
+func TestGetFactoryResponseEventsBySessionId_DeadlineExceededStreamCompletesWithoutHang(t *testing.T) {
+	t.Parallel()
+
+	handler := NewHandler(Dependencies{
+		DurableProjection: durableResponseEventsProjectionFake{
+			subscribe: func(ctx context.Context, request factorysessions.ResponseEventSubscriptionRequest) (apisurface.FactoryResponseEventSubscription, error) {
+				return &blockingResponseEventSubscription{}, nil
+			},
+		},
+	}, zap.NewNop())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	recorder := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		handler.GetFactoryResponseEventsBySessionId(
+			recorder,
+			httptest.NewRequest(http.MethodGet, "/factory-sessions/dur-sess-1/response-events", nil).WithContext(ctx),
+			"dur-sess-1",
+			factoryapi.GetFactoryResponseEventsBySessionIdParams{},
+		)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetFactoryResponseEventsBySessionId hung after request deadline")
+	}
+	if body := recorder.Body.String(); body != "" {
+		t.Fatalf("response body = %q, want empty timeout-oriented stream outcome", body)
+	}
+}
+
+type blockingResponseEventSubscription struct{}
+
+func (blockingResponseEventSubscription) Next(ctx context.Context) ([]apisurface.FactoryResponseEventRecord, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (blockingResponseEventSubscription) Detach() {}
 
 func TestGetFactoryResponseEventsBySessionId_DurableSessionStreamsSSE(t *testing.T) {
 	t.Parallel()

--- a/pkg/services/factory_sessions/transports/http/inventory_boundary_test.go
+++ b/pkg/services/factory_sessions/transports/http/inventory_boundary_test.go
@@ -1,0 +1,38 @@
+package http_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestPackageBoundary_DoesNotImportFactorySessionsInternal(t *testing.T) {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	packageDir := filepath.Dir(filename)
+
+	forbidden := "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal"
+	entries, err := os.ReadDir(packageDir)
+	if err != nil {
+		t.Fatalf("read HTTP adapter package: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(packageDir, entry.Name())
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if strings.Contains(string(content), forbidden) {
+			t.Fatalf("%s must not import %s", entry.Name(), forbidden)
+		}
+	}
+}

--- a/pkg/services/factory_sessions/transports/http/manifest_registration_test.go
+++ b/pkg/services/factory_sessions/transports/http/manifest_registration_test.go
@@ -1,0 +1,144 @@
+package http_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/ownershipinventory"
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+const (
+	httpAdapterPackagePath = "pkg/services/factory_sessions/transports/http"
+	httpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/factory_sessions/transports/http"
+	factorySessionsOwner   = "factory_sessions"
+)
+
+type coverageMinimumManifest struct {
+	Lane     string `json:"lane"`
+	Packages []struct {
+		Package string  `json:"package"`
+		Minimum float64 `json:"minimum"`
+	} `json:"packages"`
+}
+
+func TestManifestRegistration_HTTPAdapterPackageIsRegistered(t *testing.T) {
+	t.Helper()
+
+	assertPackageTargetManifestRegistration(t)
+	assertOwnershipInventoryRegistration(t)
+	assertCoverageMinimumRegistration(t, "unit", "docs/internal/baselines/go-unit-coverage-package-minimums.json")
+	assertCoverageMinimumRegistration(t, "functional", "docs/internal/baselines/go-functional-coverage-package-minimums.json")
+}
+
+func assertPackageTargetManifestRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, "docs/internal/packaged-service-structure/package-target-manifest.json"))
+	if err != nil {
+		t.Fatalf("read package-target manifest: %v", err)
+	}
+
+	var manifest struct {
+		Inventory []string `json:"inventory"`
+		Packages  []struct {
+			PackagePath string `json:"packagePath"`
+			Disposition string `json:"disposition"`
+			Destination string `json:"destination"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode package-target manifest: %v", err)
+	}
+
+	foundInventory := false
+	for _, packagePath := range manifest.Inventory {
+		if packagePath == httpAdapterPackagePath {
+			foundInventory = true
+			break
+		}
+	}
+	if !foundInventory {
+		t.Fatalf("package-target manifest inventory missing %q", httpAdapterPackagePath)
+	}
+
+	for _, row := range manifest.Packages {
+		if row.PackagePath != httpAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("package-target manifest disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != factorySessionsOwner {
+			t.Fatalf("package-target manifest destination = %q, want %q", row.Destination, factorySessionsOwner)
+		}
+		return
+	}
+	t.Fatalf("package-target manifest packages missing %q", httpAdapterPackagePath)
+}
+
+func assertOwnershipInventoryRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, ownershipinventory.InventoryRelativePath))
+	if err != nil {
+		t.Fatalf("read ownership inventory: %v", err)
+	}
+
+	var inventory struct {
+		Packages []ownershipinventory.PackageRow `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		t.Fatalf("decode ownership inventory: %v", err)
+	}
+
+	for _, row := range inventory.Packages {
+		if row.PackagePath != httpAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("ownership inventory disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != factorySessionsOwner {
+			t.Fatalf("ownership inventory destination = %q, want %q", row.Destination, factorySessionsOwner)
+		}
+		if row.DestinationKind != ownershipinventory.DestinationKindOwner {
+			t.Fatalf(
+				"ownership inventory destinationKind = %q, want %q",
+				row.DestinationKind,
+				ownershipinventory.DestinationKindOwner,
+			)
+		}
+		return
+	}
+	t.Fatalf("ownership inventory packages missing %q", httpAdapterPackagePath)
+}
+
+func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, relativePath))
+	if err != nil {
+		t.Fatalf("read %s coverage manifest: %v", lane, err)
+	}
+
+	var manifest coverageMinimumManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode %s coverage manifest: %v", lane, err)
+	}
+	if manifest.Lane != lane {
+		t.Fatalf("%s coverage manifest lane = %q, want %q", relativePath, manifest.Lane, lane)
+	}
+
+	for _, entry := range manifest.Packages {
+		if entry.Package != httpAdapterImportPath {
+			continue
+		}
+		if entry.Minimum < 0 {
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterImportPath)
+		}
+		return
+	}
+	t.Fatalf("%s coverage manifest missing %q", lane, httpAdapterImportPath)
+}

--- a/pkg/services/factory_sessions/transports/http/request_context.go
+++ b/pkg/services/factory_sessions/transports/http/request_context.go
@@ -1,0 +1,46 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+// sessionsRequestContextErrorResponse maps request-context cancellation and
+// deadline failures to the adapter's documented HTTP outcomes. Canceled
+// requests terminate without an error body; deadline failures return 504.
+func sessionsRequestContextErrorResponse(err error) (status int, response any, handled bool) {
+	if err == nil {
+		return 0, nil, false
+	}
+	switch {
+	case errors.Is(err, context.Canceled):
+		return 0, nil, true
+	case errors.Is(err, context.DeadlineExceeded):
+		return http.StatusGatewayTimeout, factoryapi.ErrorResponse{
+			Message: "factory session request timed out",
+			Family:  factoryapi.ErrorFamilyInternalServerError,
+			Code:    factoryapi.ErrorResponseCodeINTERNALERROR,
+		}, true
+	default:
+		return 0, nil, false
+	}
+}
+
+func (s *Server) writeSessionsRequestContextOutcome(w http.ResponseWriter, err error) bool {
+	status, response, ok := sessionsRequestContextErrorResponse(err)
+	if !ok {
+		return false
+	}
+	if response == nil {
+		return true
+	}
+	s.writeJSON(w, status, response)
+	return true
+}
+
+func (s *Server) guardSessionsRequestContext(w http.ResponseWriter, r *http.Request) bool {
+	return s.writeSessionsRequestContextOutcome(w, r.Context().Err())
+}

--- a/pkg/services/factory_sessions/transports/http/request_context_test.go
+++ b/pkg/services/factory_sessions/transports/http/request_context_test.go
@@ -1,0 +1,153 @@
+package http_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factorysessionshttp "github.com/portpowered/infinite-you/pkg/services/factory_sessions/transports/http"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+func waitForRootGetSession(ctx context.Context, _ string) (factorysessions.SessionProjection, error) {
+	<-ctx.Done()
+	return factorysessions.SessionProjection{}, ctx.Err()
+}
+
+func TestHandlerFromRoot_GetFactorySessionCanceledDuringRootCallCompletesWithoutHang(t *testing.T) {
+	t.Parallel()
+
+	root := &httpSessionsRootFake{
+		getSession: waitForRootGetSession,
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/factory-sessions/session-alpha", nil).WithContext(ctx)
+	recorder := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		handler.GetFactorySession(recorder, req, "session-alpha")
+		close(done)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetFactorySession hung after request cancellation")
+	}
+	if body := recorder.Body.String(); body != "" {
+		t.Fatalf("response body = %q, want empty cancel-oriented outcome", body)
+	}
+}
+
+func TestHandlerFromRoot_GetFactorySessionCanceledBeforeRootCallCompletesWithoutBody(t *testing.T) {
+	t.Parallel()
+
+	root := &httpSessionsRootFake{}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	recorder := httptest.NewRecorder()
+	handler.GetFactorySession(recorder, httptest.NewRequest(http.MethodGet, "/factory-sessions/session-alpha", nil).WithContext(ctx), "session-alpha")
+
+	if body := recorder.Body.String(); body != "" {
+		t.Fatalf("response body = %q, want empty cancel-oriented outcome", body)
+	}
+}
+
+func TestHandlerFromRoot_ListFactorySessionsDeadlineExceededReturnsGatewayTimeout(t *testing.T) {
+	t.Parallel()
+
+	root := &httpSessionsRootFake{
+		listSessions: func(ctx context.Context, request factorysessions.ListSessionsRequest) (factorysessions.ListSessionsResult, error) {
+			<-ctx.Done()
+			return factorysessions.ListSessionsResult{}, ctx.Err()
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	recorder := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		handler.ListFactorySessions(recorder, httptest.NewRequest(http.MethodGet, "/factory-sessions", nil).WithContext(ctx), factoryapi.ListFactorySessionsParams{})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ListFactorySessions hung after request deadline")
+	}
+	if recorder.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504 Gateway Timeout", recorder.Code)
+	}
+	assertErrorResponse(t, recorder.Body.Bytes(), factoryapi.ErrorFamilyInternalServerError, factoryapi.ErrorResponseCodeINTERNALERROR, "factory session request timed out")
+}
+
+func TestHandlerFromRoot_CloseFactorySessionDeadlineExceededReturnsGatewayTimeout(t *testing.T) {
+	t.Parallel()
+
+	root := &httpSessionsRootFake{
+		onClose: func(ctx context.Context, _ string) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	recorder := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		handler.CloseFactorySession(recorder, httptest.NewRequest(http.MethodDelete, "/factory-sessions/session-alpha", nil).WithContext(ctx), "session-alpha")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("CloseFactorySession hung after request deadline")
+	}
+	if recorder.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504 Gateway Timeout", recorder.Code)
+	}
+	assertErrorResponse(t, recorder.Body.Bytes(), factoryapi.ErrorFamilyInternalServerError, factoryapi.ErrorResponseCodeINTERNALERROR, "factory session request timed out")
+}
+
+func TestSessionsRequestContextErrorResponseForTest(t *testing.T) {
+	t.Parallel()
+
+	if status, response, ok := factorysessionshttp.SessionsRequestContextErrorResponseForTest(context.Canceled); !ok || status != 0 || response != nil {
+		t.Fatalf("canceled = (%d, %#v, %v), want (0, nil, true)", status, response, ok)
+	}
+
+	status, response, ok := factorysessionshttp.SessionsRequestContextErrorResponseForTest(context.DeadlineExceeded)
+	if !ok || status != http.StatusGatewayTimeout {
+		t.Fatalf("deadline status = %d, ok = %v, want 504 true", status, ok)
+	}
+	body, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	if !strings.Contains(string(body), "factory session request timed out") {
+		t.Fatalf("response = %s, want timeout message", body)
+	}
+}

--- a/pkg/services/factory_sessions/transports/http/root_binding.go
+++ b/pkg/services/factory_sessions/transports/http/root_binding.go
@@ -52,10 +52,7 @@ func (noopRequestPreparation) PrepareInterruptDispatch(request factorysessions.I
 	return request, nil
 }
 func (noopRequestPreparation) PrepareListSessions(request factorysessions.ListSessionsRequest) (factorysessions.ListSessionsRequest, error) {
-	if request.Scope == "" {
-		request.Scope = factorysessions.DefaultSessionListScope
-	}
-	return request, nil
+	return normalizeListSessionsScope(request)
 }
 func (noopRequestPreparation) PrepareResult(request factorysessions.ResultRequest) (factorysessions.ResultRequest, error) {
 	return request, nil

--- a/pkg/services/factory_sessions/transports/http/root_binding.go
+++ b/pkg/services/factory_sessions/transports/http/root_binding.go
@@ -1,0 +1,73 @@
+package http
+
+import (
+	"net/http"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	"go.uber.org/zap"
+)
+
+// SessionsRoot is the accepted Factory Sessions root contract used by the HTTP
+// adapter. Adapter-owned operations invoke this surface rather than Sessions
+// internal packages.
+type SessionsRoot = factorysessions.Service
+
+// RootBinding binds the HTTP adapter to one injected Sessions root.
+type RootBinding struct {
+	Sessions SessionsRoot
+	Prepare  RequestPreparation
+}
+
+// NewHandlerFromRoot constructs an HTTP adapter that calls through the supplied
+// Sessions root. Tests inject a focused fake implementing SessionsRoot without
+// constructing durable runtime state or importing Sessions internals.
+func NewHandlerFromRoot(binding RootBinding, logger *zap.Logger) *Adapter {
+	if binding.Prepare == nil {
+		binding.Prepare = noopRequestPreparation{}
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return NewHandler(Dependencies{
+		SessionsRoot:    binding.Sessions,
+		SessionRequests: binding.Prepare,
+	}, logger)
+}
+
+type noopRequestPreparation struct{}
+
+func (noopRequestPreparation) PrepareStart(request factorysessions.StartRequest) (factorysessions.StartRequest, error) {
+	return request, nil
+}
+func (noopRequestPreparation) PrepareControl(request factorysessions.ControlRequest) (factorysessions.ControlRequest, error) {
+	return request, nil
+}
+func (noopRequestPreparation) PrepareApprove(request factorysessions.ApproveRequest) (factorysessions.ApproveRequest, error) {
+	return request, nil
+}
+func (noopRequestPreparation) PrepareRetryDispatch(request factorysessions.RetryDispatchRequest) (factorysessions.RetryDispatchRequest, error) {
+	return request, nil
+}
+func (noopRequestPreparation) PrepareInterruptDispatch(request factorysessions.InterruptDispatchRequest) (factorysessions.InterruptDispatchRequest, error) {
+	return request, nil
+}
+func (noopRequestPreparation) PrepareListSessions(request factorysessions.ListSessionsRequest) (factorysessions.ListSessionsRequest, error) {
+	if request.Scope == "" {
+		request.Scope = factorysessions.DefaultSessionListScope
+	}
+	return request, nil
+}
+func (noopRequestPreparation) PrepareResult(request factorysessions.ResultRequest) (factorysessions.ResultRequest, error) {
+	return request, nil
+}
+func (noopRequestPreparation) PrepareEventReconnect(request factorysessions.EventReconnectRequest) (factorysessions.EventReconnectRequest, error) {
+	return request, nil
+}
+
+func (s *Server) requireSessionsRoot(w http.ResponseWriter) (SessionsRoot, bool) {
+	if s.sessionsRoot == nil {
+		s.writeError(w, http.StatusInternalServerError, "session-scoped API is unavailable", "INTERNAL_ERROR")
+		return nil, false
+	}
+	return s.sessionsRoot, true
+}

--- a/pkg/services/factory_sessions/transports/http/root_binding_test.go
+++ b/pkg/services/factory_sessions/transports/http/root_binding_test.go
@@ -74,6 +74,7 @@ func TestHandlerFromRoot_ListFactorySessionsInvokesSessionsRoot(t *testing.T) {
 
 type httpSessionsRootFake struct {
 	sessions     map[string]factorysessions.SessionProjection
+	getSession   func(context.Context, string) (factorysessions.SessionProjection, error)
 	listReads    func(context.Context) ([]factorysessions.ReadProjection, error)
 	listSessions func(context.Context, factorysessions.ListSessionsRequest) (factorysessions.ListSessionsResult, error)
 	onOpen       func(context.Context, factorysessions.OpenRequest) (*factorysessions.OpenResult, error)
@@ -96,7 +97,10 @@ func (fake *httpSessionsRootFake) ListFactorySessions(ctx context.Context) ([]fa
 	return fake.listReads(ctx)
 }
 
-func (fake *httpSessionsRootFake) GetFactorySession(_ context.Context, sessionID string) (factorysessions.SessionProjection, error) {
+func (fake *httpSessionsRootFake) GetFactorySession(ctx context.Context, sessionID string) (factorysessions.SessionProjection, error) {
+	if fake.getSession != nil {
+		return fake.getSession(ctx, sessionID)
+	}
 	if projection, ok := fake.sessions[sessionID]; ok {
 		return projection, nil
 	}

--- a/pkg/services/factory_sessions/transports/http/root_binding_test.go
+++ b/pkg/services/factory_sessions/transports/http/root_binding_test.go
@@ -1,0 +1,266 @@
+package http_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factorysessionshttp "github.com/portpowered/infinite-you/pkg/services/factory_sessions/transports/http"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+func TestHandlerFromRoot_GetFactorySessionInvokesSessionsRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &httpSessionsRootFake{
+		sessions: map[string]factorysessions.SessionProjection{
+			"session-alpha": {
+				Context: factorysessions.ProjectionContext{
+					FactorySessionID: "session-alpha",
+					Session: &factorysessions.ScopedLiveSessionSummary{
+						ID: "session-alpha", FactoryDir: "/workspace/alpha", FolderPath: "/workspace",
+						Project: "alpha", Target: factorysessions.TargetRef{Kind: factorysessions.TargetKindNamed},
+					},
+				},
+			},
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.GetFactorySession(recorder, httptest.NewRequest(http.MethodGet, "/factory-sessions/session-alpha", nil), "session-alpha")
+
+	if recorder.Code != http.StatusOK || !strings.Contains(recorder.Body.String(), `"id":"session-alpha"`) {
+		t.Fatalf("response = %d %s, want encoded session from Sessions root", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestHandlerFromRoot_ListFactorySessionsInvokesSessionsRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &httpSessionsRootFake{
+		listSessions: func(_ context.Context, request factorysessions.ListSessionsRequest) (factorysessions.ListSessionsResult, error) {
+			if request.Scope != factorysessions.SessionListScopeAll {
+				t.Fatalf("durable inventory scope = %q, want all", request.Scope)
+			}
+			return factorysessions.ListSessionsResult{Scope: factorysessions.SessionListScopeLive}, nil
+		},
+		listReads: func(context.Context) ([]factorysessions.ReadProjection, error) {
+			return []factorysessions.ReadProjection{{
+				Context: factorysessions.ProjectionContext{
+					FactorySessionID: "session-alpha",
+					Session: &factorysessions.ScopedLiveSessionSummary{
+						ID: "session-alpha", FactoryDir: "/workspace/alpha", FolderPath: "/workspace", Project: "alpha",
+					},
+				},
+			}}, nil
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.ListFactorySessions(recorder, httptest.NewRequest(http.MethodGet, "/factory-sessions", nil), factoryapi.ListFactorySessionsParams{})
+
+	if recorder.Code != http.StatusOK || !strings.Contains(recorder.Body.String(), `"id":"session-alpha"`) {
+		t.Fatalf("response = %d %s, want encoded session list from Sessions root", recorder.Code, recorder.Body.String())
+	}
+}
+
+type httpSessionsRootFake struct {
+	sessions     map[string]factorysessions.SessionProjection
+	listReads    func(context.Context) ([]factorysessions.ReadProjection, error)
+	listSessions func(context.Context, factorysessions.ListSessionsRequest) (factorysessions.ListSessionsResult, error)
+}
+
+var _ factorysessions.Service = (*httpSessionsRootFake)(nil)
+
+func (fake *httpSessionsRootFake) ForRuntime(factorysessions.OpeningBindingRequest) (factorysessions.Service, error) {
+	return fake, nil
+}
+
+func (fake *httpSessionsRootFake) ListFactorySessions(ctx context.Context) ([]factorysessions.ReadProjection, error) {
+	if fake.listReads == nil {
+		return nil, nil
+	}
+	return fake.listReads(ctx)
+}
+
+func (fake *httpSessionsRootFake) GetFactorySession(_ context.Context, sessionID string) (factorysessions.SessionProjection, error) {
+	if projection, ok := fake.sessions[sessionID]; ok {
+		return projection, nil
+	}
+	return factorysessions.SessionProjection{}, factorysessions.ErrSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) ListSessions(ctx context.Context, request factorysessions.ListSessionsRequest) (factorysessions.ListSessionsResult, error) {
+	if fake.listSessions == nil {
+		return factorysessions.ListSessionsResult{}, nil
+	}
+	return fake.listSessions(ctx, request)
+}
+
+func (fake *httpSessionsRootFake) OpenFactorySession(context.Context, factorysessions.OpenRequest) (*factorysessions.OpenResult, error) {
+	return &factorysessions.OpenResult{SessionID: factorysessions.DefaultSessionID}, nil
+}
+
+func (fake *httpSessionsRootFake) OpenFactorySessionFromFolder(context.Context, string, *factorysessions.TargetRef, bool, bool) (*factorysessions.OpenResult, error) {
+	return &factorysessions.OpenResult{SessionID: factorysessions.DefaultSessionID}, nil
+}
+
+func (fake *httpSessionsRootFake) GetFactorySessionSyncPreflight(context.Context, string, *factorydefinitions.FactoryEventReconnectCursor, *factorydefinitions.FactorySessionLogicalResolveHint) (factorysessions.SyncPreflightResult, error) {
+	return factorysessions.SyncPreflightResult{}, factorysessions.ErrSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) GetFactorySessionResult(context.Context, string) (factoryruntime.LiveSessionResult, error) {
+	return factoryruntime.LiveSessionResult{}, factorysessions.ErrSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) GetFactorySessionPartialResult(context.Context, string) (factoryruntime.PartialSessionResult, error) {
+	return factoryruntime.PartialSessionResult{}, factorysessions.ErrSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) SubscribeFactoryResponseEvents(context.Context, factorysessions.ResponseEventSubscriptionRequest) (*factorysessions.ResponseEventCursor, error) {
+	return nil, factorysessions.ErrSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) SubscribeFactoryEventsForSession(context.Context, string, *factorydefinitions.FactoryEventReconnectCursor) (*factorydefinitions.FactoryEventStream, error) {
+	return nil, factorysessions.ErrSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) ProbeFactoryEventsForSession(context.Context, string, *factorydefinitions.FactoryEventReconnectCursor) error {
+	return factorysessions.ErrSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) ReadDurableFactorySessionEventStream(context.Context, string, factorysessions.EventReconnectRequest) (*factorydefinitions.FactoryEventStream, error) {
+	return nil, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) ProbeDurableFactorySessionEvents(context.Context, string, factorysessions.EventReconnectRequest) error {
+	return factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) GetEngineStateSnapshotForSession(context.Context, string) (*factoryruntime.StateSnapshot, error) {
+	return nil, factorysessions.ErrSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) ObserveForSession(context.Context, string, factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error) {
+	return factoryruntime.ObserveResult{}, factorysessions.ErrSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) PauseLiveFactorySession(context.Context, string, factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error) {
+	return factorysessions.LifecycleControlResult{}, factorysessions.ErrSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) ResumeLiveFactorySession(context.Context, string, factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error) {
+	return factorysessions.LifecycleControlResult{}, factorysessions.ErrSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) CloseFactorySession(context.Context, string) error {
+	return factorysessions.ErrSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) PauseDurableFactorySession(context.Context, string, factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error) {
+	return factorysessions.LifecycleControlResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) ResumeDurableFactorySession(context.Context, string, factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error) {
+	return factorysessions.LifecycleControlResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) CancelDurableFactorySession(context.Context, string, factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error) {
+	return factorysessions.LifecycleControlResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) TerminateDurableFactorySession(context.Context, string, factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error) {
+	return factorysessions.LifecycleControlResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) ApproveDurableFactorySession(context.Context, string, factorysessions.ApproveRequest) (factorysessions.LifecycleControlResult, error) {
+	return factorysessions.LifecycleControlResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) RetryDurableFactorySessionDispatch(context.Context, string, factorysessions.RetryDispatchRequest) (factorysessions.LifecycleControlResult, error) {
+	return factorysessions.LifecycleControlResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) InterruptDurableFactorySessionDispatch(context.Context, string, factorysessions.InterruptDispatchRequest) (factorysessions.LifecycleControlResult, error) {
+	return factorysessions.LifecycleControlResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) StartAsync(context.Context, factorysessions.StartRequest) (factorysessions.AsyncStartResult, error) {
+	return factorysessions.AsyncStartResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) StartSync(context.Context, factorysessions.StartRequest) (factorysessions.SyncStartResult, error) {
+	return factorysessions.SyncStartResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) ResumeInterruptedSession(context.Context, string, factorysessions.ResumeSessionRequest) (factorysessions.AsyncStartResult, error) {
+	return factorysessions.AsyncStartResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) GetSession(context.Context, string) (factorysessions.SessionReadResult, error) {
+	return factorysessions.SessionReadResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) Pause(context.Context, string, factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error) {
+	return factorysessions.LifecycleControlResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) Resume(context.Context, string, factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error) {
+	return factorysessions.LifecycleControlResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) Cancel(context.Context, string, factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error) {
+	return factorysessions.LifecycleControlResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) Terminate(context.Context, string, factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error) {
+	return factorysessions.LifecycleControlResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) Approve(context.Context, string, factorysessions.ApproveRequest) (factorysessions.LifecycleControlResult, error) {
+	return factorysessions.LifecycleControlResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) RetryDispatch(context.Context, string, factorysessions.RetryDispatchRequest) (factorysessions.LifecycleControlResult, error) {
+	return factorysessions.LifecycleControlResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) InterruptDispatch(context.Context, string, factorysessions.InterruptDispatchRequest) (factorysessions.LifecycleControlResult, error) {
+	return factorysessions.LifecycleControlResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) GetResult(context.Context, string, factorysessions.ResultRequest) (factorysessions.ResultReadResult, error) {
+	return factorysessions.ResultReadResult{}, factorysessions.ErrDurableSessionNotFound
+}
+
+func (fake *httpSessionsRootFake) ListDispatches(context.Context, string) (factorysessions.ListDispatchesResult, error) {
+	return factorysessions.ListDispatchesResult{}, nil
+}
+
+func (fake *httpSessionsRootFake) QueryDispatches(context.Context, factorysessions.DispatchQueryRequest) (factorysessions.ListDispatchesResult, error) {
+	return factorysessions.ListDispatchesResult{}, nil
+}
+
+func (fake *httpSessionsRootFake) GetDispatch(context.Context, string, string) (factorysessions.DispatchDetail, error) {
+	return factorysessions.DispatchDetail{}, factorysessions.ErrDispatchNotFound
+}
+
+func (fake *httpSessionsRootFake) ListArtifacts(context.Context, string) (factorysessions.ListArtifactsResult, error) {
+	return factorysessions.ListArtifactsResult{}, nil
+}
+
+func (fake *httpSessionsRootFake) GetArtifact(context.Context, string, string) (factorysessions.ArtifactDetail, error) {
+	return factorysessions.ArtifactDetail{}, factorysessions.ErrArtifactNotFound
+}
+
+func (fake *httpSessionsRootFake) ReadEvents(context.Context, string, factorysessions.EventReconnectRequest) (factorysessions.EventReadResult, error) {
+	return factorysessions.EventReadResult{}, factorysessions.ErrDurableSessionNotFound
+}

--- a/pkg/services/factory_sessions/transports/http/root_binding_test.go
+++ b/pkg/services/factory_sessions/transports/http/root_binding_test.go
@@ -76,6 +76,11 @@ type httpSessionsRootFake struct {
 	sessions     map[string]factorysessions.SessionProjection
 	listReads    func(context.Context) ([]factorysessions.ReadProjection, error)
 	listSessions func(context.Context, factorysessions.ListSessionsRequest) (factorysessions.ListSessionsResult, error)
+	onOpen       func(context.Context, factorysessions.OpenRequest) (*factorysessions.OpenResult, error)
+	onClose      func(context.Context, string) error
+	onStartAsync func(context.Context, factorysessions.StartRequest) (factorysessions.AsyncStartResult, error)
+	onPauseDurable func(context.Context, string, factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error)
+	onPauseLive    func(context.Context, string, factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error)
 }
 
 var _ factorysessions.Service = (*httpSessionsRootFake)(nil)
@@ -105,7 +110,10 @@ func (fake *httpSessionsRootFake) ListSessions(ctx context.Context, request fact
 	return fake.listSessions(ctx, request)
 }
 
-func (fake *httpSessionsRootFake) OpenFactorySession(context.Context, factorysessions.OpenRequest) (*factorysessions.OpenResult, error) {
+func (fake *httpSessionsRootFake) OpenFactorySession(ctx context.Context, request factorysessions.OpenRequest) (*factorysessions.OpenResult, error) {
+	if fake.onOpen != nil {
+		return fake.onOpen(ctx, request)
+	}
 	return &factorysessions.OpenResult{SessionID: factorysessions.DefaultSessionID}, nil
 }
 
@@ -153,7 +161,10 @@ func (fake *httpSessionsRootFake) ObserveForSession(context.Context, string, fac
 	return factoryruntime.ObserveResult{}, factorysessions.ErrSessionNotFound
 }
 
-func (fake *httpSessionsRootFake) PauseLiveFactorySession(context.Context, string, factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error) {
+func (fake *httpSessionsRootFake) PauseLiveFactorySession(ctx context.Context, sessionID string, control factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error) {
+	if fake.onPauseLive != nil {
+		return fake.onPauseLive(ctx, sessionID, control)
+	}
 	return factorysessions.LifecycleControlResult{}, factorysessions.ErrSessionNotFound
 }
 
@@ -161,11 +172,17 @@ func (fake *httpSessionsRootFake) ResumeLiveFactorySession(context.Context, stri
 	return factorysessions.LifecycleControlResult{}, factorysessions.ErrSessionNotFound
 }
 
-func (fake *httpSessionsRootFake) CloseFactorySession(context.Context, string) error {
+func (fake *httpSessionsRootFake) CloseFactorySession(ctx context.Context, sessionID string) error {
+	if fake.onClose != nil {
+		return fake.onClose(ctx, sessionID)
+	}
 	return factorysessions.ErrSessionNotFound
 }
 
-func (fake *httpSessionsRootFake) PauseDurableFactorySession(context.Context, string, factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error) {
+func (fake *httpSessionsRootFake) PauseDurableFactorySession(ctx context.Context, sessionID string, control factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error) {
+	if fake.onPauseDurable != nil {
+		return fake.onPauseDurable(ctx, sessionID, control)
+	}
 	return factorysessions.LifecycleControlResult{}, factorysessions.ErrDurableSessionNotFound
 }
 
@@ -193,7 +210,10 @@ func (fake *httpSessionsRootFake) InterruptDurableFactorySessionDispatch(context
 	return factorysessions.LifecycleControlResult{}, factorysessions.ErrDurableSessionNotFound
 }
 
-func (fake *httpSessionsRootFake) StartAsync(context.Context, factorysessions.StartRequest) (factorysessions.AsyncStartResult, error) {
+func (fake *httpSessionsRootFake) StartAsync(ctx context.Context, request factorysessions.StartRequest) (factorysessions.AsyncStartResult, error) {
+	if fake.onStartAsync != nil {
+		return fake.onStartAsync(ctx, request)
+	}
 	return factorysessions.AsyncStartResult{}, factorysessions.ErrDurableSessionNotFound
 }
 

--- a/pkg/services/factory_sessions/transports/http/root_errors.go
+++ b/pkg/services/factory_sessions/transports/http/root_errors.go
@@ -18,6 +18,10 @@ func sessionsRootErrorResponse(sessionID string, err error) (int, any, bool) {
 		return 0, nil, false
 	}
 
+	if status, response, ok := sessionsRequestContextErrorResponse(err); ok {
+		return status, response, true
+	}
+
 	if status, response, ok := factorysession.LifecycleControlErrorResponse(sessionID, err); ok {
 		return status, response, true
 	}
@@ -68,6 +72,9 @@ func sessionsRootNotFoundErrorResponse(err error) (int, factoryapi.ErrorResponse
 
 func (s *Server) writeSessionsRootError(w http.ResponseWriter, sessionID string, err error) bool {
 	if status, response, ok := sessionsRootErrorResponse(sessionID, err); ok {
+		if response == nil {
+			return true
+		}
 		s.writeJSON(w, status, response)
 		return true
 	}

--- a/pkg/services/factory_sessions/transports/http/root_errors.go
+++ b/pkg/services/factory_sessions/transports/http/root_errors.go
@@ -1,0 +1,86 @@
+package http
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/pkg/transports/mapping/factorysession"
+)
+
+// sessionsRootErrorResponse maps typed Sessions root failures to HTTP status and a
+// public response body. sessionID may be empty when the operation is not
+// session-scoped.
+func sessionsRootErrorResponse(sessionID string, err error) (int, any, bool) {
+	if err == nil {
+		return 0, nil, false
+	}
+
+	if status, response, ok := factorysession.LifecycleControlErrorResponse(sessionID, err); ok {
+		return status, response, true
+	}
+	if status, response, ok := factorysession.ExecutionErrorResponse(err); ok {
+		return status, response, true
+	}
+	if status, response, ok := sessionsRootNotFoundErrorResponse(err); ok {
+		return status, response, true
+	}
+
+	var validationErr *factorysessions.ExecutionValidationError
+	if errors.As(err, &validationErr) {
+		return http.StatusBadRequest, factoryapi.ErrorResponse{
+			Message: validationErr.Message,
+			Family:  factoryapi.ErrorFamilyBadRequest,
+			Code:    factoryapi.ErrorResponseCodeBADREQUEST,
+		}, true
+	}
+
+	return 0, nil, false
+}
+
+func sessionsRootNotFoundErrorResponse(err error) (int, factoryapi.ErrorResponse, bool) {
+	switch {
+	case errors.Is(err, factorysessions.ErrSessionNotFound),
+		errors.Is(err, factorysessions.ErrDurableSessionNotFound):
+		return http.StatusNotFound, factoryapi.ErrorResponse{
+			Message: "factory session not found",
+			Family:  factoryapi.ErrorFamilyNotFound,
+			Code:    factoryapi.ErrorResponseCodeNOTFOUND,
+		}, true
+	case errors.Is(err, factorysessions.ErrDispatchNotFound):
+		return http.StatusNotFound, factoryapi.ErrorResponse{
+			Message: "dispatch not found",
+			Family:  factoryapi.ErrorFamilyNotFound,
+			Code:    factoryapi.ErrorResponseCodeNOTFOUND,
+		}, true
+	case errors.Is(err, factorysessions.ErrArtifactNotFound):
+		return http.StatusNotFound, factoryapi.ErrorResponse{
+			Message: "factory session artifact not found",
+			Family:  factoryapi.ErrorFamilyNotFound,
+			Code:    factoryapi.ErrorResponseCodeNOTFOUND,
+		}, true
+	default:
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+}
+
+func (s *Server) writeSessionsRootError(w http.ResponseWriter, sessionID string, err error) bool {
+	if status, response, ok := sessionsRootErrorResponse(sessionID, err); ok {
+		s.writeJSON(w, status, response)
+		return true
+	}
+	return false
+}
+
+func (s *Server) writeSessionsRootErrorOrInternal(w http.ResponseWriter, sessionID string, err error, fallbackMessage string) {
+	if s.writeSessionsRootError(w, sessionID, err) {
+		return
+	}
+	message := strings.TrimSpace(fallbackMessage)
+	if message == "" {
+		message = "factory session request failed"
+	}
+	s.writeError(w, http.StatusInternalServerError, message, string(factoryapi.ErrorResponseCodeINTERNALERROR))
+}

--- a/pkg/services/factory_sessions/transports/http/root_errors_test.go
+++ b/pkg/services/factory_sessions/transports/http/root_errors_test.go
@@ -1,0 +1,198 @@
+package http_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factorysessionshttp "github.com/portpowered/infinite-you/pkg/services/factory_sessions/transports/http"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+func TestHandlerFromRoot_CloseFactorySessionNotFoundReturnsTypedErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	root := &httpSessionsRootFake{
+		onClose: func(context.Context, string) error {
+			return factorysessions.ErrSessionNotFound
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.CloseFactorySession(recorder, httptest.NewRequest(http.MethodDelete, "/factory-sessions/missing-session", nil), "missing-session")
+
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", recorder.Code)
+	}
+	assertErrorResponse(t, recorder.Body.Bytes(), factoryapi.ErrorFamilyNotFound, factoryapi.ErrorResponseCodeNOTFOUND, "factory session not found")
+}
+
+func TestHandlerFromRoot_StartDurableFactorySessionAsyncValidationErrorReturnsTypedErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	root := &httpSessionsRootFake{
+		onStartAsync: func(context.Context, factorysessions.StartRequest) (factorysessions.AsyncStartResult, error) {
+			return factorysessions.AsyncStartResult{}, &factorysessions.ExecutionValidationError{
+				Field:   "requestId",
+				Message: "requestId is required",
+			}
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"requestId":"req-alpha","source":{"kind":"FACTORY_ID","factoryId":"factory-alpha"}}`)
+
+	handler.StartDurableFactorySessionAsync(recorder, httptest.NewRequest(http.MethodPost, "/factory-sessions/execution/async", body))
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", recorder.Code)
+	}
+	assertErrorResponse(t, recorder.Body.Bytes(), factoryapi.ErrorFamilyBadRequest, factoryapi.ErrorResponseCodeBADREQUEST, "requestId is required")
+}
+
+func TestHandlerFromRoot_PauseDurableFactorySessionControlConflictReturnsTypedLifecycleResponse(t *testing.T) {
+	t.Parallel()
+
+	root := &httpSessionsRootFake{
+		onPauseDurable: func(_ context.Context, sessionID string, _ factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error) {
+			return factorysessions.LifecycleControlResult{}, &factorysessions.ControlError{
+				Operation: factorysessions.LifecycleControlPause,
+				Outcome:   factorysessions.LifecycleControlOutcomeInvalidState,
+				Status:    factorysessions.LifecycleStatusRunning,
+				Message:   "factory session is already running",
+			}
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.PauseFactorySession(
+		recorder,
+		httptest.NewRequest(http.MethodPost, "/factory-sessions/dur-sess-pause-conflict/pause", bytes.NewBufferString(`{"reason":"operator pause"}`)),
+		"dur-sess-pause-conflict",
+	)
+
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", recorder.Code)
+	}
+	var response factoryapi.FactorySessionLifecycleControlResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeInvalidState {
+		t.Fatalf("outcome = %q, want INVALID_STATE", response.Outcome)
+	}
+}
+
+func TestHandlerFromRoot_GetFactorySessionUnmappedRootErrorDoesNotLeakInternalDetail(t *testing.T) {
+	t.Parallel()
+
+	internalErr := fmt.Errorf("pkg/services/factory_sessions/internal/execution/runtime_service.go: unexpected failure")
+	root := &httpSessionsRootFake{
+		getSession: func(context.Context, string) (factorysessions.SessionProjection, error) {
+			return factorysessions.SessionProjection{}, internalErr
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.GetFactorySession(recorder, httptest.NewRequest(http.MethodGet, "/factory-sessions/session-alpha", nil), "session-alpha")
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", recorder.Code)
+	}
+	body := recorder.Body.String()
+	if strings.Contains(body, "pkg/services/factory_sessions/internal") {
+		t.Fatalf("body leaks internal package path: %s", body)
+	}
+	assertErrorResponse(t, recorder.Body.Bytes(), factoryapi.ErrorFamilyInternalServerError, factoryapi.ErrorResponseCodeINTERNALERROR, "failed to get factory session")
+}
+
+func TestHandlerFromRoot_StartDurableFactorySessionAsyncRequestIDConflictReturnsTypedErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	root := &httpSessionsRootFake{
+		onStartAsync: func(context.Context, factorysessions.StartRequest) (factorysessions.AsyncStartResult, error) {
+			return factorysessions.AsyncStartResult{}, factorysessions.ErrExecutionRequestIDConflict
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"requestId":"req-conflict","source":{"kind":"FACTORY_ID","factoryId":"factory-alpha"}}`)
+
+	handler.StartDurableFactorySessionAsync(recorder, httptest.NewRequest(http.MethodPost, "/factory-sessions/execution/async", body))
+
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", recorder.Code)
+	}
+	assertErrorResponse(t, recorder.Body.Bytes(), factoryapi.ErrorFamilyConflict, factoryapi.ErrorResponseCodeEXECUTIONREQUESTIDCONFLICT, "requestId was already used with different execution inputs.")
+}
+
+func assertErrorResponse(
+	t *testing.T,
+	body []byte,
+	wantFamily factoryapi.ErrorFamily,
+	wantCode factoryapi.ErrorResponseCode,
+	wantMessage string,
+) {
+	t.Helper()
+
+	var errResp factoryapi.ErrorResponse
+	if err := json.Unmarshal(body, &errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errResp.Family != wantFamily {
+		t.Fatalf("family = %q, want %q", errResp.Family, wantFamily)
+	}
+	if errResp.Code != wantCode {
+		t.Fatalf("code = %q, want %q", errResp.Code, wantCode)
+	}
+	if errResp.Message != wantMessage {
+		t.Fatalf("message = %q, want %q", errResp.Message, wantMessage)
+	}
+}
+
+func TestSessionsRootErrorResponseReturnsFalseForNilError(t *testing.T) {
+	t.Parallel()
+
+	if status, response, ok := factorysessionshttp.SessionsRootErrorResponseForTest("", nil); ok {
+		t.Fatalf("sessionsRootErrorResponse(nil) = (%d, %#v, true), want false", status, response)
+	}
+}
+
+func TestSessionsRootErrorResponseMapsWrappedNotFound(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("lookup failed: %w", factorysessions.ErrDurableSessionNotFound)
+	status, response, ok := factorysessionshttp.SessionsRootErrorResponseForTest("dur-sess-001", wrapped)
+	if !ok {
+		t.Fatal("sessionsRootErrorResponse = false, want true")
+	}
+	if status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", status)
+	}
+	errResp, ok := response.(factoryapi.ErrorResponse)
+	if !ok {
+		t.Fatalf("response = %#v, want ErrorResponse", response)
+	}
+	if errResp.Code != factoryapi.ErrorResponseCodeNOTFOUND {
+		t.Fatalf("code = %q, want NOT_FOUND", errResp.Code)
+	}
+}
+
+func TestSessionsRootErrorResponseReturnsFalseForUnknownError(t *testing.T) {
+	t.Parallel()
+
+	if _, _, ok := factorysessionshttp.SessionsRootErrorResponseForTest("", errors.New("opaque")); ok {
+		t.Fatal("sessionsRootErrorResponse = true, want false")
+	}
+}

--- a/pkg/services/factory_sessions/transports/http/session_control.go
+++ b/pkg/services/factory_sessions/transports/http/session_control.go
@@ -1,0 +1,157 @@
+package http
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/pkg/transports/mapping/factorysession"
+	"go.uber.org/zap"
+)
+
+func decodeOpenFactorySessionRequest(body io.Reader) (factoryapi.OpenFactorySessionRequest, error) {
+	return decodeOpenFactorySessionBody(body)
+}
+
+func decodeStartFactorySessionRequest(body io.Reader, prepare RequestPreparation) (factorysessions.StartRequest, error) {
+	req, err := decodeStrictJSON[factoryapi.FactorySessionExecutionRequest](body)
+	if err != nil {
+		return factorysessions.StartRequest{}, err
+	}
+	raw, err := factorysession.StartRequestFromAPI(req)
+	if err != nil {
+		return factorysessions.StartRequest{}, err
+	}
+	if prepare == nil {
+		prepare = noopRequestPreparation{}
+	}
+	return prepare.PrepareStart(raw)
+}
+
+func decodeLifecycleControlRequest(body io.Reader, prepare RequestPreparation) (factorysessions.ControlRequest, error) {
+	req, err := decodeOptionalLifecycleControlRequest(body)
+	if err != nil {
+		return factorysessions.ControlRequest{}, err
+	}
+	control, err := factorysession.ControlRequestFromAPI(req)
+	if err != nil {
+		return factorysessions.ControlRequest{}, err
+	}
+	if prepare == nil {
+		prepare = noopRequestPreparation{}
+	}
+	return prepare.PrepareControl(control)
+}
+
+func decodeApproveFactorySessionRequest(body io.Reader, prepare RequestPreparation) (factorysessions.ApproveRequest, error) {
+	req, err := decodeOptionalApproveRequest(body)
+	if err != nil {
+		return factorysessions.ApproveRequest{}, err
+	}
+	approve, err := factorysession.ApproveRequestFromAPI(req)
+	if err != nil {
+		return factorysessions.ApproveRequest{}, err
+	}
+	if prepare == nil {
+		prepare = noopRequestPreparation{}
+	}
+	return prepare.PrepareApprove(approve)
+}
+
+func decodeRetryDispatchRequest(body io.Reader, prepare RequestPreparation) (factorysessions.RetryDispatchRequest, error) {
+	req, err := decodeOptionalRetryDispatchRequest(body)
+	if err != nil {
+		return factorysessions.RetryDispatchRequest{}, err
+	}
+	retry, err := factorysession.RetryDispatchRequestFromAPI(req)
+	if err != nil {
+		return factorysessions.RetryDispatchRequest{}, err
+	}
+	if prepare == nil {
+		prepare = noopRequestPreparation{}
+	}
+	return prepare.PrepareRetryDispatch(retry)
+}
+
+func decodeInterruptDispatchRequest(body io.Reader, prepare RequestPreparation) (factorysessions.InterruptDispatchRequest, error) {
+	req, err := decodeOptionalInterruptDispatchRequest(body)
+	if err != nil {
+		return factorysessions.InterruptDispatchRequest{}, err
+	}
+	interrupt, err := factorysession.InterruptDispatchRequestFromAPI(req)
+	if err != nil {
+		return factorysessions.InterruptDispatchRequest{}, err
+	}
+	if prepare == nil {
+		prepare = noopRequestPreparation{}
+	}
+	return prepare.PrepareInterruptDispatch(interrupt)
+}
+
+func (s *Server) finishRootLifecycleControl(
+	w http.ResponseWriter,
+	sessionID string,
+	operation string,
+	result factorysessions.LifecycleControlResult,
+	err error,
+) {
+	if err != nil {
+		if s.writeDurableLifecycleControlError(w, sessionID, err) {
+			return
+		}
+		s.logger.Error("factory session lifecycle control failed",
+			zap.Error(err),
+			zap.String("session_id", sessionID),
+			zap.String("operation", operation),
+		)
+		s.writeError(w, http.StatusInternalServerError, "factory session lifecycle control failed", "INTERNAL_ERROR")
+		return
+	}
+	s.writeLifecycleControlSuccess(w, factorysession.LifecycleControlResponseToAPI(result))
+}
+
+func (s *Server) invokeRootDurableLifecycleControl(
+	w http.ResponseWriter,
+	ctx context.Context,
+	sessionID factoryapi.SessionID,
+	operation string,
+	control factorysessions.ControlRequest,
+) {
+	switch operation {
+	case "pause":
+		result, err := s.sessionsRoot.PauseDurableFactorySession(ctx, string(sessionID), control)
+		s.finishRootLifecycleControl(w, string(sessionID), operation, result, err)
+	case "resume":
+		result, err := s.sessionsRoot.ResumeDurableFactorySession(ctx, string(sessionID), control)
+		s.finishRootLifecycleControl(w, string(sessionID), operation, result, err)
+	case "cancel":
+		result, err := s.sessionsRoot.CancelDurableFactorySession(ctx, string(sessionID), control)
+		s.finishRootLifecycleControl(w, string(sessionID), operation, result, err)
+	case "terminate":
+		result, err := s.sessionsRoot.TerminateDurableFactorySession(ctx, string(sessionID), control)
+		s.finishRootLifecycleControl(w, string(sessionID), operation, result, err)
+	default:
+		s.writeError(w, http.StatusInternalServerError, "durable factory session lifecycle control failed", "INTERNAL_ERROR")
+	}
+}
+
+func (s *Server) invokeRootLiveLifecycleControl(
+	w http.ResponseWriter,
+	ctx context.Context,
+	sessionID factoryapi.SessionID,
+	operation string,
+	control factorysessions.ControlRequest,
+) {
+	switch operation {
+	case "pause":
+		result, err := s.sessionsRoot.PauseLiveFactorySession(ctx, string(sessionID), control)
+		s.finishRootLifecycleControl(w, string(sessionID), operation, result, err)
+	case "resume":
+		result, err := s.sessionsRoot.ResumeLiveFactorySession(ctx, string(sessionID), control)
+		s.finishRootLifecycleControl(w, string(sessionID), operation, result, err)
+	default:
+		s.writeError(w, http.StatusInternalServerError, "live factory session lifecycle control failed", "INTERNAL_ERROR")
+	}
+}

--- a/pkg/services/factory_sessions/transports/http/session_control.go
+++ b/pkg/services/factory_sessions/transports/http/session_control.go
@@ -98,7 +98,7 @@ func (s *Server) finishRootLifecycleControl(
 	err error,
 ) {
 	if err != nil {
-		if s.writeDurableLifecycleControlError(w, sessionID, err) {
+		if s.writeSessionsRootError(w, sessionID, err) {
 			return
 		}
 		s.logger.Error("factory session lifecycle control failed",
@@ -106,7 +106,7 @@ func (s *Server) finishRootLifecycleControl(
 			zap.String("session_id", sessionID),
 			zap.String("operation", operation),
 		)
-		s.writeError(w, http.StatusInternalServerError, "factory session lifecycle control failed", "INTERNAL_ERROR")
+		s.writeSessionsRootErrorOrInternal(w, sessionID, err, "factory session lifecycle control failed")
 		return
 	}
 	s.writeLifecycleControlSuccess(w, factorysession.LifecycleControlResponseToAPI(result))

--- a/pkg/services/factory_sessions/transports/http/session_control_test.go
+++ b/pkg/services/factory_sessions/transports/http/session_control_test.go
@@ -1,0 +1,243 @@
+package http_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factorysessionshttp "github.com/portpowered/infinite-you/pkg/services/factory_sessions/transports/http"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+func TestHandlerFromRoot_OpenFactorySessionEncodesRootResult(t *testing.T) {
+	t.Parallel()
+
+	root := &httpSessionsRootFake{
+		onOpen: func(_ context.Context, request factorysessions.OpenRequest) (*factorysessions.OpenResult, error) {
+			if request.FolderPath != "/workspace/alpha" {
+				t.Fatalf("folderPath = %q, want /workspace/alpha", request.FolderPath)
+			}
+			return &factorysessions.OpenResult{
+				SessionID: "session-open-alpha",
+				Session: &factorysessions.ScopedLiveSessionSummary{
+					ID:         "session-open-alpha",
+					FolderPath: "/workspace/alpha",
+				},
+			}, nil
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"folderPath":"/workspace/alpha"}`)
+
+	handler.OpenFactorySession(recorder, httptest.NewRequest(http.MethodPost, "/factory-sessions/open", body))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	var response factoryapi.OpenFactorySessionResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Session == nil || response.Session.Id != "session-open-alpha" {
+		t.Fatalf("session = %#v, want encoded open session", response.Session)
+	}
+}
+
+func TestHandlerFromRoot_OpenFactorySessionMissingFolderPathReturnsBadRequestWithoutRootCall(t *testing.T) {
+	t.Parallel()
+
+	root := &httpSessionsRootFake{
+		onOpen: func(context.Context, factorysessions.OpenRequest) (*factorysessions.OpenResult, error) {
+			t.Fatal("fake root must not be invoked when folderPath is missing")
+			return nil, nil
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"folderPath":""}`)
+
+	handler.OpenFactorySession(recorder, httptest.NewRequest(http.MethodPost, "/factory-sessions/open", body))
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", recorder.Code)
+	}
+	var errResp factoryapi.ErrorResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errResp.Code != factoryapi.ErrorResponseCodeBADREQUEST {
+		t.Fatalf("code = %q, want BAD_REQUEST", errResp.Code)
+	}
+}
+
+func TestHandlerFromRoot_StartDurableFactorySessionAsyncInvokesRootWithDecodedRequest(t *testing.T) {
+	t.Parallel()
+
+	root := &httpSessionsRootFake{
+		onStartAsync: func(_ context.Context, request factorysessions.StartRequest) (factorysessions.AsyncStartResult, error) {
+			if request.RequestID != "req-async-alpha" {
+				t.Fatalf("requestId = %q, want req-async-alpha", request.RequestID)
+			}
+			return factorysessions.AsyncStartResult{
+				SessionID: "dur-sess-async-alpha",
+				Status:    string(factorysessions.LifecycleStatusRunning),
+			}, nil
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"requestId":"req-async-alpha","source":{"kind":"FACTORY_ID","factoryId":"factory-alpha"}}`)
+
+	handler.StartDurableFactorySessionAsync(recorder, httptest.NewRequest(http.MethodPost, "/factory-sessions/execution/async", body))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	var response factoryapi.FactorySessionExecutionResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.SessionId != "dur-sess-async-alpha" {
+		t.Fatalf("sessionId = %q, want dur-sess-async-alpha", response.SessionId)
+	}
+	if response.Status != factoryapi.FactorySessionDurableLifecycleStatusRunning {
+		t.Fatalf("status = %q, want RUNNING", response.Status)
+	}
+}
+
+func TestHandlerFromRoot_StartDurableFactorySessionAsyncInvalidSourceReturnsBadRequestWithoutRootCall(t *testing.T) {
+	t.Parallel()
+
+	root := &httpSessionsRootFake{
+		onStartAsync: func(context.Context, factorysessions.StartRequest) (factorysessions.AsyncStartResult, error) {
+			t.Fatal("fake root must not be invoked for invalid execution source")
+			return factorysessions.AsyncStartResult{}, nil
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"requestId":"req-bad-inline","source":{"kind":"INLINE_WORKFLOW"}}`)
+
+	handler.StartDurableFactorySessionAsync(recorder, httptest.NewRequest(http.MethodPost, "/factory-sessions/execution/async", body))
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", recorder.Code)
+	}
+	var errResp factoryapi.ErrorResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errResp.Family != factoryapi.ErrorFamilyBadRequest {
+		t.Fatalf("family = %q, want bad_request", errResp.Family)
+	}
+	if !strings.Contains(errResp.Message, "inlineWorkflow") {
+		t.Fatalf("message = %q, want inline workflow validation text", errResp.Message)
+	}
+}
+
+func TestHandlerFromRoot_CloseFactorySessionInvokesRoot(t *testing.T) {
+	t.Parallel()
+
+	closed := false
+	root := &httpSessionsRootFake{
+		onClose: func(_ context.Context, sessionID string) error {
+			if sessionID != "session-close-alpha" {
+				t.Fatalf("sessionId = %q, want session-close-alpha", sessionID)
+			}
+			closed = true
+			return nil
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.CloseFactorySession(recorder, httptest.NewRequest(http.MethodDelete, "/factory-sessions/session-close-alpha", nil), "session-close-alpha")
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", recorder.Code)
+	}
+	if !closed {
+		t.Fatal("fake root close was not invoked")
+	}
+}
+
+func TestHandlerFromRoot_PauseDurableFactorySessionEncodesRootLifecycleControl(t *testing.T) {
+	t.Parallel()
+
+	root := &httpSessionsRootFake{
+		onPauseDurable: func(_ context.Context, sessionID string, control factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error) {
+			if sessionID != "dur-sess-pause-alpha" {
+				t.Fatalf("sessionId = %q, want dur-sess-pause-alpha", sessionID)
+			}
+			if control.Reason != "operator pause" {
+				t.Fatalf("reason = %q, want operator pause", control.Reason)
+			}
+			return factorysessions.LifecycleControlResult{
+				SessionID: sessionID,
+				Operation: factorysessions.LifecycleControlPause,
+				Outcome:   factorysessions.LifecycleControlOutcomeAccepted,
+				Status:    factorysessions.LifecycleStatusPaused,
+			}, nil
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"reason":"operator pause"}`)
+
+	handler.PauseFactorySession(recorder, httptest.NewRequest(http.MethodPost, "/factory-sessions/dur-sess-pause-alpha/pause", body), "dur-sess-pause-alpha")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	var response factoryapi.FactorySessionLifecycleControlResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Operation != factoryapi.FactorySessionLifecycleControlKindPause {
+		t.Fatalf("operation = %q, want PAUSE", response.Operation)
+	}
+	if response.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
+		t.Fatalf("outcome = %q, want ACCEPTED", response.Outcome)
+	}
+}
+
+func TestHandlerFromRoot_PauseLiveFactorySessionEncodesRootLifecycleControl(t *testing.T) {
+	t.Parallel()
+
+	root := &httpSessionsRootFake{
+		onPauseLive: func(_ context.Context, sessionID string, _ factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error) {
+			if sessionID != "session-live-pause" {
+				t.Fatalf("sessionId = %q, want session-live-pause", sessionID)
+			}
+			return factorysessions.LifecycleControlResult{
+				SessionID: sessionID,
+				Operation: factorysessions.LifecycleControlPause,
+				Outcome:   factorysessions.LifecycleControlOutcomeAccepted,
+				Status:    factorysessions.LifecycleStatusPaused,
+			}, nil
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.PauseFactorySession(recorder, httptest.NewRequest(http.MethodPost, "/factory-sessions/session-live-pause/pause", io.NopCloser(bytes.NewBuffer(nil))), "session-live-pause")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	var response factoryapi.FactorySessionLifecycleControlResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Operation != factoryapi.FactorySessionLifecycleControlKindPause {
+		t.Fatalf("operation = %q, want PAUSE", response.Operation)
+	}
+}

--- a/pkg/services/factory_sessions/transports/http/session_listing.go
+++ b/pkg/services/factory_sessions/transports/http/session_listing.go
@@ -2,11 +2,17 @@ package http
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sort"
+	"strings"
 
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
-	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/scopedlisting"
 )
+
+// ErrDurableReaderRequired reports that persisted-scope listing requires a durable
+// Sessions root reader.
+var ErrDurableReaderRequired = errors.New("durable Factory Session list reader is required")
 
 // LiveSessionListReader is the exact detached live-list role consumed by the
 // Factory Sessions HTTP adapter.
@@ -34,5 +40,199 @@ func (reader ReadProjectionSessionListReader) ListScopedLiveSessions(ctx context
 	if err != nil {
 		return nil, err
 	}
-	return scopedlisting.ProjectLiveSessions(reads), nil
+	return projectLiveSessions(reads), nil
+}
+
+type scopedLiveReader interface {
+	ListScopedLiveSessions(context.Context) ([]factorysessions.ScopedLiveSessionSummary, error)
+}
+
+type scopedDurableReader interface {
+	ListSessions(context.Context, factorysessions.ListSessionsRequest) (factorysessions.ListSessionsResult, error)
+}
+
+func mergeScopedSessionList(
+	ctx context.Context,
+	request factorysessions.ListSessionsRequest,
+	live scopedLiveReader,
+	durable scopedDurableReader,
+) (factorysessions.ScopedSessionListResult, error) {
+	scope := request.Scope
+	if scope == "" {
+		scope = factorysessions.DefaultSessionListScope
+	}
+	request.Scope = scope
+
+	var workspace []factorysessions.ScopedLiveSessionSummary
+	if scope == factorysessions.SessionListScopeLive || scope == factorysessions.SessionListScopeAll {
+		if live == nil {
+			return factorysessions.ScopedSessionListResult{}, fmt.Errorf("list scoped Factory Sessions: live session reader is required")
+		}
+		rows, err := live.ListScopedLiveSessions(ctx)
+		if err != nil {
+			return factorysessions.ScopedSessionListResult{}, err
+		}
+		workspace = append([]factorysessions.ScopedLiveSessionSummary(nil), rows...)
+	}
+
+	var durableResult factorysessions.ListSessionsResult
+	if scope == factorysessions.SessionListScopePersisted && durable == nil {
+		return factorysessions.ScopedSessionListResult{}, ErrDurableReaderRequired
+	}
+	if durable != nil {
+		result, err := durable.ListSessions(ctx, factorysessions.ListSessionsRequest{Scope: factorysessions.SessionListScopeAll})
+		if err != nil {
+			return factorysessions.ScopedSessionListResult{}, err
+		}
+		durableResult = result
+	}
+	scoped := applySessionListScope(durableResult, request)
+	liveRows := append(workspace, projectDurableLiveSessions(scoped.LiveSessions)...)
+	sort.SliceStable(liveRows, func(left, right int) bool {
+		return strings.Compare(liveRows[left].ID, liveRows[right].ID) < 0
+	})
+	return factorysessions.ScopedSessionListResult{
+		Scope:           scope,
+		LiveSessions:    liveRows,
+		DurableSessions: append([]factorysessions.DurableSessionListSummary(nil), scoped.DurableSessions...),
+	}, nil
+}
+
+func projectLiveSessions(reads []factorysessions.ReadProjection) []factorysessions.ScopedLiveSessionSummary {
+	if len(reads) == 0 {
+		return nil
+	}
+	projected := make([]factorysessions.ScopedLiveSessionSummary, 0, len(reads))
+	for _, read := range reads {
+		session := read.Context.Session
+		if session == nil {
+			continue
+		}
+		row := factorysessions.ScopedLiveSessionSummary{
+			ID: read.Context.FactorySessionID, FactoryDir: session.FactoryDir,
+			FolderPath: session.FolderPath, Project: session.Project,
+			IsDefault: session.IsDefault, Target: session.Target,
+		}
+		if read.RuntimeAvailable {
+			runtime := read.Runtime
+			row.Runtime = &runtime
+		}
+		if read.Context.NormalizedTarget != nil {
+			target := *read.Context.NormalizedTarget
+			row.NormalizedTarget = &target
+		}
+		projected = append(projected, row)
+	}
+	return projected
+}
+
+func projectDurableLiveSessions(sessions []factorysessions.LiveSessionSummary) []factorysessions.ScopedLiveSessionSummary {
+	if len(sessions) == 0 {
+		return nil
+	}
+	projected := make([]factorysessions.ScopedLiveSessionSummary, 0, len(sessions))
+	for _, session := range sessions {
+		projected = append(projected, factorysessions.ScopedLiveSessionSummary{
+			ID: session.ID, FactoryDir: session.FactoryDir, FolderPath: session.FolderPath,
+			Project: session.Project, IsDefault: session.IsDefault,
+		})
+	}
+	return projected
+}
+
+func applySessionListScope(result factorysessions.ListSessionsResult, request factorysessions.ListSessionsRequest) factorysessions.ListSessionsResult {
+	scope := request.Scope
+	if scope == "" {
+		scope = factorysessions.DefaultSessionListScope
+	}
+
+	durable := append([]factorysessions.DurableSessionListSummary(nil), result.DurableSessions...)
+	live := append([]factorysessions.LiveSessionSummary(nil), result.LiveSessions...)
+
+	switch scope {
+	case factorysessions.SessionListScopeLive:
+		return factorysessions.ListSessionsResult{
+			Scope:        scope,
+			LiveSessions: sortLiveSessionSummaries(live),
+		}
+	case factorysessions.SessionListScopePersisted:
+		return factorysessions.ListSessionsResult{
+			Scope:           scope,
+			DurableSessions: sortDurableSessionSummaries(filterPersistedSessionSummaries(durable)),
+		}
+	default:
+		return factorysessions.ListSessionsResult{
+			Scope:           scope,
+			LiveSessions:    sortLiveSessionSummaries(deduplicateLiveSessionsForAllScope(live, durable)),
+			DurableSessions: sortDurableSessionSummaries(durable),
+		}
+	}
+}
+
+func filterPersistedSessionSummaries(summaries []factorysessions.DurableSessionListSummary) []factorysessions.DurableSessionListSummary {
+	if len(summaries) == 0 {
+		return nil
+	}
+	filtered := make([]factorysessions.DurableSessionListSummary, 0, len(summaries))
+	for _, summary := range summaries {
+		if isPersistedListCandidate(summary) {
+			filtered = append(filtered, summary)
+		}
+	}
+	return filtered
+}
+
+func isPersistedListCandidate(summary factorysessions.DurableSessionListSummary) bool {
+	if factorysessions.IsTerminalLifecycleStatus(summary.Status) {
+		return true
+	}
+	if summary.Status == factorysessions.LifecycleStatusInterrupted {
+		return true
+	}
+	return summary.Recoverable
+}
+
+func deduplicateLiveSessionsForAllScope(
+	live []factorysessions.LiveSessionSummary,
+	durable []factorysessions.DurableSessionListSummary,
+) []factorysessions.LiveSessionSummary {
+	if len(live) == 0 || len(durable) == 0 {
+		return append([]factorysessions.LiveSessionSummary(nil), live...)
+	}
+	durableIDs := make(map[string]struct{}, len(durable))
+	for _, summary := range durable {
+		if id := strings.TrimSpace(summary.SessionID); id != "" {
+			durableIDs[id] = struct{}{}
+		}
+	}
+	filtered := make([]factorysessions.LiveSessionSummary, 0, len(live))
+	for _, session := range live {
+		if _, exists := durableIDs[strings.TrimSpace(session.ID)]; exists {
+			continue
+		}
+		filtered = append(filtered, session)
+	}
+	return filtered
+}
+
+func sortDurableSessionSummaries(summaries []factorysessions.DurableSessionListSummary) []factorysessions.DurableSessionListSummary {
+	if len(summaries) == 0 {
+		return nil
+	}
+	sorted := append([]factorysessions.DurableSessionListSummary(nil), summaries...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return strings.Compare(sorted[i].SessionID, sorted[j].SessionID) < 0
+	})
+	return sorted
+}
+
+func sortLiveSessionSummaries(sessions []factorysessions.LiveSessionSummary) []factorysessions.LiveSessionSummary {
+	if len(sessions) == 0 {
+		return nil
+	}
+	sorted := append([]factorysessions.LiveSessionSummary(nil), sessions...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return strings.Compare(sorted[i].ID, sorted[j].ID) < 0
+	})
+	return sorted
 }

--- a/pkg/services/factory_sessions/transports/http/session_read.go
+++ b/pkg/services/factory_sessions/transports/http/session_read.go
@@ -1,0 +1,44 @@
+package http
+
+import (
+	"fmt"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/pkg/transports/mapping/factorysession"
+)
+
+func decodeListFactorySessionsRequest(
+	params factoryapi.ListFactorySessionsParams,
+	prepare RequestPreparation,
+) (factorysessions.ListSessionsRequest, error) {
+	raw, err := factorysession.ListSessionsRequestFromAPI(params)
+	if err != nil {
+		return factorysessions.ListSessionsRequest{}, err
+	}
+	if prepare == nil {
+		prepare = noopRequestPreparation{}
+	}
+	return prepare.PrepareListSessions(raw)
+}
+
+func decodeGetFactorySessionRequest(sessionID factoryapi.SessionID) string {
+	return string(sessionID)
+}
+
+func normalizeListSessionsScope(request factorysessions.ListSessionsRequest) (factorysessions.ListSessionsRequest, error) {
+	if request.Scope == "" {
+		request.Scope = factorysessions.DefaultSessionListScope
+	}
+	switch request.Scope {
+	case factorysessions.SessionListScopeLive,
+		factorysessions.SessionListScopePersisted,
+		factorysessions.SessionListScopeAll:
+		return request, nil
+	default:
+		return factorysessions.ListSessionsRequest{}, &factorysessions.ExecutionValidationError{
+			Field:   "scope",
+			Message: fmt.Sprintf("scope must be live, persisted, or all (got %q)", request.Scope),
+		}
+	}
+}

--- a/pkg/services/factory_sessions/transports/http/session_read_test.go
+++ b/pkg/services/factory_sessions/transports/http/session_read_test.go
@@ -1,0 +1,150 @@
+package http_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factorysessionshttp "github.com/portpowered/infinite-you/pkg/services/factory_sessions/transports/http"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+func TestHandlerFromRoot_ListFactorySessionsDecodesScopeBeforeRootInvocation(t *testing.T) {
+	t.Parallel()
+
+	persistedScope := factoryapi.FactorySessionListScopePersisted
+	root := &httpSessionsRootFake{
+		listSessions: func(_ context.Context, request factorysessions.ListSessionsRequest) (factorysessions.ListSessionsResult, error) {
+			if request.Scope != factorysessions.SessionListScopeAll {
+				t.Fatalf("durable inventory scope = %q, want all", request.Scope)
+			}
+			return factorysessions.ListSessionsResult{
+				Scope: factorysessions.SessionListScopePersisted,
+				DurableSessions: []factorysessions.DurableSessionListSummary{{
+					SessionID: "dur-sess-alpha", Status: factorysessions.LifecycleStatusSucceeded,
+				}},
+			}, nil
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.ListFactorySessions(recorder, httptest.NewRequest(http.MethodGet, "/factory-sessions?scope=persisted", nil), factoryapi.ListFactorySessionsParams{Scope: &persistedScope})
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	var response factoryapi.ListFactorySessionsResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Scope == nil || *response.Scope != factoryapi.FactorySessionListScopePersisted {
+		t.Fatalf("scope = %#v, want persisted", response.Scope)
+	}
+	if len(response.Sessions) != 0 {
+		t.Fatalf("live sessions = %#v, want none for persisted scope", response.Sessions)
+	}
+	if response.DurableSessions == nil || len(*response.DurableSessions) != 1 || (*response.DurableSessions)[0].SessionId != "dur-sess-alpha" {
+		t.Fatalf("durable sessions = %#v, want one persisted row", response.DurableSessions)
+	}
+}
+
+func TestHandlerFromRoot_ListFactorySessionsInvalidScopeReturnsBadRequestWithoutRootCall(t *testing.T) {
+	t.Parallel()
+
+	unsupportedScope := factoryapi.FactorySessionListScope("workspace")
+	root := &httpSessionsRootFake{
+		listSessions: func(context.Context, factorysessions.ListSessionsRequest) (factorysessions.ListSessionsResult, error) {
+			t.Fatal("fake root must not be invoked for invalid list scope")
+			return factorysessions.ListSessionsResult{}, nil
+		},
+		listReads: func(context.Context) ([]factorysessions.ReadProjection, error) {
+			t.Fatal("fake root must not be invoked for invalid list scope")
+			return nil, nil
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.ListFactorySessions(recorder, httptest.NewRequest(http.MethodGet, "/factory-sessions?scope=workspace", nil), factoryapi.ListFactorySessionsParams{Scope: &unsupportedScope})
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", recorder.Code)
+	}
+	var errResp factoryapi.ErrorResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errResp.Code != factoryapi.ErrorResponseCodeBADREQUEST || errResp.Family != factoryapi.ErrorFamilyBadRequest {
+		t.Fatalf("error = %#v, want BAD_REQUEST family/code", errResp)
+	}
+	if !strings.Contains(errResp.Message, "scope must be live, persisted, or all") {
+		t.Fatalf("message = %q, want scope validation text", errResp.Message)
+	}
+}
+
+func TestHandlerFromRoot_GetFactorySessionEncodesRootProjectionToAPI(t *testing.T) {
+	t.Parallel()
+
+	root := &httpSessionsRootFake{
+		sessions: map[string]factorysessions.SessionProjection{
+			"session-alpha": {
+				Context: factorysessions.ProjectionContext{
+					FactorySessionID: "session-alpha",
+					Session: &factorysessions.ScopedLiveSessionSummary{
+						ID: "session-alpha", FactoryDir: "/workspace/alpha", FolderPath: "/workspace",
+						Project: "alpha", IsDefault: true,
+						Target: factorysessions.TargetRef{Kind: factorysessions.TargetKindNamed, Name: "alpha"},
+					},
+				},
+			},
+		},
+	}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.GetFactorySession(recorder, httptest.NewRequest(http.MethodGet, "/factory-sessions/session-alpha", nil), "session-alpha")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	var response factoryapi.FactorySession
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Id != "session-alpha" || response.Project != "alpha" || response.FactoryDir != "/workspace/alpha" {
+		t.Fatalf("response = %#v, want encoded live session fields", response)
+	}
+	if !response.IsDefault {
+		t.Fatalf("isDefault = %v, want true", response.IsDefault)
+	}
+}
+
+func TestHandlerFromRoot_GetFactorySessionNotFoundReturnsTypedErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	root := &httpSessionsRootFake{}
+	handler := factorysessionshttp.NewHandlerFromRoot(factorysessionshttp.RootBinding{Sessions: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.GetFactorySession(recorder, httptest.NewRequest(http.MethodGet, "/factory-sessions/missing-session", nil), "missing-session")
+
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", recorder.Code)
+	}
+	var errResp factoryapi.ErrorResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errResp.Code != factoryapi.ErrorResponseCodeNOTFOUND || errResp.Family != factoryapi.ErrorFamilyNotFound {
+		t.Fatalf("error = %#v, want NOT_FOUND family/code", errResp)
+	}
+	if errResp.Message != "factory session not found" {
+		t.Fatalf("message = %q, want stable not-found text", errResp.Message)
+	}
+}


### PR DESCRIPTION
{
  "project": "PSS HTTP-SES — Factory Sessions Owner-Local HTTP Adapter",
  "branchName": "pss-http-ses-adapter",
  "description": "Complete the Factory Sessions service-owned HTTP adapter so Sessions HTTP requests decode/map through the accepted Sessions root, typed errors become stable HTTP ErrorResponse bodies, and fake-root tests prove mapping plus cancel/timeout parity—without importing Sessions internals, owning canonical state, authoring shared OpenAPI, or editing Wire/root/initializer/CLI composition.",
  "context": {
    "customerAsk": "Implement HTTP-SES as the Factory Sessions service-owned HTTP adapter. Decode/map Sessions HTTP requests through the accepted Sessions root, translate typed errors, and prove fake-root parity for mapping and cancel/timeout behavior without importing Sessions internals or owning canonical state. Do not author shared OpenAPI or perform PSS-I02 route/client fan-in. Do not edit pkg/wire, pkg/root, pkg/initializer, top-level CLI composition, or reopen Sessions IMP/LWR/CLI ownership. Shared coverage, ownership, and package-target manifest edits are allowed and must be rebased through the merge loop. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Factory Sessions already has an owner-local HTTP package path and accepted root/contracts, while CLI-SES is a separate active lane. HTTP-SES still needs complete Sessions-owned HTTP adapter behavior: decode/map through the accepted Sessions root only, translate typed Sessions errors into stable HTTP responses, and prove fake-root mapping and cancel/timeout parity—without drifting into internals, shared OpenAPI authorship, or composition ownership reserved for later PSS fan-in.",
    "solution": "Complete the Factory Sessions owner-local HTTP adapter so it decodes and maps public Sessions HTTP operations through the accepted Sessions root, translates typed root errors into public HTTP error responses, and proves fake-root parity for mapping plus cancel/timeout behavior without importing Sessions internals, owning canonical session state, authoring shared OpenAPI, or changing Wire/root/initializer/CLI composition."
  },
  "acceptanceCriteria": [
    "AC-1: Factory Sessions HTTP operations owned by this packet decode requests and map responses through the accepted Sessions root contract only (no Sessions internal imports; adapter does not become canonical state owner)",
    "AC-2: Typed Sessions root errors surface as stable public HTTP ErrorResponse bodies with reviewer-verifiable status/code/family outcomes",
    "AC-3: Focused fake-root tests prove request/response mapping parity for the adapter-owned Sessions HTTP operations covered by this packet",
    "AC-4: Focused fake-root tests prove cancel and timeout behavior at the HTTP adapter edge (canceled or deadline-exceeded request context yields the adapter’s documented HTTP outcome without hanging)",
    "AC-5: Shared coverage, ownership, and package-target manifest edits occur only as required to register the Sessions HTTP adapter package and remain rebased through the merge loop",
    "AC-6: Diff stays inside HTTP-SES ownership: Sessions HTTP adapter paths and allowed shared manifests; no shared OpenAPI authorship, no PSS-I02 route/client fan-in, no pkg/wire / pkg/root / pkg/initializer, no top-level CLI composition, and no CLI-SES / other-service HTTP adapter edits",
    "AC-7: Quality checks pass (typecheck, lint, tests)",
    "AC-8: Delivery loop continues until required CI is terminal and passing, all blocking PR conversation feedback is addressed, merge conflicts and shared-file churn are reconciled, and the PR is actually merged"
  ],
  "userStories": [
    {
      "id": "pss-http-ses-adapter-001",
      "title": "Bind Sessions HTTP adapter to Sessions root via fake-root seam",
      "description": "As a maintainer, I want the Factory Sessions HTTP adapter to invoke the accepted Sessions root (or a fake implementing that root) so HTTP adaptation cannot depend on Sessions internals or own canonical session state.",
      "acceptanceCriteria": [
        "Adapter-owned Sessions HTTP operations call through the accepted Sessions root contract surface rather than Sessions internal packages",
        "A focused fake Sessions root can be injected for adapter tests without constructing real session durability or live runtime state",
        "Package-boundary evidence shows the adapter package does not import pkg/services/factory_sessions/internal/**",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-ses-adapter-002",
      "title": "Decode and map core Sessions HTTP reads through the root",
      "description": "As an API client, I want core Factory Session read/list HTTP requests to decode into Sessions root requests and encode root results so HTTP responses match the root contract outcomes.",
      "acceptanceCriteria": [
        "Representative owned read/list HTTP operations decode path/query/body inputs into Sessions root request values before invocation",
        "Fake-root success results are encoded into the public HTTP success response shape for those operations",
        "Invalid request payloads that fail decode/validation are rejected with a typed bad-request HTTP outcome before the fake root is invoked",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-ses-adapter-003",
      "title": "Decode and map Sessions HTTP control and write operations through the root",
      "description": "As an API client, I want Sessions control/write HTTP operations owned by this adapter to map through the Sessions root so open/control/execution-adjacent HTTP behavior stays aligned with root vocabulary.",
      "acceptanceCriteria": [
        "Representative owned control/write HTTP operations decode into Sessions root request values and invoke the fake root with those values",
        "Fake-root success results are encoded into the public HTTP success response shape for those operations",
        "Decode/validation failures for those operations return typed bad-request HTTP outcomes without invoking the fake root",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-ses-adapter-004",
      "title": "Translate typed Sessions root errors to HTTP ErrorResponse",
      "description": "As an API client, I want typed Sessions root failures to become stable HTTP error responses so callers can rely on status, family, and code without opaque transport failures.",
      "acceptanceCriteria": [
        "Fake root returns of representative typed Sessions errors (at least not-found and validation/bad-request class) map to the documented HTTP status, error family, and error code",
        "Error response body is a public ErrorResponse (message + family + code) rather than an untyped plaintext failure",
        "Unmapped/internal fake-root failures do not leak Sessions internal package paths or stack traces in the HTTP body",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-ses-adapter-005",
      "title": "Prove cancel and timeout parity at the HTTP adapter edge",
      "description": "As an API client, I want canceled or timed-out Sessions HTTP requests to terminate with the adapter’s documented outcome so long-running session reads/streams do not hang after the client gives up.",
      "acceptanceCriteria": [
        "When the request context is canceled before or during a fake-root call, the adapter completes with the documented cancel-oriented HTTP/stream outcome and does not hang",
        "When the request context deadline is exceeded during a fake-root call, the adapter completes with the documented timeout-oriented HTTP/stream outcome and does not hang",
        "Fake-root tests cover at least one non-streaming and one streaming-or-long-poll-style Sessions HTTP path owned by the adapter when such a path exists in scope; otherwise cover two distinct non-streaming owned paths",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-ses-adapter-006",
      "title": "Register adapter package in allowed shared manifests",
      "description": "As a maintainer, I want the Sessions HTTP adapter package registered in shared coverage/ownership/package-target manifests only as required so package ownership and verification targets stay accurate without widening into excluded composition surfaces.",
      "acceptanceCriteria": [
        "Shared coverage, ownership, and/or package-target manifest entries for pkg/services/factory_sessions/transports/http are added or updated only when required for adapter package registration",
        "Manifest edits stay limited to those allowed shared manifests; no shared OpenAPI authorship and no PSS-I02 route/client fan-in changes",
        "Diff does not edit pkg/wire, pkg/root, pkg/initializer, top-level CLI composition, CLI-SES paths, or other services’ HTTP adapters",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-ses-adapter-007",
      "title": "Close delivery loop through merged PR",
      "description": "As a maintainer, I want the HTTP-SES implementation/review cycle to continue until the PR is actually merged so the Factory work item is not left merely green or approved.",
      "acceptanceCriteria": [
        "Implementation PR for pss-http-ses-adapter is opened against the integration branch used by this program",
        "Required CI is terminal and passing on the PR head used for merge",
        "Every blocking PR conversation comment is explicitly addressed (fixed or answered with rationale)",
        "Merge conflicts and shared-file churn (including allowed manifest files) are reconciled",
        "PR is actually merged; opened/green/approved/ready-to-merge alone is not sufficient",
        "Typecheck passes"
      ],
      "priority": 7,
      "passes": false,
      "notes": ""
    }
  ]
}
