### PR TITLE
pss-lwr-set-service-wire

### DIFF
--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -802,6 +802,13 @@ response-stream output.
   `internal/service` and `wire` only. Query the accepted `providers.Service` root
   for provider identity canonicalization at resolve time; do not cache availability
   in settings state or add Providers→Operator Settings imports.
+- Operator Settings owner-local Wire at `pkg/services/operator_settings/wire`
+  must stay registered under destination `operator_settings` in
+  `docs/internal/packaged-service-structure/package-target-manifest.json`,
+  `docs/internal/baselines/ownership-inventory.json`, and both
+  `go-*-coverage-package-minimums.json` baselines; prove registration with
+  `wire/manifest_registration_test.go` rather than re-editing manifests when
+  IMP-SET already landed the rows.
 - When global named-factory guidance changes, update its authored
   `contracts/cli/commands.json` records and the task-oriented guidance in
   `docs/reference/authoring-factories.md` plus `config.md`; do not restore

--- a/pkg/services/operator_settings/internal/service/service.go
+++ b/pkg/services/operator_settings/internal/service/service.go
@@ -1,49 +1,52 @@
 // Package service implements the published Operator Settings root Service by
-// delegating effective resolution to the parent-private resolution subservice.
+// delegating document operations and effective resolution to parent-private
+// owner subservices.
 package service
 
 import (
 	"fmt"
 
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	settingsdocument "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document"
 	resolution "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution"
 )
 
 // Service fulfills the published Operator Settings root contract.
 type Service struct {
+	document   settingsdocument.Service
 	resolution resolution.Service
 }
 
 var _ operatorsettings.Service = (*Service)(nil)
 
 // New constructs an inert Operator Settings root facade over the private
-// resolution capability. Document operations remain outside this packet until
-// the document subservice is composed.
-func New(resolutionService resolution.Service) (operatorsettings.Service, error) {
+// document and resolution capabilities.
+func New(
+	documentService settingsdocument.Service,
+	resolutionService resolution.Service,
+) (operatorsettings.Service, error) {
+	if documentService == nil {
+		return nil, fmt.Errorf("construct Operator Settings: document is required")
+	}
 	if resolutionService == nil {
 		return nil, fmt.Errorf("construct Operator Settings: resolution is required")
 	}
-	return &Service{resolution: resolutionService}, nil
+	return &Service{
+		document:   documentService,
+		resolution: resolutionService,
+	}, nil
 }
 
 func (s *Service) LoadDocument(
 	request operatorsettings.LoadDocumentRequest,
 ) (operatorsettings.LoadDocumentResult, error) {
-	return operatorsettings.LoadDocumentResult{}, operatorsettings.DocumentFailure{
-		Kind:    operatorsettings.DocumentFailureKindUnsupported,
-		Message: "document subservice is not composed",
-		Path:    request.Path,
-	}
+	return s.document.LoadDocument(request)
 }
 
 func (s *Service) ApplyDocumentUpdate(
 	request operatorsettings.ApplyDocumentUpdateRequest,
 ) (operatorsettings.ApplyDocumentUpdateResult, error) {
-	return operatorsettings.ApplyDocumentUpdateResult{}, operatorsettings.DocumentFailure{
-		Kind:    operatorsettings.DocumentFailureKindUnsupported,
-		Message: "document subservice is not composed",
-		Path:    request.Path,
-	}
+	return s.document.ApplyDocumentUpdate(request)
 }
 
 func (s *Service) ResolveEffective(

--- a/pkg/services/operator_settings/internal/service/service_test.go
+++ b/pkg/services/operator_settings/internal/service/service_test.go
@@ -1,10 +1,12 @@
 package service_test
 
 import (
+	"io/fs"
 	"testing"
 
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	operatorservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/service"
+	documentwire "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/wire"
 	resolutionwire "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/wire"
 	providerswire "github.com/portpowered/infinite-you/pkg/services/providers/wire"
 )
@@ -16,11 +18,18 @@ func TestRootDelegatesResolveEffectiveToPrivateOwner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("providerswire.NewService() = %v", err)
 	}
+	documentService := documentwire.NewService(
+		&rootTestFileSystem{},
+		rootTestCreateTemporaryFile,
+		rootTestConfigDecoder,
+		rootTestConfigEncoder,
+		rootTestProviderCatalog,
+	)
 	resolutionService, err := resolutionwire.NewService(providersRoot)
 	if err != nil {
 		t.Fatalf("resolutionwire.NewService() = %v", err)
 	}
-	root, err := operatorservice.New(resolutionService)
+	root, err := operatorservice.New(documentService, resolutionService)
 	if err != nil {
 		t.Fatalf("New() = %v", err)
 	}
@@ -48,11 +57,75 @@ func TestRootDelegatesResolveEffectiveToPrivateOwner(t *testing.T) {
 	}
 }
 
+func TestNew_RejectsNilDocument(t *testing.T) {
+	t.Parallel()
+
+	providersRoot, err := providerswire.NewService()
+	if err != nil {
+		t.Fatalf("providerswire.NewService() = %v", err)
+	}
+	resolutionService, err := resolutionwire.NewService(providersRoot)
+	if err != nil {
+		t.Fatalf("resolutionwire.NewService() = %v", err)
+	}
+
+	service, err := operatorservice.New(nil, resolutionService)
+	if err == nil || service != nil {
+		t.Fatalf("New(nil, resolution) = (%v, %v), want error", service, err)
+	}
+}
+
 func TestNew_RejectsNilResolution(t *testing.T) {
 	t.Parallel()
 
-	service, err := operatorservice.New(nil)
+	documentService := documentwire.NewService(
+		&rootTestFileSystem{},
+		rootTestCreateTemporaryFile,
+		rootTestConfigDecoder,
+		rootTestConfigEncoder,
+		rootTestProviderCatalog,
+	)
+
+	service, err := operatorservice.New(documentService, nil)
 	if err == nil || service != nil {
-		t.Fatalf("New(nil) = (%v, %v), want error", service, err)
+		t.Fatalf("New(document, nil) = (%v, %v), want error", service, err)
 	}
+}
+
+type rootTestFileSystem struct{}
+
+func (rootTestFileSystem) ReadFile(string) ([]byte, error) {
+	panic("filesystem read during root service test")
+}
+
+func (rootTestFileSystem) MkdirAll(string, fs.FileMode) error {
+	panic("filesystem mkdir during root service test")
+}
+
+func (rootTestFileSystem) Remove(string) error {
+	panic("filesystem remove during root service test")
+}
+
+func (rootTestFileSystem) Chmod(string, fs.FileMode) error {
+	panic("filesystem chmod during root service test")
+}
+
+func (rootTestFileSystem) Rename(string, string) error {
+	panic("filesystem rename during root service test")
+}
+
+func rootTestCreateTemporaryFile(string, string) (operatorsettings.TemporaryFile, error) {
+	panic("temp-file creation during root service test")
+}
+
+func rootTestConfigDecoder([]byte) (operatorsettings.Config, error) {
+	panic("config decode during root service test")
+}
+
+func rootTestConfigEncoder(operatorsettings.Config) ([]byte, error) {
+	panic("config encode during root service test")
+}
+
+func rootTestProviderCatalog(string) (string, bool) {
+	panic("provider catalog during root service test")
 }

--- a/pkg/services/operator_settings/wire/manifest_registration_test.go
+++ b/pkg/services/operator_settings/wire/manifest_registration_test.go
@@ -1,0 +1,144 @@
+package wire_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/ownershipinventory"
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+const (
+	settingsWirePackagePath = "pkg/services/operator_settings/wire"
+	settingsWireImportPath  = "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
+	settingsOwner           = "operator_settings"
+)
+
+type coverageMinimumManifest struct {
+	Lane     string `json:"lane"`
+	Packages []struct {
+		Package string  `json:"package"`
+		Minimum float64 `json:"minimum"`
+	} `json:"packages"`
+}
+
+func TestManifestRegistration_SettingsWirePackageIsRegistered(t *testing.T) {
+	t.Helper()
+
+	assertPackageTargetManifestRegistration(t)
+	assertOwnershipInventoryRegistration(t)
+	assertCoverageMinimumRegistration(t, "unit", "docs/internal/baselines/go-unit-coverage-package-minimums.json")
+	assertCoverageMinimumRegistration(t, "functional", "docs/internal/baselines/go-functional-coverage-package-minimums.json")
+}
+
+func assertPackageTargetManifestRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, "docs/internal/packaged-service-structure/package-target-manifest.json"))
+	if err != nil {
+		t.Fatalf("read package-target manifest: %v", err)
+	}
+
+	var manifest struct {
+		Inventory []string `json:"inventory"`
+		Packages  []struct {
+			PackagePath string `json:"packagePath"`
+			Disposition string `json:"disposition"`
+			Destination string `json:"destination"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode package-target manifest: %v", err)
+	}
+
+	foundInventory := false
+	for _, packagePath := range manifest.Inventory {
+		if packagePath == settingsWirePackagePath {
+			foundInventory = true
+			break
+		}
+	}
+	if !foundInventory {
+		t.Fatalf("package-target manifest inventory missing %q", settingsWirePackagePath)
+	}
+
+	for _, row := range manifest.Packages {
+		if row.PackagePath != settingsWirePackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("package-target manifest disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != settingsOwner {
+			t.Fatalf("package-target manifest destination = %q, want %q", row.Destination, settingsOwner)
+		}
+		return
+	}
+	t.Fatalf("package-target manifest packages missing %q", settingsWirePackagePath)
+}
+
+func assertOwnershipInventoryRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, ownershipinventory.InventoryRelativePath))
+	if err != nil {
+		t.Fatalf("read ownership inventory: %v", err)
+	}
+
+	var inventory struct {
+		Packages []ownershipinventory.PackageRow `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		t.Fatalf("decode ownership inventory: %v", err)
+	}
+
+	for _, row := range inventory.Packages {
+		if row.PackagePath != settingsWirePackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("ownership inventory disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != settingsOwner {
+			t.Fatalf("ownership inventory destination = %q, want %q", row.Destination, settingsOwner)
+		}
+		if row.DestinationKind != ownershipinventory.DestinationKindOwner {
+			t.Fatalf(
+				"ownership inventory destinationKind = %q, want %q",
+				row.DestinationKind,
+				ownershipinventory.DestinationKindOwner,
+			)
+		}
+		return
+	}
+	t.Fatalf("ownership inventory packages missing %q", settingsWirePackagePath)
+}
+
+func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, relativePath))
+	if err != nil {
+		t.Fatalf("read %s coverage manifest: %v", lane, err)
+	}
+
+	var manifest coverageMinimumManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode %s coverage manifest: %v", lane, err)
+	}
+	if manifest.Lane != lane {
+		t.Fatalf("%s coverage manifest lane = %q, want %q", relativePath, manifest.Lane, lane)
+	}
+
+	for _, entry := range manifest.Packages {
+		if entry.Package != settingsWireImportPath {
+			continue
+		}
+		if entry.Minimum < 0 {
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, settingsWireImportPath)
+		}
+		return
+	}
+	t.Fatalf("%s coverage manifest missing %q", lane, settingsWireImportPath)
+}

--- a/pkg/services/operator_settings/wire/wire.go
+++ b/pkg/services/operator_settings/wire/wire.go
@@ -1,20 +1,83 @@
-// Package wire constructs the published Operator Settings root Service from the
-// parent-private resolution subservice.
+// Package wire is the Operator Settings service composition boundary.
+//
+// Wire performs construction only, returns the singular operatorsettings.Service
+// root interface, and starts no lifecycle components. Parent-private document
+// and resolution owner wiring stays inside the owner service assembly path;
+// peers depend on Service rather than owner internals or construction ports.
 package wire
 
 import (
+	"fmt"
+
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	operatorservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/service"
+	documentwire "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/wire"
 	resolutionwire "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/wire"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
-// NewService constructs one inert Operator Settings root over the private
-// resolution capability backed by the accepted Providers root.
-func NewService(providersRoot providers.Service) (operatorsettings.Service, error) {
+// NewService constructs an inert Operator Settings root from construction and
+// process-edge ports. It composes the accepted root through parent-private
+// document and resolution owners without publishing owner types on the returned
+// peer surface.
+func NewService(
+	files operatorsettings.FileSystem,
+	createTemp operatorsettings.CreateTemporaryFile,
+	decoder operatorsettings.ConfigDecoder,
+	encoder operatorsettings.ConfigEncoder,
+	providersCatalog operatorsettings.ProviderCatalog,
+	providersRoot providers.Service,
+) (operatorsettings.Service, error) {
+	if err := validateNewServiceInputs(
+		files,
+		createTemp,
+		decoder,
+		encoder,
+		providersCatalog,
+		providersRoot,
+	); err != nil {
+		return nil, err
+	}
+
+	documentService := documentwire.NewService(
+		files,
+		createTemp,
+		decoder,
+		encoder,
+		providersCatalog,
+	)
 	resolutionService, err := resolutionwire.NewService(providersRoot)
 	if err != nil {
 		return nil, err
 	}
-	return operatorservice.New(resolutionService)
+	return operatorservice.New(documentService, resolutionService)
+}
+
+func validateNewServiceInputs(
+	files operatorsettings.FileSystem,
+	createTemp operatorsettings.CreateTemporaryFile,
+	decoder operatorsettings.ConfigDecoder,
+	encoder operatorsettings.ConfigEncoder,
+	providersCatalog operatorsettings.ProviderCatalog,
+	providersRoot providers.Service,
+) error {
+	if files == nil {
+		return fmt.Errorf("construct Operator Settings: filesystem is required")
+	}
+	if createTemp == nil {
+		return fmt.Errorf("construct Operator Settings: create temporary file is required")
+	}
+	if decoder == nil {
+		return fmt.Errorf("construct Operator Settings: config decoder is required")
+	}
+	if encoder == nil {
+		return fmt.Errorf("construct Operator Settings: config encoder is required")
+	}
+	if providersCatalog == nil {
+		return fmt.Errorf("construct Operator Settings: provider catalog is required")
+	}
+	if providersRoot == nil {
+		return fmt.Errorf("construct Operator Settings: providers root is required")
+	}
+	return nil
 }

--- a/pkg/services/operator_settings/wire/wire_test.go
+++ b/pkg/services/operator_settings/wire/wire_test.go
@@ -1,11 +1,15 @@
 package wire_test
 
 import (
+	"context"
 	"io/fs"
+	"runtime"
 	"testing"
+	"time"
 
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 	providerswire "github.com/portpowered/infinite-you/pkg/services/providers/wire"
 )
 
@@ -35,6 +39,83 @@ func TestNewServiceConstructsPublishedRoot(t *testing.T) {
 	var root operatorsettings.Service = service
 	if root == nil {
 		t.Fatal("constructed value is not assignable to operatorsettings.Service")
+	}
+}
+
+func TestNewServiceConstructsInertRoot(t *testing.T) {
+	t.Parallel()
+
+	files := &recordingFileSystem{}
+	createTemp := newRecordingCreateTemporaryFile()
+	decoder := newRecordingConfigDecoder()
+	encoder := newRecordingConfigEncoder()
+	providersCatalog := newRecordingProviderCatalog()
+	providersRoot := &recordingProvidersRoot{}
+
+	runtime.GC()
+	time.Sleep(20 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	service, err := settingswire.NewService(
+		files,
+		createTemp.fn,
+		decoder.fn,
+		encoder.fn,
+		providersCatalog.fn,
+		providersRoot,
+	)
+	if err != nil {
+		t.Fatalf("NewService() = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+
+	var root operatorsettings.Service = service
+	if root == nil {
+		t.Fatal("constructed value is not assignable to operatorsettings.Service")
+	}
+
+	if files.readCalls != 0 {
+		t.Fatalf("construction invoked ReadFile %d times, want inert construction", files.readCalls)
+	}
+	if files.mkdirCalls != 0 || files.removeCalls != 0 || files.chmodCalls != 0 || files.renameCalls != 0 {
+		t.Fatalf(
+			"construction invoked filesystem mutations (mkdir=%d remove=%d chmod=%d rename=%d), want inert construction",
+			files.mkdirCalls,
+			files.removeCalls,
+			files.chmodCalls,
+			files.renameCalls,
+		)
+	}
+	if createTemp.calls != 0 {
+		t.Fatalf("construction invoked temp-file creation %d times, want inert construction", createTemp.calls)
+	}
+	if decoder.calls != 0 {
+		t.Fatalf("construction invoked decoder %d times, want inert construction", decoder.calls)
+	}
+	if encoder.calls != 0 {
+		t.Fatalf("construction invoked encoder %d times, want inert construction", encoder.calls)
+	}
+	if providersCatalog.calls != 0 {
+		t.Fatalf("construction invoked provider catalog %d times, want inert construction", providersCatalog.calls)
+	}
+	if providersRoot.listCalls != 0 || providersRoot.getCalls != 0 || providersRoot.executeCalls != 0 {
+		t.Fatalf(
+			"construction invoked providers root (list=%d get=%d execute=%d), want inert construction",
+			providersRoot.listCalls,
+			providersRoot.getCalls,
+			providersRoot.executeCalls,
+		)
+	}
+
+	runtime.GC()
+	time.Sleep(20 * time.Millisecond)
+	if leaked := runtime.NumGoroutine() - baseline; leaked > 4 {
+		t.Fatalf(
+			"goroutine leak after construction: baseline=%d current=%d delta=%d, want no lifecycle goroutines",
+			baseline, runtime.NumGoroutine(), leaked,
+		)
 	}
 }
 
@@ -189,4 +270,125 @@ func stubConfigEncoder(operatorsettings.Config) ([]byte, error) {
 
 func stubProviderCatalog(string) (string, bool) {
 	panic("provider catalog during wire construction test")
+}
+
+type recordingFileSystem struct {
+	readCalls   int
+	mkdirCalls  int
+	removeCalls int
+	chmodCalls  int
+	renameCalls int
+}
+
+func (files *recordingFileSystem) ReadFile(string) ([]byte, error) {
+	files.readCalls++
+	panic("filesystem read during inert construction")
+}
+
+func (files *recordingFileSystem) MkdirAll(string, fs.FileMode) error {
+	files.mkdirCalls++
+	panic("filesystem mkdir during inert construction")
+}
+
+func (files *recordingFileSystem) Remove(string) error {
+	files.removeCalls++
+	panic("filesystem remove during inert construction")
+}
+
+func (files *recordingFileSystem) Chmod(string, fs.FileMode) error {
+	files.chmodCalls++
+	panic("filesystem chmod during inert construction")
+}
+
+func (files *recordingFileSystem) Rename(string, string) error {
+	files.renameCalls++
+	panic("filesystem rename during inert construction")
+}
+
+type recordingCreateTemporaryFile struct {
+	calls int
+	fn    operatorsettings.CreateTemporaryFile
+}
+
+func newRecordingCreateTemporaryFile() *recordingCreateTemporaryFile {
+	recorder := &recordingCreateTemporaryFile{}
+	recorder.fn = func(string, string) (operatorsettings.TemporaryFile, error) {
+		recorder.calls++
+		panic("temp-file creation during inert construction")
+	}
+	return recorder
+}
+
+type recordingConfigDecoder struct {
+	calls int
+	fn    operatorsettings.ConfigDecoder
+}
+
+func newRecordingConfigDecoder() *recordingConfigDecoder {
+	recorder := &recordingConfigDecoder{}
+	recorder.fn = func([]byte) (operatorsettings.Config, error) {
+		recorder.calls++
+		panic("config decode during inert construction")
+	}
+	return recorder
+}
+
+type recordingConfigEncoder struct {
+	calls int
+	fn    operatorsettings.ConfigEncoder
+}
+
+func newRecordingConfigEncoder() *recordingConfigEncoder {
+	recorder := &recordingConfigEncoder{}
+	recorder.fn = func(operatorsettings.Config) ([]byte, error) {
+		recorder.calls++
+		panic("config encode during inert construction")
+	}
+	return recorder
+}
+
+type recordingProviderCatalog struct {
+	calls int
+	fn    operatorsettings.ProviderCatalog
+}
+
+func newRecordingProviderCatalog() *recordingProviderCatalog {
+	recorder := &recordingProviderCatalog{}
+	recorder.fn = func(string) (string, bool) {
+		recorder.calls++
+		panic("provider catalog during inert construction")
+	}
+	return recorder
+}
+
+type recordingProvidersRoot struct {
+	listCalls    int
+	getCalls     int
+	executeCalls int
+}
+
+var _ providers.Service = (*recordingProvidersRoot)(nil)
+
+func (root *recordingProvidersRoot) ListProviders(
+	context.Context,
+	providers.ListProvidersRequest,
+) (providers.ListProvidersResult, error) {
+	root.listCalls++
+	panic("providers list during inert construction")
+}
+
+func (root *recordingProvidersRoot) GetProvider(
+	context.Context,
+	providers.GetProviderRequest,
+) (providers.GetProviderResult, error) {
+	root.getCalls++
+	panic("providers get during inert construction")
+}
+
+func (root *recordingProvidersRoot) Execute(
+	context.Context,
+	providers.ExecuteRequest,
+) (providers.ExecuteResult, error) {
+	root.executeCalls++
+	panic("providers execute during inert construction")
 }

--- a/pkg/services/operator_settings/wire/wire_test.go
+++ b/pkg/services/operator_settings/wire/wire_test.go
@@ -1,0 +1,192 @@
+package wire_test
+
+import (
+	"io/fs"
+	"testing"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
+	providerswire "github.com/portpowered/infinite-you/pkg/services/providers/wire"
+)
+
+func TestNewServiceConstructsPublishedRoot(t *testing.T) {
+	t.Parallel()
+
+	providersRoot, err := providerswire.NewService()
+	if err != nil {
+		t.Fatalf("providerswire.NewService() = %v", err)
+	}
+
+	service, err := settingswire.NewService(
+		&stubFileSystem{},
+		stubCreateTemporaryFile,
+		stubConfigDecoder,
+		stubConfigEncoder,
+		stubProviderCatalog,
+		providersRoot,
+	)
+	if err != nil {
+		t.Fatalf("NewService() = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+
+	var root operatorsettings.Service = service
+	if root == nil {
+		t.Fatal("constructed value is not assignable to operatorsettings.Service")
+	}
+}
+
+func TestNewServiceRejectsMissingRequiredPorts(t *testing.T) {
+	t.Parallel()
+
+	providersRoot, err := providerswire.NewService()
+	if err != nil {
+		t.Fatalf("providerswire.NewService() = %v", err)
+	}
+
+	tests := []struct {
+		name string
+		call func() (operatorsettings.Service, error)
+		want string
+	}{
+		{
+			name: "filesystem",
+			call: func() (operatorsettings.Service, error) {
+				return settingswire.NewService(
+					nil,
+					stubCreateTemporaryFile,
+					stubConfigDecoder,
+					stubConfigEncoder,
+					stubProviderCatalog,
+					providersRoot,
+				)
+			},
+			want: "construct Operator Settings: filesystem is required",
+		},
+		{
+			name: "create temporary file",
+			call: func() (operatorsettings.Service, error) {
+				return settingswire.NewService(
+					&stubFileSystem{},
+					nil,
+					stubConfigDecoder,
+					stubConfigEncoder,
+					stubProviderCatalog,
+					providersRoot,
+				)
+			},
+			want: "construct Operator Settings: create temporary file is required",
+		},
+		{
+			name: "config decoder",
+			call: func() (operatorsettings.Service, error) {
+				return settingswire.NewService(
+					&stubFileSystem{},
+					stubCreateTemporaryFile,
+					nil,
+					stubConfigEncoder,
+					stubProviderCatalog,
+					providersRoot,
+				)
+			},
+			want: "construct Operator Settings: config decoder is required",
+		},
+		{
+			name: "config encoder",
+			call: func() (operatorsettings.Service, error) {
+				return settingswire.NewService(
+					&stubFileSystem{},
+					stubCreateTemporaryFile,
+					stubConfigDecoder,
+					nil,
+					stubProviderCatalog,
+					providersRoot,
+				)
+			},
+			want: "construct Operator Settings: config encoder is required",
+		},
+		{
+			name: "provider catalog",
+			call: func() (operatorsettings.Service, error) {
+				return settingswire.NewService(
+					&stubFileSystem{},
+					stubCreateTemporaryFile,
+					stubConfigDecoder,
+					stubConfigEncoder,
+					nil,
+					providersRoot,
+				)
+			},
+			want: "construct Operator Settings: provider catalog is required",
+		},
+		{
+			name: "providers root",
+			call: func() (operatorsettings.Service, error) {
+				return settingswire.NewService(
+					&stubFileSystem{},
+					stubCreateTemporaryFile,
+					stubConfigDecoder,
+					stubConfigEncoder,
+					stubProviderCatalog,
+					nil,
+				)
+			},
+			want: "construct Operator Settings: providers root is required",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			service, err := test.call()
+			if err == nil || service != nil {
+				t.Fatalf("call = (%v, %v), want error %q", service, err, test.want)
+			}
+			if err.Error() != test.want {
+				t.Fatalf("error = %q, want %q", err.Error(), test.want)
+			}
+		})
+	}
+}
+
+type stubFileSystem struct{}
+
+func (stubFileSystem) ReadFile(string) ([]byte, error) {
+	panic("filesystem read during wire construction test")
+}
+
+func (stubFileSystem) MkdirAll(string, fs.FileMode) error {
+	panic("filesystem mkdir during wire construction test")
+}
+
+func (stubFileSystem) Remove(string) error {
+	panic("filesystem remove during wire construction test")
+}
+
+func (stubFileSystem) Chmod(string, fs.FileMode) error {
+	panic("filesystem chmod during wire construction test")
+}
+
+func (stubFileSystem) Rename(string, string) error {
+	panic("filesystem rename during wire construction test")
+}
+
+func stubCreateTemporaryFile(string, string) (operatorsettings.TemporaryFile, error) {
+	panic("temp-file creation during wire construction test")
+}
+
+func stubConfigDecoder([]byte) (operatorsettings.Config, error) {
+	panic("config decode during wire construction test")
+}
+
+func stubConfigEncoder(operatorsettings.Config) ([]byte, error) {
+	panic("config encode during wire construction test")
+}
+
+func stubProviderCatalog(string) (string, bool) {
+	panic("provider catalog during wire construction test")
+}

--- a/pkg/services/operator_settings/wire/wire_test.go
+++ b/pkg/services/operator_settings/wire/wire_test.go
@@ -2,6 +2,7 @@ package wire_test
 
 import (
 	"context"
+	"errors"
 	"io/fs"
 	"runtime"
 	"testing"
@@ -39,6 +40,72 @@ func TestNewServiceConstructsPublishedRoot(t *testing.T) {
 	var root operatorsettings.Service = service
 	if root == nil {
 		t.Fatal("constructed value is not assignable to operatorsettings.Service")
+	}
+}
+
+func TestNewServiceServesPublishedPeerBehavior(t *testing.T) {
+	t.Parallel()
+
+	providersRoot, err := providerswire.NewService()
+	if err != nil {
+		t.Fatalf("providerswire.NewService() = %v", err)
+	}
+
+	service, err := settingswire.NewService(
+		&stubFileSystem{},
+		stubCreateTemporaryFile,
+		stubConfigDecoder,
+		stubConfigEncoder,
+		stubProviderCatalog,
+		providersRoot,
+	)
+	if err != nil {
+		t.Fatalf("NewService() = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+
+	var root operatorsettings.Service = service
+	if root == nil {
+		t.Fatal("constructed root is nil")
+	}
+
+	configPath := "/home/operator/.you-agent-factory/config.json"
+	baseline := operatorsettings.DocumentDefaults{
+		WorkerModelProvider: "codex",
+		WorkerModel:         "gpt-5",
+	}
+	resolved, err := root.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		DocumentBaseline: baseline,
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "gemini",
+			WorkerModel:         "flag-model",
+		},
+		ConfigPath: configPath,
+	})
+	if err != nil {
+		t.Fatalf("ResolveEffective() = %v", err)
+	}
+	if resolved.Selection.WorkerModelProvider != "GEMINI" ||
+		resolved.Selection.WorkerModel != "flag-model" ||
+		resolved.Selection.ConfigPath != configPath {
+		t.Fatalf("ResolveEffective() = %#v", resolved.Selection)
+	}
+
+	_, err = root.ResolveEffective(operatorsettings.ResolveEffectiveRequest{
+		InvocationOverrides: operatorsettings.EffectiveOverrideFacts{
+			WorkerModelProvider: "unsupported-provider",
+		},
+		ConfigPath: configPath,
+	})
+	if !errors.Is(err, operatorsettings.ErrResolutionUnsupportedOverride) {
+		t.Fatalf("unsupported override error = %v, want ErrResolutionUnsupportedOverride", err)
+	}
+
+	_, err = root.LoadDocument(operatorsettings.LoadDocumentRequest{})
+	if !errors.Is(err, operatorsettings.ErrDocumentMalformed) {
+		t.Fatalf("empty load path error = %v, want ErrDocumentMalformed", err)
 	}
 }
 


### PR DESCRIPTION
{
  "project": "LWR-SET: Package Settings service-local Wire",
  "branchName": "pss-lwr-set-service-wire",
  "description": "Implement LWR-SET as the Settings (operator_settings) service-local Wire packet: compose the accepted Settings root from parent-private document and resolution owners through an inert Wire path that returns only operatorsettings.Service and starts no lifecycle; prove inert construction and published peer behavior; register shared manifests as required; leave pkg/wire, pkg/root, pkg/initializer, OpenAPI, CLI composition, other-service Wire, HTTP/CLI/MCP Settings adapters, and IMP-SET ownership interiors untouched beyond Wire composition; finish only after the PR is merged.",
  "context": {
    "customerAsk": "Implement LWR-SET as the Settings (operator_settings) service-local Wire packet. Compose the accepted Settings root from parent-private document/resolution owners through an inert Wire path that returns only the root interface and starts no lifecycle. Do not edit pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, or other services' Wire. Do not expand into HTTP/CLI/MCP adapters or reopen IMP-SET ownership. Shared coverage, ownership, and package-target manifest edits are allowed and must be rebased through the merge loop. Explicitly loop through implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, the PR is merged, and only then complete the Factory work.",
    "problem": "Operator Settings already has an accepted singular Service contract and terminal IMP-SET owner packets for document and resolution, but Packaged Service Structure still lacks the landed LWR-SET owner-local inert Wire composition boundary that returns only operatorsettings.Service and composes both document and resolution. Later shared Wire cutover and Settings adapters cannot depend on a Settings-owned construction path without that packet landing.",
    "solution": "Deliver LWR-SET by aligning pkg/services/operator_settings/wire so it composes the accepted root from the parent-private document and resolution owners, returns only operatorsettings.Service, starts no lifecycle, proves inert construction and published peer behavior with focused tests, registers shared manifests as required, leaves root Wire/initializer/OpenAPI/CLI/other-service Wire and Settings transport adapters untouched, then finishes verification and merges the packet PR."
  },
  "acceptanceCriteria": [
    "AC-1: pkg/services/operator_settings/wire (or owner-local equivalent) exposes a focused constructor that returns only the published operatorsettings.Service and composes it from accepted parent-private document and resolution owners",
    "AC-2: Focused inert construction proof shows Wire construction returns a usable root interface without starting lifecycle components (no filesystem read/write/persist, no codec encode/decode, no Providers catalog/query side effects, no background goroutine activity attributable to construction)",
    "AC-3: Wire-constructed root exercises at least one published peer behavior successfully (for example ResolveEffective with valid detached inputs, or LoadDocument for a missing/valid path once document is composed) and returns a typed Settings failure for an invalid/missing request (for example malformed document path → typed document failure, invalid resolution input → typed resolution failure, or missing required construction ports → deterministic construction error)",
    "AC-4: Diff stays inside Settings Wire composition/tests plus accepted shared coverage/ownership/package-target manifest reconciliation and the minimal root-assembly adaptation required to compose already-accepted document/resolution owners; no edits to pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, other services' Wire, HTTP/CLI/MCP Settings adapters, or IMP-SET ownership interiors beyond Wire composition consumption",
    "AC-5: Quality checks pass (typecheck, lint, focused Settings Wire tests, and repository verification gates such as make verify-fast)",
    "AC-6: Delivery loop completes: required CI is terminal and passing, blocking PR conversation feedback is addressed, merge conflicts and shared-file churn are reconciled, and the PR is merged (opening, green CI, or approval alone is not completion)"
  ],
  "userStories": [
    {
      "id": "pss-lwr-set-service-wire-001",
      "title": "Publish Settings service-local Wire constructor",
      "description": "As an application composition maintainer, I want a Settings owner-local Wire constructor that returns only operatorsettings.Service so later root Wire cutover and Settings adapters can compose Settings without importing parent-private document/resolution internals or the concrete root implementation type from outside the owner boundary.",
      "acceptanceCriteria": [
        "pkg/services/operator_settings/wire (or the owner-local Settings Wire composition path) publishes a constructor such as NewService that accepts Settings construction/process-edge ports required by the accepted document and resolution owners and returns (operatorsettings.Service, error)",
        "The Wire path composes the accepted root through parent-private document and resolution owner construction/assembly already terminal under IMP-SET-01 / IMP-SET-02, without publishing those owner types on the returned peer surface",
        "Missing required construction ports fail with a deterministic construction error and a nil service",
        "Package documentation states that Wire performs construction only, returns the singular root interface, and starts no lifecycle",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-set-service-wire-002",
      "title": "Prove inert Wire construction",
      "description": "As a Packaged Service Structure reviewer, I want focused proof that Settings Wire construction is inert so process composition can hold a constructed Settings root without starting document persist, codec, Providers query, or resolution work.",
      "acceptanceCriteria": [
        "Focused Wire tests construct the root with panic or recording stubs for required effect ports (for example filesystem, temporary-file creator, decoder/encoder, Providers root/catalog) where those ports are part of construction inputs",
        "Construction completes without invoking those effect stubs for lifecycle work and without starting background lifecycle goroutines attributable to construction",
        "After construction, the returned value remains usable only through operatorsettings.Service (compile-time assignment and/or focused assertion that the returned peer is non-nil and typed as the root interface) and has not implied that document persist, codec, Providers query, or resolution work already started",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-set-service-wire-003",
      "title": "Prove Wire-built root serves published peer behavior",
      "description": "As a peer-service consumer, I want the Wire-constructed Settings root to perform published root-contract behavior so the composition path is proven by observable Settings outcomes, not by package shape alone.",
      "acceptanceCriteria": [
        "A focused Wire (or Wire-driven) test constructs the root through the service-local Wire path and successfully completes at least one published peer success path (for example ResolveEffective returns a coherent immutable effective selection for valid detached inputs, or LoadDocument returns an empty/valid document for an accepted missing/valid path once document is composed)",
        "The same Wire-built root returns a typed Operator Settings failure without panicking for at least one invalid peer call (for example malformed document request → typed document failure, invalid resolution input → typed resolution failure, or an equivalent accepted typed root failure)",
        "Success and failure outcomes are exercised through operatorsettings.Service without the test importing parent-private document/resolution packages as the peer API",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-set-service-wire-004",
      "title": "Register Wire package and pass focused verification",
      "description": "As a Packaged Service Structure steward, I want the Settings Wire package registered in shared coverage/ownership/package-target manifests as required, with focused verification green, so the packet is merge-safe without expanding into root Wire cutover, transports, or IMP-SET ownership rewrites.",
      "acceptanceCriteria": [
        "pkg/services/operator_settings/wire is registered in the package-target manifest (and coverage/ownership manifests only as required by Wire package registration)",
        "Focused Settings Wire tests pass",
        "Changed Go files are gofmt-clean; vet/lint and applicable ownership/package-target checks for changed paths pass",
        "make verify-fast (or the repository’s equivalent required short verification gate) passes",
        "Diff does not edit pkg/wire, pkg/root, pkg/initializer, OpenAPI generation, CLI root/manifest composition, other services' Wire, HTTP/CLI/MCP Settings adapters, or reopen IMP-SET ownership interiors beyond Wire composition consumption",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-set-service-wire-005",
      "title": "Open, land, and merge the LWR-SET PR",
      "description": "As a Factory delivery owner, I want the LWR-SET branch reviewed and merged so Settings service-local Wire is actually landed, not merely implemented on a long-lived branch.",
      "acceptanceCriteria": [
        "Branch pss-lwr-set-service-wire is pushed and a PR is opened or updated against the integration base",
        "Required CI checks on the PR reach a terminal passing state",
        "Every blocking PR conversation comment is explicitly addressed (fix, follow-up commit, or recorded resolution)",
        "Merge conflicts and shared-file churn (including manifests) are rebased/reconciled as needed",
        "The PR is merged; work is not marked complete while the PR is only open, green, approved, or ready to merge",
        "Typecheck passes"
      ],
      "priority": 5,
      "passes": false,
      "notes": ""
    }
  ]
}
