### PR TITLE
ft-wave1-cli-stdin

### DIFF
--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -7117,14 +7117,44 @@
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/stdin_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestRunReadsPromptFromStdin",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/stdin_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/stdin_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestSubmitBatchReadsJSONFromStdin",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/stdin_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/stdin_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLIEmptyRequiredStdinFailsWithoutDispatch",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/stdin_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
     }
   ],
-  "scanned_at_utc": "2026-07-28T01:55:00Z",
+  "scanned_at_utc": "2026-07-28T02:10:00Z",
   "summary": {
     "by_catch_all": {
       "bootstrap_portability": 22,
       "guards_batch": 23,
-      "none": 434,
+      "none": 437,
       "replay_contracts": 23,
       "runtime_api": 96,
       "smoke": 62,
@@ -7148,15 +7178,15 @@
       "sessionparity": 13,
       "sessions": 3,
       "smoke": 62,
-      "transport": 96,
+      "transport": 99,
       "work": 2,
       "workers": 70,
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 692,
+    "customer_top_level_Test_scenarios": 695,
     "lane_functionallong": 95,
-    "lane_short": 597,
+    "lane_short": 600,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 13,
       "you-agent-factory/tests/functional/automations": 7,
@@ -7201,7 +7231,7 @@
       "you-agent-factory/tests/functional/transport/cli/commands": 20,
       "you-agent-factory/tests/functional/transport/cli/output": 13,
       "you-agent-factory/tests/functional/transport/cli/parameters": 19,
-      "you-agent-factory/tests/functional/transport/cli/process": 9,
+      "you-agent-factory/tests/functional/transport/cli/process": 12,
       "you-agent-factory/tests/functional/transport/docs": 1,
       "you-agent-factory/tests/functional/transport/http": 1,
       "you-agent-factory/tests/functional/transport/http/server": 14,
@@ -7233,7 +7263,7 @@
       "you-agent-factory/tests/functional/workstations/repeater": 13,
       "you-agent-factory/tests/functional/workstations/watcher": 9
     },
-    "files_with_customer_Test": 232,
+    "files_with_customer_Test": 233,
     "functional_test_go_files": 251,
     "helper_only_non_customer_files": 51,
     "internal_harness_Test_functions": 15,

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -42,7 +42,7 @@ intentionally small enough to distribute across many agents.
   - `TestCLIUnknownCommandReturnsUsageExitCode` verifies stdout remains empty
     and the process returns the documented non-success code.
 
-- [ ] `tests/functional/transport/cli/process/stdin_test.go`
+- [x] `tests/functional/transport/cli/process/stdin_test.go`
   - `TestRunReadsPromptFromStdin` verifies `you run -` consumes stdin and sends
     the exact value to the selected worker.
   - `TestSubmitBatchReadsJSONFromStdin` verifies `you submit batch -` consumes

--- a/internal/builtcliacceptance/harness.go
+++ b/internal/builtcliacceptance/harness.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -172,15 +173,20 @@ func (s *Session) ProcessEnvWith(extra ...string) []string {
 
 // Run executes the built you binary with the session's hermetic environment.
 func (s *Session) Run(ctx context.Context, args ...string) (RunResult, error) {
-	return s.run(ctx, s.ProcessEnv(), args...)
+	return s.run(ctx, s.ProcessEnv(), nil, args...)
+}
+
+// RunWithStdin executes the built you binary with piped stdin content.
+func (s *Session) RunWithStdin(ctx context.Context, stdin string, args ...string) (RunResult, error) {
+	return s.run(ctx, s.ProcessEnv(), strings.NewReader(stdin), args...)
 }
 
 // RunWithEnv executes the built you binary with extra environment variables.
 func (s *Session) RunWithEnv(ctx context.Context, extraEnv []string, args ...string) (RunResult, error) {
-	return s.run(ctx, s.ProcessEnvWith(extraEnv...), args...)
+	return s.run(ctx, s.ProcessEnvWith(extraEnv...), nil, args...)
 }
 
-func (s *Session) run(ctx context.Context, env []string, args ...string) (RunResult, error) {
+func (s *Session) run(ctx context.Context, env []string, stdin io.Reader, args ...string) (RunResult, error) {
 	if s.harness == nil {
 		return RunResult{}, errors.New("session harness is nil")
 	}
@@ -191,6 +197,9 @@ func (s *Session) run(ctx context.Context, env []string, args ...string) (RunRes
 	cmd := exec.CommandContext(ctx, s.harness.BinaryPath, args...)
 	cmd.Dir = s.WorkDir
 	cmd.Env = env
+	if stdin != nil {
+		cmd.Stdin = stdin
+	}
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/tests/functional/transport/cli/process/fixtures_test.go
+++ b/tests/functional/transport/cli/process/fixtures_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -78,6 +79,81 @@ func writeRejectingGoalMockWorkers(t *testing.T) string {
 	path := filepath.Join(t.TempDir(), "rejecting-mock-workers.json")
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatalf("write rejecting mock workers: %v", err)
+	}
+	return path
+}
+
+const (
+	stdinRunWorkTypeName      = "prompt-task"
+	stdinRunWorkstationName   = "process-prompt"
+	stdinRunWorkerName        = "mock-worker"
+	stdinRunFactoryConfigName = "stdin-run-process"
+)
+
+func writeStdinRunFactory(t testing.TB, workDir string) string {
+	t.Helper()
+
+	factoryDir := filepath.Join(workDir, "stdin-run-factory")
+	if err := os.MkdirAll(factoryDir, 0o755); err != nil {
+		t.Fatalf("create stdin run factory directory: %v", err)
+	}
+
+	factoryJSON := fmt.Sprintf(`{
+  "name": %q,
+  "workTypes": [{
+    "name": %q,
+    "handlingBehavior": ["DEFAULT"],
+    "states": [
+      {"name": "init", "type": "INITIAL"},
+      {"name": "complete", "type": "TERMINAL"},
+      {"name": "failed", "type": "FAILED"}
+    ]
+  }],
+  "workers": [{"name": %q}],
+  "workstations": [{
+    "name": %q,
+    "worker": %q,
+    "inputs": [{"workType": %q, "state": "init"}],
+    "outputs": [{"workType": %q, "state": "complete"}],
+    "onFailure": [{"workType": %q, "state": "failed"}]
+  }]
+}`,
+		stdinRunFactoryConfigName,
+		stdinRunWorkTypeName,
+		stdinRunWorkerName,
+		stdinRunWorkstationName,
+		stdinRunWorkerName,
+		stdinRunWorkTypeName,
+		stdinRunWorkTypeName,
+		stdinRunWorkTypeName,
+	)
+	factoryPath := filepath.Join(factoryDir, "factory.json")
+	if err := os.WriteFile(factoryPath, []byte(factoryJSON), 0o600); err != nil {
+		t.Fatalf("write stdin run factory.json: %v", err)
+	}
+
+	workstationPath := filepath.Join(factoryDir, "workstations", stdinRunWorkstationName, "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(workstationPath), 0o755); err != nil {
+		t.Fatalf("create stdin run workstation directory: %v", err)
+	}
+	workstationConfig := "---\ntype: MODEL_WORKSTATION\n---\nProcess {{ (index .Inputs 0).Payload }}.\n"
+	if err := os.WriteFile(workstationPath, []byte(workstationConfig), 0o644); err != nil {
+		t.Fatalf("write stdin run workstation config: %v", err)
+	}
+
+	return factoryPath
+}
+
+func writeStdinRunDefaultMockWorkers(t testing.TB) string {
+	t.Helper()
+
+	data, err := json.MarshalIndent(workers.NewEmptyMockWorkersConfig(), "", "  ")
+	if err != nil {
+		t.Fatalf("marshal stdin run mock workers: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "stdin-run-mock-workers.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write stdin run mock workers: %v", err)
 	}
 	return path
 }

--- a/tests/functional/transport/cli/process/stdin_test.go
+++ b/tests/functional/transport/cli/process/stdin_test.go
@@ -112,3 +112,55 @@ func TestSubmitBatchReadsJSONFromStdin(t *testing.T) {
 	_ = command.Process.Kill()
 	_ = command.Wait()
 }
+
+// TestCLIEmptyRequiredStdinFailsWithoutDispatch proves you run - rejects EOF or
+// empty required stdin through the public built you CLI process boundary before
+// any worker-bound primary result or other external worker effect attributable
+// to the invocation.
+func TestCLIEmptyRequiredStdinFailsWithoutDispatch(t *testing.T) {
+	harness := builtcliacceptance.NewHarness(t, testutil.MustRepoRoot(t))
+	session := harness.NewSession(t).WithNoExternalServer(t)
+
+	factoryPath := writeStdinRunFactory(t, session.WorkDir)
+	mockWorkersPath := writeStdinRunDefaultMockWorkers(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	args := append([]string{}, session.RuntimeLogDirFlags()...)
+	args = append(args, session.ServerFlags()...)
+	args = append(args,
+		"run",
+		"--factory", factoryPath,
+		"--with-mock-workers", mockWorkersPath,
+		"--no-record",
+		"--quiet",
+		"-",
+	)
+
+	result, err := session.RunWithStdin(ctx, "", args...)
+	if err == nil {
+		t.Fatalf(
+			"you run - with empty stdin succeeded; want pre-dispatch rejection\nstdout:\n%s\nstderr:\n%s",
+			result.Stdout,
+			result.Stderr,
+		)
+	}
+	if result.ExitCode != 1 {
+		t.Fatalf("exit code = %d, want documented validation-failure exit 1", result.ExitCode)
+	}
+	if strings.TrimSpace(result.Stdout) != "" {
+		t.Fatalf(
+			"stdout = %q, want empty (no worker-bound primary result before stdin rejection)",
+			result.Stdout,
+		)
+	}
+	diagnostic := result.Stderr + "\n" + err.Error()
+	if !strings.Contains(diagnostic, "INVOCATION_INPUT_EMPTY") {
+		t.Fatalf(
+			"empty stdin diagnostic missing INVOCATION_INPUT_EMPTY:\nstdout:\n%s\nstderr:\n%s",
+			result.Stdout,
+			result.Stderr,
+		)
+	}
+}

--- a/tests/functional/transport/cli/process/stdin_test.go
+++ b/tests/functional/transport/cli/process/stdin_test.go
@@ -1,0 +1,50 @@
+package process_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/builtcliacceptance"
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+// TestRunReadsPromptFromStdin proves you run - consumes piped stdin and
+// delivers the exact prompt bytes to the selected worker through the public
+// built you CLI process boundary.
+func TestRunReadsPromptFromStdin(t *testing.T) {
+	harness := builtcliacceptance.NewHarness(t, testutil.MustRepoRoot(t))
+	session := harness.NewSession(t).WithNoExternalServer(t)
+
+	factoryPath := writeStdinRunFactory(t, session.WorkDir)
+	mockWorkersPath := writeStdinRunDefaultMockWorkers(t)
+	prompt := fmt.Sprintf("functional-stdin-run-café-résumé-%d", time.Now().UnixNano())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	args := append([]string{}, session.RuntimeLogDirFlags()...)
+	args = append(args, session.ServerFlags()...)
+	args = append(args,
+		"run",
+		"--factory", factoryPath,
+		"--with-mock-workers", mockWorkersPath,
+		"--no-record",
+		"--quiet",
+		"-",
+	)
+
+	result, err := session.RunWithStdin(ctx, prompt, args...)
+	if err != nil {
+		t.Fatalf(
+			"you run - via stdin: %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			result.Stdout,
+			result.Stderr,
+		)
+	}
+	if got := result.Stdout; got != prompt {
+		t.Fatalf("worker-bound primary result = %q, want exact stdin prompt %q", got, prompt)
+	}
+}

--- a/tests/functional/transport/cli/process/stdin_test.go
+++ b/tests/functional/transport/cli/process/stdin_test.go
@@ -3,11 +3,18 @@ package process_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/portpowered/infinite-you/internal/builtcliacceptance"
 	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+const (
+	stdinSubmitBatchRequestID = "functional-stdin-submit-batch"
+	stdinSubmitBatchWorkName  = "stdin-batch-task"
+	stdinSubmitBatchWorkType  = "task"
 )
 
 // TestRunReadsPromptFromStdin proves you run - consumes piped stdin and
@@ -47,4 +54,61 @@ func TestRunReadsPromptFromStdin(t *testing.T) {
 	if got := result.Stdout; got != prompt {
 		t.Fatalf("worker-bound primary result = %q, want exact stdin prompt %q", got, prompt)
 	}
+}
+
+// TestSubmitBatchReadsJSONFromStdin proves you submit batch - consumes one
+// canonical FACTORY_REQUEST_BATCH document from piped stdin and acknowledges the
+// accepted work through the public built you CLI process boundary.
+func TestSubmitBatchReadsJSONFromStdin(t *testing.T) {
+	harness := builtcliacceptance.NewHarness(t, testutil.MustRepoRoot(t))
+	session := harness.NewSession(t).WithNoExternalServer(t)
+
+	command, lines, scanErr, stderr := startBuiltCLIServerCommand(t, session, harness.BinaryPath)
+	stopped := false
+	defer func() {
+		if !stopped {
+			_ = command.Process.Kill()
+			_ = command.Wait()
+		}
+	}()
+	_ = waitForDashboardURL(t, lines, scanErr, stderr, 45*time.Second)
+
+	batchJSON := fmt.Sprintf(
+		`{"requestId":%q,"type":"FACTORY_REQUEST_BATCH","works":[{"name":%q,"workTypeName":%q,"payload":{"title":"Stdin submit batch process"}}]}`,
+		stdinSubmitBatchRequestID,
+		stdinSubmitBatchWorkName,
+		stdinSubmitBatchWorkType,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	args := append([]string{}, session.ServerFlags()...)
+	args = append(args, "submit", "batch", "-")
+
+	result, err := session.RunWithStdin(ctx, batchJSON, args...)
+	if err != nil {
+		t.Fatalf(
+			"you submit batch - via stdin: %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			result.Stdout,
+			result.Stderr,
+		)
+	}
+
+	output := result.Stdout
+	for _, marker := range []string{
+		"requestId: " + stdinSubmitBatchRequestID,
+		"traceId:",
+		"work count: 1",
+		stdinSubmitBatchWorkName + " (" + stdinSubmitBatchWorkType + ")",
+	} {
+		if !strings.Contains(output, marker) {
+			t.Fatalf("submit batch output missing %q:\n%s", marker, output)
+		}
+	}
+
+	stopped = true
+	_ = command.Process.Kill()
+	_ = command.Wait()
 }


### PR DESCRIPTION
```json
{
  "project": "CLI Stdin Process Contract Functional Coverage",
  "branchName": "ft-wave1-cli-stdin",
  "description": "Implement only tests/functional/transport/cli/process/stdin_test.go so the public built you CLI proves you run - consumes stdin and sends the exact prompt to the selected worker, you submit batch - consumes one canonical Work Request batch from stdin, and EOF/empty required stdin is rejected before any external worker effect—without inventing migration-ledger deletion obligations when none map to this destination.",
  "context": {
    "customerAsk": "Implement only tests/functional/transport/cli/process/stdin_test.go. Through the public built you CLI process boundary, prove: (1) TestRunReadsPromptFromStdin — `you run -` consumes stdin and sends the exact value to the selected worker; (2) TestSubmitBatchReadsJSONFromStdin — `you submit batch -` consumes one canonical Work Request batch; (3) TestCLIEmptyRequiredStdinFailsWithoutDispatch — EOF/empty required input is rejected before any external worker effect. Do not invent migration-ledger deletion obligations when none map to this destination. Do not implement stdout_stderr or context_cancellation. Avoid service/internal imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled ownership/coverage/catalog/migration metadata required for this cell; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for CLI stdin process behavior does not exist yet even though unknown_command has freed transport/cli/process. Nearby stdin scenarios already map to completed run_wiring under smoke-delete-04, but maintainers lack a focused, catalogued process proof that you run - delivers the exact stdin prompt to the selected worker, you submit batch - consumes one canonical Work Request batch from stdin, and EOF/empty required stdin is rejected before any external worker effect.",
    "solution": "Implement the three checklist scenarios in tests/functional/transport/cli/process/stdin_test.go through the public built you CLI process boundary with customer-readable Go docs on every top-level Test. Assert exact prompt-from-stdin delivery, one canonical Work Request batch consumption from stdin, and pre-dispatch rejection for EOF/empty required stdin; do not invent migration-ledger deletion obligations; apply only narrowly coupled ownership/coverage/catalog/migration metadata; leave held process siblings untouched; and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/transport/cli/process/stdin_test.go exists as the transport-owned functional cell and covers run prompt-from-stdin, submit-batch JSON-from-stdin, and empty/EOF required-stdin rejection.",
    "Through the public built you CLI process boundary, you run - consumes stdin and the selected worker receives the exact prompt value that was piped in.",
    "Through the public built you CLI process boundary, you submit batch - consumes one canonical Work Request batch from stdin.",
    "Through the public built you CLI process boundary, EOF/empty required stdin is rejected before any external worker effect attributable to the invocation.",
    "No migration-ledger deletion obligations are invented for this destination; only narrowly coupled ownership/coverage/catalog metadata for this cell are updated; coverage uses the public built you CLI process boundary / approved helpers and does not import service implementations or internal Petri primitives as the proof owner, with customer-readable Go docs on every top-level Test*; held process siblings stay untouched.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave1-cli-stdin-001",
      "title": "Prove run reads prompt from stdin",
      "description": "As a CLI customer piping a prompt into you run -, I want the process to consume stdin and deliver that exact value to the selected worker so scripted invocations match interactive prompt input.",
      "acceptanceCriteria": [
        "tests/functional/transport/cli/process/stdin_test.go includes TestRunReadsPromptFromStdin (or equivalent top-level name matching the checklist intent).",
        "Through the public built you CLI process boundary, invoking you run - (with the minimal Factory/worker fixture needed for observation) consumes the piped stdin prompt.",
        "The selected worker receives the exact prompt value that was provided on stdin (byte-for-byte / string-equality fidelity for the observed worker input surface—no truncation, wrapping, or substitution).",
        "Assertions stay on stdin prompt consumption and worker-bound value fidelity at the public process boundary and do not re-own Factory path/named/packaged selection (run_wiring), stdout/stderr stream shaping, or context-cancellation proofs belonging to sibling cells.",
        "The top-level test has a customer-readable Go doc comment describing the observable you run - stdin prompt behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-stdin-002",
      "title": "Prove submit batch reads JSON from stdin",
      "description": "As a CLI customer piping a Work Request batch into you submit batch -, I want the process to consume one canonical batch from stdin so automation can submit work without temporary files.",
      "acceptanceCriteria": [
        "The stdin cell includes TestSubmitBatchReadsJSONFromStdin (or equivalent top-level name matching the checklist intent).",
        "Through the public built you CLI process boundary, invoking you submit batch - consumes one canonical Work Request batch from stdin (a single well-formed batch document matching the public Work Request batch shape used by CLI submit).",
        "Observable outcome proves the batch was accepted from stdin (for example successful submit exit / acknowledged work identifiers / equivalent customer-visible accept markers for the piped batch), not merely that the process started.",
        "Assertions remain on stdin batch JSON consumption at the public process boundary and do not widen into Work list/move/show product depth (work_wiring), stdout/stderr stream ownership, or context-cancellation ownership.",
        "The top-level test has a customer-readable Go doc comment describing the observable you submit batch - stdin behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-stdin-003",
      "title": "Prove empty required stdin fails without dispatch",
      "description": "As a CLI customer or automation that accidentally provides EOF/empty required stdin, I want the process to reject the invocation before any external worker effect so scripts fail cleanly without side effects.",
      "acceptanceCriteria": [
        "The stdin cell includes TestCLIEmptyRequiredStdinFailsWithoutDispatch (or equivalent top-level name matching the checklist intent).",
        "Through the public built you CLI process boundary, providing EOF/empty input where stdin is required (for example you run - or an equivalent documented required-stdin probe with closed/empty stdin) fails the invocation.",
        "The failure occurs before any external worker effect attributable to the invocation (no worker dispatch / provider process / external work marker for the empty-stdin path).",
        "Assertions remain on pre-dispatch rejection for empty/EOF required stdin and do not widen into stdout_stderr stream-shape ownership or context_cancellation external-work-stop proofs.",
        "The top-level test has a customer-readable Go doc comment describing the observable empty/EOF required-stdin rejection contract.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-stdin-004",
      "title": "Close ownership metadata and verification gates",
      "description": "As a maintainer executing Wave 1 migration, I want this cell catalogued with only narrowly coupled metadata updates and passing focused boundary/viz gates, without inventing migration-ledger deletion obligations or widening into held siblings.",
      "acceptanceCriteria": [
        "No migration-ledger deletion obligations are invented for tests/functional/transport/cli/process/stdin_test.go when none currently map to this destination (checklist-authoritative); nearby stdin scenarios already mapped to completed run_wiring under smoke-delete-04 are left alone.",
        "Only narrowly coupled ownership, coverage, or catalog metadata required for this cell are updated; held Wave 1 leftovers (stdout_stderr, context_cancellation) stay untouched.",
        "Neighboring unknown_command, help_and_version, and exit_codes coverage in the same package is not rewritten beyond what is required to leave the package compiling and sharing support helpers safely.",
        "Focused package tests for tests/functional/transport/cli/process pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as transport/cli/process).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
```

## Summary
- Adds tests/functional/transport/cli/process/stdin_test.go with three built-CLI process proofs.
- Extends builtcliacceptance with RunWithStdin and process-package fixtures.
- Closes Wave 1 metadata for the stdin cell without invented deletion obligations.

## Test plan
- [x] go test -short ./tests/functional/transport/cli/process/...
- [x] make functional-boundary-check
- [x] go run ./cmd/migrationledgercheck
- [x] go test -short ./internal/functionaltestmetadata/... ./internal/functionaltestviz/...
