### PR TITLE
pss-http-run-adapter

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -715,6 +715,16 @@
       "minimum": 0.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/http",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/mcp",
       "exception": {
         "kind": "measurement",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -649,6 +649,10 @@
       "minimum": 86.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/http",
+      "minimum": 82.30
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/mcp",
       "minimum": 81.48
     },

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -1217,6 +1217,12 @@
     },
     {
       "fromOwner": "factory_runtime",
+      "toOwner": "transports",
+      "class": "command",
+      "evidence": "pkg/services/factory_runtime/transports/http -\u003e pkg/transports/http/generated"
+    },
+    {
+      "fromOwner": "factory_runtime",
       "toOwner": "work",
       "class": "command",
       "evidence": "pkg/services/factory_runtime/engine -\u003e pkg/services/work"
@@ -3199,6 +3205,12 @@
     },
     {
       "packagePath": "pkg/services/factory_runtime/transports/cli",
+      "disposition": "retain",
+      "destination": "factory_runtime",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/factory_runtime/transports/http",
       "disposition": "retain",
       "destination": "factory_runtime",
       "destinationKind": "owner"

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -181,6 +181,7 @@
     "pkg/services/factory_runtime/tooling/javascript/catalog",
     "pkg/services/factory_runtime/tooling/javascript/symbolidentity",
     "pkg/services/factory_runtime/transports/cli",
+    "pkg/services/factory_runtime/transports/http",
     "pkg/services/factory_runtime/transports/mcp",
     "pkg/services/factory_runtime/wire",
     "pkg/services/factory_sessions",
@@ -1197,6 +1198,11 @@
     },
     {
       "packagePath": "pkg/services/factory_runtime/transports/cli",
+      "disposition": "retain",
+      "destination": "factory_runtime"
+    },
+    {
+      "packagePath": "pkg/services/factory_runtime/transports/http",
       "disposition": "retain",
       "destination": "factory_runtime"
     },

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -70,6 +70,16 @@ Use this map when changing the public REST contract.
   requests terminate without an error body and deadline failures return 504 via
   `request_context.go`, with guards before root invocation and centralized
   handling in `writeRootOrInternalError`.
+- The Factory Runtime HTTP adapter package must stay registered in the allowed
+  shared manifests only: retain `pkg/services/factory_runtime/transports/http`
+  under destination `factory_runtime` in
+  `docs/internal/packaged-service-structure/package-target-manifest.json` and
+  `docs/internal/baselines/ownership-inventory.json`, and keep measured floors
+  in both `docs/internal/baselines/go-unit-coverage-package-minimums.json` and
+  `docs/internal/baselines/go-functional-coverage-package-minimums.json`.
+  Prove registration with `manifest_registration_test.go`; do not edit
+  `pkg/wire`, `pkg/root`, `pkg/initializer`, top-level CLI composition, or
+  other services' HTTP adapters when reconciling manifest churn.
 - Factory Definitions HTTP decoding, generated-contract mapping, service
   invocation, typed error mapping, and cancel/timeout handling live in
   `pkg/services/factory_definitions/transports/http`. The top-level

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -52,7 +52,10 @@ Use this map when changing the public REST contract.
   `apisurface.FactoryStatusToAPI`, and route session-scoped reads through an
   injected `SessionObserver` peer binding rather than Runtime datastores.
   Typed observation failures map through `error_mapping.go` before success
-  encoding.
+  encoding. Runtime control (`handlers_control.go`) maps pause, resume, and
+  terminate through `ControlPause`, `ControlResume`, and `ControlTerminate`
+  with published `ControlOutcome` success vocabulary; operator move-work maps
+  `moveWorkBySessionId` through `ControlMoveWork` in `move_work_mapping.go`.
 - Factory Definitions HTTP decoding, generated-contract mapping, service
   invocation, typed error mapping, and cancel/timeout handling live in
   `pkg/services/factory_definitions/transports/http`. The top-level

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -38,6 +38,15 @@ Use this map when changing the public REST contract.
   `docs/internal/baselines/go-unit-coverage-package-minimums.json` and
   `docs/internal/baselines/go-functional-coverage-package-minimums.json` when
   introducing new adapter packages.
+- Factory Runtime HTTP decoding, generated-contract mapping, Runtime root
+  invocation, typed error mapping, and cancel/timeout handling live in
+  `pkg/services/factory_runtime/transports/http`. The adapter consumes the
+  accepted `factory_runtime.Service` root only; fake-root tests inject a focused
+  root fake without constructing hosting, Petri, JavaScript, or Wire graphs.
+  Declare owned generated operationIds in `owned_surface.go` and prove adapter
+  production sources do not directly import
+  `pkg/services/factory_runtime/internal/**` (source scan, not transitive deps
+  through the accepted root package).
 - Factory Definitions HTTP decoding, generated-contract mapping, service
   invocation, typed error mapping, and cancel/timeout handling live in
   `pkg/services/factory_definitions/transports/http`. The top-level

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -51,21 +51,21 @@ Use this map when changing the public REST contract.
   `ObservationScopeFull`, project success via `FactoryStatusFromObservation` +
   `apisurface.FactoryStatusToAPI`, and route session-scoped reads through an
   injected `SessionObserver` peer binding rather than Runtime datastores.
-  Typed observation failures map through `error_mapping.go` before success
-  encoding. Runtime control (`handlers_control.go`) maps pause, resume, and
-  terminate through `ControlPause`, `ControlResume`, and `ControlTerminate`
-  with published `ControlOutcome` success vocabulary; operator move-work maps
+  Published Runtime root sentinel failures map through centralized
+  `error_mapping.go` (`RootErrorResponse`) into public `ErrorResponse` bodies
+  with stable status, family, and code; unmapped failures use sanitized
+  internal messages via `writeRootOrInternalError`. Runtime control
+  (`handlers_control.go`) maps pause, resume, and terminate through
+  `ControlPause`, `ControlResume`, and `ControlTerminate` with published
+  `ControlOutcome` success vocabulary; operator move-work maps
   `moveWorkBySessionId` through `ControlMoveWork` in `move_work_mapping.go`.
   Dispatch-plan adaptation (`handlers_dispatch_plan.go`) maps plan-dispatch and
   accept-dispatch-result through `PlanDispatch` and `AcceptDispatchResult` with
   published `DispatchPlanOutcome` success vocabulary in
-  `dispatch_plan_mapping.go`; typed dispatch-plan failures map at the adapter
-  edge before story 006 centralizes the full sentinel set. Checkpoint adaptation
-  (`handlers_checkpoint.go`) maps capture/load/restore through
-  `CaptureCheckpoint`, `LoadCheckpoint`, and `RestoreCheckpoint` with published
-  `CheckpointOutcome` success vocabulary in `checkpoint_mapping.go`; typed
-  checkpoint failures map at the adapter edge before story 006 centralizes the
-  full sentinel set.
+  `dispatch_plan_mapping.go`. Checkpoint adaptation (`handlers_checkpoint.go`)
+  maps capture/load/restore through `CaptureCheckpoint`, `LoadCheckpoint`, and
+  `RestoreCheckpoint` with published `CheckpointOutcome` success vocabulary in
+  `checkpoint_mapping.go`.
 - Factory Definitions HTTP decoding, generated-contract mapping, service
   invocation, typed error mapping, and cancel/timeout handling live in
   `pkg/services/factory_definitions/transports/http`. The top-level

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -46,7 +46,13 @@ Use this map when changing the public REST contract.
   Declare owned generated operationIds in `owned_surface.go` and prove adapter
   production sources do not directly import
   `pkg/services/factory_runtime/internal/**` (source scan, not transitive deps
-  through the accepted root package).
+  through the accepted root package). Status reads (`handlers_status.go`) map
+  `getStatus` / `getStatusBySessionId` through `Observe` with
+  `ObservationScopeFull`, project success via `FactoryStatusFromObservation` +
+  `apisurface.FactoryStatusToAPI`, and route session-scoped reads through an
+  injected `SessionObserver` peer binding rather than Runtime datastores.
+  Typed observation failures map through `error_mapping.go` before success
+  encoding.
 - Factory Definitions HTTP decoding, generated-contract mapping, service
   invocation, typed error mapping, and cancel/timeout handling live in
   `pkg/services/factory_definitions/transports/http`. The top-level

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -65,7 +65,11 @@ Use this map when changing the public REST contract.
   `dispatch_plan_mapping.go`. Checkpoint adaptation (`handlers_checkpoint.go`)
   maps capture/load/restore through `CaptureCheckpoint`, `LoadCheckpoint`, and
   `RestoreCheckpoint` with published `CheckpointOutcome` success vocabulary in
-  `checkpoint_mapping.go`.
+  `checkpoint_mapping.go`. Request-context cancellation and deadline exhaustion
+  end without mapping to ordinary business `INTERNAL_ERROR` outcomes: canceled
+  requests terminate without an error body and deadline failures return 504 via
+  `request_context.go`, with guards before root invocation and centralized
+  handling in `writeRootOrInternalError`.
 - Factory Definitions HTTP decoding, generated-contract mapping, service
   invocation, typed error mapping, and cancel/timeout handling live in
   `pkg/services/factory_definitions/transports/http`. The top-level

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -56,6 +56,11 @@ Use this map when changing the public REST contract.
   terminate through `ControlPause`, `ControlResume`, and `ControlTerminate`
   with published `ControlOutcome` success vocabulary; operator move-work maps
   `moveWorkBySessionId` through `ControlMoveWork` in `move_work_mapping.go`.
+  Dispatch-plan adaptation (`handlers_dispatch_plan.go`) maps plan-dispatch and
+  accept-dispatch-result through `PlanDispatch` and `AcceptDispatchResult` with
+  published `DispatchPlanOutcome` success vocabulary in
+  `dispatch_plan_mapping.go`; typed dispatch-plan failures map at the adapter
+  edge before story 006 centralizes the full sentinel set.
 - Factory Definitions HTTP decoding, generated-contract mapping, service
   invocation, typed error mapping, and cancel/timeout handling live in
   `pkg/services/factory_definitions/transports/http`. The top-level

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -60,7 +60,12 @@ Use this map when changing the public REST contract.
   accept-dispatch-result through `PlanDispatch` and `AcceptDispatchResult` with
   published `DispatchPlanOutcome` success vocabulary in
   `dispatch_plan_mapping.go`; typed dispatch-plan failures map at the adapter
-  edge before story 006 centralizes the full sentinel set.
+  edge before story 006 centralizes the full sentinel set. Checkpoint adaptation
+  (`handlers_checkpoint.go`) maps capture/load/restore through
+  `CaptureCheckpoint`, `LoadCheckpoint`, and `RestoreCheckpoint` with published
+  `CheckpointOutcome` success vocabulary in `checkpoint_mapping.go`; typed
+  checkpoint failures map at the adapter edge before story 006 centralizes the
+  full sentinel set.
 - Factory Definitions HTTP decoding, generated-contract mapping, service
   invocation, typed error mapping, and cancel/timeout handling live in
   `pkg/services/factory_definitions/transports/http`. The top-level

--- a/pkg/services/factory_runtime/transports/http/adapter.go
+++ b/pkg/services/factory_runtime/transports/http/adapter.go
@@ -7,6 +7,7 @@
 package http
 
 import (
+	"context"
 	"errors"
 
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
@@ -17,10 +18,17 @@ import (
 // internal packages.
 type RuntimeRoot = factoryruntime.Service
 
+// SessionObserver routes session-scoped Runtime observation requests through
+// the Factory Sessions peer surface without importing Sessions internals.
+type SessionObserver interface {
+	ObserveForSession(context.Context, string, factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error)
+}
+
 // Adapter maps Factory Runtime HTTP operations through the accepted root
 // contract without importing Runtime internals or owning canonical state.
 type Adapter struct {
-	root RuntimeRoot
+	root     RuntimeRoot
+	sessions SessionObserver
 }
 
 // NewAdapter constructs the Factory Runtime HTTP adapter bound to the accepted
@@ -30,6 +38,13 @@ func NewAdapter(root RuntimeRoot) *Adapter {
 		return nil
 	}
 	return &Adapter{root: root}
+}
+
+// BindSessionObserver attaches the peer used for session-scoped status reads.
+func (a *Adapter) BindSessionObserver(sessions SessionObserver) {
+	if a != nil {
+		a.sessions = sessions
+	}
 }
 
 // Root returns the injected Factory Runtime root consumed by adapter-owned

--- a/pkg/services/factory_runtime/transports/http/adapter.go
+++ b/pkg/services/factory_runtime/transports/http/adapter.go
@@ -1,0 +1,49 @@
+// Package http owns HTTP adaptation for Factory Runtime operations.
+//
+// The top-level HTTP transport registers generated routes and composes this
+// adapter when PSS fan-in arrives. Request decoding, generated contract mapping,
+// Runtime root invocation, error mapping, and cancel/timeout policy for
+// Runtime-owned HTTP operations remain here with the owning service.
+package http
+
+import (
+	"errors"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+// RuntimeRoot is the accepted Factory Runtime root contract used by the HTTP
+// adapter. Adapter-owned operations invoke this surface rather than Runtime
+// internal packages.
+type RuntimeRoot = factoryruntime.Service
+
+// Adapter maps Factory Runtime HTTP operations through the accepted root
+// contract without importing Runtime internals or owning canonical state.
+type Adapter struct {
+	root RuntimeRoot
+}
+
+// NewAdapter constructs the Factory Runtime HTTP adapter bound to the accepted
+// root Service seam. Nil roots fail closed by returning nil.
+func NewAdapter(root RuntimeRoot) *Adapter {
+	if root == nil {
+		return nil
+	}
+	return &Adapter{root: root}
+}
+
+// Root returns the injected Factory Runtime root consumed by adapter-owned
+// operations.
+func (a *Adapter) Root() RuntimeRoot {
+	if a == nil {
+		return nil
+	}
+	return a.root
+}
+
+func (a *Adapter) runtimeRoot() (RuntimeRoot, error) {
+	if a == nil || a.root == nil {
+		return nil, errors.New("factory runtime service is required")
+	}
+	return a.root, nil
+}

--- a/pkg/services/factory_runtime/transports/http/adapter_edge_test.go
+++ b/pkg/services/factory_runtime/transports/http/adapter_edge_test.go
@@ -1,0 +1,98 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+func TestAdapter_NilReceiverHelpersFailClosed(t *testing.T) {
+	t.Parallel()
+
+	var adapter *Adapter
+	if adapter.Root() != nil {
+		t.Fatal("Root() on nil adapter must return nil")
+	}
+
+	root, err := adapter.runtimeRoot()
+	if err == nil || root != nil {
+		t.Fatalf("runtimeRoot() = (%v, %v), want (nil, error)", root, err)
+	}
+}
+
+func TestAdapter_RuntimeRootFailsWhenRootUnset(t *testing.T) {
+	t.Parallel()
+
+	adapter := &Adapter{}
+	rec := httptest.NewRecorder()
+	adapter.invokeControlResume(rec, context.Background())
+	assertErrorResponse(t, rec, http.StatusInternalServerError, "INTERNAL_ERROR", "factory runtime service is required")
+}
+
+func TestControlResume_MapsTypedLifecycleFailures(t *testing.T) {
+	t.Parallel()
+
+	fake := &runtimeRootFake{
+		resume: func(context.Context, factoryruntime.ResumeRequest) (factoryruntime.ResumeResult, error) {
+			return factoryruntime.ResumeResult{}, factoryruntime.ErrInvalidLifecycleTransition
+		},
+	}
+	adapter := NewAdapter(fake)
+
+	rec := httptest.NewRecorder()
+	adapter.ControlResume(rec, httptest.NewRequest(http.MethodPost, "/control/resume", nil))
+	assertErrorResponse(t, rec, http.StatusBadRequest, "BAD_REQUEST", "factory runtime invalid lifecycle transition")
+}
+
+func TestAcceptDispatchResult_RejectsInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewAdapter(&runtimeRootFake{})
+	rec := httptest.NewRecorder()
+	adapter.AcceptDispatchResult(rec, httptest.NewRequest(http.MethodPost, "/runtime/dispatch/accept-result", strings.NewReader("{")))
+	assertErrorResponse(t, rec, http.StatusBadRequest, "BAD_REQUEST", "invalid request payload")
+}
+
+func TestLoadCheckpoint_RejectsInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewAdapter(&runtimeRootFake{})
+	rec := httptest.NewRecorder()
+	adapter.LoadCheckpoint(rec, httptest.NewRequest(http.MethodPost, "/runtime/checkpoint/load", strings.NewReader("{")))
+	assertErrorResponse(t, rec, http.StatusBadRequest, "BAD_REQUEST", "invalid request payload")
+}
+
+func TestRestoreCheckpoint_RejectsInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewAdapter(&runtimeRootFake{})
+	rec := httptest.NewRecorder()
+	adapter.RestoreCheckpoint(rec, httptest.NewRequest(http.MethodPost, "/runtime/checkpoint/restore", strings.NewReader("{")))
+	assertErrorResponse(t, rec, http.StatusBadRequest, "BAD_REQUEST", "invalid request payload")
+}
+
+func TestMoveWorkBySessionId_RejectsInvalidJSONBody(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewAdapter(&runtimeRootFake{})
+	rec := httptest.NewRecorder()
+	adapter.MoveWorkBySessionId(
+		rec,
+		httptest.NewRequest(http.MethodPost, "/sessions/session-1/work/work-1/move", strings.NewReader("{")),
+		"session-1",
+		factoryapi.WorkOrTokenID("work-1"),
+	)
+	assertErrorResponse(t, rec, http.StatusBadRequest, "BAD_REQUEST", "invalid request payload")
+}
+
+func TestBindSessionObserver_NoOpsOnNilAdapter(t *testing.T) {
+	t.Parallel()
+
+	var adapter *Adapter
+	adapter.BindSessionObserver(&sessionObserverFake{})
+}

--- a/pkg/services/factory_runtime/transports/http/adapter_test.go
+++ b/pkg/services/factory_runtime/transports/http/adapter_test.go
@@ -50,11 +50,13 @@ func TestNewAdapter_RejectsNilRoot(t *testing.T) {
 }
 
 type runtimeRootFake struct {
-	observe   func(context.Context, factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error)
-	pause     func(context.Context, factoryruntime.PauseRequest) (factoryruntime.PauseResult, error)
-	resume    func(context.Context, factoryruntime.ResumeRequest) (factoryruntime.ResumeResult, error)
-	terminate func(context.Context, factoryruntime.TerminateRequest) (factoryruntime.TerminateResult, error)
-	moveWork  func(context.Context, factoryruntime.MoveWorkRequest) (factoryruntime.MoveWorkResult, error)
+	observe              func(context.Context, factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error)
+	pause                func(context.Context, factoryruntime.PauseRequest) (factoryruntime.PauseResult, error)
+	resume               func(context.Context, factoryruntime.ResumeRequest) (factoryruntime.ResumeResult, error)
+	terminate            func(context.Context, factoryruntime.TerminateRequest) (factoryruntime.TerminateResult, error)
+	moveWork             func(context.Context, factoryruntime.MoveWorkRequest) (factoryruntime.MoveWorkResult, error)
+	planDispatch         func(context.Context, factoryruntime.PlanDispatchRequest) (factoryruntime.PlanDispatchResult, error)
+	acceptDispatchResult func(context.Context, factoryruntime.AcceptDispatchResultRequest) (factoryruntime.AcceptDispatchResultResult, error)
 }
 
 var _ factoryruntime.Service = (*runtimeRootFake)(nil)
@@ -94,10 +96,16 @@ func (fake *runtimeRootFake) Observe(ctx context.Context, req factoryruntime.Obs
 	}
 	return factoryruntime.ObserveResult{}, nil
 }
-func (fake *runtimeRootFake) PlanDispatch(context.Context, factoryruntime.PlanDispatchRequest) (factoryruntime.PlanDispatchResult, error) {
+func (fake *runtimeRootFake) PlanDispatch(ctx context.Context, req factoryruntime.PlanDispatchRequest) (factoryruntime.PlanDispatchResult, error) {
+	if fake.planDispatch != nil {
+		return fake.planDispatch(ctx, req)
+	}
 	return factoryruntime.PlanDispatchResult{}, nil
 }
-func (fake *runtimeRootFake) AcceptDispatchResult(context.Context, factoryruntime.AcceptDispatchResultRequest) (factoryruntime.AcceptDispatchResultResult, error) {
+func (fake *runtimeRootFake) AcceptDispatchResult(ctx context.Context, req factoryruntime.AcceptDispatchResultRequest) (factoryruntime.AcceptDispatchResultResult, error) {
+	if fake.acceptDispatchResult != nil {
+		return fake.acceptDispatchResult(ctx, req)
+	}
 	return factoryruntime.AcceptDispatchResultResult{}, nil
 }
 func (fake *runtimeRootFake) CaptureCheckpoint(context.Context, factoryruntime.CaptureCheckpointRequest) (factoryruntime.CaptureCheckpointResult, error) {

--- a/pkg/services/factory_runtime/transports/http/adapter_test.go
+++ b/pkg/services/factory_runtime/transports/http/adapter_test.go
@@ -57,6 +57,9 @@ type runtimeRootFake struct {
 	moveWork             func(context.Context, factoryruntime.MoveWorkRequest) (factoryruntime.MoveWorkResult, error)
 	planDispatch         func(context.Context, factoryruntime.PlanDispatchRequest) (factoryruntime.PlanDispatchResult, error)
 	acceptDispatchResult func(context.Context, factoryruntime.AcceptDispatchResultRequest) (factoryruntime.AcceptDispatchResultResult, error)
+	captureCheckpoint    func(context.Context, factoryruntime.CaptureCheckpointRequest) (factoryruntime.CaptureCheckpointResult, error)
+	loadCheckpoint       func(context.Context, factoryruntime.LoadCheckpointRequest) (factoryruntime.LoadCheckpointResult, error)
+	restoreCheckpoint    func(context.Context, factoryruntime.RestoreCheckpointRequest) (factoryruntime.RestoreCheckpointResult, error)
 }
 
 var _ factoryruntime.Service = (*runtimeRootFake)(nil)
@@ -108,12 +111,21 @@ func (fake *runtimeRootFake) AcceptDispatchResult(ctx context.Context, req facto
 	}
 	return factoryruntime.AcceptDispatchResultResult{}, nil
 }
-func (fake *runtimeRootFake) CaptureCheckpoint(context.Context, factoryruntime.CaptureCheckpointRequest) (factoryruntime.CaptureCheckpointResult, error) {
+func (fake *runtimeRootFake) CaptureCheckpoint(ctx context.Context, req factoryruntime.CaptureCheckpointRequest) (factoryruntime.CaptureCheckpointResult, error) {
+	if fake.captureCheckpoint != nil {
+		return fake.captureCheckpoint(ctx, req)
+	}
 	return factoryruntime.CaptureCheckpointResult{}, nil
 }
-func (fake *runtimeRootFake) LoadCheckpoint(context.Context, factoryruntime.LoadCheckpointRequest) (factoryruntime.LoadCheckpointResult, error) {
+func (fake *runtimeRootFake) LoadCheckpoint(ctx context.Context, req factoryruntime.LoadCheckpointRequest) (factoryruntime.LoadCheckpointResult, error) {
+	if fake.loadCheckpoint != nil {
+		return fake.loadCheckpoint(ctx, req)
+	}
 	return factoryruntime.LoadCheckpointResult{}, nil
 }
-func (fake *runtimeRootFake) RestoreCheckpoint(context.Context, factoryruntime.RestoreCheckpointRequest) (factoryruntime.RestoreCheckpointResult, error) {
+func (fake *runtimeRootFake) RestoreCheckpoint(ctx context.Context, req factoryruntime.RestoreCheckpointRequest) (factoryruntime.RestoreCheckpointResult, error) {
+	if fake.restoreCheckpoint != nil {
+		return fake.restoreCheckpoint(ctx, req)
+	}
 	return factoryruntime.RestoreCheckpointResult{}, nil
 }

--- a/pkg/services/factory_runtime/transports/http/adapter_test.go
+++ b/pkg/services/factory_runtime/transports/http/adapter_test.go
@@ -50,18 +50,31 @@ func TestNewAdapter_RejectsNilRoot(t *testing.T) {
 }
 
 type runtimeRootFake struct {
-	observe func(context.Context, factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error)
+	observe   func(context.Context, factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error)
+	pause     func(context.Context, factoryruntime.PauseRequest) (factoryruntime.PauseResult, error)
+	resume    func(context.Context, factoryruntime.ResumeRequest) (factoryruntime.ResumeResult, error)
+	terminate func(context.Context, factoryruntime.TerminateRequest) (factoryruntime.TerminateResult, error)
+	moveWork  func(context.Context, factoryruntime.MoveWorkRequest) (factoryruntime.MoveWorkResult, error)
 }
 
 var _ factoryruntime.Service = (*runtimeRootFake)(nil)
 
-func (fake *runtimeRootFake) ControlPause(context.Context, factoryruntime.PauseRequest) (factoryruntime.PauseResult, error) {
+func (fake *runtimeRootFake) ControlPause(ctx context.Context, req factoryruntime.PauseRequest) (factoryruntime.PauseResult, error) {
+	if fake.pause != nil {
+		return fake.pause(ctx, req)
+	}
 	return factoryruntime.PauseResult{}, nil
 }
-func (fake *runtimeRootFake) ControlResume(context.Context, factoryruntime.ResumeRequest) (factoryruntime.ResumeResult, error) {
+func (fake *runtimeRootFake) ControlResume(ctx context.Context, req factoryruntime.ResumeRequest) (factoryruntime.ResumeResult, error) {
+	if fake.resume != nil {
+		return fake.resume(ctx, req)
+	}
 	return factoryruntime.ResumeResult{}, nil
 }
-func (fake *runtimeRootFake) ControlTerminate(context.Context, factoryruntime.TerminateRequest) (factoryruntime.TerminateResult, error) {
+func (fake *runtimeRootFake) ControlTerminate(ctx context.Context, req factoryruntime.TerminateRequest) (factoryruntime.TerminateResult, error) {
+	if fake.terminate != nil {
+		return fake.terminate(ctx, req)
+	}
 	return factoryruntime.TerminateResult{}, nil
 }
 func (*runtimeRootFake) ControlWaitToComplete(factoryruntime.WaitToCompleteRequest) factoryruntime.WaitToCompleteResult {
@@ -69,7 +82,10 @@ func (*runtimeRootFake) ControlWaitToComplete(factoryruntime.WaitToCompleteReque
 	close(done)
 	return factoryruntime.WaitToCompleteResult{Done: done}
 }
-func (fake *runtimeRootFake) ControlMoveWork(context.Context, factoryruntime.MoveWorkRequest) (factoryruntime.MoveWorkResult, error) {
+func (fake *runtimeRootFake) ControlMoveWork(ctx context.Context, req factoryruntime.MoveWorkRequest) (factoryruntime.MoveWorkResult, error) {
+	if fake.moveWork != nil {
+		return fake.moveWork(ctx, req)
+	}
 	return factoryruntime.MoveWorkResult{}, nil
 }
 func (fake *runtimeRootFake) Observe(ctx context.Context, req factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error) {

--- a/pkg/services/factory_runtime/transports/http/adapter_test.go
+++ b/pkg/services/factory_runtime/transports/http/adapter_test.go
@@ -1,0 +1,95 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+func TestAdapter_BindsRuntimeRootViaFakeRootSeam(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := &runtimeRootFake{
+		observe: func(_ context.Context, _ factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error) {
+			invoked = true
+			return factoryruntime.ObserveResult{}, factoryruntime.ErrNotRunning
+		},
+	}
+
+	adapter := NewAdapter(fake)
+	if adapter.Root() != fake {
+		t.Fatal("adapter must expose the injected Runtime root")
+	}
+
+	root, err := adapter.runtimeRoot()
+	if err != nil {
+		t.Fatalf("runtimeRoot() error = %v", err)
+	}
+	if root != fake {
+		t.Fatal("runtimeRoot() must return the injected Runtime root")
+	}
+
+	_, err = root.Observe(context.Background(), factoryruntime.ObserveRequest{})
+	if !invoked {
+		t.Fatal("adapter-owned operation did not reach the injected Runtime root")
+	}
+	if !errors.Is(err, factoryruntime.ErrNotRunning) {
+		t.Fatalf("Observe error = %v, want ErrNotRunning", err)
+	}
+}
+
+func TestNewAdapter_RejectsNilRoot(t *testing.T) {
+	t.Parallel()
+
+	if NewAdapter(nil) != nil {
+		t.Fatal("NewAdapter(nil) must return nil")
+	}
+}
+
+type runtimeRootFake struct {
+	observe func(context.Context, factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error)
+}
+
+var _ factoryruntime.Service = (*runtimeRootFake)(nil)
+
+func (fake *runtimeRootFake) ControlPause(context.Context, factoryruntime.PauseRequest) (factoryruntime.PauseResult, error) {
+	return factoryruntime.PauseResult{}, nil
+}
+func (fake *runtimeRootFake) ControlResume(context.Context, factoryruntime.ResumeRequest) (factoryruntime.ResumeResult, error) {
+	return factoryruntime.ResumeResult{}, nil
+}
+func (fake *runtimeRootFake) ControlTerminate(context.Context, factoryruntime.TerminateRequest) (factoryruntime.TerminateResult, error) {
+	return factoryruntime.TerminateResult{}, nil
+}
+func (*runtimeRootFake) ControlWaitToComplete(factoryruntime.WaitToCompleteRequest) factoryruntime.WaitToCompleteResult {
+	done := make(chan struct{})
+	close(done)
+	return factoryruntime.WaitToCompleteResult{Done: done}
+}
+func (fake *runtimeRootFake) ControlMoveWork(context.Context, factoryruntime.MoveWorkRequest) (factoryruntime.MoveWorkResult, error) {
+	return factoryruntime.MoveWorkResult{}, nil
+}
+func (fake *runtimeRootFake) Observe(ctx context.Context, req factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error) {
+	if fake.observe != nil {
+		return fake.observe(ctx, req)
+	}
+	return factoryruntime.ObserveResult{}, nil
+}
+func (fake *runtimeRootFake) PlanDispatch(context.Context, factoryruntime.PlanDispatchRequest) (factoryruntime.PlanDispatchResult, error) {
+	return factoryruntime.PlanDispatchResult{}, nil
+}
+func (fake *runtimeRootFake) AcceptDispatchResult(context.Context, factoryruntime.AcceptDispatchResultRequest) (factoryruntime.AcceptDispatchResultResult, error) {
+	return factoryruntime.AcceptDispatchResultResult{}, nil
+}
+func (fake *runtimeRootFake) CaptureCheckpoint(context.Context, factoryruntime.CaptureCheckpointRequest) (factoryruntime.CaptureCheckpointResult, error) {
+	return factoryruntime.CaptureCheckpointResult{}, nil
+}
+func (fake *runtimeRootFake) LoadCheckpoint(context.Context, factoryruntime.LoadCheckpointRequest) (factoryruntime.LoadCheckpointResult, error) {
+	return factoryruntime.LoadCheckpointResult{}, nil
+}
+func (fake *runtimeRootFake) RestoreCheckpoint(context.Context, factoryruntime.RestoreCheckpointRequest) (factoryruntime.RestoreCheckpointResult, error) {
+	return factoryruntime.RestoreCheckpointResult{}, nil
+}

--- a/pkg/services/factory_runtime/transports/http/boundary_test.go
+++ b/pkg/services/factory_runtime/transports/http/boundary_test.go
@@ -1,0 +1,38 @@
+package http_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestPackageBoundary_DoesNotImportFactoryRuntimeInternals(t *testing.T) {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	packageDir := filepath.Dir(filename)
+
+	forbidden := "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal"
+	entries, err := os.ReadDir(packageDir)
+	if err != nil {
+		t.Fatalf("read HTTP adapter package: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(packageDir, entry.Name())
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if strings.Contains(string(content), forbidden) {
+			t.Fatalf("%s must not import %s", entry.Name(), forbidden)
+		}
+	}
+}

--- a/pkg/services/factory_runtime/transports/http/checkpoint_mapping.go
+++ b/pkg/services/factory_runtime/transports/http/checkpoint_mapping.go
@@ -1,0 +1,161 @@
+package http
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+type runtimeCheckpointHTTP struct {
+	CheckpointID  string `json:"checkpointId"`
+	SchemaVersion int    `json:"schemaVersion"`
+	StrategyKind  string `json:"strategyKind,omitempty"`
+	Payload       []byte `json:"payload,omitempty"`
+}
+
+type runtimeCaptureCheckpointHTTPRequest struct {
+	CheckpointID string `json:"checkpointId"`
+}
+
+type runtimeCaptureCheckpointHTTPResponse struct {
+	Outcome    factoryruntime.CheckpointOutcome `json:"outcome"`
+	Checkpoint runtimeCheckpointHTTP            `json:"checkpoint"`
+}
+
+type runtimeLoadCheckpointHTTPRequest struct {
+	CheckpointID          string `json:"checkpointId"`
+	ExpectedSchemaVersion int    `json:"expectedSchemaVersion,omitempty"`
+}
+
+type runtimeLoadCheckpointHTTPResponse struct {
+	Outcome    factoryruntime.CheckpointOutcome `json:"outcome"`
+	Checkpoint runtimeCheckpointHTTP            `json:"checkpoint"`
+	Compatible bool                             `json:"compatible"`
+}
+
+type runtimeRestoreCheckpointHTTPRequest struct {
+	Checkpoint runtimeCheckpointHTTP `json:"checkpoint"`
+}
+
+type runtimeRestoreCheckpointHTTPResponse struct {
+	Outcome      factoryruntime.CheckpointOutcome `json:"outcome"`
+	CheckpointID string                           `json:"checkpointId"`
+}
+
+func decodeCaptureCheckpointRequest(body io.Reader) (factoryruntime.CaptureCheckpointRequest, error) {
+	payload, err := io.ReadAll(body)
+	if err != nil {
+		return factoryruntime.CaptureCheckpointRequest{}, err
+	}
+	if len(payload) == 0 {
+		return factoryruntime.CaptureCheckpointRequest{}, errRequestBodyRequired
+	}
+	var req runtimeCaptureCheckpointHTTPRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return factoryruntime.CaptureCheckpointRequest{}, err
+	}
+	return captureCheckpointRequestFromHTTP(req), nil
+}
+
+func decodeLoadCheckpointRequest(body io.Reader) (factoryruntime.LoadCheckpointRequest, error) {
+	payload, err := io.ReadAll(body)
+	if err != nil {
+		return factoryruntime.LoadCheckpointRequest{}, err
+	}
+	if len(payload) == 0 {
+		return factoryruntime.LoadCheckpointRequest{}, errRequestBodyRequired
+	}
+	var req runtimeLoadCheckpointHTTPRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return factoryruntime.LoadCheckpointRequest{}, err
+	}
+	return loadCheckpointRequestFromHTTP(req), nil
+}
+
+func decodeRestoreCheckpointRequest(body io.Reader) (factoryruntime.RestoreCheckpointRequest, error) {
+	payload, err := io.ReadAll(body)
+	if err != nil {
+		return factoryruntime.RestoreCheckpointRequest{}, err
+	}
+	if len(payload) == 0 {
+		return factoryruntime.RestoreCheckpointRequest{}, errRequestBodyRequired
+	}
+	var req runtimeRestoreCheckpointHTTPRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return factoryruntime.RestoreCheckpointRequest{}, err
+	}
+	return restoreCheckpointRequestFromHTTP(req), nil
+}
+
+func captureCheckpointRequestFromHTTP(
+	req runtimeCaptureCheckpointHTTPRequest,
+) factoryruntime.CaptureCheckpointRequest {
+	return factoryruntime.CaptureCheckpointRequest{
+		CheckpointID: strings.TrimSpace(req.CheckpointID),
+	}
+}
+
+func loadCheckpointRequestFromHTTP(
+	req runtimeLoadCheckpointHTTPRequest,
+) factoryruntime.LoadCheckpointRequest {
+	return factoryruntime.LoadCheckpointRequest{
+		CheckpointID:          strings.TrimSpace(req.CheckpointID),
+		ExpectedSchemaVersion: req.ExpectedSchemaVersion,
+	}
+}
+
+func restoreCheckpointRequestFromHTTP(
+	req runtimeRestoreCheckpointHTTPRequest,
+) factoryruntime.RestoreCheckpointRequest {
+	return factoryruntime.RestoreCheckpointRequest{
+		Checkpoint: checkpointFromHTTP(req.Checkpoint),
+	}
+}
+
+func checkpointFromHTTP(checkpoint runtimeCheckpointHTTP) factoryruntime.Checkpoint {
+	return factoryruntime.Checkpoint{
+		CheckpointID:  strings.TrimSpace(checkpoint.CheckpointID),
+		SchemaVersion: checkpoint.SchemaVersion,
+		StrategyKind:  strings.TrimSpace(checkpoint.StrategyKind),
+		Payload:       checkpoint.Payload,
+	}
+}
+
+func checkpointToHTTP(checkpoint factoryruntime.Checkpoint) runtimeCheckpointHTTP {
+	return runtimeCheckpointHTTP{
+		CheckpointID:  checkpoint.CheckpointID,
+		SchemaVersion: checkpoint.SchemaVersion,
+		StrategyKind:  checkpoint.StrategyKind,
+		Payload:       checkpoint.Payload,
+	}
+}
+
+func captureCheckpointResponseFromResult(
+	result factoryruntime.CaptureCheckpointResult,
+) runtimeCaptureCheckpointHTTPResponse {
+	return runtimeCaptureCheckpointHTTPResponse{
+		Outcome:    result.Outcome,
+		Checkpoint: checkpointToHTTP(result.Checkpoint),
+	}
+}
+
+func loadCheckpointResponseFromResult(
+	result factoryruntime.LoadCheckpointResult,
+) runtimeLoadCheckpointHTTPResponse {
+	return runtimeLoadCheckpointHTTPResponse{
+		Outcome:    result.Outcome,
+		Checkpoint: checkpointToHTTP(result.Checkpoint),
+		Compatible: result.Compatible,
+	}
+}
+
+func restoreCheckpointResponseFromResult(
+	result factoryruntime.RestoreCheckpointResult,
+) runtimeRestoreCheckpointHTTPResponse {
+	return runtimeRestoreCheckpointHTTPResponse{
+		Outcome:      result.Outcome,
+		CheckpointID: result.CheckpointID,
+	}
+}

--- a/pkg/services/factory_runtime/transports/http/control_mapping.go
+++ b/pkg/services/factory_runtime/transports/http/control_mapping.go
@@ -1,0 +1,26 @@
+package http
+
+import (
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+type runtimeControlHTTPResponse struct {
+	Outcome factoryruntime.ControlOutcome `json:"outcome"`
+}
+
+func controlResponseFromPauseResult(result factoryruntime.PauseResult) runtimeControlHTTPResponse {
+	return runtimeControlHTTPResponse{Outcome: result.Outcome}
+}
+
+func controlResponseFromResumeResult(result factoryruntime.ResumeResult) runtimeControlHTTPResponse {
+	return runtimeControlHTTPResponse{Outcome: result.Outcome}
+}
+
+func controlResponseFromTerminateResult(result factoryruntime.TerminateResult) runtimeControlHTTPResponse {
+	return runtimeControlHTTPResponse{Outcome: result.Outcome}
+}
+
+func terminateRequestFromAPI(req factoryapi.FactorySessionLifecycleControlRequest) factoryruntime.TerminateRequest {
+	return factoryruntime.TerminateRequest{Reason: stringValue(req.Reason)}
+}

--- a/pkg/services/factory_runtime/transports/http/dispatch_plan_mapping.go
+++ b/pkg/services/factory_runtime/transports/http/dispatch_plan_mapping.go
@@ -1,0 +1,109 @@
+package http
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+type runtimeDispatchPlanHTTPRequest struct {
+	DispatchID      string   `json:"dispatchId"`
+	CorrelationID   string   `json:"correlationId"`
+	WorkIDs         []string `json:"workIds"`
+	WorkstationName string   `json:"workstationName"`
+	WorkerType      string   `json:"workerType"`
+	ReplayKey       string   `json:"replayKey"`
+}
+
+type runtimeAcceptDispatchResultHTTPRequest struct {
+	DispatchID    string `json:"dispatchId"`
+	CorrelationID string `json:"correlationId"`
+	WorkID        string `json:"workId"`
+	ResultOutcome string `json:"resultOutcome"`
+}
+
+type runtimeDispatchPlanHTTPResponse struct {
+	Outcome       factoryruntime.DispatchPlanOutcome `json:"outcome"`
+	DispatchID    string                             `json:"dispatchId"`
+	CorrelationID string                             `json:"correlationId,omitempty"`
+}
+
+func decodePlanDispatchRequest(body io.Reader) (factoryruntime.PlanDispatchRequest, error) {
+	payload, err := io.ReadAll(body)
+	if err != nil {
+		return factoryruntime.PlanDispatchRequest{}, err
+	}
+	if len(payload) == 0 {
+		return factoryruntime.PlanDispatchRequest{}, errRequestBodyRequired
+	}
+	var req runtimeDispatchPlanHTTPRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return factoryruntime.PlanDispatchRequest{}, err
+	}
+	return planDispatchRequestFromHTTP(req), nil
+}
+
+func decodeAcceptDispatchResultRequest(body io.Reader) (factoryruntime.AcceptDispatchResultRequest, error) {
+	payload, err := io.ReadAll(body)
+	if err != nil {
+		return factoryruntime.AcceptDispatchResultRequest{}, err
+	}
+	if len(payload) == 0 {
+		return factoryruntime.AcceptDispatchResultRequest{}, errRequestBodyRequired
+	}
+	var req runtimeAcceptDispatchResultHTTPRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return factoryruntime.AcceptDispatchResultRequest{}, err
+	}
+	return acceptDispatchResultRequestFromHTTP(req), nil
+}
+
+func planDispatchRequestFromHTTP(req runtimeDispatchPlanHTTPRequest) factoryruntime.PlanDispatchRequest {
+	workIDs := make([]string, 0, len(req.WorkIDs))
+	for _, workID := range req.WorkIDs {
+		if trimmed := strings.TrimSpace(workID); trimmed != "" {
+			workIDs = append(workIDs, trimmed)
+		}
+	}
+	return factoryruntime.PlanDispatchRequest{
+		DispatchID:      strings.TrimSpace(req.DispatchID),
+		CorrelationID:   strings.TrimSpace(req.CorrelationID),
+		WorkIDs:         workIDs,
+		WorkstationName: strings.TrimSpace(req.WorkstationName),
+		WorkerType:      strings.TrimSpace(req.WorkerType),
+		ReplayKey:       strings.TrimSpace(req.ReplayKey),
+	}
+}
+
+func acceptDispatchResultRequestFromHTTP(
+	req runtimeAcceptDispatchResultHTTPRequest,
+) factoryruntime.AcceptDispatchResultRequest {
+	return factoryruntime.AcceptDispatchResultRequest{
+		DispatchID:    strings.TrimSpace(req.DispatchID),
+		CorrelationID: strings.TrimSpace(req.CorrelationID),
+		WorkID:        strings.TrimSpace(req.WorkID),
+		ResultOutcome: factoryruntime.DispatchResultOutcome(strings.TrimSpace(req.ResultOutcome)),
+	}
+}
+
+func dispatchPlanResponseFromPlanResult(
+	result factoryruntime.PlanDispatchResult,
+) runtimeDispatchPlanHTTPResponse {
+	return runtimeDispatchPlanHTTPResponse{
+		Outcome:       result.Outcome,
+		DispatchID:    result.DispatchID,
+		CorrelationID: result.CorrelationID,
+	}
+}
+
+func dispatchPlanResponseFromAcceptResult(
+	result factoryruntime.AcceptDispatchResultResult,
+) runtimeDispatchPlanHTTPResponse {
+	return runtimeDispatchPlanHTTPResponse{
+		Outcome:       result.Outcome,
+		DispatchID:    result.DispatchID,
+		CorrelationID: result.CorrelationID,
+	}
+}

--- a/pkg/services/factory_runtime/transports/http/error_mapping.go
+++ b/pkg/services/factory_runtime/transports/http/error_mapping.go
@@ -1,0 +1,64 @@
+package http
+
+import (
+	"errors"
+	"net/http"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	apisurface "github.com/portpowered/infinite-you/pkg/transports/mapping"
+)
+
+var errSessionObserverRequired = errors.New("factory session observation is required for session-scoped status reads")
+
+func observeErrorResponse(err error) (int, factoryapi.ErrorResponse, bool) {
+	if err == nil {
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+	switch {
+	case errors.Is(err, errSessionObserverRequired):
+		return serviceUnavailableErrorResponse("factory status is unavailable")
+	case errors.Is(err, apisurface.ErrFactorySessionNotFound):
+		return notFoundErrorResponse("factory session not found")
+	case errors.Is(err, factoryruntime.ErrInvalidObservationScope):
+		return badRequestErrorResponse("invalid observation scope")
+	case errors.Is(err, factoryruntime.ErrNotFound):
+		return notFoundErrorResponse("factory runtime target not found")
+	case errors.Is(err, factoryruntime.ErrNotRunning):
+		return serviceUnavailableErrorResponse("factory runtime is not running")
+	default:
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+}
+
+func (a *Adapter) writeObserveError(w http.ResponseWriter, err error) bool {
+	if status, response, ok := observeErrorResponse(err); ok {
+		a.writeJSON(w, status, response)
+		return true
+	}
+	return false
+}
+
+func badRequestErrorResponse(message string) (int, factoryapi.ErrorResponse, bool) {
+	return http.StatusBadRequest, factoryapi.ErrorResponse{
+		Message: message,
+		Family:  factoryapi.ErrorFamilyBadRequest,
+		Code:    factoryapi.ErrorResponseCodeBADREQUEST,
+	}, true
+}
+
+func notFoundErrorResponse(message string) (int, factoryapi.ErrorResponse, bool) {
+	return http.StatusNotFound, factoryapi.ErrorResponse{
+		Message: message,
+		Family:  factoryapi.ErrorFamilyNotFound,
+		Code:    factoryapi.ErrorResponseCodeNOTFOUND,
+	}, true
+}
+
+func serviceUnavailableErrorResponse(message string) (int, factoryapi.ErrorResponse, bool) {
+	return http.StatusServiceUnavailable, factoryapi.ErrorResponse{
+		Message: message,
+		Family:  factoryapi.ErrorFamilyInternalServerError,
+		Code:    factoryapi.ErrorResponseCode("SERVICE_UNAVAILABLE"),
+	}, true
+}

--- a/pkg/services/factory_runtime/transports/http/error_mapping.go
+++ b/pkg/services/factory_runtime/transports/http/error_mapping.go
@@ -11,32 +11,111 @@ import (
 
 var errSessionObserverRequired = errors.New("factory session observation is required for session-scoped status reads")
 
-func observeErrorResponse(err error) (int, factoryapi.ErrorResponse, bool) {
+type runtimeHTTPOperation int
+
+const (
+	runtimeHTTPOperationObserve runtimeHTTPOperation = iota
+	runtimeHTTPOperationControl
+	runtimeHTTPOperationMoveWork
+	runtimeHTTPOperationDispatchPlan
+	runtimeHTTPOperationCheckpoint
+)
+
+// RootErrorResponse maps published Runtime root sentinel failures to HTTP status
+// and the public ErrorResponse shape. It returns false when err is not a known
+// mapped typed failure for the operation.
+func RootErrorResponse(err error, operation runtimeHTTPOperation) (int, factoryapi.ErrorResponse, bool) {
 	if err == nil {
 		return 0, factoryapi.ErrorResponse{}, false
 	}
-	switch {
-	case errors.Is(err, errSessionObserverRequired):
-		return serviceUnavailableErrorResponse("factory status is unavailable")
-	case errors.Is(err, apisurface.ErrFactorySessionNotFound):
-		return notFoundErrorResponse("factory session not found")
-	case errors.Is(err, factoryruntime.ErrInvalidObservationScope):
-		return badRequestErrorResponse("invalid observation scope")
-	case errors.Is(err, factoryruntime.ErrNotFound):
-		return notFoundErrorResponse("factory runtime target not found")
-	case errors.Is(err, factoryruntime.ErrNotRunning):
-		return serviceUnavailableErrorResponse("factory runtime is not running")
-	default:
-		return 0, factoryapi.ErrorResponse{}, false
+
+	switch operation {
+	case runtimeHTTPOperationObserve:
+		if errors.Is(err, errSessionObserverRequired) {
+			return serviceUnavailableErrorResponse("factory status is unavailable")
+		}
+		if errors.Is(err, apisurface.ErrFactorySessionNotFound) {
+			return notFoundErrorResponse("factory session not found")
+		}
+		if errors.Is(err, factoryruntime.ErrInvalidObservationScope) {
+			return badRequestErrorResponse("invalid observation scope")
+		}
+	case runtimeHTTPOperationControl:
+		if errors.Is(err, factoryruntime.ErrAlreadyStopped) {
+			return conflictErrorResponse("factory runtime is already stopped")
+		}
+		if errors.Is(err, factoryruntime.ErrInvalidLifecycleTransition) {
+			return badRequestErrorResponse("factory runtime invalid lifecycle transition")
+		}
+	case runtimeHTTPOperationMoveWork:
+		if errors.Is(err, factoryruntime.ErrMoveWorkNotFound) {
+			return notFoundErrorResponse("work not found")
+		}
+		if errors.Is(err, factoryruntime.ErrMoveWorkInvalidState) {
+			return badRequestErrorResponse("invalid target state for work type")
+		}
+		if errors.Is(err, factoryruntime.ErrMoveWorkInFlightDispatch) {
+			return badRequestErrorResponse("work is in an active dispatch")
+		}
+		if errors.Is(err, factoryruntime.ErrMoveWorkEngineTerminated) {
+			return badRequestErrorResponse("engine has terminated")
+		}
+		if errors.Is(err, factoryruntime.ErrMoveWorkRequestConflict) {
+			return moveWorkRequestConflictErrorResponse()
+		}
+	case runtimeHTTPOperationDispatchPlan:
+		if errors.Is(err, factoryruntime.ErrDuplicateDispatchIntent) {
+			return conflictErrorResponse("dispatch intent conflicts with an existing plan")
+		}
+		if errors.Is(err, factoryruntime.ErrUnknownDispatchCorrelation) {
+			return notFoundErrorResponse("dispatch correlation not found")
+		}
+		if errors.Is(err, factoryruntime.ErrInvalidDispatchResultBoundary) {
+			return badRequestErrorResponse("invalid dispatch result boundary")
+		}
+	case runtimeHTTPOperationCheckpoint:
+		if errors.Is(err, factoryruntime.ErrCheckpointNotFound) {
+			return notFoundErrorResponse("factory runtime checkpoint not found")
+		}
+		if errors.Is(err, factoryruntime.ErrCorruptCheckpoint) {
+			return badRequestErrorResponse("factory runtime checkpoint is corrupt")
+		}
+		if errors.Is(err, factoryruntime.ErrIncompatibleCheckpoint) {
+			return conflictErrorResponse("factory runtime checkpoint is incompatible")
+		}
 	}
+
+	if errors.Is(err, factoryruntime.ErrCapabilityUnavailable) {
+		return serviceUnavailableErrorResponse("factory runtime capability is unavailable")
+	}
+	if errors.Is(err, factoryruntime.ErrNotRunning) {
+		return serviceUnavailableErrorResponse("factory runtime is not running")
+	}
+	if errors.Is(err, factoryruntime.ErrNotFound) {
+		return notFoundErrorResponse("factory runtime target not found")
+	}
+
+	return 0, factoryapi.ErrorResponse{}, false
 }
 
-func (a *Adapter) writeObserveError(w http.ResponseWriter, err error) bool {
-	if status, response, ok := observeErrorResponse(err); ok {
+func (a *Adapter) writeRootError(w http.ResponseWriter, operation runtimeHTTPOperation, err error) bool {
+	if status, response, ok := RootErrorResponse(err, operation); ok {
 		a.writeJSON(w, status, response)
 		return true
 	}
 	return false
+}
+
+func (a *Adapter) writeRootOrInternalError(
+	w http.ResponseWriter,
+	operation runtimeHTTPOperation,
+	internalMessage string,
+	err error,
+) {
+	if a.writeRootError(w, operation, err) {
+		return
+	}
+	a.writeError(w, http.StatusInternalServerError, internalMessage, "INTERNAL_ERROR")
 }
 
 func badRequestErrorResponse(message string) (int, factoryapi.ErrorResponse, bool) {
@@ -55,10 +134,26 @@ func notFoundErrorResponse(message string) (int, factoryapi.ErrorResponse, bool)
 	}, true
 }
 
+func conflictErrorResponse(message string) (int, factoryapi.ErrorResponse, bool) {
+	return http.StatusConflict, factoryapi.ErrorResponse{
+		Message: message,
+		Family:  factoryapi.ErrorFamilyConflict,
+		Code:    factoryapi.ErrorResponseCode("CONFLICT"),
+	}, true
+}
+
 func serviceUnavailableErrorResponse(message string) (int, factoryapi.ErrorResponse, bool) {
 	return http.StatusServiceUnavailable, factoryapi.ErrorResponse{
 		Message: message,
 		Family:  factoryapi.ErrorFamilyInternalServerError,
 		Code:    factoryapi.ErrorResponseCode("SERVICE_UNAVAILABLE"),
+	}, true
+}
+
+func moveWorkRequestConflictErrorResponse() (int, factoryapi.ErrorResponse, bool) {
+	return http.StatusConflict, factoryapi.ErrorResponse{
+		Message: "Operator move request was already applied.",
+		Family:  factoryapi.ErrorFamilyConflict,
+		Code:    factoryapi.ErrorResponseCodeMOVEWORKREQUESTALREADYAPPLIED,
 	}, true
 }

--- a/pkg/services/factory_runtime/transports/http/error_mapping.go
+++ b/pkg/services/factory_runtime/transports/http/error_mapping.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -108,10 +109,18 @@ func (a *Adapter) writeRootError(w http.ResponseWriter, operation runtimeHTTPOpe
 
 func (a *Adapter) writeRootOrInternalError(
 	w http.ResponseWriter,
+	ctx context.Context,
 	operation runtimeHTTPOperation,
 	internalMessage string,
 	err error,
 ) {
+	if requestContextEnded(ctx) {
+		a.writeRuntimeRequestContextOutcome(w, ctx.Err())
+		return
+	}
+	if a.writeRuntimeRequestContextOutcome(w, err) {
+		return
+	}
 	if a.writeRootError(w, operation, err) {
 		return
 	}

--- a/pkg/services/factory_runtime/transports/http/error_mapping_test.go
+++ b/pkg/services/factory_runtime/transports/http/error_mapping_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -358,7 +359,7 @@ func TestWriteRootOrInternalError_SanitizesUnmappedFailures(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	err := errors.New("pkg/services/factory_runtime/internal/service: boom")
 
-	adapter.writeRootOrInternalError(recorder, runtimeHTTPOperationObserve, "failed to observe factory runtime status", err)
+	adapter.writeRootOrInternalError(recorder, context.Background(), runtimeHTTPOperationObserve, "failed to observe factory runtime status", err)
 
 	body := recorder.Body.String()
 	if recorder.Code != http.StatusInternalServerError ||

--- a/pkg/services/factory_runtime/transports/http/error_mapping_test.go
+++ b/pkg/services/factory_runtime/transports/http/error_mapping_test.go
@@ -1,0 +1,388 @@
+package http
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	apisurface "github.com/portpowered/infinite-you/pkg/transports/mapping"
+)
+
+func TestRootErrorResponse_MapsSharedRuntimeSentinels(t *testing.T) {
+	t.Parallel()
+
+	operations := []runtimeHTTPOperation{
+		runtimeHTTPOperationObserve,
+		runtimeHTTPOperationControl,
+		runtimeHTTPOperationMoveWork,
+		runtimeHTTPOperationDispatchPlan,
+		runtimeHTTPOperationCheckpoint,
+	}
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   factoryapi.ErrorResponseCode
+		wantMsg    string
+	}{
+		{
+			name:       "not running",
+			err:        factoryruntime.ErrNotRunning,
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   factoryapi.ErrorResponseCode("SERVICE_UNAVAILABLE"),
+			wantMsg:    "factory runtime is not running",
+		},
+		{
+			name:       "not found",
+			err:        factoryruntime.ErrNotFound,
+			wantStatus: http.StatusNotFound,
+			wantCode:   factoryapi.ErrorResponseCodeNOTFOUND,
+			wantMsg:    "factory runtime target not found",
+		},
+		{
+			name:       "capability unavailable",
+			err:        factoryruntime.ErrCapabilityUnavailable,
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   factoryapi.ErrorResponseCode("SERVICE_UNAVAILABLE"),
+			wantMsg:    "factory runtime capability is unavailable",
+		},
+	}
+
+	for _, operation := range operations {
+		for _, tc := range cases {
+			tc := tc
+			operation := operation
+			t.Run(fmt.Sprintf("%s/%s", operationName(operation), tc.name), func(t *testing.T) {
+				t.Parallel()
+				status, response, ok := RootErrorResponse(tc.err, operation)
+				if !ok {
+					t.Fatalf("RootErrorResponse(%v, %s) = not handled", tc.err, operationName(operation))
+				}
+				if status != tc.wantStatus || response.Code != tc.wantCode || response.Message != tc.wantMsg {
+					t.Fatalf("RootErrorResponse(%v, %s) = %d %#v, want %d code=%s msg=%q",
+						tc.err, operationName(operation), status, response, tc.wantStatus, tc.wantCode, tc.wantMsg)
+				}
+			})
+		}
+	}
+}
+
+func TestRootErrorResponse_MapsObservationFailures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   factoryapi.ErrorResponseCode
+		wantMsg    string
+	}{
+		{
+			name:       "session observer required",
+			err:        errSessionObserverRequired,
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   factoryapi.ErrorResponseCode("SERVICE_UNAVAILABLE"),
+			wantMsg:    "factory status is unavailable",
+		},
+		{
+			name:       "session not found",
+			err:        factorysessions.ErrSessionNotFound,
+			wantStatus: http.StatusNotFound,
+			wantCode:   factoryapi.ErrorResponseCodeNOTFOUND,
+			wantMsg:    "factory session not found",
+		},
+		{
+			name:       "invalid observation scope",
+			err:        factoryruntime.ErrInvalidObservationScope,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   factoryapi.ErrorResponseCodeBADREQUEST,
+			wantMsg:    "invalid observation scope",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			status, response, ok := RootErrorResponse(tc.err, runtimeHTTPOperationObserve)
+			if !ok {
+				t.Fatalf("RootErrorResponse(%v) = not handled", tc.err)
+			}
+			if status != tc.wantStatus || response.Code != tc.wantCode || response.Message != tc.wantMsg {
+				t.Fatalf("RootErrorResponse(%v) = %d %#v, want %d code=%s msg=%q",
+					tc.err, status, response, tc.wantStatus, tc.wantCode, tc.wantMsg)
+			}
+		})
+	}
+}
+
+func TestRootErrorResponse_MapsControlFailures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   factoryapi.ErrorResponseCode
+		wantMsg    string
+	}{
+		{
+			name:       "already stopped",
+			err:        factoryruntime.ErrAlreadyStopped,
+			wantStatus: http.StatusConflict,
+			wantCode:   factoryapi.ErrorResponseCode("CONFLICT"),
+			wantMsg:    "factory runtime is already stopped",
+		},
+		{
+			name:       "invalid lifecycle transition",
+			err:        factoryruntime.ErrInvalidLifecycleTransition,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   factoryapi.ErrorResponseCodeBADREQUEST,
+			wantMsg:    "factory runtime invalid lifecycle transition",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			status, response, ok := RootErrorResponse(tc.err, runtimeHTTPOperationControl)
+			if !ok {
+				t.Fatalf("RootErrorResponse(%v) = not handled", tc.err)
+			}
+			if status != tc.wantStatus || response.Code != tc.wantCode || response.Message != tc.wantMsg {
+				t.Fatalf("RootErrorResponse(%v) = %d %#v", tc.err, status, response)
+			}
+		})
+	}
+}
+
+func TestRootErrorResponse_MapsMoveWorkFailures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   factoryapi.ErrorResponseCode
+		wantMsg    string
+	}{
+		{
+			name:       "work not found",
+			err:        factoryruntime.ErrMoveWorkNotFound,
+			wantStatus: http.StatusNotFound,
+			wantCode:   factoryapi.ErrorResponseCodeNOTFOUND,
+			wantMsg:    "work not found",
+		},
+		{
+			name:       "invalid state",
+			err:        factoryruntime.ErrMoveWorkInvalidState,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   factoryapi.ErrorResponseCodeBADREQUEST,
+			wantMsg:    "invalid target state for work type",
+		},
+		{
+			name:       "in flight dispatch",
+			err:        factoryruntime.ErrMoveWorkInFlightDispatch,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   factoryapi.ErrorResponseCodeBADREQUEST,
+			wantMsg:    "work is in an active dispatch",
+		},
+		{
+			name:       "engine terminated",
+			err:        factoryruntime.ErrMoveWorkEngineTerminated,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   factoryapi.ErrorResponseCodeBADREQUEST,
+			wantMsg:    "engine has terminated",
+		},
+		{
+			name:       "request conflict",
+			err:        factoryruntime.ErrMoveWorkRequestConflict,
+			wantStatus: http.StatusConflict,
+			wantCode:   factoryapi.ErrorResponseCodeMOVEWORKREQUESTALREADYAPPLIED,
+			wantMsg:    "Operator move request was already applied.",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			status, response, ok := RootErrorResponse(tc.err, runtimeHTTPOperationMoveWork)
+			if !ok {
+				t.Fatalf("RootErrorResponse(%v) = not handled", tc.err)
+			}
+			if status != tc.wantStatus || response.Code != tc.wantCode || response.Message != tc.wantMsg {
+				t.Fatalf("RootErrorResponse(%v) = %d %#v", tc.err, status, response)
+			}
+		})
+	}
+}
+
+func TestRootErrorResponse_MapsDispatchPlanFailures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   factoryapi.ErrorResponseCode
+		wantMsg    string
+	}{
+		{
+			name:       "duplicate intent",
+			err:        factoryruntime.ErrDuplicateDispatchIntent,
+			wantStatus: http.StatusConflict,
+			wantCode:   factoryapi.ErrorResponseCode("CONFLICT"),
+			wantMsg:    "dispatch intent conflicts with an existing plan",
+		},
+		{
+			name:       "unknown correlation",
+			err:        factoryruntime.ErrUnknownDispatchCorrelation,
+			wantStatus: http.StatusNotFound,
+			wantCode:   factoryapi.ErrorResponseCodeNOTFOUND,
+			wantMsg:    "dispatch correlation not found",
+		},
+		{
+			name:       "invalid result boundary",
+			err:        factoryruntime.ErrInvalidDispatchResultBoundary,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   factoryapi.ErrorResponseCodeBADREQUEST,
+			wantMsg:    "invalid dispatch result boundary",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			status, response, ok := RootErrorResponse(tc.err, runtimeHTTPOperationDispatchPlan)
+			if !ok {
+				t.Fatalf("RootErrorResponse(%v) = not handled", tc.err)
+			}
+			if status != tc.wantStatus || response.Code != tc.wantCode || response.Message != tc.wantMsg {
+				t.Fatalf("RootErrorResponse(%v) = %d %#v", tc.err, status, response)
+			}
+		})
+	}
+}
+
+func TestRootErrorResponse_MapsCheckpointFailures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   factoryapi.ErrorResponseCode
+		wantMsg    string
+	}{
+		{
+			name:       "checkpoint not found",
+			err:        factoryruntime.ErrCheckpointNotFound,
+			wantStatus: http.StatusNotFound,
+			wantCode:   factoryapi.ErrorResponseCodeNOTFOUND,
+			wantMsg:    "factory runtime checkpoint not found",
+		},
+		{
+			name:       "corrupt checkpoint",
+			err:        factoryruntime.ErrCorruptCheckpoint,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   factoryapi.ErrorResponseCodeBADREQUEST,
+			wantMsg:    "factory runtime checkpoint is corrupt",
+		},
+		{
+			name:       "incompatible checkpoint",
+			err:        factoryruntime.ErrIncompatibleCheckpoint,
+			wantStatus: http.StatusConflict,
+			wantCode:   factoryapi.ErrorResponseCode("CONFLICT"),
+			wantMsg:    "factory runtime checkpoint is incompatible",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			status, response, ok := RootErrorResponse(tc.err, runtimeHTTPOperationCheckpoint)
+			if !ok {
+				t.Fatalf("RootErrorResponse(%v) = not handled", tc.err)
+			}
+			if status != tc.wantStatus || response.Code != tc.wantCode || response.Message != tc.wantMsg {
+				t.Fatalf("RootErrorResponse(%v) = %d %#v", tc.err, status, response)
+			}
+		})
+	}
+}
+
+func TestRootErrorResponse_IgnoresCrossOperationTypedFailures(t *testing.T) {
+	t.Parallel()
+
+	if _, _, ok := RootErrorResponse(factoryruntime.ErrMoveWorkNotFound, runtimeHTTPOperationControl); ok {
+		t.Fatal("move-work not found must not map through control operation")
+	}
+	if _, _, ok := RootErrorResponse(factoryruntime.ErrAlreadyStopped, runtimeHTTPOperationMoveWork); ok {
+		t.Fatal("already stopped must not map through move-work operation")
+	}
+	if _, _, ok := RootErrorResponse(factoryruntime.ErrDuplicateDispatchIntent, runtimeHTTPOperationCheckpoint); ok {
+		t.Fatal("duplicate dispatch intent must not map through checkpoint operation")
+	}
+	if _, _, ok := RootErrorResponse(apisurface.ErrFactorySessionNotFound, runtimeHTTPOperationControl); ok {
+		t.Fatal("session not found must not map through control operation")
+	}
+}
+
+func TestRootErrorResponse_ReturnsFalseForUnmappedFailures(t *testing.T) {
+	t.Parallel()
+
+	err := fmt.Errorf("pkg/services/factory_runtime/internal/service: boom")
+	operations := []runtimeHTTPOperation{
+		runtimeHTTPOperationObserve,
+		runtimeHTTPOperationControl,
+		runtimeHTTPOperationMoveWork,
+		runtimeHTTPOperationDispatchPlan,
+		runtimeHTTPOperationCheckpoint,
+	}
+	for _, operation := range operations {
+		if _, _, ok := RootErrorResponse(err, operation); ok {
+			t.Fatalf("unmapped failure %#v must not be handled for %s", err, operationName(operation))
+		}
+	}
+}
+
+func TestWriteRootOrInternalError_SanitizesUnmappedFailures(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewAdapter(&runtimeRootFake{})
+	recorder := httptest.NewRecorder()
+	err := errors.New("pkg/services/factory_runtime/internal/service: boom")
+
+	adapter.writeRootOrInternalError(recorder, runtimeHTTPOperationObserve, "failed to observe factory runtime status", err)
+
+	body := recorder.Body.String()
+	if recorder.Code != http.StatusInternalServerError ||
+		!strings.Contains(body, `"code":"INTERNAL_ERROR"`) ||
+		!strings.Contains(body, `"family":"INTERNAL_SERVER_ERROR"`) ||
+		strings.Contains(body, "pkg/services/factory_runtime") ||
+		strings.Contains(body, "boom") {
+		t.Fatalf("response = %d %s, want sanitized internal error", recorder.Code, body)
+	}
+}
+
+func operationName(operation runtimeHTTPOperation) string {
+	switch operation {
+	case runtimeHTTPOperationObserve:
+		return "observe"
+	case runtimeHTTPOperationControl:
+		return "control"
+	case runtimeHTTPOperationMoveWork:
+		return "move-work"
+	case runtimeHTTPOperationDispatchPlan:
+		return "dispatch-plan"
+	case runtimeHTTPOperationCheckpoint:
+		return "checkpoint"
+	default:
+		return fmt.Sprintf("operation(%d)", operation)
+	}
+}

--- a/pkg/services/factory_runtime/transports/http/export_test.go
+++ b/pkg/services/factory_runtime/transports/http/export_test.go
@@ -1,0 +1,3 @@
+package http
+
+var RuntimeRequestContextErrorResponseForTest = runtimeRequestContextErrorResponse

--- a/pkg/services/factory_runtime/transports/http/handlers_checkpoint.go
+++ b/pkg/services/factory_runtime/transports/http/handlers_checkpoint.go
@@ -45,6 +45,9 @@ func (a *Adapter) invokeCaptureCheckpoint(
 	ctx context.Context,
 	req factoryruntime.CaptureCheckpointRequest,
 ) {
+	if a.writeRuntimeRequestContextOutcome(w, ctx.Err()) {
+		return
+	}
 	root, err := a.runtimeRoot()
 	if err != nil {
 		a.writeError(w, http.StatusInternalServerError, "factory runtime service is required", "INTERNAL_ERROR")
@@ -52,7 +55,7 @@ func (a *Adapter) invokeCaptureCheckpoint(
 	}
 	result, err := root.CaptureCheckpoint(ctx, req)
 	if err != nil {
-		a.writeRootOrInternalError(w, runtimeHTTPOperationCheckpoint, "failed to capture checkpoint", err)
+		a.writeRootOrInternalError(w, ctx, runtimeHTTPOperationCheckpoint, "failed to capture checkpoint", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, captureCheckpointResponseFromResult(result))
@@ -63,6 +66,9 @@ func (a *Adapter) invokeLoadCheckpoint(
 	ctx context.Context,
 	req factoryruntime.LoadCheckpointRequest,
 ) {
+	if a.writeRuntimeRequestContextOutcome(w, ctx.Err()) {
+		return
+	}
 	root, err := a.runtimeRoot()
 	if err != nil {
 		a.writeError(w, http.StatusInternalServerError, "factory runtime service is required", "INTERNAL_ERROR")
@@ -70,7 +76,7 @@ func (a *Adapter) invokeLoadCheckpoint(
 	}
 	result, err := root.LoadCheckpoint(ctx, req)
 	if err != nil {
-		a.writeRootOrInternalError(w, runtimeHTTPOperationCheckpoint, "failed to load checkpoint", err)
+		a.writeRootOrInternalError(w, ctx, runtimeHTTPOperationCheckpoint, "failed to load checkpoint", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, loadCheckpointResponseFromResult(result))
@@ -81,6 +87,9 @@ func (a *Adapter) invokeRestoreCheckpoint(
 	ctx context.Context,
 	req factoryruntime.RestoreCheckpointRequest,
 ) {
+	if a.writeRuntimeRequestContextOutcome(w, ctx.Err()) {
+		return
+	}
 	root, err := a.runtimeRoot()
 	if err != nil {
 		a.writeError(w, http.StatusInternalServerError, "factory runtime service is required", "INTERNAL_ERROR")
@@ -88,7 +97,7 @@ func (a *Adapter) invokeRestoreCheckpoint(
 	}
 	result, err := root.RestoreCheckpoint(ctx, req)
 	if err != nil {
-		a.writeRootOrInternalError(w, runtimeHTTPOperationCheckpoint, "failed to restore checkpoint", err)
+		a.writeRootOrInternalError(w, ctx, runtimeHTTPOperationCheckpoint, "failed to restore checkpoint", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, restoreCheckpointResponseFromResult(result))

--- a/pkg/services/factory_runtime/transports/http/handlers_checkpoint.go
+++ b/pkg/services/factory_runtime/transports/http/handlers_checkpoint.go
@@ -2,11 +2,9 @@ package http
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
-	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 )
 
 // CaptureCheckpoint handles Runtime root checkpoint capture through the
@@ -54,10 +52,7 @@ func (a *Adapter) invokeCaptureCheckpoint(
 	}
 	result, err := root.CaptureCheckpoint(ctx, req)
 	if err != nil {
-		if a.writeCheckpointError(w, err) {
-			return
-		}
-		a.writeError(w, http.StatusInternalServerError, "failed to capture checkpoint", "INTERNAL_ERROR")
+		a.writeRootOrInternalError(w, runtimeHTTPOperationCheckpoint, "failed to capture checkpoint", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, captureCheckpointResponseFromResult(result))
@@ -75,10 +70,7 @@ func (a *Adapter) invokeLoadCheckpoint(
 	}
 	result, err := root.LoadCheckpoint(ctx, req)
 	if err != nil {
-		if a.writeCheckpointError(w, err) {
-			return
-		}
-		a.writeError(w, http.StatusInternalServerError, "failed to load checkpoint", "INTERNAL_ERROR")
+		a.writeRootOrInternalError(w, runtimeHTTPOperationCheckpoint, "failed to load checkpoint", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, loadCheckpointResponseFromResult(result))
@@ -96,41 +88,9 @@ func (a *Adapter) invokeRestoreCheckpoint(
 	}
 	result, err := root.RestoreCheckpoint(ctx, req)
 	if err != nil {
-		if a.writeCheckpointError(w, err) {
-			return
-		}
-		a.writeError(w, http.StatusInternalServerError, "failed to restore checkpoint", "INTERNAL_ERROR")
+		a.writeRootOrInternalError(w, runtimeHTTPOperationCheckpoint, "failed to restore checkpoint", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, restoreCheckpointResponseFromResult(result))
 }
 
-func (a *Adapter) writeCheckpointError(w http.ResponseWriter, err error) bool {
-	if status, response, ok := checkpointErrorResponse(err); ok {
-		a.writeJSON(w, status, response)
-		return true
-	}
-	return false
-}
-
-func checkpointErrorResponse(err error) (int, factoryapi.ErrorResponse, bool) {
-	if err == nil {
-		return 0, factoryapi.ErrorResponse{}, false
-	}
-	switch {
-	case errors.Is(err, factoryruntime.ErrCheckpointNotFound):
-		return notFoundErrorResponse("factory runtime checkpoint not found")
-	case errors.Is(err, factoryruntime.ErrCorruptCheckpoint):
-		return badRequestErrorResponse("factory runtime checkpoint is corrupt")
-	case errors.Is(err, factoryruntime.ErrIncompatibleCheckpoint):
-		return conflictErrorResponse("factory runtime checkpoint is incompatible")
-	case errors.Is(err, factoryruntime.ErrNotFound):
-		return notFoundErrorResponse("factory runtime target not found")
-	case errors.Is(err, factoryruntime.ErrNotRunning):
-		return serviceUnavailableErrorResponse("factory runtime is not running")
-	case errors.Is(err, factoryruntime.ErrCapabilityUnavailable):
-		return serviceUnavailableErrorResponse("factory runtime capability is unavailable")
-	default:
-		return 0, factoryapi.ErrorResponse{}, false
-	}
-}

--- a/pkg/services/factory_runtime/transports/http/handlers_checkpoint.go
+++ b/pkg/services/factory_runtime/transports/http/handlers_checkpoint.go
@@ -1,0 +1,136 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+// CaptureCheckpoint handles Runtime root checkpoint capture through the
+// accepted root slice.
+func (a *Adapter) CaptureCheckpoint(w http.ResponseWriter, r *http.Request) {
+	req, err := decodeCaptureCheckpointRequest(r.Body)
+	if err != nil {
+		a.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
+		return
+	}
+	a.invokeCaptureCheckpoint(w, r.Context(), req)
+}
+
+// LoadCheckpoint handles Runtime root checkpoint load/inspect through the
+// accepted root slice.
+func (a *Adapter) LoadCheckpoint(w http.ResponseWriter, r *http.Request) {
+	req, err := decodeLoadCheckpointRequest(r.Body)
+	if err != nil {
+		a.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
+		return
+	}
+	a.invokeLoadCheckpoint(w, r.Context(), req)
+}
+
+// RestoreCheckpoint handles Runtime root checkpoint restore through the
+// accepted root slice.
+func (a *Adapter) RestoreCheckpoint(w http.ResponseWriter, r *http.Request) {
+	req, err := decodeRestoreCheckpointRequest(r.Body)
+	if err != nil {
+		a.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
+		return
+	}
+	a.invokeRestoreCheckpoint(w, r.Context(), req)
+}
+
+func (a *Adapter) invokeCaptureCheckpoint(
+	w http.ResponseWriter,
+	ctx context.Context,
+	req factoryruntime.CaptureCheckpointRequest,
+) {
+	root, err := a.runtimeRoot()
+	if err != nil {
+		a.writeError(w, http.StatusInternalServerError, "factory runtime service is required", "INTERNAL_ERROR")
+		return
+	}
+	result, err := root.CaptureCheckpoint(ctx, req)
+	if err != nil {
+		if a.writeCheckpointError(w, err) {
+			return
+		}
+		a.writeError(w, http.StatusInternalServerError, "failed to capture checkpoint", "INTERNAL_ERROR")
+		return
+	}
+	a.writeJSON(w, http.StatusOK, captureCheckpointResponseFromResult(result))
+}
+
+func (a *Adapter) invokeLoadCheckpoint(
+	w http.ResponseWriter,
+	ctx context.Context,
+	req factoryruntime.LoadCheckpointRequest,
+) {
+	root, err := a.runtimeRoot()
+	if err != nil {
+		a.writeError(w, http.StatusInternalServerError, "factory runtime service is required", "INTERNAL_ERROR")
+		return
+	}
+	result, err := root.LoadCheckpoint(ctx, req)
+	if err != nil {
+		if a.writeCheckpointError(w, err) {
+			return
+		}
+		a.writeError(w, http.StatusInternalServerError, "failed to load checkpoint", "INTERNAL_ERROR")
+		return
+	}
+	a.writeJSON(w, http.StatusOK, loadCheckpointResponseFromResult(result))
+}
+
+func (a *Adapter) invokeRestoreCheckpoint(
+	w http.ResponseWriter,
+	ctx context.Context,
+	req factoryruntime.RestoreCheckpointRequest,
+) {
+	root, err := a.runtimeRoot()
+	if err != nil {
+		a.writeError(w, http.StatusInternalServerError, "factory runtime service is required", "INTERNAL_ERROR")
+		return
+	}
+	result, err := root.RestoreCheckpoint(ctx, req)
+	if err != nil {
+		if a.writeCheckpointError(w, err) {
+			return
+		}
+		a.writeError(w, http.StatusInternalServerError, "failed to restore checkpoint", "INTERNAL_ERROR")
+		return
+	}
+	a.writeJSON(w, http.StatusOK, restoreCheckpointResponseFromResult(result))
+}
+
+func (a *Adapter) writeCheckpointError(w http.ResponseWriter, err error) bool {
+	if status, response, ok := checkpointErrorResponse(err); ok {
+		a.writeJSON(w, status, response)
+		return true
+	}
+	return false
+}
+
+func checkpointErrorResponse(err error) (int, factoryapi.ErrorResponse, bool) {
+	if err == nil {
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+	switch {
+	case errors.Is(err, factoryruntime.ErrCheckpointNotFound):
+		return notFoundErrorResponse("factory runtime checkpoint not found")
+	case errors.Is(err, factoryruntime.ErrCorruptCheckpoint):
+		return badRequestErrorResponse("factory runtime checkpoint is corrupt")
+	case errors.Is(err, factoryruntime.ErrIncompatibleCheckpoint):
+		return conflictErrorResponse("factory runtime checkpoint is incompatible")
+	case errors.Is(err, factoryruntime.ErrNotFound):
+		return notFoundErrorResponse("factory runtime target not found")
+	case errors.Is(err, factoryruntime.ErrNotRunning):
+		return serviceUnavailableErrorResponse("factory runtime is not running")
+	case errors.Is(err, factoryruntime.ErrCapabilityUnavailable):
+		return serviceUnavailableErrorResponse("factory runtime capability is unavailable")
+	default:
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+}

--- a/pkg/services/factory_runtime/transports/http/handlers_checkpoint_test.go
+++ b/pkg/services/factory_runtime/transports/http/handlers_checkpoint_test.go
@@ -1,0 +1,267 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+func TestCaptureCheckpoint_ForwardsDecodedFieldsToRoot(t *testing.T) {
+	t.Parallel()
+
+	var got factoryruntime.CaptureCheckpointRequest
+	fake := &runtimeRootFake{
+		captureCheckpoint: func(_ context.Context, req factoryruntime.CaptureCheckpointRequest) (factoryruntime.CaptureCheckpointResult, error) {
+			got = req
+			return factoryruntime.CaptureCheckpointResult{
+				Outcome: factoryruntime.CheckpointOutcomeCaptured,
+				Checkpoint: factoryruntime.Checkpoint{
+					CheckpointID:  req.CheckpointID,
+					SchemaVersion: 1,
+					StrategyKind:  "opaque",
+					Payload:       []byte("payload"),
+				},
+			}, nil
+		},
+	}
+	adapter := NewAdapter(fake)
+
+	body := strings.NewReader(`{"checkpointId":" checkpoint-1 "}`)
+	rec := httptest.NewRecorder()
+	adapter.CaptureCheckpoint(rec, httptest.NewRequest(http.MethodPost, "/runtime/checkpoint/capture", body))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if got.CheckpointID != "checkpoint-1" {
+		t.Fatalf("capture request = %#v, want trimmed checkpoint id", got)
+	}
+
+	var response runtimeCaptureCheckpointHTTPResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Outcome != factoryruntime.CheckpointOutcomeCaptured {
+		t.Fatalf("outcome = %q, want CAPTURED", response.Outcome)
+	}
+	if response.Checkpoint.CheckpointID != "checkpoint-1" || response.Checkpoint.SchemaVersion != 1 {
+		t.Fatalf("checkpoint = %#v, want captured checkpoint fields", response.Checkpoint)
+	}
+}
+
+func TestLoadCheckpoint_ForwardsDecodedFieldsToRoot(t *testing.T) {
+	t.Parallel()
+
+	var got factoryruntime.LoadCheckpointRequest
+	fake := &runtimeRootFake{
+		loadCheckpoint: func(_ context.Context, req factoryruntime.LoadCheckpointRequest) (factoryruntime.LoadCheckpointResult, error) {
+			got = req
+			return factoryruntime.LoadCheckpointResult{
+				Outcome: factoryruntime.CheckpointOutcomeLoaded,
+				Checkpoint: factoryruntime.Checkpoint{
+					CheckpointID:  req.CheckpointID,
+					SchemaVersion: req.ExpectedSchemaVersion,
+				},
+				Compatible: true,
+			}, nil
+		},
+	}
+	adapter := NewAdapter(fake)
+
+	body := strings.NewReader(`{"checkpointId":"checkpoint-1","expectedSchemaVersion":2}`)
+	rec := httptest.NewRecorder()
+	adapter.LoadCheckpoint(rec, httptest.NewRequest(http.MethodPost, "/runtime/checkpoint/load", body))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if got.CheckpointID != "checkpoint-1" || got.ExpectedSchemaVersion != 2 {
+		t.Fatalf("load request = %#v, want decoded checkpoint fields", got)
+	}
+
+	var response runtimeLoadCheckpointHTTPResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Outcome != factoryruntime.CheckpointOutcomeLoaded || !response.Compatible {
+		t.Fatalf("response = %#v, want LOADED compatible checkpoint", response)
+	}
+}
+
+func TestRestoreCheckpoint_ForwardsDecodedFieldsToRoot(t *testing.T) {
+	t.Parallel()
+
+	var got factoryruntime.RestoreCheckpointRequest
+	fake := &runtimeRootFake{
+		restoreCheckpoint: func(_ context.Context, req factoryruntime.RestoreCheckpointRequest) (factoryruntime.RestoreCheckpointResult, error) {
+			got = req
+			return factoryruntime.RestoreCheckpointResult{
+				Outcome:      factoryruntime.CheckpointOutcomeRestored,
+				CheckpointID: req.Checkpoint.CheckpointID,
+			}, nil
+		},
+	}
+	adapter := NewAdapter(fake)
+
+	body := strings.NewReader(`{
+		"checkpoint":{
+			"checkpointId":"checkpoint-1",
+			"schemaVersion":1,
+			"strategyKind":"opaque",
+			"payload":"cGF5bG9hZA=="
+		}
+	}`)
+	rec := httptest.NewRecorder()
+	adapter.RestoreCheckpoint(rec, httptest.NewRequest(http.MethodPost, "/runtime/checkpoint/restore", body))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if got.Checkpoint.CheckpointID != "checkpoint-1" || got.Checkpoint.SchemaVersion != 1 ||
+		got.Checkpoint.StrategyKind != "opaque" || string(got.Checkpoint.Payload) != "payload" {
+		t.Fatalf("restore request = %#v, want decoded checkpoint fields", got)
+	}
+
+	var response runtimeRestoreCheckpointHTTPResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Outcome != factoryruntime.CheckpointOutcomeRestored || response.CheckpointID != "checkpoint-1" {
+		t.Fatalf("response = %#v, want RESTORED checkpoint id", response)
+	}
+}
+
+func TestCheckpointHandlers_MapTypedFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		programmed error
+		invoke     func(*Adapter, *httptest.ResponseRecorder)
+		wantStatus int
+		wantCode   string
+		wantMsg    string
+	}{
+		{
+			name:       "capture checkpoint not found",
+			programmed: factoryruntime.ErrCheckpointNotFound,
+			invoke: func(adapter *Adapter, rec *httptest.ResponseRecorder) {
+				adapter.CaptureCheckpoint(
+					rec,
+					httptest.NewRequest(
+						http.MethodPost,
+						"/runtime/checkpoint/capture",
+						strings.NewReader(`{"checkpointId":"missing"}`),
+					),
+				)
+			},
+			wantStatus: http.StatusNotFound,
+			wantCode:   "NOT_FOUND",
+			wantMsg:    "factory runtime checkpoint not found",
+		},
+		{
+			name:       "load corrupt checkpoint",
+			programmed: factoryruntime.ErrCorruptCheckpoint,
+			invoke: func(adapter *Adapter, rec *httptest.ResponseRecorder) {
+				adapter.LoadCheckpoint(
+					rec,
+					httptest.NewRequest(
+						http.MethodPost,
+						"/runtime/checkpoint/load",
+						strings.NewReader(`{"checkpointId":"bad"}`),
+					),
+				)
+			},
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "BAD_REQUEST",
+			wantMsg:    "factory runtime checkpoint is corrupt",
+		},
+		{
+			name:       "restore incompatible checkpoint",
+			programmed: factoryruntime.ErrIncompatibleCheckpoint,
+			invoke: func(adapter *Adapter, rec *httptest.ResponseRecorder) {
+				adapter.RestoreCheckpoint(
+					rec,
+					httptest.NewRequest(
+						http.MethodPost,
+						"/runtime/checkpoint/restore",
+						strings.NewReader(`{"checkpoint":{"checkpointId":"checkpoint-1","schemaVersion":1}}`),
+					),
+				)
+			},
+			wantStatus: http.StatusConflict,
+			wantCode:   "CONFLICT",
+			wantMsg:    "factory runtime checkpoint is incompatible",
+		},
+		{
+			name:       "capture capability unavailable",
+			programmed: factoryruntime.ErrCapabilityUnavailable,
+			invoke: func(adapter *Adapter, rec *httptest.ResponseRecorder) {
+				adapter.CaptureCheckpoint(
+					rec,
+					httptest.NewRequest(
+						http.MethodPost,
+						"/runtime/checkpoint/capture",
+						strings.NewReader(`{"checkpointId":"checkpoint-1"}`),
+					),
+				)
+			},
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   "SERVICE_UNAVAILABLE",
+			wantMsg:    "factory runtime capability is unavailable",
+		},
+		{
+			name:       "restore not running",
+			programmed: factoryruntime.ErrNotRunning,
+			invoke: func(adapter *Adapter, rec *httptest.ResponseRecorder) {
+				adapter.RestoreCheckpoint(
+					rec,
+					httptest.NewRequest(
+						http.MethodPost,
+						"/runtime/checkpoint/restore",
+						strings.NewReader(`{"checkpoint":{"checkpointId":"checkpoint-1","schemaVersion":1}}`),
+					),
+				)
+			},
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   "SERVICE_UNAVAILABLE",
+			wantMsg:    "factory runtime is not running",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fake := &runtimeRootFake{
+				captureCheckpoint: func(context.Context, factoryruntime.CaptureCheckpointRequest) (factoryruntime.CaptureCheckpointResult, error) {
+					return factoryruntime.CaptureCheckpointResult{}, tc.programmed
+				},
+				loadCheckpoint: func(context.Context, factoryruntime.LoadCheckpointRequest) (factoryruntime.LoadCheckpointResult, error) {
+					return factoryruntime.LoadCheckpointResult{}, tc.programmed
+				},
+				restoreCheckpoint: func(context.Context, factoryruntime.RestoreCheckpointRequest) (factoryruntime.RestoreCheckpointResult, error) {
+					return factoryruntime.RestoreCheckpointResult{}, tc.programmed
+				},
+			}
+			adapter := NewAdapter(fake)
+			rec := httptest.NewRecorder()
+			tc.invoke(adapter, rec)
+			assertErrorResponse(t, rec, tc.wantStatus, tc.wantCode, tc.wantMsg)
+		})
+	}
+}
+
+func TestCaptureCheckpoint_RejectsInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewAdapter(&runtimeRootFake{})
+	rec := httptest.NewRecorder()
+	adapter.CaptureCheckpoint(rec, httptest.NewRequest(http.MethodPost, "/runtime/checkpoint/capture", strings.NewReader("{")))
+	assertErrorResponse(t, rec, http.StatusBadRequest, "BAD_REQUEST", "invalid request payload")
+}

--- a/pkg/services/factory_runtime/transports/http/handlers_common.go
+++ b/pkg/services/factory_runtime/transports/http/handlers_common.go
@@ -1,0 +1,35 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+func (a *Adapter) writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func (a *Adapter) writeError(w http.ResponseWriter, status int, message, code string) {
+	a.writeJSON(w, status, factoryapi.ErrorResponse{
+		Message: message,
+		Family:  errorFamilyForStatus(status),
+		Code:    factoryapi.ErrorResponseCode(code),
+	})
+}
+
+func errorFamilyForStatus(status int) factoryapi.ErrorFamily {
+	switch status {
+	case http.StatusBadRequest:
+		return factoryapi.ErrorFamilyBadRequest
+	case http.StatusNotFound:
+		return factoryapi.ErrorFamilyNotFound
+	case http.StatusConflict:
+		return factoryapi.ErrorFamilyConflict
+	default:
+		return factoryapi.ErrorFamilyInternalServerError
+	}
+}

--- a/pkg/services/factory_runtime/transports/http/handlers_control.go
+++ b/pkg/services/factory_runtime/transports/http/handlers_control.go
@@ -1,0 +1,219 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+// ControlPause handles Runtime root pause control through the accepted root slice.
+func (a *Adapter) ControlPause(w http.ResponseWriter, r *http.Request) {
+	a.invokeControlPause(w, r.Context())
+}
+
+// ControlResume handles Runtime root resume control through the accepted root slice.
+func (a *Adapter) ControlResume(w http.ResponseWriter, r *http.Request) {
+	a.invokeControlResume(w, r.Context())
+}
+
+// ControlTerminate handles Runtime root terminate control through the accepted root slice.
+func (a *Adapter) ControlTerminate(w http.ResponseWriter, r *http.Request) {
+	req, err := decodeTerminateControlRequest(r.Body)
+	if err != nil {
+		a.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
+		return
+	}
+	a.invokeControlTerminate(w, r.Context(), req)
+}
+
+func (a *Adapter) invokeControlPause(w http.ResponseWriter, ctx context.Context) {
+	root, err := a.runtimeRoot()
+	if err != nil {
+		a.writeError(w, http.StatusInternalServerError, "factory runtime service is required", "INTERNAL_ERROR")
+		return
+	}
+	result, err := root.ControlPause(ctx, factoryruntime.PauseRequest{})
+	if err != nil {
+		if a.writeControlError(w, err) {
+			return
+		}
+		a.writeError(w, http.StatusInternalServerError, "failed to pause factory runtime", "INTERNAL_ERROR")
+		return
+	}
+	a.writeJSON(w, http.StatusOK, controlResponseFromPauseResult(result))
+}
+
+func (a *Adapter) invokeControlResume(w http.ResponseWriter, ctx context.Context) {
+	root, err := a.runtimeRoot()
+	if err != nil {
+		a.writeError(w, http.StatusInternalServerError, "factory runtime service is required", "INTERNAL_ERROR")
+		return
+	}
+	result, err := root.ControlResume(ctx, factoryruntime.ResumeRequest{})
+	if err != nil {
+		if a.writeControlError(w, err) {
+			return
+		}
+		a.writeError(w, http.StatusInternalServerError, "failed to resume factory runtime", "INTERNAL_ERROR")
+		return
+	}
+	a.writeJSON(w, http.StatusOK, controlResponseFromResumeResult(result))
+}
+
+func (a *Adapter) invokeControlTerminate(
+	w http.ResponseWriter,
+	ctx context.Context,
+	req factoryruntime.TerminateRequest,
+) {
+	root, err := a.runtimeRoot()
+	if err != nil {
+		a.writeError(w, http.StatusInternalServerError, "factory runtime service is required", "INTERNAL_ERROR")
+		return
+	}
+	result, err := root.ControlTerminate(ctx, req)
+	if err != nil {
+		if a.writeControlError(w, err) {
+			return
+		}
+		a.writeError(w, http.StatusInternalServerError, "failed to terminate factory runtime", "INTERNAL_ERROR")
+		return
+	}
+	a.writeJSON(w, http.StatusOK, controlResponseFromTerminateResult(result))
+}
+
+func decodeTerminateControlRequest(body io.Reader) (factoryruntime.TerminateRequest, error) {
+	payload, err := io.ReadAll(body)
+	if err != nil {
+		return factoryruntime.TerminateRequest{}, err
+	}
+	if len(payload) == 0 {
+		return factoryruntime.TerminateRequest{}, nil
+	}
+	var req factoryapi.FactorySessionLifecycleControlRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return factoryruntime.TerminateRequest{}, err
+	}
+	return terminateRequestFromAPI(req), nil
+}
+
+func decodeMoveWorkRequestBody(body io.Reader) (factoryapi.MoveWorkRequest, error) {
+	payload, err := io.ReadAll(body)
+	if err != nil {
+		return factoryapi.MoveWorkRequest{}, err
+	}
+	if len(payload) == 0 {
+		return factoryapi.MoveWorkRequest{}, errors.New("request body is required")
+	}
+	var req factoryapi.MoveWorkRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return factoryapi.MoveWorkRequest{}, err
+	}
+	return req, nil
+}
+
+// MoveWorkBySessionId handles operator move-work through the accepted Runtime root slice.
+// Session identity is preserved for generated-contract compatibility; root invocation
+// uses the published Runtime move vocabulary only.
+func (a *Adapter) MoveWorkBySessionId(
+	w http.ResponseWriter,
+	r *http.Request,
+	_ factoryapi.SessionID,
+	workID factoryapi.WorkOrTokenID,
+) {
+	req, err := decodeMoveWorkRequestBody(r.Body)
+	if err != nil {
+		a.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
+		return
+	}
+	moveReq := moveWorkRequestFromAPI(string(workID), req)
+	if moveReq.StateName == "" {
+		a.writeError(w, http.StatusBadRequest, "stateName is required", "BAD_REQUEST")
+		return
+	}
+
+	root, err := a.runtimeRoot()
+	if err != nil {
+		a.writeError(w, http.StatusInternalServerError, "factory runtime service is required", "INTERNAL_ERROR")
+		return
+	}
+	result, err := root.ControlMoveWork(r.Context(), moveReq)
+	if err != nil {
+		if a.writeMoveWorkError(w, err) {
+			return
+		}
+		a.writeError(w, http.StatusInternalServerError, "failed to move work", "INTERNAL_ERROR")
+		return
+	}
+	a.writeJSON(w, http.StatusOK, workResponseFromMoveResult(result))
+}
+
+func (a *Adapter) writeControlError(w http.ResponseWriter, err error) bool {
+	if status, response, ok := controlErrorResponse(err); ok {
+		a.writeJSON(w, status, response)
+		return true
+	}
+	return false
+}
+
+func (a *Adapter) writeMoveWorkError(w http.ResponseWriter, err error) bool {
+	if status, response, ok := moveWorkErrorResponse(err); ok {
+		a.writeJSON(w, status, response)
+		return true
+	}
+	return false
+}
+
+func moveWorkErrorResponse(err error) (int, factoryapi.ErrorResponse, bool) {
+	if err == nil {
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+	switch {
+	case errors.Is(err, factoryruntime.ErrMoveWorkNotFound):
+		return notFoundErrorResponse("work not found")
+	case errors.Is(err, factoryruntime.ErrMoveWorkInvalidState):
+		return badRequestErrorResponse("invalid target state for work type")
+	case errors.Is(err, factoryruntime.ErrMoveWorkInFlightDispatch):
+		return badRequestErrorResponse("work is in an active dispatch")
+	case errors.Is(err, factoryruntime.ErrMoveWorkEngineTerminated):
+		return badRequestErrorResponse("engine has terminated")
+	case errors.Is(err, factoryruntime.ErrMoveWorkRequestConflict):
+		return http.StatusConflict, factoryapi.ErrorResponse{
+			Message: "Operator move request was already applied.",
+			Family:  factoryapi.ErrorFamilyConflict,
+			Code:    factoryapi.ErrorResponseCodeMOVEWORKREQUESTALREADYAPPLIED,
+		}, true
+	case errors.Is(err, factoryruntime.ErrNotRunning):
+		return serviceUnavailableErrorResponse("factory runtime is not running")
+	default:
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+}
+
+func controlErrorResponse(err error) (int, factoryapi.ErrorResponse, bool) {
+	if err == nil {
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+	switch {
+	case errors.Is(err, factoryruntime.ErrNotRunning):
+		return serviceUnavailableErrorResponse("factory runtime is not running")
+	case errors.Is(err, factoryruntime.ErrAlreadyStopped):
+		return conflictErrorResponse("factory runtime is already stopped")
+	case errors.Is(err, factoryruntime.ErrInvalidLifecycleTransition):
+		return badRequestErrorResponse("factory runtime invalid lifecycle transition")
+	default:
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+}
+
+func conflictErrorResponse(message string) (int, factoryapi.ErrorResponse, bool) {
+	return http.StatusConflict, factoryapi.ErrorResponse{
+		Message: message,
+		Family:  factoryapi.ErrorFamilyConflict,
+		Code:    factoryapi.ErrorResponseCode("CONFLICT"),
+	}, true
+}

--- a/pkg/services/factory_runtime/transports/http/handlers_control.go
+++ b/pkg/services/factory_runtime/transports/http/handlers_control.go
@@ -39,10 +39,7 @@ func (a *Adapter) invokeControlPause(w http.ResponseWriter, ctx context.Context)
 	}
 	result, err := root.ControlPause(ctx, factoryruntime.PauseRequest{})
 	if err != nil {
-		if a.writeControlError(w, err) {
-			return
-		}
-		a.writeError(w, http.StatusInternalServerError, "failed to pause factory runtime", "INTERNAL_ERROR")
+		a.writeRootOrInternalError(w, runtimeHTTPOperationControl, "failed to pause factory runtime", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, controlResponseFromPauseResult(result))
@@ -56,10 +53,7 @@ func (a *Adapter) invokeControlResume(w http.ResponseWriter, ctx context.Context
 	}
 	result, err := root.ControlResume(ctx, factoryruntime.ResumeRequest{})
 	if err != nil {
-		if a.writeControlError(w, err) {
-			return
-		}
-		a.writeError(w, http.StatusInternalServerError, "failed to resume factory runtime", "INTERNAL_ERROR")
+		a.writeRootOrInternalError(w, runtimeHTTPOperationControl, "failed to resume factory runtime", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, controlResponseFromResumeResult(result))
@@ -77,10 +71,7 @@ func (a *Adapter) invokeControlTerminate(
 	}
 	result, err := root.ControlTerminate(ctx, req)
 	if err != nil {
-		if a.writeControlError(w, err) {
-			return
-		}
-		a.writeError(w, http.StatusInternalServerError, "failed to terminate factory runtime", "INTERNAL_ERROR")
+		a.writeRootOrInternalError(w, runtimeHTTPOperationControl, "failed to terminate factory runtime", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, controlResponseFromTerminateResult(result))
@@ -143,77 +134,8 @@ func (a *Adapter) MoveWorkBySessionId(
 	}
 	result, err := root.ControlMoveWork(r.Context(), moveReq)
 	if err != nil {
-		if a.writeMoveWorkError(w, err) {
-			return
-		}
-		a.writeError(w, http.StatusInternalServerError, "failed to move work", "INTERNAL_ERROR")
+		a.writeRootOrInternalError(w, runtimeHTTPOperationMoveWork, "failed to move work", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, workResponseFromMoveResult(result))
-}
-
-func (a *Adapter) writeControlError(w http.ResponseWriter, err error) bool {
-	if status, response, ok := controlErrorResponse(err); ok {
-		a.writeJSON(w, status, response)
-		return true
-	}
-	return false
-}
-
-func (a *Adapter) writeMoveWorkError(w http.ResponseWriter, err error) bool {
-	if status, response, ok := moveWorkErrorResponse(err); ok {
-		a.writeJSON(w, status, response)
-		return true
-	}
-	return false
-}
-
-func moveWorkErrorResponse(err error) (int, factoryapi.ErrorResponse, bool) {
-	if err == nil {
-		return 0, factoryapi.ErrorResponse{}, false
-	}
-	switch {
-	case errors.Is(err, factoryruntime.ErrMoveWorkNotFound):
-		return notFoundErrorResponse("work not found")
-	case errors.Is(err, factoryruntime.ErrMoveWorkInvalidState):
-		return badRequestErrorResponse("invalid target state for work type")
-	case errors.Is(err, factoryruntime.ErrMoveWorkInFlightDispatch):
-		return badRequestErrorResponse("work is in an active dispatch")
-	case errors.Is(err, factoryruntime.ErrMoveWorkEngineTerminated):
-		return badRequestErrorResponse("engine has terminated")
-	case errors.Is(err, factoryruntime.ErrMoveWorkRequestConflict):
-		return http.StatusConflict, factoryapi.ErrorResponse{
-			Message: "Operator move request was already applied.",
-			Family:  factoryapi.ErrorFamilyConflict,
-			Code:    factoryapi.ErrorResponseCodeMOVEWORKREQUESTALREADYAPPLIED,
-		}, true
-	case errors.Is(err, factoryruntime.ErrNotRunning):
-		return serviceUnavailableErrorResponse("factory runtime is not running")
-	default:
-		return 0, factoryapi.ErrorResponse{}, false
-	}
-}
-
-func controlErrorResponse(err error) (int, factoryapi.ErrorResponse, bool) {
-	if err == nil {
-		return 0, factoryapi.ErrorResponse{}, false
-	}
-	switch {
-	case errors.Is(err, factoryruntime.ErrNotRunning):
-		return serviceUnavailableErrorResponse("factory runtime is not running")
-	case errors.Is(err, factoryruntime.ErrAlreadyStopped):
-		return conflictErrorResponse("factory runtime is already stopped")
-	case errors.Is(err, factoryruntime.ErrInvalidLifecycleTransition):
-		return badRequestErrorResponse("factory runtime invalid lifecycle transition")
-	default:
-		return 0, factoryapi.ErrorResponse{}, false
-	}
-}
-
-func conflictErrorResponse(message string) (int, factoryapi.ErrorResponse, bool) {
-	return http.StatusConflict, factoryapi.ErrorResponse{
-		Message: message,
-		Family:  factoryapi.ErrorFamilyConflict,
-		Code:    factoryapi.ErrorResponseCode("CONFLICT"),
-	}, true
 }

--- a/pkg/services/factory_runtime/transports/http/handlers_control.go
+++ b/pkg/services/factory_runtime/transports/http/handlers_control.go
@@ -32,6 +32,9 @@ func (a *Adapter) ControlTerminate(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *Adapter) invokeControlPause(w http.ResponseWriter, ctx context.Context) {
+	if a.writeRuntimeRequestContextOutcome(w, ctx.Err()) {
+		return
+	}
 	root, err := a.runtimeRoot()
 	if err != nil {
 		a.writeError(w, http.StatusInternalServerError, "factory runtime service is required", "INTERNAL_ERROR")
@@ -39,13 +42,16 @@ func (a *Adapter) invokeControlPause(w http.ResponseWriter, ctx context.Context)
 	}
 	result, err := root.ControlPause(ctx, factoryruntime.PauseRequest{})
 	if err != nil {
-		a.writeRootOrInternalError(w, runtimeHTTPOperationControl, "failed to pause factory runtime", err)
+		a.writeRootOrInternalError(w, ctx, runtimeHTTPOperationControl, "failed to pause factory runtime", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, controlResponseFromPauseResult(result))
 }
 
 func (a *Adapter) invokeControlResume(w http.ResponseWriter, ctx context.Context) {
+	if a.writeRuntimeRequestContextOutcome(w, ctx.Err()) {
+		return
+	}
 	root, err := a.runtimeRoot()
 	if err != nil {
 		a.writeError(w, http.StatusInternalServerError, "factory runtime service is required", "INTERNAL_ERROR")
@@ -53,7 +59,7 @@ func (a *Adapter) invokeControlResume(w http.ResponseWriter, ctx context.Context
 	}
 	result, err := root.ControlResume(ctx, factoryruntime.ResumeRequest{})
 	if err != nil {
-		a.writeRootOrInternalError(w, runtimeHTTPOperationControl, "failed to resume factory runtime", err)
+		a.writeRootOrInternalError(w, ctx, runtimeHTTPOperationControl, "failed to resume factory runtime", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, controlResponseFromResumeResult(result))
@@ -64,6 +70,9 @@ func (a *Adapter) invokeControlTerminate(
 	ctx context.Context,
 	req factoryruntime.TerminateRequest,
 ) {
+	if a.writeRuntimeRequestContextOutcome(w, ctx.Err()) {
+		return
+	}
 	root, err := a.runtimeRoot()
 	if err != nil {
 		a.writeError(w, http.StatusInternalServerError, "factory runtime service is required", "INTERNAL_ERROR")
@@ -71,7 +80,7 @@ func (a *Adapter) invokeControlTerminate(
 	}
 	result, err := root.ControlTerminate(ctx, req)
 	if err != nil {
-		a.writeRootOrInternalError(w, runtimeHTTPOperationControl, "failed to terminate factory runtime", err)
+		a.writeRootOrInternalError(w, ctx, runtimeHTTPOperationControl, "failed to terminate factory runtime", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, controlResponseFromTerminateResult(result))
@@ -126,6 +135,9 @@ func (a *Adapter) MoveWorkBySessionId(
 		a.writeError(w, http.StatusBadRequest, "stateName is required", "BAD_REQUEST")
 		return
 	}
+	if a.guardRuntimeRequestContext(w, r) {
+		return
+	}
 
 	root, err := a.runtimeRoot()
 	if err != nil {
@@ -134,7 +146,7 @@ func (a *Adapter) MoveWorkBySessionId(
 	}
 	result, err := root.ControlMoveWork(r.Context(), moveReq)
 	if err != nil {
-		a.writeRootOrInternalError(w, runtimeHTTPOperationMoveWork, "failed to move work", err)
+		a.writeRootOrInternalError(w, r.Context(), runtimeHTTPOperationMoveWork, "failed to move work", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, workResponseFromMoveResult(result))

--- a/pkg/services/factory_runtime/transports/http/handlers_control_test.go
+++ b/pkg/services/factory_runtime/transports/http/handlers_control_test.go
@@ -1,0 +1,159 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+func TestControlPause_ForwardsToRootAndEncodesOutcome(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := &runtimeRootFake{
+		pause: func(_ context.Context, _ factoryruntime.PauseRequest) (factoryruntime.PauseResult, error) {
+			invoked = true
+			return factoryruntime.PauseResult{Outcome: factoryruntime.ControlOutcomeAccepted}, nil
+		},
+	}
+	adapter := NewAdapter(fake)
+
+	rec := httptest.NewRecorder()
+	adapter.ControlPause(rec, httptest.NewRequest(http.MethodPost, "/control/pause", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if !invoked {
+		t.Fatal("ControlPause did not reach injected Runtime root")
+	}
+	var response runtimeControlHTTPResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Outcome != factoryruntime.ControlOutcomeAccepted {
+		t.Fatalf("outcome = %q, want ACCEPTED", response.Outcome)
+	}
+}
+
+func TestControlResume_ForwardsToRootAndEncodesNoOpOutcome(t *testing.T) {
+	t.Parallel()
+
+	fake := &runtimeRootFake{
+		resume: func(_ context.Context, _ factoryruntime.ResumeRequest) (factoryruntime.ResumeResult, error) {
+			return factoryruntime.ResumeResult{Outcome: factoryruntime.ControlOutcomeNoOp}, nil
+		},
+	}
+	adapter := NewAdapter(fake)
+
+	rec := httptest.NewRecorder()
+	adapter.ControlResume(rec, httptest.NewRequest(http.MethodPost, "/control/resume", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var response runtimeControlHTTPResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Outcome != factoryruntime.ControlOutcomeNoOp {
+		t.Fatalf("outcome = %q, want NO_OP", response.Outcome)
+	}
+}
+
+func TestControlTerminate_ForwardsDecodedReasonToRoot(t *testing.T) {
+	t.Parallel()
+
+	var gotReason string
+	fake := &runtimeRootFake{
+		terminate: func(_ context.Context, req factoryruntime.TerminateRequest) (factoryruntime.TerminateResult, error) {
+			gotReason = req.Reason
+			return factoryruntime.TerminateResult{Outcome: factoryruntime.ControlOutcomeAccepted}, nil
+		},
+	}
+	adapter := NewAdapter(fake)
+
+	body := strings.NewReader(`{"reason":"operator stop"}`)
+	rec := httptest.NewRecorder()
+	adapter.ControlTerminate(rec, httptest.NewRequest(http.MethodPost, "/control/terminate", body))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if gotReason != "operator stop" {
+		t.Fatalf("reason = %q, want operator stop", gotReason)
+	}
+}
+
+func TestControlPause_MapsTypedLifecycleFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		programmed error
+		wantStatus int
+		wantCode   string
+		wantMsg    string
+	}{
+		{
+			name:       "not running",
+			programmed: factoryruntime.ErrNotRunning,
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   "SERVICE_UNAVAILABLE",
+			wantMsg:    "factory runtime is not running",
+		},
+		{
+			name:       "invalid transition",
+			programmed: factoryruntime.ErrInvalidLifecycleTransition,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "BAD_REQUEST",
+			wantMsg:    "factory runtime invalid lifecycle transition",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fake := &runtimeRootFake{
+				pause: func(context.Context, factoryruntime.PauseRequest) (factoryruntime.PauseResult, error) {
+					return factoryruntime.PauseResult{}, tc.programmed
+				},
+			}
+			adapter := NewAdapter(fake)
+			rec := httptest.NewRecorder()
+			adapter.ControlPause(rec, httptest.NewRequest(http.MethodPost, "/control/pause", nil))
+			assertErrorResponse(t, rec, tc.wantStatus, tc.wantCode, tc.wantMsg)
+		})
+	}
+}
+
+func TestControlTerminate_MapsAlreadyStopped(t *testing.T) {
+	t.Parallel()
+
+	fake := &runtimeRootFake{
+		terminate: func(context.Context, factoryruntime.TerminateRequest) (factoryruntime.TerminateResult, error) {
+			return factoryruntime.TerminateResult{}, factoryruntime.ErrAlreadyStopped
+		},
+	}
+	adapter := NewAdapter(fake)
+
+	rec := httptest.NewRecorder()
+	adapter.ControlTerminate(rec, httptest.NewRequest(http.MethodPost, "/control/terminate", bytes.NewReader(nil)))
+	assertErrorResponse(t, rec, http.StatusConflict, "CONFLICT", "factory runtime is already stopped")
+}
+
+func TestControlTerminate_RejectsInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewAdapter(&runtimeRootFake{})
+	rec := httptest.NewRecorder()
+	adapter.ControlTerminate(rec, httptest.NewRequest(http.MethodPost, "/control/terminate", strings.NewReader("{")))
+	assertErrorResponse(t, rec, http.StatusBadRequest, "BAD_REQUEST", "invalid request payload")
+}

--- a/pkg/services/factory_runtime/transports/http/handlers_dispatch_plan.go
+++ b/pkg/services/factory_runtime/transports/http/handlers_dispatch_plan.go
@@ -1,0 +1,106 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+var errRequestBodyRequired = errors.New("request body is required")
+
+// PlanDispatch handles Runtime root dispatch intent planning through the
+// accepted root slice.
+func (a *Adapter) PlanDispatch(w http.ResponseWriter, r *http.Request) {
+	req, err := decodePlanDispatchRequest(r.Body)
+	if err != nil {
+		a.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
+		return
+	}
+	a.invokePlanDispatch(w, r.Context(), req)
+}
+
+// AcceptDispatchResult handles correlated worker result acceptance through the
+// accepted Runtime root slice.
+func (a *Adapter) AcceptDispatchResult(w http.ResponseWriter, r *http.Request) {
+	req, err := decodeAcceptDispatchResultRequest(r.Body)
+	if err != nil {
+		a.writeError(w, http.StatusBadRequest, "invalid request payload", "BAD_REQUEST")
+		return
+	}
+	a.invokeAcceptDispatchResult(w, r.Context(), req)
+}
+
+func (a *Adapter) invokePlanDispatch(
+	w http.ResponseWriter,
+	ctx context.Context,
+	req factoryruntime.PlanDispatchRequest,
+) {
+	root, err := a.runtimeRoot()
+	if err != nil {
+		a.writeError(w, http.StatusInternalServerError, "factory runtime service is required", "INTERNAL_ERROR")
+		return
+	}
+	result, err := root.PlanDispatch(ctx, req)
+	if err != nil {
+		if a.writeDispatchPlanError(w, err) {
+			return
+		}
+		a.writeError(w, http.StatusInternalServerError, "failed to plan dispatch", "INTERNAL_ERROR")
+		return
+	}
+	a.writeJSON(w, http.StatusOK, dispatchPlanResponseFromPlanResult(result))
+}
+
+func (a *Adapter) invokeAcceptDispatchResult(
+	w http.ResponseWriter,
+	ctx context.Context,
+	req factoryruntime.AcceptDispatchResultRequest,
+) {
+	root, err := a.runtimeRoot()
+	if err != nil {
+		a.writeError(w, http.StatusInternalServerError, "factory runtime service is required", "INTERNAL_ERROR")
+		return
+	}
+	result, err := root.AcceptDispatchResult(ctx, req)
+	if err != nil {
+		if a.writeDispatchPlanError(w, err) {
+			return
+		}
+		a.writeError(w, http.StatusInternalServerError, "failed to accept dispatch result", "INTERNAL_ERROR")
+		return
+	}
+	a.writeJSON(w, http.StatusOK, dispatchPlanResponseFromAcceptResult(result))
+}
+
+func (a *Adapter) writeDispatchPlanError(w http.ResponseWriter, err error) bool {
+	if status, response, ok := dispatchPlanErrorResponse(err); ok {
+		a.writeJSON(w, status, response)
+		return true
+	}
+	return false
+}
+
+func dispatchPlanErrorResponse(err error) (int, factoryapi.ErrorResponse, bool) {
+	if err == nil {
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+	switch {
+	case errors.Is(err, factoryruntime.ErrDuplicateDispatchIntent):
+		return conflictErrorResponse("dispatch intent conflicts with an existing plan")
+	case errors.Is(err, factoryruntime.ErrUnknownDispatchCorrelation):
+		return notFoundErrorResponse("dispatch correlation not found")
+	case errors.Is(err, factoryruntime.ErrInvalidDispatchResultBoundary):
+		return badRequestErrorResponse("invalid dispatch result boundary")
+	case errors.Is(err, factoryruntime.ErrNotFound):
+		return notFoundErrorResponse("factory runtime target not found")
+	case errors.Is(err, factoryruntime.ErrNotRunning):
+		return serviceUnavailableErrorResponse("factory runtime is not running")
+	case errors.Is(err, factoryruntime.ErrCapabilityUnavailable):
+		return serviceUnavailableErrorResponse("factory runtime capability is unavailable")
+	default:
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+}

--- a/pkg/services/factory_runtime/transports/http/handlers_dispatch_plan.go
+++ b/pkg/services/factory_runtime/transports/http/handlers_dispatch_plan.go
@@ -37,6 +37,9 @@ func (a *Adapter) invokePlanDispatch(
 	ctx context.Context,
 	req factoryruntime.PlanDispatchRequest,
 ) {
+	if a.writeRuntimeRequestContextOutcome(w, ctx.Err()) {
+		return
+	}
 	root, err := a.runtimeRoot()
 	if err != nil {
 		a.writeError(w, http.StatusInternalServerError, "factory runtime service is required", "INTERNAL_ERROR")
@@ -44,7 +47,7 @@ func (a *Adapter) invokePlanDispatch(
 	}
 	result, err := root.PlanDispatch(ctx, req)
 	if err != nil {
-		a.writeRootOrInternalError(w, runtimeHTTPOperationDispatchPlan, "failed to plan dispatch", err)
+		a.writeRootOrInternalError(w, ctx, runtimeHTTPOperationDispatchPlan, "failed to plan dispatch", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, dispatchPlanResponseFromPlanResult(result))
@@ -55,6 +58,9 @@ func (a *Adapter) invokeAcceptDispatchResult(
 	ctx context.Context,
 	req factoryruntime.AcceptDispatchResultRequest,
 ) {
+	if a.writeRuntimeRequestContextOutcome(w, ctx.Err()) {
+		return
+	}
 	root, err := a.runtimeRoot()
 	if err != nil {
 		a.writeError(w, http.StatusInternalServerError, "factory runtime service is required", "INTERNAL_ERROR")
@@ -62,7 +68,7 @@ func (a *Adapter) invokeAcceptDispatchResult(
 	}
 	result, err := root.AcceptDispatchResult(ctx, req)
 	if err != nil {
-		a.writeRootOrInternalError(w, runtimeHTTPOperationDispatchPlan, "failed to accept dispatch result", err)
+		a.writeRootOrInternalError(w, ctx, runtimeHTTPOperationDispatchPlan, "failed to accept dispatch result", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, dispatchPlanResponseFromAcceptResult(result))

--- a/pkg/services/factory_runtime/transports/http/handlers_dispatch_plan.go
+++ b/pkg/services/factory_runtime/transports/http/handlers_dispatch_plan.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
-	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 )
 
 var errRequestBodyRequired = errors.New("request body is required")
@@ -45,10 +44,7 @@ func (a *Adapter) invokePlanDispatch(
 	}
 	result, err := root.PlanDispatch(ctx, req)
 	if err != nil {
-		if a.writeDispatchPlanError(w, err) {
-			return
-		}
-		a.writeError(w, http.StatusInternalServerError, "failed to plan dispatch", "INTERNAL_ERROR")
+		a.writeRootOrInternalError(w, runtimeHTTPOperationDispatchPlan, "failed to plan dispatch", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, dispatchPlanResponseFromPlanResult(result))
@@ -66,41 +62,9 @@ func (a *Adapter) invokeAcceptDispatchResult(
 	}
 	result, err := root.AcceptDispatchResult(ctx, req)
 	if err != nil {
-		if a.writeDispatchPlanError(w, err) {
-			return
-		}
-		a.writeError(w, http.StatusInternalServerError, "failed to accept dispatch result", "INTERNAL_ERROR")
+		a.writeRootOrInternalError(w, runtimeHTTPOperationDispatchPlan, "failed to accept dispatch result", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, dispatchPlanResponseFromAcceptResult(result))
 }
 
-func (a *Adapter) writeDispatchPlanError(w http.ResponseWriter, err error) bool {
-	if status, response, ok := dispatchPlanErrorResponse(err); ok {
-		a.writeJSON(w, status, response)
-		return true
-	}
-	return false
-}
-
-func dispatchPlanErrorResponse(err error) (int, factoryapi.ErrorResponse, bool) {
-	if err == nil {
-		return 0, factoryapi.ErrorResponse{}, false
-	}
-	switch {
-	case errors.Is(err, factoryruntime.ErrDuplicateDispatchIntent):
-		return conflictErrorResponse("dispatch intent conflicts with an existing plan")
-	case errors.Is(err, factoryruntime.ErrUnknownDispatchCorrelation):
-		return notFoundErrorResponse("dispatch correlation not found")
-	case errors.Is(err, factoryruntime.ErrInvalidDispatchResultBoundary):
-		return badRequestErrorResponse("invalid dispatch result boundary")
-	case errors.Is(err, factoryruntime.ErrNotFound):
-		return notFoundErrorResponse("factory runtime target not found")
-	case errors.Is(err, factoryruntime.ErrNotRunning):
-		return serviceUnavailableErrorResponse("factory runtime is not running")
-	case errors.Is(err, factoryruntime.ErrCapabilityUnavailable):
-		return serviceUnavailableErrorResponse("factory runtime capability is unavailable")
-	default:
-		return 0, factoryapi.ErrorResponse{}, false
-	}
-}

--- a/pkg/services/factory_runtime/transports/http/handlers_dispatch_plan_test.go
+++ b/pkg/services/factory_runtime/transports/http/handlers_dispatch_plan_test.go
@@ -1,0 +1,274 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+func TestPlanDispatch_ForwardsDecodedFieldsToRoot(t *testing.T) {
+	t.Parallel()
+
+	var got factoryruntime.PlanDispatchRequest
+	fake := &runtimeRootFake{
+		planDispatch: func(_ context.Context, req factoryruntime.PlanDispatchRequest) (factoryruntime.PlanDispatchResult, error) {
+			got = req
+			return factoryruntime.PlanDispatchResult{
+				Outcome:       factoryruntime.DispatchPlanOutcomeAccepted,
+				DispatchID:      req.DispatchID,
+				CorrelationID: req.CorrelationID,
+			}, nil
+		},
+	}
+	adapter := NewAdapter(fake)
+
+	body := strings.NewReader(`{
+		"dispatchId":"dispatch-1",
+		"correlationId":"corr-1",
+		"workIds":["work-1"," work-2 "],
+		"workstationName":"ws-alpha",
+		"workerType":"agent",
+		"replayKey":"replay-1"
+	}`)
+	rec := httptest.NewRecorder()
+	adapter.PlanDispatch(rec, httptest.NewRequest(http.MethodPost, "/runtime/dispatch/plan", body))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if got.DispatchID != "dispatch-1" || got.CorrelationID != "corr-1" ||
+		got.WorkstationName != "ws-alpha" || got.WorkerType != "agent" || got.ReplayKey != "replay-1" {
+		t.Fatalf("plan request = %#v, want decoded dispatch fields", got)
+	}
+	if len(got.WorkIDs) != 2 || got.WorkIDs[0] != "work-1" || got.WorkIDs[1] != "work-2" {
+		t.Fatalf("workIds = %#v, want [work-1 work-2]", got.WorkIDs)
+	}
+
+	var response runtimeDispatchPlanHTTPResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Outcome != factoryruntime.DispatchPlanOutcomeAccepted {
+		t.Fatalf("outcome = %q, want ACCEPTED", response.Outcome)
+	}
+}
+
+func TestPlanDispatch_EncodesDuplicateIdempotentOutcome(t *testing.T) {
+	t.Parallel()
+
+	fake := &runtimeRootFake{
+		planDispatch: func(_ context.Context, req factoryruntime.PlanDispatchRequest) (factoryruntime.PlanDispatchResult, error) {
+			return factoryruntime.PlanDispatchResult{
+				Outcome:       factoryruntime.DispatchPlanOutcomeDuplicateIdempotent,
+				DispatchID:    req.DispatchID,
+				CorrelationID: req.CorrelationID,
+			}, nil
+		},
+	}
+	adapter := NewAdapter(fake)
+
+	rec := httptest.NewRecorder()
+	adapter.PlanDispatch(
+		rec,
+		httptest.NewRequest(
+			http.MethodPost,
+			"/runtime/dispatch/plan",
+			strings.NewReader(`{"dispatchId":"dispatch-1","correlationId":"corr-1","workIds":["work-1"],"workstationName":"ws","workerType":"agent","replayKey":"replay-1"}`),
+		),
+	)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var response runtimeDispatchPlanHTTPResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Outcome != factoryruntime.DispatchPlanOutcomeDuplicateIdempotent {
+		t.Fatalf("outcome = %q, want DUPLICATE_IDEMPOTENT", response.Outcome)
+	}
+}
+
+func TestAcceptDispatchResult_ForwardsDecodedFieldsToRoot(t *testing.T) {
+	t.Parallel()
+
+	var got factoryruntime.AcceptDispatchResultRequest
+	fake := &runtimeRootFake{
+		acceptDispatchResult: func(_ context.Context, req factoryruntime.AcceptDispatchResultRequest) (factoryruntime.AcceptDispatchResultResult, error) {
+			got = req
+			return factoryruntime.AcceptDispatchResultResult{
+				Outcome:       factoryruntime.DispatchPlanOutcomeRetired,
+				DispatchID:    req.DispatchID,
+				CorrelationID: req.CorrelationID,
+			}, nil
+		},
+	}
+	adapter := NewAdapter(fake)
+
+	body := strings.NewReader(`{
+		"dispatchId":"dispatch-1",
+		"correlationId":"corr-1",
+		"workId":"work-1",
+		"resultOutcome":"SUCCESS"
+	}`)
+	rec := httptest.NewRecorder()
+	adapter.AcceptDispatchResult(rec, httptest.NewRequest(http.MethodPost, "/runtime/dispatch/accept-result", body))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if got.DispatchID != "dispatch-1" || got.CorrelationID != "corr-1" ||
+		got.WorkID != "work-1" || got.ResultOutcome != factoryruntime.DispatchResultOutcomeSuccess {
+		t.Fatalf("accept request = %#v, want decoded dispatch result fields", got)
+	}
+
+	var response runtimeDispatchPlanHTTPResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Outcome != factoryruntime.DispatchPlanOutcomeRetired {
+		t.Fatalf("outcome = %q, want RETIRED", response.Outcome)
+	}
+}
+
+func TestPlanDispatch_MapsTypedDispatchFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		programmed error
+		wantStatus int
+		wantCode   string
+		wantMsg    string
+	}{
+		{
+			name:       "duplicate intent",
+			programmed: factoryruntime.ErrDuplicateDispatchIntent,
+			wantStatus: http.StatusConflict,
+			wantCode:   "CONFLICT",
+			wantMsg:    "dispatch intent conflicts with an existing plan",
+		},
+		{
+			name:       "invalid boundary",
+			programmed: factoryruntime.ErrInvalidDispatchResultBoundary,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "BAD_REQUEST",
+			wantMsg:    "invalid dispatch result boundary",
+		},
+		{
+			name:       "not found",
+			programmed: factoryruntime.ErrNotFound,
+			wantStatus: http.StatusNotFound,
+			wantCode:   "NOT_FOUND",
+			wantMsg:    "factory runtime target not found",
+		},
+		{
+			name:       "not running",
+			programmed: factoryruntime.ErrNotRunning,
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   "SERVICE_UNAVAILABLE",
+			wantMsg:    "factory runtime is not running",
+		},
+		{
+			name:       "capability unavailable",
+			programmed: factoryruntime.ErrCapabilityUnavailable,
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   "SERVICE_UNAVAILABLE",
+			wantMsg:    "factory runtime capability is unavailable",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fake := &runtimeRootFake{
+				planDispatch: func(context.Context, factoryruntime.PlanDispatchRequest) (factoryruntime.PlanDispatchResult, error) {
+					return factoryruntime.PlanDispatchResult{}, tc.programmed
+				},
+			}
+			adapter := NewAdapter(fake)
+			rec := httptest.NewRecorder()
+			adapter.PlanDispatch(
+				rec,
+				httptest.NewRequest(
+					http.MethodPost,
+					"/runtime/dispatch/plan",
+					strings.NewReader(`{"dispatchId":"dispatch-1","correlationId":"corr-1","workIds":["work-1"],"workstationName":"ws","workerType":"agent","replayKey":"replay-1"}`),
+				),
+			)
+			assertErrorResponse(t, rec, tc.wantStatus, tc.wantCode, tc.wantMsg)
+		})
+	}
+}
+
+func TestAcceptDispatchResult_MapsTypedDispatchFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		programmed error
+		wantStatus int
+		wantCode   string
+		wantMsg    string
+	}{
+		{
+			name:       "unknown correlation",
+			programmed: factoryruntime.ErrUnknownDispatchCorrelation,
+			wantStatus: http.StatusNotFound,
+			wantCode:   "NOT_FOUND",
+			wantMsg:    "dispatch correlation not found",
+		},
+		{
+			name:       "invalid boundary",
+			programmed: factoryruntime.ErrInvalidDispatchResultBoundary,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "BAD_REQUEST",
+			wantMsg:    "invalid dispatch result boundary",
+		},
+		{
+			name:       "not running",
+			programmed: factoryruntime.ErrNotRunning,
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   "SERVICE_UNAVAILABLE",
+			wantMsg:    "factory runtime is not running",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fake := &runtimeRootFake{
+				acceptDispatchResult: func(context.Context, factoryruntime.AcceptDispatchResultRequest) (factoryruntime.AcceptDispatchResultResult, error) {
+					return factoryruntime.AcceptDispatchResultResult{}, tc.programmed
+				},
+			}
+			adapter := NewAdapter(fake)
+			rec := httptest.NewRecorder()
+			adapter.AcceptDispatchResult(
+				rec,
+				httptest.NewRequest(
+					http.MethodPost,
+					"/runtime/dispatch/accept-result",
+					strings.NewReader(`{"dispatchId":"dispatch-1","correlationId":"corr-1","workId":"work-1","resultOutcome":"SUCCESS"}`),
+				),
+			)
+			assertErrorResponse(t, rec, tc.wantStatus, tc.wantCode, tc.wantMsg)
+		})
+	}
+}
+
+func TestPlanDispatch_RejectsInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewAdapter(&runtimeRootFake{})
+	rec := httptest.NewRecorder()
+	adapter.PlanDispatch(rec, httptest.NewRequest(http.MethodPost, "/runtime/dispatch/plan", strings.NewReader("{")))
+	assertErrorResponse(t, rec, http.StatusBadRequest, "BAD_REQUEST", "invalid request payload")
+}

--- a/pkg/services/factory_runtime/transports/http/handlers_move_work_test.go
+++ b/pkg/services/factory_runtime/transports/http/handlers_move_work_test.go
@@ -1,0 +1,137 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+func TestMoveWorkBySessionId_ForwardsDecodedFieldsToRoot(t *testing.T) {
+	t.Parallel()
+
+	var got factoryruntime.MoveWorkRequest
+	fake := &runtimeRootFake{
+		moveWork: func(_ context.Context, req factoryruntime.MoveWorkRequest) (factoryruntime.MoveWorkResult, error) {
+			got = req
+			return factoryruntime.MoveWorkResult{
+				WorkID:     req.WorkID,
+				WorkTypeID: "task",
+				FromState:  "processing",
+				ToState:    req.StateName,
+			}, nil
+		},
+	}
+	adapter := NewAdapter(fake)
+
+	body := strings.NewReader(`{"stateName":"complete","requestId":"move-req-1"}`)
+	rec := httptest.NewRecorder()
+	adapter.MoveWorkBySessionId(
+		rec,
+		httptest.NewRequest(http.MethodPost, "/factory-sessions/session-alpha/work/work-1/move", body),
+		"session-alpha",
+		"work-1",
+	)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if got.WorkID != "work-1" || got.StateName != "complete" || got.RequestID != "move-req-1" {
+		t.Fatalf("move request = %#v, want work-1 complete move-req-1", got)
+	}
+	if got.Source != factoryruntime.WorkMoveSourceAPI {
+		t.Fatalf("source = %q, want api", got.Source)
+	}
+
+	var response factoryapi.Work
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.WorkId == nil || *response.WorkId != "work-1" {
+		t.Fatalf("workId = %#v, want work-1", response.WorkId)
+	}
+	if response.State == nil || response.State.Name != "complete" {
+		t.Fatalf("state = %#v, want complete", response.State)
+	}
+}
+
+func TestMoveWorkBySessionId_MapsTypedMoveFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		programmed error
+		wantStatus int
+		wantCode   string
+		wantMsg    string
+	}{
+		{
+			name:       "not found",
+			programmed: factoryruntime.ErrMoveWorkNotFound,
+			wantStatus: http.StatusNotFound,
+			wantCode:   "NOT_FOUND",
+			wantMsg:    "work not found",
+		},
+		{
+			name:       "invalid state",
+			programmed: factoryruntime.ErrMoveWorkInvalidState,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "BAD_REQUEST",
+			wantMsg:    "invalid target state for work type",
+		},
+		{
+			name:       "request conflict",
+			programmed: factoryruntime.ErrMoveWorkRequestConflict,
+			wantStatus: http.StatusConflict,
+			wantCode:   "MOVE_WORK_REQUEST_ALREADY_APPLIED",
+			wantMsg:    "Operator move request was already applied.",
+		},
+		{
+			name:       "not running",
+			programmed: factoryruntime.ErrNotRunning,
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   "SERVICE_UNAVAILABLE",
+			wantMsg:    "factory runtime is not running",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fake := &runtimeRootFake{
+				moveWork: func(context.Context, factoryruntime.MoveWorkRequest) (factoryruntime.MoveWorkResult, error) {
+					return factoryruntime.MoveWorkResult{}, tc.programmed
+				},
+			}
+			adapter := NewAdapter(fake)
+			rec := httptest.NewRecorder()
+			adapter.MoveWorkBySessionId(
+				rec,
+				httptest.NewRequest(http.MethodPost, "/factory-sessions/session-alpha/work/work-1/move", strings.NewReader(`{"stateName":"complete"}`)),
+				"session-alpha",
+				"work-1",
+			)
+			assertErrorResponse(t, rec, tc.wantStatus, tc.wantCode, tc.wantMsg)
+		})
+	}
+}
+
+func TestMoveWorkBySessionId_RequiresStateName(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewAdapter(&runtimeRootFake{})
+	rec := httptest.NewRecorder()
+	adapter.MoveWorkBySessionId(
+		rec,
+		httptest.NewRequest(http.MethodPost, "/factory-sessions/session-alpha/work/work-1/move", strings.NewReader(`{"stateName":"  "}`)),
+		"session-alpha",
+		"work-1",
+	)
+	assertErrorResponse(t, rec, http.StatusBadRequest, "BAD_REQUEST", "stateName is required")
+}

--- a/pkg/services/factory_runtime/transports/http/handlers_status.go
+++ b/pkg/services/factory_runtime/transports/http/handlers_status.go
@@ -26,10 +26,7 @@ func (a *Adapter) GetStatusBySessionId(
 func (a *Adapter) getStatus(w http.ResponseWriter, r *http.Request, sessionID string) {
 	result, err := a.observeStatus(r.Context(), sessionID)
 	if err != nil {
-		if a.writeObserveError(w, err) {
-			return
-		}
-		a.writeError(w, http.StatusInternalServerError, "failed to observe factory runtime status", "INTERNAL_ERROR")
+		a.writeRootOrInternalError(w, runtimeHTTPOperationObserve, "failed to observe factory runtime status", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, statusResponseFromObservation(result.Observation))

--- a/pkg/services/factory_runtime/transports/http/handlers_status.go
+++ b/pkg/services/factory_runtime/transports/http/handlers_status.go
@@ -24,9 +24,12 @@ func (a *Adapter) GetStatusBySessionId(
 }
 
 func (a *Adapter) getStatus(w http.ResponseWriter, r *http.Request, sessionID string) {
+	if a.guardRuntimeRequestContext(w, r) {
+		return
+	}
 	result, err := a.observeStatus(r.Context(), sessionID)
 	if err != nil {
-		a.writeRootOrInternalError(w, runtimeHTTPOperationObserve, "failed to observe factory runtime status", err)
+		a.writeRootOrInternalError(w, r.Context(), runtimeHTTPOperationObserve, "failed to observe factory runtime status", err)
 		return
 	}
 	a.writeJSON(w, http.StatusOK, statusResponseFromObservation(result.Observation))

--- a/pkg/services/factory_runtime/transports/http/handlers_status.go
+++ b/pkg/services/factory_runtime/transports/http/handlers_status.go
@@ -1,0 +1,51 @@
+package http
+
+import (
+	"context"
+	"net/http"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+// GetStatus handles GET /status through the accepted Runtime observation slice.
+func (a *Adapter) GetStatus(w http.ResponseWriter, r *http.Request) {
+	a.getStatus(w, r, "")
+}
+
+// GetStatusBySessionId handles GET /factory-sessions/{session_id}/status through
+// the accepted Runtime observation slice for one live session.
+func (a *Adapter) GetStatusBySessionId(
+	w http.ResponseWriter,
+	r *http.Request,
+	sessionID factoryapi.SessionID,
+) {
+	a.getStatus(w, r, string(sessionID))
+}
+
+func (a *Adapter) getStatus(w http.ResponseWriter, r *http.Request, sessionID string) {
+	result, err := a.observeStatus(r.Context(), sessionID)
+	if err != nil {
+		if a.writeObserveError(w, err) {
+			return
+		}
+		a.writeError(w, http.StatusInternalServerError, "failed to observe factory runtime status", "INTERNAL_ERROR")
+		return
+	}
+	a.writeJSON(w, http.StatusOK, statusResponseFromObservation(result.Observation))
+}
+
+func (a *Adapter) observeStatus(ctx context.Context, sessionID string) (factoryruntime.ObserveResult, error) {
+	root, err := a.runtimeRoot()
+	if err != nil {
+		return factoryruntime.ObserveResult{}, err
+	}
+	request := factoryruntime.ObserveRequest{Scope: statusObserveScope}
+	if sessionID == "" {
+		return root.Observe(ctx, request)
+	}
+	if a == nil || a.sessions == nil {
+		return factoryruntime.ObserveResult{}, errSessionObserverRequired
+	}
+	return a.sessions.ObserveForSession(ctx, sessionID, request)
+}

--- a/pkg/services/factory_runtime/transports/http/handlers_status_test.go
+++ b/pkg/services/factory_runtime/transports/http/handlers_status_test.go
@@ -1,0 +1,204 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+func TestGetStatus_MapsRootObservationToStatusResponse(t *testing.T) {
+	t.Parallel()
+
+	var gotScope factoryruntime.ObservationScope
+	fake := &runtimeRootFake{
+		observe: func(_ context.Context, req factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error) {
+			gotScope = req.Scope
+			return factoryruntime.ObserveResult{Observation: factoryruntime.Observation{
+				Status: factoryruntime.ObservationStatusActive,
+				Progress: factoryruntime.ObservationProgress{
+					TotalWorkCount: 4,
+					WorkCategories: factoryruntime.ObservationWorkCategories{
+						Initial:    1,
+						Processing: 2,
+						Terminal:   1,
+					},
+				},
+				Health: factoryruntime.ObservationHealth{FactoryState: "RUNNING"},
+			}}, nil
+		},
+	}
+	adapter := NewAdapter(fake)
+
+	rec := httptest.NewRecorder()
+	adapter.GetStatus(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if gotScope != factoryruntime.ObservationScopeFull {
+		t.Fatalf("Observe scope = %q, want FULL", gotScope)
+	}
+	var response factoryapi.StatusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.FactoryState != "RUNNING" || response.RuntimeStatus != "ACTIVE" || response.TotalTokens != 4 ||
+		response.Categories.Initial != 1 || response.Categories.Processing != 2 || response.Categories.Terminal != 1 {
+		t.Fatalf("response = %#v, want mapped observation status", response)
+	}
+}
+
+func TestGetStatusBySessionId_ForwardsSessionScopedObservation(t *testing.T) {
+	t.Parallel()
+
+	var gotSessionID string
+	var gotScope factoryruntime.ObservationScope
+	sessions := &sessionObserverFake{
+		observe: func(_ context.Context, sessionID string, req factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error) {
+			gotSessionID = sessionID
+			gotScope = req.Scope
+			return factoryruntime.ObserveResult{Observation: factoryruntime.Observation{
+				Status:   factoryruntime.ObservationStatusActive,
+				Progress: factoryruntime.ObservationProgress{TotalWorkCount: 2},
+				Health:   factoryruntime.ObservationHealth{FactoryState: "SCOPED"},
+			}}, nil
+		},
+	}
+	adapter := NewAdapter(&runtimeRootFake{})
+	adapter.BindSessionObserver(sessions)
+
+	rec := httptest.NewRecorder()
+	adapter.GetStatusBySessionId(rec, httptest.NewRequest(http.MethodGet, "/factory-sessions/session-beta/status", nil), "session-beta")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if gotSessionID != "session-beta" {
+		t.Fatalf("sessionID = %q, want session-beta", gotSessionID)
+	}
+	if gotScope != factoryruntime.ObservationScopeFull {
+		t.Fatalf("Observe scope = %q, want FULL", gotScope)
+	}
+	var response factoryapi.StatusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.FactoryState != "SCOPED" || response.TotalTokens != 2 {
+		t.Fatalf("response = %#v, want scoped observation projection", response)
+	}
+}
+
+func TestGetStatusBySessionId_RequiresSessionObserver(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewAdapter(&runtimeRootFake{})
+	rec := httptest.NewRecorder()
+	adapter.GetStatusBySessionId(rec, httptest.NewRequest(http.MethodGet, "/factory-sessions/session-beta/status", nil), "session-beta")
+
+	assertErrorResponse(t, rec, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "factory status is unavailable")
+}
+
+func TestGetStatus_MapsTypedObservationFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		programmed error
+		wantStatus int
+		wantCode   string
+		wantMsg    string
+	}{
+		{
+			name:       "not running",
+			programmed: factoryruntime.ErrNotRunning,
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   "SERVICE_UNAVAILABLE",
+			wantMsg:    "factory runtime is not running",
+		},
+		{
+			name:       "not found",
+			programmed: factoryruntime.ErrNotFound,
+			wantStatus: http.StatusNotFound,
+			wantCode:   "NOT_FOUND",
+			wantMsg:    "factory runtime target not found",
+		},
+		{
+			name:       "invalid scope",
+			programmed: factoryruntime.ErrInvalidObservationScope,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "BAD_REQUEST",
+			wantMsg:    "invalid observation scope",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fake := &runtimeRootFake{
+				observe: func(context.Context, factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error) {
+					return factoryruntime.ObserveResult{}, tc.programmed
+				},
+			}
+			adapter := NewAdapter(fake)
+			rec := httptest.NewRecorder()
+			adapter.GetStatus(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
+			assertErrorResponse(t, rec, tc.wantStatus, tc.wantCode, tc.wantMsg)
+		})
+	}
+}
+
+func TestGetStatusBySessionId_MapsSessionNotFound(t *testing.T) {
+	t.Parallel()
+
+	sessions := &sessionObserverFake{
+		observe: func(context.Context, string, factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error) {
+			return factoryruntime.ObserveResult{}, factorysessions.ErrSessionNotFound
+		},
+	}
+	adapter := NewAdapter(&runtimeRootFake{})
+	adapter.BindSessionObserver(sessions)
+
+	rec := httptest.NewRecorder()
+	adapter.GetStatusBySessionId(rec, httptest.NewRequest(http.MethodGet, "/factory-sessions/missing/status", nil), "missing")
+	assertErrorResponse(t, rec, http.StatusNotFound, "NOT_FOUND", "factory session not found")
+}
+
+func assertErrorResponse(t *testing.T, rec *httptest.ResponseRecorder, wantStatus int, wantCode, wantMsg string) {
+	t.Helper()
+	if rec.Code != wantStatus {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, wantStatus, rec.Body.String())
+	}
+	var response factoryapi.ErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if string(response.Code) != wantCode {
+		t.Fatalf("code = %q, want %q", response.Code, wantCode)
+	}
+	if response.Message != wantMsg {
+		t.Fatalf("message = %q, want %q", response.Message, wantMsg)
+	}
+}
+
+type sessionObserverFake struct {
+	observe func(context.Context, string, factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error)
+}
+
+func (fake *sessionObserverFake) ObserveForSession(
+	ctx context.Context,
+	sessionID string,
+	req factoryruntime.ObserveRequest,
+) (factoryruntime.ObserveResult, error) {
+	if fake.observe != nil {
+		return fake.observe(ctx, sessionID, req)
+	}
+	return factoryruntime.ObserveResult{}, errors.New("unexpected ObserveForSession call")
+}

--- a/pkg/services/factory_runtime/transports/http/manifest_registration_test.go
+++ b/pkg/services/factory_runtime/transports/http/manifest_registration_test.go
@@ -1,0 +1,144 @@
+package http_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/ownershipinventory"
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+const (
+	httpAdapterPackagePath = "pkg/services/factory_runtime/transports/http"
+	httpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/http"
+	factoryRuntimeOwner    = "factory_runtime"
+)
+
+type coverageMinimumManifest struct {
+	Lane     string `json:"lane"`
+	Packages []struct {
+		Package string  `json:"package"`
+		Minimum float64 `json:"minimum"`
+	} `json:"packages"`
+}
+
+func TestManifestRegistration_HTTPAdapterPackageIsRegistered(t *testing.T) {
+	t.Helper()
+
+	assertPackageTargetManifestRegistration(t)
+	assertOwnershipInventoryRegistration(t)
+	assertCoverageMinimumRegistration(t, "unit", "docs/internal/baselines/go-unit-coverage-package-minimums.json")
+	assertCoverageMinimumRegistration(t, "functional", "docs/internal/baselines/go-functional-coverage-package-minimums.json")
+}
+
+func assertPackageTargetManifestRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, "docs/internal/packaged-service-structure/package-target-manifest.json"))
+	if err != nil {
+		t.Fatalf("read package-target manifest: %v", err)
+	}
+
+	var manifest struct {
+		Inventory []string `json:"inventory"`
+		Packages  []struct {
+			PackagePath string `json:"packagePath"`
+			Disposition string `json:"disposition"`
+			Destination string `json:"destination"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode package-target manifest: %v", err)
+	}
+
+	foundInventory := false
+	for _, packagePath := range manifest.Inventory {
+		if packagePath == httpAdapterPackagePath {
+			foundInventory = true
+			break
+		}
+	}
+	if !foundInventory {
+		t.Fatalf("package-target manifest inventory missing %q", httpAdapterPackagePath)
+	}
+
+	for _, row := range manifest.Packages {
+		if row.PackagePath != httpAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("package-target manifest disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != factoryRuntimeOwner {
+			t.Fatalf("package-target manifest destination = %q, want %q", row.Destination, factoryRuntimeOwner)
+		}
+		return
+	}
+	t.Fatalf("package-target manifest packages missing %q", httpAdapterPackagePath)
+}
+
+func assertOwnershipInventoryRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, ownershipinventory.InventoryRelativePath))
+	if err != nil {
+		t.Fatalf("read ownership inventory: %v", err)
+	}
+
+	var inventory struct {
+		Packages []ownershipinventory.PackageRow `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		t.Fatalf("decode ownership inventory: %v", err)
+	}
+
+	for _, row := range inventory.Packages {
+		if row.PackagePath != httpAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("ownership inventory disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != factoryRuntimeOwner {
+			t.Fatalf("ownership inventory destination = %q, want %q", row.Destination, factoryRuntimeOwner)
+		}
+		if row.DestinationKind != ownershipinventory.DestinationKindOwner {
+			t.Fatalf(
+				"ownership inventory destinationKind = %q, want %q",
+				row.DestinationKind,
+				ownershipinventory.DestinationKindOwner,
+			)
+		}
+		return
+	}
+	t.Fatalf("ownership inventory packages missing %q", httpAdapterPackagePath)
+}
+
+func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, relativePath))
+	if err != nil {
+		t.Fatalf("read %s coverage manifest: %v", lane, err)
+	}
+
+	var manifest coverageMinimumManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode %s coverage manifest: %v", lane, err)
+	}
+	if manifest.Lane != lane {
+		t.Fatalf("%s coverage manifest lane = %q, want %q", relativePath, manifest.Lane, lane)
+	}
+
+	for _, entry := range manifest.Packages {
+		if entry.Package != httpAdapterImportPath {
+			continue
+		}
+		if entry.Minimum < 0 {
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterImportPath)
+		}
+		return
+	}
+	t.Fatalf("%s coverage manifest missing %q", lane, httpAdapterImportPath)
+}

--- a/pkg/services/factory_runtime/transports/http/move_work_mapping.go
+++ b/pkg/services/factory_runtime/transports/http/move_work_mapping.go
@@ -1,0 +1,42 @@
+package http
+
+import (
+	"strings"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+func moveWorkRequestFromAPI(workID string, req factoryapi.MoveWorkRequest) factoryruntime.MoveWorkRequest {
+	return factoryruntime.MoveWorkRequest{
+		WorkID:    workID,
+		StateName: strings.TrimSpace(req.StateName),
+		Source:    factoryruntime.WorkMoveSourceAPI,
+		RequestID: strings.TrimSpace(stringValue(req.RequestId)),
+	}
+}
+
+func workResponseFromMoveResult(result factoryruntime.MoveWorkResult) factoryapi.Work {
+	work := factoryapi.Work{
+		WorkId:       stringPtrIfNotEmpty(result.WorkID),
+		WorkTypeName: stringPtrIfNotEmpty(result.WorkTypeID),
+	}
+	if result.ToState != "" {
+		work.State = &factoryapi.WorkState{Name: result.ToState}
+	}
+	return work
+}
+
+func stringPtrIfNotEmpty(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/pkg/services/factory_runtime/transports/http/owned_surface.go
+++ b/pkg/services/factory_runtime/transports/http/owned_surface.go
@@ -1,0 +1,10 @@
+package http
+
+// OwnedHTTPOperationIDs lists the generated OpenAPI operationIds adapted by
+// this package. HTTP-RUN owns Runtime status reads only in the initial binding
+// packet; later stories add control, dispatch-plan, and checkpoint slices
+// without authoring new shared OpenAPI operations.
+var OwnedHTTPOperationIDs = []string{
+	"getStatus",
+	"getStatusBySessionId",
+}

--- a/pkg/services/factory_runtime/transports/http/owned_surface.go
+++ b/pkg/services/factory_runtime/transports/http/owned_surface.go
@@ -1,8 +1,8 @@
 package http
 
 // OwnedHTTPOperationIDs lists the generated OpenAPI operationIds adapted by
-// this package. HTTP-RUN adds Runtime control and move-work slices without
-// authoring new shared OpenAPI operations; later stories add dispatch-plan and
+// this package. HTTP-RUN adds Runtime control, move-work, and dispatch-plan
+// slices without authoring new shared OpenAPI operations; later stories add
 // checkpoint slices.
 var OwnedHTTPOperationIDs = []string{
 	"getStatus",

--- a/pkg/services/factory_runtime/transports/http/owned_surface.go
+++ b/pkg/services/factory_runtime/transports/http/owned_surface.go
@@ -1,9 +1,8 @@
 package http
 
 // OwnedHTTPOperationIDs lists the generated OpenAPI operationIds adapted by
-// this package. HTTP-RUN adds Runtime control, move-work, and dispatch-plan
-// slices without authoring new shared OpenAPI operations; later stories add
-// checkpoint slices.
+// this package. HTTP-RUN adds Runtime control, move-work, dispatch-plan, and
+// checkpoint slices without authoring new shared OpenAPI operations.
 var OwnedHTTPOperationIDs = []string{
 	"getStatus",
 	"getStatusBySessionId",

--- a/pkg/services/factory_runtime/transports/http/owned_surface.go
+++ b/pkg/services/factory_runtime/transports/http/owned_surface.go
@@ -1,10 +1,11 @@
 package http
 
 // OwnedHTTPOperationIDs lists the generated OpenAPI operationIds adapted by
-// this package. HTTP-RUN owns Runtime status reads only in the initial binding
-// packet; later stories add control, dispatch-plan, and checkpoint slices
-// without authoring new shared OpenAPI operations.
+// this package. HTTP-RUN adds Runtime control and move-work slices without
+// authoring new shared OpenAPI operations; later stories add dispatch-plan and
+// checkpoint slices.
 var OwnedHTTPOperationIDs = []string{
 	"getStatus",
 	"getStatusBySessionId",
+	"moveWorkBySessionId",
 }

--- a/pkg/services/factory_runtime/transports/http/owned_surface_test.go
+++ b/pkg/services/factory_runtime/transports/http/owned_surface_test.go
@@ -8,7 +8,7 @@ import (
 func TestOwnedHTTPSurfaceIncludesStatusReads(t *testing.T) {
 	t.Parallel()
 
-	want := []string{"getStatus", "getStatusBySessionId"}
+	want := []string{"getStatus", "getStatusBySessionId", "moveWorkBySessionId"}
 	if !slices.Equal(OwnedHTTPOperationIDs, want) {
 		t.Fatalf("OwnedHTTPOperationIDs = %#v, want %#v", OwnedHTTPOperationIDs, want)
 	}

--- a/pkg/services/factory_runtime/transports/http/owned_surface_test.go
+++ b/pkg/services/factory_runtime/transports/http/owned_surface_test.go
@@ -1,0 +1,15 @@
+package http
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestOwnedHTTPSurfaceIncludesStatusReads(t *testing.T) {
+	t.Parallel()
+
+	want := []string{"getStatus", "getStatusBySessionId"}
+	if !slices.Equal(OwnedHTTPOperationIDs, want) {
+		t.Fatalf("OwnedHTTPOperationIDs = %#v, want %#v", OwnedHTTPOperationIDs, want)
+	}
+}

--- a/pkg/services/factory_runtime/transports/http/request_context.go
+++ b/pkg/services/factory_runtime/transports/http/request_context.go
@@ -1,0 +1,61 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+// runtimeRequestContextErrorResponse maps request-context cancellation and
+// deadline failures to the adapter's documented HTTP outcomes. Canceled
+// requests terminate without an error body; deadline failures return 504.
+func runtimeRequestContextErrorResponse(err error) (status int, response any, handled bool) {
+	if err == nil {
+		return 0, nil, false
+	}
+	switch {
+	case errors.Is(err, context.Canceled):
+		return 0, nil, true
+	case errors.Is(err, context.DeadlineExceeded):
+		return http.StatusGatewayTimeout, factoryapi.ErrorResponse{
+			Message: "factory runtime request timed out",
+			Family:  factoryapi.ErrorFamilyInternalServerError,
+			Code:    factoryapi.ErrorResponseCodeINTERNALERROR,
+		}, true
+	default:
+		return 0, nil, false
+	}
+}
+
+func requestContextEnded(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	return isRequestContextEnded(ctx.Err())
+}
+
+func isRequestContextEnded(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+func shouldEndOnRequestContext(ctx context.Context, err error) bool {
+	return requestContextEnded(ctx) || isRequestContextEnded(err)
+}
+
+func (a *Adapter) writeRuntimeRequestContextOutcome(w http.ResponseWriter, err error) bool {
+	status, response, ok := runtimeRequestContextErrorResponse(err)
+	if !ok {
+		return false
+	}
+	if response == nil {
+		return true
+	}
+	a.writeJSON(w, status, response)
+	return true
+}
+
+func (a *Adapter) guardRuntimeRequestContext(w http.ResponseWriter, r *http.Request) bool {
+	return a.writeRuntimeRequestContextOutcome(w, r.Context().Err())
+}

--- a/pkg/services/factory_runtime/transports/http/request_context_mapping_test.go
+++ b/pkg/services/factory_runtime/transports/http/request_context_mapping_test.go
@@ -1,0 +1,27 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestShouldEndOnRequestContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if !shouldEndOnRequestContext(ctx, nil) {
+		t.Fatal("canceled request context should end the handler")
+	}
+	if !shouldEndOnRequestContext(context.Background(), context.Canceled) {
+		t.Fatal("context.Canceled error should end the handler")
+	}
+	if !shouldEndOnRequestContext(context.Background(), context.DeadlineExceeded) {
+		t.Fatal("context.DeadlineExceeded error should end the handler")
+	}
+	if shouldEndOnRequestContext(context.Background(), errors.New("boom")) {
+		t.Fatal("unrelated errors must not end the handler")
+	}
+}

--- a/pkg/services/factory_runtime/transports/http/request_context_test.go
+++ b/pkg/services/factory_runtime/transports/http/request_context_test.go
@@ -1,0 +1,240 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+func TestGetStatus_EndsWithoutBodyWhenContextCanceledBeforeFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	adapter := NewAdapter(&runtimeRootFake{
+		observe: func(context.Context, factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error) {
+			invoked = true
+			return factoryruntime.ObserveResult{}, nil
+		},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	recorder := httptest.NewRecorder()
+	assertHandlerReturnsWithin(t, time.Second, func() {
+		adapter.GetStatus(recorder, httptest.NewRequest(http.MethodGet, "/status", nil).WithContext(ctx))
+	})
+
+	if invoked {
+		t.Fatal("canceled request context must end before Runtime root Observe")
+	}
+	if recorder.Body.Len() != 0 || strings.Contains(recorder.Body.String(), `"code":"INTERNAL_ERROR"`) {
+		t.Fatalf("response = %d %q, want no encoded body on pre-root cancellation", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestGetStatus_EndsWithoutErrorWhenCanceledDuringFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	adapter := NewAdapter(&runtimeRootFake{
+		observe: func(blockCtx context.Context, _ factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error) {
+			<-blockCtx.Done()
+			return factoryruntime.ObserveResult{}, context.Canceled
+		},
+	})
+	recorder := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		adapter.GetStatus(recorder, httptest.NewRequest(http.MethodGet, "/status", nil).WithContext(ctx))
+		close(done)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("status handler hung after request context cancellation")
+	}
+	if strings.Contains(recorder.Body.String(), `"code":"INTERNAL_ERROR"`) &&
+		!strings.Contains(recorder.Body.String(), "factory runtime request timed out") {
+		t.Fatalf("response must not map cancellation to ordinary INTERNAL_ERROR: %s", recorder.Body.String())
+	}
+}
+
+func TestGetStatus_DeadlineExceededReturnsGatewayTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	adapter := NewAdapter(&runtimeRootFake{
+		observe: func(blockCtx context.Context, _ factoryruntime.ObserveRequest) (factoryruntime.ObserveResult, error) {
+			<-blockCtx.Done()
+			return factoryruntime.ObserveResult{}, context.DeadlineExceeded
+		},
+	})
+	recorder := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		adapter.GetStatus(recorder, httptest.NewRequest(http.MethodGet, "/status", nil).WithContext(ctx))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("status handler hung after request context timeout")
+	}
+	if recorder.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504 Gateway Timeout", recorder.Code)
+	}
+	assertTimeoutErrorResponse(t, recorder.Body.Bytes())
+}
+
+func TestControlPause_EndsWithoutBodyWhenContextCanceledBeforeFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	adapter := NewAdapter(&runtimeRootFake{
+		pause: func(context.Context, factoryruntime.PauseRequest) (factoryruntime.PauseResult, error) {
+			invoked = true
+			return factoryruntime.PauseResult{}, nil
+		},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	recorder := httptest.NewRecorder()
+	assertHandlerReturnsWithin(t, time.Second, func() {
+		adapter.ControlPause(recorder, httptest.NewRequest(http.MethodPost, "/control/pause", nil).WithContext(ctx))
+	})
+
+	if invoked {
+		t.Fatal("canceled request context must end before Runtime root ControlPause")
+	}
+	if recorder.Body.Len() != 0 || strings.Contains(recorder.Body.String(), `"code":"INTERNAL_ERROR"`) {
+		t.Fatalf("response = %d %q, want no encoded body on pre-root cancellation", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestControlPause_EndsWithoutErrorWhenCanceledDuringFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	adapter := NewAdapter(&runtimeRootFake{
+		pause: func(blockCtx context.Context, _ factoryruntime.PauseRequest) (factoryruntime.PauseResult, error) {
+			<-blockCtx.Done()
+			return factoryruntime.PauseResult{}, context.Canceled
+		},
+	})
+	recorder := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		adapter.ControlPause(recorder, httptest.NewRequest(http.MethodPost, "/control/pause", nil).WithContext(ctx))
+		close(done)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("control pause handler hung after request context cancellation")
+	}
+	if strings.Contains(recorder.Body.String(), `"code":"INTERNAL_ERROR"`) &&
+		!strings.Contains(recorder.Body.String(), "factory runtime request timed out") {
+		t.Fatalf("response must not map cancellation to ordinary INTERNAL_ERROR: %s", recorder.Body.String())
+	}
+}
+
+func TestControlPause_DeadlineExceededReturnsGatewayTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	adapter := NewAdapter(&runtimeRootFake{
+		pause: func(blockCtx context.Context, _ factoryruntime.PauseRequest) (factoryruntime.PauseResult, error) {
+			<-blockCtx.Done()
+			return factoryruntime.PauseResult{}, context.DeadlineExceeded
+		},
+	})
+	recorder := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		adapter.ControlPause(recorder, httptest.NewRequest(http.MethodPost, "/control/pause", nil).WithContext(ctx))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("control pause handler hung after request context timeout")
+	}
+	if recorder.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504 Gateway Timeout", recorder.Code)
+	}
+	assertTimeoutErrorResponse(t, recorder.Body.Bytes())
+}
+
+func TestRuntimeRequestContextErrorResponseForTest(t *testing.T) {
+	t.Parallel()
+
+	if status, response, ok := RuntimeRequestContextErrorResponseForTest(context.Canceled); !ok || status != 0 || response != nil {
+		t.Fatalf("canceled = (%d, %#v, %v), want (0, nil, true)", status, response, ok)
+	}
+
+	status, response, ok := RuntimeRequestContextErrorResponseForTest(context.DeadlineExceeded)
+	if !ok || status != http.StatusGatewayTimeout {
+		t.Fatalf("deadline status = %d, ok = %v, want 504 true", status, ok)
+	}
+	body, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	if !strings.Contains(string(body), "factory runtime request timed out") {
+		t.Fatalf("response = %s, want timeout message", body)
+	}
+}
+
+func assertTimeoutErrorResponse(t *testing.T, body []byte) {
+	t.Helper()
+	var response factoryapi.ErrorResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if response.Code != factoryapi.ErrorResponseCodeINTERNALERROR {
+		t.Fatalf("code = %q, want INTERNAL_ERROR timeout code", response.Code)
+	}
+	if response.Message != "factory runtime request timed out" {
+		t.Fatalf("message = %q, want factory runtime request timed out", response.Message)
+	}
+}
+
+func assertHandlerReturnsWithin(t *testing.T, timeout time.Duration, fn func()) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		fn()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatalf("handler did not return within %s", timeout)
+	}
+}

--- a/pkg/services/factory_runtime/transports/http/status_mapping.go
+++ b/pkg/services/factory_runtime/transports/http/status_mapping.go
@@ -1,0 +1,13 @@
+package http
+
+import (
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	apisurface "github.com/portpowered/infinite-you/pkg/transports/mapping"
+)
+
+const statusObserveScope = factoryruntime.ObservationScopeFull
+
+func statusResponseFromObservation(observation factoryruntime.Observation) factoryapi.StatusResponse {
+	return apisurface.FactoryStatusToAPI(factoryruntime.FactoryStatusFromObservation(observation))
+}


### PR DESCRIPTION
{
  "project": "PSS HTTP-RUN: Factory Runtime Owner-Local HTTP Adapter",
  "branchName": "pss-http-run-adapter",
  "description": "Implement HTTP-RUN as the Factory Runtime service-owned HTTP adapter that decodes/maps Runtime HTTP requests through the accepted Runtime root, translates typed errors, and proves fake-root parity for mapping and cancel/timeout without importing Runtime internals, owning canonical state, authoring shared OpenAPI, or performing PSS-I02 fan-in.",
  "context": {
    "customerAsk": "Implement HTTP-RUN as the Factory Runtime service-owned HTTP adapter. Decode/map Runtime HTTP requests through the accepted Runtime root, translate typed errors, and prove fake-root parity for mapping and cancel/timeout behavior without importing Runtime internals or owning canonical state. Do not author shared OpenAPI or perform PSS-I02 route/client fan-in. Do not edit pkg/wire, pkg/root, pkg/initializer, top-level CLI composition, or reopen Runtime IMP/LWR ownership. Shared coverage, ownership, and package-target manifest edits are allowed and must be rebased through the merge loop. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Factory Runtime publishes an accepted root Service contract with typed errors, but has no owner-local HTTP adapter. Runtime-tagged HTTP behavior such as getStatus still lives outside Runtime ownership, so decode/map, typed-error translation, and cancel/timeout policy cannot be proven against a focused Runtime fake root without importing internals.",
    "solution": "Add pkg/services/factory_runtime/transports/http bound only to the accepted Runtime root, map existing generated Runtime HTTP shapes through that root, translate published typed errors, prove fake-root cancel/timeout parity, and register the package in shared manifests while leaving OpenAPI, PSS-I02, Wire/root/initializer, sibling adapters, CLI/MCP-RUN, and IMP-RUN-04 untouched."
  },
  "acceptanceCriteria": [
    "Factory Runtime owns an HTTP adapter package under its service tree that constructs only from the accepted Runtime root Service and does not import Runtime internal packages",
    "Existing Runtime-tagged HTTP operations (getStatus, getStatusBySessionId) and adapter-owned Runtime root slices decode inputs, invoke the root, and encode success/typed-failure outcomes with focused fake-root proof",
    "Published Runtime typed errors map to stable HTTP status plus public ErrorResponse codes/messages; cancel and deadline failures do not become opaque INTERNAL_ERROR success-path mishandling",
    "Shared package-target, ownership, and coverage manifests include the new adapter package as required for package registration, rebased through the merge loop",
    "Diff stays on Factory Runtime HTTP adapter paths and allowed shared manifests; no shared OpenAPI authorship, PSS-I02 fan-in, Wire/root/initializer, sibling-service HTTP adapters, CLI-RUN/MCP-RUN, or IMP-RUN-04 ownership reopen",
    "Quality checks pass (typecheck, lint, tests)",
    "Delivery loop continues until required CI is terminal and passing, all blocking PR conversation feedback is addressed, merge conflicts and shared-file churn are reconciled, and the PR is actually merged"
  ],
  "userStories": [
    {
      "id": "pss-http-run-adapter-001",
      "title": "Bind HTTP adapter to accepted Runtime root",
      "description": "As a maintainer, I want a Factory Runtime HTTP adapter package that constructs only from the accepted Runtime root so later composition can depend on a peer-facing seam instead of Runtime internals.",
      "acceptanceCriteria": [
        "Owner-local package exists under pkg/services/factory_runtime/transports/http (or the declared owner-local Runtime HTTP path)",
        "Adapter construction requires an injected Runtime root Service (or equivalent accepted root binding); nil root fails closed",
        "Adapter exposes a root accessor or binding that returns the injected root for owned operations",
        "Package declares the Runtime HTTP operation surface it owns (at least getStatus and getStatusBySessionId) without authoring new OpenAPI operations",
        "Non-test production sources do not import pkg/services/factory_runtime/internal/**",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-run-adapter-002",
      "title": "Map status reads through Runtime Observe",
      "description": "As an API consumer, I want Runtime status HTTP reads to resolve through the accepted Runtime observation slice so status responses reflect root observation outcomes rather than adapter-owned engine state.",
      "acceptanceCriteria": [
        "Adapter maps getStatus / getStatusBySessionId inputs into Runtime root observation requests without reading Runtime datastores directly",
        "Successful fake-root observation results encode into the existing public status response shape",
        "Typed observation failures from the root (for example not-running, not-found, invalid observation scope) produce mapped HTTP error outcomes rather than inventing adapter-local status state",
        "Fake-root tests prove request to root invocation to response/error mapping without constructing hosting, Petri, JavaScript, or Wire graphs",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-run-adapter-003",
      "title": "Map control and move-work calls through Runtime root",
      "description": "As a protocol maintainer, I want Runtime control and operator move-work HTTP adaptation to call the accepted control/move root slices so pause, resume, terminate, and move outcomes stay aligned with published Runtime vocabulary.",
      "acceptanceCriteria": [
        "Adapter provides decode/map/invoke/encode paths for Runtime root control pause, resume, and terminate through the accepted root",
        "Adapter provides decode/map/invoke/encode for operator move-work through ControlMoveWork using published Runtime move vocabulary",
        "Fake-root tests assert the adapter forwards the decoded request fields and returns success or typed-failure outcomes from the root",
        "Adapter does not own durable stop wiring or reopen IMP-RUN lifecycle ownership",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-run-adapter-004",
      "title": "Map dispatch-plan calls through Runtime root",
      "description": "As a protocol maintainer, I want dispatch-plan HTTP adaptation to call PlanDispatch and AcceptDispatchResult on the accepted Runtime root so intent publish and result acceptance stay Runtime-owned.",
      "acceptanceCriteria": [
        "Adapter maps plan-dispatch and accept-dispatch-result inputs through the accepted root slices",
        "Fake-root success paths return the root success vocabulary encoded for HTTP consumers",
        "Typed dispatch-plan failures (duplicate intent, unknown correlation, invalid result boundary, not-running, not-found, capability unavailable) remain distinguishable at the adapter edge",
        "Adapter does not execute workers or own dispatch durability",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-run-adapter-005",
      "title": "Map checkpoint calls without owning IMP-RUN-04 durability",
      "description": "As a protocol maintainer, I want checkpoint HTTP adaptation to call the published Runtime checkpoint slices and surface typed capability/availability failures so HTTP-RUN stays clear of IMP-RUN-04 durable recovery ownership.",
      "acceptanceCriteria": [
        "Adapter maps capture/load/restore checkpoint requests through the accepted Runtime root",
        "Fake-root tests prove typed outcomes such as capability unavailable, checkpoint not found, corrupt, or incompatible checkpoint map at the adapter edge",
        "No durable checkpoint store, recovery algorithm, or IMP-RUN-04 ownership is introduced in this packet",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-run-adapter-006",
      "title": "Translate Runtime typed errors to HTTP ErrorResponse",
      "description": "As an API consumer, I want published Runtime sentinel errors to become stable HTTP status and ErrorResponse outcomes so clients can branch without parsing free-form internal messages.",
      "acceptanceCriteria": [
        "Adapter translates published Runtime root sentinels (including not-running, not-found, already-stopped, invalid lifecycle transition, invalid observation scope, move-work failures, dispatch-plan failures, checkpoint failures, and capability unavailable) into explicit HTTP status plus public error code/message pairs",
        "Unknown non-context errors fall back to a documented internal/server failure path without pretending success",
        "Focused tests cover representative typed-error to HTTP mappings using the fake root",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-run-adapter-007",
      "title": "Prove cancel and timeout request-context behavior",
      "description": "As an API consumer, I want canceled or timed-out Runtime HTTP requests to end promptly and not be reported as ordinary internal success-path failures.",
      "acceptanceCriteria": [
        "When the request context is already canceled before root invocation, the adapter ends without calling the root or without treating cancellation as an ordinary mapped business success",
        "When the root returns context.Canceled or context.DeadlineExceeded, the adapter ends without mapping those outcomes to opaque business success or mislabeled ordinary INTERNAL_ERROR business failures in the cancel/timeout path",
        "Fake-root tests cover pre-root cancel, mid-invocation cancel, and timeout for at least one representative owned HTTP operation (status read) and one representative root-invoking control or observation path",
        "Handlers return within a bounded test timeout after cancel/deadline",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 7,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-run-adapter-008",
      "title": "Register adapter package in shared manifests",
      "description": "As a maintainer, I want the Runtime HTTP adapter package registered in package-target, ownership, and coverage manifests so PSS package accounting stays accurate after the adapter lands.",
      "acceptanceCriteria": [
        "Package-target manifest inventory/packages include the new Runtime HTTP adapter package with retain disposition under factory_runtime",
        "Ownership inventory registration required by sibling HTTP adapters is updated for the new package",
        "Unit/functional coverage package-minimum manifests include the new package when sibling adapter registration requires it",
        "Manifest edits stay limited to registration required by this adapter; no OpenAPI, Wire, root, initializer, or sibling-adapter fan-in changes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 8,
      "passes": true,
      "notes": ""
    }
  ]
}
