### PR TITLE
pss-mcp-mod-adapter

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1333,6 +1333,16 @@
       "minimum": 61.93
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/transports/mcp",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/wire",
       "minimum": 53.93
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1177,6 +1177,10 @@
       "minimum": 76.42
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/transports/mcp",
+      "minimum": 75.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/wire",
       "minimum": 71.18
     },

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -3834,6 +3834,12 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/models/transports/mcp",
+      "disposition": "retain",
+      "destination": "models",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/models/wire",
       "disposition": "retain",
       "destination": "models",

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -287,6 +287,7 @@
     "pkg/services/models/internal/services/runtime_scopes/wire",
     "pkg/services/models/transports/cli",
     "pkg/services/models/transports/http",
+    "pkg/services/models/transports/mcp",
     "pkg/services/models/wire",
     "pkg/services/operator_settings",
     "pkg/services/operator_settings/identityinventory",
@@ -1726,6 +1727,11 @@
     },
     {
       "packagePath": "pkg/services/models/transports/http",
+      "disposition": "retain",
+      "destination": "models"
+    },
+    {
+      "packagePath": "pkg/services/models/transports/mcp",
       "disposition": "retain",
       "destination": "models"
     },

--- a/pkg/services/models/transports/mcp/acquire_lease.go
+++ b/pkg/services/models/transports/mcp/acquire_lease.go
@@ -21,6 +21,9 @@ func AcquireLease(
 	service models.Service,
 	input AcquireLeaseInput,
 ) ToolResponse[AcquireLeaseResult] {
+	if response, done := requestContextErrorResponse[AcquireLeaseResult](ctx); done {
+		return response
+	}
 	if service == nil {
 		envelope := unavailableServiceErrorEnvelope()
 		return ToolResponse[AcquireLeaseResult]{Error: &envelope}

--- a/pkg/services/models/transports/mcp/acquire_lease.go
+++ b/pkg/services/models/transports/mcp/acquire_lease.go
@@ -1,0 +1,52 @@
+package modelmcp
+
+import (
+	"context"
+	"strings"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+// AcquireLeaseInput is the MCP request shape for you.model.acquire_lease.
+type AcquireLeaseInput struct {
+	RuntimeScopeRef string `json:"runtimeScopeRef"`
+	Name            string `json:"name"`
+	Holder          string `json:"holder"`
+}
+
+// AcquireLease reserves scoped model capacity through the
+// you.model.acquire_lease MCP tool.
+func AcquireLease(
+	ctx context.Context,
+	service models.Service,
+	input AcquireLeaseInput,
+) ToolResponse[AcquireLeaseResult] {
+	if service == nil {
+		envelope := unavailableServiceErrorEnvelope()
+		return ToolResponse[AcquireLeaseResult]{Error: &envelope}
+	}
+	scope, err := (models.RuntimeScopeRef{}).Parse(input.RuntimeScopeRef)
+	if err != nil {
+		envelope := decodeInputErrorEnvelope("decode acquire lease input", err)
+		return ToolResponse[AcquireLeaseResult]{Error: &envelope}
+	}
+	if strings.TrimSpace(input.Name) == "" {
+		envelope := decodeInputErrorEnvelope("decode acquire lease input", errEmptyModelName)
+		return ToolResponse[AcquireLeaseResult]{Error: &envelope}
+	}
+	if strings.TrimSpace(input.Holder) == "" {
+		envelope := decodeInputErrorEnvelope("decode acquire lease input", errEmptyLeaseHolder)
+		return ToolResponse[AcquireLeaseResult]{Error: &envelope}
+	}
+	result, err := service.AcquireModelLease(ctx, models.AcquireModelLeaseRequest{
+		Scope:  scope,
+		Name:   input.Name,
+		Holder: input.Holder,
+	})
+	if err != nil {
+		envelope := acquireLeaseErrorEnvelope(err)
+		return ToolResponse[AcquireLeaseResult]{Error: &envelope}
+	}
+	projected := projectAcquireLeaseResult(result)
+	return ToolResponse[AcquireLeaseResult]{Result: &projected}
+}

--- a/pkg/services/models/transports/mcp/acquire_lease_test.go
+++ b/pkg/services/models/transports/mcp/acquire_lease_test.go
@@ -1,0 +1,204 @@
+package modelmcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	modelmcp "github.com/portpowered/infinite-you/pkg/services/models/transports/mcp"
+)
+
+const (
+	testLeaseHolder    = "mcp-worker-1"
+	testLeaseRef       = "model-lease-test-001"
+	testInvokeOperation = "generate"
+)
+
+func TestBind_AcquireLeaseSuccessReturnsLeaseFactsFromInjectedRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	expiresAt := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	fake := fakeModelsRoot{
+		invoked: &invoked,
+		acquireModelLease: func(_ context.Context, request models.AcquireModelLeaseRequest) (models.AcquireModelLeaseResult, error) {
+			if request.Scope.String() != testRuntimeScopeRef {
+				t.Fatalf("scope = %q, want %q", request.Scope.String(), testRuntimeScopeRef)
+			}
+			if request.Name != testPrepareModelName {
+				t.Fatalf("name = %q, want %q", request.Name, testPrepareModelName)
+			}
+			if request.Holder != testLeaseHolder {
+				t.Fatalf("holder = %q, want %q", request.Holder, testLeaseHolder)
+			}
+			leaseRef, err := (models.ModelLeaseRef{}).Parse(testLeaseRef)
+			if err != nil {
+				t.Fatalf("parse lease ref: %v", err)
+			}
+			scope, err := (models.RuntimeScopeRef{}).Parse(testRuntimeScopeRef)
+			if err != nil {
+				t.Fatalf("parse scope: %v", err)
+			}
+			return models.AcquireModelLeaseResult{
+				Lease: models.ModelLease{
+					Lease:         leaseRef,
+					Scope:         scope,
+					ModelName:     testPrepareModelName,
+					Holder:        testLeaseHolder,
+					ExpiresAt:     expiresAt,
+					Status:        models.ModelLeaseStatusActive,
+					HostReadiness: models.ReadinessStateReady,
+				},
+			}, nil
+		},
+	}
+	operation := modelmcp.Bind(modelmcp.RootBinding{Models: fake})
+	raw, err := operation(
+		context.Background(),
+		modelmcp.ToolAcquireLease,
+		acquireLeaseInputJSON(testRuntimeScopeRef, testPrepareModelName, testLeaseHolder),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(acquire_lease) transport error = %v, want typed tool response", err)
+	}
+	if !invoked {
+		t.Fatal("fake models root was not invoked")
+	}
+	var response modelmcp.ToolResponse[modelmcp.AcquireLeaseResult]
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode tool response: %v", err)
+	}
+	if response.Error != nil || response.Result == nil {
+		t.Fatalf("tool response = %s, want success envelope", raw)
+	}
+	if response.Result.Lease.Lease != testLeaseRef {
+		t.Fatalf("lease ref = %q, want %q", response.Result.Lease.Lease, testLeaseRef)
+	}
+	if response.Result.Lease.ModelName != testPrepareModelName {
+		t.Fatalf("lease.modelName = %q, want %q", response.Result.Lease.ModelName, testPrepareModelName)
+	}
+	if response.Result.Lease.Holder != testLeaseHolder {
+		t.Fatalf("lease.holder = %q, want %q", response.Result.Lease.Holder, testLeaseHolder)
+	}
+	if response.Result.Lease.Status != models.ModelLeaseStatusActive {
+		t.Fatalf("lease.status = %q, want %q", response.Result.Lease.Status, models.ModelLeaseStatusActive)
+	}
+}
+
+func TestBind_AcquireLeaseDomainErrorsReturnTypedEnvelopes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		rootErr       error
+		wantCode      string
+		wantRetryable bool
+	}{
+		{
+			name:          "capacity exhausted",
+			rootErr:       models.ErrHostCapacityExhausted,
+			wantCode:      "model.lease.capacity_exhausted",
+			wantRetryable: true,
+		},
+		{
+			name:          "runtime not ready",
+			rootErr:       models.ErrHostRuntimeNotReady,
+			wantCode:      "model.host.runtime_not_ready",
+			wantRetryable: true,
+		},
+		{
+			name:          "capacity contended",
+			rootErr:       models.ErrHostCapacityContended,
+			wantCode:      "model.lease.capacity_contended",
+			wantRetryable: true,
+		},
+		{
+			name:          "foreign scope",
+			rootErr:       models.ErrRuntimeScopeForeign,
+			wantCode:      "model.runtime_scope.foreign",
+			wantRetryable: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := fakeModelsRoot{
+				acquireModelLease: func(context.Context, models.AcquireModelLeaseRequest) (models.AcquireModelLeaseResult, error) {
+					return models.AcquireModelLeaseResult{}, test.rootErr
+				},
+			}
+			operation := modelmcp.Bind(modelmcp.RootBinding{Models: fake})
+			raw, err := operation(
+				context.Background(),
+				modelmcp.ToolAcquireLease,
+				acquireLeaseInputJSON(testRuntimeScopeRef, testPrepareModelName, testLeaseHolder),
+			)
+			if err != nil {
+				t.Fatalf("CallTool(acquire_lease) transport error = %v, want typed tool response", err)
+			}
+			envelope := assertTypedToolErrorEnvelope(t, raw, test.wantCode, test.wantRetryable)
+			if envelope.Details == nil || envelope.Details["reason"] != test.rootErr.Error() {
+				t.Fatalf("error.details = %#v, want reason %q", envelope.Details, test.rootErr.Error())
+			}
+		})
+	}
+}
+
+func TestBind_AcquireLeaseInvalidJSONReturnsBadRequestWithoutInvokingFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	operation := modelmcp.Bind(modelmcp.RootBinding{
+		Models: fakeModelsRoot{invoked: &invoked},
+	})
+	raw, err := operation(
+		context.Background(),
+		modelmcp.ToolAcquireLease,
+		json.RawMessage(`{"runtimeScopeRef":"`+testRuntimeScopeRef+`",`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(acquire_lease) transport error = %v, want typed tool response", err)
+	}
+	assertBadRequestToolResponse(t, raw)
+	if invoked {
+		t.Fatal("fake models root was invoked for invalid JSON decode")
+	}
+}
+
+func TestBind_AcquireLeaseMissingHolderReturnsBadRequestWithoutInvokingFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	operation := modelmcp.Bind(modelmcp.RootBinding{
+		Models: fakeModelsRoot{invoked: &invoked},
+	})
+	raw, err := operation(
+		context.Background(),
+		modelmcp.ToolAcquireLease,
+		json.RawMessage(`{"runtimeScopeRef":"`+testRuntimeScopeRef+`","name":"`+testPrepareModelName+`","holder":""}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(acquire_lease) transport error = %v, want typed tool response", err)
+	}
+	assertBadRequestToolResponse(t, raw)
+	if invoked {
+		t.Fatal("fake models root was invoked for missing holder")
+	}
+}
+
+func acquireLeaseInputJSON(runtimeScopeRef, name, holder string) json.RawMessage {
+	payload, err := json.Marshal(map[string]string{
+		"runtimeScopeRef": runtimeScopeRef,
+		"name":            name,
+		"holder":          holder,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return payload
+}

--- a/pkg/services/models/transports/mcp/bind_test.go
+++ b/pkg/services/models/transports/mcp/bind_test.go
@@ -116,9 +116,11 @@ func TestPackageBoundary_DoesNotImportModelsInternal(t *testing.T) {
 
 type fakeModelsRoot struct {
 	models.Service
-	invoked            *bool
-	listCatalog        func(context.Context, models.ListModelsRequest) (models.ListModelsResult, error)
-	prepareModelAssets func(context.Context, models.PrepareModelAssetsRequest) (models.PrepareModelAssetsResult, error)
+	invoked              *bool
+	listCatalog          func(context.Context, models.ListModelsRequest) (models.ListModelsResult, error)
+	prepareModelAssets   func(context.Context, models.PrepareModelAssetsRequest) (models.PrepareModelAssetsResult, error)
+	acquireModelLease    func(context.Context, models.AcquireModelLeaseRequest) (models.AcquireModelLeaseResult, error)
+	invokeModelWithLease func(context.Context, models.InvokeModelRequest) (models.InvokeModelResult, error)
 }
 
 func (fake fakeModelsRoot) markInvoked() {
@@ -147,6 +149,28 @@ func (fake fakeModelsRoot) PrepareModelAssets(
 		panic("unexpected PrepareModelAssets on fake models root")
 	}
 	return fake.prepareModelAssets(ctx, request)
+}
+
+func (fake fakeModelsRoot) AcquireModelLease(
+	ctx context.Context,
+	request models.AcquireModelLeaseRequest,
+) (models.AcquireModelLeaseResult, error) {
+	fake.markInvoked()
+	if fake.acquireModelLease == nil {
+		panic("unexpected AcquireModelLease on fake models root")
+	}
+	return fake.acquireModelLease(ctx, request)
+}
+
+func (fake fakeModelsRoot) InvokeModelWithLease(
+	ctx context.Context,
+	request models.InvokeModelRequest,
+) (models.InvokeModelResult, error) {
+	fake.markInvoked()
+	if fake.invokeModelWithLease == nil {
+		panic("unexpected InvokeModelWithLease on fake models root")
+	}
+	return fake.invokeModelWithLease(ctx, request)
 }
 
 func assertPackageDirectImportsForbidden(t *testing.T, packagePath string, forbiddenRoots []string) {

--- a/pkg/services/models/transports/mcp/bind_test.go
+++ b/pkg/services/models/transports/mcp/bind_test.go
@@ -116,8 +116,9 @@ func TestPackageBoundary_DoesNotImportModelsInternal(t *testing.T) {
 
 type fakeModelsRoot struct {
 	models.Service
-	invoked     *bool
-	listCatalog func(context.Context, models.ListModelsRequest) (models.ListModelsResult, error)
+	invoked            *bool
+	listCatalog        func(context.Context, models.ListModelsRequest) (models.ListModelsResult, error)
+	prepareModelAssets func(context.Context, models.PrepareModelAssetsRequest) (models.PrepareModelAssetsResult, error)
 }
 
 func (fake fakeModelsRoot) markInvoked() {
@@ -135,6 +136,17 @@ func (fake fakeModelsRoot) ListCatalog(
 		panic("unexpected ListCatalog on fake models root")
 	}
 	return fake.listCatalog(ctx, request)
+}
+
+func (fake fakeModelsRoot) PrepareModelAssets(
+	ctx context.Context,
+	request models.PrepareModelAssetsRequest,
+) (models.PrepareModelAssetsResult, error) {
+	fake.markInvoked()
+	if fake.prepareModelAssets == nil {
+		panic("unexpected PrepareModelAssets on fake models root")
+	}
+	return fake.prepareModelAssets(ctx, request)
 }
 
 func assertPackageDirectImportsForbidden(t *testing.T, packagePath string, forbiddenRoots []string) {

--- a/pkg/services/models/transports/mcp/bind_test.go
+++ b/pkg/services/models/transports/mcp/bind_test.go
@@ -1,0 +1,156 @@
+package modelmcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"testing"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	modelmcp "github.com/portpowered/infinite-you/pkg/services/models/transports/mcp"
+)
+
+const testRuntimeScopeRef = "models-mcp-bind-scope-001"
+
+func TestBind_FakeRootInvokedThroughListCatalogTool(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := fakeModelsRoot{
+		invoked: &invoked,
+		listCatalog: func(_ context.Context, request models.ListModelsRequest) (models.ListModelsResult, error) {
+			if request.Scope.String() != testRuntimeScopeRef {
+				t.Fatalf("scope = %q, want %q", request.Scope.String(), testRuntimeScopeRef)
+			}
+			return models.ListModelsResult{
+				Models: []models.Summary{{
+					Name:   "stub-model",
+					Status: models.StatusReady,
+				}},
+			}, nil
+		},
+	}
+	operation := modelmcp.Bind(modelmcp.RootBinding{Models: fake})
+	raw, err := operation(
+		context.Background(),
+		modelmcp.ToolListCatalog,
+		json.RawMessage(`{"runtimeScopeRef":"`+testRuntimeScopeRef+`"}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(list_catalog) error = %v", err)
+	}
+	if !invoked {
+		t.Fatal("fake models root was not invoked")
+	}
+	var response modelmcp.ToolResponse[models.ListModelsResult]
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode tool response: %v", err)
+	}
+	if response.Error != nil || response.Result == nil {
+		t.Fatalf("CallTool(list_catalog) = %s, want success", raw)
+	}
+	if len(response.Result.Models) != 1 || response.Result.Models[0].Name != "stub-model" {
+		t.Fatalf("models = %#v, want one stub-model summary", response.Result.Models)
+	}
+}
+
+func TestNewFromRoot_FakeRootInvokedThroughListCatalogTool(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := fakeModelsRoot{
+		invoked: &invoked,
+		listCatalog: func(context.Context, models.ListModelsRequest) (models.ListModelsResult, error) {
+			return models.ListModelsResult{}, nil
+		},
+	}
+	operation := modelmcp.NewFromRoot(modelmcp.RootBinding{Models: fake})
+	_, err := operation(
+		context.Background(),
+		modelmcp.ToolListCatalog,
+		json.RawMessage(`{"runtimeScopeRef":"`+testRuntimeScopeRef+`"}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(list_catalog) error = %v", err)
+	}
+	if !invoked {
+		t.Fatal("fake models root was not invoked through NewFromRoot binding")
+	}
+}
+
+func TestCallTool_UnknownToolReturnsStableError(t *testing.T) {
+	t.Parallel()
+
+	_, err := modelmcp.CallTool(
+		context.Background(),
+		fakeModelsRoot{},
+		"you.model.unknown_tool",
+		json.RawMessage(`{}`),
+	)
+	if err == nil {
+		t.Fatal("CallTool(unknown tool) error = nil, want unsupported-tool error")
+	}
+	if got := err.Error(); got != `unsupported tool "you.model.unknown_tool"` {
+		t.Fatalf("CallTool(unknown tool) error = %q, want %q", got, `unsupported tool "you.model.unknown_tool"`)
+	}
+}
+
+func TestBind_ToolOperationRejectsMissingContext(t *testing.T) {
+	t.Parallel()
+
+	operation := modelmcp.BindToolOperation(fakeModelsRoot{})
+	_, err := operation(nil, modelmcp.ToolListCatalog, json.RawMessage(`{}`))
+	if err == nil || !strings.Contains(err.Error(), "context is required") {
+		t.Fatalf("ToolOperation(nil context) error = %v, want required-context error", err)
+	}
+}
+
+func TestPackageBoundary_DoesNotImportModelsInternal(t *testing.T) {
+	t.Parallel()
+
+	forbidden := "github.com/portpowered/infinite-you/pkg/services/models/internal"
+	packagePath := "github.com/portpowered/infinite-you/pkg/services/models/transports/mcp"
+	assertPackageDirectImportsForbidden(t, packagePath, []string{forbidden})
+}
+
+type fakeModelsRoot struct {
+	models.Service
+	invoked     *bool
+	listCatalog func(context.Context, models.ListModelsRequest) (models.ListModelsResult, error)
+}
+
+func (fake fakeModelsRoot) markInvoked() {
+	if fake.invoked != nil {
+		*fake.invoked = true
+	}
+}
+
+func (fake fakeModelsRoot) ListCatalog(
+	ctx context.Context,
+	request models.ListModelsRequest,
+) (models.ListModelsResult, error) {
+	fake.markInvoked()
+	if fake.listCatalog == nil {
+		panic("unexpected ListCatalog on fake models root")
+	}
+	return fake.listCatalog(ctx, request)
+}
+
+func assertPackageDirectImportsForbidden(t *testing.T, packagePath string, forbiddenRoots []string) {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", "-f", "{{.Imports}}", packagePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list imports for %s: %v\n%s", packagePath, err, output)
+	}
+	imports := strings.Fields(strings.Trim(string(output), "[]"))
+	for _, importPath := range imports {
+		for _, forbidden := range forbiddenRoots {
+			if importPath == forbidden || strings.HasPrefix(importPath, forbidden+"/") {
+				t.Fatalf("%s must not import forbidden ownership %s; found direct import %s", packagePath, forbidden, importPath)
+			}
+		}
+	}
+}

--- a/pkg/services/models/transports/mcp/client.go
+++ b/pkg/services/models/transports/mcp/client.go
@@ -51,8 +51,10 @@ type canonicalToolHandler func(
 ) (json.RawMessage, error)
 
 var canonicalToolHandlers = map[string]canonicalToolHandler{
-	ToolListCatalog:   handleListCatalog,
-	ToolPrepareAssets: handlePrepareAssets,
+	ToolListCatalog:      handleListCatalog,
+	ToolPrepareAssets:    handlePrepareAssets,
+	ToolAcquireLease:     handleAcquireLease,
+	ToolInvokeWithLease:  handleInvokeWithLease,
 }
 
 func handleListCatalog(
@@ -72,6 +74,26 @@ func handlePrepareAssets(
 ) (json.RawMessage, error) {
 	return callToolJSON(input, "decode prepare assets input", func(request PrepareAssetsInput) ToolResponse[models.PrepareModelAssetsResult] {
 		return PrepareAssets(ctx, service, request)
+	})
+}
+
+func handleAcquireLease(
+	ctx context.Context,
+	service models.Service,
+	input json.RawMessage,
+) (json.RawMessage, error) {
+	return callToolJSON(input, "decode acquire lease input", func(request AcquireLeaseInput) ToolResponse[AcquireLeaseResult] {
+		return AcquireLease(ctx, service, request)
+	})
+}
+
+func handleInvokeWithLease(
+	ctx context.Context,
+	service models.Service,
+	input json.RawMessage,
+) (json.RawMessage, error) {
+	return callToolJSON(input, "decode invoke with lease input", func(request InvokeWithLeaseInput) ToolResponse[InvokeWithLeaseResult] {
+		return InvokeWithLease(ctx, service, request)
 	})
 }
 

--- a/pkg/services/models/transports/mcp/client.go
+++ b/pkg/services/models/transports/mcp/client.go
@@ -1,0 +1,84 @@
+package modelmcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+var errMissingRequestContext = errors.New("MCP request context is required")
+
+// ToolOperation is the single injected execution role used by every MCP
+// protocol server. Production binds its Models dependencies once; protocol
+// tests replace this exact function role.
+type ToolOperation func(context.Context, string, json.RawMessage) (json.RawMessage, error)
+
+// Bind constructs the canonical ToolOperation from an injected Models root.
+// Adapter tests replace Models with a root-shaped fake without constructing
+// real catalog, assets, host, lease, inference graphs, or service-local Wire.
+func Bind(binding RootBinding) ToolOperation {
+	return func(ctx context.Context, name string, input json.RawMessage) (json.RawMessage, error) {
+		return CallTool(ctx, binding.Models, name, input)
+	}
+}
+
+// BindToolOperation binds the canonical tool registry to an explicit Models
+// Service root without constructing an alternate MCP client.
+func BindToolOperation(service models.Service) ToolOperation {
+	return Bind(RootBinding{Models: service})
+}
+
+func callToolJSON[Input any, Output any](
+	input json.RawMessage,
+	decodeErr string,
+	handler func(Input) ToolResponse[Output],
+) (json.RawMessage, error) {
+	var request Input
+	if err := json.Unmarshal(input, &request); err != nil {
+		envelope := decodeInputErrorEnvelope(decodeErr, err)
+		return json.Marshal(ToolResponse[Output]{Error: &envelope})
+	}
+	return json.Marshal(handler(request))
+}
+
+type canonicalToolHandler func(
+	context.Context,
+	models.Service,
+	json.RawMessage,
+) (json.RawMessage, error)
+
+var canonicalToolHandlers = map[string]canonicalToolHandler{
+	ToolListCatalog: handleListCatalog,
+}
+
+func handleListCatalog(
+	ctx context.Context,
+	service models.Service,
+	input json.RawMessage,
+) (json.RawMessage, error) {
+	return callToolJSON(input, "decode list catalog input", func(request ListCatalogInput) ToolResponse[models.ListModelsResult] {
+		return ListCatalog(ctx, service, request)
+	})
+}
+
+// CallTool invokes one Models tool against an explicitly supplied Service root.
+// Protocol servers receive the bound ToolOperation rather than choosing
+// between construction paths.
+func CallTool(
+	ctx context.Context,
+	service models.Service,
+	name string,
+	input json.RawMessage,
+) (json.RawMessage, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("call MCP tool: %w", errMissingRequestContext)
+	}
+	handler, ok := canonicalToolHandlers[name]
+	if !ok {
+		return nil, fmt.Errorf("unsupported tool %q", name)
+	}
+	return handler(ctx, service, input)
+}

--- a/pkg/services/models/transports/mcp/client.go
+++ b/pkg/services/models/transports/mcp/client.go
@@ -51,7 +51,8 @@ type canonicalToolHandler func(
 ) (json.RawMessage, error)
 
 var canonicalToolHandlers = map[string]canonicalToolHandler{
-	ToolListCatalog: handleListCatalog,
+	ToolListCatalog:   handleListCatalog,
+	ToolPrepareAssets: handlePrepareAssets,
 }
 
 func handleListCatalog(
@@ -61,6 +62,16 @@ func handleListCatalog(
 ) (json.RawMessage, error) {
 	return callToolJSON(input, "decode list catalog input", func(request ListCatalogInput) ToolResponse[models.ListModelsResult] {
 		return ListCatalog(ctx, service, request)
+	})
+}
+
+func handlePrepareAssets(
+	ctx context.Context,
+	service models.Service,
+	input json.RawMessage,
+) (json.RawMessage, error) {
+	return callToolJSON(input, "decode prepare assets input", func(request PrepareAssetsInput) ToolResponse[models.PrepareModelAssetsResult] {
+		return PrepareAssets(ctx, service, request)
 	})
 }
 

--- a/pkg/services/models/transports/mcp/errors.go
+++ b/pkg/services/models/transports/mcp/errors.go
@@ -8,7 +8,11 @@ import (
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 )
 
-var errEmptyModelName = fmt.Errorf("%w: empty model name", models.ErrNotFound)
+var (
+	errEmptyModelName      = fmt.Errorf("%w: empty model name", models.ErrNotFound)
+	errEmptyLeaseHolder    = fmt.Errorf("%w: empty lease holder", models.ErrHostInvalidHolder)
+	errEmptyModelOperation = fmt.Errorf("%w: empty model operation", models.ErrUnsupportedModelOperation)
+)
 
 const (
 	errorCodeBadRequest            = "BAD_REQUEST"
@@ -21,6 +25,17 @@ const (
 	errorCodeAssetSourceUnsupported       = "model.asset.source_unsupported"
 	errorCodeAssetIntegrityFailed         = "model.asset.integrity_failed"
 	errorCodeAssetPreparationInterrupted  = "model.asset.preparation_interrupted"
+	errorCodeAssetUnavailable             = "model.asset.unavailable"
+	errorCodeLeaseCapacityExhausted       = "model.lease.capacity_exhausted"
+	errorCodeLeaseCapacityContended       = "model.lease.capacity_contended"
+	errorCodeLeaseExpired                 = "model.lease.expired"
+	errorCodeLeaseInvalidHolder           = "model.lease.invalid_holder"
+	errorCodeLeaseNotFound                = "model.lease.not_found"
+	errorCodeHostRuntimeNotReady          = "model.host.runtime_not_ready"
+	errorCodeInferenceFailed              = "model.inference.failed"
+	errorCodeInferenceTimeout             = "model.inference.timeout"
+	errorCodeModelOperationUnsupported    = "model.operation.unsupported"
+	errorCodeInferenceResponseUnsupported = "model.inference.response_mode_unsupported"
 	errorCodeInternalExecution            = "model.execution.internal"
 	errorMessageRuntimeScopeInvalid = "models runtime scope is invalid"
 	errorMessageRuntimeScopeStale   = "models runtime scope is stale"
@@ -31,6 +46,17 @@ const (
 	errorMessageAssetSourceUnsupported      = "models asset source is unsupported"
 	errorMessageAssetIntegrityFailed        = "models asset integrity verification failed"
 	errorMessageAssetPreparationInterrupted = "models asset preparation was interrupted"
+	errorMessageAssetUnavailable            = "models assets are unavailable"
+	errorMessageLeaseCapacityExhausted      = "models lease capacity is exhausted"
+	errorMessageLeaseCapacityContended      = "models lease capacity is contended"
+	errorMessageLeaseExpired                = "models lease has expired"
+	errorMessageLeaseInvalidHolder          = "models lease holder is invalid"
+	errorMessageLeaseNotFound               = "models lease was not found"
+	errorMessageHostRuntimeNotReady         = "models host runtime is not ready"
+	errorMessageInferenceFailed             = "models inference failed"
+	errorMessageInferenceTimeout            = "models inference timed out"
+	errorMessageModelOperationUnsupported   = "models operation is not supported"
+	errorMessageInferenceResponseUnsupported = "models inference response mode is not supported"
 	errorMessageInternalExecution           = "models execution failed"
 )
 
@@ -96,6 +122,161 @@ func prepareAssetsErrorEnvelope(err error) ToolErrorEnvelope {
 			Code:      errorCodeAssetPreparationInterrupted,
 			Message:   errorMessageAssetPreparationInterrupted,
 			Retryable: true,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	default:
+		return executionErrorEnvelope(err)
+	}
+}
+
+func acquireLeaseErrorEnvelope(err error) ToolErrorEnvelope {
+	if envelope, ok := runtimeScopeErrorEnvelope(err); ok {
+		return envelope
+	}
+	switch {
+	case errors.Is(err, models.ErrHostCapacityExhausted):
+		return ToolErrorEnvelope{
+			Code:      errorCodeLeaseCapacityExhausted,
+			Message:   errorMessageLeaseCapacityExhausted,
+			Retryable: true,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	case errors.Is(err, models.ErrHostCapacityContended):
+		return ToolErrorEnvelope{
+			Code:      errorCodeLeaseCapacityContended,
+			Message:   errorMessageLeaseCapacityContended,
+			Retryable: true,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	case errors.Is(err, models.ErrHostRuntimeNotReady):
+		return ToolErrorEnvelope{
+			Code:      errorCodeHostRuntimeNotReady,
+			Message:   errorMessageHostRuntimeNotReady,
+			Retryable: true,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	case errors.Is(err, models.ErrHostInvalidHolder):
+		return ToolErrorEnvelope{
+			Code:      errorCodeLeaseInvalidHolder,
+			Message:   errorMessageLeaseInvalidHolder,
+			Retryable: false,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	default:
+		return executionErrorEnvelope(err)
+	}
+}
+
+func invokeWithLeaseErrorEnvelope(err error) ToolErrorEnvelope {
+	if envelope, ok := runtimeScopeErrorEnvelope(err); ok {
+		return envelope
+	}
+	switch {
+	case errors.Is(err, models.ErrHostCapacityExhausted):
+		return ToolErrorEnvelope{
+			Code:      errorCodeLeaseCapacityExhausted,
+			Message:   errorMessageLeaseCapacityExhausted,
+			Retryable: true,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	case errors.Is(err, models.ErrHostCapacityContended):
+		return ToolErrorEnvelope{
+			Code:      errorCodeLeaseCapacityContended,
+			Message:   errorMessageLeaseCapacityContended,
+			Retryable: true,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	case errors.Is(err, models.ErrHostRuntimeNotReady):
+		return ToolErrorEnvelope{
+			Code:      errorCodeHostRuntimeNotReady,
+			Message:   errorMessageHostRuntimeNotReady,
+			Retryable: true,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	case errors.Is(err, models.ErrHostLeaseExpired):
+		return ToolErrorEnvelope{
+			Code:      errorCodeLeaseExpired,
+			Message:   errorMessageLeaseExpired,
+			Retryable: false,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	case errors.Is(err, models.ErrHostLeaseNotFound):
+		return ToolErrorEnvelope{
+			Code:      errorCodeLeaseNotFound,
+			Message:   errorMessageLeaseNotFound,
+			Retryable: false,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	case errors.Is(err, models.ErrHostInvalidHolder):
+		return ToolErrorEnvelope{
+			Code:      errorCodeLeaseInvalidHolder,
+			Message:   errorMessageLeaseInvalidHolder,
+			Retryable: false,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	case errors.Is(err, models.ErrAssetUnavailable):
+		return ToolErrorEnvelope{
+			Code:      errorCodeAssetUnavailable,
+			Message:   errorMessageAssetUnavailable,
+			Retryable: true,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	case errors.Is(err, models.ErrInferenceTimeout):
+		return ToolErrorEnvelope{
+			Code:      errorCodeInferenceTimeout,
+			Message:   errorMessageInferenceTimeout,
+			Retryable: true,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	case errors.Is(err, models.ErrInferenceFailed):
+		return ToolErrorEnvelope{
+			Code:      errorCodeInferenceFailed,
+			Message:   errorMessageInferenceFailed,
+			Retryable: false,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	case errors.Is(err, models.ErrUnsupportedModelOperation):
+		return ToolErrorEnvelope{
+			Code:      errorCodeModelOperationUnsupported,
+			Message:   errorMessageModelOperationUnsupported,
+			Retryable: false,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	case errors.Is(err, models.ErrUnsupportedResponseMode):
+		return ToolErrorEnvelope{
+			Code:      errorCodeInferenceResponseUnsupported,
+			Message:   errorMessageInferenceResponseUnsupported,
+			Retryable: false,
 			Details: map[string]any{
 				"reason": err.Error(),
 			},

--- a/pkg/services/models/transports/mcp/errors.go
+++ b/pkg/services/models/transports/mcp/errors.go
@@ -1,10 +1,27 @@
 package modelmcp
 
 import (
+	"errors"
 	"strings"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
 )
 
-const errorCodeBadRequest = "BAD_REQUEST"
+const (
+	errorCodeBadRequest            = "BAD_REQUEST"
+	errorCodeRuntimeScopeInvalid   = "model.runtime_scope.invalid"
+	errorCodeRuntimeScopeStale     = "model.runtime_scope.stale"
+	errorCodeRuntimeScopeForeign   = "model.runtime_scope.foreign"
+	errorCodeRuntimeScopeClosed    = "model.runtime_scope.closed"
+	errorCodeCatalogUnavailable    = "model.catalog.unavailable"
+	errorCodeInternalExecution     = "model.execution.internal"
+	errorMessageRuntimeScopeInvalid = "models runtime scope is invalid"
+	errorMessageRuntimeScopeStale   = "models runtime scope is stale"
+	errorMessageRuntimeScopeForeign = "models runtime scope is foreign"
+	errorMessageRuntimeScopeClosed  = "models runtime scope is closed"
+	errorMessageCatalogUnavailable  = "models catalog is unavailable"
+	errorMessageInternalExecution   = "models execution failed"
+)
 
 func decodeInputErrorEnvelope(context string, err error) ToolErrorEnvelope {
 	message := context
@@ -31,8 +48,68 @@ func unavailableServiceErrorEnvelope() ToolErrorEnvelope {
 	}
 }
 
+func listCatalogErrorEnvelope(err error) ToolErrorEnvelope {
+	if envelope, ok := runtimeScopeErrorEnvelope(err); ok {
+		return envelope
+	}
+	if errors.Is(err, models.ErrUnavailable) {
+		return ToolErrorEnvelope{
+			Code:      errorCodeCatalogUnavailable,
+			Message:   errorMessageCatalogUnavailable,
+			Retryable: true,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	}
+	return executionErrorEnvelope(err)
+}
+
+func runtimeScopeErrorEnvelope(err error) (ToolErrorEnvelope, bool) {
+	switch {
+	case errors.Is(err, models.ErrRuntimeScopeInvalid):
+		return ToolErrorEnvelope{
+			Code:      errorCodeRuntimeScopeInvalid,
+			Message:   errorMessageRuntimeScopeInvalid,
+			Retryable: false,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}, true
+	case errors.Is(err, models.ErrRuntimeScopeStale):
+		return ToolErrorEnvelope{
+			Code:      errorCodeRuntimeScopeStale,
+			Message:   errorMessageRuntimeScopeStale,
+			Retryable: false,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}, true
+	case errors.Is(err, models.ErrRuntimeScopeForeign):
+		return ToolErrorEnvelope{
+			Code:      errorCodeRuntimeScopeForeign,
+			Message:   errorMessageRuntimeScopeForeign,
+			Retryable: false,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}, true
+	case errors.Is(err, models.ErrRuntimeScopeClosed):
+		return ToolErrorEnvelope{
+			Code:      errorCodeRuntimeScopeClosed,
+			Message:   errorMessageRuntimeScopeClosed,
+			Retryable: false,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}, true
+	default:
+		return ToolErrorEnvelope{}, false
+	}
+}
+
 func executionErrorEnvelope(err error) ToolErrorEnvelope {
-	message := "models execution failed"
+	message := errorMessageInternalExecution
 	details := map[string]any{}
 	if err != nil {
 		if trimmed := strings.TrimSpace(err.Error()); trimmed != "" {
@@ -41,7 +118,7 @@ func executionErrorEnvelope(err error) ToolErrorEnvelope {
 		details["reason"] = err.Error()
 	}
 	return ToolErrorEnvelope{
-		Code:      "model.execution.internal",
+		Code:      errorCodeInternalExecution,
 		Message:   message,
 		Retryable: false,
 		Details:   details,

--- a/pkg/services/models/transports/mcp/errors.go
+++ b/pkg/services/models/transports/mcp/errors.go
@@ -2,10 +2,13 @@ package modelmcp
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 )
+
+var errEmptyModelName = fmt.Errorf("%w: empty model name", models.ErrNotFound)
 
 const (
 	errorCodeBadRequest            = "BAD_REQUEST"
@@ -13,14 +16,22 @@ const (
 	errorCodeRuntimeScopeStale     = "model.runtime_scope.stale"
 	errorCodeRuntimeScopeForeign   = "model.runtime_scope.foreign"
 	errorCodeRuntimeScopeClosed    = "model.runtime_scope.closed"
-	errorCodeCatalogUnavailable    = "model.catalog.unavailable"
-	errorCodeInternalExecution     = "model.execution.internal"
+	errorCodeCatalogUnavailable           = "model.catalog.unavailable"
+	errorCodeAssetSourceMissing           = "model.asset.source_missing"
+	errorCodeAssetSourceUnsupported       = "model.asset.source_unsupported"
+	errorCodeAssetIntegrityFailed         = "model.asset.integrity_failed"
+	errorCodeAssetPreparationInterrupted  = "model.asset.preparation_interrupted"
+	errorCodeInternalExecution            = "model.execution.internal"
 	errorMessageRuntimeScopeInvalid = "models runtime scope is invalid"
 	errorMessageRuntimeScopeStale   = "models runtime scope is stale"
 	errorMessageRuntimeScopeForeign = "models runtime scope is foreign"
 	errorMessageRuntimeScopeClosed  = "models runtime scope is closed"
-	errorMessageCatalogUnavailable  = "models catalog is unavailable"
-	errorMessageInternalExecution   = "models execution failed"
+	errorMessageCatalogUnavailable          = "models catalog is unavailable"
+	errorMessageAssetSourceMissing          = "models asset source is missing"
+	errorMessageAssetSourceUnsupported      = "models asset source is unsupported"
+	errorMessageAssetIntegrityFailed        = "models asset integrity verification failed"
+	errorMessageAssetPreparationInterrupted = "models asset preparation was interrupted"
+	errorMessageInternalExecution           = "models execution failed"
 )
 
 func decodeInputErrorEnvelope(context string, err error) ToolErrorEnvelope {
@@ -45,6 +56,52 @@ func unavailableServiceErrorEnvelope() ToolErrorEnvelope {
 		Code:      "model.service.unavailable",
 		Message:   "models service is unavailable",
 		Retryable: false,
+	}
+}
+
+func prepareAssetsErrorEnvelope(err error) ToolErrorEnvelope {
+	if envelope, ok := runtimeScopeErrorEnvelope(err); ok {
+		return envelope
+	}
+	switch {
+	case errors.Is(err, models.ErrAssetSourceMissing):
+		return ToolErrorEnvelope{
+			Code:      errorCodeAssetSourceMissing,
+			Message:   errorMessageAssetSourceMissing,
+			Retryable: false,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	case errors.Is(err, models.ErrAssetSourceUnsupported):
+		return ToolErrorEnvelope{
+			Code:      errorCodeAssetSourceUnsupported,
+			Message:   errorMessageAssetSourceUnsupported,
+			Retryable: false,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	case errors.Is(err, models.ErrAssetIntegrityFailed):
+		return ToolErrorEnvelope{
+			Code:      errorCodeAssetIntegrityFailed,
+			Message:   errorMessageAssetIntegrityFailed,
+			Retryable: false,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	case errors.Is(err, models.ErrAssetPreparationInterrupted):
+		return ToolErrorEnvelope{
+			Code:      errorCodeAssetPreparationInterrupted,
+			Message:   errorMessageAssetPreparationInterrupted,
+			Retryable: true,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	default:
+		return executionErrorEnvelope(err)
 	}
 }
 

--- a/pkg/services/models/transports/mcp/errors.go
+++ b/pkg/services/models/transports/mcp/errors.go
@@ -1,6 +1,7 @@
 package modelmcp
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -37,6 +38,8 @@ const (
 	errorCodeModelOperationUnsupported    = "model.operation.unsupported"
 	errorCodeInferenceResponseUnsupported = "model.inference.response_mode_unsupported"
 	errorCodeInternalExecution            = "model.execution.internal"
+	errorCodeRequestCanceled              = "model.request.canceled"
+	errorCodeRequestTimedOut              = "model.request.timed_out"
 	errorMessageRuntimeScopeInvalid = "models runtime scope is invalid"
 	errorMessageRuntimeScopeStale   = "models runtime scope is stale"
 	errorMessageRuntimeScopeForeign = "models runtime scope is foreign"
@@ -58,7 +61,51 @@ const (
 	errorMessageModelOperationUnsupported   = "models operation is not supported"
 	errorMessageInferenceResponseUnsupported = "models inference response mode is not supported"
 	errorMessageInternalExecution           = "models execution failed"
+	errorMessageRequestCanceled             = "models request was canceled"
+	errorMessageRequestTimedOut               = "models request timed out"
 )
+
+func requestContextErrorResponse[T any](ctx context.Context) (ToolResponse[T], bool) {
+	if envelope, ok := contextRequestErrorEnvelope(ctx.Err()); ok {
+		return ToolResponse[T]{Error: &envelope}, true
+	}
+	return ToolResponse[T]{}, false
+}
+
+func contextRequestErrorEnvelope(err error) (ToolErrorEnvelope, bool) {
+	if err == nil {
+		return ToolErrorEnvelope{}, false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return contextDeadlineExceededErrorEnvelope(), true
+	}
+	if errors.Is(err, context.Canceled) {
+		return contextCanceledErrorEnvelope(), true
+	}
+	return ToolErrorEnvelope{}, false
+}
+
+func contextCanceledErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeRequestCanceled,
+		Message:   errorMessageRequestCanceled,
+		Retryable: false,
+		Details: map[string]any{
+			"reason": "CANCELED",
+		},
+	}
+}
+
+func contextDeadlineExceededErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeRequestTimedOut,
+		Message:   errorMessageRequestTimedOut,
+		Retryable: true,
+		Details: map[string]any{
+			"reason": "TIMED_OUT",
+		},
+	}
+}
 
 func decodeInputErrorEnvelope(context string, err error) ToolErrorEnvelope {
 	message := context
@@ -347,6 +394,9 @@ func runtimeScopeErrorEnvelope(err error) (ToolErrorEnvelope, bool) {
 }
 
 func executionErrorEnvelope(err error) ToolErrorEnvelope {
+	if envelope, ok := contextRequestErrorEnvelope(err); ok {
+		return envelope
+	}
 	message := errorMessageInternalExecution
 	details := map[string]any{}
 	if err != nil {

--- a/pkg/services/models/transports/mcp/errors.go
+++ b/pkg/services/models/transports/mcp/errors.go
@@ -1,0 +1,49 @@
+package modelmcp
+
+import (
+	"strings"
+)
+
+const errorCodeBadRequest = "BAD_REQUEST"
+
+func decodeInputErrorEnvelope(context string, err error) ToolErrorEnvelope {
+	message := context
+	details := map[string]any{}
+	if err != nil {
+		if trimmed := strings.TrimSpace(err.Error()); trimmed != "" {
+			message = context + ": " + trimmed
+		}
+		details["reason"] = err.Error()
+	}
+	return ToolErrorEnvelope{
+		Code:      errorCodeBadRequest,
+		Message:   message,
+		Retryable: false,
+		Details:   details,
+	}
+}
+
+func unavailableServiceErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      "model.service.unavailable",
+		Message:   "models service is unavailable",
+		Retryable: false,
+	}
+}
+
+func executionErrorEnvelope(err error) ToolErrorEnvelope {
+	message := "models execution failed"
+	details := map[string]any{}
+	if err != nil {
+		if trimmed := strings.TrimSpace(err.Error()); trimmed != "" {
+			message = trimmed
+		}
+		details["reason"] = err.Error()
+	}
+	return ToolErrorEnvelope{
+		Code:      "model.execution.internal",
+		Message:   message,
+		Retryable: false,
+		Details:   details,
+	}
+}

--- a/pkg/services/models/transports/mcp/invoke_with_lease.go
+++ b/pkg/services/models/transports/mcp/invoke_with_lease.go
@@ -1,0 +1,81 @@
+package modelmcp
+
+import (
+	"context"
+	"strings"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+// InferenceInputPayload is the nested MCP inference input for invoke_with_lease.
+type InferenceInputPayload struct {
+	ContentType string `json:"contentType"`
+	Content     string `json:"content"`
+}
+
+// InvokeWithLeaseInput is the MCP request shape for you.model.invoke_with_lease.
+type InvokeWithLeaseInput struct {
+	RuntimeScopeRef string                `json:"runtimeScopeRef"`
+	LeaseRef        string                `json:"leaseRef"`
+	Holder          string                `json:"holder"`
+	ModelName       string                `json:"modelName"`
+	Operation       string                `json:"operation"`
+	ResponseMode    string                `json:"responseMode,omitempty"`
+	Input           InferenceInputPayload `json:"input"`
+}
+
+// InvokeWithLease runs one scoped model operation under an issued lease through
+// the you.model.invoke_with_lease MCP tool.
+func InvokeWithLease(
+	ctx context.Context,
+	service models.Service,
+	input InvokeWithLeaseInput,
+) ToolResponse[InvokeWithLeaseResult] {
+	if service == nil {
+		envelope := unavailableServiceErrorEnvelope()
+		return ToolResponse[InvokeWithLeaseResult]{Error: &envelope}
+	}
+	scope, err := (models.RuntimeScopeRef{}).Parse(input.RuntimeScopeRef)
+	if err != nil {
+		envelope := decodeInputErrorEnvelope("decode invoke with lease input", err)
+		return ToolResponse[InvokeWithLeaseResult]{Error: &envelope}
+	}
+	lease, err := (models.ModelLeaseRef{}).Parse(input.LeaseRef)
+	if err != nil {
+		envelope := decodeInputErrorEnvelope("decode invoke with lease input", err)
+		return ToolResponse[InvokeWithLeaseResult]{Error: &envelope}
+	}
+	if strings.TrimSpace(input.Holder) == "" {
+		envelope := decodeInputErrorEnvelope("decode invoke with lease input", errEmptyLeaseHolder)
+		return ToolResponse[InvokeWithLeaseResult]{Error: &envelope}
+	}
+	if strings.TrimSpace(input.ModelName) == "" {
+		envelope := decodeInputErrorEnvelope("decode invoke with lease input", errEmptyModelName)
+		return ToolResponse[InvokeWithLeaseResult]{Error: &envelope}
+	}
+	if strings.TrimSpace(input.Operation) == "" {
+		envelope := decodeInputErrorEnvelope("decode invoke with lease input", errEmptyModelOperation)
+		return ToolResponse[InvokeWithLeaseResult]{Error: &envelope}
+	}
+	request := models.InvokeModelRequest{
+		Scope:     scope,
+		Lease:     lease,
+		Holder:    input.Holder,
+		ModelName: input.ModelName,
+		Operation: input.Operation,
+		Input: models.InferenceInput{
+			ContentType: input.Input.ContentType,
+			Content:     input.Input.Content,
+		},
+	}
+	if strings.TrimSpace(input.ResponseMode) != "" {
+		request.ResponseMode = models.ResponseMode(input.ResponseMode)
+	}
+	result, err := service.InvokeModelWithLease(ctx, request)
+	if err != nil {
+		envelope := invokeWithLeaseErrorEnvelope(err)
+		return ToolResponse[InvokeWithLeaseResult]{Error: &envelope}
+	}
+	projected := projectInvokeWithLeaseResult(result)
+	return ToolResponse[InvokeWithLeaseResult]{Result: &projected}
+}

--- a/pkg/services/models/transports/mcp/invoke_with_lease.go
+++ b/pkg/services/models/transports/mcp/invoke_with_lease.go
@@ -31,6 +31,9 @@ func InvokeWithLease(
 	service models.Service,
 	input InvokeWithLeaseInput,
 ) ToolResponse[InvokeWithLeaseResult] {
+	if response, done := requestContextErrorResponse[InvokeWithLeaseResult](ctx); done {
+		return response
+	}
 	if service == nil {
 		envelope := unavailableServiceErrorEnvelope()
 		return ToolResponse[InvokeWithLeaseResult]{Error: &envelope}

--- a/pkg/services/models/transports/mcp/invoke_with_lease_test.go
+++ b/pkg/services/models/transports/mcp/invoke_with_lease_test.go
@@ -1,0 +1,240 @@
+package modelmcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	modelmcp "github.com/portpowered/infinite-you/pkg/services/models/transports/mcp"
+)
+
+func TestBind_InvokeWithLeaseSuccessReturnsInvokeFactsFromInjectedRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	leaseRef, err := (models.ModelLeaseRef{}).Parse(testLeaseRef)
+	if err != nil {
+		t.Fatalf("parse lease ref: %v", err)
+	}
+	scope, err := (models.RuntimeScopeRef{}).Parse(testRuntimeScopeRef)
+	if err != nil {
+		t.Fatalf("parse scope: %v", err)
+	}
+	invocationRef, err := (models.ModelInvocationRef{}).Parse("model-invocation-test-001")
+	if err != nil {
+		t.Fatalf("parse invocation ref: %v", err)
+	}
+	artifactRef, err := (models.InferenceArtifactRef{}).Parse("artifact-test-001")
+	if err != nil {
+		t.Fatalf("parse artifact ref: %v", err)
+	}
+	fake := fakeModelsRoot{
+		invoked: &invoked,
+		invokeModelWithLease: func(_ context.Context, request models.InvokeModelRequest) (models.InvokeModelResult, error) {
+			if request.Scope.String() != testRuntimeScopeRef {
+				t.Fatalf("scope = %q, want %q", request.Scope.String(), testRuntimeScopeRef)
+			}
+			if request.Lease.String() != testLeaseRef {
+				t.Fatalf("lease = %q, want %q", request.Lease.String(), testLeaseRef)
+			}
+			if request.Holder != testLeaseHolder {
+				t.Fatalf("holder = %q, want %q", request.Holder, testLeaseHolder)
+			}
+			if request.ModelName != testPrepareModelName {
+				t.Fatalf("modelName = %q, want %q", request.ModelName, testPrepareModelName)
+			}
+			if request.Operation != testInvokeOperation {
+				t.Fatalf("operation = %q, want %q", request.Operation, testInvokeOperation)
+			}
+			if request.Input.ContentType != "text/plain" || request.Input.Content != "hello" {
+				t.Fatalf("input = %#v, want text/plain hello", request.Input)
+			}
+			return models.InvokeModelResult{
+				Invocation:       invocationRef,
+				Scope:            scope,
+				Lease:            leaseRef,
+				ModelName:        testPrepareModelName,
+				Operation:        testInvokeOperation,
+				Status:           models.ModelInvocationStatusCompleted,
+				Content:          []models.InferenceContent{{ContentType: "text/plain", Content: "models-owned-output"}},
+				Artifacts:        []models.InferenceArtifact{{Artifact: artifactRef, Name: "output.txt", MediaType: "text/plain", SizeBytes: 5}},
+				LeaseDisposition: models.InvocationLeaseReleased,
+			}, nil
+		},
+	}
+	operation := modelmcp.Bind(modelmcp.RootBinding{Models: fake})
+	raw, err := operation(
+		context.Background(),
+		modelmcp.ToolInvokeWithLease,
+		invokeWithLeaseInputJSON(testRuntimeScopeRef, testLeaseRef, testLeaseHolder, testPrepareModelName, testInvokeOperation),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(invoke_with_lease) transport error = %v, want typed tool response", err)
+	}
+	if !invoked {
+		t.Fatal("fake models root was not invoked")
+	}
+	var response modelmcp.ToolResponse[modelmcp.InvokeWithLeaseResult]
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode tool response: %v", err)
+	}
+	if response.Error != nil || response.Result == nil {
+		t.Fatalf("tool response = %s, want success envelope", raw)
+	}
+	if response.Result.Invocation != invocationRef.String() {
+		t.Fatalf("invocation = %q, want %q", response.Result.Invocation, invocationRef.String())
+	}
+	if response.Result.Lease != testLeaseRef {
+		t.Fatalf("lease = %q, want %q", response.Result.Lease, testLeaseRef)
+	}
+	if response.Result.Status != models.ModelInvocationStatusCompleted {
+		t.Fatalf("status = %q, want %q", response.Result.Status, models.ModelInvocationStatusCompleted)
+	}
+	if response.Result.LeaseDisposition != models.InvocationLeaseReleased {
+		t.Fatalf("leaseDisposition = %q, want %q", response.Result.LeaseDisposition, models.InvocationLeaseReleased)
+	}
+	if len(response.Result.Content) != 1 || response.Result.Content[0].Content != "models-owned-output" {
+		t.Fatalf("content = %#v, want one models-owned-output item", response.Result.Content)
+	}
+	if len(response.Result.Artifacts) != 1 || response.Result.Artifacts[0].Name != "output.txt" {
+		t.Fatalf("artifacts = %#v, want one output.txt artifact", response.Result.Artifacts)
+	}
+	if response.Result.Artifacts[0].Artifact != artifactRef.String() {
+		t.Fatalf("artifact ref = %q, want %q", response.Result.Artifacts[0].Artifact, artifactRef.String())
+	}
+}
+
+func TestBind_InvokeWithLeaseDomainErrorsReturnDistinctTypedEnvelopes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		rootErr       error
+		wantCode      string
+		wantRetryable bool
+	}{
+		{
+			name:          "inference timeout",
+			rootErr:       models.ErrInferenceTimeout,
+			wantCode:      "model.inference.timeout",
+			wantRetryable: true,
+		},
+		{
+			name:          "asset unavailable",
+			rootErr:       models.ErrAssetUnavailable,
+			wantCode:      "model.asset.unavailable",
+			wantRetryable: true,
+		},
+		{
+			name:          "inference failed",
+			rootErr:       models.ErrInferenceFailed,
+			wantCode:      "model.inference.failed",
+			wantRetryable: false,
+		},
+		{
+			name:          "unsupported operation",
+			rootErr:       models.ErrUnsupportedModelOperation,
+			wantCode:      "model.operation.unsupported",
+			wantRetryable: false,
+		},
+		{
+			name:          "lease expired",
+			rootErr:       models.ErrHostLeaseExpired,
+			wantCode:      "model.lease.expired",
+			wantRetryable: false,
+		},
+		{
+			name:          "capacity exhausted",
+			rootErr:       models.ErrHostCapacityExhausted,
+			wantCode:      "model.lease.capacity_exhausted",
+			wantRetryable: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := fakeModelsRoot{
+				invokeModelWithLease: func(context.Context, models.InvokeModelRequest) (models.InvokeModelResult, error) {
+					return models.InvokeModelResult{}, test.rootErr
+				},
+			}
+			operation := modelmcp.Bind(modelmcp.RootBinding{Models: fake})
+			raw, err := operation(
+				context.Background(),
+				modelmcp.ToolInvokeWithLease,
+				invokeWithLeaseInputJSON(testRuntimeScopeRef, testLeaseRef, testLeaseHolder, testPrepareModelName, testInvokeOperation),
+			)
+			if err != nil {
+				t.Fatalf("CallTool(invoke_with_lease) transport error = %v, want typed tool response", err)
+			}
+			envelope := assertTypedToolErrorEnvelope(t, raw, test.wantCode, test.wantRetryable)
+			if envelope.Details == nil || envelope.Details["reason"] != test.rootErr.Error() {
+				t.Fatalf("error.details = %#v, want reason %q", envelope.Details, test.rootErr.Error())
+			}
+		})
+	}
+}
+
+func TestBind_InvokeWithLeaseInvalidJSONReturnsBadRequestWithoutInvokingFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	operation := modelmcp.Bind(modelmcp.RootBinding{
+		Models: fakeModelsRoot{invoked: &invoked},
+	})
+	raw, err := operation(
+		context.Background(),
+		modelmcp.ToolInvokeWithLease,
+		json.RawMessage(`{"runtimeScopeRef":"`+testRuntimeScopeRef+`",`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(invoke_with_lease) transport error = %v, want typed tool response", err)
+	}
+	assertBadRequestToolResponse(t, raw)
+	if invoked {
+		t.Fatal("fake models root was invoked for invalid JSON decode")
+	}
+}
+
+func TestBind_InvokeWithLeaseMissingOperationReturnsBadRequestWithoutInvokingFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	operation := modelmcp.Bind(modelmcp.RootBinding{
+		Models: fakeModelsRoot{invoked: &invoked},
+	})
+	raw, err := operation(
+		context.Background(),
+		modelmcp.ToolInvokeWithLease,
+		invokeWithLeaseInputJSON(testRuntimeScopeRef, testLeaseRef, testLeaseHolder, testPrepareModelName, ""),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(invoke_with_lease) transport error = %v, want typed tool response", err)
+	}
+	assertBadRequestToolResponse(t, raw)
+	if invoked {
+		t.Fatal("fake models root was invoked for missing operation")
+	}
+}
+
+func invokeWithLeaseInputJSON(runtimeScopeRef, leaseRef, holder, modelName, operation string) json.RawMessage {
+	payload, err := json.Marshal(map[string]any{
+		"runtimeScopeRef": runtimeScopeRef,
+		"leaseRef":        leaseRef,
+		"holder":          holder,
+		"modelName":       modelName,
+		"operation":       operation,
+		"input": map[string]string{
+			"contentType": "text/plain",
+			"content":     "hello",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return payload
+}

--- a/pkg/services/models/transports/mcp/list_catalog.go
+++ b/pkg/services/models/transports/mcp/list_catalog.go
@@ -18,6 +18,9 @@ func ListCatalog(
 	service models.Service,
 	input ListCatalogInput,
 ) ToolResponse[models.ListModelsResult] {
+	if response, done := requestContextErrorResponse[models.ListModelsResult](ctx); done {
+		return response
+	}
 	if service == nil {
 		envelope := unavailableServiceErrorEnvelope()
 		return ToolResponse[models.ListModelsResult]{Error: &envelope}

--- a/pkg/services/models/transports/mcp/list_catalog.go
+++ b/pkg/services/models/transports/mcp/list_catalog.go
@@ -1,0 +1,36 @@
+package modelmcp
+
+import (
+	"context"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+// ListCatalogInput is the MCP request shape for you.model.list_catalog.
+type ListCatalogInput struct {
+	RuntimeScopeRef string `json:"runtimeScopeRef"`
+}
+
+// ListCatalog returns detached catalog summaries through the you.model.list_catalog
+// MCP tool.
+func ListCatalog(
+	ctx context.Context,
+	service models.Service,
+	input ListCatalogInput,
+) ToolResponse[models.ListModelsResult] {
+	if service == nil {
+		envelope := unavailableServiceErrorEnvelope()
+		return ToolResponse[models.ListModelsResult]{Error: &envelope}
+	}
+	scope, err := (models.RuntimeScopeRef{}).Parse(input.RuntimeScopeRef)
+	if err != nil {
+		envelope := decodeInputErrorEnvelope("decode list catalog input", err)
+		return ToolResponse[models.ListModelsResult]{Error: &envelope}
+	}
+	result, err := service.ListCatalog(ctx, models.ListModelsRequest{Scope: scope})
+	if err != nil {
+		envelope := executionErrorEnvelope(err)
+		return ToolResponse[models.ListModelsResult]{Error: &envelope}
+	}
+	return ToolResponse[models.ListModelsResult]{Result: &result}
+}

--- a/pkg/services/models/transports/mcp/list_catalog.go
+++ b/pkg/services/models/transports/mcp/list_catalog.go
@@ -29,7 +29,7 @@ func ListCatalog(
 	}
 	result, err := service.ListCatalog(ctx, models.ListModelsRequest{Scope: scope})
 	if err != nil {
-		envelope := executionErrorEnvelope(err)
+		envelope := listCatalogErrorEnvelope(err)
 		return ToolResponse[models.ListModelsResult]{Error: &envelope}
 	}
 	return ToolResponse[models.ListModelsResult]{Result: &result}

--- a/pkg/services/models/transports/mcp/list_catalog_test.go
+++ b/pkg/services/models/transports/mcp/list_catalog_test.go
@@ -1,0 +1,195 @@
+package modelmcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	modelmcp "github.com/portpowered/infinite-you/pkg/services/models/transports/mcp"
+)
+
+func TestBind_ListCatalogSuccessReturnsCatalogSummariesFromInjectedRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := fakeModelsRoot{
+		invoked: &invoked,
+		listCatalog: func(_ context.Context, request models.ListModelsRequest) (models.ListModelsResult, error) {
+			if request.Scope.String() != testRuntimeScopeRef {
+				t.Fatalf("scope = %q, want %q", request.Scope.String(), testRuntimeScopeRef)
+			}
+			return models.ListModelsResult{
+				Models: []models.Summary{{
+					Name:   "local-model",
+					Status: models.StatusReady,
+				}},
+			}, nil
+		},
+	}
+	operation := modelmcp.Bind(modelmcp.RootBinding{Models: fake})
+	raw, err := operation(
+		context.Background(),
+		modelmcp.ToolListCatalog,
+		json.RawMessage(`{"runtimeScopeRef":"`+testRuntimeScopeRef+`"}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(list_catalog) transport error = %v, want typed tool response", err)
+	}
+	if !invoked {
+		t.Fatal("fake models root was not invoked")
+	}
+	var response modelmcp.ToolResponse[models.ListModelsResult]
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode tool response: %v", err)
+	}
+	if response.Error != nil || response.Result == nil {
+		t.Fatalf("tool response = %s, want success envelope", raw)
+	}
+	if len(response.Result.Models) != 1 || response.Result.Models[0].Name != "local-model" {
+		t.Fatalf("models = %#v, want one local-model summary", response.Result.Models)
+	}
+}
+
+func TestBind_ListCatalogRuntimeScopeErrorsReturnTypedDomainEnvelopes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		rootErr       error
+		wantCode      string
+		wantRetryable bool
+	}{
+		{
+			name:          "invalid",
+			rootErr:       models.ErrRuntimeScopeInvalid,
+			wantCode:      "model.runtime_scope.invalid",
+			wantRetryable: false,
+		},
+		{
+			name:          "stale",
+			rootErr:       models.ErrRuntimeScopeStale,
+			wantCode:      "model.runtime_scope.stale",
+			wantRetryable: false,
+		},
+		{
+			name:          "foreign",
+			rootErr:       models.ErrRuntimeScopeForeign,
+			wantCode:      "model.runtime_scope.foreign",
+			wantRetryable: false,
+		},
+		{
+			name:          "unavailable catalog",
+			rootErr:       models.ErrUnavailable,
+			wantCode:      "model.catalog.unavailable",
+			wantRetryable: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := fakeModelsRoot{
+				listCatalog: func(context.Context, models.ListModelsRequest) (models.ListModelsResult, error) {
+					return models.ListModelsResult{}, test.rootErr
+				},
+			}
+			operation := modelmcp.Bind(modelmcp.RootBinding{Models: fake})
+			raw, err := operation(
+				context.Background(),
+				modelmcp.ToolListCatalog,
+				json.RawMessage(`{"runtimeScopeRef":"`+testRuntimeScopeRef+`"}`),
+			)
+			if err != nil {
+				t.Fatalf("CallTool(list_catalog) transport error = %v, want typed tool response", err)
+			}
+			envelope := assertTypedToolErrorEnvelope(t, raw, test.wantCode, test.wantRetryable)
+			if envelope.Details == nil || envelope.Details["reason"] != test.rootErr.Error() {
+				t.Fatalf("error.details = %#v, want reason %q", envelope.Details, test.rootErr.Error())
+			}
+		})
+	}
+}
+
+func TestBind_ListCatalogInvalidJSONReturnsBadRequestWithoutInvokingFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	operation := modelmcp.Bind(modelmcp.RootBinding{
+		Models: fakeModelsRoot{invoked: &invoked},
+	})
+	raw, err := operation(
+		context.Background(),
+		modelmcp.ToolListCatalog,
+		json.RawMessage(`{"runtimeScopeRef":`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(list_catalog) transport error = %v, want typed tool response", err)
+	}
+	assertBadRequestToolResponse(t, raw)
+	if invoked {
+		t.Fatal("fake models root was invoked for invalid JSON decode")
+	}
+}
+
+func TestBind_ListCatalogMissingRuntimeScopeRefReturnsBadRequestWithoutInvokingFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	operation := modelmcp.Bind(modelmcp.RootBinding{
+		Models: fakeModelsRoot{invoked: &invoked},
+	})
+	raw, err := operation(
+		context.Background(),
+		modelmcp.ToolListCatalog,
+		json.RawMessage(`{}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(list_catalog) transport error = %v, want typed tool response", err)
+	}
+	assertBadRequestToolResponse(t, raw)
+	if invoked {
+		t.Fatal("fake models root was invoked for missing runtimeScopeRef")
+	}
+}
+
+func assertBadRequestToolResponse(t *testing.T, raw json.RawMessage) {
+	t.Helper()
+	assertTypedToolErrorEnvelope(t, raw, "BAD_REQUEST", false)
+}
+
+func assertTypedToolErrorEnvelope(
+	t *testing.T,
+	raw json.RawMessage,
+	wantCode string,
+	wantRetryable bool,
+) *modelmcp.ToolErrorEnvelope {
+	t.Helper()
+
+	var response struct {
+		Result *json.RawMessage           `json:"result"`
+		Error  *modelmcp.ToolErrorEnvelope `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode tool response: %v", err)
+	}
+	if response.Result != nil {
+		t.Fatalf("tool response result = %s, want error envelope only", raw)
+	}
+	if response.Error == nil {
+		t.Fatalf("tool response = %s, want typed error envelope", raw)
+	}
+	if response.Error.Code != wantCode {
+		t.Fatalf("error.code = %q, want %q; envelope = %#v", response.Error.Code, wantCode, response.Error)
+	}
+	if response.Error.Retryable != wantRetryable {
+		t.Fatalf("error.retryable = %v, want %v; envelope = %#v", response.Error.Retryable, wantRetryable, response.Error)
+	}
+	if strings.TrimSpace(response.Error.Message) == "" {
+		t.Fatalf("error.message is required; envelope = %#v", response.Error)
+	}
+	return response.Error
+}

--- a/pkg/services/models/transports/mcp/manifest_registration_test.go
+++ b/pkg/services/models/transports/mcp/manifest_registration_test.go
@@ -1,0 +1,153 @@
+package modelmcp_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/ownershipinventory"
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+const (
+	mcpAdapterPackagePath = "pkg/services/models/transports/mcp"
+	mcpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/models/transports/mcp"
+	modelsOwner           = "models"
+)
+
+type coverageMinimumManifest struct {
+	Lane     string `json:"lane"`
+	Packages []struct {
+		Package   string  `json:"package"`
+		Minimum   float64 `json:"minimum"`
+		Exception *struct {
+			Kind string `json:"kind"`
+		} `json:"exception"`
+	} `json:"packages"`
+}
+
+func TestManifestRegistration_MCPAdapterPackageIsRegistered(t *testing.T) {
+	t.Helper()
+
+	assertPackageTargetManifestRegistration(t)
+	assertOwnershipInventoryRegistration(t)
+	assertCoverageMinimumRegistration(t, "unit", "docs/internal/baselines/go-unit-coverage-package-minimums.json")
+	assertCoverageMinimumRegistration(t, "functional", "docs/internal/baselines/go-functional-coverage-package-minimums.json")
+}
+
+func assertPackageTargetManifestRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, "docs/internal/packaged-service-structure/package-target-manifest.json"))
+	if err != nil {
+		t.Fatalf("read package-target manifest: %v", err)
+	}
+
+	var manifest struct {
+		Inventory []string `json:"inventory"`
+		Packages  []struct {
+			PackagePath string `json:"packagePath"`
+			Disposition string `json:"disposition"`
+			Destination string `json:"destination"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode package-target manifest: %v", err)
+	}
+
+	foundInventory := false
+	for _, packagePath := range manifest.Inventory {
+		if packagePath == mcpAdapterPackagePath {
+			foundInventory = true
+			break
+		}
+	}
+	if !foundInventory {
+		t.Fatalf("package-target manifest inventory missing %q", mcpAdapterPackagePath)
+	}
+
+	for _, row := range manifest.Packages {
+		if row.PackagePath != mcpAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("package-target manifest disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != modelsOwner {
+			t.Fatalf("package-target manifest destination = %q, want %q", row.Destination, modelsOwner)
+		}
+		return
+	}
+	t.Fatalf("package-target manifest packages missing %q", mcpAdapterPackagePath)
+}
+
+func assertOwnershipInventoryRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, ownershipinventory.InventoryRelativePath))
+	if err != nil {
+		t.Fatalf("read ownership inventory: %v", err)
+	}
+
+	var inventory struct {
+		Packages []ownershipinventory.PackageRow `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		t.Fatalf("decode ownership inventory: %v", err)
+	}
+
+	for _, row := range inventory.Packages {
+		if row.PackagePath != mcpAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("ownership inventory disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != modelsOwner {
+			t.Fatalf("ownership inventory destination = %q, want %q", row.Destination, modelsOwner)
+		}
+		if row.DestinationKind != ownershipinventory.DestinationKindOwner {
+			t.Fatalf(
+				"ownership inventory destinationKind = %q, want %q",
+				row.DestinationKind,
+				ownershipinventory.DestinationKindOwner,
+			)
+		}
+		return
+	}
+	t.Fatalf("ownership inventory packages missing %q", mcpAdapterPackagePath)
+}
+
+func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, relativePath))
+	if err != nil {
+		t.Fatalf("read %s coverage manifest: %v", lane, err)
+	}
+
+	var manifest coverageMinimumManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode %s coverage manifest: %v", lane, err)
+	}
+	if manifest.Lane != lane {
+		t.Fatalf("%s coverage manifest lane = %q, want %q", relativePath, manifest.Lane, lane)
+	}
+
+	for _, entry := range manifest.Packages {
+		if entry.Package != mcpAdapterImportPath {
+			continue
+		}
+		if entry.Exception != nil {
+			if entry.Exception.Kind != "measurement" {
+				t.Fatalf("%s coverage exception kind for %q = %q, want measurement", lane, mcpAdapterImportPath, entry.Exception.Kind)
+			}
+			return
+		}
+		if entry.Minimum < 0 {
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterImportPath)
+		}
+		return
+	}
+	t.Fatalf("%s coverage manifest missing %q", lane, mcpAdapterImportPath)
+}

--- a/pkg/services/models/transports/mcp/prepare_assets.go
+++ b/pkg/services/models/transports/mcp/prepare_assets.go
@@ -20,6 +20,9 @@ func PrepareAssets(
 	service models.Service,
 	input PrepareAssetsInput,
 ) ToolResponse[models.PrepareModelAssetsResult] {
+	if response, done := requestContextErrorResponse[models.PrepareModelAssetsResult](ctx); done {
+		return response
+	}
 	if service == nil {
 		envelope := unavailableServiceErrorEnvelope()
 		return ToolResponse[models.PrepareModelAssetsResult]{Error: &envelope}

--- a/pkg/services/models/transports/mcp/prepare_assets.go
+++ b/pkg/services/models/transports/mcp/prepare_assets.go
@@ -1,0 +1,45 @@
+package modelmcp
+
+import (
+	"context"
+	"strings"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+// PrepareAssetsInput is the MCP request shape for you.model.prepare_assets.
+type PrepareAssetsInput struct {
+	RuntimeScopeRef string `json:"runtimeScopeRef"`
+	Name            string `json:"name"`
+}
+
+// PrepareAssets makes scoped model assets available through the
+// you.model.prepare_assets MCP tool.
+func PrepareAssets(
+	ctx context.Context,
+	service models.Service,
+	input PrepareAssetsInput,
+) ToolResponse[models.PrepareModelAssetsResult] {
+	if service == nil {
+		envelope := unavailableServiceErrorEnvelope()
+		return ToolResponse[models.PrepareModelAssetsResult]{Error: &envelope}
+	}
+	scope, err := (models.RuntimeScopeRef{}).Parse(input.RuntimeScopeRef)
+	if err != nil {
+		envelope := decodeInputErrorEnvelope("decode prepare assets input", err)
+		return ToolResponse[models.PrepareModelAssetsResult]{Error: &envelope}
+	}
+	if strings.TrimSpace(input.Name) == "" {
+		envelope := decodeInputErrorEnvelope("decode prepare assets input", errEmptyModelName)
+		return ToolResponse[models.PrepareModelAssetsResult]{Error: &envelope}
+	}
+	result, err := service.PrepareModelAssets(ctx, models.PrepareModelAssetsRequest{
+		Scope: scope,
+		Name:  input.Name,
+	})
+	if err != nil {
+		envelope := prepareAssetsErrorEnvelope(err)
+		return ToolResponse[models.PrepareModelAssetsResult]{Error: &envelope}
+	}
+	return ToolResponse[models.PrepareModelAssetsResult]{Result: &result}
+}

--- a/pkg/services/models/transports/mcp/prepare_assets_test.go
+++ b/pkg/services/models/transports/mcp/prepare_assets_test.go
@@ -1,0 +1,237 @@
+package modelmcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	modelmcp "github.com/portpowered/infinite-you/pkg/services/models/transports/mcp"
+)
+
+const testPrepareModelName = "local-model"
+
+func TestBind_PrepareAssetsSuccessReturnsOutcomeFromInjectedRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := fakeModelsRoot{
+		invoked: &invoked,
+		prepareModelAssets: func(_ context.Context, request models.PrepareModelAssetsRequest) (models.PrepareModelAssetsResult, error) {
+			if request.Scope.String() != testRuntimeScopeRef {
+				t.Fatalf("scope = %q, want %q", request.Scope.String(), testRuntimeScopeRef)
+			}
+			if request.Name != testPrepareModelName {
+				t.Fatalf("name = %q, want %q", request.Name, testPrepareModelName)
+			}
+			return models.PrepareModelAssetsResult{
+				Asset: models.AssetSnapshot{
+					ModelName: testPrepareModelName,
+					Readiness: models.AssetReadinessAvailable,
+				},
+				Outcome: models.AssetPreparationPrepared,
+			}, nil
+		},
+	}
+	operation := modelmcp.Bind(modelmcp.RootBinding{Models: fake})
+	raw, err := operation(
+		context.Background(),
+		modelmcp.ToolPrepareAssets,
+		prepareAssetsInputJSON(testRuntimeScopeRef, testPrepareModelName),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(prepare_assets) transport error = %v, want typed tool response", err)
+	}
+	if !invoked {
+		t.Fatal("fake models root was not invoked")
+	}
+	var response modelmcp.ToolResponse[models.PrepareModelAssetsResult]
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode tool response: %v", err)
+	}
+	if response.Error != nil || response.Result == nil {
+		t.Fatalf("tool response = %s, want success envelope", raw)
+	}
+	if response.Result.Outcome != models.AssetPreparationPrepared {
+		t.Fatalf("outcome = %q, want %q", response.Result.Outcome, models.AssetPreparationPrepared)
+	}
+	if response.Result.Asset.ModelName != testPrepareModelName {
+		t.Fatalf("asset.modelName = %q, want %q", response.Result.Asset.ModelName, testPrepareModelName)
+	}
+	if response.Result.Asset.Readiness != models.AssetReadinessAvailable {
+		t.Fatalf("asset.readiness = %q, want %q", response.Result.Asset.Readiness, models.AssetReadinessAvailable)
+	}
+}
+
+func TestBind_PrepareAssetsSuccessEncodesCallToolResultTransport(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeModelsRoot{
+		prepareModelAssets: func(_ context.Context, _ models.PrepareModelAssetsRequest) (models.PrepareModelAssetsResult, error) {
+			return models.PrepareModelAssetsResult{
+				Asset: models.AssetSnapshot{
+					ModelName: testPrepareModelName,
+					Readiness: models.AssetReadinessAvailable,
+				},
+				Outcome: models.AssetPreparationAlreadyAvailable,
+			}, nil
+		},
+	}
+	operation := modelmcp.Bind(modelmcp.RootBinding{Models: fake})
+	raw, err := operation(
+		context.Background(),
+		modelmcp.ToolPrepareAssets,
+		prepareAssetsInputJSON(testRuntimeScopeRef, testPrepareModelName),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(prepare_assets) transport error = %v, want typed tool response", err)
+	}
+
+	projected, err := modelmcp.MarshalSuccessCallToolResultJSON(raw)
+	if err != nil {
+		t.Fatalf("MarshalSuccessCallToolResultJSON() error = %v", err)
+	}
+	var envelope struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+		IsError *bool `json:"isError"`
+	}
+	if err := json.Unmarshal(projected, &envelope); err != nil {
+		t.Fatalf("decode CallToolResult envelope: %v", err)
+	}
+	if len(envelope.Content) != 1 {
+		t.Fatalf("content item count = %d, want 1", len(envelope.Content))
+	}
+	if envelope.Content[0].Type != "text" {
+		t.Fatalf("content[0].type = %q, want text", envelope.Content[0].Type)
+	}
+	if envelope.Content[0].Text != string(raw) {
+		t.Fatalf("content[0].text = %q, want serialized tool response %q", envelope.Content[0].Text, raw)
+	}
+	if envelope.IsError != nil {
+		t.Fatalf("isError = %v, want omitted or false for success transport", *envelope.IsError)
+	}
+}
+
+func TestBind_PrepareAssetsDomainErrorsReturnTypedEnvelopes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		rootErr       error
+		wantCode      string
+		wantRetryable bool
+	}{
+		{
+			name:          "missing source",
+			rootErr:       models.ErrAssetSourceMissing,
+			wantCode:      "model.asset.source_missing",
+			wantRetryable: false,
+		},
+		{
+			name:          "unsupported source",
+			rootErr:       models.ErrAssetSourceUnsupported,
+			wantCode:      "model.asset.source_unsupported",
+			wantRetryable: false,
+		},
+		{
+			name:          "integrity failed",
+			rootErr:       models.ErrAssetIntegrityFailed,
+			wantCode:      "model.asset.integrity_failed",
+			wantRetryable: false,
+		},
+		{
+			name:          "preparation interrupted",
+			rootErr:       models.ErrAssetPreparationInterrupted,
+			wantCode:      "model.asset.preparation_interrupted",
+			wantRetryable: true,
+		},
+		{
+			name:          "foreign scope",
+			rootErr:       models.ErrRuntimeScopeForeign,
+			wantCode:      "model.runtime_scope.foreign",
+			wantRetryable: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := fakeModelsRoot{
+				prepareModelAssets: func(context.Context, models.PrepareModelAssetsRequest) (models.PrepareModelAssetsResult, error) {
+					return models.PrepareModelAssetsResult{}, test.rootErr
+				},
+			}
+			operation := modelmcp.Bind(modelmcp.RootBinding{Models: fake})
+			raw, err := operation(
+				context.Background(),
+				modelmcp.ToolPrepareAssets,
+				prepareAssetsInputJSON(testRuntimeScopeRef, testPrepareModelName),
+			)
+			if err != nil {
+				t.Fatalf("CallTool(prepare_assets) transport error = %v, want typed tool response", err)
+			}
+			envelope := assertTypedToolErrorEnvelope(t, raw, test.wantCode, test.wantRetryable)
+			if envelope.Details == nil || envelope.Details["reason"] != test.rootErr.Error() {
+				t.Fatalf("error.details = %#v, want reason %q", envelope.Details, test.rootErr.Error())
+			}
+		})
+	}
+}
+
+func TestBind_PrepareAssetsInvalidJSONReturnsBadRequestWithoutInvokingFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	operation := modelmcp.Bind(modelmcp.RootBinding{
+		Models: fakeModelsRoot{invoked: &invoked},
+	})
+	raw, err := operation(
+		context.Background(),
+		modelmcp.ToolPrepareAssets,
+		json.RawMessage(`{"runtimeScopeRef":"`+testRuntimeScopeRef+`",`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(prepare_assets) transport error = %v, want typed tool response", err)
+	}
+	assertBadRequestToolResponse(t, raw)
+	if invoked {
+		t.Fatal("fake models root was invoked for invalid JSON decode")
+	}
+}
+
+func TestBind_PrepareAssetsMissingModelNameReturnsBadRequestWithoutInvokingFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	operation := modelmcp.Bind(modelmcp.RootBinding{
+		Models: fakeModelsRoot{invoked: &invoked},
+	})
+	raw, err := operation(
+		context.Background(),
+		modelmcp.ToolPrepareAssets,
+		json.RawMessage(`{"runtimeScopeRef":"`+testRuntimeScopeRef+`","name":""}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(prepare_assets) transport error = %v, want typed tool response", err)
+	}
+	assertBadRequestToolResponse(t, raw)
+	if invoked {
+		t.Fatal("fake models root was invoked for missing model name")
+	}
+}
+
+func prepareAssetsInputJSON(runtimeScopeRef, name string) json.RawMessage {
+	payload, err := json.Marshal(map[string]string{
+		"runtimeScopeRef": runtimeScopeRef,
+		"name":            name,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return payload
+}

--- a/pkg/services/models/transports/mcp/registry.go
+++ b/pkg/services/models/transports/mcp/registry.go
@@ -1,0 +1,110 @@
+package modelmcp
+
+// DiscoverTools returns the canonical Models MCP tool catalog in stable
+// discovery order. Schemas mirror accepted Models root request contracts.
+func DiscoverTools() []ToolDefinition {
+	return []ToolDefinition{
+		listCatalogTool(),
+		prepareAssetsTool(),
+		acquireLeaseTool(),
+		invokeWithLeaseTool(),
+	}
+}
+
+// ToolNames returns stable canonical tool names in discovery order.
+func ToolNames() []string {
+	tools := DiscoverTools()
+	names := make([]string, len(tools))
+	for i, tool := range tools {
+		names[i] = tool.Name
+	}
+	return names
+}
+
+// ToolByName returns one canonical tool definition by stable name.
+func ToolByName(name string) (ToolDefinition, bool) {
+	for _, tool := range DiscoverTools() {
+		if tool.Name == name {
+			return tool, true
+		}
+	}
+	return ToolDefinition{}, false
+}
+
+// IsCanonicalToolHandlerRegistered reports whether the live CallTool path
+// registers a handler for one canonical Models tool name.
+func IsCanonicalToolHandlerRegistered(name string) bool {
+	_, ok := canonicalToolHandlers[name]
+	return ok
+}
+
+func listCatalogTool() ToolDefinition {
+	return ToolDefinition{
+		Name: ToolListCatalog,
+		Description: "List detached catalog summaries for one open runtime scope through the accepted " +
+			"Models root without constructing Models internals.",
+		InputSchema:  listCatalogInputSchema(),
+		OutputSchema: toolResponseSchema(listCatalogResultSchema()),
+		SuccessStableFields: []string{
+			"result.Models",
+			"result.Models[].Name",
+			"result.Models[].Status",
+			"result.Models[].LoadState",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}
+
+func prepareAssetsTool() ToolDefinition {
+	return ToolDefinition{
+		Name: ToolPrepareAssets,
+		Description: "Prepare scoped model assets through the accepted Models root and distinguish " +
+			"already-available assets from newly prepared assets without HTTP or CLI transport paths.",
+		InputSchema:  prepareAssetsInputSchema(),
+		OutputSchema: toolResponseSchema(prepareAssetsResultSchema()),
+		SuccessStableFields: []string{
+			"result.Asset.ModelName",
+			"result.Asset.Readiness",
+			"result.Outcome",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}
+
+func acquireLeaseTool() ToolDefinition {
+	return ToolDefinition{
+		Name: ToolAcquireLease,
+		Description: "Acquire detached Models lease capability for one scoped model and holder through " +
+			"the accepted Models root without constructing host or lease internals.",
+		InputSchema:  acquireLeaseInputSchema(),
+		OutputSchema: toolResponseSchema(acquireLeaseResultSchema()),
+		SuccessStableFields: []string{
+			"result.Lease.Lease",
+			"result.Lease.ModelName",
+			"result.Lease.Holder",
+			"result.Lease.Status",
+			"result.Lease.HostReadiness",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}
+
+func invokeWithLeaseTool() ToolDefinition {
+	return ToolDefinition{
+		Name: ToolInvokeWithLease,
+		Description: "Invoke one scoped model operation under an issued Models lease through the accepted " +
+			"Models root and return detached content, artifact, identity, and lease-disposition facts.",
+		InputSchema:  invokeWithLeaseInputSchema(),
+		OutputSchema: toolResponseSchema(invokeWithLeaseResultSchema()),
+		SuccessStableFields: []string{
+			"result.Invocation",
+			"result.ModelName",
+			"result.Operation",
+			"result.Status",
+			"result.Content",
+			"result.Artifacts",
+			"result.LeaseDisposition",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}

--- a/pkg/services/models/transports/mcp/registry_test.go
+++ b/pkg/services/models/transports/mcp/registry_test.go
@@ -157,6 +157,8 @@ func TestIsCanonicalToolHandlerRegistered_ReportsLiveTools(t *testing.T) {
 	for _, toolName := range []string{
 		modelmcp.ToolListCatalog,
 		modelmcp.ToolPrepareAssets,
+		modelmcp.ToolAcquireLease,
+		modelmcp.ToolInvokeWithLease,
 	} {
 		if !modelmcp.IsCanonicalToolHandlerRegistered(toolName) {
 			t.Fatalf("handler for %q should be registered", toolName)

--- a/pkg/services/models/transports/mcp/registry_test.go
+++ b/pkg/services/models/transports/mcp/registry_test.go
@@ -151,11 +151,16 @@ func TestToolByName_ReturnsCatalogEntryForKnownTools(t *testing.T) {
 	}
 }
 
-func TestIsCanonicalToolHandlerRegistered_ReportsListCatalogTool(t *testing.T) {
+func TestIsCanonicalToolHandlerRegistered_ReportsLiveTools(t *testing.T) {
 	t.Parallel()
 
-	if !modelmcp.IsCanonicalToolHandlerRegistered(modelmcp.ToolListCatalog) {
-		t.Fatalf("handler for %q should be registered", modelmcp.ToolListCatalog)
+	for _, toolName := range []string{
+		modelmcp.ToolListCatalog,
+		modelmcp.ToolPrepareAssets,
+	} {
+		if !modelmcp.IsCanonicalToolHandlerRegistered(toolName) {
+			t.Fatalf("handler for %q should be registered", toolName)
+		}
 	}
 }
 

--- a/pkg/services/models/transports/mcp/registry_test.go
+++ b/pkg/services/models/transports/mcp/registry_test.go
@@ -1,0 +1,170 @@
+package modelmcp_test
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+
+	modelmcp "github.com/portpowered/infinite-you/pkg/services/models/transports/mcp"
+)
+
+func TestDiscoverTools_ExposesExpectedModelsTools(t *testing.T) {
+	t.Parallel()
+
+	tools := modelmcp.DiscoverTools()
+	if len(tools) != 4 {
+		t.Fatalf("tool count = %d, want 4", len(tools))
+	}
+
+	wantNames := []string{
+		modelmcp.ToolListCatalog,
+		modelmcp.ToolPrepareAssets,
+		modelmcp.ToolAcquireLease,
+		modelmcp.ToolInvokeWithLease,
+	}
+	gotNames := modelmcp.ToolNames()
+	if !slices.Equal(gotNames, wantNames) {
+		t.Fatalf("tool names = %#v, want %#v", gotNames, wantNames)
+	}
+}
+
+func TestDiscoverTools_EachToolHasSchemasDescriptionsAndStableFields(t *testing.T) {
+	t.Parallel()
+
+	for _, tool := range modelmcp.DiscoverTools() {
+		if strings.TrimSpace(tool.Name) == "" {
+			t.Fatal("tool name is required")
+		}
+		if strings.TrimSpace(tool.Description) == "" {
+			t.Fatalf("tool %q description is required", tool.Name)
+		}
+		if len(tool.InputSchema) == 0 {
+			t.Fatalf("tool %q input schema is required", tool.Name)
+		}
+		if schemaType, _ := tool.InputSchema["type"].(string); schemaType != "object" {
+			t.Fatalf("tool %q input schema type = %q, want object", tool.Name, schemaType)
+		}
+		additional, ok := tool.InputSchema["additionalProperties"].(bool)
+		if !ok || additional {
+			t.Fatalf("tool %q input schema additionalProperties = %v, want false", tool.Name, tool.InputSchema["additionalProperties"])
+		}
+		if len(tool.OutputSchema) == 0 {
+			t.Fatalf("tool %q output schema is required", tool.Name)
+		}
+		if len(tool.SuccessStableFields) == 0 {
+			t.Fatalf("tool %q success stable fields are required", tool.Name)
+		}
+		if len(tool.ErrorStableFields) == 0 {
+			t.Fatalf("tool %q error stable fields are required", tool.Name)
+		}
+	}
+}
+
+func TestDiscoverTools_RepresentativeSchemaFields(t *testing.T) {
+	t.Parallel()
+
+	byName := toolDefinitionsByName(t)
+
+	listProps := byName[modelmcp.ToolListCatalog].InputSchema["properties"].(map[string]any)
+	if _, ok := listProps["runtimeScopeRef"]; !ok {
+		t.Fatal("list catalog input missing runtimeScopeRef")
+	}
+
+	prepareProps := byName[modelmcp.ToolPrepareAssets].InputSchema["properties"].(map[string]any)
+	for _, field := range []string{"runtimeScopeRef", "name"} {
+		if _, ok := prepareProps[field]; !ok {
+			t.Fatalf("prepare assets input missing %q", field)
+		}
+	}
+
+	acquireProps := byName[modelmcp.ToolAcquireLease].InputSchema["properties"].(map[string]any)
+	for _, field := range []string{"runtimeScopeRef", "name", "holder"} {
+		if _, ok := acquireProps[field]; !ok {
+			t.Fatalf("acquire lease input missing %q", field)
+		}
+	}
+
+	invokeProps := byName[modelmcp.ToolInvokeWithLease].InputSchema["properties"].(map[string]any)
+	for _, field := range []string{"runtimeScopeRef", "leaseRef", "holder", "modelName", "operation", "input"} {
+		if _, ok := invokeProps[field]; !ok {
+			t.Fatalf("invoke with lease input missing %q", field)
+		}
+	}
+}
+
+func TestDiscoverTools_OutputSchemasDocumentSharedErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	for _, tool := range modelmcp.DiscoverTools() {
+		properties, ok := tool.OutputSchema["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("tool %q output schema properties missing", tool.Name)
+		}
+		errorSchema, ok := properties["error"].(map[string]any)
+		if !ok {
+			t.Fatalf("tool %q output schema missing error envelope", tool.Name)
+		}
+		errorProps, ok := errorSchema["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("tool %q error envelope properties missing", tool.Name)
+		}
+		for _, field := range []string{"code", "message", "retryable"} {
+			if _, ok := errorProps[field]; !ok {
+				t.Fatalf("tool %q error envelope missing %q", tool.Name, field)
+			}
+		}
+	}
+}
+
+func TestDiscoverTools_RepeatDiscoveryIsStable(t *testing.T) {
+	t.Parallel()
+
+	first, err := json.Marshal(modelmcp.DiscoverTools())
+	if err != nil {
+		t.Fatalf("marshal first discovery: %v", err)
+	}
+	second, err := json.Marshal(modelmcp.DiscoverTools())
+	if err != nil {
+		t.Fatalf("marshal second discovery: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Fatalf("repeat discovery differs:\nfirst=%s\nsecond=%s", first, second)
+	}
+}
+
+func TestToolByName_ReturnsCatalogEntryForKnownTools(t *testing.T) {
+	t.Parallel()
+
+	for _, want := range modelmcp.DiscoverTools() {
+		got, ok := modelmcp.ToolByName(want.Name)
+		if !ok {
+			t.Fatalf("ToolByName(%q) = false, want true", want.Name)
+		}
+		if got.Name != want.Name || got.Description != want.Description {
+			t.Fatalf("ToolByName(%q) = %#v, want %#v", want.Name, got, want)
+		}
+	}
+
+	if _, ok := modelmcp.ToolByName("you.model.unknown_tool"); ok {
+		t.Fatal("ToolByName(unknown) = true, want false")
+	}
+}
+
+func TestIsCanonicalToolHandlerRegistered_ReportsListCatalogTool(t *testing.T) {
+	t.Parallel()
+
+	if !modelmcp.IsCanonicalToolHandlerRegistered(modelmcp.ToolListCatalog) {
+		t.Fatalf("handler for %q should be registered", modelmcp.ToolListCatalog)
+	}
+}
+
+func toolDefinitionsByName(t *testing.T) map[string]modelmcp.ToolDefinition {
+	t.Helper()
+
+	byName := make(map[string]modelmcp.ToolDefinition, len(modelmcp.DiscoverTools()))
+	for _, tool := range modelmcp.DiscoverTools() {
+		byName[tool.Name] = tool
+	}
+	return byName
+}

--- a/pkg/services/models/transports/mcp/request_context_test.go
+++ b/pkg/services/models/transports/mcp/request_context_test.go
@@ -1,0 +1,124 @@
+package modelmcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	modelmcp "github.com/portpowered/infinite-you/pkg/services/models/transports/mcp"
+)
+
+func TestBind_PrepareAssetsContextCanceledBeforeRootReturnsDocumentedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	operation := modelmcp.Bind(modelmcp.RootBinding{
+		Models: fakeModelsRoot{invoked: &invoked},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	raw, err := operation(
+		ctx,
+		modelmcp.ToolPrepareAssets,
+		prepareAssetsInputJSON(testRuntimeScopeRef, testPrepareModelName),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(prepare_assets) transport error = %v, want typed tool response", err)
+	}
+	if invoked {
+		t.Fatal("fake models root was invoked for pre-canceled context")
+	}
+	envelope := assertTypedToolErrorEnvelope(
+		t,
+		raw,
+		"model.request.canceled",
+		false,
+	)
+	if envelope.Message != "models request was canceled" {
+		t.Fatalf("error.message = %q, want canceled request message; envelope = %#v", envelope.Message, envelope)
+	}
+}
+
+func TestBind_PrepareAssetsContextCanceledDuringRootReturnsDocumentedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	entered := make(chan struct{})
+	var enteredOnce sync.Once
+	fake := fakeModelsRoot{
+		prepareModelAssets: func(ctx context.Context, _ models.PrepareModelAssetsRequest) (models.PrepareModelAssetsResult, error) {
+			enteredOnce.Do(func() { close(entered) })
+			<-ctx.Done()
+			return models.PrepareModelAssetsResult{}, ctx.Err()
+		},
+	}
+	operation := modelmcp.Bind(modelmcp.RootBinding{Models: fake})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	var raw json.RawMessage
+	var callErr error
+	go func() {
+		defer close(done)
+		raw, callErr = operation(
+			ctx,
+			modelmcp.ToolPrepareAssets,
+			prepareAssetsInputJSON(testRuntimeScopeRef, testPrepareModelName),
+		)
+	}()
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fake models root did not start before cancellation")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("CallTool(prepare_assets) hung after cancellation")
+	}
+	if callErr != nil {
+		t.Fatalf("CallTool(prepare_assets) transport error = %v, want typed tool response", callErr)
+	}
+	envelope := assertTypedToolErrorEnvelope(
+		t,
+		raw,
+		"model.request.canceled",
+		false,
+	)
+	if envelope.Message != "models request was canceled" {
+		t.Fatalf("error.message = %q, want canceled request message; envelope = %#v", envelope.Message, envelope)
+	}
+}
+
+func TestBind_PrepareAssetsContextDeadlineExceededDuringRootReturnsDocumentedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeModelsRoot{
+		prepareModelAssets: func(ctx context.Context, _ models.PrepareModelAssetsRequest) (models.PrepareModelAssetsResult, error) {
+			<-ctx.Done()
+			return models.PrepareModelAssetsResult{}, ctx.Err()
+		},
+	}
+	operation := modelmcp.Bind(modelmcp.RootBinding{Models: fake})
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	raw, err := operation(
+		ctx,
+		modelmcp.ToolPrepareAssets,
+		prepareAssetsInputJSON(testRuntimeScopeRef, testPrepareModelName),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(prepare_assets) transport error = %v, want typed tool response", err)
+	}
+	envelope := assertTypedToolErrorEnvelope(
+		t,
+		raw,
+		"model.request.timed_out",
+		true,
+	)
+	if envelope.Message != "models request timed out" {
+		t.Fatalf("error.message = %q, want timed out request message; envelope = %#v", envelope.Message, envelope)
+	}
+}

--- a/pkg/services/models/transports/mcp/result_policy.go
+++ b/pkg/services/models/transports/mcp/result_policy.go
@@ -1,0 +1,27 @@
+package modelmcp
+
+import "encoding/json"
+
+const (
+	// SuccessTextEncodingSerializedJSON documents serialized JSON tool payloads in text content.
+	SuccessTextEncodingSerializedJSON = "serialized-json"
+)
+
+// EncodeSuccessCallToolResult builds the live MCP tools/call success envelope for one
+// serialized tool-response payload. Callers use this shape to document current server
+// transport without mutating handlers.
+func EncodeSuccessCallToolResult(toolResponse json.RawMessage) map[string]any {
+	return map[string]any{
+		"content": []map[string]any{
+			{
+				"type": "text",
+				"text": string(toolResponse),
+			},
+		},
+	}
+}
+
+// MarshalSuccessCallToolResultJSON encodes one success CallToolResult with stable key order.
+func MarshalSuccessCallToolResultJSON(toolResponse json.RawMessage) ([]byte, error) {
+	return json.Marshal(EncodeSuccessCallToolResult(toolResponse))
+}

--- a/pkg/services/models/transports/mcp/result_projection.go
+++ b/pkg/services/models/transports/mcp/result_projection.go
@@ -1,0 +1,85 @@
+package modelmcp
+
+import (
+	"time"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+// AcquireLeaseResult is the MCP JSON projection for you.model.acquire_lease.
+type AcquireLeaseResult struct {
+	Lease ModelLeaseResult `json:"Lease"`
+}
+
+// ModelLeaseResult carries detached lease capability facts with serialized
+// opaque references for MCP hosts.
+type ModelLeaseResult struct {
+	Lease         string                  `json:"Lease"`
+	Scope         string                  `json:"Scope"`
+	ModelName     string                  `json:"ModelName"`
+	Holder        string                  `json:"Holder"`
+	ExpiresAt     time.Time               `json:"ExpiresAt"`
+	Status        models.ModelLeaseStatus `json:"Status"`
+	HostReadiness models.ReadinessState   `json:"HostReadiness"`
+}
+
+// InvokeWithLeaseResult is the MCP JSON projection for you.model.invoke_with_lease.
+type InvokeWithLeaseResult struct {
+	Invocation       string                              `json:"Invocation"`
+	Scope            string                              `json:"Scope"`
+	Lease            string                              `json:"Lease"`
+	ModelName        string                              `json:"ModelName"`
+	Operation        string                              `json:"Operation"`
+	Status           models.ModelInvocationStatus        `json:"Status"`
+	Content          []models.InferenceContent           `json:"Content"`
+	Artifacts        []InferenceArtifactResult           `json:"Artifacts"`
+	LeaseDisposition models.InvocationLeaseDisposition `json:"LeaseDisposition"`
+}
+
+// InferenceArtifactResult carries detached artifact metadata with a serialized
+// opaque artifact reference for MCP hosts.
+type InferenceArtifactResult struct {
+	Artifact  string `json:"Artifact"`
+	Name      string `json:"Name"`
+	MediaType string `json:"MediaType"`
+	SizeBytes int64  `json:"SizeBytes"`
+}
+
+func projectAcquireLeaseResult(result models.AcquireModelLeaseResult) AcquireLeaseResult {
+	return AcquireLeaseResult{Lease: projectModelLease(result.Lease)}
+}
+
+func projectModelLease(lease models.ModelLease) ModelLeaseResult {
+	return ModelLeaseResult{
+		Lease:         lease.Lease.String(),
+		Scope:         lease.Scope.String(),
+		ModelName:     lease.ModelName,
+		Holder:        lease.Holder,
+		ExpiresAt:     lease.ExpiresAt,
+		Status:        lease.Status,
+		HostReadiness: lease.HostReadiness,
+	}
+}
+
+func projectInvokeWithLeaseResult(result models.InvokeModelResult) InvokeWithLeaseResult {
+	artifacts := make([]InferenceArtifactResult, len(result.Artifacts))
+	for i, artifact := range result.Artifacts {
+		artifacts[i] = InferenceArtifactResult{
+			Artifact:  artifact.Artifact.String(),
+			Name:      artifact.Name,
+			MediaType: artifact.MediaType,
+			SizeBytes: artifact.SizeBytes,
+		}
+	}
+	return InvokeWithLeaseResult{
+		Invocation:       result.Invocation.String(),
+		Scope:            result.Scope.String(),
+		Lease:            result.Lease.String(),
+		ModelName:        result.ModelName,
+		Operation:        result.Operation,
+		Status:           result.Status,
+		Content:          append([]models.InferenceContent(nil), result.Content...),
+		Artifacts:        artifacts,
+		LeaseDisposition: result.LeaseDisposition,
+	}
+}

--- a/pkg/services/models/transports/mcp/root_binding.go
+++ b/pkg/services/models/transports/mcp/root_binding.go
@@ -1,0 +1,22 @@
+package modelmcp
+
+import (
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+// ModelsRoot is the accepted Models root contract used by the MCP adapter.
+// Adapter-owned operations invoke this surface rather than Models internal
+// packages.
+type ModelsRoot = models.Service
+
+// RootBinding binds the MCP adapter to one injected Models root.
+type RootBinding struct {
+	Models ModelsRoot
+}
+
+// NewFromRoot constructs an MCP tool operation that calls through the supplied
+// Models root binding. Tests inject focused fakes without constructing real
+// catalog, assets, host, lease, inference graphs, or service-local Wire.
+func NewFromRoot(binding RootBinding) ToolOperation {
+	return Bind(binding)
+}

--- a/pkg/services/models/transports/mcp/schemas.go
+++ b/pkg/services/models/transports/mcp/schemas.go
@@ -1,0 +1,175 @@
+package modelmcp
+
+func objectSchema(properties map[string]any, required ...string) map[string]any {
+	schema := map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties":           properties,
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+func stringProperty(description string) map[string]any {
+	return map[string]any{
+		"type":        "string",
+		"description": description,
+	}
+}
+
+func integerProperty(description string) map[string]any {
+	return map[string]any{
+		"type":        "integer",
+		"description": description,
+	}
+}
+
+func toolResponseSchema(resultSchema map[string]any) map[string]any {
+	return objectSchema(map[string]any{
+		"result": resultSchema,
+		"error":  toolErrorEnvelopeSchema(),
+	})
+}
+
+func toolErrorEnvelopeSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"code":      stringProperty("Stable machine-readable failure code."),
+		"message":   stringProperty("Human-readable failure summary for MCP hosts."),
+		"retryable": map[string]any{"type": "boolean", "description": "Whether the caller should retry the same request later."},
+		"details": map[string]any{
+			"type":                 "object",
+			"additionalProperties": true,
+			"description":          "Optional structured diagnostics such as validation issues or scope hints.",
+		},
+	}, "code", "message", "retryable")
+}
+
+func runtimeScopeRefProperty() map[string]any {
+	return stringProperty("Opaque Models runtime-scope reference from OpenRuntimeScope.")
+}
+
+func listCatalogInputSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"runtimeScopeRef": runtimeScopeRefProperty(),
+	}, "runtimeScopeRef")
+}
+
+func prepareAssetsInputSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"runtimeScopeRef": runtimeScopeRefProperty(),
+		"name":            stringProperty("Scoped catalog model name whose assets should be prepared."),
+	}, "runtimeScopeRef", "name")
+}
+
+func acquireLeaseInputSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"runtimeScopeRef": runtimeScopeRefProperty(),
+		"name":            stringProperty("Scoped catalog model name whose capacity should be leased."),
+		"holder":          stringProperty("Non-empty lease holder identity for capacity accounting."),
+	}, "runtimeScopeRef", "name", "holder")
+}
+
+func inferenceInputSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"contentType": stringProperty("Detached inference input content type."),
+		"content":     stringProperty("Detached inference input payload."),
+	}, "contentType", "content")
+}
+
+func invokeWithLeaseInputSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"runtimeScopeRef": runtimeScopeRefProperty(),
+		"leaseRef":        stringProperty("Opaque Models lease capability reference from acquire_lease."),
+		"holder":          stringProperty("Lease holder identity that must match the issued lease."),
+		"modelName":       stringProperty("Scoped catalog model name to invoke."),
+		"operation":       stringProperty("Scoped model operation identifier."),
+		"responseMode":    stringProperty("Optional response-mode selector when the operation supports alternate representations."),
+		"input":           inferenceInputSchema(),
+	}, "runtimeScopeRef", "leaseRef", "holder", "modelName", "operation", "input")
+}
+
+func catalogSummarySchema() map[string]any {
+	return objectSchema(map[string]any{
+		"Name":             stringProperty("Catalog model name."),
+		"ProviderLocality": stringProperty("Detached provider locality classification."),
+		"Status":           stringProperty("Catalog readiness status."),
+		"LoadState":        stringProperty("Detached runtime load state."),
+	})
+}
+
+func listCatalogResultSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"Models": map[string]any{
+			"type":        "array",
+			"description": "Detached catalog summaries for the scoped runtime.",
+			"items":       catalogSummarySchema(),
+		},
+	})
+}
+
+func assetSnapshotSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"ModelName": stringProperty("Scoped model name for the prepared assets."),
+		"Readiness": stringProperty("Detached asset readiness state."),
+	})
+}
+
+func prepareAssetsResultSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"Asset":   assetSnapshotSchema(),
+		"Outcome": stringProperty("Whether assets were already available or newly prepared."),
+	})
+}
+
+func modelLeaseSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"Lease": map[string]any{
+			"type":        "object",
+			"description": "Opaque issued lease capability reference.",
+		},
+		"Scope":         runtimeScopeRefProperty(),
+		"ModelName":     stringProperty("Scoped catalog model name bound to the lease."),
+		"Holder":        stringProperty("Lease holder identity."),
+		"ExpiresAt":     stringProperty("RFC3339 lease expiry timestamp."),
+		"Status":        stringProperty("Observable lease lifecycle status."),
+		"HostReadiness": stringProperty("Detached host readiness state at lease issue."),
+	})
+}
+
+func acquireLeaseResultSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"Lease": modelLeaseSchema(),
+	})
+}
+
+func inferenceContentSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"ContentType": stringProperty("Detached inference output content type."),
+		"Content":     stringProperty("Detached inference output payload."),
+	})
+}
+
+func inferenceArtifactSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"Artifact":  stringProperty("Opaque inference artifact reference."),
+		"Name":      stringProperty("Artifact display name."),
+		"MediaType": stringProperty("Artifact media type."),
+		"SizeBytes": integerProperty("Artifact size in bytes."),
+	})
+}
+
+func invokeWithLeaseResultSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"Invocation":       stringProperty("Opaque invocation identity."),
+		"Scope":            runtimeScopeRefProperty(),
+		"Lease":            stringProperty("Opaque lease capability reference used for the invocation."),
+		"ModelName":        stringProperty("Scoped catalog model name that was invoked."),
+		"Operation":        stringProperty("Scoped model operation identifier."),
+		"Status":           stringProperty("Observable invocation lifecycle status."),
+		"Content":          map[string]any{"type": "array", "items": inferenceContentSchema()},
+		"Artifacts":        map[string]any{"type": "array", "items": inferenceArtifactSchema()},
+		"LeaseDisposition": stringProperty("Whether capacity was retained, released, or expired after invocation."),
+	})
+}

--- a/pkg/services/models/transports/mcp/tool.go
+++ b/pkg/services/models/transports/mcp/tool.go
@@ -6,7 +6,10 @@ import "encoding/json"
 
 // Tool names use Models vocabulary and align with accepted root operations.
 const (
-	ToolListCatalog = "you.model.list_catalog"
+	ToolListCatalog      = "you.model.list_catalog"
+	ToolPrepareAssets    = "you.model.prepare_assets"
+	ToolAcquireLease     = "you.model.acquire_lease"
+	ToolInvokeWithLease  = "you.model.invoke_with_lease"
 )
 
 // Stable error envelope fields shared by every Models MCP tool.

--- a/pkg/services/models/transports/mcp/tool.go
+++ b/pkg/services/models/transports/mcp/tool.go
@@ -1,0 +1,49 @@
+// Package modelmcp exposes MCP tool operations for Models service root
+// contracts backed by an injected Models Service root.
+package modelmcp
+
+import "encoding/json"
+
+// Tool names use Models vocabulary and align with accepted root operations.
+const (
+	ToolListCatalog = "you.model.list_catalog"
+)
+
+// Stable error envelope fields shared by every Models MCP tool.
+var sharedErrorStableFields = []string{
+	"error.code",
+	"error.message",
+	"error.retryable",
+	"error.details",
+}
+
+// ToolErrorEnvelope is the stable MCP failure shape for Models tools.
+type ToolErrorEnvelope struct {
+	Code      string         `json:"code"`
+	Message   string         `json:"message"`
+	Retryable bool           `json:"retryable"`
+	Details   map[string]any `json:"details,omitempty"`
+}
+
+// ToolResponse wraps one tool outcome with either a typed result or a stable error.
+type ToolResponse[T any] struct {
+	Result *T                 `json:"result,omitempty"`
+	Error  *ToolErrorEnvelope `json:"error,omitempty"`
+}
+
+// ToolDefinition is one discoverable MCP tool with typed schemas and documented
+// stable response fields for success and error envelopes.
+type ToolDefinition struct {
+	Name                string         `json:"name"`
+	Description         string         `json:"description"`
+	InputSchema         map[string]any `json:"inputSchema"`
+	OutputSchema        map[string]any `json:"outputSchema"`
+	SuccessStableFields []string       `json:"successStableFields"`
+	ErrorStableFields   []string       `json:"errorStableFields"`
+}
+
+// MarshalJSON encodes one tool definition for MCP hosts and mock clients.
+func (t ToolDefinition) MarshalJSON() ([]byte, error) {
+	type alias ToolDefinition
+	return json.Marshal(alias(t))
+}


### PR DESCRIPTION
{
  "project": "PSS MCP-MOD — Models Owner-Local MCP Adapter",
  "branchName": "pss-mcp-mod-adapter",
  "description": "Package a Models service-owned MCP adapter that exposes focused Models tools through the accepted Models root with discovery/result/error parity, without importing Models internals, owning canonical state, or touching shared MCP registry composition (PSS-I04).",
  "context": {
    "customerAsk": "Implement MCP-MOD as the Models service-owned MCP adapter. Expose Models tools through the accepted Models root with discovery/result/error parity, without importing Models internals or owning canonical state. Do not edit shared MCP registry/server composition (PSS-I04), pkg/wire, pkg/root, pkg/initializer, top-level CLI composition, or reopen Models IMP/LWR/HTTP/CLI ownership. Shared coverage, ownership, and package-target manifest edits are allowed and must be rebased through the merge loop. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Models already has an accepted root contract, terminal owner-local IMP packets through IMP-MOD-06, and service-local Wire, and Sessions/Definitions/Recordings already own complete MCP adapter patterns, but Models still has no owner-local MCP adapter. Agent clients therefore cannot discover or invoke Models root operations through a Models-owned MCP surface with root-injection, discovery, result, and error parity.",
    "solution": "Package a focused Models MCP adapter that binds an injected Models Service root, publishes a stable tool catalog for list-catalog, prepare-assets, acquire-lease, and invoke-with-lease, proves success/error/cancel/timeout parity through that root, and registers the package in shared coverage/ownership/package-target manifests only as required, leaving shared MCP fan-in to PSS-I04."
  },
  "acceptanceCriteria": [
    "Models owns an MCP adapter under its service-local transports/mcp path that calls only the accepted Models root and does not import Models internals or construct canonical Models state",
    "MCP hosts can discover a stable Models tool catalog with deterministic names, descriptions, and input schemas for list-catalog, prepare-assets, acquire-lease, and invoke-with-lease operations",
    "Calling each Models tool with a root-shaped fake returns the expected success payload or typed domain error envelope without touching shared MCP registry composition",
    "Canceled and deadline-exceeded request contexts produce stable Models MCP error envelopes (non-retryable cancel; retryable timeout)",
    "Adapter package registration appears in package-target, ownership, and coverage-minimum manifests with models retain ownership",
    "Diff stays off excluded paths: shared MCP registry/server/discovery composition (PSS-I04), pkg/wire, pkg/root, pkg/initializer, top-level CLI composition, HTTP-MOD/CLI-MOD paths, and other services' MCP adapters",
    "Quality checks pass (typecheck, lint, tests)",
    "Delivery loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file churn are reconciled, and the PR is merged (opened/green/approved/ready-to-merge alone is not complete)"
  ],
  "userStories": [
    {
      "id": "pss-mcp-mod-adapter-001",
      "title": "Bind MCP adapter to injected Models root",
      "description": "As a maintainer, I want the Models MCP adapter to depend only on an injected Models root so tool execution never imports Models internals or owns canonical state.",
      "acceptanceCriteria": [
        "Adapter exposes a bind/construction entrypoint that accepts an injected Models Service root and returns a callable MCP tool operation",
        "A fake-root test proves a tool dispatch reaches the injected root method rather than constructing real catalog/assets/host/lease/inference graphs or service-local Wire",
        "Production adapter sources do not import pkg/services/models/internal or other Models private implementation packages",
        "Diff does not modify shared MCP registry/server/discovery composition, pkg/wire, pkg/root, pkg/initializer, HTTP-MOD, CLI-MOD, or other services' MCP adapters",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-mod-adapter-002",
      "title": "Publish discoverable Models MCP tool catalog",
      "description": "As an MCP host, I want to discover the Models tool inventory with stable identities and input schemas so I can present and invoke Models operations without guessing names.",
      "acceptanceCriteria": [
        "Discovery returns a deterministic catalog that includes at least: you.model.list_catalog, you.model.prepare_assets, you.model.acquire_lease, and you.model.invoke_with_lease",
        "Each discovered tool has a non-empty description and a JSON-schema input object with additionalProperties false for known fields",
        "Catalog projection is stable under repeated discovery (same tool names and schema shape)",
        "Unknown tool names are rejected with a stable MCP error outcome rather than panicking or silently succeeding",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-mod-adapter-003",
      "title": "List model catalog through MCP",
      "description": "As an agent client, I want to list scoped catalog summaries through MCP so I observe the same detached catalog facts the accepted Models root returns, without owning catalog state in the adapter.",
      "acceptanceCriteria": [
        "Calling you.model.list_catalog with a valid runtime-scope reference returns a success tool response whose result carries the catalog summaries produced by the injected Models root",
        "Calling the tool when the root returns a typed invalid/stale/foreign-scope or unavailable-catalog failure returns a typed domain error envelope with stable code/message/retryable fields",
        "Malformed JSON arguments return a decode/bad-request style error envelope without invoking the root",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-mod-adapter-004",
      "title": "Prepare model assets through MCP",
      "description": "As an agent client, I want to prepare scoped model assets through MCP so Models asset-prepare behavior is available through the injected root without constructing Models internals or using HTTP-MOD/CLI-MOD paths.",
      "acceptanceCriteria": [
        "Calling you.model.prepare_assets with a valid scoped prepare request returns a success tool response whose result carries the prepare outcome (at least already-available versus newly-prepared facts the root returns) from the injected Models root",
        "Calling the tool when the root returns a typed missing/unsupported-source, integrity, or interrupted-prepare failure returns a typed domain error envelope distinguishable from catalog/scope failures",
        "Malformed JSON arguments return a decode/bad-request style error envelope without invoking the root",
        "Success responses encode as MCP CallToolResult success content with serialized JSON text (same success transport policy shape Sessions MCP uses)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-mod-adapter-005",
      "title": "Acquire lease and invoke with lease through MCP",
      "description": "As an agent client, I want to acquire a Models lease and invoke a scoped model operation under that lease through MCP so lease and inference outcomes from the accepted Models root are reachable without HTTP-MOD or CLI-MOD paths.",
      "acceptanceCriteria": [
        "Calling you.model.acquire_lease with a valid scoped acquire request returns detached lease capability facts produced by the injected Models root",
        "Calling you.model.invoke_with_lease with a valid scoped invoke request and issued lease returns detached invoke result facts (content/artifact/identity/lease-disposition) produced by the injected Models root",
        "Capacity-exhausted / runtime-not-ready lease failures and typed invoke failures (timeout, unavailable asset, normalized inference failure) map to stable domain error envelopes (distinct codes or messages a reviewer can distinguish)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-mod-adapter-006",
      "title": "Prove cancel and timeout error parity for Models MCP tools",
      "description": "As an agent client, I want canceled and timed-out Models MCP calls to return stable request-context error envelopes so long-running prepare/lease/invoke calls fail predictably under cancel and deadline.",
      "acceptanceCriteria": [
        "When the request context is canceled before or during a Models tool call, the tool response error uses a non-retryable canceled code/message envelope",
        "When the request context deadline is exceeded, the tool response error uses a retryable timed-out code/message envelope",
        "Cancel/timeout proof covers at least one Models tool path using a blocking fake root (same behavioral class as Sessions MCP request-context proof)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-mod-adapter-007",
      "title": "Register Models MCP adapter package ownership",
      "description": "As a Packaged Service Structure maintainer, I want the new Models MCP adapter package registered in package-target, ownership, and coverage-minimum manifests so the owner-local adapter is retained under models and covered by baseline lanes.",
      "acceptanceCriteria": [
        "Package-target manifest inventory and packages rows include pkg/services/models/transports/mcp with retain disposition and models destination",
        "Ownership inventory includes the same package path with retain disposition, owner destination, and owner destination kind",
        "Unit and functional coverage-minimum manifests include the adapter import path with an explicit minimum",
        "Shared-manifest edits are limited to adapter package registration and are rebased through the merge loop if concurrent packets touch the same files",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 7,
      "passes": true,
      "notes": ""
    }
  ]
}
