### PR TITLE
pss-lwr-wrk-service-wire

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -2117,6 +2117,16 @@
       "minimum": 19.51
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/workers/wire",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/worktree",
       "minimum": 53.54
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1781,6 +1781,10 @@
       "minimum": 90.24
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/workers/wire",
+      "minimum": 87.20
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/worktree",
       "minimum": 59.05
     },

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -4654,6 +4654,12 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/workers/wire",
+      "disposition": "retain",
+      "destination": "workers",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/workers/worktree",
       "disposition": "retain",
       "destination": "workers",

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -409,6 +409,7 @@
     "pkg/services/workers/services/inference",
     "pkg/services/workers/services/testing",
     "pkg/services/workers/skippermissions",
+    "pkg/services/workers/wire",
     "pkg/services/workers/worktree",
     "pkg/transports/cli",
     "pkg/transports/cli/baseline",
@@ -2323,6 +2324,11 @@
     },
     {
       "packagePath": "pkg/services/workers/skippermissions",
+      "disposition": "retain",
+      "destination": "workers"
+    },
+    {
+      "packagePath": "pkg/services/workers/wire",
       "disposition": "retain",
       "destination": "workers"
     },

--- a/pkg/services/workers/service/root.go
+++ b/pkg/services/workers/service/root.go
@@ -1,0 +1,28 @@
+package service
+
+import (
+	"fmt"
+
+	runtimeassembly "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runtime_assembly"
+	workstations "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/workstations"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+)
+
+// NewRoot constructs the inert Workers root from parent-private runtime
+// assembly and workstation owners. It starts no lifecycle, runner execution, or
+// workstation pool admission.
+func NewRoot(
+	runtimeAssembly runtimeassembly.Service,
+	workstationsOwner workstations.Service,
+) (workers.Service, error) {
+	if runtimeAssembly == nil {
+		return nil, fmt.Errorf("construct Workers: runtime assembly owner is required")
+	}
+	if workstationsOwner == nil {
+		return nil, fmt.Errorf("construct Workers: workstations owner is required")
+	}
+	return &Service{
+		runtimeAssembly: runtimeAssembly,
+		workstations:    workstationsOwner,
+	}, nil
+}

--- a/pkg/services/workers/service/root_test.go
+++ b/pkg/services/workers/service/root_test.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"testing"
+
+	workstationswire "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/workstations/wire"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+)
+
+func TestNewRootConstructsPublishedWorkersService(t *testing.T) {
+	t.Parallel()
+
+	root, err := NewRoot(&recordingRuntimeAssembly{}, workstationswire.NewService())
+	if err != nil {
+		t.Fatalf("NewRoot() error = %v", err)
+	}
+	if root == nil {
+		t.Fatal("NewRoot() returned nil service")
+	}
+	var published workers.Service = root
+	if published == nil {
+		t.Fatal("constructed root is nil")
+	}
+}

--- a/pkg/services/workers/wire/manifest_registration_test.go
+++ b/pkg/services/workers/wire/manifest_registration_test.go
@@ -1,0 +1,144 @@
+package wire_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/ownershipinventory"
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+const (
+	workersWirePackagePath = "pkg/services/workers/wire"
+	workersWireImportPath  = "github.com/portpowered/infinite-you/pkg/services/workers/wire"
+	workersOwner           = "workers"
+)
+
+type coverageMinimumManifest struct {
+	Lane     string `json:"lane"`
+	Packages []struct {
+		Package string  `json:"package"`
+		Minimum float64 `json:"minimum"`
+	} `json:"packages"`
+}
+
+func TestManifestRegistration_WorkersWirePackageIsRegistered(t *testing.T) {
+	t.Helper()
+
+	assertPackageTargetManifestRegistration(t)
+	assertOwnershipInventoryRegistration(t)
+	assertCoverageMinimumRegistration(t, "unit", "docs/internal/baselines/go-unit-coverage-package-minimums.json")
+	assertCoverageMinimumRegistration(t, "functional", "docs/internal/baselines/go-functional-coverage-package-minimums.json")
+}
+
+func assertPackageTargetManifestRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, "docs/internal/packaged-service-structure/package-target-manifest.json"))
+	if err != nil {
+		t.Fatalf("read package-target manifest: %v", err)
+	}
+
+	var manifest struct {
+		Inventory []string `json:"inventory"`
+		Packages  []struct {
+			PackagePath string `json:"packagePath"`
+			Disposition string `json:"disposition"`
+			Destination string `json:"destination"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode package-target manifest: %v", err)
+	}
+
+	foundInventory := false
+	for _, packagePath := range manifest.Inventory {
+		if packagePath == workersWirePackagePath {
+			foundInventory = true
+			break
+		}
+	}
+	if !foundInventory {
+		t.Fatalf("package-target manifest inventory missing %q", workersWirePackagePath)
+	}
+
+	for _, row := range manifest.Packages {
+		if row.PackagePath != workersWirePackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("package-target manifest disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != workersOwner {
+			t.Fatalf("package-target manifest destination = %q, want %q", row.Destination, workersOwner)
+		}
+		return
+	}
+	t.Fatalf("package-target manifest packages missing %q", workersWirePackagePath)
+}
+
+func assertOwnershipInventoryRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, ownershipinventory.InventoryRelativePath))
+	if err != nil {
+		t.Fatalf("read ownership inventory: %v", err)
+	}
+
+	var inventory struct {
+		Packages []ownershipinventory.PackageRow `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		t.Fatalf("decode ownership inventory: %v", err)
+	}
+
+	for _, row := range inventory.Packages {
+		if row.PackagePath != workersWirePackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("ownership inventory disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != workersOwner {
+			t.Fatalf("ownership inventory destination = %q, want %q", row.Destination, workersOwner)
+		}
+		if row.DestinationKind != ownershipinventory.DestinationKindOwner {
+			t.Fatalf(
+				"ownership inventory destinationKind = %q, want %q",
+				row.DestinationKind,
+				ownershipinventory.DestinationKindOwner,
+			)
+		}
+		return
+	}
+	t.Fatalf("ownership inventory packages missing %q", workersWirePackagePath)
+}
+
+func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, relativePath))
+	if err != nil {
+		t.Fatalf("read %s coverage manifest: %v", lane, err)
+	}
+
+	var manifest coverageMinimumManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode %s coverage manifest: %v", lane, err)
+	}
+	if manifest.Lane != lane {
+		t.Fatalf("%s coverage manifest lane = %q, want %q", relativePath, manifest.Lane, lane)
+	}
+
+	for _, entry := range manifest.Packages {
+		if entry.Package != workersWireImportPath {
+			continue
+		}
+		if entry.Minimum < 0 {
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, workersWireImportPath)
+		}
+		return
+	}
+	t.Fatalf("%s coverage manifest missing %q", lane, workersWireImportPath)
+}

--- a/pkg/services/workers/wire/wire.go
+++ b/pkg/services/workers/wire/wire.go
@@ -10,6 +10,7 @@ package wire
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	"github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners"
@@ -22,7 +23,9 @@ import (
 // NewService constructs an inert Workers root from construction ports. It
 // composes the accepted root through parent-private runtime_assembly,
 // workstations, and runners (agent/script/inference) owner construction
-// without publishing owner types on the returned peer surface.
+// without publishing owner types on the returned peer surface. Missing required
+// construction ports fail with a deterministic construction error and a nil
+// service.
 func NewService(
 	agentDependencies runners.AgentDependencies,
 	scriptConfig runners.ScriptConfig,
@@ -30,6 +33,15 @@ func NewService(
 	inferenceConfig runners.InferenceConfig,
 	inferenceDependencies runners.InferenceDependencies,
 ) (workers.Service, error) {
+	if err := validateConstructionPorts(
+		agentDependencies,
+		scriptConfig,
+		scriptDependencies,
+		inferenceConfig,
+		inferenceDependencies,
+	); err != nil {
+		return nil, err
+	}
 	agentRegistry, err := runnerswire.NewAgentRegistry(agentDependencies)
 	if err != nil {
 		return nil, fmt.Errorf("construct Workers: %w", err)
@@ -51,6 +63,46 @@ func NewService(
 		return nil, err
 	}
 	return workerservice.NewRoot(runtimeAssembly, workstationswire.NewService())
+}
+
+func validateConstructionPorts(
+	agentDependencies runners.AgentDependencies,
+	scriptConfig runners.ScriptConfig,
+	scriptDependencies runners.ScriptDependencies,
+	inferenceConfig runners.InferenceConfig,
+	inferenceDependencies runners.InferenceDependencies,
+) error {
+	if agentDependencies.Providers == nil {
+		return fmt.Errorf("construct Workers: agent Providers service is required")
+	}
+	if agentDependencies.Publish == nil {
+		return fmt.Errorf("construct Workers: agent progress publisher is required")
+	}
+	if strings.TrimSpace(scriptConfig.Command) == "" {
+		return fmt.Errorf("construct Workers: script command is required")
+	}
+	if scriptDependencies.CommandRunner == nil {
+		return fmt.Errorf("construct Workers: script command runner is required")
+	}
+	if scriptDependencies.FactoryDocs == nil {
+		return fmt.Errorf("construct Workers: script Factory docs loader is required")
+	}
+	if scriptDependencies.Now == nil {
+		return fmt.Errorf("construct Workers: script clock is required")
+	}
+	if scriptDependencies.Publish == nil {
+		return fmt.Errorf("construct Workers: script progress publisher is required")
+	}
+	if scriptDependencies.Record == nil {
+		return fmt.Errorf("construct Workers: script event recorder is required")
+	}
+	if strings.TrimSpace(inferenceConfig.Worker.Name) == "" {
+		return fmt.Errorf("construct Workers: inference worker name is required")
+	}
+	if inferenceDependencies.Models == nil {
+		return fmt.Errorf("construct Workers: inference Models service is required")
+	}
+	return nil
 }
 
 func combineRunnerRegistries(

--- a/pkg/services/workers/wire/wire.go
+++ b/pkg/services/workers/wire/wire.go
@@ -1,0 +1,100 @@
+// Package wire is the Workers service composition boundary.
+//
+// Wire performs construction only, returns the singular workers.Service root
+// interface, and starts no lifecycle components. Parent-private runtime_assembly,
+// workstations, and runners (agent/script/inference) owner wiring stays inside
+// the owner service assembly path; peers depend on Service rather than owner
+// internals or construction ports. Hosted runner ownership is not constructed.
+package wire
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	"github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners"
+	runnerswire "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/wire"
+	runtimeassemblywire "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runtime_assembly/wire"
+	workstationswire "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/workstations/wire"
+	workerservice "github.com/portpowered/infinite-you/pkg/services/workers/service"
+)
+
+// NewService constructs an inert Workers root from construction ports. It
+// composes the accepted root through parent-private runtime_assembly,
+// workstations, and runners (agent/script/inference) owner construction
+// without publishing owner types on the returned peer surface.
+func NewService(
+	agentDependencies runners.AgentDependencies,
+	scriptConfig runners.ScriptConfig,
+	scriptDependencies runners.ScriptDependencies,
+	inferenceConfig runners.InferenceConfig,
+	inferenceDependencies runners.InferenceDependencies,
+) (workers.Service, error) {
+	agentRegistry, err := runnerswire.NewAgentRegistry(agentDependencies)
+	if err != nil {
+		return nil, fmt.Errorf("construct Workers: %w", err)
+	}
+	scriptRegistry, err := runnerswire.NewScriptRegistry(scriptConfig, scriptDependencies)
+	if err != nil {
+		return nil, fmt.Errorf("construct Workers: %w", err)
+	}
+	inferenceRegistry, err := runnerswire.NewInferenceRegistry(inferenceConfig, inferenceDependencies)
+	if err != nil {
+		return nil, fmt.Errorf("construct Workers: %w", err)
+	}
+	runnerRegistry, err := combineRunnerRegistries(agentRegistry, scriptRegistry, inferenceRegistry)
+	if err != nil {
+		return nil, err
+	}
+	runtimeAssembly, err := runtimeassemblywire.NewService(runnerRegistry, defaultBindingAssembler)
+	if err != nil {
+		return nil, err
+	}
+	return workerservice.NewRoot(runtimeAssembly, workstationswire.NewService())
+}
+
+func combineRunnerRegistries(
+	agentRegistry runners.Service,
+	scriptRegistry runners.Service,
+	inferenceRegistry runners.Service,
+) (runners.Service, error) {
+	registrations := make([]runners.Registration, 0, 3)
+	for _, entry := range []struct {
+		service  runners.Service
+		identity string
+	}{
+		{agentRegistry, runners.AgentIdentity},
+		{scriptRegistry, runners.ScriptIdentity},
+		{inferenceRegistry, runners.InferenceIdentity},
+	} {
+		binding, err := entry.service.Resolve(runners.ResolutionRequest{
+			Identity: entry.identity,
+		})
+		if err != nil {
+			return nil, fmt.Errorf(
+				"construct Workers runner registry: resolve %s runner: %w",
+				entry.identity,
+				err,
+			)
+		}
+		registrations = append(registrations, runners.Registration{
+			Identity: binding.Identity,
+			Metadata: binding.Metadata,
+			Runner:   binding.Runner,
+		})
+	}
+	return runnerswire.NewService(registrations)
+}
+
+func defaultBindingAssembler(
+	_ context.Context,
+	role workers.RuntimeBuildRoleRequest,
+	_ workers.RuntimeBuildOpeningOptions,
+	selection workers.ResolvedRunnerSelection,
+) (workers.AssembledRuntimeBinding, error) {
+	return workers.AssembledRuntimeBinding{
+		RoleName:        role.Name,
+		RoleKind:        role.Kind,
+		RunnerSelection: selection,
+	}, nil
+}

--- a/pkg/services/workers/wire/wire_test.go
+++ b/pkg/services/workers/wire/wire_test.go
@@ -3,6 +3,7 @@ package wire
 import (
 	"context"
 	"errors"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -196,6 +197,117 @@ func TestNewServiceRejectsMissingRequiredDependencies(t *testing.T) {
 				t.Fatalf("NewService() = %#v, want nil service", service)
 			}
 		})
+	}
+}
+
+func TestNewServiceConstructsInertRoot(t *testing.T) {
+	t.Parallel()
+
+	providers := &wireProvidersFake{}
+	models := &wireInferenceInvoker{}
+	command := &recordingWireCommandRunner{}
+	agentPublishCalls := 0
+	scriptPublishCalls := 0
+	scriptRecordCalls := 0
+	factoryDocsCalls := 0
+	clockCalls := 0
+	inputs := validNewServiceInputs()
+	inputs.agentDependencies.Providers = providers
+	inputs.agentDependencies.Publish = func(workers.ProgressFragment) {
+		agentPublishCalls++
+		panic("agent progress published during inert construction")
+	}
+	inputs.scriptDependencies.CommandRunner = command
+	inputs.scriptDependencies.FactoryDocs = func(string) (map[string]string, error) {
+		factoryDocsCalls++
+		panic("Factory docs loaded during inert construction")
+	}
+	inputs.scriptDependencies.Now = func() time.Time {
+		clockCalls++
+		panic("script clock read during inert construction")
+	}
+	inputs.scriptDependencies.Publish = func(workers.ProgressFragment) {
+		scriptPublishCalls++
+		panic("script progress published during inert construction")
+	}
+	inputs.scriptDependencies.Record = func(workers.ScriptEvent) {
+		scriptRecordCalls++
+		panic("script event recorded during inert construction")
+	}
+	inputs.inferenceDependencies.Models = models
+
+	runtime.GC()
+	time.Sleep(20 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	service, err := inputs.callNewService()
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+	var root workers.Service = service
+	if root == nil {
+		t.Fatal("constructed root is nil")
+	}
+	if providers.calls.Load() != 0 {
+		t.Fatalf("Providers.Execute calls = %d, want no construction activity", providers.calls.Load())
+	}
+	if command.calls.Load() != 0 {
+		t.Fatalf("command runner calls = %d, want no construction activity", command.calls.Load())
+	}
+	if models.calls.Load() != 0 {
+		t.Fatalf("Models.InvokeLocal calls = %d, want no construction activity", models.calls.Load())
+	}
+	if agentPublishCalls != 0 || scriptPublishCalls != 0 || scriptRecordCalls != 0 ||
+		factoryDocsCalls != 0 || clockCalls != 0 {
+		t.Fatalf(
+			"construction invoked process edges (agent publish=%d script publish=%d record=%d docs=%d clock=%d), want inert construction",
+			agentPublishCalls, scriptPublishCalls, scriptRecordCalls, factoryDocsCalls, clockCalls,
+		)
+	}
+
+	runtime.GC()
+	time.Sleep(20 * time.Millisecond)
+	if leaked := runtime.NumGoroutine() - baseline; leaked > 4 {
+		t.Fatalf(
+			"goroutine leak after construction: baseline=%d current=%d delta=%d",
+			baseline, runtime.NumGoroutine(), leaked,
+		)
+	}
+
+	ctx := context.Background()
+	if _, err := service.WorkstationRoute(
+		ctx,
+		workers.WorkstationRouteRequest{WorkstationName: "review"},
+	); !errors.Is(err, workers.ErrWorkstationPoolUnavailable) {
+		t.Fatalf(
+			"WorkstationRoute() after construction error = %v, want ErrWorkstationPoolUnavailable",
+			err,
+		)
+	}
+
+	started, err := service.StartWorkstationPool(ctx, workers.WorkstationPoolStartRequest{
+		Bindings: []workers.AssembledRuntimeBinding{
+			{RoleName: "review", RoleKind: workers.RuntimeBuildRoleKindWorkstation},
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartWorkstationPool() error = %v", err)
+	}
+	if started.Outcome != workers.WorkstationPoolLifecycleOutcomeStarted {
+		t.Fatalf("StartWorkstationPool() outcome = %q, want STARTED", started.Outcome)
+	}
+	route, err := service.WorkstationRoute(
+		ctx,
+		workers.WorkstationRouteRequest{WorkstationName: "review"},
+	)
+	if err != nil {
+		t.Fatalf("WorkstationRoute() after start error = %v", err)
+	}
+	if !route.Available || route.WorkstationName != "review" {
+		t.Fatalf("WorkstationRoute() after start = %#v", route)
 	}
 }
 

--- a/pkg/services/workers/wire/wire_test.go
+++ b/pkg/services/workers/wire/wire_test.go
@@ -1,0 +1,229 @@
+package wire
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/models"
+	"github.com/portpowered/infinite-you/pkg/services/providers"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	"github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners"
+)
+
+func TestNewServiceConstructsPublishedRoot(t *testing.T) {
+	t.Parallel()
+
+	service, err := validNewServiceInputs().callNewService()
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+	var root workers.Service = service
+	if root == nil {
+		t.Fatal("constructed root is nil")
+	}
+}
+
+func TestNewServiceAssignsRuntimeRolesWithoutLifecycle(t *testing.T) {
+	t.Parallel()
+
+	service, err := validNewServiceInputs().callNewService()
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+
+	for _, runnerID := range []string{
+		runners.AgentIdentity,
+		runners.ScriptIdentity,
+		runners.InferenceIdentity,
+	} {
+		t.Run(runnerID, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := service.BuildRuntime(t.Context(), workers.RuntimeBuildRequest{
+				RunnerID: runnerID,
+				Roles: []workers.RuntimeBuildRoleRequest{
+					{Name: "writer", Kind: workers.RuntimeBuildRoleKindWorker},
+					{Name: "review", Kind: workers.RuntimeBuildRoleKindWorkstation},
+				},
+			})
+			if err != nil {
+				t.Fatalf("BuildRuntime(%q) error = %v", runnerID, err)
+			}
+			if result.RunnerSelection.RunnerID != runnerID {
+				t.Fatalf(
+					"BuildRuntime(%q) selection = %#v, want runner %q",
+					runnerID,
+					result.RunnerSelection,
+					runnerID,
+				)
+			}
+			if len(result.Bindings) != 2 {
+				t.Fatalf("BuildRuntime(%q) bindings = %#v, want two", runnerID, result.Bindings)
+			}
+			for _, binding := range result.Bindings {
+				if binding.RunnerSelection.RunnerID != runnerID {
+					t.Fatalf("binding selection = %#v, want runner %q", binding.RunnerSelection, runnerID)
+				}
+			}
+		})
+	}
+}
+
+func TestNewServiceRejectsUnknownRunnerSelection(t *testing.T) {
+	t.Parallel()
+
+	service, err := validNewServiceInputs().callNewService()
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	_, err = service.BuildRuntime(t.Context(), workers.RuntimeBuildRequest{
+		RunnerID: workers.RunnerIDCodex,
+		Roles: []workers.RuntimeBuildRoleRequest{
+			{Name: "writer", Kind: workers.RuntimeBuildRoleKindWorker},
+		},
+	})
+	if !errors.Is(err, workers.ErrUnknownRunnerSelection) {
+		t.Fatalf("BuildRuntime(codex) error = %v, want ErrUnknownRunnerSelection", err)
+	}
+}
+
+func TestNewServiceDoesNotRegisterHostedRunner(t *testing.T) {
+	t.Parallel()
+
+	service, err := validNewServiceInputs().callNewService()
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	_, err = service.BuildRuntime(t.Context(), workers.RuntimeBuildRequest{
+		RunnerID: "hosted",
+		Roles: []workers.RuntimeBuildRoleRequest{
+			{Name: "writer", Kind: workers.RuntimeBuildRoleKindWorker},
+		},
+	})
+	if !errors.Is(err, workers.ErrUnknownRunnerSelection) {
+		t.Fatalf("BuildRuntime(hosted) error = %v, want ErrUnknownRunnerSelection", err)
+	}
+}
+
+type newServiceInputs struct {
+	agentDependencies     runners.AgentDependencies
+	scriptConfig          runners.ScriptConfig
+	scriptDependencies    runners.ScriptDependencies
+	inferenceConfig       runners.InferenceConfig
+	inferenceDependencies runners.InferenceDependencies
+}
+
+func validNewServiceInputs() newServiceInputs {
+	return newServiceInputs{
+		agentDependencies: runners.AgentDependencies{
+			Providers: &wireProvidersFake{},
+			Publish:   func(workers.ProgressFragment) {},
+		},
+		scriptConfig: runners.ScriptConfig{
+			Command:          "fixture",
+			Args:             []string{"arg"},
+			FactoryDirectory: "factory-root",
+		},
+		scriptDependencies: runners.ScriptDependencies{
+			CommandRunner: &wireStreamingCommandRunner{},
+			FactoryDocs:   func(string) (map[string]string, error) { return map[string]string{}, nil },
+			Now:           func() time.Time { return time.Unix(1, 0) },
+			Publish:       func(workers.ProgressFragment) {},
+			Record:        func(workers.ScriptEvent) {},
+		},
+		inferenceConfig: runners.InferenceConfig{
+			Worker: models.LocalWorker{
+				Name:  "inference-worker",
+				Type:  interfaces.WorkerTypeInference,
+				Model: "WHISPER",
+			},
+			Resources: []models.LocalResource{{
+				Name: "gpu",
+				Type: "gpu",
+			}},
+		},
+		inferenceDependencies: runners.InferenceDependencies{
+			Models: &wireInferenceInvoker{},
+		},
+	}
+}
+
+func (in newServiceInputs) callNewService() (workers.Service, error) {
+	return NewService(
+		in.agentDependencies,
+		in.scriptConfig,
+		in.scriptDependencies,
+		in.inferenceConfig,
+		in.inferenceDependencies,
+	)
+}
+
+type wireProvidersFake struct {
+	calls atomic.Int32
+}
+
+func (fake *wireProvidersFake) Execute(
+	context.Context,
+	providers.ExecuteRequest,
+) (providers.ExecuteResult, error) {
+	fake.calls.Add(1)
+	return providers.ExecuteResult{Content: "fixture"}, nil
+}
+
+func (*wireProvidersFake) ListProviders(
+	context.Context,
+	providers.ListProvidersRequest,
+) (providers.ListProvidersResult, error) {
+	return providers.ListProvidersResult{}, nil
+}
+
+func (*wireProvidersFake) GetProvider(
+	context.Context,
+	providers.GetProviderRequest,
+) (providers.GetProviderResult, error) {
+	return providers.GetProviderResult{}, nil
+}
+
+type wireStreamingCommandRunner struct{}
+
+func (*wireStreamingCommandRunner) Run(
+	context.Context,
+	workers.CommandRequest,
+) (workers.CommandResult, error) {
+	return workers.CommandResult{}, nil
+}
+
+func (*wireStreamingCommandRunner) RunStreaming(
+	context.Context,
+	workers.CommandRequest,
+	platformprocess.OutputChunkObserver,
+) (workers.CommandResult, error) {
+	return workers.CommandResult{ExitCode: 0}, nil
+}
+
+type wireInferenceInvoker struct {
+	calls atomic.Int32
+}
+
+func (invoker *wireInferenceInvoker) InvokeLocal(
+	context.Context,
+	models.LocalInvocationRequest,
+) (models.LocalInvocationResult, error) {
+	invoker.calls.Add(1)
+	return models.LocalInvocationResult{}, nil
+}
+
+var _ providers.Service = (*wireProvidersFake)(nil)

--- a/pkg/services/workers/wire/wire_test.go
+++ b/pkg/services/workers/wire/wire_test.go
@@ -99,6 +99,136 @@ func TestNewServiceRejectsUnknownRunnerSelection(t *testing.T) {
 	}
 }
 
+func TestNewServiceRejectsMissingRequiredDependencies(t *testing.T) {
+	t.Parallel()
+
+	valid := validNewServiceInputs()
+	tests := []struct {
+		name   string
+		mutate func(*newServiceInputs)
+		want   string
+	}{
+		{
+			name: "agent Providers root",
+			mutate: func(in *newServiceInputs) {
+				in.agentDependencies.Providers = nil
+			},
+			want: "construct Workers: agent Providers service is required",
+		},
+		{
+			name: "agent progress publisher",
+			mutate: func(in *newServiceInputs) {
+				in.agentDependencies.Publish = nil
+			},
+			want: "construct Workers: agent progress publisher is required",
+		},
+		{
+			name: "script command",
+			mutate: func(in *newServiceInputs) {
+				in.scriptConfig = runners.ScriptConfig{}
+			},
+			want: "construct Workers: script command is required",
+		},
+		{
+			name: "script command runner",
+			mutate: func(in *newServiceInputs) {
+				in.scriptDependencies.CommandRunner = nil
+			},
+			want: "construct Workers: script command runner is required",
+		},
+		{
+			name: "script Factory docs loader",
+			mutate: func(in *newServiceInputs) {
+				in.scriptDependencies.FactoryDocs = nil
+			},
+			want: "construct Workers: script Factory docs loader is required",
+		},
+		{
+			name: "script clock",
+			mutate: func(in *newServiceInputs) {
+				in.scriptDependencies.Now = nil
+			},
+			want: "construct Workers: script clock is required",
+		},
+		{
+			name: "script progress publisher",
+			mutate: func(in *newServiceInputs) {
+				in.scriptDependencies.Publish = nil
+			},
+			want: "construct Workers: script progress publisher is required",
+		},
+		{
+			name: "script event recorder",
+			mutate: func(in *newServiceInputs) {
+				in.scriptDependencies.Record = nil
+			},
+			want: "construct Workers: script event recorder is required",
+		},
+		{
+			name: "inference worker",
+			mutate: func(in *newServiceInputs) {
+				in.inferenceConfig = runners.InferenceConfig{}
+			},
+			want: "construct Workers: inference worker name is required",
+		},
+		{
+			name: "inference Models service",
+			mutate: func(in *newServiceInputs) {
+				in.inferenceDependencies.Models = nil
+			},
+			want: "construct Workers: inference Models service is required",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			inputs := valid
+			test.mutate(&inputs)
+			service, err := inputs.callNewService()
+			if err == nil {
+				t.Fatalf("NewService() error = nil, want missing %s dependency", test.name)
+			}
+			if err.Error() != test.want {
+				t.Fatalf("NewService() error = %q, want %q", err.Error(), test.want)
+			}
+			if service != nil {
+				t.Fatalf("NewService() = %#v, want nil service", service)
+			}
+		})
+	}
+}
+
+func TestNewServiceFailedConstructionStartsNothing(t *testing.T) {
+	t.Parallel()
+
+	providers := &wireProvidersFake{}
+	models := &wireInferenceInvoker{}
+	command := &recordingWireCommandRunner{}
+	inputs := validNewServiceInputs()
+	inputs.agentDependencies.Providers = providers
+	inputs.scriptDependencies.CommandRunner = command
+	inputs.inferenceDependencies.Models = models
+	inputs.inferenceConfig = runners.InferenceConfig{}
+
+	service, err := inputs.callNewService()
+	if err == nil {
+		t.Fatal("NewService() error = nil, want missing inference worker")
+	}
+	if service != nil {
+		t.Fatalf("NewService() = %#v, want nil service", service)
+	}
+	if providers.calls.Load() != 0 {
+		t.Fatalf("Providers.Execute calls = %d, want no construction activity", providers.calls.Load())
+	}
+	if command.calls.Load() != 0 {
+		t.Fatalf("command runner calls = %d, want no construction activity", command.calls.Load())
+	}
+	if models.calls.Load() != 0 {
+		t.Fatalf("Models.InvokeLocal calls = %d, want no construction activity", models.calls.Load())
+	}
+}
+
 func TestNewServiceDoesNotRegisterHostedRunner(t *testing.T) {
 	t.Parallel()
 
@@ -198,6 +328,27 @@ func (*wireProvidersFake) GetProvider(
 }
 
 type wireStreamingCommandRunner struct{}
+
+type recordingWireCommandRunner struct {
+	calls atomic.Int32
+}
+
+func (runner *recordingWireCommandRunner) Run(
+	context.Context,
+	workers.CommandRequest,
+) (workers.CommandResult, error) {
+	runner.calls.Add(1)
+	panic("command runner invoked during failed construction")
+}
+
+func (runner *recordingWireCommandRunner) RunStreaming(
+	context.Context,
+	workers.CommandRequest,
+	platformprocess.OutputChunkObserver,
+) (workers.CommandResult, error) {
+	runner.calls.Add(1)
+	panic("command runner invoked during failed construction")
+}
 
 func (*wireStreamingCommandRunner) Run(
 	context.Context,


### PR DESCRIPTION
{
  "project": "PSS LWR-WRK — Workers Service-Local Wire",
  "branchName": "pss-lwr-wrk-service-wire",
  "description": "Implement LWR-WRK as the Workers service-local Wire packet: compose the accepted Workers root from parent-private runtime_assembly/workstations/runners (agent/script/inference) owners through an inert Wire path that returns only the root interface and starts no lifecycle, then deliver through review/CI/merge.",
  "context": {
    "customerAsk": "Implement LWR-WRK as the Workers service-local Wire packet. Compose the accepted Workers root from parent-private runtime_assembly/workstations/runners (agent/script/inference) owners through an inert Wire path that returns only the root interface and starts no lifecycle. Do not implement hosted runner (IMP-WRK-07). Do not edit pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, or other services' Wire. Do not expand into HTTP/CLI/MCP adapters or reopen IMP-WRK ownership. Shared coverage, ownership, and package-target manifest edits are allowed and must be rebased through the merge loop. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Workers already has an accepted root contract and terminal owner-local IMP packets for runtime assembly, workstations, runners, and agent/script/inference runners, but peers still lack a singular Workers service-local Wire entrypoint that constructs that root through those parent-private owners, returns only the published Workers root interface, and starts nothing.",
    "solution": "Add an owner-local Workers Wire composition path that constructs the accepted Workers root from parent-private runtime_assembly, workstations, and runners (agent/script/inference) owners, returns only the Workers root interface, proves construction is inert, registers the package in shared manifests only as required, and completes only after PR merge."
  },
  "acceptanceCriteria": [
    "AC-1: Workers exposes one service-local Wire construction entrypoint that returns only the published Workers root interface",
    "AC-2: Wire construction composes parent-private runtime_assembly, workstations, and runners (agent/script/inference) owners and does not publish those owner types on the returned peer surface",
    "AC-3: Calling the Wire constructor with valid construction ports starts no Workers lifecycle: no workstation pool start, no runner execution, and no process-edge effect invocation during construction",
    "AC-4: Missing required construction ports fail with a deterministic construction error and a nil root",
    "AC-5: Hosted runner (IMP-WRK-07) is not constructed or registered by this Wire path",
    "AC-6: Diff stays inside Workers Wire ownership plus required shared coverage/ownership/package-target manifest registration; no edits to pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, other services' Wire, or HTTP/CLI/MCP Workers adapters",
    "AC-7: Quality checks pass (typecheck, lint, tests)",
    "AC-8: Delivery loop continues until required CI is terminal green, all blocking PR conversation feedback is addressed, merge conflicts/shared-file churn are reconciled, and the PR is actually merged"
  ],
  "userStories": [
    {
      "id": "pss-lwr-wrk-service-wire-001",
      "title": "Expose inert Workers Wire root construction",
      "description": "As a maintainer composing Workers for peers, I want a service-local Wire entrypoint that builds the accepted Workers root from parent-private runtime_assembly, workstations, and runners (agent/script/inference) owners so consumers depend only on the published Workers root.",
      "acceptanceCriteria": [
        "Workers Wire exposes a construction entrypoint that returns only the published Workers root interface (not owner internals or construction-port types)",
        "Successful construction with valid ports returns a non-nil Workers root that satisfies the accepted Workers root contract methods available without starting lifecycle (for example root identity / role surface assignment succeeds)",
        "Construction routes through parent-private runtime_assembly, workstations, and runners owner composition for agent, script, and inference runners",
        "Hosted runner ownership is not constructed, registered, or required by this entrypoint",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-wrk-service-wire-002",
      "title": "Reject missing Workers Wire construction ports",
      "description": "As a maintainer wiring Workers, I want missing required construction or process-edge ports to fail immediately with a deterministic error and a nil root so bad graphs cannot partially start.",
      "acceptanceCriteria": [
        "For each required construction port, omitting that port causes Wire construction to return a non-nil error whose message identifies the missing dependency",
        "Failed construction returns a nil Workers root",
        "No Workers lifecycle side effect is observable after a failed construction attempt (no workstation pool start, no runner execution)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-wrk-service-wire-003",
      "title": "Prove Workers Wire construction starts nothing",
      "description": "As a reviewer of the LWR-WRK packet, I want focused inert-construction proof that building the Workers root does not start lifecycle or invoke process edges so service-local Wire matches the accepted LWR-SES / LWR-RUN / LWR-VIS pattern.",
      "acceptanceCriteria": [
        "A focused Wire construction test builds a Workers root with recording/stub process-edge ports and asserts those ports are not invoked during construction",
        "After construction, workstation pool state remains unstarted until an explicit later StartWorkstationPool call (construction alone does not activate admission)",
        "Construction does not increase goroutine count beyond an accepted inert baseline used by peer LWR Wire proofs",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-wrk-service-wire-004",
      "title": "Register Workers Wire in shared package manifests",
      "description": "As a maintainer enforcing packaged-service ownership, I want the new Workers Wire package registered in shared coverage/ownership/package-target manifests so ownership checks recognize the owner-local composition path.",
      "acceptanceCriteria": [
        "Shared package-target / ownership / coverage manifests required by Wire package registration include the Workers service-local Wire path",
        "Manifest edits are limited to registration of this Wire package and do not retarget unrelated packages",
        "Package-boundary / ownership checks that consume those manifests accept the registered Workers Wire path",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-wrk-service-wire-005",
      "title": "Merge LWR-WRK through the delivery loop",
      "description": "As the Factory program owner, I want the LWR-WRK implementation loop to continue through review, CI, conflict reconciliation, and actual PR merge so the packet is terminal only when merged.",
      "acceptanceCriteria": [
        "PR for pss-lwr-wrk-service-wire is opened against the integration branch with the Workers Wire behavior above",
        "Required CI is terminal and passing on the merged head",
        "Every blocking PR conversation comment is explicitly addressed",
        "Merge conflicts and shared-file churn (including manifests) are reconciled",
        "PR is actually merged; opened/green/approved/ready-to-merge alone does not complete this story",
        "Typecheck passes"
      ],
      "priority": 5,
      "passes": false,
      "notes": ""
    }
  ]
}
