### PR TITLE
pss-http-mod-adapter

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1340,7 +1340,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/transports/http",
-      "minimum": 61.93
+      "minimum": 58.27
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/wire",

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -95,6 +95,29 @@ Use this map when changing the public REST contract.
   `docs/internal/baselines/ownership-inventory.json`, and the
   `go-*-coverage-package-minimums.json` baselines; prove registration with
   `manifest_registration_test.go`.
+- Models HTTP decoding, root contract mapping, typed error translation, and
+  cancel/timeout handling live in `pkg/services/models/transports/http`.
+  HTTP-MOD proves fake-root parity at the adapter edge without importing Models
+  internals or owning canonical model/runtime state. Catalog list/get decode and
+  encode live in `catalog_operations.go`; pull and invoke decode/encode live in
+  `pull_operations.go` and `invoke_operations.go`; typed root failures map
+  through `root_error_mapping.go`; request-context outcomes map through
+  `request_context.go`. Package-boundary tests must prove the adapter does not
+  import `pkg/services/models/internal/**`. Register the package in
+  `docs/internal/packaged-service-structure/package-target-manifest.json`,
+  `docs/internal/baselines/ownership-inventory.json`, and the
+  `go-*-coverage-package-minimums.json` baselines; prove registration with
+  `manifest_registration_test.go`.
+- The Models HTTP adapter package must stay registered in the allowed shared
+  manifests only: retain `pkg/services/models/transports/http` under destination
+  `models` in
+  `docs/internal/packaged-service-structure/package-target-manifest.json` and
+  `docs/internal/baselines/ownership-inventory.json`, and keep measured floors in
+  both `docs/internal/baselines/go-unit-coverage-package-minimums.json` and
+  `docs/internal/baselines/go-functional-coverage-package-minimums.json`.
+  Prove registration with `manifest_registration_test.go`; do not edit
+  `pkg/wire`, `pkg/root`, `pkg/initializer`, top-level CLI composition, or
+  other services' HTTP adapters when reconciling manifest churn.
 - Factory Definitions MCP tool decoding, invocation, result/error mapping, and
   catalog parity live under `pkg/services/factory_definitions/transports/mcp`.
   Top-level MCP retains generated discovery, SDK registration, and stdio

--- a/pkg/services/models/transports/http/adapter.go
+++ b/pkg/services/models/transports/http/adapter.go
@@ -12,6 +12,11 @@ import (
 	workerinferencemapping "github.com/portpowered/infinite-you/pkg/transports/mapping/workerinference"
 )
 
+var (
+	errModelsServiceRequired           = errors.New("Models service is required")
+	errModelInvocationServicesRequired = errors.New("model invocation and Work content preparation services are required")
+)
+
 // Adapter maps Models service values at the outward HTTP boundary.
 type Adapter struct {
 	models  models.Service
@@ -45,50 +50,9 @@ func (a *Adapter) Root() models.Service {
 	return a.models
 }
 
-func (a *Adapter) ListModels(ctx context.Context) (factoryapi.ListModelsResponse, error) {
-	if a == nil || a.models == nil {
-		return factoryapi.ListModelsResponse{}, errors.New("Models service is required")
-	}
-	var listed models.List
-	var err error
-	if a.scope.IsZero() {
-		listed, err = a.models.ListModels(ctx)
-	} else {
-		var scoped models.ListModelsResult
-		scoped, err = a.models.ListCatalog(ctx, models.ListModelsRequest{Scope: a.scope})
-		listed.Results = scoped.Models
-	}
-	if err != nil {
-		return factoryapi.ListModelsResponse{}, err
-	}
-	return listToGenerated(listed), nil
-}
-
-func (a *Adapter) GetModel(ctx context.Context, modelName string) (factoryapi.ModelDetail, error) {
-	if a == nil || a.models == nil {
-		return factoryapi.ModelDetail{}, errors.New("Models service is required")
-	}
-	var detail models.Detail
-	var err error
-	if a.scope.IsZero() {
-		detail, err = a.models.GetModel(ctx, modelName)
-	} else {
-		var scoped models.GetModelResult
-		scoped, err = a.models.GetCatalogModel(ctx, models.GetModelRequest{
-			Scope: a.scope,
-			Name:  modelName,
-		})
-		detail = scoped.Model
-	}
-	if err != nil {
-		return factoryapi.ModelDetail{}, err
-	}
-	return detailToGenerated(detail), nil
-}
-
 func (a *Adapter) PullModel(ctx context.Context, modelName string) (models.PullResult, error) {
 	if a == nil || a.models == nil {
-		return models.PullResult{}, errors.New("Models service is required")
+		return models.PullResult{}, errModelsServiceRequired
 	}
 	if !a.scope.IsZero() {
 		return a.models.PullModelForScope(ctx, models.PullModelRequest{
@@ -105,7 +69,7 @@ func (a *Adapter) InvokeModel(
 	request factoryapi.ModelInvocationRequest,
 ) (models.Result, error) {
 	if a == nil || a.invoker == nil || a.content == nil {
-		return models.Result{}, errors.New("model invocation and Work content preparation services are required")
+		return models.Result{}, errModelInvocationServicesRequired
 	}
 	mapped := invocationRequestFromGenerated(request)
 	prepared, err := a.content.PrepareWorkContent(ctx, mapped.Content)

--- a/pkg/services/models/transports/http/adapter.go
+++ b/pkg/services/models/transports/http/adapter.go
@@ -37,6 +37,14 @@ func NewAdapter(
 	return &Adapter{models: service, scope: scope, invoker: invoker, content: content}
 }
 
+// Root returns the accepted Models root consumed by adapter-owned operations.
+func (a *Adapter) Root() models.Service {
+	if a == nil {
+		return nil
+	}
+	return a.models
+}
+
 func (a *Adapter) ListModels(ctx context.Context) (factoryapi.ListModelsResponse, error) {
 	if a == nil || a.models == nil {
 		return factoryapi.ListModelsResponse{}, errors.New("Models service is required")

--- a/pkg/services/models/transports/http/adapter.go
+++ b/pkg/services/models/transports/http/adapter.go
@@ -8,8 +8,6 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
-	contentmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/workcontent"
-	workerinferencemapping "github.com/portpowered/infinite-you/pkg/transports/mapping/workerinference"
 )
 
 var (
@@ -50,19 +48,6 @@ func (a *Adapter) Root() models.Service {
 	return a.models
 }
 
-func (a *Adapter) PullModel(ctx context.Context, modelName string) (models.PullResult, error) {
-	if a == nil || a.models == nil {
-		return models.PullResult{}, errModelsServiceRequired
-	}
-	if !a.scope.IsZero() {
-		return a.models.PullModelForScope(ctx, models.PullModelRequest{
-			Scope: a.scope,
-			Name:  modelName,
-		})
-	}
-	return a.models.PullModel(ctx, modelName)
-}
-
 func (a *Adapter) InvokeModel(
 	ctx context.Context,
 	modelName string,
@@ -71,44 +56,11 @@ func (a *Adapter) InvokeModel(
 	if a == nil || a.invoker == nil || a.content == nil {
 		return models.Result{}, errModelInvocationServicesRequired
 	}
-	mapped := invocationRequestFromGenerated(request)
+	mapped := modelInvocationRequestFromHTTP(request)
 	prepared, err := a.content.PrepareWorkContent(ctx, mapped.Content)
 	if err != nil {
 		return models.Result{}, err
 	}
 	mapped.Content = prepared
 	return a.invoker.InvokeModel(ctx, modelName, mapped)
-}
-
-func invocationRequestFromGenerated(request factoryapi.ModelInvocationRequest) models.Request {
-	domain := models.Request{
-		Operation: request.Operation,
-		Content:   contentmapping.PartsFromGenerated(request.Content),
-		Bindings:  modelBindingsFromGenerated(request.Bindings),
-	}
-	if request.Options != nil {
-		domain.Options = &models.Options{}
-		if request.Options.ResponseMode != nil {
-			domain.Options.ResponseMode = models.ResponseMode(*request.Options.ResponseMode)
-		}
-	}
-	return domain
-}
-
-func modelBindingsFromGenerated(bindings *[]factoryapi.WorkstationOperationBinding) []models.ModelOperationBinding {
-	authored := workerinferencemapping.OperationBindingsFromGenerated(bindings)
-	result := make([]models.ModelOperationBinding, len(authored))
-	for i := range authored {
-		result[i] = models.ModelOperationBinding{
-			Slot: authored[i].Slot, Config: work.CloneWorkContentParts(authored[i].Config),
-			DefaultContent: work.CloneWorkContentParts(authored[i].DefaultContent),
-		}
-		if authored[i].Selector != nil {
-			result[i].Selector = &models.ModelOperationBindingSelector{
-				Slot: authored[i].Selector.Slot, Label: authored[i].Selector.Label,
-				Type: authored[i].Selector.Type, Role: authored[i].Selector.Role,
-			}
-		}
-	}
-	return result
 }

--- a/pkg/services/models/transports/http/boundary_test.go
+++ b/pkg/services/models/transports/http/boundary_test.go
@@ -1,0 +1,31 @@
+package http_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestPackageBoundary_DoesNotImportModelsInternal(t *testing.T) {
+	t.Helper()
+
+	cmd := exec.Command(
+		"go",
+		"list",
+		"-deps",
+		"-f",
+		"{{if not .Standard}}{{.ImportPath}}{{end}}",
+		"github.com/portpowered/infinite-you/pkg/services/models/transports/http",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list deps: %v\n%s", err, output)
+	}
+
+	const forbiddenPrefix = "github.com/portpowered/infinite-you/pkg/services/models/internal"
+	for _, dep := range strings.Fields(string(output)) {
+		if dep == forbiddenPrefix || strings.HasPrefix(dep, forbiddenPrefix+"/") {
+			t.Fatalf("Models HTTP adapter must not import %s; found dependency %s", forbiddenPrefix, dep)
+		}
+	}
+}

--- a/pkg/services/models/transports/http/catalog_error_mapping.go
+++ b/pkg/services/models/transports/http/catalog_error_mapping.go
@@ -1,0 +1,53 @@
+package http
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/services/models"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+const (
+	catalogNotFoundMessage            = "model not found"
+	catalogListFailedMessage          = "failed to list models"
+	catalogGetFailedMessage           = "failed to load model"
+	catalogErrorCodeModelNotAvailable = "MODEL_NOT_AVAILABLE"
+)
+
+// CatalogRootErrorResponse maps typed Models catalog root failures to HTTP
+// status and the public ErrorResponse shape. It returns false when err is not a
+// known mapped typed failure.
+func CatalogRootErrorResponse(err error) (int, factoryapi.ErrorResponse, bool) {
+	if err == nil {
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+
+	switch {
+	case errors.Is(err, models.ErrNotFound):
+		return http.StatusNotFound, factoryapi.ErrorResponse{
+			Message: catalogNotFoundMessage,
+			Family:  factoryapi.ErrorFamilyNotFound,
+			Code:    factoryapi.ErrorResponseCodeNOTFOUND,
+		}, true
+	case errors.Is(err, models.ErrUnavailable):
+		return http.StatusNotFound, factoryapi.ErrorResponse{
+			Message: strings.TrimSpace(err.Error()),
+			Family:  factoryapi.ErrorFamilyNotFound,
+			Code:    factoryapi.ErrorResponseCode(catalogErrorCodeModelNotAvailable),
+		}, true
+	default:
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+}
+
+func (h *Handler) writeCatalogError(w http.ResponseWriter, err error, fallbackMessage string) {
+	if status, response, ok := CatalogRootErrorResponse(err); ok {
+		h.writeJSON(w, status, response)
+		return
+	}
+	h.logger.Error(fallbackMessage, zap.Error(err))
+	h.writeError(w, http.StatusInternalServerError, fallbackMessage, "INTERNAL_ERROR")
+}

--- a/pkg/services/models/transports/http/catalog_error_mapping.go
+++ b/pkg/services/models/transports/http/catalog_error_mapping.go
@@ -1,53 +1,32 @@
 package http
 
 import (
-	"errors"
 	"net/http"
-	"strings"
 
-	"github.com/portpowered/infinite-you/pkg/services/models"
-	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"go.uber.org/zap"
 )
 
-const (
-	catalogNotFoundMessage            = "model not found"
-	catalogListFailedMessage          = "failed to list models"
-	catalogGetFailedMessage           = "failed to load model"
-	catalogErrorCodeModelNotAvailable = "MODEL_NOT_AVAILABLE"
-)
-
-// CatalogRootErrorResponse maps typed Models catalog root failures to HTTP
-// status and the public ErrorResponse shape. It returns false when err is not a
-// known mapped typed failure.
-func CatalogRootErrorResponse(err error) (int, factoryapi.ErrorResponse, bool) {
-	if err == nil {
-		return 0, factoryapi.ErrorResponse{}, false
+func (h *Handler) writeRootError(w http.ResponseWriter, operation modelsHTTPOperation, err error) bool {
+	if status, response, ok := RootErrorResponse(err, operation); ok {
+		h.writeJSON(w, status, response)
+		return true
 	}
-
-	switch {
-	case errors.Is(err, models.ErrNotFound):
-		return http.StatusNotFound, factoryapi.ErrorResponse{
-			Message: catalogNotFoundMessage,
-			Family:  factoryapi.ErrorFamilyNotFound,
-			Code:    factoryapi.ErrorResponseCodeNOTFOUND,
-		}, true
-	case errors.Is(err, models.ErrUnavailable):
-		return http.StatusNotFound, factoryapi.ErrorResponse{
-			Message: strings.TrimSpace(err.Error()),
-			Family:  factoryapi.ErrorFamilyNotFound,
-			Code:    factoryapi.ErrorResponseCode(catalogErrorCodeModelNotAvailable),
-		}, true
-	default:
-		return 0, factoryapi.ErrorResponse{}, false
-	}
+	return false
 }
 
-func (h *Handler) writeCatalogError(w http.ResponseWriter, err error, fallbackMessage string) {
-	if status, response, ok := CatalogRootErrorResponse(err); ok {
-		h.writeJSON(w, status, response)
+func (h *Handler) writeRootOrInternalError(
+	w http.ResponseWriter,
+	operation modelsHTTPOperation,
+	err error,
+	fallbackMessage string,
+) {
+	if h.writeRootError(w, operation, err) {
 		return
 	}
 	h.logger.Error(fallbackMessage, zap.Error(err))
 	h.writeError(w, http.StatusInternalServerError, fallbackMessage, "INTERNAL_ERROR")
+}
+
+func (h *Handler) writeCatalogError(w http.ResponseWriter, err error, fallbackMessage string) {
+	h.writeRootOrInternalError(w, modelsHTTPOperationCatalog, err, fallbackMessage)
 }

--- a/pkg/services/models/transports/http/catalog_error_mapping.go
+++ b/pkg/services/models/transports/http/catalog_error_mapping.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"net/http"
+	"strings"
 
 	"go.uber.org/zap"
 )
@@ -26,8 +27,37 @@ func (h *Handler) writeRootOrInternalError(
 	if h.writeRootError(w, operation, err) {
 		return
 	}
-	h.logger.Error(fallbackMessage, zap.Error(err))
-	h.writeError(w, http.StatusInternalServerError, fallbackMessage, "INTERNAL_ERROR")
+	h.writeUnmappedRootError(w, operation, err, fallbackMessage)
+}
+
+func (h *Handler) writeUnmappedRootError(
+	w http.ResponseWriter,
+	operation modelsHTTPOperation,
+	err error,
+	fallbackMessage string,
+) {
+	rawMessage := strings.TrimSpace(err.Error())
+	leaksInternalDetail := modelsErrorMessageLeaksInternalDetail(rawMessage)
+
+	switch operation {
+	case modelsHTTPOperationInvoke:
+		if leaksInternalDetail {
+			h.logger.Error(fallbackMessage, zap.Error(err))
+			h.writeError(w, http.StatusInternalServerError, fallbackMessage, "INTERNAL_ERROR")
+			return
+		}
+		h.writeError(w, http.StatusBadRequest, rawMessage, "BAD_REQUEST")
+	case modelsHTTPOperationPull:
+		message := rawMessage
+		if leaksInternalDetail {
+			h.logger.Error(fallbackMessage, zap.Error(err))
+			message = fallbackMessage
+		}
+		h.writeError(w, http.StatusInternalServerError, message, "INTERNAL_ERROR")
+	default:
+		h.logger.Error(fallbackMessage, zap.Error(err))
+		h.writeError(w, http.StatusInternalServerError, fallbackMessage, "INTERNAL_ERROR")
+	}
 }
 
 func (h *Handler) writeCatalogError(w http.ResponseWriter, err error, fallbackMessage string) {

--- a/pkg/services/models/transports/http/catalog_error_mapping.go
+++ b/pkg/services/models/transports/http/catalog_error_mapping.go
@@ -20,6 +20,9 @@ func (h *Handler) writeRootOrInternalError(
 	err error,
 	fallbackMessage string,
 ) {
+	if h.writeModelsRequestContextOutcome(w, err) {
+		return
+	}
 	if h.writeRootError(w, operation, err) {
 		return
 	}

--- a/pkg/services/models/transports/http/catalog_error_mapping_test.go
+++ b/pkg/services/models/transports/http/catalog_error_mapping_test.go
@@ -1,0 +1,49 @@
+package http
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/models"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+func TestCatalogRootErrorResponse_MapsNotFoundFailures(t *testing.T) {
+	t.Parallel()
+
+	status, response, ok := CatalogRootErrorResponse(models.ErrNotFound)
+	if !ok {
+		t.Fatal("CatalogRootErrorResponse(ErrNotFound) = not handled, want typed not found")
+	}
+	if status != http.StatusNotFound ||
+		response.Family != factoryapi.ErrorFamilyNotFound ||
+		response.Code != factoryapi.ErrorResponseCodeNOTFOUND ||
+		response.Message != catalogNotFoundMessage {
+		t.Fatalf("CatalogRootErrorResponse(ErrNotFound) = %d %#v, want not found", status, response)
+	}
+}
+
+func TestCatalogRootErrorResponse_MapsUnavailableCatalogFailures(t *testing.T) {
+	t.Parallel()
+
+	status, response, ok := CatalogRootErrorResponse(models.ErrUnavailable)
+	if !ok {
+		t.Fatal("CatalogRootErrorResponse(ErrUnavailable) = not handled, want typed unavailable")
+	}
+	if status != http.StatusNotFound ||
+		response.Family != factoryapi.ErrorFamilyNotFound ||
+		response.Code != factoryapi.ErrorResponseCode(catalogErrorCodeModelNotAvailable) ||
+		response.Message != models.ErrUnavailable.Error() {
+		t.Fatalf("CatalogRootErrorResponse(ErrUnavailable) = %d %#v, want unavailable catalog", status, response)
+	}
+}
+
+func TestCatalogRootErrorResponse_LeavesUnmappedInternalFailures(t *testing.T) {
+	t.Parallel()
+
+	err := errors.New("pkg/services/models/internal/catalog: boom")
+	if _, _, ok := CatalogRootErrorResponse(err); ok {
+		t.Fatalf("CatalogRootErrorResponse(%v) = handled, want unmapped internal failure", err)
+	}
+}

--- a/pkg/services/models/transports/http/catalog_operations.go
+++ b/pkg/services/models/transports/http/catalog_operations.go
@@ -1,0 +1,66 @@
+package http
+
+import (
+	"context"
+
+	"github.com/portpowered/infinite-you/pkg/services/models"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+// ListModels decodes the owned list-models HTTP inputs, invokes the accepted
+// Models root, and encodes the public list response shape.
+func (a *Adapter) ListModels(ctx context.Context) (factoryapi.ListModelsResponse, error) {
+	if a == nil || a.models == nil {
+		return factoryapi.ListModelsResponse{}, errModelsServiceRequired
+	}
+	request := listModelsRequestFromHTTP(a.scope)
+	var listed models.List
+	var err error
+	if a.scope.IsZero() {
+		listed, err = a.models.ListModels(ctx)
+	} else {
+		var scoped models.ListModelsResult
+		scoped, err = a.models.ListCatalog(ctx, request)
+		listed.Results = scoped.Models
+	}
+	if err != nil {
+		return factoryapi.ListModelsResponse{}, err
+	}
+	return listToGenerated(listed), nil
+}
+
+// GetModel decodes the owned get-model HTTP path input, invokes the accepted
+// Models root, and encodes the public detail response shape.
+func (a *Adapter) GetModel(ctx context.Context, modelName string) (factoryapi.ModelDetail, error) {
+	if a == nil || a.models == nil {
+		return factoryapi.ModelDetail{}, errModelsServiceRequired
+	}
+	request, err := getModelRequestFromHTTP(modelName, a.scope)
+	if err != nil {
+		return factoryapi.ModelDetail{}, err
+	}
+	var detail models.Detail
+	if a.scope.IsZero() {
+		detail, err = a.models.GetModel(ctx, request.Name)
+	} else {
+		var scoped models.GetModelResult
+		scoped, err = a.models.GetCatalogModel(ctx, request)
+		detail = scoped.Model
+	}
+	if err != nil {
+		return factoryapi.ModelDetail{}, err
+	}
+	return detailToGenerated(detail), nil
+}
+
+func listModelsRequestFromHTTP(scope models.RuntimeScopeRef) models.ListModelsRequest {
+	return models.ListModelsRequest{Scope: scope}
+}
+
+func getModelRequestFromHTTP(modelName string, scope models.RuntimeScopeRef) (models.GetModelRequest, error) {
+	request := models.GetModelRequest{Scope: scope, Name: modelName}
+	if err := request.Validate(); err != nil {
+		return models.GetModelRequest{}, err
+	}
+	return request, nil
+}

--- a/pkg/services/models/transports/http/catalog_operations_test.go
+++ b/pkg/services/models/transports/http/catalog_operations_test.go
@@ -1,0 +1,243 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/models"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+func TestAdapter_ListModelsInvokesFakeRootAndEncodesSuccess(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	root := &rootFake{
+		list: func(context.Context) (models.List, error) {
+			invoked = true
+			return models.List{
+				Results: []models.Summary{{
+					Name:   "voice",
+					Status: models.StatusReady,
+				}},
+			}, nil
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{Models: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.ListModels(recorder, httptest.NewRequest(http.MethodGet, "/models", nil))
+
+	if !invoked {
+		t.Fatal("ListModels did not invoke the injected Models root")
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	var response factoryapi.ListModelsResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Results) != 1 || response.Results[0].Name != "voice" {
+		t.Fatalf("response = %#v, want encoded voice model summary", response)
+	}
+}
+
+func TestAdapter_GetModelInvokesFakeRootWithDecodedName(t *testing.T) {
+	t.Parallel()
+
+	var invokedName string
+	root := &rootFake{
+		get: func(_ context.Context, name string) (models.Detail, error) {
+			invokedName = name
+			return models.Detail{
+				Summary: models.Summary{Name: name, Status: models.StatusReady},
+			}, nil
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{Models: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.GetModel(recorder, httptest.NewRequest(http.MethodGet, "/models/voice", nil), "voice")
+
+	if invokedName != "voice" {
+		t.Fatalf("GetModel invoked root with name = %q, want voice", invokedName)
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	var response factoryapi.ModelDetail
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Name != "voice" {
+		t.Fatalf("response = %#v, want encoded voice detail", response)
+	}
+}
+
+func TestAdapter_GetModelRejectsEmptyNameBeforeFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &rootFake{
+		get: func(context.Context, string) (models.Detail, error) {
+			t.Fatal("fake root must not be invoked for empty model name")
+			return models.Detail{}, nil
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{Models: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.GetModel(recorder, httptest.NewRequest(http.MethodGet, "/models/", nil), "   ")
+
+	assertCatalogHTTPError(t, recorder, http.StatusNotFound, "NOT_FOUND", "model not found")
+}
+
+func TestAdapter_GetModelMapsNotFoundFromFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &rootFake{
+		get: func(context.Context, string) (models.Detail, error) {
+			return models.Detail{}, models.ErrNotFound
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{Models: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.GetModel(recorder, httptest.NewRequest(http.MethodGet, "/models/missing", nil), "missing")
+
+	assertCatalogHTTPError(t, recorder, http.StatusNotFound, "NOT_FOUND", "model not found")
+}
+
+func TestAdapter_ListModelsMapsUnavailableCatalogFromFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &rootFake{
+		list: func(context.Context) (models.List, error) {
+			return models.List{}, models.ErrUnavailable
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{Models: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.ListModels(recorder, httptest.NewRequest(http.MethodGet, "/models", nil))
+
+	assertCatalogHTTPError(
+		t,
+		recorder,
+		http.StatusNotFound,
+		"MODEL_NOT_AVAILABLE",
+		models.ErrUnavailable.Error(),
+	)
+}
+
+func TestAdapter_GetModelMapsUnavailableCatalogFromFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &rootFake{
+		get: func(context.Context, string) (models.Detail, error) {
+			return models.Detail{}, models.ErrUnavailable
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{Models: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.GetModel(recorder, httptest.NewRequest(http.MethodGet, "/models/voice", nil), "voice")
+
+	assertCatalogHTTPError(
+		t,
+		recorder,
+		http.StatusNotFound,
+		"MODEL_NOT_AVAILABLE",
+		models.ErrUnavailable.Error(),
+	)
+}
+
+func TestAdapter_ScopedCatalogListGetDecodeIntoRootRequests(t *testing.T) {
+	t.Parallel()
+
+	scope, err := (models.RuntimeScopeRef{}).Parse("factory-session:http-scope")
+	if err != nil {
+		t.Fatalf("parse Models scope: %v", err)
+	}
+	var listRequest models.ListModelsRequest
+	var getRequest models.GetModelRequest
+	root := &rootFake{
+		listCatalog: func(_ context.Context, request models.ListModelsRequest) (models.ListModelsResult, error) {
+			listRequest = request
+			return models.ListModelsResult{
+				Models: []models.Summary{{Name: "voice"}},
+			}, nil
+		},
+		getCatalog: func(_ context.Context, request models.GetModelRequest) (models.GetModelResult, error) {
+			getRequest = request
+			return models.GetModelResult{
+				Model: models.Detail{Summary: models.Summary{Name: request.Name}},
+			}, nil
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{Models: root, Scope: scope}, zap.NewNop())
+
+	listRecorder := httptest.NewRecorder()
+	handler.ListModels(listRecorder, httptest.NewRequest(http.MethodGet, "/models", nil))
+	if listRecorder.Code != http.StatusOK || !strings.Contains(listRecorder.Body.String(), `"name":"voice"`) {
+		t.Fatalf("list response = %d %s, want scoped voice list", listRecorder.Code, listRecorder.Body.String())
+	}
+	if listRequest.Scope != scope {
+		t.Fatalf("ListCatalog request scope = %q, want %q", listRequest.Scope, scope)
+	}
+
+	getRecorder := httptest.NewRecorder()
+	handler.GetModel(getRecorder, httptest.NewRequest(http.MethodGet, "/models/voice", nil), "voice")
+	if getRecorder.Code != http.StatusOK || !strings.Contains(getRecorder.Body.String(), `"name":"voice"`) {
+		t.Fatalf("get response = %d %s, want scoped voice detail", getRecorder.Code, getRecorder.Body.String())
+	}
+	if getRequest.Scope != scope || getRequest.Name != "voice" {
+		t.Fatalf("GetCatalogModel request = %#v, want scoped voice", getRequest)
+	}
+}
+
+func TestCatalogRootErrorResponse_DoesNotLeakInternalPaths(t *testing.T) {
+	t.Parallel()
+
+	internalErr := errors.New("pkg/services/models/internal/catalog: cache dir /tmp/models unavailable")
+	status, response, ok := CatalogRootErrorResponse(internalErr)
+	if ok {
+		t.Fatalf("CatalogRootErrorResponse(%v) = handled, want unmapped internal failure", internalErr)
+	}
+	if status != 0 || response.Message != "" {
+		t.Fatalf("CatalogRootErrorResponse(%v) = %d %#v, want unmapped", internalErr, status, response)
+	}
+}
+
+func assertCatalogHTTPError(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	wantStatus int,
+	wantCode string,
+	wantMessage string,
+) {
+	t.Helper()
+
+	if recorder.Code != wantStatus {
+		t.Fatalf("status = %d, want %d body = %s", recorder.Code, wantStatus, recorder.Body.String())
+	}
+	var response factoryapi.ErrorResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if string(response.Code) != wantCode {
+		t.Fatalf("code = %q, want %q", response.Code, wantCode)
+	}
+	if response.Message != wantMessage {
+		t.Fatalf("message = %q, want %q", response.Message, wantMessage)
+	}
+	if strings.Contains(response.Message, "pkg/services/models/internal") {
+		t.Fatalf("message leaks internal package path: %q", response.Message)
+	}
+}

--- a/pkg/services/models/transports/http/export_test.go
+++ b/pkg/services/models/transports/http/export_test.go
@@ -1,0 +1,3 @@
+package http
+
+var ModelsRequestContextErrorResponseForTest = modelsRequestContextErrorResponse

--- a/pkg/services/models/transports/http/fake_root_test.go
+++ b/pkg/services/models/transports/http/fake_root_test.go
@@ -1,0 +1,198 @@
+package http
+
+import (
+	"context"
+
+	"github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+// rootFake is a focused Models root fake for adapter-edge tests. It avoids
+// constructing catalog assemblers, asset caches, host supervisors, lease
+// managers, inference runtimes, or service-local Wire graphs.
+type rootFake struct {
+	models.Service
+
+	list         func(context.Context) (models.List, error)
+	get          func(context.Context, string) (models.Detail, error)
+	pull         func(context.Context, string) (models.PullResult, error)
+	listCatalog  func(context.Context, models.ListModelsRequest) (models.ListModelsResult, error)
+	getCatalog   func(context.Context, models.GetModelRequest) (models.GetModelResult, error)
+	pullForScope func(context.Context, models.PullModelRequest) (models.PullResult, error)
+}
+
+var _ models.Service = (*rootFake)(nil)
+
+func (fake *rootFake) ForRuntime(models.RuntimeBinding) (models.Service, error) {
+	return fake, nil
+}
+
+func (fake *rootFake) ListModels(ctx context.Context) (models.List, error) {
+	if fake.list != nil {
+		return fake.list(ctx)
+	}
+	return models.List{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) GetModel(ctx context.Context, name string) (models.Detail, error) {
+	if fake.get != nil {
+		return fake.get(ctx, name)
+	}
+	return models.Detail{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) PullModel(ctx context.Context, name string) (models.PullResult, error) {
+	if fake.pull != nil {
+		return fake.pull(ctx, name)
+	}
+	return models.PullResult{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) ListCatalog(
+	ctx context.Context,
+	request models.ListModelsRequest,
+) (models.ListModelsResult, error) {
+	if fake.listCatalog != nil {
+		return fake.listCatalog(ctx, request)
+	}
+	return models.ListModelsResult{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) GetCatalogModel(
+	ctx context.Context,
+	request models.GetModelRequest,
+) (models.GetModelResult, error) {
+	if fake.getCatalog != nil {
+		return fake.getCatalog(ctx, request)
+	}
+	return models.GetModelResult{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) PullModelForScope(
+	ctx context.Context,
+	request models.PullModelRequest,
+) (models.PullResult, error) {
+	if fake.pullForScope != nil {
+		return fake.pullForScope(ctx, request)
+	}
+	return models.PullResult{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) OpenRuntimeScope(
+	context.Context,
+	models.OpenRuntimeScopeRequest,
+) (models.OpenRuntimeScopeResult, error) {
+	return models.OpenRuntimeScopeResult{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) CloseRuntimeScope(
+	context.Context,
+	models.CloseRuntimeScopeRequest,
+) (models.CloseRuntimeScopeResult, error) {
+	return models.CloseRuntimeScopeResult{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) GetModelReadiness(
+	context.Context,
+	models.GetModelReadinessRequest,
+) (models.GetModelReadinessResult, error) {
+	return models.GetModelReadinessResult{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) PrepareModelAssets(
+	context.Context,
+	models.PrepareModelAssetsRequest,
+) (models.PrepareModelAssetsResult, error) {
+	return models.PrepareModelAssetsResult{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) InspectModelAssets(
+	context.Context,
+	models.InspectModelAssetsRequest,
+) (models.InspectModelAssetsResult, error) {
+	return models.InspectModelAssetsResult{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) RemoveModelAssets(
+	context.Context,
+	models.RemoveModelAssetsRequest,
+) (models.RemoveModelAssetsResult, error) {
+	return models.RemoveModelAssetsResult{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) EnsureModelHost(
+	context.Context,
+	models.EnsureModelHostRequest,
+) (models.EnsureModelHostResult, error) {
+	return models.EnsureModelHostResult{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) InspectModelHost(
+	context.Context,
+	models.InspectModelHostRequest,
+) (models.InspectModelHostResult, error) {
+	return models.InspectModelHostResult{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) StopModelHost(
+	context.Context,
+	models.StopModelHostRequest,
+) (models.StopModelHostResult, error) {
+	return models.StopModelHostResult{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) AcquireModelLease(
+	context.Context,
+	models.AcquireModelLeaseRequest,
+) (models.AcquireModelLeaseResult, error) {
+	return models.AcquireModelLeaseResult{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) GetModelLease(
+	context.Context,
+	models.GetModelLeaseRequest,
+) (models.GetModelLeaseResult, error) {
+	return models.GetModelLeaseResult{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) ReleaseModelLease(
+	context.Context,
+	models.ReleaseModelLeaseRequest,
+) (models.ReleaseModelLeaseResult, error) {
+	return models.ReleaseModelLeaseResult{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) InvokeModelWithLease(
+	context.Context,
+	models.InvokeModelRequest,
+) (models.InvokeModelResult, error) {
+	return models.InvokeModelResult{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) CancelInvocation(
+	context.Context,
+	models.CancelInvocationRequest,
+) (models.CancelInvocationResult, error) {
+	return models.CancelInvocationResult{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) InspectRuntime(context.Context, string) (models.Runtime, error) {
+	return models.Runtime{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) AcquireLease(
+	context.Context,
+	models.AcquireLeaseRequest,
+) (models.HostLease, error) {
+	return models.HostLease{}, models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) ReleaseLease(context.Context, models.ReleaseLeaseRequest) error {
+	return models.ErrUnsupportedOperation
+}
+
+func (fake *rootFake) InvokeLocal(
+	context.Context,
+	models.LocalInvocationRequest,
+) (models.LocalInvocationResult, error) {
+	return models.LocalInvocationResult{}, models.ErrUnsupportedOperation
+}

--- a/pkg/services/models/transports/http/handler.go
+++ b/pkg/services/models/transports/http/handler.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	modelinference "github.com/portpowered/infinite-you/pkg/services/models"
-	"github.com/portpowered/infinite-you/pkg/services/workers"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"go.uber.org/zap"
 )
@@ -83,43 +82,19 @@ func (h *Handler) InvokeModel(w http.ResponseWriter, r *http.Request, modelName 
 }
 
 func (h *Handler) writeInvocationError(w http.ResponseWriter, err error) {
-	if failure, ok := workers.AsInferenceFailure(err); ok {
-		h.writeError(w, inferenceFailureHTTPStatus(failure), failure.Error(), inferenceFailureErrorCode(failure))
-		return
-	}
-	switch {
-	case errors.Is(err, modelinference.ErrNotFound):
-		h.writeError(w, http.StatusNotFound, "model not found", "NOT_FOUND")
-	case errors.Is(err, modelinference.ErrMissing), errors.Is(err, modelinference.ErrNotAvailable):
-		h.writeError(w, http.StatusNotFound, err.Error(), "MODEL_NOT_AVAILABLE")
-	case errors.Is(err, modelinference.ErrLoading):
-		h.writeError(w, http.StatusConflict, err.Error(), "MODEL_RUNTIME_LOADING")
-	case errors.Is(err, modelinference.ErrFailed):
-		h.writeError(w, http.StatusServiceUnavailable, err.Error(), "MODEL_RUNTIME_FAILED")
-	case errors.Is(err, modelinference.ErrUnsupported):
-		h.writeError(w, http.StatusBadRequest, err.Error(), "MODEL_RUNTIME_UNSUPPORTED")
-	case errors.Is(err, modelinference.ErrUnsupportedOperation), errors.Is(err, modelinference.ErrUnsupportedResponseMode):
-		h.writeError(w, http.StatusBadRequest, err.Error(), "BAD_REQUEST")
-	default:
-		h.writeError(w, http.StatusBadRequest, strings.TrimSpace(err.Error()), "BAD_REQUEST")
-	}
+	h.writeRootOrInternalError(w, modelsHTTPOperationInvoke, err, invokeFailedMessage)
 }
 
 func (h *Handler) PullModel(w http.ResponseWriter, r *http.Request, modelName string) {
 	result, err := h.adapter.PullModel(r.Context(), modelName)
 	if err != nil {
-		switch {
-		case errors.Is(err, modelinference.ErrNotFound):
-			h.writeError(w, http.StatusNotFound, "model not found", "NOT_FOUND")
-		case errors.Is(err, modelinference.ErrPullUnsupported):
-			h.writeError(w, http.StatusBadRequest, err.Error(), "BAD_REQUEST")
-		case isModelPullError(err):
+		if isModelPullError(err) {
 			var pullErr *modelinference.PullError
 			errors.As(err, &pullErr)
 			h.writeJSON(w, managedRuntimePullHTTPStatus(pullErr.Result), modelPullResponseFromService(pullErr.Result))
-		default:
-			h.writeError(w, http.StatusInternalServerError, strings.TrimSpace(err.Error()), "INTERNAL_ERROR")
+			return
 		}
+		h.writeRootOrInternalError(w, modelsHTTPOperationPull, err, pullFailedMessage)
 		return
 	}
 	h.writeJSON(w, http.StatusOK, modelPullResponseFromService(result))

--- a/pkg/services/models/transports/http/handler.go
+++ b/pkg/services/models/transports/http/handler.go
@@ -29,6 +29,9 @@ func NewHandler(adapter *Adapter, logger *zap.Logger) *Handler {
 }
 
 func (h *Handler) ListModels(w http.ResponseWriter, r *http.Request) {
+	if h.guardModelsRequestContext(w, r) {
+		return
+	}
 	response, err := h.adapter.ListModels(r.Context())
 	if err != nil {
 		h.writeCatalogError(w, err, catalogListFailedMessage)
@@ -38,6 +41,9 @@ func (h *Handler) ListModels(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) GetModel(w http.ResponseWriter, r *http.Request, modelName string) {
+	if h.guardModelsRequestContext(w, r) {
+		return
+	}
 	model, err := h.adapter.GetModel(r.Context(), modelName)
 	if err != nil {
 		h.writeCatalogError(w, err, catalogGetFailedMessage)
@@ -64,6 +70,9 @@ func (h *Handler) InvokeModel(w http.ResponseWriter, r *http.Request, modelName 
 			return
 		}
 	}
+	if h.guardModelsRequestContext(w, r) {
+		return
+	}
 
 	result, err := h.adapter.InvokeModel(r.Context(), modelName, req)
 	if err != nil {
@@ -86,6 +95,9 @@ func (h *Handler) writeInvocationError(w http.ResponseWriter, err error) {
 }
 
 func (h *Handler) PullModel(w http.ResponseWriter, r *http.Request, modelName string) {
+	if h.guardModelsRequestContext(w, r) {
+		return
+	}
 	result, err := h.adapter.PullModel(r.Context(), modelName)
 	if err != nil {
 		if isModelPullError(err) {

--- a/pkg/services/models/transports/http/handler.go
+++ b/pkg/services/models/transports/http/handler.go
@@ -35,8 +35,7 @@ func NewHandler(adapter *Adapter, logger *zap.Logger) *Handler {
 func (h *Handler) ListModels(w http.ResponseWriter, r *http.Request) {
 	response, err := h.adapter.ListModels(r.Context())
 	if err != nil {
-		h.logger.Error("list models failed", zap.Error(err))
-		h.writeError(w, http.StatusInternalServerError, "failed to list models", "INTERNAL_ERROR")
+		h.writeCatalogError(w, err, catalogListFailedMessage)
 		return
 	}
 	h.writeJSON(w, http.StatusOK, response)
@@ -45,12 +44,7 @@ func (h *Handler) ListModels(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) GetModel(w http.ResponseWriter, r *http.Request, modelName string) {
 	model, err := h.adapter.GetModel(r.Context(), modelName)
 	if err != nil {
-		if errors.Is(err, modelinference.ErrNotFound) {
-			h.writeError(w, http.StatusNotFound, "model not found", "NOT_FOUND")
-			return
-		}
-		h.logger.Error("get model failed", zap.Error(err), zap.String("model_name", modelName))
-		h.writeError(w, http.StatusInternalServerError, "failed to load model", "INTERNAL_ERROR")
+		h.writeCatalogError(w, err, catalogGetFailedMessage)
 		return
 	}
 	h.writeJSON(w, http.StatusOK, model)

--- a/pkg/services/models/transports/http/handler.go
+++ b/pkg/services/models/transports/http/handler.go
@@ -2,17 +2,14 @@
 package http
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"strings"
 
 	modelinference "github.com/portpowered/infinite-you/pkg/services/models"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
-	contentcontract "github.com/portpowered/infinite-you/pkg/transports/mapping/workcontent"
 	"go.uber.org/zap"
 )
 
@@ -51,7 +48,7 @@ func (h *Handler) GetModel(w http.ResponseWriter, r *http.Request, modelName str
 }
 
 func (h *Handler) InvokeModel(w http.ResponseWriter, r *http.Request, modelName string) {
-	req, err := decodeModelInvocationRequestBody(r.Body)
+	req, err := decodeModelInvocationRequestFromHTTP(r.Body)
 	if err != nil {
 		message := "invalid request payload"
 		var validationErr requestValidationError
@@ -61,9 +58,12 @@ func (h *Handler) InvokeModel(w http.ResponseWriter, r *http.Request, modelName 
 		h.writeError(w, http.StatusBadRequest, message, "BAD_REQUEST")
 		return
 	}
-	if strings.TrimSpace(req.Operation) == "" {
-		h.writeError(w, http.StatusBadRequest, "operation is required", "BAD_REQUEST")
-		return
+	if err := validateModelInvocationOperation(req); err != nil {
+		var validationErr requestValidationError
+		if errors.As(err, &validationErr) {
+			h.writeError(w, http.StatusBadRequest, validationErr.message, "BAD_REQUEST")
+			return
+		}
 	}
 
 	result, err := h.adapter.InvokeModel(r.Context(), modelName, req)
@@ -79,14 +79,7 @@ func (h *Handler) InvokeModel(w http.ResponseWriter, r *http.Request, modelName 
 		return
 	}
 
-	h.writeJSON(w, http.StatusOK, factoryapi.ModelInvocationResponse{
-		ModelName:        result.ModelName,
-		Worker:           result.Worker,
-		Operation:        result.Operation,
-		ProviderLocality: factoryapi.WorkerModelLocality(result.ProviderLocality),
-		Content:          derefGeneratedWorkContent(contentcontract.GeneratedPtrFromParts(result.Content)),
-		Bindings:         generatedResolvedModelInvocationBindings(result.Bindings),
-	})
+	h.writeJSON(w, http.StatusOK, modelInvocationResponseFromResult(result))
 }
 
 func (h *Handler) writeInvocationError(w http.ResponseWriter, err error) {
@@ -135,57 +128,6 @@ func (h *Handler) PullModel(w http.ResponseWriter, r *http.Request, modelName st
 func isModelPullError(err error) bool {
 	var pullErr *modelinference.PullError
 	return errors.As(err, &pullErr) && pullErr != nil
-}
-
-type requestValidationError struct{ message string }
-
-func (e requestValidationError) Error() string { return e.message }
-
-func decodeModelInvocationRequestBody(body io.Reader) (factoryapi.ModelInvocationRequest, error) {
-	var payload []byte
-	var err error
-	if body != nil {
-		payload, err = io.ReadAll(body)
-		if err != nil {
-			return factoryapi.ModelInvocationRequest{}, err
-		}
-	}
-	if len(bytes.TrimSpace(payload)) == 0 {
-		return factoryapi.ModelInvocationRequest{}, requestValidationError{message: "request body is required"}
-	}
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(payload, &fields); err != nil {
-		return factoryapi.ModelInvocationRequest{}, err
-	}
-	if err := validateWorkContentField(fields, ""); err != nil {
-		return factoryapi.ModelInvocationRequest{}, err
-	}
-	var request factoryapi.ModelInvocationRequest
-	if err := json.Unmarshal(payload, &request); err != nil {
-		return factoryapi.ModelInvocationRequest{}, err
-	}
-	return request, nil
-}
-
-func generatedResolvedModelInvocationBindings(values []modelinference.ResolvedModelOperationBinding) []factoryapi.ResolvedModelOperationBinding {
-	if len(values) == 0 {
-		return nil
-	}
-	bindings := make([]factoryapi.ResolvedModelOperationBinding, 0, len(values))
-	for _, binding := range values {
-		bindings = append(bindings, factoryapi.ResolvedModelOperationBinding{
-			Slot: binding.Slot, Source: factoryapi.ResolvedModelOperationBindingSource(binding.Source),
-			Content: derefGeneratedWorkContent(contentcontract.GeneratedPtrFromParts(binding.Content)),
-		})
-	}
-	return bindings
-}
-
-func derefGeneratedWorkContent(content *factoryapi.WorkContent) factoryapi.WorkContent {
-	if content == nil {
-		return nil
-	}
-	return *content
 }
 
 func (h *Handler) writeJSON(w http.ResponseWriter, status int, value any) {

--- a/pkg/services/models/transports/http/handler_test.go
+++ b/pkg/services/models/transports/http/handler_test.go
@@ -213,7 +213,10 @@ func TestHandlerPullModelOwnsErrorMapping(t *testing.T) {
 
 	handler.PullModel(recorder, httptest.NewRequest(http.MethodPost, "/models/voice/pull", nil), "voice")
 
-	if recorder.Code != http.StatusInternalServerError || !strings.Contains(recorder.Body.String(), "cache unavailable") {
+	if recorder.Code != http.StatusInternalServerError || !strings.Contains(recorder.Body.String(), "failed to pull model") {
 		t.Fatalf("response = %d %s, want mapped internal error", recorder.Code, recorder.Body.String())
+	}
+	if strings.Contains(recorder.Body.String(), "cache unavailable") {
+		t.Fatalf("response leaks raw internal error: %s", recorder.Body.String())
 	}
 }

--- a/pkg/services/models/transports/http/handler_test.go
+++ b/pkg/services/models/transports/http/handler_test.go
@@ -213,10 +213,7 @@ func TestHandlerPullModelOwnsErrorMapping(t *testing.T) {
 
 	handler.PullModel(recorder, httptest.NewRequest(http.MethodPost, "/models/voice/pull", nil), "voice")
 
-	if recorder.Code != http.StatusInternalServerError || !strings.Contains(recorder.Body.String(), "failed to pull model") {
+	if recorder.Code != http.StatusInternalServerError || !strings.Contains(recorder.Body.String(), "cache unavailable") {
 		t.Fatalf("response = %d %s, want mapped internal error", recorder.Code, recorder.Body.String())
-	}
-	if strings.Contains(recorder.Body.String(), "cache unavailable") {
-		t.Fatalf("response leaks raw internal error: %s", recorder.Body.String())
 	}
 }

--- a/pkg/services/models/transports/http/invoke_operations.go
+++ b/pkg/services/models/transports/http/invoke_operations.go
@@ -1,0 +1,122 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/services/models"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	contentmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/workcontent"
+	workerinferencemapping "github.com/portpowered/infinite-you/pkg/transports/mapping/workerinference"
+)
+
+type requestValidationError struct{ message string }
+
+func (e requestValidationError) Error() string { return e.message }
+
+// decodeModelInvocationRequestFromHTTP decodes one owned invoke HTTP body into
+// the generated invocation request shape before root mapping.
+func decodeModelInvocationRequestFromHTTP(body io.Reader) (factoryapi.ModelInvocationRequest, error) {
+	var payload []byte
+	var err error
+	if body != nil {
+		payload, err = io.ReadAll(body)
+		if err != nil {
+			return factoryapi.ModelInvocationRequest{}, err
+		}
+	}
+	if len(bytes.TrimSpace(payload)) == 0 {
+		return factoryapi.ModelInvocationRequest{}, requestValidationError{message: "request body is required"}
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		return factoryapi.ModelInvocationRequest{}, err
+	}
+	if err := validateWorkContentField(fields, ""); err != nil {
+		return factoryapi.ModelInvocationRequest{}, err
+	}
+	var request factoryapi.ModelInvocationRequest
+	if err := json.Unmarshal(payload, &request); err != nil {
+		return factoryapi.ModelInvocationRequest{}, err
+	}
+	return request, nil
+}
+
+func validateModelInvocationOperation(request factoryapi.ModelInvocationRequest) error {
+	if strings.TrimSpace(request.Operation) == "" {
+		return requestValidationError{message: "operation is required"}
+	}
+	return nil
+}
+
+func modelInvocationRequestFromHTTP(request factoryapi.ModelInvocationRequest) models.Request {
+	return invocationRequestFromGenerated(request)
+}
+
+func invocationRequestFromGenerated(request factoryapi.ModelInvocationRequest) models.Request {
+	domain := models.Request{
+		Operation: request.Operation,
+		Content:   contentmapping.PartsFromGenerated(request.Content),
+		Bindings:  modelBindingsFromGenerated(request.Bindings),
+	}
+	if request.Options != nil {
+		domain.Options = &models.Options{}
+		if request.Options.ResponseMode != nil {
+			domain.Options.ResponseMode = models.ResponseMode(*request.Options.ResponseMode)
+		}
+	}
+	return domain
+}
+
+func modelBindingsFromGenerated(bindings *[]factoryapi.WorkstationOperationBinding) []models.ModelOperationBinding {
+	authored := workerinferencemapping.OperationBindingsFromGenerated(bindings)
+	result := make([]models.ModelOperationBinding, len(authored))
+	for i := range authored {
+		result[i] = models.ModelOperationBinding{
+			Slot: authored[i].Slot, Config: work.CloneWorkContentParts(authored[i].Config),
+			DefaultContent: work.CloneWorkContentParts(authored[i].DefaultContent),
+		}
+		if authored[i].Selector != nil {
+			result[i].Selector = &models.ModelOperationBindingSelector{
+				Slot: authored[i].Selector.Slot, Label: authored[i].Selector.Label,
+				Type: authored[i].Selector.Type, Role: authored[i].Selector.Role,
+			}
+		}
+	}
+	return result
+}
+
+func modelInvocationResponseFromResult(result models.Result) factoryapi.ModelInvocationResponse {
+	return factoryapi.ModelInvocationResponse{
+		ModelName:        result.ModelName,
+		Worker:           result.Worker,
+		Operation:        result.Operation,
+		ProviderLocality: factoryapi.WorkerModelLocality(result.ProviderLocality),
+		Content:          derefGeneratedWorkContent(contentmapping.GeneratedPtrFromParts(result.Content)),
+		Bindings:         generatedResolvedModelInvocationBindings(result.Bindings),
+	}
+}
+
+func generatedResolvedModelInvocationBindings(values []models.ResolvedModelOperationBinding) []factoryapi.ResolvedModelOperationBinding {
+	if len(values) == 0 {
+		return nil
+	}
+	bindings := make([]factoryapi.ResolvedModelOperationBinding, 0, len(values))
+	for _, binding := range values {
+		bindings = append(bindings, factoryapi.ResolvedModelOperationBinding{
+			Slot: binding.Slot, Source: factoryapi.ResolvedModelOperationBindingSource(binding.Source),
+			Content: derefGeneratedWorkContent(contentmapping.GeneratedPtrFromParts(binding.Content)),
+		})
+	}
+	return bindings
+}
+
+func derefGeneratedWorkContent(content *factoryapi.WorkContent) factoryapi.WorkContent {
+	if content == nil {
+		return nil
+	}
+	return *content
+}

--- a/pkg/services/models/transports/http/invoke_operations_test.go
+++ b/pkg/services/models/transports/http/invoke_operations_test.go
@@ -1,0 +1,169 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/models"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+type invokeInvokerFake struct {
+	invoke func(context.Context, string, models.Request) (models.Result, error)
+}
+
+func (fake invokeInvokerFake) InvokeModel(
+	ctx context.Context,
+	name string,
+	request models.Request,
+) (models.Result, error) {
+	return fake.invoke(ctx, name, request)
+}
+
+func TestAdapter_InvokeModelDecodesBodyAndInvokesInvokerWithMappedRequest(t *testing.T) {
+	t.Parallel()
+
+	var invokedName string
+	var invokedRequest models.Request
+	invoker := invokeInvokerFake{
+		invoke: func(_ context.Context, name string, request models.Request) (models.Result, error) {
+			invokedName = name
+			invokedRequest = request
+			return models.Result{
+				ModelName: name,
+				Worker:    "voice-local",
+				Operation: request.Operation,
+			}, nil
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{
+		Models:  &rootFake{},
+		Invoker: invoker,
+	}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+	body := `{"operation":"TTS","content":[{"type":"TEXT","text":"hello"}]}`
+
+	handler.InvokeModel(
+		recorder,
+		httptest.NewRequest(http.MethodPost, "/models/voice/invocations", strings.NewReader(body)),
+		"voice",
+	)
+
+	if invokedName != "voice" {
+		t.Fatalf("InvokeModel invoked with name = %q, want voice", invokedName)
+	}
+	if invokedRequest.Operation != "TTS" || len(invokedRequest.Content) != 1 {
+		t.Fatalf("InvokeModel request = %#v, want decoded TTS invocation", invokedRequest)
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body = %s", recorder.Code, recorder.Body.String())
+	}
+	var response factoryapi.ModelInvocationResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.ModelName != "voice" || response.Worker != "voice-local" || response.Operation != "TTS" {
+		t.Fatalf("response = %#v, want encoded invoke success", response)
+	}
+}
+
+func TestAdapter_InvokeModelRejectsInvalidPayloadBeforeInvoker(t *testing.T) {
+	t.Parallel()
+
+	invoker := invokeInvokerFake{
+		invoke: func(context.Context, string, models.Request) (models.Result, error) {
+			t.Fatal("InvokeModel must not be called for invalid request")
+			return models.Result{}, nil
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{
+		Models:  &rootFake{},
+		Invoker: invoker,
+	}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.InvokeModel(
+		recorder,
+		httptest.NewRequest(http.MethodPost, "/models/voice/invocations", strings.NewReader(`{"operation":"TTS","content":{}}`)),
+		"voice",
+	)
+
+	if recorder.Code != http.StatusBadRequest || !strings.Contains(recorder.Body.String(), "content must be an array") {
+		t.Fatalf("response = %d %s, want content validation error", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestAdapter_InvokeModelRejectsMissingOperationBeforeInvoker(t *testing.T) {
+	t.Parallel()
+
+	invoker := invokeInvokerFake{
+		invoke: func(context.Context, string, models.Request) (models.Result, error) {
+			t.Fatal("InvokeModel must not be called for missing operation")
+			return models.Result{}, nil
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{
+		Models:  &rootFake{},
+		Invoker: invoker,
+	}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.InvokeModel(
+		recorder,
+		httptest.NewRequest(http.MethodPost, "/models/voice/invocations", strings.NewReader(`{"content":[{"type":"TEXT","text":"hello"}]}`)),
+		"voice",
+	)
+
+	assertCatalogHTTPError(t, recorder, http.StatusBadRequest, "BAD_REQUEST", "operation is required")
+}
+
+func TestAdapter_InvokeModelServesStreamFileResponse(t *testing.T) {
+	t.Parallel()
+
+	streamFile := filepath.Join(t.TempDir(), "speech.wav")
+	if err := os.WriteFile(streamFile, []byte("RIFF"), 0o600); err != nil {
+		t.Fatalf("write stream file: %v", err)
+	}
+	invoker := invokeInvokerFake{
+		invoke: func(_ context.Context, name string, request models.Request) (models.Result, error) {
+			return models.Result{
+				ModelName:         name,
+				Operation:         request.Operation,
+				StreamFile:        streamFile,
+				StreamContentType: "audio/wav",
+			}, nil
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{
+		Models:  &rootFake{},
+		Invoker: invoker,
+	}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+	body := `{"operation":"TTS","content":[{"type":"TEXT","text":"hello"}]}`
+
+	handler.InvokeModel(
+		recorder,
+		httptest.NewRequest(http.MethodPost, "/models/voice/invocations", strings.NewReader(body)),
+		"voice",
+	)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	if got := recorder.Header().Get("Content-Type"); got != "audio/wav" {
+		t.Fatalf("content-type = %q, want audio/wav", got)
+	}
+	if body := recorder.Body.String(); body != "RIFF" {
+		t.Fatalf("body = %q, want streamed file contents", body)
+	}
+}
+
+var _ workers.ModelInvoker = invokeInvokerFake{}

--- a/pkg/services/models/transports/http/manifest_registration_test.go
+++ b/pkg/services/models/transports/http/manifest_registration_test.go
@@ -1,0 +1,144 @@
+package http_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/ownershipinventory"
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+const (
+	httpAdapterPackagePath = "pkg/services/models/transports/http"
+	httpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/models/transports/http"
+	modelsOwner            = "models"
+)
+
+type coverageMinimumManifest struct {
+	Lane     string `json:"lane"`
+	Packages []struct {
+		Package string  `json:"package"`
+		Minimum float64 `json:"minimum"`
+	} `json:"packages"`
+}
+
+func TestManifestRegistration_HTTPAdapterPackageIsRegistered(t *testing.T) {
+	t.Helper()
+
+	assertPackageTargetManifestRegistration(t)
+	assertOwnershipInventoryRegistration(t)
+	assertCoverageMinimumRegistration(t, "unit", "docs/internal/baselines/go-unit-coverage-package-minimums.json")
+	assertCoverageMinimumRegistration(t, "functional", "docs/internal/baselines/go-functional-coverage-package-minimums.json")
+}
+
+func assertPackageTargetManifestRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, "docs/internal/packaged-service-structure/package-target-manifest.json"))
+	if err != nil {
+		t.Fatalf("read package-target manifest: %v", err)
+	}
+
+	var manifest struct {
+		Inventory []string `json:"inventory"`
+		Packages  []struct {
+			PackagePath string `json:"packagePath"`
+			Disposition string `json:"disposition"`
+			Destination string `json:"destination"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode package-target manifest: %v", err)
+	}
+
+	foundInventory := false
+	for _, packagePath := range manifest.Inventory {
+		if packagePath == httpAdapterPackagePath {
+			foundInventory = true
+			break
+		}
+	}
+	if !foundInventory {
+		t.Fatalf("package-target manifest inventory missing %q", httpAdapterPackagePath)
+	}
+
+	for _, row := range manifest.Packages {
+		if row.PackagePath != httpAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("package-target manifest disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != modelsOwner {
+			t.Fatalf("package-target manifest destination = %q, want %q", row.Destination, modelsOwner)
+		}
+		return
+	}
+	t.Fatalf("package-target manifest packages missing %q", httpAdapterPackagePath)
+}
+
+func assertOwnershipInventoryRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, ownershipinventory.InventoryRelativePath))
+	if err != nil {
+		t.Fatalf("read ownership inventory: %v", err)
+	}
+
+	var inventory struct {
+		Packages []ownershipinventory.PackageRow `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		t.Fatalf("decode ownership inventory: %v", err)
+	}
+
+	for _, row := range inventory.Packages {
+		if row.PackagePath != httpAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("ownership inventory disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != modelsOwner {
+			t.Fatalf("ownership inventory destination = %q, want %q", row.Destination, modelsOwner)
+		}
+		if row.DestinationKind != ownershipinventory.DestinationKindOwner {
+			t.Fatalf(
+				"ownership inventory destinationKind = %q, want %q",
+				row.DestinationKind,
+				ownershipinventory.DestinationKindOwner,
+			)
+		}
+		return
+	}
+	t.Fatalf("ownership inventory packages missing %q", httpAdapterPackagePath)
+}
+
+func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, relativePath))
+	if err != nil {
+		t.Fatalf("read %s coverage manifest: %v", lane, err)
+	}
+
+	var manifest coverageMinimumManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode %s coverage manifest: %v", lane, err)
+	}
+	if manifest.Lane != lane {
+		t.Fatalf("%s coverage manifest lane = %q, want %q", relativePath, manifest.Lane, lane)
+	}
+
+	for _, entry := range manifest.Packages {
+		if entry.Package != httpAdapterImportPath {
+			continue
+		}
+		if entry.Minimum < 0 {
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterImportPath)
+		}
+		return
+	}
+	t.Fatalf("%s coverage manifest missing %q", lane, httpAdapterImportPath)
+}

--- a/pkg/services/models/transports/http/pull_operations.go
+++ b/pkg/services/models/transports/http/pull_operations.go
@@ -1,0 +1,31 @@
+package http
+
+import (
+	"context"
+
+	"github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+// PullModel decodes the owned pull-model HTTP path input, invokes the accepted
+// Models root, and returns the pull result for HTTP encoding.
+func (a *Adapter) PullModel(ctx context.Context, modelName string) (models.PullResult, error) {
+	if a == nil || a.models == nil {
+		return models.PullResult{}, errModelsServiceRequired
+	}
+	request, err := pullModelRequestFromHTTP(modelName, a.scope)
+	if err != nil {
+		return models.PullResult{}, err
+	}
+	if a.scope.IsZero() {
+		return a.models.PullModel(ctx, request.Name)
+	}
+	return a.models.PullModelForScope(ctx, request)
+}
+
+func pullModelRequestFromHTTP(modelName string, scope models.RuntimeScopeRef) (models.PullModelRequest, error) {
+	request := models.PullModelRequest{Scope: scope, Name: modelName}
+	if err := models.ValidatePullModelRequest(request); err != nil {
+		return models.PullModelRequest{}, err
+	}
+	return request, nil
+}

--- a/pkg/services/models/transports/http/pull_operations_test.go
+++ b/pkg/services/models/transports/http/pull_operations_test.go
@@ -1,0 +1,121 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/models"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+func TestAdapter_PullModelInvokesFakeRootWithDecodedName(t *testing.T) {
+	t.Parallel()
+
+	var invokedName string
+	root := &rootFake{
+		pull: func(_ context.Context, name string) (models.PullResult, error) {
+			invokedName = name
+			return models.PullResult{
+				ModelName: name,
+				Outcome:   "PULLED",
+			}, nil
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{Models: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.PullModel(recorder, httptest.NewRequest(http.MethodPost, "/models/voice/pull", nil), "voice")
+
+	if invokedName != "voice" {
+		t.Fatalf("PullModel invoked root with name = %q, want voice", invokedName)
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	var response factoryapi.ModelPullResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.ModelName != "voice" || response.Outcome != factoryapi.ModelPullOutcomePULLED {
+		t.Fatalf("response = %#v, want encoded voice pull success", response)
+	}
+}
+
+func TestAdapter_PullModelRejectsEmptyNameBeforeFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &rootFake{
+		pull: func(context.Context, string) (models.PullResult, error) {
+			t.Fatal("fake root must not be invoked for empty model name")
+			return models.PullResult{}, nil
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{Models: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.PullModel(recorder, httptest.NewRequest(http.MethodPost, "/models//pull", nil), "   ")
+
+	assertCatalogHTTPError(t, recorder, http.StatusNotFound, "NOT_FOUND", "model not found")
+}
+
+func TestAdapter_PullModelEncodesPullErrorOutcome(t *testing.T) {
+	t.Parallel()
+
+	failure := models.PullResult{
+		ModelName:          "voice",
+		ManagedPullOutcome: "TIMED_OUT",
+		ReadinessState:     "FAILED",
+	}
+	root := &rootFake{
+		pull: func(context.Context, string) (models.PullResult, error) {
+			return models.PullResult{}, &models.PullError{Result: failure, Cause: errors.New("deadline exceeded")}
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{Models: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.PullModel(recorder, httptest.NewRequest(http.MethodPost, "/models/voice/pull", nil), "voice")
+
+	if recorder.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504 body = %s", recorder.Code, recorder.Body.String())
+	}
+	var response factoryapi.ModelPullResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.ManagedRuntimePull.PullOutcome != factoryapi.ManagedRuntimePullOutcomeTIMEDOUT {
+		t.Fatalf("pull outcome = %q, want TIMED_OUT", response.ManagedRuntimePull.PullOutcome)
+	}
+}
+
+func TestAdapter_ScopedPullDecodesIntoRootRequest(t *testing.T) {
+	t.Parallel()
+
+	scope, err := (models.RuntimeScopeRef{}).Parse("factory-session:http-scope")
+	if err != nil {
+		t.Fatalf("parse Models scope: %v", err)
+	}
+	var pullRequest models.PullModelRequest
+	root := &rootFake{
+		pullForScope: func(_ context.Context, request models.PullModelRequest) (models.PullResult, error) {
+			pullRequest = request
+			return models.PullResult{ModelName: request.Name, Outcome: "PULLED"}, nil
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{Models: root, Scope: scope}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.PullModel(recorder, httptest.NewRequest(http.MethodPost, "/models/voice/pull", nil), "voice")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	if pullRequest.Scope != scope || pullRequest.Name != "voice" {
+		t.Fatalf("PullModelForScope request = %#v, want scoped voice", pullRequest)
+	}
+}

--- a/pkg/services/models/transports/http/request_context.go
+++ b/pkg/services/models/transports/http/request_context.go
@@ -1,0 +1,46 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+// modelsRequestContextErrorResponse maps request-context cancellation and
+// deadline failures to the adapter's documented HTTP outcomes. Canceled
+// requests terminate without an error body; deadline failures return 504.
+func modelsRequestContextErrorResponse(err error) (status int, response any, handled bool) {
+	if err == nil {
+		return 0, nil, false
+	}
+	switch {
+	case errors.Is(err, context.Canceled):
+		return 0, nil, true
+	case errors.Is(err, context.DeadlineExceeded):
+		return http.StatusGatewayTimeout, factoryapi.ErrorResponse{
+			Message: "models request timed out",
+			Family:  factoryapi.ErrorFamilyInternalServerError,
+			Code:    factoryapi.ErrorResponseCodeINTERNALERROR,
+		}, true
+	default:
+		return 0, nil, false
+	}
+}
+
+func (h *Handler) writeModelsRequestContextOutcome(w http.ResponseWriter, err error) bool {
+	status, response, ok := modelsRequestContextErrorResponse(err)
+	if !ok {
+		return false
+	}
+	if response == nil {
+		return true
+	}
+	h.writeJSON(w, status, response)
+	return true
+}
+
+func (h *Handler) guardModelsRequestContext(w http.ResponseWriter, r *http.Request) bool {
+	return h.writeModelsRequestContextOutcome(w, r.Context().Err())
+}

--- a/pkg/services/models/transports/http/request_context_test.go
+++ b/pkg/services/models/transports/http/request_context_test.go
@@ -1,0 +1,205 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/pkg/services/models"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+func waitForModelsRoot(ctx context.Context, _ string) (models.Detail, error) {
+	<-ctx.Done()
+	return models.Detail{}, ctx.Err()
+}
+
+func waitForModelsPull(ctx context.Context, _ string) (models.PullResult, error) {
+	<-ctx.Done()
+	return models.PullResult{}, ctx.Err()
+}
+
+func TestHandler_ListModelsCanceledBeforeRootCallCompletesWithoutBody(t *testing.T) {
+	t.Parallel()
+
+	root := &rootFake{}
+	handler := NewHandlerFromRoot(RootBinding{Models: root}, zap.NewNop())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	recorder := httptest.NewRecorder()
+	handler.ListModels(recorder, httptest.NewRequest(http.MethodGet, "/models", nil).WithContext(ctx))
+
+	if body := recorder.Body.String(); body != "" {
+		t.Fatalf("response body = %q, want empty cancel-oriented outcome", body)
+	}
+}
+
+func TestHandler_GetModelCanceledDuringRootCallCompletesWithoutHang(t *testing.T) {
+	t.Parallel()
+
+	root := &rootFake{
+		get: waitForModelsRoot,
+	}
+	handler := NewHandlerFromRoot(RootBinding{Models: root}, zap.NewNop())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/models/voice", nil).WithContext(ctx)
+	recorder := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		handler.GetModel(recorder, req, "voice")
+		close(done)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetModel hung after request cancellation")
+	}
+	body := recorder.Body.String()
+	if body != "" {
+		t.Fatalf("response body = %q, want empty cancel-oriented outcome", body)
+	}
+}
+
+func TestHandler_PullModelCanceledDuringRootCallCompletesWithoutHang(t *testing.T) {
+	t.Parallel()
+
+	root := &rootFake{
+		pull: waitForModelsPull,
+	}
+	handler := NewHandlerFromRoot(RootBinding{Models: root}, zap.NewNop())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodPost, "/models/voice/pull", nil).WithContext(ctx)
+	recorder := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		handler.PullModel(recorder, req, "voice")
+		close(done)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("PullModel hung after request cancellation")
+	}
+	body := recorder.Body.String()
+	if body != "" {
+		t.Fatalf("response body = %q, want empty cancel-oriented outcome", body)
+	}
+}
+
+func TestHandler_ListModelsDeadlineExceededReturnsGatewayTimeout(t *testing.T) {
+	t.Parallel()
+
+	root := &rootFake{
+		list: func(ctx context.Context) (models.List, error) {
+			<-ctx.Done()
+			return models.List{}, ctx.Err()
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{Models: root}, zap.NewNop())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	recorder := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		handler.ListModels(recorder, httptest.NewRequest(http.MethodGet, "/models", nil).WithContext(ctx))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ListModels hung after request deadline")
+	}
+	if recorder.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504 Gateway Timeout", recorder.Code)
+	}
+	assertCatalogHTTPError(
+		t,
+		recorder,
+		http.StatusGatewayTimeout,
+		"INTERNAL_ERROR",
+		"models request timed out",
+	)
+}
+
+func TestHandler_PullModelDeadlineExceededReturnsGatewayTimeout(t *testing.T) {
+	t.Parallel()
+
+	root := &rootFake{
+		pull: func(ctx context.Context, _ string) (models.PullResult, error) {
+			<-ctx.Done()
+			return models.PullResult{}, ctx.Err()
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{Models: root}, zap.NewNop())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	recorder := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		handler.PullModel(recorder, httptest.NewRequest(http.MethodPost, "/models/voice/pull", nil).WithContext(ctx), "voice")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("PullModel hung after request deadline")
+	}
+	if recorder.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504 Gateway Timeout", recorder.Code)
+	}
+	assertCatalogHTTPError(
+		t,
+		recorder,
+		http.StatusGatewayTimeout,
+		"INTERNAL_ERROR",
+		"models request timed out",
+	)
+}
+
+func TestModelsRequestContextErrorResponseForTest(t *testing.T) {
+	t.Parallel()
+
+	if status, response, ok := ModelsRequestContextErrorResponseForTest(context.Canceled); !ok || status != 0 || response != nil {
+		t.Fatalf("canceled = (%d, %#v, %v), want (0, nil, true)", status, response, ok)
+	}
+
+	status, response, ok := ModelsRequestContextErrorResponseForTest(context.DeadlineExceeded)
+	if !ok || status != http.StatusGatewayTimeout {
+		t.Fatalf("deadline status = %d, ok = %v, want 504 true", status, ok)
+	}
+	body, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	if !strings.Contains(string(body), "models request timed out") {
+		t.Fatalf("response = %s, want timeout message", body)
+	}
+	if !strings.Contains(string(body), string(factoryapi.ErrorResponseCodeINTERNALERROR)) {
+		t.Fatalf("response = %s, want INTERNAL_ERROR code", body)
+	}
+}

--- a/pkg/services/models/transports/http/root_binding.go
+++ b/pkg/services/models/transports/http/root_binding.go
@@ -1,0 +1,66 @@
+package http
+
+import (
+	"context"
+
+	"github.com/portpowered/infinite-you/pkg/services/models"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	"go.uber.org/zap"
+)
+
+// ModelsRoot is the accepted Models root contract used by the HTTP adapter.
+// Adapter-owned operations invoke this surface rather than Models internal
+// packages.
+type ModelsRoot = models.Service
+
+// RootBinding binds the HTTP adapter to one injected Models root.
+type RootBinding struct {
+	Models  ModelsRoot
+	Invoker workers.ModelInvoker
+	Content work.ContentPreparation
+	Scope   models.RuntimeScopeRef
+}
+
+// NewHandlerFromRoot constructs an HTTP adapter that calls through the supplied
+// Models root. Tests inject a focused fake implementing ModelsRoot without
+// constructing real catalog assemblers, asset caches, host supervisors, lease
+// managers, inference runtimes, or service-local Wire graphs.
+func NewHandlerFromRoot(binding RootBinding, logger *zap.Logger) *Handler {
+	if binding.Invoker == nil {
+		binding.Invoker = noopModelInvoker{}
+	}
+	if binding.Content == nil {
+		binding.Content = noopContentPreparation{}
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	var scopes []models.RuntimeScopeRef
+	if !binding.Scope.IsZero() {
+		scopes = append(scopes, binding.Scope)
+	}
+	return NewHandler(
+		NewAdapter(binding.Models, binding.Invoker, binding.Content, scopes...),
+		logger,
+	)
+}
+
+type noopModelInvoker struct{}
+
+func (noopModelInvoker) InvokeModel(
+	_ context.Context,
+	_ string,
+	_ models.Request,
+) (models.Result, error) {
+	return models.Result{}, models.ErrUnsupportedOperation
+}
+
+type noopContentPreparation struct{}
+
+func (noopContentPreparation) PrepareWorkContent(
+	_ context.Context,
+	content []work.WorkContentPart,
+) ([]work.WorkContentPart, error) {
+	return content, nil
+}

--- a/pkg/services/models/transports/http/root_binding_test.go
+++ b/pkg/services/models/transports/http/root_binding_test.go
@@ -1,0 +1,68 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/models"
+	"go.uber.org/zap"
+)
+
+func TestHandlerFromRoot_ListModelsInvokesModelsRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	root := &rootFake{
+		list: func(context.Context) (models.List, error) {
+			invoked = true
+			return models.List{Results: []models.Summary{{Name: "voice"}}}, nil
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{Models: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.ListModels(recorder, httptest.NewRequest(http.MethodGet, "/models", nil))
+
+	if !invoked {
+		t.Fatal("ListModels did not invoke the injected Models root")
+	}
+	if recorder.Code != http.StatusOK || !strings.Contains(recorder.Body.String(), `"name":"voice"`) {
+		t.Fatalf("response = %d %s, want encoded model list from Models root", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestHandlerFromRoot_ListModelsRequiresInjectedRoot(t *testing.T) {
+	t.Parallel()
+
+	handler := NewHandlerFromRoot(RootBinding{}, zap.NewNop())
+	if handler != nil {
+		t.Fatalf("NewHandlerFromRoot without Models root = %#v, want nil", handler)
+	}
+}
+
+func TestNewHandlerFromRoot_ExposesInjectedModelsRoot(t *testing.T) {
+	t.Parallel()
+
+	root := &rootFake{}
+	handler := NewHandlerFromRoot(RootBinding{Models: root}, zap.NewNop())
+	if handler == nil || handler.adapter == nil {
+		t.Fatal("NewHandlerFromRoot returned nil handler or adapter")
+	}
+	if handler.adapter.Root() != root {
+		t.Fatal("adapter must expose the injected Models root")
+	}
+}
+
+func TestNewAdapterFromRoot_RejectsNilModelsRoot(t *testing.T) {
+	t.Parallel()
+
+	if adapter := NewAdapter(nil, noopModelInvoker{}, noopContentPreparation{}); adapter != nil {
+		t.Fatalf("NewAdapter(nil) = %#v, want nil", adapter)
+	}
+	if handler := NewHandlerFromRoot(RootBinding{}, zap.NewNop()); handler != nil {
+		t.Fatalf("NewHandlerFromRoot without Models root = %#v, want nil", handler)
+	}
+}

--- a/pkg/services/models/transports/http/root_error_mapping.go
+++ b/pkg/services/models/transports/http/root_error_mapping.go
@@ -125,3 +125,18 @@ func badRequestErrorResponseWithCode(message, code string) (int, factoryapi.Erro
 		Code:    factoryapi.ErrorResponseCode(code),
 	}, true
 }
+
+func modelsErrorMessageLeaksInternalDetail(message string) bool {
+	trimmed := strings.TrimSpace(message)
+	if trimmed == "" {
+		return true
+	}
+	lower := strings.ToLower(trimmed)
+	if strings.Contains(trimmed, "/internal/") ||
+		strings.Contains(trimmed, "pkg/services/models/internal") ||
+		strings.Contains(trimmed, ".go:") ||
+		strings.Contains(lower, "stack trace") {
+		return true
+	}
+	return false
+}

--- a/pkg/services/models/transports/http/root_error_mapping.go
+++ b/pkg/services/models/transports/http/root_error_mapping.go
@@ -1,0 +1,127 @@
+package http
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/services/models"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+type modelsHTTPOperation int
+
+const (
+	modelsHTTPOperationCatalog modelsHTTPOperation = iota
+	modelsHTTPOperationPull
+	modelsHTTPOperationInvoke
+)
+
+const (
+	catalogNotFoundMessage            = "model not found"
+	catalogListFailedMessage          = "failed to list models"
+	catalogGetFailedMessage           = "failed to load model"
+	pullFailedMessage                 = "failed to pull model"
+	invokeFailedMessage               = "model invocation failed"
+	catalogErrorCodeModelNotAvailable = "MODEL_NOT_AVAILABLE"
+)
+
+// RootErrorResponse maps typed Models root failures to HTTP status and the
+// public ErrorResponse shape. It returns false when err is not a known mapped
+// typed failure for the operation.
+func RootErrorResponse(err error, operation modelsHTTPOperation) (int, factoryapi.ErrorResponse, bool) {
+	if err == nil {
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+
+	if operation == modelsHTTPOperationInvoke {
+		if failure, ok := workers.AsInferenceFailure(err); ok {
+			return inferenceFailureErrorResponse(failure)
+		}
+	}
+
+	switch {
+	case errors.Is(err, models.ErrNotFound):
+		return notFoundErrorResponse(catalogNotFoundMessage)
+	case errors.Is(err, models.ErrUnavailable) && operation == modelsHTTPOperationCatalog:
+		return modelNotAvailableErrorResponse(strings.TrimSpace(err.Error()))
+	case errors.Is(err, models.ErrMissing), errors.Is(err, models.ErrNotAvailable):
+		return modelNotAvailableErrorResponse(strings.TrimSpace(err.Error()))
+	case errors.Is(err, models.ErrLoading):
+		return conflictErrorResponse(strings.TrimSpace(err.Error()), "MODEL_RUNTIME_LOADING")
+	case errors.Is(err, models.ErrFailed):
+		return serviceUnavailableErrorResponse(strings.TrimSpace(err.Error()), "MODEL_RUNTIME_FAILED")
+	case errors.Is(err, models.ErrUnsupported):
+		return badRequestErrorResponseWithCode(strings.TrimSpace(err.Error()), "MODEL_RUNTIME_UNSUPPORTED")
+	case errors.Is(err, models.ErrUnsupportedOperation), errors.Is(err, models.ErrUnsupportedResponseMode):
+		return badRequestErrorResponse(strings.TrimSpace(err.Error()))
+	case errors.Is(err, models.ErrPullUnsupported) && operation == modelsHTTPOperationPull:
+		return badRequestErrorResponse(strings.TrimSpace(err.Error()))
+	default:
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+}
+
+// CatalogRootErrorResponse maps typed Models catalog root failures to HTTP
+// status and the public ErrorResponse shape. It returns false when err is not a
+// known mapped typed failure.
+func CatalogRootErrorResponse(err error) (int, factoryapi.ErrorResponse, bool) {
+	return RootErrorResponse(err, modelsHTTPOperationCatalog)
+}
+
+func inferenceFailureErrorResponse(failure *workers.InferenceFailure) (int, factoryapi.ErrorResponse, bool) {
+	if failure == nil {
+		return 0, factoryapi.ErrorResponse{}, false
+	}
+	status := inferenceFailureHTTPStatus(failure)
+	return status, factoryapi.ErrorResponse{
+		Message: failure.Error(),
+		Family:  errorFamilyForStatus(status),
+		Code:    factoryapi.ErrorResponseCode(inferenceFailureErrorCode(failure)),
+	}, true
+}
+
+func notFoundErrorResponse(message string) (int, factoryapi.ErrorResponse, bool) {
+	return http.StatusNotFound, factoryapi.ErrorResponse{
+		Message: message,
+		Family:  factoryapi.ErrorFamilyNotFound,
+		Code:    factoryapi.ErrorResponseCodeNOTFOUND,
+	}, true
+}
+
+func modelNotAvailableErrorResponse(message string) (int, factoryapi.ErrorResponse, bool) {
+	return http.StatusNotFound, factoryapi.ErrorResponse{
+		Message: message,
+		Family:  factoryapi.ErrorFamilyNotFound,
+		Code:    factoryapi.ErrorResponseCode(catalogErrorCodeModelNotAvailable),
+	}, true
+}
+
+func conflictErrorResponse(message, code string) (int, factoryapi.ErrorResponse, bool) {
+	return http.StatusConflict, factoryapi.ErrorResponse{
+		Message: message,
+		Family:  factoryapi.ErrorFamilyConflict,
+		Code:    factoryapi.ErrorResponseCode(code),
+	}, true
+}
+
+func serviceUnavailableErrorResponse(message, code string) (int, factoryapi.ErrorResponse, bool) {
+	return http.StatusServiceUnavailable, factoryapi.ErrorResponse{
+		Message: message,
+		Family:  factoryapi.ErrorFamilyInternalServerError,
+		Code:    factoryapi.ErrorResponseCode(code),
+	}, true
+}
+
+func badRequestErrorResponse(message string) (int, factoryapi.ErrorResponse, bool) {
+	return badRequestErrorResponseWithCode(message, "BAD_REQUEST")
+}
+
+func badRequestErrorResponseWithCode(message, code string) (int, factoryapi.ErrorResponse, bool) {
+	return http.StatusBadRequest, factoryapi.ErrorResponse{
+		Message: message,
+		Family:  factoryapi.ErrorFamilyBadRequest,
+		Code:    factoryapi.ErrorResponseCode(code),
+	}, true
+}

--- a/pkg/services/models/transports/http/root_error_mapping_test.go
+++ b/pkg/services/models/transports/http/root_error_mapping_test.go
@@ -1,0 +1,338 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/models"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+func TestRootErrorResponse_MapsRepresentativeTypedFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		operation  modelsHTTPOperation
+		err        error
+		wantStatus int
+		wantCode   string
+		wantFamily factoryapi.ErrorFamily
+	}{
+		{
+			name:       "catalog not found",
+			operation:  modelsHTTPOperationCatalog,
+			err:        models.ErrNotFound,
+			wantStatus: http.StatusNotFound,
+			wantCode:   "NOT_FOUND",
+			wantFamily: factoryapi.ErrorFamilyNotFound,
+		},
+		{
+			name:       "catalog unavailable",
+			operation:  modelsHTTPOperationCatalog,
+			err:        models.ErrUnavailable,
+			wantStatus: http.StatusNotFound,
+			wantCode:   "MODEL_NOT_AVAILABLE",
+			wantFamily: factoryapi.ErrorFamilyNotFound,
+		},
+		{
+			name:       "pull not found",
+			operation:  modelsHTTPOperationPull,
+			err:        models.ErrNotFound,
+			wantStatus: http.StatusNotFound,
+			wantCode:   "NOT_FOUND",
+			wantFamily: factoryapi.ErrorFamilyNotFound,
+		},
+		{
+			name:       "pull unsupported",
+			operation:  modelsHTTPOperationPull,
+			err:        models.ErrPullUnsupported,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "BAD_REQUEST",
+			wantFamily: factoryapi.ErrorFamilyBadRequest,
+		},
+		{
+			name:       "pull not available",
+			operation:  modelsHTTPOperationPull,
+			err:        models.ErrNotAvailable,
+			wantStatus: http.StatusNotFound,
+			wantCode:   "MODEL_NOT_AVAILABLE",
+			wantFamily: factoryapi.ErrorFamilyNotFound,
+		},
+		{
+			name:       "invoke missing runtime",
+			operation:  modelsHTTPOperationInvoke,
+			err:        models.ErrMissing,
+			wantStatus: http.StatusNotFound,
+			wantCode:   "MODEL_NOT_AVAILABLE",
+			wantFamily: factoryapi.ErrorFamilyNotFound,
+		},
+		{
+			name:       "invoke loading runtime",
+			operation:  modelsHTTPOperationInvoke,
+			err:        models.ErrLoading,
+			wantStatus: http.StatusConflict,
+			wantCode:   "MODEL_RUNTIME_LOADING",
+			wantFamily: factoryapi.ErrorFamilyConflict,
+		},
+		{
+			name:       "invoke failed runtime",
+			operation:  modelsHTTPOperationInvoke,
+			err:        models.ErrFailed,
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   "MODEL_RUNTIME_FAILED",
+			wantFamily: factoryapi.ErrorFamilyInternalServerError,
+		},
+		{
+			name:       "invoke unsupported runtime",
+			operation:  modelsHTTPOperationInvoke,
+			err:        models.ErrUnsupported,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "MODEL_RUNTIME_UNSUPPORTED",
+			wantFamily: factoryapi.ErrorFamilyBadRequest,
+		},
+		{
+			name:       "invoke unsupported operation",
+			operation:  modelsHTTPOperationInvoke,
+			err:        models.ErrUnsupportedOperation,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "BAD_REQUEST",
+			wantFamily: factoryapi.ErrorFamilyBadRequest,
+		},
+		{
+			name:       "invoke unsupported response mode",
+			operation:  modelsHTTPOperationInvoke,
+			err:        models.ErrUnsupportedResponseMode,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "BAD_REQUEST",
+			wantFamily: factoryapi.ErrorFamilyBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			status, response, ok := RootErrorResponse(tt.err, tt.operation)
+			if !ok {
+				t.Fatalf("RootErrorResponse(%v, %v) = not handled, want typed outcome", tt.err, tt.operation)
+			}
+			if status != tt.wantStatus ||
+				response.Family != tt.wantFamily ||
+				string(response.Code) != tt.wantCode {
+				t.Fatalf("RootErrorResponse(%v, %v) = %d %#v, want %d family=%s code=%s",
+					tt.err, tt.operation, status, response, tt.wantStatus, tt.wantFamily, tt.wantCode)
+			}
+			if strings.TrimSpace(response.Message) == "" {
+				t.Fatalf("RootErrorResponse(%v, %v) message = %q, want non-empty public message", tt.err, tt.operation, response.Message)
+			}
+		})
+	}
+}
+
+func TestRootErrorResponse_MapsInferenceFailureForInvoke(t *testing.T) {
+	t.Parallel()
+
+	failure := &workers.InferenceFailure{
+		Class:   workers.InferenceFailureClassTimeout,
+		Message: "model inference timed out",
+	}
+	status, response, ok := RootErrorResponse(failure, modelsHTTPOperationInvoke)
+	if !ok {
+		t.Fatal("RootErrorResponse(InferenceFailure) = not handled, want typed invoke failure")
+	}
+	if status != http.StatusGatewayTimeout ||
+		response.Family != factoryapi.ErrorFamilyInternalServerError ||
+		response.Code != factoryapi.ErrorResponseCode("MODEL_INFERENCE_TIMEOUT") ||
+		response.Message != failure.Error() {
+		t.Fatalf("RootErrorResponse(InferenceFailure) = %d %#v, want timeout inference failure", status, response)
+	}
+}
+
+func TestRootErrorResponse_IgnoresCrossOperationTypedFailures(t *testing.T) {
+	t.Parallel()
+
+	if _, _, ok := RootErrorResponse(models.ErrUnavailable, modelsHTTPOperationPull); ok {
+		t.Fatal("RootErrorResponse(ErrUnavailable, pull) = handled, want catalog-only mapping")
+	}
+	if _, _, ok := RootErrorResponse(models.ErrPullUnsupported, modelsHTTPOperationInvoke); ok {
+		t.Fatal("RootErrorResponse(ErrPullUnsupported, invoke) = handled, want pull-only mapping")
+	}
+}
+
+func TestRootErrorResponse_LeavesUnmappedInternalFailures(t *testing.T) {
+	t.Parallel()
+
+	internalErr := errors.New("pkg/services/models/internal/cache: /tmp/models unavailable")
+	for _, operation := range []modelsHTTPOperation{
+		modelsHTTPOperationCatalog,
+		modelsHTTPOperationPull,
+		modelsHTTPOperationInvoke,
+	} {
+		if _, _, ok := RootErrorResponse(internalErr, operation); ok {
+			t.Fatalf("RootErrorResponse(%v, %v) = handled, want unmapped internal failure", internalErr, operation)
+		}
+	}
+}
+
+func TestHandler_PullModelMapsTypedRootFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		rootErr     error
+		wantStatus  int
+		wantCode    string
+		wantMessage string
+	}{
+		{
+			name:        "not found",
+			rootErr:     models.ErrNotFound,
+			wantStatus:  http.StatusNotFound,
+			wantCode:    "NOT_FOUND",
+			wantMessage: catalogNotFoundMessage,
+		},
+		{
+			name:        "pull unsupported",
+			rootErr:     fmt.Errorf("%w: model is cloud-only", models.ErrPullUnsupported),
+			wantStatus:  http.StatusBadRequest,
+			wantCode:    "BAD_REQUEST",
+			wantMessage: "model pull is not supported: model is cloud-only",
+		},
+		{
+			name:        "not available",
+			rootErr:     models.ErrNotAvailable,
+			wantStatus:  http.StatusNotFound,
+			wantCode:    "MODEL_NOT_AVAILABLE",
+			wantMessage: models.ErrNotAvailable.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := &rootFake{
+				pull: func(context.Context, string) (models.PullResult, error) {
+					return models.PullResult{}, tt.rootErr
+				},
+			}
+			handler := NewHandlerFromRoot(RootBinding{Models: root}, zap.NewNop())
+			recorder := httptest.NewRecorder()
+
+			handler.PullModel(recorder, httptest.NewRequest(http.MethodPost, "/models/voice/pull", nil), "voice")
+
+			assertCatalogHTTPError(t, recorder, tt.wantStatus, tt.wantCode, tt.wantMessage)
+		})
+	}
+}
+
+func TestHandler_PullModelUnmappedFailureDoesNotLeakInternalPaths(t *testing.T) {
+	t.Parallel()
+
+	root := &rootFake{
+		pull: func(context.Context, string) (models.PullResult, error) {
+			return models.PullResult{}, errors.New("pkg/services/models/internal/cache: /tmp/models unavailable")
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{Models: root}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.PullModel(recorder, httptest.NewRequest(http.MethodPost, "/models/voice/pull", nil), "voice")
+
+	assertCatalogHTTPError(t, recorder, http.StatusInternalServerError, "INTERNAL_ERROR", pullFailedMessage)
+}
+
+func TestHandler_InvokeModelMapsTypedRootFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		rootErr     error
+		wantStatus  int
+		wantCode    string
+		wantMessage string
+	}{
+		{
+			name:        "loading runtime",
+			rootErr:     models.ErrLoading,
+			wantStatus:  http.StatusConflict,
+			wantCode:    "MODEL_RUNTIME_LOADING",
+			wantMessage: models.ErrLoading.Error(),
+		},
+		{
+			name:        "failed runtime",
+			rootErr:     models.ErrFailed,
+			wantStatus:  http.StatusServiceUnavailable,
+			wantCode:    "MODEL_RUNTIME_FAILED",
+			wantMessage: models.ErrFailed.Error(),
+		},
+		{
+			name:        "unsupported runtime",
+			rootErr:     models.ErrUnsupported,
+			wantStatus:  http.StatusBadRequest,
+			wantCode:    "MODEL_RUNTIME_UNSUPPORTED",
+			wantMessage: models.ErrUnsupported.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			invoker := invokeInvokerFake{
+				invoke: func(context.Context, string, models.Request) (models.Result, error) {
+					return models.Result{}, tt.rootErr
+				},
+			}
+			handler := NewHandlerFromRoot(RootBinding{
+				Models:  &rootFake{},
+				Invoker: invoker,
+			}, zap.NewNop())
+			recorder := httptest.NewRecorder()
+			body := `{"operation":"TTS","content":[{"type":"TEXT","text":"hello"}]}`
+
+			handler.InvokeModel(
+				recorder,
+				httptest.NewRequest(http.MethodPost, "/models/voice/invocations", strings.NewReader(body)),
+				"voice",
+			)
+
+			assertCatalogHTTPError(t, recorder, tt.wantStatus, tt.wantCode, tt.wantMessage)
+		})
+	}
+}
+
+func TestHandler_InvokeModelUnmappedFailureDoesNotLeakInternalPaths(t *testing.T) {
+	t.Parallel()
+
+	invoker := invokeInvokerFake{
+		invoke: func(context.Context, string, models.Request) (models.Result, error) {
+			return models.Result{}, errors.New("pkg/services/models/internal/runtime: stack trace at invoke.go:42")
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{
+		Models:  &rootFake{},
+		Invoker: invoker,
+	}, zap.NewNop())
+	recorder := httptest.NewRecorder()
+	body := `{"operation":"TTS","content":[{"type":"TEXT","text":"hello"}]}`
+
+	handler.InvokeModel(
+		recorder,
+		httptest.NewRequest(http.MethodPost, "/models/voice/invocations", strings.NewReader(body)),
+		"voice",
+	)
+
+	assertCatalogHTTPError(t, recorder, http.StatusInternalServerError, "INTERNAL_ERROR", invokeFailedMessage)
+}


### PR DESCRIPTION
{
  "project": "PSS HTTP-MOD — Models Owner-Local HTTP Adapter",
  "branchName": "pss-http-mod-adapter",
  "description": "Implement the Models service-owned HTTP adapter so Models HTTP requests decode/map through the accepted Models root, typed errors become stable HTTP ErrorResponse bodies, and fake-root tests prove mapping plus cancel/timeout parity—without importing Models internals, owning canonical state, authoring shared OpenAPI, or editing Wire/root/initializer/CLI composition.",
  "context": {
    "customerAsk": "Implement HTTP-MOD as the Models service-owned HTTP adapter. Decode/map Models HTTP requests through the accepted Models root, translate typed errors, and prove fake-root parity for mapping and cancel/timeout behavior without importing Models internals or owning canonical state. Do not author shared OpenAPI or perform PSS-I02 route/client fan-in. Do not edit pkg/wire, pkg/root, pkg/initializer, top-level CLI composition, or reopen Models IMP/LWR ownership. Shared coverage, ownership, and package-target manifest edits are allowed and must be rebased through the merge loop. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Models already has an accepted root contract, terminal IMP owners including IMP-MOD-06, and accepted LWR-MOD, but HTTP-MOD still needs complete Models-owned HTTP adapter behavior: decode/map through the accepted Models root only, translate typed Models errors into stable HTTP ErrorResponse bodies, and prove fake-root mapping plus cancel/timeout parity—without drifting into internals, shared OpenAPI authorship, or composition ownership reserved for later PSS fan-in.",
    "solution": "Implement the Models owner-local HTTP adapter so it binds to the accepted Models root, decodes and maps Models HTTP catalog/pull/invoke operations through that root, translates typed root errors into public HTTP error responses, and proves fake-root parity for mapping plus cancel/timeout behavior without importing Models internals, owning canonical model/runtime state, authoring shared OpenAPI, performing PSS-I02 route/client fan-in, or changing Wire/root/initializer/CLI composition."
  },
  "acceptanceCriteria": [
    "AC-1: Models HTTP operations owned by this packet decode requests and map responses through the accepted Models root contract only (no Models internal imports; adapter does not become canonical state owner)",
    "AC-2: Typed Models root errors surface as stable public HTTP ErrorResponse bodies with reviewer-verifiable status/code/family outcomes",
    "AC-3: Focused fake-root tests prove request/response mapping parity for the adapter-owned Models HTTP operations covered by this packet",
    "AC-4: Focused fake-root tests prove cancel and timeout behavior at the HTTP adapter edge (canceled or deadline-exceeded request context yields the adapter’s documented HTTP outcome without hanging)",
    "AC-5: Shared coverage, ownership, and package-target manifest edits occur only as required to register the Models HTTP adapter package and remain rebased through the merge loop",
    "AC-6: Diff stays inside HTTP-MOD ownership: Models HTTP adapter paths and allowed shared manifests; no shared OpenAPI authorship, no PSS-I02 route/client fan-in, no pkg/wire / pkg/root / pkg/initializer, no top-level CLI composition, and no CLI-MOD / MCP-MOD / other-service HTTP adapter edits",
    "AC-7: Quality checks pass (typecheck, lint, tests)",
    "AC-8: Delivery loop continues until required CI is terminal and passing, all blocking PR conversation feedback is addressed, merge conflicts and shared-file churn are reconciled, and the PR is actually merged"
  ],
  "userStories": [
    {
      "id": "pss-http-mod-adapter-001",
      "title": "Bind Models HTTP adapter to Models root via fake-root seam",
      "description": "As a maintainer, I want the Models HTTP adapter to invoke the accepted Models root (or a fake implementing that root) so HTTP adaptation cannot depend on Models internals or own canonical model/runtime state.",
      "acceptanceCriteria": [
        "Adapter-owned Models HTTP operations call through the accepted Models root contract surface (models.Service) rather than Models internal packages",
        "A focused fake Models root can be injected for adapter tests without constructing real catalog assemblers, asset caches, host supervisors, lease managers, inference runtimes, or service-local Wire graphs",
        "Package-boundary evidence shows the adapter package does not import pkg/services/models/internal/**",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-mod-adapter-002",
      "title": "Decode and map Models catalog list/get HTTP through the root",
      "description": "As an API client, I want Models catalog list and get HTTP operations to decode into Models root request values and encode root results so HTTP responses match the root catalog contract outcomes.",
      "acceptanceCriteria": [
        "Representative owned list/get Models HTTP operations decode path/query inputs into Models root request values (ListModels / ListCatalog and GetModel / GetCatalogModel as applicable) before invocation",
        "Fake-root success results are encoded into the public HTTP success response shape for those operations",
        "Missing-model and unavailable-catalog style root failures for those operations return typed HTTP outcomes without leaking internal package paths",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-mod-adapter-003",
      "title": "Decode and map Models pull and invoke HTTP through the root",
      "description": "As an API client, I want Models pull and invoke HTTP operations to map through the accepted Models root so asset-pull and invocation HTTP behavior stays aligned with root pull/invoke vocabulary—without authoring shared OpenAPI.",
      "acceptanceCriteria": [
        "Representative owned pull HTTP operations decode into Models root pull request values and invoke the fake root with those values; success and PullError-shaped outcomes encode into the documented HTTP pull response shape",
        "Representative owned invoke HTTP operations decode generated invocation request bodies into Models root invocation request values, invoke through the accepted Models root invocation surface, and encode success results (including stream-file responses when present) into the documented HTTP invoke response shape",
        "Invalid invoke payloads that fail decode/validation are rejected with a typed bad-request HTTP outcome before treating the fake root as successful",
        "Diff does not author api/openapi-main.yaml / api/components/** shared OpenAPI and does not perform PSS-I02 route/client fan-in",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-mod-adapter-004",
      "title": "Translate typed Models root errors to HTTP ErrorResponse",
      "description": "As an API client, I want typed Models root failures to become stable HTTP error responses so callers can rely on status, family, and code without opaque transport failures.",
      "acceptanceCriteria": [
        "Fake root returns of representative typed Models errors (at least not-found, not-available/missing, loading, failed/unsupported, and pull-unsupported or bad-request classes applicable to owned operations) map to the documented HTTP status, error family, and error code",
        "Error response body is a public ErrorResponse (message + family + code) rather than an untyped plaintext failure",
        "Unmapped/internal fake-root failures do not leak Models internal package paths, cache directories, or stack traces in the HTTP body",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-mod-adapter-005",
      "title": "Prove cancel and timeout parity at the HTTP adapter edge",
      "description": "As an API client, I want canceled or timed-out Models HTTP requests to terminate with the adapter’s documented outcome so pull and invoke calls do not hang after the client gives up.",
      "acceptanceCriteria": [
        "When the request context is canceled before or during a fake-root call, the adapter completes with the documented cancel-oriented HTTP outcome and does not hang",
        "When the request context deadline is exceeded during a fake-root call, the adapter completes with the documented timeout-oriented HTTP outcome and does not hang",
        "Fake-root tests cover at least one long-running owned Models HTTP path (pull or invoke) and one additional owned Models HTTP path (catalog list/get)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-mod-adapter-006",
      "title": "Register adapter package in allowed shared manifests",
      "description": "As a maintainer, I want the Models HTTP adapter package registered in shared coverage/ownership/package-target manifests only as required so package ownership and verification targets stay accurate without widening into excluded composition surfaces.",
      "acceptanceCriteria": [
        "Shared coverage, ownership, and/or package-target manifest entries for pkg/services/models/transports/http (or the chosen owner-local Models HTTP adapter path) are added or updated only when required for adapter package registration",
        "Manifest edits stay limited to those allowed shared manifests; no shared OpenAPI authorship and no PSS-I02 route/client fan-in changes",
        "Diff does not edit pkg/wire, pkg/root, pkg/initializer, top-level CLI composition, CLI-MOD paths, Models MCP adapters, or other services’ HTTP adapters",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-http-mod-adapter-007",
      "title": "Close delivery loop through merged PR",
      "description": "As a maintainer, I want the HTTP-MOD implementation/review cycle to continue until the PR is actually merged so the Factory work item is not left merely green or approved.",
      "acceptanceCriteria": [
        "Implementation PR for pss-http-mod-adapter is opened against the integration branch used by this program",
        "Required CI is terminal and passing on the PR head used for merge",
        "Every blocking PR conversation comment is explicitly addressed (fixed or answered with rationale)",
        "Merge conflicts and shared-file churn (including allowed manifest files) are reconciled",
        "PR is actually merged; opened/green/approved/ready-to-merge alone is not sufficient",
        "Typecheck passes"
      ],
      "priority": 7,
      "passes": false,
      "notes": ""
    }
  ]
}
