### PR TITLE
ft-wave1-cli-unknown-command

### DIFF
--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -7087,14 +7087,44 @@
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/unknown_command_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLIUnknownCommandWritesActionableStderr",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/unknown_command_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/unknown_command_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLIUnknownCommandReturnsUsageExitCode",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/unknown_command_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/workers/agent/root_build_test.go",
+      "package": "you-agent-factory/tests/functional/workers/agent",
+      "scenario": "TestAgentRunnerDeliveryRemainsInertThroughRootBuildProcessConstruction",
+      "lane": "short",
+      "destination": "wrong-layer: package-integration — root.BuildProcess and Providers wire composition smoke without proving a customer product scenario. Replacement evidence owner: pkg/root and pkg/services/providers/wire package-integration tests.",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
     }
   ],
-  "scanned_at_utc": "2026-07-27T23:58:26Z",
+  "scanned_at_utc": "2026-07-28T01:55:00Z",
   "summary": {
     "by_catch_all": {
       "bootstrap_portability": 22,
       "guards_batch": 23,
-      "none": 431,
+      "none": 434,
       "replay_contracts": 23,
       "runtime_api": 96,
       "smoke": 62,
@@ -7118,15 +7148,15 @@
       "sessionparity": 13,
       "sessions": 3,
       "smoke": 62,
-      "transport": 94,
+      "transport": 96,
       "work": 2,
-      "workers": 69,
+      "workers": 70,
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 689,
+    "customer_top_level_Test_scenarios": 692,
     "lane_functionallong": 95,
-    "lane_short": 594,
+    "lane_short": 597,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 13,
       "you-agent-factory/tests/functional/automations": 7,
@@ -7171,7 +7201,7 @@
       "you-agent-factory/tests/functional/transport/cli/commands": 20,
       "you-agent-factory/tests/functional/transport/cli/output": 13,
       "you-agent-factory/tests/functional/transport/cli/parameters": 19,
-      "you-agent-factory/tests/functional/transport/cli/process": 7,
+      "you-agent-factory/tests/functional/transport/cli/process": 9,
       "you-agent-factory/tests/functional/transport/docs": 1,
       "you-agent-factory/tests/functional/transport/http": 1,
       "you-agent-factory/tests/functional/transport/http/server": 14,
@@ -7184,6 +7214,7 @@
       "you-agent-factory/tests/functional/transport/submit": 2,
       "you-agent-factory/tests/functional/work/cli": 1,
       "you-agent-factory/tests/functional/work/visualization": 1,
+      "you-agent-factory/tests/functional/workers/agent": 1,
       "you-agent-factory/tests/functional/workers/inference": 16,
       "you-agent-factory/tests/functional/workers/inference/agy": 3,
       "you-agent-factory/tests/functional/workers/inference/claude": 4,
@@ -7202,7 +7233,7 @@
       "you-agent-factory/tests/functional/workstations/repeater": 13,
       "you-agent-factory/tests/functional/workstations/watcher": 9
     },
-    "files_with_customer_Test": 231,
+    "files_with_customer_Test": 232,
     "functional_test_go_files": 251,
     "helper_only_non_customer_files": 51,
     "internal_harness_Test_functions": 15,

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -36,7 +36,7 @@ intentionally small enough to distribute across many agents.
   - `TestCLIVersionWritesOneMachineReadableVersion` verifies version output is
     stdout-only and contains no startup noise.
 
-- [ ] `tests/functional/transport/cli/process/unknown_command_test.go`
+- [x] `tests/functional/transport/cli/process/unknown_command_test.go`
   - `TestCLIUnknownCommandWritesActionableStderr` verifies the invalid token is
     named and suggestions are customer-safe.
   - `TestCLIUnknownCommandReturnsUsageExitCode` verifies stdout remains empty

--- a/tests/functional/transport/cli/process/unknown_command_test.go
+++ b/tests/functional/transport/cli/process/unknown_command_test.go
@@ -1,0 +1,76 @@
+package process_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/builtcliacceptance"
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+const unknownCommandProbeToken = "not-a-command"
+
+// TestCLIUnknownCommandWritesActionableStderr proves that mistyping a root
+// command through the public built you CLI writes stderr that names the invalid
+// token and keeps any command guidance limited to customer-visible surfaces
+// without leaking hidden or internal discovery commands.
+func TestCLIUnknownCommandWritesActionableStderr(t *testing.T) {
+	t.Parallel()
+
+	harness := builtcliacceptance.NewHarness(t, testutil.MustRepoRoot(t))
+	session := harness.NewSession(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	result, err := session.Run(ctx, unknownCommandProbeToken)
+	if err == nil {
+		t.Fatalf("unknown root command result = %#v; want process failure", result)
+	}
+
+	stderr := strings.TrimSpace(result.Stderr)
+	if stderr == "" {
+		t.Fatal("unknown command stderr was empty; want actionable diagnostic")
+	}
+
+	wantDiagnostic := `unknown command "` + unknownCommandProbeToken + `" for "you"`
+	if strings.Count(stderr, wantDiagnostic) != 1 {
+		t.Fatalf("stderr = %q, want exactly one diagnostic naming %q", stderr, unknownCommandProbeToken)
+	}
+	if !strings.Contains(stderr, "unknown command") {
+		t.Fatalf("stderr = %q, want unknown-command guidance", stderr)
+	}
+
+	for _, forbidden := range forbiddenRootDiscoveryCommands {
+		if containsSuggestionToken(stderr, forbidden) {
+			t.Fatalf("unknown command stderr leaked hidden or nested-only command %q:\n%s", forbidden, stderr)
+		}
+	}
+
+	for _, marker := range []string{
+		"Factory initiated:",
+		"Dashboard URL:",
+		"Available Commands:",
+	} {
+		if strings.Contains(stderr, marker) {
+			t.Fatalf("unknown command stderr contains non-diagnostic surface %q:\n%s", marker, stderr)
+		}
+	}
+}
+
+func containsSuggestionToken(stderr, command string) bool {
+	for _, line := range strings.Split(stderr, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		for _, field := range strings.Fields(line) {
+			if strings.Trim(field, `"'`) == command {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/tests/functional/transport/cli/process/unknown_command_test.go
+++ b/tests/functional/transport/cli/process/unknown_command_test.go
@@ -60,6 +60,46 @@ func TestCLIUnknownCommandWritesActionableStderr(t *testing.T) {
 	}
 }
 
+// TestCLIUnknownCommandReturnsUsageExitCode proves that rejecting a mistyped root
+// command through the public built you CLI leaves stdout empty, returns the
+// documented non-success usage/validation exit code, and does not start Factory
+// load, server, or worker dispatch attributable to the rejected invocation.
+func TestCLIUnknownCommandReturnsUsageExitCode(t *testing.T) {
+	t.Parallel()
+
+	harness := builtcliacceptance.NewHarness(t, testutil.MustRepoRoot(t))
+	session := harness.NewSession(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	result, err := session.Run(ctx, unknownCommandProbeToken)
+	if err == nil {
+		t.Fatalf("unknown root command result = %#v; want process failure", result)
+	}
+	if result.ExitCode != 1 {
+		t.Fatalf("exit code = %d, want documented usage/validation exit 1", result.ExitCode)
+	}
+
+	stdout := strings.TrimSpace(result.Stdout)
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty (no primary result, usage dump, or lifecycle chatter)", result.Stdout)
+	}
+	for _, forbidden := range []string{
+		"Factory initiated:",
+		"Dashboard URL:",
+		"Dashboard server disabled",
+		"Available Commands:",
+		"How to use:",
+	} {
+		if strings.Contains(result.Stdout, forbidden) {
+			t.Fatalf("stdout contains product activation or help surface %q:\n%s", forbidden, result.Stdout)
+		}
+	}
+
+	assertRootHelpDiscoveryHasNoProductFilesystemEffects(t, session)
+}
+
 func containsSuggestionToken(stderr, command string) bool {
 	for _, line := range strings.Split(stderr, "\n") {
 		line = strings.TrimSpace(line)


### PR DESCRIPTION
{
  "project": "CLI Unknown-Command Process Contract Functional Coverage",
  "branchName": "ft-wave1-cli-unknown-command",
  "description": "Implement only tests/functional/transport/cli/process/unknown_command_test.go so the public built you CLI proves an invalid token is named in stderr with customer-safe suggestions (no hidden/internal leakage), stdout remains empty, and the process returns the documented non-success usage/validation exit code without starting Factory load, server, or worker dispatch—without inventing migration-ledger deletion obligations when none map to this destination.",
  "context": {
    "customerAsk": "Implement only tests/functional/transport/cli/process/unknown_command_test.go. Through the public built you CLI process boundary, prove: (1) TestCLIUnknownCommandWritesActionableStderr — an invalid token is named in stderr and suggestions are customer-safe (no hidden/internal command leakage); (2) TestCLIUnknownCommandReturnsUsageExitCode — stdout remains empty and the process returns the documented non-success usage/validation exit code without starting Factory load, server, or worker dispatch. Do not invent migration-ledger deletion obligations when none map to this destination. Do not implement stdin, stdout_stderr, or context_cancellation. Avoid service/internal imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled ownership/coverage/catalog/migration metadata required for this cell; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for CLI unknown-command process behavior does not exist yet even though help_and_version has freed transport/cli/process. Scattered release/unit coverage can mention unknown-command strings, but maintainers lack a focused, catalogued process proof that an invalid token is named in stderr with customer-safe suggestions, stdout stays empty, the documented usage/validation exit is returned, and Factory load, server, or worker dispatch do not start.",
    "solution": "Implement the two checklist scenarios in tests/functional/transport/cli/process/unknown_command_test.go through the public built you CLI process boundary with customer-readable Go docs on every top-level Test. Assert actionable stderr, customer-safe suggestions, empty stdout, documented non-success usage/validation exit, and absence of Factory/server/worker activation; do not invent migration-ledger deletion obligations; apply only narrowly coupled ownership/coverage/catalog/migration metadata; leave held process siblings untouched; and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/transport/cli/process/unknown_command_test.go exists as the transport-owned functional cell and covers actionable unknown-command stderr plus usage/validation exit with empty stdout.",
    "Through the public built you CLI process boundary, invoking an invalid root command token writes stderr that names that token and keeps any suggestions customer-safe (no hidden/internal command leakage).",
    "Through the public built you CLI process boundary, the unknown-command rejection leaves stdout empty and returns the documented non-success usage/validation exit code.",
    "The unknown-command path does not start Factory load, server, or worker dispatch attributable to the rejected invocation.",
    "No migration-ledger deletion obligations are invented for this destination; only narrowly coupled ownership/coverage/catalog metadata for this cell are updated; coverage uses the public built you CLI process boundary / approved helpers and does not import service implementations or internal Petri primitives as the proof owner, with customer-readable Go docs on every top-level Test*; held process siblings stay untouched.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave1-cli-unknown-command-001",
      "title": "Prove unknown command writes actionable stderr",
      "passes": true
    },
    {
      "id": "ft-wave1-cli-unknown-command-002",
      "title": "Prove usage exit code with empty stdout and no product activation",
      "passes": true
    },
    {
      "id": "ft-wave1-cli-unknown-command-003",
      "title": "Close ownership metadata and verification gates",
      "passes": true
    }
  ]
}

Made with [Cursor](https://cursor.com)