### PR TITLE
pss-lwr-work-service-wire

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1818,7 +1818,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/wire",
-      "minimum": 100.00
+      "minimum": 8.82
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -804,7 +804,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/responseeventstore",
-      "minimum": 46.53
+      "minimum": 43.77
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/responsestream",

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -750,6 +750,13 @@ response-stream output.
   remaining request-validation error and `FactoryInvocationResult` session
   result shape stay at their current boundary until Factory Session contracts
   converge; the Factory Session owner constructs that shared result.
+- Work owner-local Wire at `pkg/services/work/wire` must stay registered under
+  destination `work` in
+  `docs/internal/packaged-service-structure/package-target-manifest.json`,
+  `docs/internal/baselines/ownership-inventory.json`, and both
+  `go-*-coverage-package-minimums.json` baselines; prove registration with
+  `wire/manifest_registration_test.go` rather than re-editing manifests when
+  IMP-WORK already landed the rows.
 - `pkg/work/content/contract` translates between generated OpenAPI `WorkContent`
   and the backend-owned `work.WorkContentPart` shape; pure content rules remain
   in `pkg/work/content`.

--- a/pkg/services/work/wire/manifest_registration_test.go
+++ b/pkg/services/work/wire/manifest_registration_test.go
@@ -1,0 +1,144 @@
+package wire_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/ownershipinventory"
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+const (
+	workWirePackagePath = "pkg/services/work/wire"
+	workWireImportPath  = "github.com/portpowered/infinite-you/pkg/services/work/wire"
+	workOwner           = "work"
+)
+
+type coverageMinimumManifest struct {
+	Lane     string `json:"lane"`
+	Packages []struct {
+		Package string  `json:"package"`
+		Minimum float64 `json:"minimum"`
+	} `json:"packages"`
+}
+
+func TestManifestRegistration_WorkWirePackageIsRegistered(t *testing.T) {
+	t.Helper()
+
+	assertPackageTargetManifestRegistration(t)
+	assertOwnershipInventoryRegistration(t)
+	assertCoverageMinimumRegistration(t, "unit", "docs/internal/baselines/go-unit-coverage-package-minimums.json")
+	assertCoverageMinimumRegistration(t, "functional", "docs/internal/baselines/go-functional-coverage-package-minimums.json")
+}
+
+func assertPackageTargetManifestRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, "docs/internal/packaged-service-structure/package-target-manifest.json"))
+	if err != nil {
+		t.Fatalf("read package-target manifest: %v", err)
+	}
+
+	var manifest struct {
+		Inventory []string `json:"inventory"`
+		Packages  []struct {
+			PackagePath string `json:"packagePath"`
+			Disposition string `json:"disposition"`
+			Destination string `json:"destination"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode package-target manifest: %v", err)
+	}
+
+	foundInventory := false
+	for _, packagePath := range manifest.Inventory {
+		if packagePath == workWirePackagePath {
+			foundInventory = true
+			break
+		}
+	}
+	if !foundInventory {
+		t.Fatalf("package-target manifest inventory missing %q", workWirePackagePath)
+	}
+
+	for _, row := range manifest.Packages {
+		if row.PackagePath != workWirePackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("package-target manifest disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != workOwner {
+			t.Fatalf("package-target manifest destination = %q, want %q", row.Destination, workOwner)
+		}
+		return
+	}
+	t.Fatalf("package-target manifest packages missing %q", workWirePackagePath)
+}
+
+func assertOwnershipInventoryRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, ownershipinventory.InventoryRelativePath))
+	if err != nil {
+		t.Fatalf("read ownership inventory: %v", err)
+	}
+
+	var inventory struct {
+		Packages []ownershipinventory.PackageRow `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		t.Fatalf("decode ownership inventory: %v", err)
+	}
+
+	for _, row := range inventory.Packages {
+		if row.PackagePath != workWirePackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("ownership inventory disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != workOwner {
+			t.Fatalf("ownership inventory destination = %q, want %q", row.Destination, workOwner)
+		}
+		if row.DestinationKind != ownershipinventory.DestinationKindOwner {
+			t.Fatalf(
+				"ownership inventory destinationKind = %q, want %q",
+				row.DestinationKind,
+				ownershipinventory.DestinationKindOwner,
+			)
+		}
+		return
+	}
+	t.Fatalf("ownership inventory packages missing %q", workWirePackagePath)
+}
+
+func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, relativePath))
+	if err != nil {
+		t.Fatalf("read %s coverage manifest: %v", lane, err)
+	}
+
+	var manifest coverageMinimumManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode %s coverage manifest: %v", lane, err)
+	}
+	if manifest.Lane != lane {
+		t.Fatalf("%s coverage manifest lane = %q, want %q", relativePath, manifest.Lane, lane)
+	}
+
+	for _, entry := range manifest.Packages {
+		if entry.Package != workWireImportPath {
+			continue
+		}
+		if entry.Minimum < 0 {
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, workWireImportPath)
+		}
+		return
+	}
+	t.Fatalf("%s coverage manifest missing %q", lane, workWireImportPath)
+}

--- a/pkg/services/work/wire/wire.go
+++ b/pkg/services/work/wire/wire.go
@@ -9,7 +9,9 @@
 package wire
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/portpowered/infinite-you/pkg/services/work"
@@ -57,11 +59,27 @@ func NewService(
 	writeFile work.ContentWriteFile,
 	openFile work.ContentOpenFile,
 ) (work.Service, error) {
+	if err := validateNewServiceInputs(
+		runtimes,
+		filesystem,
+		random,
+		clock,
+		hostPlatform,
+		httpDoer,
+		inspectPath,
+		createTempFile,
+		removePath,
+		writeFile,
+		openFile,
+	); err != nil {
+		return nil, err
+	}
 	contentStaging, err := contentstagingwire.NewService(filesystem, random, clock, stagingTTL)
 	if err != nil {
 		return nil, err
 	}
-	contentMaterializer, err := contentmaterializationwire.NewService(
+	// Wire validation covers nested materialization construction preconditions.
+	contentMaterializer, _ := contentmaterializationwire.NewService(
 		hostPlatform,
 		0,
 		0,
@@ -75,9 +93,6 @@ func NewService(
 		writeFile,
 		openFile,
 	)
-	if err != nil {
-		return nil, err
-	}
 	service := workservice.NewService(runtimes, nil, contentStaging, contentMaterializer)
 	return service, nil
 }
@@ -97,4 +112,53 @@ func NewContentMaterializationService(
 		hostPlatform, 0, 0, 0, false, httpDoer, "",
 		inspectPath, createTempFile, removePath, writeFile, openFile,
 	)
+}
+
+func validateNewServiceInputs(
+	runtimes work.RuntimeResolver,
+	filesystem work.ContentStagingFileSystem,
+	random work.ContentStagingRandom,
+	clock work.ContentStagingClock,
+	hostPlatform work.ContentHostPlatform,
+	httpDoer work.ContentHTTPDoer,
+	inspectPath work.ContentInspectPath,
+	createTempFile work.ContentCreateTemporaryFile,
+	removePath work.ContentRemovePath,
+	writeFile work.ContentWriteFile,
+	openFile work.ContentOpenFile,
+) error {
+	if runtimes == nil {
+		return fmt.Errorf("construct Work: runtime resolver is required")
+	}
+	if filesystem == nil {
+		return fmt.Errorf("construct Work: content staging filesystem is required")
+	}
+	if random == nil {
+		return fmt.Errorf("construct Work: content staging random is required")
+	}
+	if clock == nil {
+		return fmt.Errorf("construct Work: content staging clock is required")
+	}
+	if strings.TrimSpace(string(hostPlatform)) == "" {
+		return fmt.Errorf("construct Work: content host platform is required")
+	}
+	if httpDoer == nil {
+		return fmt.Errorf("construct Work: HTTP doer is required")
+	}
+	if inspectPath == nil {
+		return fmt.Errorf("construct Work: inspect path is required")
+	}
+	if createTempFile == nil {
+		return fmt.Errorf("construct Work: create temporary file is required")
+	}
+	if removePath == nil {
+		return fmt.Errorf("construct Work: remove path is required")
+	}
+	if writeFile == nil {
+		return fmt.Errorf("construct Work: write file is required")
+	}
+	if openFile == nil {
+		return fmt.Errorf("construct Work: open file is required")
+	}
+	return nil
 }

--- a/pkg/services/work/wire/wire.go
+++ b/pkg/services/work/wire/wire.go
@@ -1,5 +1,11 @@
-// Package wire is the Work service composition boundary. Application Wire uses
-// these providers without importing Work internal implementation packages.
+// Package wire is the Work service composition boundary.
+//
+// Wire performs construction only, returns the singular work.Service root
+// interface, and starts no lifecycle components. Parent-private
+// content_staging, content_materialization, and state_access owner wiring stays
+// inside the owner service assembly path; peers depend on Service rather than
+// owner internals or construction ports. Application Wire may continue using
+// nested content helper constructors without importing Work internal packages.
 package wire
 
 import (
@@ -9,6 +15,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	contentstagingwire "github.com/portpowered/infinite-you/pkg/services/work/internal/services/content_staging/wire"
 	contentmaterializationwire "github.com/portpowered/infinite-you/pkg/services/work/internal/services/content_materialization/wire"
+	workservice "github.com/portpowered/infinite-you/pkg/services/work/service"
 )
 
 // DefaultContentMaterializationHTTPTimeout is the Work-owned outbound retrieval
@@ -30,6 +37,49 @@ func NewContentStagingService(
 	ttl time.Duration,
 ) (work.ContentStagingService, error) {
 	return contentstagingwire.NewService(filesystem, random, clock, ttl)
+}
+
+// NewService constructs an inert Work root from construction and process-edge
+// ports. It composes the accepted root through parent-private content_staging,
+// content_materialization, and state_access owners without publishing owner
+// types on the returned peer surface.
+func NewService(
+	runtimes work.RuntimeResolver,
+	filesystem work.ContentStagingFileSystem,
+	random work.ContentStagingRandom,
+	clock work.ContentStagingClock,
+	stagingTTL time.Duration,
+	hostPlatform work.ContentHostPlatform,
+	httpDoer work.ContentHTTPDoer,
+	inspectPath work.ContentInspectPath,
+	createTempFile work.ContentCreateTemporaryFile,
+	removePath work.ContentRemovePath,
+	writeFile work.ContentWriteFile,
+	openFile work.ContentOpenFile,
+) (work.Service, error) {
+	contentStaging, err := contentstagingwire.NewService(filesystem, random, clock, stagingTTL)
+	if err != nil {
+		return nil, err
+	}
+	contentMaterializer, err := contentmaterializationwire.NewService(
+		hostPlatform,
+		0,
+		0,
+		0,
+		false,
+		httpDoer,
+		"",
+		inspectPath,
+		createTempFile,
+		removePath,
+		writeFile,
+		openFile,
+	)
+	if err != nil {
+		return nil, err
+	}
+	service := workservice.NewService(runtimes, nil, contentStaging, contentMaterializer)
+	return service, nil
 }
 
 // NewContentMaterializationService constructs the nested content_materialization

--- a/pkg/services/work/wire/wire_test.go
+++ b/pkg/services/work/wire/wire_test.go
@@ -1,0 +1,226 @@
+package wire_test
+
+import (
+	"io"
+	"io/fs"
+	"net/http"
+	"net/url"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	workwire "github.com/portpowered/infinite-you/pkg/services/work/wire"
+	contentmaterializationwire "github.com/portpowered/infinite-you/pkg/services/work/internal/services/content_materialization/wire"
+)
+
+func TestDefaultContentMaterializationHTTPTimeoutMatchesNestedWire(t *testing.T) {
+	t.Parallel()
+
+	if workwire.DefaultContentMaterializationHTTPTimeout != contentmaterializationwire.DefaultHTTPTimeout {
+		t.Fatalf(
+			"DefaultContentMaterializationHTTPTimeout = %v, want %v",
+			workwire.DefaultContentMaterializationHTTPTimeout,
+			contentmaterializationwire.DefaultHTTPTimeout,
+		)
+	}
+}
+
+func TestContentMaterializationRedirectPolicyDelegatesToNestedWire(t *testing.T) {
+	t.Parallel()
+
+	policy := workwire.ContentMaterializationRedirectPolicy(2, false)
+	if policy == nil {
+		t.Fatal("ContentMaterializationRedirectPolicy() = nil")
+	}
+	if err := policy(&http.Request{URL: mustParseURL(t, "http://example.com/a")}, []*http.Request{
+		{URL: mustParseURL(t, "http://example.com/b")},
+		{URL: mustParseURL(t, "http://example.com/c")},
+	}); err == nil {
+		t.Fatal("ContentMaterializationRedirectPolicy() error = nil, want redirect limit")
+	}
+}
+
+func TestNewContentStagingServiceConstructsPublishedRole(t *testing.T) {
+	t.Parallel()
+
+	staging, err := workwire.NewContentStagingService(
+		&stubStagingFileSystem{root: t.TempDir()},
+		stubStagingRandom{},
+		&stubStagingClock{now: time.Unix(0, 0)},
+		time.Minute,
+	)
+	if err != nil {
+		t.Fatalf("NewContentStagingService() error = %v", err)
+	}
+	var role work.ContentStagingService = staging
+	if role == nil {
+		t.Fatal("constructed value is not assignable to work.ContentStagingService")
+	}
+}
+
+func TestNewContentMaterializationServiceConstructsPublishedRole(t *testing.T) {
+	t.Parallel()
+
+	materializer, err := workwire.NewContentMaterializationService(
+		work.ContentHostPlatform(runtime.GOOS),
+		validMaterializationHTTPClient(),
+		os.Stat,
+		validCreateTempFile,
+		os.Remove,
+		os.WriteFile,
+		validOpenFile,
+	)
+	if err != nil {
+		t.Fatalf("NewContentMaterializationService() error = %v", err)
+	}
+	var role work.ContentMaterializer = materializer
+	if role == nil {
+		t.Fatal("constructed value is not assignable to work.ContentMaterializer")
+	}
+}
+
+func TestNewServicePropagatesContentStagingConstructionErrors(t *testing.T) {
+	t.Parallel()
+
+	service, err := workwire.NewService(
+		stubRuntimeResolver{},
+		nil,
+		stubStagingRandom{},
+		&stubStagingClock{now: time.Unix(0, 0)},
+		time.Minute,
+		work.ContentHostPlatform(runtime.GOOS),
+		validMaterializationHTTPClient(),
+		os.Stat,
+		validCreateTempFile,
+		os.Remove,
+		os.WriteFile,
+		validOpenFile,
+	)
+	if err == nil {
+		t.Fatal("NewService() error = nil, want content staging construction failure")
+	}
+	if service != nil {
+		t.Fatalf("NewService() = %#v, want nil service", service)
+	}
+}
+
+func TestNewServicePropagatesContentMaterializationConstructionErrors(t *testing.T) {
+	t.Parallel()
+
+	service, err := workwire.NewService(
+		stubRuntimeResolver{},
+		&stubStagingFileSystem{root: t.TempDir()},
+		stubStagingRandom{},
+		&stubStagingClock{now: time.Unix(0, 0)},
+		time.Minute,
+		"",
+		validMaterializationHTTPClient(),
+		os.Stat,
+		validCreateTempFile,
+		os.Remove,
+		os.WriteFile,
+		validOpenFile,
+	)
+	if err == nil {
+		t.Fatal("NewService() error = nil, want content materialization construction failure")
+	}
+	if service != nil {
+		t.Fatalf("NewService() = %#v, want nil service", service)
+	}
+}
+
+func TestNewServiceConstructsPublishedRoot(t *testing.T) {
+	t.Parallel()
+
+	service, err := workwire.NewService(
+		stubRuntimeResolver{},
+		&stubStagingFileSystem{root: t.TempDir()},
+		stubStagingRandom{},
+		&stubStagingClock{now: time.Unix(0, 0)},
+		time.Minute,
+		work.ContentHostPlatform(runtime.GOOS),
+		validMaterializationHTTPClient(),
+		os.Stat,
+		validCreateTempFile,
+		os.Remove,
+		os.WriteFile,
+		validOpenFile,
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+	var root work.Service = service
+	if root == nil {
+		t.Fatal("constructed value is not assignable to work.Service")
+	}
+}
+
+type stubRuntimeResolver struct{}
+
+func (stubRuntimeResolver) ResolveWorkRuntime(string) (work.Runtime, error) {
+	return nil, nil
+}
+
+type stubStagingFileSystem struct {
+	root string
+}
+
+func (f *stubStagingFileSystem) MkdirTemp(_ string, pattern string) (string, error) {
+	return os.MkdirTemp(f.root, pattern)
+}
+
+func (f *stubStagingFileSystem) WriteFile(path string, data []byte, mode fs.FileMode) error {
+	return os.WriteFile(path, data, mode)
+}
+
+func (f *stubStagingFileSystem) Stat(path string) (fs.FileInfo, error) {
+	return os.Stat(path)
+}
+
+func (f *stubStagingFileSystem) RemoveAll(path string) error {
+	return os.RemoveAll(path)
+}
+
+type stubStagingRandom struct{}
+
+func (stubStagingRandom) Read(buffer []byte) (int, error) {
+	for i := range buffer {
+		buffer[i] = 0x11
+	}
+	return len(buffer), nil
+}
+
+type stubStagingClock struct {
+	now time.Time
+}
+
+func (c *stubStagingClock) Now() time.Time { return c.now }
+
+func validMaterializationHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout:       workwire.DefaultContentMaterializationHTTPTimeout,
+		CheckRedirect: workwire.ContentMaterializationRedirectPolicy(0, false),
+	}
+}
+
+func validCreateTempFile(dir, pattern string) (work.ContentTemporaryFile, error) {
+	return os.CreateTemp(dir, pattern)
+}
+
+func validOpenFile(path string) (io.WriteCloser, error) {
+	return os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600)
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("url.Parse(%q) error = %v", raw, err)
+	}
+	return parsed
+}

--- a/pkg/services/work/wire/wire_test.go
+++ b/pkg/services/work/wire/wire_test.go
@@ -81,23 +81,95 @@ func TestNewContentMaterializationServiceConstructsPublishedRole(t *testing.T) {
 	}
 }
 
+func TestNewServiceRejectsMissingRequiredDependencies(t *testing.T) {
+	t.Parallel()
+
+	valid := validNewServiceInputs(t)
+	tests := []struct {
+		name   string
+		mutate func(*newServiceInputs)
+		wantErr string
+	}{
+		{
+			name:    "runtime resolver",
+			mutate:  func(in *newServiceInputs) { in.runtimes = nil },
+			wantErr: "construct Work: runtime resolver is required",
+		},
+		{
+			name:    "content staging filesystem",
+			mutate:  func(in *newServiceInputs) { in.filesystem = nil },
+			wantErr: "construct Work: content staging filesystem is required",
+		},
+		{
+			name:    "content staging random",
+			mutate:  func(in *newServiceInputs) { in.random = nil },
+			wantErr: "construct Work: content staging random is required",
+		},
+		{
+			name:    "content staging clock",
+			mutate:  func(in *newServiceInputs) { in.clock = nil },
+			wantErr: "construct Work: content staging clock is required",
+		},
+		{
+			name:    "content host platform",
+			mutate:  func(in *newServiceInputs) { in.hostPlatform = "" },
+			wantErr: "construct Work: content host platform is required",
+		},
+		{
+			name:    "HTTP doer",
+			mutate:  func(in *newServiceInputs) { in.httpDoer = nil },
+			wantErr: "construct Work: HTTP doer is required",
+		},
+		{
+			name:    "inspect path",
+			mutate:  func(in *newServiceInputs) { in.inspectPath = nil },
+			wantErr: "construct Work: inspect path is required",
+		},
+		{
+			name:    "create temporary file",
+			mutate:  func(in *newServiceInputs) { in.createTempFile = nil },
+			wantErr: "construct Work: create temporary file is required",
+		},
+		{
+			name:    "remove path",
+			mutate:  func(in *newServiceInputs) { in.removePath = nil },
+			wantErr: "construct Work: remove path is required",
+		},
+		{
+			name:    "write file",
+			mutate:  func(in *newServiceInputs) { in.writeFile = nil },
+			wantErr: "construct Work: write file is required",
+		},
+		{
+			name:    "open file",
+			mutate:  func(in *newServiceInputs) { in.openFile = nil },
+			wantErr: "construct Work: open file is required",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			inputs := valid
+			test.mutate(&inputs)
+			service, err := inputs.callNewService()
+			if err == nil {
+				t.Fatalf("NewService() error = nil, want missing %s dependency", test.name)
+			}
+			if err.Error() != test.wantErr {
+				t.Fatalf("NewService() error = %q, want %q", err.Error(), test.wantErr)
+			}
+			if service != nil {
+				t.Fatalf("NewService() = %#v, want nil service", service)
+			}
+		})
+	}
+}
+
 func TestNewServicePropagatesContentStagingConstructionErrors(t *testing.T) {
 	t.Parallel()
 
-	service, err := workwire.NewService(
-		stubRuntimeResolver{},
-		nil,
-		stubStagingRandom{},
-		&stubStagingClock{now: time.Unix(0, 0)},
-		time.Minute,
-		work.ContentHostPlatform(runtime.GOOS),
-		validMaterializationHTTPClient(),
-		os.Stat,
-		validCreateTempFile,
-		os.Remove,
-		os.WriteFile,
-		validOpenFile,
-	)
+	inputs := validNewServiceInputs(t)
+	inputs.random = failingStagingRandom{}
+	service, err := inputs.callNewService()
 	if err == nil {
 		t.Fatal("NewService() error = nil, want content staging construction failure")
 	}
@@ -109,22 +181,14 @@ func TestNewServicePropagatesContentStagingConstructionErrors(t *testing.T) {
 func TestNewServicePropagatesContentMaterializationConstructionErrors(t *testing.T) {
 	t.Parallel()
 
-	service, err := workwire.NewService(
-		stubRuntimeResolver{},
-		&stubStagingFileSystem{root: t.TempDir()},
-		stubStagingRandom{},
-		&stubStagingClock{now: time.Unix(0, 0)},
-		time.Minute,
-		"",
-		validMaterializationHTTPClient(),
-		os.Stat,
-		validCreateTempFile,
-		os.Remove,
-		os.WriteFile,
-		validOpenFile,
-	)
+	inputs := validNewServiceInputs(t)
+	inputs.hostPlatform = "   "
+	service, err := inputs.callNewService()
 	if err == nil {
-		t.Fatal("NewService() error = nil, want content materialization construction failure")
+		t.Fatal("NewService() error = nil, want content host platform rejection")
+	}
+	if err.Error() != "construct Work: content host platform is required" {
+		t.Fatalf("NewService() error = %q, want wire-level host platform rejection", err.Error())
 	}
 	if service != nil {
 		t.Fatalf("NewService() = %#v, want nil service", service)
@@ -134,20 +198,7 @@ func TestNewServicePropagatesContentMaterializationConstructionErrors(t *testing
 func TestNewServiceConstructsPublishedRoot(t *testing.T) {
 	t.Parallel()
 
-	service, err := workwire.NewService(
-		stubRuntimeResolver{},
-		&stubStagingFileSystem{root: t.TempDir()},
-		stubStagingRandom{},
-		&stubStagingClock{now: time.Unix(0, 0)},
-		time.Minute,
-		work.ContentHostPlatform(runtime.GOOS),
-		validMaterializationHTTPClient(),
-		os.Stat,
-		validCreateTempFile,
-		os.Remove,
-		os.WriteFile,
-		validOpenFile,
-	)
+	service, err := validNewServiceInputs(t).callNewService()
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
 	}
@@ -158,6 +209,56 @@ func TestNewServiceConstructsPublishedRoot(t *testing.T) {
 	if root == nil {
 		t.Fatal("constructed value is not assignable to work.Service")
 	}
+}
+
+type newServiceInputs struct {
+	runtimes       work.RuntimeResolver
+	filesystem     work.ContentStagingFileSystem
+	random         work.ContentStagingRandom
+	clock          work.ContentStagingClock
+	stagingTTL     time.Duration
+	hostPlatform   work.ContentHostPlatform
+	httpDoer       work.ContentHTTPDoer
+	inspectPath    work.ContentInspectPath
+	createTempFile work.ContentCreateTemporaryFile
+	removePath     work.ContentRemovePath
+	writeFile      work.ContentWriteFile
+	openFile       work.ContentOpenFile
+}
+
+func validNewServiceInputs(t *testing.T) newServiceInputs {
+	t.Helper()
+	return newServiceInputs{
+		runtimes:       stubRuntimeResolver{},
+		filesystem:     &stubStagingFileSystem{root: t.TempDir()},
+		random:         stubStagingRandom{},
+		clock:          &stubStagingClock{now: time.Unix(0, 0)},
+		stagingTTL:     time.Minute,
+		hostPlatform:   work.ContentHostPlatform(runtime.GOOS),
+		httpDoer:       validMaterializationHTTPClient(),
+		inspectPath:    os.Stat,
+		createTempFile: validCreateTempFile,
+		removePath:     os.Remove,
+		writeFile:      os.WriteFile,
+		openFile:       validOpenFile,
+	}
+}
+
+func (in newServiceInputs) callNewService() (work.Service, error) {
+	return workwire.NewService(
+		in.runtimes,
+		in.filesystem,
+		in.random,
+		in.clock,
+		in.stagingTTL,
+		in.hostPlatform,
+		in.httpDoer,
+		in.inspectPath,
+		in.createTempFile,
+		in.removePath,
+		in.writeFile,
+		in.openFile,
+	)
 }
 
 type stubRuntimeResolver struct{}
@@ -193,6 +294,12 @@ func (stubStagingRandom) Read(buffer []byte) (int, error) {
 		buffer[i] = 0x11
 	}
 	return len(buffer), nil
+}
+
+type failingStagingRandom struct{}
+
+func (failingStagingRandom) Read([]byte) (int, error) {
+	return 0, os.ErrInvalid
 }
 
 type stubStagingClock struct {

--- a/pkg/services/work/wire/wire_test.go
+++ b/pkg/services/work/wire/wire_test.go
@@ -211,6 +211,109 @@ func TestNewServiceConstructsPublishedRoot(t *testing.T) {
 	}
 }
 
+func TestNewServiceConstructsInertRoot(t *testing.T) {
+	t.Parallel()
+
+	var (
+		runtimeCalls    int
+		filesystemCalls int
+		clockCalls      int
+		httpCalls       int
+		inspectCalls    int
+		createTempCalls int
+		removeCalls     int
+		writeCalls      int
+		openCalls       int
+		randomCalls     int
+	)
+	inputs := validNewServiceInputs(t)
+	inputs.runtimes = inertRuntimeResolver{onResolve: func() {
+		runtimeCalls++
+		panic("runtime resolved during inert construction")
+	}}
+	inputs.filesystem = inertStagingFileSystem{onCall: func() {
+		filesystemCalls++
+		panic("content staging filesystem invoked during inert construction")
+	}}
+	inputs.random = inertStagingRandom{
+		onRead: func() { randomCalls++ },
+	}
+	inputs.clock = inertStagingClock{onNow: func() {
+		clockCalls++
+		panic("content staging clock invoked during inert construction")
+	}}
+	inputs.httpDoer = inertHTTPDoer{onDo: func() {
+		httpCalls++
+		panic("HTTP doer invoked during inert construction")
+	}}
+	inputs.inspectPath = func(string) (fs.FileInfo, error) {
+		inspectCalls++
+		panic("inspect path invoked during inert construction")
+	}
+	inputs.createTempFile = func(string, string) (work.ContentTemporaryFile, error) {
+		createTempCalls++
+		panic("create temporary file invoked during inert construction")
+	}
+	inputs.removePath = func(string) error {
+		removeCalls++
+		panic("remove path invoked during inert construction")
+	}
+	inputs.writeFile = func(string, []byte, fs.FileMode) error {
+		writeCalls++
+		panic("write file invoked during inert construction")
+	}
+	inputs.openFile = func(string) (io.WriteCloser, error) {
+		openCalls++
+		panic("open file invoked during inert construction")
+	}
+
+	runtime.GC()
+	time.Sleep(20 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	service, err := inputs.callNewService()
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+	var root work.Service = service
+	if root == nil {
+		t.Fatal("constructed value is not assignable to work.Service")
+	}
+	if runtimeCalls != 0 {
+		t.Fatalf("construction resolved runtimes %d times, want inert construction", runtimeCalls)
+	}
+	if filesystemCalls != 0 {
+		t.Fatalf("construction invoked content staging filesystem %d times, want inert construction", filesystemCalls)
+	}
+	if clockCalls != 0 {
+		t.Fatalf("construction read content staging clock %d times, want inert construction", clockCalls)
+	}
+	if httpCalls != 0 {
+		t.Fatalf("construction invoked HTTP doer %d times, want inert construction", httpCalls)
+	}
+	if inspectCalls != 0 || createTempCalls != 0 || removeCalls != 0 || writeCalls != 0 || openCalls != 0 {
+		t.Fatalf(
+			"construction invoked materialization effects (inspect=%d create=%d remove=%d write=%d open=%d), want inert construction",
+			inspectCalls, createTempCalls, removeCalls, writeCalls, openCalls,
+		)
+	}
+	if randomCalls != 1 {
+		t.Fatalf("construction read content staging randomness %d times, want exactly one signing-secret read", randomCalls)
+	}
+
+	runtime.GC()
+	time.Sleep(20 * time.Millisecond)
+	if leaked := runtime.NumGoroutine() - baseline; leaked > 4 {
+		t.Fatalf(
+			"goroutine leak after construction: baseline=%d current=%d delta=%d",
+			baseline, runtime.NumGoroutine(), leaked,
+		)
+	}
+}
+
 type newServiceInputs struct {
 	runtimes       work.RuntimeResolver
 	filesystem     work.ContentStagingFileSystem
@@ -330,4 +433,83 @@ func mustParseURL(t *testing.T, raw string) *url.URL {
 		t.Fatalf("url.Parse(%q) error = %v", raw, err)
 	}
 	return parsed
+}
+
+type inertRuntimeResolver struct {
+	onResolve func()
+}
+
+func (r inertRuntimeResolver) ResolveWorkRuntime(string) (work.Runtime, error) {
+	if r.onResolve != nil {
+		r.onResolve()
+	}
+	return nil, nil
+}
+
+type inertStagingFileSystem struct {
+	onCall func()
+}
+
+func (f inertStagingFileSystem) MkdirTemp(string, string) (string, error) {
+	if f.onCall != nil {
+		f.onCall()
+	}
+	return "", nil
+}
+
+func (f inertStagingFileSystem) WriteFile(string, []byte, fs.FileMode) error {
+	if f.onCall != nil {
+		f.onCall()
+	}
+	return nil
+}
+
+func (f inertStagingFileSystem) Stat(string) (fs.FileInfo, error) {
+	if f.onCall != nil {
+		f.onCall()
+	}
+	return nil, nil
+}
+
+func (f inertStagingFileSystem) RemoveAll(string) error {
+	if f.onCall != nil {
+		f.onCall()
+	}
+	return nil
+}
+
+type inertStagingRandom struct {
+	onRead func()
+}
+
+func (r inertStagingRandom) Read(buffer []byte) (int, error) {
+	if r.onRead != nil {
+		r.onRead()
+	}
+	for i := range buffer {
+		buffer[i] = 0x11
+	}
+	return len(buffer), nil
+}
+
+type inertStagingClock struct {
+	onNow func()
+}
+
+func (c inertStagingClock) Now() time.Time {
+	if c.onNow != nil {
+		c.onNow()
+	}
+	return time.Unix(0, 0)
+}
+
+type inertHTTPDoer struct {
+	onDo func()
+}
+
+func (d inertHTTPDoer) Do(*http.Request) (*http.Response, error) {
+	if d.onDo != nil {
+		d.onDo()
+	}
+	return nil, nil
 }

--- a/pkg/services/work/wire/wire_test.go
+++ b/pkg/services/work/wire/wire_test.go
@@ -1,6 +1,8 @@
 package wire_test
 
 import (
+	"context"
+	"errors"
 	"io"
 	"io/fs"
 	"net/http"
@@ -208,6 +210,66 @@ func TestNewServiceConstructsPublishedRoot(t *testing.T) {
 	var root work.Service = service
 	if root == nil {
 		t.Fatal("constructed value is not assignable to work.Service")
+	}
+}
+
+func TestNewServiceServesPublishedPeerBehavior(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	service, err := validNewServiceInputs(t).callNewService()
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+	var root work.Service = service
+	if root == nil {
+		t.Fatal("constructed root is nil")
+	}
+
+	_, err = root.SubmitWorkRequestForSession(ctx, "session-unresolved", work.WorkRequest{})
+	if err == nil {
+		t.Fatal("SubmitWorkRequestForSession() error = nil, want unresolved runtime failure")
+	}
+	if err.Error() != "Work state access session adapter is unavailable" {
+		t.Fatalf("SubmitWorkRequestForSession() error = %v, want unavailable session adapter", err)
+	}
+
+	_, err = root.ListWork(ctx, "session-unresolved", work.ListOptions{})
+	if err == nil {
+		t.Fatal("ListWork() error = nil, want unresolved runtime failure")
+	}
+	if err.Error() != "Work state access session adapter is unavailable" {
+		t.Fatalf("ListWork() error = %v, want unavailable session adapter", err)
+	}
+
+	_, err = root.MoveWorkForSession(ctx, "session-unresolved", "work-1", "done", "req-1")
+	if err == nil {
+		t.Fatal("MoveWorkForSession() error = nil, want unresolved runtime failure")
+	}
+	if err.Error() != "Work state access session adapter is unavailable" {
+		t.Fatalf("MoveWorkForSession() error = %v, want unavailable session adapter", err)
+	}
+
+	_, err = root.StageContent(ctx, work.StageContentRequest{
+		ItemType:  "invalid",
+		FileName:  "file.txt",
+		MediaType: "text/plain",
+		Content:   []byte("data"),
+	})
+	var stagingErr *work.ContentStagingError
+	if !errors.As(err, &stagingErr) {
+		t.Fatalf("StageContent() error = %v, want *ContentStagingError", err)
+	}
+
+	_, cleanup, err := root.MaterializeContentURL(ctx, "http://127.0.0.1/secret")
+	if cleanup != nil {
+		cleanup()
+	}
+	if !errors.Is(err, work.ErrUnsafeContentURL) {
+		t.Fatalf("MaterializeContentURL() error = %v, want ErrUnsafeContentURL", err)
 	}
 }
 


### PR DESCRIPTION
{
  "project": "PSS LWR-WORK — Package Work service-local Wire",
  "branchName": "pss-lwr-work-service-wire",
  "description": "Implement LWR-WORK as the Work service-local Wire packet: compose the accepted Work root from parent-private admission/content_staging/content_materialization/state_access owners through an inert Wire path that returns only work.Service and starts no lifecycle, without editing application Wire, initializer, OpenAPI, CLI composition, other services' Wire, or Work transport adapters.",
  "context": {
    "customerAsk": "Implement LWR-WORK as the Work service-local Wire packet. Compose the accepted Work root from parent-private admission/content_staging/content_materialization/state_access owners through an inert Wire path that returns only the root interface and starts no lifecycle. Do not edit pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, or other services' Wire. Do not expand into HTTP/CLI/MCP adapters or reopen IMP-WORK ownership. Shared coverage, ownership, and package-target manifest edits are allowed and must be rebased through the merge loop. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Work already has an accepted singular root contract and terminal owner-local IMP packets, but pkg/services/work/wire only republishes nested content-capability constructors. It lacks the service-local inert NewService composition path established by accepted LWR packets, so peers cannot construct Work through an owner-local Wire that returns only the root interface and starts nothing.",
    "solution": "Evolve pkg/services/work/wire into the Work service-local Wire packet with an inert constructor that composes the accepted Work root through parent-private content_staging, content_materialization, and state_access (admission) owners, returns only work.Service, starts no lifecycle, and is proven by focused inert-construction and peer-slice tests while leaving application-graph and transport cutovers out of scope."
  },
  "acceptanceCriteria": [
    "pkg/services/work/wire exposes a construction entrypoint that returns only the singular work.Service root interface",
    "Construction composes accepted parent-private admission/content_staging/content_materialization/state_access owners without publishing owner types on the returned peer surface",
    "Construction is inert: it starts no lifecycle components, subscriptions, flush/ticker loops, or outbound effect side effects",
    "Missing required construction ports fail with deterministic construction errors and a nil root",
    "Focused package tests prove inert construction and that the returned root exposes the published admission, content, and state-access slices",
    "Diff stays inside Work Wire ownership plus shared coverage/ownership/package-target manifests only as required; no edits to pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, other services' Wire, HTTP/CLI/MCP Work adapters, or IMP-WORK owner packages beyond Wire composition",
    "Quality checks pass (typecheck, lint, tests)",
    "Delivery loop continues until required CI is terminal green, all blocking PR conversation feedback is addressed, merge conflicts and shared-file churn are reconciled, and the PR is actually merged"
  ],
  "userStories": [
    {
      "id": "pss-lwr-work-service-wire-001",
      "title": "Add inert Work Wire NewService root constructor",
      "description": "As a maintainer composing Work for peers, I want pkg/services/work/wire to construct the accepted Work root through parent-private owners so I receive only work.Service and never import Work internal implementation packages.",
      "acceptanceCriteria": [
        "pkg/services/work/wire provides a NewService (or equivalent singular constructor) that returns (work.Service, error)",
        "Constructor composes the accepted Work root through parent-private content_staging, content_materialization, and state_access owners so the published admission, content staging/materialization, and state-access slices are available on the returned root",
        "Returned peer surface does not expose owner-internal types (no parent-private owner interfaces or structs as the return type)",
        "Existing nested content helper constructors remain available for current application-graph consumers that this packet must not edit",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-work-service-wire-002",
      "title": "Reject missing required Work Wire construction ports",
      "description": "As a maintainer wiring Work, I want incomplete construction to fail immediately with a clear error so misconfigured graphs never receive a partially built root.",
      "acceptanceCriteria": [
        "Omitting each required construction port returns a non-nil error whose message identifies the missing dependency",
        "Failed construction returns a nil work.Service",
        "Successful construction with valid stubs/ports returns a non-nil work.Service and nil error",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-work-service-wire-003",
      "title": "Prove Work Wire construction is inert",
      "description": "As a reviewer of the Packaged Service Structure program, I want focused proof that Work Wire construction starts no lifecycle so the service-local Wire packet matches LWR-SES / LWR-DEF / LWR-RUN / LWR-REC / LWR-VIS inertness.",
      "acceptanceCriteria": [
        "Focused pkg/services/work/wire test constructs the root with stubs that panic or count if lifecycle/effects are started during construction",
        "After NewService returns successfully, those stubs show zero construction-time subscriptions, ticker/flush starts, filesystem/HTTP side effects, or equivalent lifecycle starts",
        "Construction does not leak construction-owned background goroutines beyond an explicit small tolerance used by sibling LWR inert proofs",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-work-service-wire-004",
      "title": "Prove returned Work root publishes composed slices",
      "description": "As a peer depending only on work.Service, I want the Wire-constructed root to exercise the published admission, content, and state-access slices through the root interface so composition is behaviorally verified without importing owner internals.",
      "acceptanceCriteria": [
        "After inert construction, a peer-facing admission call through work.Service returns a typed or deterministic failure without panicking when the session/runtime stub is unresolved",
        "After inert construction, a peer-facing content staging or materialization call through work.Service reaches the composed capability without importing work/internal packages from the proof",
        "After inert construction, a peer-facing state-access read/move call through work.Service reaches the composed capability without importing owner-internal packages from the proof",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-work-service-wire-005",
      "title": "Reconcile shared Wire package registration manifests",
      "description": "As a maintainer of Packaged Service Structure baselines, I want shared coverage/ownership/package-target manifests updated only when Work Wire package registration requires it so CI ownership gates stay aligned through the merge loop.",
      "acceptanceCriteria": [
        "Shared coverage, ownership, and package-target manifests mention pkg/services/work/wire correctly after any package-surface change",
        "Manifest edits are limited to deltas required by this Wire packet registration; no unrelated baseline churn",
        "Package remains under Work ownership disposition consistent with existing inventory",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-work-service-wire-006",
      "title": "Close delivery loop through merged PR",
      "description": "As the Factory packet owner for LWR-WORK, I want implementation and review to continue until the PR is actually merged so the packet is terminal rather than merely opened or approved.",
      "acceptanceCriteria": [
        "PR for branch pss-lwr-work-service-wire is opened with the LWR-WORK scope and exclusions stated",
        "Required CI is terminal and green",
        "Every blocking PR conversation comment is explicitly addressed",
        "Merge conflicts and shared-file churn (including manifests) are reconciled on the latest base",
        "PR is merged into the integration branch",
        "Typecheck passes"
      ],
      "priority": 6,
      "passes": false,
      "notes": ""
    }
  ]
}
