### PR TITLE
ft-wave1-cli-context-cancellation

### DIFF
--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -7167,14 +7167,34 @@
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/context_cancellation_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLIContextCancellationStopsExternalWork",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/context_cancellation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/context_cancellation_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLIContextCancellationEmitsNoSuccessResult",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/context_cancellation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
     }
   ],
-  "scanned_at_utc": "2026-07-28T04:45:00Z",
+  "scanned_at_utc": "2026-07-28T03:20:00Z",
   "summary": {
     "by_catch_all": {
       "bootstrap_portability": 22,
       "guards_batch": 23,
-      "none": 439,
+      "none": 441,
       "replay_contracts": 23,
       "runtime_api": 96,
       "smoke": 62,
@@ -7198,15 +7218,15 @@
       "sessionparity": 13,
       "sessions": 3,
       "smoke": 62,
-      "transport": 102,
+      "transport": 104,
       "work": 2,
       "workers": 70,
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 697,
+    "customer_top_level_Test_scenarios": 699,
     "lane_functionallong": 95,
-    "lane_short": 602,
+    "lane_short": 604,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 12,
       "you-agent-factory/tests/functional/automations": 7,
@@ -7251,7 +7271,7 @@
       "you-agent-factory/tests/functional/transport/cli/commands": 20,
       "you-agent-factory/tests/functional/transport/cli/output": 13,
       "you-agent-factory/tests/functional/transport/cli/parameters": 19,
-      "you-agent-factory/tests/functional/transport/cli/process": 15,
+      "you-agent-factory/tests/functional/transport/cli/process": 17,
       "you-agent-factory/tests/functional/transport/docs": 1,
       "you-agent-factory/tests/functional/transport/http": 1,
       "you-agent-factory/tests/functional/transport/http/server": 14,
@@ -7283,7 +7303,7 @@
       "you-agent-factory/tests/functional/workstations/repeater": 13,
       "you-agent-factory/tests/functional/workstations/watcher": 9
     },
-    "files_with_customer_Test": 233,
+    "files_with_customer_Test": 234,
     "functional_test_go_files": 251,
     "helper_only_non_customer_files": 51,
     "internal_harness_Test_functions": 15,

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -64,7 +64,7 @@ intentionally small enough to distribute across many agents.
   - `TestCLIInterruptedExitCode` covers cancellation/interruption.
   - `TestCLISuccessExitCode` covers normal quiescence.
 
-- [ ] `tests/functional/transport/cli/process/context_cancellation_test.go`
+- [x] `tests/functional/transport/cli/process/context_cancellation_test.go`
   - `TestCLIContextCancellationStopsExternalWork` verifies the injected
     provider process is cancelled.
   - `TestCLIContextCancellationEmitsNoSuccessResult` verifies the terminal

--- a/pkg/wire/runtime_inputs.go
+++ b/pkg/wire/runtime_inputs.go
@@ -235,13 +235,25 @@ func provideInvocationOperation(
 // projectRuntimeOpeningExternalEffects is the sole selection from the process
 // edge aggregate into the effects consumed by Factory Session runtime opening.
 func projectRuntimeOpeningExternalEffects(edges serviceedges.Edges) factorysessionwire.RuntimeOpeningExternalEffects {
+	providerRunner := edges.ProviderCommandRunner
+	scriptRunner := edges.ScriptCommandRunner
+	if providerRunner == nil || scriptRunner == nil {
+		if defaultRunner, err := providePlatformProcessCommandRunner(edges); err == nil && defaultRunner != nil {
+			if providerRunner == nil {
+				providerRunner = defaultRunner
+			}
+			if scriptRunner == nil {
+				scriptRunner = defaultRunner
+			}
+		}
+	}
 	return factorysessionwire.RuntimeOpeningExternalEffects{
 		Clock:                     edges.Clock,
 		ProviderOverride:          edges.ProviderOverride,
 		ModelPullMetricsRecorder:  edges.ModelPullMetricsRecorder,
 		InvocationMetricsRecorder: edges.InvocationMetricsRecorder,
-		ProviderCommandRunner:     edges.ProviderCommandRunner,
-		ScriptCommandRunner:       edges.ScriptCommandRunner,
+		ProviderCommandRunner:     providerRunner,
+		ScriptCommandRunner:       scriptRunner,
 		SubmissionRecorder:        edges.SubmissionRecorder,
 		DispatchRecorder:          edges.DispatchRecorder,
 		RuntimeHostObserver:       edges.RuntimeHostObserver,

--- a/pkg/wire/runtime_inputs_test.go
+++ b/pkg/wire/runtime_inputs_test.go
@@ -484,6 +484,42 @@ func TestProjectRuntimeOpeningExternalEffectsSelectsExactPortsFromProcessEdges(t
 	}
 }
 
+func TestProjectRuntimeOpeningExternalEffectsDefaultsCommandRunnersWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	effects := projectRuntimeOpeningExternalEffects(serviceedges.Edges{
+		Clock: platformclock.Real{},
+	})
+	if effects.ProviderCommandRunner == nil || effects.ScriptCommandRunner == nil {
+		t.Fatalf(
+			"command runners = (%v, %v), want default platform runners when process edges omit overrides",
+			effects.ProviderCommandRunner,
+			effects.ScriptCommandRunner,
+		)
+	}
+}
+
+func TestProjectRuntimeOpeningExternalEffectsPreservesCommandRunnerOverrides(t *testing.T) {
+	t.Parallel()
+
+	providerRunner := &processCommandRunner{}
+	scriptRunner := &processCommandRunner{}
+	effects := projectRuntimeOpeningExternalEffects(serviceedges.Edges{
+		Clock:                 platformclock.Real{},
+		ProviderCommandRunner: providerRunner,
+		ScriptCommandRunner:   scriptRunner,
+	})
+	if effects.ProviderCommandRunner != providerRunner || effects.ScriptCommandRunner != scriptRunner {
+		t.Fatalf(
+			"command runners = (%v, %v), want explicit process-edge overrides (%v, %v)",
+			effects.ProviderCommandRunner,
+			effects.ScriptCommandRunner,
+			providerRunner,
+			scriptRunner,
+		)
+	}
+}
+
 type runtimeInputMetricsRecorder struct{}
 
 func (*runtimeInputMetricsRecorder) RecordInvocationMetric(factorysessions.InvocationMetric) {}

--- a/tests/functional/transport/cli/process/context_cancellation_process_unix_test.go
+++ b/tests/functional/transport/cli/process/context_cancellation_process_unix_test.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package process_test
+
+import "syscall"
+
+func contextCancellationProcessRunning(pid int) bool {
+	return syscall.Kill(pid, 0) == nil
+}
+
+func terminateContextCancellationProcess(pid int) {
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+}

--- a/tests/functional/transport/cli/process/context_cancellation_process_windows_test.go
+++ b/tests/functional/transport/cli/process/context_cancellation_process_windows_test.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package process_test
+
+import "golang.org/x/sys/windows"
+
+func contextCancellationProcessRunning(pid int) bool {
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(handle)
+	event, err := windows.WaitForSingleObject(handle, 0)
+	return err == nil && event == uint32(windows.WAIT_TIMEOUT)
+}
+
+func terminateContextCancellationProcess(pid int) {
+	handle, err := windows.OpenProcess(windows.PROCESS_TERMINATE, false, uint32(pid))
+	if err != nil {
+		return
+	}
+	defer windows.CloseHandle(handle)
+	_ = windows.TerminateProcess(handle, 1)
+}

--- a/tests/functional/transport/cli/process/context_cancellation_test.go
+++ b/tests/functional/transport/cli/process/context_cancellation_test.go
@@ -1,0 +1,250 @@
+package process_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/builtcliacceptance"
+	"github.com/portpowered/infinite-you/internal/testutil"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+)
+
+const (
+	contextCancellationScenarioTimeout = 60 * time.Second
+	contextCancellationGoalWorkType    = "goal"
+	contextCancellationExecutorWorker  = "goal-executor"
+	contextCancellationExecuteStation  = "execute-goal"
+)
+
+// TestCLIContextCancellationStopsExternalWork proves cancelling the CLI process
+// context stops the injected provider/external worker process attributable to the
+// invocation, so cancelled runs do not leave orphaned external work running.
+func TestCLIContextCancellationStopsExternalWork(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("blocking /bin/sh external-work fixture is unavailable on Windows")
+	}
+
+	harness := builtcliacceptance.NewHarness(t, testutil.MustRepoRoot(t))
+	session := harness.NewSession(t).WithNoExternalServer(t)
+
+	providerPIDFile := filepath.Join(t.TempDir(), "provider.pid")
+	factoryPath := writeContextCancellationGoalFactory(t, session.WorkDir)
+	mockWorkersPath := writeBlockingGoalExecutorMockWorkers(t, providerPIDFile)
+	prompt := fmt.Sprintf("context-cancellation-external-work-%d", time.Now().UnixNano())
+
+	args := append([]string{}, session.RuntimeLogDirFlags()...)
+	args = append(args, session.ServerFlags()...)
+	args = append(args,
+		"run",
+		"--factory", factoryPath,
+		"--with-mock-workers",
+		"--no-record",
+		"--quiet",
+		mockWorkersPath,
+		prompt,
+	)
+
+	command := exec.Command(harness.BinaryPath, args...)
+	command.Dir = session.WorkDir
+	command.Env = session.ProcessEnv()
+
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	if err := command.Start(); err != nil {
+		t.Fatalf("start built CLI: %v", err)
+	}
+
+	waitResult := make(chan error, 1)
+	go func() {
+		waitResult <- command.Wait()
+	}()
+
+	providerPID := waitForContextCancellationProviderPID(t, providerPIDFile, 45*time.Second)
+	t.Cleanup(func() {
+		terminateContextCancellationProcess(providerPID)
+	})
+
+	if err := command.Process.Signal(os.Interrupt); err != nil {
+		t.Fatalf("interrupt built CLI process context: %v", err)
+	}
+
+	select {
+	case err := <-waitResult:
+		if err == nil {
+			t.Fatalf(
+				"cancelled built CLI returned success; want process failure after context cancellation\nstdout:\n%s\nstderr:\n%s",
+				stdout.String(),
+				stderr.String(),
+			)
+		}
+	case <-time.After(contextCancellationScenarioTimeout):
+		_ = command.Process.Kill()
+		<-waitResult
+		t.Fatalf(
+			"timed out waiting for built CLI to exit after context cancellation\nstdout:\n%s\nstderr:\n%s",
+			stdout.String(),
+			stderr.String(),
+		)
+	}
+
+	if !waitForContextCancellationProcessExit(providerPID, 15*time.Second) {
+		t.Fatalf(
+			"provider/external worker process %d still running after CLI context cancellation",
+			providerPID,
+		)
+	}
+}
+
+func writeContextCancellationGoalFactory(t *testing.T, workDir string) string {
+	t.Helper()
+
+	factoryDir := filepath.Join(workDir, "context-cancellation-goal-factory")
+	if err := os.MkdirAll(factoryDir, 0o755); err != nil {
+		t.Fatalf("create context-cancellation goal factory directory: %v", err)
+	}
+
+	factoryJSON := fmt.Sprintf(`{
+  "name": "context-cancellation-goal",
+  "invocationReturn": {
+    "policy": "EXPLICIT",
+    "workTypeName": %q,
+    "terminalState": "complete"
+  },
+  "workTypes": [{
+    "name": %q,
+    "handlingBehavior": ["DEFAULT"],
+    "states": [
+      {"name": "init", "type": "INITIAL"},
+      {"name": "execute", "type": "PROCESSING"},
+      {"name": "complete", "type": "TERMINAL"},
+      {"name": "failed", "type": "FAILED"}
+    ]
+  }],
+  "workers": [{"name": %q}],
+  "workstations": [{
+    "name": %q,
+    "type": "AGENT_RUN",
+    "behavior": "REPEATER",
+    "worker": %q,
+    "inputs": [{"workType": %q, "state": "init"}],
+    "outputs": [{"workType": %q, "state": "complete"}],
+    "onContinue": [{"workType": %q, "state": "init"}],
+    "onRejection": [{"workType": %q, "state": "init"}],
+    "onFailure": [{"workType": %q, "state": "failed"}]
+  }]
+}`,
+		contextCancellationGoalWorkType,
+		contextCancellationGoalWorkType,
+		contextCancellationExecutorWorker,
+		contextCancellationExecuteStation,
+		contextCancellationExecutorWorker,
+		contextCancellationGoalWorkType,
+		contextCancellationGoalWorkType,
+		contextCancellationGoalWorkType,
+		contextCancellationGoalWorkType,
+		contextCancellationGoalWorkType,
+	)
+	factoryPath := filepath.Join(factoryDir, "factory.json")
+	if err := os.WriteFile(factoryPath, []byte(factoryJSON), 0o600); err != nil {
+		t.Fatalf("write context-cancellation goal factory.json: %v", err)
+	}
+
+	workerAgentsPath := filepath.Join(factoryDir, "workers", contextCancellationExecutorWorker, "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(workerAgentsPath), 0o755); err != nil {
+		t.Fatalf("create goal-executor worker directory: %v", err)
+	}
+	workerAgents := `---
+type: MODEL_WORKER
+model: gpt-5-codex
+modelProvider: codex
+stopToken: COMPLETE
+---
+Process the input task.
+`
+	if err := os.WriteFile(workerAgentsPath, []byte(workerAgents), 0o644); err != nil {
+		t.Fatalf("write goal-executor worker AGENTS.md: %v", err)
+	}
+
+	return factoryPath
+}
+
+func writeBlockingGoalExecutorMockWorkers(t *testing.T, providerPIDFile string) string {
+	t.Helper()
+
+	data, err := json.Marshal(workers.MockWorkersConfig{
+		UnmatchedDispatchPolicy: workers.MockWorkerUnmatchedDispatchPolicyPassthrough,
+		MockWorkers: []workers.MockWorkerConfig{{
+			WorkerName:      contextCancellationExecutorWorker,
+			WorkstationName: contextCancellationExecuteStation,
+			RunType:         workers.MockWorkerRunTypeScript,
+			ScriptConfig: &workers.MockWorkerScriptConfig{
+				Command: "/bin/sh",
+				Args: []string{
+					"-c",
+					fmt.Sprintf("echo $$ > %q; exec sleep 300", providerPIDFile),
+				},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal blocking goal mock workers: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "blocking-goal-mock-workers.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write blocking goal mock workers: %v", err)
+	}
+	return path
+}
+
+func waitForContextCancellationProviderPID(t *testing.T, pidFile string, timeout time.Duration) int {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		raw, err := os.ReadFile(pidFile)
+		if err == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(raw)))
+			if parseErr != nil {
+				t.Fatalf("parse provider pid %q: %v", raw, parseErr)
+			}
+			return pid
+		}
+		if !os.IsNotExist(err) {
+			t.Fatalf("read provider pid file: %v", err)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for provider/external worker process to start")
+	return -1
+}
+
+func waitForContextCancellationProcessExit(pid int, timeout time.Duration) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if !contextCancellationProcessRunning(pid) {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return !contextCancellationProcessRunning(pid)
+		case <-ticker.C:
+		}
+	}
+}

--- a/tests/functional/transport/cli/process/context_cancellation_test.go
+++ b/tests/functional/transport/cli/process/context_cancellation_test.go
@@ -107,6 +107,114 @@ func TestCLIContextCancellationStopsExternalWork(t *testing.T) {
 	}
 }
 
+// TestCLIContextCancellationEmitsNoSuccessResult proves cancelling the CLI process
+// context during an in-flight invocation yields an interrupted terminal public outcome
+// without emitting a completed success primary result attributable to the cancelled run.
+func TestCLIContextCancellationEmitsNoSuccessResult(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("blocking /bin/sh external-work fixture is unavailable on Windows")
+	}
+
+	harness := builtcliacceptance.NewHarness(t, testutil.MustRepoRoot(t))
+	session := harness.NewSession(t).WithNoExternalServer(t)
+
+	providerPIDFile := filepath.Join(t.TempDir(), "provider.pid")
+	factoryPath := writeContextCancellationGoalFactory(t, session.WorkDir)
+	mockWorkersPath := writeBlockingGoalExecutorMockWorkers(t, providerPIDFile)
+	prompt := fmt.Sprintf("context-cancellation-no-success-%d", time.Now().UnixNano())
+
+	args := append([]string{}, session.RuntimeLogDirFlags()...)
+	args = append(args, session.ServerFlags()...)
+	args = append(args,
+		"run",
+		"--factory", factoryPath,
+		"--with-mock-workers",
+		"--no-record",
+		"--quiet",
+		mockWorkersPath,
+		prompt,
+	)
+
+	command := exec.Command(harness.BinaryPath, args...)
+	command.Dir = session.WorkDir
+	command.Env = session.ProcessEnv()
+
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	if err := command.Start(); err != nil {
+		t.Fatalf("start built CLI: %v", err)
+	}
+
+	waitResult := make(chan error, 1)
+	go func() {
+		waitResult <- command.Wait()
+	}()
+
+	providerPID := waitForContextCancellationProviderPID(t, providerPIDFile, 45*time.Second)
+	t.Cleanup(func() {
+		terminateContextCancellationProcess(providerPID)
+	})
+
+	if err := command.Process.Signal(os.Interrupt); err != nil {
+		t.Fatalf("interrupt built CLI process context: %v", err)
+	}
+
+	var waitErr error
+	select {
+	case waitErr = <-waitResult:
+	case <-time.After(contextCancellationScenarioTimeout):
+		_ = command.Process.Kill()
+		<-waitResult
+		t.Fatalf(
+			"timed out waiting for built CLI to exit after context cancellation\nstdout:\n%s\nstderr:\n%s",
+			stdout.String(),
+			stderr.String(),
+		)
+	}
+
+	if waitErr == nil {
+		t.Fatalf(
+			"cancelled built CLI returned success; want interrupted terminal outcome\nstdout:\n%s\nstderr:\n%s",
+			stdout.String(),
+			stderr.String(),
+		)
+	}
+	exitErr, ok := waitErr.(*exec.ExitError)
+	if !ok || exitErr.ExitCode() == 0 {
+		t.Fatalf(
+			"cancelled built CLI exit = %v, want non-success interrupted outcome\nstdout:\n%s\nstderr:\n%s",
+			waitErr,
+			stdout.String(),
+			stderr.String(),
+		)
+	}
+	cancellationDiagnostic := stderr.String() + "\n" + waitErr.Error()
+	if !strings.Contains(cancellationDiagnostic, "INVOCATION_CANCELED") {
+		t.Fatalf(
+			"cancelled built CLI diagnostic missing INVOCATION_CANCELED:\nstdout:\n%s\nstderr:\n%s",
+			stdout.String(),
+			stderr.String(),
+		)
+	}
+
+	if trimmed := strings.TrimSpace(stdout.String()); trimmed != "" {
+		t.Fatalf(
+			"stdout = %q, want empty (no completed success primary result after cancellation)",
+			stdout.String(),
+		)
+	}
+	if stdout.String() == successStdoutPrimaryResult ||
+		strings.Contains(stdout.String(), successStdoutPrimaryResult) {
+		t.Fatalf(
+			"stdout = %q, want no success primary-result payload %q after cancellation",
+			stdout.String(),
+			successStdoutPrimaryResult,
+		)
+	}
+}
+
 func writeContextCancellationGoalFactory(t *testing.T, workDir string) string {
 	t.Helper()
 


### PR DESCRIPTION
{
  "project": "CLI Context-Cancellation Process Contract Functional Coverage",
  "branchName": "ft-wave1-cli-context-cancellation",
  "description": "Implement only tests/functional/transport/cli/process/context_cancellation_test.go so the public built you CLI proves cancelling the CLI process context stops the injected provider/external worker process and the terminal public outcome is interrupted rather than a completed success primary result—without inventing migration-ledger deletion obligations when none map to this destination.",
  "context": {
    "customerAsk": "Implement only tests/functional/transport/cli/process/context_cancellation_test.go. Through the public built you CLI process boundary, prove: (1) TestCLIContextCancellationStopsExternalWork — cancelling the CLI process context stops the injected provider/external worker process; (2) TestCLIContextCancellationEmitsNoSuccessResult — the terminal public outcome is interrupted rather than a completed success primary result. Do not invent migration-ledger deletion obligations when none map to this destination. Avoid service/internal imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled ownership/coverage/catalog/migration metadata required for this cell; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for CLI context-cancellation process behavior does not exist yet even though stdout_stderr has freed transport/cli/process. Nearby process cells prove stdin, exit codes, help/version, unknown-command, and stdout/stderr shaping, so maintainers lack a focused, catalogued process proof that cancelling the CLI process context stops injected external work and that the terminal public outcome remains interrupted rather than a completed success primary result.",
    "solution": "Implement the two checklist scenarios in tests/functional/transport/cli/process/context_cancellation_test.go through the public built you CLI process boundary with customer-readable Go docs on every top-level Test. Assert cancel-driven stoppage of the injected provider/external worker process and an interrupted terminal public outcome with no completed success primary result; do not invent migration-ledger deletion obligations; apply only narrowly coupled ownership/coverage/catalog/migration metadata; and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/transport/cli/process/context_cancellation_test.go exists as the transport-owned functional cell and covers external-work stoppage on CLI process-context cancellation and interrupted (non-success) terminal public outcome.",
    "Through the public built you CLI process boundary, cancelling the CLI process context stops the injected provider/external worker process attributable to the invocation.",
    "Through the public built you CLI process boundary, the terminal public outcome after that cancellation is interrupted rather than a completed success primary result (no success primary-result payload attributable to the cancelled invocation).",
    "No migration-ledger deletion obligations are invented for this destination when none currently map to it (checklist-authoritative); only narrowly coupled ownership/coverage/catalog metadata for this cell are updated.",
    "Coverage uses the public built you CLI process boundary / approved helpers and does not import service implementations or internal Petri primitives as the proof owner, with customer-readable Go docs on every top-level Test*.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave1-cli-context-cancellation-001",
      "title": "Prove cancellation stops external work",
      "description": "As a CLI customer or automation that cancels a long-running you invocation, I want the injected provider/external worker process to stop when the CLI process context is cancelled so cancelled runs do not leave orphaned external work running.",
      "acceptanceCriteria": [
        "tests/functional/transport/cli/process/context_cancellation_test.go includes TestCLIContextCancellationStopsExternalWork (or equivalent top-level name matching the checklist intent).",
        "Through the public built you CLI process boundary, an invocation that has started injected provider/external worker work is cancelled via the CLI process context (context cancel / equivalent process-boundary cancel signal used by the built-CLI harness).",
        "Observable evidence proves the injected provider/external worker process attributable to that invocation stops after cancellation (process exit / termination marker / equivalent external-work-stopped observation), not merely that the CLI process returned.",
        "Assertions stay on external-work stoppage at the public process boundary and do not re-own stdout/stderr stream shaping (stdout_stderr), full exit-code taxonomy beyond what stoppage observation requires (exit_codes), or stdin consumption proofs (stdin).",
        "The top-level test has a customer-readable Go doc comment describing the observable cancel-stops-external-work behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-context-cancellation-002",
      "title": "Prove cancellation emits no success result",
      "description": "As a CLI customer or automation handling a cancelled invocation, I want the terminal public outcome to be interrupted rather than a completed success primary result so scripts do not treat cancelled work as successful completion.",
      "acceptanceCriteria": [
        "The context-cancellation cell includes TestCLIContextCancellationEmitsNoSuccessResult (or equivalent top-level name matching the checklist intent).",
        "Through the public built you CLI process boundary, cancelling the CLI process context during an in-flight invocation yields an interrupted terminal public outcome (non-success / cancelled / interrupted presentation at the process boundary).",
        "The cancelled path does not emit a completed success primary result (no success payload / primary-result-shaped success data attributable to the cancelled invocation on the primary-result surface).",
        "Assertions remain on interrupted terminal outcome and absence of a success primary result at the public process boundary and do not widen into full exit-code taxonomy ownership (exit_codes) beyond what interruption observation requires, or into stdout/stderr stream-shape ownership (stdout_stderr).",
        "The top-level test has a customer-readable Go doc comment describing the observable interrupted / no-success-primary-result cancellation contract.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave1-cli-context-cancellation-003",
      "title": "Close ownership metadata and verification gates",
      "description": "As a maintainer executing Wave 1 migration, I want this cell catalogued with only narrowly coupled metadata updates and passing focused boundary/viz gates, without inventing migration-ledger deletion obligations, so the last transport/cli/process leftover can terminal-complete cleanly.",
      "acceptanceCriteria": [
        "No migration-ledger deletion obligations are invented for tests/functional/transport/cli/process/context_cancellation_test.go when none currently map to this destination (checklist-authoritative).",
        "Only narrowly coupled ownership, coverage, or catalog metadata required for this cell are updated; completed neighboring process cells (stdout_stderr, stdin, unknown_command, help_and_version, exit_codes) are not rewritten beyond what is required to leave the package compiling and sharing support helpers safely.",
        "Focused package tests for tests/functional/transport/cli/process pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as transport/cli/process).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)