### PR TITLE
pss-mcp-def-adapter

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -437,6 +437,16 @@
       }
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/mcp",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/ttsobservability",
       "minimum": 15.55
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -407,6 +407,10 @@
       "minimum": 79.67
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/mcp",
+      "minimum": 73.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/ttsobservability",
       "minimum": 73.33
     },

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -2760,6 +2760,12 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/factory_definitions/transports/mcp",
+      "disposition": "retain",
+      "destination": "factory_definitions",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/factory_definitions/ttsobservability",
       "disposition": "retain",
       "destination": "factory_definitions",

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -125,6 +125,7 @@
     "pkg/services/factory_definitions/snapshotcapture",
     "pkg/services/factory_definitions/transports/cli",
     "pkg/services/factory_definitions/transports/http",
+    "pkg/services/factory_definitions/transports/mcp",
     "pkg/services/factory_definitions/ttsobservability",
     "pkg/services/factory_definitions/validation",
     "pkg/services/factory_definitions/wire",
@@ -894,6 +895,11 @@
     },
     {
       "packagePath": "pkg/services/factory_definitions/transports/http",
+      "disposition": "retain",
+      "destination": "factory_definitions"
+    },
+    {
+      "packagePath": "pkg/services/factory_definitions/transports/mcp",
       "disposition": "retain",
       "destination": "factory_definitions"
     },

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -34,6 +34,22 @@ Use this map when changing the public REST contract.
   Prove registration with `manifest_registration_test.go`; do not edit
   `pkg/wire`, `pkg/root`, `pkg/initializer`, top-level CLI composition, or
   other services' HTTP adapters when reconciling manifest churn.
+- Factory Definitions MCP tool decoding, invocation, result/error mapping, and
+  catalog parity live under `pkg/services/factory_definitions/transports/mcp`.
+  Top-level MCP retains generated discovery, SDK registration, and stdio
+  composition; the service-owned adapter consumes Factory Definitions root
+  contracts and does not import or construct Definitions internals.
+- The Definitions MCP adapter package must stay registered in the allowed shared
+  manifests only: retain `pkg/services/factory_definitions/transports/mcp` under
+  destination `factory_definitions` in
+  `docs/internal/packaged-service-structure/package-target-manifest.json` and
+  `docs/internal/baselines/ownership-inventory.json`, and keep measured floors in
+  both `docs/internal/baselines/go-unit-coverage-package-minimums.json` and
+  `docs/internal/baselines/go-functional-coverage-package-minimums.json`.
+  Prove registration with `manifest_registration_test.go`; do not edit
+  `pkg/wire`, `pkg/root`, `pkg/initializer`, top-level CLI composition, shared
+  MCP host/composition fan-in, or other services' MCP adapters when reconciling
+  manifest churn.
 - Factory Session CLI request construction, rendering, diagnostics, and
   operation handlers live under
   `pkg/services/factory_sessions/transports/cli`; Factory Session MCP tool

--- a/pkg/services/factory_definitions/transports/mcp/client.go
+++ b/pkg/services/factory_definitions/transports/mcp/client.go
@@ -1,0 +1,69 @@
+package factorydefinition
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+var errMissingRequestContext = errors.New("MCP request context is required")
+
+// ToolOperation is the single injected execution role used by every MCP
+// protocol server. Production binds its Factory Definitions dependencies once;
+// protocol tests replace this exact function role.
+type ToolOperation func(context.Context, string, json.RawMessage) (json.RawMessage, error)
+
+// Bind constructs the canonical ToolOperation from explicit Definitions root
+// dependencies. Adapter tests replace Definitions or Validation with
+// root-shaped fakes without constructing real catalog or distribute graphs.
+func Bind(binding RootBinding) ToolOperation {
+	return func(ctx context.Context, name string, input json.RawMessage) (json.RawMessage, error) {
+		return CallTool(ctx, binding, name, input)
+	}
+}
+
+type toolHandler func(context.Context, RootBinding, json.RawMessage) (json.RawMessage, error)
+
+var registeredToolHandlers = map[string]toolHandler{
+	ToolValidate: callValidateTool,
+}
+
+// CallTool invokes one Factory Definition tool against explicitly supplied
+// root-shaped roles. Protocol servers receive the bound ToolOperation rather
+// than choosing between construction paths.
+func CallTool(
+	ctx context.Context,
+	binding RootBinding,
+	name string,
+	input json.RawMessage,
+) (json.RawMessage, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("call MCP tool: %w", errMissingRequestContext)
+	}
+	handler, ok := registeredToolHandlers[name]
+	if !ok {
+		return nil, fmt.Errorf("unsupported tool %q", name)
+	}
+	return handler(ctx, binding, input)
+}
+
+func callValidateTool(
+	ctx context.Context,
+	binding RootBinding,
+	input json.RawMessage,
+) (json.RawMessage, error) {
+	var factory factoryapi.Factory
+	if err := json.Unmarshal(input, &factory); err != nil {
+		envelope := decodeInputErrorEnvelope("decode validate input", err)
+		return json.Marshal(ToolResponse[factoryapi.FactoryValidationResult]{Error: &envelope})
+	}
+	validation, err := resolveSubmittedDefinitionValidation(binding)
+	if err != nil {
+		envelope := unavailableValidationErrorEnvelope()
+		return json.Marshal(ToolResponse[factoryapi.FactoryValidationResult]{Error: &envelope})
+	}
+	return json.Marshal(Validate(ctx, validation, factory))
+}

--- a/pkg/services/factory_definitions/transports/mcp/client.go
+++ b/pkg/services/factory_definitions/transports/mcp/client.go
@@ -28,7 +28,9 @@ func Bind(binding RootBinding) ToolOperation {
 type toolHandler func(context.Context, RootBinding, json.RawMessage) (json.RawMessage, error)
 
 var registeredToolHandlers = map[string]toolHandler{
-	ToolValidate: callValidateTool,
+	ToolValidate:    callValidateTool,
+	ToolGetCurrent:  callGetCurrentTool,
+	ToolSaveCurrent: callSaveCurrentTool,
 }
 
 // CallTool invokes one Factory Definition tool against explicitly supplied
@@ -66,4 +68,30 @@ func callValidateTool(
 		return json.Marshal(ToolResponse[factoryapi.FactoryValidationResult]{Error: &envelope})
 	}
 	return json.Marshal(Validate(ctx, validation, factory))
+}
+
+func callGetCurrentTool(
+	ctx context.Context,
+	binding RootBinding,
+	input json.RawMessage,
+) (json.RawMessage, error) {
+	var request GetCurrentInput
+	if err := json.Unmarshal(input, &request); err != nil {
+		envelope := decodeInputErrorEnvelope("decode get current input", err)
+		return json.Marshal(ToolResponse[factoryapi.Factory]{Error: &envelope})
+	}
+	return json.Marshal(GetCurrent(ctx, binding.Definitions, request))
+}
+
+func callSaveCurrentTool(
+	ctx context.Context,
+	binding RootBinding,
+	input json.RawMessage,
+) (json.RawMessage, error) {
+	var request SaveCurrentInput
+	if err := json.Unmarshal(input, &request); err != nil {
+		envelope := decodeInputErrorEnvelope("decode save current input", err)
+		return json.Marshal(ToolResponse[factoryapi.Factory]{Error: &envelope})
+	}
+	return json.Marshal(SaveCurrent(ctx, binding.Definitions, request))
 }

--- a/pkg/services/factory_definitions/transports/mcp/client.go
+++ b/pkg/services/factory_definitions/transports/mcp/client.go
@@ -28,9 +28,10 @@ func Bind(binding RootBinding) ToolOperation {
 type toolHandler func(context.Context, RootBinding, json.RawMessage) (json.RawMessage, error)
 
 var registeredToolHandlers = map[string]toolHandler{
-	ToolValidate:    callValidateTool,
-	ToolGetCurrent:  callGetCurrentTool,
-	ToolSaveCurrent: callSaveCurrentTool,
+	ToolValidate:        callValidateTool,
+	ToolGetCurrent:      callGetCurrentTool,
+	ToolSaveCurrent:     callSaveCurrentTool,
+	ToolInstallPackaged: callInstallPackagedTool,
 }
 
 // CallTool invokes one Factory Definition tool against explicitly supplied
@@ -94,4 +95,22 @@ func callSaveCurrentTool(
 		return json.Marshal(ToolResponse[factoryapi.Factory]{Error: &envelope})
 	}
 	return json.Marshal(SaveCurrent(ctx, binding.Definitions, request))
+}
+
+func callInstallPackagedTool(
+	ctx context.Context,
+	binding RootBinding,
+	input json.RawMessage,
+) (json.RawMessage, error) {
+	var request InstallPackagedInput
+	if err := json.Unmarshal(input, &request); err != nil {
+		envelope := decodeInputErrorEnvelope("decode install packaged input", err)
+		return json.Marshal(ToolResponse[InstallPackagedResult]{Error: &envelope})
+	}
+	install, err := resolveInstallPackagedFactory(binding)
+	if err != nil {
+		envelope := unavailableInstallErrorEnvelope()
+		return json.Marshal(ToolResponse[InstallPackagedResult]{Error: &envelope})
+	}
+	return json.Marshal(InstallPackaged(ctx, install, request))
 }

--- a/pkg/services/factory_definitions/transports/mcp/current_factory.go
+++ b/pkg/services/factory_definitions/transports/mcp/current_factory.go
@@ -26,6 +26,9 @@ func GetCurrent(ctx context.Context, root DefinitionsRoot, input GetCurrentInput
 		envelope := decodeInputErrorEnvelope("get current factory", errMissingRequestContext)
 		return ToolResponse[factoryapi.Factory]{Error: &envelope}
 	}
+	if response, done := requestContextErrorResponse[factoryapi.Factory](ctx); done {
+		return response
+	}
 	if root == nil {
 		envelope := unavailableDefinitionsErrorEnvelope()
 		return ToolResponse[factoryapi.Factory]{Error: &envelope}
@@ -45,6 +48,9 @@ func SaveCurrent(ctx context.Context, root DefinitionsRoot, input SaveCurrentInp
 	if ctx == nil {
 		envelope := decodeInputErrorEnvelope("save current factory", errMissingRequestContext)
 		return ToolResponse[factoryapi.Factory]{Error: &envelope}
+	}
+	if response, done := requestContextErrorResponse[factoryapi.Factory](ctx); done {
+		return response
 	}
 	if root == nil {
 		envelope := unavailableDefinitionsErrorEnvelope()

--- a/pkg/services/factory_definitions/transports/mcp/current_factory.go
+++ b/pkg/services/factory_definitions/transports/mcp/current_factory.go
@@ -1,0 +1,64 @@
+package factorydefinition
+
+import (
+	"context"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	factorydefinitionmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/factorydefinition"
+)
+
+// GetCurrentInput is the MCP request shape for you.factory_definition.get_current.
+type GetCurrentInput struct {
+	SessionID string `json:"sessionId"`
+}
+
+// SaveCurrentInput is the MCP request shape for you.factory_definition.save_current.
+type SaveCurrentInput struct {
+	SessionID string                      `json:"sessionId"`
+	Mode      *factoryapi.FactorySaveMode   `json:"mode,omitempty"`
+	Factory   factoryapi.Factory            `json:"factory"`
+}
+
+// GetCurrent returns the current Factory for one Factory Session through the
+// you.factory_definition.get_current MCP tool.
+func GetCurrent(ctx context.Context, root DefinitionsRoot, input GetCurrentInput) ToolResponse[factoryapi.Factory] {
+	if ctx == nil {
+		envelope := decodeInputErrorEnvelope("get current factory", errMissingRequestContext)
+		return ToolResponse[factoryapi.Factory]{Error: &envelope}
+	}
+	if root == nil {
+		envelope := unavailableDefinitionsErrorEnvelope()
+		return ToolResponse[factoryapi.Factory]{Error: &envelope}
+	}
+
+	factory, err := factorydefinitionmapping.GetCurrentFactoryForSession(ctx, root, input.SessionID)
+	if err != nil {
+		envelope := currentFactoryErrorEnvelope(input.SessionID, "get", err)
+		return ToolResponse[factoryapi.Factory]{Error: &envelope}
+	}
+	return ToolResponse[factoryapi.Factory]{Result: &factory}
+}
+
+// SaveCurrent persists the current Factory for one Factory Session through the
+// you.factory_definition.save_current MCP tool.
+func SaveCurrent(ctx context.Context, root DefinitionsRoot, input SaveCurrentInput) ToolResponse[factoryapi.Factory] {
+	if ctx == nil {
+		envelope := decodeInputErrorEnvelope("save current factory", errMissingRequestContext)
+		return ToolResponse[factoryapi.Factory]{Error: &envelope}
+	}
+	if root == nil {
+		envelope := unavailableDefinitionsErrorEnvelope()
+		return ToolResponse[factoryapi.Factory]{Error: &envelope}
+	}
+
+	mode := factoryapi.FactorySaveModeReplaceCurrent
+	if input.Mode != nil {
+		mode = *input.Mode
+	}
+	saved, err := factorydefinitionmapping.New(root).Save(ctx, input.SessionID, mode, input.Factory)
+	if err != nil {
+		envelope := currentFactoryErrorEnvelope(input.SessionID, "save", err)
+		return ToolResponse[factoryapi.Factory]{Error: &envelope}
+	}
+	return ToolResponse[factoryapi.Factory]{Result: &saved}
+}

--- a/pkg/services/factory_definitions/transports/mcp/current_factory_test.go
+++ b/pkg/services/factory_definitions/transports/mcp/current_factory_test.go
@@ -1,0 +1,339 @@
+package factorydefinition_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorydefinitionmcp "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/mcp"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	apisurface "github.com/portpowered/infinite-you/pkg/transports/mapping"
+)
+
+func TestBind_GetCurrentToolEncodesFakeRootResult(t *testing.T) {
+	t.Parallel()
+
+	sessionVersion := factorydefinitions.FactoryVersion{
+		Logical:  2,
+		Physical: time.Unix(0, 2).UTC(),
+	}
+	factory := mustFactoryFromJSON(t, minimalValidationFactoryBody)
+	factory.Name = "beta"
+	root := &mcpCapturingCurrentFactoryRootFake{
+		getResult: factorydefinitions.EditableFactory{
+			Name:     "beta",
+			Version:  &sessionVersion,
+			Snapshot: mustEditableFactorySnapshot(t, factory),
+		},
+	}
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Definitions: root})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolGetCurrent,
+		json.RawMessage(`{"sessionId":"session-2"}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(get_current) error = %v", err)
+	}
+	if !root.getInvoked {
+		t.Fatal("GetCurrentFactoryForSession was not invoked")
+	}
+	if root.getSessionID != "session-2" {
+		t.Fatalf("session id = %q, want session-2", root.getSessionID)
+	}
+
+	var response struct {
+		Result *factoryapi.Factory                      `json:"result"`
+		Error  *factorydefinitionmcp.ToolErrorEnvelope `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode tool response: %v", err)
+	}
+	if response.Error != nil {
+		t.Fatalf("tool response error = %#v, want success result", response.Error)
+	}
+	if response.Result == nil || response.Result.Name != "beta" {
+		t.Fatalf("factory name = %#v, want beta", response.Result)
+	}
+	if response.Result.Version == nil || response.Result.Version.Logical.Int64() != 2 {
+		t.Fatalf("factory version = %#v, want logical 2", response.Result.Version)
+	}
+}
+
+func TestBind_GetCurrentToolSessionNotFoundReturnsTypedErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	root := &mcpCapturingCurrentFactoryRootFake{
+		getErr: fmt.Errorf("lookup session: %w", apisurface.ErrFactorySessionNotFound),
+	}
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Definitions: root})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolGetCurrent,
+		json.RawMessage(`{"sessionId":"missing-session"}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(get_current) error = %v", err)
+	}
+
+	envelope := assertTypedToolErrorEnvelope(t, raw, "factory_definition.session.not_found", false)
+	if envelope.Message != "factory session not found" {
+		t.Fatalf("error.message = %q, want factory session not found", envelope.Message)
+	}
+	if envelope.Details["sessionId"] != "missing-session" {
+		t.Fatalf("error.details.sessionId = %#v, want missing-session", envelope.Details["sessionId"])
+	}
+}
+
+func TestBind_GetCurrentToolCurrentFactoryNotFoundReturnsTypedErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	root := &mcpCapturingCurrentFactoryRootFake{
+		getErr: factorydefinitions.ErrCurrentFactoryNotFound,
+	}
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Definitions: root})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolGetCurrent,
+		json.RawMessage(`{"sessionId":"session-2"}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(get_current) error = %v", err)
+	}
+
+	envelope := assertTypedToolErrorEnvelope(t, raw, "factory_definition.current_factory.not_found", false)
+	if envelope.Message != "Current factory not found." {
+		t.Fatalf("error.message = %q, want current factory not found message", envelope.Message)
+	}
+}
+
+func TestBind_SaveCurrentToolDecodesFactoryAndInvokesFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &mcpCapturingCurrentFactoryRootFake{
+		saveResult: factorydefinitions.EditableFactory{
+			Name:     "beta",
+			Snapshot: mustEditableFactorySnapshot(t, mustFactoryFromJSON(t, `{"name":"beta","workTypes":[],"workstations":[],"workers":[]}`)),
+		},
+	}
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Definitions: root})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolSaveCurrent,
+		json.RawMessage(`{"sessionId":"session-2","factory":`+minimalValidationFactoryBody+`}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(save_current) error = %v", err)
+	}
+	if !root.saveInvoked {
+		t.Fatal("Save was not invoked")
+	}
+	if root.saveSessionID != "session-2" {
+		t.Fatalf("save session id = %q, want session-2", root.saveSessionID)
+	}
+	if root.saveMode != factorydefinitions.SaveModeReplaceCurrent {
+		t.Fatalf("save mode = %v, want replace current", root.saveMode)
+	}
+	if root.saveRequest.Name != "alpha" {
+		t.Fatalf("save request name = %q, want alpha", root.saveRequest.Name)
+	}
+
+	var response struct {
+		Result *factoryapi.Factory                      `json:"result"`
+		Error  *factorydefinitionmcp.ToolErrorEnvelope `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode tool response: %v", err)
+	}
+	if response.Error != nil {
+		t.Fatalf("tool response error = %#v, want success result", response.Error)
+	}
+	if response.Result == nil || response.Result.Name != "beta" {
+		t.Fatalf("saved factory name = %#v, want beta", response.Result)
+	}
+}
+
+func TestBind_SaveCurrentToolStaleVersionReturnsTypedErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	root := &mcpCapturingCurrentFactoryRootFake{
+		saveErr: factorydefinitions.ErrFactoryVersionStale,
+	}
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Definitions: root})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolSaveCurrent,
+		json.RawMessage(`{"sessionId":"session-2","factory":`+minimalValidationFactoryBody+`}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(save_current) error = %v", err)
+	}
+
+	envelope := assertTypedToolErrorEnvelope(t, raw, "STALE_FACTORY_VERSION", false)
+	if envelope.Message != "Current factory definition is stale. Refresh the graph before saving." {
+		t.Fatalf("error.message = %q, want stale version message", envelope.Message)
+	}
+	targets, ok := envelope.Details["targets"].([]any)
+	if !ok || len(targets) != 1 {
+		t.Fatalf("error.details.targets = %#v, want stale version target", envelope.Details["targets"])
+	}
+}
+
+func TestBind_SaveCurrentToolMalformedJSONReturnsBadRequestWithoutInvokingRoot(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "malformed", body: `{"sessionId":"session-2","factory":{"name":"beta"`},
+		{name: "empty", body: ""},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := &mcpCapturingCurrentFactoryRootFake{}
+			operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Definitions: root})
+			raw, err := operation(
+				context.Background(),
+				factorydefinitionmcp.ToolSaveCurrent,
+				json.RawMessage(tc.body),
+			)
+			if err != nil {
+				t.Fatalf("CallTool(save_current) error = %v", err)
+			}
+			if root.saveInvoked {
+				t.Fatal("Save was invoked before request decode succeeded")
+			}
+			envelope := assertTypedToolErrorEnvelope(t, raw, "BAD_REQUEST", false)
+			if !strings.Contains(envelope.Message, "decode save current input") {
+				t.Fatalf("error.message = %q, want decode save current input context", envelope.Message)
+			}
+		})
+	}
+}
+
+func TestBind_GetCurrentToolSuccessMatchesCallToolResultTransportPolicy(t *testing.T) {
+	t.Parallel()
+
+	root := &mcpCapturingCurrentFactoryRootFake{
+		getResult: factorydefinitions.EditableFactory{
+			Name:     "beta",
+			Snapshot: mustEditableFactorySnapshot(t, mustFactoryFromJSON(t, `{"name":"beta","workTypes":[],"workstations":[],"workers":[]}`)),
+		},
+	}
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Definitions: root})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolGetCurrent,
+		json.RawMessage(`{"sessionId":"session-2"}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(get_current) error = %v", err)
+	}
+
+	projected, err := factorydefinitionmcp.MarshalSuccessCallToolResultJSON(raw)
+	if err != nil {
+		t.Fatalf("MarshalSuccessCallToolResultJSON() error = %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(projected, &decoded); err != nil {
+		t.Fatalf("decode CallToolResult: %v", err)
+	}
+	content, ok := decoded["content"].([]any)
+	if !ok || len(content) != 1 {
+		t.Fatalf("content = %#v, want one text item", decoded["content"])
+	}
+	item, ok := content[0].(map[string]any)
+	if !ok {
+		t.Fatalf("content item = %#v, want object", content[0])
+	}
+	if item["type"] != "text" {
+		t.Fatalf("content type = %#v, want text", item["type"])
+	}
+	text, ok := item["text"].(string)
+	if !ok || !strings.Contains(text, `"name":"beta"`) {
+		t.Fatalf("content text = %#v, want serialized success payload", item["text"])
+	}
+	if decoded["isError"] == true {
+		t.Fatalf("CallToolResult isError = true, want false for success transport")
+	}
+}
+
+type mcpCapturingCurrentFactoryRootFake struct {
+	mcpDefinitionsRootFake
+
+	getInvoked   bool
+	getSessionID string
+	getResult    factorydefinitions.EditableFactory
+	getErr       error
+
+	saveInvoked   bool
+	saveSessionID string
+	saveMode      factorydefinitions.SaveMode
+	saveRequest   factorydefinitions.EditableFactory
+	saveResult    factorydefinitions.EditableFactory
+	saveErr       error
+}
+
+func (fake *mcpCapturingCurrentFactoryRootFake) GetCurrentFactoryForSession(
+	_ context.Context,
+	sessionID string,
+) (factorydefinitions.EditableFactory, error) {
+	fake.getInvoked = true
+	fake.getSessionID = sessionID
+	if fake.getErr != nil {
+		return factorydefinitions.EditableFactory{}, fake.getErr
+	}
+	if fake.getResult.Name != "" || fake.getResult.Snapshot != nil {
+		return fake.getResult, nil
+	}
+	return factorydefinitions.EditableFactory{}, factorydefinitions.ErrCurrentFactoryNotFound
+}
+
+func (fake *mcpCapturingCurrentFactoryRootFake) Save(
+	_ context.Context,
+	sessionID string,
+	mode factorydefinitions.SaveMode,
+	request factorydefinitions.EditableFactory,
+) (factorydefinitions.EditableFactory, error) {
+	fake.saveInvoked = true
+	fake.saveSessionID = sessionID
+	fake.saveMode = mode
+	fake.saveRequest = request
+	if fake.saveErr != nil {
+		return factorydefinitions.EditableFactory{}, fake.saveErr
+	}
+	if fake.saveResult.Name != "" || fake.saveResult.Snapshot != nil {
+		return fake.saveResult, nil
+	}
+	return request, nil
+}
+
+func mustFactoryFromJSON(t *testing.T, body string) factoryapi.Factory {
+	t.Helper()
+
+	var factory factoryapi.Factory
+	if err := json.Unmarshal([]byte(body), &factory); err != nil {
+		t.Fatalf("decode factory JSON: %v", err)
+	}
+	return factory
+}
+
+func mustEditableFactorySnapshot(t *testing.T, factory factoryapi.Factory) *factorydefinitions.FactorySnapshot {
+	t.Helper()
+
+	snapshot, err := factorydefinitions.NewFactorySnapshot(factory)
+	if err != nil {
+		t.Fatalf("NewFactorySnapshot: %v", err)
+	}
+	return snapshot
+}

--- a/pkg/services/factory_definitions/transports/mcp/errors.go
+++ b/pkg/services/factory_definitions/transports/mcp/errors.go
@@ -1,0 +1,23 @@
+package factorydefinition
+
+import (
+	"fmt"
+)
+
+const errorCodeBadRequest = "BAD_REQUEST"
+
+func decodeInputErrorEnvelope(operation string, err error) ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeBadRequest,
+		Message:   fmt.Sprintf("%s: %v", operation, err),
+		Retryable: false,
+	}
+}
+
+func unavailableValidationErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      "factory_definition.service.unavailable",
+		Message:   "factory definition validation is unavailable",
+		Retryable: false,
+	}
+}

--- a/pkg/services/factory_definitions/transports/mcp/errors.go
+++ b/pkg/services/factory_definitions/transports/mcp/errors.go
@@ -11,16 +11,22 @@ import (
 )
 
 const (
-	errorCodeBadRequest               = "BAD_REQUEST"
-	errorCodeInvalidFactory           = "INVALID_FACTORY"
-	errorCodeSessionNotFound          = "factory_definition.session.not_found"
-	errorCodeCurrentFactoryNotFound   = "factory_definition.current_factory.not_found"
-	errorCodeStaleFactoryVersion      = "STALE_FACTORY_VERSION"
-	errorCodeInternalCurrentFactory   = "factory_definition.current_factory.internal"
-	errorMessageSessionNotFound       = "factory session not found"
+	errorCodeBadRequest                 = "BAD_REQUEST"
+	errorCodeInvalidFactory             = "INVALID_FACTORY"
+	errorCodeSessionNotFound            = "factory_definition.session.not_found"
+	errorCodeCurrentFactoryNotFound     = "factory_definition.current_factory.not_found"
+	errorCodeStaleFactoryVersion        = "STALE_FACTORY_VERSION"
+	errorCodeInternalCurrentFactory     = "factory_definition.current_factory.internal"
+	errorCodeUnknownPackagedFactory     = "factory_definition.packaged.unknown_identity"
+	errorCodeFactoryAlreadyExists       = "FACTORY_ALREADY_EXISTS"
+	errorCodePackagedDistributeFailed   = "factory_definition.packaged.distribute_failed"
+	errorMessageSessionNotFound         = "factory session not found"
 	errorMessageCurrentFactoryNotFound  = "Current factory not found."
 	errorMessageStaleFactoryVersion     = "Current factory definition is stale. Refresh the graph before saving."
 	errorMessageInternalCurrentFactory  = "failed to load current factory"
+	errorMessageMissingPackageIdentity  = "package name is required"
+	errorMessageNamedFactoryExists      = "Named factory already exists."
+	errorMessagePackagedDistributeFailed = "factory distribute failed"
 	invalidFactoryDefinitionMessage   = "Factory payload is not a valid Agent Factory definition."
 	invalidRequestPayloadMessage      = "invalid request payload"
 )
@@ -190,6 +196,87 @@ func opaqueCurrentFactoryErrorEnvelope(action string) ToolErrorEnvelope {
 	return ToolErrorEnvelope{
 		Code:      errorCodeInternalCurrentFactory,
 		Message:   message,
+		Retryable: false,
+	}
+}
+
+func unavailableInstallErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      "factory_definition.service.unavailable",
+		Message:   "packaged factory installation is unavailable",
+		Retryable: false,
+	}
+}
+
+func missingPackageIdentityErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeBadRequest,
+		Message:   errorMessageMissingPackageIdentity,
+		Retryable: false,
+	}
+}
+
+func installPackagedErrorEnvelope(err error) ToolErrorEnvelope {
+	if err == nil {
+		return opaqueInstallPackagedErrorEnvelope()
+	}
+	if envelope, ok := unknownPackagedFactoryErrorEnvelope(err); ok {
+		return envelope
+	}
+	if errors.Is(err, factorydefinitions.ErrIncompatibleFactoryDistributeOptions) {
+		return ToolErrorEnvelope{
+			Code:      errorCodeBadRequest,
+			Message:   err.Error(),
+			Retryable: false,
+		}
+	}
+	if errors.Is(err, factorydefinitions.ErrNamedFactoryAlreadyExists) {
+		return ToolErrorEnvelope{
+			Code:      errorCodeFactoryAlreadyExists,
+			Message:   errorMessageNamedFactoryExists,
+			Retryable: false,
+		}
+	}
+	if errors.Is(err, factorydefinitions.ErrFactoryDistributeFailed) {
+		return ToolErrorEnvelope{
+			Code:      errorCodePackagedDistributeFailed,
+			Message:   errorMessagePackagedDistributeFailed,
+			Retryable: false,
+		}
+	}
+	return opaqueInstallPackagedErrorEnvelope()
+}
+
+func unknownPackagedFactoryErrorEnvelope(err error) (ToolErrorEnvelope, bool) {
+	var unknown *factorydefinitions.UnknownPackagedFactoryError
+	if !errors.As(err, &unknown) && !errors.Is(err, factorydefinitions.ErrUnknownPackagedFactoryIdentity) {
+		return ToolErrorEnvelope{}, false
+	}
+	details := map[string]any{}
+	if unknown != nil {
+		if trimmed := strings.TrimSpace(unknown.Name); trimmed != "" {
+			details["package"] = trimmed
+		}
+		if len(unknown.Available) > 0 {
+			details["available"] = append([]string(nil), unknown.Available...)
+		}
+	}
+	message := factorydefinitions.ErrUnknownPackagedFactoryIdentity.Error()
+	if unknown != nil && unknown.Error() != "" {
+		message = unknown.Error()
+	}
+	return ToolErrorEnvelope{
+		Code:      errorCodeUnknownPackagedFactory,
+		Message:   message,
+		Retryable: false,
+		Details:   details,
+	}, true
+}
+
+func opaqueInstallPackagedErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodePackagedDistributeFailed,
+		Message:   errorMessagePackagedDistributeFailed,
 		Retryable: false,
 	}
 }

--- a/pkg/services/factory_definitions/transports/mcp/errors.go
+++ b/pkg/services/factory_definitions/transports/mcp/errors.go
@@ -3,6 +3,7 @@ package factorydefinition
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
@@ -10,10 +11,18 @@ import (
 )
 
 const (
-	errorCodeBadRequest             = "BAD_REQUEST"
-	errorCodeInvalidFactory         = "INVALID_FACTORY"
-	invalidFactoryDefinitionMessage = "Factory payload is not a valid Agent Factory definition."
-	invalidRequestPayloadMessage    = "invalid request payload"
+	errorCodeBadRequest               = "BAD_REQUEST"
+	errorCodeInvalidFactory           = "INVALID_FACTORY"
+	errorCodeSessionNotFound          = "factory_definition.session.not_found"
+	errorCodeCurrentFactoryNotFound   = "factory_definition.current_factory.not_found"
+	errorCodeStaleFactoryVersion      = "STALE_FACTORY_VERSION"
+	errorCodeInternalCurrentFactory   = "factory_definition.current_factory.internal"
+	errorMessageSessionNotFound       = "factory session not found"
+	errorMessageCurrentFactoryNotFound  = "Current factory not found."
+	errorMessageStaleFactoryVersion     = "Current factory definition is stale. Refresh the graph before saving."
+	errorMessageInternalCurrentFactory  = "failed to load current factory"
+	invalidFactoryDefinitionMessage   = "Factory payload is not a valid Agent Factory definition."
+	invalidRequestPayloadMessage      = "invalid request payload"
 )
 
 func decodeInputErrorEnvelope(operation string, err error) ToolErrorEnvelope {
@@ -105,6 +114,82 @@ func opaqueValidationErrorEnvelope() ToolErrorEnvelope {
 	return ToolErrorEnvelope{
 		Code:      errorCodeBadRequest,
 		Message:   invalidRequestPayloadMessage,
+		Retryable: false,
+	}
+}
+
+func unavailableDefinitionsErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      "factory_definition.service.unavailable",
+		Message:   "factory definition service is unavailable",
+		Retryable: false,
+	}
+}
+
+func currentFactoryErrorEnvelope(sessionID string, action string, err error) ToolErrorEnvelope {
+	if err == nil {
+		return opaqueCurrentFactoryErrorEnvelope(action)
+	}
+	if envelope, ok := validationErrorEnvelope(err); ok {
+		return envelope
+	}
+	if envelope, ok := invalidFactoryDefinitionPayloadErrorEnvelope(err); ok {
+		return envelope
+	}
+	switch {
+	case errors.Is(err, apisurface.ErrFactorySessionNotFound):
+		return sessionNotFoundErrorEnvelope(sessionID)
+	case errors.Is(err, apisurface.ErrCurrentFactoryNotFound):
+		return currentFactoryNotFoundErrorEnvelope()
+	case errors.Is(err, apisurface.ErrFactoryVersionStale):
+		return staleFactoryVersionErrorEnvelope()
+	default:
+		return opaqueCurrentFactoryErrorEnvelope(action)
+	}
+}
+
+func sessionNotFoundErrorEnvelope(sessionID string) ToolErrorEnvelope {
+	details := map[string]any{}
+	if trimmed := strings.TrimSpace(sessionID); trimmed != "" {
+		details["sessionId"] = trimmed
+	}
+	return ToolErrorEnvelope{
+		Code:      errorCodeSessionNotFound,
+		Message:   errorMessageSessionNotFound,
+		Retryable: false,
+		Details:   details,
+	}
+}
+
+func currentFactoryNotFoundErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeCurrentFactoryNotFound,
+		Message:   errorMessageCurrentFactoryNotFound,
+		Retryable: false,
+	}
+}
+
+func staleFactoryVersionErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeStaleFactoryVersion,
+		Message:   errorMessageStaleFactoryVersion,
+		Retryable: false,
+		Details: map[string]any{
+			"targets": []factoryapi.FactoryValidationTarget{
+				apisurface.FactoryValidationTargetToAPI(factorydefinitions.StaleFactoryVersionValidationTarget()),
+			},
+		},
+	}
+}
+
+func opaqueCurrentFactoryErrorEnvelope(action string) ToolErrorEnvelope {
+	message := errorMessageInternalCurrentFactory
+	if action == "save" {
+		message = "failed to save current factory"
+	}
+	return ToolErrorEnvelope{
+		Code:      errorCodeInternalCurrentFactory,
+		Message:   message,
 		Retryable: false,
 	}
 }

--- a/pkg/services/factory_definitions/transports/mcp/errors.go
+++ b/pkg/services/factory_definitions/transports/mcp/errors.go
@@ -1,10 +1,20 @@
 package factorydefinition
 
 import (
+	"errors"
 	"fmt"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	apisurface "github.com/portpowered/infinite-you/pkg/transports/mapping"
 )
 
-const errorCodeBadRequest = "BAD_REQUEST"
+const (
+	errorCodeBadRequest             = "BAD_REQUEST"
+	errorCodeInvalidFactory         = "INVALID_FACTORY"
+	invalidFactoryDefinitionMessage = "Factory payload is not a valid Agent Factory definition."
+	invalidRequestPayloadMessage    = "invalid request payload"
+)
 
 func decodeInputErrorEnvelope(operation string, err error) ToolErrorEnvelope {
 	return ToolErrorEnvelope{
@@ -18,6 +28,83 @@ func unavailableValidationErrorEnvelope() ToolErrorEnvelope {
 	return ToolErrorEnvelope{
 		Code:      "factory_definition.service.unavailable",
 		Message:   "factory definition validation is unavailable",
+		Retryable: false,
+	}
+}
+
+func validationErrorEnvelope(err error) (ToolErrorEnvelope, bool) {
+	if err == nil {
+		return ToolErrorEnvelope{}, false
+	}
+	if envelope, ok := invalidFactoryDefinitionPayloadErrorEnvelope(err); ok {
+		return envelope, true
+	}
+	if envelope, ok := validationFailedErrorEnvelope(err); ok {
+		return envelope, true
+	}
+
+	var topologyErr *apisurface.TopologyValidationError
+	var domainTopologyErr *factorydefinitions.ValidationTopologyError
+	switch {
+	case errors.As(err, &topologyErr):
+		return invalidFactoryErrorEnvelope(topologyErr.Targets), true
+	case errors.As(err, &domainTopologyErr):
+		return invalidFactoryErrorEnvelope(
+			apisurface.FactoryValidationTargetsToAPI(domainTopologyErr.Targets),
+		), true
+	case errors.Is(err, apisurface.ErrInvalidNamedFactory):
+		return invalidFactoryErrorEnvelope([]factoryapi.FactoryValidationTarget{
+			apisurface.FactoryValidationTargetToAPI(factorydefinitions.FormFactoryPayloadValidationTarget()),
+		}), true
+	default:
+		return ToolErrorEnvelope{}, false
+	}
+}
+
+func invalidFactoryDefinitionPayloadErrorEnvelope(err error) (ToolErrorEnvelope, bool) {
+	if !errors.Is(err, factorydefinitions.ErrInvalidFactoryDefinitionPayload) {
+		return ToolErrorEnvelope{}, false
+	}
+	return ToolErrorEnvelope{
+		Code:      errorCodeBadRequest,
+		Message:   invalidRequestPayloadMessage,
+		Retryable: false,
+	}, true
+}
+
+func validationFailedErrorEnvelope(err error) (ToolErrorEnvelope, bool) {
+	var validationFailure *factorydefinitions.FactoryDefinitionValidationFailure
+	if errors.As(err, &validationFailure) {
+		return invalidFactoryErrorEnvelope(
+			apisurface.FactoryValidationTargetsToAPI(validationFailure.Validation.Targets),
+		), true
+	}
+	if errors.Is(err, factorydefinitions.ErrFactoryDefinitionValidationFailed) {
+		return invalidFactoryErrorEnvelope(nil), true
+	}
+	return ToolErrorEnvelope{}, false
+}
+
+func invalidFactoryErrorEnvelope(targets []factoryapi.FactoryValidationTarget) ToolErrorEnvelope {
+	if len(targets) == 0 {
+		targets = []factoryapi.FactoryValidationTarget{
+			apisurface.FactoryValidationTargetToAPI(factorydefinitions.FormFactoryPayloadValidationTarget()),
+		}
+	}
+	return ToolErrorEnvelope{
+		Code:      errorCodeInvalidFactory,
+		Message:   invalidFactoryDefinitionMessage,
+		Retryable: false,
+		Details: map[string]any{
+			"targets": targets,
+		},
+	}
+}
+
+func opaqueValidationErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeBadRequest,
+		Message:   invalidRequestPayloadMessage,
 		Retryable: false,
 	}
 }

--- a/pkg/services/factory_definitions/transports/mcp/errors.go
+++ b/pkg/services/factory_definitions/transports/mcp/errors.go
@@ -1,6 +1,7 @@
 package factorydefinition
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -12,6 +13,10 @@ import (
 
 const (
 	errorCodeBadRequest                 = "BAD_REQUEST"
+	errorCodeRequestCanceled            = "factory_definition.request.canceled"
+	errorCodeRequestTimedOut            = "factory_definition.request.timed_out"
+	errorMessageRequestCanceled         = "factory definition request was canceled"
+	errorMessageRequestTimedOut         = "factory definition request timed out"
 	errorCodeInvalidFactory             = "INVALID_FACTORY"
 	errorCodeSessionNotFound            = "factory_definition.session.not_found"
 	errorCodeCurrentFactoryNotFound     = "factory_definition.current_factory.not_found"
@@ -30,6 +35,48 @@ const (
 	invalidFactoryDefinitionMessage   = "Factory payload is not a valid Agent Factory definition."
 	invalidRequestPayloadMessage      = "invalid request payload"
 )
+
+func requestContextErrorResponse[T any](ctx context.Context) (ToolResponse[T], bool) {
+	if envelope, ok := contextRequestErrorEnvelope(ctx.Err()); ok {
+		return ToolResponse[T]{Error: &envelope}, true
+	}
+	return ToolResponse[T]{}, false
+}
+
+func contextRequestErrorEnvelope(err error) (ToolErrorEnvelope, bool) {
+	if err == nil {
+		return ToolErrorEnvelope{}, false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return contextDeadlineExceededErrorEnvelope(), true
+	}
+	if errors.Is(err, context.Canceled) {
+		return contextCanceledErrorEnvelope(), true
+	}
+	return ToolErrorEnvelope{}, false
+}
+
+func contextCanceledErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeRequestCanceled,
+		Message:   errorMessageRequestCanceled,
+		Retryable: false,
+		Details: map[string]any{
+			"reason": "CANCELED",
+		},
+	}
+}
+
+func contextDeadlineExceededErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeRequestTimedOut,
+		Message:   errorMessageRequestTimedOut,
+		Retryable: true,
+		Details: map[string]any{
+			"reason": "TIMED_OUT",
+		},
+	}
+}
 
 func decodeInputErrorEnvelope(operation string, err error) ToolErrorEnvelope {
 	return ToolErrorEnvelope{
@@ -136,6 +183,9 @@ func currentFactoryErrorEnvelope(sessionID string, action string, err error) Too
 	if err == nil {
 		return opaqueCurrentFactoryErrorEnvelope(action)
 	}
+	if envelope, ok := contextRequestErrorEnvelope(err); ok {
+		return envelope
+	}
 	if envelope, ok := validationErrorEnvelope(err); ok {
 		return envelope
 	}
@@ -219,6 +269,9 @@ func missingPackageIdentityErrorEnvelope() ToolErrorEnvelope {
 func installPackagedErrorEnvelope(err error) ToolErrorEnvelope {
 	if err == nil {
 		return opaqueInstallPackagedErrorEnvelope()
+	}
+	if envelope, ok := contextRequestErrorEnvelope(err); ok {
+		return envelope
 	}
 	if envelope, ok := unknownPackagedFactoryErrorEnvelope(err); ok {
 		return envelope

--- a/pkg/services/factory_definitions/transports/mcp/install_packaged.go
+++ b/pkg/services/factory_definitions/transports/mcp/install_packaged.go
@@ -1,0 +1,129 @@
+package factorydefinition
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	startupcli "github.com/portpowered/infinite-you/pkg/initializer/process"
+)
+
+// InstallPackagedInput is the MCP request shape for you.factory_definition.install_packaged.
+type InstallPackagedInput struct {
+	Package string `json:"package"`
+	Dir     string `json:"dir,omitempty"`
+	Format  string `json:"format,omitempty"`
+	Replace *bool  `json:"replace,omitempty"`
+}
+
+// InstallPackagedResult is the structured success payload for packaged installation.
+type InstallPackagedResult struct {
+	Name       string `json:"name"`
+	FactoryDir string `json:"factoryDir"`
+	Outcome    string `json:"outcome"`
+	Format     string `json:"format"`
+}
+
+// InstallPackaged installs one built-in packaged Factory through the
+// you.factory_definition.install_packaged MCP tool.
+func InstallPackaged(
+	ctx context.Context,
+	install factorydefinitions.InstallPackagedFactoryOperation,
+	input InstallPackagedInput,
+) ToolResponse[InstallPackagedResult] {
+	if ctx == nil {
+		envelope := decodeInputErrorEnvelope("install packaged factory", errMissingRequestContext)
+		return ToolResponse[InstallPackagedResult]{Error: &envelope}
+	}
+	if install == nil {
+		envelope := unavailableInstallErrorEnvelope()
+		return ToolResponse[InstallPackagedResult]{Error: &envelope}
+	}
+	if strings.TrimSpace(input.Package) == "" {
+		envelope := missingPackageIdentityErrorEnvelope()
+		return ToolResponse[InstallPackagedResult]{Error: &envelope}
+	}
+
+	rootDir, err := resolveInstallRootDir(ctx, input)
+	if err != nil {
+		envelope := decodeInputErrorEnvelope("resolve install destination", err)
+		return ToolResponse[InstallPackagedResult]{Error: &envelope}
+	}
+	format, err := parseInstallFormat(input.Format)
+	if err != nil {
+		envelope := decodeInputErrorEnvelope("parse install format", err)
+		return ToolResponse[InstallPackagedResult]{Error: &envelope}
+	}
+	replace := false
+	if input.Replace != nil {
+		replace = *input.Replace
+	}
+
+	result, err := install(
+		ctx,
+		factorydefinitions.InstallPackagedFactoryRequest{
+			RootDir: rootDir,
+			Name:    strings.TrimSpace(input.Package),
+			Format:  format,
+			Replace: replace,
+		},
+	)
+	if err != nil {
+		envelope := installPackagedErrorEnvelope(err)
+		return ToolResponse[InstallPackagedResult]{Error: &envelope}
+	}
+
+	payload := InstallPackagedResult{
+		Name:       result.Definition.Name,
+		FactoryDir: result.Definition.FactoryDir,
+		Outcome:    string(result.Outcome),
+		Format:     string(result.Format),
+	}
+	return ToolResponse[InstallPackagedResult]{Result: &payload}
+}
+
+func resolveInstallRootDir(ctx context.Context, input InstallPackagedInput) (string, error) {
+	trimmedDir := strings.TrimSpace(input.Dir)
+	if trimmedDir != "" {
+		if filepath.IsAbs(trimmedDir) {
+			return trimmedDir, nil
+		}
+		workingDirectory := ""
+		if ctx != nil {
+			workingDirectory = strings.TrimSpace(startupcli.WorkingDirectory(ctx))
+		}
+		if workingDirectory == "" {
+			return "", fmt.Errorf("process working directory is required for relative destination %q", trimmedDir)
+		}
+		return filepath.Join(workingDirectory, trimmedDir), nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("user home directory is required")
+	}
+	return factorydefinitions.NamedFactoriesRoot(homeDir), nil
+}
+
+func parseInstallFormat(raw string) (factorydefinitions.PackagedFactoryFormat, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", nil
+	}
+	switch strings.ToLower(trimmed) {
+	case "json":
+		return factorydefinitions.PackagedFactoryFormatJSON, nil
+	case "yaml":
+		return factorydefinitions.PackagedFactoryFormatYAML, nil
+	case "yml":
+		return factorydefinitions.PackagedFactoryFormatYML, nil
+	default:
+		return "", fmt.Errorf(
+			"unsupported format %q; accepted values are json, yaml, and yml",
+			raw,
+		)
+	}
+}

--- a/pkg/services/factory_definitions/transports/mcp/install_packaged.go
+++ b/pkg/services/factory_definitions/transports/mcp/install_packaged.go
@@ -38,6 +38,9 @@ func InstallPackaged(
 		envelope := decodeInputErrorEnvelope("install packaged factory", errMissingRequestContext)
 		return ToolResponse[InstallPackagedResult]{Error: &envelope}
 	}
+	if response, done := requestContextErrorResponse[InstallPackagedResult](ctx); done {
+		return response
+	}
 	if install == nil {
 		envelope := unavailableInstallErrorEnvelope()
 		return ToolResponse[InstallPackagedResult]{Error: &envelope}

--- a/pkg/services/factory_definitions/transports/mcp/install_packaged_test.go
+++ b/pkg/services/factory_definitions/transports/mcp/install_packaged_test.go
@@ -205,6 +205,74 @@ func TestBind_InstallPackagedToolUnknownPackageReturnsTypedErrorEnvelope(t *test
 	}
 }
 
+func TestBind_InstallPackagedToolAcceptsYmlFormat(t *testing.T) {
+	t.Parallel()
+
+	destDir := t.TempDir()
+	var gotFormat factorydefinitions.PackagedFactoryFormat
+	install := factorydefinitions.InstallPackagedFactoryOperation(func(
+		_ context.Context,
+		request factorydefinitions.InstallPackagedFactoryRequest,
+	) (factorydefinitions.InstallPackagedFactoryResult, error) {
+		gotFormat = request.Format
+		return factorydefinitions.InstallPackagedFactoryResult{
+			Definition: factorydefinitions.DistributedFactoryDefinitionFacts{
+				Name:       "@you/goal",
+				FactoryDir: destDir + "/goal",
+			},
+			Outcome: factorydefinitions.PackagedFactoryInstallCreated,
+			Format:  factorydefinitions.PackagedFactoryFormatYML,
+		}, nil
+	})
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Install: install})
+	_, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolInstallPackaged,
+		installPackagedToolInput(t, map[string]any{
+			"package": "@you/goal",
+			"dir":     destDir,
+			"format":  "yml",
+		}),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(install_packaged) error = %v", err)
+	}
+	if gotFormat != factorydefinitions.PackagedFactoryFormatYML {
+		t.Fatalf("install request format = %q, want YML", gotFormat)
+	}
+}
+
+func TestBind_InstallPackagedToolRejectsUnsupportedTomlFormat(t *testing.T) {
+	t.Parallel()
+
+	destDir := t.TempDir()
+	install := factorydefinitions.InstallPackagedFactoryOperation(func(
+		context.Context,
+		factorydefinitions.InstallPackagedFactoryRequest,
+	) (factorydefinitions.InstallPackagedFactoryResult, error) {
+		t.Fatal("install should not run when format is unsupported")
+		return factorydefinitions.InstallPackagedFactoryResult{}, nil
+	})
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Install: install})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolInstallPackaged,
+		installPackagedToolInput(t, map[string]any{
+			"package": "@you/goal",
+			"dir":     destDir,
+			"format":  "toml",
+		}),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(install_packaged) error = %v", err)
+	}
+
+	envelope := assertTypedToolErrorEnvelope(t, raw, "BAD_REQUEST", false)
+	if !strings.Contains(envelope.Message, "unsupported format") {
+		t.Fatalf("error.message = %q, want unsupported format context", envelope.Message)
+	}
+}
+
 func TestBind_InstallPackagedToolMalformedJSONDoesNotInvokeInstallRole(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_definitions/transports/mcp/install_packaged_test.go
+++ b/pkg/services/factory_definitions/transports/mcp/install_packaged_test.go
@@ -1,0 +1,285 @@
+package factorydefinition_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorydefinitionmcp "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/mcp"
+)
+
+func installPackagedToolInput(t *testing.T, payload map[string]any) json.RawMessage {
+	t.Helper()
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal install packaged input: %v", err)
+	}
+	return raw
+}
+
+func TestBind_InstallPackagedToolInvokesInjectedInstallRole(t *testing.T) {
+	t.Parallel()
+
+	destDir := t.TempDir()
+	var got factorydefinitions.InstallPackagedFactoryRequest
+	install := factorydefinitions.InstallPackagedFactoryOperation(func(
+		_ context.Context,
+		request factorydefinitions.InstallPackagedFactoryRequest,
+	) (factorydefinitions.InstallPackagedFactoryResult, error) {
+		got = request
+		return factorydefinitions.InstallPackagedFactoryResult{
+			Definition: factorydefinitions.DistributedFactoryDefinitionFacts{
+				Name:       "@you/goal",
+				FactoryDir: destDir + "/goal",
+			},
+			Outcome: factorydefinitions.PackagedFactoryInstallCreated,
+			Format:  factorydefinitions.PackagedFactoryFormatJSON,
+		}, nil
+	})
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Install: install})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolInstallPackaged,
+		installPackagedToolInput(t, map[string]any{
+			"package": "@you/goal",
+			"dir":     destDir,
+			"format":  "json",
+			"replace": true,
+		}),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(install_packaged) error = %v", err)
+	}
+	if got.Name != "@you/goal" {
+		t.Fatalf("install request name = %q, want @you/goal", got.Name)
+	}
+	if got.RootDir != destDir {
+		t.Fatalf("install request rootDir = %q, want %q", got.RootDir, destDir)
+	}
+	if got.Format != factorydefinitions.PackagedFactoryFormatJSON {
+		t.Fatalf("install request format = %q, want JSON", got.Format)
+	}
+	if !got.Replace {
+		t.Fatal("install request replace = false, want true")
+	}
+
+	var response struct {
+		Result *factorydefinitionmcp.InstallPackagedResult `json:"result"`
+		Error  *factorydefinitionmcp.ToolErrorEnvelope     `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode tool response: %v", err)
+	}
+	if response.Error != nil {
+		t.Fatalf("tool response error = %#v, want success result", response.Error)
+	}
+	if response.Result == nil {
+		t.Fatal("tool response result = nil, want install payload")
+	}
+	if response.Result.Name != "@you/goal" || response.Result.FactoryDir != destDir+"/goal" {
+		t.Fatalf("install result = %#v, want goal install facts", response.Result)
+	}
+	if response.Result.Outcome != string(factorydefinitions.PackagedFactoryInstallCreated) {
+		t.Fatalf("install outcome = %q, want created", response.Result.Outcome)
+	}
+	if response.Result.Format != string(factorydefinitions.PackagedFactoryFormatJSON) {
+		t.Fatalf("install format = %q, want JSON", response.Result.Format)
+	}
+}
+
+func TestBind_InstallPackagedToolUsesDefinitionsRootWhenInstallRoleUnset(t *testing.T) {
+	t.Parallel()
+
+	destDir := t.TempDir()
+	root := &mcpCapturingInstallRootFake{
+		result: factorydefinitions.InstallPackagedFactoryResult{
+			Definition: factorydefinitions.DistributedFactoryDefinitionFacts{
+				Name:       "@you/goal",
+				FactoryDir: destDir + "/goal",
+			},
+			Outcome: factorydefinitions.PackagedFactoryInstallCreated,
+			Format:  factorydefinitions.PackagedFactoryFormatJSON,
+		},
+	}
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Definitions: root})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolInstallPackaged,
+		installPackagedToolInput(t, map[string]any{
+			"package": "@you/goal",
+			"dir":     destDir,
+		}),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(install_packaged) error = %v", err)
+	}
+	if !root.invoked {
+		t.Fatal("InstallPackagedFactory was not invoked through the injected Definitions root")
+	}
+	if root.request.Name != "@you/goal" {
+		t.Fatalf("install request name = %q, want @you/goal", root.request.Name)
+	}
+
+	var response struct {
+		Result *factorydefinitionmcp.InstallPackagedResult `json:"result"`
+		Error  *factorydefinitionmcp.ToolErrorEnvelope     `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode tool response: %v", err)
+	}
+	if response.Error != nil {
+		t.Fatalf("tool response error = %#v, want success result", response.Error)
+	}
+	if response.Result == nil || response.Result.Name != "@you/goal" {
+		t.Fatalf("install result = %#v, want goal install payload", response.Result)
+	}
+}
+
+func TestBind_InstallPackagedToolMissingPackageReturnsTypedErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	destDir := t.TempDir()
+	install := factorydefinitions.InstallPackagedFactoryOperation(func(
+		context.Context,
+		factorydefinitions.InstallPackagedFactoryRequest,
+	) (factorydefinitions.InstallPackagedFactoryResult, error) {
+		t.Fatal("install should not run when package identity is missing")
+		return factorydefinitions.InstallPackagedFactoryResult{}, nil
+	})
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Install: install})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolInstallPackaged,
+		installPackagedToolInput(t, map[string]any{"dir": destDir}),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(install_packaged) error = %v", err)
+	}
+
+	envelope := assertTypedToolErrorEnvelope(t, raw, "BAD_REQUEST", false)
+	if envelope.Message != "package name is required" {
+		t.Fatalf("error.message = %q, want package name is required", envelope.Message)
+	}
+}
+
+func TestBind_InstallPackagedToolUnknownPackageReturnsTypedErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	destDir := t.TempDir()
+	installErr := &factorydefinitions.UnknownPackagedFactoryError{
+		Name:      "@you/missing",
+		Available: []string{"@you/goal"},
+	}
+	install := factorydefinitions.InstallPackagedFactoryOperation(func(
+		context.Context,
+		factorydefinitions.InstallPackagedFactoryRequest,
+	) (factorydefinitions.InstallPackagedFactoryResult, error) {
+		return factorydefinitions.InstallPackagedFactoryResult{}, installErr
+	})
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Install: install})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolInstallPackaged,
+		installPackagedToolInput(t, map[string]any{
+			"package": "@you/missing",
+			"dir":     destDir,
+		}),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(install_packaged) error = %v", err)
+	}
+
+	envelope := assertTypedToolErrorEnvelope(t, raw, "factory_definition.packaged.unknown_identity", false)
+	if !strings.Contains(envelope.Message, "@you/missing") {
+		t.Fatalf("error.message = %q, want missing package identity context", envelope.Message)
+	}
+	if envelope.Details["package"] != "@you/missing" {
+		t.Fatalf("error.details.package = %#v, want @you/missing", envelope.Details["package"])
+	}
+	available, ok := envelope.Details["available"].([]any)
+	if !ok || len(available) != 1 || available[0] != "@you/goal" {
+		t.Fatalf("error.details.available = %#v, want [@you/goal]", envelope.Details["available"])
+	}
+}
+
+func TestBind_InstallPackagedToolMalformedJSONDoesNotInvokeInstallRole(t *testing.T) {
+	t.Parallel()
+
+	install := factorydefinitions.InstallPackagedFactoryOperation(func(
+		context.Context,
+		factorydefinitions.InstallPackagedFactoryRequest,
+	) (factorydefinitions.InstallPackagedFactoryResult, error) {
+		t.Fatal("install should not run before request decode succeeds")
+		return factorydefinitions.InstallPackagedFactoryResult{}, nil
+	})
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Install: install})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolInstallPackaged,
+		json.RawMessage(`{"package":`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(install_packaged) error = %v", err)
+	}
+
+	envelope := assertTypedToolErrorEnvelope(t, raw, "BAD_REQUEST", false)
+	if !strings.Contains(envelope.Message, "decode install packaged input") {
+		t.Fatalf("error.message = %q, want decode install packaged input context", envelope.Message)
+	}
+}
+
+func TestBind_InstallPackagedToolDistributeFailureReturnsTypedErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	destDir := t.TempDir()
+	install := factorydefinitions.InstallPackagedFactoryOperation(func(
+		context.Context,
+		factorydefinitions.InstallPackagedFactoryRequest,
+	) (factorydefinitions.InstallPackagedFactoryResult, error) {
+		return factorydefinitions.InstallPackagedFactoryResult{}, factorydefinitions.ErrFactoryDistributeFailed
+	})
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Install: install})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolInstallPackaged,
+		installPackagedToolInput(t, map[string]any{
+			"package": "@you/goal",
+			"dir":     destDir,
+		}),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(install_packaged) error = %v", err)
+	}
+
+	envelope := assertTypedToolErrorEnvelope(t, raw, "factory_definition.packaged.distribute_failed", false)
+	if envelope.Message != "factory distribute failed" {
+		t.Fatalf("error.message = %q, want factory distribute failed", envelope.Message)
+	}
+}
+
+type mcpCapturingInstallRootFake struct {
+	mcpDefinitionsRootFake
+
+	invoked bool
+	request factorydefinitions.InstallPackagedFactoryRequest
+	result  factorydefinitions.InstallPackagedFactoryResult
+	err     error
+}
+
+func (fake *mcpCapturingInstallRootFake) InstallPackagedFactory(
+	_ context.Context,
+	request factorydefinitions.InstallPackagedFactoryRequest,
+) (factorydefinitions.InstallPackagedFactoryResult, error) {
+	fake.invoked = true
+	fake.request = request
+	if fake.err != nil {
+		return factorydefinitions.InstallPackagedFactoryResult{}, fake.err
+	}
+	if fake.result.Definition.Name != "" || fake.result.Outcome != "" {
+		return fake.result, nil
+	}
+	return factorydefinitions.InstallPackagedFactoryResult{}, factorydefinitions.ErrFactoryDistributeFailed
+}

--- a/pkg/services/factory_definitions/transports/mcp/inventory_boundary_test.go
+++ b/pkg/services/factory_definitions/transports/mcp/inventory_boundary_test.go
@@ -1,0 +1,38 @@
+package factorydefinition_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestPackageBoundary_DoesNotImportFactoryDefinitionsInternal(t *testing.T) {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	packageDir := filepath.Dir(filename)
+
+	forbidden := "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal"
+	entries, err := os.ReadDir(packageDir)
+	if err != nil {
+		t.Fatalf("read MCP adapter package: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(packageDir, entry.Name())
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if strings.Contains(string(content), forbidden) {
+			t.Fatalf("%s must not import %s", entry.Name(), forbidden)
+		}
+	}
+}

--- a/pkg/services/factory_definitions/transports/mcp/manifest_registration_test.go
+++ b/pkg/services/factory_definitions/transports/mcp/manifest_registration_test.go
@@ -1,0 +1,144 @@
+package factorydefinition_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/ownershipinventory"
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+const (
+	mcpAdapterPackagePath   = "pkg/services/factory_definitions/transports/mcp"
+	mcpAdapterImportPath    = "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/mcp"
+	factoryDefinitionsOwner = "factory_definitions"
+)
+
+type coverageMinimumManifest struct {
+	Lane     string `json:"lane"`
+	Packages []struct {
+		Package string  `json:"package"`
+		Minimum float64 `json:"minimum"`
+	} `json:"packages"`
+}
+
+func TestManifestRegistration_MCPAdapterPackageIsRegistered(t *testing.T) {
+	t.Helper()
+
+	assertPackageTargetManifestRegistration(t)
+	assertOwnershipInventoryRegistration(t)
+	assertCoverageMinimumRegistration(t, "unit", "docs/internal/baselines/go-unit-coverage-package-minimums.json")
+	assertCoverageMinimumRegistration(t, "functional", "docs/internal/baselines/go-functional-coverage-package-minimums.json")
+}
+
+func assertPackageTargetManifestRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, "docs/internal/packaged-service-structure/package-target-manifest.json"))
+	if err != nil {
+		t.Fatalf("read package-target manifest: %v", err)
+	}
+
+	var manifest struct {
+		Inventory []string `json:"inventory"`
+		Packages  []struct {
+			PackagePath string `json:"packagePath"`
+			Disposition string `json:"disposition"`
+			Destination string `json:"destination"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode package-target manifest: %v", err)
+	}
+
+	foundInventory := false
+	for _, packagePath := range manifest.Inventory {
+		if packagePath == mcpAdapterPackagePath {
+			foundInventory = true
+			break
+		}
+	}
+	if !foundInventory {
+		t.Fatalf("package-target manifest inventory missing %q", mcpAdapterPackagePath)
+	}
+
+	for _, row := range manifest.Packages {
+		if row.PackagePath != mcpAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("package-target manifest disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != factoryDefinitionsOwner {
+			t.Fatalf("package-target manifest destination = %q, want %q", row.Destination, factoryDefinitionsOwner)
+		}
+		return
+	}
+	t.Fatalf("package-target manifest packages missing %q", mcpAdapterPackagePath)
+}
+
+func assertOwnershipInventoryRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, ownershipinventory.InventoryRelativePath))
+	if err != nil {
+		t.Fatalf("read ownership inventory: %v", err)
+	}
+
+	var inventory struct {
+		Packages []ownershipinventory.PackageRow `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		t.Fatalf("decode ownership inventory: %v", err)
+	}
+
+	for _, row := range inventory.Packages {
+		if row.PackagePath != mcpAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("ownership inventory disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != factoryDefinitionsOwner {
+			t.Fatalf("ownership inventory destination = %q, want %q", row.Destination, factoryDefinitionsOwner)
+		}
+		if row.DestinationKind != ownershipinventory.DestinationKindOwner {
+			t.Fatalf(
+				"ownership inventory destinationKind = %q, want %q",
+				row.DestinationKind,
+				ownershipinventory.DestinationKindOwner,
+			)
+		}
+		return
+	}
+	t.Fatalf("ownership inventory packages missing %q", mcpAdapterPackagePath)
+}
+
+func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, relativePath))
+	if err != nil {
+		t.Fatalf("read %s coverage manifest: %v", lane, err)
+	}
+
+	var manifest coverageMinimumManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode %s coverage manifest: %v", lane, err)
+	}
+	if manifest.Lane != lane {
+		t.Fatalf("%s coverage manifest lane = %q, want %q", relativePath, manifest.Lane, lane)
+	}
+
+	for _, entry := range manifest.Packages {
+		if entry.Package != mcpAdapterImportPath {
+			continue
+		}
+		if entry.Minimum < 0 {
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterImportPath)
+		}
+		return
+	}
+	t.Fatalf("%s coverage manifest missing %q", lane, mcpAdapterImportPath)
+}

--- a/pkg/services/factory_definitions/transports/mcp/registry.go
+++ b/pkg/services/factory_definitions/transports/mcp/registry.go
@@ -1,0 +1,105 @@
+package factorydefinition
+
+// DiscoverTools returns the canonical Factory Definitions MCP tool catalog in
+// stable discovery order. Schemas mirror HTTP-DEF validation and current-factory
+// contracts.
+func DiscoverTools() []ToolDefinition {
+	return []ToolDefinition{
+		validateTool(),
+		getCurrentTool(),
+		saveCurrentTool(),
+		installPackagedTool(),
+	}
+}
+
+// ToolNames returns stable canonical tool names in discovery order.
+func ToolNames() []string {
+	tools := DiscoverTools()
+	names := make([]string, len(tools))
+	for i, tool := range tools {
+		names[i] = tool.Name
+	}
+	return names
+}
+
+// ToolByName returns one canonical tool definition by stable name.
+func ToolByName(name string) (ToolDefinition, bool) {
+	for _, tool := range DiscoverTools() {
+		if tool.Name == name {
+			return tool, true
+		}
+	}
+	return ToolDefinition{}, false
+}
+
+func validateTool() ToolDefinition {
+	return ToolDefinition{
+		Name: ToolValidate,
+		Description: "Validate one submitted Factory definition through the canonical " +
+			"Definitions validation contract (POST /factory-validations) without starting sessions " +
+			"or mutating catalog state.",
+		InputSchema:  factoryDefinitionInputSchema(),
+		OutputSchema: toolResponseSchema(factoryValidationResultSchema()),
+		SuccessStableFields: []string{
+			"result.targets",
+			"result.targets[].code",
+			"result.targets[].message",
+			"result.targets[].severity",
+			"result.targets[].subject",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}
+
+func getCurrentTool() ToolDefinition {
+	return ToolDefinition{
+		Name: ToolGetCurrent,
+		Description: "Read the current Factory for one Factory Session through the accepted " +
+			"Definitions root (GET /factory-sessions/{session_id}/factory).",
+		InputSchema:  getCurrentFactoryInputSchema(),
+		OutputSchema: toolResponseSchema(factoryPayloadSchema()),
+		SuccessStableFields: []string{
+			"result.name",
+			"result.version",
+			"result.workTypes",
+			"result.workers",
+			"result.workstations",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}
+
+func saveCurrentTool() ToolDefinition {
+	return ToolDefinition{
+		Name: ToolSaveCurrent,
+		Description: "Save the current Factory for one Factory Session through the accepted " +
+			"Definitions root (PUT /factory-sessions/{session_id}/factory).",
+		InputSchema:  saveCurrentFactoryInputSchema(),
+		OutputSchema: toolResponseSchema(factoryPayloadSchema()),
+		SuccessStableFields: []string{
+			"result.name",
+			"result.version",
+			"result.workTypes",
+			"result.workers",
+			"result.workstations",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}
+
+func installPackagedTool() ToolDefinition {
+	return ToolDefinition{
+		Name: ToolInstallPackaged,
+		Description: "Install one built-in packaged Factory through the Definitions-owned " +
+			"distribute contract without using the CLI adapter path.",
+		InputSchema:  installPackagedFactoryInputSchema(),
+		OutputSchema: toolResponseSchema(installPackagedFactoryResultSchema()),
+		SuccessStableFields: []string{
+			"result.name",
+			"result.factoryDir",
+			"result.outcome",
+			"result.format",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}

--- a/pkg/services/factory_definitions/transports/mcp/registry_test.go
+++ b/pkg/services/factory_definitions/transports/mcp/registry_test.go
@@ -1,0 +1,165 @@
+package factorydefinition_test
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+
+	factorydefinitionmcp "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/mcp"
+)
+
+func TestDiscoverTools_ExposesExpectedFactoryDefinitionTools(t *testing.T) {
+	t.Parallel()
+
+	tools := factorydefinitionmcp.DiscoverTools()
+	if len(tools) != 4 {
+		t.Fatalf("tool count = %d, want 4", len(tools))
+	}
+
+	wantNames := []string{
+		factorydefinitionmcp.ToolValidate,
+		factorydefinitionmcp.ToolGetCurrent,
+		factorydefinitionmcp.ToolSaveCurrent,
+		factorydefinitionmcp.ToolInstallPackaged,
+	}
+	gotNames := factorydefinitionmcp.ToolNames()
+	if !slices.Equal(gotNames, wantNames) {
+		t.Fatalf("tool names = %#v, want %#v", gotNames, wantNames)
+	}
+}
+
+func TestDiscoverTools_EachToolHasSchemasDescriptionsAndStableFields(t *testing.T) {
+	t.Parallel()
+
+	for _, tool := range factorydefinitionmcp.DiscoverTools() {
+		if strings.TrimSpace(tool.Name) == "" {
+			t.Fatal("tool name is required")
+		}
+		if strings.TrimSpace(tool.Description) == "" {
+			t.Fatalf("tool %q description is required", tool.Name)
+		}
+		if len(tool.InputSchema) == 0 {
+			t.Fatalf("tool %q input schema is required", tool.Name)
+		}
+		if schemaType, _ := tool.InputSchema["type"].(string); schemaType != "object" {
+			t.Fatalf("tool %q input schema type = %q, want object", tool.Name, schemaType)
+		}
+		if additional, ok := tool.InputSchema["additionalProperties"].(bool); !ok || additional {
+			t.Fatalf("tool %q input schema additionalProperties = %#v, want false", tool.Name, tool.InputSchema["additionalProperties"])
+		}
+		if len(tool.OutputSchema) == 0 {
+			t.Fatalf("tool %q output schema is required", tool.Name)
+		}
+		if len(tool.SuccessStableFields) == 0 {
+			t.Fatalf("tool %q success stable fields are required", tool.Name)
+		}
+		if len(tool.ErrorStableFields) == 0 {
+			t.Fatalf("tool %q error stable fields are required", tool.Name)
+		}
+		for _, field := range append(tool.SuccessStableFields, tool.ErrorStableFields...) {
+			if strings.TrimSpace(field) == "" {
+				t.Fatalf("tool %q has empty stable field entry", tool.Name)
+			}
+		}
+	}
+}
+
+func TestDiscoverTools_RepresentativeSchemaFields(t *testing.T) {
+	t.Parallel()
+
+	byName := toolDefinitionsByName(t)
+	validateProps := byName[factorydefinitionmcp.ToolValidate].InputSchema["properties"].(map[string]any)
+	for _, field := range []string{"name", "workTypes", "workers", "workstations"} {
+		if _, ok := validateProps[field]; !ok {
+			t.Fatalf("validate input missing %q", field)
+		}
+	}
+
+	getCurrentProps := byName[factorydefinitionmcp.ToolGetCurrent].InputSchema["properties"].(map[string]any)
+	if _, ok := getCurrentProps["sessionId"]; !ok {
+		t.Fatal("get current input missing sessionId")
+	}
+
+	saveCurrentProps := byName[factorydefinitionmcp.ToolSaveCurrent].InputSchema["properties"].(map[string]any)
+	for _, field := range []string{"sessionId", "mode", "factory"} {
+		if _, ok := saveCurrentProps[field]; !ok {
+			t.Fatalf("save current input missing %q", field)
+		}
+	}
+
+	installProps := byName[factorydefinitionmcp.ToolInstallPackaged].InputSchema["properties"].(map[string]any)
+	for _, field := range []string{"package", "dir", "format", "replace"} {
+		if _, ok := installProps[field]; !ok {
+			t.Fatalf("install packaged input missing %q", field)
+		}
+	}
+}
+
+func TestDiscoverTools_OutputSchemasDocumentSharedErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	for _, tool := range factorydefinitionmcp.DiscoverTools() {
+		properties, ok := tool.OutputSchema["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("tool %q output schema properties missing", tool.Name)
+		}
+		errorSchema, ok := properties["error"].(map[string]any)
+		if !ok {
+			t.Fatalf("tool %q output schema missing error envelope", tool.Name)
+		}
+		errorProps, ok := errorSchema["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("tool %q error envelope properties missing", tool.Name)
+		}
+		for _, field := range []string{"code", "message", "retryable"} {
+			if _, ok := errorProps[field]; !ok {
+				t.Fatalf("tool %q error envelope missing %q", tool.Name, field)
+			}
+		}
+	}
+}
+
+func TestDiscoverTools_RepeatDiscoveryIsStable(t *testing.T) {
+	t.Parallel()
+
+	first, err := json.Marshal(factorydefinitionmcp.DiscoverTools())
+	if err != nil {
+		t.Fatalf("marshal first discovery: %v", err)
+	}
+	second, err := json.Marshal(factorydefinitionmcp.DiscoverTools())
+	if err != nil {
+		t.Fatalf("marshal second discovery: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Fatalf("repeat discovery differs:\nfirst=%s\nsecond=%s", first, second)
+	}
+}
+
+func TestToolByName_ReturnsCanonicalDefinitions(t *testing.T) {
+	t.Parallel()
+
+	for _, want := range factorydefinitionmcp.DiscoverTools() {
+		got, ok := factorydefinitionmcp.ToolByName(want.Name)
+		if !ok {
+			t.Fatalf("ToolByName(%q) ok = false, want true", want.Name)
+		}
+		if got.Name != want.Name || got.Description != want.Description {
+			t.Fatalf("ToolByName(%q) = %#v, want %#v", want.Name, got, want)
+		}
+	}
+
+	if _, ok := factorydefinitionmcp.ToolByName("you.factory_definition.unknown"); ok {
+		t.Fatal("ToolByName(unknown) ok = true, want false")
+	}
+}
+
+func toolDefinitionsByName(t *testing.T) map[string]factorydefinitionmcp.ToolDefinition {
+	t.Helper()
+
+	byName := make(map[string]factorydefinitionmcp.ToolDefinition, len(factorydefinitionmcp.DiscoverTools()))
+	for _, tool := range factorydefinitionmcp.DiscoverTools() {
+		byName[tool.Name] = tool
+	}
+	return byName
+}

--- a/pkg/services/factory_definitions/transports/mcp/registry_test.go
+++ b/pkg/services/factory_definitions/transports/mcp/registry_test.go
@@ -96,6 +96,26 @@ func TestDiscoverTools_RepresentativeSchemaFields(t *testing.T) {
 	}
 }
 
+func TestDiscoverTools_InstallPackagedFormatEnumMatchesRuntimeAcceptedValues(t *testing.T) {
+	t.Parallel()
+
+	byName := toolDefinitionsByName(t)
+	installProps := byName[factorydefinitionmcp.ToolInstallPackaged].InputSchema["properties"].(map[string]any)
+	formatSchema, ok := installProps["format"].(map[string]any)
+	if !ok {
+		t.Fatal("install packaged format schema missing")
+	}
+	enumValues, ok := formatSchema["enum"].([]string)
+	if !ok {
+		t.Fatalf("install packaged format enum = %#v, want []string", formatSchema["enum"])
+	}
+
+	want := []string{"json", "yaml", "yml"}
+	if !slices.Equal(enumValues, want) {
+		t.Fatalf("install packaged format enum = %#v, want %#v", enumValues, want)
+	}
+}
+
 func TestDiscoverTools_OutputSchemasDocumentSharedErrorEnvelope(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_definitions/transports/mcp/request_context_test.go
+++ b/pkg/services/factory_definitions/transports/mcp/request_context_test.go
@@ -1,0 +1,129 @@
+package factorydefinition_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorydefinitionmcp "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/mcp"
+)
+
+func TestBind_ValidateContextCanceledBeforeRootReturnsDocumentedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	validation := &mcpDefinitionsValidationFake{}
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Validation: validation})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	raw, err := operation(
+		ctx,
+		factorydefinitionmcp.ToolValidate,
+		json.RawMessage(minimalValidationFactoryBody),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(validate) transport error = %v, want typed tool response", err)
+	}
+	if validation.invoked {
+		t.Fatal("fake validation root was invoked for pre-canceled context")
+	}
+	envelope := assertTypedToolErrorEnvelope(
+		t,
+		raw,
+		"factory_definition.request.canceled",
+		false,
+	)
+	if envelope.Message != "factory definition request was canceled" {
+		t.Fatalf("error.message = %q, want canceled request message; envelope = %#v", envelope.Message, envelope)
+	}
+}
+
+func TestBind_ValidateContextCanceledDuringRootReturnsDocumentedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	entered := make(chan struct{})
+	var enteredOnce sync.Once
+	validation := &blockingDefinitionsValidationFake{entered: entered, enteredOnce: &enteredOnce}
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Validation: validation})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	var raw json.RawMessage
+	var callErr error
+	go func() {
+		defer close(done)
+		raw, callErr = operation(
+			ctx,
+			factorydefinitionmcp.ToolValidate,
+			json.RawMessage(minimalValidationFactoryBody),
+		)
+	}()
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fake validation root did not start before cancellation")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("CallTool(validate) hung after cancellation")
+	}
+	if callErr != nil {
+		t.Fatalf("CallTool(validate) transport error = %v, want typed tool response", callErr)
+	}
+	envelope := assertTypedToolErrorEnvelope(
+		t,
+		raw,
+		"factory_definition.request.canceled",
+		false,
+	)
+	if envelope.Message != "factory definition request was canceled" {
+		t.Fatalf("error.message = %q, want canceled request message; envelope = %#v", envelope.Message, envelope)
+	}
+}
+
+func TestBind_ValidateContextDeadlineExceededDuringRootReturnsDocumentedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	validation := &blockingDefinitionsValidationFake{}
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Validation: validation})
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	raw, err := operation(
+		ctx,
+		factorydefinitionmcp.ToolValidate,
+		json.RawMessage(minimalValidationFactoryBody),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(validate) transport error = %v, want typed tool response", err)
+	}
+	envelope := assertTypedToolErrorEnvelope(
+		t,
+		raw,
+		"factory_definition.request.timed_out",
+		true,
+	)
+	if envelope.Message != "factory definition request timed out" {
+		t.Fatalf("error.message = %q, want timed out request message; envelope = %#v", envelope.Message, envelope)
+	}
+}
+
+type blockingDefinitionsValidationFake struct {
+	entered       chan struct{}
+	enteredOnce   *sync.Once
+}
+
+func (fake *blockingDefinitionsValidationFake) ValidateSubmittedDefinition(
+	ctx context.Context,
+	_ factorydefinitions.SubmittedDefinitionValidationRequest,
+) (factorydefinitions.ValidationResult, error) {
+	if fake.entered != nil && fake.enteredOnce != nil {
+		fake.enteredOnce.Do(func() { close(fake.entered) })
+	}
+	<-ctx.Done()
+	return factorydefinitions.ValidationResult{}, ctx.Err()
+}
+
+var _ factorydefinitions.SubmittedDefinitionValidationOperation = (*blockingDefinitionsValidationFake)(nil)

--- a/pkg/services/factory_definitions/transports/mcp/result_policy.go
+++ b/pkg/services/factory_definitions/transports/mcp/result_policy.go
@@ -1,0 +1,27 @@
+package factorydefinition
+
+import "encoding/json"
+
+const (
+	// SuccessTextEncodingSerializedJSON documents serialized JSON tool payloads in text content.
+	SuccessTextEncodingSerializedJSON = "serialized-json"
+)
+
+// EncodeSuccessCallToolResult builds the live MCP tools/call success envelope for one
+// serialized tool-response payload. Inventory callers and tests use this shape to
+// document current server transport without mutating handlers.
+func EncodeSuccessCallToolResult(toolResponse json.RawMessage) map[string]any {
+	return map[string]any{
+		"content": []map[string]any{
+			{
+				"type": "text",
+				"text": string(toolResponse),
+			},
+		},
+	}
+}
+
+// MarshalSuccessCallToolResultJSON encodes one success CallToolResult with stable key order.
+func MarshalSuccessCallToolResultJSON(toolResponse json.RawMessage) ([]byte, error) {
+	return json.Marshal(EncodeSuccessCallToolResult(toolResponse))
+}

--- a/pkg/services/factory_definitions/transports/mcp/root_binding.go
+++ b/pkg/services/factory_definitions/transports/mcp/root_binding.go
@@ -1,0 +1,71 @@
+package factorydefinition
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+)
+
+// DefinitionsRoot is the accepted Factory Definitions root contract used by the
+// MCP adapter. Adapter-owned operations invoke this surface rather than
+// Definitions internal packages.
+type DefinitionsRoot = factorydefinitions.Service
+
+// RootBinding binds the MCP adapter to one injected Definitions root and
+// optional root-shaped validation and distribute roles already used by
+// HTTP-DEF and CLI-DEF.
+type RootBinding struct {
+	Definitions DefinitionsRoot
+	Validation  factorydefinitions.SubmittedDefinitionValidationOperation
+	Install     factorydefinitions.InstallPackagedFactoryOperation
+}
+
+// NewFromRoot constructs an MCP tool operation that calls through the supplied
+// Definitions root binding. Tests inject focused fakes without constructing
+// real catalog, authoring, compile, validate, snapshot, distribute, or
+// service-local Wire graphs.
+func NewFromRoot(binding RootBinding) ToolOperation {
+	return Bind(binding)
+}
+
+func resolveSubmittedDefinitionValidation(binding RootBinding) (factorydefinitions.SubmittedDefinitionValidationOperation, error) {
+	if binding.Validation != nil {
+		return binding.Validation, nil
+	}
+	if binding.Definitions == nil {
+		return nil, errValidationUnavailable
+	}
+	return submittedDefinitionValidationFromRoot{binding.Definitions}, nil
+}
+
+var errValidationUnavailable = fmt.Errorf("factory definition validation is unavailable")
+
+type submittedDefinitionValidationFromRoot struct {
+	root DefinitionsRoot
+}
+
+func (adapter submittedDefinitionValidationFromRoot) ValidateSubmittedDefinition(
+	ctx context.Context,
+	request factorydefinitions.SubmittedDefinitionValidationRequest,
+) (factorydefinitions.ValidationResult, error) {
+	if request.Config == nil {
+		return factorydefinitions.ValidationResult{}, factorydefinitions.ErrInvalidFactoryDefinitionPayload
+	}
+	payload, err := json.Marshal(request.Config)
+	if err != nil {
+		return factorydefinitions.ValidationResult{}, factorydefinitions.ErrInvalidFactoryDefinitionPayload
+	}
+	result, err := adapter.root.ValidateStructuralFactoryDefinition(
+		ctx,
+		factorydefinitions.ValidateStructuralFactoryDefinitionRequest{
+			Canonical: payload,
+			Profile:   factorydefinitions.ValidationProfileTopology,
+		},
+	)
+	if err != nil {
+		return factorydefinitions.ValidationResult{}, err
+	}
+	return result.Validation, nil
+}

--- a/pkg/services/factory_definitions/transports/mcp/root_binding.go
+++ b/pkg/services/factory_definitions/transports/mcp/root_binding.go
@@ -40,7 +40,25 @@ func resolveSubmittedDefinitionValidation(binding RootBinding) (factorydefinitio
 	return submittedDefinitionValidationFromRoot{binding.Definitions}, nil
 }
 
-var errValidationUnavailable = fmt.Errorf("factory definition validation is unavailable")
+func resolveInstallPackagedFactory(binding RootBinding) (factorydefinitions.InstallPackagedFactoryOperation, error) {
+	if binding.Install != nil {
+		return binding.Install, nil
+	}
+	if binding.Definitions == nil {
+		return nil, errInstallUnavailable
+	}
+	return func(
+		ctx context.Context,
+		request factorydefinitions.InstallPackagedFactoryRequest,
+	) (factorydefinitions.InstallPackagedFactoryResult, error) {
+		return binding.Definitions.InstallPackagedFactory(ctx, request)
+	}, nil
+}
+
+var (
+	errValidationUnavailable = fmt.Errorf("factory definition validation is unavailable")
+	errInstallUnavailable    = fmt.Errorf("packaged factory installation is unavailable")
+)
 
 type submittedDefinitionValidationFromRoot struct {
 	root DefinitionsRoot

--- a/pkg/services/factory_definitions/transports/mcp/root_binding_test.go
+++ b/pkg/services/factory_definitions/transports/mcp/root_binding_test.go
@@ -1,0 +1,312 @@
+package factorydefinition_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorydefinitionmcp "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/mcp"
+)
+
+const minimalValidationFactoryBody = `{
+  "name": "alpha",
+  "workTypes": [{
+    "name": "task",
+    "states": [
+      {"name": "init", "type": "INITIAL"},
+      {"name": "done", "type": "TERMINAL"},
+      {"name": "failed", "type": "FAILED"}
+    ]
+  }],
+  "workers": [{
+    "name": "planner",
+    "type": "MODEL_WORKER",
+    "modelProvider": "CLAUDE",
+    "executorProvider": "SCRIPT_WRAP",
+    "model": "claude-sonnet-4-20250514"
+  }],
+  "workstations": [{
+    "name": "plan-task",
+    "behavior": "STANDARD",
+    "type": "MODEL_WORKSTATION",
+    "worker": "planner",
+    "inputs": [{"workType": "task", "state": "init"}],
+    "outputs": [{"workType": "task", "state": "done"}]
+  }]
+}`
+
+func TestBind_FakeValidationInvokedThroughValidateTool(t *testing.T) {
+	t.Parallel()
+
+	validation := &mcpDefinitionsValidationFake{}
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Validation: validation})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolValidate,
+		json.RawMessage(minimalValidationFactoryBody),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(validate) error = %v", err)
+	}
+	if !validation.invoked {
+		t.Fatal("ValidateSubmittedDefinition was not invoked through the injected validation operation")
+	}
+	if !strings.Contains(string(raw), `"targets"`) {
+		t.Fatalf("CallTool(validate) = %s, want encoded validation result", raw)
+	}
+}
+
+func TestBind_FakeDefinitionsRootInvokedThroughValidateTool(t *testing.T) {
+	t.Parallel()
+
+	root := &mcpDefinitionsRootFake{}
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Definitions: root})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolValidate,
+		json.RawMessage(minimalValidationFactoryBody),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(validate) error = %v", err)
+	}
+	if !root.validateStructuralInvoked {
+		t.Fatal("ValidateStructuralFactoryDefinition was not invoked through the injected Definitions root")
+	}
+	if !strings.Contains(string(raw), `"targets"`) {
+		t.Fatalf("CallTool(validate) = %s, want encoded validation result", raw)
+	}
+}
+
+func TestBind_UnsupportedToolReturnsStableError(t *testing.T) {
+	t.Parallel()
+
+	operation := factorydefinitionmcp.NewFromRoot(factorydefinitionmcp.RootBinding{})
+	_, err := operation(context.Background(), "you.factory_definition.unknown", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("CallTool(unknown) error = nil, want unsupported tool error")
+	}
+	if !strings.Contains(err.Error(), "unsupported tool") {
+		t.Fatalf("CallTool(unknown) error = %v, want unsupported tool message", err)
+	}
+}
+
+type mcpDefinitionsValidationFake struct {
+	invoked bool
+}
+
+func (fake *mcpDefinitionsValidationFake) ValidateSubmittedDefinition(
+	_ context.Context,
+	_ factorydefinitions.SubmittedDefinitionValidationRequest,
+) (factorydefinitions.ValidationResult, error) {
+	fake.invoked = true
+	return factorydefinitions.ValidationResult{
+		Targets: []factorydefinitions.ValidationTarget{{
+			Code:     "factory.validation.stub",
+			Severity: factorydefinitions.ValidationSeverityError,
+			Message:  "stub validation finding",
+			Subject: factorydefinitions.ValidationSubject{
+				Type:     factorydefinitions.ValidationSubjectTypeFactory,
+				Location: factorydefinitions.ValidationSubjectLocationDefinition,
+			},
+		}},
+	}, nil
+}
+
+type mcpDefinitionsRootFake struct {
+	validateStructuralInvoked bool
+}
+
+var _ factorydefinitions.Service = (*mcpDefinitionsRootFake)(nil)
+
+func (fake *mcpDefinitionsRootFake) ValidateStructuralFactoryDefinition(
+	_ context.Context,
+	request factorydefinitions.ValidateStructuralFactoryDefinitionRequest,
+) (factorydefinitions.ValidateStructuralFactoryDefinitionResult, error) {
+	fake.validateStructuralInvoked = true
+	if len(request.Canonical) == 0 {
+		return factorydefinitions.ValidateStructuralFactoryDefinitionResult{}, factorydefinitions.ErrInvalidFactoryDefinitionPayload
+	}
+	return factorydefinitions.ValidateStructuralFactoryDefinitionResult{
+		Validation: factorydefinitions.ValidationResult{},
+	}, nil
+}
+
+func (fake *mcpDefinitionsRootFake) ActivateNamedFactory(context.Context, string) error { return nil }
+
+func (fake *mcpDefinitionsRootFake) Save(
+	context.Context,
+	string,
+	factorydefinitions.SaveMode,
+	factorydefinitions.EditableFactory,
+) (factorydefinitions.EditableFactory, error) {
+	return factorydefinitions.EditableFactory{}, nil
+}
+
+func (fake *mcpDefinitionsRootFake) GetCurrentNamedFactory(context.Context) (*factorydefinitions.FactorySnapshot, error) {
+	return nil, factorydefinitions.ErrCurrentFactoryNotFound
+}
+
+func (fake *mcpDefinitionsRootFake) GetCurrentFactoryForSession(
+	context.Context,
+	string,
+) (factorydefinitions.EditableFactory, error) {
+	return factorydefinitions.EditableFactory{}, factorydefinitions.ErrCurrentFactoryNotFound
+}
+
+func (fake *mcpDefinitionsRootFake) CurrentFactoryDefinitionVersionAtRoot(
+	string,
+	string,
+) (factorydefinitions.FactoryVersion, error) {
+	return factorydefinitions.FactoryVersion{}, factorydefinitions.ErrCurrentFactoryNotFound
+}
+
+func (fake *mcpDefinitionsRootFake) ListEffectiveFactories(
+	context.Context,
+	factorydefinitions.ListEffectiveFactoriesRequest,
+) (factorydefinitions.ListEffectiveFactoriesResult, error) {
+	return factorydefinitions.ListEffectiveFactoriesResult{}, nil
+}
+
+func (fake *mcpDefinitionsRootFake) ListNamedFactories(
+	context.Context,
+	factorydefinitions.ListNamedFactoriesRequest,
+) (factorydefinitions.ListNamedFactoriesResult, error) {
+	return factorydefinitions.ListNamedFactoriesResult{}, nil
+}
+
+func (fake *mcpDefinitionsRootFake) GetNamedFactory(
+	context.Context,
+	factorydefinitions.GetNamedFactoryRequest,
+) (factorydefinitions.GetNamedFactoryResult, error) {
+	return factorydefinitions.GetNamedFactoryResult{}, factorydefinitions.ErrNamedFactoryNotFound
+}
+
+func (fake *mcpDefinitionsRootFake) ResolveNamedFactory(
+	context.Context,
+	factorydefinitions.ResolveNamedFactoryRequest,
+) (factorydefinitions.ResolveNamedFactoryResult, error) {
+	return factorydefinitions.ResolveNamedFactoryResult{}, factorydefinitions.ErrNamedFactoryNotFound
+}
+
+func (fake *mcpDefinitionsRootFake) DeleteNamedFactory(
+	context.Context,
+	factorydefinitions.DeleteNamedFactoryRequest,
+) (factorydefinitions.DeleteNamedFactoryResult, error) {
+	return factorydefinitions.DeleteNamedFactoryResult{}, factorydefinitions.ErrNamedFactoryNotFound
+}
+
+func (fake *mcpDefinitionsRootFake) GetCurrentFactoryPointer(
+	context.Context,
+	factorydefinitions.GetCurrentFactoryPointerRequest,
+) (factorydefinitions.GetCurrentFactoryPointerResult, error) {
+	return factorydefinitions.GetCurrentFactoryPointerResult{}, factorydefinitions.ErrCurrentFactoryNotFound
+}
+
+func (fake *mcpDefinitionsRootFake) SetCurrentFactoryPointer(
+	context.Context,
+	factorydefinitions.SetCurrentFactoryPointerRequest,
+) (factorydefinitions.SetCurrentFactoryPointerResult, error) {
+	return factorydefinitions.SetCurrentFactoryPointerResult{}, factorydefinitions.ErrCurrentFactoryNotFound
+}
+
+func (fake *mcpDefinitionsRootFake) PrepareFactoryLayout(
+	context.Context,
+	factorydefinitions.PrepareFactoryLayoutRequest,
+) (factorydefinitions.PrepareFactoryLayoutResult, error) {
+	return factorydefinitions.PrepareFactoryLayoutResult{}, factorydefinitions.ErrMalformedFactoryLayoutPayload
+}
+
+func (fake *mcpDefinitionsRootFake) FlattenFactoryLayout(
+	context.Context,
+	factorydefinitions.FlattenFactoryLayoutRequest,
+) (factorydefinitions.FlattenFactoryLayoutResult, error) {
+	return factorydefinitions.FlattenFactoryLayoutResult{}, factorydefinitions.ErrMalformedFactoryLayoutPayload
+}
+
+func (fake *mcpDefinitionsRootFake) ExpandFactoryLayout(
+	context.Context,
+	factorydefinitions.ExpandFactoryLayoutRequest,
+) (factorydefinitions.ExpandFactoryLayoutResult, error) {
+	return factorydefinitions.ExpandFactoryLayoutResult{}, factorydefinitions.ErrMalformedFactoryLayoutPayload
+}
+
+func (fake *mcpDefinitionsRootFake) CreateNamedFactory(
+	context.Context,
+	factorydefinitions.CreateNamedFactoryRequest,
+) (factorydefinitions.CreateNamedFactoryResult, error) {
+	return factorydefinitions.CreateNamedFactoryResult{}, factorydefinitions.ErrAtomicFactoryWriteFailed
+}
+
+func (fake *mcpDefinitionsRootFake) ReplaceNamedFactory(
+	context.Context,
+	factorydefinitions.ReplaceNamedFactoryRequest,
+) (factorydefinitions.ReplaceNamedFactoryResult, error) {
+	return factorydefinitions.ReplaceNamedFactoryResult{}, factorydefinitions.ErrAtomicFactoryWriteFailed
+}
+
+func (fake *mcpDefinitionsRootFake) CompileEffectiveFactorySource(
+	context.Context,
+	factorydefinitions.CompileEffectiveFactorySourceRequest,
+) (factorydefinitions.CompileEffectiveFactorySourceResult, error) {
+	return factorydefinitions.CompileEffectiveFactorySourceResult{}, factorydefinitions.ErrInvalidAuthoredFactorySource
+}
+
+func (fake *mcpDefinitionsRootFake) ValidateEffectiveFactoryDefinition(
+	context.Context,
+	factorydefinitions.ValidateEffectiveFactoryDefinitionRequest,
+) (factorydefinitions.ValidateEffectiveFactoryDefinitionResult, error) {
+	return factorydefinitions.ValidateEffectiveFactoryDefinitionResult{}, factorydefinitions.ErrInvalidFactoryDefinitionPayload
+}
+
+func (fake *mcpDefinitionsRootFake) CaptureFactorySnapshot(
+	context.Context,
+	factorydefinitions.CaptureFactorySnapshotRequest,
+) (factorydefinitions.CaptureFactorySnapshotResult, error) {
+	return factorydefinitions.CaptureFactorySnapshotResult{}, factorydefinitions.ErrInvalidFactorySnapshotPayload
+}
+
+func (fake *mcpDefinitionsRootFake) PrepareFactorySnapshotImport(
+	context.Context,
+	factorydefinitions.PrepareFactorySnapshotImportRequest,
+) (factorydefinitions.PrepareFactorySnapshotImportResult, error) {
+	return factorydefinitions.PrepareFactorySnapshotImportResult{}, factorydefinitions.ErrInvalidFactorySnapshotPayload
+}
+
+func (fake *mcpDefinitionsRootFake) MaterializeFactorySnapshot(
+	context.Context,
+	factorydefinitions.MaterializeFactorySnapshotRequest,
+) (factorydefinitions.MaterializeFactorySnapshotResult, error) {
+	return factorydefinitions.MaterializeFactorySnapshotResult{}, factorydefinitions.ErrUnsafeFactorySnapshotMaterialize
+}
+
+func (fake *mcpDefinitionsRootFake) ListBuiltInPackagedFactories(
+	context.Context,
+	factorydefinitions.ListBuiltInPackagedFactoriesRequest,
+) (factorydefinitions.ListBuiltInPackagedFactoriesResult, error) {
+	return factorydefinitions.ListBuiltInPackagedFactoriesResult{}, nil
+}
+
+func (fake *mcpDefinitionsRootFake) ResolveBuiltInPackagedFactory(
+	context.Context,
+	factorydefinitions.ResolveBuiltInPackagedFactoryRequest,
+) (factorydefinitions.ResolveBuiltInPackagedFactoryResult, error) {
+	return factorydefinitions.ResolveBuiltInPackagedFactoryResult{}, factorydefinitions.ErrUnknownPackagedFactoryIdentity
+}
+
+func (fake *mcpDefinitionsRootFake) InstallPackagedFactory(
+	context.Context,
+	factorydefinitions.InstallPackagedFactoryRequest,
+) (factorydefinitions.InstallPackagedFactoryResult, error) {
+	return factorydefinitions.InstallPackagedFactoryResult{}, factorydefinitions.ErrFactoryDistributeFailed
+}
+
+func (fake *mcpDefinitionsRootFake) CreateFactoryScaffold(
+	context.Context,
+	factorydefinitions.CreateFactoryScaffoldRequest,
+) (factorydefinitions.CreateFactoryScaffoldResult, error) {
+	return factorydefinitions.CreateFactoryScaffoldResult{}, factorydefinitions.ErrFactoryDistributeFailed
+}
+
+var _ factorydefinitions.SubmittedDefinitionValidationOperation = (*mcpDefinitionsValidationFake)(nil)

--- a/pkg/services/factory_definitions/transports/mcp/root_binding_test.go
+++ b/pkg/services/factory_definitions/transports/mcp/root_binding_test.go
@@ -94,6 +94,7 @@ func TestBind_UnsupportedToolReturnsStableError(t *testing.T) {
 
 type mcpDefinitionsValidationFake struct {
 	invoked bool
+	result  factorydefinitions.ValidationResult
 }
 
 func (fake *mcpDefinitionsValidationFake) ValidateSubmittedDefinition(
@@ -101,6 +102,9 @@ func (fake *mcpDefinitionsValidationFake) ValidateSubmittedDefinition(
 	_ factorydefinitions.SubmittedDefinitionValidationRequest,
 ) (factorydefinitions.ValidationResult, error) {
 	fake.invoked = true
+	if len(fake.result.Targets) > 0 {
+		return fake.result, nil
+	}
 	return factorydefinitions.ValidationResult{
 		Targets: []factorydefinitions.ValidationTarget{{
 			Code:     "factory.validation.stub",

--- a/pkg/services/factory_definitions/transports/mcp/schemas.go
+++ b/pkg/services/factory_definitions/transports/mcp/schemas.go
@@ -154,7 +154,7 @@ func installPackagedFactoryInputSchema() map[string]any {
 		"dir":     stringProperty("Destination named-factory root directory. Defaults to the caller home directory when omitted."),
 		"format": enumStringProperty(
 			"Portable editable format for the installed factory layout.",
-			"json", "yaml", "toml",
+			"json", "yaml", "yml",
 		),
 		"replace": booleanProperty("When true, replace an existing installed factory at the destination."),
 	}, "package")

--- a/pkg/services/factory_definitions/transports/mcp/schemas.go
+++ b/pkg/services/factory_definitions/transports/mcp/schemas.go
@@ -1,0 +1,170 @@
+package factorydefinition
+
+func objectSchema(properties map[string]any, required ...string) map[string]any {
+	schema := map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties":           properties,
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+func stringProperty(description string) map[string]any {
+	return map[string]any{
+		"type":        "string",
+		"description": description,
+	}
+}
+
+func booleanProperty(description string) map[string]any {
+	return map[string]any{
+		"type":        "boolean",
+		"description": description,
+	}
+}
+
+func enumStringProperty(description string, values ...string) map[string]any {
+	return map[string]any{
+		"type":        "string",
+		"description": description,
+		"enum":        values,
+	}
+}
+
+func toolResponseSchema(resultSchema map[string]any) map[string]any {
+	return objectSchema(map[string]any{
+		"result": resultSchema,
+		"error":  toolErrorEnvelopeSchema(),
+	})
+}
+
+func toolErrorEnvelopeSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"code":      stringProperty("Stable machine-readable failure code."),
+		"message":   stringProperty("Human-readable failure summary for MCP hosts."),
+		"retryable": map[string]any{"type": "boolean", "description": "Whether the caller should retry the same request later."},
+		"details": map[string]any{
+			"type":                 "object",
+			"additionalProperties": true,
+			"description":          "Optional structured diagnostics such as validation issues or availability hints.",
+		},
+	}, "code", "message", "retryable")
+}
+
+func factoryDefinitionInputSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"name":        stringProperty("Factory name for the submitted definition."),
+		"description": stringProperty("Optional customer-facing explanation of this Factory."),
+		"id":          stringProperty("Factory identifier used as the factory-level template context fallback."),
+		"version": map[string]any{
+			"type":        "object",
+			"description": "Server-managed current-factory version metadata echoed on replacement saves.",
+		},
+		"workTypes": map[string]any{
+			"type":        "array",
+			"description": "Customer-authored work item categories and lifecycle states.",
+			"items":       map[string]any{"type": "object"},
+		},
+		"workers": map[string]any{
+			"type":        "array",
+			"description": "Workers that execute work at workstations.",
+			"items":       map[string]any{"type": "object"},
+		},
+		"workstations": map[string]any{
+			"type":        "array",
+			"description": "Workstations that bind workers to work-type transitions.",
+			"items":       map[string]any{"type": "object"},
+		},
+		"resources": map[string]any{
+			"type":        "array",
+			"description": "Shared capacity pools consumed while work executes.",
+			"items":       map[string]any{"type": "object"},
+		},
+		"guards": map[string]any{
+			"type":        "array",
+			"description": "Root-level guards that apply across the factory.",
+			"items":       map[string]any{"type": "object"},
+		},
+	}, "name")
+}
+
+func factoryValidationResultSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"targets": map[string]any{
+			"type":        "array",
+			"description": "Canonical validation targets for the submitted factory definition.",
+			"items": objectSchema(map[string]any{
+				"code":     stringProperty("Validation issue code."),
+				"message":  stringProperty("Validation issue message."),
+				"severity": stringProperty("Validation severity."),
+				"subject": map[string]any{
+					"type":        "object",
+					"description": "Factory-domain component referenced by one validation target.",
+				},
+			}),
+		},
+	}, "targets")
+}
+
+func factoryPayloadSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"name": stringProperty("Factory name for the current-factory payload."),
+		"version": map[string]any{
+			"type":        "object",
+			"description": "Current-factory version metadata for stale-write detection.",
+		},
+		"workTypes": map[string]any{
+			"type":  "array",
+			"items": map[string]any{"type": "object"},
+		},
+		"workers": map[string]any{
+			"type":  "array",
+			"items": map[string]any{"type": "object"},
+		},
+		"workstations": map[string]any{
+			"type":  "array",
+			"items": map[string]any{"type": "object"},
+		},
+	}, "name")
+}
+
+func saveCurrentFactoryInputSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"sessionId": stringProperty("Stable Factory Session identifier whose current factory is being saved."),
+		"mode": enumStringProperty(
+			"Explicit save mode. Defaults to REPLACE_CURRENT when omitted.",
+			"REPLACE_CURRENT", "UPSERT_NAMED_AND_ACTIVATE",
+		),
+		"factory": factoryPayloadSchema(),
+	}, "sessionId", "factory")
+}
+
+func getCurrentFactoryInputSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"sessionId": stringProperty("Stable Factory Session identifier whose current factory should be read."),
+	}, "sessionId")
+}
+
+func installPackagedFactoryInputSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"package": stringProperty("Built-in packaged Factory identity, such as @you/example."),
+		"dir":     stringProperty("Destination named-factory root directory. Defaults to the caller home directory when omitted."),
+		"format": enumStringProperty(
+			"Portable editable format for the installed factory layout.",
+			"json", "yaml", "toml",
+		),
+		"replace": booleanProperty("When true, replace an existing installed factory at the destination."),
+	}, "package")
+}
+
+func installPackagedFactoryResultSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"name":       stringProperty("Installed packaged Factory name."),
+		"factoryDir": stringProperty("Destination directory containing the installed factory layout."),
+		"outcome":    stringProperty("Definitions-owned install outcome such as CREATED, SKIPPED, or REPLACED."),
+		"format":     stringProperty("Portable editable format used for the installed factory layout."),
+	}, "name", "outcome")
+}

--- a/pkg/services/factory_definitions/transports/mcp/tool.go
+++ b/pkg/services/factory_definitions/transports/mcp/tool.go
@@ -14,6 +14,14 @@ const (
 	ToolInstallPackaged = "you.factory_definition.install_packaged"
 )
 
+// Stable error envelope fields shared by every Factory Definition MCP tool.
+var sharedErrorStableFields = []string{
+	"error.code",
+	"error.message",
+	"error.retryable",
+	"error.details",
+}
+
 // ToolErrorEnvelope is the stable MCP failure shape for Factory Definition tools.
 type ToolErrorEnvelope struct {
 	Code      string         `json:"code"`

--- a/pkg/services/factory_definitions/transports/mcp/tool.go
+++ b/pkg/services/factory_definitions/transports/mcp/tool.go
@@ -1,0 +1,46 @@
+// Package factorydefinition exposes MCP tool operations for Factory Definitions
+// backed by the accepted Definitions root contract.
+package factorydefinition
+
+import (
+	"encoding/json"
+)
+
+// Tool names use Factory Definition vocabulary and align with HTTP-DEF routes.
+const (
+	ToolValidate        = "you.factory_definition.validate"
+	ToolGetCurrent      = "you.factory_definition.get_current"
+	ToolSaveCurrent     = "you.factory_definition.save_current"
+	ToolInstallPackaged = "you.factory_definition.install_packaged"
+)
+
+// ToolErrorEnvelope is the stable MCP failure shape for Factory Definition tools.
+type ToolErrorEnvelope struct {
+	Code      string         `json:"code"`
+	Message   string         `json:"message"`
+	Retryable bool           `json:"retryable"`
+	Details   map[string]any `json:"details,omitempty"`
+}
+
+// ToolResponse wraps one tool outcome with either a typed result or a stable error.
+type ToolResponse[T any] struct {
+	Result *T                 `json:"result,omitempty"`
+	Error  *ToolErrorEnvelope `json:"error,omitempty"`
+}
+
+// MarshalJSON encodes one tool definition for MCP hosts and mock clients.
+func (t ToolDefinition) MarshalJSON() ([]byte, error) {
+	type alias ToolDefinition
+	return json.Marshal(alias(t))
+}
+
+// ToolDefinition is one discoverable MCP tool with typed schemas and documented
+// stable response fields for success and error envelopes.
+type ToolDefinition struct {
+	Name                string         `json:"name"`
+	Description         string         `json:"description"`
+	InputSchema         map[string]any `json:"inputSchema"`
+	OutputSchema        map[string]any `json:"outputSchema"`
+	SuccessStableFields []string       `json:"successStableFields"`
+	ErrorStableFields   []string       `json:"errorStableFields"`
+}

--- a/pkg/services/factory_definitions/transports/mcp/validate.go
+++ b/pkg/services/factory_definitions/transports/mcp/validate.go
@@ -20,6 +20,9 @@ func Validate(
 		envelope := decodeInputErrorEnvelope("validate factory definition", errMissingRequestContext)
 		return ToolResponse[factoryapi.FactoryValidationResult]{Error: &envelope}
 	}
+	if response, done := requestContextErrorResponse[factoryapi.FactoryValidationResult](ctx); done {
+		return response
+	}
 	if validation == nil {
 		envelope := unavailableValidationErrorEnvelope()
 		return ToolResponse[factoryapi.FactoryValidationResult]{Error: &envelope}
@@ -27,6 +30,9 @@ func Validate(
 
 	result, err := validationentry.ValidateFactoryAPI(ctx, factory, validation)
 	if err != nil {
+		if envelope, ok := contextRequestErrorEnvelope(err); ok {
+			return ToolResponse[factoryapi.FactoryValidationResult]{Error: &envelope}
+		}
 		if envelope, ok := validationErrorEnvelope(err); ok {
 			return ToolResponse[factoryapi.FactoryValidationResult]{Error: &envelope}
 		}

--- a/pkg/services/factory_definitions/transports/mcp/validate.go
+++ b/pkg/services/factory_definitions/transports/mcp/validate.go
@@ -27,7 +27,10 @@ func Validate(
 
 	result, err := validationentry.ValidateFactoryAPI(ctx, factory, validation)
 	if err != nil {
-		envelope := decodeInputErrorEnvelope("validate factory definition", err)
+		if envelope, ok := validationErrorEnvelope(err); ok {
+			return ToolResponse[factoryapi.FactoryValidationResult]{Error: &envelope}
+		}
+		envelope := opaqueValidationErrorEnvelope()
 		return ToolResponse[factoryapi.FactoryValidationResult]{Error: &envelope}
 	}
 	apiResult := apisurface.FactoryValidationResultToAPI(result)

--- a/pkg/services/factory_definitions/transports/mcp/validate.go
+++ b/pkg/services/factory_definitions/transports/mcp/validate.go
@@ -1,0 +1,35 @@
+package factorydefinition
+
+import (
+	"context"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	apisurface "github.com/portpowered/infinite-you/pkg/transports/mapping"
+	"github.com/portpowered/infinite-you/pkg/transports/mapping/validationentry"
+)
+
+// Validate runs the canonical Factory validation contract for the
+// you.factory_definition.validate MCP tool.
+func Validate(
+	ctx context.Context,
+	validation factorydefinitions.SubmittedDefinitionValidationOperation,
+	factory factoryapi.Factory,
+) ToolResponse[factoryapi.FactoryValidationResult] {
+	if ctx == nil {
+		envelope := decodeInputErrorEnvelope("validate factory definition", errMissingRequestContext)
+		return ToolResponse[factoryapi.FactoryValidationResult]{Error: &envelope}
+	}
+	if validation == nil {
+		envelope := unavailableValidationErrorEnvelope()
+		return ToolResponse[factoryapi.FactoryValidationResult]{Error: &envelope}
+	}
+
+	result, err := validationentry.ValidateFactoryAPI(ctx, factory, validation)
+	if err != nil {
+		envelope := decodeInputErrorEnvelope("validate factory definition", err)
+		return ToolResponse[factoryapi.FactoryValidationResult]{Error: &envelope}
+	}
+	apiResult := apisurface.FactoryValidationResultToAPI(result)
+	return ToolResponse[factoryapi.FactoryValidationResult]{Result: &apiResult}
+}

--- a/pkg/services/factory_definitions/transports/mcp/validate_test.go
+++ b/pkg/services/factory_definitions/transports/mcp/validate_test.go
@@ -1,0 +1,252 @@
+package factorydefinition_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorydefinitionmcp "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/mcp"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+func TestBind_ValidateToolEncodesValidationTargetsFromFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	validation := &mcpDefinitionsValidationFake{
+		result: factorydefinitions.ValidationResult{
+			Targets: []factorydefinitions.ValidationTarget{{
+				Code:     "factory.validation.stub",
+				Severity: factorydefinitions.ValidationSeverityError,
+				Message:  "stub validation finding",
+				Path:     "workers[0].model",
+				Subject: factorydefinitions.ValidationSubject{
+					Type:     factorydefinitions.ValidationSubjectTypeWorker,
+					ID:       "planner",
+					Location: factorydefinitions.ValidationSubjectLocationDefinition,
+				},
+			}},
+		},
+	}
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Validation: validation})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolValidate,
+		json.RawMessage(minimalValidationFactoryBody),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(validate) error = %v", err)
+	}
+
+	var response struct {
+		Result *factoryapi.FactoryValidationResult `json:"result"`
+		Error  *factorydefinitionmcp.ToolErrorEnvelope `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode tool response: %v", err)
+	}
+	if response.Error != nil {
+		t.Fatalf("tool response error = %#v, want success result", response.Error)
+	}
+	if response.Result == nil || len(response.Result.Targets) != 1 {
+		t.Fatalf("result targets = %#v, want one encoded finding", response.Result)
+	}
+	target := response.Result.Targets[0]
+	if target.Code != "factory.validation.stub" {
+		t.Fatalf("target code = %q, want factory.validation.stub", target.Code)
+	}
+	if target.Message != "stub validation finding" {
+		t.Fatalf("target message = %q, want stub validation finding", target.Message)
+	}
+	if target.Severity != factoryapi.FactoryValidationSeverityError {
+		t.Fatalf("target severity = %q, want error", target.Severity)
+	}
+	if target.Path == nil || *target.Path != "workers[0].model" {
+		t.Fatalf("target path = %#v, want workers[0].model", target.Path)
+	}
+}
+
+func TestBind_ValidateToolInvalidFactoryDefinitionPayloadReturnsTypedErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	validation := &mcpDefinitionsValidationErrorFake{
+		err: factorydefinitions.ErrInvalidFactoryDefinitionPayload,
+	}
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Validation: validation})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolValidate,
+		json.RawMessage(minimalValidationFactoryBody),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(validate) error = %v", err)
+	}
+
+	envelope := assertTypedToolErrorEnvelope(t, raw, "BAD_REQUEST", false)
+	if envelope.Message != "invalid request payload" {
+		t.Fatalf("error.message = %q, want invalid request payload", envelope.Message)
+	}
+}
+
+func TestBind_ValidateToolValidationFailedReturnsInvalidFactoryWithTargets(t *testing.T) {
+	t.Parallel()
+
+	validation := &mcpDefinitionsValidationErrorFake{
+		err: &factorydefinitions.FactoryDefinitionValidationFailure{
+			Validation: factorydefinitions.ValidationResult{
+				Targets: []factorydefinitions.ValidationTarget{{
+					Code:     "factory.validation.stub",
+					Severity: factorydefinitions.ValidationSeverityError,
+					Message:  "stub validation finding",
+					Path:     "workers[0].model",
+					Subject: factorydefinitions.ValidationSubject{
+						Type:     factorydefinitions.ValidationSubjectTypeWorker,
+						ID:       "planner",
+						Location: factorydefinitions.ValidationSubjectLocationDefinition,
+					},
+				}},
+			},
+		},
+	}
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Validation: validation})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolValidate,
+		json.RawMessage(minimalValidationFactoryBody),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(validate) error = %v", err)
+	}
+
+	envelope := assertTypedToolErrorEnvelope(t, raw, "INVALID_FACTORY", false)
+	if envelope.Message != "Factory payload is not a valid Agent Factory definition." {
+		t.Fatalf("error.message = %q, want invalid factory message", envelope.Message)
+	}
+	targets, ok := envelope.Details["targets"].([]any)
+	if !ok || len(targets) != 1 {
+		t.Fatalf("error.details.targets = %#v, want one encoded finding", envelope.Details["targets"])
+	}
+	targetMap, ok := targets[0].(map[string]any)
+	if !ok {
+		t.Fatalf("target = %#v, want object", targets[0])
+	}
+	if targetMap["code"] != "factory.validation.stub" {
+		t.Fatalf("target code = %#v, want factory.validation.stub", targetMap["code"])
+	}
+}
+
+func TestBind_ValidateToolOpaqueRootFailureDoesNotLeakInternalDetails(t *testing.T) {
+	t.Parallel()
+
+	const leakedPath = "/var/lib/factory/pkg/services/factory_definitions/internal/catalog"
+	validation := &mcpDefinitionsValidationErrorFake{
+		err: fmt.Errorf("load catalog: %s", leakedPath),
+	}
+	operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Validation: validation})
+	raw, err := operation(
+		context.Background(),
+		factorydefinitionmcp.ToolValidate,
+		json.RawMessage(minimalValidationFactoryBody),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(validate) error = %v", err)
+	}
+
+	envelope := assertTypedToolErrorEnvelope(t, raw, "BAD_REQUEST", false)
+	if envelope.Message != "invalid request payload" {
+		t.Fatalf("error.message = %q, want opaque invalid request payload", envelope.Message)
+	}
+	if strings.Contains(string(raw), leakedPath) {
+		t.Fatalf("tool response leaked internal path: %s", raw)
+	}
+	if strings.Contains(string(raw), "factory_definitions/internal") {
+		t.Fatalf("tool response leaked internal package path: %s", raw)
+	}
+}
+
+func TestBind_ValidateToolMalformedJSONReturnsBadRequestWithoutInvokingRoot(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "malformed", body: `{"name":"alpha"`},
+		{name: "empty", body: ""},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			validation := &mcpDefinitionsValidationFake{}
+			operation := factorydefinitionmcp.Bind(factorydefinitionmcp.RootBinding{Validation: validation})
+			raw, err := operation(
+				context.Background(),
+				factorydefinitionmcp.ToolValidate,
+				json.RawMessage(tc.body),
+			)
+			if err != nil {
+				t.Fatalf("CallTool(validate) error = %v", err)
+			}
+			if validation.invoked {
+				t.Fatal("ValidateSubmittedDefinition was invoked before request decode succeeded")
+			}
+			envelope := assertTypedToolErrorEnvelope(t, raw, "BAD_REQUEST", false)
+			if !strings.Contains(envelope.Message, "decode validate input") {
+				t.Fatalf("error.message = %q, want decode validate input context", envelope.Message)
+			}
+		})
+	}
+}
+
+type mcpDefinitionsValidationErrorFake struct {
+	invoked bool
+	err     error
+}
+
+func (fake *mcpDefinitionsValidationErrorFake) ValidateSubmittedDefinition(
+	_ context.Context,
+	_ factorydefinitions.SubmittedDefinitionValidationRequest,
+) (factorydefinitions.ValidationResult, error) {
+	fake.invoked = true
+	return factorydefinitions.ValidationResult{}, fake.err
+}
+
+var _ factorydefinitions.SubmittedDefinitionValidationOperation = (*mcpDefinitionsValidationErrorFake)(nil)
+
+func assertTypedToolErrorEnvelope(
+	t *testing.T,
+	raw json.RawMessage,
+	wantCode string,
+	wantRetryable bool,
+) *factorydefinitionmcp.ToolErrorEnvelope {
+	t.Helper()
+
+	var response struct {
+		Result *json.RawMessage                          `json:"result"`
+		Error  *factorydefinitionmcp.ToolErrorEnvelope `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode tool response: %v", err)
+	}
+	if response.Result != nil {
+		t.Fatalf("tool response result = %s, want error envelope only", raw)
+	}
+	if response.Error == nil {
+		t.Fatalf("tool response = %s, want typed error envelope", raw)
+	}
+	if response.Error.Code != wantCode {
+		t.Fatalf("error.code = %q, want %q; envelope = %#v", response.Error.Code, wantCode, response.Error)
+	}
+	if response.Error.Retryable != wantRetryable {
+		t.Fatalf("error.retryable = %v, want %v; envelope = %#v", response.Error.Retryable, wantRetryable, response.Error)
+	}
+	if strings.TrimSpace(response.Error.Message) == "" {
+		t.Fatalf("error.message is required; envelope = %#v", response.Error)
+	}
+	return response.Error
+}


### PR DESCRIPTION
{
  "project": "PSS MCP-DEF — Factory Definitions Owner-Local MCP Adapter",
  "branchName": "pss-mcp-def-adapter",
  "description": "Package a Factory Definitions service-owned MCP adapter that exposes focused Definitions tools through the accepted Definitions root with discovery/result/error parity, without importing Definitions internals, owning canonical state, or touching shared MCP registry composition.",
  "context": {
    "customerAsk": "Implement MCP-DEF as the Factory Definitions service-owned MCP adapter. Expose Definitions tools through the accepted Definitions root with discovery/result/error parity, without importing Definitions internals or owning canonical state. Do not edit shared MCP registry/server composition (PSS-I04), pkg/wire, pkg/root, pkg/initializer, top-level CLI composition, or reopen Definitions IMP/LWR/HTTP/CLI ownership. Loop until required CI is terminal green, blocking PR feedback is addressed, conflicts are reconciled, and the PR is merged.",
    "problem": "Definitions has accepted root, Wire, HTTP, and CLI ownership, and Sessions already has an MCP adapter pattern, but Definitions still has no owner-local MCP adapter. Agent clients therefore cannot discover or invoke Definitions validate/current-factory/install-packaged operations through a Definitions-owned MCP surface with root-injection and discovery/result/error parity.",
    "solution": "Add pkg/services/factory_definitions/transports/mcp that binds an injected Definitions root, publishes a stable four-tool catalog (validate, get_current, save_current, install_packaged), proves success/domain-error/cancel/timeout parity with fake-root tests, and registers the package in shared coverage/ownership/package-target manifests only. Leave shared MCP fan-in to PSS-I04 and complete only after the PR merges."
  },
  "acceptanceCriteria": [
    "Factory Definitions owns an MCP adapter under its service-local transports/mcp path that calls only the accepted Definitions root (or root-shaped injected roles) and does not import Definitions internals or construct canonical Definitions state",
    "MCP hosts can discover a stable Definitions tool catalog with deterministic names, descriptions, and input schemas for validate, current-factory get/save, and install-packaged operations",
    "Calling each Definitions tool with a root-shaped fake returns the expected success payload or typed domain error envelope without touching shared MCP registry composition",
    "Canceled and deadline-exceeded request contexts produce stable Definitions MCP error envelopes (non-retryable cancel; retryable timeout)",
    "Adapter package registration appears in package-target, ownership, and coverage-minimum manifests with factory_definitions retain ownership",
    "Diff stays off excluded paths: shared MCP registry/server/discovery composition (PSS-I04), pkg/wire, pkg/root, pkg/initializer, top-level CLI composition, HTTP-DEF/CLI-DEF paths, and other services' MCP adapters",
    "Quality checks pass (typecheck, lint, tests)",
    "Delivery loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file churn are reconciled, and the PR is merged (opened/green/approved/ready-to-merge alone is not complete)"
  ],
  "userStories": [
    {
      "id": "pss-mcp-def-adapter-001",
      "title": "Bind MCP adapter to injected Definitions root",
      "description": "As a maintainer, I want the Definitions MCP adapter to depend only on an injected Definitions root (and root-shaped validation/distribute roles) so tool execution never imports Definitions internals or owns canonical state.",
      "acceptanceCriteria": [
        "Adapter exposes a bind/construction entrypoint that accepts an injected Definitions root (and optional root-shaped validation/distribute roles already used by HTTP/CLI) and returns a callable MCP tool operation",
        "A fake-root test proves a tool dispatch reaches the injected root method rather than constructing real catalog/authoring/compile/validate/snapshot/distribute graphs",
        "Production adapter sources do not import pkg/services/factory_definitions/internal or other Definitions private implementation packages",
        "Diff does not modify shared MCP registry/server/discovery composition, pkg/wire, pkg/root, pkg/initializer, HTTP-DEF, CLI-DEF, or other services' MCP adapters",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-def-adapter-002",
      "title": "Publish discoverable Definitions MCP tool catalog",
      "description": "As an MCP host, I want to discover the Definitions tool inventory with stable identities and input schemas so I can present and invoke Definitions operations without guessing names.",
      "acceptanceCriteria": [
        "Discovery returns a deterministic catalog that includes at least: you.factory_definition.validate, you.factory_definition.get_current, you.factory_definition.save_current, and you.factory_definition.install_packaged",
        "Each discovered tool has a non-empty description and a JSON-schema input object with additionalProperties false for known fields",
        "Catalog projection is stable under repeated discovery (same tool names and schema shape)",
        "Unknown tool names are rejected with a stable MCP error outcome rather than panicking or silently succeeding",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-def-adapter-003",
      "title": "Validate Factory definition through MCP",
      "description": "As an agent client, I want to validate a Factory definition through MCP so I get the same Definitions validation outcome I would through the accepted Definitions validation surface, without starting sessions or mutating catalog state.",
      "acceptanceCriteria": [
        "Calling you.factory_definition.validate with a valid definition payload returns a success tool response whose result carries the Definitions validation outcome from the injected root/validation role",
        "Calling the tool with an invalid payload or a root that returns a typed invalid-definition/validation failure returns a typed domain error envelope with stable code/message/retryable fields",
        "Malformed JSON arguments return a decode/bad-request style error envelope without invoking the root",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-def-adapter-004",
      "title": "Get and save current Factory through MCP",
      "description": "As an agent client, I want to read and save the current Factory for a session through MCP so Definitions current-factory behavior is available with the same root authority HTTP-DEF already uses.",
      "acceptanceCriteria": [
        "Calling you.factory_definition.get_current with a session id returns the current Factory payload produced by the injected Definitions root",
        "Calling you.factory_definition.save_current with session id, save mode, and Factory payload persists through the injected root and returns the saved Factory payload",
        "Missing-session / missing-current-factory / stale-version typed root failures map to stable domain error envelopes (distinct codes or messages a reviewer can distinguish)",
        "Success responses encode as MCP CallToolResult success content with serialized JSON text (same success transport policy shape Sessions MCP uses)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-def-adapter-005",
      "title": "Install packaged Factory through MCP",
      "description": "As an agent client, I want to install a built-in packaged Factory through MCP so distribute/install behavior owned by Definitions is reachable without using the CLI adapter path.",
      "acceptanceCriteria": [
        "Calling you.factory_definition.install_packaged with package identity and destination inputs invokes the injected Definitions install/distribute root role",
        "Successful installation returns a structured result including at least factory name and outcome",
        "Missing package identity or typed install failure from the root returns a domain error envelope without constructing Definitions internals",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-def-adapter-006",
      "title": "Prove cancel and timeout error parity for Definitions MCP tools",
      "description": "As an agent client, I want canceled and timed-out Definitions MCP calls to return stable request-context error envelopes so long-running validate/get/save/install calls fail predictably under cancel and deadline.",
      "acceptanceCriteria": [
        "When the request context is canceled before or during a Definitions tool call, the tool response error uses a non-retryable canceled code/message envelope",
        "When the request context deadline is exceeded, the tool response error uses a retryable timed-out code/message envelope",
        "Cancel/timeout proof covers at least one Definitions tool path using a blocking fake root (same behavioral class as HTTP-DEF request-context proof)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-def-adapter-007",
      "title": "Register Definitions MCP adapter package ownership",
      "description": "As a Packaged Service Structure maintainer, I want the new Definitions MCP adapter package registered in package-target, ownership, and coverage-minimum manifests so the owner-local adapter is retained under factory_definitions and covered by baseline lanes.",
      "acceptanceCriteria": [
        "Package-target manifest inventory and packages rows include pkg/services/factory_definitions/transports/mcp with retain disposition and factory_definitions destination",
        "Ownership inventory includes the same package path with retain disposition, owner destination, and owner destination kind",
        "Unit and functional coverage-minimum manifests include the adapter import path with an explicit minimum",
        "Shared-manifest edits are limited to adapter package registration and are rebased through the merge loop if concurrent packets touch the same files",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 7,
      "passes": true,
      "notes": ""
    }
  ]
}
