### PR TITLE
pss-imp-mod-06-inference

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1033,6 +1033,46 @@
       "minimum": 45.45
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/internal/artifacts",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/internal/service",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/wire",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host",
       "exception": {
         "kind": "measurement",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -985,6 +985,28 @@
       "minimum": 54.50
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active unit coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/internal/artifacts",
+      "minimum": 65.20
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/internal/service",
+      "minimum": 79.60
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/wire",
+      "minimum": 100.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host",
       "exception": {
         "kind": "measurement",

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -3570,6 +3570,30 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/models/internal/services/inference",
+      "disposition": "retain",
+      "destination": "models",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/inference/internal/artifacts",
+      "disposition": "retain",
+      "destination": "models",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/inference/internal/service",
+      "disposition": "retain",
+      "destination": "models",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/inference/wire",
+      "disposition": "retain",
+      "destination": "models",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/models/internal/services/runtime_host",
       "disposition": "retain",
       "destination": "models",

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -248,6 +248,10 @@
     "pkg/services/models/internal/services/catalog",
     "pkg/services/models/internal/services/catalog/internal/service",
     "pkg/services/models/internal/services/catalog/wire",
+    "pkg/services/models/internal/services/inference",
+    "pkg/services/models/internal/services/inference/internal/artifacts",
+    "pkg/services/models/internal/services/inference/internal/service",
+    "pkg/services/models/internal/services/inference/wire",
     "pkg/services/models/internal/services/runtime_host",
     "pkg/services/models/internal/services/runtime_host/internal/service",
     "pkg/services/models/internal/services/runtime_host/internal/services/leases",
@@ -291,6 +295,9 @@
     "pkg/services/recordings/internal/services/artifacts_export",
     "pkg/services/recordings/internal/services/artifacts_export/internal/service",
     "pkg/services/recordings/internal/services/artifacts_export/wire",
+    "pkg/services/recordings/internal/services/canonical_ledger",
+    "pkg/services/recordings/internal/services/canonical_ledger/internal/service",
+    "pkg/services/recordings/internal/services/canonical_ledger/wire",
     "pkg/services/recordings/internal/services/projection_query",
     "pkg/services/recordings/internal/services/projection_query/internal/service",
     "pkg/services/recordings/internal/services/projection_query/wire",
@@ -1477,6 +1484,26 @@
       "destination": "models/internal/services/catalog"
     },
     {
+      "packagePath": "pkg/services/models/internal/services/inference",
+      "disposition": "retain",
+      "destination": "models/internal/services/inference"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/inference/internal/artifacts",
+      "disposition": "retain",
+      "destination": "models/internal/services/inference"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/inference/internal/service",
+      "disposition": "retain",
+      "destination": "models/internal/services/inference"
+    },
+    {
+      "packagePath": "pkg/services/models/internal/services/inference/wire",
+      "disposition": "retain",
+      "destination": "models/internal/services/inference"
+    },
+    {
       "packagePath": "pkg/services/models/internal/services/runtime_host",
       "disposition": "retain",
       "destination": "models/internal/services/runtime_host"
@@ -1690,6 +1717,21 @@
       "packagePath": "pkg/services/recordings/internal/services/artifacts_export/wire",
       "disposition": "retain",
       "destination": "recordings/internal/services/artifacts_export"
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal/services/canonical_ledger",
+      "disposition": "retain",
+      "destination": "recordings/internal/services/canonical_ledger"
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal/services/canonical_ledger/internal/service",
+      "disposition": "retain",
+      "destination": "recordings/internal/services/canonical_ledger"
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal/services/canonical_ledger/wire",
+      "disposition": "retain",
+      "destination": "recordings/internal/services/canonical_ledger"
     },
     {
       "packagePath": "pkg/services/recordings/internal/services/projection_query",

--- a/pkg/services/models/internal/service/runtime_factory.go
+++ b/pkg/services/models/internal/service/runtime_factory.go
@@ -13,6 +13,7 @@ import (
 	localmodels "github.com/portpowered/infinite-you/pkg/services/models/internal/local"
 	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
 	modelcatalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
+	modelinference "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference"
 	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
 	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
 	"go.uber.org/zap"
@@ -32,6 +33,7 @@ type Root struct {
 	runtimeScopes   runtimescopes.Service
 	assets          scopedassets.Service
 	runtimeHost     runtimehost.Service
+	inference       modelinference.Service
 	runtimeMu       sync.RWMutex
 	runtimeByScope  map[models.RuntimeScopeRef]models.Service
 	catalog         modelcatalog.Service
@@ -54,6 +56,7 @@ func NewRoot(
 	catalogService modelcatalog.Service,
 	assetService scopedassets.Service,
 	runtimeHostService runtimehost.Service,
+	inferenceService modelinference.Service,
 	processDependencies ...models.ProcessDependencies,
 ) (*Root, error) {
 	if processLauncher == nil {
@@ -92,6 +95,9 @@ func NewRoot(
 	if runtimeHostService == nil {
 		return nil, missingDependencyError("Models Runtime Host service")
 	}
+	if inferenceService == nil {
+		return nil, missingDependencyError("Models Inference service")
+	}
 	process := models.ProcessDependencies{}
 	if len(processDependencies) > 0 {
 		process = processDependencies[0]
@@ -107,7 +113,7 @@ func NewRoot(
 		runtimeRunner: runtimeRunner, runtimeHTTP: runtimeHTTP,
 		runtimeInspect: runtimeInspect, runtimeTempDir: runtimeTempDir, runtimeTempFile: runtimeTempFile,
 		runtimeScopes: runtimeScopes, catalog: catalogService, assets: assetService,
-		runtimeHost: runtimeHostService,
+		runtimeHost: runtimeHostService, inference: inferenceService,
 		runtimeByScope: make(map[models.RuntimeScopeRef]models.Service),
 		process:        process,
 	}, nil
@@ -360,17 +366,23 @@ func (o *Root) ReleaseModelLease(
 }
 
 func (o *Root) InvokeModelWithLease(
-	context.Context,
-	models.InvokeModelRequest,
+	ctx context.Context,
+	request models.InvokeModelRequest,
 ) (models.InvokeModelResult, error) {
-	return models.InvokeModelResult{}, models.ErrUnsupportedOperation
+	if o == nil || o.inference == nil {
+		return models.InvokeModelResult{}, models.ErrUnsupportedOperation
+	}
+	return o.inference.InvokeModelWithLease(ctx, request)
 }
 
 func (o *Root) CancelInvocation(
-	context.Context,
-	models.CancelInvocationRequest,
+	ctx context.Context,
+	request models.CancelInvocationRequest,
 ) (models.CancelInvocationResult, error) {
-	return models.CancelInvocationResult{}, models.ErrUnsupportedOperation
+	if o == nil || o.inference == nil {
+		return models.CancelInvocationResult{}, models.ErrUnsupportedOperation
+	}
+	return o.inference.CancelInvocation(ctx, request)
 }
 
 func (o *Root) ListModels(context.Context) (models.List, error) {

--- a/pkg/services/models/internal/service/runtime_factory_inference_test.go
+++ b/pkg/services/models/internal/service/runtime_factory_inference_test.go
@@ -107,7 +107,7 @@ func TestInferenceWireConstructionIsInert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("construct Catalog: %v", err)
 	}
-	inference, err := inferencewire.NewService(scopes, catalog, runtimeHost, inference.InputEchoInvocationRuntime{}, clock.Now)
+	inference, err := inferencewire.NewService(scopes, assets, catalog, runtimeHost, inference.InputEchoInvocationRuntime{}, clock.Now)
 	if err != nil {
 		t.Fatalf("construct Inference: %v", err)
 	}

--- a/pkg/services/models/internal/service/runtime_factory_inference_test.go
+++ b/pkg/services/models/internal/service/runtime_factory_inference_test.go
@@ -11,6 +11,7 @@ import (
 	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
 	catalogwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire"
 	inferencewire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/wire"
+	inference "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference"
 	runtimehostwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/wire"
 	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
 )
@@ -106,7 +107,7 @@ func TestInferenceWireConstructionIsInert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("construct Catalog: %v", err)
 	}
-	inference, err := inferencewire.NewService(scopes, catalog, runtimeHost, clock.Now)
+	inference, err := inferencewire.NewService(scopes, catalog, runtimeHost, inference.InputEchoInvocationRuntime{}, clock.Now)
 	if err != nil {
 		t.Fatalf("construct Inference: %v", err)
 	}

--- a/pkg/services/models/internal/service/runtime_factory_inference_test.go
+++ b/pkg/services/models/internal/service/runtime_factory_inference_test.go
@@ -1,0 +1,212 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
+	catalogwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire"
+	inferencewire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/wire"
+	runtimehostwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/wire"
+	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
+)
+
+func TestRootDelegatesInferenceThroughInjectedOwner(t *testing.T) {
+	t.Parallel()
+
+	privateInference := &delegatingInferenceService{}
+	root := &Root{inference: privateInference}
+	request := models.InvokeModelRequest{ModelName: "scoped-model", Operation: "generate"}
+
+	_, err := root.InvokeModelWithLease(context.Background(), request)
+	if !errors.Is(err, models.ErrUnsupportedOperation) {
+		t.Fatalf("InvokeModelWithLease error = %v, want ErrUnsupportedOperation", err)
+	}
+	if privateInference.invokeRequest != request {
+		t.Fatalf("InvokeModelWithLease request = %#v, want %#v", privateInference.invokeRequest, request)
+	}
+
+	cancelRequest := models.CancelInvocationRequest{Invocation: mustInferenceInvocationRef(t, "inv-1")}
+	_, err = root.CancelInvocation(context.Background(), cancelRequest)
+	if !errors.Is(err, models.ErrUnsupportedOperation) {
+		t.Fatalf("CancelInvocation error = %v, want ErrUnsupportedOperation", err)
+	}
+	if privateInference.cancelRequest != cancelRequest {
+		t.Fatalf("CancelInvocation request = %#v, want %#v", privateInference.cancelRequest, cancelRequest)
+	}
+}
+
+func TestScopedRuntimeResolutionDoesNotReplaceInjectedInferenceOwner(t *testing.T) {
+	t.Parallel()
+
+	scopes, err := runtimescopeswire.NewService(func() string { return "inference-root-test" })
+	if err != nil {
+		t.Fatalf("construct Runtime Scopes: %v", err)
+	}
+	privateRef, err := scopes.Open(models.RuntimeBinding{
+		RuntimeConfig: func() *models.RuntimeConfig {
+			return &models.RuntimeConfig{}
+		},
+	})
+	if err != nil {
+		t.Fatalf("open runtime scope: %v", err)
+	}
+	scope, err := (models.RuntimeScopeRef{}).Parse(string(privateRef))
+	if err != nil {
+		t.Fatalf("parse runtime scope: %v", err)
+	}
+
+	privateInference := &delegatingInferenceService{}
+	root := &Root{
+		runtimeScopes:  scopes,
+		assets:         inferenceRecordingAssetsService{},
+		inference:      privateInference,
+		runtimeByScope: make(map[models.RuntimeScopeRef]models.Service),
+	}
+
+	_, err = root.PullModelForScope(context.Background(), models.PullModelRequest{
+		Scope: scope,
+		Name:  "voice",
+	})
+	if err == nil {
+		t.Fatal("PullModelForScope error = nil, want scoped runtime construction failure")
+	}
+	if root.inference != privateInference {
+		t.Fatal("scoped runtime resolution replaced process-scoped inference owner")
+	}
+}
+
+func TestInferenceWireConstructionIsInert(t *testing.T) {
+	t.Parallel()
+
+	scopes, err := runtimescopeswire.NewService(func() string { return "inference-inert-test" })
+	if err != nil {
+		t.Fatalf("construct Runtime Scopes: %v", err)
+	}
+	assets := inferenceRecordingAssetsService{}
+	launcher := &inferenceRecordingProcessLauncher{}
+	clock := &inferenceTestClock{}
+	runtimeHost, err := runtimehostwire.NewService(
+		scopes,
+		assets,
+		launcher,
+		http.DefaultClient,
+		clock,
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("construct Runtime Host: %v", err)
+	}
+	catalog, err := catalogwire.NewService(scopes)
+	if err != nil {
+		t.Fatalf("construct Catalog: %v", err)
+	}
+	inference, err := inferencewire.NewService(scopes, catalog, runtimeHost, clock.Now)
+	if err != nil {
+		t.Fatalf("construct Inference: %v", err)
+	}
+	if inference == nil {
+		t.Fatal("construct Inference returned nil service")
+	}
+	if launcher.starts != 0 || clock.timerCalls != 0 {
+		t.Fatalf(
+			"inert construction side effects = (starts %d, timers %d), want 0/0",
+			launcher.starts,
+			clock.timerCalls,
+		)
+	}
+}
+
+type delegatingInferenceService struct {
+	invokeCalls   int
+	invokeRequest models.InvokeModelRequest
+	cancelRequest models.CancelInvocationRequest
+}
+
+func (service *delegatingInferenceService) InvokeModelWithLease(
+	_ context.Context,
+	request models.InvokeModelRequest,
+) (models.InvokeModelResult, error) {
+	service.invokeCalls++
+	service.invokeRequest = request
+	return models.InvokeModelResult{}, models.ErrUnsupportedOperation
+}
+
+func (service *delegatingInferenceService) CancelInvocation(
+	_ context.Context,
+	request models.CancelInvocationRequest,
+) (models.CancelInvocationResult, error) {
+	service.cancelRequest = request
+	return models.CancelInvocationResult{}, models.ErrUnsupportedOperation
+}
+
+type inferenceRecordingProcessLauncher struct {
+	starts int
+}
+
+func (launcher *inferenceRecordingProcessLauncher) Start(
+	context.Context,
+	models.HostProcessStartSpec,
+) (models.HostManagedProcess, error) {
+	launcher.starts++
+	panic("process launcher called during inert inference composition")
+}
+
+type inferenceTestClock struct {
+	timerCalls int
+}
+
+func (clock *inferenceTestClock) Now() time.Time {
+	return time.Unix(0, 0)
+}
+
+func (clock *inferenceTestClock) NewTimer(time.Duration) models.HostTimer {
+	clock.timerCalls++
+	panic("host timer created during inert inference composition")
+}
+
+type inferenceRecordingAssetsService struct{}
+
+var _ scopedassets.Service = inferenceRecordingAssetsService{}
+
+func (inferenceRecordingAssetsService) PrepareModelAssets(
+	context.Context,
+	models.PrepareModelAssetsRequest,
+) (models.PrepareModelAssetsResult, error) {
+	return models.PrepareModelAssetsResult{}, models.ErrUnsupportedOperation
+}
+
+func (inferenceRecordingAssetsService) InspectModelAssets(
+	context.Context,
+	models.InspectModelAssetsRequest,
+) (models.InspectModelAssetsResult, error) {
+	return models.InspectModelAssetsResult{}, models.ErrUnsupportedOperation
+}
+
+func (inferenceRecordingAssetsService) ResolveRuntimeCache(
+	context.Context,
+	models.InspectModelAssetsRequest,
+) (scopedassets.RuntimeCacheLayout, error) {
+	return scopedassets.RuntimeCacheLayout{}, models.ErrUnsupportedOperation
+}
+
+func (inferenceRecordingAssetsService) InspectRuntimeCache(
+	context.Context,
+	models.InspectModelAssetsRequest,
+) (scopedassets.RuntimeCacheInspection, error) {
+	return scopedassets.RuntimeCacheInspection{}, models.ErrUnsupportedOperation
+}
+
+func mustInferenceInvocationRef(t *testing.T, value string) models.ModelInvocationRef {
+	t.Helper()
+	ref, err := (models.ModelInvocationRef{}).Parse(value)
+	if err != nil {
+		t.Fatalf("parse invocation ref: %v", err)
+	}
+	return ref
+}

--- a/pkg/services/models/internal/service/runtime_factory_inference_test.go
+++ b/pkg/services/models/internal/service/runtime_factory_inference_test.go
@@ -107,7 +107,15 @@ func TestInferenceWireConstructionIsInert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("construct Catalog: %v", err)
 	}
-	inference, err := inferencewire.NewService(scopes, assets, catalog, runtimeHost, inference.InputEchoInvocationRuntime{}, clock.Now)
+	inference, err := inferencewire.NewService(
+		scopes,
+		assets,
+		catalog,
+		runtimeHost,
+		inference.InputEchoInvocationRuntime{},
+		inference.InertArtifactFileSystem{},
+		clock.Now,
+	)
 	if err != nil {
 		t.Fatalf("construct Inference: %v", err)
 	}

--- a/pkg/services/models/internal/services/inference/default_runtime.go
+++ b/pkg/services/models/internal/services/inference/default_runtime.go
@@ -1,0 +1,28 @@
+package inference
+
+import (
+	"context"
+	"strings"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+// InputEchoInvocationRuntime returns detached content derived from validated
+// invocation input. It performs no network, process, or filesystem IO.
+type InputEchoInvocationRuntime struct{}
+
+var _ InvocationRuntime = InputEchoInvocationRuntime{}
+
+func (InputEchoInvocationRuntime) Invoke(
+	_ context.Context,
+	request models.InvokeModelRequest,
+) ([]models.InferenceContent, error) {
+	contentType := strings.TrimSpace(request.Input.ContentType)
+	if contentType == "" {
+		contentType = "text/plain"
+	}
+	return []models.InferenceContent{{
+		ContentType: contentType,
+		Content:     request.Input.Content,
+	}}, nil
+}

--- a/pkg/services/models/internal/services/inference/default_runtime.go
+++ b/pkg/services/models/internal/services/inference/default_runtime.go
@@ -15,14 +15,16 @@ var _ InvocationRuntime = InputEchoInvocationRuntime{}
 
 func (InputEchoInvocationRuntime) Invoke(
 	_ context.Context,
-	request models.InvokeModelRequest,
-) ([]models.InferenceContent, error) {
-	contentType := strings.TrimSpace(request.Input.ContentType)
+	request InvocationRuntimeRequest,
+) (InvocationRuntimeResult, error) {
+	contentType := strings.TrimSpace(request.Request.Input.ContentType)
 	if contentType == "" {
 		contentType = "text/plain"
 	}
-	return []models.InferenceContent{{
-		ContentType: contentType,
-		Content:     request.Input.Content,
-	}}, nil
+	return InvocationRuntimeResult{
+		Content: []models.InferenceContent{{
+			ContentType: contentType,
+			Content:     request.Request.Input.Content,
+		}},
+	}, nil
 }

--- a/pkg/services/models/internal/services/inference/inert_artifact_filesystem.go
+++ b/pkg/services/models/internal/services/inference/inert_artifact_filesystem.go
@@ -1,0 +1,18 @@
+package inference
+
+import (
+	"fmt"
+	"io"
+)
+
+// InertArtifactFileSystem satisfies Inference construction without opening
+// files. Export fails until a real filesystem port is injected at export time.
+type InertArtifactFileSystem struct{}
+
+func (InertArtifactFileSystem) Open(string) (io.ReadCloser, error) {
+	return nil, fmt.Errorf("inference artifact open requires an explicit export filesystem")
+}
+
+func (InertArtifactFileSystem) Create(string) (io.WriteCloser, error) {
+	return nil, fmt.Errorf("inference artifact create requires an explicit export filesystem")
+}

--- a/pkg/services/models/internal/services/inference/internal/artifacts/registrar.go
+++ b/pkg/services/models/internal/services/inference/internal/artifacts/registrar.go
@@ -1,0 +1,117 @@
+// Package artifacts owns Inference-internal invocation artifact registration and
+// export over an injected filesystem port. It has no independent public
+// lifecycle or peer-facing service interface.
+package artifacts
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	inference "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference"
+)
+
+// Registrar materializes detached artifact metadata and exports runtime-owned
+// sources through an injected filesystem port.
+type Registrar struct {
+	filesystem models.InvocationArtifactFileSystem
+
+	mu     sync.Mutex
+	nextID int
+	sources map[string]string
+}
+
+// NewRegistrar constructs an artifact registrar over the exact filesystem port
+// used for export. Construction validates the port without opening files.
+func NewRegistrar(filesystem models.InvocationArtifactFileSystem) (*Registrar, error) {
+	if filesystem == nil {
+		return nil, fmt.Errorf(
+			"%w: Models Inference artifact filesystem is required",
+			models.ErrInvalidInferenceDependencies,
+		)
+	}
+	return &Registrar{
+		filesystem: filesystem,
+		sources:    make(map[string]string),
+	}, nil
+}
+
+// Register returns detached artifact metadata for one runtime-owned source.
+func (r *Registrar) Register(source inference.InvocationArtifactSource) (models.InferenceArtifact, error) {
+	if r == nil {
+		return models.InferenceArtifact{}, models.ErrUnavailable
+	}
+	rawRef := source.RefValue
+	if rawRef != "" && strings.TrimSpace(rawRef) == "" {
+		return models.InferenceArtifact{}, models.ErrInferenceArtifactInvalid
+	}
+	refValue := strings.TrimSpace(rawRef)
+	if refValue == "" {
+		r.mu.Lock()
+		r.nextID++
+		refValue = fmt.Sprintf("models-inference:artifact:%d", r.nextID)
+		r.mu.Unlock()
+	}
+	ref, err := (models.InferenceArtifactRef{}).Parse(refValue)
+	if err != nil {
+		return models.InferenceArtifact{}, err
+	}
+	if strings.TrimSpace(source.SourcePath) != "" {
+		r.mu.Lock()
+		r.sources[ref.String()] = source.SourcePath
+		r.mu.Unlock()
+	}
+	return models.InferenceArtifact{
+		Artifact:   ref,
+		Name:       source.Name,
+		MediaType:  source.MediaType,
+		SizeBytes:  source.SizeBytes,
+		Properties: cloneStringMap(source.Properties),
+	}.Clone(), nil
+}
+
+// ExportInvocationArtifact copies one registered runtime-owned source to a
+// caller-selected destination.
+func (r *Registrar) ExportInvocationArtifact(
+	ref models.InferenceArtifactRef,
+	destinationPath string,
+) error {
+	if r == nil || r.filesystem == nil {
+		return fmt.Errorf("model inference artifact registrar is required")
+	}
+	r.mu.Lock()
+	sourcePath, ok := r.sources[ref.String()]
+	r.mu.Unlock()
+	if !ok || strings.TrimSpace(sourcePath) == "" {
+		return models.ErrInferenceArtifactInvalid
+	}
+	input, err := r.filesystem.Open(sourcePath)
+	if err != nil {
+		return fmt.Errorf("open streamed invocation output: %w", err)
+	}
+	defer input.Close()
+
+	output, err := r.filesystem.Create(destinationPath)
+	if err != nil {
+		return fmt.Errorf("create output file: %w", err)
+	}
+	defer output.Close()
+
+	if _, err := io.Copy(output, input); err != nil {
+		return fmt.Errorf("write output file: %w", err)
+	}
+	return nil
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}

--- a/pkg/services/models/internal/services/inference/internal/artifacts/registrar_test.go
+++ b/pkg/services/models/internal/services/inference/internal/artifacts/registrar_test.go
@@ -1,0 +1,87 @@
+package artifacts_test
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	inference "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference"
+	"github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/internal/artifacts"
+)
+
+func TestRegistrarExportsInvocationArtifactThroughInjectedFilesystem(t *testing.T) {
+	t.Parallel()
+
+	filesystem := &memoryFilesystem{files: map[string]string{
+		"runtime/output.wav": "models-owned-bytes",
+	}}
+	registrar, err := artifacts.NewRegistrar(filesystem)
+	if err != nil {
+		t.Fatalf("NewRegistrar: %v", err)
+	}
+	artifact, err := registrar.Register(inference.InvocationArtifactSource{
+		RefValue:   "models-inference:artifact:1",
+		SourcePath: "runtime/output.wav",
+		Name:       "output.wav",
+		MediaType:  "audio/wav",
+		SizeBytes:  17,
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if artifact.Artifact.IsZero() || artifact.Name != "output.wav" {
+		t.Fatalf("artifact = %#v, want detached metadata", artifact)
+	}
+	if err := registrar.ExportInvocationArtifact(artifact.Artifact, "customer/output.wav"); err != nil {
+		t.Fatalf("ExportInvocationArtifact: %v", err)
+	}
+	if filesystem.files["customer/output.wav"] != "models-owned-bytes" {
+		t.Fatalf("exported content = %q, want models-owned-bytes", filesystem.files["customer/output.wav"])
+	}
+}
+
+func TestRegistrarRejectsInvalidArtifactReference(t *testing.T) {
+	t.Parallel()
+
+	registrar, err := artifacts.NewRegistrar(&memoryFilesystem{files: map[string]string{}})
+	if err != nil {
+		t.Fatalf("NewRegistrar: %v", err)
+	}
+	_, err = registrar.Register(inference.InvocationArtifactSource{RefValue: "  "})
+	if !errors.Is(err, models.ErrInferenceArtifactInvalid) {
+		t.Fatalf("Register invalid ref = %v, want ErrInferenceArtifactInvalid", err)
+	}
+}
+
+type memoryFilesystem struct {
+	files map[string]string
+}
+
+func (fs *memoryFilesystem) Open(path string) (io.ReadCloser, error) {
+	content, ok := fs.files[path]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return io.NopCloser(strings.NewReader(content)), nil
+}
+
+func (fs *memoryFilesystem) Create(path string) (io.WriteCloser, error) {
+	return &memoryWriter{fs: fs, path: path}, nil
+}
+
+type memoryWriter struct {
+	fs   *memoryFilesystem
+	path string
+	buf  strings.Builder
+}
+
+func (w *memoryWriter) Write(p []byte) (int, error) {
+	return w.buf.Write(p)
+}
+
+func (w *memoryWriter) Close() error {
+	w.fs.files[w.path] = w.buf.String()
+	return nil
+}

--- a/pkg/services/models/internal/services/inference/internal/service/cancel.go
+++ b/pkg/services/models/internal/services/inference/internal/service/cancel.go
@@ -1,0 +1,88 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+)
+
+func (s *service) CancelInvocation(
+	ctx context.Context,
+	request models.CancelInvocationRequest,
+) (models.CancelInvocationResult, error) {
+	if s == nil {
+		return models.CancelInvocationResult{}, models.ErrUnsupportedOperation
+	}
+	if err := request.Validate(); err != nil {
+		return models.CancelInvocationResult{}, err
+	}
+	if err := invokeContextError(ctx); err != nil {
+		return models.CancelInvocationResult{}, err
+	}
+	if err := s.resolveScopeError(request.Scope); err != nil {
+		return models.CancelInvocationResult{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	invocation, ok := s.invocations[request.Invocation]
+	if !ok || invocation.Scope != request.Scope {
+		return models.CancelInvocationResult{}, models.ErrInvocationNotFound
+	}
+
+	result := models.CancelInvocationResult{
+		Invocation:       request.Invocation,
+		Status:           invocation.Status,
+		LeaseDisposition: invocation.LeaseDisposition,
+	}
+	switch invocation.Status {
+	case models.ModelInvocationStatusAccepted:
+		invocation.Status = models.ModelInvocationStatusCancelled
+		invocation.LeaseDisposition = models.InvocationLeaseReleased
+		invocation.CancellationOutcome = models.InvocationCancellationRequested
+		s.invocations[request.Invocation] = invocation
+		s.releaseInvocationLease(ctx, models.InvokeModelRequest{
+			Scope: invocation.Scope,
+			Lease: invocation.Lease,
+		})
+		result.Status = invocation.Status
+		result.LeaseDisposition = invocation.LeaseDisposition
+		result.Outcome = models.InvocationCancellationRequested
+	case models.ModelInvocationStatusCancelled:
+		result.Outcome = models.InvocationCancellationAlreadyCancelled
+	default:
+		result.Outcome = models.InvocationCancellationAlreadyCompleted
+	}
+	return result, nil
+}
+
+func (s *service) resolveScopeError(scope models.RuntimeScopeRef) error {
+	if scope.IsZero() {
+		return models.ErrRuntimeScopeInvalid
+	}
+	if s == nil || s.scopes == nil {
+		return models.ErrUnavailable
+	}
+	_, err := s.scopes.Resolve(runtimescopes.Reference(scope.String()))
+	if err != nil {
+		return inferenceScopeError(err)
+	}
+	return nil
+}
+
+func inferenceScopeError(err error) error {
+	switch {
+	case errors.Is(err, runtimescopes.ErrScopeForeign):
+		return fmt.Errorf("%w: %v", models.ErrRuntimeScopeForeign, err)
+	case errors.Is(err, runtimescopes.ErrScopeClosed):
+		return fmt.Errorf("%w: %v", models.ErrRuntimeScopeClosed, err)
+	case errors.Is(err, runtimescopes.ErrScopeUnknown):
+		return fmt.Errorf("%w: %v", models.ErrRuntimeScopeStale, err)
+	default:
+		return models.ErrUnavailable
+	}
+}

--- a/pkg/services/models/internal/services/inference/internal/service/host_slot.go
+++ b/pkg/services/models/internal/services/inference/internal/service/host_slot.go
@@ -1,0 +1,56 @@
+package service
+
+import (
+	"context"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	inference "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference"
+)
+
+type hostSlotKey struct {
+	scope     models.RuntimeScopeRef
+	modelName string
+}
+
+type hostSlotEntry struct {
+	warm bool
+}
+
+func (s *service) acquireHostSlot(
+	ctx context.Context,
+	request models.InvokeModelRequest,
+) (inference.HostHandleSlot, error) {
+	if s == nil || s.runtimeHost == nil {
+		return inference.HostHandleSlot{}, models.ErrUnavailable
+	}
+	key := hostSlotKey{scope: request.Scope, modelName: request.ModelName}
+
+	s.hostMu.Lock()
+	entry := s.hostSlots[key]
+	if entry != nil && entry.warm {
+		s.hostMu.Unlock()
+		return inference.HostHandleSlot{Reused: true}, nil
+	}
+	s.hostMu.Unlock()
+
+	result, err := s.runtimeHost.EnsureModelHost(ctx, models.EnsureModelHostRequest{
+		Scope: request.Scope,
+		Name:  request.ModelName,
+	})
+	if err != nil {
+		return inference.HostHandleSlot{}, err
+	}
+	if result.Host.ReadinessState != models.ReadinessStateReady {
+		return inference.HostHandleSlot{}, models.ErrHostRuntimeNotReady
+	}
+
+	s.hostMu.Lock()
+	if s.hostSlots[key] == nil {
+		s.hostSlots[key] = &hostSlotEntry{}
+	}
+	reused := s.hostSlots[key].warm
+	s.hostSlots[key].warm = true
+	s.hostMu.Unlock()
+
+	return inference.HostHandleSlot{Reused: reused}, nil
+}

--- a/pkg/services/models/internal/services/inference/internal/service/invoke.go
+++ b/pkg/services/models/internal/services/inference/internal/service/invoke.go
@@ -7,46 +7,12 @@ import (
 	"strings"
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
+	inference "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference"
 )
-
-func validateInvocationLease(
-	request models.InvokeModelRequest,
-	lease models.ModelLease,
-) error {
-	if lease.Scope != request.Scope {
-		return models.ErrHostLeaseNotFound
-	}
-	if lease.ModelName != request.ModelName {
-		return models.ErrHostLeaseNotFound
-	}
-	if strings.TrimSpace(lease.Holder) != strings.TrimSpace(request.Holder) {
-		return models.ErrHostInvalidHolder
-	}
-	if lease.Status != models.ModelLeaseStatusActive {
-		return models.ErrHostLeaseNotFound
-	}
-	return nil
-}
-
-func (s *service) nextInvocationRef() (models.ModelInvocationRef, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.nextInvocation++
-	return (models.ModelInvocationRef{}).Parse(
-		fmt.Sprintf("models-inference:%d", s.nextInvocation),
-	)
-}
-
-func catalogInvokeError(err error) error {
-	if errors.Is(err, models.ErrUnsupportedOperation) {
-		return models.ErrUnsupportedModelOperation
-	}
-	return err
-}
 
 func invokeContextError(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
-		return err
+		return fmt.Errorf("%w: %v", models.ErrInferenceCancelled, err)
 	}
 	return nil
 }
@@ -87,4 +53,43 @@ func failedInvocationResult(
 		Status:           models.ModelInvocationStatusFailed,
 		LeaseDisposition: models.InvocationLeaseReleased,
 	}.Clone()
+}
+
+func validateInvocationLease(
+	request models.InvokeModelRequest,
+	lease models.ModelLease,
+) error {
+	if lease.Scope != request.Scope {
+		return models.ErrHostLeaseNotFound
+	}
+	if lease.ModelName != request.ModelName {
+		return models.ErrHostLeaseNotFound
+	}
+	if strings.TrimSpace(lease.Holder) != strings.TrimSpace(request.Holder) {
+		return models.ErrHostInvalidHolder
+	}
+	if lease.Status != models.ModelLeaseStatusActive {
+		return models.ErrHostLeaseNotFound
+	}
+	return nil
+}
+
+func catalogInvokeError(err error) error {
+	if errors.Is(err, models.ErrUnsupportedOperation) {
+		return models.ErrUnsupportedModelOperation
+	}
+	return err
+}
+
+func (s *service) nextInvocationRef() (models.ModelInvocationRef, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextInvocation++
+	return (models.ModelInvocationRef{}).Parse(
+		fmt.Sprintf("models-inference:%d", s.nextInvocation),
+	)
+}
+
+func isInvocationInFlight(err error) bool {
+	return errors.Is(err, inference.ErrInvocationInFlight)
 }

--- a/pkg/services/models/internal/services/inference/internal/service/invoke.go
+++ b/pkg/services/models/internal/services/inference/internal/service/invoke.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+func validateInvocationLease(
+	request models.InvokeModelRequest,
+	lease models.ModelLease,
+) error {
+	if lease.Scope != request.Scope {
+		return models.ErrHostLeaseNotFound
+	}
+	if lease.ModelName != request.ModelName {
+		return models.ErrHostLeaseNotFound
+	}
+	if strings.TrimSpace(lease.Holder) != strings.TrimSpace(request.Holder) {
+		return models.ErrHostInvalidHolder
+	}
+	if lease.Status != models.ModelLeaseStatusActive {
+		return models.ErrHostLeaseNotFound
+	}
+	return nil
+}
+
+func (s *service) nextInvocationRef() (models.ModelInvocationRef, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextInvocation++
+	return (models.ModelInvocationRef{}).Parse(
+		fmt.Sprintf("models-inference:%d", s.nextInvocation),
+	)
+}
+
+func catalogInvokeError(err error) error {
+	if errors.Is(err, models.ErrUnsupportedOperation) {
+		return models.ErrUnsupportedModelOperation
+	}
+	return err
+}
+
+func invokeContextError(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/services/models/internal/services/inference/internal/service/invoke.go
+++ b/pkg/services/models/internal/services/inference/internal/service/invoke.go
@@ -50,3 +50,41 @@ func invokeContextError(ctx context.Context) error {
 	}
 	return nil
 }
+
+func validateInvocationResponseMode(request models.InvokeModelRequest) error {
+	if request.ResponseMode != "" &&
+		request.ResponseMode != models.ResponseModeAudioStream {
+		return models.ErrUnsupportedResponseMode
+	}
+	return nil
+}
+
+func releasesInferenceCapacity(err error) bool {
+	return errors.Is(err, models.ErrInferenceTimeout) ||
+		errors.Is(err, models.ErrInferenceFailed)
+}
+
+func normalizeInvokeError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if releasesInferenceCapacity(err) {
+		return err
+	}
+	return fmt.Errorf("%w: %v", models.ErrInferenceFailed, err)
+}
+
+func failedInvocationResult(
+	request models.InvokeModelRequest,
+	invocation models.ModelInvocationRef,
+) models.InvokeModelResult {
+	return models.InvokeModelResult{
+		Invocation:       invocation,
+		Scope:            request.Scope,
+		Lease:            request.Lease,
+		ModelName:        request.ModelName,
+		Operation:        request.Operation,
+		Status:           models.ModelInvocationStatusFailed,
+		LeaseDisposition: models.InvocationLeaseReleased,
+	}.Clone()
+}

--- a/pkg/services/models/internal/services/inference/internal/service/invoke_lifecycle.go
+++ b/pkg/services/models/internal/services/inference/internal/service/invoke_lifecycle.go
@@ -102,8 +102,12 @@ func (s *service) finishCompletedInvocation(
 	ctx context.Context,
 	request models.InvokeModelRequest,
 	invocation models.ModelInvocationRef,
-	content []models.InferenceContent,
+	runtimeResult inference.InvocationRuntimeResult,
 ) (models.InvokeModelResult, error) {
+	artifacts, err := s.registerInvocationArtifacts(runtimeResult.Artifacts)
+	if err != nil {
+		return s.finishFailedInvocation(ctx, request, invocation, err)
+	}
 	result := models.InvokeModelResult{
 		Invocation:       invocation,
 		Scope:            request.Scope,
@@ -111,12 +115,33 @@ func (s *service) finishCompletedInvocation(
 		ModelName:        request.ModelName,
 		Operation:        request.Operation,
 		Status:           models.ModelInvocationStatusCompleted,
-		Content:          append([]models.InferenceContent(nil), content...),
+		Content:          append([]models.InferenceContent(nil), runtimeResult.Content...),
+		Artifacts:        artifacts,
 		LeaseDisposition: models.InvocationLeaseReleased,
 	}.Clone()
 	s.putInvocation(invocation, result)
 	s.releaseInvocationLease(ctx, request)
 	return result, nil
+}
+
+func (s *service) registerInvocationArtifacts(
+	sources []inference.InvocationArtifactSource,
+) ([]models.InferenceArtifact, error) {
+	if len(sources) == 0 {
+		return nil, nil
+	}
+	if s == nil || s.artifacts == nil {
+		return nil, models.ErrUnavailable
+	}
+	artifacts := make([]models.InferenceArtifact, 0, len(sources))
+	for _, source := range sources {
+		artifact, err := s.artifacts.Register(source)
+		if err != nil {
+			return nil, err
+		}
+		artifacts = append(artifacts, artifact)
+	}
+	return artifacts, nil
 }
 
 func classifyInvokeCancellationError(err error) error {
@@ -140,6 +165,9 @@ func classifyInvokeRuntimeError(ctx context.Context, err error) error {
 		return err
 	}
 	if errors.Is(err, models.ErrInferenceCancelled) {
+		return err
+	}
+	if errors.Is(err, models.ErrInferenceArtifactInvalid) {
 		return err
 	}
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {

--- a/pkg/services/models/internal/services/inference/internal/service/invoke_lifecycle.go
+++ b/pkg/services/models/internal/services/inference/internal/service/invoke_lifecycle.go
@@ -30,8 +30,8 @@ func (s *service) invokeWithDeadline(parent context.Context) (context.Context, c
 	if duration <= 0 {
 		return parent, func() {}
 	}
-	if parentDeadline, ok := parent.Deadline(); ok {
-		remaining := time.Until(parentDeadline)
+	if parentDeadline, ok := parent.Deadline(); ok && s.clock != nil {
+		remaining := parentDeadline.Sub(s.clock())
 		if remaining > 0 && remaining < duration {
 			return parent, func() {}
 		}

--- a/pkg/services/models/internal/services/inference/internal/service/invoke_lifecycle.go
+++ b/pkg/services/models/internal/services/inference/internal/service/invoke_lifecycle.go
@@ -1,0 +1,152 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	inference "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference"
+)
+
+const defaultInferenceExecutionDeadline = 30 * time.Minute
+
+func defaultExecutionDeadline() time.Duration {
+	return defaultInferenceExecutionDeadline
+}
+
+func (s *service) putInvocation(invocation models.ModelInvocationRef, result models.InvokeModelResult) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.invocations[invocation] = result.Clone()
+}
+
+func (s *service) invokeWithDeadline(parent context.Context) (context.Context, context.CancelFunc) {
+	if s == nil || s.executionDeadline == nil {
+		return parent, func() {}
+	}
+	duration := s.executionDeadline()
+	if duration <= 0 {
+		return parent, func() {}
+	}
+	if parentDeadline, ok := parent.Deadline(); ok {
+		remaining := time.Until(parentDeadline)
+		if remaining > 0 && remaining < duration {
+			return parent, func() {}
+		}
+	}
+	return context.WithTimeout(parent, duration)
+}
+
+func acceptedInvocationResult(
+	request models.InvokeModelRequest,
+	invocation models.ModelInvocationRef,
+) models.InvokeModelResult {
+	return models.InvokeModelResult{
+		Invocation:       invocation,
+		Scope:            request.Scope,
+		Lease:            request.Lease,
+		ModelName:        request.ModelName,
+		Operation:        request.Operation,
+		Status:           models.ModelInvocationStatusAccepted,
+		LeaseDisposition: models.InvocationLeaseRetained,
+	}.Clone()
+}
+
+func cancelledInvocationResult(
+	request models.InvokeModelRequest,
+	invocation models.ModelInvocationRef,
+) models.InvokeModelResult {
+	return models.InvokeModelResult{
+		Invocation:          invocation,
+		Scope:               request.Scope,
+		Lease:               request.Lease,
+		ModelName:           request.ModelName,
+		Operation:           request.Operation,
+		Status:              models.ModelInvocationStatusCancelled,
+		LeaseDisposition:    models.InvocationLeaseReleased,
+		CancellationOutcome: models.InvocationCancellationRequested,
+	}.Clone()
+}
+
+func (s *service) finishCancelledInvocation(
+	ctx context.Context,
+	request models.InvokeModelRequest,
+	invocation models.ModelInvocationRef,
+	cause error,
+) (models.InvokeModelResult, error) {
+	result := cancelledInvocationResult(request, invocation)
+	s.putInvocation(invocation, result)
+	s.releaseInvocationLease(ctx, request)
+	return result.Clone(), classifyInvokeCancellationError(cause)
+}
+
+func (s *service) finishFailedInvocation(
+	invokeCtx context.Context,
+	request models.InvokeModelRequest,
+	invocation models.ModelInvocationRef,
+	runtimeErr error,
+) (models.InvokeModelResult, error) {
+	classified := classifyInvokeRuntimeError(invokeCtx, runtimeErr)
+	result := failedInvocationResult(request, invocation)
+	if errors.Is(classified, models.ErrInferenceCancelled) {
+		result = cancelledInvocationResult(request, invocation)
+	}
+	s.putInvocation(invocation, result)
+	s.releaseInvocationLease(invokeCtx, request)
+	return result.Clone(), classified
+}
+
+func (s *service) finishCompletedInvocation(
+	ctx context.Context,
+	request models.InvokeModelRequest,
+	invocation models.ModelInvocationRef,
+	content []models.InferenceContent,
+) (models.InvokeModelResult, error) {
+	result := models.InvokeModelResult{
+		Invocation:       invocation,
+		Scope:            request.Scope,
+		Lease:            request.Lease,
+		ModelName:        request.ModelName,
+		Operation:        request.Operation,
+		Status:           models.ModelInvocationStatusCompleted,
+		Content:          append([]models.InferenceContent(nil), content...),
+		LeaseDisposition: models.InvocationLeaseReleased,
+	}.Clone()
+	s.putInvocation(invocation, result)
+	s.releaseInvocationLease(ctx, request)
+	return result, nil
+}
+
+func classifyInvokeCancellationError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, models.ErrInferenceCancelled) {
+		return err
+	}
+	return fmt.Errorf("%w: %v", models.ErrInferenceCancelled, err)
+}
+
+func classifyInvokeRuntimeError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, inference.ErrInvocationInFlight) {
+		return err
+	}
+	if errors.Is(err, models.ErrInferenceTimeout) {
+		return err
+	}
+	if errors.Is(err, models.ErrInferenceCancelled) {
+		return err
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return models.ErrInferenceTimeout
+	}
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return fmt.Errorf("%w: %v", models.ErrInferenceCancelled, ctx.Err())
+	}
+	return normalizeInvokeError(err)
+}

--- a/pkg/services/models/internal/services/inference/internal/service/service.go
+++ b/pkg/services/models/internal/services/inference/internal/service/service.go
@@ -10,6 +10,7 @@ import (
 	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
 	modelcatalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
 	inference "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference"
+	inferenceartifacts "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/internal/artifacts"
 	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
 	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
 )
@@ -20,9 +21,12 @@ type service struct {
 	catalog     modelcatalog.Service
 	runtimeHost runtimehost.Service
 	runtime     inference.InvocationRuntime
+	artifacts   *inferenceartifacts.Registrar
 	clock       func() time.Time
 	executionDeadline func() time.Duration
 
+	hostMu     sync.Mutex
+	hostSlots  map[hostSlotKey]*hostSlotEntry
 	mu             sync.Mutex
 	nextInvocation int
 	invocations    map[models.ModelInvocationRef]models.InvokeModelResult
@@ -39,6 +43,7 @@ func New(
 	catalog modelcatalog.Service,
 	runtimeHost runtimehost.Service,
 	runtime inference.InvocationRuntime,
+	artifacts *inferenceartifacts.Registrar,
 	clock func() time.Time,
 	executionDeadline func() time.Duration,
 ) inference.Service {
@@ -51,8 +56,10 @@ func New(
 		catalog:           catalog,
 		runtimeHost:       runtimeHost,
 		runtime:           runtime,
+		artifacts:         artifacts,
 		clock:             clock,
 		executionDeadline: executionDeadline,
+		hostSlots:         make(map[hostSlotKey]*hostSlotEntry),
 		invocations:       make(map[models.ModelInvocationRef]models.InvokeModelResult),
 	}
 }
@@ -96,6 +103,11 @@ func (s *service) InvokeModelWithLease(
 		return models.InvokeModelResult{}, err
 	}
 
+	hostSlot, err := s.acquireHostSlot(validationCtx, request)
+	if err != nil {
+		return models.InvokeModelResult{}, err
+	}
+
 	if s.runtime == nil {
 		return models.InvokeModelResult{}, models.ErrUnavailable
 	}
@@ -115,7 +127,10 @@ func (s *service) InvokeModelWithLease(
 	invokeCtx, cancelDeadline := s.invokeWithDeadline(ctx)
 	defer cancelDeadline()
 
-	content, err := s.runtime.Invoke(invokeCtx, request)
+	runtimeResult, err := s.runtime.Invoke(invokeCtx, inference.InvocationRuntimeRequest{
+		Request:  request,
+		HostSlot: hostSlot,
+	})
 	if isInvocationInFlight(err) {
 		return accepted.Clone(), nil
 	}
@@ -123,7 +138,7 @@ func (s *service) InvokeModelWithLease(
 		return s.finishFailedInvocation(invokeCtx, request, invocation, err)
 	}
 
-	return s.finishCompletedInvocation(ctx, request, invocation, content)
+	return s.finishCompletedInvocation(ctx, request, invocation, runtimeResult)
 }
 
 func (s *service) ensureModelAssetsAvailable(

--- a/pkg/services/models/internal/services/inference/internal/service/service.go
+++ b/pkg/services/models/internal/services/inference/internal/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
@@ -15,7 +16,11 @@ type service struct {
 	scopes      runtimescopes.Service
 	catalog     modelcatalog.Service
 	runtimeHost runtimehost.Service
+	runtime     inference.InvocationRuntime
 	clock       func() time.Time
+
+	mu             sync.Mutex
+	nextInvocation int
 }
 
 var _ inference.Service = (*service)(nil)
@@ -27,24 +32,79 @@ func New(
 	scopes runtimescopes.Service,
 	catalog modelcatalog.Service,
 	runtimeHost runtimehost.Service,
+	runtime inference.InvocationRuntime,
 	clock func() time.Time,
 ) inference.Service {
 	return &service{
 		scopes:      scopes,
 		catalog:     catalog,
 		runtimeHost: runtimeHost,
+		runtime:     runtime,
 		clock:       clock,
 	}
 }
 
 func (s *service) InvokeModelWithLease(
-	context.Context,
-	models.InvokeModelRequest,
+	ctx context.Context,
+	request models.InvokeModelRequest,
 ) (models.InvokeModelResult, error) {
 	if s == nil {
 		return models.InvokeModelResult{}, models.ErrUnsupportedOperation
 	}
-	return models.InvokeModelResult{}, models.ErrUnsupportedOperation
+	if err := request.Validate(); err != nil {
+		return models.InvokeModelResult{}, err
+	}
+	if err := invokeContextError(ctx); err != nil {
+		return models.InvokeModelResult{}, err
+	}
+
+	leaseResult, err := s.runtimeHost.GetModelLease(ctx, models.GetModelLeaseRequest{
+		Scope: request.Scope,
+		Lease: request.Lease,
+	})
+	if err != nil {
+		return models.InvokeModelResult{}, err
+	}
+	if err := validateInvocationLease(request, leaseResult.Lease); err != nil {
+		return models.InvokeModelResult{}, err
+	}
+
+	if _, err := s.catalog.GetCatalogModel(ctx, models.GetModelRequest{
+		Scope:     request.Scope,
+		Name:      request.ModelName,
+		Operation: request.Operation,
+	}); err != nil {
+		return models.InvokeModelResult{}, catalogInvokeError(err)
+	}
+
+	if s.runtime == nil {
+		return models.InvokeModelResult{}, models.ErrUnavailable
+	}
+	content, err := s.runtime.Invoke(ctx, request)
+	if err != nil {
+		return models.InvokeModelResult{}, err
+	}
+
+	invocation, err := s.nextInvocationRef()
+	if err != nil {
+		return models.InvokeModelResult{}, err
+	}
+
+	_, _ = s.runtimeHost.ReleaseModelLease(ctx, models.ReleaseModelLeaseRequest{
+		Scope: request.Scope,
+		Lease: request.Lease,
+	})
+
+	return models.InvokeModelResult{
+		Invocation:       invocation,
+		Scope:            request.Scope,
+		Lease:            request.Lease,
+		ModelName:        request.ModelName,
+		Operation:        request.Operation,
+		Status:           models.ModelInvocationStatusCompleted,
+		Content:          append([]models.InferenceContent(nil), content...),
+		LeaseDisposition: models.InvocationLeaseReleased,
+	}.Clone(), nil
 }
 
 func (s *service) CancelInvocation(

--- a/pkg/services/models/internal/services/inference/internal/service/service.go
+++ b/pkg/services/models/internal/services/inference/internal/service/service.go
@@ -2,10 +2,12 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
+	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
 	modelcatalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
 	inference "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference"
 	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
@@ -14,6 +16,7 @@ import (
 
 type service struct {
 	scopes      runtimescopes.Service
+	assets      scopedassets.Service
 	catalog     modelcatalog.Service
 	runtimeHost runtimehost.Service
 	runtime     inference.InvocationRuntime
@@ -30,6 +33,7 @@ var _ inference.Service = (*service)(nil)
 // application lifecycle.
 func New(
 	scopes runtimescopes.Service,
+	assets scopedassets.Service,
 	catalog modelcatalog.Service,
 	runtimeHost runtimehost.Service,
 	runtime inference.InvocationRuntime,
@@ -37,6 +41,7 @@ func New(
 ) inference.Service {
 	return &service{
 		scopes:      scopes,
+		assets:      assets,
 		catalog:     catalog,
 		runtimeHost: runtimeHost,
 		runtime:     runtime,
@@ -52,6 +57,9 @@ func (s *service) InvokeModelWithLease(
 		return models.InvokeModelResult{}, models.ErrUnsupportedOperation
 	}
 	if err := request.Validate(); err != nil {
+		return models.InvokeModelResult{}, err
+	}
+	if err := validateInvocationResponseMode(request); err != nil {
 		return models.InvokeModelResult{}, err
 	}
 	if err := invokeContextError(ctx); err != nil {
@@ -77,12 +85,12 @@ func (s *service) InvokeModelWithLease(
 		return models.InvokeModelResult{}, catalogInvokeError(err)
 	}
 
+	if err := s.ensureModelAssetsAvailable(ctx, request); err != nil {
+		return models.InvokeModelResult{}, err
+	}
+
 	if s.runtime == nil {
 		return models.InvokeModelResult{}, models.ErrUnavailable
-	}
-	content, err := s.runtime.Invoke(ctx, request)
-	if err != nil {
-		return models.InvokeModelResult{}, err
 	}
 
 	invocation, err := s.nextInvocationRef()
@@ -90,10 +98,14 @@ func (s *service) InvokeModelWithLease(
 		return models.InvokeModelResult{}, err
 	}
 
-	_, _ = s.runtimeHost.ReleaseModelLease(ctx, models.ReleaseModelLeaseRequest{
-		Scope: request.Scope,
-		Lease: request.Lease,
-	})
+	content, err := s.runtime.Invoke(ctx, request)
+	if err != nil {
+		s.releaseInvocationLease(ctx, request)
+		return failedInvocationResult(request, invocation),
+			normalizeInvokeError(err)
+	}
+
+	s.releaseInvocationLease(ctx, request)
 
 	return models.InvokeModelResult{
 		Invocation:       invocation,
@@ -115,4 +127,34 @@ func (s *service) CancelInvocation(
 		return models.CancelInvocationResult{}, models.ErrUnsupportedOperation
 	}
 	return models.CancelInvocationResult{}, models.ErrUnsupportedOperation
+}
+
+func (s *service) ensureModelAssetsAvailable(
+	ctx context.Context,
+	request models.InvokeModelRequest,
+) error {
+	if s == nil || s.assets == nil {
+		return models.ErrUnavailable
+	}
+	inspection, err := s.assets.InspectRuntimeCache(ctx, models.InspectModelAssetsRequest{
+		Scope: request.Scope,
+		Name:  request.ModelName,
+	})
+	if err != nil {
+		return err
+	}
+	if inspection.Supported && !inspection.Installed {
+		return fmt.Errorf("%w: %s", models.ErrAssetUnavailable, request.ModelName)
+	}
+	return nil
+}
+
+func (s *service) releaseInvocationLease(
+	ctx context.Context,
+	request models.InvokeModelRequest,
+) {
+	_, _ = s.runtimeHost.ReleaseModelLease(ctx, models.ReleaseModelLeaseRequest{
+		Scope: request.Scope,
+		Lease: request.Lease,
+	})
 }

--- a/pkg/services/models/internal/services/inference/internal/service/service.go
+++ b/pkg/services/models/internal/services/inference/internal/service/service.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	modelcatalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
+	inference "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference"
+	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+)
+
+type service struct {
+	scopes      runtimescopes.Service
+	catalog     modelcatalog.Service
+	runtimeHost runtimehost.Service
+	clock       func() time.Time
+}
+
+var _ inference.Service = (*service)(nil)
+
+// New constructs an inert Inference owner that validates and retains injected
+// effects without launching subprocesses, opening listeners, or starting
+// application lifecycle.
+func New(
+	scopes runtimescopes.Service,
+	catalog modelcatalog.Service,
+	runtimeHost runtimehost.Service,
+	clock func() time.Time,
+) inference.Service {
+	return &service{
+		scopes:      scopes,
+		catalog:     catalog,
+		runtimeHost: runtimeHost,
+		clock:       clock,
+	}
+}
+
+func (s *service) InvokeModelWithLease(
+	context.Context,
+	models.InvokeModelRequest,
+) (models.InvokeModelResult, error) {
+	if s == nil {
+		return models.InvokeModelResult{}, models.ErrUnsupportedOperation
+	}
+	return models.InvokeModelResult{}, models.ErrUnsupportedOperation
+}
+
+func (s *service) CancelInvocation(
+	context.Context,
+	models.CancelInvocationRequest,
+) (models.CancelInvocationResult, error) {
+	if s == nil {
+		return models.CancelInvocationResult{}, models.ErrUnsupportedOperation
+	}
+	return models.CancelInvocationResult{}, models.ErrUnsupportedOperation
+}

--- a/pkg/services/models/internal/services/inference/internal/service/service.go
+++ b/pkg/services/models/internal/services/inference/internal/service/service.go
@@ -21,9 +21,11 @@ type service struct {
 	runtimeHost runtimehost.Service
 	runtime     inference.InvocationRuntime
 	clock       func() time.Time
+	executionDeadline func() time.Duration
 
 	mu             sync.Mutex
 	nextInvocation int
+	invocations    map[models.ModelInvocationRef]models.InvokeModelResult
 }
 
 var _ inference.Service = (*service)(nil)
@@ -38,14 +40,20 @@ func New(
 	runtimeHost runtimehost.Service,
 	runtime inference.InvocationRuntime,
 	clock func() time.Time,
+	executionDeadline func() time.Duration,
 ) inference.Service {
+	if executionDeadline == nil {
+		executionDeadline = defaultExecutionDeadline
+	}
 	return &service{
-		scopes:      scopes,
-		assets:      assets,
-		catalog:     catalog,
-		runtimeHost: runtimeHost,
-		runtime:     runtime,
-		clock:       clock,
+		scopes:            scopes,
+		assets:            assets,
+		catalog:           catalog,
+		runtimeHost:       runtimeHost,
+		runtime:           runtime,
+		clock:             clock,
+		executionDeadline: executionDeadline,
+		invocations:       make(map[models.ModelInvocationRef]models.InvokeModelResult),
 	}
 }
 
@@ -62,11 +70,10 @@ func (s *service) InvokeModelWithLease(
 	if err := validateInvocationResponseMode(request); err != nil {
 		return models.InvokeModelResult{}, err
 	}
-	if err := invokeContextError(ctx); err != nil {
-		return models.InvokeModelResult{}, err
-	}
 
-	leaseResult, err := s.runtimeHost.GetModelLease(ctx, models.GetModelLeaseRequest{
+	validationCtx := context.WithoutCancel(ctx)
+
+	leaseResult, err := s.runtimeHost.GetModelLease(validationCtx, models.GetModelLeaseRequest{
 		Scope: request.Scope,
 		Lease: request.Lease,
 	})
@@ -77,7 +84,7 @@ func (s *service) InvokeModelWithLease(
 		return models.InvokeModelResult{}, err
 	}
 
-	if _, err := s.catalog.GetCatalogModel(ctx, models.GetModelRequest{
+	if _, err := s.catalog.GetCatalogModel(validationCtx, models.GetModelRequest{
 		Scope:     request.Scope,
 		Name:      request.ModelName,
 		Operation: request.Operation,
@@ -85,7 +92,7 @@ func (s *service) InvokeModelWithLease(
 		return models.InvokeModelResult{}, catalogInvokeError(err)
 	}
 
-	if err := s.ensureModelAssetsAvailable(ctx, request); err != nil {
+	if err := s.ensureModelAssetsAvailable(validationCtx, request); err != nil {
 		return models.InvokeModelResult{}, err
 	}
 
@@ -98,35 +105,25 @@ func (s *service) InvokeModelWithLease(
 		return models.InvokeModelResult{}, err
 	}
 
-	content, err := s.runtime.Invoke(ctx, request)
+	accepted := acceptedInvocationResult(request, invocation)
+	s.putInvocation(invocation, accepted)
+
+	if err := invokeContextError(ctx); err != nil {
+		return s.finishCancelledInvocation(ctx, request, invocation, err)
+	}
+
+	invokeCtx, cancelDeadline := s.invokeWithDeadline(ctx)
+	defer cancelDeadline()
+
+	content, err := s.runtime.Invoke(invokeCtx, request)
+	if isInvocationInFlight(err) {
+		return accepted.Clone(), nil
+	}
 	if err != nil {
-		s.releaseInvocationLease(ctx, request)
-		return failedInvocationResult(request, invocation),
-			normalizeInvokeError(err)
+		return s.finishFailedInvocation(invokeCtx, request, invocation, err)
 	}
 
-	s.releaseInvocationLease(ctx, request)
-
-	return models.InvokeModelResult{
-		Invocation:       invocation,
-		Scope:            request.Scope,
-		Lease:            request.Lease,
-		ModelName:        request.ModelName,
-		Operation:        request.Operation,
-		Status:           models.ModelInvocationStatusCompleted,
-		Content:          append([]models.InferenceContent(nil), content...),
-		LeaseDisposition: models.InvocationLeaseReleased,
-	}.Clone(), nil
-}
-
-func (s *service) CancelInvocation(
-	context.Context,
-	models.CancelInvocationRequest,
-) (models.CancelInvocationResult, error) {
-	if s == nil {
-		return models.CancelInvocationResult{}, models.ErrUnsupportedOperation
-	}
-	return models.CancelInvocationResult{}, models.ErrUnsupportedOperation
+	return s.finishCompletedInvocation(ctx, request, invocation, content)
 }
 
 func (s *service) ensureModelAssetsAvailable(

--- a/pkg/services/models/internal/services/inference/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/inference/internal/service/service_test.go
@@ -1,0 +1,422 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	modelcatalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
+	catalogwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire"
+	inference "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/internal/service"
+	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
+)
+
+func TestInvokeModelWithLeaseValidatesPeerControlledInput(t *testing.T) {
+	t.Parallel()
+
+	service := newInferenceService(t, "invoke-validate", nil)
+
+	tests := []struct {
+		name    string
+		request models.InvokeModelRequest
+		want    error
+	}{
+		{
+			name:    "scope",
+			request: models.InvokeModelRequest{Lease: mustLeaseRef(t, "lease-1"), Holder: "worker", ModelName: "model", Operation: "generate"},
+			want:    models.ErrRuntimeScopeInvalid,
+		},
+		{
+			name:    "lease",
+			request: models.InvokeModelRequest{Scope: mustScopeRef(t, "scope-1"), Holder: "worker", ModelName: "model", Operation: "generate"},
+			want:    models.ErrHostLeaseNotFound,
+		},
+		{
+			name:    "holder",
+			request: models.InvokeModelRequest{Scope: mustScopeRef(t, "scope-1"), Lease: mustLeaseRef(t, "lease-1"), ModelName: "model", Operation: "generate"},
+			want:    models.ErrHostInvalidHolder,
+		},
+		{
+			name:    "model",
+			request: models.InvokeModelRequest{Scope: mustScopeRef(t, "scope-1"), Lease: mustLeaseRef(t, "lease-1"), Holder: "worker", Operation: "generate"},
+			want:    models.ErrNotFound,
+		},
+		{
+			name:    "operation",
+			request: models.InvokeModelRequest{Scope: mustScopeRef(t, "scope-1"), Lease: mustLeaseRef(t, "lease-1"), Holder: "worker", ModelName: "model"},
+			want:    models.ErrUnsupportedModelOperation,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := service.InvokeModelWithLease(context.Background(), test.request)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("InvokeModelWithLease = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestInvokeModelWithLeaseRejectsUnknownAndExpiredLeases(t *testing.T) {
+	t.Parallel()
+
+	scopes, scope := openInferenceScope(t, "invoke-lease", "scoped-model", "generate")
+	catalog := mustCatalog(t, scopes)
+	now := time.Date(2026, time.July, 28, 12, 0, 0, 0, time.UTC)
+	activeLease := mustLeaseRef(t, "lease-active")
+	expiredLease := mustLeaseRef(t, "lease-expired")
+	host := &recordingInferenceHost{
+		leases: map[string]models.ModelLease{
+			activeLease.String(): {
+				Lease: activeLease, Scope: scope, ModelName: "scoped-model",
+				Holder: "worker-1", Status: models.ModelLeaseStatusActive,
+				ExpiresAt: now.Add(time.Minute),
+			},
+			expiredLease.String(): {
+				Lease: expiredLease, Scope: scope, ModelName: "scoped-model",
+				Holder: "worker-1", Status: models.ModelLeaseStatusExpired,
+				ExpiresAt: now.Add(-time.Minute),
+			},
+		},
+	}
+	service := internalservice.New(
+		scopes,
+		catalog,
+		host,
+		&recordingInvocationRuntime{},
+		func() time.Time { return now },
+	)
+
+	_, err := service.InvokeModelWithLease(context.Background(), invokeRequest(scope, activeLease, "worker-2", "scoped-model", "generate"))
+	if !errors.Is(err, models.ErrHostInvalidHolder) {
+		t.Fatalf("holder mismatch = %v, want ErrHostInvalidHolder", err)
+	}
+
+	_, err = service.InvokeModelWithLease(context.Background(), invokeRequest(scope, mustLeaseRef(t, "missing"), "worker-1", "scoped-model", "generate"))
+	if !errors.Is(err, models.ErrHostLeaseNotFound) {
+		t.Fatalf("unknown lease = %v, want ErrHostLeaseNotFound", err)
+	}
+
+	_, err = service.InvokeModelWithLease(context.Background(), invokeRequest(scope, expiredLease, "worker-1", "scoped-model", "generate"))
+	if !errors.Is(err, models.ErrHostLeaseExpired) {
+		t.Fatalf("expired lease = %v, want ErrHostLeaseExpired", err)
+	}
+}
+
+func TestInvokeModelWithLeaseRejectsUnknownModelAndUnsupportedOperation(t *testing.T) {
+	t.Parallel()
+
+	scopes, scope := openInferenceScope(t, "invoke-catalog", "scoped-model", "generate")
+	catalog := mustCatalog(t, scopes)
+	lease := mustLeaseRef(t, "lease-1")
+	host := &recordingInferenceHost{
+		leases: map[string]models.ModelLease{
+			lease.String(): activeLease(scope, lease, "missing-model", "worker-1"),
+		},
+	}
+	service := internalservice.New(
+		scopes,
+		catalog,
+		host,
+		&recordingInvocationRuntime{},
+		fixedClock(),
+	)
+
+	_, err := service.InvokeModelWithLease(context.Background(), invokeRequest(scope, lease, "worker-1", "missing-model", "generate"))
+	if !errors.Is(err, models.ErrNotFound) {
+		t.Fatalf("unknown model = %v, want ErrNotFound", err)
+	}
+
+	scopedLease := mustLeaseRef(t, "lease-2")
+	host.leases[scopedLease.String()] = activeLease(scope, scopedLease, "scoped-model", "worker-1")
+	_, err = service.InvokeModelWithLease(context.Background(), invokeRequest(scope, scopedLease, "worker-1", "scoped-model", "unsupported"))
+	if !errors.Is(err, models.ErrUnsupportedModelOperation) {
+		t.Fatalf("unsupported operation = %v, want ErrUnsupportedModelOperation", err)
+	}
+}
+
+func TestInvokeModelWithLeaseReturnsDetachedCompletedResult(t *testing.T) {
+	t.Parallel()
+
+	scopes, scope := openInferenceScope(t, "invoke-success", "scoped-model", "generate")
+	catalog := mustCatalog(t, scopes)
+	lease := mustLeaseRef(t, "lease-1")
+	host := &recordingInferenceHost{
+		leases: map[string]models.ModelLease{
+			lease.String(): activeLease(scope, lease, "scoped-model", "worker-1"),
+		},
+	}
+	runtime := &recordingInvocationRuntime{
+		content: []models.InferenceContent{{
+			ContentType: "text/plain",
+			Content:     "models-owned-output",
+		}},
+	}
+	service := internalservice.New(scopes, catalog, host, runtime, fixedClock())
+
+	result, err := service.InvokeModelWithLease(context.Background(), models.InvokeModelRequest{
+		Scope:     scope,
+		Lease:     lease,
+		Holder:    "worker-1",
+		ModelName: "scoped-model",
+		Operation: "generate",
+		Input: models.InferenceInput{
+			ContentType: "text/plain",
+			Content:     "hello",
+		},
+	})
+	if err != nil {
+		t.Fatalf("InvokeModelWithLease: %v", err)
+	}
+	if result.Invocation.IsZero() ||
+		result.Status != models.ModelInvocationStatusCompleted ||
+		result.LeaseDisposition != models.InvocationLeaseReleased ||
+		result.Lease != lease {
+		t.Fatalf("result = %#v, want completed released lease-backed invocation", result)
+	}
+	if len(result.Content) != 1 || result.Content[0].Content != "models-owned-output" {
+		t.Fatalf("content = %#v, want detached runtime output", result.Content)
+	}
+	if runtime.invokeCalls != 1 {
+		t.Fatalf("runtime invoke calls = %d, want 1", runtime.invokeCalls)
+	}
+	if host.releaseCalls != 1 {
+		t.Fatalf("lease release calls = %d, want 1", host.releaseCalls)
+	}
+	released := host.leases[lease.String()]
+	if released.Status != models.ModelLeaseStatusReleased {
+		t.Fatalf("lease status = %q, want RELEASED", released.Status)
+	}
+}
+
+func newInferenceService(
+	t *testing.T,
+	issuer string,
+	host *recordingInferenceHost,
+) inference.Service {
+	t.Helper()
+	scopes, scope := openInferenceScope(t, issuer, "scoped-model", "generate")
+	if host == nil {
+		lease := mustLeaseRef(t, "lease-1")
+		host = &recordingInferenceHost{
+			leases: map[string]models.ModelLease{
+				lease.String(): activeLease(scope, lease, "scoped-model", "worker-1"),
+			},
+		}
+	}
+	return internalservice.New(
+		scopes,
+		mustCatalog(t, scopes),
+		host,
+		&recordingInvocationRuntime{},
+		fixedClock(),
+	)
+}
+
+func openInferenceScope(
+	t *testing.T,
+	issuer string,
+	model string,
+	operation string,
+) (runtimescopes.Service, models.RuntimeScopeRef) {
+	t.Helper()
+	scopes, err := runtimescopeswire.NewService(func() string { return issuer })
+	if err != nil {
+		t.Fatalf("construct Runtime Scopes: %v", err)
+	}
+	privateRef, err := scopes.Open(models.RuntimeBinding{
+		RuntimeConfig: func() *models.RuntimeConfig {
+			return &models.RuntimeConfig{
+				Workers: []models.RuntimeWorker{inferenceWorker(model, operation)},
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("open scope: %v", err)
+	}
+	scope, err := (models.RuntimeScopeRef{}).Parse(string(privateRef))
+	if err != nil {
+		t.Fatalf("parse scope: %v", err)
+	}
+	return scopes, scope
+}
+
+func inferenceWorker(model, operation string) models.RuntimeWorker {
+	return models.RuntimeWorker{
+		Name: "worker", Type: models.RuntimeWorkerTypeInference,
+		Model: model, ModelLocality: models.RuntimeModelLocalityLocal,
+		Operations: []models.RuntimeOperation{{
+			Name: operation,
+			Inputs: []models.RuntimeOperationSlot{{
+				Name: "input", ContentTypes: []string{models.RuntimeContentTypeText},
+			}},
+		}},
+		Resources: []models.RuntimeResource{{Name: "model-cache"}},
+	}
+}
+
+func mustCatalog(t *testing.T, scopes runtimescopes.Service) modelcatalog.Service {
+	t.Helper()
+	service, err := catalogwire.NewService(scopes)
+	if err != nil {
+		t.Fatalf("construct Catalog: %v", err)
+	}
+	return service
+}
+
+func invokeRequest(
+	scope models.RuntimeScopeRef,
+	lease models.ModelLeaseRef,
+	holder string,
+	model string,
+	operation string,
+) models.InvokeModelRequest {
+	return models.InvokeModelRequest{
+		Scope: scope, Lease: lease, Holder: holder,
+		ModelName: model, Operation: operation,
+	}
+}
+
+func activeLease(
+	scope models.RuntimeScopeRef,
+	lease models.ModelLeaseRef,
+	model string,
+	holder string,
+) models.ModelLease {
+	return models.ModelLease{
+		Lease: lease, Scope: scope, ModelName: model, Holder: holder,
+		Status: models.ModelLeaseStatusActive,
+		ExpiresAt: time.Date(2026, time.July, 28, 13, 0, 0, 0, time.UTC),
+	}
+}
+
+func fixedClock() func() time.Time {
+	return func() time.Time {
+		return time.Date(2026, time.July, 28, 12, 0, 0, 0, time.UTC)
+	}
+}
+
+func mustScopeRef(t *testing.T, value string) models.RuntimeScopeRef {
+	t.Helper()
+	ref, err := (models.RuntimeScopeRef{}).Parse(value)
+	if err != nil {
+		t.Fatalf("parse scope: %v", err)
+	}
+	return ref
+}
+
+func mustLeaseRef(t *testing.T, value string) models.ModelLeaseRef {
+	t.Helper()
+	ref, err := (models.ModelLeaseRef{}).Parse(value)
+	if err != nil {
+		t.Fatalf("parse lease: %v", err)
+	}
+	return ref
+}
+
+type recordingInvocationRuntime struct {
+	invokeCalls int
+	content     []models.InferenceContent
+}
+
+func (runtime *recordingInvocationRuntime) Invoke(
+	_ context.Context,
+	request models.InvokeModelRequest,
+) ([]models.InferenceContent, error) {
+	runtime.invokeCalls++
+	if runtime.content != nil {
+		return append([]models.InferenceContent(nil), runtime.content...), nil
+	}
+	return []models.InferenceContent{{
+		ContentType: request.Input.ContentType,
+		Content:     request.Input.Content,
+	}}, nil
+}
+
+type recordingInferenceHost struct {
+	leases       map[string]models.ModelLease
+	releaseCalls int
+}
+
+var _ runtimehost.Service = (*recordingInferenceHost)(nil)
+
+func (host *recordingInferenceHost) InspectModelHost(
+	context.Context,
+	models.InspectModelHostRequest,
+) (models.InspectModelHostResult, error) {
+	return models.InspectModelHostResult{}, models.ErrUnsupportedOperation
+}
+
+func (host *recordingInferenceHost) EnsureModelHost(
+	context.Context,
+	models.EnsureModelHostRequest,
+) (models.EnsureModelHostResult, error) {
+	return models.EnsureModelHostResult{}, models.ErrUnsupportedOperation
+}
+
+func (host *recordingInferenceHost) StopModelHost(
+	context.Context,
+	models.StopModelHostRequest,
+) (models.StopModelHostResult, error) {
+	return models.StopModelHostResult{}, models.ErrUnsupportedOperation
+}
+
+func (host *recordingInferenceHost) AcquireModelLease(
+	context.Context,
+	models.AcquireModelLeaseRequest,
+) (models.AcquireModelLeaseResult, error) {
+	return models.AcquireModelLeaseResult{}, models.ErrUnsupportedOperation
+}
+
+func (host *recordingInferenceHost) GetModelLease(
+	_ context.Context,
+	request models.GetModelLeaseRequest,
+) (models.GetModelLeaseResult, error) {
+	lease, ok := host.leases[request.Lease.String()]
+	if !ok || lease.Scope != request.Scope {
+		return models.GetModelLeaseResult{}, models.ErrHostLeaseNotFound
+	}
+	if lease.Status == models.ModelLeaseStatusExpired {
+		return models.GetModelLeaseResult{Lease: lease}, models.ErrHostLeaseExpired
+	}
+	return models.GetModelLeaseResult{Lease: lease}, nil
+}
+
+func (host *recordingInferenceHost) ReleaseModelLease(
+	_ context.Context,
+	request models.ReleaseModelLeaseRequest,
+) (models.ReleaseModelLeaseResult, error) {
+	host.releaseCalls++
+	lease, ok := host.leases[request.Lease.String()]
+	if !ok || lease.Scope != request.Scope {
+		return models.ReleaseModelLeaseResult{}, models.ErrHostLeaseNotFound
+	}
+	lease.Status = models.ModelLeaseStatusReleased
+	host.leases[request.Lease.String()] = lease
+	return models.ReleaseModelLeaseResult{
+		Lease:   lease,
+		Outcome: models.ModelLeaseReleased,
+	}, nil
+}
+
+func TestInputEchoInvocationRuntimeReturnsDetachedContent(t *testing.T) {
+	t.Parallel()
+
+	content, err := inference.InputEchoInvocationRuntime{}.Invoke(
+		context.Background(),
+		models.InvokeModelRequest{
+			Input: models.InferenceInput{ContentType: "text/plain", Content: "hello"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if len(content) != 1 || content[0].Content != "hello" {
+		t.Fatalf("content = %#v, want echoed input", content)
+	}
+}

--- a/pkg/services/models/internal/services/inference/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/inference/internal/service/service_test.go
@@ -3,10 +3,12 @@ package service_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
+	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
 	modelcatalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
 	catalogwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire"
 	inference "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference"
@@ -86,6 +88,7 @@ func TestInvokeModelWithLeaseRejectsUnknownAndExpiredLeases(t *testing.T) {
 	}
 	service := internalservice.New(
 		scopes,
+		availableInferenceAssets{},
 		catalog,
 		host,
 		&recordingInvocationRuntime{},
@@ -121,6 +124,7 @@ func TestInvokeModelWithLeaseRejectsUnknownModelAndUnsupportedOperation(t *testi
 	}
 	service := internalservice.New(
 		scopes,
+		availableInferenceAssets{},
 		catalog,
 		host,
 		&recordingInvocationRuntime{},
@@ -157,7 +161,7 @@ func TestInvokeModelWithLeaseReturnsDetachedCompletedResult(t *testing.T) {
 			Content:     "models-owned-output",
 		}},
 	}
-	service := internalservice.New(scopes, catalog, host, runtime, fixedClock())
+	service := internalservice.New(scopes, availableInferenceAssets{}, catalog, host, runtime, fixedClock())
 
 	result, err := service.InvokeModelWithLease(context.Background(), models.InvokeModelRequest{
 		Scope:     scope,
@@ -194,6 +198,163 @@ func TestInvokeModelWithLeaseReturnsDetachedCompletedResult(t *testing.T) {
 	}
 }
 
+func TestInvokeModelWithLeaseRejectsUnavailableAssets(t *testing.T) {
+	t.Parallel()
+
+	scopes, scope := openInferenceScope(t, "invoke-unavailable-assets", "scoped-model", "generate")
+	catalog := mustCatalog(t, scopes)
+	lease := mustLeaseRef(t, "lease-1")
+	host := &recordingInferenceHost{
+		leases: map[string]models.ModelLease{
+			lease.String(): activeLease(scope, lease, "scoped-model", "worker-1"),
+		},
+	}
+	service := internalservice.New(
+		scopes,
+		&recordingInferenceAssets{
+			inspection: scopedassets.RuntimeCacheInspection{Supported: true},
+		},
+		catalog,
+		host,
+		&recordingInvocationRuntime{},
+		fixedClock(),
+	)
+
+	_, err := service.InvokeModelWithLease(context.Background(), invokeRequest(scope, lease, "worker-1", "scoped-model", "generate"))
+	if !errors.Is(err, models.ErrAssetUnavailable) {
+		t.Fatalf("uninstalled assets = %v, want ErrAssetUnavailable", err)
+	}
+	if host.releaseCalls != 0 {
+		t.Fatalf("lease release calls = %d, want 0 for pre-acceptance failure", host.releaseCalls)
+	}
+
+	service = internalservice.New(
+		scopes,
+		&recordingInferenceAssets{err: fmt.Errorf("%w: scoped-model", models.ErrAssetUnavailable)},
+		catalog,
+		host,
+		&recordingInvocationRuntime{},
+		fixedClock(),
+	)
+	_, err = service.InvokeModelWithLease(context.Background(), invokeRequest(scope, lease, "worker-1", "scoped-model", "generate"))
+	if !errors.Is(err, models.ErrAssetUnavailable) {
+		t.Fatalf("asset inspection error = %v, want ErrAssetUnavailable", err)
+	}
+}
+
+func TestInvokeModelWithLeaseRejectsUnsupportedResponseMode(t *testing.T) {
+	t.Parallel()
+
+	scopes, scope := openInferenceScope(t, "invoke-response-mode", "scoped-model", "generate")
+	catalog := mustCatalog(t, scopes)
+	lease := mustLeaseRef(t, "lease-1")
+	host := &recordingInferenceHost{
+		leases: map[string]models.ModelLease{
+			lease.String(): activeLease(scope, lease, "scoped-model", "worker-1"),
+		},
+	}
+	service := internalservice.New(
+		scopes,
+		availableInferenceAssets{},
+		catalog,
+		host,
+		&recordingInvocationRuntime{},
+		fixedClock(),
+	)
+	request := invokeRequest(scope, lease, "worker-1", "scoped-model", "generate")
+	request.ResponseMode = models.ResponseMode("JSON")
+
+	_, err := service.InvokeModelWithLease(context.Background(), request)
+	if !errors.Is(err, models.ErrUnsupportedResponseMode) {
+		t.Fatalf("unsupported response mode = %v, want ErrUnsupportedResponseMode", err)
+	}
+}
+
+func TestInvokeModelWithLeaseNormalizesRuntimeFailure(t *testing.T) {
+	t.Parallel()
+
+	scopes, scope := openInferenceScope(t, "invoke-failure", "scoped-model", "generate")
+	catalog := mustCatalog(t, scopes)
+	lease := mustLeaseRef(t, "lease-1")
+	host := &recordingInferenceHost{
+		leases: map[string]models.ModelLease{
+			lease.String(): activeLease(scope, lease, "scoped-model", "worker-1"),
+		},
+	}
+	runtime := &recordingInvocationRuntime{invokeErr: models.ErrInferenceFailed}
+	service := internalservice.New(
+		scopes,
+		availableInferenceAssets{},
+		catalog,
+		host,
+		runtime,
+		fixedClock(),
+	)
+
+	result, err := service.InvokeModelWithLease(context.Background(), invokeRequest(scope, lease, "worker-1", "scoped-model", "generate"))
+	if !errors.Is(err, models.ErrInferenceFailed) {
+		t.Fatalf("runtime failure = %v, want ErrInferenceFailed", err)
+	}
+	if result.Invocation.IsZero() ||
+		result.Status != models.ModelInvocationStatusFailed ||
+		result.LeaseDisposition != models.InvocationLeaseReleased {
+		t.Fatalf("result = %#v, want failed released post-acceptance invocation", result)
+	}
+	if host.releaseCalls != 1 {
+		t.Fatalf("lease release calls = %d, want 1", host.releaseCalls)
+	}
+}
+
+func TestInvokeModelFailureOutcomesRemainDistinct(t *testing.T) {
+	t.Parallel()
+
+	failures := []error{
+		models.ErrAssetUnavailable,
+		models.ErrHostRuntimeNotReady,
+		models.ErrHostCapacityExhausted,
+		models.ErrHostLeaseExpired,
+		models.ErrUnsupportedModelOperation,
+		models.ErrInferenceTimeout,
+		models.ErrInferenceFailed,
+	}
+	for _, want := range failures {
+		for _, other := range failures {
+			if want != other && errors.Is(want, other) {
+				t.Fatalf("failure classifications must stay distinct: %v vs %v", want, other)
+			}
+		}
+	}
+
+	scopes, scope := openInferenceScope(t, "invoke-distinct", "scoped-model", "generate")
+	catalog := mustCatalog(t, scopes)
+	lease := mustLeaseRef(t, "lease-1")
+	host := &recordingInferenceHost{
+		leases: map[string]models.ModelLease{
+			lease.String(): activeLease(scope, lease, "scoped-model", "worker-1"),
+		},
+	}
+	service := internalservice.New(
+		scopes,
+		availableInferenceAssets{},
+		catalog,
+		host,
+		&recordingInvocationRuntime{invokeErr: models.ErrInferenceFailed},
+		fixedClock(),
+	)
+	result, err := service.InvokeModelWithLease(context.Background(), invokeRequest(scope, lease, "worker-1", "scoped-model", "generate"))
+	if !errors.Is(err, models.ErrInferenceFailed) {
+		t.Fatalf("normalized failure = %v, want ErrInferenceFailed", err)
+	}
+	for _, other := range failures {
+		if other != models.ErrInferenceFailed && errors.Is(err, other) {
+			t.Fatalf("normalized failure must stay distinct from %v: %v", other, err)
+		}
+	}
+	if result.Status != models.ModelInvocationStatusFailed {
+		t.Fatalf("result status = %q, want FAILED", result.Status)
+	}
+}
+
 func newInferenceService(
 	t *testing.T,
 	issuer string,
@@ -211,6 +372,7 @@ func newInferenceService(
 	}
 	return internalservice.New(
 		scopes,
+		availableInferenceAssets{},
 		mustCatalog(t, scopes),
 		host,
 		&recordingInvocationRuntime{},
@@ -322,6 +484,7 @@ func mustLeaseRef(t *testing.T, value string) models.ModelLeaseRef {
 type recordingInvocationRuntime struct {
 	invokeCalls int
 	content     []models.InferenceContent
+	invokeErr   error
 }
 
 func (runtime *recordingInvocationRuntime) Invoke(
@@ -329,6 +492,9 @@ func (runtime *recordingInvocationRuntime) Invoke(
 	request models.InvokeModelRequest,
 ) ([]models.InferenceContent, error) {
 	runtime.invokeCalls++
+	if runtime.invokeErr != nil {
+		return nil, runtime.invokeErr
+	}
 	if runtime.content != nil {
 		return append([]models.InferenceContent(nil), runtime.content...), nil
 	}
@@ -402,6 +568,79 @@ func (host *recordingInferenceHost) ReleaseModelLease(
 		Lease:   lease,
 		Outcome: models.ModelLeaseReleased,
 	}, nil
+}
+
+type availableInferenceAssets struct{}
+
+var _ scopedassets.Service = availableInferenceAssets{}
+
+func (availableInferenceAssets) PrepareModelAssets(
+	context.Context,
+	models.PrepareModelAssetsRequest,
+) (models.PrepareModelAssetsResult, error) {
+	return models.PrepareModelAssetsResult{}, models.ErrUnsupportedOperation
+}
+
+func (availableInferenceAssets) InspectModelAssets(
+	context.Context,
+	models.InspectModelAssetsRequest,
+) (models.InspectModelAssetsResult, error) {
+	return models.InspectModelAssetsResult{}, models.ErrUnsupportedOperation
+}
+
+func (availableInferenceAssets) ResolveRuntimeCache(
+	context.Context,
+	models.InspectModelAssetsRequest,
+) (scopedassets.RuntimeCacheLayout, error) {
+	return scopedassets.RuntimeCacheLayout{}, models.ErrUnsupportedOperation
+}
+
+func (availableInferenceAssets) InspectRuntimeCache(
+	context.Context,
+	models.InspectModelAssetsRequest,
+) (scopedassets.RuntimeCacheInspection, error) {
+	return scopedassets.RuntimeCacheInspection{
+		Supported: true,
+		Installed: true,
+	}, nil
+}
+
+type recordingInferenceAssets struct {
+	inspection scopedassets.RuntimeCacheInspection
+	err        error
+}
+
+var _ scopedassets.Service = (*recordingInferenceAssets)(nil)
+
+func (assets *recordingInferenceAssets) PrepareModelAssets(
+	context.Context,
+	models.PrepareModelAssetsRequest,
+) (models.PrepareModelAssetsResult, error) {
+	return models.PrepareModelAssetsResult{}, models.ErrUnsupportedOperation
+}
+
+func (assets *recordingInferenceAssets) InspectModelAssets(
+	context.Context,
+	models.InspectModelAssetsRequest,
+) (models.InspectModelAssetsResult, error) {
+	return models.InspectModelAssetsResult{}, models.ErrUnsupportedOperation
+}
+
+func (assets *recordingInferenceAssets) ResolveRuntimeCache(
+	context.Context,
+	models.InspectModelAssetsRequest,
+) (scopedassets.RuntimeCacheLayout, error) {
+	return scopedassets.RuntimeCacheLayout{}, models.ErrUnsupportedOperation
+}
+
+func (assets *recordingInferenceAssets) InspectRuntimeCache(
+	context.Context,
+	models.InspectModelAssetsRequest,
+) (scopedassets.RuntimeCacheInspection, error) {
+	if assets.err != nil {
+		return scopedassets.RuntimeCacheInspection{}, assets.err
+	}
+	return assets.inspection, nil
 }
 
 func TestInputEchoInvocationRuntimeReturnsDetachedContent(t *testing.T) {

--- a/pkg/services/models/internal/services/inference/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/inference/internal/service/service_test.go
@@ -93,6 +93,7 @@ func TestInvokeModelWithLeaseRejectsUnknownAndExpiredLeases(t *testing.T) {
 		host,
 		&recordingInvocationRuntime{},
 		func() time.Time { return now },
+		nil,
 	)
 
 	_, err := service.InvokeModelWithLease(context.Background(), invokeRequest(scope, activeLease, "worker-2", "scoped-model", "generate"))
@@ -129,6 +130,7 @@ func TestInvokeModelWithLeaseRejectsUnknownModelAndUnsupportedOperation(t *testi
 		host,
 		&recordingInvocationRuntime{},
 		fixedClock(),
+		nil,
 	)
 
 	_, err := service.InvokeModelWithLease(context.Background(), invokeRequest(scope, lease, "worker-1", "missing-model", "generate"))
@@ -161,7 +163,7 @@ func TestInvokeModelWithLeaseReturnsDetachedCompletedResult(t *testing.T) {
 			Content:     "models-owned-output",
 		}},
 	}
-	service := internalservice.New(scopes, availableInferenceAssets{}, catalog, host, runtime, fixedClock())
+	service := internalservice.New(scopes, availableInferenceAssets{}, catalog, host, runtime, fixedClock(), nil)
 
 	result, err := service.InvokeModelWithLease(context.Background(), models.InvokeModelRequest{
 		Scope:     scope,
@@ -218,6 +220,7 @@ func TestInvokeModelWithLeaseRejectsUnavailableAssets(t *testing.T) {
 		host,
 		&recordingInvocationRuntime{},
 		fixedClock(),
+		nil,
 	)
 
 	_, err := service.InvokeModelWithLease(context.Background(), invokeRequest(scope, lease, "worker-1", "scoped-model", "generate"))
@@ -235,6 +238,7 @@ func TestInvokeModelWithLeaseRejectsUnavailableAssets(t *testing.T) {
 		host,
 		&recordingInvocationRuntime{},
 		fixedClock(),
+		nil,
 	)
 	_, err = service.InvokeModelWithLease(context.Background(), invokeRequest(scope, lease, "worker-1", "scoped-model", "generate"))
 	if !errors.Is(err, models.ErrAssetUnavailable) {
@@ -260,6 +264,7 @@ func TestInvokeModelWithLeaseRejectsUnsupportedResponseMode(t *testing.T) {
 		host,
 		&recordingInvocationRuntime{},
 		fixedClock(),
+		nil,
 	)
 	request := invokeRequest(scope, lease, "worker-1", "scoped-model", "generate")
 	request.ResponseMode = models.ResponseMode("JSON")
@@ -289,6 +294,7 @@ func TestInvokeModelWithLeaseNormalizesRuntimeFailure(t *testing.T) {
 		host,
 		runtime,
 		fixedClock(),
+		nil,
 	)
 
 	result, err := service.InvokeModelWithLease(context.Background(), invokeRequest(scope, lease, "worker-1", "scoped-model", "generate"))
@@ -340,6 +346,7 @@ func TestInvokeModelFailureOutcomesRemainDistinct(t *testing.T) {
 		host,
 		&recordingInvocationRuntime{invokeErr: models.ErrInferenceFailed},
 		fixedClock(),
+		nil,
 	)
 	result, err := service.InvokeModelWithLease(context.Background(), invokeRequest(scope, lease, "worker-1", "scoped-model", "generate"))
 	if !errors.Is(err, models.ErrInferenceFailed) {
@@ -352,6 +359,210 @@ func TestInvokeModelFailureOutcomesRemainDistinct(t *testing.T) {
 	}
 	if result.Status != models.ModelInvocationStatusFailed {
 		t.Fatalf("result status = %q, want FAILED", result.Status)
+	}
+}
+
+func TestInvokeModelWithLeaseTimesOutWithReleasedLeaseDisposition(t *testing.T) {
+	t.Parallel()
+
+	scopes, scope := openInferenceScope(t, "invoke-timeout", "scoped-model", "generate")
+	catalog := mustCatalog(t, scopes)
+	lease := mustLeaseRef(t, "lease-1")
+	host := &recordingInferenceHost{
+		leases: map[string]models.ModelLease{
+			lease.String(): activeLease(scope, lease, "scoped-model", "worker-1"),
+		},
+	}
+	now := time.Now()
+	service := internalservice.New(
+		scopes,
+		availableInferenceAssets{},
+		catalog,
+		host,
+		&deadlineInvocationRuntime{},
+		func() time.Time { return now },
+		func() time.Duration { return time.Millisecond },
+	)
+
+	result, err := service.InvokeModelWithLease(context.Background(), invokeRequest(scope, lease, "worker-1", "scoped-model", "generate"))
+	if !errors.Is(err, models.ErrInferenceTimeout) {
+		t.Fatalf("timeout = %v, want ErrInferenceTimeout", err)
+	}
+	if result.Status != models.ModelInvocationStatusFailed ||
+		result.LeaseDisposition != models.InvocationLeaseReleased {
+		t.Fatalf("result = %#v, want failed released timeout outcome", result)
+	}
+	if host.releaseCalls != 1 {
+		t.Fatalf("lease release calls = %d, want 1", host.releaseCalls)
+	}
+}
+
+func TestCancelInvocationReleasesAcceptedInvocationCapacity(t *testing.T) {
+	t.Parallel()
+
+	scopes, scope := openInferenceScope(t, "invoke-cancel", "scoped-model", "hold")
+	catalog := mustCatalog(t, scopes)
+	lease := mustLeaseRef(t, "lease-1")
+	host := &recordingInferenceHost{
+		leases: map[string]models.ModelLease{
+			lease.String(): activeLease(scope, lease, "scoped-model", "worker-1"),
+		},
+	}
+	service := internalservice.New(
+		scopes,
+		availableInferenceAssets{},
+		catalog,
+		host,
+		holdInvocationRuntime{},
+		fixedClock(),
+		nil,
+	)
+
+	accepted, err := service.InvokeModelWithLease(
+		context.Background(),
+		invokeRequest(scope, lease, "worker-1", "scoped-model", "hold"),
+	)
+	if err != nil {
+		t.Fatalf("InvokeModelWithLease hold: %v", err)
+	}
+	if accepted.Status != models.ModelInvocationStatusAccepted ||
+		accepted.LeaseDisposition != models.InvocationLeaseRetained {
+		t.Fatalf("accepted = %#v, want retained accepted invocation", accepted)
+	}
+
+	cancelled, err := service.CancelInvocation(context.Background(), models.CancelInvocationRequest{
+		Scope:      scope,
+		Invocation: accepted.Invocation,
+	})
+	if err != nil {
+		t.Fatalf("CancelInvocation: %v", err)
+	}
+	if cancelled.Outcome != models.InvocationCancellationRequested ||
+		cancelled.Status != models.ModelInvocationStatusCancelled ||
+		cancelled.LeaseDisposition != models.InvocationLeaseReleased {
+		t.Fatalf("cancelled = %#v, want cancelled released outcome", cancelled)
+	}
+
+	repeated, err := service.CancelInvocation(context.Background(), models.CancelInvocationRequest{
+		Scope:      scope,
+		Invocation: accepted.Invocation,
+	})
+	if err != nil {
+		t.Fatalf("CancelInvocation repeated: %v", err)
+	}
+	if repeated.Outcome != models.InvocationCancellationAlreadyCancelled {
+		t.Fatalf("repeated cancellation = %#v, want ALREADY_CANCELLED", repeated)
+	}
+	if host.releaseCalls != 1 {
+		t.Fatalf("lease release calls = %d, want 1", host.releaseCalls)
+	}
+}
+
+func TestCancelInvocationReportsAlreadyCompletedForFinishedInvocation(t *testing.T) {
+	t.Parallel()
+
+	scopes, scope := openInferenceScope(t, "invoke-cancel-complete", "scoped-model", "generate")
+	catalog := mustCatalog(t, scopes)
+	lease := mustLeaseRef(t, "lease-1")
+	host := &recordingInferenceHost{
+		leases: map[string]models.ModelLease{
+			lease.String(): activeLease(scope, lease, "scoped-model", "worker-1"),
+		},
+	}
+	service := internalservice.New(
+		scopes,
+		availableInferenceAssets{},
+		catalog,
+		host,
+		&recordingInvocationRuntime{},
+		fixedClock(),
+		nil,
+	)
+
+	result, err := service.InvokeModelWithLease(
+		context.Background(),
+		invokeRequest(scope, lease, "worker-1", "scoped-model", "generate"),
+	)
+	if err != nil {
+		t.Fatalf("InvokeModelWithLease: %v", err)
+	}
+
+	cancelled, err := service.CancelInvocation(context.Background(), models.CancelInvocationRequest{
+		Scope:      scope,
+		Invocation: result.Invocation,
+	})
+	if err != nil {
+		t.Fatalf("CancelInvocation completed: %v", err)
+	}
+	if cancelled.Outcome != models.InvocationCancellationAlreadyCompleted {
+		t.Fatalf("late cancellation = %#v, want ALREADY_COMPLETED", cancelled)
+	}
+}
+
+func TestInvokeContextCancellationConvergesWithExplicitCancel(t *testing.T) {
+	t.Parallel()
+
+	scopes, scope := openInferenceScope(t, "invoke-context-cancel", "scoped-model", "generate")
+	catalog := mustCatalog(t, scopes)
+	lease := mustLeaseRef(t, "lease-1")
+	host := &recordingInferenceHost{
+		leases: map[string]models.ModelLease{
+			lease.String(): activeLease(scope, lease, "scoped-model", "worker-1"),
+		},
+	}
+	service := internalservice.New(
+		scopes,
+		availableInferenceAssets{},
+		catalog,
+		host,
+		&deadlineInvocationRuntime{},
+		fixedClock(),
+		nil,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	contextResult, err := service.InvokeModelWithLease(
+		ctx,
+		invokeRequest(scope, lease, "worker-1", "scoped-model", "generate"),
+	)
+	if !errors.Is(err, models.ErrInferenceCancelled) {
+		t.Fatalf("context cancellation = %v, want ErrInferenceCancelled", err)
+	}
+	if contextResult.Status != models.ModelInvocationStatusCancelled ||
+		contextResult.LeaseDisposition != models.InvocationLeaseReleased ||
+		contextResult.CancellationOutcome != models.InvocationCancellationRequested {
+		t.Fatalf("context cancellation = %#v, want cancelled released outcome", contextResult)
+	}
+	if host.releaseCalls != 1 {
+		t.Fatalf("lease release calls = %d, want 1", host.releaseCalls)
+	}
+}
+
+func TestCancelInvocationRejectsUnknownInvocation(t *testing.T) {
+	t.Parallel()
+
+	scopes, scope := openInferenceScope(t, "invoke-cancel-unknown", "scoped-model", "generate")
+	catalog := mustCatalog(t, scopes)
+	service := internalservice.New(
+		scopes,
+		availableInferenceAssets{},
+		catalog,
+		&recordingInferenceHost{},
+		&recordingInvocationRuntime{},
+		fixedClock(),
+		nil,
+	)
+	unknown, err := (models.ModelInvocationRef{}).Parse("models-inference:unknown")
+	if err != nil {
+		t.Fatalf("parse unknown invocation: %v", err)
+	}
+	_, err = service.CancelInvocation(context.Background(), models.CancelInvocationRequest{
+		Scope:      scope,
+		Invocation: unknown,
+	})
+	if !errors.Is(err, models.ErrInvocationNotFound) {
+		t.Fatalf("CancelInvocation unknown = %v, want ErrInvocationNotFound", err)
 	}
 }
 
@@ -377,6 +588,7 @@ func newInferenceService(
 		host,
 		&recordingInvocationRuntime{},
 		fixedClock(),
+		nil,
 	)
 }
 
@@ -502,6 +714,28 @@ func (runtime *recordingInvocationRuntime) Invoke(
 		ContentType: request.Input.ContentType,
 		Content:     request.Input.Content,
 	}}, nil
+}
+
+type holdInvocationRuntime struct{}
+
+func (holdInvocationRuntime) Invoke(
+	context.Context,
+	models.InvokeModelRequest,
+) ([]models.InferenceContent, error) {
+	return nil, inference.ErrInvocationInFlight
+}
+
+type deadlineInvocationRuntime struct{}
+
+func (deadlineInvocationRuntime) Invoke(ctx context.Context, _ models.InvokeModelRequest) ([]models.InferenceContent, error) {
+	<-ctx.Done()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return nil, models.ErrInferenceTimeout
+	}
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return nil, fmt.Errorf("%w: %v", models.ErrInferenceCancelled, ctx.Err())
+	}
+	return nil, ctx.Err()
 }
 
 type recordingInferenceHost struct {

--- a/pkg/services/models/internal/services/inference/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/inference/internal/service/service_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +14,7 @@ import (
 	modelcatalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
 	catalogwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire"
 	inference "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference"
+	inferenceartifacts "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/internal/artifacts"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/internal/service"
 	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
 	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
@@ -86,15 +89,7 @@ func TestInvokeModelWithLeaseRejectsUnknownAndExpiredLeases(t *testing.T) {
 			},
 		},
 	}
-	service := internalservice.New(
-		scopes,
-		availableInferenceAssets{},
-		catalog,
-		host,
-		&recordingInvocationRuntime{},
-		func() time.Time { return now },
-		nil,
-	)
+	service := newInferenceServiceWithHost(t, scopes, catalog, host, &recordingInvocationRuntime{}, fixedClock(), nil)
 
 	_, err := service.InvokeModelWithLease(context.Background(), invokeRequest(scope, activeLease, "worker-2", "scoped-model", "generate"))
 	if !errors.Is(err, models.ErrHostInvalidHolder) {
@@ -123,15 +118,7 @@ func TestInvokeModelWithLeaseRejectsUnknownModelAndUnsupportedOperation(t *testi
 			lease.String(): activeLease(scope, lease, "missing-model", "worker-1"),
 		},
 	}
-	service := internalservice.New(
-		scopes,
-		availableInferenceAssets{},
-		catalog,
-		host,
-		&recordingInvocationRuntime{},
-		fixedClock(),
-		nil,
-	)
+	service := newInferenceServiceWithHost(t, scopes, catalog, host, &recordingInvocationRuntime{}, fixedClock(), nil)
 
 	_, err := service.InvokeModelWithLease(context.Background(), invokeRequest(scope, lease, "worker-1", "missing-model", "generate"))
 	if !errors.Is(err, models.ErrNotFound) {
@@ -163,7 +150,7 @@ func TestInvokeModelWithLeaseReturnsDetachedCompletedResult(t *testing.T) {
 			Content:     "models-owned-output",
 		}},
 	}
-	service := internalservice.New(scopes, availableInferenceAssets{}, catalog, host, runtime, fixedClock(), nil)
+	service := newInferenceServiceWithHost(t, scopes, catalog, host, runtime, fixedClock(), nil)
 
 	result, err := service.InvokeModelWithLease(context.Background(), models.InvokeModelRequest{
 		Scope:     scope,
@@ -211,16 +198,16 @@ func TestInvokeModelWithLeaseRejectsUnavailableAssets(t *testing.T) {
 			lease.String(): activeLease(scope, lease, "scoped-model", "worker-1"),
 		},
 	}
-	service := internalservice.New(
+	service := newInferenceServiceWithHost(
+		t,
 		scopes,
-		&recordingInferenceAssets{
-			inspection: scopedassets.RuntimeCacheInspection{Supported: true},
-		},
 		catalog,
 		host,
 		&recordingInvocationRuntime{},
 		fixedClock(),
-		nil,
+		&recordingInferenceAssets{
+			inspection: scopedassets.RuntimeCacheInspection{Supported: true},
+		},
 	)
 
 	_, err := service.InvokeModelWithLease(context.Background(), invokeRequest(scope, lease, "worker-1", "scoped-model", "generate"))
@@ -231,14 +218,14 @@ func TestInvokeModelWithLeaseRejectsUnavailableAssets(t *testing.T) {
 		t.Fatalf("lease release calls = %d, want 0 for pre-acceptance failure", host.releaseCalls)
 	}
 
-	service = internalservice.New(
+	service = newInferenceServiceWithHost(
+		t,
 		scopes,
-		&recordingInferenceAssets{err: fmt.Errorf("%w: scoped-model", models.ErrAssetUnavailable)},
 		catalog,
 		host,
 		&recordingInvocationRuntime{},
 		fixedClock(),
-		nil,
+		&recordingInferenceAssets{err: fmt.Errorf("%w: scoped-model", models.ErrAssetUnavailable)},
 	)
 	_, err = service.InvokeModelWithLease(context.Background(), invokeRequest(scope, lease, "worker-1", "scoped-model", "generate"))
 	if !errors.Is(err, models.ErrAssetUnavailable) {
@@ -257,15 +244,7 @@ func TestInvokeModelWithLeaseRejectsUnsupportedResponseMode(t *testing.T) {
 			lease.String(): activeLease(scope, lease, "scoped-model", "worker-1"),
 		},
 	}
-	service := internalservice.New(
-		scopes,
-		availableInferenceAssets{},
-		catalog,
-		host,
-		&recordingInvocationRuntime{},
-		fixedClock(),
-		nil,
-	)
+	service := newInferenceServiceWithHost(t, scopes, catalog, host, &recordingInvocationRuntime{}, fixedClock(), nil)
 	request := invokeRequest(scope, lease, "worker-1", "scoped-model", "generate")
 	request.ResponseMode = models.ResponseMode("JSON")
 
@@ -287,15 +266,7 @@ func TestInvokeModelWithLeaseNormalizesRuntimeFailure(t *testing.T) {
 		},
 	}
 	runtime := &recordingInvocationRuntime{invokeErr: models.ErrInferenceFailed}
-	service := internalservice.New(
-		scopes,
-		availableInferenceAssets{},
-		catalog,
-		host,
-		runtime,
-		fixedClock(),
-		nil,
-	)
+	service := newInferenceServiceWithHost(t, scopes, catalog, host, runtime, fixedClock(), nil)
 
 	result, err := service.InvokeModelWithLease(context.Background(), invokeRequest(scope, lease, "worker-1", "scoped-model", "generate"))
 	if !errors.Is(err, models.ErrInferenceFailed) {
@@ -339,9 +310,9 @@ func TestInvokeModelFailureOutcomesRemainDistinct(t *testing.T) {
 			lease.String(): activeLease(scope, lease, "scoped-model", "worker-1"),
 		},
 	}
-	service := internalservice.New(
+	service := newInferenceServiceWithHost(
+		t,
 		scopes,
-		availableInferenceAssets{},
 		catalog,
 		host,
 		&recordingInvocationRuntime{invokeErr: models.ErrInferenceFailed},
@@ -374,13 +345,14 @@ func TestInvokeModelWithLeaseTimesOutWithReleasedLeaseDisposition(t *testing.T) 
 		},
 	}
 	now := time.Now()
-	service := internalservice.New(
+	service := newInferenceServiceWithHost(
+		t,
 		scopes,
-		availableInferenceAssets{},
 		catalog,
 		host,
 		&deadlineInvocationRuntime{},
 		func() time.Time { return now },
+		nil,
 		func() time.Duration { return time.Millisecond },
 	)
 
@@ -408,15 +380,7 @@ func TestCancelInvocationReleasesAcceptedInvocationCapacity(t *testing.T) {
 			lease.String(): activeLease(scope, lease, "scoped-model", "worker-1"),
 		},
 	}
-	service := internalservice.New(
-		scopes,
-		availableInferenceAssets{},
-		catalog,
-		host,
-		holdInvocationRuntime{},
-		fixedClock(),
-		nil,
-	)
+	service := newInferenceServiceWithHost(t, scopes, catalog, host, holdInvocationRuntime{}, fixedClock(), nil)
 
 	accepted, err := service.InvokeModelWithLease(
 		context.Background(),
@@ -469,15 +433,7 @@ func TestCancelInvocationReportsAlreadyCompletedForFinishedInvocation(t *testing
 			lease.String(): activeLease(scope, lease, "scoped-model", "worker-1"),
 		},
 	}
-	service := internalservice.New(
-		scopes,
-		availableInferenceAssets{},
-		catalog,
-		host,
-		&recordingInvocationRuntime{},
-		fixedClock(),
-		nil,
-	)
+	service := newInferenceServiceWithHost(t, scopes, catalog, host, &recordingInvocationRuntime{}, fixedClock(), nil)
 
 	result, err := service.InvokeModelWithLease(
 		context.Background(),
@@ -510,15 +466,7 @@ func TestInvokeContextCancellationConvergesWithExplicitCancel(t *testing.T) {
 			lease.String(): activeLease(scope, lease, "scoped-model", "worker-1"),
 		},
 	}
-	service := internalservice.New(
-		scopes,
-		availableInferenceAssets{},
-		catalog,
-		host,
-		&deadlineInvocationRuntime{},
-		fixedClock(),
-		nil,
-	)
+	service := newInferenceServiceWithHost(t, scopes, catalog, host, &deadlineInvocationRuntime{}, fixedClock(), nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -544,9 +492,9 @@ func TestCancelInvocationRejectsUnknownInvocation(t *testing.T) {
 
 	scopes, scope := openInferenceScope(t, "invoke-cancel-unknown", "scoped-model", "generate")
 	catalog := mustCatalog(t, scopes)
-	service := internalservice.New(
+	service := newInferenceServiceWithHost(
+		t,
 		scopes,
-		availableInferenceAssets{},
 		catalog,
 		&recordingInferenceHost{},
 		&recordingInvocationRuntime{},
@@ -581,15 +529,55 @@ func newInferenceService(
 			},
 		}
 	}
-	return internalservice.New(
+	return newInferenceServiceWithHost(
+		t,
 		scopes,
-		availableInferenceAssets{},
 		mustCatalog(t, scopes),
 		host,
 		&recordingInvocationRuntime{},
 		fixedClock(),
 		nil,
 	)
+}
+
+func newInferenceServiceWithHost(
+	t *testing.T,
+	scopes runtimescopes.Service,
+	catalog modelcatalog.Service,
+	host runtimehost.Service,
+	runtime inference.InvocationRuntime,
+	clock func() time.Time,
+	assets scopedassets.Service,
+	deadline ...func() time.Duration,
+) inference.Service {
+	t.Helper()
+	if assets == nil {
+		assets = availableInferenceAssets{}
+	}
+	var executionDeadline func() time.Duration
+	if len(deadline) > 0 {
+		executionDeadline = deadline[0]
+	}
+	registrar := mustTestArtifactRegistrar(t)
+	return internalservice.New(
+		scopes,
+		assets,
+		catalog,
+		host,
+		runtime,
+		registrar,
+		clock,
+		executionDeadline,
+	)
+}
+
+func mustTestArtifactRegistrar(t *testing.T) *inferenceartifacts.Registrar {
+	t.Helper()
+	registrar, err := inferenceartifacts.NewRegistrar(&memoryArtifactFilesystem{files: map[string]string{}})
+	if err != nil {
+		t.Fatalf("construct artifact registrar: %v", err)
+	}
+	return registrar
 }
 
 func openInferenceScope(
@@ -694,69 +682,119 @@ func mustLeaseRef(t *testing.T, value string) models.ModelLeaseRef {
 }
 
 type recordingInvocationRuntime struct {
-	invokeCalls int
-	content     []models.InferenceContent
-	invokeErr   error
+	invokeCalls      int
+	reusedHostSlots  int
+	content          []models.InferenceContent
+	artifactSources  []inference.InvocationArtifactSource
+	invokeErr        error
 }
 
 func (runtime *recordingInvocationRuntime) Invoke(
 	_ context.Context,
-	request models.InvokeModelRequest,
-) ([]models.InferenceContent, error) {
+	request inference.InvocationRuntimeRequest,
+) (inference.InvocationRuntimeResult, error) {
 	runtime.invokeCalls++
+	if request.HostSlot.Reused {
+		runtime.reusedHostSlots++
+	}
 	if runtime.invokeErr != nil {
-		return nil, runtime.invokeErr
+		return inference.InvocationRuntimeResult{}, runtime.invokeErr
 	}
+	result := inference.InvocationRuntimeResult{}
 	if runtime.content != nil {
-		return append([]models.InferenceContent(nil), runtime.content...), nil
+		result.Content = append([]models.InferenceContent(nil), runtime.content...)
 	}
-	return []models.InferenceContent{{
-		ContentType: request.Input.ContentType,
-		Content:     request.Input.Content,
-	}}, nil
+	if runtime.artifactSources != nil {
+		result.Artifacts = append([]inference.InvocationArtifactSource(nil), runtime.artifactSources...)
+	} else if len(result.Content) == 0 {
+		result.Content = []models.InferenceContent{{
+			ContentType: request.Request.Input.ContentType,
+			Content:     request.Request.Input.Content,
+		}}
+	}
+	return result, nil
 }
 
 type holdInvocationRuntime struct{}
 
 func (holdInvocationRuntime) Invoke(
 	context.Context,
-	models.InvokeModelRequest,
-) ([]models.InferenceContent, error) {
-	return nil, inference.ErrInvocationInFlight
+	inference.InvocationRuntimeRequest,
+) (inference.InvocationRuntimeResult, error) {
+	return inference.InvocationRuntimeResult{}, inference.ErrInvocationInFlight
 }
 
 type deadlineInvocationRuntime struct{}
 
-func (deadlineInvocationRuntime) Invoke(ctx context.Context, _ models.InvokeModelRequest) ([]models.InferenceContent, error) {
+func (deadlineInvocationRuntime) Invoke(
+	ctx context.Context,
+	_ inference.InvocationRuntimeRequest,
+) (inference.InvocationRuntimeResult, error) {
 	<-ctx.Done()
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return nil, models.ErrInferenceTimeout
+		return inference.InvocationRuntimeResult{}, models.ErrInferenceTimeout
 	}
 	if errors.Is(ctx.Err(), context.Canceled) {
-		return nil, fmt.Errorf("%w: %v", models.ErrInferenceCancelled, ctx.Err())
+		return inference.InvocationRuntimeResult{}, fmt.Errorf("%w: %v", models.ErrInferenceCancelled, ctx.Err())
 	}
-	return nil, ctx.Err()
+	return inference.InvocationRuntimeResult{}, ctx.Err()
 }
 
 type recordingInferenceHost struct {
 	leases       map[string]models.ModelLease
+	warmHosts    map[string]bool
+	ensureCalls  int
 	releaseCalls int
 }
 
 var _ runtimehost.Service = (*recordingInferenceHost)(nil)
 
+func (host *recordingInferenceHost) hostKey(scope models.RuntimeScopeRef, modelName string) string {
+	return scope.String() + ":" + modelName
+}
+
 func (host *recordingInferenceHost) InspectModelHost(
-	context.Context,
-	models.InspectModelHostRequest,
+	_ context.Context,
+	request models.InspectModelHostRequest,
 ) (models.InspectModelHostResult, error) {
-	return models.InspectModelHostResult{}, models.ErrUnsupportedOperation
+	if host.warmHosts == nil {
+		host.warmHosts = make(map[string]bool)
+	}
+	if host.warmHosts[host.hostKey(request.Scope, request.Name)] {
+		return models.InspectModelHostResult{
+			Host: models.ModelHostSnapshot{
+				Scope:          request.Scope,
+				ModelName:      request.Name,
+				ReadinessState: models.ReadinessStateReady,
+			},
+		}, nil
+	}
+	return models.InspectModelHostResult{}, models.ErrHostRuntimeNotReady
 }
 
 func (host *recordingInferenceHost) EnsureModelHost(
-	context.Context,
-	models.EnsureModelHostRequest,
+	_ context.Context,
+	request models.EnsureModelHostRequest,
 ) (models.EnsureModelHostResult, error) {
-	return models.EnsureModelHostResult{}, models.ErrUnsupportedOperation
+	if host.warmHosts == nil {
+		host.warmHosts = make(map[string]bool)
+	}
+	key := host.hostKey(request.Scope, request.Name)
+	outcome := models.HostEnsureBecameReady
+	if host.warmHosts[key] {
+		outcome = models.HostEnsureAlreadyReady
+	} else {
+		host.ensureCalls++
+		host.warmHosts[key] = true
+	}
+	return models.EnsureModelHostResult{
+		Host: models.ModelHostSnapshot{
+			Scope:          request.Scope,
+			ModelName:      request.Name,
+			ReadinessState: models.ReadinessStateReady,
+		},
+		Outcome: outcome,
+	}, nil
 }
 
 func (host *recordingInferenceHost) StopModelHost(
@@ -880,16 +918,174 @@ func (assets *recordingInferenceAssets) InspectRuntimeCache(
 func TestInputEchoInvocationRuntimeReturnsDetachedContent(t *testing.T) {
 	t.Parallel()
 
-	content, err := inference.InputEchoInvocationRuntime{}.Invoke(
+	result, err := inference.InputEchoInvocationRuntime{}.Invoke(
 		context.Background(),
-		models.InvokeModelRequest{
-			Input: models.InferenceInput{ContentType: "text/plain", Content: "hello"},
+		inference.InvocationRuntimeRequest{
+			Request: models.InvokeModelRequest{
+				Input: models.InferenceInput{ContentType: "text/plain", Content: "hello"},
+			},
 		},
 	)
 	if err != nil {
 		t.Fatalf("Invoke: %v", err)
 	}
-	if len(content) != 1 || content[0].Content != "hello" {
-		t.Fatalf("content = %#v, want echoed input", content)
+	if len(result.Content) != 1 || result.Content[0].Content != "hello" {
+		t.Fatalf("content = %#v, want echoed input", result.Content)
 	}
+}
+
+func TestInvokeModelWithLeaseReusesWarmHostSlotForConsecutiveInvokes(t *testing.T) {
+	t.Parallel()
+
+	scopes, scope := openInferenceScope(t, "invoke-handle-reuse", "scoped-model", "generate")
+	catalog := mustCatalog(t, scopes)
+	lease := mustLeaseRef(t, "lease-1")
+	leaseTwo := mustLeaseRef(t, "lease-2")
+	host := &recordingInferenceHost{
+		leases: map[string]models.ModelLease{
+			lease.String():   activeLease(scope, lease, "scoped-model", "worker-1"),
+			leaseTwo.String(): activeLease(scope, leaseTwo, "scoped-model", "worker-1"),
+		},
+		warmHosts: make(map[string]bool),
+	}
+	runtime := &recordingInvocationRuntime{}
+	service := newInferenceServiceWithHost(t, scopes, catalog, host, runtime, fixedClock(), nil)
+
+	_, err := service.InvokeModelWithLease(
+		context.Background(),
+		invokeRequest(scope, lease, "worker-1", "scoped-model", "generate"),
+	)
+	if err != nil {
+		t.Fatalf("first invoke: %v", err)
+	}
+	_, err = service.InvokeModelWithLease(
+		context.Background(),
+		invokeRequest(scope, leaseTwo, "worker-1", "scoped-model", "generate"),
+	)
+	if err != nil {
+		t.Fatalf("second invoke: %v", err)
+	}
+	if host.ensureCalls != 1 {
+		t.Fatalf("ensure calls = %d, want 1 shared host slot", host.ensureCalls)
+	}
+	if runtime.reusedHostSlots != 1 {
+		t.Fatalf("reused host slots = %d, want 1", runtime.reusedHostSlots)
+	}
+}
+
+func TestInvokeModelWithLeaseReturnsDetachedArtifactMetadata(t *testing.T) {
+	t.Parallel()
+
+	scopes, scope := openInferenceScope(t, "invoke-artifact", "scoped-model", "generate")
+	catalog := mustCatalog(t, scopes)
+	lease := mustLeaseRef(t, "lease-1")
+	host := &recordingInferenceHost{
+		leases: map[string]models.ModelLease{
+			lease.String(): activeLease(scope, lease, "scoped-model", "worker-1"),
+		},
+		warmHosts: make(map[string]bool),
+	}
+	runtime := &recordingInvocationRuntime{
+		artifactSources: []inference.InvocationArtifactSource{{
+			RefValue:   "models-inference:artifact:detached",
+			SourcePath: "runtime/output.txt",
+			Name:       "result.txt",
+			MediaType:  "text/plain",
+			SizeBytes:  19,
+			Properties: map[string]string{"digest": "sha256:detached"},
+		}},
+	}
+	service := newInferenceServiceWithHost(t, scopes, catalog, host, runtime, fixedClock(), nil)
+
+	result, err := service.InvokeModelWithLease(
+		context.Background(),
+		invokeRequest(scope, lease, "worker-1", "scoped-model", "generate"),
+	)
+	if err != nil {
+		t.Fatalf("InvokeModelWithLease: %v", err)
+	}
+	if len(result.Artifacts) != 1 || result.Artifacts[0].Artifact.IsZero() {
+		t.Fatalf("artifacts = %#v, want detached opaque artifact", result.Artifacts)
+	}
+	if result.Artifacts[0].Name != "result.txt" ||
+		result.Artifacts[0].Properties["digest"] != "sha256:detached" {
+		t.Fatalf("artifact metadata = %#v, want detached facts", result.Artifacts[0])
+	}
+	cloned := result.Clone()
+	cloned.Artifacts[0].Properties["digest"] = "peer-mutated"
+	if result.Artifacts[0].Properties["digest"] != "sha256:detached" {
+		t.Fatalf("artifact metadata retained peer mutation: %#v", result.Artifacts)
+	}
+}
+
+func TestInvokeModelWithLeaseRejectsInvalidArtifactReference(t *testing.T) {
+	t.Parallel()
+
+	scopes, scope := openInferenceScope(t, "invoke-artifact-invalid", "scoped-model", "generate")
+	catalog := mustCatalog(t, scopes)
+	lease := mustLeaseRef(t, "lease-1")
+	host := &recordingInferenceHost{
+		leases: map[string]models.ModelLease{
+			lease.String(): activeLease(scope, lease, "scoped-model", "worker-1"),
+		},
+		warmHosts: make(map[string]bool),
+	}
+	runtime := &recordingInvocationRuntime{
+		artifactSources: []inference.InvocationArtifactSource{{
+			RefValue: "   ",
+			Name:     "result.txt",
+		}},
+	}
+	service := newInferenceServiceWithHost(t, scopes, catalog, host, runtime, fixedClock(), nil)
+
+	result, err := service.InvokeModelWithLease(
+		context.Background(),
+		invokeRequest(scope, lease, "worker-1", "scoped-model", "generate"),
+	)
+	if !errors.Is(err, models.ErrInferenceArtifactInvalid) {
+		t.Fatalf("invalid artifact = %v, want ErrInferenceArtifactInvalid", err)
+	}
+	for _, other := range []error{
+		models.ErrInferenceTimeout,
+		models.ErrInferenceCancelled,
+		models.ErrAssetUnavailable,
+	} {
+		if errors.Is(err, other) {
+			t.Fatalf("invalid artifact must stay distinct from %v: %v", other, err)
+		}
+	}
+	if result.Status != models.ModelInvocationStatusFailed {
+		t.Fatalf("result status = %q, want FAILED", result.Status)
+	}
+}
+
+type memoryArtifactFilesystem struct {
+	files map[string]string
+}
+
+func (fs *memoryArtifactFilesystem) Open(path string) (io.ReadCloser, error) {
+	content, ok := fs.files[path]
+	if !ok {
+		return nil, fmt.Errorf("open %q: not found", path)
+	}
+	return io.NopCloser(strings.NewReader(content)), nil
+}
+
+func (fs *memoryArtifactFilesystem) Create(path string) (io.WriteCloser, error) {
+	return &memoryArtifactWriter{fs: fs, path: path}, nil
+}
+
+type memoryArtifactWriter struct {
+	fs   *memoryArtifactFilesystem
+	path string
+	buf  strings.Builder
+}
+
+func (w *memoryArtifactWriter) Write(p []byte) (int, error) {
+	return w.buf.Write(p)
+}
+
+func (w *memoryArtifactWriter) Close() error {
+	w.fs.files[w.path] = w.buf.String()
+	return nil
 }

--- a/pkg/services/models/internal/services/inference/runtime_contract.go
+++ b/pkg/services/models/internal/services/inference/runtime_contract.go
@@ -1,0 +1,38 @@
+package inference
+
+import (
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+// HostHandleSlot carries parent-private host-slot facts for one scoped invoke.
+// It does not expose supervisor handles, endpoints, processes, or filesystem
+// paths to peers.
+type HostHandleSlot struct {
+	Reused bool
+}
+
+// InvocationArtifactSource is runtime-owned artifact materialization input kept
+// inside Inference. SourcePath is for internal export only and never crosses
+// the peer boundary.
+type InvocationArtifactSource struct {
+	RefValue   string
+	SourcePath string
+	Name       string
+	MediaType  string
+	SizeBytes  int64
+	Properties map[string]string
+}
+
+// InvocationRuntimeRequest is the parent-private invoke input for one accepted
+// lease-backed operation.
+type InvocationRuntimeRequest struct {
+	Request  models.InvokeModelRequest
+	HostSlot HostHandleSlot
+}
+
+// InvocationRuntimeResult contains detached runtime output facts without
+// exposing private handles, endpoints, processes, or filesystem paths.
+type InvocationRuntimeResult struct {
+	Content   []models.InferenceContent
+	Artifacts []InvocationArtifactSource
+}

--- a/pkg/services/models/internal/services/inference/runtime_sentinel.go
+++ b/pkg/services/models/internal/services/inference/runtime_sentinel.go
@@ -1,0 +1,8 @@
+package inference
+
+import "errors"
+
+// ErrInvocationInFlight reports that an invocation runtime accepted work without
+// completing it. Inference retains lease capacity until explicit cancel or context
+// cancellation converges the outcome.
+var ErrInvocationInFlight = errors.New("model invocation in flight")

--- a/pkg/services/models/internal/services/inference/service.go
+++ b/pkg/services/models/internal/services/inference/service.go
@@ -1,0 +1,22 @@
+// Package inference defines the parent-private Models inference service.
+package inference
+
+import (
+	"context"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+// Service owns scoped invoke and cancellation behind the singular Models root.
+// Peers reach lease-backed invocation only through the process-scoped Models
+// service; this interface stays parent-private.
+type Service interface {
+	InvokeModelWithLease(
+		context.Context,
+		models.InvokeModelRequest,
+	) (models.InvokeModelResult, error)
+	CancelInvocation(
+		context.Context,
+		models.CancelInvocationRequest,
+	) (models.CancelInvocationResult, error)
+}

--- a/pkg/services/models/internal/services/inference/service.go
+++ b/pkg/services/models/internal/services/inference/service.go
@@ -8,10 +8,11 @@ import (
 )
 
 // InvocationRuntime executes one validated scoped model operation under accepted
-// lease capacity. Implementations must return detached content facts without
-// exposing runtime handles, endpoints, processes, or filesystem paths.
+// lease capacity. Implementations must return detached content and artifact
+// source facts without exposing runtime handles, endpoints, processes, or
+// filesystem paths to peers.
 type InvocationRuntime interface {
-	Invoke(context.Context, models.InvokeModelRequest) ([]models.InferenceContent, error)
+	Invoke(context.Context, InvocationRuntimeRequest) (InvocationRuntimeResult, error)
 }
 
 // Service owns scoped invoke and cancellation behind the singular Models root.

--- a/pkg/services/models/internal/services/inference/service.go
+++ b/pkg/services/models/internal/services/inference/service.go
@@ -7,6 +7,13 @@ import (
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 )
 
+// InvocationRuntime executes one validated scoped model operation under accepted
+// lease capacity. Implementations must return detached content facts without
+// exposing runtime handles, endpoints, processes, or filesystem paths.
+type InvocationRuntime interface {
+	Invoke(context.Context, models.InvokeModelRequest) ([]models.InferenceContent, error)
+}
+
 // Service owns scoped invoke and cancellation behind the singular Models root.
 // Peers reach lease-backed invocation only through the process-scoped Models
 // service; this interface stays parent-private.

--- a/pkg/services/models/internal/services/inference/wire/wire.go
+++ b/pkg/services/models/internal/services/inference/wire/wire.go
@@ -10,6 +10,7 @@ import (
 	modelcatalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
 	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
 	inference "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference"
+	inferenceartifacts "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/internal/artifacts"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/internal/service"
 	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
 	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
@@ -24,6 +25,7 @@ func NewService(
 	catalog modelcatalog.Service,
 	runtimeHost runtimehost.Service,
 	invocationRuntime inference.InvocationRuntime,
+	fileSystem models.InvocationArtifactFileSystem,
 	clock func() time.Time,
 ) (inference.Service, error) {
 	if scopes == nil {
@@ -62,12 +64,17 @@ func NewService(
 			models.ErrInvalidInferenceDependencies,
 		)
 	}
+	artifactRegistrar, err := inferenceartifacts.NewRegistrar(fileSystem)
+	if err != nil {
+		return nil, err
+	}
 	return internalservice.New(
 		scopes,
 		assets,
 		catalog,
 		runtimeHost,
 		invocationRuntime,
+		artifactRegistrar,
 		clock,
 		nil,
 	), nil

--- a/pkg/services/models/internal/services/inference/wire/wire.go
+++ b/pkg/services/models/internal/services/inference/wire/wire.go
@@ -8,6 +8,7 @@ import (
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 	modelcatalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
+	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
 	inference "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/internal/service"
 	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
@@ -19,6 +20,7 @@ import (
 // and allocates inference state only; it does not launch subprocesses.
 func NewService(
 	scopes runtimescopes.Service,
+	assets scopedassets.Service,
 	catalog modelcatalog.Service,
 	runtimeHost runtimehost.Service,
 	invocationRuntime inference.InvocationRuntime,
@@ -27,6 +29,12 @@ func NewService(
 	if scopes == nil {
 		return nil, fmt.Errorf(
 			"%w: Models Runtime Scopes service is required",
+			models.ErrInvalidInferenceDependencies,
+		)
+	}
+	if isNilDependency(assets) {
+		return nil, fmt.Errorf(
+			"%w: Models Assets service is required",
 			models.ErrInvalidInferenceDependencies,
 		)
 	}
@@ -54,7 +62,7 @@ func NewService(
 			models.ErrInvalidInferenceDependencies,
 		)
 	}
-	return internalservice.New(scopes, catalog, runtimeHost, invocationRuntime, clock), nil
+	return internalservice.New(scopes, assets, catalog, runtimeHost, invocationRuntime, clock), nil
 }
 
 func isNilDependency(value any) bool {

--- a/pkg/services/models/internal/services/inference/wire/wire.go
+++ b/pkg/services/models/internal/services/inference/wire/wire.go
@@ -1,0 +1,64 @@
+// Package wire constructs the private Models Inference subservice.
+package wire
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	modelcatalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
+	inference "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/internal/service"
+	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+)
+
+// NewService constructs an inert Inference owner over accepted runtime-scope,
+// catalog, and runtime-host contracts. Construction validates injected effects
+// and allocates inference state only; it does not launch subprocesses.
+func NewService(
+	scopes runtimescopes.Service,
+	catalog modelcatalog.Service,
+	runtimeHost runtimehost.Service,
+	clock func() time.Time,
+) (inference.Service, error) {
+	if scopes == nil {
+		return nil, fmt.Errorf(
+			"%w: Models Runtime Scopes service is required",
+			models.ErrInvalidInferenceDependencies,
+		)
+	}
+	if isNilDependency(catalog) {
+		return nil, fmt.Errorf(
+			"%w: Models Catalog service is required",
+			models.ErrInvalidInferenceDependencies,
+		)
+	}
+	if isNilDependency(runtimeHost) {
+		return nil, fmt.Errorf(
+			"%w: Models Runtime Host service is required",
+			models.ErrInvalidInferenceDependencies,
+		)
+	}
+	if clock == nil {
+		return nil, fmt.Errorf(
+			"%w: Models Inference clock is required",
+			models.ErrInvalidInferenceDependencies,
+		)
+	}
+	return internalservice.New(scopes, catalog, runtimeHost, clock), nil
+}
+
+func isNilDependency(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/pkg/services/models/internal/services/inference/wire/wire.go
+++ b/pkg/services/models/internal/services/inference/wire/wire.go
@@ -21,6 +21,7 @@ func NewService(
 	scopes runtimescopes.Service,
 	catalog modelcatalog.Service,
 	runtimeHost runtimehost.Service,
+	invocationRuntime inference.InvocationRuntime,
 	clock func() time.Time,
 ) (inference.Service, error) {
 	if scopes == nil {
@@ -41,13 +42,19 @@ func NewService(
 			models.ErrInvalidInferenceDependencies,
 		)
 	}
+	if isNilDependency(invocationRuntime) {
+		return nil, fmt.Errorf(
+			"%w: Models Inference invocation runtime is required",
+			models.ErrInvalidInferenceDependencies,
+		)
+	}
 	if clock == nil {
 		return nil, fmt.Errorf(
 			"%w: Models Inference clock is required",
 			models.ErrInvalidInferenceDependencies,
 		)
 	}
-	return internalservice.New(scopes, catalog, runtimeHost, clock), nil
+	return internalservice.New(scopes, catalog, runtimeHost, invocationRuntime, clock), nil
 }
 
 func isNilDependency(value any) bool {

--- a/pkg/services/models/internal/services/inference/wire/wire.go
+++ b/pkg/services/models/internal/services/inference/wire/wire.go
@@ -62,7 +62,15 @@ func NewService(
 			models.ErrInvalidInferenceDependencies,
 		)
 	}
-	return internalservice.New(scopes, assets, catalog, runtimeHost, invocationRuntime, clock), nil
+	return internalservice.New(
+		scopes,
+		assets,
+		catalog,
+		runtimeHost,
+		invocationRuntime,
+		clock,
+		nil,
+	), nil
 }
 
 func isNilDependency(value any) bool {

--- a/pkg/services/models/internal/services/inference/wire/wire_test.go
+++ b/pkg/services/models/internal/services/inference/wire/wire_test.go
@@ -23,12 +23,14 @@ func TestNewServiceRequiresInferenceDependencies(t *testing.T) {
 
 	scopes := testRuntimeScopes(t)
 	catalog := testCatalogService(t, scopes)
+	assets := recordingAssetsService{}
 	runtimeHost := testRuntimeHostService()
 	clock := testInferenceClock{}
 
 	tests := []struct {
 		name            string
 		scopes          runtimescopes.Service
+		assets          scopedassets.Service
 		catalog         modelcatalog.Service
 		runtimeHost     runtimehost.Service
 		invocationRuntime inference.InvocationRuntime
@@ -37,31 +39,36 @@ func TestNewServiceRequiresInferenceDependencies(t *testing.T) {
 		wantInvalidDeps bool
 	}{
 		{
-			name: "valid", scopes: scopes, catalog: catalog,
+			name: "valid", scopes: scopes, assets: assets, catalog: catalog,
 			runtimeHost: runtimeHost, invocationRuntime: inference.InputEchoInvocationRuntime{},
 			clock: clock.Now,
 		},
 		{
-			name: "scopes", catalog: catalog, runtimeHost: runtimeHost,
+			name: "scopes", assets: assets, catalog: catalog, runtimeHost: runtimeHost,
 			invocationRuntime: inference.InputEchoInvocationRuntime{}, clock: clock.Now,
 			wantContains: "Runtime Scopes", wantInvalidDeps: true,
 		},
 		{
-			name: "catalog", scopes: scopes, runtimeHost: runtimeHost,
+			name: "assets", scopes: scopes, catalog: catalog, runtimeHost: runtimeHost,
+			invocationRuntime: inference.InputEchoInvocationRuntime{}, clock: clock.Now,
+			wantContains: "Assets", wantInvalidDeps: true,
+		},
+		{
+			name: "catalog", scopes: scopes, assets: assets, runtimeHost: runtimeHost,
 			invocationRuntime: inference.InputEchoInvocationRuntime{}, clock: clock.Now,
 			wantContains: "Catalog", wantInvalidDeps: true,
 		},
 		{
-			name: "runtime host", scopes: scopes, catalog: catalog,
+			name: "runtime host", scopes: scopes, assets: assets, catalog: catalog,
 			invocationRuntime: inference.InputEchoInvocationRuntime{}, clock: clock.Now,
 			wantContains: "Runtime Host", wantInvalidDeps: true,
 		},
 		{
-			name: "invocation runtime", scopes: scopes, catalog: catalog, runtimeHost: runtimeHost,
+			name: "invocation runtime", scopes: scopes, assets: assets, catalog: catalog, runtimeHost: runtimeHost,
 			clock: clock.Now, wantContains: "invocation runtime", wantInvalidDeps: true,
 		},
 		{
-			name: "clock", scopes: scopes, catalog: catalog, runtimeHost: runtimeHost,
+			name: "clock", scopes: scopes, assets: assets, catalog: catalog, runtimeHost: runtimeHost,
 			invocationRuntime: inference.InputEchoInvocationRuntime{},
 			wantContains: "clock", wantInvalidDeps: true,
 		},
@@ -70,6 +77,7 @@ func TestNewServiceRequiresInferenceDependencies(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			service, err := inferencewire.NewService(
 				test.scopes,
+				test.assets,
 				test.catalog,
 				test.runtimeHost,
 				test.invocationRuntime,

--- a/pkg/services/models/internal/services/inference/wire/wire_test.go
+++ b/pkg/services/models/internal/services/inference/wire/wire_test.go
@@ -1,0 +1,202 @@
+package wire_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
+	modelcatalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
+	catalogwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire"
+	inferencewire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/wire"
+	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
+)
+
+func TestNewServiceRequiresInferenceDependencies(t *testing.T) {
+	t.Parallel()
+
+	scopes := testRuntimeScopes(t)
+	catalog := testCatalogService(t, scopes)
+	runtimeHost := testRuntimeHostService()
+	clock := testInferenceClock{}
+
+	tests := []struct {
+		name            string
+		scopes          runtimescopes.Service
+		catalog         modelcatalog.Service
+		runtimeHost     runtimehost.Service
+		clock           func() time.Time
+		wantContains    string
+		wantInvalidDeps bool
+	}{
+		{
+			name: "valid", scopes: scopes, catalog: catalog,
+			runtimeHost: runtimeHost, clock: clock.Now,
+		},
+		{
+			name: "scopes", catalog: catalog, runtimeHost: runtimeHost, clock: clock.Now,
+			wantContains: "Runtime Scopes", wantInvalidDeps: true,
+		},
+		{
+			name: "catalog", scopes: scopes, runtimeHost: runtimeHost, clock: clock.Now,
+			wantContains: "Catalog", wantInvalidDeps: true,
+		},
+		{
+			name: "runtime host", scopes: scopes, catalog: catalog, clock: clock.Now,
+			wantContains: "Runtime Host", wantInvalidDeps: true,
+		},
+		{
+			name: "clock", scopes: scopes, catalog: catalog, runtimeHost: runtimeHost,
+			wantContains: "clock", wantInvalidDeps: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service, err := inferencewire.NewService(
+				test.scopes,
+				test.catalog,
+				test.runtimeHost,
+				test.clock,
+			)
+			if test.wantInvalidDeps {
+				if service != nil || err == nil {
+					t.Fatalf("NewService = (%#v, %v), want dependency error", service, err)
+				}
+				if !errors.Is(err, models.ErrInvalidInferenceDependencies) {
+					t.Fatalf("error = %v, want ErrInvalidInferenceDependencies", err)
+				}
+				if test.wantContains != "" && !strings.Contains(err.Error(), test.wantContains) {
+					t.Fatalf("error = %q, want substring %q", err.Error(), test.wantContains)
+				}
+				if clock.timerCalls != 0 {
+					t.Fatalf("timer calls during validation = %d, want 0", clock.timerCalls)
+				}
+				return
+			}
+			if service == nil || err != nil {
+				t.Fatalf("NewService = (%#v, %v), want service", service, err)
+			}
+			if clock.timerCalls != 0 {
+				t.Fatalf("timer calls during construction = %d, want 0", clock.timerCalls)
+			}
+		})
+	}
+}
+
+func testRuntimeScopes(t *testing.T) runtimescopes.Service {
+	t.Helper()
+	scopes, err := runtimescopeswire.NewService(func() string { return "inference-wire-test" })
+	if err != nil {
+		t.Fatalf("construct runtime scopes: %v", err)
+	}
+	return scopes
+}
+
+func testCatalogService(t *testing.T, scopes runtimescopes.Service) modelcatalog.Service {
+	t.Helper()
+	service, err := catalogwire.NewService(scopes)
+	if err != nil {
+		t.Fatalf("construct catalog: %v", err)
+	}
+	return service
+}
+
+func testRuntimeHostService() runtimehost.Service {
+	return recordingRuntimeHostService{}
+}
+
+type testInferenceClock struct {
+	timerCalls int
+}
+
+func (clock *testInferenceClock) Now() time.Time {
+	return time.Unix(0, 0)
+}
+
+func (clock *testInferenceClock) NewTimer(time.Duration) models.HostTimer {
+	clock.timerCalls++
+	panic("host timer created during inert inference construction")
+}
+
+type recordingRuntimeHostService struct{}
+
+var _ runtimehost.Service = recordingRuntimeHostService{}
+
+func (recordingRuntimeHostService) InspectModelHost(
+	context.Context,
+	models.InspectModelHostRequest,
+) (models.InspectModelHostResult, error) {
+	return models.InspectModelHostResult{}, models.ErrUnsupportedOperation
+}
+
+func (recordingRuntimeHostService) EnsureModelHost(
+	context.Context,
+	models.EnsureModelHostRequest,
+) (models.EnsureModelHostResult, error) {
+	return models.EnsureModelHostResult{}, models.ErrUnsupportedOperation
+}
+
+func (recordingRuntimeHostService) StopModelHost(
+	context.Context,
+	models.StopModelHostRequest,
+) (models.StopModelHostResult, error) {
+	return models.StopModelHostResult{}, models.ErrUnsupportedOperation
+}
+
+func (recordingRuntimeHostService) AcquireModelLease(
+	context.Context,
+	models.AcquireModelLeaseRequest,
+) (models.AcquireModelLeaseResult, error) {
+	return models.AcquireModelLeaseResult{}, models.ErrUnsupportedOperation
+}
+
+func (recordingRuntimeHostService) GetModelLease(
+	context.Context,
+	models.GetModelLeaseRequest,
+) (models.GetModelLeaseResult, error) {
+	return models.GetModelLeaseResult{}, models.ErrUnsupportedOperation
+}
+
+func (recordingRuntimeHostService) ReleaseModelLease(
+	context.Context,
+	models.ReleaseModelLeaseRequest,
+) (models.ReleaseModelLeaseResult, error) {
+	return models.ReleaseModelLeaseResult{}, models.ErrUnsupportedOperation
+}
+
+type recordingAssetsService struct{}
+
+var _ scopedassets.Service = recordingAssetsService{}
+
+func (recordingAssetsService) PrepareModelAssets(
+	context.Context,
+	models.PrepareModelAssetsRequest,
+) (models.PrepareModelAssetsResult, error) {
+	return models.PrepareModelAssetsResult{}, models.ErrUnsupportedOperation
+}
+
+func (recordingAssetsService) InspectModelAssets(
+	context.Context,
+	models.InspectModelAssetsRequest,
+) (models.InspectModelAssetsResult, error) {
+	return models.InspectModelAssetsResult{}, models.ErrUnsupportedOperation
+}
+
+func (recordingAssetsService) ResolveRuntimeCache(
+	context.Context,
+	models.InspectModelAssetsRequest,
+) (scopedassets.RuntimeCacheLayout, error) {
+	return scopedassets.RuntimeCacheLayout{}, models.ErrUnsupportedOperation
+}
+
+func (recordingAssetsService) InspectRuntimeCache(
+	context.Context,
+	models.InspectModelAssetsRequest,
+) (scopedassets.RuntimeCacheInspection, error) {
+	return scopedassets.RuntimeCacheInspection{}, models.ErrUnsupportedOperation
+}

--- a/pkg/services/models/internal/services/inference/wire/wire_test.go
+++ b/pkg/services/models/internal/services/inference/wire/wire_test.go
@@ -34,6 +34,7 @@ func TestNewServiceRequiresInferenceDependencies(t *testing.T) {
 		catalog         modelcatalog.Service
 		runtimeHost     runtimehost.Service
 		invocationRuntime inference.InvocationRuntime
+		fileSystem      models.InvocationArtifactFileSystem
 		clock           func() time.Time
 		wantContains    string
 		wantInvalidDeps bool
@@ -41,35 +42,46 @@ func TestNewServiceRequiresInferenceDependencies(t *testing.T) {
 		{
 			name: "valid", scopes: scopes, assets: assets, catalog: catalog,
 			runtimeHost: runtimeHost, invocationRuntime: inference.InputEchoInvocationRuntime{},
-			clock: clock.Now,
+			fileSystem: inference.InertArtifactFileSystem{}, clock: clock.Now,
 		},
 		{
 			name: "scopes", assets: assets, catalog: catalog, runtimeHost: runtimeHost,
-			invocationRuntime: inference.InputEchoInvocationRuntime{}, clock: clock.Now,
+			invocationRuntime: inference.InputEchoInvocationRuntime{},
+			fileSystem: inference.InertArtifactFileSystem{}, clock: clock.Now,
 			wantContains: "Runtime Scopes", wantInvalidDeps: true,
 		},
 		{
 			name: "assets", scopes: scopes, catalog: catalog, runtimeHost: runtimeHost,
-			invocationRuntime: inference.InputEchoInvocationRuntime{}, clock: clock.Now,
+			invocationRuntime: inference.InputEchoInvocationRuntime{},
+			fileSystem: inference.InertArtifactFileSystem{}, clock: clock.Now,
 			wantContains: "Assets", wantInvalidDeps: true,
 		},
 		{
 			name: "catalog", scopes: scopes, assets: assets, runtimeHost: runtimeHost,
-			invocationRuntime: inference.InputEchoInvocationRuntime{}, clock: clock.Now,
+			invocationRuntime: inference.InputEchoInvocationRuntime{},
+			fileSystem: inference.InertArtifactFileSystem{}, clock: clock.Now,
 			wantContains: "Catalog", wantInvalidDeps: true,
 		},
 		{
 			name: "runtime host", scopes: scopes, assets: assets, catalog: catalog,
-			invocationRuntime: inference.InputEchoInvocationRuntime{}, clock: clock.Now,
+			invocationRuntime: inference.InputEchoInvocationRuntime{},
+			fileSystem: inference.InertArtifactFileSystem{}, clock: clock.Now,
 			wantContains: "Runtime Host", wantInvalidDeps: true,
 		},
 		{
 			name: "invocation runtime", scopes: scopes, assets: assets, catalog: catalog, runtimeHost: runtimeHost,
-			clock: clock.Now, wantContains: "invocation runtime", wantInvalidDeps: true,
+			fileSystem: inference.InertArtifactFileSystem{}, clock: clock.Now,
+			wantContains: "invocation runtime", wantInvalidDeps: true,
+		},
+		{
+			name: "filesystem", scopes: scopes, assets: assets, catalog: catalog, runtimeHost: runtimeHost,
+			invocationRuntime: inference.InputEchoInvocationRuntime{}, clock: clock.Now,
+			wantContains: "filesystem", wantInvalidDeps: true,
 		},
 		{
 			name: "clock", scopes: scopes, assets: assets, catalog: catalog, runtimeHost: runtimeHost,
 			invocationRuntime: inference.InputEchoInvocationRuntime{},
+			fileSystem: inference.InertArtifactFileSystem{},
 			wantContains: "clock", wantInvalidDeps: true,
 		},
 	}
@@ -81,6 +93,7 @@ func TestNewServiceRequiresInferenceDependencies(t *testing.T) {
 				test.catalog,
 				test.runtimeHost,
 				test.invocationRuntime,
+				test.fileSystem,
 				test.clock,
 			)
 			if test.wantInvalidDeps {

--- a/pkg/services/models/internal/services/inference/wire/wire_test.go
+++ b/pkg/services/models/internal/services/inference/wire/wire_test.go
@@ -12,6 +12,7 @@ import (
 	modelcatalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
 	catalogwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire"
 	inferencewire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/wire"
+	inference "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference"
 	runtimehost "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host"
 	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
 	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
@@ -30,28 +31,38 @@ func TestNewServiceRequiresInferenceDependencies(t *testing.T) {
 		scopes          runtimescopes.Service
 		catalog         modelcatalog.Service
 		runtimeHost     runtimehost.Service
+		invocationRuntime inference.InvocationRuntime
 		clock           func() time.Time
 		wantContains    string
 		wantInvalidDeps bool
 	}{
 		{
 			name: "valid", scopes: scopes, catalog: catalog,
-			runtimeHost: runtimeHost, clock: clock.Now,
+			runtimeHost: runtimeHost, invocationRuntime: inference.InputEchoInvocationRuntime{},
+			clock: clock.Now,
 		},
 		{
-			name: "scopes", catalog: catalog, runtimeHost: runtimeHost, clock: clock.Now,
+			name: "scopes", catalog: catalog, runtimeHost: runtimeHost,
+			invocationRuntime: inference.InputEchoInvocationRuntime{}, clock: clock.Now,
 			wantContains: "Runtime Scopes", wantInvalidDeps: true,
 		},
 		{
-			name: "catalog", scopes: scopes, runtimeHost: runtimeHost, clock: clock.Now,
+			name: "catalog", scopes: scopes, runtimeHost: runtimeHost,
+			invocationRuntime: inference.InputEchoInvocationRuntime{}, clock: clock.Now,
 			wantContains: "Catalog", wantInvalidDeps: true,
 		},
 		{
-			name: "runtime host", scopes: scopes, catalog: catalog, clock: clock.Now,
+			name: "runtime host", scopes: scopes, catalog: catalog,
+			invocationRuntime: inference.InputEchoInvocationRuntime{}, clock: clock.Now,
 			wantContains: "Runtime Host", wantInvalidDeps: true,
 		},
 		{
+			name: "invocation runtime", scopes: scopes, catalog: catalog, runtimeHost: runtimeHost,
+			clock: clock.Now, wantContains: "invocation runtime", wantInvalidDeps: true,
+		},
+		{
 			name: "clock", scopes: scopes, catalog: catalog, runtimeHost: runtimeHost,
+			invocationRuntime: inference.InputEchoInvocationRuntime{},
 			wantContains: "clock", wantInvalidDeps: true,
 		},
 	}
@@ -61,6 +72,7 @@ func TestNewServiceRequiresInferenceDependencies(t *testing.T) {
 				test.scopes,
 				test.catalog,
 				test.runtimeHost,
+				test.invocationRuntime,
 				test.clock,
 			)
 			if test.wantInvalidDeps {

--- a/pkg/services/models/local_execution_contract.go
+++ b/pkg/services/models/local_execution_contract.go
@@ -29,6 +29,9 @@ const (
 var ErrUnsupportedResponseMode = errors.New("model invocation response mode is not supported")
 
 var (
+	// ErrInvalidInferenceDependencies classifies Models Inference construction
+	// failures.
+	ErrInvalidInferenceDependencies = errors.New("model inference dependencies are invalid")
 	// ErrInferenceCancelled reports that model inference was cancelled through
 	// its context or the explicit cancellation operation.
 	ErrInferenceCancelled = errors.New("model inference cancelled")

--- a/pkg/services/models/wire/wire.go
+++ b/pkg/services/models/wire/wire.go
@@ -127,6 +127,7 @@ func NewService(
 		catalogService,
 		runtimeHost,
 		inference.InputEchoInvocationRuntime{},
+		inference.InertArtifactFileSystem{},
 		now,
 	)
 	if err != nil {

--- a/pkg/services/models/wire/wire.go
+++ b/pkg/services/models/wire/wire.go
@@ -20,6 +20,7 @@ import (
 	catalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
 	catalogwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire"
 	inferencewire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/wire"
+	inference "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference"
 	runtimehostwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/wire"
 	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
 	"go.uber.org/zap"
@@ -124,6 +125,7 @@ func NewService(
 		runtimeScopes,
 		catalogService,
 		runtimeHost,
+		inference.InputEchoInvocationRuntime{},
 		now,
 	)
 	if err != nil {

--- a/pkg/services/models/wire/wire.go
+++ b/pkg/services/models/wire/wire.go
@@ -19,6 +19,7 @@ import (
 	assetswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets/wire"
 	catalog "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog"
 	catalogwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire"
+	inferencewire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/wire"
 	runtimehostwire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/wire"
 	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
 	"go.uber.org/zap"
@@ -119,11 +120,20 @@ func NewService(
 	if err != nil {
 		return nil, err
 	}
+	inferenceService, err := inferencewire.NewService(
+		runtimeScopes,
+		catalogService,
+		runtimeHost,
+		now,
+	)
+	if err != nil {
+		return nil, err
+	}
 	service, err := modelsservice.NewRoot(
 		launcher, hostHTTP, clock,
 		runtimeRunner, runtimeHTTP, localmodels.InspectFile(runtimeInspect),
 		localmodels.TempDirectory(runtimeTempDir), createTempFile,
-		runtimeScopes, catalogService, assetService, runtimeHost,
+		runtimeScopes, catalogService, assetService, runtimeHost, inferenceService,
 		models.ProcessDependencies{
 			Logger: logger, Clock: now, PullMetrics: pullMetrics,
 			HostLogger: hostLogger, HostMetrics: hostMetrics, LocalHooks: localHooks,

--- a/pkg/services/models/wire/wire.go
+++ b/pkg/services/models/wire/wire.go
@@ -123,6 +123,7 @@ func NewService(
 	}
 	inferenceService, err := inferencewire.NewService(
 		runtimeScopes,
+		assetService,
 		catalogService,
 		runtimeHost,
 		inference.InputEchoInvocationRuntime{},


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "pss-imp-mod-06-inference",
  "description": "Package Models inference as a parent-private owner that performs scoped invoke through an accepted host lease, with inert construction, injected effects, and deterministic timeout, unavailable-asset, handle-reuse, artifact, and normalized-failure behavior, without absorbing runtime_scopes, catalog, assets, runtime_host, or lease ownership.",
  "context": {
    "customerAsk": "Implement IMP-MOD-06 as the parent-private Models inference owner. Provide scoped invoke through an accepted host lease with deterministic timeout, unavailable-asset, handle-reuse, artifact, and normalized-failure behavior while keeping construction inert and effects injected. Do not absorb runtime_scopes, catalog, assets, runtime_host, or lease ownership. Do not edit pkg/wire, pkg/root, OpenAPI generation, or top-level CLI composition. Shared coverage, ownership, and package-target manifest edits are allowed. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Scoped model invocation still lacks a parent-private Inference owner under pkg/services/models/internal/services/inference. Root InvokeModelWithLease/CancelInvocation remain unsupported stubs or legacy local-execution paths, while invocation, handle caching, artifact export, and failure normalization stay entangled with internal/local and compatibility host seams, making timeout, unavailable-asset, handle-reuse, artifact, and normalized-failure outcomes hard to prove as one coherent invoke authority.",
    "solution": "Create the parent-private Models Inference subservice as the sole owner of scoped invoke through an accepted host lease. Keep construction inert with injected effects, return only detached invocation/content/artifact/lease-disposition facts, prove deterministic timeout/unavailable-asset/handle-reuse/artifact/normalized-failure outcomes, adapt focused Models invoke call sites, and update shared ownership/package-target/coverage manifests without absorbing runtime_scopes, catalog, assets, runtime_host, or lease ownership."
  },
  "acceptanceCriteria": [
    "AC-1: Scoped invoke and cancel are owned by models/internal/services/inference and reached by peers only through the singular process-scoped Models root composition path.",
    "AC-2: Inference construction is inert: validating and composing the inference owner allocates state and accepts injected effects without launching supervised processes, opening network listeners, or starting application lifecycle.",
    "AC-3: InvokeModelWithLease under an accepted host lease returns detached invocation identity, content, artifact metadata, status, and lease-disposition facts without exposing runtime handles, endpoints, processes, or filesystem paths to peers.",
    "AC-4: Timeout, unavailable-asset, handle-reuse, artifact, cancel, and normalized-failure outcomes behave deterministically with distinct Models-owned classifications under errors.Is.",
    "AC-5: This packet does not absorb runtime_scopes, catalog, assets, runtime_host, or lease ownership; does not edit pkg/wire, pkg/root, OpenAPI generation, or top-level CLI composition; shared coverage, ownership-inventory, and package-target manifest edits remain limited to proving the inference ownership move.",
    "AC-6: Quality gates pass: typecheck, lint, focused Models inference tests, and the required repository test suite.",
    "AC-7: The implementation/review cycle continues until required CI is terminal and passing, every blocking PR conversation comment is explicitly addressed, merge conflicts and shared coverage/ownership/package-target manifest churn are reconciled, and the PR is actually merged; opening, approving, or making the PR merge-ready is not completion."
  ],
  "userStories": [
    {
      "id": "pss-imp-mod-06-inference-001",
      "title": "Compose an inert Inference owner behind the Models root",
      "description": "As a maintainer, I want Inference ownership constructed once as a parent-private Models child so peers cannot reach invoke internals and Factory selection cannot reconstruct Models.",
      "acceptanceCriteria": [
        "The process-scoped Models root composes one parent-private Inference capability under internal/services/inference, and peer callers reach InvokeModelWithLease / CancelInvocation only through the singular Models root.",
        "Constructing Models/Inference with valid injected effects allocates inference state without launching a supervised subprocess, opening network listeners, or starting application lifecycle.",
        "Missing or invalid required inference dependencies fail synchronously at construction with the Models-owned invalid-dependencies classification and still launch no process.",
        "Constructing or selecting a Factory/runtime scope does not construct another Models service, inference owner, host, leases owner, puller, or deferred dependency bundle for invoke capacity.",
        "Focused inert-construction and composition tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-mod-06-inference-002",
      "title": "Invoke a scoped operation through an accepted host lease",
      "description": "As a Models consumer, I want to run one scoped model operation under an issued host lease so Workers and Models transports receive detached invocation results without touching host internals.",
      "acceptanceCriteria": [
        "Invoking with a live runtime scope, accepted active lease, non-empty holder, known model, and supported operation returns a non-empty opaque invocation identity, COMPLETED status on success, detached content facts, and a lease-disposition fact without exposing private handles, endpoints, processes, or filesystem paths.",
        "Invalid peer-controlled inputs fail closed using existing Models validations (ErrRuntimeScopeInvalid, ErrHostLeaseNotFound, ErrHostInvalidHolder, ErrNotFound, ErrUnsupportedModelOperation) and do not start an invocation.",
        "Invoking with an expired or unknown lease fails with the corresponding Models-owned lease classification and does not report a successful completed invocation.",
        "Focused scoped-invoke success and validation tests pass using injected host-lease and runtime effects.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-mod-06-inference-003",
      "title": "Reject unavailable assets and normalize distinct failure outcomes",
      "description": "As a runtime operator, I want unavailable assets and inference failures to surface distinct Models-owned classifications so callers can recover without guessing which fault occurred.",
      "acceptanceCriteria": [
        "When required model assets are unavailable for the scoped invoke, Inference fails with ErrAssetUnavailable (or the accepted Models asset-unavailable classification) and does not report a completed invocation.",
        "Unsupported response mode fails with ErrUnsupportedResponseMode and remains distinct from readiness and lease failures.",
        "Normalized inference failure returns ErrInferenceFailed with FAILED status and released lease disposition when the failure is terminal after acceptance; pre-acceptance failures do not invent a peer-visible completed invocation.",
        "Unavailable-asset, runtime-not-ready, capacity-exhausted, lease-expired, unsupported-operation, timeout, and normalized-failure outcomes remain distinct under errors.Is.",
        "Focused unavailable-asset and normalized-failure tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-mod-06-inference-004",
      "title": "Enforce deterministic timeout and cancellation with lease disposition",
      "description": "As a Models consumer, I want timed-out and cancelled invokes to free or report capacity deterministically so holders cannot strand runtime slots after abandoned work.",
      "acceptanceCriteria": [
        "When inference exceeds the Models-owned execution deadline (via injected clock/deadline effects), the outcome is ErrInferenceTimeout with failed/cancelled status and a released or expired lease disposition consistent with the accepted root contract.",
        "Explicit CancelInvocation for an accepted in-flight invocation returns CANCELLED status, CANCELLED cancellation outcome, and released-capacity disposition; repeated cancel returns ALREADY_CANCELLED; late cancel after completion returns ALREADY_COMPLETED.",
        "Context cancellation during invoke converges on the same cancelled status, cancellation outcome, and lease-disposition facts as explicit cancel (ErrInferenceCancelled).",
        "Unknown invocation cancel fails with ErrInvocationNotFound and does not mutate unrelated invocations or leases.",
        "Focused timeout and cancel tests pass using injected clock/context effects.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-mod-06-inference-005",
      "title": "Reuse host handles and surface detached artifact facts",
      "description": "As a Models consumer, I want repeated invokes under a ready host to reuse the supervised handle and return detached artifact metadata so capacity and outputs stay coherent without peer-visible filesystem leakage.",
      "acceptanceCriteria": [
        "Consecutive successful invokes for the same ready model under accepted lease capacity reuse one Runtime Host handle/slot path rather than forcing a fresh supervised launch for each invoke while the host remains ready.",
        "Successful invoke results may include detached InferenceArtifact metadata without exposing private filesystem paths or exporter internals to peers.",
        "Invalid or malformed opaque artifact references fail with ErrInferenceArtifactInvalid and remain distinct from timeout, cancel, and unavailable-asset classifications.",
        "Artifact export remains an Inference-internal module over an injected filesystem port; it has no independent public lifecycle or peer-facing service interface.",
        "Focused handle-reuse and artifact tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-imp-mod-06-inference-006",
      "title": "Cut over focused invoke call sites and prove package ownership through merge",
      "description": "As a maintainer, I want focused Models invoke call sites and package-boundary gates aligned to the Inference owner, then delivered through actual PR merge.",
      "acceptanceCriteria": [
        "Focused Models scoped-invoke-through-host-lease call sites delegate to the parent-private Inference owner; superseded stub/legacy invoke paths for that behavior are removed or reduced to zero callers after behavioral parity is proven.",
        "Package-boundary, ownership-inventory, and package-target-manifest verification gates record models/inference under pkg/services/models/internal/services/inference and pass for the moved ownership.",
        "This story does not absorb runtime_scopes, catalog, assets, runtime_host, or lease ownership; does not edit pkg/wire, pkg/root, OpenAPI generation, or top-level CLI composition; shared coverage/ownership/package-target edits stay limited to this packet.",
        "Required CI is terminal and passing, every blocking PR conversation comment is explicitly addressed, merge conflicts and shared-file churn are reconciled, and the PR is actually merged.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": false,
      "notes": ""
    }
  ]
}
