### PR TITLE
pss-cli-boot-adapter

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1751,6 +1751,16 @@
       "minimum": 38.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/system_initialization/transports/cli",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/system_initialization/wire",
       "minimum": 75.00
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1457,6 +1457,10 @@
       "minimum": 80.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/system_initialization/transports/cli",
+      "minimum": 87.90
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/system_initialization/wire",
       "minimum": 100.00
     },

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -4176,6 +4176,12 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/system_initialization/transports/cli",
+      "disposition": "retain",
+      "destination": "system_initialization",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/system_initialization/wire",
       "disposition": "retain",
       "destination": "system_initialization",

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -342,6 +342,7 @@
     "pkg/services/recordings/wire",
     "pkg/services/system_initialization",
     "pkg/services/system_initialization/internal/workflow",
+    "pkg/services/system_initialization/transports/cli",
     "pkg/services/system_initialization/wire",
     "pkg/services/work",
     "pkg/services/work/internal/services/content_materialization",
@@ -1989,6 +1990,11 @@
     },
     {
       "packagePath": "pkg/services/system_initialization/internal/workflow",
+      "disposition": "retain",
+      "destination": "system_initialization"
+    },
+    {
+      "packagePath": "pkg/services/system_initialization/transports/cli",
       "disposition": "retain",
       "destination": "system_initialization"
     },

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -866,7 +866,11 @@ response-stream output.
   `docs/internal/baselines/ownership-inventory.json`, and both
   `go-*-coverage-package-minimums.json` baselines; prove registration with
   `wire/manifest_registration_test.go` rather than re-editing manifests when
-  IMP-BOOT already landed the rows. Bare root/help, invalid commands,
+  IMP-BOOT already landed the rows. The Bootstrap CLI adapter at
+  `pkg/services/system_initialization/transports/cli` must stay registered under
+  destination `system_initialization` in the same shared manifests; prove
+  registration with `transports/cli/manifest_registration_test.go` rather than
+  re-editing manifests when CLI-BOOT already landed the rows. Bare root/help, invalid commands,
   and `you init` do not activate system initialization: `you init` owns only the
   atomic provider/model settings update. The retired `you config init` command,
   its CLI renderer, and installer invocation must remain absent. Root-built

--- a/pkg/services/system_initialization/transports/cli/composition.go
+++ b/pkg/services/system_initialization/transports/cli/composition.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"context"
+
+	initializerapplication "github.com/portpowered/infinite-you/pkg/initializer/application"
+	systeminitialization "github.com/portpowered/infinite-you/pkg/services/system_initialization"
+)
+
+// InitializeSystemOperation is the composition-facing system-initialization role
+// that Wire adapts from the Bootstrap root before lifecycle commands run.
+type InitializeSystemOperation = initializerapplication.SystemInitializationOperation
+
+// InitializeOperation is the composition-facing initialize role with full CLI
+// presentation inputs when composition owns writers or diagnostics.
+type InitializeOperation func(InitializeConfig) (systeminitialization.Result, error)
+
+// BindInitializeSystem returns the composition-facing operation closure that
+// delegates system initialization to the Bootstrap-owned CLI adapter Service.
+// Wire and other composition roots inject the returned function without
+// constructing the Service at the composition boundary.
+func BindInitializeSystem(root systeminitialization.Service) InitializeSystemOperation {
+	if root == nil {
+		return nil
+	}
+	return func(ctx context.Context, homeDir string) error {
+		return InitializeSystem(ctx, homeDir, root)
+	}
+}
+
+// BindInitialize returns the composition-facing operation closure that delegates
+// Bootstrap initialize presentation to the owned CLI adapter Service.
+func BindInitialize(root systeminitialization.Service) InitializeOperation {
+	if root == nil {
+		return nil
+	}
+	return func(cfg InitializeConfig) (systeminitialization.Result, error) {
+		return Initialize(cfg, root)
+	}
+}

--- a/pkg/services/system_initialization/transports/cli/composition_test.go
+++ b/pkg/services/system_initialization/transports/cli/composition_test.go
@@ -1,0 +1,183 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/initializer"
+	initializerapplication "github.com/portpowered/infinite-you/pkg/initializer/application"
+	startupcli "github.com/portpowered/infinite-you/pkg/initializer/process"
+	systeminitialization "github.com/portpowered/infinite-you/pkg/services/system_initialization"
+	systeminitializationcli "github.com/portpowered/infinite-you/pkg/services/system_initialization/transports/cli"
+)
+
+func TestBindInitializeSystemRequiresBootstrapRoot(t *testing.T) {
+	t.Parallel()
+
+	if operation := systeminitializationcli.BindInitializeSystem(nil); operation != nil {
+		t.Fatalf("BindInitializeSystem(nil) = %T, want nil", operation)
+	}
+}
+
+func TestBindInitializeRequiresBootstrapRoot(t *testing.T) {
+	t.Parallel()
+
+	if operation := systeminitializationcli.BindInitialize(nil); operation != nil {
+		t.Fatalf("BindInitialize(nil) = %T, want nil", operation)
+	}
+}
+
+func TestBindInitializeSystemDelegatesThroughAdapterService(t *testing.T) {
+	t.Parallel()
+
+	root := &fakeBootstrapRoot{
+		result: systeminitialization.Result{
+			HomeDir:             "/home/operator",
+			ConfigPath:          "/home/operator/.you-agent-factory/config.json",
+			NamedFactoriesRoot:  "/home/operator/.you-agent-factory/factories",
+			SystemConfigOutcome: systeminitialization.SystemConfigCreated,
+		},
+	}
+	operation := systeminitializationcli.BindInitializeSystem(root)
+	if operation == nil {
+		t.Fatal("BindInitializeSystem(root) = nil, want composition operation")
+	}
+
+	ctx := context.WithValue(context.Background(), contextKey("invocation"), "run")
+	if err := operation(ctx, "/home/operator"); err != nil {
+		t.Fatalf("operation(ctx, homeDir) error = %v", err)
+	}
+	if root.request.HomeDir != "/home/operator" {
+		t.Fatalf("request.HomeDir = %q, want /home/operator", root.request.HomeDir)
+	}
+}
+
+func TestBindInitializeDelegatesThroughAdapterService(t *testing.T) {
+	t.Parallel()
+
+	root := &fakeBootstrapRoot{
+		result: systeminitialization.Result{
+			HomeDir:             "/home/operator",
+			ConfigPath:          "/home/operator/.you-agent-factory/config.json",
+			NamedFactoriesRoot:  "/home/operator/.you-agent-factory/factories",
+			SystemConfigOutcome: systeminitialization.SystemConfigCreated,
+			PackagedFactories: []systeminitialization.PackagedFactoryResult{
+				{
+					Name:       "@you/goal",
+					FactoryDir: "/home/operator/.you-agent-factory/factories/@you/goal",
+					Outcome:    systeminitialization.PackagedFactoryCreated,
+				},
+			},
+		},
+	}
+	operation := systeminitializationcli.BindInitialize(root)
+	if operation == nil {
+		t.Fatal("BindInitialize(root) = nil, want composition operation")
+	}
+
+	var output bytes.Buffer
+	cfg := systeminitializationcli.InitializeConfig{
+		Context: context.Background(),
+		HomeDir: "/home/operator",
+		Output:  &output,
+	}
+	result, err := operation(cfg)
+	if err != nil {
+		t.Fatalf("operation(cfg) error = %v", err)
+	}
+	if result.SystemConfigOutcome != systeminitialization.SystemConfigCreated {
+		t.Fatalf("result.SystemConfigOutcome = %q, want created", result.SystemConfigOutcome)
+	}
+	if root.request.HomeDir != "/home/operator" {
+		t.Fatalf("request.HomeDir = %q, want /home/operator", root.request.HomeDir)
+	}
+	if output.String() == "" {
+		t.Fatal("operation output is empty, want human success presentation")
+	}
+}
+
+func TestBindInitializeSystemMatchesFreeFunctionFacade(t *testing.T) {
+	t.Parallel()
+
+	root := &fakeBootstrapRoot{
+		err: fmt.Errorf("%w", systeminitialization.ErrMissingHomeDir),
+	}
+	operation := systeminitializationcli.BindInitializeSystem(root)
+
+	ctx := context.Background()
+	boundErr := operation(ctx, "")
+	directErr := systeminitializationcli.InitializeSystem(ctx, "", root)
+	if (boundErr == nil) != (directErr == nil) {
+		t.Fatalf("bound error = %v, direct error = %v", boundErr, directErr)
+	}
+	if boundErr != nil && !errors.Is(boundErr, systeminitialization.ErrMissingHomeDir) {
+		t.Fatalf("bound error = %v, want ErrMissingHomeDir", boundErr)
+	}
+}
+
+func TestBindInitializeMatchesFreeFunctionFacade(t *testing.T) {
+	t.Parallel()
+
+	root := &fakeBootstrapRoot{
+		err: fmt.Errorf("%w", systeminitialization.ErrMissingHomeDir),
+	}
+	operation := systeminitializationcli.BindInitialize(root)
+
+	cfg := systeminitializationcli.InitializeConfig{
+		Context: context.Background(),
+		HomeDir: "",
+	}
+	boundResult, boundErr := operation(cfg)
+	_, directErr := systeminitializationcli.Initialize(cfg, root)
+	if (boundErr == nil) != (directErr == nil) {
+		t.Fatalf("bound error = %v, direct error = %v", boundErr, directErr)
+	}
+	if boundErr != nil && !errors.Is(boundErr, systeminitialization.ErrMissingHomeDir) {
+		t.Fatalf("bound error = %v, want ErrMissingHomeDir", boundErr)
+	}
+	if boundResult.HomeDir != "" || len(boundResult.PackagedFactories) != 0 {
+		t.Fatalf("bound result = %#v, want zero result on failure", boundResult)
+	}
+}
+
+func TestBindInitializeSystemRoutesThroughInitializerCompositionPath(t *testing.T) {
+	t.Parallel()
+
+	root := &fakeBootstrapRoot{
+		result: systeminitialization.Result{
+			HomeDir:             "customer-home",
+			ConfigPath:          "customer-home/.you-agent-factory/config.json",
+			NamedFactoriesRoot:  "customer-home/.you-agent-factory/factories",
+			SystemConfigOutcome: systeminitialization.SystemConfigCreated,
+		},
+	}
+	initializer, err := initializerapplication.NewInitializer(
+		&compositionStdioOpener{},
+		systeminitializationcli.BindInitializeSystem(root),
+	)
+	if err != nil {
+		t.Fatalf("NewInitializer() error = %v", err)
+	}
+
+	ctx := context.WithValue(context.Background(), contextKey("invocation"), "mcp-serve")
+	if err := initializer.InitializeSystem(ctx, "customer-home"); err != nil {
+		t.Fatalf("InitializeSystem() error = %v", err)
+	}
+	if root.request.HomeDir != "customer-home" {
+		t.Fatalf("request.HomeDir = %q, want customer-home", root.request.HomeDir)
+	}
+}
+
+type contextKey string
+
+type compositionStdioOpener struct{}
+
+func (compositionStdioOpener) OpenStdio(
+	context.Context,
+	startupcli.MCPIntent,
+) (initializer.RunApplication, error) {
+	panic("composition test does not open stdio")
+}

--- a/pkg/services/system_initialization/transports/cli/initialize.go
+++ b/pkg/services/system_initialization/transports/cli/initialize.go
@@ -1,0 +1,201 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	systeminitialization "github.com/portpowered/infinite-you/pkg/services/system_initialization"
+)
+
+// InitializeConfig carries resolved CLI inputs for one Bootstrap initialize
+// invocation.
+type InitializeConfig struct {
+	Context     context.Context
+	HomeDir     string
+	JSON        bool
+	Verbose     bool
+	Output      io.Writer
+	Diagnostics io.Writer
+}
+
+// InitializeResult is the structured success payload for Bootstrap initialize
+// presentation.
+type InitializeResult struct {
+	HomeDir             string                         `json:"homeDir"`
+	ConfigPath          string                         `json:"configPath"`
+	NamedFactoriesRoot  string                         `json:"namedFactoriesRoot"`
+	SystemConfigOutcome string                         `json:"systemConfigOutcome"`
+	PackagedFactories   []InitializePackagedFactory    `json:"packagedFactories"`
+}
+
+// InitializePackagedFactory summarizes one packaged Factory outcome for CLI
+// presentation.
+type InitializePackagedFactory struct {
+	Name       string `json:"name"`
+	FactoryDir string `json:"factoryDir"`
+	Outcome    string `json:"outcome"`
+}
+
+// Initialize delegates home-directory intent to the Bootstrap root and surfaces
+// typed results, validation/cancellation failures, and partial-failure rollback
+// facts for CLI consumption.
+func Initialize(
+	cfg InitializeConfig,
+	root systeminitialization.Service,
+) (systeminitialization.Result, error) {
+	adapter := New(root)
+	if adapter == nil {
+		return systeminitialization.Result{}, fmt.Errorf("system bootstrap service is required")
+	}
+	return adapter.Initialize(cfg)
+}
+
+// InitializeSystem is a composition-stable facade over the owned Service for
+// callers that only need exit-relevant success or failure.
+func InitializeSystem(
+	ctx context.Context,
+	homeDir string,
+	root systeminitialization.Service,
+) error {
+	_, err := Initialize(InitializeConfig{
+		Context: ctx,
+		HomeDir: homeDir,
+	}, root)
+	return err
+}
+
+func (service *service) Initialize(
+	cfg InitializeConfig,
+) (systeminitialization.Result, error) {
+	if cfg.Context == nil {
+		return systeminitialization.Result{}, fmt.Errorf("context is required")
+	}
+	diagnosticPrintf(
+		cfg.Diagnostics,
+		cfg.Verbose,
+		"initialize system request homeDir=%q",
+		strings.TrimSpace(cfg.HomeDir),
+	)
+	result, err := service.root.Initialize(
+		cfg.Context,
+		systeminitialization.Request{HomeDir: cfg.HomeDir},
+	)
+	if err != nil {
+		diagnosticPrintf(
+			cfg.Diagnostics,
+			cfg.Verbose,
+			"initialize system failed homeDir=%q err=%v",
+			strings.TrimSpace(cfg.HomeDir),
+			err,
+		)
+		return systeminitialization.Result{}, renderInitializeError(err)
+	}
+	diagnosticPrintf(
+		cfg.Diagnostics,
+		cfg.Verbose,
+		"initialize system complete homeDir=%q systemConfigOutcome=%s packagedFactories=%d",
+		result.HomeDir,
+		result.SystemConfigOutcome,
+		len(result.PackagedFactories),
+	)
+	if cfg.Output != nil {
+		if renderErr := renderInitializeSuccess(cfg, result); renderErr != nil {
+			return result, renderErr
+		}
+	}
+	return result, nil
+}
+
+func renderInitializeError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, systeminitialization.ErrMissingHomeDir) ||
+		errors.Is(err, systeminitialization.ErrInitializeCancelled) ||
+		errors.Is(err, systeminitialization.ErrInitializePartialFailure) {
+		return err
+	}
+	var partialFailure systeminitialization.InitializePartialFailure
+	if errors.As(err, &partialFailure) {
+		return err
+	}
+	return fmt.Errorf("initialize system: %w", err)
+}
+
+func renderInitializeSuccess(
+	cfg InitializeConfig,
+	result systeminitialization.Result,
+) error {
+	payload := initializeResultPayload(result)
+	if cfg.JSON {
+		return json.NewEncoder(cfg.Output).Encode(payload)
+	}
+	for _, factory := range payload.PackagedFactories {
+		switch factory.Outcome {
+		case string(systeminitialization.PackagedFactorySkipped):
+			if _, err := fmt.Fprintf(
+				cfg.Output,
+				"Packaged factory %s is already installed at %s\n",
+				factory.Name,
+				factory.FactoryDir,
+			); err != nil {
+				return err
+			}
+		default:
+			if _, err := fmt.Fprintf(
+				cfg.Output,
+				"Installed packaged factory %s\nDirectory: %s\n",
+				factory.Name,
+				factory.FactoryDir,
+			); err != nil {
+				return err
+			}
+		}
+	}
+	switch result.SystemConfigOutcome {
+	case systeminitialization.SystemConfigSkipped:
+		_, err := fmt.Fprintf(
+			cfg.Output,
+			"Operator config already present at %s\n",
+			result.ConfigPath,
+		)
+		return err
+	default:
+		_, err := fmt.Fprintf(
+			cfg.Output,
+			"Initialized operator config at %s\nNamed factories root: %s\n",
+			result.ConfigPath,
+			result.NamedFactoriesRoot,
+		)
+		return err
+	}
+}
+
+func initializeResultPayload(result systeminitialization.Result) InitializeResult {
+	factories := make([]InitializePackagedFactory, 0, len(result.PackagedFactories))
+	for _, factory := range result.PackagedFactories {
+		factories = append(factories, InitializePackagedFactory{
+			Name:       factory.Name,
+			FactoryDir: factory.FactoryDir,
+			Outcome:    string(factory.Outcome),
+		})
+	}
+	return InitializeResult{
+		HomeDir:             result.HomeDir,
+		ConfigPath:          result.ConfigPath,
+		NamedFactoriesRoot:  result.NamedFactoriesRoot,
+		SystemConfigOutcome: string(result.SystemConfigOutcome),
+		PackagedFactories:   factories,
+	}
+}
+
+func diagnosticPrintf(output io.Writer, enabled bool, format string, args ...any) {
+	if !enabled || output == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(output, format+"\n", args...)
+}

--- a/pkg/services/system_initialization/transports/cli/manifest_registration_test.go
+++ b/pkg/services/system_initialization/transports/cli/manifest_registration_test.go
@@ -1,0 +1,144 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/ownershipinventory"
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+const (
+	cliAdapterPackagePath     = "pkg/services/system_initialization/transports/cli"
+	cliAdapterImportPath      = "github.com/portpowered/infinite-you/pkg/services/system_initialization/transports/cli"
+	systemInitializationOwner = "system_initialization"
+)
+
+type coverageMinimumManifest struct {
+	Lane     string `json:"lane"`
+	Packages []struct {
+		Package string  `json:"package"`
+		Minimum float64 `json:"minimum"`
+	} `json:"packages"`
+}
+
+func TestManifestRegistration_CLIAdapterPackageIsRegistered(t *testing.T) {
+	t.Helper()
+
+	assertPackageTargetManifestRegistration(t)
+	assertOwnershipInventoryRegistration(t)
+	assertCoverageMinimumRegistration(t, "unit", "docs/internal/baselines/go-unit-coverage-package-minimums.json")
+	assertCoverageMinimumRegistration(t, "functional", "docs/internal/baselines/go-functional-coverage-package-minimums.json")
+}
+
+func assertPackageTargetManifestRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, "docs/internal/packaged-service-structure/package-target-manifest.json"))
+	if err != nil {
+		t.Fatalf("read package-target manifest: %v", err)
+	}
+
+	var manifest struct {
+		Inventory []string `json:"inventory"`
+		Packages  []struct {
+			PackagePath string `json:"packagePath"`
+			Disposition string `json:"disposition"`
+			Destination string `json:"destination"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode package-target manifest: %v", err)
+	}
+
+	foundInventory := false
+	for _, packagePath := range manifest.Inventory {
+		if packagePath == cliAdapterPackagePath {
+			foundInventory = true
+			break
+		}
+	}
+	if !foundInventory {
+		t.Fatalf("package-target manifest inventory missing %q", cliAdapterPackagePath)
+	}
+
+	for _, row := range manifest.Packages {
+		if row.PackagePath != cliAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("package-target manifest disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != systemInitializationOwner {
+			t.Fatalf("package-target manifest destination = %q, want %q", row.Destination, systemInitializationOwner)
+		}
+		return
+	}
+	t.Fatalf("package-target manifest packages missing %q", cliAdapterPackagePath)
+}
+
+func assertOwnershipInventoryRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, ownershipinventory.InventoryRelativePath))
+	if err != nil {
+		t.Fatalf("read ownership inventory: %v", err)
+	}
+
+	var inventory struct {
+		Packages []ownershipinventory.PackageRow `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		t.Fatalf("decode ownership inventory: %v", err)
+	}
+
+	for _, row := range inventory.Packages {
+		if row.PackagePath != cliAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("ownership inventory disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != systemInitializationOwner {
+			t.Fatalf("ownership inventory destination = %q, want %q", row.Destination, systemInitializationOwner)
+		}
+		if row.DestinationKind != ownershipinventory.DestinationKindOwner {
+			t.Fatalf(
+				"ownership inventory destinationKind = %q, want %q",
+				row.DestinationKind,
+				ownershipinventory.DestinationKindOwner,
+			)
+		}
+		return
+	}
+	t.Fatalf("ownership inventory packages missing %q", cliAdapterPackagePath)
+}
+
+func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, relativePath))
+	if err != nil {
+		t.Fatalf("read %s coverage manifest: %v", lane, err)
+	}
+
+	var manifest coverageMinimumManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode %s coverage manifest: %v", lane, err)
+	}
+	if manifest.Lane != lane {
+		t.Fatalf("%s coverage manifest lane = %q, want %q", relativePath, manifest.Lane, lane)
+	}
+
+	for _, entry := range manifest.Packages {
+		if entry.Package != cliAdapterImportPath {
+			continue
+		}
+		if entry.Minimum < 0 {
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, cliAdapterImportPath)
+		}
+		return
+	}
+	t.Fatalf("%s coverage manifest missing %q", lane, cliAdapterImportPath)
+}

--- a/pkg/services/system_initialization/transports/cli/service.go
+++ b/pkg/services/system_initialization/transports/cli/service.go
@@ -1,0 +1,24 @@
+// Package cli defines the System Bootstrap service-owned CLI adapter.
+package cli
+
+import (
+	systeminitialization "github.com/portpowered/infinite-you/pkg/services/system_initialization"
+)
+
+// Service exposes System Bootstrap CLI command operations to Cobra composition.
+type Service interface {
+	Initialize(InitializeConfig) (systeminitialization.Result, error)
+}
+
+type service struct {
+	root systeminitialization.Service
+}
+
+// New constructs the System Bootstrap CLI service from the accepted Bootstrap
+// root contract.
+func New(root systeminitialization.Service) Service {
+	if root == nil {
+		return nil
+	}
+	return &service{root: root}
+}

--- a/pkg/services/system_initialization/transports/cli/service_parity_test.go
+++ b/pkg/services/system_initialization/transports/cli/service_parity_test.go
@@ -1,0 +1,543 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	systeminitialization "github.com/portpowered/infinite-you/pkg/services/system_initialization"
+	systeminitializationcli "github.com/portpowered/infinite-you/pkg/services/system_initialization/transports/cli"
+)
+
+func constructedBootstrapCLIService(
+	t *testing.T,
+	root *fakeBootstrapRoot,
+) systeminitializationcli.Service {
+	t.Helper()
+	service := systeminitializationcli.New(root)
+	if service == nil {
+		t.Fatal("New(root) = nil, want Bootstrap CLI service")
+	}
+	return service
+}
+
+func TestConstructedService_InitializeHumanOutcomesMatchPackageCommand(t *testing.T) {
+	t.Parallel()
+
+	factoryDir := "/home/operator/.you-agent-factory/factories/@you/goal"
+	configPath := "/home/operator/.you-agent-factory/config.json"
+	namedFactoriesRoot := "/home/operator/.you-agent-factory/factories"
+	cases := []struct {
+		name                string
+		systemConfigOutcome systeminitialization.SystemConfigOutcome
+		factoryOutcome      systeminitialization.PackagedFactoryOutcome
+		wantContains        []string
+	}{
+		{
+			name:                "created",
+			systemConfigOutcome: systeminitialization.SystemConfigCreated,
+			factoryOutcome:      systeminitialization.PackagedFactoryCreated,
+			wantContains: []string{
+				"Initialized operator config at " + configPath,
+				"Named factories root: " + namedFactoriesRoot,
+				"Installed packaged factory @you/goal",
+				factoryDir,
+			},
+		},
+		{
+			name:                "skipped",
+			systemConfigOutcome: systeminitialization.SystemConfigSkipped,
+			factoryOutcome:      systeminitialization.PackagedFactorySkipped,
+			wantContains: []string{
+				"Operator config already present at " + configPath,
+				"Packaged factory @you/goal is already installed at " + factoryDir,
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := &fakeBootstrapRoot{
+				result: systeminitialization.Result{
+					HomeDir:             "/home/operator",
+					ConfigPath:          configPath,
+					NamedFactoriesRoot:  namedFactoriesRoot,
+					SystemConfigOutcome: tc.systemConfigOutcome,
+					PackagedFactories: []systeminitialization.PackagedFactoryResult{
+						{
+							Name:       "@you/goal",
+							FactoryDir: factoryDir,
+							Outcome:    tc.factoryOutcome,
+						},
+					},
+				},
+			}
+			service := constructedBootstrapCLIService(t, root)
+			cfg := systeminitializationcli.InitializeConfig{
+				Context: context.Background(),
+				HomeDir: "/home/operator",
+			}
+			assertInitializeParity(t, service, root, cfg, nil)
+
+			var output bytes.Buffer
+			cfg.Output = &output
+			if _, err := service.Initialize(cfg); err != nil {
+				t.Fatalf("Initialize() error = %v", err)
+			}
+			got := output.String()
+			for _, want := range tc.wantContains {
+				if !strings.Contains(got, want) {
+					t.Fatalf("stdout = %q, want human output containing %q", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestConstructedService_InitializeJSONOutcomesMatchPackageCommand(t *testing.T) {
+	t.Parallel()
+
+	factoryDir := "/home/operator/.you-agent-factory/factories/@you/goal"
+	configPath := "/home/operator/.you-agent-factory/config.json"
+	namedFactoriesRoot := "/home/operator/.you-agent-factory/factories"
+	cases := []struct {
+		name                string
+		systemConfigOutcome systeminitialization.SystemConfigOutcome
+		factoryOutcome      systeminitialization.PackagedFactoryOutcome
+	}{
+		{
+			name:                "created",
+			systemConfigOutcome: systeminitialization.SystemConfigCreated,
+			factoryOutcome:      systeminitialization.PackagedFactoryCreated,
+		},
+		{
+			name:                "skipped",
+			systemConfigOutcome: systeminitialization.SystemConfigSkipped,
+			factoryOutcome:      systeminitialization.PackagedFactorySkipped,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := &fakeBootstrapRoot{
+				result: systeminitialization.Result{
+					HomeDir:             "/home/operator",
+					ConfigPath:          configPath,
+					NamedFactoriesRoot:  namedFactoriesRoot,
+					SystemConfigOutcome: tc.systemConfigOutcome,
+					PackagedFactories: []systeminitialization.PackagedFactoryResult{
+						{
+							Name:       "@you/goal",
+							FactoryDir: factoryDir,
+							Outcome:    tc.factoryOutcome,
+						},
+					},
+				},
+			}
+			service := constructedBootstrapCLIService(t, root)
+			cfg := systeminitializationcli.InitializeConfig{
+				Context: context.Background(),
+				HomeDir: "/home/operator",
+				JSON:    true,
+			}
+			assertInitializeParity(t, service, root, cfg, nil)
+
+			var output bytes.Buffer
+			cfg.Output = &output
+			if _, err := service.Initialize(cfg); err != nil {
+				t.Fatalf("Initialize() error = %v", err)
+			}
+			var payload systeminitializationcli.InitializeResult
+			if err := json.Unmarshal(output.Bytes(), &payload); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+			if payload.HomeDir != "/home/operator" ||
+				payload.ConfigPath != configPath ||
+				payload.NamedFactoriesRoot != namedFactoriesRoot ||
+				payload.SystemConfigOutcome != string(tc.systemConfigOutcome) {
+				t.Fatalf("payload = %#v, want retained JSON fields", payload)
+			}
+			if len(payload.PackagedFactories) != 1 ||
+				payload.PackagedFactories[0].Name != "@you/goal" ||
+				payload.PackagedFactories[0].FactoryDir != factoryDir ||
+				payload.PackagedFactories[0].Outcome != string(tc.factoryOutcome) {
+				t.Fatalf("packaged factories = %#v, want retained JSON fields", payload.PackagedFactories)
+			}
+		})
+	}
+}
+
+func TestConstructedService_InitializeValidationFailuresMatchPackageCommand(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		cfg  systeminitializationcli.InitializeConfig
+		want error
+	}{
+		{
+			name: "missing home directory",
+			cfg: systeminitializationcli.InitializeConfig{
+				Context: context.Background(),
+			},
+			want: systeminitialization.ErrMissingHomeDir,
+		},
+		{
+			name: "blank home directory",
+			cfg: systeminitializationcli.InitializeConfig{
+				Context: context.Background(),
+				HomeDir: "   ",
+			},
+			want: systeminitialization.ErrMissingHomeDir,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := &fakeBootstrapRoot{
+				err: fmt.Errorf("%w", systeminitialization.ErrMissingHomeDir),
+			}
+			service := constructedBootstrapCLIService(t, root)
+			assertInitializeParity(t, service, root, tc.cfg, func() {
+				var output bytes.Buffer
+				cfg := tc.cfg
+				cfg.Output = &output
+				_, err := service.Initialize(cfg)
+				if err == nil || !errors.Is(err, tc.want) {
+					t.Fatalf("error = %v, want %v", err, tc.want)
+				}
+				if output.Len() != 0 {
+					t.Fatalf("stdout = %q, want empty on validation failure", output.String())
+				}
+			})
+		})
+	}
+}
+
+func TestConstructedService_InitializeBootstrapErrorsMatchPackageCommand(t *testing.T) {
+	t.Parallel()
+
+	partialFailure := systeminitialization.InitializePartialFailure{
+		Message: "packaged factory install failed",
+		Facts: []systeminitialization.RollbackFact{
+			{
+				Step:    systeminitialization.InitializeStepSystemConfig,
+				Outcome: systeminitialization.RollbackStepCompleted,
+			},
+			{
+				Step:    systeminitialization.InitializeStepPackagedFactories,
+				Outcome: systeminitialization.RollbackStepUnresolved,
+			},
+		},
+	}
+	cases := []struct {
+		name      string
+		root      *fakeBootstrapRoot
+		wantIs    error
+		wantWraps string
+	}{
+		{
+			name: "missing home directory",
+			root: &fakeBootstrapRoot{
+				err: fmt.Errorf("%w", systeminitialization.ErrMissingHomeDir),
+			},
+			wantIs: systeminitialization.ErrMissingHomeDir,
+		},
+		{
+			name: "initialize cancelled",
+			root: &fakeBootstrapRoot{
+				err: fmt.Errorf("initialize system: %w: %w", systeminitialization.ErrInitializeCancelled, context.Canceled),
+			},
+			wantIs: systeminitialization.ErrInitializeCancelled,
+		},
+		{
+			name:   "partial failure rollback facts",
+			root:   &fakeBootstrapRoot{err: partialFailure},
+			wantIs: systeminitialization.ErrInitializePartialFailure,
+		},
+		{
+			name: "wrapped bootstrap rejection",
+			root: &fakeBootstrapRoot{
+				err: errors.New("bootstrap rejected"),
+			},
+			wantWraps: "initialize system: bootstrap rejected",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			service := constructedBootstrapCLIService(t, tc.root)
+			cfg := systeminitializationcli.InitializeConfig{
+				Context: context.Background(),
+				HomeDir: "/home/operator",
+			}
+			assertInitializeParity(t, service, tc.root, cfg, func() {
+				var output bytes.Buffer
+				cfg.Output = &output
+				_, err := service.Initialize(cfg)
+				if err == nil {
+					t.Fatal("Initialize() error = nil, want failure")
+				}
+				if tc.wantIs != nil && !errors.Is(err, tc.wantIs) {
+					t.Fatalf("error = %v, want %v", err, tc.wantIs)
+				}
+				if tc.wantWraps != "" && err.Error() != tc.wantWraps {
+					t.Fatalf("error = %q, want %q", err.Error(), tc.wantWraps)
+				}
+				if tc.wantIs == systeminitialization.ErrInitializePartialFailure {
+					var got systeminitialization.InitializePartialFailure
+					if !errors.As(err, &got) {
+						t.Fatalf("error = %T(%v), want InitializePartialFailure", err, err)
+					}
+					if len(got.Facts) != 2 || got.Facts[1].Outcome != systeminitialization.RollbackStepUnresolved {
+						t.Fatalf("rollback facts = %#v, want inspectable partial-failure facts", got.Facts)
+					}
+				}
+				if output.Len() != 0 {
+					t.Fatalf("stdout = %q, want empty on failure", output.String())
+				}
+			})
+		})
+	}
+}
+
+func TestConstructedService_InitializeVerboseDiagnosticsMatchPackageCommand(t *testing.T) {
+	t.Parallel()
+
+	root := &fakeBootstrapRoot{
+		result: systeminitialization.Result{
+			HomeDir:             "/home/operator",
+			ConfigPath:          "/home/operator/.you-agent-factory/config.json",
+			NamedFactoriesRoot:  "/home/operator/.you-agent-factory/factories",
+			SystemConfigOutcome: systeminitialization.SystemConfigCreated,
+			PackagedFactories: []systeminitialization.PackagedFactoryResult{
+				{
+					Name:       "@you/goal",
+					FactoryDir: "/home/operator/.you-agent-factory/factories/@you/goal",
+					Outcome:    systeminitialization.PackagedFactoryCreated,
+				},
+			},
+		},
+	}
+	service := constructedBootstrapCLIService(t, root)
+	baseCfg := systeminitializationcli.InitializeConfig{
+		Context: context.Background(),
+		HomeDir: "/home/operator",
+		Verbose: true,
+	}
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		var serviceDiag, commandDiag bytes.Buffer
+		var serviceOut, commandOut bytes.Buffer
+		serviceCfg := baseCfg
+		serviceCfg.Output = &serviceOut
+		serviceCfg.Diagnostics = &serviceDiag
+		if _, err := service.Initialize(serviceCfg); err != nil {
+			t.Fatalf("service.Initialize() error = %v", err)
+		}
+
+		commandCfg := baseCfg
+		commandCfg.Output = &commandOut
+		commandCfg.Diagnostics = &commandDiag
+		if _, err := systeminitializationcli.Initialize(commandCfg, root); err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+		if serviceOut.String() != commandOut.String() {
+			t.Fatalf("service output = %q, command output = %q", serviceOut.String(), commandOut.String())
+		}
+		for _, want := range []string{
+			`initialize system request homeDir="/home/operator"`,
+			`initialize system complete homeDir="/home/operator" systemConfigOutcome=created packagedFactories=1`,
+		} {
+			if !strings.Contains(serviceDiag.String(), want) {
+				t.Fatalf("service diagnostics missing %q:\n%s", want, serviceDiag.String())
+			}
+			if !strings.Contains(commandDiag.String(), want) {
+				t.Fatalf("command diagnostics missing %q:\n%s", want, commandDiag.String())
+			}
+		}
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		t.Parallel()
+
+		failingRoot := &fakeBootstrapRoot{
+			err: fmt.Errorf("%w", systeminitialization.ErrMissingHomeDir),
+		}
+		failingService := constructedBootstrapCLIService(t, failingRoot)
+
+		var serviceDiag, commandDiag bytes.Buffer
+		serviceCfg := baseCfg
+		serviceCfg.Output = io.Discard
+		serviceCfg.Diagnostics = &serviceDiag
+		_, serviceErr := failingService.Initialize(serviceCfg)
+
+		commandCfg := baseCfg
+		commandCfg.Output = io.Discard
+		commandCfg.Diagnostics = &commandDiag
+		_, commandErr := systeminitializationcli.Initialize(commandCfg, failingRoot)
+
+		if (serviceErr == nil) != (commandErr == nil) {
+			t.Fatalf("service error = %v, command error = %v", serviceErr, commandErr)
+		}
+		if serviceErr != nil && serviceErr.Error() != commandErr.Error() {
+			t.Fatalf("service error = %q, command error = %q", serviceErr.Error(), commandErr.Error())
+		}
+		for _, want := range []string{
+			`initialize system request homeDir="/home/operator"`,
+			`initialize system failed homeDir="/home/operator"`,
+		} {
+			if !strings.Contains(serviceDiag.String(), want) {
+				t.Fatalf("service diagnostics missing %q:\n%s", want, serviceDiag.String())
+			}
+			if !strings.Contains(commandDiag.String(), want) {
+				t.Fatalf("command diagnostics missing %q:\n%s", want, commandDiag.String())
+			}
+		}
+	})
+}
+
+func TestConstructedService_InitializeHonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	root := &fakeBootstrapRoot{
+		err: fmt.Errorf("initialize system: %w: %w", systeminitialization.ErrInitializeCancelled, context.Canceled),
+	}
+	service := constructedBootstrapCLIService(t, root)
+	cfg := systeminitializationcli.InitializeConfig{
+		Context: ctx,
+		HomeDir: "/home/operator",
+	}
+
+	var serviceOut bytes.Buffer
+	serviceCfg := cfg
+	serviceCfg.Output = &serviceOut
+	_, serviceErr := service.Initialize(serviceCfg)
+	if !errors.Is(serviceErr, systeminitialization.ErrInitializeCancelled) {
+		t.Fatalf("service error = %v, want ErrInitializeCancelled", serviceErr)
+	}
+	if serviceOut.Len() != 0 {
+		t.Fatalf("service output = %q, want empty on cancellation", serviceOut.String())
+	}
+
+	var commandOut bytes.Buffer
+	commandCfg := cfg
+	commandCfg.Output = &commandOut
+	_, commandErr := systeminitializationcli.Initialize(commandCfg, root)
+	if !errors.Is(commandErr, systeminitialization.ErrInitializeCancelled) {
+		t.Fatalf("Initialize() error = %v, want ErrInitializeCancelled", commandErr)
+	}
+	if commandOut.Len() != 0 {
+		t.Fatalf("command output = %q, want empty on cancellation", commandOut.String())
+	}
+}
+
+func TestInitializeSystemPreservesExitErrorsOnFailurePaths(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want error
+	}{
+		{
+			name: "missing home",
+			err:  fmt.Errorf("%w", systeminitialization.ErrMissingHomeDir),
+			want: systeminitialization.ErrMissingHomeDir,
+		},
+		{
+			name: "cancelled",
+			err:  fmt.Errorf("initialize system: %w: %w", systeminitialization.ErrInitializeCancelled, context.Canceled),
+			want: systeminitialization.ErrInitializeCancelled,
+		},
+		{
+			name: "partial failure",
+			err: systeminitialization.InitializePartialFailure{
+				Message: "packaged factory install failed",
+			},
+			want: systeminitialization.ErrInitializePartialFailure,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := &fakeBootstrapRoot{err: tc.err}
+			err := systeminitializationcli.InitializeSystem(context.Background(), "/home/operator", root)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("InitializeSystem() error = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func assertInitializeParity(
+	t *testing.T,
+	service systeminitializationcli.Service,
+	root *fakeBootstrapRoot,
+	cfg systeminitializationcli.InitializeConfig,
+	after func(),
+) {
+	t.Helper()
+
+	var serviceOut, commandOut bytes.Buffer
+	serviceCfg := cfg
+	serviceCfg.Output = &serviceOut
+	commandCfg := cfg
+	commandCfg.Output = &commandOut
+
+	serviceResult, serviceErr := service.Initialize(serviceCfg)
+	commandResult, commandErr := systeminitializationcli.Initialize(commandCfg, root)
+
+	if (serviceErr == nil) != (commandErr == nil) {
+		t.Fatalf("service error = %v, command error = %v", serviceErr, commandErr)
+	}
+	if serviceErr != nil && commandErr != nil {
+		if !errors.Is(serviceErr, commandErr) && serviceErr.Error() != commandErr.Error() {
+			t.Fatalf("service error = %q, command error = %q", serviceErr.Error(), commandErr.Error())
+		}
+	}
+	if serviceOut.String() != commandOut.String() {
+		t.Fatalf("service output = %q, command output = %q", serviceOut.String(), commandOut.String())
+	}
+	if serviceErr == nil && serviceResult.HomeDir != commandResult.HomeDir {
+		t.Fatalf("service result = %#v, command result = %#v", serviceResult, commandResult)
+	}
+	if cfg.JSON && serviceErr == nil {
+		var payload systeminitializationcli.InitializeResult
+		if err := json.Unmarshal(serviceOut.Bytes(), &payload); err != nil {
+			t.Fatalf("json.Unmarshal() error = %v", err)
+		}
+		if payload.HomeDir == "" || payload.ConfigPath == "" || payload.NamedFactoriesRoot == "" {
+			t.Fatalf("payload = %#v, want retained JSON fields", payload)
+		}
+	}
+	if serviceErr == nil && !cfg.JSON && serviceOut.Len() > 0 {
+		got := strings.ToLower(serviceOut.String())
+		if !strings.Contains(got, "operator config") && !strings.Contains(got, "packaged factory") {
+			t.Fatalf("stdout = %q, want human success output", serviceOut.String())
+		}
+	}
+	if after != nil {
+		after()
+	}
+}

--- a/pkg/services/system_initialization/transports/cli/service_test.go
+++ b/pkg/services/system_initialization/transports/cli/service_test.go
@@ -1,0 +1,255 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	systeminitialization "github.com/portpowered/infinite-you/pkg/services/system_initialization"
+	systeminitializationcli "github.com/portpowered/infinite-you/pkg/services/system_initialization/transports/cli"
+)
+
+func TestNewRequiresBootstrapRoot(t *testing.T) {
+	t.Parallel()
+
+	if service := systeminitializationcli.New(nil); service != nil {
+		t.Fatalf("New(nil) = %T, want nil", service)
+	}
+}
+
+func TestConstructedService_InitializeCreatedPath(t *testing.T) {
+	t.Parallel()
+
+	root := &fakeBootstrapRoot{
+		result: systeminitialization.Result{
+			HomeDir:             "/home/operator",
+			ConfigPath:          "/home/operator/.you-agent-factory/config.json",
+			NamedFactoriesRoot:  "/home/operator/.you-agent-factory/factories",
+			SystemConfigOutcome: systeminitialization.SystemConfigCreated,
+			PackagedFactories: []systeminitialization.PackagedFactoryResult{
+				{
+					Name:       "@you/goal",
+					FactoryDir: "/home/operator/.you-agent-factory/factories/@you/goal",
+					Outcome:    systeminitialization.PackagedFactoryCreated,
+				},
+			},
+		},
+	}
+	service := systeminitializationcli.New(root)
+	if service == nil {
+		t.Fatal("New(root) = nil, want Bootstrap CLI service")
+	}
+
+	result, err := service.Initialize(systeminitializationcli.InitializeConfig{
+		Context: context.Background(),
+		HomeDir: "/home/operator",
+	})
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	if result.SystemConfigOutcome != systeminitialization.SystemConfigCreated {
+		t.Fatalf("result.SystemConfigOutcome = %q, want created", result.SystemConfigOutcome)
+	}
+	if root.request.HomeDir != "/home/operator" {
+		t.Fatalf("request.HomeDir = %q, want /home/operator", root.request.HomeDir)
+	}
+}
+
+func TestConstructedService_InitializeSkippedPath(t *testing.T) {
+	t.Parallel()
+
+	root := &fakeBootstrapRoot{
+		result: systeminitialization.Result{
+			HomeDir:             "/home/operator",
+			ConfigPath:          "/home/operator/.you-agent-factory/config.json",
+			NamedFactoriesRoot:  "/home/operator/.you-agent-factory/factories",
+			SystemConfigOutcome: systeminitialization.SystemConfigSkipped,
+			PackagedFactories: []systeminitialization.PackagedFactoryResult{
+				{
+					Name:       "@you/goal",
+					FactoryDir: "/home/operator/.you-agent-factory/factories/@you/goal",
+					Outcome:    systeminitialization.PackagedFactorySkipped,
+				},
+			},
+		},
+	}
+	service := systeminitializationcli.New(root)
+	if service == nil {
+		t.Fatal("New(root) = nil, want Bootstrap CLI service")
+	}
+
+	result, err := service.Initialize(systeminitializationcli.InitializeConfig{
+		Context: context.Background(),
+		HomeDir: "/home/operator",
+	})
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	if result.SystemConfigOutcome != systeminitialization.SystemConfigSkipped {
+		t.Fatalf("result.SystemConfigOutcome = %q, want skipped", result.SystemConfigOutcome)
+	}
+	if result.PackagedFactories[0].Outcome != systeminitialization.PackagedFactorySkipped {
+		t.Fatalf("packaged factory outcome = %q, want skipped", result.PackagedFactories[0].Outcome)
+	}
+}
+
+func TestConstructedService_InitializeMissingHomeDir(t *testing.T) {
+	t.Parallel()
+
+	root := &fakeBootstrapRoot{
+		err: fmt.Errorf("%w", systeminitialization.ErrMissingHomeDir),
+	}
+	service := systeminitializationcli.New(root)
+	if service == nil {
+		t.Fatal("New(root) = nil, want Bootstrap CLI service")
+	}
+
+	_, err := service.Initialize(systeminitializationcli.InitializeConfig{
+		Context: context.Background(),
+		HomeDir: "",
+	})
+	if !errors.Is(err, systeminitialization.ErrMissingHomeDir) {
+		t.Fatalf("Initialize() error = %v, want ErrMissingHomeDir", err)
+	}
+}
+
+func TestConstructedService_InitializeCancelledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	root := &fakeBootstrapRoot{
+		err: fmt.Errorf("initialize system: %w: %w", systeminitialization.ErrInitializeCancelled, context.Canceled),
+	}
+	service := systeminitializationcli.New(root)
+	if service == nil {
+		t.Fatal("New(root) = nil, want Bootstrap CLI service")
+	}
+
+	_, err := service.Initialize(systeminitializationcli.InitializeConfig{
+		Context: ctx,
+		HomeDir: "/home/operator",
+	})
+	if !errors.Is(err, systeminitialization.ErrInitializeCancelled) {
+		t.Fatalf("Initialize() error = %v, want ErrInitializeCancelled", err)
+	}
+}
+
+func TestConstructedService_InitializePartialFailureRollbackFacts(t *testing.T) {
+	t.Parallel()
+
+	partialFailure := systeminitialization.InitializePartialFailure{
+		Message: "packaged factory install failed",
+		Facts: []systeminitialization.RollbackFact{
+			{
+				Step:    systeminitialization.InitializeStepSystemConfig,
+				Outcome: systeminitialization.RollbackStepCompleted,
+			},
+			{
+				Step:    systeminitialization.InitializeStepPackagedFactories,
+				Outcome: systeminitialization.RollbackStepUnresolved,
+			},
+		},
+	}
+	root := &fakeBootstrapRoot{err: partialFailure}
+	service := systeminitializationcli.New(root)
+	if service == nil {
+		t.Fatal("New(root) = nil, want Bootstrap CLI service")
+	}
+
+	_, err := service.Initialize(systeminitializationcli.InitializeConfig{
+		Context: context.Background(),
+		HomeDir: "/home/operator",
+	})
+	if !errors.Is(err, systeminitialization.ErrInitializePartialFailure) {
+		t.Fatalf("Initialize() error = %v, want ErrInitializePartialFailure", err)
+	}
+	var got systeminitialization.InitializePartialFailure
+	if !errors.As(err, &got) {
+		t.Fatalf("Initialize() error = %T(%v), want InitializePartialFailure", err, err)
+	}
+	if len(got.Facts) != 2 || got.Facts[1].Outcome != systeminitialization.RollbackStepUnresolved {
+		t.Fatalf("rollback facts = %#v, want inspectable partial-failure facts", got.Facts)
+	}
+}
+
+func TestInitializeFacadeMatchesConstructedService(t *testing.T) {
+	t.Parallel()
+
+	root := &fakeBootstrapRoot{
+		result: systeminitialization.Result{
+			HomeDir:             "/home/operator",
+			ConfigPath:          "/home/operator/.you-agent-factory/config.json",
+			NamedFactoriesRoot:  "/home/operator/.you-agent-factory/factories",
+			SystemConfigOutcome: systeminitialization.SystemConfigCreated,
+		},
+	}
+	service := systeminitializationcli.New(root)
+	if service == nil {
+		t.Fatal("New(root) = nil, want Bootstrap CLI service")
+	}
+
+	cfg := systeminitializationcli.InitializeConfig{
+		Context: context.Background(),
+		HomeDir: "/home/operator",
+		JSON:    true,
+	}
+	var serviceOut, commandOut bytes.Buffer
+	serviceCfg := cfg
+	serviceCfg.Output = &serviceOut
+	commandCfg := cfg
+	commandCfg.Output = &commandOut
+
+	serviceResult, serviceErr := service.Initialize(serviceCfg)
+	commandResult, commandErr := systeminitializationcli.Initialize(commandCfg, root)
+	if (serviceErr == nil) != (commandErr == nil) {
+		t.Fatalf("service error = %v, command error = %v", serviceErr, commandErr)
+	}
+	if serviceOut.String() != commandOut.String() {
+		t.Fatalf("service output = %q, command output = %q", serviceOut.String(), commandOut.String())
+	}
+	if serviceResult.HomeDir != commandResult.HomeDir {
+		t.Fatalf("service result = %#v, command result = %#v", serviceResult, commandResult)
+	}
+	if serviceErr == nil {
+		var payload systeminitializationcli.InitializeResult
+		if err := json.Unmarshal(serviceOut.Bytes(), &payload); err != nil {
+			t.Fatalf("json.Unmarshal() error = %v", err)
+		}
+		if payload.HomeDir == "" || payload.ConfigPath == "" || payload.NamedFactoriesRoot == "" {
+			t.Fatalf("payload = %#v, want retained JSON fields", payload)
+		}
+	}
+}
+
+func TestInitializeSystemFacadePreservesExitErrors(t *testing.T) {
+	t.Parallel()
+
+	root := &fakeBootstrapRoot{
+		err: fmt.Errorf("%w", systeminitialization.ErrMissingHomeDir),
+	}
+	err := systeminitializationcli.InitializeSystem(context.Background(), "", root)
+	if !errors.Is(err, systeminitialization.ErrMissingHomeDir) {
+		t.Fatalf("InitializeSystem() error = %v, want ErrMissingHomeDir", err)
+	}
+}
+
+type fakeBootstrapRoot struct {
+	request systeminitialization.Request
+	result  systeminitialization.Result
+	err     error
+}
+
+func (fake *fakeBootstrapRoot) Initialize(
+	_ context.Context,
+	request systeminitialization.Request,
+) (systeminitialization.Result, error) {
+	fake.request = request
+	if fake.err != nil {
+		return systeminitialization.Result{}, fake.err
+	}
+	return fake.result, nil
+}


### PR DESCRIPTION
{
  "project": "PSS CLI-BOOT System Bootstrap Service-Owned CLI Adapter",
  "branchName": "pss-cli-boot-adapter",
  "description": "Implement CLI-BOOT by moving System Bootstrap initialize/rollback CLI behavior behind one Bootstrap-owned adapter Service constructed over the accepted Bootstrap root, while preserving the accepted Schema-Driven/Clean CLI command/flag/error/output/exit/cancel contract and keeping top-level CLI, Wire, root, and initializer composition unchanged.",
  "context": {
    "customerAsk": "Implement CLI-BOOT as the Bootstrap service-owned CLI adapter. Move Bootstrap initialize/rollback command behavior behind an injected adapter over the accepted Bootstrap root while preserving the accepted Schema-Driven/Clean CLI command, flag, error, output, and completion contract. Top-level Cobra/root/manifest composition remains out of scope (PSS-I03). Do not edit pkg/wire, pkg/root, pkg/initializer, or reopen Bootstrap IMP/LWR ownership. Shared coverage, ownership, and package-target manifest edits are allowed and must be rebased through the merge loop. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Schema-Driven CLI and Clean CLI UX are accepted complete, CTR-BOOT / IMP-BOOT-01 / LWR-BOOT are accepted, and peer services already have service-owned CLI adapters, but System Bootstrap still has no owner-local CLI adapter under pkg/services/system_initialization/transports/cli. Customer-facing initialize behavior remains adapted only through process-lifecycle InitializeSystem seams that discard typed Bootstrap results and leave CLI presentation of created/skipped outcomes, typed validation/cancellation failures, and partial-failure rollback facts outside Bootstrap CLI ownership. CLI-VIS / CLI-RUN may be live elsewhere, so this packet must stay on Bootstrap CLI ownership only and must not reopen PSS-I03 or process-graph wiring.",
    "solution": "Give System Bootstrap a Models/CLI-SES/CLI-DEF-like CLI Service constructed from the accepted Bootstrap root inside pkg/services/system_initialization/transports/cli/**, keep composition-facing entry points as thin package-local facades so pkg/wire, pkg/root, pkg/initializer, and PSS-I03 need not change, and prove command/output/exit/cancel parity for the accepted Bootstrap initialize/rollback CLI contract without authoring HTTP/MCP Bootstrap adapters or reopening Bootstrap IMP/LWR ownership."
  },
  "acceptanceCriteria": [
    "AC-1: System Bootstrap initialize/rollback CLI behavior owned by this packet is reachable only through one Bootstrap-owned CLI adapter Service constructed over the accepted Bootstrap root (composition may still call thin package-local facades that delegate to that Service)",
    "AC-2: Top-level CLI retains existing Cobra tree/flag/completion composition for accepted Bootstrap-facing initialize surfaces and continues to delegate without redesigning command paths, flags, help, completion, or UX",
    "AC-3: Accepted Bootstrap CLI initialize command/flag/error/output/exit/cancel behavior remains unchanged for success (created/skipped outcomes), idempotent repeat, typed validation and cancellation failures, and partial-failure rollback-fact reporting",
    "AC-4: Focused adapter tests prove success and failure outcomes through the Bootstrap-owned package, including required writers where presentation applies, diagnostics, exit-relevant errors, rollback-fact inspectability, and cancellation semantics on adapter-owned request-bound paths",
    "AC-5: Diff stays inside Bootstrap CLI adapter ownership plus shared coverage/ownership/package-target manifest registration as required; no pkg/wire / pkg/root / pkg/initializer edits, no PSS-I03 root/manifest composition redesign, no HTTP/MCP Bootstrap adapters, and no other-services CLI adapter edits",
    "AC-6: Quality checks pass (typecheck, lint, tests)",
    "AC-7: Delivery loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and accepted shared-file churn are reconciled, and the PR is actually merged"
  ],
  "userStories": [
    {
      "id": "pss-cli-boot-adapter-001",
      "title": "Own Bootstrap CLI Service construction over the Bootstrap root",
      "description": "As a maintainer, I want System Bootstrap to construct one typed CLI adapter Service from the accepted Bootstrap root inside the Bootstrap CLI adapter package so Bootstrap owns adapter construction the same way Models, CLI-SES, and CLI-DEF do.",
      "acceptanceCriteria": [
        "Bootstrap CLI adapter under pkg/services/system_initialization/transports/cli/** (or the equivalent owner-local Bootstrap CLI adapter path) exposes a durable constructor that returns a typed Service from the accepted Bootstrap root systeminitialization.Service",
        "Constructed Service methods cover Bootstrap initialize CLI behavior owned by this packet, including mapping home-dir intent into Bootstrap Request, invoking root Initialize, and surfacing typed Result / typed-error / rollback-fact outcomes for CLI consumption",
        "Focused adapter tests invoke those Service methods against a fake or stub Bootstrap root and observe success outcomes for created and skipped paths plus failure outcomes for missing/blank home, cancelled context, and partial-failure rollback facts",
        "Free-function entry points that existing composition already calls, if retained or introduced as composition-stable facades, are thin package-local facades over the owned Service rather than a second durable production implementation",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cli-boot-adapter-002",
      "title": "Keep composition-facing Bootstrap CLI delegation without PSS-I03 or Wire edits",
      "description": "As a maintainer, I want existing top-level CLI composition to keep delegating Bootstrap initialize behavior through the Bootstrap-owned adapter surface so customer-facing commands continue to work without editing pkg/wire, pkg/root, pkg/initializer, or PSS-I03 Cobra/root/manifest composition.",
      "acceptanceCriteria": [
        "Existing composition-facing Bootstrap initialize entry contracts remain callable with the same context/home-dir (and any writer/presentation) contracts composition already uses for system initialization",
        "Representative initialize invocations through the existing composition path still map inputs the same way and dispatch through the Bootstrap-owned adapter ownership path for durable CLI behavior (thin facades allowed; no second production implementation)",
        "Diff does not edit pkg/wire, pkg/root, or pkg/initializer",
        "Diff does not regenerate CLI manifests / contracts/cli/commands.json authorship beyond unavoidable adapter-local wiring, redesign command UX, edit CLI-VIS / CLI-RUN / other services' CLI adapters, author HTTP/MCP Bootstrap adapters, or reopen PSS-I03 root/manifest composition",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cli-boot-adapter-003",
      "title": "Prove Bootstrap CLI command/output/exit/cancel parity",
      "description": "As a CLI user and reviewer, I want focused proof that Bootstrap-owned CLI adapter behavior preserves accepted initialize output, diagnostics, errors, exit behavior, rollback-fact reporting, and cancellation semantics after the adapter ownership move.",
      "acceptanceCriteria": [
        "Focused tests through the Bootstrap-owned adapter prove representative success paths preserve accepted initialize outcomes for created and skipped system-config / packaged-factory results (and any retained human/JSON presentation fields such as homeDir, configPath, namedFactoriesRoot, and packaged factory name/dir/outcome when presentation is part of the owned CLI contract)",
        "Focused tests prove failure paths preserve diagnostics/error messaging and exit-relevant error returns for missing/blank home, Bootstrap-root rejection cases, and partial-failure paths where peers can inspect Bootstrap-owned rollback facts (ErrInitializePartialFailure / InitializePartialFailure) without inventing transport-owned rollback policy",
        "Focused tests prove cancellation or context cancellation is honored on at least one adapter-owned request-bound Bootstrap CLI path without changing customer-visible cancel semantics (ErrInitializeCancelled or equivalent accepted cancel/exit outcome)",
        "Accepted Clean CLI / Schema-Driven CLI command paths, flags, help text, and completion behavior for Bootstrap-facing initialize surfaces are not redesigned",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cli-boot-adapter-004",
      "title": "Register adapter ownership only where manifests require it",
      "description": "As a maintainer, I want shared coverage, ownership, and package-target manifests updated only if the Bootstrap CLI adapter registration requires it so package-structure checks continue to recognize Bootstrap ownership.",
      "acceptanceCriteria": [
        "Shared coverage/ownership/package-target manifests change only when required by Bootstrap CLI adapter package registration or moved construction ownership",
        "Package-structure / ownership checks that cover Bootstrap CLI adapter placement continue to pass for the owned path under pkg/services/system_initialization/transports/cli/** (or the equivalent owner-local path)",
        "No unrelated ownership inventory rewrite, CLI-VIS / CLI-RUN churn, HTTP/MCP Bootstrap churn, or broad path-lease churn is included",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
