### PR TITLE
pss-http-auto-adapter

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -207,6 +207,16 @@
       "minimum": 62.80
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/automations/transports/http",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations/wire",
       "exception": {
         "kind": "measurement",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -207,6 +207,10 @@
       "minimum": 83.73
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/automations/transports/http",
+      "minimum": 85.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations/wire",
       "minimum": 92.59
     },

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -1036,6 +1036,12 @@
     },
     {
       "fromOwner": "automations",
+      "toOwner": "transports",
+      "class": "command",
+      "evidence": "pkg/services/automations/transports/http -\u003e pkg/transports/http/generated"
+    },
+    {
+      "fromOwner": "automations",
       "toOwner": "work",
       "class": "command",
       "evidence": "pkg/services/automations -\u003e pkg/services/work"
@@ -2443,6 +2449,12 @@
     },
     {
       "packagePath": "pkg/services/automations/service",
+      "disposition": "retain",
+      "destination": "automations",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/automations/transports/http",
       "disposition": "retain",
       "destination": "automations",
       "destinationKind": "owner"

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -81,6 +81,7 @@
     "pkg/services/automations/internal/services/script_pollers/internal/service",
     "pkg/services/automations/internal/services/script_pollers/wire",
     "pkg/services/automations/service",
+    "pkg/services/automations/transports/http",
     "pkg/services/automations/wire",
     "pkg/services/edges",
     "pkg/services/factory_definitions",
@@ -683,6 +684,11 @@
     },
     {
       "packagePath": "pkg/services/automations/service",
+      "disposition": "retain",
+      "destination": "automations"
+    },
+    {
+      "packagePath": "pkg/services/automations/transports/http",
       "disposition": "retain",
       "destination": "automations"
     },

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -64,6 +64,21 @@ Use this map when changing the public REST contract.
   Prove registration with `manifest_registration_test.go`; do not edit
   `pkg/wire`, `pkg/root`, `pkg/initializer`, top-level CLI composition, or
   other services' HTTP adapters when reconciling manifest churn.
+- Automations HTTP decoding, transport-local DTO mapping, accepted root
+  invocation, typed error mapping, and cancel/timeout handling live in
+  `pkg/services/automations/transports/http`. The top-level `pkg/transports/http`
+  server composes injected service-owned adapters when PSS-I02 fans routes in;
+  HTTP-AUTO proves fake-root parity at the adapter edge without importing
+  Automations internals or authoring shared OpenAPI. Lifecycle decode/encode lives
+  in `lifecycle_mapping.go` / `lifecycle_operations.go`; reconcile/status/cursor
+  mapping lives in `convergence_mapping.go` / `convergence_operations.go`;
+  typed root failures map through `error_mapping.go`; request-context outcomes
+  map through `request_context.go`. Package-boundary tests must prove the adapter
+  does not import `pkg/services/automations/internal/**`. Register the package in
+  `docs/internal/packaged-service-structure/package-target-manifest.json`,
+  `docs/internal/baselines/ownership-inventory.json`, and the
+  `go-*-coverage-package-minimums.json` baselines; prove registration with
+  `manifest_registration_test.go`.
 - Factory Session CLI request construction, rendering, diagnostics, and
   operation handlers live under
   `pkg/services/factory_sessions/transports/cli`; Factory Session MCP tool

--- a/pkg/services/automations/transports/http/adapter.go
+++ b/pkg/services/automations/transports/http/adapter.go
@@ -1,0 +1,44 @@
+// Package http adapts Automations HTTP operations through the accepted
+// Automations root contract. Request decoding, representation mapping, service
+// invocation, error mapping, and response encoding for owned Automations HTTP
+// operations remain here with the owning service.
+package http
+
+import (
+	"context"
+	"errors"
+
+	"github.com/portpowered/infinite-you/pkg/services/automations"
+)
+
+// Adapter maps Automations HTTP operations through the accepted root contract
+// without importing Automations internals or owning canonical automation state.
+type Adapter struct {
+	root automations.Root
+}
+
+// NewAdapter constructs the Automations HTTP adapter bound to the accepted root.
+func NewAdapter(root automations.Root) *Adapter {
+	if root.Operations == nil {
+		return nil
+	}
+	return &Adapter{root: root}
+}
+
+// Root returns the accepted Automations root consumed by adapter-owned operations.
+func (a *Adapter) Root() automations.Root {
+	if a == nil {
+		return automations.Root{}
+	}
+	return a.root
+}
+
+func (a *Adapter) invokeSourceStatus(
+	ctx context.Context,
+	request automations.SourceStatusRequest,
+) (automations.SourceStatusResult, error) {
+	if a == nil || a.root.Operations == nil {
+		return automations.SourceStatusResult{}, errors.New("automations root is required")
+	}
+	return a.root.SourceStatus(ctx, request)
+}

--- a/pkg/services/automations/transports/http/boundary_test.go
+++ b/pkg/services/automations/transports/http/boundary_test.go
@@ -1,0 +1,38 @@
+package http_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestPackageBoundary_DoesNotImportAutomationsInternal(t *testing.T) {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	packageDir := filepath.Dir(filename)
+
+	forbidden := "github.com/portpowered/infinite-you/pkg/services/automations/internal"
+	entries, err := os.ReadDir(packageDir)
+	if err != nil {
+		t.Fatalf("read HTTP adapter package: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(packageDir, entry.Name())
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if strings.Contains(string(content), forbidden) {
+			t.Fatalf("%s must not import %s", entry.Name(), forbidden)
+		}
+	}
+}

--- a/pkg/services/automations/transports/http/convergence_mapping.go
+++ b/pkg/services/automations/transports/http/convergence_mapping.go
@@ -1,0 +1,276 @@
+package http
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/services/automations"
+)
+
+var (
+	// ErrInvalidReconcileDesired reports malformed desired specs at the Automations
+	// reconcile HTTP adapter edge.
+	ErrInvalidReconcileDesired = errors.New("automations http: invalid reconcile desired spec")
+	// ErrInvalidReconcileObserved reports malformed observed instances at the
+	// Automations reconcile HTTP adapter edge.
+	ErrInvalidReconcileObserved = errors.New("automations http: invalid reconcile observed instance")
+	// ErrInvalidInstanceIdentity reports missing or blank instance identifiers
+	// at the Automations status/cursor HTTP adapter edge.
+	ErrInvalidInstanceIdentity = errors.New("automations http: invalid instance identity")
+)
+
+// DesiredSpecInput carries one decoded desired automation spec for reconcile.
+type DesiredSpecInput struct {
+	AutomationID string
+	SourceID     string
+	Kind         string
+	State        string
+}
+
+// ObservedInstanceInput carries one decoded observed automation instance for
+// reconcile.
+type ObservedInstanceInput struct {
+	AutomationID string
+	SourceID     string
+	InstanceID   string
+	State        string
+}
+
+// ReconcileInput carries decoded HTTP inputs for one Automations reconcile
+// operation owned by this adapter.
+type ReconcileInput struct {
+	Desired  []DesiredSpecInput
+	Observed []ObservedInstanceInput
+}
+
+// GetStatusInput carries decoded HTTP inputs for one Automations instance-status
+// operation owned by this adapter.
+type GetStatusInput struct {
+	InstanceID string
+}
+
+// GetCursorInput carries decoded HTTP inputs for one Automations cursor read
+// operation owned by this adapter.
+type GetCursorInput struct {
+	InstanceID     string
+	ExpectedCursor string
+}
+
+// ConvergenceOutcomeResponse is the adapter-owned HTTP success shape for one
+// reconcile convergence outcome.
+type ConvergenceOutcomeResponse struct {
+	AutomationID string `json:"automationId"`
+	SourceID     string `json:"sourceId"`
+	InstanceID   string `json:"instanceId"`
+	Action       string `json:"action"`
+	Desired      string `json:"desired"`
+	Observed     string `json:"observed"`
+	Convergence  string `json:"convergence"`
+}
+
+// GeneratedWorkRequestResponse is the adapter-owned HTTP success shape for one
+// generated work request.
+type GeneratedWorkRequestResponse struct {
+	AutomationID     string `json:"automationId"`
+	SourceID         string `json:"sourceId"`
+	RequestID        string `json:"requestId"`
+	Payload          []byte `json:"payload,omitempty"`
+	PayloadReference string `json:"payloadReference,omitempty"`
+}
+
+// GeneratedWorkRequestOutcomeResponse is the adapter-owned HTTP success shape
+// for one generated work request admission outcome.
+type GeneratedWorkRequestOutcomeResponse struct {
+	Request           GeneratedWorkRequestResponse `json:"request"`
+	Status            string                       `json:"status"`
+	RejectionReason   string                       `json:"rejectionReason,omitempty"`
+	OriginalRequestID string                       `json:"originalRequestId,omitempty"`
+}
+
+// ReconcileResponse is the adapter-owned HTTP success shape for reconcile.
+type ReconcileResponse struct {
+	Outcomes              []ConvergenceOutcomeResponse            `json:"outcomes"`
+	GeneratedWorkRequests []GeneratedWorkRequestOutcomeResponse `json:"generatedWorkRequests,omitempty"`
+}
+
+// GetStatusResponse is the adapter-owned HTTP success shape for instance status.
+type GetStatusResponse struct {
+	AutomationID string `json:"automationId"`
+	InstanceID   string `json:"instanceId"`
+	Status       string `json:"status"`
+}
+
+// GetCursorResponse is the adapter-owned HTTP success shape for cursor reads.
+type GetCursorResponse struct {
+	AutomationID string `json:"automationId"`
+	InstanceID   string `json:"instanceId"`
+	Cursor       string `json:"cursor"`
+	Checkpoint   string `json:"checkpoint,omitempty"`
+}
+
+// IsConvergenceBadRequest reports whether an error is a decode/validation failure
+// that maps to a typed bad-request HTTP outcome before root invocation.
+func IsConvergenceBadRequest(err error) bool {
+	return errors.Is(err, ErrInvalidReconcileDesired) ||
+		errors.Is(err, ErrInvalidReconcileObserved) ||
+		errors.Is(err, ErrInvalidInstanceIdentity)
+}
+
+// ReconcileRequestFromHTTP maps one reconcile HTTP request into the accepted
+// Automations root request vocabulary.
+func ReconcileRequestFromHTTP(input ReconcileInput) (automations.ReconcileRequest, error) {
+	desired := make([]automations.DesiredSpec, 0, len(input.Desired))
+	for i, spec := range input.Desired {
+		mapped, err := desiredSpecFromHTTP(spec)
+		if err != nil {
+			return automations.ReconcileRequest{}, fmt.Errorf("%w at index %d: %v", ErrInvalidReconcileDesired, i, err)
+		}
+		desired = append(desired, mapped)
+	}
+	observed := make([]automations.ObservedInstance, 0, len(input.Observed))
+	for i, instance := range input.Observed {
+		mapped, err := observedInstanceFromHTTP(instance)
+		if err != nil {
+			return automations.ReconcileRequest{}, fmt.Errorf("%w at index %d: %v", ErrInvalidReconcileObserved, i, err)
+		}
+		observed = append(observed, mapped)
+	}
+	return automations.ReconcileRequest{
+		Desired:  desired,
+		Observed: observed,
+	}, nil
+}
+
+// GetStatusRequestFromHTTP maps one instance-status HTTP request into the
+// accepted Automations root request vocabulary.
+func GetStatusRequestFromHTTP(input GetStatusInput) (automations.GetStatusRequest, error) {
+	instanceID, err := instanceIdentityFromHTTP(input.InstanceID)
+	if err != nil {
+		return automations.GetStatusRequest{}, err
+	}
+	return automations.GetStatusRequest{InstanceID: instanceID}, nil
+}
+
+// GetCursorRequestFromHTTP maps one cursor HTTP request into the accepted
+// Automations root request vocabulary.
+func GetCursorRequestFromHTTP(input GetCursorInput) (automations.GetCursorRequest, error) {
+	instanceID, err := instanceIdentityFromHTTP(input.InstanceID)
+	if err != nil {
+		return automations.GetCursorRequest{}, err
+	}
+	return automations.GetCursorRequest{
+		InstanceID:     instanceID,
+		ExpectedCursor: automations.Cursor(strings.TrimSpace(input.ExpectedCursor)),
+	}, nil
+}
+
+// ReconcileResponseToHTTP encodes one fake-root reconcile result into the
+// adapter-owned HTTP success response shape.
+func ReconcileResponseToHTTP(result automations.ReconcileResult) ReconcileResponse {
+	outcomes := make([]ConvergenceOutcomeResponse, 0, len(result.Outcomes))
+	for _, outcome := range result.Outcomes {
+		outcomes = append(outcomes, convergenceOutcomeToHTTP(outcome))
+	}
+	generated := make([]GeneratedWorkRequestOutcomeResponse, 0, len(result.GeneratedWorkRequests))
+	for _, outcome := range result.GeneratedWorkRequests {
+		generated = append(generated, generatedWorkRequestOutcomeToHTTP(outcome))
+	}
+	return ReconcileResponse{
+		Outcomes:              outcomes,
+		GeneratedWorkRequests: generated,
+	}
+}
+
+// GetStatusResponseToHTTP encodes one fake-root instance-status result into
+// the adapter-owned HTTP success response shape.
+func GetStatusResponseToHTTP(result automations.GetStatusResult) GetStatusResponse {
+	return GetStatusResponse{
+		AutomationID: result.AutomationID,
+		InstanceID:   result.InstanceID,
+		Status:       string(result.Status),
+	}
+}
+
+// GetCursorResponseToHTTP encodes one fake-root cursor result into the
+// adapter-owned HTTP success response shape.
+func GetCursorResponseToHTTP(result automations.GetCursorResult) GetCursorResponse {
+	return GetCursorResponse{
+		AutomationID: result.AutomationID,
+		InstanceID:   result.InstanceID,
+		Cursor:       string(result.Cursor),
+		Checkpoint:   result.Checkpoint,
+	}
+}
+
+func desiredSpecFromHTTP(input DesiredSpecInput) (automations.DesiredSpec, error) {
+	automationID := strings.TrimSpace(input.AutomationID)
+	sourceID := strings.TrimSpace(input.SourceID)
+	kind := strings.TrimSpace(input.Kind)
+	if automationID == "" || sourceID == "" || kind == "" {
+		return automations.DesiredSpec{}, errors.New("automationId, sourceId, and kind are required")
+	}
+	state, err := desiredLifecycleFromHTTP(input.State)
+	if err != nil {
+		return automations.DesiredSpec{}, err
+	}
+	return automations.DesiredSpec{
+		AutomationID: automationID,
+		SourceID:     sourceID,
+		Kind:         kind,
+		State:        state,
+	}, nil
+}
+
+func observedInstanceFromHTTP(input ObservedInstanceInput) (automations.ObservedInstance, error) {
+	automationID := strings.TrimSpace(input.AutomationID)
+	sourceID := strings.TrimSpace(input.SourceID)
+	instanceID := strings.TrimSpace(input.InstanceID)
+	state := strings.TrimSpace(input.State)
+	if automationID == "" || sourceID == "" || instanceID == "" || state == "" {
+		return automations.ObservedInstance{}, errors.New("automationId, sourceId, instanceId, and state are required")
+	}
+	return automations.ObservedInstance{
+		AutomationID: automationID,
+		SourceID:     sourceID,
+		InstanceID:   instanceID,
+		State:        automations.ObservedLifecycleState(state),
+	}, nil
+}
+
+func instanceIdentityFromHTTP(instanceID string) (string, error) {
+	instanceID = strings.TrimSpace(instanceID)
+	if instanceID == "" {
+		return "", ErrInvalidInstanceIdentity
+	}
+	return instanceID, nil
+}
+
+func convergenceOutcomeToHTTP(outcome automations.ConvergenceOutcome) ConvergenceOutcomeResponse {
+	return ConvergenceOutcomeResponse{
+		AutomationID: outcome.AutomationID,
+		SourceID:     outcome.SourceID,
+		InstanceID:   outcome.InstanceID,
+		Action:       string(outcome.Action),
+		Desired:      string(outcome.Desired),
+		Observed:     string(outcome.Observed),
+		Convergence:  string(outcome.Convergence),
+	}
+}
+
+func generatedWorkRequestOutcomeToHTTP(
+	outcome automations.GeneratedWorkRequestOutcome,
+) GeneratedWorkRequestOutcomeResponse {
+	return GeneratedWorkRequestOutcomeResponse{
+		Request: GeneratedWorkRequestResponse{
+			AutomationID:     outcome.Request.Identity.AutomationID,
+			SourceID:         outcome.Request.Identity.SourceID,
+			RequestID:        outcome.Request.Identity.RequestID,
+			Payload:          outcome.Request.Payload,
+			PayloadReference: outcome.Request.PayloadReference,
+		},
+		Status:            string(outcome.Status),
+		RejectionReason:   string(outcome.RejectionReason),
+		OriginalRequestID: outcome.OriginalRequestID,
+	}
+}

--- a/pkg/services/automations/transports/http/convergence_mapping_test.go
+++ b/pkg/services/automations/transports/http/convergence_mapping_test.go
@@ -1,0 +1,195 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/automations"
+)
+
+func TestReconcileRequestFromHTTP_MapsRootRequest(t *testing.T) {
+	t.Parallel()
+
+	request, err := ReconcileRequestFromHTTP(ReconcileInput{
+		Desired: []DesiredSpecInput{
+			{
+				AutomationID: "automation-1",
+				SourceID:     "source-1",
+				Kind:         "schedule",
+				State:        "running",
+			},
+		},
+		Observed: []ObservedInstanceInput{
+			{
+				AutomationID: "automation-1",
+				SourceID:     "source-1",
+				InstanceID:   "instance-1",
+				State:        string(automations.ObservedLifecycleRunning),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReconcileRequestFromHTTP: %v", err)
+	}
+	if len(request.Desired) != 1 || len(request.Observed) != 1 {
+		t.Fatalf("request = %#v, want one desired and one observed entry", request)
+	}
+	if request.Desired[0].State != automations.DesiredLifecycleRunning {
+		t.Fatalf("desired state = %q, want running", request.Desired[0].State)
+	}
+	if request.Observed[0].InstanceID != "instance-1" {
+		t.Fatalf("observed = %#v, want instance-1", request.Observed[0])
+	}
+}
+
+func TestReconcileRequestFromHTTP_RejectsMalformedInputsBeforeRoot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input ReconcileInput
+	}{
+		{
+			name: "missing desired automation id",
+			input: ReconcileInput{
+				Desired: []DesiredSpecInput{{
+					SourceID: "source-1",
+					Kind:     "schedule",
+					State:    "running",
+				}},
+			},
+		},
+		{
+			name: "invalid desired state",
+			input: ReconcileInput{
+				Desired: []DesiredSpecInput{{
+					AutomationID: "automation-1",
+					SourceID:     "source-1",
+					Kind:         "schedule",
+					State:        "paused",
+				}},
+			},
+		},
+		{
+			name: "missing observed instance id",
+			input: ReconcileInput{
+				Observed: []ObservedInstanceInput{{
+					AutomationID: "automation-1",
+					SourceID:     "source-1",
+					State:        string(automations.ObservedLifecycleRunning),
+				}},
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := ReconcileRequestFromHTTP(test.input)
+			if err == nil || !IsConvergenceBadRequest(err) {
+				t.Fatalf("ReconcileRequestFromHTTP = %v, want typed bad request", err)
+			}
+		})
+	}
+}
+
+func TestGetStatusRequestFromHTTP_MapsRootRequest(t *testing.T) {
+	t.Parallel()
+
+	request, err := GetStatusRequestFromHTTP(GetStatusInput{InstanceID: "instance-1"})
+	if err != nil {
+		t.Fatalf("GetStatusRequestFromHTTP: %v", err)
+	}
+	if request.InstanceID != "instance-1" {
+		t.Fatalf("request = %#v, want instance-1", request)
+	}
+}
+
+func TestGetStatusRequestFromHTTP_RejectsMissingInstanceBeforeRoot(t *testing.T) {
+	t.Parallel()
+
+	_, err := GetStatusRequestFromHTTP(GetStatusInput{})
+	if err == nil || !IsConvergenceBadRequest(err) {
+		t.Fatalf("GetStatusRequestFromHTTP = %v, want typed bad request", err)
+	}
+}
+
+func TestGetCursorRequestFromHTTP_MapsRootRequest(t *testing.T) {
+	t.Parallel()
+
+	request, err := GetCursorRequestFromHTTP(GetCursorInput{
+		InstanceID:     "instance-1",
+		ExpectedCursor: "cursor-1",
+	})
+	if err != nil {
+		t.Fatalf("GetCursorRequestFromHTTP: %v", err)
+	}
+	if request.InstanceID != "instance-1" || request.ExpectedCursor != "cursor-1" {
+		t.Fatalf("request = %#v, want instance-1 with expected cursor", request)
+	}
+}
+
+func TestGetCursorRequestFromHTTP_RejectsMissingInstanceBeforeRoot(t *testing.T) {
+	t.Parallel()
+
+	_, err := GetCursorRequestFromHTTP(GetCursorInput{ExpectedCursor: "cursor-1"})
+	if err == nil || !IsConvergenceBadRequest(err) {
+		t.Fatalf("GetCursorRequestFromHTTP = %v, want typed bad request", err)
+	}
+}
+
+func TestConvergenceResponsesToHTTP_EncodeFakeRootSuccess(t *testing.T) {
+	t.Parallel()
+
+	reconciled := ReconcileResponseToHTTP(automations.ReconcileResult{
+		Outcomes: []automations.ConvergenceOutcome{
+			{
+				AutomationID: "automation-1",
+				SourceID:     "source-1",
+				InstanceID:   "instance-1",
+				Action:       automations.ConvergenceActionCreated,
+				Desired:      automations.DesiredLifecycleRunning,
+				Observed:     automations.ObservedLifecycleRunning,
+				Convergence:  automations.ConvergenceStatusConverged,
+			},
+		},
+		GeneratedWorkRequests: []automations.GeneratedWorkRequestOutcome{
+			{
+				Request: automations.GeneratedWorkRequest{
+					Identity: automations.GeneratedWorkRequestIdentity{
+						AutomationID: "automation-1",
+						SourceID:     "source-1",
+						RequestID:    "request-1",
+					},
+					Payload: []byte("payload"),
+				},
+				Status: automations.WorkRequestAdmissionAccepted,
+			},
+		},
+	})
+	if len(reconciled.Outcomes) != 1 || reconciled.Outcomes[0].Action != "created" {
+		t.Fatalf("reconcile response = %#v, want encoded outcome", reconciled)
+	}
+	if len(reconciled.GeneratedWorkRequests) != 1 ||
+		reconciled.GeneratedWorkRequests[0].Status != "accepted" {
+		t.Fatalf("generated work requests = %#v, want encoded admission", reconciled.GeneratedWorkRequests)
+	}
+
+	status := GetStatusResponseToHTTP(automations.GetStatusResult{
+		AutomationID: "automation-1",
+		InstanceID:   "instance-1",
+		Status:       automations.ObservedLifecycleRunning,
+	})
+	if status.Status != string(automations.ObservedLifecycleRunning) {
+		t.Fatalf("status response = %#v, want encoded status", status)
+	}
+
+	cursor := GetCursorResponseToHTTP(automations.GetCursorResult{
+		AutomationID: "automation-1",
+		InstanceID:   "instance-1",
+		Cursor:       "cursor-1",
+		Checkpoint:   "checkpoint-1",
+	})
+	if cursor.Cursor != "cursor-1" || cursor.Checkpoint != "checkpoint-1" {
+		t.Fatalf("cursor response = %#v, want encoded cursor facts", cursor)
+	}
+}

--- a/pkg/services/automations/transports/http/convergence_operations.go
+++ b/pkg/services/automations/transports/http/convergence_operations.go
@@ -1,0 +1,89 @@
+package http
+
+import (
+	"context"
+	"errors"
+
+	"github.com/portpowered/infinite-you/pkg/services/automations"
+)
+
+// Reconcile decodes one reconcile HTTP request, invokes the accepted Automations
+// root, and encodes the success response shape.
+func (a *Adapter) Reconcile(
+	ctx context.Context,
+	input ReconcileInput,
+) (ReconcileResponse, error) {
+	request, err := ReconcileRequestFromHTTP(input)
+	if err != nil {
+		return ReconcileResponse{}, err
+	}
+	result, err := a.invokeReconcile(ctx, request)
+	if err != nil {
+		return ReconcileResponse{}, err
+	}
+	return ReconcileResponseToHTTP(result), nil
+}
+
+// GetStatus decodes one instance-status HTTP request, invokes the accepted
+// Automations root, and encodes the success response shape.
+func (a *Adapter) GetStatus(
+	ctx context.Context,
+	input GetStatusInput,
+) (GetStatusResponse, error) {
+	request, err := GetStatusRequestFromHTTP(input)
+	if err != nil {
+		return GetStatusResponse{}, err
+	}
+	result, err := a.invokeGetStatus(ctx, request)
+	if err != nil {
+		return GetStatusResponse{}, err
+	}
+	return GetStatusResponseToHTTP(result), nil
+}
+
+// GetCursor decodes one cursor HTTP request, invokes the accepted Automations
+// root, and encodes the success response shape.
+func (a *Adapter) GetCursor(
+	ctx context.Context,
+	input GetCursorInput,
+) (GetCursorResponse, error) {
+	request, err := GetCursorRequestFromHTTP(input)
+	if err != nil {
+		return GetCursorResponse{}, err
+	}
+	result, err := a.invokeGetCursor(ctx, request)
+	if err != nil {
+		return GetCursorResponse{}, err
+	}
+	return GetCursorResponseToHTTP(result), nil
+}
+
+func (a *Adapter) invokeReconcile(
+	ctx context.Context,
+	request automations.ReconcileRequest,
+) (automations.ReconcileResult, error) {
+	if a == nil || a.root.Operations == nil {
+		return automations.ReconcileResult{}, errors.New("automations root is required")
+	}
+	return a.root.Reconcile(ctx, request)
+}
+
+func (a *Adapter) invokeGetStatus(
+	ctx context.Context,
+	request automations.GetStatusRequest,
+) (automations.GetStatusResult, error) {
+	if a == nil || a.root.Operations == nil {
+		return automations.GetStatusResult{}, errors.New("automations root is required")
+	}
+	return a.root.GetStatus(ctx, request)
+}
+
+func (a *Adapter) invokeGetCursor(
+	ctx context.Context,
+	request automations.GetCursorRequest,
+) (automations.GetCursorResult, error) {
+	if a == nil || a.root.Operations == nil {
+		return automations.GetCursorResult{}, errors.New("automations root is required")
+	}
+	return a.root.GetCursor(ctx, request)
+}

--- a/pkg/services/automations/transports/http/convergence_operations.go
+++ b/pkg/services/automations/transports/http/convergence_operations.go
@@ -17,6 +17,9 @@ func (a *Adapter) Reconcile(
 	if err != nil {
 		return ReconcileResponse{}, err
 	}
+	if err := guardRequestContext(ctx); err != nil {
+		return ReconcileResponse{}, err
+	}
 	result, err := a.invokeReconcile(ctx, request)
 	if err != nil {
 		return ReconcileResponse{}, err
@@ -34,6 +37,9 @@ func (a *Adapter) GetStatus(
 	if err != nil {
 		return GetStatusResponse{}, err
 	}
+	if err := guardRequestContext(ctx); err != nil {
+		return GetStatusResponse{}, err
+	}
 	result, err := a.invokeGetStatus(ctx, request)
 	if err != nil {
 		return GetStatusResponse{}, err
@@ -49,6 +55,9 @@ func (a *Adapter) GetCursor(
 ) (GetCursorResponse, error) {
 	request, err := GetCursorRequestFromHTTP(input)
 	if err != nil {
+		return GetCursorResponse{}, err
+	}
+	if err := guardRequestContext(ctx); err != nil {
 		return GetCursorResponse{}, err
 	}
 	result, err := a.invokeGetCursor(ctx, request)

--- a/pkg/services/automations/transports/http/convergence_operations_test.go
+++ b/pkg/services/automations/transports/http/convergence_operations_test.go
@@ -1,0 +1,191 @@
+package http
+
+import (
+	"context"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/automations"
+)
+
+func TestAdapter_ReconcileInvokesFakeRootAndEncodesSuccess(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := &rootFake{
+		reconcile: func(
+			_ context.Context,
+			request automations.ReconcileRequest,
+		) (automations.ReconcileResult, error) {
+			invoked = true
+			if len(request.Desired) != 1 ||
+				request.Desired[0].AutomationID != "automation-1" ||
+				request.Desired[0].SourceID != "source-1" {
+				t.Fatalf("ReconcileRequest = %#v, want automation-1/source-1 desired spec", request)
+			}
+			return automations.ReconcileResult{
+				Outcomes: []automations.ConvergenceOutcome{
+					{
+						AutomationID: "automation-1",
+						SourceID:     "source-1",
+						InstanceID:   "instance-1",
+						Action:       automations.ConvergenceActionCreated,
+						Desired:      automations.DesiredLifecycleRunning,
+						Observed:     automations.ObservedLifecycleRunning,
+						Convergence:  automations.ConvergenceStatusConverged,
+					},
+				},
+			}, nil
+		},
+	}
+	adapter := NewAdapterFromRoot(RootBinding{Automations: automations.Root{Operations: fake}})
+
+	response, err := adapter.Reconcile(context.Background(), ReconcileInput{
+		Desired: []DesiredSpecInput{
+			{
+				AutomationID: "automation-1",
+				SourceID:     "source-1",
+				Kind:         "schedule",
+				State:        "running",
+			},
+		},
+	})
+	if !invoked {
+		t.Fatal("Reconcile did not invoke the injected Automations root")
+	}
+	if err != nil {
+		t.Fatalf("Reconcile error = %v", err)
+	}
+	if len(response.Outcomes) != 1 || response.Outcomes[0].Convergence != "converged" {
+		t.Fatalf("response = %#v, want encoded reconcile outcome", response)
+	}
+}
+
+func TestAdapter_ReconcileRejectsInvalidInputBeforeFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	fake := &rootFake{
+		reconcile: func(context.Context, automations.ReconcileRequest) (automations.ReconcileResult, error) {
+			t.Fatal("fake root must not be invoked for invalid reconcile input")
+			return automations.ReconcileResult{}, nil
+		},
+	}
+	adapter := NewAdapterFromRoot(RootBinding{Automations: automations.Root{Operations: fake}})
+
+	_, err := adapter.Reconcile(context.Background(), ReconcileInput{
+		Desired: []DesiredSpecInput{{
+			AutomationID: "automation-1",
+			SourceID:     "source-1",
+			Kind:         "schedule",
+			State:        "unknown",
+		}},
+	})
+	if err == nil || !IsConvergenceBadRequest(err) {
+		t.Fatalf("Reconcile error = %v, want typed bad request", err)
+	}
+}
+
+func TestAdapter_GetStatusInvokesFakeRootAndEncodesSuccess(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := &rootFake{
+		getStatus: func(
+			_ context.Context,
+			request automations.GetStatusRequest,
+		) (automations.GetStatusResult, error) {
+			invoked = true
+			if request.InstanceID != "instance-1" {
+				t.Fatalf("GetStatusRequest = %#v, want instance-1", request)
+			}
+			return automations.GetStatusResult{
+				AutomationID: "automation-1",
+				InstanceID:   request.InstanceID,
+				Status:       automations.ObservedLifecycleRunning,
+			}, nil
+		},
+	}
+	adapter := NewAdapterFromRoot(RootBinding{Automations: automations.Root{Operations: fake}})
+
+	response, err := adapter.GetStatus(context.Background(), GetStatusInput{InstanceID: "instance-1"})
+	if !invoked {
+		t.Fatal("GetStatus did not invoke the injected Automations root")
+	}
+	if err != nil {
+		t.Fatalf("GetStatus error = %v", err)
+	}
+	if response.Status != string(automations.ObservedLifecycleRunning) {
+		t.Fatalf("response = %#v, want encoded instance status", response)
+	}
+}
+
+func TestAdapter_GetStatusRejectsMissingInstanceBeforeFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	fake := &rootFake{
+		getStatus: func(context.Context, automations.GetStatusRequest) (automations.GetStatusResult, error) {
+			t.Fatal("fake root must not be invoked for invalid status input")
+			return automations.GetStatusResult{}, nil
+		},
+	}
+	adapter := NewAdapterFromRoot(RootBinding{Automations: automations.Root{Operations: fake}})
+
+	_, err := adapter.GetStatus(context.Background(), GetStatusInput{})
+	if err == nil || !IsConvergenceBadRequest(err) {
+		t.Fatalf("GetStatus error = %v, want typed bad request", err)
+	}
+}
+
+func TestAdapter_GetCursorInvokesFakeRootAndEncodesSuccess(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := &rootFake{
+		getCursor: func(
+			_ context.Context,
+			request automations.GetCursorRequest,
+		) (automations.GetCursorResult, error) {
+			invoked = true
+			if request.InstanceID != "instance-1" || request.ExpectedCursor != "cursor-expected" {
+				t.Fatalf("GetCursorRequest = %#v, want instance-1 with expected cursor", request)
+			}
+			return automations.GetCursorResult{
+				AutomationID: "automation-1",
+				InstanceID:   request.InstanceID,
+				Cursor:       "cursor-1",
+				Checkpoint:   "checkpoint-1",
+			}, nil
+		},
+	}
+	adapter := NewAdapterFromRoot(RootBinding{Automations: automations.Root{Operations: fake}})
+
+	response, err := adapter.GetCursor(context.Background(), GetCursorInput{
+		InstanceID:     "instance-1",
+		ExpectedCursor: "cursor-expected",
+	})
+	if !invoked {
+		t.Fatal("GetCursor did not invoke the injected Automations root")
+	}
+	if err != nil {
+		t.Fatalf("GetCursor error = %v", err)
+	}
+	if response.Cursor != "cursor-1" || response.Checkpoint != "checkpoint-1" {
+		t.Fatalf("response = %#v, want encoded cursor facts", response)
+	}
+}
+
+func TestAdapter_GetCursorRejectsMissingInstanceBeforeFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	fake := &rootFake{
+		getCursor: func(context.Context, automations.GetCursorRequest) (automations.GetCursorResult, error) {
+			t.Fatal("fake root must not be invoked for invalid cursor input")
+			return automations.GetCursorResult{}, nil
+		},
+	}
+	adapter := NewAdapterFromRoot(RootBinding{Automations: automations.Root{Operations: fake}})
+
+	_, err := adapter.GetCursor(context.Background(), GetCursorInput{ExpectedCursor: "cursor-1"})
+	if err == nil || !IsConvergenceBadRequest(err) {
+		t.Fatalf("GetCursor error = %v, want typed bad request", err)
+	}
+}

--- a/pkg/services/automations/transports/http/error_mapping.go
+++ b/pkg/services/automations/transports/http/error_mapping.go
@@ -1,0 +1,108 @@
+package http
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/portpowered/infinite-you/pkg/services/automations"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+const (
+	automationsInvalidRequestMessage      = "invalid automations request"
+	automationsNotFoundMessage            = "automations resource not found"
+	automationsConflictMessage            = "automations operation conflicted with observed state"
+	automationsNotReadyMessage            = "automations service is not ready"
+	automationsSupervisionFailedMessage   = "automation source supervision failed"
+	automationsInternalFailureMessage     = "automations request failed"
+	automationsErrorCodeConflict          = "CONFLICT"
+	automationsErrorCodeServiceUnavailable = "SERVICE_UNAVAILABLE"
+)
+
+// RootErrorResponse maps typed Automations root failures and adapter decode
+// validation failures to HTTP status and the public ErrorResponse shape. It
+// returns false when err is not a known mapped typed failure.
+func RootErrorResponse(err error) (int, factoryapi.ErrorResponse, bool) {
+	if err == nil {
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+
+	if IsLifecycleBadRequest(err) || IsConvergenceBadRequest(err) {
+		return badRequestErrorResponse(automationsInvalidRequestMessage)
+	}
+
+	switch {
+	case errors.Is(err, automations.ErrInvalidRequest):
+		return badRequestErrorResponse(automationsInvalidRequestMessage)
+	case errors.Is(err, automations.ErrNotFound):
+		return notFoundErrorResponse(automationsNotFoundMessage)
+	case errors.Is(err, automations.ErrConflict):
+		return conflictErrorResponse(automationsConflictMessage)
+	case errors.Is(err, automations.ErrNotReady):
+		return serviceUnavailableErrorResponse(automationsNotReadyMessage)
+	case errors.Is(err, automations.ErrSupervisionFailed):
+		return internalErrorResponse(automationsSupervisionFailedMessage)
+	default:
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+}
+
+func (a *Adapter) writeRootError(w http.ResponseWriter, err error) bool {
+	if status, response, ok := RootErrorResponse(err); ok {
+		a.writeJSON(w, status, response)
+		return true
+	}
+	return false
+}
+
+func (a *Adapter) writeRootOrInternalError(w http.ResponseWriter, err error) {
+	if a.writeRootError(w, err) {
+		return
+	}
+	a.writeError(
+		w,
+		http.StatusInternalServerError,
+		automationsInternalFailureMessage,
+		string(factoryapi.ErrorResponseCodeINTERNALERROR),
+	)
+}
+
+func badRequestErrorResponse(message string) (int, factoryapi.ErrorResponse, bool) {
+	return http.StatusBadRequest, factoryapi.ErrorResponse{
+		Message: message,
+		Family:  factoryapi.ErrorFamilyBadRequest,
+		Code:    factoryapi.ErrorResponseCodeBADREQUEST,
+	}, true
+}
+
+func notFoundErrorResponse(message string) (int, factoryapi.ErrorResponse, bool) {
+	return http.StatusNotFound, factoryapi.ErrorResponse{
+		Message: message,
+		Family:  factoryapi.ErrorFamilyNotFound,
+		Code:    factoryapi.ErrorResponseCodeNOTFOUND,
+	}, true
+}
+
+func conflictErrorResponse(message string) (int, factoryapi.ErrorResponse, bool) {
+	return http.StatusConflict, factoryapi.ErrorResponse{
+		Message: message,
+		Family:  factoryapi.ErrorFamilyConflict,
+		Code:    factoryapi.ErrorResponseCode(automationsErrorCodeConflict),
+	}, true
+}
+
+func serviceUnavailableErrorResponse(message string) (int, factoryapi.ErrorResponse, bool) {
+	return http.StatusServiceUnavailable, factoryapi.ErrorResponse{
+		Message: message,
+		Family:  factoryapi.ErrorFamilyInternalServerError,
+		Code:    factoryapi.ErrorResponseCode(automationsErrorCodeServiceUnavailable),
+	}, true
+}
+
+func internalErrorResponse(message string) (int, factoryapi.ErrorResponse, bool) {
+	return http.StatusInternalServerError, factoryapi.ErrorResponse{
+		Message: message,
+		Family:  factoryapi.ErrorFamilyInternalServerError,
+		Code:    factoryapi.ErrorResponseCodeINTERNALERROR,
+	}, true
+}

--- a/pkg/services/automations/transports/http/error_mapping.go
+++ b/pkg/services/automations/transports/http/error_mapping.go
@@ -27,6 +27,15 @@ func RootErrorResponse(err error) (int, factoryapi.ErrorResponse, bool) {
 		return 0, factoryapi.ErrorResponse{}, false
 	}
 
+	if status, response, ok := automationsRequestContextErrorResponse(err); ok {
+		if response == nil {
+			return 0, factoryapi.ErrorResponse{}, true
+		}
+		if errResp, ok := response.(factoryapi.ErrorResponse); ok {
+			return status, errResp, true
+		}
+	}
+
 	if IsLifecycleBadRequest(err) || IsConvergenceBadRequest(err) {
 		return badRequestErrorResponse(automationsInvalidRequestMessage)
 	}
@@ -48,6 +57,9 @@ func RootErrorResponse(err error) (int, factoryapi.ErrorResponse, bool) {
 }
 
 func (a *Adapter) writeRootError(w http.ResponseWriter, err error) bool {
+	if a.writeAutomationsRequestContextOutcome(w, err) {
+		return true
+	}
 	if status, response, ok := RootErrorResponse(err); ok {
 		a.writeJSON(w, status, response)
 		return true

--- a/pkg/services/automations/transports/http/error_mapping_test.go
+++ b/pkg/services/automations/transports/http/error_mapping_test.go
@@ -1,0 +1,200 @@
+package http_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/automations"
+	automationshttp "github.com/portpowered/infinite-you/pkg/services/automations/transports/http"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+func TestRootErrorResponse_MapsInvalidRequestFailures(t *testing.T) {
+	t.Parallel()
+
+	cases := []error{
+		automations.ErrInvalidRequest,
+		typedAutomationsError("Reconcile", automations.ErrorCodeInvalid, automations.ErrInvalidRequest),
+		automationshttp.ErrInvalidSourceIdentity,
+		automationshttp.ErrInvalidReconcileDesired,
+	}
+	for _, err := range cases {
+		t.Run(err.Error(), func(t *testing.T) {
+			t.Parallel()
+			status, response, ok := automationshttp.AutomationsRootErrorResponseForTest(err)
+			if !ok {
+				t.Fatalf("RootErrorResponse(%v) = not handled, want typed bad request", err)
+			}
+			if status != http.StatusBadRequest ||
+				response.Family != factoryapi.ErrorFamilyBadRequest ||
+				response.Code != factoryapi.ErrorResponseCodeBADREQUEST ||
+				response.Message != "invalid automations request" {
+				t.Fatalf("RootErrorResponse(%v) = %d %#v, want bad request", err, status, response)
+			}
+		})
+	}
+}
+
+func TestRootErrorResponse_MapsNotFoundFailures(t *testing.T) {
+	t.Parallel()
+
+	cases := []error{
+		automations.ErrNotFound,
+		typedAutomationsError("SourceStatus", automations.ErrorCodeNotFound, automations.ErrNotFound),
+	}
+	for _, err := range cases {
+		t.Run(err.Error(), func(t *testing.T) {
+			t.Parallel()
+			status, response, ok := automationshttp.AutomationsRootErrorResponseForTest(err)
+			if !ok {
+				t.Fatalf("RootErrorResponse(%v) = not handled, want typed not found", err)
+			}
+			if status != http.StatusNotFound ||
+				response.Family != factoryapi.ErrorFamilyNotFound ||
+				response.Code != factoryapi.ErrorResponseCodeNOTFOUND ||
+				response.Message != "automations resource not found" {
+				t.Fatalf("RootErrorResponse(%v) = %d %#v, want not found", err, status, response)
+			}
+		})
+	}
+}
+
+func TestRootErrorResponse_MapsConflictFailures(t *testing.T) {
+	t.Parallel()
+
+	cases := []error{
+		automations.ErrConflict,
+		typedAutomationsError("GetCursor", automations.ErrorCodeConflict, automations.ErrConflict),
+	}
+	for _, err := range cases {
+		t.Run(err.Error(), func(t *testing.T) {
+			t.Parallel()
+			status, response, ok := automationshttp.AutomationsRootErrorResponseForTest(err)
+			if !ok {
+				t.Fatalf("RootErrorResponse(%v) = not handled, want typed conflict", err)
+			}
+			if status != http.StatusConflict ||
+				response.Family != factoryapi.ErrorFamilyConflict ||
+				response.Code != factoryapi.ErrorResponseCode("CONFLICT") ||
+				response.Message != "automations operation conflicted with observed state" {
+				t.Fatalf("RootErrorResponse(%v) = %d %#v, want conflict", err, status, response)
+			}
+		})
+	}
+}
+
+func TestRootErrorResponse_MapsNotReadyFailures(t *testing.T) {
+	t.Parallel()
+
+	cases := []error{
+		automations.ErrNotReady,
+		typedAutomationsError("StartSource", automations.ErrorCodeNotReady, automations.ErrNotReady),
+	}
+	for _, err := range cases {
+		t.Run(err.Error(), func(t *testing.T) {
+			t.Parallel()
+			status, response, ok := automationshttp.AutomationsRootErrorResponseForTest(err)
+			if !ok {
+				t.Fatalf("RootErrorResponse(%v) = not handled, want typed not ready", err)
+			}
+			if status != http.StatusServiceUnavailable ||
+				response.Family != factoryapi.ErrorFamilyInternalServerError ||
+				response.Code != factoryapi.ErrorResponseCode("SERVICE_UNAVAILABLE") ||
+				response.Message != "automations service is not ready" {
+				t.Fatalf("RootErrorResponse(%v) = %d %#v, want service unavailable", err, status, response)
+			}
+		})
+	}
+}
+
+func TestRootErrorResponse_MapsSupervisionFailedFailures(t *testing.T) {
+	t.Parallel()
+
+	err := typedAutomationsError(
+		"WaitSource",
+		automations.ErrorCodeFailed,
+		fmt.Errorf("%w: observed failed state", automations.ErrSupervisionFailed),
+	)
+	status, response, ok := automationshttp.AutomationsRootErrorResponseForTest(err)
+	if !ok {
+		t.Fatalf("RootErrorResponse(%v) = not handled, want typed supervision failure", err)
+	}
+	if status != http.StatusInternalServerError ||
+		response.Family != factoryapi.ErrorFamilyInternalServerError ||
+		response.Code != factoryapi.ErrorResponseCodeINTERNALERROR ||
+		response.Message != "automation source supervision failed" {
+		t.Fatalf("RootErrorResponse(%v) = %d %#v, want supervision failure", err, status, response)
+	}
+}
+
+func TestRootErrorResponse_ReturnsFalseForNilAndUnmappedFailures(t *testing.T) {
+	t.Parallel()
+
+	if _, _, ok := automationshttp.AutomationsRootErrorResponseForTest(nil); ok {
+		t.Fatal("RootErrorResponse(nil) = handled, want false")
+	}
+
+	err := errors.New("pkg/services/automations/internal/service: boom")
+	if _, _, ok := automationshttp.AutomationsRootErrorResponseForTest(err); ok {
+		t.Fatalf("unmapped failure %#v must not be handled", err)
+	}
+}
+
+func TestWriteRootOrInternalError_SanitizesUnmappedFailures(t *testing.T) {
+	t.Parallel()
+
+	adapter := automationshttp.NewAdapterFromRoot(automationshttp.RootBinding{
+		Automations: automations.Root{Operations: &rootFakeProbe{}},
+	})
+	recorder := httptest.NewRecorder()
+	err := errors.New("pkg/services/automations/internal/service: boom")
+
+	automationshttp.WriteRootOrInternalErrorForTest(adapter, recorder, err)
+
+	body := recorder.Body.String()
+	if recorder.Code != http.StatusInternalServerError ||
+		!strings.Contains(body, `"code":"INTERNAL_ERROR"`) ||
+		!strings.Contains(body, `"family":"INTERNAL_SERVER_ERROR"`) ||
+		!strings.Contains(body, `"message":"automations request failed"`) ||
+		strings.Contains(body, "pkg/services/automations") ||
+		strings.Contains(body, "boom") {
+		t.Fatalf("response = %d %s, want sanitized internal error", recorder.Code, body)
+	}
+}
+
+type rootFakeProbe struct{}
+
+func (rootFakeProbe) Reconcile(context.Context, automations.ReconcileRequest) (automations.ReconcileResult, error) {
+	return automations.ReconcileResult{}, nil
+}
+func (rootFakeProbe) StartSource(context.Context, automations.StartSourceRequest) (automations.StartSourceResult, error) {
+	return automations.StartSourceResult{}, nil
+}
+func (rootFakeProbe) StopSource(context.Context, automations.StopSourceRequest) (automations.StopSourceResult, error) {
+	return automations.StopSourceResult{}, nil
+}
+func (rootFakeProbe) WaitSource(context.Context, automations.WaitSourceRequest) (automations.WaitSourceResult, error) {
+	return automations.WaitSourceResult{}, nil
+}
+func (rootFakeProbe) SourceStatus(context.Context, automations.SourceStatusRequest) (automations.SourceStatusResult, error) {
+	return automations.SourceStatusResult{}, nil
+}
+func (rootFakeProbe) GetStatus(context.Context, automations.GetStatusRequest) (automations.GetStatusResult, error) {
+	return automations.GetStatusResult{}, nil
+}
+func (rootFakeProbe) GetCursor(context.Context, automations.GetCursorRequest) (automations.GetCursorResult, error) {
+	return automations.GetCursorResult{}, nil
+}
+
+func typedAutomationsError(op string, code automations.ErrorCode, err error) error {
+	return &automations.Error{
+		Op:   op,
+		Code: code,
+		Err:  err,
+	}
+}

--- a/pkg/services/automations/transports/http/export_test.go
+++ b/pkg/services/automations/transports/http/export_test.go
@@ -1,0 +1,6 @@
+package http
+
+var (
+	AutomationsRootErrorResponseForTest = RootErrorResponse
+	WriteRootOrInternalErrorForTest     = (*Adapter).writeRootOrInternalError
+)

--- a/pkg/services/automations/transports/http/export_test.go
+++ b/pkg/services/automations/transports/http/export_test.go
@@ -1,6 +1,8 @@
 package http
 
 var (
-	AutomationsRootErrorResponseForTest = RootErrorResponse
-	WriteRootOrInternalErrorForTest     = (*Adapter).writeRootOrInternalError
+	AutomationsRootErrorResponseForTest            = RootErrorResponse
+	AutomationsRequestContextErrorResponseForTest  = automationsRequestContextErrorResponse
+	WriteRootOrInternalErrorForTest                = (*Adapter).writeRootOrInternalError
+	WriteAutomationsRequestContextOutcomeForTest   = (*Adapter).writeAutomationsRequestContextOutcome
 )

--- a/pkg/services/automations/transports/http/fake_root_test.go
+++ b/pkg/services/automations/transports/http/fake_root_test.go
@@ -1,0 +1,90 @@
+package http
+
+import (
+	"context"
+
+	"github.com/portpowered/infinite-you/pkg/services/automations"
+)
+
+// rootFake is a focused Automations root fake for adapter-edge tests. It avoids
+// constructing reconciliation, cron, script-poller, filesystem-watcher, hosted-source,
+// or service-local Wire graphs.
+type rootFake struct {
+	reconcile    func(context.Context, automations.ReconcileRequest) (automations.ReconcileResult, error)
+	startSource  func(context.Context, automations.StartSourceRequest) (automations.StartSourceResult, error)
+	stopSource   func(context.Context, automations.StopSourceRequest) (automations.StopSourceResult, error)
+	waitSource   func(context.Context, automations.WaitSourceRequest) (automations.WaitSourceResult, error)
+	sourceStatus func(context.Context, automations.SourceStatusRequest) (automations.SourceStatusResult, error)
+	getStatus    func(context.Context, automations.GetStatusRequest) (automations.GetStatusResult, error)
+	getCursor    func(context.Context, automations.GetCursorRequest) (automations.GetCursorResult, error)
+}
+
+func (fake *rootFake) Reconcile(
+	ctx context.Context,
+	request automations.ReconcileRequest,
+) (automations.ReconcileResult, error) {
+	if fake.reconcile != nil {
+		return fake.reconcile(ctx, request)
+	}
+	return automations.ReconcileResult{}, automations.ErrNotReady
+}
+
+func (fake *rootFake) StartSource(
+	ctx context.Context,
+	request automations.StartSourceRequest,
+) (automations.StartSourceResult, error) {
+	if fake.startSource != nil {
+		return fake.startSource(ctx, request)
+	}
+	return automations.StartSourceResult{}, automations.ErrNotReady
+}
+
+func (fake *rootFake) StopSource(
+	ctx context.Context,
+	request automations.StopSourceRequest,
+) (automations.StopSourceResult, error) {
+	if fake.stopSource != nil {
+		return fake.stopSource(ctx, request)
+	}
+	return automations.StopSourceResult{}, automations.ErrNotReady
+}
+
+func (fake *rootFake) WaitSource(
+	ctx context.Context,
+	request automations.WaitSourceRequest,
+) (automations.WaitSourceResult, error) {
+	if fake.waitSource != nil {
+		return fake.waitSource(ctx, request)
+	}
+	return automations.WaitSourceResult{}, automations.ErrNotReady
+}
+
+func (fake *rootFake) SourceStatus(
+	ctx context.Context,
+	request automations.SourceStatusRequest,
+) (automations.SourceStatusResult, error) {
+	if fake.sourceStatus != nil {
+		return fake.sourceStatus(ctx, request)
+	}
+	return automations.SourceStatusResult{}, automations.ErrNotFound
+}
+
+func (fake *rootFake) GetStatus(
+	ctx context.Context,
+	request automations.GetStatusRequest,
+) (automations.GetStatusResult, error) {
+	if fake.getStatus != nil {
+		return fake.getStatus(ctx, request)
+	}
+	return automations.GetStatusResult{}, automations.ErrNotFound
+}
+
+func (fake *rootFake) GetCursor(
+	ctx context.Context,
+	request automations.GetCursorRequest,
+) (automations.GetCursorResult, error) {
+	if fake.getCursor != nil {
+		return fake.getCursor(ctx, request)
+	}
+	return automations.GetCursorResult{}, automations.ErrNotFound
+}

--- a/pkg/services/automations/transports/http/handlers_common.go
+++ b/pkg/services/automations/transports/http/handlers_common.go
@@ -1,0 +1,35 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+func (a *Adapter) writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func (a *Adapter) writeError(w http.ResponseWriter, status int, message, code string) {
+	a.writeJSON(w, status, factoryapi.ErrorResponse{
+		Message: message,
+		Family:  errorFamilyForStatus(status),
+		Code:    factoryapi.ErrorResponseCode(code),
+	})
+}
+
+func errorFamilyForStatus(status int) factoryapi.ErrorFamily {
+	switch status {
+	case http.StatusBadRequest:
+		return factoryapi.ErrorFamilyBadRequest
+	case http.StatusConflict:
+		return factoryapi.ErrorFamilyConflict
+	case http.StatusNotFound:
+		return factoryapi.ErrorFamilyNotFound
+	default:
+		return factoryapi.ErrorFamilyInternalServerError
+	}
+}

--- a/pkg/services/automations/transports/http/lifecycle_mapping.go
+++ b/pkg/services/automations/transports/http/lifecycle_mapping.go
@@ -1,0 +1,256 @@
+package http
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/services/automations"
+)
+
+var (
+	// ErrInvalidSourceIdentity reports missing or blank automation/source identifiers
+	// at the Automations lifecycle HTTP adapter edge.
+	ErrInvalidSourceIdentity = errors.New("automations http: invalid source identity")
+	// ErrInvalidSourceKind reports a missing or blank source kind for start.
+	ErrInvalidSourceKind = errors.New("automations http: invalid source kind")
+	// ErrInvalidLifecycleDesired reports an unsupported desired lifecycle state.
+	ErrInvalidLifecycleDesired = errors.New("automations http: invalid lifecycle desired state")
+	// ErrInvalidResumeObservation reports malformed resume facts on start.
+	ErrInvalidResumeObservation = errors.New("automations http: invalid resume observation")
+)
+
+// SourceObservationResponse is the adapter-owned HTTP success shape for one
+// detached source observation.
+type SourceObservationResponse struct {
+	AutomationID string `json:"automationId"`
+	SourceID     string `json:"sourceId"`
+	InstanceID   string `json:"instanceId"`
+	State        string `json:"state"`
+	Cursor       string `json:"cursor,omitempty"`
+}
+
+// LifecycleOutcomeResponse is the adapter-owned HTTP success shape for one
+// lifecycle command outcome.
+type LifecycleOutcomeResponse struct {
+	Desired     string                    `json:"desired"`
+	Observation SourceObservationResponse `json:"observation"`
+	Convergence string                    `json:"convergence"`
+	Idempotent  bool                      `json:"idempotent"`
+}
+
+// StartSourceInput carries decoded HTTP inputs for one Automations start-source
+// operation owned by this adapter.
+type StartSourceInput struct {
+	AutomationID string
+	SourceID     string
+	Kind         string
+	Resume       *SourceObservationResponse
+}
+
+// StopSourceInput carries decoded HTTP inputs for one Automations stop-source
+// operation owned by this adapter.
+type StopSourceInput struct {
+	AutomationID string
+	SourceID     string
+}
+
+// WaitSourceInput carries decoded HTTP inputs for one Automations wait-source
+// operation owned by this adapter.
+type WaitSourceInput struct {
+	AutomationID string
+	SourceID     string
+	Desired      string
+}
+
+// SourceStatusInput carries decoded HTTP inputs for one Automations source-status
+// operation owned by this adapter.
+type SourceStatusInput struct {
+	AutomationID string
+	SourceID     string
+}
+
+// StartSourceResponse is the adapter-owned HTTP success shape for start-source.
+type StartSourceResponse struct {
+	Outcome LifecycleOutcomeResponse `json:"outcome"`
+}
+
+// StopSourceResponse is the adapter-owned HTTP success shape for stop-source.
+type StopSourceResponse struct {
+	Outcome LifecycleOutcomeResponse `json:"outcome"`
+}
+
+// WaitSourceResponse is the adapter-owned HTTP success shape for wait-source.
+type WaitSourceResponse struct {
+	Outcome LifecycleOutcomeResponse `json:"outcome"`
+}
+
+// SourceStatusResponse is the adapter-owned HTTP success shape for source-status.
+type SourceStatusResponse struct {
+	Observation SourceObservationResponse `json:"observation"`
+}
+
+// IsLifecycleBadRequest reports whether an error is a decode/validation failure
+// that maps to a typed bad-request HTTP outcome before root invocation.
+func IsLifecycleBadRequest(err error) bool {
+	return errors.Is(err, ErrInvalidSourceIdentity) ||
+		errors.Is(err, ErrInvalidSourceKind) ||
+		errors.Is(err, ErrInvalidLifecycleDesired) ||
+		errors.Is(err, ErrInvalidResumeObservation)
+}
+
+// StartSourceRequestFromHTTP maps one start-source HTTP request into the accepted
+// Automations root request vocabulary.
+func StartSourceRequestFromHTTP(input StartSourceInput) (automations.StartSourceRequest, error) {
+	identity, err := sourceIdentityFromHTTP(input.AutomationID, input.SourceID)
+	if err != nil {
+		return automations.StartSourceRequest{}, err
+	}
+	kind := strings.TrimSpace(input.Kind)
+	if kind == "" {
+		return automations.StartSourceRequest{}, ErrInvalidSourceKind
+	}
+	request := automations.StartSourceRequest{
+		Identity: identity,
+		Kind:     kind,
+	}
+	if input.Resume == nil {
+		return request, nil
+	}
+	resume, err := resumeObservationFromHTTP(identity, *input.Resume)
+	if err != nil {
+		return automations.StartSourceRequest{}, err
+	}
+	request.Resume = &resume
+	return request, nil
+}
+
+// StopSourceRequestFromHTTP maps one stop-source HTTP request into the accepted
+// Automations root request vocabulary.
+func StopSourceRequestFromHTTP(input StopSourceInput) (automations.StopSourceRequest, error) {
+	identity, err := sourceIdentityFromHTTP(input.AutomationID, input.SourceID)
+	if err != nil {
+		return automations.StopSourceRequest{}, err
+	}
+	return automations.StopSourceRequest{Identity: identity}, nil
+}
+
+// WaitSourceRequestFromHTTP maps one wait-source HTTP request into the accepted
+// Automations root request vocabulary.
+func WaitSourceRequestFromHTTP(input WaitSourceInput) (automations.WaitSourceRequest, error) {
+	identity, err := sourceIdentityFromHTTP(input.AutomationID, input.SourceID)
+	if err != nil {
+		return automations.WaitSourceRequest{}, err
+	}
+	desired, err := desiredLifecycleFromHTTP(input.Desired)
+	if err != nil {
+		return automations.WaitSourceRequest{}, err
+	}
+	return automations.WaitSourceRequest{
+		Identity: identity,
+		Desired:  desired,
+	}, nil
+}
+
+// SourceStatusRequestFromHTTP maps one source-status HTTP request into the
+// accepted Automations root request vocabulary.
+func SourceStatusRequestFromHTTP(input SourceStatusInput) (automations.SourceStatusRequest, error) {
+	identity, err := sourceIdentityFromHTTP(input.AutomationID, input.SourceID)
+	if err != nil {
+		return automations.SourceStatusRequest{}, err
+	}
+	return automations.SourceStatusRequest{Identity: identity}, nil
+}
+
+// StartSourceResponseToHTTP encodes one fake-root start-source result into the
+// adapter-owned HTTP success response shape.
+func StartSourceResponseToHTTP(result automations.StartSourceResult) StartSourceResponse {
+	return StartSourceResponse{Outcome: lifecycleOutcomeToHTTP(result.Outcome)}
+}
+
+// StopSourceResponseToHTTP encodes one fake-root stop-source result into the
+// adapter-owned HTTP success response shape.
+func StopSourceResponseToHTTP(result automations.StopSourceResult) StopSourceResponse {
+	return StopSourceResponse{Outcome: lifecycleOutcomeToHTTP(result.Outcome)}
+}
+
+// WaitSourceResponseToHTTP encodes one fake-root wait-source result into the
+// adapter-owned HTTP success response shape.
+func WaitSourceResponseToHTTP(result automations.WaitSourceResult) WaitSourceResponse {
+	return WaitSourceResponse{Outcome: lifecycleOutcomeToHTTP(result.Outcome)}
+}
+
+// SourceStatusResponseToHTTP encodes one fake-root source-status result into
+// the adapter-owned HTTP success response shape.
+func SourceStatusResponseToHTTP(result automations.SourceStatusResult) SourceStatusResponse {
+	return SourceStatusResponse{Observation: sourceObservationToHTTP(result.Observation)}
+}
+
+func sourceIdentityFromHTTP(automationID, sourceID string) (automations.SourceIdentity, error) {
+	automationID = strings.TrimSpace(automationID)
+	sourceID = strings.TrimSpace(sourceID)
+	if automationID == "" || sourceID == "" {
+		return automations.SourceIdentity{}, ErrInvalidSourceIdentity
+	}
+	return automations.SourceIdentity{
+		AutomationID: automationID,
+		SourceID:     sourceID,
+	}, nil
+}
+
+func desiredLifecycleFromHTTP(value string) (automations.DesiredLifecycleState, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case string(automations.DesiredLifecycleRunning):
+		return automations.DesiredLifecycleRunning, nil
+	case string(automations.DesiredLifecycleStopped):
+		return automations.DesiredLifecycleStopped, nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrInvalidLifecycleDesired, value)
+	}
+}
+
+func resumeObservationFromHTTP(
+	identity automations.SourceIdentity,
+	input SourceObservationResponse,
+) (automations.SourceObservation, error) {
+	instanceID := strings.TrimSpace(input.InstanceID)
+	state := strings.TrimSpace(input.State)
+	if instanceID == "" || state == "" {
+		return automations.SourceObservation{}, ErrInvalidResumeObservation
+	}
+	resumeIdentity, err := sourceIdentityFromHTTP(input.AutomationID, input.SourceID)
+	if err != nil {
+		return automations.SourceObservation{}, err
+	}
+	if resumeIdentity != identity {
+		return automations.SourceObservation{}, fmt.Errorf(
+			"%w: resume identity must match path identity",
+			ErrInvalidResumeObservation,
+		)
+	}
+	return automations.SourceObservation{
+		Identity:   resumeIdentity,
+		InstanceID: instanceID,
+		State:      automations.ObservedLifecycleState(state),
+		Cursor:     automations.Cursor(strings.TrimSpace(input.Cursor)),
+	}, nil
+}
+
+func lifecycleOutcomeToHTTP(outcome automations.LifecycleOutcome) LifecycleOutcomeResponse {
+	return LifecycleOutcomeResponse{
+		Desired:     string(outcome.Desired),
+		Observation: sourceObservationToHTTP(outcome.Observation),
+		Convergence: string(outcome.Convergence),
+		Idempotent:  outcome.Idempotent,
+	}
+}
+
+func sourceObservationToHTTP(observation automations.SourceObservation) SourceObservationResponse {
+	return SourceObservationResponse{
+		AutomationID: observation.Identity.AutomationID,
+		SourceID:     observation.Identity.SourceID,
+		InstanceID:   observation.InstanceID,
+		State:        string(observation.State),
+		Cursor:       string(observation.Cursor),
+	}
+}

--- a/pkg/services/automations/transports/http/lifecycle_mapping_test.go
+++ b/pkg/services/automations/transports/http/lifecycle_mapping_test.go
@@ -1,0 +1,208 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/automations"
+)
+
+func TestStartSourceRequestFromHTTP_MapsRootRequest(t *testing.T) {
+	t.Parallel()
+
+	request, err := StartSourceRequestFromHTTP(StartSourceInput{
+		AutomationID: "automation-1",
+		SourceID:     "source-1",
+		Kind:         "schedule",
+	})
+	if err != nil {
+		t.Fatalf("StartSourceRequestFromHTTP: %v", err)
+	}
+	if request.Identity.AutomationID != "automation-1" ||
+		request.Identity.SourceID != "source-1" ||
+		request.Kind != "schedule" ||
+		request.Resume != nil {
+		t.Fatalf("request = %#v, want start-source root request", request)
+	}
+}
+
+func TestStartSourceRequestFromHTTP_MapsResumeObservation(t *testing.T) {
+	t.Parallel()
+
+	request, err := StartSourceRequestFromHTTP(StartSourceInput{
+		AutomationID: "automation-1",
+		SourceID:     "source-1",
+		Kind:         "watcher",
+		Resume: &SourceObservationResponse{
+			AutomationID: "automation-1",
+			SourceID:     "source-1",
+			InstanceID:   "instance-1",
+			State:        string(automations.ObservedLifecycleRunning),
+			Cursor:       "cursor-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartSourceRequestFromHTTP: %v", err)
+	}
+	if request.Resume == nil ||
+		request.Resume.InstanceID != "instance-1" ||
+		request.Resume.State != automations.ObservedLifecycleRunning ||
+		request.Resume.Cursor != "cursor-1" {
+		t.Fatalf("request = %#v, want resume observation", request)
+	}
+}
+
+func TestStartSourceRequestFromHTTP_RejectsMalformedInputsBeforeRoot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input StartSourceInput
+	}{
+		{
+			name: "missing automation id",
+			input: StartSourceInput{
+				SourceID: "source-1",
+				Kind:     "schedule",
+			},
+		},
+		{
+			name: "missing source id",
+			input: StartSourceInput{
+				AutomationID: "automation-1",
+				Kind:         "schedule",
+			},
+		},
+		{
+			name: "missing kind",
+			input: StartSourceInput{
+				AutomationID: "automation-1",
+				SourceID:     "source-1",
+			},
+		},
+		{
+			name: "resume identity mismatch",
+			input: StartSourceInput{
+				AutomationID: "automation-1",
+				SourceID:     "source-1",
+				Kind:         "schedule",
+				Resume: &SourceObservationResponse{
+					AutomationID: "other",
+					SourceID:     "source-1",
+					InstanceID:   "instance-1",
+					State:        string(automations.ObservedLifecycleRunning),
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := StartSourceRequestFromHTTP(test.input)
+			if err == nil || !IsLifecycleBadRequest(err) {
+				t.Fatalf("StartSourceRequestFromHTTP = %v, want typed bad request", err)
+			}
+		})
+	}
+}
+
+func TestStopSourceRequestFromHTTP_MapsRootRequest(t *testing.T) {
+	t.Parallel()
+
+	request, err := StopSourceRequestFromHTTP(StopSourceInput{
+		AutomationID: "automation-1",
+		SourceID:     "source-1",
+	})
+	if err != nil {
+		t.Fatalf("StopSourceRequestFromHTTP: %v", err)
+	}
+	if request.Identity.AutomationID != "automation-1" || request.Identity.SourceID != "source-1" {
+		t.Fatalf("request = %#v, want stop-source root request", request)
+	}
+}
+
+func TestWaitSourceRequestFromHTTP_MapsDesiredLifecycle(t *testing.T) {
+	t.Parallel()
+
+	request, err := WaitSourceRequestFromHTTP(WaitSourceInput{
+		AutomationID: "automation-1",
+		SourceID:     "source-1",
+		Desired:      "running",
+	})
+	if err != nil {
+		t.Fatalf("WaitSourceRequestFromHTTP: %v", err)
+	}
+	if request.Desired != automations.DesiredLifecycleRunning {
+		t.Fatalf("request = %#v, want desired running", request)
+	}
+}
+
+func TestWaitSourceRequestFromHTTP_RejectsInvalidDesiredBeforeRoot(t *testing.T) {
+	t.Parallel()
+
+	_, err := WaitSourceRequestFromHTTP(WaitSourceInput{
+		AutomationID: "automation-1",
+		SourceID:     "source-1",
+		Desired:      "paused",
+	})
+	if err == nil || !IsLifecycleBadRequest(err) {
+		t.Fatalf("WaitSourceRequestFromHTTP = %v, want typed bad request", err)
+	}
+}
+
+func TestSourceStatusRequestFromHTTP_MapsRootRequest(t *testing.T) {
+	t.Parallel()
+
+	request, err := SourceStatusRequestFromHTTP(SourceStatusInput{
+		AutomationID: "automation-1",
+		SourceID:     "source-1",
+	})
+	if err != nil {
+		t.Fatalf("SourceStatusRequestFromHTTP: %v", err)
+	}
+	if request.Identity.AutomationID != "automation-1" || request.Identity.SourceID != "source-1" {
+		t.Fatalf("request = %#v, want source-status root request", request)
+	}
+}
+
+func TestLifecycleResponsesToHTTP_EncodeFakeRootSuccess(t *testing.T) {
+	t.Parallel()
+
+	observation := automations.SourceObservation{
+		Identity: automations.SourceIdentity{
+			AutomationID: "automation-1",
+			SourceID:     "source-1",
+		},
+		InstanceID: "instance-1",
+		State:      automations.ObservedLifecycleRunning,
+		Cursor:     "cursor-1",
+	}
+	outcome := automations.LifecycleOutcome{
+		Desired:     automations.DesiredLifecycleRunning,
+		Observation: observation,
+		Convergence: automations.ConvergenceStatusConverged,
+		Idempotent:  true,
+	}
+
+	started := StartSourceResponseToHTTP(automations.StartSourceResult{Outcome: outcome})
+	if started.Outcome.Desired != "running" ||
+		started.Outcome.Observation.InstanceID != "instance-1" ||
+		!started.Outcome.Idempotent {
+		t.Fatalf("start response = %#v, want encoded lifecycle outcome", started)
+	}
+
+	stopped := StopSourceResponseToHTTP(automations.StopSourceResult{Outcome: outcome})
+	if stopped.Outcome.Observation.State != string(automations.ObservedLifecycleRunning) {
+		t.Fatalf("stop response = %#v, want encoded observation", stopped)
+	}
+
+	waited := WaitSourceResponseToHTTP(automations.WaitSourceResult{Outcome: outcome})
+	if waited.Outcome.Convergence != string(automations.ConvergenceStatusConverged) {
+		t.Fatalf("wait response = %#v, want encoded convergence", waited)
+	}
+
+	status := SourceStatusResponseToHTTP(automations.SourceStatusResult{Observation: observation})
+	if status.Observation.Cursor != "cursor-1" {
+		t.Fatalf("status response = %#v, want encoded observation", status)
+	}
+}

--- a/pkg/services/automations/transports/http/lifecycle_operations.go
+++ b/pkg/services/automations/transports/http/lifecycle_operations.go
@@ -17,6 +17,9 @@ func (a *Adapter) StartSource(
 	if err != nil {
 		return StartSourceResponse{}, err
 	}
+	if err := guardRequestContext(ctx); err != nil {
+		return StartSourceResponse{}, err
+	}
 	result, err := a.invokeStartSource(ctx, request)
 	if err != nil {
 		return StartSourceResponse{}, err
@@ -32,6 +35,9 @@ func (a *Adapter) StopSource(
 ) (StopSourceResponse, error) {
 	request, err := StopSourceRequestFromHTTP(input)
 	if err != nil {
+		return StopSourceResponse{}, err
+	}
+	if err := guardRequestContext(ctx); err != nil {
 		return StopSourceResponse{}, err
 	}
 	result, err := a.invokeStopSource(ctx, request)
@@ -51,6 +57,9 @@ func (a *Adapter) WaitSource(
 	if err != nil {
 		return WaitSourceResponse{}, err
 	}
+	if err := guardRequestContext(ctx); err != nil {
+		return WaitSourceResponse{}, err
+	}
 	result, err := a.invokeWaitSource(ctx, request)
 	if err != nil {
 		return WaitSourceResponse{}, err
@@ -66,6 +75,9 @@ func (a *Adapter) SourceStatus(
 ) (SourceStatusResponse, error) {
 	request, err := SourceStatusRequestFromHTTP(input)
 	if err != nil {
+		return SourceStatusResponse{}, err
+	}
+	if err := guardRequestContext(ctx); err != nil {
 		return SourceStatusResponse{}, err
 	}
 	result, err := a.invokeSourceStatus(ctx, request)

--- a/pkg/services/automations/transports/http/lifecycle_operations.go
+++ b/pkg/services/automations/transports/http/lifecycle_operations.go
@@ -1,0 +1,106 @@
+package http
+
+import (
+	"context"
+	"errors"
+
+	"github.com/portpowered/infinite-you/pkg/services/automations"
+)
+
+// StartSource decodes one start-source HTTP request, invokes the accepted
+// Automations root, and encodes the success response shape.
+func (a *Adapter) StartSource(
+	ctx context.Context,
+	input StartSourceInput,
+) (StartSourceResponse, error) {
+	request, err := StartSourceRequestFromHTTP(input)
+	if err != nil {
+		return StartSourceResponse{}, err
+	}
+	result, err := a.invokeStartSource(ctx, request)
+	if err != nil {
+		return StartSourceResponse{}, err
+	}
+	return StartSourceResponseToHTTP(result), nil
+}
+
+// StopSource decodes one stop-source HTTP request, invokes the accepted
+// Automations root, and encodes the success response shape.
+func (a *Adapter) StopSource(
+	ctx context.Context,
+	input StopSourceInput,
+) (StopSourceResponse, error) {
+	request, err := StopSourceRequestFromHTTP(input)
+	if err != nil {
+		return StopSourceResponse{}, err
+	}
+	result, err := a.invokeStopSource(ctx, request)
+	if err != nil {
+		return StopSourceResponse{}, err
+	}
+	return StopSourceResponseToHTTP(result), nil
+}
+
+// WaitSource decodes one wait-source HTTP request, invokes the accepted
+// Automations root, and encodes the success response shape.
+func (a *Adapter) WaitSource(
+	ctx context.Context,
+	input WaitSourceInput,
+) (WaitSourceResponse, error) {
+	request, err := WaitSourceRequestFromHTTP(input)
+	if err != nil {
+		return WaitSourceResponse{}, err
+	}
+	result, err := a.invokeWaitSource(ctx, request)
+	if err != nil {
+		return WaitSourceResponse{}, err
+	}
+	return WaitSourceResponseToHTTP(result), nil
+}
+
+// SourceStatus decodes one source-status HTTP request, invokes the accepted
+// Automations root, and encodes the success response shape.
+func (a *Adapter) SourceStatus(
+	ctx context.Context,
+	input SourceStatusInput,
+) (SourceStatusResponse, error) {
+	request, err := SourceStatusRequestFromHTTP(input)
+	if err != nil {
+		return SourceStatusResponse{}, err
+	}
+	result, err := a.invokeSourceStatus(ctx, request)
+	if err != nil {
+		return SourceStatusResponse{}, err
+	}
+	return SourceStatusResponseToHTTP(result), nil
+}
+
+func (a *Adapter) invokeStartSource(
+	ctx context.Context,
+	request automations.StartSourceRequest,
+) (automations.StartSourceResult, error) {
+	if a == nil || a.root.Operations == nil {
+		return automations.StartSourceResult{}, errors.New("automations root is required")
+	}
+	return a.root.StartSource(ctx, request)
+}
+
+func (a *Adapter) invokeStopSource(
+	ctx context.Context,
+	request automations.StopSourceRequest,
+) (automations.StopSourceResult, error) {
+	if a == nil || a.root.Operations == nil {
+		return automations.StopSourceResult{}, errors.New("automations root is required")
+	}
+	return a.root.StopSource(ctx, request)
+}
+
+func (a *Adapter) invokeWaitSource(
+	ctx context.Context,
+	request automations.WaitSourceRequest,
+) (automations.WaitSourceResult, error) {
+	if a == nil || a.root.Operations == nil {
+		return automations.WaitSourceResult{}, errors.New("automations root is required")
+	}
+	return a.root.WaitSource(ctx, request)
+}

--- a/pkg/services/automations/transports/http/lifecycle_operations_test.go
+++ b/pkg/services/automations/transports/http/lifecycle_operations_test.go
@@ -1,0 +1,217 @@
+package http
+
+import (
+	"context"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/automations"
+)
+
+func TestAdapter_StartSourceInvokesFakeRootAndEncodesSuccess(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := &rootFake{
+		startSource: func(
+			_ context.Context,
+			request automations.StartSourceRequest,
+		) (automations.StartSourceResult, error) {
+			invoked = true
+			if request.Identity.AutomationID != "automation-1" ||
+				request.Identity.SourceID != "source-1" ||
+				request.Kind != "schedule" {
+				t.Fatalf("StartSourceRequest = %#v, want automation-1/source-1 schedule", request)
+			}
+			return automations.StartSourceResult{
+				Outcome: automations.LifecycleOutcome{
+					Desired: automations.DesiredLifecycleRunning,
+					Observation: automations.SourceObservation{
+						Identity:   request.Identity,
+						InstanceID: "instance-1",
+						State:      automations.ObservedLifecycleRunning,
+					},
+					Convergence: automations.ConvergenceStatusConverged,
+				},
+			}, nil
+		},
+	}
+	adapter := NewAdapterFromRoot(RootBinding{Automations: automations.Root{Operations: fake}})
+
+	response, err := adapter.StartSource(context.Background(), StartSourceInput{
+		AutomationID: "automation-1",
+		SourceID:     "source-1",
+		Kind:         "schedule",
+	})
+	if !invoked {
+		t.Fatal("StartSource did not invoke the injected Automations root")
+	}
+	if err != nil {
+		t.Fatalf("StartSource error = %v", err)
+	}
+	if response.Outcome.Observation.InstanceID != "instance-1" ||
+		response.Outcome.Desired != string(automations.DesiredLifecycleRunning) {
+		t.Fatalf("response = %#v, want encoded start outcome", response)
+	}
+}
+
+func TestAdapter_StartSourceRejectsInvalidInputBeforeFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	fake := &rootFake{
+		startSource: func(context.Context, automations.StartSourceRequest) (automations.StartSourceResult, error) {
+			t.Fatal("fake root must not be invoked for invalid start input")
+			return automations.StartSourceResult{}, nil
+		},
+	}
+	adapter := NewAdapterFromRoot(RootBinding{Automations: automations.Root{Operations: fake}})
+
+	_, err := adapter.StartSource(context.Background(), StartSourceInput{
+		AutomationID: "automation-1",
+		SourceID:     "source-1",
+	})
+	if err == nil || !IsLifecycleBadRequest(err) {
+		t.Fatalf("StartSource error = %v, want typed bad request", err)
+	}
+}
+
+func TestAdapter_StopSourceInvokesFakeRootAndEncodesSuccess(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := &rootFake{
+		stopSource: func(
+			_ context.Context,
+			request automations.StopSourceRequest,
+		) (automations.StopSourceResult, error) {
+			invoked = true
+			return automations.StopSourceResult{
+				Outcome: automations.LifecycleOutcome{
+					Desired: automations.DesiredLifecycleStopped,
+					Observation: automations.SourceObservation{
+						Identity:   request.Identity,
+						InstanceID: "instance-1",
+						State:      automations.ObservedLifecycleStopped,
+					},
+					Convergence: automations.ConvergenceStatusConverged,
+					Idempotent:  true,
+				},
+			}, nil
+		},
+	}
+	adapter := NewAdapterFromRoot(RootBinding{Automations: automations.Root{Operations: fake}})
+
+	response, err := adapter.StopSource(context.Background(), StopSourceInput{
+		AutomationID: "automation-1",
+		SourceID:     "source-1",
+	})
+	if !invoked {
+		t.Fatal("StopSource did not invoke the injected Automations root")
+	}
+	if err != nil {
+		t.Fatalf("StopSource error = %v", err)
+	}
+	if !response.Outcome.Idempotent || response.Outcome.Desired != "stopped" {
+		t.Fatalf("response = %#v, want encoded stop outcome", response)
+	}
+}
+
+func TestAdapter_WaitSourceInvokesFakeRootAndEncodesSuccess(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := &rootFake{
+		waitSource: func(
+			_ context.Context,
+			request automations.WaitSourceRequest,
+		) (automations.WaitSourceResult, error) {
+			invoked = true
+			if request.Desired != automations.DesiredLifecycleRunning {
+				t.Fatalf("WaitSourceRequest desired = %q, want running", request.Desired)
+			}
+			return automations.WaitSourceResult{
+				Outcome: automations.LifecycleOutcome{
+					Desired: automations.DesiredLifecycleRunning,
+					Observation: automations.SourceObservation{
+						Identity:   request.Identity,
+						InstanceID: "instance-1",
+						State:      automations.ObservedLifecycleRunning,
+					},
+					Convergence: automations.ConvergenceStatusConverged,
+				},
+			}, nil
+		},
+	}
+	adapter := NewAdapterFromRoot(RootBinding{Automations: automations.Root{Operations: fake}})
+
+	response, err := adapter.WaitSource(context.Background(), WaitSourceInput{
+		AutomationID: "automation-1",
+		SourceID:     "source-1",
+		Desired:      "running",
+	})
+	if !invoked {
+		t.Fatal("WaitSource did not invoke the injected Automations root")
+	}
+	if err != nil {
+		t.Fatalf("WaitSource error = %v", err)
+	}
+	if response.Outcome.Observation.State != string(automations.ObservedLifecycleRunning) {
+		t.Fatalf("response = %#v, want encoded wait outcome", response)
+	}
+}
+
+func TestAdapter_SourceStatusInvokesFakeRootAndEncodesSuccess(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := &rootFake{
+		sourceStatus: func(
+			_ context.Context,
+			request automations.SourceStatusRequest,
+		) (automations.SourceStatusResult, error) {
+			invoked = true
+			return automations.SourceStatusResult{
+				Observation: automations.SourceObservation{
+					Identity:   request.Identity,
+					InstanceID: "instance-1",
+					State:      automations.ObservedLifecycleRunning,
+				},
+			}, nil
+		},
+	}
+	adapter := NewAdapterFromRoot(RootBinding{Automations: automations.Root{Operations: fake}})
+
+	response, err := adapter.SourceStatus(context.Background(), SourceStatusInput{
+		AutomationID: "automation-1",
+		SourceID:     "source-1",
+	})
+	if !invoked {
+		t.Fatal("SourceStatus did not invoke the injected Automations root")
+	}
+	if err != nil {
+		t.Fatalf("SourceStatus error = %v", err)
+	}
+	if response.Observation.InstanceID != "instance-1" {
+		t.Fatalf("response = %#v, want encoded source status", response)
+	}
+}
+
+func TestAdapter_WaitSourceRejectsInvalidDesiredBeforeFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	fake := &rootFake{
+		waitSource: func(context.Context, automations.WaitSourceRequest) (automations.WaitSourceResult, error) {
+			t.Fatal("fake root must not be invoked for invalid wait desired state")
+			return automations.WaitSourceResult{}, nil
+		},
+	}
+	adapter := NewAdapterFromRoot(RootBinding{Automations: automations.Root{Operations: fake}})
+
+	_, err := adapter.WaitSource(context.Background(), WaitSourceInput{
+		AutomationID: "automation-1",
+		SourceID:     "source-1",
+		Desired:      "unknown",
+	})
+	if err == nil || !IsLifecycleBadRequest(err) {
+		t.Fatalf("WaitSource error = %v, want typed bad request", err)
+	}
+}

--- a/pkg/services/automations/transports/http/manifest_registration_test.go
+++ b/pkg/services/automations/transports/http/manifest_registration_test.go
@@ -1,0 +1,144 @@
+package http_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/ownershipinventory"
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+const (
+	httpAdapterPackagePath = "pkg/services/automations/transports/http"
+	httpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/automations/transports/http"
+	automationsOwner       = "automations"
+)
+
+type coverageMinimumManifest struct {
+	Lane     string `json:"lane"`
+	Packages []struct {
+		Package string  `json:"package"`
+		Minimum float64 `json:"minimum"`
+	} `json:"packages"`
+}
+
+func TestManifestRegistration_HTTPAdapterPackageIsRegistered(t *testing.T) {
+	t.Helper()
+
+	assertPackageTargetManifestRegistration(t)
+	assertOwnershipInventoryRegistration(t)
+	assertCoverageMinimumRegistration(t, "unit", "docs/internal/baselines/go-unit-coverage-package-minimums.json")
+	assertCoverageMinimumRegistration(t, "functional", "docs/internal/baselines/go-functional-coverage-package-minimums.json")
+}
+
+func assertPackageTargetManifestRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, "docs/internal/packaged-service-structure/package-target-manifest.json"))
+	if err != nil {
+		t.Fatalf("read package-target manifest: %v", err)
+	}
+
+	var manifest struct {
+		Inventory []string `json:"inventory"`
+		Packages  []struct {
+			PackagePath string `json:"packagePath"`
+			Disposition string `json:"disposition"`
+			Destination string `json:"destination"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode package-target manifest: %v", err)
+	}
+
+	foundInventory := false
+	for _, packagePath := range manifest.Inventory {
+		if packagePath == httpAdapterPackagePath {
+			foundInventory = true
+			break
+		}
+	}
+	if !foundInventory {
+		t.Fatalf("package-target manifest inventory missing %q", httpAdapterPackagePath)
+	}
+
+	for _, row := range manifest.Packages {
+		if row.PackagePath != httpAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("package-target manifest disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != automationsOwner {
+			t.Fatalf("package-target manifest destination = %q, want %q", row.Destination, automationsOwner)
+		}
+		return
+	}
+	t.Fatalf("package-target manifest packages missing %q", httpAdapterPackagePath)
+}
+
+func assertOwnershipInventoryRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, ownershipinventory.InventoryRelativePath))
+	if err != nil {
+		t.Fatalf("read ownership inventory: %v", err)
+	}
+
+	var inventory struct {
+		Packages []ownershipinventory.PackageRow `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		t.Fatalf("decode ownership inventory: %v", err)
+	}
+
+	for _, row := range inventory.Packages {
+		if row.PackagePath != httpAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("ownership inventory disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != automationsOwner {
+			t.Fatalf("ownership inventory destination = %q, want %q", row.Destination, automationsOwner)
+		}
+		if row.DestinationKind != ownershipinventory.DestinationKindOwner {
+			t.Fatalf(
+				"ownership inventory destinationKind = %q, want %q",
+				row.DestinationKind,
+				ownershipinventory.DestinationKindOwner,
+			)
+		}
+		return
+	}
+	t.Fatalf("ownership inventory packages missing %q", httpAdapterPackagePath)
+}
+
+func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, relativePath))
+	if err != nil {
+		t.Fatalf("read %s coverage manifest: %v", lane, err)
+	}
+
+	var manifest coverageMinimumManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode %s coverage manifest: %v", lane, err)
+	}
+	if manifest.Lane != lane {
+		t.Fatalf("%s coverage manifest lane = %q, want %q", relativePath, manifest.Lane, lane)
+	}
+
+	for _, entry := range manifest.Packages {
+		if entry.Package != httpAdapterImportPath {
+			continue
+		}
+		if entry.Minimum < 0 {
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterImportPath)
+		}
+		return
+	}
+	t.Fatalf("%s coverage manifest missing %q", lane, httpAdapterImportPath)
+}

--- a/pkg/services/automations/transports/http/request_context.go
+++ b/pkg/services/automations/transports/http/request_context.go
@@ -1,0 +1,73 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+// Request-context outcomes at the Automations HTTP adapter edge:
+//
+//   - Canceled requests terminate without an ErrorResponse body.
+//   - Deadline exhaustion returns 504 with a public ErrorResponse.
+//   - Context cancellation and deadline exhaustion must not be mapped to
+//     INTERNAL_ERROR.
+func isRequestContextEnded(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+func requestContextEnded(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	return isRequestContextEnded(ctx.Err())
+}
+
+func shouldEndOnRequestContext(ctx context.Context, err error) bool {
+	return requestContextEnded(ctx) || isRequestContextEnded(err)
+}
+
+// automationsRequestContextErrorResponse maps request-context cancellation and
+// deadline failures to the adapter's documented HTTP outcomes.
+func automationsRequestContextErrorResponse(err error) (status int, response any, handled bool) {
+	if err == nil {
+		return 0, nil, false
+	}
+	switch {
+	case errors.Is(err, context.Canceled):
+		return 0, nil, true
+	case errors.Is(err, context.DeadlineExceeded):
+		return http.StatusGatewayTimeout, factoryapi.ErrorResponse{
+			Message: "automations request timed out",
+			Family:  factoryapi.ErrorFamilyInternalServerError,
+			Code:    factoryapi.ErrorResponseCodeINTERNALERROR,
+		}, true
+	default:
+		return 0, nil, false
+	}
+}
+
+func (a *Adapter) writeAutomationsRequestContextOutcome(w http.ResponseWriter, err error) bool {
+	status, response, ok := automationsRequestContextErrorResponse(err)
+	if !ok {
+		return false
+	}
+	if response == nil {
+		return true
+	}
+	a.writeJSON(w, status, response)
+	return true
+}
+
+func (a *Adapter) guardAutomationsRequestContext(w http.ResponseWriter, r *http.Request) bool {
+	return a.writeAutomationsRequestContextOutcome(w, r.Context().Err())
+}
+
+func guardRequestContext(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Err()
+}

--- a/pkg/services/automations/transports/http/request_context_test.go
+++ b/pkg/services/automations/transports/http/request_context_test.go
@@ -1,0 +1,259 @@
+package http_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/pkg/services/automations"
+	automationshttp "github.com/portpowered/infinite-you/pkg/services/automations/transports/http"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+func waitForAutomationsRootContext(
+	ctx context.Context,
+) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func TestAutomationsRequestContextErrorResponseForTest(t *testing.T) {
+	t.Parallel()
+
+	if status, response, ok := automationshttp.AutomationsRequestContextErrorResponseForTest(context.Canceled); !ok || status != 0 || response != nil {
+		t.Fatalf("canceled = (%d, %#v, %v), want (0, nil, true)", status, response, ok)
+	}
+
+	status, response, ok := automationshttp.AutomationsRequestContextErrorResponseForTest(context.DeadlineExceeded)
+	if !ok || status != http.StatusGatewayTimeout {
+		t.Fatalf("deadline status = %d, ok = %v, want 504 true", status, ok)
+	}
+	errResp, ok := response.(factoryapi.ErrorResponse)
+	if !ok {
+		t.Fatalf("deadline response = %#v, want ErrorResponse", response)
+	}
+	if errResp.Message != "automations request timed out" ||
+		errResp.Family != factoryapi.ErrorFamilyInternalServerError ||
+		errResp.Code != factoryapi.ErrorResponseCodeINTERNALERROR {
+		t.Fatalf("deadline response = %#v, want timeout message", errResp)
+	}
+}
+
+func TestRootErrorResponse_MapsRequestContextFailures(t *testing.T) {
+	t.Parallel()
+
+	status, response, ok := automationshttp.AutomationsRootErrorResponseForTest(context.Canceled)
+	if !ok || status != 0 || response.Message != "" {
+		t.Fatalf("canceled = (%d, %#v, %v), want handled cancel outcome", status, response, ok)
+	}
+
+	status, response, ok = automationshttp.AutomationsRootErrorResponseForTest(context.DeadlineExceeded)
+	if !ok || status != http.StatusGatewayTimeout || response.Message != "automations request timed out" {
+		t.Fatalf("deadline = (%d, %#v, %v), want 504 timeout outcome", status, response, ok)
+	}
+}
+
+func TestAdapter_WaitSourceCanceledBeforeRootCallCompletesWithoutInvoke(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := &blockingAutomationsRootFake{
+		waitSource: func(context.Context, automations.WaitSourceRequest) (automations.WaitSourceResult, error) {
+			invoked = true
+			return automations.WaitSourceResult{}, nil
+		},
+	}
+	adapter := automationshttp.NewAdapterFromRoot(automationshttp.RootBinding{
+		Automations: automations.Root{Operations: fake},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := adapter.WaitSource(ctx, automationshttp.WaitSourceInput{
+		AutomationID: "automation-1",
+		SourceID:     "source-1",
+		Desired:      "running",
+	})
+	if invoked {
+		t.Fatal("WaitSource invoked fake root after request context was canceled")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("WaitSource error = %v, want context.Canceled", err)
+	}
+}
+
+func TestAdapter_WaitSourceCanceledDuringRootCallCompletesWithoutHang(t *testing.T) {
+	t.Parallel()
+
+	fake := &blockingAutomationsRootFake{
+		waitSource: func(ctx context.Context, _ automations.WaitSourceRequest) (automations.WaitSourceResult, error) {
+			return automations.WaitSourceResult{}, waitForAutomationsRootContext(ctx)
+		},
+	}
+	adapter := automationshttp.NewAdapterFromRoot(automationshttp.RootBinding{
+		Automations: automations.Root{Operations: fake},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := adapter.WaitSource(ctx, automationshttp.WaitSourceInput{
+			AutomationID: "automation-1",
+			SourceID:     "source-1",
+			Desired:      "running",
+		})
+		done <- err
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("WaitSource error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitSource hung after request context cancellation")
+	}
+}
+
+func TestAdapter_GetStatusDeadlineExceededDuringRootCallCompletesWithoutHang(t *testing.T) {
+	t.Parallel()
+
+	fake := &blockingAutomationsRootFake{
+		getStatus: func(ctx context.Context, _ automations.GetStatusRequest) (automations.GetStatusResult, error) {
+			return automations.GetStatusResult{}, waitForAutomationsRootContext(ctx)
+		},
+	}
+	adapter := automationshttp.NewAdapterFromRoot(automationshttp.RootBinding{
+		Automations: automations.Root{Operations: fake},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := adapter.GetStatus(ctx, automationshttp.GetStatusInput{
+			InstanceID: "instance-1",
+		})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("GetStatus error = %v, want context.DeadlineExceeded", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetStatus hung after request context deadline")
+	}
+}
+
+func TestWriteRootOrInternalError_DoesNotMapCancelToInternalError(t *testing.T) {
+	t.Parallel()
+
+	adapter := automationshttp.NewAdapterFromRoot(automationshttp.RootBinding{
+		Automations: automations.Root{Operations: &blockingAutomationsRootFake{}},
+	})
+	recorder := httptest.NewRecorder()
+
+	automationshttp.WriteRootOrInternalErrorForTest(adapter, recorder, context.Canceled)
+
+	if body := recorder.Body.String(); body != "" {
+		t.Fatalf("response body = %q, want empty cancel-oriented outcome", body)
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want default recorder status without encoded body", recorder.Code)
+	}
+}
+
+func TestWriteRootOrInternalError_MapsDeadlineExceededToGatewayTimeout(t *testing.T) {
+	t.Parallel()
+
+	adapter := automationshttp.NewAdapterFromRoot(automationshttp.RootBinding{
+		Automations: automations.Root{Operations: &blockingAutomationsRootFake{}},
+	})
+	recorder := httptest.NewRecorder()
+
+	automationshttp.WriteRootOrInternalErrorForTest(adapter, recorder, context.DeadlineExceeded)
+
+	if recorder.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504 Gateway Timeout", recorder.Code)
+	}
+	var response factoryapi.ErrorResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Message != "automations request timed out" ||
+		response.Code != factoryapi.ErrorResponseCodeINTERNALERROR {
+		t.Fatalf("response = %s, want timeout ErrorResponse", recorder.Body.String())
+	}
+}
+
+type blockingAutomationsRootFake struct {
+	waitSource func(context.Context, automations.WaitSourceRequest) (automations.WaitSourceResult, error)
+	getStatus  func(context.Context, automations.GetStatusRequest) (automations.GetStatusResult, error)
+}
+
+func (fake *blockingAutomationsRootFake) Reconcile(
+	context.Context,
+	automations.ReconcileRequest,
+) (automations.ReconcileResult, error) {
+	return automations.ReconcileResult{}, nil
+}
+
+func (fake *blockingAutomationsRootFake) StartSource(
+	context.Context,
+	automations.StartSourceRequest,
+) (automations.StartSourceResult, error) {
+	return automations.StartSourceResult{}, nil
+}
+
+func (fake *blockingAutomationsRootFake) StopSource(
+	context.Context,
+	automations.StopSourceRequest,
+) (automations.StopSourceResult, error) {
+	return automations.StopSourceResult{}, nil
+}
+
+func (fake *blockingAutomationsRootFake) WaitSource(
+	ctx context.Context,
+	request automations.WaitSourceRequest,
+) (automations.WaitSourceResult, error) {
+	if fake.waitSource != nil {
+		return fake.waitSource(ctx, request)
+	}
+	return automations.WaitSourceResult{}, nil
+}
+
+func (fake *blockingAutomationsRootFake) SourceStatus(
+	context.Context,
+	automations.SourceStatusRequest,
+) (automations.SourceStatusResult, error) {
+	return automations.SourceStatusResult{}, nil
+}
+
+func (fake *blockingAutomationsRootFake) GetStatus(
+	ctx context.Context,
+	request automations.GetStatusRequest,
+) (automations.GetStatusResult, error) {
+	if fake.getStatus != nil {
+		return fake.getStatus(ctx, request)
+	}
+	return automations.GetStatusResult{}, nil
+}
+
+func (fake *blockingAutomationsRootFake) GetCursor(
+	context.Context,
+	automations.GetCursorRequest,
+) (automations.GetCursorResult, error) {
+	return automations.GetCursorResult{}, nil
+}

--- a/pkg/services/automations/transports/http/root_binding.go
+++ b/pkg/services/automations/transports/http/root_binding.go
@@ -1,0 +1,23 @@
+package http
+
+import (
+	"github.com/portpowered/infinite-you/pkg/services/automations"
+)
+
+// AutomationsRoot is the accepted Automations root contract used by the HTTP
+// adapter. Adapter-owned operations invoke this surface rather than Automations
+// internal packages.
+type AutomationsRoot = automations.Root
+
+// RootBinding binds the HTTP adapter to one injected Automations root.
+type RootBinding struct {
+	Automations AutomationsRoot
+}
+
+// NewAdapterFromRoot constructs an HTTP adapter that calls through the supplied
+// Automations root. Tests inject a focused fake implementing Root operations
+// without constructing real reconciliation, cron, script-poller, filesystem-watcher,
+// hosted-source, or service-local Wire graphs.
+func NewAdapterFromRoot(binding RootBinding) *Adapter {
+	return NewAdapter(binding.Automations)
+}

--- a/pkg/services/automations/transports/http/root_binding_test.go
+++ b/pkg/services/automations/transports/http/root_binding_test.go
@@ -1,0 +1,101 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/automations"
+)
+
+func TestAdapter_BindsAutomationsRootViaFakeRootSeam(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := &rootFake{
+		sourceStatus: func(
+			_ context.Context,
+			request automations.SourceStatusRequest,
+		) (automations.SourceStatusResult, error) {
+			invoked = true
+			if request.Identity.AutomationID != "automation-1" || request.Identity.SourceID != "source-1" {
+				t.Fatalf("SourceStatusRequest identity = %#v, want automation-1/source-1", request.Identity)
+			}
+			return automations.SourceStatusResult{
+				Observation: automations.SourceObservation{
+					Identity:   request.Identity,
+					InstanceID: "instance-1",
+					State:      automations.ObservedLifecycleRunning,
+				},
+			}, nil
+		},
+	}
+
+	adapter := NewAdapterFromRoot(RootBinding{Automations: automations.Root{Operations: fake}})
+	if adapter.Root().Operations != fake {
+		t.Fatal("adapter must expose the injected Automations root")
+	}
+
+	result, err := adapter.invokeSourceStatus(context.Background(), automations.SourceStatusRequest{
+		Identity: automations.SourceIdentity{
+			AutomationID: "automation-1",
+			SourceID:     "source-1",
+		},
+	})
+	if !invoked {
+		t.Fatal("adapter-owned operation did not invoke the injected Automations root")
+	}
+	if err != nil {
+		t.Fatalf("invokeSourceStatus error = %v", err)
+	}
+	if result.Observation.InstanceID != "instance-1" {
+		t.Fatalf("SourceStatusResult = %#v, want instance-1 observation", result)
+	}
+}
+
+func TestNewAdapter_RejectsNilRootOperations(t *testing.T) {
+	t.Parallel()
+
+	if NewAdapter(automations.Root{}) != nil {
+		t.Fatal("NewAdapter with nil Operations must return nil")
+	}
+	if NewAdapterFromRoot(RootBinding{}) != nil {
+		t.Fatal("NewAdapterFromRoot with nil Operations must return nil")
+	}
+}
+
+func TestAdapter_PropagatesTypedRootFailures(t *testing.T) {
+	t.Parallel()
+
+	fake := &rootFake{
+		sourceStatus: func(
+			context.Context,
+			automations.SourceStatusRequest,
+		) (automations.SourceStatusResult, error) {
+			return automations.SourceStatusResult{}, &automations.Error{
+				Op:   "SourceStatus",
+				Code: automations.ErrorCodeNotFound,
+				Err:  automations.ErrNotFound,
+			}
+		},
+	}
+	adapter := NewAdapterFromRoot(RootBinding{Automations: automations.Root{Operations: fake}})
+
+	_, err := adapter.invokeSourceStatus(context.Background(), automations.SourceStatusRequest{
+		Identity: automations.SourceIdentity{AutomationID: "missing", SourceID: "source"},
+	})
+	if !errors.Is(err, automations.ErrNotFound) {
+		t.Fatalf("invokeSourceStatus error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestAdapter_RequiresInjectedRoot(t *testing.T) {
+	t.Parallel()
+
+	var adapter *Adapter
+
+	_, err := adapter.invokeSourceStatus(context.Background(), automations.SourceStatusRequest{})
+	if err == nil {
+		t.Fatal("invokeSourceStatus on nil adapter = nil, want error")
+	}
+}


### PR DESCRIPTION
{
  "project": "PSS HTTP-AUTO — Automations Owner-Local HTTP Adapter",
  "branchName": "pss-http-auto-adapter",
  "description": "Implement the Automations service-owned HTTP adapter so Automations HTTP requests decode/map through the accepted Automations root, typed errors become stable HTTP ErrorResponse bodies, and fake-root tests prove mapping plus cancel/timeout parity—without importing Automations internals, owning canonical state, authoring shared OpenAPI, or editing Wire/root/initializer/CLI composition.",
  "context": {
    "customerAsk": "Implement HTTP-AUTO as the Automations service-owned HTTP adapter. Decode/map Automations HTTP requests through the accepted Automations root, translate typed errors, and prove fake-root parity for mapping and cancel/timeout behavior without importing Automations internals or owning canonical state. Do not author shared OpenAPI or perform PSS-I02 route/client fan-in. Do not edit pkg/wire, pkg/root, pkg/initializer, top-level CLI composition, or reopen Automations IMP/LWR ownership. Shared coverage, ownership, and package-target manifest edits are allowed and must be rebased through the merge loop. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Automations already has an accepted root contract, terminal IMP owners (IMP-AUTO-01 through IMP-AUTO-05), and accepted LWR-AUTO, but there is still no Automations-owned HTTP adapter that decodes/maps through that root, translates typed Automations errors into stable HTTP ErrorResponse bodies, and proves fake-root mapping plus cancel/timeout parity—without drifting into internals, shared OpenAPI authorship, or composition ownership reserved for later PSS fan-in.",
    "solution": "Implement the Automations owner-local HTTP adapter so it binds to the accepted Automations root, decodes and maps Automations HTTP operations through that root, translates typed root errors into public HTTP error responses, and proves fake-root parity for mapping plus cancel/timeout behavior without importing Automations internals, owning canonical automation state, authoring shared OpenAPI, performing PSS-I02 route/client fan-in, or changing Wire/root/initializer/CLI composition."
  },
  "acceptanceCriteria": [
    "AC-1: Automations HTTP operations owned by this packet decode requests and map responses through the accepted Automations root contract only (no Automations internal imports; adapter does not become canonical state owner)",
    "AC-2: Typed Automations root errors surface as stable public HTTP ErrorResponse bodies with reviewer-verifiable status/code/family outcomes",
    "AC-3: Focused fake-root tests prove request/response mapping parity for the adapter-owned Automations HTTP operations covered by this packet",
    "AC-4: Focused fake-root tests prove cancel and timeout behavior at the HTTP adapter edge (canceled or deadline-exceeded request context yields the adapter’s documented HTTP outcome without hanging)",
    "AC-5: Shared coverage, ownership, and package-target manifest edits occur only as required to register the Automations HTTP adapter package and remain rebased through the merge loop",
    "AC-6: Diff stays inside HTTP-AUTO ownership: Automations HTTP adapter paths and allowed shared manifests; no shared OpenAPI authorship, no PSS-I02 route/client fan-in, no pkg/wire / pkg/root / pkg/initializer, no top-level CLI composition, and no CLI/MCP Automations or other-service HTTP adapter edits",
    "AC-7: Quality checks pass (typecheck, lint, tests)",
    "AC-8: Delivery loop continues until required CI is terminal and passing, all blocking PR conversation feedback is addressed, merge conflicts and shared-file churn are reconciled, and the PR is actually merged"
  ],
  "userStories": [
    {
      "id": "pss-http-auto-adapter-001",
      "title": "Bind Automations HTTP adapter to Automations root via fake-root seam",
      "description": "As a maintainer, I want the Automations HTTP adapter to invoke the accepted Automations root (or a fake implementing that root) so HTTP adaptation cannot depend on Automations internals or own canonical automation state.",
      "acceptanceCriteria": [
        "Adapter-owned Automations HTTP operations call through the accepted Automations root contract surface (automations.Root / published root Operations) rather than Automations internal packages",
        "A focused fake Automations root can be injected for adapter tests without constructing real reconciliation, cron, script-poller, filesystem-watcher, hosted-source, or service-local Wire graphs",
        "Package-boundary evidence shows the adapter package does not import pkg/services/automations/internal/**",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-auto-adapter-002",
      "title": "Decode and map Automations source lifecycle HTTP through the root",
      "description": "As an API client, I want Automations-owned source lifecycle HTTP operations (start, stop, wait, and source status) to decode into Automations root request values and encode root results so HTTP responses match the root contract outcomes.",
      "acceptanceCriteria": [
        "Representative owned lifecycle HTTP operations decode path/body/query inputs into Automations root request values (StartSource, StopSource, WaitSource, and/or SourceStatus) before invocation",
        "Fake-root success results are encoded into the adapter’s documented HTTP success response shape for those operations",
        "Invalid request payloads or identities that fail decode/validation are rejected with a typed bad-request HTTP outcome before the fake root is invoked",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-auto-adapter-003",
      "title": "Decode and map Automations reconcile, status, and cursor HTTP through the root",
      "description": "As an API client, I want Automations-owned reconcile, instance-status, and cursor HTTP mapping to go through the accepted Automations root so convergence and recovery reads stay aligned with root Reconcile / GetStatus / GetCursor vocabulary—without authoring shared OpenAPI.",
      "acceptanceCriteria": [
        "Representative owned reconcile and/or status/cursor HTTP mapping operations decode into Automations root request values and invoke the fake root with those values",
        "Fake-root success results are encoded into the adapter’s documented HTTP success response shape for those operations",
        "Decode/validation failures for those operations return typed bad-request HTTP outcomes without invoking the fake root",
        "Diff does not author api/openapi-main.yaml / api/components/** shared OpenAPI and does not perform PSS-I02 route/client fan-in",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-auto-adapter-004",
      "title": "Translate typed Automations root errors to HTTP ErrorResponse",
      "description": "As an API client, I want typed Automations root failures to become stable HTTP error responses so callers can rely on status, family, and code without opaque transport failures.",
      "acceptanceCriteria": [
        "Fake root returns of representative typed Automations errors (at least invalid-request / not-found / conflict classes such as ErrInvalidRequest, ErrNotFound, and ErrConflict, plus not-ready or supervision-failed when applicable to owned operations) map to the documented HTTP status, error family, and error code",
        "Error response body is a public ErrorResponse (message + family + code) rather than an untyped plaintext failure",
        "Unmapped/internal fake-root failures do not leak Automations internal package paths, filesystem roots, or stack traces in the HTTP body",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-auto-adapter-005",
      "title": "Prove cancel and timeout parity at the HTTP adapter edge",
      "description": "As an API client, I want canceled or timed-out Automations HTTP requests to terminate with the adapter’s documented outcome so lifecycle wait/reconcile and status/cursor calls do not hang after the client gives up.",
      "acceptanceCriteria": [
        "When the request context is canceled before or during a fake-root call, the adapter completes with the documented cancel-oriented HTTP outcome and does not hang",
        "When the request context deadline is exceeded during a fake-root call, the adapter completes with the documented timeout-oriented HTTP outcome and does not hang",
        "Fake-root tests cover at least one lifecycle/wait-style Automations HTTP path and one additional owned Automations HTTP path (status/cursor or reconcile)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-auto-adapter-006",
      "title": "Register adapter package in allowed shared manifests",
      "description": "As a maintainer, I want the Automations HTTP adapter package registered in shared coverage/ownership/package-target manifests only as required so package ownership and verification targets stay accurate without widening into excluded composition surfaces.",
      "acceptanceCriteria": [
        "Shared coverage, ownership, and/or package-target manifest entries for pkg/services/automations/transports/http (or the chosen owner-local Automations HTTP adapter path) are added or updated only when required for adapter package registration",
        "Manifest edits stay limited to those allowed shared manifests; no shared OpenAPI authorship and no PSS-I02 route/client fan-in changes",
        "Diff does not edit pkg/wire, pkg/root, pkg/initializer, top-level CLI composition, Automations CLI/MCP adapter paths, or other services’ HTTP adapters",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-auto-adapter-007",
      "title": "Close delivery loop through merged PR",
      "description": "As a maintainer, I want the HTTP-AUTO implementation/review cycle to continue until the PR is actually merged so the Factory work item is not left merely green or approved.",
      "acceptanceCriteria": [
        "Implementation PR for pss-http-auto-adapter is opened against the integration branch used by this program",
        "Required CI is terminal and passing on the PR head used for merge",
        "Every blocking PR conversation comment is explicitly addressed (fixed or answered with rationale)",
        "Merge conflicts and shared-file churn (including allowed manifest files) are reconciled",
        "PR is actually merged; opened/green/approved/ready-to-merge alone is not sufficient",
        "Typecheck passes"
      ],
      "priority": 7,
      "passes": false,
      "notes": ""
    }
  ]
}
