### PR TITLE
pss-cut-pses-prov

### DIFF
--- a/pkg/services/provider_sessions/details_providers_boundary_test.go
+++ b/pkg/services/provider_sessions/details_providers_boundary_test.go
@@ -1,0 +1,169 @@
+package providersessions_test
+
+import (
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+
+	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+	providersessionsservice "github.com/portpowered/infinite-you/pkg/services/provider_sessions/service"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+// TestDetails_ProvidersRootBoundary_Success proves Provider Sessions Details
+// bridges provider/kind/id strings into Providers-root SessionRef construction
+// (providers.ID + providers.SessionIDKind) and returns the existing observable
+// Detail for stored Codex and Cursor sessions.
+func TestDetails_ProvidersRootBoundary_Success(t *testing.T) {
+	t.Run("codex", func(t *testing.T) {
+		root := writeCodexSessionFixture(t, "boundary-details-codex")
+		svc := newServiceForRoots(t, root, "")
+
+		detail, err := svc.Details("codex", providers.SessionIDKind, "boundary-details-codex")
+		if err != nil {
+			t.Fatalf("Details: %v", err)
+		}
+		if detail.ProviderSession.Provider != providersessions.ProviderCodex ||
+			detail.ProviderSession.ID != "boundary-details-codex" {
+			t.Fatalf("ProviderSession = %#v, want codex boundary-details-codex", detail.ProviderSession)
+		}
+		if detail.Source.RelativePath == "" {
+			t.Fatalf("Detail.Source.RelativePath empty")
+		}
+	})
+
+	t.Run("cursor", func(t *testing.T) {
+		root, sessionID := writeCursorSessionFixture(t)
+		svc := newServiceForRoots(t, t.TempDir(), root)
+
+		detail, err := svc.Details("cursor", providers.SessionIDKind, sessionID)
+		if err != nil {
+			t.Fatalf("Details: %v", err)
+		}
+		if detail.ProviderSession.Provider != providersessions.ProviderCursor {
+			t.Fatalf("ProviderSession = %#v, want Cursor", detail.ProviderSession)
+		}
+		assertRootCursorProjection(t, detail)
+	})
+}
+
+// TestDetails_ProvidersRootBoundary_NormalizesProviderAliases proves Details
+// normalizes legacy provider strings into Providers-root provider IDs before
+// reader dispatch.
+func TestDetails_ProvidersRootBoundary_NormalizesProviderAliases(t *testing.T) {
+	root := t.TempDir()
+	svc := newServiceForRoots(t, t.TempDir(), root)
+
+	for _, provider := range []string{"cursor", "agent", "cursor-agent"} {
+		t.Run(provider, func(t *testing.T) {
+			_, err := svc.Details(provider, providers.SessionIDKind, "missing-session")
+			if !errors.Is(err, providersessions.ErrSessionNotFound) {
+				t.Fatalf("Details error = %v, want ErrSessionNotFound", err)
+			}
+			var lookupErr *providersessions.LookupError
+			if !errors.As(err, &lookupErr) {
+				t.Fatalf("Details error = %T, want LookupError", err)
+			}
+			if lookupErr.Provider != providersessions.ProviderCursor || lookupErr.Root != root {
+				t.Fatalf("LookupError = %#v, want normalized Cursor root context", lookupErr)
+			}
+		})
+	}
+}
+
+// TestDetails_ProvidersRootBoundary_TypedErrors proves Details validates
+// Providers-root SessionRef identity before storage access and preserves the
+// existing typed Provider Sessions failures.
+func TestDetails_ProvidersRootBoundary_TypedErrors(t *testing.T) {
+	files := &openRecordingFileSystem{base: platformfilesystem.Local{}}
+	svc, err := providersessionsservice.NewForRoots(
+		files,
+		filepath.WalkDir,
+		filepath.EvalSymlinks,
+		filepath.WalkDir,
+		filepath.EvalSymlinks,
+		sql.Open,
+		t.TempDir(),
+		t.TempDir(),
+	)
+	if err != nil {
+		t.Fatalf("NewForRoots: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		provider string
+		kind     string
+		id       string
+		want     error
+	}{
+		{
+			name:     "unsupported provider",
+			provider: "openai",
+			kind:     providers.SessionIDKind,
+			id:       "session-1",
+			want:     providersessions.ErrUnsupportedProvider,
+		},
+		{
+			name:     "unsupported kind",
+			provider: "codex",
+			kind:     "path",
+			id:       "session-1",
+			want:     providersessions.ErrUnsupportedKind,
+		},
+		{
+			name:     "invalid identifier",
+			provider: "codex",
+			kind:     providers.SessionIDKind,
+			id:       "../secret",
+			want:     providersessions.ErrInvalidIdentifier,
+		},
+		{
+			name:     "blank identifier",
+			provider: "codex",
+			kind:     providers.SessionIDKind,
+			id:       "   ",
+			want:     providersessions.ErrInvalidIdentifier,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			_, detailsErr := svc.Details(test.provider, test.kind, test.id)
+			if !errors.Is(detailsErr, test.want) {
+				t.Fatalf("Details error = %v, want %v", detailsErr, test.want)
+			}
+		})
+	}
+	if files.opens != 0 {
+		t.Fatalf("native file opens = %d, want 0 before validation passes", files.opens)
+	}
+}
+
+// TestDetails_ProvidersRootBoundary_MatchesInspectOutcome proves equivalent
+// string-keyed Details inputs and Providers-root Inspect requests still yield
+// the same observable source metadata.
+func TestDetails_ProvidersRootBoundary_MatchesInspectOutcome(t *testing.T) {
+	root := writeCodexSessionFixture(t, "boundary-details-equivalence")
+	svc := newServiceForRoots(t, root, "")
+	ref := providers.SessionRef{
+		Provider: providers.IDCodex,
+		Kind:     providers.SessionIDKind,
+		ID:       "boundary-details-equivalence",
+	}
+
+	detail, err := svc.Details("codex", providers.SessionIDKind, ref.ID)
+	if err != nil {
+		t.Fatalf("Details: %v", err)
+	}
+	inspected, err := svc.Inspect(providersessions.InspectRequest{Session: ref})
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if inspected.Source.RelativePath != detail.Source.RelativePath ||
+		inspected.Source.SizeBytes != detail.Source.SizeBytes {
+		t.Fatalf("Inspect source = %#v, want Details source %#v", inspected.Source, detail.Source)
+	}
+}

--- a/pkg/services/provider_sessions/inspect_providers_boundary_test.go
+++ b/pkg/services/provider_sessions/inspect_providers_boundary_test.go
@@ -1,0 +1,145 @@
+package providersessions_test
+
+import (
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+
+	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+	providersessionsservice "github.com/portpowered/infinite-you/pkg/services/provider_sessions/service"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+// Compile-time proof that InspectRequest carries the Providers-owned SessionRef
+// alias rather than a parallel Provider Sessions identity type.
+var _ providers.SessionRef = providersessions.InspectRequest{}.Session
+
+// TestInspect_ProvidersRootBoundary_Success proves Provider Sessions Inspect
+// accepts a Providers-root SessionRef (providers.ID + providers.SessionIDKind)
+// and returns the existing observable InspectResult for stored Codex and Cursor
+// sessions.
+func TestInspect_ProvidersRootBoundary_Success(t *testing.T) {
+	t.Run("codex", func(t *testing.T) {
+		root := writeCodexSessionFixture(t, "boundary-inspect-codex")
+		svc := newServiceForRoots(t, root, "")
+		ref := providers.SessionRef{
+			Provider: providers.IDCodex,
+			Kind:     providers.SessionIDKind,
+			ID:       "boundary-inspect-codex",
+		}
+
+		result, err := svc.Inspect(providersessions.InspectRequest{Session: ref})
+		if err != nil {
+			t.Fatalf("Inspect: %v", err)
+		}
+		if result.Session != ref {
+			t.Fatalf("InspectResult.Session = %#v, want %#v", result.Session, ref)
+		}
+		if result.Source.RelativePath == "" {
+			t.Fatalf("InspectResult.Source.RelativePath empty")
+		}
+	})
+
+	t.Run("cursor", func(t *testing.T) {
+		root, sessionID := writeCursorSessionFixture(t)
+		svc := newServiceForRoots(t, t.TempDir(), root)
+		ref := providers.SessionRef{
+			Provider: providers.IDCursor,
+			Kind:     providers.SessionIDKind,
+			ID:       sessionID,
+		}
+
+		result, err := svc.Inspect(providersessions.InspectRequest{Session: ref})
+		if err != nil {
+			t.Fatalf("Inspect: %v", err)
+		}
+		if result.Session != ref {
+			t.Fatalf("InspectResult.Session = %#v, want %#v", result.Session, ref)
+		}
+		if result.Source.RelativePath == "" {
+			t.Fatalf("InspectResult.Source.RelativePath empty")
+		}
+	})
+}
+
+// TestInspect_ProvidersRootBoundary_TypedErrors proves Inspect validates
+// Providers-root SessionRef identity before storage access and preserves the
+// existing typed Provider Sessions failures.
+func TestInspect_ProvidersRootBoundary_TypedErrors(t *testing.T) {
+	files := &openRecordingFileSystem{base: platformfilesystem.Local{}}
+	svc, err := providersessionsservice.NewForRoots(
+		files,
+		filepath.WalkDir,
+		filepath.EvalSymlinks,
+		filepath.WalkDir,
+		filepath.EvalSymlinks,
+		sql.Open,
+		t.TempDir(),
+		t.TempDir(),
+	)
+	if err != nil {
+		t.Fatalf("NewForRoots: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		ref  providers.SessionRef
+		want error
+	}{
+		{
+			name: "unsupported provider",
+			ref:  providers.SessionRef{Provider: "openai", Kind: providers.SessionIDKind, ID: "session-1"},
+			want: providersessions.ErrUnsupportedProvider,
+		},
+		{
+			name: "unsupported kind",
+			ref:  providers.SessionRef{Provider: providers.IDCodex, Kind: "path", ID: "session-1"},
+			want: providersessions.ErrUnsupportedKind,
+		},
+		{
+			name: "invalid identifier",
+			ref:  providers.SessionRef{Provider: providers.IDCodex, Kind: providers.SessionIDKind, ID: "../secret"},
+			want: providersessions.ErrInvalidIdentifier,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			_, inspectErr := svc.Inspect(providersessions.InspectRequest{Session: test.ref})
+			if !errors.Is(inspectErr, test.want) {
+				t.Fatalf("Inspect error = %v, want %v", inspectErr, test.want)
+			}
+		})
+	}
+	if files.opens != 0 {
+		t.Fatalf("native file opens = %d, want 0 before validation passes", files.opens)
+	}
+}
+
+// TestInspect_ProvidersRootBoundary_MatchesDetailsOutcome proves equivalent
+// string-keyed Details inputs and Providers-root Inspect requests still yield
+// the same observable source metadata.
+func TestInspect_ProvidersRootBoundary_MatchesDetailsOutcome(t *testing.T) {
+	root := writeCodexSessionFixture(t, "boundary-inspect-equivalence")
+	svc := newServiceForRoots(t, root, "")
+	ref := providers.SessionRef{
+		Provider: providers.IDCodex,
+		Kind:     providers.SessionIDKind,
+		ID:       "boundary-inspect-equivalence",
+	}
+
+	detail, err := svc.Details("codex", providers.SessionIDKind, ref.ID)
+	if err != nil {
+		t.Fatalf("Details: %v", err)
+	}
+	inspected, err := svc.Inspect(providersessions.InspectRequest{Session: ref})
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if inspected.Source.RelativePath != detail.Source.RelativePath ||
+		inspected.Source.SizeBytes != detail.Source.SizeBytes {
+		t.Fatalf("Inspect source = %#v, want Details source %#v", inspected.Source, detail.Source)
+	}
+}

--- a/pkg/services/provider_sessions/project_providers_boundary_test.go
+++ b/pkg/services/provider_sessions/project_providers_boundary_test.go
@@ -1,0 +1,151 @@
+package providersessions_test
+
+import (
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+
+	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+	providersessionsservice "github.com/portpowered/infinite-you/pkg/services/provider_sessions/service"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+// Compile-time proof that ProjectRequest carries the Providers-owned SessionRef
+// alias rather than a parallel Provider Sessions identity type.
+var _ providers.SessionRef = providersessions.ProjectRequest{}.Session
+
+// TestProject_ProvidersRootBoundary_Success proves Provider Sessions Project
+// accepts a Providers-root SessionRef (providers.ID + providers.SessionIDKind)
+// and returns the existing observable Detail-shaped ProjectResult for stored
+// Codex and Cursor sessions.
+func TestProject_ProvidersRootBoundary_Success(t *testing.T) {
+	t.Run("codex", func(t *testing.T) {
+		root := writeCodexSessionFixture(t, "boundary-project-codex")
+		svc := newServiceForRoots(t, root, "")
+		ref := providers.SessionRef{
+			Provider: providers.IDCodex,
+			Kind:     providers.SessionIDKind,
+			ID:       "boundary-project-codex",
+		}
+
+		result, err := svc.Project(providersessions.ProjectRequest{Session: ref})
+		if err != nil {
+			t.Fatalf("Project: %v", err)
+		}
+		if result.Session != ref {
+			t.Fatalf("ProjectResult.Session = %#v, want %#v", result.Session, ref)
+		}
+		if result.Detail.ProviderSession.Provider != providersessions.ProviderCodex ||
+			result.Detail.ProviderSession.ID != ref.ID {
+			t.Fatalf("ProjectResult.Detail.ProviderSession = %#v", result.Detail.ProviderSession)
+		}
+		if result.Detail.Source.RelativePath == "" {
+			t.Fatalf("ProjectResult.Detail.Source.RelativePath empty")
+		}
+	})
+
+	t.Run("cursor", func(t *testing.T) {
+		root, sessionID := writeCursorSessionFixture(t)
+		svc := newServiceForRoots(t, t.TempDir(), root)
+		ref := providers.SessionRef{
+			Provider: providers.IDCursor,
+			Kind:     providers.SessionIDKind,
+			ID:       sessionID,
+		}
+
+		result, err := svc.Project(providersessions.ProjectRequest{Session: ref})
+		if err != nil {
+			t.Fatalf("Project: %v", err)
+		}
+		if result.Session != ref {
+			t.Fatalf("ProjectResult.Session = %#v, want %#v", result.Session, ref)
+		}
+		if result.Detail.ProviderSession.Provider != providersessions.ProviderCursor {
+			t.Fatalf("ProjectResult.Detail.ProviderSession = %#v, want Cursor", result.Detail.ProviderSession)
+		}
+		assertRootCursorProjection(t, result.Detail)
+	})
+}
+
+// TestProject_ProvidersRootBoundary_TypedErrors proves Project validates
+// Providers-root SessionRef identity before storage access and preserves the
+// existing typed Provider Sessions failures.
+func TestProject_ProvidersRootBoundary_TypedErrors(t *testing.T) {
+	files := &openRecordingFileSystem{base: platformfilesystem.Local{}}
+	svc, err := providersessionsservice.NewForRoots(
+		files,
+		filepath.WalkDir,
+		filepath.EvalSymlinks,
+		filepath.WalkDir,
+		filepath.EvalSymlinks,
+		sql.Open,
+		t.TempDir(),
+		t.TempDir(),
+	)
+	if err != nil {
+		t.Fatalf("NewForRoots: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		ref  providers.SessionRef
+		want error
+	}{
+		{
+			name: "unsupported provider",
+			ref:  providers.SessionRef{Provider: "openai", Kind: providers.SessionIDKind, ID: "session-1"},
+			want: providersessions.ErrUnsupportedProvider,
+		},
+		{
+			name: "unsupported kind",
+			ref:  providers.SessionRef{Provider: providers.IDCodex, Kind: "path", ID: "session-1"},
+			want: providersessions.ErrUnsupportedKind,
+		},
+		{
+			name: "invalid identifier",
+			ref:  providers.SessionRef{Provider: providers.IDCodex, Kind: providers.SessionIDKind, ID: "../secret"},
+			want: providersessions.ErrInvalidIdentifier,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			_, projectErr := svc.Project(providersessions.ProjectRequest{Session: test.ref})
+			if !errors.Is(projectErr, test.want) {
+				t.Fatalf("Project error = %v, want %v", projectErr, test.want)
+			}
+		})
+	}
+	if files.opens != 0 {
+		t.Fatalf("native file opens = %d, want 0 before validation passes", files.opens)
+	}
+}
+
+// TestProject_ProvidersRootBoundary_MatchesDetailsOutcome proves equivalent
+// string-keyed Details inputs and Providers-root Project requests still yield
+// the same observable normalized detail facts.
+func TestProject_ProvidersRootBoundary_MatchesDetailsOutcome(t *testing.T) {
+	root := writeCodexSessionFixture(t, "boundary-project-equivalence")
+	svc := newServiceForRoots(t, root, "")
+	ref := providers.SessionRef{
+		Provider: providers.IDCodex,
+		Kind:     providers.SessionIDKind,
+		ID:       "boundary-project-equivalence",
+	}
+
+	detail, err := svc.Details("codex", providers.SessionIDKind, ref.ID)
+	if err != nil {
+		t.Fatalf("Details: %v", err)
+	}
+	projected, err := svc.Project(providersessions.ProjectRequest{Session: ref})
+	if err != nil {
+		t.Fatalf("Project: %v", err)
+	}
+	if projected.Detail.Source.RelativePath != detail.Source.RelativePath ||
+		projected.Detail.Source.SizeBytes != detail.Source.SizeBytes ||
+		projected.Detail.ProviderSession != detail.ProviderSession {
+		t.Fatalf("Project detail = %#v, want Details detail %#v", projected.Detail, detail)
+	}
+}

--- a/pkg/services/provider_sessions/providers_import_boundary_test.go
+++ b/pkg/services/provider_sessions/providers_import_boundary_test.go
@@ -1,0 +1,119 @@
+package providersessions_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// productionPackages are Provider Sessions packages that ship production
+// behavior. Boundary tests scan their dependency closure so non-root Providers
+// or Workers-owned transitional provider packages cannot re-enter through a
+// nested import.
+var productionPackages = []string{
+	"github.com/portpowered/infinite-you/pkg/services/provider_sessions",
+	"github.com/portpowered/infinite-you/pkg/services/provider_sessions/service",
+	"github.com/portpowered/infinite-you/pkg/services/provider_sessions/wire",
+	"github.com/portpowered/infinite-you/pkg/services/provider_sessions/transports/http",
+	"github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader",
+	"github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader/wire",
+	"github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader/internal/service",
+	"github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/cursor_reader",
+	"github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/cursor_reader/wire",
+	"github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/cursor_reader/internal/service",
+	"github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/cursor_reader/internal/cursor",
+}
+
+var forbiddenProvidersConsumerRoots = []string{
+	"github.com/portpowered/infinite-you/pkg/services/providers/internal",
+	"github.com/portpowered/infinite-you/pkg/services/providers/wire",
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider",
+}
+
+const providersServiceRoot = "github.com/portpowered/infinite-you/pkg/services/providers"
+
+func TestProductionPackages_ImportProvidersOnlyThroughServiceRoot(t *testing.T) {
+	t.Parallel()
+
+	for _, packagePath := range productionPackages {
+		packagePath := packagePath
+		t.Run(packagePath, func(t *testing.T) {
+			t.Parallel()
+			assertPackageDepsForbidden(t, packagePath, forbiddenProvidersConsumerRoots)
+		})
+	}
+}
+
+func TestProductionPackages_DirectProvidersImportsResolveToServiceRoot(t *testing.T) {
+	t.Parallel()
+
+	for _, packagePath := range productionPackages {
+		packagePath := packagePath
+		t.Run(packagePath, func(t *testing.T) {
+			t.Parallel()
+			for _, importPath := range listDirectImports(t, packagePath) {
+				if !strings.HasPrefix(importPath, "github.com/portpowered/infinite-you/pkg/services/providers") {
+					continue
+				}
+				if importPath != providersServiceRoot {
+					t.Fatalf(
+						"%s must import Providers only through %s; found direct import %s",
+						packagePath,
+						providersServiceRoot,
+						importPath,
+					)
+				}
+			}
+		})
+	}
+}
+
+func assertPackageDepsForbidden(t *testing.T, packagePath string, forbiddenRoots []string) {
+	t.Helper()
+
+	for _, dep := range listTransitiveDeps(t, packagePath) {
+		for _, forbidden := range forbiddenRoots {
+			if dep == forbidden || strings.HasPrefix(dep, forbidden+"/") {
+				t.Fatalf(
+					"%s must not depend on forbidden Providers consumer path %s; found dependency %s",
+					packagePath,
+					forbidden,
+					dep,
+				)
+			}
+		}
+	}
+}
+
+func listDirectImports(t *testing.T, packagePath string) []string {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", "-f", "{{join .Imports \"\\n\"}}", packagePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list imports for %s: %v\n%s", packagePath, err, output)
+	}
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "\n")
+}
+
+func listTransitiveDeps(t *testing.T, packagePath string) []string {
+	t.Helper()
+
+	cmd := exec.Command(
+		"go",
+		"list",
+		"-deps",
+		"-f",
+		"{{if not .Standard}}{{.ImportPath}}{{end}}",
+		packagePath,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list deps for %s: %v\n%s", packagePath, err, output)
+	}
+	return strings.Fields(string(output))
+}

--- a/pkg/services/provider_sessions/readers_providers_boundary_test.go
+++ b/pkg/services/provider_sessions/readers_providers_boundary_test.go
@@ -1,0 +1,230 @@
+package providersessions_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+
+	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+	codexreader "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader"
+	codexreaderwire "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader/wire"
+	cursorreaderwire "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/cursor_reader/wire"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+// Compile-time proof that parent-private Codex and Cursor reader contracts
+// accept only Providers-owned SessionRef at their production call sites.
+var (
+	_ providers.SessionRef = providers.SessionRef{
+		Provider: providers.IDCodex,
+		Kind:     providers.SessionIDKind,
+		ID:       "compile-time-codex",
+	}
+	_ providers.SessionRef = providers.SessionRef{
+		Provider: providers.IDCursor,
+		Kind:     providers.SessionIDKind,
+		ID:       "compile-time-cursor",
+	}
+)
+
+func newCodexReaderForRoot(t *testing.T, root string) codexreader.Service {
+	t.Helper()
+	reader, err := codexreaderwire.NewService(codexreader.Dependencies{
+		Files:           platformfilesystem.Local{},
+		WalkDirectory:   providersessions.CodexWalkDirectory(filepath.WalkDir),
+		ResolveSymlinks: providersessions.CodexResolveSymlinks(filepath.EvalSymlinks),
+		SessionsRoot:    root,
+	})
+	if err != nil {
+		t.Fatalf("codexreaderwire.NewService: %v", err)
+	}
+	return reader
+}
+
+func newCursorReaderForRoot(t *testing.T, root string) interface {
+	Read(context.Context, providers.SessionRef) (providersessions.Detail, error)
+} {
+	t.Helper()
+	reader, err := cursorreaderwire.NewService(
+		platformfilesystem.Local{},
+		providersessions.CursorWalkDirectory(filepath.WalkDir),
+		providersessions.CursorResolveSymlinks(filepath.EvalSymlinks),
+		providersessions.CursorOpenSQLDatabase(sql.Open),
+		root,
+	)
+	if err != nil {
+		t.Fatalf("cursorreaderwire.NewService: %v", err)
+	}
+	return reader
+}
+
+// TestCodexReader_ProvidersRootBoundary_Success proves the Codex reader handoff
+// accepts a Providers-root SessionRef and returns the existing observable Detail.
+func TestCodexReader_ProvidersRootBoundary_Success(t *testing.T) {
+	root := writeCodexSessionFixture(t, "boundary-reader-codex")
+	reader := newCodexReaderForRoot(t, root)
+	ref := providers.SessionRef{
+		Provider: providers.IDCodex,
+		Kind:     providers.SessionIDKind,
+		ID:       "boundary-reader-codex",
+	}
+
+	detail, err := reader.Details(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Codex Details: %v", err)
+	}
+	if detail.ProviderSession.Provider != providersessions.ProviderCodex ||
+		detail.ProviderSession.ID != ref.ID {
+		t.Fatalf("ProviderSession = %#v, want codex %s", detail.ProviderSession, ref.ID)
+	}
+	if detail.Source.RelativePath == "" {
+		t.Fatalf("Detail.Source.RelativePath empty")
+	}
+}
+
+// TestCursorReader_ProvidersRootBoundary_Success proves the Cursor reader handoff
+// accepts a Providers-root SessionRef and returns the existing observable Detail.
+func TestCursorReader_ProvidersRootBoundary_Success(t *testing.T) {
+	root, sessionID := writeCursorSessionFixture(t)
+	reader := newCursorReaderForRoot(t, root)
+	ref := providers.SessionRef{
+		Provider: providers.IDCursor,
+		Kind:     providers.SessionIDKind,
+		ID:       sessionID,
+	}
+
+	detail, err := reader.Read(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Cursor Read: %v", err)
+	}
+	if detail.ProviderSession.Provider != providersessions.ProviderCursor {
+		t.Fatalf("ProviderSession = %#v, want Cursor", detail.ProviderSession)
+	}
+	assertRootCursorProjection(t, detail)
+}
+
+// TestCodexReader_ProvidersRootBoundary_TypedErrors proves Codex reader validates
+// Providers-root SessionRef identity and preserves existing typed failures.
+func TestCodexReader_ProvidersRootBoundary_TypedErrors(t *testing.T) {
+	reader := newCodexReaderForRoot(t, t.TempDir())
+
+	cases := []struct {
+		name string
+		ref  providers.SessionRef
+		want error
+	}{
+		{
+			name: "unsupported provider",
+			ref:  providers.SessionRef{Provider: "openai", Kind: providers.SessionIDKind, ID: "session-1"},
+			want: providersessions.ErrUnsupportedProvider,
+		},
+		{
+			name: "unsupported kind",
+			ref:  providers.SessionRef{Provider: providers.IDCodex, Kind: "path", ID: "session-1"},
+			want: providersessions.ErrUnsupportedKind,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := reader.Details(context.Background(), test.ref)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("Codex Details error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+// TestCursorReader_ProvidersRootBoundary_TypedErrors proves Cursor reader validates
+// Providers-root SessionRef identity and preserves existing typed failures.
+func TestCursorReader_ProvidersRootBoundary_TypedErrors(t *testing.T) {
+	reader := newCursorReaderForRoot(t, t.TempDir())
+
+	cases := []struct {
+		name string
+		ref  providers.SessionRef
+		want error
+	}{
+		{
+			name: "unsupported provider",
+			ref:  providers.SessionRef{Provider: "openai", Kind: providers.SessionIDKind, ID: "session-1"},
+			want: providersessions.ErrUnsupportedProvider,
+		},
+		{
+			name: "codex provider on cursor reader",
+			ref:  providers.SessionRef{Provider: providers.IDCodex, Kind: providers.SessionIDKind, ID: "session-1"},
+			want: providersessions.ErrUnsupportedProvider,
+		},
+		{
+			name: "unsupported kind",
+			ref:  providers.SessionRef{Provider: providers.IDCursor, Kind: "path", ID: "session-1"},
+			want: providersessions.ErrUnsupportedKind,
+		},
+		{
+			name: "invalid identifier",
+			ref:  providers.SessionRef{Provider: providers.IDCursor, Kind: providers.SessionIDKind, ID: "   "},
+			want: providersessions.ErrInvalidIdentifier,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := reader.Read(context.Background(), test.ref)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("Cursor Read error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+// TestReaders_ProvidersRootBoundary_ServiceHandoff proves Provider Sessions
+// dispatches Providers-root SessionRef to Codex and Cursor readers without
+// reintroducing Workers provider or Providers implementation types.
+func TestReaders_ProvidersRootBoundary_ServiceHandoff(t *testing.T) {
+	t.Run("codex via Details", func(t *testing.T) {
+		root := writeCodexSessionFixture(t, "boundary-handoff-codex")
+		svc := newServiceForRoots(t, root, "")
+		ref := providers.SessionRef{
+			Provider: providers.IDCodex,
+			Kind:     providers.SessionIDKind,
+			ID:       "boundary-handoff-codex",
+		}
+
+		detail, err := svc.Details("codex", providers.SessionIDKind, ref.ID)
+		if err != nil {
+			t.Fatalf("Details: %v", err)
+		}
+		projected, err := svc.Project(providersessions.ProjectRequest{Session: ref})
+		if err != nil {
+			t.Fatalf("Project: %v", err)
+		}
+		if projected.Detail.Source.RelativePath != detail.Source.RelativePath {
+			t.Fatalf("Project source = %#v, want Details source %#v", projected.Detail.Source, detail.Source)
+		}
+	})
+
+	t.Run("cursor via Details", func(t *testing.T) {
+		root, sessionID := writeCursorSessionFixture(t)
+		svc := newServiceForRoots(t, t.TempDir(), root)
+		ref := providers.SessionRef{
+			Provider: providers.IDCursor,
+			Kind:     providers.SessionIDKind,
+			ID:       sessionID,
+		}
+
+		detail, err := svc.Details("cursor", providers.SessionIDKind, sessionID)
+		if err != nil {
+			t.Fatalf("Details: %v", err)
+		}
+		projected, err := svc.Project(providersessions.ProjectRequest{Session: ref})
+		if err != nil {
+			t.Fatalf("Project: %v", err)
+		}
+		assertRootCursorProjection(t, projected.Detail)
+		if projected.Detail.Source.RelativePath != detail.Source.RelativePath {
+			t.Fatalf("Project source = %#v, want Details source %#v", projected.Detail.Source, detail.Source)
+		}
+	})
+}

--- a/pkg/services/provider_sessions/root_contracts_providers_boundary_test.go
+++ b/pkg/services/provider_sessions/root_contracts_providers_boundary_test.go
@@ -1,0 +1,225 @@
+package providersessions_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+const providerSessionsRootPackage = "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+
+// Compile-time proofs that Provider Sessions root identity contracts are aliases
+// of or carry Providers-owned SessionRef values rather than parallel vocabulary.
+var (
+	_ providers.SessionRef = providersessions.SessionRef{}
+	_ providers.SessionRef = providersessions.InspectRequest{}.Session
+	_ providers.SessionRef = providersessions.InspectResult{}.Session
+	_ providers.SessionRef = providersessions.ProjectRequest{}.Session
+	_ providers.SessionRef = providersessions.ProjectResult{}.Session
+)
+
+var providersRootIdentityContracts = []reflect.Type{
+	reflect.TypeOf(providersessions.SessionRef{}),
+	reflect.TypeOf(providersessions.InspectRequest{}),
+	reflect.TypeOf(providersessions.InspectResult{}),
+	reflect.TypeOf(providersessions.ProjectRequest{}),
+	reflect.TypeOf(providersessions.ProjectResult{}),
+}
+
+var forbiddenProvidersPeerSurfaceRoots = []string{
+	"github.com/portpowered/infinite-you/pkg/services/providers/internal",
+	"github.com/portpowered/infinite-you/pkg/services/providers/wire",
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider",
+}
+
+func TestRootPackage_ImportsProvidersOnlyThroughServiceRoot(t *testing.T) {
+	t.Parallel()
+
+	assertPackageDepsForbidden(t, providerSessionsRootPackage, forbiddenProvidersConsumerRoots)
+	for _, importPath := range listDirectImports(t, providerSessionsRootPackage) {
+		if !strings.HasPrefix(importPath, "github.com/portpowered/infinite-you/pkg/services/providers") {
+			continue
+		}
+		if importPath != providersServiceRoot {
+			t.Fatalf(
+				"%s must import Providers only through %s; found direct import %s",
+				providerSessionsRootPackage,
+				providersServiceRoot,
+				importPath,
+			)
+		}
+	}
+}
+
+func TestRootContracts_ProvidersRootBoundary_PeerSurfaceUsesProvidersIdentityOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, typ := range providersRootIdentityContracts {
+		typ := typ
+		t.Run(typ.String(), func(t *testing.T) {
+			t.Parallel()
+			assertContractTypeUsesOnlyProvidersRootIdentity(t, typ, map[reflect.Type]bool{})
+		})
+	}
+}
+
+func assertContractTypeUsesOnlyProvidersRootIdentity(
+	t *testing.T,
+	typ reflect.Type,
+	visiting map[reflect.Type]bool,
+) {
+	t.Helper()
+
+	for typ.Kind() == reflect.Pointer || typ.Kind() == reflect.Slice ||
+		typ.Kind() == reflect.Array || typ.Kind() == reflect.Map {
+		typ = typ.Elem()
+	}
+	if visiting[typ] {
+		return
+	}
+	visiting[typ] = true
+	defer delete(visiting, typ)
+
+	switch typ.Kind() {
+	case reflect.Interface:
+		if typ.PkgPath() == "context" {
+			return
+		}
+		t.Fatalf("root contract %s must not expose non-context interface dependency", typ)
+	case reflect.Func, reflect.Chan:
+		t.Fatalf("root contract %s must not expose non-value dependency %s", typ, typ.Kind())
+	case reflect.Struct:
+		for index := 0; index < typ.NumField(); index++ {
+			field := typ.Field(index)
+			if field.PkgPath != "" && !field.IsExported() {
+				continue
+			}
+			assertContractTypeUsesOnlyProvidersRootIdentity(t, field.Type, visiting)
+		}
+	case reflect.String, reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32,
+		reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Uintptr, reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128:
+		return
+	default:
+		if typ.PkgPath() == "" {
+			return
+		}
+	}
+
+	pkgPath := typ.PkgPath()
+	if pkgPath == "" || pkgPath == "context" || pkgPath == "time" {
+		return
+	}
+	if pkgPath == providerSessionsRootPackage || pkgPath == providersServiceRoot {
+		return
+	}
+	for _, forbidden := range forbiddenProvidersPeerSurfaceRoots {
+		if pkgPath == forbidden || strings.HasPrefix(pkgPath, forbidden+"/") {
+			t.Fatalf("root contract type %s depends on forbidden Providers consumer path %s", typ, pkgPath)
+		}
+	}
+	t.Fatalf(
+		"root contract type %s depends on unexpected package %s; peer surface must use only Provider Sessions root and Providers service-root identity types",
+		typ,
+		pkgPath,
+	)
+}
+
+// peerConstructProvidersRootIdentity builds Inspect/Project/Details inputs using
+// only Provider Sessions root contracts and Providers-root SessionRef vocabulary.
+func peerConstructProvidersRootIdentity(
+	provider, kind, id string,
+) (providersessions.InspectRequest, providersessions.ProjectRequest, providers.SessionRef) {
+	ref := providers.SessionRef{
+		Provider: providers.ID(provider),
+		Kind:     kind,
+		ID:       id,
+	}
+	return providersessions.InspectRequest{Session: ref},
+		providersessions.ProjectRequest{Session: ref},
+		ref
+}
+
+// TestRootContracts_ProvidersRootBoundary_IdentityConstruction proves peers can
+// construct Inspect, Project, and Details identity through Provider Sessions
+// root contracts and Providers-root SessionRef without Workers provider or
+// Providers implementation types.
+func TestRootContracts_ProvidersRootBoundary_IdentityConstruction(t *testing.T) {
+	t.Run("codex", func(t *testing.T) {
+		root := writeCodexSessionFixture(t, "boundary-root-contract-codex")
+		svc := newServiceForRoots(t, root, "")
+		inspectReq, projectReq, ref := peerConstructProvidersRootIdentity(
+			string(providers.IDCodex),
+			providers.SessionIDKind,
+			"boundary-root-contract-codex",
+		)
+
+		detail, err := svc.Details("codex", providers.SessionIDKind, ref.ID)
+		if err != nil {
+			t.Fatalf("Details: %v", err)
+		}
+		if detail.ProviderSession.Provider != providersessions.ProviderCodex ||
+			detail.ProviderSession.Kind != providers.SessionIDKind ||
+			detail.ProviderSession.ID != ref.ID {
+			t.Fatalf("Detail.ProviderSession = %#v, want codex identity for %q", detail.ProviderSession, ref.ID)
+		}
+
+		inspected, err := svc.Inspect(inspectReq)
+		if err != nil {
+			t.Fatalf("Inspect: %v", err)
+		}
+		if inspected.Session != ref {
+			t.Fatalf("InspectResult.Session = %#v, want %#v", inspected.Session, ref)
+		}
+
+		projected, err := svc.Project(projectReq)
+		if err != nil {
+			t.Fatalf("Project: %v", err)
+		}
+		if projected.Session != ref {
+			t.Fatalf("ProjectResult.Session = %#v, want %#v", projected.Session, ref)
+		}
+		if projected.Detail.ProviderSession.ID != ref.ID {
+			t.Fatalf("ProjectResult.Detail.ProviderSession = %#v, want id %q", projected.Detail.ProviderSession, ref.ID)
+		}
+	})
+
+	t.Run("cursor", func(t *testing.T) {
+		root, sessionID := writeCursorSessionFixture(t)
+		svc := newServiceForRoots(t, t.TempDir(), root)
+		inspectReq, projectReq, ref := peerConstructProvidersRootIdentity(
+			string(providers.IDCursor),
+			providers.SessionIDKind,
+			sessionID,
+		)
+
+		detail, err := svc.Details("cursor", providers.SessionIDKind, sessionID)
+		if err != nil {
+			t.Fatalf("Details: %v", err)
+		}
+		if detail.ProviderSession.Provider != providersessions.ProviderCursor ||
+			detail.ProviderSession.ID != sessionID {
+			t.Fatalf("Detail.ProviderSession = %#v, want cursor %q", detail.ProviderSession, sessionID)
+		}
+
+		inspected, err := svc.Inspect(inspectReq)
+		if err != nil {
+			t.Fatalf("Inspect: %v", err)
+		}
+		if inspected.Session != ref {
+			t.Fatalf("InspectResult.Session = %#v, want %#v", inspected.Session, ref)
+		}
+
+		projected, err := svc.Project(projectReq)
+		if err != nil {
+			t.Fatalf("Project: %v", err)
+		}
+		if projected.Session != ref {
+			t.Fatalf("ProjectResult.Session = %#v, want %#v", projected.Session, ref)
+		}
+		assertRootCursorProjection(t, projected.Detail)
+	})
+}


### PR DESCRIPTION
{
  "project": "CUT-PSES-PROV: Provider Sessions consumes Providers root only",
  "branchName": "pss-cut-pses-prov",
  "description": "Seal the Provider Sessions→Providers consumer edge so Provider Sessions imports and constructs Providers-owned SessionRef / Inspect / Project identity only through the Providers service root contract (`pkg/services/providers`), with focused Provider Sessions/Providers boundary tests proving request construction, without folding or deleting provider_sessions/service, editing root pkg/wire, admitting IMP-PROV-04/LWR-PROV, or touching Automations or Recordings.",
  "context": {
    "customerAsk": "CUT-PSES-PROV: lease only Provider Sessions call sites that still reach Providers through non-root paths or Workers-owned transitional provider packages; retarget those imports/call sites to the standalone Providers service root contract so Provider Sessions no longer depends on Providers/Workers implementation packages. Do not fold or delete provider_sessions/service; do not edit root pkg/wire; do not admit IMP-PROV-04 or LWR-PROV; do not touch Automations or Recordings; prove with focused Provider Sessions/Providers boundary tests; loop until CI is terminal green, blocking feedback is addressed, conflicts are resolved, and the PR is merged.",
    "problem": "Provider Sessions inspects provider-produced session artifacts using Providers-owned SessionRef identity. Any remaining non-root Providers or Workers transitional provider dependency leaks Providers ownership into Provider Sessions and blocks the Provider Sessions vertical completion sequence (CUT → fold → DEL → FUN).",
    "solution": "Retarget Provider Sessions→Providers call sites to the Providers service root contract and Providers-owned SessionRef identity types, keep provider_sessions/service fold/delete and root Wire out of scope, and prove SessionRef / Inspect / Project request construction through focused Provider Sessions/Providers boundary tests before merge."
  },
  "acceptanceCriteria": [
    "Provider Sessions production code imports Providers only through the Providers service root contract (pkg/services/providers)",
    "No new Provider Sessions imports of Providers implementation packages or Workers-owned transitional provider packages",
    "Inspect, Project, and Details paths construct and validate Providers-owned SessionRef / identity vocabulary through the Providers root",
    "Focused Provider Sessions/Providers boundary tests prove Providers request construction (SessionRef / Inspect / Project) through the Providers root boundary",
    "Observable Provider Sessions Inspect/Project/Details behavior is preserved for equivalent inputs",
    "Quality checks pass (typecheck, lint, and tests); required CI is terminal and green",
    "Delivery loop completes: blocking PR feedback addressed, merge conflicts resolved, and the PR is merged before Factory completion"
  ],
  "userStories": [
    {
      "id": "pss-cut-pses-prov-001",
      "title": "Seal Provider Sessions→Providers imports to the Providers root",
      "description": "As a maintainer, I need Provider Sessions production packages to depend on Providers only through pkg/services/providers so Provider Sessions cannot couple to Providers implementation packages or Workers-owned transitional provider packages.",
      "acceptanceCriteria": [
        "Every Provider Sessions production import of Providers resolves to the Providers service root (pkg/services/providers), not providers/internal/**, providers/wire, or other Providers implementation packages",
        "Any Provider Sessions call site still reaching Providers through a Workers-owned transitional provider package (workers/provider/** or related) is retargeted to the Providers root contract",
        "No new Provider Sessions import of Providers/Workers provider implementation packages is introduced",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cut-pses-prov-002",
      "title": "Inspect constructs SessionRef through the Providers root",
      "description": "As a peer service integrator, I want Provider Sessions Inspect to accept and validate a Providers-owned SessionRef so detached session inspection stays on the Providers root identity vocabulary.",
      "acceptanceCriteria": [
        "Inspect request construction uses Providers root types (providers.SessionRef, providers.ID, providers.SessionIDKind) and does not import Providers/Workers provider implementation packages",
        "A focused Provider Sessions/Providers boundary test shows an Inspect request is constructed with a Providers root SessionRef and yields the existing observable success or typed-error outcome for that identity",
        "Equivalent Inspect inputs still produce the same observable outcomes as before the cut",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cut-pses-prov-003",
      "title": "Project constructs SessionRef through the Providers root",
      "description": "As a peer service integrator, I want Provider Sessions Project to accept and project from a Providers-owned SessionRef so normalized transcript/detail projection stays on the Providers root identity vocabulary.",
      "acceptanceCriteria": [
        "Project request construction uses Providers root types (providers.SessionRef, providers.ID, providers.SessionIDKind) and does not import Providers/Workers provider implementation packages",
        "A focused Provider Sessions/Providers boundary test shows a Project request is constructed with a Providers root SessionRef and yields the existing observable Detail-shaped success or typed-error outcome for that identity",
        "Equivalent Project inputs still produce the same observable outcomes as before the cut",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cut-pses-prov-004",
      "title": "Details bridges string identity into Providers root SessionRef construction",
      "description": "As a peer service integrator, I want the Provider Sessions Details path to normalize provider/kind/id strings into Providers root identity construction before reader dispatch so string-keyed inspection does not invent a parallel Providers vocabulary.",
      "acceptanceCriteria": [
        "Details bridges provider/kind/id strings into Providers root SessionRef / ID / SessionIDKind construction (or an equivalent Providers-root-typed handoff) before Codex/Cursor reader dispatch",
        "A focused Provider Sessions/Providers boundary test proves Details constructs that Providers root identity and preserves existing success and typed-error outcomes for supported and unsupported identities",
        "Equivalent Details inputs still produce the same observable outcomes as before the cut",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cut-pses-prov-005",
      "title": "Codex and Cursor readers consume Providers root SessionRef only",
      "description": "As a maintainer, I need private Codex and Cursor reader call sites under Provider Sessions to accept only Providers root SessionRef values so nested inspection paths cannot reintroduce Workers provider or Providers implementation types.",
      "acceptanceCriteria": [
        "Codex and Cursor reader production call sites accept Providers root SessionRef (and related Providers root identity constants) rather than Workers provider types or Providers implementation types",
        "A focused Provider Sessions/Providers boundary test proves Codex and Cursor reader handoff uses Providers root SessionRef construction for at least one supported identity each",
        "Unsupported provider/kind/id values still fail with the existing Provider Sessions-observable typed errors",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cut-pses-prov-006",
      "title": "Provider Sessions root contracts stay Providers-root-typed for SessionRef",
      "description": "As a peer service integrator, I want Provider Sessions root contracts that carry session identity to expose only Providers root SessionRef vocabulary so peers can wire Provider Sessions without touching Providers/Workers implementation packages.",
      "acceptanceCriteria": [
        "Provider Sessions root contracts that carry Providers identity (SessionRef alias, InspectRequest, ProjectRequest, InspectResult, ProjectResult, and related root surfaces) reference only Providers root types from pkg/services/providers",
        "A focused Provider Sessions/Providers boundary characterization (or equivalent package test) proves Provider Sessions constructs Inspect/Project/Details identity through the Providers root without importing Providers/Workers provider implementation packages",
        "No Provider Sessions root export reintroduces Providers implementation or Workers provider types on the peer surface",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    }
  ]
}
