### PR TITLE
pss-cli-run-adapter

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -2222,7 +2222,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/run",
-      "minimum": 57.71
+      "minimum": 56.97
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/runconfig",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -691,6 +691,10 @@
       "minimum": 0.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/cli",
+      "minimum": 0.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/wire",
       "exception": {
         "kind": "measurement",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1874,7 +1874,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/run",
-      "minimum": 81.14
+      "minimum": 80.81
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/runconfig",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -637,6 +637,10 @@
       "minimum": 97.11
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/cli",
+      "minimum": 86.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/wire",
       "minimum": 78.57
     },

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -1205,6 +1205,12 @@
     },
     {
       "fromOwner": "factory_runtime",
+      "toOwner": "transports",
+      "class": "command",
+      "evidence": "pkg/services/factory_runtime/transports/cli -\u003e pkg/transports/cli/cliserver"
+    },
+    {
+      "fromOwner": "factory_runtime",
       "toOwner": "work",
       "class": "command",
       "evidence": "pkg/services/factory_runtime/engine -\u003e pkg/services/work"
@@ -3157,6 +3163,12 @@
     },
     {
       "packagePath": "pkg/services/factory_runtime/tooling/javascript/symbolidentity",
+      "disposition": "retain",
+      "destination": "factory_runtime",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/factory_runtime/transports/cli",
       "disposition": "retain",
       "destination": "factory_runtime",
       "destinationKind": "owner"

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -178,6 +178,7 @@
     "pkg/services/factory_runtime/tooling/javascript/callbehavior",
     "pkg/services/factory_runtime/tooling/javascript/catalog",
     "pkg/services/factory_runtime/tooling/javascript/symbolidentity",
+    "pkg/services/factory_runtime/transports/cli",
     "pkg/services/factory_runtime/wire",
     "pkg/services/factory_sessions",
     "pkg/services/factory_sessions/internal/applicationopening",
@@ -1170,6 +1171,11 @@
       "packagePath": "pkg/services/factory_runtime/tooling/javascript/symbolidentity",
       "disposition": "move",
       "destination": "factory_runtime/internal/services/orchestration"
+    },
+    {
+      "packagePath": "pkg/services/factory_runtime/transports/cli",
+      "disposition": "retain",
+      "destination": "factory_runtime"
     },
     {
       "packagePath": "pkg/services/factory_runtime/wire",

--- a/pkg/services/factory_runtime/transports/cli/composition.go
+++ b/pkg/services/factory_runtime/transports/cli/composition.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"context"
+	"time"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+// NormalizeInvocationOutputMode delegates invocation output normalization to the
+// Runtime-owned CLI adapter Service.
+func NormalizeInvocationOutputMode(raw string) (string, error) {
+	return New(Config{}).NormalizeInvocationOutputMode(raw)
+}
+
+// ValidateInvocationOutputSelection delegates invocation output selection
+// validation to the Runtime-owned CLI adapter Service.
+func ValidateInvocationOutputSelection(quiet, jsonOutput, explicitOutput bool) error {
+	return New(Config{}).ValidateInvocationOutputSelection(quiet, jsonOutput, explicitOutput)
+}
+
+// ValidateInvocationOutputMode delegates invocation output mode validation to
+// the Runtime-owned CLI adapter Service.
+func ValidateInvocationOutputMode(req ValidateInvocationOutputModeRequest) error {
+	return New(Config{}).ValidateInvocationOutputMode(req)
+}
+
+// MapCurrentFactoryFailure delegates Current Factory failure mapping to the
+// Runtime-owned CLI adapter Service.
+func MapCurrentFactoryFailure(err error) error {
+	return New(Config{}).MapCurrentFactoryFailure(err)
+}
+
+// MapServerFailure delegates server bind failure mapping to the Runtime-owned
+// CLI adapter Service.
+func MapServerFailure(err error) error {
+	return New(Config{}).MapServerFailure(err)
+}
+
+// MapInvocationFailure delegates invocation failure mapping to the Runtime-owned
+// CLI adapter Service.
+func MapInvocationFailure(err error) error {
+	return New(Config{}).MapInvocationFailure(err)
+}
+
+// MapRuntimeRootFailure delegates Runtime root failure mapping to the
+// Runtime-owned CLI adapter Service.
+func MapRuntimeRootFailure(runtime factoryruntime.Service, err error) error {
+	return New(Config{Runtime: runtime}).MapRuntimeRootFailure(err)
+}
+
+// ObserveRuntime delegates one Runtime observation request through the
+// Runtime-owned CLI adapter Service.
+func ObserveRuntime(
+	ctx context.Context,
+	runtime factoryruntime.Service,
+	req factoryruntime.ObserveRequest,
+) error {
+	return New(Config{Runtime: runtime}).ObserveRuntime(ctx, req)
+}
+
+// CountTokenStates delegates token-state presentation to the Runtime-owned CLI
+// adapter Service.
+func CountTokenStates(snap *factoryruntime.PetriMarkingSnapshot) (wip, completed, failed int) {
+	return New(Config{}).CountTokenStates(snap)
+}
+
+// FormatDuration delegates duration presentation to the Runtime-owned CLI
+// adapter Service.
+func FormatDuration(d time.Duration) string {
+	return New(Config{}).FormatDuration(d)
+}

--- a/pkg/services/factory_runtime/transports/cli/composition.go
+++ b/pkg/services/factory_runtime/transports/cli/composition.go
@@ -7,6 +7,14 @@ import (
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 )
 
+// BindService returns the composition-facing Factory Runtime CLI adapter Service
+// constructed from accepted Runtime-root collaborators. Wire and other
+// composition roots inject the returned Service without constructing adapter
+// behavior at the composition boundary.
+func BindService(cfg Config) Service {
+	return New(cfg)
+}
+
 // NormalizeInvocationOutputMode delegates invocation output normalization to the
 // Runtime-owned CLI adapter Service.
 func NormalizeInvocationOutputMode(raw string) (string, error) {

--- a/pkg/services/factory_runtime/transports/cli/composition_test.go
+++ b/pkg/services/factory_runtime/transports/cli/composition_test.go
@@ -1,0 +1,64 @@
+package cli_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryruntimecli "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/cli"
+)
+
+func TestBindServiceDelegatesThroughAdapterService(t *testing.T) {
+	t.Parallel()
+
+	service := factoryruntimecli.BindService(factoryruntimecli.Config{
+		Runtime: stubRuntimeRoot{observeErr: factoryruntime.ErrNotRunning},
+	})
+	if service == nil {
+		t.Fatal("BindService(runtime) = nil, want Runtime CLI service")
+	}
+	err := service.ObserveRuntime(context.Background(), factoryruntime.ObserveRequest{})
+	var invocationErr *factoryruntimecli.InvocationError
+	if !errors.As(err, &invocationErr) {
+		t.Fatalf("error = %#v, want InvocationError", err)
+	}
+	if invocationErr.Message != "factory runtime is not running" {
+		t.Fatalf("message = %q, want factory runtime is not running", invocationErr.Message)
+	}
+}
+
+func TestBindServiceMatchesFreeFunctionFacade(t *testing.T) {
+	t.Parallel()
+
+	service := factoryruntimecli.BindService(factoryruntimecli.Config{})
+	gotService, errService := service.NormalizeInvocationOutputMode("primary")
+	gotPackage, errPackage := factoryruntimecli.NormalizeInvocationOutputMode("primary")
+	if (errService == nil) != (errPackage == nil) {
+		t.Fatalf("service error = %v, package error = %v", errService, errPackage)
+	}
+	if gotService != gotPackage {
+		t.Fatalf("service mode = %q, package mode = %q", gotService, gotPackage)
+	}
+}
+
+func TestBindServicePreservesRuntimeRootCollaborator(t *testing.T) {
+	t.Parallel()
+
+	runtime := stubRuntimeRoot{}
+	service := factoryruntimecli.BindService(factoryruntimecli.Config{Runtime: runtime})
+	if err := service.ObserveRuntime(context.Background(), factoryruntime.ObserveRequest{}); err != nil {
+		t.Fatalf("ObserveRuntime() error = %v, want nil for successful stub", err)
+	}
+}
+
+func TestBindServiceSupportsStatelessPresentationMethods(t *testing.T) {
+	t.Parallel()
+
+	service := factoryruntimecli.BindService(factoryruntimecli.Config{})
+	duration := 90 * time.Minute
+	if got := service.FormatDuration(duration); got != factoryruntimecli.FormatDuration(duration) {
+		t.Fatalf("FormatDuration() = %q, want %q", got, factoryruntimecli.FormatDuration(duration))
+	}
+}

--- a/pkg/services/factory_runtime/transports/cli/invocation_error.go
+++ b/pkg/services/factory_runtime/transports/cli/invocation_error.go
@@ -1,0 +1,245 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"strings"
+
+	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	"github.com/portpowered/infinite-you/pkg/transports/cli/cliserver"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+const (
+	InvocationErrorCodeFailed       = "RUN_INVOCATION_FAILED"
+	InvocationErrorCodeCancelled    = "RUN_INVOCATION_CANCELLED"
+	InvocationErrorCodeTimeout      = "RUN_INVOCATION_TIMEOUT"
+	CurrentFactoryNotFoundCode      = "CURRENT_FACTORY_NOT_FOUND"
+	CurrentFactoryInvalidCode       = "CURRENT_FACTORY_INVALID"
+	InvocationOutputConflictCode    = "INVOCATION_OUTPUT_CONFLICT"
+	InvocationOutputUnsupportedCode = "INVOCATION_OUTPUT_UNSUPPORTED"
+	ServerBindFailedCode            = "SERVER_BIND_FAILED"
+)
+
+const (
+	// InvocationOutputPrimaryResult is the default one-shot invocation stdout
+	// contract: primary-result-only output with no live progress rendering.
+	InvocationOutputPrimaryResult = ""
+	// invocationOutputPrimaryLiteral is the documented spelling for the default
+	// primary-result-only output mode.
+	invocationOutputPrimaryLiteral = "primary"
+	// InvocationOutputResponseStream enables live internal SessionResponseStream
+	// progress rendering for supported one-shot factory invocations.
+	InvocationOutputResponseStream = "response-stream"
+)
+
+// InvocationError is the stable clean-invocation failure contract.
+type InvocationError struct {
+	Code    string
+	Message string
+	Cause   error
+}
+
+func (e *InvocationError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if strings.TrimSpace(e.Message) == "" {
+		return e.Code
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+func (e *InvocationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+// ValidateInvocationOutputModeRequest carries invocation output validation inputs.
+type ValidateInvocationOutputModeRequest struct {
+	InvocationOutputMode string
+	Continuously         bool
+	InvocationMode       bool
+}
+
+// InvocationCLIError is the optional CLI-authored failure contract rendered by
+// WriteInvocationError.
+type InvocationCLIError interface {
+	error
+	InvocationErrorCode() string
+	InvocationErrorMessage() string
+}
+
+// WriteInvocationError renders the stable clean-invocation failure contract to
+// stderr. It returns true when err matched an invocation contract error.
+func WriteInvocationError(w io.Writer, err error, _ bool) bool {
+	payload, ok := invocationErrorResponse(err)
+	if !ok {
+		return false
+	}
+	if w == nil {
+		return true
+	}
+	data, marshalErr := json.Marshal(payload)
+	if marshalErr == nil {
+		_, _ = fmt.Fprintln(w, string(data))
+	}
+	return true
+}
+
+func invocationErrorResponse(err error) (factoryapi.ErrorResponse, bool) {
+	var invocationErr *InvocationError
+	if errors.As(err, &invocationErr) {
+		return newInvocationErrorResponse(invocationErr.Code, invocationErr.Message), true
+	}
+
+	var cliErr InvocationCLIError
+	if errors.As(err, &cliErr) {
+		return newInvocationErrorResponse(cliErr.InvocationErrorCode(), cliErr.InvocationErrorMessage()), true
+	}
+	return factoryapi.ErrorResponse{}, false
+}
+
+func newInvocationErrorResponse(code, message string) factoryapi.ErrorResponse {
+	code = strings.TrimSpace(code)
+	if code == "" {
+		code = InvocationErrorCodeFailed
+	}
+	family := factoryapi.ErrorFamilyInternalServerError
+	switch code {
+	case CurrentFactoryNotFoundCode:
+		family = factoryapi.ErrorFamilyNotFound
+	case CurrentFactoryInvalidCode, InvocationOutputConflictCode, InvocationOutputUnsupportedCode:
+		family = factoryapi.ErrorFamilyBadRequest
+	}
+	return factoryapi.ErrorResponse{
+		Code:    factoryapi.ErrorResponseCode(code),
+		Family:  family,
+		Message: strings.TrimSpace(message),
+	}
+}
+
+func mapCurrentFactoryFailure(err error) error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := invocationErrorResponse(err); ok {
+		return err
+	}
+	code := CurrentFactoryInvalidCode
+	if errors.Is(err, fs.ErrNotExist) || errors.Is(err, factorydefinitions.ErrFactoryLayoutNotFound) {
+		code = CurrentFactoryNotFoundCode
+	}
+	return &InvocationError{Code: code, Message: strings.TrimSpace(err.Error()), Cause: err}
+}
+
+func mapServerFailure(err error) error {
+	if err == nil ||
+		(!platformhttpserver.IsBindError(err) && !cliserver.IsLocalBindError(err)) {
+		return err
+	}
+	return &InvocationError{
+		Code: ServerBindFailedCode, Message: strings.TrimSpace(err.Error()), Cause: err,
+	}
+}
+
+func mapInvocationFailure(err error) error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := invocationErrorResponse(err); ok {
+		return err
+	}
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return &InvocationError{Code: InvocationErrorCodeTimeout, Message: "clean invocation timed out", Cause: err}
+	case errors.Is(err, context.Canceled):
+		return &InvocationError{Code: InvocationErrorCodeCancelled, Message: "clean invocation cancelled", Cause: err}
+	default:
+		return &InvocationError{Code: InvocationErrorCodeFailed, Message: strings.TrimSpace(err.Error()), Cause: err}
+	}
+}
+
+func mapRuntimeRootFailure(err error) error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := invocationErrorResponse(err); ok {
+		return err
+	}
+	switch {
+	case errors.Is(err, factoryruntime.ErrNotRunning):
+		return &InvocationError{
+			Code:    InvocationErrorCodeFailed,
+			Message: "factory runtime is not running",
+			Cause:   err,
+		}
+	case errors.Is(err, factoryruntime.ErrAlreadyStopped):
+		return &InvocationError{
+			Code:    InvocationErrorCodeFailed,
+			Message: "factory runtime is already stopped",
+			Cause:   err,
+		}
+	default:
+		return mapInvocationFailure(err)
+	}
+}
+
+func normalizeInvocationOutputMode(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	switch trimmed {
+	case InvocationOutputPrimaryResult, invocationOutputPrimaryLiteral:
+		return InvocationOutputPrimaryResult, nil
+	case InvocationOutputResponseStream:
+		return InvocationOutputResponseStream, nil
+	default:
+		return "", &InvocationError{
+			Code: InvocationOutputUnsupportedCode,
+			Message: fmt.Sprintf(
+				"unsupported --output value %q; supported values are primary (default) and response-stream",
+				trimmed,
+			),
+		}
+	}
+}
+
+func validateInvocationOutputSelection(quiet, jsonOutput, explicitOutput bool) error {
+	if !quiet || (!jsonOutput && !explicitOutput) {
+		return nil
+	}
+	return &InvocationError{
+		Code:    InvocationOutputConflictCode,
+		Message: "--quiet cannot be used with --json or --output",
+	}
+}
+
+func isResponseStreamOutputMode(mode string) bool {
+	return strings.TrimSpace(mode) == InvocationOutputResponseStream
+}
+
+func validateInvocationOutputMode(req ValidateInvocationOutputModeRequest) error {
+	if !isResponseStreamOutputMode(req.InvocationOutputMode) {
+		return nil
+	}
+	if req.Continuously {
+		return &InvocationError{
+			Code:    InvocationOutputUnsupportedCode,
+			Message: "response-stream output is not supported with --continuously",
+		}
+	}
+	if !req.InvocationMode {
+		return &InvocationError{
+			Code:    InvocationOutputUnsupportedCode,
+			Message: "response-stream output requires a one-shot factory invocation such as you run --named or you run --factory with positional text or piped stdin",
+		}
+	}
+	return nil
+}

--- a/pkg/services/factory_runtime/transports/cli/manifest_registration_test.go
+++ b/pkg/services/factory_runtime/transports/cli/manifest_registration_test.go
@@ -1,0 +1,144 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/ownershipinventory"
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+const (
+	cliAdapterPackagePath = "pkg/services/factory_runtime/transports/cli"
+	cliAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/cli"
+	factoryRuntimeOwner   = "factory_runtime"
+)
+
+type coverageMinimumManifest struct {
+	Lane     string `json:"lane"`
+	Packages []struct {
+		Package string  `json:"package"`
+		Minimum float64 `json:"minimum"`
+	} `json:"packages"`
+}
+
+func TestManifestRegistration_CLIAdapterPackageIsRegistered(t *testing.T) {
+	t.Helper()
+
+	assertPackageTargetManifestRegistration(t)
+	assertOwnershipInventoryRegistration(t)
+	assertCoverageMinimumRegistration(t, "unit", "docs/internal/baselines/go-unit-coverage-package-minimums.json")
+	assertCoverageMinimumRegistration(t, "functional", "docs/internal/baselines/go-functional-coverage-package-minimums.json")
+}
+
+func assertPackageTargetManifestRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, "docs/internal/packaged-service-structure/package-target-manifest.json"))
+	if err != nil {
+		t.Fatalf("read package-target manifest: %v", err)
+	}
+
+	var manifest struct {
+		Inventory []string `json:"inventory"`
+		Packages  []struct {
+			PackagePath string `json:"packagePath"`
+			Disposition string `json:"disposition"`
+			Destination string `json:"destination"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode package-target manifest: %v", err)
+	}
+
+	foundInventory := false
+	for _, packagePath := range manifest.Inventory {
+		if packagePath == cliAdapterPackagePath {
+			foundInventory = true
+			break
+		}
+	}
+	if !foundInventory {
+		t.Fatalf("package-target manifest inventory missing %q", cliAdapterPackagePath)
+	}
+
+	for _, row := range manifest.Packages {
+		if row.PackagePath != cliAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("package-target manifest disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != factoryRuntimeOwner {
+			t.Fatalf("package-target manifest destination = %q, want %q", row.Destination, factoryRuntimeOwner)
+		}
+		return
+	}
+	t.Fatalf("package-target manifest packages missing %q", cliAdapterPackagePath)
+}
+
+func assertOwnershipInventoryRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, ownershipinventory.InventoryRelativePath))
+	if err != nil {
+		t.Fatalf("read ownership inventory: %v", err)
+	}
+
+	var inventory struct {
+		Packages []ownershipinventory.PackageRow `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		t.Fatalf("decode ownership inventory: %v", err)
+	}
+
+	for _, row := range inventory.Packages {
+		if row.PackagePath != cliAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("ownership inventory disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != factoryRuntimeOwner {
+			t.Fatalf("ownership inventory destination = %q, want %q", row.Destination, factoryRuntimeOwner)
+		}
+		if row.DestinationKind != ownershipinventory.DestinationKindOwner {
+			t.Fatalf(
+				"ownership inventory destinationKind = %q, want %q",
+				row.DestinationKind,
+				ownershipinventory.DestinationKindOwner,
+			)
+		}
+		return
+	}
+	t.Fatalf("ownership inventory packages missing %q", cliAdapterPackagePath)
+}
+
+func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, relativePath))
+	if err != nil {
+		t.Fatalf("read %s coverage manifest: %v", lane, err)
+	}
+
+	var manifest coverageMinimumManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode %s coverage manifest: %v", lane, err)
+	}
+	if manifest.Lane != lane {
+		t.Fatalf("%s coverage manifest lane = %q, want %q", relativePath, manifest.Lane, lane)
+	}
+
+	for _, entry := range manifest.Packages {
+		if entry.Package != cliAdapterImportPath {
+			continue
+		}
+		if entry.Minimum < 0 {
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, cliAdapterImportPath)
+		}
+		return
+	}
+	t.Fatalf("%s coverage manifest missing %q", lane, cliAdapterImportPath)
+}

--- a/pkg/services/factory_runtime/transports/cli/presentation.go
+++ b/pkg/services/factory_runtime/transports/cli/presentation.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"strings"
+	"time"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	"github.com/portpowered/infinite-you/pkg/transports/cli/dashboard"
+)
+
+const (
+	completedPlaceIDSuffix = "completed"
+	failedPlaceIDSuffix    = "failed"
+)
+
+func countTokenStates(snap *factoryruntime.PetriMarkingSnapshot) (wip, completed, failed int) {
+	if snap == nil {
+		return 0, 0, 0
+	}
+	for _, token := range snap.Tokens {
+		placeID := token.PlaceID
+		state := placeID
+		if idx := strings.LastIndexByte(placeID, ':'); idx >= 0 {
+			state = placeID[idx+1:]
+		}
+
+		switch {
+		case isFailedState(state):
+			failed++
+		case isTerminalState(state):
+			completed++
+		default:
+			wip++
+		}
+	}
+	return wip, completed, failed
+}
+
+func isTerminalState(state string) bool {
+	return state == completedPlaceIDSuffix
+}
+
+func isFailedState(state string) bool {
+	return state == failedPlaceIDSuffix
+}
+
+func formatDuration(d time.Duration) string {
+	return dashboard.FormatDuration(d)
+}

--- a/pkg/services/factory_runtime/transports/cli/service.go
+++ b/pkg/services/factory_runtime/transports/cli/service.go
@@ -1,0 +1,88 @@
+// Package cli defines the Factory Runtime service-owned CLI adapter.
+package cli
+
+import (
+	"context"
+	"time"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+// Service exposes Factory Runtime CLI command operations to Cobra composition.
+type Service interface {
+	NormalizeInvocationOutputMode(raw string) (string, error)
+	ValidateInvocationOutputSelection(quiet, jsonOutput, explicitOutput bool) error
+	ValidateInvocationOutputMode(req ValidateInvocationOutputModeRequest) error
+	MapCurrentFactoryFailure(err error) error
+	MapServerFailure(err error) error
+	MapInvocationFailure(err error) error
+	MapRuntimeRootFailure(err error) error
+	ObserveRuntime(ctx context.Context, req factoryruntime.ObserveRequest) error
+	CountTokenStates(snap *factoryruntime.PetriMarkingSnapshot) (wip, completed, failed int)
+	FormatDuration(d time.Duration) string
+}
+
+// Config carries accepted Runtime-root collaborators for adapter construction.
+type Config struct {
+	Runtime factoryruntime.Service
+}
+
+type service struct {
+	runtime factoryruntime.Service
+}
+
+// New constructs the Factory Runtime CLI service from the accepted Runtime root
+// and any other Runtime-root collaborators required by adapter-owned behavior.
+func New(cfg Config) Service {
+	return &service{runtime: cfg.Runtime}
+}
+
+func (service *service) NormalizeInvocationOutputMode(raw string) (string, error) {
+	return normalizeInvocationOutputMode(raw)
+}
+
+func (service *service) ValidateInvocationOutputSelection(quiet, jsonOutput, explicitOutput bool) error {
+	return validateInvocationOutputSelection(quiet, jsonOutput, explicitOutput)
+}
+
+func (service *service) ValidateInvocationOutputMode(req ValidateInvocationOutputModeRequest) error {
+	return validateInvocationOutputMode(req)
+}
+
+func (service *service) MapCurrentFactoryFailure(err error) error {
+	return mapCurrentFactoryFailure(err)
+}
+
+func (service *service) MapServerFailure(err error) error {
+	return mapServerFailure(err)
+}
+
+func (service *service) MapInvocationFailure(err error) error {
+	return mapInvocationFailure(err)
+}
+
+func (service *service) MapRuntimeRootFailure(err error) error {
+	return mapRuntimeRootFailure(err)
+}
+
+func (service *service) ObserveRuntime(
+	ctx context.Context,
+	req factoryruntime.ObserveRequest,
+) error {
+	if service.runtime == nil {
+		return &InvocationError{
+			Code:    InvocationErrorCodeFailed,
+			Message: "factory runtime root is required",
+		}
+	}
+	_, err := service.runtime.Observe(ctx, req)
+	return service.MapRuntimeRootFailure(err)
+}
+
+func (service *service) CountTokenStates(snap *factoryruntime.PetriMarkingSnapshot) (wip, completed, failed int) {
+	return countTokenStates(snap)
+}
+
+func (service *service) FormatDuration(d time.Duration) string {
+	return formatDuration(d)
+}

--- a/pkg/services/factory_runtime/transports/cli/service_parity_test.go
+++ b/pkg/services/factory_runtime/transports/cli/service_parity_test.go
@@ -1,0 +1,554 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"strings"
+	"testing"
+	"time"
+
+	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryruntimecli "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/cli"
+	"github.com/portpowered/infinite-you/pkg/transports/cli/cliserver"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+type stubInvocationCLIError struct {
+	code    string
+	message string
+}
+
+func (err stubInvocationCLIError) Error() string {
+	return err.message
+}
+
+func (err stubInvocationCLIError) InvocationErrorCode() string {
+	return err.code
+}
+
+func (err stubInvocationCLIError) InvocationErrorMessage() string {
+	return err.message
+}
+
+type cancelingRuntimeRoot struct {
+	stubRuntimeRoot
+}
+
+func (stub cancelingRuntimeRoot) Observe(
+	ctx context.Context,
+	req factoryruntime.ObserveRequest,
+) (factoryruntime.ObserveResult, error) {
+	if err := ctx.Err(); err != nil {
+		return factoryruntime.ObserveResult{}, err
+	}
+	return stub.stubRuntimeRoot.Observe(ctx, req)
+}
+
+func assertRuntimeCLIParity(
+	t *testing.T,
+	runService func() (any, error),
+	runPackage func() (any, error),
+) {
+	t.Helper()
+
+	gotService, serviceErr := runService()
+	gotPackage, packageErr := runPackage()
+
+	if (serviceErr == nil) != (packageErr == nil) {
+		t.Fatalf("service error = %v, package error = %v", serviceErr, packageErr)
+	}
+	if serviceErr != nil && packageErr != nil {
+		var serviceInvocationErr, packageInvocationErr *factoryruntimecli.InvocationError
+		if errors.As(serviceErr, &serviceInvocationErr) || errors.As(packageErr, &packageInvocationErr) {
+			if !errors.As(serviceErr, &serviceInvocationErr) ||
+				!errors.As(packageErr, &packageInvocationErr) {
+				t.Fatalf("typed invocation error mismatch: service = %v, package = %v", serviceErr, packageErr)
+			}
+			if serviceInvocationErr.Code != packageInvocationErr.Code ||
+				serviceInvocationErr.Message != packageInvocationErr.Message {
+				t.Fatalf(
+					"service error = %#v, package error = %#v",
+					serviceInvocationErr,
+					packageInvocationErr,
+				)
+			}
+			return
+		}
+		if serviceErr.Error() != packageErr.Error() {
+			t.Fatalf("service error = %q, package error = %q", serviceErr.Error(), packageErr.Error())
+		}
+		return
+	}
+	if fmt.Sprint(gotService) != fmt.Sprint(gotPackage) {
+		t.Fatalf("service result = %#v, package result = %#v", gotService, gotPackage)
+	}
+}
+
+func assertWriteInvocationErrorParity(t *testing.T, err error) {
+	t.Helper()
+
+	var serviceStderr, packageStderr bytes.Buffer
+	serviceHandled := factoryruntimecli.WriteInvocationError(&serviceStderr, err, false)
+	packageHandled := factoryruntimecli.WriteInvocationError(&packageStderr, err, false)
+	if serviceHandled != packageHandled {
+		t.Fatalf("handled = %v, want package handled = %v", serviceHandled, packageHandled)
+	}
+	if !serviceHandled {
+		return
+	}
+	if serviceStderr.String() != packageStderr.String() {
+		t.Fatalf("service stderr = %q, package stderr = %q", serviceStderr.String(), packageStderr.String())
+	}
+}
+
+func TestConstructedService_MapCurrentFactoryFailureMatchesPackageCommand(t *testing.T) {
+	t.Parallel()
+
+	service := constructedRuntimeCLIService(t, nil)
+	cases := []struct {
+		name       string
+		err        error
+		wantCode   factoryapi.ErrorResponseCode
+		wantFamily factoryapi.ErrorFamily
+	}{
+		{
+			name:       "missing",
+			err:        fmt.Errorf("load Current Factory: %w", fs.ErrNotExist),
+			wantCode:   factoryruntimecli.CurrentFactoryNotFoundCode,
+			wantFamily: factoryapi.ErrorFamilyNotFound,
+		},
+		{
+			name:       "invalid",
+			err:        errors.New("parse Current Factory: malformed JSON"),
+			wantCode:   factoryruntimecli.CurrentFactoryInvalidCode,
+			wantFamily: factoryapi.ErrorFamilyBadRequest,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assertRuntimeCLIParity(t,
+				func() (any, error) {
+					return nil, service.MapCurrentFactoryFailure(tc.err)
+				},
+				func() (any, error) {
+					return nil, factoryruntimecli.MapCurrentFactoryFailure(tc.err)
+				},
+			)
+
+			mapped := service.MapCurrentFactoryFailure(tc.err)
+			var stderr bytes.Buffer
+			if !factoryruntimecli.WriteInvocationError(&stderr, mapped, false) {
+				t.Fatal("WriteInvocationError did not recognize Current Factory failure")
+			}
+			var response factoryapi.ErrorResponse
+			if err := json.Unmarshal(bytes.TrimSpace(stderr.Bytes()), &response); err != nil {
+				t.Fatalf("decode ErrorResponse: %v\n%s", err, stderr.String())
+			}
+			if response.Code != tc.wantCode || response.Family != tc.wantFamily {
+				t.Fatalf("ErrorResponse = %#v", response)
+			}
+		})
+	}
+}
+
+func TestConstructedService_MapServerFailureMatchesPackageCommand(t *testing.T) {
+	t.Parallel()
+
+	service := constructedRuntimeCLIService(t, nil)
+	cause := &platformhttpserver.BindError{
+		Host: "127.0.0.1", PreferredPort: 65534, Cause: errors.New("address in use"),
+	}
+	rootErr := fmt.Errorf("host runtime: %w", cause)
+
+	assertRuntimeCLIParity(t,
+		func() (any, error) {
+			return nil, service.MapServerFailure(rootErr)
+		},
+		func() (any, error) {
+			return nil, factoryruntimecli.MapServerFailure(rootErr)
+		},
+	)
+
+	mapped := service.MapServerFailure(rootErr)
+	var stderr bytes.Buffer
+	if !factoryruntimecli.WriteInvocationError(&stderr, mapped, false) {
+		t.Fatal("WriteInvocationError did not recognize server bind failure")
+	}
+	var response factoryapi.ErrorResponse
+	if err := json.Unmarshal(stderr.Bytes(), &response); err != nil {
+		t.Fatalf("decode ErrorResponse: %v\n%s", err, stderr.String())
+	}
+	if response.Code != factoryapi.ErrorResponseCode(factoryruntimecli.ServerBindFailedCode) ||
+		response.Family != factoryapi.ErrorFamilyInternalServerError {
+		t.Fatalf("ErrorResponse = %#v", response)
+	}
+	if !cliserver.IsLocalBindError(cause) && !platformhttpserver.IsBindError(cause) {
+		t.Fatal("test bind error should classify as bind failure")
+	}
+}
+
+func TestConstructedService_MapInvocationFailurePreservesCancellationAndTimeout(t *testing.T) {
+	t.Parallel()
+
+	service := constructedRuntimeCLIService(t, nil)
+	cases := []struct {
+		name     string
+		cause    error
+		wantCode string
+	}{
+		{
+			name:     "cancelled",
+			cause:    context.Canceled,
+			wantCode: factoryruntimecli.InvocationErrorCodeCancelled,
+		},
+		{
+			name:     "timeout",
+			cause:    context.DeadlineExceeded,
+			wantCode: factoryruntimecli.InvocationErrorCodeTimeout,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assertRuntimeCLIParity(t,
+				func() (any, error) {
+					return nil, service.MapInvocationFailure(tc.cause)
+				},
+				func() (any, error) {
+					return nil, factoryruntimecli.MapInvocationFailure(tc.cause)
+				},
+			)
+
+			mapped := service.MapInvocationFailure(tc.cause)
+			var invocationErr *factoryruntimecli.InvocationError
+			if !errors.As(mapped, &invocationErr) {
+				t.Fatalf("error = %T, want InvocationError", mapped)
+			}
+			if invocationErr.Code != tc.wantCode || !errors.Is(mapped, tc.cause) {
+				t.Fatalf("InvocationError = %#v", invocationErr)
+			}
+			assertWriteInvocationErrorParity(t, mapped)
+		})
+	}
+}
+
+func TestConstructedService_MapRuntimeRootFailureMatchesPackageCommand(t *testing.T) {
+	t.Parallel()
+
+	runtime := stubRuntimeRoot{observeErr: factoryruntime.ErrAlreadyStopped}
+	service := constructedRuntimeCLIService(t, runtime)
+
+	assertRuntimeCLIParity(t,
+		func() (any, error) {
+			return nil, service.MapRuntimeRootFailure(factoryruntime.ErrAlreadyStopped)
+		},
+		func() (any, error) {
+			return nil, factoryruntimecli.MapRuntimeRootFailure(runtime, factoryruntime.ErrAlreadyStopped)
+		},
+	)
+
+	mapped := service.MapRuntimeRootFailure(factoryruntime.ErrAlreadyStopped)
+	var invocationErr *factoryruntimecli.InvocationError
+	if !errors.As(mapped, &invocationErr) {
+		t.Fatalf("error = %#v, want InvocationError", mapped)
+	}
+	if invocationErr.Message != "factory runtime is already stopped" {
+		t.Fatalf("message = %q, want factory runtime is already stopped", invocationErr.Message)
+	}
+}
+
+func TestConstructedService_WriteInvocationErrorRendersInvocationCLIErrorContract(t *testing.T) {
+	t.Parallel()
+
+	service := constructedRuntimeCLIService(t, nil)
+	cliErr := stubInvocationCLIError{
+		code:    "INVOCATION_RUNTIME_FAILURE",
+		message: "goal execution failed",
+	}
+	if service == nil {
+		t.Fatal("constructed service = nil")
+	}
+
+	var stderr strings.Builder
+	if !factoryruntimecli.WriteInvocationError(&stderr, cliErr, false) {
+		t.Fatal("terminal invocation failure was not handled")
+	}
+	var response factoryapi.ErrorResponse
+	if err := json.Unmarshal([]byte(stderr.String()), &response); err != nil {
+		t.Fatalf("stderr is not one ErrorResponse: %v\n%s", err, stderr.String())
+	}
+	if response.Family != factoryapi.ErrorFamilyInternalServerError ||
+		response.Code != factoryapi.ErrorResponseCode("INVOCATION_RUNTIME_FAILURE") {
+		t.Fatalf("ErrorResponse = %#v", response)
+	}
+	if response.Message != "goal execution failed" {
+		t.Fatalf("message = %q", response.Message)
+	}
+}
+
+func TestConstructedService_ValidateInvocationOutputSelectionQuietMatchesPackage(t *testing.T) {
+	t.Parallel()
+
+	service := constructedRuntimeCLIService(t, nil)
+	cases := []struct {
+		name           string
+		quiet          bool
+		jsonOutput     bool
+		explicitOutput bool
+		wantConflict   bool
+	}{
+		{name: "human"},
+		{name: "quiet", quiet: true},
+		{name: "single JSON", jsonOutput: true},
+		{name: "JSON response stream", jsonOutput: true, explicitOutput: true},
+		{name: "quiet and JSON", quiet: true, jsonOutput: true, wantConflict: true},
+		{name: "quiet and explicit output", quiet: true, explicitOutput: true, wantConflict: true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assertRuntimeCLIParity(t,
+				func() (any, error) {
+					return nil, service.ValidateInvocationOutputSelection(
+						tc.quiet,
+						tc.jsonOutput,
+						tc.explicitOutput,
+					)
+				},
+				func() (any, error) {
+					return nil, factoryruntimecli.ValidateInvocationOutputSelection(
+						tc.quiet,
+						tc.jsonOutput,
+						tc.explicitOutput,
+					)
+				},
+			)
+
+			err := service.ValidateInvocationOutputSelection(tc.quiet, tc.jsonOutput, tc.explicitOutput)
+			if !tc.wantConflict {
+				if err != nil {
+					t.Fatalf("ValidateInvocationOutputSelection() error = %v", err)
+				}
+				return
+			}
+			var invocationErr *factoryruntimecli.InvocationError
+			if !errors.As(err, &invocationErr) ||
+				invocationErr.Code != factoryruntimecli.InvocationOutputConflictCode {
+				t.Fatalf("error = %#v, want %s InvocationError", err, factoryruntimecli.InvocationOutputConflictCode)
+			}
+			assertWriteInvocationErrorParity(t, err)
+		})
+	}
+}
+
+func TestConstructedService_ValidateInvocationOutputModeFailurePathsMatchPackage(t *testing.T) {
+	t.Parallel()
+
+	service := constructedRuntimeCLIService(t, nil)
+	cases := []struct {
+		name string
+		req  factoryruntimecli.ValidateInvocationOutputModeRequest
+	}{
+		{
+			name: "continuous unsupported",
+			req: factoryruntimecli.ValidateInvocationOutputModeRequest{
+				InvocationOutputMode: factoryruntimecli.InvocationOutputResponseStream,
+				Continuously:         true,
+				InvocationMode:       true,
+			},
+		},
+		{
+			name: "non-invocation run unsupported",
+			req: factoryruntimecli.ValidateInvocationOutputModeRequest{
+				InvocationOutputMode: factoryruntimecli.InvocationOutputResponseStream,
+				InvocationMode:       false,
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assertRuntimeCLIParity(t,
+				func() (any, error) {
+					return nil, service.ValidateInvocationOutputMode(tc.req)
+				},
+				func() (any, error) {
+					return nil, factoryruntimecli.ValidateInvocationOutputMode(tc.req)
+				},
+			)
+
+			err := service.ValidateInvocationOutputMode(tc.req)
+			var invocationErr *factoryruntimecli.InvocationError
+			if !errors.As(err, &invocationErr) ||
+				invocationErr.Code != factoryruntimecli.InvocationOutputUnsupportedCode {
+				t.Fatalf("error = %#v, want unsupported output mode", err)
+			}
+			assertWriteInvocationErrorParity(t, err)
+		})
+	}
+}
+
+func TestConstructedService_NormalizeInvocationOutputModeMatchesPackage(t *testing.T) {
+	t.Parallel()
+
+	service := constructedRuntimeCLIService(t, nil)
+	cases := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr string
+	}{
+		{
+			name: "empty defaults to primary",
+			raw:  "",
+			want: factoryruntimecli.InvocationOutputPrimaryResult,
+		},
+		{
+			name: "primary literal accepted",
+			raw:  "primary",
+			want: factoryruntimecli.InvocationOutputPrimaryResult,
+		},
+		{
+			name: "response-stream accepted",
+			raw:  "response-stream",
+			want: factoryruntimecli.InvocationOutputResponseStream,
+		},
+		{
+			name:    "unknown rejected",
+			raw:     "sse",
+			wantErr: "unsupported --output value",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assertRuntimeCLIParity(t,
+				func() (any, error) {
+					return service.NormalizeInvocationOutputMode(tc.raw)
+				},
+				func() (any, error) {
+					return factoryruntimecli.NormalizeInvocationOutputMode(tc.raw)
+				},
+			)
+
+			got, err := service.NormalizeInvocationOutputMode(tc.raw)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("NormalizeInvocationOutputMode(%q) error = %v, want %q", tc.raw, err, tc.wantErr)
+				}
+				assertWriteInvocationErrorParity(t, err)
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeInvocationOutputMode(%q): %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Fatalf("mode = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConstructedService_FormatDurationHumanPresentationMatchesPackage(t *testing.T) {
+	t.Parallel()
+
+	service := constructedRuntimeCLIService(t, nil)
+	cases := []time.Duration{
+		90 * time.Minute,
+		2*time.Hour + 15*time.Minute,
+		45 * time.Second,
+	}
+	for _, duration := range cases {
+		duration := duration
+		t.Run(duration.String(), func(t *testing.T) {
+			t.Parallel()
+
+			assertRuntimeCLIParity(t,
+				func() (any, error) {
+					return service.FormatDuration(duration), nil
+				},
+				func() (any, error) {
+					return factoryruntimecli.FormatDuration(duration), nil
+				},
+			)
+		})
+	}
+}
+
+func TestConstructedService_ObserveRuntimeHonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	service := constructedRuntimeCLIService(t, cancelingRuntimeRoot{})
+	serviceErr := service.ObserveRuntime(ctx, factoryruntime.ObserveRequest{})
+	packageErr := factoryruntimecli.ObserveRuntime(ctx, cancelingRuntimeRoot{}, factoryruntime.ObserveRequest{})
+
+	if (serviceErr == nil) != (packageErr == nil) {
+		t.Fatalf("service error = %v, package error = %v", serviceErr, packageErr)
+	}
+	var serviceInvocationErr, packageInvocationErr *factoryruntimecli.InvocationError
+	if !errors.As(serviceErr, &serviceInvocationErr) || !errors.As(packageErr, &packageInvocationErr) {
+		t.Fatalf("errors = %#v / %#v, want InvocationError", serviceErr, packageErr)
+	}
+	if serviceInvocationErr.Code != factoryruntimecli.InvocationErrorCodeCancelled ||
+		packageInvocationErr.Code != factoryruntimecli.InvocationErrorCodeCancelled {
+		t.Fatalf(
+			"service code = %q, package code = %q, want %q",
+			serviceInvocationErr.Code,
+			packageInvocationErr.Code,
+			factoryruntimecli.InvocationErrorCodeCancelled,
+		)
+	}
+	if !errors.Is(serviceErr, context.Canceled) || !errors.Is(packageErr, context.Canceled) {
+		t.Fatalf("service cause = %v, package cause = %v, want context.Canceled", serviceErr, packageErr)
+	}
+	assertWriteInvocationErrorParity(t, serviceErr)
+}
+
+func TestConstructedService_WriteInvocationErrorNilWriterStillRecognizesContract(t *testing.T) {
+	t.Parallel()
+
+	service := constructedRuntimeCLIService(t, nil)
+	mapped := service.MapInvocationFailure(context.Canceled)
+	if !factoryruntimecli.WriteInvocationError(io.Discard, mapped, true) {
+		t.Fatal("WriteInvocationError should recognize cancellation in quiet mode")
+	}
+	if !factoryruntimecli.WriteInvocationError(nil, mapped, true) {
+		t.Fatal("WriteInvocationError should recognize cancellation with nil writer")
+	}
+}
+
+func TestConstructedService_MapCurrentFactoryFailurePreservesFactoryLayoutNotFound(t *testing.T) {
+	t.Parallel()
+
+	service := constructedRuntimeCLIService(t, nil)
+	err := fmt.Errorf("load Current Factory: %w", factorydefinitions.ErrFactoryLayoutNotFound)
+	mapped := service.MapCurrentFactoryFailure(err)
+	var invocationErr *factoryruntimecli.InvocationError
+	if !errors.As(mapped, &invocationErr) {
+		t.Fatalf("error = %#v, want InvocationError", mapped)
+	}
+	if invocationErr.Code != factoryruntimecli.CurrentFactoryNotFoundCode {
+		t.Fatalf("code = %q, want %q", invocationErr.Code, factoryruntimecli.CurrentFactoryNotFoundCode)
+	}
+}

--- a/pkg/services/factory_runtime/transports/cli/service_test.go
+++ b/pkg/services/factory_runtime/transports/cli/service_test.go
@@ -1,0 +1,248 @@
+package cli_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryruntimecli "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/cli"
+)
+
+type stubRuntimeRoot struct {
+	observeErr error
+}
+
+func (stub stubRuntimeRoot) ControlPause(context.Context, factoryruntime.PauseRequest) (factoryruntime.PauseResult, error) {
+	return factoryruntime.PauseResult{}, factoryruntime.ErrNotRunning
+}
+
+func (stub stubRuntimeRoot) ControlResume(context.Context, factoryruntime.ResumeRequest) (factoryruntime.ResumeResult, error) {
+	return factoryruntime.ResumeResult{}, factoryruntime.ErrNotRunning
+}
+
+func (stub stubRuntimeRoot) ControlTerminate(context.Context, factoryruntime.TerminateRequest) (factoryruntime.TerminateResult, error) {
+	return factoryruntime.TerminateResult{}, factoryruntime.ErrNotRunning
+}
+
+func (stub stubRuntimeRoot) ControlWaitToComplete(factoryruntime.WaitToCompleteRequest) factoryruntime.WaitToCompleteResult {
+	return factoryruntime.WaitToCompleteResult{}
+}
+
+func (stub stubRuntimeRoot) ControlMoveWork(context.Context, factoryruntime.MoveWorkRequest) (factoryruntime.MoveWorkResult, error) {
+	return factoryruntime.MoveWorkResult{}, factoryruntime.ErrNotRunning
+}
+
+func (stub stubRuntimeRoot) Observe(context.Context, factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error) {
+	return factoryruntime.ObserveResult{}, stub.observeErr
+}
+
+func (stub stubRuntimeRoot) PlanDispatch(context.Context, factoryruntime.PlanDispatchRequest) (factoryruntime.PlanDispatchResult, error) {
+	return factoryruntime.PlanDispatchResult{}, factoryruntime.ErrNotRunning
+}
+
+func (stub stubRuntimeRoot) AcceptDispatchResult(context.Context, factoryruntime.AcceptDispatchResultRequest) (factoryruntime.AcceptDispatchResultResult, error) {
+	return factoryruntime.AcceptDispatchResultResult{}, factoryruntime.ErrNotRunning
+}
+
+func (stub stubRuntimeRoot) CaptureCheckpoint(context.Context, factoryruntime.CaptureCheckpointRequest) (factoryruntime.CaptureCheckpointResult, error) {
+	return factoryruntime.CaptureCheckpointResult{}, factoryruntime.ErrNotRunning
+}
+
+func (stub stubRuntimeRoot) LoadCheckpoint(context.Context, factoryruntime.LoadCheckpointRequest) (factoryruntime.LoadCheckpointResult, error) {
+	return factoryruntime.LoadCheckpointResult{}, factoryruntime.ErrNotRunning
+}
+
+func (stub stubRuntimeRoot) RestoreCheckpoint(context.Context, factoryruntime.RestoreCheckpointRequest) (factoryruntime.RestoreCheckpointResult, error) {
+	return factoryruntime.RestoreCheckpointResult{}, factoryruntime.ErrNotRunning
+}
+
+func constructedRuntimeCLIService(
+	t *testing.T,
+	runtime factoryruntime.Service,
+) factoryruntimecli.Service {
+	t.Helper()
+	return factoryruntimecli.New(factoryruntimecli.Config{Runtime: runtime})
+}
+
+func TestConstructedService_RequiresRuntimeRootForObservation(t *testing.T) {
+	t.Parallel()
+
+	service := constructedRuntimeCLIService(t, nil)
+	err := service.ObserveRuntime(context.Background(), factoryruntime.ObserveRequest{})
+	var invocationErr *factoryruntimecli.InvocationError
+	if !errors.As(err, &invocationErr) {
+		t.Fatalf("error = %#v, want InvocationError", err)
+	}
+	if invocationErr.Code != factoryruntimecli.InvocationErrorCodeFailed ||
+		invocationErr.Message != "factory runtime root is required" {
+		t.Fatalf("error = %#v, want missing runtime root failure", err)
+	}
+}
+
+func TestConstructedService_ObserveRuntimeMapsRuntimeRootRejection(t *testing.T) {
+	t.Parallel()
+
+	service := constructedRuntimeCLIService(t, stubRuntimeRoot{observeErr: factoryruntime.ErrNotRunning})
+	err := service.ObserveRuntime(context.Background(), factoryruntime.ObserveRequest{})
+	var invocationErr *factoryruntimecli.InvocationError
+	if !errors.As(err, &invocationErr) {
+		t.Fatalf("error = %#v, want InvocationError", err)
+	}
+	if invocationErr.Message != "factory runtime is not running" {
+		t.Fatalf("message = %q, want factory runtime is not running", invocationErr.Message)
+	}
+	if !errors.Is(invocationErr, factoryruntime.ErrNotRunning) {
+		t.Fatalf("cause = %v, want ErrNotRunning", invocationErr.Unwrap())
+	}
+}
+
+func TestConstructedService_NormalizeInvocationOutputModeMatchesPackageFunction(t *testing.T) {
+	t.Parallel()
+
+	service := constructedRuntimeCLIService(t, nil)
+	assertInvocationOutputModeParity(t, service, "")
+}
+
+func TestConstructedService_ValidateInvocationOutputSelectionMatchesPackageFunction(t *testing.T) {
+	t.Parallel()
+
+	service := constructedRuntimeCLIService(t, nil)
+	err := service.ValidateInvocationOutputSelection(true, true, false)
+	assertInvocationOutputSelectionParity(t, service, true, true, false, err)
+}
+
+func TestConstructedService_ValidateInvocationOutputModeMatchesPackageFunction(t *testing.T) {
+	t.Parallel()
+
+	service := constructedRuntimeCLIService(t, nil)
+	req := factoryruntimecli.ValidateInvocationOutputModeRequest{
+		InvocationOutputMode: factoryruntimecli.InvocationOutputResponseStream,
+		Continuously:         true,
+		InvocationMode:       true,
+	}
+	err := service.ValidateInvocationOutputMode(req)
+	assertInvocationOutputModeValidationParity(t, service, req, err)
+}
+
+func TestConstructedService_MapInvocationFailureMatchesPackageFunction(t *testing.T) {
+	t.Parallel()
+
+	service := constructedRuntimeCLIService(t, nil)
+	err := service.MapInvocationFailure(context.Canceled)
+	assertInvocationFailureParity(t, service, context.Canceled, err)
+}
+
+func TestConstructedService_CountTokenStatesMatchesPackageFunction(t *testing.T) {
+	t.Parallel()
+
+	service := constructedRuntimeCLIService(t, nil)
+	snap := &factoryruntime.PetriMarkingSnapshot{
+		Tokens: map[string]*factoryruntime.RuntimeToken{
+			"t1": {ID: "t1", PlaceID: "task:todo"},
+			"t2": {ID: "t2", PlaceID: "task:completed"},
+			"t3": {ID: "t3", PlaceID: "task:failed"},
+		},
+	}
+	assertCountTokenStatesParity(t, service, snap)
+}
+
+func TestConstructedService_FormatDurationMatchesPackageFunction(t *testing.T) {
+	t.Parallel()
+
+	service := constructedRuntimeCLIService(t, nil)
+	duration := 90 * time.Minute
+	if got := service.FormatDuration(duration); got != factoryruntimecli.FormatDuration(duration) {
+		t.Fatalf("FormatDuration() = %q, want %q", got, factoryruntimecli.FormatDuration(duration))
+	}
+}
+
+func assertInvocationOutputModeParity(
+	t *testing.T,
+	service factoryruntimecli.Service,
+	raw string,
+) {
+	t.Helper()
+	gotService, errService := service.NormalizeInvocationOutputMode(raw)
+	gotPackage, errPackage := factoryruntimecli.NormalizeInvocationOutputMode(raw)
+	if (errService == nil) != (errPackage == nil) {
+		t.Fatalf("service error = %v, package error = %v", errService, errPackage)
+	}
+	if gotService != gotPackage {
+		t.Fatalf("service mode = %q, package mode = %q", gotService, gotPackage)
+	}
+}
+
+func assertInvocationOutputSelectionParity(
+	t *testing.T,
+	service factoryruntimecli.Service,
+	quiet, jsonOutput, explicitOutput bool,
+	err error,
+) {
+	t.Helper()
+	gotPackage := factoryruntimecli.ValidateInvocationOutputSelection(quiet, jsonOutput, explicitOutput)
+	if (err == nil) != (gotPackage == nil) {
+		t.Fatalf("service error = %v, package error = %v", err, gotPackage)
+	}
+}
+
+func assertInvocationOutputModeValidationParity(
+	t *testing.T,
+	service factoryruntimecli.Service,
+	req factoryruntimecli.ValidateInvocationOutputModeRequest,
+	err error,
+) {
+	t.Helper()
+	gotPackage := factoryruntimecli.ValidateInvocationOutputMode(req)
+	if (err == nil) != (gotPackage == nil) {
+		t.Fatalf("service error = %v, package error = %v", err, gotPackage)
+	}
+	if err != nil && gotPackage != nil {
+		var serviceErr, packageErr *factoryruntimecli.InvocationError
+		if !errors.As(err, &serviceErr) || !errors.As(gotPackage, &packageErr) {
+			t.Fatalf("errors = %#v / %#v, want InvocationError", err, gotPackage)
+		}
+		if serviceErr.Code != packageErr.Code || !strings.Contains(serviceErr.Message, "continuously") {
+			t.Fatalf("service error = %#v, package error = %#v", serviceErr, packageErr)
+		}
+	}
+}
+
+func assertInvocationFailureParity(
+	t *testing.T,
+	service factoryruntimecli.Service,
+	cause error,
+	err error,
+) {
+	t.Helper()
+	gotPackage := factoryruntimecli.MapInvocationFailure(cause)
+	if (err == nil) != (gotPackage == nil) {
+		t.Fatalf("service error = %v, package error = %v", err, gotPackage)
+	}
+	var serviceErr, packageErr *factoryruntimecli.InvocationError
+	if !errors.As(err, &serviceErr) || !errors.As(gotPackage, &packageErr) {
+		t.Fatalf("errors = %#v / %#v, want InvocationError", err, gotPackage)
+	}
+	if serviceErr.Code != packageErr.Code {
+		t.Fatalf("service code = %q, package code = %q", serviceErr.Code, packageErr.Code)
+	}
+}
+
+func assertCountTokenStatesParity(
+	t *testing.T,
+	service factoryruntimecli.Service,
+	snap *factoryruntime.PetriMarkingSnapshot,
+) {
+	t.Helper()
+	wipService, doneService, failedService := service.CountTokenStates(snap)
+	wipPackage, donePackage, failedPackage := factoryruntimecli.CountTokenStates(snap)
+	if wipService != wipPackage || doneService != donePackage || failedService != failedPackage {
+		t.Fatalf(
+			"service counts = (%d,%d,%d), package counts = (%d,%d,%d)",
+			wipService, doneService, failedService,
+			wipPackage, donePackage, failedPackage,
+		)
+	}
+}

--- a/pkg/transports/cli/command_factory_injection_test.go
+++ b/pkg/transports/cli/command_factory_injection_test.go
@@ -14,6 +14,7 @@ import (
 	startupcli "github.com/portpowered/infinite-you/pkg/initializer/process"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factorydefinitionscli "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/cli"
+	factoryruntimecli "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/cli"
 	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/transports/cli/session"
 	modelscli "github.com/portpowered/infinite-you/pkg/services/models/transports/cli"
 	"github.com/portpowered/infinite-you/pkg/services/work"
@@ -433,6 +434,18 @@ func TestNewCommandFactoryDoesNotInstallTransportDefaults(t *testing.T) {
 }
 
 // pkgmaintcheck:ignore-cyclomatic-complexity service-ownership migration preserves this decision flow; simplify branches and remove this exemption.
+func TestNewCommandFactoryPreservesInjectedRuntimeCLIAdapter(t *testing.T) {
+	t.Parallel()
+
+	adapter := factoryruntimecli.BindService(factoryruntimecli.Config{})
+	factory := NewCommandFactory(CommandOperations{
+		RunDefaults: runcli.RunConfig{RuntimeCLI: adapter},
+	})
+	if factory.runDefaults.RuntimeCLI == nil {
+		t.Fatal("injected Runtime CLI adapter is missing from composed run defaults")
+	}
+}
+
 func TestNewCommandFactoryPreservesInjectedOperations(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/transports/cli/run/factory_invocation_input.go
+++ b/pkg/transports/cli/run/factory_invocation_input.go
@@ -380,6 +380,14 @@ type invocationCLIError struct {
 	WorkState string
 }
 
+func (e invocationCLIError) InvocationErrorCode() string {
+	return e.Code
+}
+
+func (e invocationCLIError) InvocationErrorMessage() string {
+	return e.responseMessage()
+}
+
 func (e invocationCLIError) Error() string {
 	contextSuffix := e.contextSuffix()
 	switch {

--- a/pkg/transports/cli/run/invocation_error.go
+++ b/pkg/transports/cli/run/invocation_error.go
@@ -1,216 +1,70 @@
 package run
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
 	"io"
-	"io/fs"
 	"strings"
 
-	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
-	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
-	"github.com/portpowered/infinite-you/pkg/transports/cli/cliserver"
-	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	factoryruntimecli "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/cli"
 )
 
 const (
-	InvocationErrorCodeFailed       = "RUN_INVOCATION_FAILED"
-	InvocationErrorCodeCancelled    = "RUN_INVOCATION_CANCELLED"
-	InvocationErrorCodeTimeout      = "RUN_INVOCATION_TIMEOUT"
-	CurrentFactoryNotFoundCode      = "CURRENT_FACTORY_NOT_FOUND"
-	CurrentFactoryInvalidCode       = "CURRENT_FACTORY_INVALID"
-	InvocationOutputConflictCode    = "INVOCATION_OUTPUT_CONFLICT"
-	InvocationOutputUnsupportedCode = "INVOCATION_OUTPUT_UNSUPPORTED"
-	ServerBindFailedCode            = "SERVER_BIND_FAILED"
+	InvocationErrorCodeFailed       = factoryruntimecli.InvocationErrorCodeFailed
+	InvocationErrorCodeCancelled    = factoryruntimecli.InvocationErrorCodeCancelled
+	InvocationErrorCodeTimeout      = factoryruntimecli.InvocationErrorCodeTimeout
+	CurrentFactoryNotFoundCode      = factoryruntimecli.CurrentFactoryNotFoundCode
+	CurrentFactoryInvalidCode       = factoryruntimecli.CurrentFactoryInvalidCode
+	InvocationOutputConflictCode    = factoryruntimecli.InvocationOutputConflictCode
+	InvocationOutputUnsupportedCode = factoryruntimecli.InvocationOutputUnsupportedCode
+	ServerBindFailedCode            = factoryruntimecli.ServerBindFailedCode
+	InvocationOutputPrimaryResult   = factoryruntimecli.InvocationOutputPrimaryResult
+	InvocationOutputResponseStream  = factoryruntimecli.InvocationOutputResponseStream
 )
 
-type InvocationError struct {
-	Code    string
-	Message string
-	Cause   error
-}
-
-func (e *InvocationError) Error() string {
-	if e == nil {
-		return ""
-	}
-	if strings.TrimSpace(e.Message) == "" {
-		return e.Code
-	}
-	return fmt.Sprintf("%s: %s", e.Code, e.Message)
-}
-
-func (e *InvocationError) Unwrap() error {
-	if e == nil {
-		return nil
-	}
-	return e.Cause
-}
+type InvocationError = factoryruntimecli.InvocationError
 
 // WriteInvocationError renders the stable clean-invocation failure contract to
 // stderr. It returns true when err matched an invocation contract error.
-func WriteInvocationError(w io.Writer, err error, _ bool) bool {
-	payload, ok := invocationErrorResponse(err)
-	if !ok {
-		return false
-	}
-	if w == nil {
-		return true
-	}
-	data, marshalErr := json.Marshal(payload)
-	if marshalErr == nil {
-		_, _ = fmt.Fprintln(w, string(data))
-	}
-	return true
-}
-
-func invocationErrorResponse(err error) (factoryapi.ErrorResponse, bool) {
-	var invocationErr *InvocationError
-	if errors.As(err, &invocationErr) {
-		return newInvocationErrorResponse(invocationErr.Code, invocationErr.Message), true
-	}
-
-	var cliErr invocationCLIError
-	if errors.As(err, &cliErr) {
-		return newInvocationErrorResponse(cliErr.Code, cliErr.responseMessage()), true
-	}
-	return factoryapi.ErrorResponse{}, false
-}
-
-func newInvocationErrorResponse(code, message string) factoryapi.ErrorResponse {
-	code = strings.TrimSpace(code)
-	if code == "" {
-		code = InvocationErrorCodeFailed
-	}
-	family := factoryapi.ErrorFamilyInternalServerError
-	switch code {
-	case CurrentFactoryNotFoundCode:
-		family = factoryapi.ErrorFamilyNotFound
-	case CurrentFactoryInvalidCode, InvocationOutputConflictCode, InvocationOutputUnsupportedCode:
-		family = factoryapi.ErrorFamilyBadRequest
-	}
-	return factoryapi.ErrorResponse{
-		Code:    factoryapi.ErrorResponseCode(code),
-		Family:  family,
-		Message: strings.TrimSpace(message),
-	}
+func WriteInvocationError(w io.Writer, err error, quiet bool) bool {
+	return factoryruntimecli.WriteInvocationError(w, err, quiet)
 }
 
 // MapCurrentFactoryFailure classifies failures from the exact Current Factory
 // selection before they cross the public run-command error boundary.
 func MapCurrentFactoryFailure(err error) error {
-	if err == nil {
-		return nil
-	}
-	if _, ok := invocationErrorResponse(err); ok {
-		return err
-	}
-	code := CurrentFactoryInvalidCode
-	if errors.Is(err, fs.ErrNotExist) || errors.Is(err, factorydefinitions.ErrFactoryLayoutNotFound) {
-		code = CurrentFactoryNotFoundCode
-	}
-	return &InvocationError{Code: code, Message: strings.TrimSpace(err.Error()), Cause: err}
+	return factoryruntimecli.MapCurrentFactoryFailure(err)
 }
 
 // MapServerFailure classifies terminal listener binding failures at the CLI
 // boundary while preserving all other errors for their owning mapper.
 func MapServerFailure(err error) error {
-	if err == nil ||
-		(!platformhttpserver.IsBindError(err) && !cliserver.IsLocalBindError(err)) {
-		return err
-	}
-	return &InvocationError{
-		Code: ServerBindFailedCode, Message: strings.TrimSpace(err.Error()), Cause: err,
-	}
+	return factoryruntimecli.MapServerFailure(err)
 }
 
 // MapInvocationFailure preserves authored invocation errors and classifies
 // pre-terminal failures that occurred before an InvocationResponse existed.
 func MapInvocationFailure(err error) error {
-	if err == nil {
-		return nil
-	}
-	if _, ok := invocationErrorResponse(err); ok {
-		return err
-	}
-	switch {
-	case errors.Is(err, context.DeadlineExceeded):
-		return &InvocationError{Code: InvocationErrorCodeTimeout, Message: "clean invocation timed out", Cause: err}
-	case errors.Is(err, context.Canceled):
-		return &InvocationError{Code: InvocationErrorCodeCancelled, Message: "clean invocation cancelled", Cause: err}
-	default:
-		return &InvocationError{Code: InvocationErrorCodeFailed, Message: strings.TrimSpace(err.Error()), Cause: err}
-	}
+	return factoryruntimecli.MapInvocationFailure(err)
 }
-
-const (
-	// InvocationOutputPrimaryResult is the default one-shot invocation stdout
-	// contract: primary-result-only output with no live progress rendering.
-	InvocationOutputPrimaryResult = ""
-	// invocationOutputPrimaryLiteral is the documented spelling for the default
-	// primary-result-only output mode.
-	invocationOutputPrimaryLiteral = "primary"
-	// InvocationOutputResponseStream enables live internal SessionResponseStream
-	// progress rendering for supported one-shot factory invocations.
-	InvocationOutputResponseStream = "response-stream"
-)
 
 func NormalizeInvocationOutputMode(raw string) (string, error) {
-	return normalizeInvocationOutputMode(raw)
-}
-
-func normalizeInvocationOutputMode(raw string) (string, error) {
-	trimmed := strings.TrimSpace(raw)
-	switch trimmed {
-	case InvocationOutputPrimaryResult, invocationOutputPrimaryLiteral:
-		return InvocationOutputPrimaryResult, nil
-	case InvocationOutputResponseStream:
-		return InvocationOutputResponseStream, nil
-	default:
-		return "", &InvocationError{
-			Code: InvocationOutputUnsupportedCode,
-			Message: fmt.Sprintf(
-				"unsupported --output value %q; supported values are primary (default) and response-stream",
-				trimmed,
-			),
-		}
-	}
+	return factoryruntimecli.NormalizeInvocationOutputMode(raw)
 }
 
 // ValidateInvocationOutputSelection rejects competing public stdout selectors.
 // JSON plus response-stream is one accepted JSON-stream selection; quiet cannot
 // be combined with either global JSON or an explicit --output selection.
 func ValidateInvocationOutputSelection(quiet, jsonOutput, explicitOutput bool) error {
-	if !quiet || (!jsonOutput && !explicitOutput) {
-		return nil
-	}
-	return &InvocationError{
-		Code:    InvocationOutputConflictCode,
-		Message: "--quiet cannot be used with --json or --output",
-	}
+	return factoryruntimecli.ValidateInvocationOutputSelection(quiet, jsonOutput, explicitOutput)
+}
+
+func validateInvocationOutputMode(cfg RunConfig, invocationMode bool) error {
+	return factoryruntimecli.ValidateInvocationOutputMode(factoryruntimecli.ValidateInvocationOutputModeRequest{
+		InvocationOutputMode: cfg.InvocationOutputMode,
+		Continuously:         cfg.Continuously,
+		InvocationMode:       invocationMode,
+	})
 }
 
 func isResponseStreamOutputMode(mode string) bool {
 	return strings.TrimSpace(mode) == InvocationOutputResponseStream
-}
-
-func validateInvocationOutputMode(cfg RunConfig, invocationMode bool) error {
-	if !isResponseStreamOutputMode(cfg.InvocationOutputMode) {
-		return nil
-	}
-	if cfg.Continuously {
-		return &InvocationError{
-			Code:    InvocationOutputUnsupportedCode,
-			Message: "response-stream output is not supported with --continuously",
-		}
-	}
-	if !invocationMode {
-		return &InvocationError{
-			Code:    InvocationOutputUnsupportedCode,
-			Message: "response-stream output requires a one-shot factory invocation such as you run --named or you run --factory with positional text or piped stdin",
-		}
-	}
-	return nil
 }

--- a/pkg/transports/cli/run/invocation_error.go
+++ b/pkg/transports/cli/run/invocation_error.go
@@ -58,7 +58,7 @@ func ValidateInvocationOutputSelection(quiet, jsonOutput, explicitOutput bool) e
 }
 
 func validateInvocationOutputMode(cfg RunConfig, invocationMode bool) error {
-	return factoryruntimecli.ValidateInvocationOutputMode(factoryruntimecli.ValidateInvocationOutputModeRequest{
+	return runtimeCLIService(cfg).ValidateInvocationOutputMode(factoryruntimecli.ValidateInvocationOutputModeRequest{
 		InvocationOutputMode: cfg.InvocationOutputMode,
 		Continuously:         cfg.Continuously,
 		InvocationMode:       invocationMode,

--- a/pkg/transports/cli/run/run.go
+++ b/pkg/transports/cli/run/run.go
@@ -26,6 +26,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/platform/runtimeartifact"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	state "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryruntimecli "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/cli"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
 	recordingscli "github.com/portpowered/infinite-you/pkg/services/recordings/transports/cli"
@@ -704,24 +705,7 @@ func openDashboardAtBoundEndpoint(
 // Place IDs follow the pattern '{work_type_id}:{state_value}'.
 // Terminal states contain "completed", failed states contain "failed".
 func CountTokenStates(snap *state.PetriMarkingSnapshot) (wip, completed, failed int) {
-	for _, t := range snap.Tokens {
-		placeID := t.PlaceID
-		// Extract state from place ID (after the last ':').
-		state := placeID
-		if idx := strings.LastIndexByte(placeID, ':'); idx >= 0 {
-			state = placeID[idx+1:]
-		}
-
-		switch {
-		case isFailedState(state):
-			failed++
-		case isTerminalState(state):
-			completed++
-		default:
-			wip++
-		}
-	}
-	return
+	return factoryruntimecli.CountTokenStates(snap)
 }
 
 func isTerminalState(state string) bool {
@@ -734,5 +718,5 @@ func isFailedState(state string) bool {
 
 // FormatDuration formats a duration as "Xm" or "Xh Ym".
 func FormatDuration(d time.Duration) string {
-	return dashboard.FormatDuration(d)
+	return factoryruntimecli.FormatDuration(d)
 }

--- a/pkg/transports/cli/run/runtime_adapter.go
+++ b/pkg/transports/cli/run/runtime_adapter.go
@@ -1,0 +1,12 @@
+package run
+
+import (
+	factoryruntimecli "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/cli"
+)
+
+func runtimeCLIService(cfg RunConfig) factoryruntimecli.Service {
+	if cfg.RuntimeCLI != nil {
+		return cfg.RuntimeCLI
+	}
+	return factoryruntimecli.BindService(factoryruntimecli.Config{})
+}

--- a/pkg/transports/cli/run/runtime_adapter_test.go
+++ b/pkg/transports/cli/run/runtime_adapter_test.go
@@ -1,0 +1,119 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryruntimecli "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/cli"
+)
+
+func TestValidateInvocationOutputModeDelegatesToInjectedRuntimeCLIAdapter(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	adapter := stubRuntimeCLIAdapter{
+		validateInvocationOutputMode: func(req factoryruntimecli.ValidateInvocationOutputModeRequest) error {
+			called = true
+			if !req.Continuously || !req.InvocationMode ||
+				req.InvocationOutputMode != InvocationOutputResponseStream {
+				t.Fatalf("request = %#v", req)
+			}
+			return &factoryruntimecli.InvocationError{
+				Code:    InvocationOutputUnsupportedCode,
+				Message: "injected adapter rejection",
+			}
+		},
+	}
+
+	text := "Plan the sprint"
+	err := validateInvocationOutputMode(RunConfig{
+		RuntimeCLI:               adapter,
+		InvocationOutputMode:     InvocationOutputResponseStream,
+		Continuously:             true,
+		InvocationPositionalText: &text,
+	}, true)
+	if !called {
+		t.Fatal("expected injected Runtime CLI adapter to validate invocation output mode")
+	}
+	var invocationErr *InvocationError
+	if !errors.As(err, &invocationErr) {
+		t.Fatalf("error = %#v, want InvocationError", err)
+	}
+	if invocationErr.Code != InvocationOutputUnsupportedCode ||
+		invocationErr.Message != "injected adapter rejection" {
+		t.Fatalf("error = %#v, want injected adapter rejection", invocationErr)
+	}
+}
+
+func TestRuntimeCLIServiceFallsBackToBoundAdapterWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	service := runtimeCLIService(RunConfig{})
+	if service == nil {
+		t.Fatal("runtimeCLIService() = nil, want bound Runtime CLI adapter")
+	}
+	got, err := service.NormalizeInvocationOutputMode("primary")
+	if err != nil {
+		t.Fatalf("NormalizeInvocationOutputMode() error = %v", err)
+	}
+	if got != InvocationOutputPrimaryResult {
+		t.Fatalf("mode = %q, want %q", got, InvocationOutputPrimaryResult)
+	}
+}
+
+type stubRuntimeCLIAdapter struct {
+	validateInvocationOutputMode func(factoryruntimecli.ValidateInvocationOutputModeRequest) error
+}
+
+func (adapter stubRuntimeCLIAdapter) NormalizeInvocationOutputMode(raw string) (string, error) {
+	return factoryruntimecli.NormalizeInvocationOutputMode(raw)
+}
+
+func (adapter stubRuntimeCLIAdapter) ValidateInvocationOutputSelection(quiet, jsonOutput, explicitOutput bool) error {
+	return factoryruntimecli.ValidateInvocationOutputSelection(quiet, jsonOutput, explicitOutput)
+}
+
+func (adapter stubRuntimeCLIAdapter) ValidateInvocationOutputMode(
+	req factoryruntimecli.ValidateInvocationOutputModeRequest,
+) error {
+	if adapter.validateInvocationOutputMode != nil {
+		return adapter.validateInvocationOutputMode(req)
+	}
+	return factoryruntimecli.ValidateInvocationOutputMode(req)
+}
+
+func (adapter stubRuntimeCLIAdapter) MapCurrentFactoryFailure(err error) error {
+	return factoryruntimecli.MapCurrentFactoryFailure(err)
+}
+
+func (adapter stubRuntimeCLIAdapter) MapServerFailure(err error) error {
+	return factoryruntimecli.MapServerFailure(err)
+}
+
+func (adapter stubRuntimeCLIAdapter) MapInvocationFailure(err error) error {
+	return factoryruntimecli.MapInvocationFailure(err)
+}
+
+func (adapter stubRuntimeCLIAdapter) MapRuntimeRootFailure(err error) error {
+	return factoryruntimecli.MapRuntimeRootFailure(nil, err)
+}
+
+func (adapter stubRuntimeCLIAdapter) ObserveRuntime(
+	ctx context.Context,
+	req factoryruntime.ObserveRequest,
+) error {
+	return factoryruntimecli.ObserveRuntime(ctx, nil, req)
+}
+
+func (adapter stubRuntimeCLIAdapter) CountTokenStates(
+	snap *factoryruntime.PetriMarkingSnapshot,
+) (wip, completed, failed int) {
+	return factoryruntimecli.CountTokenStates(snap)
+}
+
+func (adapter stubRuntimeCLIAdapter) FormatDuration(d time.Duration) string {
+	return factoryruntimecli.FormatDuration(d)
+}

--- a/pkg/transports/cli/runconfig/config.go
+++ b/pkg/transports/cli/runconfig/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	platformmetrics "github.com/portpowered/infinite-you/pkg/platform/metrics"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryruntimecli "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/cli"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	operatorconfig "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
@@ -62,6 +63,7 @@ type Config struct {
 	DisableDefaultRecording       bool
 	RecordingTargetPlanner        recordings.LiveRecordingTargetPlanner
 	RecordingsCLI                 recordingscli.Adapter
+	RuntimeCLI                    factoryruntimecli.Service
 	Clock                         recordings.RecordingClock
 	RuntimeLogDir                 string
 	RuntimeLogConfig              logging.RuntimeLogConfig


### PR DESCRIPTION
{
  "project": "PSS CLI-RUN Factory Runtime Service-Owned CLI Adapter",
  "branchName": "pss-cli-run-adapter",
  "description": "Implement CLI-RUN by moving Factory Runtime CLI behavior behind a service-owned adapter constructed over the accepted Runtime root, while preserving accepted Clean CLI human/JSON/quiet/NDJSON output, diagnostics, symbolic errors, exits, and cancellation, and keeping top-level CLI, Wire, root, and initializer composition unchanged.",
  "context": {
    "customerAsk": "Implement CLI-RUN as the Factory Runtime service-owned CLI adapter. Move or delegate Runtime-facing CLI behavior behind the service-owned adapter while preserving accepted Clean CLI human/JSON/quiet/NDJSON output, diagnostics, symbolic errors, exits, and cancellation. Keep any top-level transport path as a narrow compatibility/delegation surface so this packet does not edit root/manifest/Cobra composition (PSS-I03). Do not reopen accepted Clean CLI UX/schema design. Shared coverage, ownership, and package-target manifest edits are allowed and must be rebased through the merge loop. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "LWR-RUN is accepted, so Factory Runtime has an accepted singular root and service-local Wire, and CLI-SES/CLI-DEF already established service-owned CLI adapters. Runtime-facing CLI behavior still lives under top-level pkg/transports/cli/run instead of an owner-local Factory Runtime CLI adapter, so Runtime lacks Models/CLI-SES/CLI-DEF-like adapter ownership and focused human/JSON/quiet/NDJSON plus symbolic-error/exit/cancel proof through the accepted Runtime root. CLI-REC and CLI-VIS may still be live, so this packet must stay on Factory Runtime CLI paths only and must not perform PSS-I03 top-level fan-in.",
    "solution": "Give Factory Runtime a Models/CLI-SES/CLI-DEF-like CLI adapter Service constructed over the accepted Runtime root inside pkg/services/factory_runtime/transports/cli/**, move or delegate Runtime-facing CLI behavior behind that Service, keep existing top-level composition-facing entry points as thin compatibility/delegation facades so pkg/wire, pkg/root, pkg/initializer, and PSS-I03 need not change, and prove human/JSON/quiet/NDJSON, diagnostics, symbolic-error, exit, and cancel parity without touching HTTP-RUN, MCP-RUN, other services' CLI adapters, or reopening Clean CLI UX/schema design."
  },
  "acceptanceCriteria": [
    "AC-1: Factory Runtime CLI command behavior owned by this packet is reachable only through one Runtime-owned CLI adapter Service constructed over the accepted Runtime root (composition may still call thin package-local facades that delegate to that Service)",
    "AC-2: Top-level CLI retains existing Cobra tree/flag/completion composition for accepted Runtime-facing commands (including you run) and continues to delegate without redesigning command paths, flags, help, completion, or UX",
    "AC-3: Accepted Runtime-facing Clean CLI human, JSON, quiet, and NDJSON output plus diagnostics, symbolic errors, exits, and cancellation behavior remain unchanged for representative success and failure paths",
    "AC-4: Focused adapter tests prove success and failure outcomes through the Runtime-owned package, including required writers, human/JSON/quiet/NDJSON presentation, diagnostics, exit-relevant symbolic errors, and cancellation semantics on adapter-owned request-bound paths through the accepted Runtime root",
    "AC-5: Diff stays inside Factory Runtime CLI adapter ownership plus shared coverage/ownership/package-target manifest registration as required; no pkg/wire / pkg/root / pkg/initializer edits, no PSS-I03 root/manifest/Cobra composition redesign, and no HTTP-RUN / MCP-RUN / other-services CLI adapter edits",
    "AC-6: Quality checks pass (typecheck, lint, tests)",
    "AC-7: Delivery loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and accepted shared-file churn are reconciled, and the PR is actually merged"
  ],
  "userStories": [
    {
      "id": "pss-cli-run-adapter-001",
      "title": "Own Runtime CLI Service construction over the Runtime root",
      "description": "As a maintainer, I want Factory Runtime to construct one typed CLI adapter Service from the accepted Runtime root collaborator(s) inside the Runtime CLI adapter package so Runtime owns adapter construction the same way Models, CLI-SES, and CLI-DEF do.",
      "acceptanceCriteria": [
        "Runtime CLI adapter under pkg/services/factory_runtime/transports/cli/** exposes a durable constructor that returns a typed Service from the accepted Runtime root (factory.Service) and any other Runtime-root collaborators already required by adapter-owned CLI behavior",
        "Constructed Service methods cover the Runtime-facing CLI surfaces moved or delegated by this packet (representative you run / Runtime presentation, error mapping, and request-bound Runtime CLI paths owned by the adapter)",
        "Focused adapter tests invoke those Service methods and observe the same success and failure outcomes previously proven for the delegated Runtime-facing command behavior (including required context/output writer failures and Runtime-root rejection paths)",
        "Free-function or package entry points that existing composition already calls, if retained under top-level transport paths, are thin package-local compatibility facades over the owned Service rather than a second durable production implementation",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cli-run-adapter-002",
      "title": "Keep composition-facing Runtime CLI delegation without PSS-I03 or process-graph edits",
      "description": "As a maintainer, I want existing top-level CLI composition to keep delegating Runtime-facing CLI behavior through the Runtime-owned adapter surface so customer-facing commands continue to work without editing pkg/wire, pkg/root, pkg/initializer, or PSS-I03 Cobra/root/manifest composition.",
      "acceptanceCriteria": [
        "Existing composition-facing Runtime CLI entry points remain callable with the same config/operation contracts composition already uses for accepted Runtime-facing commands",
        "Representative Runtime-facing invocations through the existing composition path still map flags/arguments the same way and dispatch through the Runtime-owned adapter ownership path",
        "Diff does not edit pkg/wire, pkg/root, or pkg/initializer",
        "Diff does not regenerate CLI manifests, redesign command UX, edit pkg/transports/cli/root*, pkg/transports/cli/commandregistry, pkg/transports/cli/climanifest*, HTTP-RUN, MCP-RUN, CLI-REC, CLI-VIS, or other services' CLI adapters, or reopen PSS-I03 root/manifest composition",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cli-run-adapter-003",
      "title": "Prove Runtime CLI human/JSON/quiet/NDJSON and exit/cancel parity",
      "description": "As a CLI user and reviewer, I want focused proof that Runtime-owned CLI adapter behavior preserves accepted human/JSON/quiet/NDJSON output, diagnostics, symbolic errors, exit behavior, and cancellation semantics after the adapter ownership move.",
      "acceptanceCriteria": [
        "Focused tests through the Runtime-owned adapter prove representative success paths preserve human and JSON presentation contracts already accepted for Runtime-facing CLI behavior",
        "Focused tests prove quiet-mode success and failure presentation preserve accepted quiet contracts (including no quiet-leak of forbidden diagnostic/provider markers on representative one-shot paths already covered by Runtime-facing CLI tests)",
        "Focused tests prove NDJSON/streaming presentation preserves accepted discriminated record shape and does not expose provider-only values already forbidden by Runtime-facing CLI tests",
        "Focused tests prove failure paths preserve diagnostics/error messaging, symbolic/exit-relevant error returns for missing required collaborators, invalid output-mode combinations, and Runtime-root rejection cases already covered by Runtime-facing CLI tests",
        "Focused tests prove cancellation or context cancellation is honored on at least one adapter-owned request-bound Runtime CLI path without changing customer-visible cancel semantics",
        "Accepted Clean CLI / Schema-Driven CLI command paths, flags, help text, and completion behavior for Runtime-facing commands are not redesigned",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cli-run-adapter-004",
      "title": "Register adapter ownership only where manifests require it",
      "description": "As a maintainer, I want shared coverage, ownership, and package-target manifests updated only if the Runtime CLI adapter registration requires it so package-structure checks continue to recognize Runtime ownership.",
      "acceptanceCriteria": [
        "Shared coverage/ownership/package-target manifests change only when required by Runtime CLI adapter package registration or moved construction ownership",
        "Package-structure / ownership checks that cover Runtime CLI adapter placement continue to pass for the owned path under pkg/services/factory_runtime/transports/cli/**",
        "No unrelated ownership inventory rewrite, HTTP-RUN / MCP-RUN churn, CLI-REC / CLI-VIS churn, or broad path-lease churn is included",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
