### PR TITLE
pss-http-vis-adapter

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1079,6 +1079,16 @@
       "minimum": 100.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/http",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/wire",
       "exception": {
         "kind": "measurement",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -989,6 +989,10 @@
       "minimum": 100.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/http",
+      "minimum": 78.83
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/wire",
       "minimum": 77.00
     },

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -3612,6 +3612,12 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/factory_visualization/transports/http",
+      "disposition": "retain",
+      "destination": "factory_visualization",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/factory_visualization/wire",
       "disposition": "retain",
       "destination": "factory_visualization",

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -252,6 +252,7 @@
     "pkg/services/factory_visualization/internal/services/response_event_presentation",
     "pkg/services/factory_visualization/internal/services/response_event_presentation/internal/service",
     "pkg/services/factory_visualization/internal/services/response_event_presentation/wire",
+    "pkg/services/factory_visualization/transports/http",
     "pkg/services/factory_visualization/wire",
     "pkg/services/models",
     "pkg/services/models/internal/artifacts",
@@ -1540,6 +1541,11 @@
       "packagePath": "pkg/services/factory_visualization/internal/services/response_event_presentation/wire",
       "disposition": "retain",
       "destination": "factory_visualization/internal/services/response_event_presentation"
+    },
+    {
+      "packagePath": "pkg/services/factory_visualization/transports/http",
+      "disposition": "retain",
+      "destination": "factory_visualization"
     },
     {
       "packagePath": "pkg/services/factory_visualization/wire",

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -44,6 +44,22 @@ Use this map when changing the public REST contract.
   `pkg/transports/http` server composes injected service-owned adapters; HTTP-DEF
   proves fake-root parity at the adapter edge without importing Definitions
   internals.
+- Factory Visualization HTTP decoding, root contract mapping, typed error
+  translation, and cancel/timeout handling live in
+  `pkg/services/factory_visualization/transports/http`. HTTP-VIS proves
+  fake-root parity at the adapter edge without importing Visualization
+  internals or owning canonical visualization state.
+- The Visualization HTTP adapter package must stay registered in the allowed
+  shared manifests only: retain
+  `pkg/services/factory_visualization/transports/http` under destination
+  `factory_visualization` in
+  `docs/internal/packaged-service-structure/package-target-manifest.json` and
+  `docs/internal/baselines/ownership-inventory.json`, and keep measured floors in
+  both `docs/internal/baselines/go-unit-coverage-package-minimums.json` and
+  `docs/internal/baselines/go-functional-coverage-package-minimums.json`.
+  Prove registration with `manifest_registration_test.go`; do not edit
+  `pkg/wire`, `pkg/root`, `pkg/initializer`, top-level CLI composition, or
+  other services' HTTP adapters when reconciling manifest churn.
 - The Sessions HTTP adapter package must stay registered in the allowed shared
   manifests only: retain `pkg/services/factory_sessions/transports/http` under
   destination `factory_sessions` in

--- a/pkg/services/factory_visualization/transports/http/export_test.go
+++ b/pkg/services/factory_visualization/transports/http/export_test.go
@@ -1,3 +1,6 @@
 package http
 
-var VisualizationRootErrorResponseForTest = visualizationRootErrorResponse
+var (
+	VisualizationRootErrorResponseForTest         = visualizationRootErrorResponse
+	VisualizationRequestContextErrorResponseForTest = visualizationRequestContextErrorResponse
+)

--- a/pkg/services/factory_visualization/transports/http/export_test.go
+++ b/pkg/services/factory_visualization/transports/http/export_test.go
@@ -1,0 +1,3 @@
+package http
+
+var VisualizationRootErrorResponseForTest = visualizationRootErrorResponse

--- a/pkg/services/factory_visualization/transports/http/handler.go
+++ b/pkg/services/factory_visualization/transports/http/handler.go
@@ -1,0 +1,43 @@
+// Package http owns HTTP adaptation for Factory Visualization operations.
+//
+// The top-level HTTP transport registers the generated routes and composes this
+// handler with adapters owned by other services. Request decoding, generated
+// contract mapping, service invocation, error mapping, and streaming policy for
+// Factory Visualization remain here with the owning service.
+package http
+
+import (
+	"go.uber.org/zap"
+)
+
+// Adapter owns the generated HTTP operation implementations for Factory
+// Visualization resources.
+type Adapter struct {
+	visualization VisualizationRoot
+	logger        *zap.Logger
+}
+
+// Dependencies are the exact injected roles used by the Factory Visualization HTTP
+// adapter. They are supplied by composition or focused fake-root tests.
+type Dependencies struct {
+	VisualizationRoot VisualizationRoot
+}
+
+// NewHandler constructs an inert Factory Visualization HTTP adapter.
+func NewHandler(deps Dependencies, logger *zap.Logger) *Adapter {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &Adapter{
+		visualization: deps.VisualizationRoot,
+		logger:        logger,
+	}
+}
+
+// Handler is retained as a public alias while handler files stay aligned with
+// established transport naming.
+type Handler = Adapter
+
+// Server is retained as a private receiver alias while handler files are kept
+// mechanically identical to the established public behavior.
+type Server = Adapter

--- a/pkg/services/factory_visualization/transports/http/handlers_common.go
+++ b/pkg/services/factory_visualization/transports/http/handlers_common.go
@@ -1,0 +1,108 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+func (a *Adapter) writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		a.logger.Error("encode response failed", zap.Error(err))
+	}
+}
+
+func (a *Adapter) writeError(w http.ResponseWriter, status int, message, code string) {
+	a.writeJSON(w, status, factoryapi.ErrorResponse{
+		Message: message,
+		Family:  errorFamilyForStatus(status),
+		Code:    factoryapi.ErrorResponseCode(code),
+	})
+}
+
+func errorFamilyForStatus(status int) factoryapi.ErrorFamily {
+	switch status {
+	case http.StatusBadRequest:
+		return factoryapi.ErrorFamilyBadRequest
+	case http.StatusConflict:
+		return factoryapi.ErrorFamilyConflict
+	case http.StatusNotFound:
+		return factoryapi.ErrorFamilyNotFound
+	default:
+		return factoryapi.ErrorFamilyInternalServerError
+	}
+}
+
+type requestFieldValidationError struct {
+	message string
+}
+
+func (e requestFieldValidationError) Error() string {
+	return e.message
+}
+
+func requestFieldValidationMessage(err error) (string, bool) {
+	var validationErr requestFieldValidationError
+	if errors.As(err, &validationErr) {
+		return validationErr.message, true
+	}
+	return "", false
+}
+
+func ensureSingleJSONObject(dec *json.Decoder) error {
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return requestFieldValidationError{message: "request payload must contain one JSON object"}
+		}
+		return err
+	}
+	return nil
+}
+
+func decodeStrictJSON[T any](body io.Reader) (T, error) {
+	var zero T
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return zero, err
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+
+	var req T
+	if err := decoder.Decode(&req); err != nil {
+		return zero, err
+	}
+	if err := ensureSingleJSONObject(decoder); err != nil {
+		return zero, err
+	}
+	return req, nil
+}
+
+func decodeOptionalJSONRequest[T any](body io.Reader, zero func() T) (T, error) {
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return zero(), err
+	}
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return zero(), nil
+	}
+	decoder := json.NewDecoder(bytes.NewReader(trimmed))
+	decoder.DisallowUnknownFields()
+	var req T
+	if err := decoder.Decode(&req); err != nil {
+		return zero(), err
+	}
+	if err := ensureSingleJSONObject(decoder); err != nil {
+		return zero(), err
+	}
+	return req, nil
+}

--- a/pkg/services/factory_visualization/transports/http/inventory_boundary_test.go
+++ b/pkg/services/factory_visualization/transports/http/inventory_boundary_test.go
@@ -1,0 +1,38 @@
+package http_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestPackageBoundary_DoesNotImportFactoryVisualizationInternal(t *testing.T) {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	packageDir := filepath.Dir(filename)
+
+	forbidden := "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal"
+	entries, err := os.ReadDir(packageDir)
+	if err != nil {
+		t.Fatalf("read HTTP adapter package: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(packageDir, entry.Name())
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if strings.Contains(string(content), forbidden) {
+			t.Fatalf("%s must not import %s", entry.Name(), forbidden)
+		}
+	}
+}

--- a/pkg/services/factory_visualization/transports/http/lifecycle_decode.go
+++ b/pkg/services/factory_visualization/transports/http/lifecycle_decode.go
@@ -1,0 +1,45 @@
+package http
+
+import (
+	"io"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+)
+
+type lifecycleHTTPDecodeError struct {
+	cause error
+}
+
+func (e lifecycleHTTPDecodeError) Error() string {
+	return e.cause.Error()
+}
+
+func (e lifecycleHTTPDecodeError) Unwrap() error {
+	return e.cause
+}
+
+func decodeActivateHTTPRequest(body io.Reader) (factoryvisualization.ActivateRequest, error) {
+	req, err := decodeStrictJSON[ActivateHTTPRequest](body)
+	if err != nil {
+		return factoryvisualization.ActivateRequest{}, lifecycleHTTPDecodeError{cause: err}
+	}
+	return factoryvisualization.ActivateRequest{
+		Mode: factoryvisualization.ActivateMode(req.Mode),
+	}, nil
+}
+
+func decodeJoinHTTPRequest(body io.Reader) (factoryvisualization.JoinRequest, error) {
+	_, err := decodeOptionalJSONRequest(body, func() struct{} { return struct{}{} })
+	if err != nil {
+		return factoryvisualization.JoinRequest{}, lifecycleHTTPDecodeError{cause: err}
+	}
+	return factoryvisualization.JoinRequest{}, nil
+}
+
+func decodeStopDrainHTTPRequest(body io.Reader) (factoryvisualization.StopDrainRequest, error) {
+	_, err := decodeOptionalJSONRequest(body, func() struct{} { return struct{}{} })
+	if err != nil {
+		return factoryvisualization.StopDrainRequest{}, lifecycleHTTPDecodeError{cause: err}
+	}
+	return factoryvisualization.StopDrainRequest{}, nil
+}

--- a/pkg/services/factory_visualization/transports/http/lifecycle_handlers.go
+++ b/pkg/services/factory_visualization/transports/http/lifecycle_handlers.go
@@ -1,0 +1,105 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+
+	"go.uber.org/zap"
+)
+
+// ActivateLifecycleHTTP decodes an owned Activate HTTP request, invokes the
+// Visualization root Activate slice, and encodes the lifecycle success shape.
+func (a *Adapter) ActivateLifecycleHTTP(
+	ctx context.Context,
+	body io.Reader,
+) (LifecycleHTTPResponse, error) {
+	req, err := decodeActivateHTTPRequest(body)
+	if err != nil {
+		return LifecycleHTTPResponse{}, err
+	}
+	result, err := a.Activate(ctx, req)
+	if err != nil {
+		return LifecycleHTTPResponse{}, err
+	}
+	return lifecycleHTTPResponseFromActivateResult(result), nil
+}
+
+// JoinLifecycleHTTP decodes an owned Join HTTP request, invokes the
+// Visualization root Join slice, and encodes the lifecycle success shape.
+func (a *Adapter) JoinLifecycleHTTP(
+	ctx context.Context,
+	body io.Reader,
+) (LifecycleHTTPResponse, error) {
+	req, err := decodeJoinHTTPRequest(body)
+	if err != nil {
+		return LifecycleHTTPResponse{}, err
+	}
+	result, err := a.Join(ctx, req)
+	if err != nil {
+		return LifecycleHTTPResponse{}, err
+	}
+	return lifecycleHTTPResponseFromJoinResult(result), nil
+}
+
+// StopDrainLifecycleHTTP decodes an owned StopDrain HTTP request, invokes the
+// Visualization root StopDrain slice, and encodes the lifecycle success shape.
+func (a *Adapter) StopDrainLifecycleHTTP(
+	ctx context.Context,
+	body io.Reader,
+) (LifecycleHTTPResponse, error) {
+	req, err := decodeStopDrainHTTPRequest(body)
+	if err != nil {
+		return LifecycleHTTPResponse{}, err
+	}
+	result, err := a.StopDrain(ctx, req)
+	if err != nil {
+		return LifecycleHTTPResponse{}, err
+	}
+	return lifecycleHTTPResponseFromStopDrainResult(result), nil
+}
+
+// HandleActivateLifecycle serves POST /factory-visualization/lifecycle/activate.
+func (a *Adapter) HandleActivateLifecycle(w http.ResponseWriter, r *http.Request) {
+	response, err := a.ActivateLifecycleHTTP(r.Context(), r.Body)
+	if err != nil {
+		a.writeLifecycleRequestError(w, err)
+		return
+	}
+	a.writeJSON(w, http.StatusOK, response)
+}
+
+// HandleJoinLifecycle serves POST /factory-visualization/lifecycle/join.
+func (a *Adapter) HandleJoinLifecycle(w http.ResponseWriter, r *http.Request) {
+	response, err := a.JoinLifecycleHTTP(r.Context(), r.Body)
+	if err != nil {
+		a.writeLifecycleRequestError(w, err)
+		return
+	}
+	a.writeJSON(w, http.StatusOK, response)
+}
+
+// HandleStopDrainLifecycle serves POST /factory-visualization/lifecycle/stop-drain.
+func (a *Adapter) HandleStopDrainLifecycle(w http.ResponseWriter, r *http.Request) {
+	response, err := a.StopDrainLifecycleHTTP(r.Context(), r.Body)
+	if err != nil {
+		a.writeLifecycleRequestError(w, err)
+		return
+	}
+	a.writeJSON(w, http.StatusOK, response)
+}
+
+func (a *Adapter) writeLifecycleRequestError(w http.ResponseWriter, err error) {
+	if message, ok := requestFieldValidationMessage(err); ok {
+		a.writeError(w, http.StatusBadRequest, message, "BAD_REQUEST")
+		return
+	}
+	var decodeErr lifecycleHTTPDecodeError
+	if errors.As(err, &decodeErr) {
+		a.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
+		return
+	}
+	a.logger.Error("factory visualization lifecycle request failed", zap.Error(err))
+	a.writeError(w, http.StatusInternalServerError, "factory visualization lifecycle request failed", "INTERNAL_ERROR")
+}

--- a/pkg/services/factory_visualization/transports/http/lifecycle_handlers.go
+++ b/pkg/services/factory_visualization/transports/http/lifecycle_handlers.go
@@ -16,6 +16,9 @@ func (a *Adapter) ActivateLifecycleHTTP(
 	if err != nil {
 		return LifecycleHTTPResponse{}, err
 	}
+	if err := visualizationContextBeforeRoot(ctx); err != nil {
+		return LifecycleHTTPResponse{}, err
+	}
 	result, err := a.Activate(ctx, req)
 	if err != nil {
 		return LifecycleHTTPResponse{}, err
@@ -33,6 +36,9 @@ func (a *Adapter) JoinLifecycleHTTP(
 	if err != nil {
 		return LifecycleHTTPResponse{}, err
 	}
+	if err := visualizationContextBeforeRoot(ctx); err != nil {
+		return LifecycleHTTPResponse{}, err
+	}
 	result, err := a.Join(ctx, req)
 	if err != nil {
 		return LifecycleHTTPResponse{}, err
@@ -48,6 +54,9 @@ func (a *Adapter) StopDrainLifecycleHTTP(
 ) (LifecycleHTTPResponse, error) {
 	req, err := decodeStopDrainHTTPRequest(body)
 	if err != nil {
+		return LifecycleHTTPResponse{}, err
+	}
+	if err := visualizationContextBeforeRoot(ctx); err != nil {
 		return LifecycleHTTPResponse{}, err
 	}
 	result, err := a.StopDrain(ctx, req)

--- a/pkg/services/factory_visualization/transports/http/lifecycle_handlers.go
+++ b/pkg/services/factory_visualization/transports/http/lifecycle_handlers.go
@@ -2,11 +2,8 @@ package http
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net/http"
-
-	"go.uber.org/zap"
 )
 
 // ActivateLifecycleHTTP decodes an owned Activate HTTP request, invokes the
@@ -91,15 +88,5 @@ func (a *Adapter) HandleStopDrainLifecycle(w http.ResponseWriter, r *http.Reques
 }
 
 func (a *Adapter) writeLifecycleRequestError(w http.ResponseWriter, err error) {
-	if message, ok := requestFieldValidationMessage(err); ok {
-		a.writeError(w, http.StatusBadRequest, message, "BAD_REQUEST")
-		return
-	}
-	var decodeErr lifecycleHTTPDecodeError
-	if errors.As(err, &decodeErr) {
-		a.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
-		return
-	}
-	a.logger.Error("factory visualization lifecycle request failed", zap.Error(err))
-	a.writeError(w, http.StatusInternalServerError, "factory visualization lifecycle request failed", "INTERNAL_ERROR")
+	a.writeVisualizationRequestError(w, err, "factory visualization lifecycle request failed")
 }

--- a/pkg/services/factory_visualization/transports/http/lifecycle_mapping.go
+++ b/pkg/services/factory_visualization/transports/http/lifecycle_mapping.go
@@ -1,0 +1,27 @@
+package http
+
+import factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+
+func lifecycleHTTPResponseFromActivateResult(
+	result factoryvisualization.ActivateResult,
+) LifecycleHTTPResponse {
+	return lifecycleHTTPResponseFromState(result.State)
+}
+
+func lifecycleHTTPResponseFromJoinResult(
+	result factoryvisualization.JoinResult,
+) LifecycleHTTPResponse {
+	return lifecycleHTTPResponseFromState(result.State)
+}
+
+func lifecycleHTTPResponseFromStopDrainResult(
+	result factoryvisualization.StopDrainResult,
+) LifecycleHTTPResponse {
+	return lifecycleHTTPResponseFromState(result.State)
+}
+
+func lifecycleHTTPResponseFromState(
+	state factoryvisualization.LifecycleState,
+) LifecycleHTTPResponse {
+	return LifecycleHTTPResponse{State: string(state)}
+}

--- a/pkg/services/factory_visualization/transports/http/lifecycle_test.go
+++ b/pkg/services/factory_visualization/transports/http/lifecycle_test.go
@@ -1,0 +1,324 @@
+package http_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	factoryvisualizationhttp "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/http"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+func TestActivateLifecycleHTTP_DecodesModeAndMapsSuccess(t *testing.T) {
+	t.Parallel()
+
+	root := &lifecycleVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	response, err := handler.ActivateLifecycleHTTP(
+		context.Background(),
+		strings.NewReader(`{"mode":"RETAINED_THEN_LIVE"}`),
+	)
+	if err != nil {
+		t.Fatalf("ActivateLifecycleHTTP: %v", err)
+	}
+	if !root.activateInvoked {
+		t.Fatal("Activate was not invoked through the injected Visualization root")
+	}
+	if root.lastActivateMode != factoryvisualization.ActivateModeRetainedThenLive {
+		t.Fatalf("lastActivateMode = %q, want RETAINED_THEN_LIVE", root.lastActivateMode)
+	}
+	if response.State != string(factoryvisualization.LifecycleStateStarted) {
+		t.Fatalf("response.State = %q, want STARTED", response.State)
+	}
+}
+
+func TestJoinLifecycleHTTP_InvokesRootAndMapsSuccess(t *testing.T) {
+	t.Parallel()
+
+	root := &lifecycleVisualizationRootFake{joinState: factoryvisualization.LifecycleStateStarted}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	response, err := handler.JoinLifecycleHTTP(context.Background(), strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("JoinLifecycleHTTP: %v", err)
+	}
+	if !root.joinInvoked {
+		t.Fatal("Join was not invoked through the injected Visualization root")
+	}
+	if response.State != string(factoryvisualization.LifecycleStateStarted) {
+		t.Fatalf("response.State = %q, want STARTED", response.State)
+	}
+}
+
+func TestStopDrainLifecycleHTTP_InvokesRootAndMapsSuccess(t *testing.T) {
+	t.Parallel()
+
+	root := &lifecycleVisualizationRootFake{stopDrainState: factoryvisualization.LifecycleStateStopped}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	response, err := handler.StopDrainLifecycleHTTP(context.Background(), strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("StopDrainLifecycleHTTP: %v", err)
+	}
+	if !root.stopDrainInvoked {
+		t.Fatal("StopDrain was not invoked through the injected Visualization root")
+	}
+	if response.State != string(factoryvisualization.LifecycleStateStopped) {
+		t.Fatalf("response.State = %q, want STOPPED", response.State)
+	}
+}
+
+func TestActivateLifecycleHTTP_RejectsMalformedJSONBeforeRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &lifecycleVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	_, err := handler.ActivateLifecycleHTTP(context.Background(), strings.NewReader(`{"mode":`))
+	if err == nil {
+		t.Fatal("ActivateLifecycleHTTP malformed JSON = nil, want error")
+	}
+	if root.activateInvoked {
+		t.Fatal("malformed Activate HTTP request must not invoke root")
+	}
+}
+
+func TestActivateLifecycleHTTP_RejectsUnknownFieldsBeforeRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &lifecycleVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	_, err := handler.ActivateLifecycleHTTP(
+		context.Background(),
+		strings.NewReader(`{"mode":"RETAINED_THEN_LIVE","extra":true}`),
+	)
+	if err == nil {
+		t.Fatal("ActivateLifecycleHTTP unknown field = nil, want error")
+	}
+	if root.activateInvoked {
+		t.Fatal("unknown-field Activate HTTP request must not invoke root")
+	}
+}
+
+func TestActivateLifecycleHTTP_PassesMissingModeToRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &lifecycleVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	_, err := handler.ActivateLifecycleHTTP(context.Background(), strings.NewReader(`{}`))
+	if err == nil {
+		t.Fatal("ActivateLifecycleHTTP missing mode = nil, want root missing-parameters error")
+	}
+	if !root.activateInvoked {
+		t.Fatal("missing-mode Activate HTTP request must invoke root for typed missing-parameters failure")
+	}
+	var lifeErr *factoryvisualization.LifecycleError
+	if !errors.As(err, &lifeErr) || lifeErr.Kind != factoryvisualization.LifecycleErrorMissingParameters {
+		t.Fatalf("err = %v, want LifecycleErrorMissingParameters", err)
+	}
+}
+
+func TestHandleActivateLifecycle_HTTPRoundTripSuccess(t *testing.T) {
+	t.Parallel()
+
+	root := &lifecycleVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/factory-visualization/lifecycle/activate", strings.NewReader(`{"mode":"RETAINED_THEN_LIVE"}`))
+	rec := httptest.NewRecorder()
+	handler.HandleActivateLifecycle(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var response factoryvisualizationhttp.LifecycleHTTPResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.State != string(factoryvisualization.LifecycleStateStarted) {
+		t.Fatalf("response.State = %q, want STARTED", response.State)
+	}
+}
+
+func TestHandleActivateLifecycle_HTTPRoundTripBadRequestBeforeRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &lifecycleVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/factory-visualization/lifecycle/activate", strings.NewReader(`not-json`))
+	rec := httptest.NewRecorder()
+	handler.HandleActivateLifecycle(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	var response factoryapi.ErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if response.Family != factoryapi.ErrorFamilyBadRequest || response.Code != factoryapi.ErrorResponseCodeBADREQUEST {
+		t.Fatalf("error response = %#v, want bad-request ErrorResponse", response)
+	}
+	if root.activateInvoked {
+		t.Fatal("malformed Activate HTTP request must not invoke root")
+	}
+}
+
+func TestHandleJoinLifecycle_HTTPRoundTripSuccess(t *testing.T) {
+	t.Parallel()
+
+	root := &lifecycleVisualizationRootFake{joinState: factoryvisualization.LifecycleStateStarted}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/factory-visualization/lifecycle/join", bytes.NewReader(nil))
+	rec := httptest.NewRecorder()
+	handler.HandleJoinLifecycle(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
+func TestHandleStopDrainLifecycle_HTTPRoundTripSuccess(t *testing.T) {
+	t.Parallel()
+
+	root := &lifecycleVisualizationRootFake{stopDrainState: factoryvisualization.LifecycleStateStopped}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/factory-visualization/lifecycle/stop-drain", strings.NewReader("{}"))
+	rec := httptest.NewRecorder()
+	handler.HandleStopDrainLifecycle(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
+type lifecycleVisualizationRootFake struct {
+	activateInvoked  bool
+	joinInvoked      bool
+	stopDrainInvoked bool
+
+	lastActivateMode factoryvisualization.ActivateMode
+	joinState        factoryvisualization.LifecycleState
+	stopDrainState   factoryvisualization.LifecycleState
+}
+
+var _ factoryvisualization.Root = (*lifecycleVisualizationRootFake)(nil)
+
+func (fake *lifecycleVisualizationRootFake) Activate(
+	_ context.Context,
+	req factoryvisualization.ActivateRequest,
+) (factoryvisualization.ActivateResult, error) {
+	fake.activateInvoked = true
+	fake.lastActivateMode = req.Mode
+	if req.Mode == "" {
+		return factoryvisualization.ActivateResult{}, &factoryvisualization.LifecycleError{
+			Kind:    factoryvisualization.LifecycleErrorMissingParameters,
+			Message: "activate Factory visualization: required request parameters are missing",
+		}
+	}
+	return factoryvisualization.ActivateResult{
+		State: factoryvisualization.LifecycleStateStarted,
+	}, nil
+}
+
+func (fake *lifecycleVisualizationRootFake) Join(
+	_ context.Context,
+	_ factoryvisualization.JoinRequest,
+) (factoryvisualization.JoinResult, error) {
+	fake.joinInvoked = true
+	state := fake.joinState
+	if state == "" {
+		state = factoryvisualization.LifecycleStateStarted
+	}
+	return factoryvisualization.JoinResult{State: state}, nil
+}
+
+func (fake *lifecycleVisualizationRootFake) StopDrain(
+	_ context.Context,
+	_ factoryvisualization.StopDrainRequest,
+) (factoryvisualization.StopDrainResult, error) {
+	fake.stopDrainInvoked = true
+	state := fake.stopDrainState
+	if state == "" {
+		state = factoryvisualization.LifecycleStateStopped
+	}
+	return factoryvisualization.StopDrainResult{State: state}, nil
+}
+
+func (fake *lifecycleVisualizationRootFake) Observe(
+	context.Context,
+	factoryvisualization.ObserveRequest,
+) (factoryvisualization.ObserveResult, error) {
+	panic("unexpected Observe call in lifecycle HTTP adapter test")
+}
+
+func (fake *lifecycleVisualizationRootFake) OpenPresentation(
+	context.Context,
+	factoryvisualization.OpenPresentationRequest,
+) (factoryvisualization.OpenPresentationResult, error) {
+	panic("unexpected OpenPresentation call in lifecycle HTTP adapter test")
+}
+
+func (fake *lifecycleVisualizationRootFake) PresentProgress(
+	context.Context,
+	factoryvisualization.PresentProgressRequest,
+) (factoryvisualization.PresentProgressResult, error) {
+	panic("unexpected PresentProgress call in lifecycle HTTP adapter test")
+}
+
+func (fake *lifecycleVisualizationRootFake) FinalizePresentation(
+	context.Context,
+	factoryvisualization.FinalizePresentationRequest,
+) (factoryvisualization.FinalizePresentationResult, error) {
+	panic("unexpected FinalizePresentation call in lifecycle HTTP adapter test")
+}
+
+func (fake *lifecycleVisualizationRootFake) ClosePresentation(
+	context.Context,
+	factoryvisualization.ClosePresentationRequest,
+) (factoryvisualization.ClosePresentationResult, error) {
+	panic("unexpected ClosePresentation call in lifecycle HTTP adapter test")
+}

--- a/pkg/services/factory_visualization/transports/http/lifecycle_types.go
+++ b/pkg/services/factory_visualization/transports/http/lifecycle_types.go
@@ -1,0 +1,14 @@
+package http
+
+// ActivateHTTPRequest is the adapter-owned HTTP request shape for Visualization
+// lifecycle Activate. PSS-I02 later fans this into shared OpenAPI route
+// registration; this packet proves decode/map at the owner-local adapter edge.
+type ActivateHTTPRequest struct {
+	Mode string `json:"mode"`
+}
+
+// LifecycleHTTPResponse is the adapter-owned HTTP success response shape for
+// Visualization lifecycle operations that publish lifecycle state.
+type LifecycleHTTPResponse struct {
+	State string `json:"state"`
+}

--- a/pkg/services/factory_visualization/transports/http/manifest_registration_test.go
+++ b/pkg/services/factory_visualization/transports/http/manifest_registration_test.go
@@ -1,0 +1,144 @@
+package http_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/ownershipinventory"
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+const (
+	httpAdapterPackagePath  = "pkg/services/factory_visualization/transports/http"
+	httpAdapterImportPath   = "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/http"
+	factoryVisualizationOwner = "factory_visualization"
+)
+
+type coverageMinimumManifest struct {
+	Lane     string `json:"lane"`
+	Packages []struct {
+		Package string  `json:"package"`
+		Minimum float64 `json:"minimum"`
+	} `json:"packages"`
+}
+
+func TestManifestRegistration_HTTPAdapterPackageIsRegistered(t *testing.T) {
+	t.Helper()
+
+	assertPackageTargetManifestRegistration(t)
+	assertOwnershipInventoryRegistration(t)
+	assertCoverageMinimumRegistration(t, "unit", "docs/internal/baselines/go-unit-coverage-package-minimums.json")
+	assertCoverageMinimumRegistration(t, "functional", "docs/internal/baselines/go-functional-coverage-package-minimums.json")
+}
+
+func assertPackageTargetManifestRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, "docs/internal/packaged-service-structure/package-target-manifest.json"))
+	if err != nil {
+		t.Fatalf("read package-target manifest: %v", err)
+	}
+
+	var manifest struct {
+		Inventory []string `json:"inventory"`
+		Packages  []struct {
+			PackagePath string `json:"packagePath"`
+			Disposition string `json:"disposition"`
+			Destination string `json:"destination"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode package-target manifest: %v", err)
+	}
+
+	foundInventory := false
+	for _, packagePath := range manifest.Inventory {
+		if packagePath == httpAdapterPackagePath {
+			foundInventory = true
+			break
+		}
+	}
+	if !foundInventory {
+		t.Fatalf("package-target manifest inventory missing %q", httpAdapterPackagePath)
+	}
+
+	for _, row := range manifest.Packages {
+		if row.PackagePath != httpAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("package-target manifest disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != factoryVisualizationOwner {
+			t.Fatalf("package-target manifest destination = %q, want %q", row.Destination, factoryVisualizationOwner)
+		}
+		return
+	}
+	t.Fatalf("package-target manifest packages missing %q", httpAdapterPackagePath)
+}
+
+func assertOwnershipInventoryRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, ownershipinventory.InventoryRelativePath))
+	if err != nil {
+		t.Fatalf("read ownership inventory: %v", err)
+	}
+
+	var inventory struct {
+		Packages []ownershipinventory.PackageRow `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		t.Fatalf("decode ownership inventory: %v", err)
+	}
+
+	for _, row := range inventory.Packages {
+		if row.PackagePath != httpAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("ownership inventory disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != factoryVisualizationOwner {
+			t.Fatalf("ownership inventory destination = %q, want %q", row.Destination, factoryVisualizationOwner)
+		}
+		if row.DestinationKind != ownershipinventory.DestinationKindOwner {
+			t.Fatalf(
+				"ownership inventory destinationKind = %q, want %q",
+				row.DestinationKind,
+				ownershipinventory.DestinationKindOwner,
+			)
+		}
+		return
+	}
+	t.Fatalf("ownership inventory packages missing %q", httpAdapterPackagePath)
+}
+
+func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, relativePath))
+	if err != nil {
+		t.Fatalf("read %s coverage manifest: %v", lane, err)
+	}
+
+	var manifest coverageMinimumManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode %s coverage manifest: %v", lane, err)
+	}
+	if manifest.Lane != lane {
+		t.Fatalf("%s coverage manifest lane = %q, want %q", relativePath, manifest.Lane, lane)
+	}
+
+	for _, entry := range manifest.Packages {
+		if entry.Package != httpAdapterImportPath {
+			continue
+		}
+		if entry.Minimum < 0 {
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterImportPath)
+		}
+		return
+	}
+	t.Fatalf("%s coverage manifest missing %q", lane, httpAdapterImportPath)
+}

--- a/pkg/services/factory_visualization/transports/http/observe_decode.go
+++ b/pkg/services/factory_visualization/transports/http/observe_decode.go
@@ -1,0 +1,36 @@
+package http
+
+import (
+	"io"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+)
+
+type observeHTTPDecodeError struct {
+	cause error
+}
+
+func (e observeHTTPDecodeError) Error() string {
+	return e.cause.Error()
+}
+
+func (e observeHTTPDecodeError) Unwrap() error {
+	return e.cause
+}
+
+func decodeObserveHTTPRequest(body io.Reader) (factoryvisualization.ObserveRequest, error) {
+	req, err := decodeStrictJSON[ObserveHTTPRequest](body)
+	if err != nil {
+		return factoryvisualization.ObserveRequest{}, observeHTTPDecodeError{cause: err}
+	}
+	rootReq := factoryvisualization.ObserveRequest{
+		Mode: factoryvisualization.ObserveMode(req.Mode),
+	}
+	if req.Reconnect != nil {
+		rootReq.Reconnect = &factoryvisualization.ObserveReconnectCursor{
+			AfterEventID:  req.Reconnect.AfterEventID,
+			AfterSequence: req.Reconnect.AfterSequence,
+		}
+	}
+	return rootReq, nil
+}

--- a/pkg/services/factory_visualization/transports/http/observe_handlers.go
+++ b/pkg/services/factory_visualization/transports/http/observe_handlers.go
@@ -2,11 +2,8 @@ package http
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net/http"
-
-	"go.uber.org/zap"
 )
 
 // ObserveHTTP decodes an owned Observe HTTP request, invokes the Visualization
@@ -37,15 +34,5 @@ func (a *Adapter) HandleObserve(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *Adapter) writeObserveRequestError(w http.ResponseWriter, err error) {
-	if message, ok := requestFieldValidationMessage(err); ok {
-		a.writeError(w, http.StatusBadRequest, message, "BAD_REQUEST")
-		return
-	}
-	var decodeErr observeHTTPDecodeError
-	if errors.As(err, &decodeErr) {
-		a.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
-		return
-	}
-	a.logger.Error("factory visualization observe request failed", zap.Error(err))
-	a.writeError(w, http.StatusInternalServerError, "factory visualization observe request failed", "INTERNAL_ERROR")
+	a.writeVisualizationRequestError(w, err, "factory visualization observe request failed")
 }

--- a/pkg/services/factory_visualization/transports/http/observe_handlers.go
+++ b/pkg/services/factory_visualization/transports/http/observe_handlers.go
@@ -16,6 +16,9 @@ func (a *Adapter) ObserveHTTP(
 	if err != nil {
 		return ObserveHTTPResponse{}, err
 	}
+	if err := visualizationContextBeforeRoot(ctx); err != nil {
+		return ObserveHTTPResponse{}, err
+	}
 	result, err := a.Observe(ctx, req)
 	if err != nil {
 		return ObserveHTTPResponse{}, err

--- a/pkg/services/factory_visualization/transports/http/observe_handlers.go
+++ b/pkg/services/factory_visualization/transports/http/observe_handlers.go
@@ -1,0 +1,51 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+
+	"go.uber.org/zap"
+)
+
+// ObserveHTTP decodes an owned Observe HTTP request, invokes the Visualization
+// root Observe slice, and encodes the projected-view success shape.
+func (a *Adapter) ObserveHTTP(
+	ctx context.Context,
+	body io.Reader,
+) (ObserveHTTPResponse, error) {
+	req, err := decodeObserveHTTPRequest(body)
+	if err != nil {
+		return ObserveHTTPResponse{}, err
+	}
+	result, err := a.Observe(ctx, req)
+	if err != nil {
+		return ObserveHTTPResponse{}, err
+	}
+	return observeHTTPResponseFromResult(result), nil
+}
+
+// HandleObserve serves POST /factory-visualization/observe.
+func (a *Adapter) HandleObserve(w http.ResponseWriter, r *http.Request) {
+	response, err := a.ObserveHTTP(r.Context(), r.Body)
+	if err != nil {
+		a.writeObserveRequestError(w, err)
+		return
+	}
+	a.writeJSON(w, http.StatusOK, response)
+}
+
+func (a *Adapter) writeObserveRequestError(w http.ResponseWriter, err error) {
+	if message, ok := requestFieldValidationMessage(err); ok {
+		a.writeError(w, http.StatusBadRequest, message, "BAD_REQUEST")
+		return
+	}
+	var decodeErr observeHTTPDecodeError
+	if errors.As(err, &decodeErr) {
+		a.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
+		return
+	}
+	a.logger.Error("factory visualization observe request failed", zap.Error(err))
+	a.writeError(w, http.StatusInternalServerError, "factory visualization observe request failed", "INTERNAL_ERROR")
+}

--- a/pkg/services/factory_visualization/transports/http/observe_mapping.go
+++ b/pkg/services/factory_visualization/transports/http/observe_mapping.go
@@ -1,0 +1,15 @@
+package http
+
+import factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+
+func observeHTTPResponseFromResult(
+	result factoryvisualization.ObserveResult,
+) ObserveHTTPResponse {
+	return ObserveHTTPResponse{
+		View: ObserveHTTPProjectedView{
+			TickCount:          result.View.TickCount,
+			RetainedEventCount: result.View.RetainedEventCount,
+			ObservedAt:         result.View.ObservedAt,
+		},
+	}
+}

--- a/pkg/services/factory_visualization/transports/http/observe_test.go
+++ b/pkg/services/factory_visualization/transports/http/observe_test.go
@@ -1,0 +1,309 @@
+package http_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	factoryvisualizationhttp "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/http"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+func TestObserveHTTP_DecodesModeAndMapsSuccess(t *testing.T) {
+	t.Parallel()
+
+	observedAt := time.Date(2026, 7, 28, 2, 30, 0, 0, time.UTC)
+	root := &observeVisualizationRootFake{
+		observeView: factoryvisualization.ProjectedView{
+			TickCount:          9,
+			RetainedEventCount: 3,
+			ObservedAt:         observedAt,
+		},
+	}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	response, err := handler.ObserveHTTP(
+		context.Background(),
+		strings.NewReader(`{"mode":"RETAINED_THEN_LIVE"}`),
+	)
+	if err != nil {
+		t.Fatalf("ObserveHTTP: %v", err)
+	}
+	if !root.observeInvoked {
+		t.Fatal("Observe was not invoked through the injected Visualization root")
+	}
+	if root.lastObserveMode != factoryvisualization.ObserveModeRetainedThenLive {
+		t.Fatalf("lastObserveMode = %q, want RETAINED_THEN_LIVE", root.lastObserveMode)
+	}
+	if root.lastObserveReconnect != nil {
+		t.Fatalf("lastObserveReconnect = %#v, want nil", root.lastObserveReconnect)
+	}
+	if response.View.TickCount != 9 {
+		t.Fatalf("response.View.TickCount = %d, want 9", response.View.TickCount)
+	}
+	if response.View.RetainedEventCount != 3 {
+		t.Fatalf("response.View.RetainedEventCount = %d, want 3", response.View.RetainedEventCount)
+	}
+	if !response.View.ObservedAt.Equal(observedAt) {
+		t.Fatalf("response.View.ObservedAt = %v, want %v", response.View.ObservedAt, observedAt)
+	}
+}
+
+func TestObserveHTTP_DecodesReconnectCursorAndMapsSuccess(t *testing.T) {
+	t.Parallel()
+
+	afterSequence := 7
+	root := &observeVisualizationRootFake{
+		observeView: factoryvisualization.ProjectedView{
+			TickCount:          4,
+			RetainedEventCount: 2,
+			ObservedAt:         time.Date(2026, 7, 28, 2, 31, 0, 0, time.UTC),
+		},
+	}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	response, err := handler.ObserveHTTP(
+		context.Background(),
+		strings.NewReader(`{"mode":"RETAINED_THEN_LIVE","reconnect":{"after_event_id":"evt-1","after_sequence":7}}`),
+	)
+	if err != nil {
+		t.Fatalf("ObserveHTTP: %v", err)
+	}
+	if !root.observeInvoked {
+		t.Fatal("Observe was not invoked through the injected Visualization root")
+	}
+	if root.lastObserveReconnect == nil {
+		t.Fatal("lastObserveReconnect = nil, want reconnect cursor")
+	}
+	if root.lastObserveReconnect.AfterEventID != "evt-1" {
+		t.Fatalf("AfterEventID = %q, want evt-1", root.lastObserveReconnect.AfterEventID)
+	}
+	if root.lastObserveReconnect.AfterSequence == nil || *root.lastObserveReconnect.AfterSequence != afterSequence {
+		t.Fatalf("AfterSequence = %#v, want %d", root.lastObserveReconnect.AfterSequence, afterSequence)
+	}
+	if response.View.TickCount != 4 {
+		t.Fatalf("response.View.TickCount = %d, want 4", response.View.TickCount)
+	}
+}
+
+func TestObserveHTTP_RejectsMalformedJSONBeforeRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &observeVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	_, err := handler.ObserveHTTP(context.Background(), strings.NewReader(`{"mode":`))
+	if err == nil {
+		t.Fatal("ObserveHTTP malformed JSON = nil, want error")
+	}
+	if root.observeInvoked {
+		t.Fatal("malformed Observe HTTP request must not invoke root")
+	}
+}
+
+func TestObserveHTTP_RejectsUnknownFieldsBeforeRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &observeVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	_, err := handler.ObserveHTTP(
+		context.Background(),
+		strings.NewReader(`{"mode":"RETAINED_THEN_LIVE","extra":true}`),
+	)
+	if err == nil {
+		t.Fatal("ObserveHTTP unknown field = nil, want error")
+	}
+	if root.observeInvoked {
+		t.Fatal("unknown-field Observe HTTP request must not invoke root")
+	}
+}
+
+func TestObserveHTTP_PassesMissingModeToRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &observeVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	_, err := handler.ObserveHTTP(context.Background(), strings.NewReader(`{}`))
+	if err == nil {
+		t.Fatal("ObserveHTTP missing mode = nil, want root invalid-input error")
+	}
+	if !root.observeInvoked {
+		t.Fatal("missing-mode Observe HTTP request must invoke root for typed invalid-input failure")
+	}
+	var projErr *factoryvisualization.ProjectionError
+	if !errors.As(err, &projErr) || projErr.Kind != factoryvisualization.ProjectionErrorInvalidInput {
+		t.Fatalf("err = %v, want ProjectionErrorInvalidInput", err)
+	}
+}
+
+func TestHandleObserve_HTTPRoundTripSuccess(t *testing.T) {
+	t.Parallel()
+
+	observedAt := time.Date(2026, 7, 28, 2, 32, 0, 0, time.UTC)
+	root := &observeVisualizationRootFake{
+		observeView: factoryvisualization.ProjectedView{
+			TickCount:          11,
+			RetainedEventCount: 5,
+			ObservedAt:         observedAt,
+		},
+	}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/factory-visualization/observe", strings.NewReader(`{"mode":"RETAINED_THEN_LIVE"}`))
+	rec := httptest.NewRecorder()
+	handler.HandleObserve(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var response factoryvisualizationhttp.ObserveHTTPResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.View.TickCount != 11 || response.View.RetainedEventCount != 5 {
+		t.Fatalf("response.View = %#v, want tick 11 retained 5", response.View)
+	}
+	if !response.View.ObservedAt.Equal(observedAt) {
+		t.Fatalf("response.View.ObservedAt = %v, want %v", response.View.ObservedAt, observedAt)
+	}
+}
+
+func TestHandleObserve_HTTPRoundTripBadRequestBeforeRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &observeVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/factory-visualization/observe", strings.NewReader(`not-json`))
+	rec := httptest.NewRecorder()
+	handler.HandleObserve(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	var response factoryapi.ErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if response.Family != factoryapi.ErrorFamilyBadRequest || response.Code != factoryapi.ErrorResponseCodeBADREQUEST {
+		t.Fatalf("error response = %#v, want bad-request ErrorResponse", response)
+	}
+	if root.observeInvoked {
+		t.Fatal("malformed Observe HTTP request must not invoke root")
+	}
+}
+
+type observeVisualizationRootFake struct {
+	observeInvoked bool
+
+	lastObserveMode      factoryvisualization.ObserveMode
+	lastObserveReconnect *factoryvisualization.ObserveReconnectCursor
+	observeView          factoryvisualization.ProjectedView
+}
+
+var _ factoryvisualization.Root = (*observeVisualizationRootFake)(nil)
+
+func (fake *observeVisualizationRootFake) Activate(
+	context.Context,
+	factoryvisualization.ActivateRequest,
+) (factoryvisualization.ActivateResult, error) {
+	panic("unexpected Activate call in observe HTTP adapter test")
+}
+
+func (fake *observeVisualizationRootFake) Join(
+	context.Context,
+	factoryvisualization.JoinRequest,
+) (factoryvisualization.JoinResult, error) {
+	panic("unexpected Join call in observe HTTP adapter test")
+}
+
+func (fake *observeVisualizationRootFake) StopDrain(
+	context.Context,
+	factoryvisualization.StopDrainRequest,
+) (factoryvisualization.StopDrainResult, error) {
+	panic("unexpected StopDrain call in observe HTTP adapter test")
+}
+
+func (fake *observeVisualizationRootFake) Observe(
+	_ context.Context,
+	req factoryvisualization.ObserveRequest,
+) (factoryvisualization.ObserveResult, error) {
+	fake.observeInvoked = true
+	fake.lastObserveMode = req.Mode
+	fake.lastObserveReconnect = req.Reconnect
+	if req.Mode == "" {
+		return factoryvisualization.ObserveResult{}, &factoryvisualization.ProjectionError{
+			Kind:    factoryvisualization.ProjectionErrorInvalidInput,
+			Message: "observe Factory visualization: required request parameters are missing",
+		}
+	}
+	if req.Reconnect != nil && req.Reconnect.AfterEventID == "" && req.Reconnect.AfterSequence == nil {
+		return factoryvisualization.ObserveResult{}, &factoryvisualization.ProjectionError{
+			Kind:    factoryvisualization.ProjectionErrorInvalidInput,
+			Message: "observe Factory visualization: reconnect cursor is empty",
+		}
+	}
+	view := fake.observeView
+	if view.ObservedAt.IsZero() {
+		view.ObservedAt = time.Date(2026, 7, 28, 0, 0, 0, 0, time.UTC)
+	}
+	return factoryvisualization.ObserveResult{View: view}, nil
+}
+
+func (fake *observeVisualizationRootFake) OpenPresentation(
+	context.Context,
+	factoryvisualization.OpenPresentationRequest,
+) (factoryvisualization.OpenPresentationResult, error) {
+	panic("unexpected OpenPresentation call in observe HTTP adapter test")
+}
+
+func (fake *observeVisualizationRootFake) PresentProgress(
+	context.Context,
+	factoryvisualization.PresentProgressRequest,
+) (factoryvisualization.PresentProgressResult, error) {
+	panic("unexpected PresentProgress call in observe HTTP adapter test")
+}
+
+func (fake *observeVisualizationRootFake) FinalizePresentation(
+	context.Context,
+	factoryvisualization.FinalizePresentationRequest,
+) (factoryvisualization.FinalizePresentationResult, error) {
+	panic("unexpected FinalizePresentation call in observe HTTP adapter test")
+}
+
+func (fake *observeVisualizationRootFake) ClosePresentation(
+	context.Context,
+	factoryvisualization.ClosePresentationRequest,
+) (factoryvisualization.ClosePresentationResult, error) {
+	panic("unexpected ClosePresentation call in observe HTTP adapter test")
+}

--- a/pkg/services/factory_visualization/transports/http/observe_types.go
+++ b/pkg/services/factory_visualization/transports/http/observe_types.go
@@ -1,0 +1,33 @@
+package http
+
+import "time"
+
+// ObserveHTTPRequest is the adapter-owned HTTP request shape for Visualization
+// Observe. PSS-I02 later fans this into shared OpenAPI route registration; this
+// packet proves decode/map at the owner-local adapter edge.
+type ObserveHTTPRequest struct {
+	Mode      string                         `json:"mode"`
+	Reconnect *ObserveReconnectCursorHTTPRequest `json:"reconnect,omitempty"`
+}
+
+// ObserveReconnectCursorHTTPRequest is the adapter-owned reconnect cursor shape
+// for Visualization Observe HTTP requests.
+type ObserveReconnectCursorHTTPRequest struct {
+	AfterEventID  string `json:"after_event_id,omitempty"`
+	AfterSequence *int   `json:"after_sequence,omitempty"`
+}
+
+// ObserveHTTPResponse is the adapter-owned HTTP success response shape for
+// Visualization Observe. Plain projected-view facts are preserved from the root
+// contract outcome.
+type ObserveHTTPResponse struct {
+	View ObserveHTTPProjectedView `json:"view"`
+}
+
+// ObserveHTTPProjectedView is the adapter-owned detached live view facts encoded
+// into Observe HTTP success responses.
+type ObserveHTTPProjectedView struct {
+	TickCount          int       `json:"tick_count"`
+	RetainedEventCount int       `json:"retained_event_count"`
+	ObservedAt         time.Time `json:"observed_at"`
+}

--- a/pkg/services/factory_visualization/transports/http/presentation_decode.go
+++ b/pkg/services/factory_visualization/transports/http/presentation_decode.go
@@ -1,0 +1,80 @@
+package http
+
+import (
+	"io"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+)
+
+type presentationHTTPDecodeError struct {
+	cause error
+}
+
+func (e presentationHTTPDecodeError) Error() string {
+	return e.cause.Error()
+}
+
+func (e presentationHTTPDecodeError) Unwrap() error {
+	return e.cause
+}
+
+func decodeOpenPresentationHTTPRequest(
+	body io.Reader,
+) (factoryvisualization.OpenPresentationRequest, error) {
+	req, err := decodeStrictJSON[OpenPresentationHTTPRequest](body)
+	if err != nil {
+		return factoryvisualization.OpenPresentationRequest{}, presentationHTTPDecodeError{cause: err}
+	}
+	return factoryvisualization.OpenPresentationRequest{
+		Mode: factoryvisualization.PresentationDeliveryMode(req.Mode),
+	}, nil
+}
+
+func decodePresentProgressHTTPRequest(
+	body io.Reader,
+) (factoryvisualization.PresentProgressRequest, error) {
+	req, err := decodeStrictJSON[PresentProgressHTTPRequest](body)
+	if err != nil {
+		return factoryvisualization.PresentProgressRequest{}, presentationHTTPDecodeError{cause: err}
+	}
+	records := make([]factoryvisualization.ProgressRecord, 0, len(req.Records))
+	for _, record := range req.Records {
+		records = append(records, factoryvisualization.ProgressRecord{
+			Payload: append([]byte(nil), record.Payload...),
+		})
+	}
+	return factoryvisualization.PresentProgressRequest{
+		SessionID: factoryvisualization.PresentationSessionID(req.SessionID),
+		Records:   records,
+	}, nil
+}
+
+func decodeFinalizePresentationHTTPRequest(
+	body io.Reader,
+) (factoryvisualization.FinalizePresentationRequest, error) {
+	req, err := decodeStrictJSON[FinalizePresentationHTTPRequest](body)
+	if err != nil {
+		return factoryvisualization.FinalizePresentationRequest{}, presentationHTTPDecodeError{cause: err}
+	}
+	rootReq := factoryvisualization.FinalizePresentationRequest{
+		SessionID: factoryvisualization.PresentationSessionID(req.SessionID),
+	}
+	if req.Terminal != nil {
+		rootReq.Terminal = &factoryvisualization.TerminalWrite{
+			Payload: append([]byte(nil), req.Terminal.Payload...),
+		}
+	}
+	return rootReq, nil
+}
+
+func decodeClosePresentationHTTPRequest(
+	body io.Reader,
+) (factoryvisualization.ClosePresentationRequest, error) {
+	req, err := decodeStrictJSON[ClosePresentationHTTPRequest](body)
+	if err != nil {
+		return factoryvisualization.ClosePresentationRequest{}, presentationHTTPDecodeError{cause: err}
+	}
+	return factoryvisualization.ClosePresentationRequest{
+		SessionID: factoryvisualization.PresentationSessionID(req.SessionID),
+	}, nil
+}

--- a/pkg/services/factory_visualization/transports/http/presentation_handlers.go
+++ b/pkg/services/factory_visualization/transports/http/presentation_handlers.go
@@ -2,11 +2,8 @@ package http
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net/http"
-
-	"go.uber.org/zap"
 )
 
 // OpenPresentationHTTP decodes an owned presentation-open HTTP request, invokes
@@ -121,15 +118,5 @@ func (a *Adapter) HandleClosePresentation(w http.ResponseWriter, r *http.Request
 }
 
 func (a *Adapter) writePresentationRequestError(w http.ResponseWriter, err error) {
-	if message, ok := requestFieldValidationMessage(err); ok {
-		a.writeError(w, http.StatusBadRequest, message, "BAD_REQUEST")
-		return
-	}
-	var decodeErr presentationHTTPDecodeError
-	if errors.As(err, &decodeErr) {
-		a.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
-		return
-	}
-	a.logger.Error("factory visualization presentation request failed", zap.Error(err))
-	a.writeError(w, http.StatusInternalServerError, "factory visualization presentation request failed", "INTERNAL_ERROR")
+	a.writeVisualizationRequestError(w, err, "factory visualization presentation request failed")
 }

--- a/pkg/services/factory_visualization/transports/http/presentation_handlers.go
+++ b/pkg/services/factory_visualization/transports/http/presentation_handlers.go
@@ -16,6 +16,9 @@ func (a *Adapter) OpenPresentationHTTP(
 	if err != nil {
 		return OpenPresentationHTTPResponse{}, err
 	}
+	if err := visualizationContextBeforeRoot(ctx); err != nil {
+		return OpenPresentationHTTPResponse{}, err
+	}
 	result, err := a.OpenPresentation(ctx, req)
 	if err != nil {
 		return OpenPresentationHTTPResponse{}, err
@@ -32,6 +35,9 @@ func (a *Adapter) PresentProgressHTTP(
 ) (PresentProgressHTTPResponse, error) {
 	req, err := decodePresentProgressHTTPRequest(body)
 	if err != nil {
+		return PresentProgressHTTPResponse{}, err
+	}
+	if err := visualizationContextBeforeRoot(ctx); err != nil {
 		return PresentProgressHTTPResponse{}, err
 	}
 	result, err := a.PresentProgress(ctx, req)
@@ -52,6 +58,9 @@ func (a *Adapter) FinalizePresentationHTTP(
 	if err != nil {
 		return FinalizePresentationHTTPResponse{}, err
 	}
+	if err := visualizationContextBeforeRoot(ctx); err != nil {
+		return FinalizePresentationHTTPResponse{}, err
+	}
 	result, err := a.FinalizePresentation(ctx, req)
 	if err != nil {
 		return FinalizePresentationHTTPResponse{}, err
@@ -68,6 +77,9 @@ func (a *Adapter) ClosePresentationHTTP(
 ) (ClosePresentationHTTPResponse, error) {
 	req, err := decodeClosePresentationHTTPRequest(body)
 	if err != nil {
+		return ClosePresentationHTTPResponse{}, err
+	}
+	if err := visualizationContextBeforeRoot(ctx); err != nil {
 		return ClosePresentationHTTPResponse{}, err
 	}
 	result, err := a.ClosePresentation(ctx, req)

--- a/pkg/services/factory_visualization/transports/http/presentation_handlers.go
+++ b/pkg/services/factory_visualization/transports/http/presentation_handlers.go
@@ -1,0 +1,135 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+
+	"go.uber.org/zap"
+)
+
+// OpenPresentationHTTP decodes an owned presentation-open HTTP request, invokes
+// the Visualization root OpenPresentation slice, and encodes the success shape.
+func (a *Adapter) OpenPresentationHTTP(
+	ctx context.Context,
+	body io.Reader,
+) (OpenPresentationHTTPResponse, error) {
+	req, err := decodeOpenPresentationHTTPRequest(body)
+	if err != nil {
+		return OpenPresentationHTTPResponse{}, err
+	}
+	result, err := a.OpenPresentation(ctx, req)
+	if err != nil {
+		return OpenPresentationHTTPResponse{}, err
+	}
+	return openPresentationHTTPResponseFromResult(result), nil
+}
+
+// PresentProgressHTTP decodes an owned presentation-progress HTTP request,
+// invokes the Visualization root PresentProgress slice, and encodes the success
+// shape.
+func (a *Adapter) PresentProgressHTTP(
+	ctx context.Context,
+	body io.Reader,
+) (PresentProgressHTTPResponse, error) {
+	req, err := decodePresentProgressHTTPRequest(body)
+	if err != nil {
+		return PresentProgressHTTPResponse{}, err
+	}
+	result, err := a.PresentProgress(ctx, req)
+	if err != nil {
+		return PresentProgressHTTPResponse{}, err
+	}
+	return presentProgressHTTPResponseFromResult(result), nil
+}
+
+// FinalizePresentationHTTP decodes an owned presentation-finalize HTTP request,
+// invokes the Visualization root FinalizePresentation slice, and encodes the
+// success shape.
+func (a *Adapter) FinalizePresentationHTTP(
+	ctx context.Context,
+	body io.Reader,
+) (FinalizePresentationHTTPResponse, error) {
+	req, err := decodeFinalizePresentationHTTPRequest(body)
+	if err != nil {
+		return FinalizePresentationHTTPResponse{}, err
+	}
+	result, err := a.FinalizePresentation(ctx, req)
+	if err != nil {
+		return FinalizePresentationHTTPResponse{}, err
+	}
+	return finalizePresentationHTTPResponseFromResult(result), nil
+}
+
+// ClosePresentationHTTP decodes an owned presentation-close HTTP request,
+// invokes the Visualization root ClosePresentation slice, and encodes the
+// success shape.
+func (a *Adapter) ClosePresentationHTTP(
+	ctx context.Context,
+	body io.Reader,
+) (ClosePresentationHTTPResponse, error) {
+	req, err := decodeClosePresentationHTTPRequest(body)
+	if err != nil {
+		return ClosePresentationHTTPResponse{}, err
+	}
+	result, err := a.ClosePresentation(ctx, req)
+	if err != nil {
+		return ClosePresentationHTTPResponse{}, err
+	}
+	return closePresentationHTTPResponseFromResult(result), nil
+}
+
+// HandleOpenPresentation serves POST /factory-visualization/presentation/open.
+func (a *Adapter) HandleOpenPresentation(w http.ResponseWriter, r *http.Request) {
+	response, err := a.OpenPresentationHTTP(r.Context(), r.Body)
+	if err != nil {
+		a.writePresentationRequestError(w, err)
+		return
+	}
+	a.writeJSON(w, http.StatusOK, response)
+}
+
+// HandlePresentProgress serves POST /factory-visualization/presentation/progress.
+func (a *Adapter) HandlePresentProgress(w http.ResponseWriter, r *http.Request) {
+	response, err := a.PresentProgressHTTP(r.Context(), r.Body)
+	if err != nil {
+		a.writePresentationRequestError(w, err)
+		return
+	}
+	a.writeJSON(w, http.StatusOK, response)
+}
+
+// HandleFinalizePresentation serves POST /factory-visualization/presentation/finalize.
+func (a *Adapter) HandleFinalizePresentation(w http.ResponseWriter, r *http.Request) {
+	response, err := a.FinalizePresentationHTTP(r.Context(), r.Body)
+	if err != nil {
+		a.writePresentationRequestError(w, err)
+		return
+	}
+	a.writeJSON(w, http.StatusOK, response)
+}
+
+// HandleClosePresentation serves POST /factory-visualization/presentation/close.
+func (a *Adapter) HandleClosePresentation(w http.ResponseWriter, r *http.Request) {
+	response, err := a.ClosePresentationHTTP(r.Context(), r.Body)
+	if err != nil {
+		a.writePresentationRequestError(w, err)
+		return
+	}
+	a.writeJSON(w, http.StatusOK, response)
+}
+
+func (a *Adapter) writePresentationRequestError(w http.ResponseWriter, err error) {
+	if message, ok := requestFieldValidationMessage(err); ok {
+		a.writeError(w, http.StatusBadRequest, message, "BAD_REQUEST")
+		return
+	}
+	var decodeErr presentationHTTPDecodeError
+	if errors.As(err, &decodeErr) {
+		a.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
+		return
+	}
+	a.logger.Error("factory visualization presentation request failed", zap.Error(err))
+	a.writeError(w, http.StatusInternalServerError, "factory visualization presentation request failed", "INTERNAL_ERROR")
+}

--- a/pkg/services/factory_visualization/transports/http/presentation_mapping.go
+++ b/pkg/services/factory_visualization/transports/http/presentation_mapping.go
@@ -1,0 +1,33 @@
+package http
+
+import factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+
+func openPresentationHTTPResponseFromResult(
+	result factoryvisualization.OpenPresentationResult,
+) OpenPresentationHTTPResponse {
+	return OpenPresentationHTTPResponse{
+		SessionID: string(result.SessionID),
+		Mode:      string(result.Mode),
+	}
+}
+
+func presentProgressHTTPResponseFromResult(
+	result factoryvisualization.PresentProgressResult,
+) PresentProgressHTTPResponse {
+	return PresentProgressHTTPResponse{AcceptedCount: result.AcceptedCount}
+}
+
+func finalizePresentationHTTPResponseFromResult(
+	result factoryvisualization.FinalizePresentationResult,
+) FinalizePresentationHTTPResponse {
+	return FinalizePresentationHTTPResponse{
+		Finalized:    result.Finalized,
+		ProgressSeen: result.ProgressSeen,
+	}
+}
+
+func closePresentationHTTPResponseFromResult(
+	result factoryvisualization.ClosePresentationResult,
+) ClosePresentationHTTPResponse {
+	return ClosePresentationHTTPResponse{DroppedCount: result.DroppedCount}
+}

--- a/pkg/services/factory_visualization/transports/http/presentation_test.go
+++ b/pkg/services/factory_visualization/transports/http/presentation_test.go
@@ -1,0 +1,443 @@
+package http_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	factoryvisualizationhttp "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/http"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+func TestOpenPresentationHTTP_DecodesModeAndMapsSuccess(t *testing.T) {
+	t.Parallel()
+
+	root := &presentationVisualizationRootFake{
+		openResult: factoryvisualization.OpenPresentationResult{
+			SessionID: "presentation-1",
+			Mode:      factoryvisualization.PresentationDeliveryLossless,
+		},
+	}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	response, err := handler.OpenPresentationHTTP(
+		context.Background(),
+		strings.NewReader(`{"mode":"LOSSLESS"}`),
+	)
+	if err != nil {
+		t.Fatalf("OpenPresentationHTTP: %v", err)
+	}
+	if !root.openInvoked {
+		t.Fatal("OpenPresentation was not invoked through the injected Visualization root")
+	}
+	if root.lastOpenMode != factoryvisualization.PresentationDeliveryLossless {
+		t.Fatalf("lastOpenMode = %q, want LOSSLESS", root.lastOpenMode)
+	}
+	if response.SessionID != "presentation-1" {
+		t.Fatalf("response.SessionID = %q, want presentation-1", response.SessionID)
+	}
+	if response.Mode != string(factoryvisualization.PresentationDeliveryLossless) {
+		t.Fatalf("response.Mode = %q, want LOSSLESS", response.Mode)
+	}
+}
+
+func TestPresentProgressHTTP_DecodesSessionAndRecordsAndMapsSuccess(t *testing.T) {
+	t.Parallel()
+
+	root := &presentationVisualizationRootFake{
+		presentResult: factoryvisualization.PresentProgressResult{AcceptedCount: 2},
+	}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	response, err := handler.PresentProgressHTTP(
+		context.Background(),
+		strings.NewReader(`{"session_id":"presentation-1","records":[{"payload":"aGVsbG8="},{"payload":"d29ybGQ="}]}`),
+	)
+	if err != nil {
+		t.Fatalf("PresentProgressHTTP: %v", err)
+	}
+	if !root.presentInvoked {
+		t.Fatal("PresentProgress was not invoked through the injected Visualization root")
+	}
+	if root.lastPresentSessionID != "presentation-1" {
+		t.Fatalf("lastPresentSessionID = %q, want presentation-1", root.lastPresentSessionID)
+	}
+	if len(root.lastPresentRecords) != 2 {
+		t.Fatalf("lastPresentRecords len = %d, want 2", len(root.lastPresentRecords))
+	}
+	if string(root.lastPresentRecords[0].Payload) != "hello" {
+		t.Fatalf("first record payload = %q, want hello", root.lastPresentRecords[0].Payload)
+	}
+	if string(root.lastPresentRecords[1].Payload) != "world" {
+		t.Fatalf("second record payload = %q, want world", root.lastPresentRecords[1].Payload)
+	}
+	if response.AcceptedCount != 2 {
+		t.Fatalf("response.AcceptedCount = %d, want 2", response.AcceptedCount)
+	}
+}
+
+func TestFinalizePresentationHTTP_DecodesSessionAndTerminalAndMapsSuccess(t *testing.T) {
+	t.Parallel()
+
+	root := &presentationVisualizationRootFake{
+		finalizeResult: factoryvisualization.FinalizePresentationResult{
+			Finalized:    true,
+			ProgressSeen: true,
+		},
+	}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	response, err := handler.FinalizePresentationHTTP(
+		context.Background(),
+		strings.NewReader(`{"session_id":"presentation-1","terminal":{"payload":"ZG9uZQ=="}}`),
+	)
+	if err != nil {
+		t.Fatalf("FinalizePresentationHTTP: %v", err)
+	}
+	if !root.finalizeInvoked {
+		t.Fatal("FinalizePresentation was not invoked through the injected Visualization root")
+	}
+	if root.lastFinalizeSessionID != "presentation-1" {
+		t.Fatalf("lastFinalizeSessionID = %q, want presentation-1", root.lastFinalizeSessionID)
+	}
+	if root.lastFinalizeTerminal == nil {
+		t.Fatal("lastFinalizeTerminal = nil, want terminal payload")
+	}
+	if string(root.lastFinalizeTerminal.Payload) != "done" {
+		t.Fatalf("terminal payload = %q, want done", root.lastFinalizeTerminal.Payload)
+	}
+	if !response.Finalized || !response.ProgressSeen {
+		t.Fatalf("response = %#v, want finalized with progress seen", response)
+	}
+}
+
+func TestClosePresentationHTTP_DecodesSessionAndMapsSuccess(t *testing.T) {
+	t.Parallel()
+
+	root := &presentationVisualizationRootFake{
+		closeResult: factoryvisualization.ClosePresentationResult{DroppedCount: 3},
+	}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	response, err := handler.ClosePresentationHTTP(
+		context.Background(),
+		strings.NewReader(`{"session_id":"presentation-1"}`),
+	)
+	if err != nil {
+		t.Fatalf("ClosePresentationHTTP: %v", err)
+	}
+	if !root.closeInvoked {
+		t.Fatal("ClosePresentation was not invoked through the injected Visualization root")
+	}
+	if root.lastCloseSessionID != "presentation-1" {
+		t.Fatalf("lastCloseSessionID = %q, want presentation-1", root.lastCloseSessionID)
+	}
+	if response.DroppedCount != 3 {
+		t.Fatalf("response.DroppedCount = %d, want 3", response.DroppedCount)
+	}
+}
+
+func TestOpenPresentationHTTP_RejectsMalformedJSONBeforeRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &presentationVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	_, err := handler.OpenPresentationHTTP(context.Background(), strings.NewReader(`{"mode":`))
+	if err == nil {
+		t.Fatal("OpenPresentationHTTP malformed JSON = nil, want error")
+	}
+	if root.openInvoked {
+		t.Fatal("malformed OpenPresentation HTTP request must not invoke root")
+	}
+}
+
+func TestPresentProgressHTTP_RejectsUnknownFieldsBeforeRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &presentationVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	_, err := handler.PresentProgressHTTP(
+		context.Background(),
+		strings.NewReader(`{"session_id":"presentation-1","records":[],"extra":true}`),
+	)
+	if err == nil {
+		t.Fatal("PresentProgressHTTP unknown field = nil, want error")
+	}
+	if root.presentInvoked {
+		t.Fatal("unknown-field PresentProgress HTTP request must not invoke root")
+	}
+}
+
+func TestOpenPresentationHTTP_PassesMissingModeToRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &presentationVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	_, err := handler.OpenPresentationHTTP(context.Background(), strings.NewReader(`{}`))
+	if err == nil {
+		t.Fatal("OpenPresentationHTTP missing mode = nil, want root invalid-input error")
+	}
+	if !root.openInvoked {
+		t.Fatal("missing-mode OpenPresentation HTTP request must invoke root for typed invalid-input failure")
+	}
+	var presErr *factoryvisualization.PresentationError
+	if !errors.As(err, &presErr) || presErr.Kind != factoryvisualization.PresentationErrorInvalidInput {
+		t.Fatalf("err = %v, want PresentationErrorInvalidInput", err)
+	}
+}
+
+func TestPresentProgressHTTP_PassesMissingSessionIDToRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &presentationVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	_, err := handler.PresentProgressHTTP(
+		context.Background(),
+		strings.NewReader(`{"records":[{"payload":"YQ=="}]}`),
+	)
+	if err == nil {
+		t.Fatal("PresentProgressHTTP missing session id = nil, want root invalid-input error")
+	}
+	if !root.presentInvoked {
+		t.Fatal("missing-session PresentProgress HTTP request must invoke root for typed invalid-input failure")
+	}
+	var presErr *factoryvisualization.PresentationError
+	if !errors.As(err, &presErr) || presErr.Kind != factoryvisualization.PresentationErrorInvalidInput {
+		t.Fatalf("err = %v, want PresentationErrorInvalidInput", err)
+	}
+}
+
+func TestHandleOpenPresentation_HTTPRoundTripSuccess(t *testing.T) {
+	t.Parallel()
+
+	root := &presentationVisualizationRootFake{
+		openResult: factoryvisualization.OpenPresentationResult{
+			SessionID: "presentation-9",
+			Mode:      factoryvisualization.PresentationDeliveryBestEffort,
+		},
+	}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/factory-visualization/presentation/open",
+		strings.NewReader(`{"mode":"BEST_EFFORT"}`),
+	)
+	rec := httptest.NewRecorder()
+	handler.HandleOpenPresentation(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var response factoryvisualizationhttp.OpenPresentationHTTPResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.SessionID != "presentation-9" || response.Mode != "BEST_EFFORT" {
+		t.Fatalf("response = %#v, want session presentation-9 mode BEST_EFFORT", response)
+	}
+}
+
+func TestHandlePresentProgress_HTTPRoundTripBadRequestBeforeRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &presentationVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/factory-visualization/presentation/progress",
+		strings.NewReader(`not-json`),
+	)
+	rec := httptest.NewRecorder()
+	handler.HandlePresentProgress(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	var response factoryapi.ErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if response.Family != factoryapi.ErrorFamilyBadRequest || response.Code != factoryapi.ErrorResponseCodeBADREQUEST {
+		t.Fatalf("error response = %#v, want bad-request ErrorResponse", response)
+	}
+	if root.presentInvoked {
+		t.Fatal("malformed PresentProgress HTTP request must not invoke root")
+	}
+}
+
+func TestHandleClosePresentation_HTTPRoundTripSuccess(t *testing.T) {
+	t.Parallel()
+
+	root := &presentationVisualizationRootFake{
+		closeResult: factoryvisualization.ClosePresentationResult{DroppedCount: 1},
+	}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/factory-visualization/presentation/close",
+		strings.NewReader(`{"session_id":"presentation-1"}`),
+	)
+	rec := httptest.NewRecorder()
+	handler.HandleClosePresentation(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var response factoryvisualizationhttp.ClosePresentationHTTPResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.DroppedCount != 1 {
+		t.Fatalf("response.DroppedCount = %d, want 1", response.DroppedCount)
+	}
+}
+
+type presentationVisualizationRootFake struct {
+	openInvoked     bool
+	presentInvoked  bool
+	finalizeInvoked bool
+	closeInvoked    bool
+
+	lastOpenMode          factoryvisualization.PresentationDeliveryMode
+	lastPresentSessionID  factoryvisualization.PresentationSessionID
+	lastPresentRecords    []factoryvisualization.ProgressRecord
+	lastFinalizeSessionID factoryvisualization.PresentationSessionID
+	lastFinalizeTerminal  *factoryvisualization.TerminalWrite
+	lastCloseSessionID    factoryvisualization.PresentationSessionID
+
+	openResult     factoryvisualization.OpenPresentationResult
+	presentResult  factoryvisualization.PresentProgressResult
+	finalizeResult factoryvisualization.FinalizePresentationResult
+	closeResult    factoryvisualization.ClosePresentationResult
+}
+
+var _ factoryvisualization.Root = (*presentationVisualizationRootFake)(nil)
+
+func (fake *presentationVisualizationRootFake) Activate(
+	context.Context,
+	factoryvisualization.ActivateRequest,
+) (factoryvisualization.ActivateResult, error) {
+	panic("unexpected Activate call in presentation HTTP adapter test")
+}
+
+func (fake *presentationVisualizationRootFake) Join(
+	context.Context,
+	factoryvisualization.JoinRequest,
+) (factoryvisualization.JoinResult, error) {
+	panic("unexpected Join call in presentation HTTP adapter test")
+}
+
+func (fake *presentationVisualizationRootFake) StopDrain(
+	context.Context,
+	factoryvisualization.StopDrainRequest,
+) (factoryvisualization.StopDrainResult, error) {
+	panic("unexpected StopDrain call in presentation HTTP adapter test")
+}
+
+func (fake *presentationVisualizationRootFake) Observe(
+	context.Context,
+	factoryvisualization.ObserveRequest,
+) (factoryvisualization.ObserveResult, error) {
+	panic("unexpected Observe call in presentation HTTP adapter test")
+}
+
+func (fake *presentationVisualizationRootFake) OpenPresentation(
+	_ context.Context,
+	req factoryvisualization.OpenPresentationRequest,
+) (factoryvisualization.OpenPresentationResult, error) {
+	fake.openInvoked = true
+	fake.lastOpenMode = req.Mode
+	if req.Mode == "" {
+		return factoryvisualization.OpenPresentationResult{}, &factoryvisualization.PresentationError{
+			Kind:    factoryvisualization.PresentationErrorInvalidInput,
+			Message: "open Factory visualization presentation: required request parameters are missing",
+		}
+	}
+	return fake.openResult, nil
+}
+
+func (fake *presentationVisualizationRootFake) PresentProgress(
+	_ context.Context,
+	req factoryvisualization.PresentProgressRequest,
+) (factoryvisualization.PresentProgressResult, error) {
+	fake.presentInvoked = true
+	fake.lastPresentSessionID = req.SessionID
+	fake.lastPresentRecords = append([]factoryvisualization.ProgressRecord(nil), req.Records...)
+	if req.SessionID == "" {
+		return factoryvisualization.PresentProgressResult{}, &factoryvisualization.PresentationError{
+			Kind:    factoryvisualization.PresentationErrorInvalidInput,
+			Message: "Factory visualization presentation: session id is required",
+		}
+	}
+	return fake.presentResult, nil
+}
+
+func (fake *presentationVisualizationRootFake) FinalizePresentation(
+	_ context.Context,
+	req factoryvisualization.FinalizePresentationRequest,
+) (factoryvisualization.FinalizePresentationResult, error) {
+	fake.finalizeInvoked = true
+	fake.lastFinalizeSessionID = req.SessionID
+	if req.Terminal != nil {
+		terminal := *req.Terminal
+		fake.lastFinalizeTerminal = &terminal
+	} else {
+		fake.lastFinalizeTerminal = nil
+	}
+	return fake.finalizeResult, nil
+}
+
+func (fake *presentationVisualizationRootFake) ClosePresentation(
+	_ context.Context,
+	req factoryvisualization.ClosePresentationRequest,
+) (factoryvisualization.ClosePresentationResult, error) {
+	fake.closeInvoked = true
+	fake.lastCloseSessionID = req.SessionID
+	return fake.closeResult, nil
+}

--- a/pkg/services/factory_visualization/transports/http/presentation_types.go
+++ b/pkg/services/factory_visualization/transports/http/presentation_types.go
@@ -1,0 +1,67 @@
+package http
+
+// OpenPresentationHTTPRequest is the adapter-owned HTTP request shape for
+// Visualization presentation open. PSS-I02 later fans this into shared OpenAPI
+// route registration; this packet proves decode/map at the owner-local adapter
+// edge.
+type OpenPresentationHTTPRequest struct {
+	Mode string `json:"mode"`
+}
+
+// OpenPresentationHTTPResponse is the adapter-owned HTTP success response shape
+// for Visualization presentation open.
+type OpenPresentationHTTPResponse struct {
+	SessionID string `json:"session_id"`
+	Mode      string `json:"mode"`
+}
+
+// PresentProgressHTTPRequest is the adapter-owned HTTP request shape for
+// Visualization presentation progress enqueue.
+type PresentProgressHTTPRequest struct {
+	SessionID string                      `json:"session_id"`
+	Records   []ProgressRecordHTTPRequest `json:"records"`
+}
+
+// ProgressRecordHTTPRequest is one adapter-owned progress payload in a
+// PresentProgress HTTP request.
+type ProgressRecordHTTPRequest struct {
+	Payload []byte `json:"payload"`
+}
+
+// PresentProgressHTTPResponse is the adapter-owned HTTP success response shape
+// for Visualization presentation progress enqueue.
+type PresentProgressHTTPResponse struct {
+	AcceptedCount int `json:"accepted_count"`
+}
+
+// FinalizePresentationHTTPRequest is the adapter-owned HTTP request shape for
+// Visualization presentation finalize.
+type FinalizePresentationHTTPRequest struct {
+	SessionID string                    `json:"session_id"`
+	Terminal  *TerminalWriteHTTPRequest `json:"terminal,omitempty"`
+}
+
+// TerminalWriteHTTPRequest is the adapter-owned terminal payload in a
+// FinalizePresentation HTTP request.
+type TerminalWriteHTTPRequest struct {
+	Payload []byte `json:"payload"`
+}
+
+// FinalizePresentationHTTPResponse is the adapter-owned HTTP success response
+// shape for Visualization presentation finalize.
+type FinalizePresentationHTTPResponse struct {
+	Finalized    bool `json:"finalized"`
+	ProgressSeen bool `json:"progress_seen"`
+}
+
+// ClosePresentationHTTPRequest is the adapter-owned HTTP request shape for
+// Visualization presentation close-and-drain.
+type ClosePresentationHTTPRequest struct {
+	SessionID string `json:"session_id"`
+}
+
+// ClosePresentationHTTPResponse is the adapter-owned HTTP success response shape
+// for Visualization presentation close-and-drain.
+type ClosePresentationHTTPResponse struct {
+	DroppedCount int `json:"dropped_count"`
+}

--- a/pkg/services/factory_visualization/transports/http/request_context.go
+++ b/pkg/services/factory_visualization/transports/http/request_context.go
@@ -1,0 +1,46 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+// visualizationRequestContextErrorResponse maps request-context cancellation and
+// deadline failures to the adapter's documented HTTP outcomes. Canceled
+// requests terminate without an error body; deadline failures return 504.
+func visualizationRequestContextErrorResponse(err error) (status int, response any, handled bool) {
+	if err == nil {
+		return 0, nil, false
+	}
+	switch {
+	case errors.Is(err, context.Canceled):
+		return 0, nil, true
+	case errors.Is(err, context.DeadlineExceeded):
+		return http.StatusGatewayTimeout, factoryapi.ErrorResponse{
+			Message: "factory visualization request timed out",
+			Family:  factoryapi.ErrorFamilyInternalServerError,
+			Code:    factoryapi.ErrorResponseCodeINTERNALERROR,
+		}, true
+	default:
+		return 0, nil, false
+	}
+}
+
+func (a *Adapter) writeVisualizationRequestContextOutcome(w http.ResponseWriter, err error) bool {
+	status, response, ok := visualizationRequestContextErrorResponse(err)
+	if !ok {
+		return false
+	}
+	if response == nil {
+		return true
+	}
+	a.writeJSON(w, status, response)
+	return true
+}
+
+func visualizationContextBeforeRoot(ctx context.Context) error {
+	return ctx.Err()
+}

--- a/pkg/services/factory_visualization/transports/http/request_context_test.go
+++ b/pkg/services/factory_visualization/transports/http/request_context_test.go
@@ -1,0 +1,311 @@
+package http_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	factoryvisualizationhttp "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/http"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+type blockingVisualizationRootFake struct {
+	mu sync.Mutex
+
+	observeInvoked bool
+	activateInvoked bool
+
+	observe func(context.Context, factoryvisualization.ObserveRequest) (factoryvisualization.ObserveResult, error)
+	activate func(context.Context, factoryvisualization.ActivateRequest) (factoryvisualization.ActivateResult, error)
+}
+
+var _ factoryvisualization.Root = (*blockingVisualizationRootFake)(nil)
+
+func (fake *blockingVisualizationRootFake) Activate(
+	ctx context.Context,
+	req factoryvisualization.ActivateRequest,
+) (factoryvisualization.ActivateResult, error) {
+	fake.mu.Lock()
+	fake.activateInvoked = true
+	activate := fake.activate
+	fake.mu.Unlock()
+	if activate != nil {
+		return activate(ctx, req)
+	}
+	<-ctx.Done()
+	return factoryvisualization.ActivateResult{}, ctx.Err()
+}
+
+func (fake *blockingVisualizationRootFake) Join(
+	context.Context,
+	factoryvisualization.JoinRequest,
+) (factoryvisualization.JoinResult, error) {
+	panic("unexpected Join call in request-context HTTP adapter test")
+}
+
+func (fake *blockingVisualizationRootFake) StopDrain(
+	context.Context,
+	factoryvisualization.StopDrainRequest,
+) (factoryvisualization.StopDrainResult, error) {
+	panic("unexpected StopDrain call in request-context HTTP adapter test")
+}
+
+func (fake *blockingVisualizationRootFake) Observe(
+	ctx context.Context,
+	req factoryvisualization.ObserveRequest,
+) (factoryvisualization.ObserveResult, error) {
+	fake.mu.Lock()
+	fake.observeInvoked = true
+	observe := fake.observe
+	fake.mu.Unlock()
+	if observe != nil {
+		return observe(ctx, req)
+	}
+	<-ctx.Done()
+	return factoryvisualization.ObserveResult{}, ctx.Err()
+}
+
+func (fake *blockingVisualizationRootFake) OpenPresentation(
+	context.Context,
+	factoryvisualization.OpenPresentationRequest,
+) (factoryvisualization.OpenPresentationResult, error) {
+	panic("unexpected OpenPresentation call in request-context HTTP adapter test")
+}
+
+func (fake *blockingVisualizationRootFake) PresentProgress(
+	context.Context,
+	factoryvisualization.PresentProgressRequest,
+) (factoryvisualization.PresentProgressResult, error) {
+	panic("unexpected PresentProgress call in request-context HTTP adapter test")
+}
+
+func (fake *blockingVisualizationRootFake) FinalizePresentation(
+	context.Context,
+	factoryvisualization.FinalizePresentationRequest,
+) (factoryvisualization.FinalizePresentationResult, error) {
+	panic("unexpected FinalizePresentation call in request-context HTTP adapter test")
+}
+
+func (fake *blockingVisualizationRootFake) ClosePresentation(
+	context.Context,
+	factoryvisualization.ClosePresentationRequest,
+) (factoryvisualization.ClosePresentationResult, error) {
+	panic("unexpected ClosePresentation call in request-context HTTP adapter test")
+}
+
+func TestHandleObserve_CanceledDuringRootCallCompletesWithoutHang(t *testing.T) {
+	t.Parallel()
+
+	root := &blockingVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/factory-visualization/observe",
+		strings.NewReader(`{"mode":"RETAINED_THEN_LIVE"}`),
+	).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		handler.HandleObserve(recorder, req)
+		close(done)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandleObserve hung after request cancellation")
+	}
+	if body := recorder.Body.String(); body != "" {
+		t.Fatalf("response body = %q, want empty cancel-oriented outcome", body)
+	}
+}
+
+func TestHandleObserve_CanceledBeforeRootCallCompletesWithoutBody(t *testing.T) {
+	t.Parallel()
+
+	root := &blockingVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/factory-visualization/observe",
+		strings.NewReader(`{"mode":"RETAINED_THEN_LIVE"}`),
+	).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	handler.HandleObserve(recorder, req)
+
+	root.mu.Lock()
+	invoked := root.observeInvoked
+	root.mu.Unlock()
+	if invoked {
+		t.Fatal("Observe was invoked after request context was canceled")
+	}
+	if body := recorder.Body.String(); body != "" {
+		t.Fatalf("response body = %q, want empty cancel-oriented outcome", body)
+	}
+}
+
+func TestHandleObserve_DeadlineExceededReturnsGatewayTimeout(t *testing.T) {
+	t.Parallel()
+
+	root := &blockingVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	recorder := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		req := httptest.NewRequest(
+			http.MethodPost,
+			"/factory-visualization/observe",
+			strings.NewReader(`{"mode":"RETAINED_THEN_LIVE"}`),
+		).WithContext(ctx)
+		req.Header.Set("Content-Type", "application/json")
+		handler.HandleObserve(recorder, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandleObserve hung after request deadline")
+	}
+	if recorder.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504 Gateway Timeout", recorder.Code)
+	}
+	assertVisualizationErrorResponse(
+		t,
+		recorder.Body.Bytes(),
+		factoryapi.ErrorFamilyInternalServerError,
+		factoryapi.ErrorResponseCodeINTERNALERROR,
+		"factory visualization request timed out",
+	)
+}
+
+func TestHandleActivateLifecycle_CanceledDuringRootCallCompletesWithoutHang(t *testing.T) {
+	t.Parallel()
+
+	root := &blockingVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/factory-visualization/lifecycle/activate",
+		strings.NewReader(`{"mode":"RETAINED_THEN_LIVE"}`),
+	).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		handler.HandleActivateLifecycle(recorder, req)
+		close(done)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandleActivateLifecycle hung after request cancellation")
+	}
+	if body := recorder.Body.String(); body != "" {
+		t.Fatalf("response body = %q, want empty cancel-oriented outcome", body)
+	}
+}
+
+func TestHandleActivateLifecycle_DeadlineExceededReturnsGatewayTimeout(t *testing.T) {
+	t.Parallel()
+
+	root := &blockingVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	recorder := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		req := httptest.NewRequest(
+			http.MethodPost,
+			"/factory-visualization/lifecycle/activate",
+			strings.NewReader(`{"mode":"RETAINED_THEN_LIVE"}`),
+		).WithContext(ctx)
+		req.Header.Set("Content-Type", "application/json")
+		handler.HandleActivateLifecycle(recorder, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandleActivateLifecycle hung after request deadline")
+	}
+	if recorder.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504 Gateway Timeout", recorder.Code)
+	}
+	assertVisualizationErrorResponse(
+		t,
+		recorder.Body.Bytes(),
+		factoryapi.ErrorFamilyInternalServerError,
+		factoryapi.ErrorResponseCodeINTERNALERROR,
+		"factory visualization request timed out",
+	)
+}
+
+func TestVisualizationRequestContextErrorResponseForTest(t *testing.T) {
+	t.Parallel()
+
+	if status, response, ok := factoryvisualizationhttp.VisualizationRequestContextErrorResponseForTest(context.Canceled); !ok || status != 0 || response != nil {
+		t.Fatalf("canceled = (%d, %#v, %v), want (0, nil, true)", status, response, ok)
+	}
+
+	status, response, ok := factoryvisualizationhttp.VisualizationRequestContextErrorResponseForTest(context.DeadlineExceeded)
+	if !ok || status != http.StatusGatewayTimeout {
+		t.Fatalf("deadline status = %d, ok = %v, want 504 true", status, ok)
+	}
+	body, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	if !strings.Contains(string(body), "factory visualization request timed out") {
+		t.Fatalf("response = %s, want timeout message", body)
+	}
+}

--- a/pkg/services/factory_visualization/transports/http/root_binding.go
+++ b/pkg/services/factory_visualization/transports/http/root_binding.go
@@ -1,0 +1,52 @@
+package http
+
+import (
+	"context"
+	"errors"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	"go.uber.org/zap"
+)
+
+// VisualizationRoot is the accepted Factory Visualization root contract used by
+// the HTTP adapter. Adapter-owned operations invoke this surface rather than
+// Visualization internal packages.
+type VisualizationRoot = factoryvisualization.Root
+
+// RootBinding binds the HTTP adapter to one injected Visualization root.
+type RootBinding struct {
+	Visualization VisualizationRoot
+}
+
+// NewHandlerFromRoot constructs an HTTP adapter that calls through the supplied
+// Visualization root. Tests inject a focused fake implementing VisualizationRoot
+// without constructing real activation_lifecycle, live_view_projection,
+// response_event_presentation, or service-local Wire graphs.
+func NewHandlerFromRoot(binding RootBinding, logger *zap.Logger) *Adapter {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return NewHandler(Dependencies{
+		VisualizationRoot: binding.Visualization,
+	}, logger)
+}
+
+func (a *Adapter) requireVisualizationRoot() (VisualizationRoot, error) {
+	if a == nil || a.visualization == nil {
+		return nil, errors.New("Factory visualization API is unavailable")
+	}
+	return a.visualization, nil
+}
+
+// Activate invokes the Visualization root Activate slice. HTTP decode and encode
+// for lifecycle operations arrive in later adapter stories.
+func (a *Adapter) Activate(
+	ctx context.Context,
+	req factoryvisualization.ActivateRequest,
+) (factoryvisualization.ActivateResult, error) {
+	root, err := a.requireVisualizationRoot()
+	if err != nil {
+		return factoryvisualization.ActivateResult{}, err
+	}
+	return root.Activate(ctx, req)
+}

--- a/pkg/services/factory_visualization/transports/http/root_binding.go
+++ b/pkg/services/factory_visualization/transports/http/root_binding.go
@@ -85,3 +85,51 @@ func (a *Adapter) Observe(
 	}
 	return root.Observe(ctx, req)
 }
+
+// OpenPresentation invokes the Visualization root OpenPresentation slice.
+func (a *Adapter) OpenPresentation(
+	ctx context.Context,
+	req factoryvisualization.OpenPresentationRequest,
+) (factoryvisualization.OpenPresentationResult, error) {
+	root, err := a.requireVisualizationRoot()
+	if err != nil {
+		return factoryvisualization.OpenPresentationResult{}, err
+	}
+	return root.OpenPresentation(ctx, req)
+}
+
+// PresentProgress invokes the Visualization root PresentProgress slice.
+func (a *Adapter) PresentProgress(
+	ctx context.Context,
+	req factoryvisualization.PresentProgressRequest,
+) (factoryvisualization.PresentProgressResult, error) {
+	root, err := a.requireVisualizationRoot()
+	if err != nil {
+		return factoryvisualization.PresentProgressResult{}, err
+	}
+	return root.PresentProgress(ctx, req)
+}
+
+// FinalizePresentation invokes the Visualization root FinalizePresentation slice.
+func (a *Adapter) FinalizePresentation(
+	ctx context.Context,
+	req factoryvisualization.FinalizePresentationRequest,
+) (factoryvisualization.FinalizePresentationResult, error) {
+	root, err := a.requireVisualizationRoot()
+	if err != nil {
+		return factoryvisualization.FinalizePresentationResult{}, err
+	}
+	return root.FinalizePresentation(ctx, req)
+}
+
+// ClosePresentation invokes the Visualization root ClosePresentation slice.
+func (a *Adapter) ClosePresentation(
+	ctx context.Context,
+	req factoryvisualization.ClosePresentationRequest,
+) (factoryvisualization.ClosePresentationResult, error) {
+	root, err := a.requireVisualizationRoot()
+	if err != nil {
+		return factoryvisualization.ClosePresentationResult{}, err
+	}
+	return root.ClosePresentation(ctx, req)
+}

--- a/pkg/services/factory_visualization/transports/http/root_binding.go
+++ b/pkg/services/factory_visualization/transports/http/root_binding.go
@@ -38,8 +38,7 @@ func (a *Adapter) requireVisualizationRoot() (VisualizationRoot, error) {
 	return a.visualization, nil
 }
 
-// Activate invokes the Visualization root Activate slice. HTTP decode and encode
-// for lifecycle operations arrive in later adapter stories.
+// Activate invokes the Visualization root Activate slice.
 func (a *Adapter) Activate(
 	ctx context.Context,
 	req factoryvisualization.ActivateRequest,
@@ -49,4 +48,28 @@ func (a *Adapter) Activate(
 		return factoryvisualization.ActivateResult{}, err
 	}
 	return root.Activate(ctx, req)
+}
+
+// Join invokes the Visualization root Join slice.
+func (a *Adapter) Join(
+	ctx context.Context,
+	req factoryvisualization.JoinRequest,
+) (factoryvisualization.JoinResult, error) {
+	root, err := a.requireVisualizationRoot()
+	if err != nil {
+		return factoryvisualization.JoinResult{}, err
+	}
+	return root.Join(ctx, req)
+}
+
+// StopDrain invokes the Visualization root StopDrain slice.
+func (a *Adapter) StopDrain(
+	ctx context.Context,
+	req factoryvisualization.StopDrainRequest,
+) (factoryvisualization.StopDrainResult, error) {
+	root, err := a.requireVisualizationRoot()
+	if err != nil {
+		return factoryvisualization.StopDrainResult{}, err
+	}
+	return root.StopDrain(ctx, req)
 }

--- a/pkg/services/factory_visualization/transports/http/root_binding.go
+++ b/pkg/services/factory_visualization/transports/http/root_binding.go
@@ -73,3 +73,15 @@ func (a *Adapter) StopDrain(
 	}
 	return root.StopDrain(ctx, req)
 }
+
+// Observe invokes the Visualization root Observe slice.
+func (a *Adapter) Observe(
+	ctx context.Context,
+	req factoryvisualization.ObserveRequest,
+) (factoryvisualization.ObserveResult, error) {
+	root, err := a.requireVisualizationRoot()
+	if err != nil {
+		return factoryvisualization.ObserveResult{}, err
+	}
+	return root.Observe(ctx, req)
+}

--- a/pkg/services/factory_visualization/transports/http/root_binding_test.go
+++ b/pkg/services/factory_visualization/transports/http/root_binding_test.go
@@ -1,0 +1,120 @@
+package http_test
+
+import (
+	"context"
+	"testing"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	factoryvisualizationhttp "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/http"
+	"go.uber.org/zap"
+)
+
+func TestHandlerFromRoot_ActivateInvokesVisualizationRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &httpVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	result, err := handler.Activate(context.Background(), factoryvisualization.ActivateRequest{
+		Mode: factoryvisualization.ActivateModeRetainedThenLive,
+	})
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if !root.activateInvoked {
+		t.Fatal("Activate was not invoked through the injected Visualization root")
+	}
+	if result.State != factoryvisualization.LifecycleStateStarted {
+		t.Fatalf("result.State = %q, want STARTED", result.State)
+	}
+}
+
+func TestHandlerFromRoot_ActivateRequiresInjectedRoot(t *testing.T) {
+	t.Parallel()
+
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{},
+		zap.NewNop(),
+	)
+
+	_, err := handler.Activate(context.Background(), factoryvisualization.ActivateRequest{
+		Mode: factoryvisualization.ActivateModeRetainedThenLive,
+	})
+	if err == nil {
+		t.Fatal("Activate without injected root = nil, want error")
+	}
+}
+
+type httpVisualizationRootFake struct {
+	activateInvoked bool
+}
+
+var _ factoryvisualization.Root = (*httpVisualizationRootFake)(nil)
+
+func (fake *httpVisualizationRootFake) Activate(
+	_ context.Context,
+	req factoryvisualization.ActivateRequest,
+) (factoryvisualization.ActivateResult, error) {
+	fake.activateInvoked = true
+	if req.Mode == "" {
+		return factoryvisualization.ActivateResult{}, &factoryvisualization.LifecycleError{
+			Kind:    factoryvisualization.LifecycleErrorMissingParameters,
+			Message: "activate Factory visualization: required request parameters are missing",
+		}
+	}
+	return factoryvisualization.ActivateResult{
+		State: factoryvisualization.LifecycleStateStarted,
+	}, nil
+}
+
+func (fake *httpVisualizationRootFake) Join(
+	context.Context,
+	factoryvisualization.JoinRequest,
+) (factoryvisualization.JoinResult, error) {
+	panic("unexpected Join call in HTTP adapter root seam test")
+}
+
+func (fake *httpVisualizationRootFake) StopDrain(
+	context.Context,
+	factoryvisualization.StopDrainRequest,
+) (factoryvisualization.StopDrainResult, error) {
+	panic("unexpected StopDrain call in HTTP adapter root seam test")
+}
+
+func (fake *httpVisualizationRootFake) Observe(
+	context.Context,
+	factoryvisualization.ObserveRequest,
+) (factoryvisualization.ObserveResult, error) {
+	panic("unexpected Observe call in HTTP adapter root seam test")
+}
+
+func (fake *httpVisualizationRootFake) OpenPresentation(
+	context.Context,
+	factoryvisualization.OpenPresentationRequest,
+) (factoryvisualization.OpenPresentationResult, error) {
+	panic("unexpected OpenPresentation call in HTTP adapter root seam test")
+}
+
+func (fake *httpVisualizationRootFake) PresentProgress(
+	context.Context,
+	factoryvisualization.PresentProgressRequest,
+) (factoryvisualization.PresentProgressResult, error) {
+	panic("unexpected PresentProgress call in HTTP adapter root seam test")
+}
+
+func (fake *httpVisualizationRootFake) FinalizePresentation(
+	context.Context,
+	factoryvisualization.FinalizePresentationRequest,
+) (factoryvisualization.FinalizePresentationResult, error) {
+	panic("unexpected FinalizePresentation call in HTTP adapter root seam test")
+}
+
+func (fake *httpVisualizationRootFake) ClosePresentation(
+	context.Context,
+	factoryvisualization.ClosePresentationRequest,
+) (factoryvisualization.ClosePresentationResult, error) {
+	panic("unexpected ClosePresentation call in HTTP adapter root seam test")
+}

--- a/pkg/services/factory_visualization/transports/http/root_errors.go
+++ b/pkg/services/factory_visualization/transports/http/root_errors.go
@@ -1,0 +1,162 @@
+package http
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+const visualizationRequestFailedMessage = "factory visualization request failed"
+
+// visualizationRootErrorResponse maps typed Visualization root failures to HTTP
+// status and a public ErrorResponse body.
+func visualizationRootErrorResponse(err error) (int, any, bool) {
+	if err == nil {
+		return 0, nil, false
+	}
+
+	var lifeErr *factoryvisualization.LifecycleError
+	if errors.As(err, &lifeErr) {
+		return lifecycleErrorResponse(lifeErr)
+	}
+
+	var projErr *factoryvisualization.ProjectionError
+	if errors.As(err, &projErr) {
+		return projectionErrorResponse(projErr)
+	}
+
+	var presErr *factoryvisualization.PresentationError
+	if errors.As(err, &presErr) {
+		return presentationErrorResponse(presErr)
+	}
+
+	return 0, nil, false
+}
+
+func lifecycleErrorResponse(err *factoryvisualization.LifecycleError) (int, factoryapi.ErrorResponse, bool) {
+	message := visualizationErrorMessage(err.Message, string(err.Kind))
+	switch err.Kind {
+	case factoryvisualization.LifecycleErrorMissingParameters:
+		return http.StatusBadRequest, factoryapi.ErrorResponse{
+			Message: message,
+			Family:  factoryapi.ErrorFamilyBadRequest,
+			Code:    factoryapi.ErrorResponseCode(factoryvisualization.LifecycleErrorMissingParameters),
+		}, true
+	case factoryvisualization.LifecycleErrorAlreadyActivated,
+		factoryvisualization.LifecycleErrorNotActivated:
+		return http.StatusConflict, factoryapi.ErrorResponse{
+			Message: message,
+			Family:  factoryapi.ErrorFamilyConflict,
+			Code:    factoryapi.ErrorResponseCode(err.Kind),
+		}, true
+	default:
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+}
+
+func projectionErrorResponse(err *factoryvisualization.ProjectionError) (int, factoryapi.ErrorResponse, bool) {
+	message := visualizationErrorMessage(err.Message, string(err.Kind))
+	switch err.Kind {
+	case factoryvisualization.ProjectionErrorInvalidInput:
+		return http.StatusBadRequest, factoryapi.ErrorResponse{
+			Message: message,
+			Family:  factoryapi.ErrorFamilyBadRequest,
+			Code:    factoryapi.ErrorResponseCode(factoryvisualization.ProjectionErrorInvalidInput),
+		}, true
+	case factoryvisualization.ProjectionErrorSnapshotUnavailable:
+		return http.StatusServiceUnavailable, factoryapi.ErrorResponse{
+			Message: message,
+			Family:  factoryapi.ErrorFamilyInternalServerError,
+			Code:    factoryapi.ErrorResponseCode(factoryvisualization.ProjectionErrorSnapshotUnavailable),
+		}, true
+	case factoryvisualization.ProjectionErrorReconstructionFailed:
+		return http.StatusInternalServerError, factoryapi.ErrorResponse{
+			Message: message,
+			Family:  factoryapi.ErrorFamilyInternalServerError,
+			Code:    factoryapi.ErrorResponseCode(factoryvisualization.ProjectionErrorReconstructionFailed),
+		}, true
+	default:
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+}
+
+func presentationErrorResponse(err *factoryvisualization.PresentationError) (int, factoryapi.ErrorResponse, bool) {
+	message := visualizationErrorMessage(err.Message, string(err.Kind))
+	switch err.Kind {
+	case factoryvisualization.PresentationErrorInvalidInput:
+		return http.StatusBadRequest, factoryapi.ErrorResponse{
+			Message: message,
+			Family:  factoryapi.ErrorFamilyBadRequest,
+			Code:    factoryapi.ErrorResponseCode(factoryvisualization.PresentationErrorInvalidInput),
+		}, true
+	case factoryvisualization.PresentationErrorEnqueueAfterClose,
+		factoryvisualization.PresentationErrorFinalizeWithoutWriter:
+		return http.StatusConflict, factoryapi.ErrorResponse{
+			Message: message,
+			Family:  factoryapi.ErrorFamilyConflict,
+			Code:    factoryapi.ErrorResponseCode(err.Kind),
+		}, true
+	case factoryvisualization.PresentationErrorBackpressureRejected:
+		return http.StatusServiceUnavailable, factoryapi.ErrorResponse{
+			Message: message,
+			Family:  factoryapi.ErrorFamilyInternalServerError,
+			Code:    factoryapi.ErrorResponseCode(factoryvisualization.PresentationErrorBackpressureRejected),
+		}, true
+	default:
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+}
+
+func visualizationErrorMessage(message, fallback string) string {
+	if trimmed := strings.TrimSpace(message); trimmed != "" {
+		return trimmed
+	}
+	return fallback
+}
+
+func (a *Adapter) writeVisualizationRootError(w http.ResponseWriter, err error) bool {
+	if status, response, ok := visualizationRootErrorResponse(err); ok {
+		if response == nil {
+			return true
+		}
+		a.writeJSON(w, status, response)
+		return true
+	}
+	return false
+}
+
+func (a *Adapter) writeVisualizationRequestError(w http.ResponseWriter, err error, logMessage string) {
+	if message, ok := requestFieldValidationMessage(err); ok {
+		a.writeError(w, http.StatusBadRequest, message, "BAD_REQUEST")
+		return
+	}
+	if isVisualizationHTTPDecodeError(err) {
+		a.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
+		return
+	}
+	if a.writeVisualizationRootError(w, err) {
+		return
+	}
+	a.logger.Error(logMessage, zap.Error(err))
+	a.writeError(
+		w,
+		http.StatusInternalServerError,
+		visualizationRequestFailedMessage,
+		string(factoryapi.ErrorResponseCodeINTERNALERROR),
+	)
+}
+
+func isVisualizationHTTPDecodeError(err error) bool {
+	var (
+		lifecycleDecodeErr    lifecycleHTTPDecodeError
+		observeDecodeErr      observeHTTPDecodeError
+		presentationDecodeErr presentationHTTPDecodeError
+	)
+	return errors.As(err, &lifecycleDecodeErr) ||
+		errors.As(err, &observeDecodeErr) ||
+		errors.As(err, &presentationDecodeErr)
+}

--- a/pkg/services/factory_visualization/transports/http/root_errors.go
+++ b/pkg/services/factory_visualization/transports/http/root_errors.go
@@ -19,6 +19,10 @@ func visualizationRootErrorResponse(err error) (int, any, bool) {
 		return 0, nil, false
 	}
 
+	if status, response, ok := visualizationRequestContextErrorResponse(err); ok {
+		return status, response, true
+	}
+
 	var lifeErr *factoryvisualization.LifecycleError
 	if errors.As(err, &lifeErr) {
 		return lifecycleErrorResponse(lifeErr)

--- a/pkg/services/factory_visualization/transports/http/root_errors_test.go
+++ b/pkg/services/factory_visualization/transports/http/root_errors_test.go
@@ -1,0 +1,460 @@
+package http_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	factoryvisualizationhttp "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/http"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+func TestVisualizationRootErrorResponseReturnsFalseForNilError(t *testing.T) {
+	t.Parallel()
+
+	if status, response, ok := factoryvisualizationhttp.VisualizationRootErrorResponseForTest(nil); ok {
+		t.Fatalf("VisualizationRootErrorResponse(nil) = (%d, %#v, true), want false", status, response)
+	}
+}
+
+func TestVisualizationRootErrorResponseMapsWrappedLifecycleMissingParameters(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("activate: %w", &factoryvisualization.LifecycleError{
+		Kind:    factoryvisualization.LifecycleErrorMissingParameters,
+		Message: "activate Factory visualization: required request parameters are missing",
+	})
+	status, response, ok := factoryvisualizationhttp.VisualizationRootErrorResponseForTest(wrapped)
+	if !ok {
+		t.Fatal("VisualizationRootErrorResponse = false, want true")
+	}
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", status)
+	}
+	errResp, ok := response.(factoryapi.ErrorResponse)
+	if !ok {
+		t.Fatalf("response = %#v, want ErrorResponse", response)
+	}
+	if errResp.Code != factoryapi.ErrorResponseCode(factoryvisualization.LifecycleErrorMissingParameters) {
+		t.Fatalf("code = %q, want MISSING_PARAMETERS", errResp.Code)
+	}
+	if errResp.Family != factoryapi.ErrorFamilyBadRequest {
+		t.Fatalf("family = %q, want BAD_REQUEST", errResp.Family)
+	}
+}
+
+func TestVisualizationRootErrorResponseMapsLifecycleStateConflicts(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		kind   factoryvisualization.LifecycleErrorKind
+		status int
+		family factoryapi.ErrorFamily
+	}{
+		{
+			name:   "already activated",
+			kind:   factoryvisualization.LifecycleErrorAlreadyActivated,
+			status: http.StatusConflict,
+			family: factoryapi.ErrorFamilyConflict,
+		},
+		{
+			name:   "not activated",
+			kind:   factoryvisualization.LifecycleErrorNotActivated,
+			status: http.StatusConflict,
+			family: factoryapi.ErrorFamilyConflict,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			status, response, ok := factoryvisualizationhttp.VisualizationRootErrorResponseForTest(
+				&factoryvisualization.LifecycleError{
+					Kind:    tc.kind,
+					Message: "lifecycle conflict",
+				},
+			)
+			if !ok {
+				t.Fatal("VisualizationRootErrorResponse = false, want true")
+			}
+			if status != tc.status {
+				t.Fatalf("status = %d, want %d", status, tc.status)
+			}
+			errResp, ok := response.(factoryapi.ErrorResponse)
+			if !ok {
+				t.Fatalf("response = %#v, want ErrorResponse", response)
+			}
+			if errResp.Code != factoryapi.ErrorResponseCode(tc.kind) {
+				t.Fatalf("code = %q, want %q", errResp.Code, tc.kind)
+			}
+			if errResp.Family != tc.family {
+				t.Fatalf("family = %q, want %q", errResp.Family, tc.family)
+			}
+		})
+	}
+}
+
+func TestVisualizationRootErrorResponseMapsProjectionErrors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		kind   factoryvisualization.ProjectionErrorKind
+		status int
+		family factoryapi.ErrorFamily
+	}{
+		{
+			name:   "invalid input",
+			kind:   factoryvisualization.ProjectionErrorInvalidInput,
+			status: http.StatusBadRequest,
+			family: factoryapi.ErrorFamilyBadRequest,
+		},
+		{
+			name:   "snapshot unavailable",
+			kind:   factoryvisualization.ProjectionErrorSnapshotUnavailable,
+			status: http.StatusServiceUnavailable,
+			family: factoryapi.ErrorFamilyInternalServerError,
+		},
+		{
+			name:   "reconstruction failed",
+			kind:   factoryvisualization.ProjectionErrorReconstructionFailed,
+			status: http.StatusInternalServerError,
+			family: factoryapi.ErrorFamilyInternalServerError,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			status, response, ok := factoryvisualizationhttp.VisualizationRootErrorResponseForTest(
+				&factoryvisualization.ProjectionError{
+					Kind:    tc.kind,
+					Message: "projection failure",
+				},
+			)
+			if !ok {
+				t.Fatal("VisualizationRootErrorResponse = false, want true")
+			}
+			if status != tc.status {
+				t.Fatalf("status = %d, want %d", status, tc.status)
+			}
+			errResp, ok := response.(factoryapi.ErrorResponse)
+			if !ok {
+				t.Fatalf("response = %#v, want ErrorResponse", response)
+			}
+			if errResp.Code != factoryapi.ErrorResponseCode(tc.kind) {
+				t.Fatalf("code = %q, want %q", errResp.Code, tc.kind)
+			}
+			if errResp.Family != tc.family {
+				t.Fatalf("family = %q, want %q", errResp.Family, tc.family)
+			}
+		})
+	}
+}
+
+func TestVisualizationRootErrorResponseMapsPresentationErrors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		kind   factoryvisualization.PresentationErrorKind
+		status int
+		family factoryapi.ErrorFamily
+	}{
+		{
+			name:   "invalid input",
+			kind:   factoryvisualization.PresentationErrorInvalidInput,
+			status: http.StatusBadRequest,
+			family: factoryapi.ErrorFamilyBadRequest,
+		},
+		{
+			name:   "enqueue after close",
+			kind:   factoryvisualization.PresentationErrorEnqueueAfterClose,
+			status: http.StatusConflict,
+			family: factoryapi.ErrorFamilyConflict,
+		},
+		{
+			name:   "finalize without writer",
+			kind:   factoryvisualization.PresentationErrorFinalizeWithoutWriter,
+			status: http.StatusConflict,
+			family: factoryapi.ErrorFamilyConflict,
+		},
+		{
+			name:   "backpressure rejected",
+			kind:   factoryvisualization.PresentationErrorBackpressureRejected,
+			status: http.StatusServiceUnavailable,
+			family: factoryapi.ErrorFamilyInternalServerError,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			status, response, ok := factoryvisualizationhttp.VisualizationRootErrorResponseForTest(
+				&factoryvisualization.PresentationError{
+					Kind:    tc.kind,
+					Message: "presentation failure",
+				},
+			)
+			if !ok {
+				t.Fatal("VisualizationRootErrorResponse = false, want true")
+			}
+			if status != tc.status {
+				t.Fatalf("status = %d, want %d", status, tc.status)
+			}
+			errResp, ok := response.(factoryapi.ErrorResponse)
+			if !ok {
+				t.Fatalf("response = %#v, want ErrorResponse", response)
+			}
+			if errResp.Code != factoryapi.ErrorResponseCode(tc.kind) {
+				t.Fatalf("code = %q, want %q", errResp.Code, tc.kind)
+			}
+			if errResp.Family != tc.family {
+				t.Fatalf("family = %q, want %q", errResp.Family, tc.family)
+			}
+		})
+	}
+}
+
+func TestVisualizationRootErrorResponseReturnsFalseForUnknownError(t *testing.T) {
+	t.Parallel()
+
+	if _, _, ok := factoryvisualizationhttp.VisualizationRootErrorResponseForTest(errors.New("opaque")); ok {
+		t.Fatal("VisualizationRootErrorResponse = true, want false")
+	}
+}
+
+func TestHandleActivateLifecycle_HTTPRoundTripMissingParametersTypedError(t *testing.T) {
+	t.Parallel()
+
+	root := &lifecycleVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/factory-visualization/lifecycle/activate", strings.NewReader(`{}`))
+	rec := httptest.NewRecorder()
+	handler.HandleActivateLifecycle(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	assertVisualizationErrorResponse(
+		t,
+		rec.Body.Bytes(),
+		factoryapi.ErrorFamilyBadRequest,
+		factoryapi.ErrorResponseCode(factoryvisualization.LifecycleErrorMissingParameters),
+		"activate Factory visualization: required request parameters are missing",
+	)
+}
+
+func TestHandleJoinLifecycle_HTTPRoundTripNotActivatedTypedError(t *testing.T) {
+	t.Parallel()
+
+	root := &joinNotActivatedVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/factory-visualization/lifecycle/join", bytes.NewReader(nil))
+	rec := httptest.NewRecorder()
+	handler.HandleJoinLifecycle(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+	assertVisualizationErrorResponse(
+		t,
+		rec.Body.Bytes(),
+		factoryapi.ErrorFamilyConflict,
+		factoryapi.ErrorResponseCode(factoryvisualization.LifecycleErrorNotActivated),
+		"join Factory visualization: not activated",
+	)
+}
+
+func TestHandleObserve_HTTPRoundTripSnapshotUnavailableTypedError(t *testing.T) {
+	t.Parallel()
+
+	root := &observeSnapshotUnavailableVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/factory-visualization/observe",
+		strings.NewReader(`{"mode":"RETAINED_THEN_LIVE"}`),
+	)
+	rec := httptest.NewRecorder()
+	handler.HandleObserve(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusServiceUnavailable, rec.Body.String())
+	}
+	assertVisualizationErrorResponse(
+		t,
+		rec.Body.Bytes(),
+		factoryapi.ErrorFamilyInternalServerError,
+		factoryapi.ErrorResponseCode(factoryvisualization.ProjectionErrorSnapshotUnavailable),
+		"observe Factory visualization: snapshot unavailable",
+	)
+}
+
+func TestHandlePresentProgress_HTTPRoundTripEnqueueAfterCloseTypedError(t *testing.T) {
+	t.Parallel()
+
+	root := &presentProgressEnqueueAfterCloseVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/factory-visualization/presentation/progress",
+		strings.NewReader(`{"session_id":"sess-001","records":[]}`),
+	)
+	rec := httptest.NewRecorder()
+	handler.HandlePresentProgress(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+	assertVisualizationErrorResponse(
+		t,
+		rec.Body.Bytes(),
+		factoryapi.ErrorFamilyConflict,
+		factoryapi.ErrorResponseCode(factoryvisualization.PresentationErrorEnqueueAfterClose),
+		"present progress: presentation session is closed",
+	)
+}
+
+func TestHandleObserve_HTTPRoundTripUnmappedErrorDoesNotLeakInternalPaths(t *testing.T) {
+	t.Parallel()
+
+	root := &observeOpaqueFailureVisualizationRootFake{}
+	handler := factoryvisualizationhttp.NewHandlerFromRoot(
+		factoryvisualizationhttp.RootBinding{Visualization: root},
+		zap.NewNop(),
+	)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/factory-visualization/observe",
+		strings.NewReader(`{"mode":"RETAINED_THEN_LIVE"}`),
+	)
+	rec := httptest.NewRecorder()
+	handler.HandleObserve(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusInternalServerError, rec.Body.String())
+	}
+	assertVisualizationErrorResponse(
+		t,
+		rec.Body.Bytes(),
+		factoryapi.ErrorFamilyInternalServerError,
+		factoryapi.ErrorResponseCodeINTERNALERROR,
+		"factory visualization request failed",
+	)
+	body := rec.Body.String()
+	if strings.Contains(body, "pkg/services/factory_visualization/internal") {
+		t.Fatalf("error body leaked internal package path: %s", body)
+	}
+}
+
+type joinNotActivatedVisualizationRootFake struct {
+	lifecycleVisualizationRootFake
+}
+
+func (fake *joinNotActivatedVisualizationRootFake) Join(
+	context.Context,
+	factoryvisualization.JoinRequest,
+) (factoryvisualization.JoinResult, error) {
+	return factoryvisualization.JoinResult{}, &factoryvisualization.LifecycleError{
+		Kind:    factoryvisualization.LifecycleErrorNotActivated,
+		Message: "join Factory visualization: not activated",
+	}
+}
+
+type observeSnapshotUnavailableVisualizationRootFake struct {
+	lifecycleVisualizationRootFake
+}
+
+func (fake *observeSnapshotUnavailableVisualizationRootFake) Observe(
+	context.Context,
+	factoryvisualization.ObserveRequest,
+) (factoryvisualization.ObserveResult, error) {
+	return factoryvisualization.ObserveResult{}, &factoryvisualization.ProjectionError{
+		Kind:    factoryvisualization.ProjectionErrorSnapshotUnavailable,
+		Message: "observe Factory visualization: snapshot unavailable",
+	}
+}
+
+type presentProgressEnqueueAfterCloseVisualizationRootFake struct {
+	lifecycleVisualizationRootFake
+}
+
+func (fake *presentProgressEnqueueAfterCloseVisualizationRootFake) PresentProgress(
+	context.Context,
+	factoryvisualization.PresentProgressRequest,
+) (factoryvisualization.PresentProgressResult, error) {
+	return factoryvisualization.PresentProgressResult{}, &factoryvisualization.PresentationError{
+		Kind:    factoryvisualization.PresentationErrorEnqueueAfterClose,
+		Message: "present progress: presentation session is closed",
+	}
+}
+
+type observeOpaqueFailureVisualizationRootFake struct {
+	lifecycleVisualizationRootFake
+}
+
+func (fake *observeOpaqueFailureVisualizationRootFake) Observe(
+	context.Context,
+	factoryvisualization.ObserveRequest,
+) (factoryvisualization.ObserveResult, error) {
+	return factoryvisualization.ObserveResult{}, errors.New(
+		"pkg/services/factory_visualization/internal/services/live_view_projection: reconstruction exploded",
+	)
+}
+
+func assertVisualizationErrorResponse(
+	t *testing.T,
+	body []byte,
+	wantFamily factoryapi.ErrorFamily,
+	wantCode factoryapi.ErrorResponseCode,
+	wantMessage string,
+) {
+	t.Helper()
+
+	var errResp factoryapi.ErrorResponse
+	if err := json.Unmarshal(body, &errResp); err != nil {
+		t.Fatalf("decode error response: %v body=%s", err, string(body))
+	}
+	if errResp.Family != wantFamily {
+		t.Fatalf("family = %q, want %q", errResp.Family, wantFamily)
+	}
+	if errResp.Code != wantCode {
+		t.Fatalf("code = %q, want %q", errResp.Code, wantCode)
+	}
+	if errResp.Message != wantMessage {
+		t.Fatalf("message = %q, want %q", errResp.Message, wantMessage)
+	}
+}


### PR DESCRIPTION
{
  "project": "PSS HTTP-VIS — Factory Visualization Owner-Local HTTP Adapter",
  "branchName": "pss-http-vis-adapter",
  "description": "Implement the Factory Visualization service-owned HTTP adapter so Visualization HTTP requests decode/map through the accepted Visualization root, typed errors become stable HTTP ErrorResponse bodies, and fake-root tests prove mapping plus cancel/timeout parity—without importing Visualization internals, owning canonical state, authoring shared OpenAPI, or editing Wire/root/initializer/CLI composition.",
  "context": {
    "customerAsk": "Implement HTTP-VIS as the Factory Visualization service-owned HTTP adapter. Decode/map Visualization HTTP requests through the accepted Visualization root, translate typed errors, and prove fake-root parity for mapping and cancel/timeout behavior without importing Visualization internals or owning canonical state. Do not author shared OpenAPI or perform PSS-I02 route/client fan-in. Do not edit pkg/wire, pkg/root, pkg/initializer, top-level CLI composition, or reopen Visualization IMP/LWR ownership. Shared coverage, ownership, and package-target manifest edits are allowed and must be rebased through the merge loop. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Factory Visualization already has an accepted singular root, terminal IMP owners for activation lifecycle, live view projection, and response-event presentation, and accepted LWR-VIS. There is no Visualization owner-local HTTP adapter package, so decode/map/error/cancel semantics are not proven at a Visualization-owned fake-root adapter edge—risking drift from root typed-error vocabulary, unproven cancel/timeout, and collisions with live HTTP-SES/HTTP-DEF/HTTP-REC/HTTP-PSES lanes, CLI-VIS, or later PSS-I02 fan-in.",
    "solution": "Implement the Factory Visualization owner-local HTTP adapter so it decodes and maps Visualization HTTP operations through the accepted Visualization root, translates typed root errors into public HTTP error responses, and proves fake-root parity for mapping plus cancel/timeout behavior without importing Visualization internals, owning canonical visualization state, authoring shared OpenAPI, or changing Wire/root/initializer/CLI composition."
  },
  "acceptanceCriteria": [
    "AC-1: Factory Visualization HTTP operations owned by this packet decode requests and map responses through the accepted Visualization root contract only (no Visualization internal imports; adapter does not become canonical state owner)",
    "AC-2: Typed Visualization root errors surface as stable public HTTP ErrorResponse bodies with reviewer-verifiable status/code/family outcomes",
    "AC-3: Focused fake-root tests prove request/response mapping parity for the adapter-owned Visualization HTTP operations covered by this packet",
    "AC-4: Focused fake-root tests prove cancel and timeout behavior at the HTTP adapter edge (canceled or deadline-exceeded request context yields the adapter’s documented HTTP outcome without hanging)",
    "AC-5: Shared coverage, ownership, and package-target manifest edits occur only as required to register the Visualization HTTP adapter package and remain rebased through the merge loop",
    "AC-6: Diff stays inside HTTP-VIS ownership: Visualization HTTP adapter paths and allowed shared manifests; no shared OpenAPI authorship, no PSS-I02 route/client fan-in, no pkg/wire / pkg/root / pkg/initializer, no top-level CLI composition, and no CLI-VIS / other-service HTTP adapter edits",
    "AC-7: Quality checks pass (typecheck, lint, tests)",
    "AC-8: Delivery loop continues until required CI is terminal and passing, all blocking PR conversation feedback is addressed, merge conflicts and shared-file churn are reconciled, and the PR is actually merged"
  ],
  "userStories": [
    {
      "id": "pss-http-vis-adapter-001",
      "title": "Bind Visualization HTTP adapter to Visualization root via fake-root seam",
      "description": "As a maintainer, I want the Factory Visualization HTTP adapter to invoke the accepted Visualization root (or a fake implementing that root) so HTTP adaptation cannot depend on Visualization internals or own canonical visualization lifecycle, projection, or presentation state.",
      "acceptanceCriteria": [
        "Adapter-owned Visualization HTTP operations call through the accepted factoryvisualization.Root contract surface rather than Visualization internal packages",
        "A focused fake Visualization root can be injected for adapter tests without constructing real activation_lifecycle, live_view_projection, response_event_presentation, or service-local Wire graphs",
        "Package-boundary evidence shows the adapter package does not import pkg/services/factory_visualization/internal/**",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-vis-adapter-002",
      "title": "Decode and map Visualization lifecycle HTTP through Activate/Join/StopDrain",
      "description": "As an API client, I want Visualization lifecycle HTTP requests to decode into root Activate/Join/StopDrain inputs and encode lifecycle results so HTTP responses match the root contract outcomes.",
      "acceptanceCriteria": [
        "Owned lifecycle HTTP requests decode into Visualization root Activate/Join/StopDrain request values (including explicit Activate mode such as retained-then-live) before invocation",
        "Fake-root success lifecycle results are encoded into the public HTTP success response shape for those operations (lifecycle state preserved as applicable)",
        "Invalid or missing lifecycle request inputs are rejected with a typed bad-request HTTP outcome before the fake root is invoked, or map through the root’s typed missing-parameters failure when that is the documented adapter path",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-vis-adapter-003",
      "title": "Decode and map Visualization Observe HTTP through the root",
      "description": "As an API client, I want Observe HTTP requests to decode into Visualization Observe inputs and encode detached projected-view results so HTTP responses match the root live-projection contract.",
      "acceptanceCriteria": [
        "Owned Observe HTTP requests decode mode and optional reconnect cursor fields into Visualization root Observe request values before invocation",
        "Fake-root success Observe results are encoded into the public HTTP success response shape (plain projected-view facts such as tick count, retained event count, and observed-at preserved as applicable)",
        "Invalid Observe inputs that fail decode/validation are rejected with a typed bad-request HTTP outcome before the fake root is invoked",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-vis-adapter-004",
      "title": "Decode and map Visualization presentation/drain HTTP through the root",
      "description": "As an API client, I want presentation/drain HTTP requests to decode into Visualization OpenPresentation/PresentProgress/FinalizePresentation/ClosePresentation inputs and encode session/progress/finalize/close results so HTTP responses match the root presentation contract.",
      "acceptanceCriteria": [
        "Owned presentation HTTP requests decode delivery mode, session id, progress records, and terminal write fields into Visualization root request values before invocation",
        "Fake-root success results for open/present/finalize/close are encoded into the public HTTP success response shapes (session id, accepted count, finalized/progress-seen, dropped count as applicable)",
        "Invalid presentation inputs that fail decode/validation are rejected with a typed bad-request HTTP outcome before the fake root is invoked",
        "Diff does not author shared OpenAPI under api/openapi-main.yaml / api/components/** and does not perform PSS-I02 route/client fan-in",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-vis-adapter-005",
      "title": "Translate typed Visualization root errors to HTTP ErrorResponse",
      "description": "As an API client, I want typed Visualization root failures to become stable HTTP error responses so callers can rely on status, family, and code without opaque transport failures.",
      "acceptanceCriteria": [
        "Fake root returns of representative typed Visualization errors map to the documented HTTP status, error family, and error code—covering at least one lifecycle class (for example missing-parameters / not-activated / already-activated), one projection class (for example invalid-input / snapshot-unavailable / reconstruction-failed), and one presentation class (for example enqueue-after-close / finalize-without-writer / backpressure-rejected)",
        "Error response body is a public ErrorResponse (message + family + code) rather than an untyped plaintext failure",
        "Unmapped/internal fake-root failures do not leak Visualization internal package paths, filesystem roots, or stack traces in the HTTP body",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-vis-adapter-006",
      "title": "Prove cancel and timeout parity at the HTTP adapter edge",
      "description": "As an API client, I want canceled or timed-out Visualization HTTP requests to terminate with the adapter’s documented outcome so observe and presentation calls do not hang after the client gives up.",
      "acceptanceCriteria": [
        "When the request context is canceled before or during a fake-root call, the adapter completes with the documented cancel-oriented HTTP outcome and does not hang",
        "When the request context deadline is exceeded during a fake-root call, the adapter completes with the documented timeout-oriented HTTP outcome and does not hang",
        "Fake-root tests cover at least two owned Visualization HTTP paths (for example Observe and one presentation or lifecycle path) for cancel and deadline-exceeded cases",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-vis-adapter-007",
      "title": "Register adapter package in allowed shared manifests",
      "description": "As a maintainer, I want the Visualization HTTP adapter package registered in shared coverage/ownership/package-target manifests only as required so package ownership and verification targets stay accurate without widening into excluded composition surfaces.",
      "acceptanceCriteria": [
        "Shared coverage, ownership, and/or package-target manifest entries for pkg/services/factory_visualization/transports/http (or the chosen owner-local path) are added or updated only when required for adapter package registration",
        "Manifest edits stay limited to those allowed shared manifests; no shared OpenAPI authorship and no PSS-I02 route/client fan-in changes",
        "Diff does not edit pkg/wire, pkg/root, pkg/initializer, top-level CLI composition, CLI-VIS paths, or other services’ HTTP adapters",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 7,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-vis-adapter-008",
      "title": "Close delivery loop through merged PR",
      "description": "As a maintainer, I want the HTTP-VIS implementation/review cycle to continue until the PR is actually merged so the Factory work item is not left merely green or approved.",
      "acceptanceCriteria": [
        "Implementation PR for pss-http-vis-adapter is opened against the integration branch used by this program",
        "Required CI is terminal and passing on the PR head used for merge",
        "Every blocking PR conversation comment is explicitly addressed (fixed or answered with rationale)",
        "Merge conflicts and shared-file churn (including allowed manifest files) are reconciled",
        "PR is actually merged; opened/green/approved/ready-to-merge alone is not sufficient",
        "Typecheck passes"
      ],
      "priority": 8,
      "passes": false,
      "notes": ""
    }
  ]
}
