### PR TITLE
pss-mcp-vis-adapter

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1100,7 +1100,13 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/mcp",
-      "minimum": 0.00
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/wire",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1079,6 +1079,10 @@
       "minimum": 100.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/mcp",
+      "minimum": 0.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/wire",
       "exception": {
         "kind": "measurement",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -989,6 +989,10 @@
       "minimum": 100.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/mcp",
+      "minimum": 75.87
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/wire",
       "minimum": 77.00
     },

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -3612,6 +3612,12 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/factory_visualization/transports/mcp",
+      "disposition": "retain",
+      "destination": "factory_visualization",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/factory_visualization/wire",
       "disposition": "retain",
       "destination": "factory_visualization",

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -252,6 +252,7 @@
     "pkg/services/factory_visualization/internal/services/response_event_presentation",
     "pkg/services/factory_visualization/internal/services/response_event_presentation/internal/service",
     "pkg/services/factory_visualization/internal/services/response_event_presentation/wire",
+    "pkg/services/factory_visualization/transports/mcp",
     "pkg/services/factory_visualization/wire",
     "pkg/services/models",
     "pkg/services/models/internal/artifacts",
@@ -1540,6 +1541,11 @@
       "packagePath": "pkg/services/factory_visualization/internal/services/response_event_presentation/wire",
       "disposition": "retain",
       "destination": "factory_visualization/internal/services/response_event_presentation"
+    },
+    {
+      "packagePath": "pkg/services/factory_visualization/transports/mcp",
+      "disposition": "retain",
+      "destination": "factory_visualization"
     },
     {
       "packagePath": "pkg/services/factory_visualization/wire",

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -84,6 +84,23 @@ Use this map when changing the public REST contract.
   `pkg/wire`, `pkg/root`, `pkg/initializer`, top-level CLI composition, shared
   MCP host/composition fan-in, or other services' MCP adapters when reconciling
   manifest churn.
+- Factory Visualization MCP tool decoding, invocation, result/error mapping, and
+  catalog parity live under
+  `pkg/services/factory_visualization/transports/mcp`. Top-level MCP retains
+  generated discovery, SDK registration, and stdio composition. Service-owned
+  adapters consume Factory Visualization root contracts and do not import or
+  construct its implementation packages or private subservices.
+- The Visualization MCP adapter package must stay registered in the allowed shared
+  manifests only: retain `pkg/services/factory_visualization/transports/mcp`
+  under destination `factory_visualization` in
+  `docs/internal/packaged-service-structure/package-target-manifest.json` and
+  `docs/internal/baselines/ownership-inventory.json`, and keep measured floors in
+  both `docs/internal/baselines/go-unit-coverage-package-minimums.json` and
+  `docs/internal/baselines/go-functional-coverage-package-minimums.json`.
+  Prove registration with `manifest_registration_test.go`; do not edit
+  `pkg/wire`, `pkg/root`, `pkg/initializer`, top-level CLI composition, shared
+  MCP host/composition fan-in, or other services' MCP adapters when reconciling
+  manifest churn.
 - Provider Session HTTP decoding, generated-contract mapping, service
   invocation, typed root error mapping (`error_mapping.go`), cancel/timeout edge
   mapping, and response encoding for owned Provider Sessions operations live in

--- a/pkg/services/factory_visualization/transports/mcp/bind_test.go
+++ b/pkg/services/factory_visualization/transports/mcp/bind_test.go
@@ -1,0 +1,184 @@
+package factoryvisualization_test
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"testing"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	mcpfactoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/mcp"
+)
+
+func TestAdapterPackageDoesNotImportVisualizationInternals(t *testing.T) {
+	t.Parallel()
+
+	forbidden := "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal"
+	packagePath := "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/mcp"
+	assertPackageDirectImportsForbidden(t, packagePath, []string{forbidden})
+}
+
+func TestBind_FakeRootInvokedThroughActivateTool(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := fakeVisualizationRoot{
+		activate: func(_ context.Context, request factoryvisualization.ActivateRequest) (factoryvisualization.ActivateResult, error) {
+			invoked = true
+			if request.Mode != factoryvisualization.ActivateModeRetainedThenLive {
+				t.Fatalf("mode = %q, want %q", request.Mode, factoryvisualization.ActivateModeRetainedThenLive)
+			}
+			return factoryvisualization.ActivateResult{State: factoryvisualization.LifecycleStateStarted}, nil
+		},
+	}
+	operation := mcpfactoryvisualization.Bind(mcpfactoryvisualization.RootDependencies{Root: fake})
+	raw, err := operation(
+		context.Background(),
+		mcpfactoryvisualization.ToolActivate,
+		json.RawMessage(`{"mode":"RETAINED_THEN_LIVE"}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(activate) error = %v", err)
+	}
+	if !invoked {
+		t.Fatal("fake visualization root was not invoked")
+	}
+	if !strings.Contains(string(raw), `"State":"STARTED"`) {
+		t.Fatalf("CallTool(activate) = %s, want started lifecycle state", raw)
+	}
+}
+
+func TestBind_UnsupportedToolReturnsStableErrorWithoutInvokingFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	operation := mcpfactoryvisualization.Bind(mcpfactoryvisualization.RootDependencies{
+		Root: fakeVisualizationRoot{invoked: &invoked},
+	})
+	_, err := operation(context.Background(), "you.factory_visualization.unknown", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("CallTool(unknown) error = nil, want unsupported tool error")
+	}
+	if !strings.Contains(err.Error(), "unsupported tool") {
+		t.Fatalf("CallTool(unknown) error = %v, want unsupported tool error", err)
+	}
+	if invoked {
+		t.Fatal("fake visualization root was invoked for unknown tool")
+	}
+}
+
+func TestToolOperationRejectsMissingContext(t *testing.T) {
+	t.Parallel()
+
+	operation := mcpfactoryvisualization.Bind(mcpfactoryvisualization.RootDependencies{
+		Root: fakeVisualizationRoot{},
+	})
+	_, err := operation(nil, mcpfactoryvisualization.ToolActivate, json.RawMessage(`{"mode":"RETAINED_THEN_LIVE"}`))
+	if err == nil {
+		t.Fatal("ToolOperation(nil context) error = nil, want required-context error")
+	}
+	if !strings.Contains(err.Error(), "MCP request context is required") {
+		t.Fatalf("ToolOperation(nil context) error = %v, want required-context error", err)
+	}
+}
+
+type fakeVisualizationRoot struct {
+	invoked  *bool
+	activate func(context.Context, factoryvisualization.ActivateRequest) (factoryvisualization.ActivateResult, error)
+	join     func(context.Context, factoryvisualization.JoinRequest) (factoryvisualization.JoinResult, error)
+	stopDrain func(context.Context, factoryvisualization.StopDrainRequest) (factoryvisualization.StopDrainResult, error)
+	observe  func(context.Context, factoryvisualization.ObserveRequest) (factoryvisualization.ObserveResult, error)
+	openPresentation func(context.Context, factoryvisualization.OpenPresentationRequest) (factoryvisualization.OpenPresentationResult, error)
+	presentProgress func(context.Context, factoryvisualization.PresentProgressRequest) (factoryvisualization.PresentProgressResult, error)
+	finalizePresentation func(context.Context, factoryvisualization.FinalizePresentationRequest) (factoryvisualization.FinalizePresentationResult, error)
+	closePresentation func(context.Context, factoryvisualization.ClosePresentationRequest) (factoryvisualization.ClosePresentationResult, error)
+}
+
+func (f fakeVisualizationRoot) markInvoked() {
+	if f.invoked != nil {
+		*f.invoked = true
+	}
+}
+
+func (f fakeVisualizationRoot) Activate(ctx context.Context, req factoryvisualization.ActivateRequest) (factoryvisualization.ActivateResult, error) {
+	if f.activate == nil {
+		panic("unexpected Activate on fake visualization root")
+	}
+	f.markInvoked()
+	return f.activate(ctx, req)
+}
+
+func (f fakeVisualizationRoot) Join(ctx context.Context, req factoryvisualization.JoinRequest) (factoryvisualization.JoinResult, error) {
+	if f.join == nil {
+		panic("unexpected Join on fake visualization root")
+	}
+	f.markInvoked()
+	return f.join(ctx, req)
+}
+
+func (f fakeVisualizationRoot) StopDrain(ctx context.Context, req factoryvisualization.StopDrainRequest) (factoryvisualization.StopDrainResult, error) {
+	if f.stopDrain == nil {
+		panic("unexpected StopDrain on fake visualization root")
+	}
+	f.markInvoked()
+	return f.stopDrain(ctx, req)
+}
+
+func (f fakeVisualizationRoot) Observe(ctx context.Context, req factoryvisualization.ObserveRequest) (factoryvisualization.ObserveResult, error) {
+	if f.observe == nil {
+		panic("unexpected Observe on fake visualization root")
+	}
+	f.markInvoked()
+	return f.observe(ctx, req)
+}
+
+func (f fakeVisualizationRoot) OpenPresentation(ctx context.Context, req factoryvisualization.OpenPresentationRequest) (factoryvisualization.OpenPresentationResult, error) {
+	if f.openPresentation == nil {
+		panic("unexpected OpenPresentation on fake visualization root")
+	}
+	f.markInvoked()
+	return f.openPresentation(ctx, req)
+}
+
+func (f fakeVisualizationRoot) PresentProgress(ctx context.Context, req factoryvisualization.PresentProgressRequest) (factoryvisualization.PresentProgressResult, error) {
+	if f.presentProgress == nil {
+		panic("unexpected PresentProgress on fake visualization root")
+	}
+	f.markInvoked()
+	return f.presentProgress(ctx, req)
+}
+
+func (f fakeVisualizationRoot) FinalizePresentation(ctx context.Context, req factoryvisualization.FinalizePresentationRequest) (factoryvisualization.FinalizePresentationResult, error) {
+	if f.finalizePresentation == nil {
+		panic("unexpected FinalizePresentation on fake visualization root")
+	}
+	f.markInvoked()
+	return f.finalizePresentation(ctx, req)
+}
+
+func (f fakeVisualizationRoot) ClosePresentation(ctx context.Context, req factoryvisualization.ClosePresentationRequest) (factoryvisualization.ClosePresentationResult, error) {
+	if f.closePresentation == nil {
+		panic("unexpected ClosePresentation on fake visualization root")
+	}
+	f.markInvoked()
+	return f.closePresentation(ctx, req)
+}
+
+func assertPackageDirectImportsForbidden(t *testing.T, packagePath string, forbiddenRoots []string) {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", "-f", "{{.Imports}}", packagePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list imports for %s: %v\n%s", packagePath, err, output)
+	}
+	imports := strings.Fields(strings.Trim(string(output), "[]"))
+	for _, importPath := range imports {
+		for _, forbidden := range forbiddenRoots {
+			if importPath == forbidden || strings.HasPrefix(importPath, forbidden+"/") {
+				t.Fatalf("%s must not import forbidden ownership %s; found direct import %s", packagePath, forbidden, importPath)
+			}
+		}
+	}
+}

--- a/pkg/services/factory_visualization/transports/mcp/client.go
+++ b/pkg/services/factory_visualization/transports/mcp/client.go
@@ -1,0 +1,81 @@
+// Package factoryvisualization exposes MCP tool execution for Factory
+// Visualization operations backed by the accepted Visualization root contract.
+package factoryvisualization
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+)
+
+var errMissingRequestContext = errors.New("MCP request context is required")
+
+// ToolOperation is the single injected execution role used by every MCP
+// protocol server. Production binds its Factory Visualization root once;
+// protocol tests replace this exact function role.
+type ToolOperation func(context.Context, string, json.RawMessage) (json.RawMessage, error)
+
+// RootDependencies are the accepted Factory Visualization root roles consumed
+// by the MCP adapter. Transports inject an implementation or test fake rather
+// than importing Visualization internals or constructing canonical state.
+type RootDependencies struct {
+	Root factoryvisualization.Root
+}
+
+// Bind constructs the canonical ToolOperation from an injected Visualization
+// root. Adapter tests replace Root with a root-shaped fake without constructing
+// real activation_lifecycle, live_view_projection, or presentation owners.
+func Bind(deps RootDependencies) ToolOperation {
+	return func(ctx context.Context, name string, input json.RawMessage) (json.RawMessage, error) {
+		return CallTool(ctx, deps.Root, name, input)
+	}
+}
+
+type canonicalToolHandler func(
+	context.Context,
+	factoryvisualization.Root,
+	json.RawMessage,
+) (json.RawMessage, error)
+
+var canonicalToolHandlers = map[string]canonicalToolHandler{
+	ToolActivate: func(ctx context.Context, root factoryvisualization.Root, input json.RawMessage) (json.RawMessage, error) {
+		return callToolJSON(input, "decode activate input", func(request ActivateInput) ToolResponse[factoryvisualization.ActivateResult] {
+			return Activate(ctx, root, request)
+		})
+	},
+}
+
+// CallTool invokes one Factory Visualization tool against an explicitly
+// supplied root. Protocol servers receive the bound ToolOperation rather than
+// choosing between construction paths.
+func CallTool(
+	ctx context.Context,
+	root factoryvisualization.Root,
+	name string,
+	input json.RawMessage,
+) (json.RawMessage, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("call MCP tool: %w", errMissingRequestContext)
+	}
+	handler, ok := canonicalToolHandlers[name]
+	if !ok {
+		return nil, fmt.Errorf("unsupported tool %q", name)
+	}
+	return handler(ctx, root, input)
+}
+
+func callToolJSON[Input any, Output any](
+	input json.RawMessage,
+	decodeErr string,
+	handler func(Input) ToolResponse[Output],
+) (json.RawMessage, error) {
+	var request Input
+	if err := json.Unmarshal(input, &request); err != nil {
+		envelope := decodeInputErrorEnvelope(decodeErr, err)
+		return json.Marshal(ToolResponse[Output]{Error: &envelope})
+	}
+	return json.Marshal(handler(request))
+}

--- a/pkg/services/factory_visualization/transports/mcp/client.go
+++ b/pkg/services/factory_visualization/transports/mcp/client.go
@@ -56,6 +56,11 @@ var canonicalToolHandlers = map[string]canonicalToolHandler{
 			return StopDrain(ctx, root, request)
 		})
 	},
+	ToolObserve: func(ctx context.Context, root factoryvisualization.Root, input json.RawMessage) (json.RawMessage, error) {
+		return callToolJSON(input, "decode observe input", func(request ObserveInput) ToolResponse[factoryvisualization.ObserveResult] {
+			return Observe(ctx, root, request)
+		})
+	},
 }
 
 // IsCanonicalToolHandlerRegistered reports whether the live CallTool path

--- a/pkg/services/factory_visualization/transports/mcp/client.go
+++ b/pkg/services/factory_visualization/transports/mcp/client.go
@@ -61,6 +61,26 @@ var canonicalToolHandlers = map[string]canonicalToolHandler{
 			return Observe(ctx, root, request)
 		})
 	},
+	ToolOpenPresentation: func(ctx context.Context, root factoryvisualization.Root, input json.RawMessage) (json.RawMessage, error) {
+		return callToolJSON(input, "decode open_presentation input", func(request OpenPresentationInput) ToolResponse[factoryvisualization.OpenPresentationResult] {
+			return OpenPresentation(ctx, root, request)
+		})
+	},
+	ToolPresentProgress: func(ctx context.Context, root factoryvisualization.Root, input json.RawMessage) (json.RawMessage, error) {
+		return callToolJSON(input, "decode present_progress input", func(request PresentProgressInput) ToolResponse[factoryvisualization.PresentProgressResult] {
+			return PresentProgress(ctx, root, request)
+		})
+	},
+	ToolFinalizePresentation: func(ctx context.Context, root factoryvisualization.Root, input json.RawMessage) (json.RawMessage, error) {
+		return callToolJSON(input, "decode finalize_presentation input", func(request FinalizePresentationInput) ToolResponse[factoryvisualization.FinalizePresentationResult] {
+			return FinalizePresentation(ctx, root, request)
+		})
+	},
+	ToolClosePresentation: func(ctx context.Context, root factoryvisualization.Root, input json.RawMessage) (json.RawMessage, error) {
+		return callToolJSON(input, "decode close_presentation input", func(request ClosePresentationInput) ToolResponse[factoryvisualization.ClosePresentationResult] {
+			return ClosePresentation(ctx, root, request)
+		})
+	},
 }
 
 // IsCanonicalToolHandlerRegistered reports whether the live CallTool path

--- a/pkg/services/factory_visualization/transports/mcp/client.go
+++ b/pkg/services/factory_visualization/transports/mcp/client.go
@@ -48,6 +48,13 @@ var canonicalToolHandlers = map[string]canonicalToolHandler{
 	},
 }
 
+// IsCanonicalToolHandlerRegistered reports whether the live CallTool path
+// registers a handler for one canonical Factory Visualization tool name.
+func IsCanonicalToolHandlerRegistered(name string) bool {
+	_, ok := canonicalToolHandlers[name]
+	return ok
+}
+
 // CallTool invokes one Factory Visualization tool against an explicitly
 // supplied root. Protocol servers receive the bound ToolOperation rather than
 // choosing between construction paths.

--- a/pkg/services/factory_visualization/transports/mcp/client.go
+++ b/pkg/services/factory_visualization/transports/mcp/client.go
@@ -46,6 +46,16 @@ var canonicalToolHandlers = map[string]canonicalToolHandler{
 			return Activate(ctx, root, request)
 		})
 	},
+	ToolJoin: func(ctx context.Context, root factoryvisualization.Root, input json.RawMessage) (json.RawMessage, error) {
+		return callToolJSON(input, "decode join input", func(request JoinInput) ToolResponse[factoryvisualization.JoinResult] {
+			return Join(ctx, root, request)
+		})
+	},
+	ToolStopDrain: func(ctx context.Context, root factoryvisualization.Root, input json.RawMessage) (json.RawMessage, error) {
+		return callToolJSON(input, "decode stop_drain input", func(request StopDrainInput) ToolResponse[factoryvisualization.StopDrainResult] {
+			return StopDrain(ctx, root, request)
+		})
+	},
 }
 
 // IsCanonicalToolHandlerRegistered reports whether the live CallTool path

--- a/pkg/services/factory_visualization/transports/mcp/errors.go
+++ b/pkg/services/factory_visualization/transports/mcp/errors.go
@@ -1,0 +1,124 @@
+package factoryvisualization
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+)
+
+const (
+	errorCodeBadRequest           = "BAD_REQUEST"
+	errorCodeServiceUnavailable   = "factory_visualization.service.unavailable"
+	errorCodeRequestCanceled      = "factory_visualization.request.canceled"
+	errorCodeRequestTimedOut      = "factory_visualization.request.timed_out"
+	errorMessageServiceUnavailable = "factory visualization service is unavailable"
+	errorMessageRequestCanceled   = "factory visualization request was canceled"
+	errorMessageRequestTimedOut   = "factory visualization request timed out"
+)
+
+func requestContextErrorResponse[T any](ctx context.Context) (ToolResponse[T], bool) {
+	if envelope, ok := contextRequestErrorEnvelope(ctx.Err()); ok {
+		return ToolResponse[T]{Error: &envelope}, true
+	}
+	return ToolResponse[T]{}, false
+}
+
+func contextRequestErrorEnvelope(err error) (ToolErrorEnvelope, bool) {
+	if err == nil {
+		return ToolErrorEnvelope{}, false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return contextDeadlineExceededErrorEnvelope(), true
+	}
+	if errors.Is(err, context.Canceled) {
+		return contextCanceledErrorEnvelope(), true
+	}
+	return ToolErrorEnvelope{}, false
+}
+
+func contextCanceledErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeRequestCanceled,
+		Message:   errorMessageRequestCanceled,
+		Retryable: false,
+		Details: map[string]any{
+			"reason": "CANCELED",
+		},
+	}
+}
+
+func contextDeadlineExceededErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeRequestTimedOut,
+		Message:   errorMessageRequestTimedOut,
+		Retryable: true,
+		Details: map[string]any{
+			"reason": "TIMED_OUT",
+		},
+	}
+}
+
+func decodeInputErrorEnvelope(context string, err error) ToolErrorEnvelope {
+	message := context
+	details := map[string]any{}
+	if err != nil {
+		if trimmed := strings.TrimSpace(err.Error()); trimmed != "" {
+			message = context + ": " + trimmed
+		}
+		details["reason"] = err.Error()
+	}
+	return ToolErrorEnvelope{
+		Code:      errorCodeBadRequest,
+		Message:   message,
+		Retryable: false,
+		Details:   details,
+	}
+}
+
+func missingContextErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeBadRequest,
+		Message:   errMissingRequestContext.Error(),
+		Retryable: false,
+	}
+}
+
+func serviceUnavailableErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeServiceUnavailable,
+		Message:   errorMessageServiceUnavailable,
+		Retryable: false,
+	}
+}
+
+func requestValidationErrorEnvelope(message string) ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeBadRequest,
+		Message:   message,
+		Retryable: false,
+	}
+}
+
+func mapRootError(err error) ToolErrorEnvelope {
+	if envelope, ok := contextRequestErrorEnvelope(err); ok {
+		return envelope
+	}
+	var lifeErr *factoryvisualization.LifecycleError
+	if errors.As(err, &lifeErr) {
+		return ToolErrorEnvelope{
+			Code:      "factory_visualization.lifecycle." + strings.ToLower(string(lifeErr.Kind)),
+			Message:   lifeErr.Error(),
+			Retryable: false,
+			Details: map[string]any{
+				"kind": string(lifeErr.Kind),
+			},
+		}
+	}
+	return ToolErrorEnvelope{
+		Code:      errorCodeBadRequest,
+		Message:   strings.TrimSpace(err.Error()),
+		Retryable: false,
+	}
+}

--- a/pkg/services/factory_visualization/transports/mcp/errors.go
+++ b/pkg/services/factory_visualization/transports/mcp/errors.go
@@ -127,6 +127,17 @@ func mapRootError(err error) ToolErrorEnvelope {
 			},
 		}
 	}
+	var presErr *factoryvisualization.PresentationError
+	if errors.As(err, &presErr) {
+		return ToolErrorEnvelope{
+			Code:      "factory_visualization.presentation." + strings.ToLower(string(presErr.Kind)),
+			Message:   presErr.Error(),
+			Retryable: false,
+			Details: map[string]any{
+				"kind": string(presErr.Kind),
+			},
+		}
+	}
 	return ToolErrorEnvelope{
 		Code:      errorCodeBadRequest,
 		Message:   strings.TrimSpace(err.Error()),

--- a/pkg/services/factory_visualization/transports/mcp/errors.go
+++ b/pkg/services/factory_visualization/transports/mcp/errors.go
@@ -116,6 +116,17 @@ func mapRootError(err error) ToolErrorEnvelope {
 			},
 		}
 	}
+	var projErr *factoryvisualization.ProjectionError
+	if errors.As(err, &projErr) {
+		return ToolErrorEnvelope{
+			Code:      "factory_visualization.projection." + strings.ToLower(string(projErr.Kind)),
+			Message:   projErr.Error(),
+			Retryable: false,
+			Details: map[string]any{
+				"kind": string(projErr.Kind),
+			},
+		}
+	}
 	return ToolErrorEnvelope{
 		Code:      errorCodeBadRequest,
 		Message:   strings.TrimSpace(err.Error()),

--- a/pkg/services/factory_visualization/transports/mcp/lifecycle_test.go
+++ b/pkg/services/factory_visualization/transports/mcp/lifecycle_test.go
@@ -1,0 +1,163 @@
+package factoryvisualization_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	mcpfactoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/mcp"
+)
+
+func TestLifecycle_ActivateSuccessReturnsRootLifecycleState(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		activate: func(_ context.Context, request factoryvisualization.ActivateRequest) (factoryvisualization.ActivateResult, error) {
+			if request.Mode != factoryvisualization.ActivateModeRetainedThenLive {
+				t.Fatalf("mode = %q, want %q", request.Mode, factoryvisualization.ActivateModeRetainedThenLive)
+			}
+			return factoryvisualization.ActivateResult{State: factoryvisualization.LifecycleStateStarted}, nil
+		},
+	}
+	response := callLifecycleTool(t, fake, mcpfactoryvisualization.ToolActivate, `{"mode":"RETAINED_THEN_LIVE"}`)
+	assertLifecycleSuccessState(t, response, `"State":"STARTED"`)
+}
+
+func TestLifecycle_JoinSuccessReturnsRootLifecycleState(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		join: func(_ context.Context, _ factoryvisualization.JoinRequest) (factoryvisualization.JoinResult, error) {
+			return factoryvisualization.JoinResult{State: factoryvisualization.LifecycleStateStarted}, nil
+		},
+	}
+	response := callLifecycleTool(t, fake, mcpfactoryvisualization.ToolJoin, `{}`)
+	assertLifecycleSuccessState(t, response, `"State":"STARTED"`)
+}
+
+func TestLifecycle_StopDrainSuccessReturnsRootLifecycleState(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		stopDrain: func(_ context.Context, _ factoryvisualization.StopDrainRequest) (factoryvisualization.StopDrainResult, error) {
+			return factoryvisualization.StopDrainResult{State: factoryvisualization.LifecycleStateStopped}, nil
+		},
+	}
+	response := callLifecycleTool(t, fake, mcpfactoryvisualization.ToolStopDrain, `{}`)
+	assertLifecycleSuccessState(t, response, `"State":"STOPPED"`)
+}
+
+func TestLifecycle_ActivateMissingParametersReturnsTypedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		activate: func(_ context.Context, request factoryvisualization.ActivateRequest) (factoryvisualization.ActivateResult, error) {
+			if request.Mode != factoryvisualization.ActivateModeRetainedThenLive {
+				return factoryvisualization.ActivateResult{}, &factoryvisualization.LifecycleError{
+					Kind:    factoryvisualization.LifecycleErrorMissingParameters,
+					Message: "activate Factory visualization: required request parameters are missing",
+				}
+			}
+			return factoryvisualization.ActivateResult{State: factoryvisualization.LifecycleStateStarted}, nil
+		},
+	}
+	response := callLifecycleTool(t, fake, mcpfactoryvisualization.ToolActivate, `{"mode":"UNSUPPORTED"}`)
+	assertLifecycleErrorEnvelope(t, response, "factory_visualization.lifecycle.missing_parameters", false)
+}
+
+func TestLifecycle_ActivateAlreadyActivatedReturnsTypedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		activate: func(context.Context, factoryvisualization.ActivateRequest) (factoryvisualization.ActivateResult, error) {
+			return factoryvisualization.ActivateResult{}, &factoryvisualization.LifecycleError{
+				Kind:    factoryvisualization.LifecycleErrorAlreadyActivated,
+				Message: "Factory visualization is already activated",
+			}
+		},
+	}
+	response := callLifecycleTool(t, fake, mcpfactoryvisualization.ToolActivate, `{"mode":"RETAINED_THEN_LIVE"}`)
+	assertLifecycleErrorEnvelope(t, response, "factory_visualization.lifecycle.already_activated", false)
+}
+
+func TestLifecycle_JoinNotActivatedReturnsTypedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		join: func(context.Context, factoryvisualization.JoinRequest) (factoryvisualization.JoinResult, error) {
+			return factoryvisualization.JoinResult{}, &factoryvisualization.LifecycleError{
+				Kind:    factoryvisualization.LifecycleErrorNotActivated,
+				Message: "Factory visualization is not activated",
+			}
+		},
+	}
+	response := callLifecycleTool(t, fake, mcpfactoryvisualization.ToolJoin, `{}`)
+	assertLifecycleErrorEnvelope(t, response, "factory_visualization.lifecycle.not_activated", false)
+}
+
+func TestLifecycle_MalformedJSONReturnsDecodeErrorWithoutInvokingRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := fakeVisualizationRoot{invoked: &invoked}
+	operation := mcpfactoryvisualization.Bind(mcpfactoryvisualization.RootDependencies{Root: fake})
+
+	raw, err := operation(context.Background(), mcpfactoryvisualization.ToolActivate, json.RawMessage(`{"mode":`))
+	if err != nil {
+		t.Fatalf("CallTool(activate) transport error = %v, want JSON response envelope", err)
+	}
+	if invoked {
+		t.Fatal("fake visualization root was invoked for malformed activate input")
+	}
+	assertLifecycleErrorEnvelope(t, string(raw), "BAD_REQUEST", false)
+	if !strings.Contains(string(raw), "decode activate input") {
+		t.Fatalf("malformed activate response = %s, want decode error message", raw)
+	}
+}
+
+func callLifecycleTool(t *testing.T, fake fakeVisualizationRoot, toolName string, input string) string {
+	t.Helper()
+
+	operation := mcpfactoryvisualization.Bind(mcpfactoryvisualization.RootDependencies{Root: fake})
+	raw, err := operation(context.Background(), toolName, json.RawMessage(input))
+	if err != nil {
+		t.Fatalf("CallTool(%s) error = %v", toolName, err)
+	}
+	return string(raw)
+}
+
+func assertLifecycleSuccessState(t *testing.T, response string, wantStateFragment string) {
+	t.Helper()
+
+	if strings.Contains(response, `"error"`) {
+		t.Fatalf("lifecycle success response = %s, want result without error envelope", response)
+	}
+	if !strings.Contains(response, wantStateFragment) {
+		t.Fatalf("lifecycle success response = %s, want state fragment %q", response, wantStateFragment)
+	}
+}
+
+func assertLifecycleErrorEnvelope(t *testing.T, response string, wantCode string, wantRetryable bool) {
+	t.Helper()
+
+	var envelope struct {
+		Error *mcpfactoryvisualization.ToolErrorEnvelope `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(response), &envelope); err != nil {
+		t.Fatalf("unmarshal lifecycle response: %v\nresponse=%s", err, response)
+	}
+	if envelope.Error == nil {
+		t.Fatalf("lifecycle response = %s, want error envelope", response)
+	}
+	if envelope.Error.Code != wantCode {
+		t.Fatalf("error code = %q, want %q", envelope.Error.Code, wantCode)
+	}
+	if envelope.Error.Retryable != wantRetryable {
+		t.Fatalf("error retryable = %v, want %v", envelope.Error.Retryable, wantRetryable)
+	}
+	if strings.TrimSpace(envelope.Error.Message) == "" {
+		t.Fatal("error message is required")
+	}
+}

--- a/pkg/services/factory_visualization/transports/mcp/manifest_registration_test.go
+++ b/pkg/services/factory_visualization/transports/mcp/manifest_registration_test.go
@@ -1,0 +1,144 @@
+package factoryvisualization_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/ownershipinventory"
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+const (
+	mcpAdapterPackagePath = "pkg/services/factory_visualization/transports/mcp"
+	mcpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/mcp"
+	factoryVisualizationOwner = "factory_visualization"
+)
+
+type coverageMinimumManifest struct {
+	Lane     string `json:"lane"`
+	Packages []struct {
+		Package string  `json:"package"`
+		Minimum float64 `json:"minimum"`
+	} `json:"packages"`
+}
+
+func TestManifestRegistration_MCPAdapterPackageIsRegistered(t *testing.T) {
+	t.Helper()
+
+	assertPackageTargetManifestRegistration(t)
+	assertOwnershipInventoryRegistration(t)
+	assertCoverageMinimumRegistration(t, "unit", "docs/internal/baselines/go-unit-coverage-package-minimums.json")
+	assertCoverageMinimumRegistration(t, "functional", "docs/internal/baselines/go-functional-coverage-package-minimums.json")
+}
+
+func assertPackageTargetManifestRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, "docs/internal/packaged-service-structure/package-target-manifest.json"))
+	if err != nil {
+		t.Fatalf("read package-target manifest: %v", err)
+	}
+
+	var manifest struct {
+		Inventory []string `json:"inventory"`
+		Packages  []struct {
+			PackagePath string `json:"packagePath"`
+			Disposition string `json:"disposition"`
+			Destination string `json:"destination"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode package-target manifest: %v", err)
+	}
+
+	foundInventory := false
+	for _, packagePath := range manifest.Inventory {
+		if packagePath == mcpAdapterPackagePath {
+			foundInventory = true
+			break
+		}
+	}
+	if !foundInventory {
+		t.Fatalf("package-target manifest inventory missing %q", mcpAdapterPackagePath)
+	}
+
+	for _, row := range manifest.Packages {
+		if row.PackagePath != mcpAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("package-target manifest disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != factoryVisualizationOwner {
+			t.Fatalf("package-target manifest destination = %q, want %q", row.Destination, factoryVisualizationOwner)
+		}
+		return
+	}
+	t.Fatalf("package-target manifest packages missing %q", mcpAdapterPackagePath)
+}
+
+func assertOwnershipInventoryRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, ownershipinventory.InventoryRelativePath))
+	if err != nil {
+		t.Fatalf("read ownership inventory: %v", err)
+	}
+
+	var inventory struct {
+		Packages []ownershipinventory.PackageRow `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		t.Fatalf("decode ownership inventory: %v", err)
+	}
+
+	for _, row := range inventory.Packages {
+		if row.PackagePath != mcpAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("ownership inventory disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != factoryVisualizationOwner {
+			t.Fatalf("ownership inventory destination = %q, want %q", row.Destination, factoryVisualizationOwner)
+		}
+		if row.DestinationKind != ownershipinventory.DestinationKindOwner {
+			t.Fatalf(
+				"ownership inventory destinationKind = %q, want %q",
+				row.DestinationKind,
+				ownershipinventory.DestinationKindOwner,
+			)
+		}
+		return
+	}
+	t.Fatalf("ownership inventory packages missing %q", mcpAdapterPackagePath)
+}
+
+func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, relativePath))
+	if err != nil {
+		t.Fatalf("read %s coverage manifest: %v", lane, err)
+	}
+
+	var manifest coverageMinimumManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode %s coverage manifest: %v", lane, err)
+	}
+	if manifest.Lane != lane {
+		t.Fatalf("%s coverage manifest lane = %q, want %q", relativePath, manifest.Lane, lane)
+	}
+
+	for _, entry := range manifest.Packages {
+		if entry.Package != mcpAdapterImportPath {
+			continue
+		}
+		if entry.Minimum < 0 {
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterImportPath)
+		}
+		return
+	}
+	t.Fatalf("%s coverage manifest missing %q", lane, mcpAdapterImportPath)
+}

--- a/pkg/services/factory_visualization/transports/mcp/manifest_registration_test.go
+++ b/pkg/services/factory_visualization/transports/mcp/manifest_registration_test.go
@@ -18,8 +18,11 @@ const (
 type coverageMinimumManifest struct {
 	Lane     string `json:"lane"`
 	Packages []struct {
-		Package string  `json:"package"`
-		Minimum float64 `json:"minimum"`
+		Package   string  `json:"package"`
+		Minimum   float64 `json:"minimum"`
+		Exception *struct {
+			Kind string `json:"kind"`
+		} `json:"exception"`
 	} `json:"packages"`
 }
 
@@ -134,6 +137,12 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	for _, entry := range manifest.Packages {
 		if entry.Package != mcpAdapterImportPath {
 			continue
+		}
+		if entry.Exception != nil {
+			if entry.Exception.Kind != "measurement" {
+				t.Fatalf("%s coverage exception kind for %q = %q, want measurement", lane, mcpAdapterImportPath, entry.Exception.Kind)
+			}
+			return
 		}
 		if entry.Minimum < 0 {
 			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterImportPath)

--- a/pkg/services/factory_visualization/transports/mcp/observe_test.go
+++ b/pkg/services/factory_visualization/transports/mcp/observe_test.go
@@ -1,0 +1,216 @@
+package factoryvisualization_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	mcpfactoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/mcp"
+)
+
+func TestObserve_SuccessReturnsRootProjectedView(t *testing.T) {
+	t.Parallel()
+
+	observedAt := time.Date(2026, 7, 28, 2, 0, 0, 0, time.UTC)
+	afterSequence := 7
+	fake := fakeVisualizationRoot{
+		observe: func(_ context.Context, request factoryvisualization.ObserveRequest) (factoryvisualization.ObserveResult, error) {
+			if request.Mode != factoryvisualization.ObserveModeRetainedThenLive {
+				t.Fatalf("mode = %q, want %q", request.Mode, factoryvisualization.ObserveModeRetainedThenLive)
+			}
+			if request.Reconnect == nil || request.Reconnect.AfterEventID != "evt-1" || request.Reconnect.AfterSequence == nil || *request.Reconnect.AfterSequence != afterSequence {
+				t.Fatalf("reconnect = %#v, want afterEventId evt-1 and afterSequence 7", request.Reconnect)
+			}
+			return factoryvisualization.ObserveResult{
+				View: factoryvisualization.ProjectedView{
+					TickCount:          9,
+					RetainedEventCount: 1,
+					ObservedAt:         observedAt,
+				},
+			}, nil
+		},
+	}
+	response := callObserveTool(t, fake, `{"mode":"RETAINED_THEN_LIVE","reconnect":{"afterEventId":"evt-1","afterSequence":7}}`)
+	assertObserveSuccessView(t, response, `"TickCount":9`, `"RetainedEventCount":1`, `"ObservedAt":"2026-07-28T02:00:00Z"`)
+}
+
+func TestObserve_InvalidInputReturnsTypedProjectionEnvelope(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		observe: func(context.Context, factoryvisualization.ObserveRequest) (factoryvisualization.ObserveResult, error) {
+			return factoryvisualization.ObserveResult{}, &factoryvisualization.ProjectionError{
+				Kind:    factoryvisualization.ProjectionErrorInvalidInput,
+				Message: "observe Factory visualization: required request parameters are missing",
+			}
+		},
+	}
+	response := callObserveTool(t, fake, `{"mode":"RETAINED_THEN_LIVE"}`)
+	assertObserveErrorEnvelope(t, response, "factory_visualization.projection.invalid_input", false)
+}
+
+func TestObserve_SnapshotUnavailableReturnsTypedProjectionEnvelope(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		observe: func(context.Context, factoryvisualization.ObserveRequest) (factoryvisualization.ObserveResult, error) {
+			return factoryvisualization.ObserveResult{}, &factoryvisualization.ProjectionError{
+				Kind:    factoryvisualization.ProjectionErrorSnapshotUnavailable,
+				Message: "observe Factory visualization: retained snapshot is unavailable",
+			}
+		},
+	}
+	response := callObserveTool(t, fake, `{"mode":"RETAINED_THEN_LIVE"}`)
+	assertObserveErrorEnvelope(t, response, "factory_visualization.projection.snapshot_unavailable", false)
+}
+
+func TestObserve_ReconstructionFailedReturnsTypedProjectionEnvelope(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		observe: func(context.Context, factoryvisualization.ObserveRequest) (factoryvisualization.ObserveResult, error) {
+			return factoryvisualization.ObserveResult{}, &factoryvisualization.ProjectionError{
+				Kind:    factoryvisualization.ProjectionErrorReconstructionFailed,
+				Message: "observe Factory visualization: retained history reconstruction failed",
+			}
+		},
+	}
+	response := callObserveTool(t, fake, `{"mode":"RETAINED_THEN_LIVE"}`)
+	assertObserveErrorEnvelope(t, response, "factory_visualization.projection.reconstruction_failed", false)
+}
+
+func TestObserve_ProjectionErrorsAreDistinguishableFromLifecycleErrors(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		observe: func(context.Context, factoryvisualization.ObserveRequest) (factoryvisualization.ObserveResult, error) {
+			return factoryvisualization.ObserveResult{}, &factoryvisualization.ProjectionError{
+				Kind:    factoryvisualization.ProjectionErrorSnapshotUnavailable,
+				Message: "observe Factory visualization: retained snapshot is unavailable",
+			}
+		},
+	}
+	response := callObserveTool(t, fake, `{"mode":"RETAINED_THEN_LIVE"}`)
+	if strings.Contains(response, "factory_visualization.lifecycle.") {
+		t.Fatalf("projection failure response = %s, want projection error code prefix", response)
+	}
+	assertObserveErrorEnvelope(t, response, "factory_visualization.projection.snapshot_unavailable", false)
+}
+
+func TestObserve_MalformedJSONReturnsDecodeErrorWithoutInvokingRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := fakeVisualizationRoot{invoked: &invoked}
+	operation := mcpfactoryvisualization.Bind(mcpfactoryvisualization.RootDependencies{Root: fake})
+
+	raw, err := operation(context.Background(), mcpfactoryvisualization.ToolObserve, json.RawMessage(`{"mode":`))
+	if err != nil {
+		t.Fatalf("CallTool(observe) transport error = %v, want JSON response envelope", err)
+	}
+	if invoked {
+		t.Fatal("fake visualization root was invoked for malformed observe input")
+	}
+	assertObserveErrorEnvelope(t, string(raw), "BAD_REQUEST", false)
+	if !strings.Contains(string(raw), "decode observe input") {
+		t.Fatalf("malformed observe response = %s, want decode error message", raw)
+	}
+}
+
+func TestObserve_SuccessEncodesAsSerializedJSONCallToolResult(t *testing.T) {
+	t.Parallel()
+
+	observedAt := time.Date(2026, 7, 28, 2, 0, 0, 0, time.UTC)
+	fake := fakeVisualizationRoot{
+		observe: func(context.Context, factoryvisualization.ObserveRequest) (factoryvisualization.ObserveResult, error) {
+			return factoryvisualization.ObserveResult{
+				View: factoryvisualization.ProjectedView{
+					TickCount:          3,
+					RetainedEventCount: 2,
+					ObservedAt:         observedAt,
+				},
+			}, nil
+		},
+	}
+	toolResponse := json.RawMessage(callObserveTool(t, fake, `{"mode":"RETAINED_THEN_LIVE"}`))
+	callToolResult, err := mcpfactoryvisualization.MarshalSuccessCallToolResultJSON(toolResponse)
+	if err != nil {
+		t.Fatalf("MarshalSuccessCallToolResultJSON() error = %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(callToolResult, &decoded); err != nil {
+		t.Fatalf("unmarshal callToolResult: %v", err)
+	}
+	content, ok := decoded["content"].([]any)
+	if !ok || len(content) != 1 {
+		t.Fatalf("callToolResult content = %#v, want one text item", decoded["content"])
+	}
+	item, ok := content[0].(map[string]any)
+	if !ok {
+		t.Fatalf("content[0] = %#v, want object", content[0])
+	}
+	if item["type"] != "text" {
+		t.Fatalf("content type = %v, want text", item["type"])
+	}
+	text, ok := item["text"].(string)
+	if !ok {
+		t.Fatalf("content text = %#v, want string", item["text"])
+	}
+	if text != string(toolResponse) {
+		t.Fatalf("content text = %s, want serialized tool response %s", text, toolResponse)
+	}
+	if _, hasError := decoded["isError"]; hasError {
+		t.Fatalf("callToolResult = %s, want success envelope without isError", callToolResult)
+	}
+}
+
+func callObserveTool(t *testing.T, fake fakeVisualizationRoot, input string) string {
+	t.Helper()
+
+	operation := mcpfactoryvisualization.Bind(mcpfactoryvisualization.RootDependencies{Root: fake})
+	raw, err := operation(context.Background(), mcpfactoryvisualization.ToolObserve, json.RawMessage(input))
+	if err != nil {
+		t.Fatalf("CallTool(observe) error = %v", err)
+	}
+	return string(raw)
+}
+
+func assertObserveSuccessView(t *testing.T, response string, wantFragments ...string) {
+	t.Helper()
+
+	if strings.Contains(response, `"error"`) {
+		t.Fatalf("observe success response = %s, want result without error envelope", response)
+	}
+	for _, fragment := range wantFragments {
+		if !strings.Contains(response, fragment) {
+			t.Fatalf("observe success response = %s, want fragment %q", response, fragment)
+		}
+	}
+}
+
+func assertObserveErrorEnvelope(t *testing.T, response string, wantCode string, wantRetryable bool) {
+	t.Helper()
+
+	var envelope struct {
+		Error *mcpfactoryvisualization.ToolErrorEnvelope `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(response), &envelope); err != nil {
+		t.Fatalf("unmarshal observe response: %v\nresponse=%s", err, response)
+	}
+	if envelope.Error == nil {
+		t.Fatalf("observe response = %s, want error envelope", response)
+	}
+	if envelope.Error.Code != wantCode {
+		t.Fatalf("error code = %q, want %q", envelope.Error.Code, wantCode)
+	}
+	if envelope.Error.Retryable != wantRetryable {
+		t.Fatalf("error retryable = %v, want %v", envelope.Error.Retryable, wantRetryable)
+	}
+	if strings.TrimSpace(envelope.Error.Message) == "" {
+		t.Fatal("error message is required")
+	}
+}

--- a/pkg/services/factory_visualization/transports/mcp/presentation_test.go
+++ b/pkg/services/factory_visualization/transports/mcp/presentation_test.go
@@ -1,0 +1,240 @@
+package factoryvisualization_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	mcpfactoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/mcp"
+)
+
+func TestPresentation_OpenPresentationSuccessReturnsSessionIdentity(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		openPresentation: func(_ context.Context, request factoryvisualization.OpenPresentationRequest) (factoryvisualization.OpenPresentationResult, error) {
+			if request.Mode != factoryvisualization.PresentationDeliveryBestEffort {
+				t.Fatalf("mode = %q, want %q", request.Mode, factoryvisualization.PresentationDeliveryBestEffort)
+			}
+			return factoryvisualization.OpenPresentationResult{
+				SessionID: "presentation-1",
+				Mode:      factoryvisualization.PresentationDeliveryBestEffort,
+			}, nil
+		},
+	}
+	response := callPresentationTool(t, fake, mcpfactoryvisualization.ToolOpenPresentation, `{"mode":"BEST_EFFORT"}`)
+	assertPresentationSuccess(t, response, `"SessionID":"presentation-1"`, `"Mode":"BEST_EFFORT"`)
+}
+
+func TestPresentation_PresentProgressSuccessReturnsAcceptedCount(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		presentProgress: func(_ context.Context, request factoryvisualization.PresentProgressRequest) (factoryvisualization.PresentProgressResult, error) {
+			if request.SessionID != "presentation-1" {
+				t.Fatalf("session id = %q, want presentation-1", request.SessionID)
+			}
+			if len(request.Records) != 2 || string(request.Records[0].Payload) != "one" || string(request.Records[1].Payload) != "two" {
+				t.Fatalf("records = %#v, want decoded one and two payloads", request.Records)
+			}
+			return factoryvisualization.PresentProgressResult{AcceptedCount: 2}, nil
+		},
+	}
+	input := `{"sessionId":"presentation-1","records":[{"payload":"` + base64.StdEncoding.EncodeToString([]byte("one")) + `"},{"payload":"` + base64.StdEncoding.EncodeToString([]byte("two")) + `"}]}`
+	response := callPresentationTool(t, fake, mcpfactoryvisualization.ToolPresentProgress, input)
+	assertPresentationSuccess(t, response, `"AcceptedCount":2`)
+}
+
+func TestPresentation_FinalizePresentationSuccessReturnsOutcome(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		finalizePresentation: func(_ context.Context, request factoryvisualization.FinalizePresentationRequest) (factoryvisualization.FinalizePresentationResult, error) {
+			if request.SessionID != "presentation-1" {
+				t.Fatalf("session id = %q, want presentation-1", request.SessionID)
+			}
+			if request.Terminal == nil || string(request.Terminal.Payload) != "done" {
+				t.Fatalf("terminal = %#v, want done payload", request.Terminal)
+			}
+			return factoryvisualization.FinalizePresentationResult{
+				Finalized:    true,
+				ProgressSeen: true,
+			}, nil
+		},
+	}
+	input := `{"sessionId":"presentation-1","terminal":{"payload":"` + base64.StdEncoding.EncodeToString([]byte("done")) + `"}}`
+	response := callPresentationTool(t, fake, mcpfactoryvisualization.ToolFinalizePresentation, input)
+	assertPresentationSuccess(t, response, `"Finalized":true`, `"ProgressSeen":true`)
+}
+
+func TestPresentation_ClosePresentationSuccessReturnsDroppedCount(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		closePresentation: func(_ context.Context, request factoryvisualization.ClosePresentationRequest) (factoryvisualization.ClosePresentationResult, error) {
+			if request.SessionID != "presentation-1" {
+				t.Fatalf("session id = %q, want presentation-1", request.SessionID)
+			}
+			return factoryvisualization.ClosePresentationResult{DroppedCount: 3}, nil
+		},
+	}
+	response := callPresentationTool(t, fake, mcpfactoryvisualization.ToolClosePresentation, `{"sessionId":"presentation-1"}`)
+	assertPresentationSuccess(t, response, `"DroppedCount":3`)
+}
+
+func TestPresentation_EnqueueAfterCloseReturnsTypedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		presentProgress: func(context.Context, factoryvisualization.PresentProgressRequest) (factoryvisualization.PresentProgressResult, error) {
+			return factoryvisualization.PresentProgressResult{}, &factoryvisualization.PresentationError{
+				Kind:    factoryvisualization.PresentationErrorEnqueueAfterClose,
+				Message: "present Factory visualization progress: presentation output is closed",
+			}
+		},
+	}
+	input := `{"sessionId":"presentation-1","records":[{"payload":"` + base64.StdEncoding.EncodeToString([]byte("late")) + `"}]}`
+	response := callPresentationTool(t, fake, mcpfactoryvisualization.ToolPresentProgress, input)
+	assertPresentationErrorEnvelope(t, response, "factory_visualization.presentation.enqueue_after_close", false)
+}
+
+func TestPresentation_FinalizeWithoutWriterReturnsTypedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		finalizePresentation: func(context.Context, factoryvisualization.FinalizePresentationRequest) (factoryvisualization.FinalizePresentationResult, error) {
+			return factoryvisualization.FinalizePresentationResult{}, &factoryvisualization.PresentationError{
+				Kind:    factoryvisualization.PresentationErrorFinalizeWithoutWriter,
+				Message: "finalize Factory visualization presentation: terminal writer is required",
+			}
+		},
+	}
+	response := callPresentationTool(t, fake, mcpfactoryvisualization.ToolFinalizePresentation, `{"sessionId":"presentation-1"}`)
+	assertPresentationErrorEnvelope(t, response, "factory_visualization.presentation.finalize_without_writer", false)
+}
+
+func TestPresentation_BackpressureRejectedReturnsTypedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		presentProgress: func(context.Context, factoryvisualization.PresentProgressRequest) (factoryvisualization.PresentProgressResult, error) {
+			return factoryvisualization.PresentProgressResult{AcceptedCount: 1}, &factoryvisualization.PresentationError{
+				Kind:    factoryvisualization.PresentationErrorBackpressureRejected,
+				Message: "present Factory visualization progress: best-effort backlog rejected record",
+			}
+		},
+	}
+	input := `{"sessionId":"presentation-1","records":[{"payload":"` + base64.StdEncoding.EncodeToString([]byte("overflow")) + `"}]}`
+	response := callPresentationTool(t, fake, mcpfactoryvisualization.ToolPresentProgress, input)
+	assertPresentationErrorEnvelope(t, response, "factory_visualization.presentation.backpressure_rejected", false)
+}
+
+func TestPresentation_ErrorsAreDistinguishableFromLifecycleAndProjectionFailures(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		presentProgress: func(context.Context, factoryvisualization.PresentProgressRequest) (factoryvisualization.PresentProgressResult, error) {
+			return factoryvisualization.PresentProgressResult{}, &factoryvisualization.PresentationError{
+				Kind:    factoryvisualization.PresentationErrorEnqueueAfterClose,
+				Message: "present Factory visualization progress: presentation output is closed",
+			}
+		},
+	}
+	input := `{"sessionId":"presentation-1","records":[{"payload":"` + base64.StdEncoding.EncodeToString([]byte("late")) + `"}]}`
+	response := callPresentationTool(t, fake, mcpfactoryvisualization.ToolPresentProgress, input)
+	if strings.Contains(response, "factory_visualization.lifecycle.") || strings.Contains(response, "factory_visualization.projection.") {
+		t.Fatalf("presentation failure response = %s, want presentation error code prefix", response)
+	}
+	assertPresentationErrorEnvelope(t, response, "factory_visualization.presentation.enqueue_after_close", false)
+}
+
+func TestPresentation_MalformedJSONReturnsDecodeErrorWithoutInvokingRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := fakeVisualizationRoot{invoked: &invoked}
+	operation := mcpfactoryvisualization.Bind(mcpfactoryvisualization.RootDependencies{Root: fake})
+
+	raw, err := operation(context.Background(), mcpfactoryvisualization.ToolOpenPresentation, json.RawMessage(`{"mode":`))
+	if err != nil {
+		t.Fatalf("CallTool(open_presentation) transport error = %v, want JSON response envelope", err)
+	}
+	if invoked {
+		t.Fatal("fake visualization root was invoked for malformed open_presentation input")
+	}
+	assertPresentationErrorEnvelope(t, string(raw), "BAD_REQUEST", false)
+	if !strings.Contains(string(raw), "decode open_presentation input") {
+		t.Fatalf("malformed open_presentation response = %s, want decode error message", raw)
+	}
+}
+
+func TestPresentation_InvalidBase64PayloadReturnsDecodeErrorWithoutInvokingRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := fakeVisualizationRoot{
+		invoked: &invoked,
+		presentProgress: func(context.Context, factoryvisualization.PresentProgressRequest) (factoryvisualization.PresentProgressResult, error) {
+			t.Fatal("fake visualization root should not be invoked for invalid base64 payload")
+			return factoryvisualization.PresentProgressResult{}, nil
+		},
+	}
+	response := callPresentationTool(t, fake, mcpfactoryvisualization.ToolPresentProgress, `{"sessionId":"presentation-1","records":[{"payload":"not-base64!!!"}]}`)
+	if invoked {
+		t.Fatal("fake visualization root was invoked for invalid base64 payload")
+	}
+	assertPresentationErrorEnvelope(t, response, "BAD_REQUEST", false)
+	if !strings.Contains(response, "decode present progress payload") {
+		t.Fatalf("invalid base64 response = %s, want decode error message", response)
+	}
+}
+
+func callPresentationTool(t *testing.T, fake fakeVisualizationRoot, toolName string, input string) string {
+	t.Helper()
+
+	operation := mcpfactoryvisualization.Bind(mcpfactoryvisualization.RootDependencies{Root: fake})
+	raw, err := operation(context.Background(), toolName, json.RawMessage(input))
+	if err != nil {
+		t.Fatalf("CallTool(%s) error = %v", toolName, err)
+	}
+	return string(raw)
+}
+
+func assertPresentationSuccess(t *testing.T, response string, wantFragments ...string) {
+	t.Helper()
+
+	if strings.Contains(response, `"error"`) {
+		t.Fatalf("presentation success response = %s, want result without error envelope", response)
+	}
+	for _, fragment := range wantFragments {
+		if !strings.Contains(response, fragment) {
+			t.Fatalf("presentation success response = %s, want fragment %q", response, fragment)
+		}
+	}
+}
+
+func assertPresentationErrorEnvelope(t *testing.T, response string, wantCode string, wantRetryable bool) {
+	t.Helper()
+
+	var envelope struct {
+		Error *mcpfactoryvisualization.ToolErrorEnvelope `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(response), &envelope); err != nil {
+		t.Fatalf("unmarshal presentation response: %v\nresponse=%s", err, response)
+	}
+	if envelope.Error == nil {
+		t.Fatalf("presentation response = %s, want error envelope", response)
+	}
+	if envelope.Error.Code != wantCode {
+		t.Fatalf("error code = %q, want %q", envelope.Error.Code, wantCode)
+	}
+	if envelope.Error.Retryable != wantRetryable {
+		t.Fatalf("error retryable = %v, want %v", envelope.Error.Retryable, wantRetryable)
+	}
+	if strings.TrimSpace(envelope.Error.Message) == "" {
+		t.Fatal("error message is required")
+	}
+}

--- a/pkg/services/factory_visualization/transports/mcp/registry.go
+++ b/pkg/services/factory_visualization/transports/mcp/registry.go
@@ -1,0 +1,173 @@
+package factoryvisualization
+
+import (
+	"encoding/json"
+)
+
+// Stable error envelope fields shared by every Visualization MCP tool.
+var sharedErrorStableFields = []string{
+	"error.code",
+	"error.message",
+	"error.retryable",
+	"error.details",
+}
+
+// ToolDefinition is one discoverable MCP tool with typed schemas and documented
+// stable response fields for success and error envelopes.
+type ToolDefinition struct {
+	Name                string         `json:"name"`
+	Description         string         `json:"description"`
+	InputSchema         map[string]any `json:"inputSchema"`
+	OutputSchema        map[string]any `json:"outputSchema"`
+	SuccessStableFields []string       `json:"successStableFields"`
+	ErrorStableFields   []string       `json:"errorStableFields"`
+}
+
+// MarshalJSON encodes one tool definition for MCP hosts and mock clients.
+func (t ToolDefinition) MarshalJSON() ([]byte, error) {
+	type alias ToolDefinition
+	return json.Marshal(alias(t))
+}
+
+// DiscoverTools returns the canonical Factory Visualization MCP tool catalog
+// in stable discovery order.
+func DiscoverTools() []ToolDefinition {
+	return []ToolDefinition{
+		activateTool(),
+		joinTool(),
+		stopDrainTool(),
+		observeTool(),
+		openPresentationTool(),
+		presentProgressTool(),
+		finalizePresentationTool(),
+		closePresentationTool(),
+	}
+}
+
+// ToolNames returns stable canonical tool names in discovery order.
+func ToolNames() []string {
+	tools := DiscoverTools()
+	names := make([]string, len(tools))
+	for i, tool := range tools {
+		names[i] = tool.Name
+	}
+	return names
+}
+
+// ToolByName returns one canonical tool definition by stable name.
+func ToolByName(name string) (ToolDefinition, bool) {
+	for _, tool := range DiscoverTools() {
+		if tool.Name == name {
+			return tool, true
+		}
+	}
+	return ToolDefinition{}, false
+}
+
+func activateTool() ToolDefinition {
+	return ToolDefinition{
+		Name:        ToolActivate,
+		Description: "Activate Factory Visualization through retained-then-live projection and leave the inert constructed state.",
+		InputSchema: activateInputSchema(),
+		OutputSchema: toolResponseSchema(activateResultSchema()),
+		SuccessStableFields: []string{
+			"result.State",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}
+
+func joinTool() ToolDefinition {
+	return ToolDefinition{
+		Name:        ToolJoin,
+		Description: "Join the Visualization live subscription and wait for it to exit after Activate.",
+		InputSchema: joinInputSchema(),
+		OutputSchema: toolResponseSchema(joinResultSchema()),
+		SuccessStableFields: []string{
+			"result.State",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}
+
+func stopDrainTool() ToolDefinition {
+	return ToolDefinition{
+		Name:        ToolStopDrain,
+		Description: "Stop the Visualization live subscription and drain one final projected view through the Visualization-owned drain path.",
+		InputSchema: stopDrainInputSchema(),
+		OutputSchema: toolResponseSchema(stopDrainResultSchema()),
+		SuccessStableFields: []string{
+			"result.State",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}
+
+func observeTool() ToolDefinition {
+	return ToolDefinition{
+		Name:        ToolObserve,
+		Description: "Observe one detached retained-then-live Factory view projection through Visualization-owned plain contracts.",
+		InputSchema: observeInputSchema(),
+		OutputSchema: toolResponseSchema(observeResultSchema()),
+		SuccessStableFields: []string{
+			"result.View.TickCount",
+			"result.View.RetainedEventCount",
+			"result.View.ObservedAt",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}
+
+func openPresentationTool() ToolDefinition {
+	return ToolDefinition{
+		Name:        ToolOpenPresentation,
+		Description: "Open one Visualization-owned presentation session using best-effort or lossless drain policy.",
+		InputSchema: openPresentationInputSchema(),
+		OutputSchema: toolResponseSchema(openPresentationResultSchema()),
+		SuccessStableFields: []string{
+			"result.SessionID",
+			"result.Mode",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}
+
+func presentProgressTool() ToolDefinition {
+	return ToolDefinition{
+		Name:        ToolPresentProgress,
+		Description: "Enqueue ordered progress records onto an opened Visualization presentation session.",
+		InputSchema: presentProgressInputSchema(),
+		OutputSchema: toolResponseSchema(presentProgressResultSchema()),
+		SuccessStableFields: []string{
+			"result.AcceptedCount",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}
+
+func finalizePresentationTool() ToolDefinition {
+	return ToolDefinition{
+		Name:        ToolFinalizePresentation,
+		Description: "Finalize one Visualization presentation session after draining accepted progress and committing a terminal write.",
+		InputSchema: finalizePresentationInputSchema(),
+		OutputSchema: toolResponseSchema(finalizePresentationResultSchema()),
+		SuccessStableFields: []string{
+			"result.Finalized",
+			"result.ProgressSeen",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}
+
+func closePresentationTool() ToolDefinition {
+	return ToolDefinition{
+		Name:        ToolClosePresentation,
+		Description: "Close and drain one Visualization presentation session without committing a terminal write.",
+		InputSchema: closePresentationInputSchema(),
+		OutputSchema: toolResponseSchema(closePresentationResultSchema()),
+		SuccessStableFields: []string{
+			"result.DroppedCount",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}

--- a/pkg/services/factory_visualization/transports/mcp/registry_test.go
+++ b/pkg/services/factory_visualization/transports/mcp/registry_test.go
@@ -130,7 +130,7 @@ func TestToolByName_UnknownToolReturnsFalse(t *testing.T) {
 	}
 }
 
-func TestIsCanonicalToolHandlerRegistered_LifecycleAndObserveToolsAreRegistered(t *testing.T) {
+func TestIsCanonicalToolHandlerRegistered_AllVisualizationToolsAreRegistered(t *testing.T) {
 	t.Parallel()
 
 	for _, name := range []string{
@@ -138,19 +138,13 @@ func TestIsCanonicalToolHandlerRegistered_LifecycleAndObserveToolsAreRegistered(
 		mcpfactoryvisualization.ToolJoin,
 		mcpfactoryvisualization.ToolStopDrain,
 		mcpfactoryvisualization.ToolObserve,
-	} {
-		if !mcpfactoryvisualization.IsCanonicalToolHandlerRegistered(name) {
-			t.Fatalf("handler for %q should be registered", name)
-		}
-	}
-	for _, name := range []string{
 		mcpfactoryvisualization.ToolOpenPresentation,
 		mcpfactoryvisualization.ToolPresentProgress,
 		mcpfactoryvisualization.ToolFinalizePresentation,
 		mcpfactoryvisualization.ToolClosePresentation,
 	} {
-		if mcpfactoryvisualization.IsCanonicalToolHandlerRegistered(name) {
-			t.Fatalf("handler for %q should not be registered yet", name)
+		if !mcpfactoryvisualization.IsCanonicalToolHandlerRegistered(name) {
+			t.Fatalf("handler for %q should be registered", name)
 		}
 	}
 }

--- a/pkg/services/factory_visualization/transports/mcp/registry_test.go
+++ b/pkg/services/factory_visualization/transports/mcp/registry_test.go
@@ -130,15 +130,19 @@ func TestToolByName_UnknownToolReturnsFalse(t *testing.T) {
 	}
 }
 
-func TestIsCanonicalToolHandlerRegistered_OnlyActivateIsRegistered(t *testing.T) {
+func TestIsCanonicalToolHandlerRegistered_LifecycleToolsAreRegistered(t *testing.T) {
 	t.Parallel()
 
-	if !mcpfactoryvisualization.IsCanonicalToolHandlerRegistered(mcpfactoryvisualization.ToolActivate) {
-		t.Fatal("activate handler should be registered")
-	}
 	for _, name := range []string{
+		mcpfactoryvisualization.ToolActivate,
 		mcpfactoryvisualization.ToolJoin,
 		mcpfactoryvisualization.ToolStopDrain,
+	} {
+		if !mcpfactoryvisualization.IsCanonicalToolHandlerRegistered(name) {
+			t.Fatalf("handler for %q should be registered", name)
+		}
+	}
+	for _, name := range []string{
 		mcpfactoryvisualization.ToolObserve,
 		mcpfactoryvisualization.ToolOpenPresentation,
 		mcpfactoryvisualization.ToolPresentProgress,

--- a/pkg/services/factory_visualization/transports/mcp/registry_test.go
+++ b/pkg/services/factory_visualization/transports/mcp/registry_test.go
@@ -130,20 +130,20 @@ func TestToolByName_UnknownToolReturnsFalse(t *testing.T) {
 	}
 }
 
-func TestIsCanonicalToolHandlerRegistered_LifecycleToolsAreRegistered(t *testing.T) {
+func TestIsCanonicalToolHandlerRegistered_LifecycleAndObserveToolsAreRegistered(t *testing.T) {
 	t.Parallel()
 
 	for _, name := range []string{
 		mcpfactoryvisualization.ToolActivate,
 		mcpfactoryvisualization.ToolJoin,
 		mcpfactoryvisualization.ToolStopDrain,
+		mcpfactoryvisualization.ToolObserve,
 	} {
 		if !mcpfactoryvisualization.IsCanonicalToolHandlerRegistered(name) {
 			t.Fatalf("handler for %q should be registered", name)
 		}
 	}
 	for _, name := range []string{
-		mcpfactoryvisualization.ToolObserve,
 		mcpfactoryvisualization.ToolOpenPresentation,
 		mcpfactoryvisualization.ToolPresentProgress,
 		mcpfactoryvisualization.ToolFinalizePresentation,

--- a/pkg/services/factory_visualization/transports/mcp/registry_test.go
+++ b/pkg/services/factory_visualization/transports/mcp/registry_test.go
@@ -1,0 +1,166 @@
+package factoryvisualization_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	mcpfactoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/mcp"
+)
+
+func TestDiscoverTools_ExposesExpectedVisualizationTools(t *testing.T) {
+	t.Parallel()
+
+	tools := mcpfactoryvisualization.DiscoverTools()
+	if len(tools) != 8 {
+		t.Fatalf("tool count = %d, want 8", len(tools))
+	}
+
+	wantNames := []string{
+		mcpfactoryvisualization.ToolActivate,
+		mcpfactoryvisualization.ToolJoin,
+		mcpfactoryvisualization.ToolStopDrain,
+		mcpfactoryvisualization.ToolObserve,
+		mcpfactoryvisualization.ToolOpenPresentation,
+		mcpfactoryvisualization.ToolPresentProgress,
+		mcpfactoryvisualization.ToolFinalizePresentation,
+		mcpfactoryvisualization.ToolClosePresentation,
+	}
+	gotNames := mcpfactoryvisualization.ToolNames()
+	if !slices.Equal(gotNames, wantNames) {
+		t.Fatalf("tool names = %#v, want %#v", gotNames, wantNames)
+	}
+}
+
+func TestDiscoverTools_EachToolHasDescriptionAndInputSchema(t *testing.T) {
+	t.Parallel()
+
+	for _, tool := range mcpfactoryvisualization.DiscoverTools() {
+		if strings.TrimSpace(tool.Name) == "" {
+			t.Fatal("tool name is required")
+		}
+		if strings.TrimSpace(tool.Description) == "" {
+			t.Fatalf("tool %q description is required", tool.Name)
+		}
+		if len(tool.InputSchema) == 0 {
+			t.Fatalf("tool %q input schema is required", tool.Name)
+		}
+		if schemaType, _ := tool.InputSchema["type"].(string); schemaType != "object" {
+			t.Fatalf("tool %q input schema type = %q, want object", tool.Name, schemaType)
+		}
+		additional, ok := tool.InputSchema["additionalProperties"].(bool)
+		if !ok || additional {
+			t.Fatalf("tool %q input schema additionalProperties = %v, want false", tool.Name, tool.InputSchema["additionalProperties"])
+		}
+	}
+}
+
+func TestDiscoverTools_CatalogIsStableUnderRepeatedDiscovery(t *testing.T) {
+	t.Parallel()
+
+	first, err := json.Marshal(mcpfactoryvisualization.DiscoverTools())
+	if err != nil {
+		t.Fatalf("marshal first discovery: %v", err)
+	}
+	second, err := json.Marshal(mcpfactoryvisualization.DiscoverTools())
+	if err != nil {
+		t.Fatalf("marshal second discovery: %v", err)
+	}
+	if !bytesEqual(first, second) {
+		t.Fatalf("repeated discovery catalogs differ:\nfirst=%s\nsecond=%s", first, second)
+	}
+}
+
+func TestDiscoverTools_RepresentativeInputSchemaFields(t *testing.T) {
+	t.Parallel()
+
+	byName := toolDefinitionsByName(t)
+
+	activateProps := byName[mcpfactoryvisualization.ToolActivate].InputSchema["properties"].(map[string]any)
+	if _, ok := activateProps["mode"]; !ok {
+		t.Fatal("activate input schema missing mode")
+	}
+
+	observeProps := byName[mcpfactoryvisualization.ToolObserve].InputSchema["properties"].(map[string]any)
+	if _, ok := observeProps["mode"]; !ok {
+		t.Fatal("observe input schema missing mode")
+	}
+	reconnect, ok := observeProps["reconnect"].(map[string]any)
+	if !ok {
+		t.Fatal("observe input schema missing reconnect object")
+	}
+	reconnectProps, ok := reconnect["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("observe reconnect schema missing properties")
+	}
+	for _, field := range []string{"afterEventId", "afterSequence"} {
+		if _, ok := reconnectProps[field]; !ok {
+			t.Fatalf("observe reconnect schema missing %q", field)
+		}
+	}
+
+	presentProps := byName[mcpfactoryvisualization.ToolPresentProgress].InputSchema["properties"].(map[string]any)
+	for _, field := range []string{"sessionId", "records"} {
+		if _, ok := presentProps[field]; !ok {
+			t.Fatalf("present_progress input schema missing %q", field)
+		}
+	}
+}
+
+func TestToolByName_ReturnsCatalogEntryForKnownTool(t *testing.T) {
+	t.Parallel()
+
+	tool, ok := mcpfactoryvisualization.ToolByName(mcpfactoryvisualization.ToolObserve)
+	if !ok {
+		t.Fatal("ToolByName(observe) ok = false, want true")
+	}
+	if tool.Name != mcpfactoryvisualization.ToolObserve {
+		t.Fatalf("ToolByName(observe).Name = %q, want %q", tool.Name, mcpfactoryvisualization.ToolObserve)
+	}
+}
+
+func TestToolByName_UnknownToolReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	_, ok := mcpfactoryvisualization.ToolByName("you.factory_visualization.unknown")
+	if ok {
+		t.Fatal("ToolByName(unknown) ok = true, want false")
+	}
+}
+
+func TestIsCanonicalToolHandlerRegistered_OnlyActivateIsRegistered(t *testing.T) {
+	t.Parallel()
+
+	if !mcpfactoryvisualization.IsCanonicalToolHandlerRegistered(mcpfactoryvisualization.ToolActivate) {
+		t.Fatal("activate handler should be registered")
+	}
+	for _, name := range []string{
+		mcpfactoryvisualization.ToolJoin,
+		mcpfactoryvisualization.ToolStopDrain,
+		mcpfactoryvisualization.ToolObserve,
+		mcpfactoryvisualization.ToolOpenPresentation,
+		mcpfactoryvisualization.ToolPresentProgress,
+		mcpfactoryvisualization.ToolFinalizePresentation,
+		mcpfactoryvisualization.ToolClosePresentation,
+	} {
+		if mcpfactoryvisualization.IsCanonicalToolHandlerRegistered(name) {
+			t.Fatalf("handler for %q should not be registered yet", name)
+		}
+	}
+}
+
+func toolDefinitionsByName(t *testing.T) map[string]mcpfactoryvisualization.ToolDefinition {
+	t.Helper()
+
+	byName := make(map[string]mcpfactoryvisualization.ToolDefinition, len(mcpfactoryvisualization.DiscoverTools()))
+	for _, tool := range mcpfactoryvisualization.DiscoverTools() {
+		byName[tool.Name] = tool
+	}
+	return byName
+}
+
+func bytesEqual(left, right []byte) bool {
+	return reflect.DeepEqual(left, right)
+}

--- a/pkg/services/factory_visualization/transports/mcp/request_context_test.go
+++ b/pkg/services/factory_visualization/transports/mcp/request_context_test.go
@@ -1,0 +1,157 @@
+package factoryvisualization_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	mcpfactoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/mcp"
+)
+
+func TestBind_ObserveContextCanceledBeforeRootReturnsDocumentedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := fakeVisualizationRoot{invoked: &invoked}
+	operation := mcpfactoryvisualization.Bind(mcpfactoryvisualization.RootDependencies{Root: fake})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	raw, err := operation(
+		ctx,
+		mcpfactoryvisualization.ToolObserve,
+		json.RawMessage(`{"mode":"RETAINED_THEN_LIVE"}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(observe) transport error = %v, want typed tool response", err)
+	}
+	if invoked {
+		t.Fatal("fake visualization root was invoked for pre-canceled context")
+	}
+	assertRequestContextErrorEnvelope(
+		t,
+		string(raw),
+		"factory_visualization.request.canceled",
+		false,
+		"factory visualization request was canceled",
+		"CANCELED",
+	)
+}
+
+func TestBind_ObserveContextCanceledDuringRootReturnsDocumentedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	entered := make(chan struct{})
+	var enteredOnce sync.Once
+	fake := fakeVisualizationRoot{
+		observe: func(ctx context.Context, _ factoryvisualization.ObserveRequest) (factoryvisualization.ObserveResult, error) {
+			enteredOnce.Do(func() { close(entered) })
+			<-ctx.Done()
+			return factoryvisualization.ObserveResult{}, ctx.Err()
+		},
+	}
+	operation := mcpfactoryvisualization.Bind(mcpfactoryvisualization.RootDependencies{Root: fake})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	var raw json.RawMessage
+	var callErr error
+	go func() {
+		defer close(done)
+		raw, callErr = operation(
+			ctx,
+			mcpfactoryvisualization.ToolObserve,
+			json.RawMessage(`{"mode":"RETAINED_THEN_LIVE"}`),
+		)
+	}()
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fake visualization root did not start before cancellation")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("CallTool(observe) hung after cancellation")
+	}
+	if callErr != nil {
+		t.Fatalf("CallTool(observe) transport error = %v, want typed tool response", callErr)
+	}
+	assertRequestContextErrorEnvelope(
+		t,
+		string(raw),
+		"factory_visualization.request.canceled",
+		false,
+		"factory visualization request was canceled",
+		"CANCELED",
+	)
+}
+
+func TestBind_ObserveContextDeadlineExceededDuringRootReturnsDocumentedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeVisualizationRoot{
+		observe: func(ctx context.Context, _ factoryvisualization.ObserveRequest) (factoryvisualization.ObserveResult, error) {
+			<-ctx.Done()
+			return factoryvisualization.ObserveResult{}, ctx.Err()
+		},
+	}
+	operation := mcpfactoryvisualization.Bind(mcpfactoryvisualization.RootDependencies{Root: fake})
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	raw, err := operation(
+		ctx,
+		mcpfactoryvisualization.ToolObserve,
+		json.RawMessage(`{"mode":"RETAINED_THEN_LIVE"}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(observe) transport error = %v, want typed tool response", err)
+	}
+	assertRequestContextErrorEnvelope(
+		t,
+		string(raw),
+		"factory_visualization.request.timed_out",
+		true,
+		"factory visualization request timed out",
+		"TIMED_OUT",
+	)
+}
+
+func assertRequestContextErrorEnvelope(
+	t *testing.T,
+	response string,
+	wantCode string,
+	wantRetryable bool,
+	wantMessage string,
+	wantReason string,
+) {
+	t.Helper()
+
+	var envelope struct {
+		Error *mcpfactoryvisualization.ToolErrorEnvelope `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(response), &envelope); err != nil {
+		t.Fatalf("unmarshal response: %v\nresponse=%s", err, response)
+	}
+	if envelope.Error == nil {
+		t.Fatalf("response = %s, want error envelope", response)
+	}
+	if envelope.Error.Code != wantCode {
+		t.Fatalf("error code = %q, want %q", envelope.Error.Code, wantCode)
+	}
+	if envelope.Error.Retryable != wantRetryable {
+		t.Fatalf("error retryable = %v, want %v", envelope.Error.Retryable, wantRetryable)
+	}
+	if envelope.Error.Message != wantMessage {
+		t.Fatalf("error.message = %q, want %q; envelope = %#v", envelope.Error.Message, wantMessage, envelope.Error)
+	}
+	if envelope.Error.Details == nil {
+		t.Fatal("error details are required for request-context envelopes")
+	}
+	reason, ok := envelope.Error.Details["reason"].(string)
+	if !ok || reason != wantReason {
+		t.Fatalf("error details reason = %v, want %q", envelope.Error.Details["reason"], wantReason)
+	}
+}

--- a/pkg/services/factory_visualization/transports/mcp/result_policy.go
+++ b/pkg/services/factory_visualization/transports/mcp/result_policy.go
@@ -1,0 +1,25 @@
+package factoryvisualization
+
+import "encoding/json"
+
+// SuccessTextEncodingSerializedJSON documents serialized JSON tool payloads in text content.
+const SuccessTextEncodingSerializedJSON = "serialized-json"
+
+// EncodeSuccessCallToolResult builds the live MCP tools/call success envelope for one
+// serialized tool-response payload. Protocol servers and tests use this shape to match
+// the Sessions MCP success transport policy without mutating handlers.
+func EncodeSuccessCallToolResult(toolResponse json.RawMessage) map[string]any {
+	return map[string]any{
+		"content": []map[string]any{
+			{
+				"type": "text",
+				"text": string(toolResponse),
+			},
+		},
+	}
+}
+
+// MarshalSuccessCallToolResultJSON encodes one success CallToolResult with stable key order.
+func MarshalSuccessCallToolResultJSON(toolResponse json.RawMessage) ([]byte, error) {
+	return json.Marshal(EncodeSuccessCallToolResult(toolResponse))
+}

--- a/pkg/services/factory_visualization/transports/mcp/schemas.go
+++ b/pkg/services/factory_visualization/transports/mcp/schemas.go
@@ -1,0 +1,175 @@
+package factoryvisualization
+
+func objectSchema(properties map[string]any, required ...string) map[string]any {
+	schema := map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties":           properties,
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+func stringProperty(description string) map[string]any {
+	return map[string]any{
+		"type":        "string",
+		"description": description,
+	}
+}
+
+func integerProperty(description string) map[string]any {
+	return map[string]any{
+		"type":        "integer",
+		"description": description,
+	}
+}
+
+func enumStringProperty(description string, values ...string) map[string]any {
+	return map[string]any{
+		"type":        "string",
+		"description": description,
+		"enum":        values,
+	}
+}
+
+func toolResponseSchema(resultSchema map[string]any) map[string]any {
+	return objectSchema(map[string]any{
+		"result": resultSchema,
+		"error":  toolErrorEnvelopeSchema(),
+	})
+}
+
+func toolErrorEnvelopeSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"code":      stringProperty("Stable machine-readable failure code."),
+		"message":   stringProperty("Human-readable failure summary for MCP hosts."),
+		"retryable": map[string]any{"type": "boolean", "description": "Whether the caller should retry the same request later."},
+		"details": map[string]any{
+			"type":                 "object",
+			"additionalProperties": true,
+			"description":          "Optional structured diagnostics such as validation issues or lifecycle hints.",
+		},
+	}, "code", "message", "retryable")
+}
+
+func activateInputSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"mode": enumStringProperty(
+			"Activation mode that leaves the inert Visualization root through retained-then-live projection.",
+			"RETAINED_THEN_LIVE",
+		),
+	}, "mode")
+}
+
+func joinInputSchema() map[string]any {
+	return objectSchema(map[string]any{})
+}
+
+func stopDrainInputSchema() map[string]any {
+	return objectSchema(map[string]any{})
+}
+
+func observeInputSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"mode": enumStringProperty(
+			"Observe mode for one detached retained-then-live Factory view projection.",
+			"RETAINED_THEN_LIVE",
+		),
+		"reconnect": objectSchema(map[string]any{
+			"afterEventId":  stringProperty("Resume observation after this retained event identifier."),
+			"afterSequence": integerProperty("Resume observation after this retained event sequence."),
+		}),
+	}, "mode")
+}
+
+func openPresentationInputSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"mode": enumStringProperty(
+			"Presentation delivery mode selecting Visualization-owned drain/backpressure policy.",
+			"BEST_EFFORT", "LOSSLESS",
+		),
+	}, "mode")
+}
+
+func presentProgressInputSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"sessionId": stringProperty("Opened Visualization presentation session identifier."),
+		"records": map[string]any{
+			"type":        "array",
+			"description": "Ordered progress records to enqueue onto the presentation session.",
+			"items": objectSchema(map[string]any{
+				"payload": stringProperty("Base64-encoded progress payload bytes."),
+			}, "payload"),
+		},
+	}, "sessionId", "records")
+}
+
+func finalizePresentationInputSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"sessionId": stringProperty("Opened Visualization presentation session identifier."),
+		"terminal": objectSchema(map[string]any{
+			"payload": stringProperty("Base64-encoded terminal payload committed after drain."),
+		}, "payload"),
+	}, "sessionId")
+}
+
+func closePresentationInputSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"sessionId": stringProperty("Opened Visualization presentation session identifier."),
+	}, "sessionId")
+}
+
+func activateResultSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"State": enumStringProperty("Published Visualization lifecycle state.", "INERT", "STARTED", "STOPPED"),
+	}, "State")
+}
+
+func joinResultSchema() map[string]any {
+	return activateResultSchema()
+}
+
+func stopDrainResultSchema() map[string]any {
+	return activateResultSchema()
+}
+
+func observeResultSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"View": objectSchema(map[string]any{
+			"TickCount":          integerProperty("Projected tick count in the detached view."),
+			"RetainedEventCount": integerProperty("Retained event count included in the projection."),
+			"ObservedAt":         stringProperty("RFC3339 timestamp when the view was observed."),
+		}),
+	})
+}
+
+func openPresentationResultSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"SessionID": stringProperty("Opened presentation session identifier."),
+		"Mode": enumStringProperty(
+			"Presentation delivery mode for the opened session.",
+			"BEST_EFFORT", "LOSSLESS",
+		),
+	})
+}
+
+func presentProgressResultSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"AcceptedCount": integerProperty("Number of progress records accepted by the presentation session."),
+	})
+}
+
+func finalizePresentationResultSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"Finalized":    map[string]any{"type": "boolean", "description": "Whether finalize committed a terminal write."},
+		"ProgressSeen": map[string]any{"type": "boolean", "description": "Whether any progress was accepted before finalize."},
+	})
+}
+
+func closePresentationResultSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"DroppedCount": integerProperty("Number of progress records dropped during close-and-drain."),
+	})
+}

--- a/pkg/services/factory_visualization/transports/mcp/tool.go
+++ b/pkg/services/factory_visualization/transports/mcp/tool.go
@@ -2,6 +2,7 @@ package factoryvisualization
 
 import (
 	"context"
+	"encoding/base64"
 
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
 )
@@ -172,4 +173,193 @@ func Observe(
 		return ToolResponse[factoryvisualization.ObserveResult]{Error: &envelope}
 	}
 	return ToolResponse[factoryvisualization.ObserveResult]{Result: &result}
+}
+
+// OpenPresentationInput is the MCP request shape for you.factory_visualization.open_presentation.
+type OpenPresentationInput struct {
+	Mode string `json:"mode"`
+}
+
+// OpenPresentation runs the Visualization root OpenPresentation contract for the open_presentation MCP tool.
+func OpenPresentation(
+	ctx context.Context,
+	root factoryvisualization.Root,
+	input OpenPresentationInput,
+) ToolResponse[factoryvisualization.OpenPresentationResult] {
+	if ctx == nil {
+		envelope := missingContextErrorEnvelope()
+		return ToolResponse[factoryvisualization.OpenPresentationResult]{Error: &envelope}
+	}
+	if response, done := requestContextErrorResponse[factoryvisualization.OpenPresentationResult](ctx); done {
+		return response
+	}
+	if root == nil {
+		envelope := serviceUnavailableErrorEnvelope()
+		return ToolResponse[factoryvisualization.OpenPresentationResult]{Error: &envelope}
+	}
+	if input.Mode == "" {
+		envelope := requestValidationErrorEnvelope("open Factory visualization presentation: required request parameters are missing")
+		return ToolResponse[factoryvisualization.OpenPresentationResult]{Error: &envelope}
+	}
+	result, err := root.OpenPresentation(ctx, factoryvisualization.OpenPresentationRequest{
+		Mode: factoryvisualization.PresentationDeliveryMode(input.Mode),
+	})
+	if err != nil {
+		envelope := mapRootError(err)
+		return ToolResponse[factoryvisualization.OpenPresentationResult]{Error: &envelope}
+	}
+	return ToolResponse[factoryvisualization.OpenPresentationResult]{Result: &result}
+}
+
+// ProgressRecordInput is one MCP progress record with a base64-encoded payload.
+type ProgressRecordInput struct {
+	Payload string `json:"payload"`
+}
+
+// PresentProgressInput is the MCP request shape for you.factory_visualization.present_progress.
+type PresentProgressInput struct {
+	SessionID string                `json:"sessionId"`
+	Records   []ProgressRecordInput `json:"records"`
+}
+
+// PresentProgress runs the Visualization root PresentProgress contract for the present_progress MCP tool.
+func PresentProgress(
+	ctx context.Context,
+	root factoryvisualization.Root,
+	input PresentProgressInput,
+) ToolResponse[factoryvisualization.PresentProgressResult] {
+	if ctx == nil {
+		envelope := missingContextErrorEnvelope()
+		return ToolResponse[factoryvisualization.PresentProgressResult]{Error: &envelope}
+	}
+	if response, done := requestContextErrorResponse[factoryvisualization.PresentProgressResult](ctx); done {
+		return response
+	}
+	if root == nil {
+		envelope := serviceUnavailableErrorEnvelope()
+		return ToolResponse[factoryvisualization.PresentProgressResult]{Error: &envelope}
+	}
+	if input.SessionID == "" {
+		envelope := requestValidationErrorEnvelope("present Factory visualization progress: required request parameters are missing")
+		return ToolResponse[factoryvisualization.PresentProgressResult]{Error: &envelope}
+	}
+	records, envelope, ok := decodeProgressRecords(input.Records)
+	if !ok {
+		return ToolResponse[factoryvisualization.PresentProgressResult]{Error: &envelope}
+	}
+	result, err := root.PresentProgress(ctx, factoryvisualization.PresentProgressRequest{
+		SessionID: factoryvisualization.PresentationSessionID(input.SessionID),
+		Records:   records,
+	})
+	if err != nil {
+		envelope := mapRootError(err)
+		return ToolResponse[factoryvisualization.PresentProgressResult]{Error: &envelope}
+	}
+	return ToolResponse[factoryvisualization.PresentProgressResult]{Result: &result}
+}
+
+// TerminalWriteInput is the MCP terminal write with a base64-encoded payload.
+type TerminalWriteInput struct {
+	Payload string `json:"payload"`
+}
+
+// FinalizePresentationInput is the MCP request shape for you.factory_visualization.finalize_presentation.
+type FinalizePresentationInput struct {
+	SessionID string              `json:"sessionId"`
+	Terminal  *TerminalWriteInput `json:"terminal,omitempty"`
+}
+
+// FinalizePresentation runs the Visualization root FinalizePresentation contract for the finalize_presentation MCP tool.
+func FinalizePresentation(
+	ctx context.Context,
+	root factoryvisualization.Root,
+	input FinalizePresentationInput,
+) ToolResponse[factoryvisualization.FinalizePresentationResult] {
+	if ctx == nil {
+		envelope := missingContextErrorEnvelope()
+		return ToolResponse[factoryvisualization.FinalizePresentationResult]{Error: &envelope}
+	}
+	if response, done := requestContextErrorResponse[factoryvisualization.FinalizePresentationResult](ctx); done {
+		return response
+	}
+	if root == nil {
+		envelope := serviceUnavailableErrorEnvelope()
+		return ToolResponse[factoryvisualization.FinalizePresentationResult]{Error: &envelope}
+	}
+	if input.SessionID == "" {
+		envelope := requestValidationErrorEnvelope("finalize Factory visualization presentation: required request parameters are missing")
+		return ToolResponse[factoryvisualization.FinalizePresentationResult]{Error: &envelope}
+	}
+	request := factoryvisualization.FinalizePresentationRequest{
+		SessionID: factoryvisualization.PresentationSessionID(input.SessionID),
+	}
+	if input.Terminal != nil {
+		payload, envelope, ok := decodeBase64Payload("decode finalize terminal payload", input.Terminal.Payload)
+		if !ok {
+			return ToolResponse[factoryvisualization.FinalizePresentationResult]{Error: &envelope}
+		}
+		request.Terminal = &factoryvisualization.TerminalWrite{Payload: payload}
+	}
+	result, err := root.FinalizePresentation(ctx, request)
+	if err != nil {
+		envelope := mapRootError(err)
+		return ToolResponse[factoryvisualization.FinalizePresentationResult]{Error: &envelope}
+	}
+	return ToolResponse[factoryvisualization.FinalizePresentationResult]{Result: &result}
+}
+
+// ClosePresentationInput is the MCP request shape for you.factory_visualization.close_presentation.
+type ClosePresentationInput struct {
+	SessionID string `json:"sessionId"`
+}
+
+// ClosePresentation runs the Visualization root ClosePresentation contract for the close_presentation MCP tool.
+func ClosePresentation(
+	ctx context.Context,
+	root factoryvisualization.Root,
+	input ClosePresentationInput,
+) ToolResponse[factoryvisualization.ClosePresentationResult] {
+	if ctx == nil {
+		envelope := missingContextErrorEnvelope()
+		return ToolResponse[factoryvisualization.ClosePresentationResult]{Error: &envelope}
+	}
+	if response, done := requestContextErrorResponse[factoryvisualization.ClosePresentationResult](ctx); done {
+		return response
+	}
+	if root == nil {
+		envelope := serviceUnavailableErrorEnvelope()
+		return ToolResponse[factoryvisualization.ClosePresentationResult]{Error: &envelope}
+	}
+	if input.SessionID == "" {
+		envelope := requestValidationErrorEnvelope("close Factory visualization presentation: required request parameters are missing")
+		return ToolResponse[factoryvisualization.ClosePresentationResult]{Error: &envelope}
+	}
+	result, err := root.ClosePresentation(ctx, factoryvisualization.ClosePresentationRequest{
+		SessionID: factoryvisualization.PresentationSessionID(input.SessionID),
+	})
+	if err != nil {
+		envelope := mapRootError(err)
+		return ToolResponse[factoryvisualization.ClosePresentationResult]{Error: &envelope}
+	}
+	return ToolResponse[factoryvisualization.ClosePresentationResult]{Result: &result}
+}
+
+func decodeProgressRecords(records []ProgressRecordInput) ([]factoryvisualization.ProgressRecord, ToolErrorEnvelope, bool) {
+	decoded := make([]factoryvisualization.ProgressRecord, 0, len(records))
+	for _, record := range records {
+		payload, envelope, ok := decodeBase64Payload("decode present progress payload", record.Payload)
+		if !ok {
+			return nil, envelope, false
+		}
+		decoded = append(decoded, factoryvisualization.ProgressRecord{Payload: payload})
+	}
+	return decoded, ToolErrorEnvelope{}, true
+}
+
+func decodeBase64Payload(context string, encoded string) ([]byte, ToolErrorEnvelope, bool) {
+	payload, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, decodeInputErrorEnvelope(context, err), false
+	}
+	return payload, ToolErrorEnvelope{}, true
 }

--- a/pkg/services/factory_visualization/transports/mcp/tool.go
+++ b/pkg/services/factory_visualization/transports/mcp/tool.go
@@ -1,0 +1,69 @@
+package factoryvisualization
+
+import (
+	"context"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+)
+
+// Tool names use Factory Visualization vocabulary.
+const (
+	ToolActivate             = "you.factory_visualization.activate"
+	ToolJoin                 = "you.factory_visualization.join"
+	ToolStopDrain            = "you.factory_visualization.stop_drain"
+	ToolObserve              = "you.factory_visualization.observe"
+	ToolOpenPresentation     = "you.factory_visualization.open_presentation"
+	ToolPresentProgress      = "you.factory_visualization.present_progress"
+	ToolFinalizePresentation = "you.factory_visualization.finalize_presentation"
+	ToolClosePresentation    = "you.factory_visualization.close_presentation"
+)
+
+// ToolErrorEnvelope is the stable MCP failure shape for Visualization tools.
+type ToolErrorEnvelope struct {
+	Code      string         `json:"code"`
+	Message   string         `json:"message"`
+	Retryable bool           `json:"retryable"`
+	Details   map[string]any `json:"details,omitempty"`
+}
+
+// ToolResponse wraps one tool outcome with either a typed result or a stable error.
+type ToolResponse[T any] struct {
+	Result *T                 `json:"result,omitempty"`
+	Error  *ToolErrorEnvelope `json:"error,omitempty"`
+}
+
+// ActivateInput is the MCP request shape for you.factory_visualization.activate.
+type ActivateInput struct {
+	Mode string `json:"mode"`
+}
+
+// Activate runs the Visualization root Activate contract for the activate MCP tool.
+func Activate(
+	ctx context.Context,
+	root factoryvisualization.Root,
+	input ActivateInput,
+) ToolResponse[factoryvisualization.ActivateResult] {
+	if ctx == nil {
+		envelope := missingContextErrorEnvelope()
+		return ToolResponse[factoryvisualization.ActivateResult]{Error: &envelope}
+	}
+	if response, done := requestContextErrorResponse[factoryvisualization.ActivateResult](ctx); done {
+		return response
+	}
+	if root == nil {
+		envelope := serviceUnavailableErrorEnvelope()
+		return ToolResponse[factoryvisualization.ActivateResult]{Error: &envelope}
+	}
+	if input.Mode == "" {
+		envelope := requestValidationErrorEnvelope("activate Factory visualization: required request parameters are missing")
+		return ToolResponse[factoryvisualization.ActivateResult]{Error: &envelope}
+	}
+	result, err := root.Activate(ctx, factoryvisualization.ActivateRequest{
+		Mode: factoryvisualization.ActivateMode(input.Mode),
+	})
+	if err != nil {
+		envelope := mapRootError(err)
+		return ToolResponse[factoryvisualization.ActivateResult]{Error: &envelope}
+	}
+	return ToolResponse[factoryvisualization.ActivateResult]{Result: &result}
+}

--- a/pkg/services/factory_visualization/transports/mcp/tool.go
+++ b/pkg/services/factory_visualization/transports/mcp/tool.go
@@ -123,3 +123,53 @@ func StopDrain(
 	}
 	return ToolResponse[factoryvisualization.StopDrainResult]{Result: &result}
 }
+
+// ObserveReconnectInput is the MCP reconnect cursor for you.factory_visualization.observe.
+type ObserveReconnectInput struct {
+	AfterEventID  string `json:"afterEventId,omitempty"`
+	AfterSequence *int   `json:"afterSequence,omitempty"`
+}
+
+// ObserveInput is the MCP request shape for you.factory_visualization.observe.
+type ObserveInput struct {
+	Mode      string                 `json:"mode"`
+	Reconnect *ObserveReconnectInput `json:"reconnect,omitempty"`
+}
+
+// Observe runs the Visualization root Observe contract for the observe MCP tool.
+func Observe(
+	ctx context.Context,
+	root factoryvisualization.Root,
+	input ObserveInput,
+) ToolResponse[factoryvisualization.ObserveResult] {
+	if ctx == nil {
+		envelope := missingContextErrorEnvelope()
+		return ToolResponse[factoryvisualization.ObserveResult]{Error: &envelope}
+	}
+	if response, done := requestContextErrorResponse[factoryvisualization.ObserveResult](ctx); done {
+		return response
+	}
+	if root == nil {
+		envelope := serviceUnavailableErrorEnvelope()
+		return ToolResponse[factoryvisualization.ObserveResult]{Error: &envelope}
+	}
+	if input.Mode == "" {
+		envelope := requestValidationErrorEnvelope("observe Factory visualization: required request parameters are missing")
+		return ToolResponse[factoryvisualization.ObserveResult]{Error: &envelope}
+	}
+	request := factoryvisualization.ObserveRequest{
+		Mode: factoryvisualization.ObserveMode(input.Mode),
+	}
+	if input.Reconnect != nil {
+		request.Reconnect = &factoryvisualization.ObserveReconnectCursor{
+			AfterEventID:  input.Reconnect.AfterEventID,
+			AfterSequence: input.Reconnect.AfterSequence,
+		}
+	}
+	result, err := root.Observe(ctx, request)
+	if err != nil {
+		envelope := mapRootError(err)
+		return ToolResponse[factoryvisualization.ObserveResult]{Error: &envelope}
+	}
+	return ToolResponse[factoryvisualization.ObserveResult]{Result: &result}
+}

--- a/pkg/services/factory_visualization/transports/mcp/tool.go
+++ b/pkg/services/factory_visualization/transports/mcp/tool.go
@@ -67,3 +67,59 @@ func Activate(
 	}
 	return ToolResponse[factoryvisualization.ActivateResult]{Result: &result}
 }
+
+// JoinInput is the MCP request shape for you.factory_visualization.join.
+type JoinInput struct{}
+
+// Join runs the Visualization root Join contract for the join MCP tool.
+func Join(
+	ctx context.Context,
+	root factoryvisualization.Root,
+	input JoinInput,
+) ToolResponse[factoryvisualization.JoinResult] {
+	if ctx == nil {
+		envelope := missingContextErrorEnvelope()
+		return ToolResponse[factoryvisualization.JoinResult]{Error: &envelope}
+	}
+	if response, done := requestContextErrorResponse[factoryvisualization.JoinResult](ctx); done {
+		return response
+	}
+	if root == nil {
+		envelope := serviceUnavailableErrorEnvelope()
+		return ToolResponse[factoryvisualization.JoinResult]{Error: &envelope}
+	}
+	result, err := root.Join(ctx, factoryvisualization.JoinRequest{})
+	if err != nil {
+		envelope := mapRootError(err)
+		return ToolResponse[factoryvisualization.JoinResult]{Error: &envelope}
+	}
+	return ToolResponse[factoryvisualization.JoinResult]{Result: &result}
+}
+
+// StopDrainInput is the MCP request shape for you.factory_visualization.stop_drain.
+type StopDrainInput struct{}
+
+// StopDrain runs the Visualization root StopDrain contract for the stop_drain MCP tool.
+func StopDrain(
+	ctx context.Context,
+	root factoryvisualization.Root,
+	input StopDrainInput,
+) ToolResponse[factoryvisualization.StopDrainResult] {
+	if ctx == nil {
+		envelope := missingContextErrorEnvelope()
+		return ToolResponse[factoryvisualization.StopDrainResult]{Error: &envelope}
+	}
+	if response, done := requestContextErrorResponse[factoryvisualization.StopDrainResult](ctx); done {
+		return response
+	}
+	if root == nil {
+		envelope := serviceUnavailableErrorEnvelope()
+		return ToolResponse[factoryvisualization.StopDrainResult]{Error: &envelope}
+	}
+	result, err := root.StopDrain(ctx, factoryvisualization.StopDrainRequest{})
+	if err != nil {
+		envelope := mapRootError(err)
+		return ToolResponse[factoryvisualization.StopDrainResult]{Error: &envelope}
+	}
+	return ToolResponse[factoryvisualization.StopDrainResult]{Result: &result}
+}


### PR DESCRIPTION
{
  "project": "PSS MCP-VIS — Factory Visualization Owner-Local MCP Adapter",
  "branchName": "pss-mcp-vis-adapter",
  "description": "Package a Factory Visualization service-owned MCP adapter that exposes Visualization lifecycle, Observe, and presentation/drain tools through the accepted Visualization root with discovery/result/error parity, without importing Visualization internals, owning canonical state, or touching shared MCP registry composition.",
  "context": {
    "customerAsk": "Implement MCP-VIS as the Factory Visualization service-owned MCP adapter. Expose Visualization tools through the accepted Visualization root with discovery/result/error parity, without importing Visualization internals or owning canonical state. Do not edit shared MCP registry/server composition (PSS-I04), pkg/wire, pkg/root, pkg/initializer, top-level CLI composition, or reopen Visualization IMP/LWR/HTTP/CLI ownership. Loop until required CI is terminal green, blocking PR feedback is addressed, conflicts are reconciled, and the PR is merged.",
    "problem": "Visualization has accepted root, IMP owners, and Wire, and Sessions already has an MCP adapter pattern, but Visualization still has no owner-local MCP adapter. Agent clients therefore cannot discover or invoke Visualization lifecycle/Observe/presentation operations through a Visualization-owned MCP surface with root-injection and discovery/result/error parity. HTTP-VIS and CLI-VIS may still be live and must remain lease-disjoint.",
    "solution": "Add pkg/services/factory_visualization/transports/mcp that binds an injected Visualization root, publishes a stable eight-tool catalog (activate, join, stop_drain, observe, open_presentation, present_progress, finalize_presentation, close_presentation), proves success/domain-error/cancel/timeout parity with fake-root tests, and registers the package in shared coverage/ownership/package-target manifests only. Leave shared MCP fan-in to PSS-I04 and complete only after the PR merges."
  },
  "acceptanceCriteria": [
    "Factory Visualization owns an MCP adapter under its service-local transports/mcp path that calls only the accepted Visualization root and does not import Visualization internals or construct canonical visualization/subscription/presentation state",
    "MCP hosts can discover a stable Visualization tool catalog with deterministic names, descriptions, and input schemas for lifecycle, Observe, and presentation/drain operations",
    "Calling each Visualization tool with a root-shaped fake returns the expected success payload or typed domain error envelope without touching shared MCP registry composition",
    "Canceled and deadline-exceeded request contexts produce stable Visualization MCP error envelopes (non-retryable cancel; retryable timeout)",
    "Adapter package registration appears in package-target, ownership, and coverage-minimum manifests with factory_visualization retain ownership",
    "Diff stays off excluded paths: shared MCP registry/server/discovery composition (PSS-I04), pkg/wire, pkg/root, pkg/initializer, top-level CLI composition, HTTP-VIS/CLI-VIS paths, and other services' MCP adapters",
    "Quality checks pass (typecheck, lint, tests)",
    "Delivery loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file churn are reconciled, and the PR is merged (opened/green/approved/ready-to-merge alone is not complete)"
  ],
  "userStories": [
    {
      "id": "pss-mcp-vis-adapter-001",
      "title": "Bind MCP adapter to injected Visualization root",
      "description": "As a maintainer, I want the Visualization MCP adapter to depend only on an injected Visualization root so tool execution never imports Visualization internals or owns canonical state.",
      "acceptanceCriteria": [
        "Adapter exposes a bind/construction entrypoint that accepts an injected factoryvisualization.Root and returns a callable MCP tool operation",
        "A fake-root test proves a tool dispatch reaches the injected root method rather than constructing real activation_lifecycle, live_view_projection, response_event_presentation, or service-local Wire graphs",
        "Production adapter sources do not import pkg/services/factory_visualization/internal or other Visualization private implementation packages",
        "Diff does not modify shared MCP registry/server/discovery composition, pkg/wire, pkg/root, pkg/initializer, HTTP-VIS, CLI-VIS, or other services' MCP adapters",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-vis-adapter-002",
      "title": "Publish discoverable Visualization MCP tool catalog",
      "description": "As an MCP host, I want to discover the Visualization tool inventory with stable identities and input schemas so I can present and invoke Visualization operations without guessing names.",
      "acceptanceCriteria": [
        "Discovery returns a deterministic catalog that includes at least: you.factory_visualization.activate, you.factory_visualization.join, you.factory_visualization.stop_drain, you.factory_visualization.observe, you.factory_visualization.open_presentation, you.factory_visualization.present_progress, you.factory_visualization.finalize_presentation, and you.factory_visualization.close_presentation",
        "Each discovered tool has a non-empty description and a JSON-schema input object with additionalProperties false for known fields",
        "Catalog projection is stable under repeated discovery (same tool names and schema shape)",
        "Unknown tool names are rejected with a stable MCP error outcome rather than panicking or silently succeeding",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-vis-adapter-003",
      "title": "Drive Visualization lifecycle through MCP",
      "description": "As an agent client, I want to Activate, Join, and StopDrain Visualization through MCP so I get the same request-activated lifecycle outcomes the accepted Visualization root returns, without owning lifecycle state in the adapter.",
      "acceptanceCriteria": [
        "Calling you.factory_visualization.activate with an explicit Activate mode (for example retained-then-live) returns a success tool response whose result carries the lifecycle state produced by the injected Visualization root",
        "Calling you.factory_visualization.join and you.factory_visualization.stop_drain return success results that carry the lifecycle state produced by the injected Visualization root",
        "Typed lifecycle root failures (missing-parameters / already-activated / not-activated) map to typed domain error envelopes with stable code/message/retryable fields",
        "Malformed JSON arguments return a decode/bad-request style error envelope without invoking the root",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-vis-adapter-004",
      "title": "Observe Visualization projected view through MCP",
      "description": "As an agent client, I want to Observe one detached retained-then-live Factory view projection through MCP so Visualization live-projection outcomes are available without HTTP-VIS or CLI-VIS paths.",
      "acceptanceCriteria": [
        "Calling you.factory_visualization.observe with a valid Observe request (mode and optional reconnect cursor) returns a success tool response whose result carries the plain projected-view facts produced by the injected Visualization root",
        "Calling the tool when the root returns a typed projection failure (for example invalid-input / snapshot-unavailable / reconstruction-failed) returns a typed domain error envelope distinguishable from lifecycle failures",
        "Malformed JSON arguments return a decode/bad-request style error envelope without invoking the root",
        "Success responses encode as MCP CallToolResult success content with serialized JSON text (same success transport policy shape Sessions MCP uses)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-vis-adapter-005",
      "title": "Open, present, finalize, and close Visualization presentation through MCP",
      "description": "As an agent client, I want to open a presentation session, enqueue progress, finalize, and close through MCP so Visualization presentation/drain behavior owned by the accepted root is reachable without constructing Visualization internals.",
      "acceptanceCriteria": [
        "Calling you.factory_visualization.open_presentation with a valid delivery mode returns a success result that includes the presentation session identity produced by the injected Visualization root",
        "Calling you.factory_visualization.present_progress with session id and progress records returns the accepted-count / progress outcome produced by the injected Visualization root",
        "Calling you.factory_visualization.finalize_presentation and you.factory_visualization.close_presentation return the finalize/close outcomes produced by the injected Visualization root (finalized/progress-seen/dropped counts as applicable)",
        "Typed presentation root failures (for example enqueue-after-close / finalize-without-writer / backpressure-rejected) map to stable domain error envelopes distinguishable from lifecycle and projection failures",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-vis-adapter-006",
      "title": "Prove cancel and timeout error parity for Visualization MCP tools",
      "description": "As an agent client, I want canceled and timed-out Visualization MCP calls to return stable request-context error envelopes so long-running Observe and presentation calls fail predictably under cancel and deadline.",
      "acceptanceCriteria": [
        "When the request context is canceled before or during a Visualization tool call, the tool response error uses a non-retryable canceled code/message envelope",
        "When the request context deadline is exceeded, the tool response error uses a retryable timed-out code/message envelope",
        "Cancel/timeout proof covers at least one Visualization tool path using a blocking fake root (same behavioral class as Sessions MCP / HTTP-VIS request-context proof), preferably Observe or a presentation path",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-vis-adapter-007",
      "title": "Register Visualization MCP adapter package ownership",
      "description": "As a Packaged Service Structure maintainer, I want the new Visualization MCP adapter package registered in package-target, ownership, and coverage-minimum manifests so the owner-local adapter is retained under factory_visualization and covered by baseline lanes.",
      "acceptanceCriteria": [
        "Package-target manifest inventory and packages rows include pkg/services/factory_visualization/transports/mcp with retain disposition and factory_visualization destination",
        "Ownership inventory includes the same package path with retain disposition, owner destination, and owner destination kind",
        "Unit and functional coverage-minimum manifests include the adapter import path with an explicit minimum",
        "Shared-manifest edits are limited to adapter package registration and are rebased through the merge loop if concurrent packets touch the same files",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 7,
      "passes": true,
      "notes": ""
    }
  ]
}
