### PR TITLE
ft-wave2-factory-deep-research-invocation

### DIFF
--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -7187,14 +7187,44 @@
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/deep_research/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/deep_research",
+      "scenario": "TestPackagedDeepResearchRequiredInputCompletes",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/deep_research/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/deep_research/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/deep_research",
+      "scenario": "TestPackagedDeepResearchOptionalInputsReachWorkers",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/deep_research/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/deep_research/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/deep_research",
+      "scenario": "TestPackagedDeepResearchWorkerFailureReturnsFailedOutcome",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/deep_research/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
     }
   ],
-  "scanned_at_utc": "2026-07-28T03:20:00Z",
+  "scanned_at_utc": "2026-07-28T03:45:00Z",
   "summary": {
     "by_catch_all": {
       "bootstrap_portability": 22,
       "guards_batch": 23,
-      "none": 441,
+      "none": 444,
       "replay_contracts": 23,
       "runtime_api": 96,
       "smoke": 62,
@@ -7205,7 +7235,7 @@
       "automations": 7,
       "bootstrap_portability": 21,
       "cli": 62,
-      "factory": 4,
+      "factory": 7,
       "guards_batch": 23,
       "models": 5,
       "observability": 9,
@@ -7224,9 +7254,9 @@
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 699,
+    "customer_top_level_Test_scenarios": 702,
     "lane_functionallong": 95,
-    "lane_short": 604,
+    "lane_short": 607,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 12,
       "you-agent-factory/tests/functional/automations": 7,
@@ -7240,6 +7270,7 @@
       "you-agent-factory/tests/functional/cli/root_discovery": 9,
       "you-agent-factory/tests/functional/cli/session_resume": 6,
       "you-agent-factory/tests/functional/factory/catalog": 3,
+      "you-agent-factory/tests/functional/factory/packaged/deep_research": 3,
       "you-agent-factory/tests/functional/factory/runtime_lifecycle": 1,
       "you-agent-factory/tests/functional/guards_batch": 23,
       "you-agent-factory/tests/functional/models/model_invoke": 3,
@@ -7303,7 +7334,7 @@
       "you-agent-factory/tests/functional/workstations/repeater": 13,
       "you-agent-factory/tests/functional/workstations/watcher": 9
     },
-    "files_with_customer_Test": 234,
+    "files_with_customer_Test": 235,
     "functional_test_go_files": 251,
     "helper_only_non_customer_files": 51,
     "internal_harness_Test_functions": 15,

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -648,7 +648,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestPackagedFactoriesRejectMissingRequiredInputs` runs the package matrix.
   - `TestPackagedFactoriesNameMissingInputAndFactory` verifies diagnostics.
 
-- [ ] `tests/functional/factory/packaged/deep_research/invocation_test.go`
+- [x] `tests/functional/factory/packaged/deep_research/invocation_test.go`
   - `TestPackagedDeepResearchRequiredInputCompletes` verifies dispatch sequence
     and primary result with mock workers.
   - `TestPackagedDeepResearchOptionalInputsReachWorkers` covers overrides.

--- a/tests/functional/factory/packaged/deep_research/invocation_test.go
+++ b/tests/functional/factory/packaged/deep_research/invocation_test.go
@@ -1,0 +1,170 @@
+package deep_research
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+// TestPackagedDeepResearchRequiredInputCompletes proves that invoking the
+// packaged @you/deep-research Factory with only the required research topic
+// completes under mock workers, runs the expected specialist-and-lead dispatch
+// sequence for a delegating topic shape, and returns a primary synthesis that
+// reflects the submitted topic.
+func TestPackagedDeepResearchRequiredInputCompletes(t *testing.T) {
+	topic := fmt.Sprintf(
+		"functional packaged deep research required topic %d with enough breadth for specialist delegation",
+		time.Now().UnixNano(),
+	)
+
+	factoryDir := support.InstallPackagedFactory(
+		t,
+		t.TempDir(),
+		factorydefinitions.PackagedDeepResearchFactoryName,
+	)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                factoryDir,
+		UseMockWorkers:            true,
+		WaitForServiceModeRuntime: true,
+	})
+
+	args := map[string]any{"topic": topic}
+	response := startPackagedDeepResearchInvocation(t, server, factoryDir, args)
+	if response.Status != factoryapi.FactorySessionDurableLifecycleStatusSucceeded {
+		t.Fatalf("session status = %q, want SUCCEEDED; response = %#v", response.Status, response)
+	}
+	if response.Result == nil || response.Result.PrimaryResult == nil || len(*response.Result.PrimaryResult) != 1 {
+		t.Fatalf("primary result = %#v, want one synthesized result part", response.Result)
+	}
+	if strings.TrimSpace(response.SessionId) == "" {
+		t.Fatal("sessionId is empty, want durable JavaScript session ID")
+	}
+
+	primary, err := json.Marshal((*response.Result.PrimaryResult)[0])
+	if err != nil {
+		t.Fatalf("marshal primary result: %v", err)
+	}
+	primaryText := string(primary)
+	for _, want := range []string{
+		topic,
+		`"researchDepth":2`,
+		`"maxSubagents":2`,
+		"lead-research-synthesis",
+		"research-specialist-technical",
+	} {
+		if !strings.Contains(primaryText, want) {
+			t.Fatalf("primary result = %s, want substring %q", primaryText, want)
+		}
+	}
+
+	dispatches := listFactorySessionDispatches(t, server.URL(), response.SessionId)
+	if len(dispatches.Dispatches) != 3 {
+		t.Fatalf(
+			"dispatch count = %d, want two bounded specialist dispatches and one lead synthesis",
+			len(dispatches.Dispatches),
+		)
+	}
+	labels := make(map[string]bool)
+	for _, dispatch := range dispatches.Dispatches {
+		if dispatch.Label != nil {
+			labels[*dispatch.Label] = true
+		}
+		if dispatch.Status != factoryapi.FactoryDispatchStatusCOMPLETED {
+			t.Fatalf("dispatch status = %q, want COMPLETED", dispatch.Status)
+		}
+	}
+	for _, want := range []string{
+		"research-specialist-technical",
+		"research-specialist-tradeoffs",
+		"lead-research-synthesis",
+	} {
+		if !labels[want] {
+			t.Fatalf("dispatch labels = %#v, want %q", labels, want)
+		}
+	}
+}
+
+func startPackagedDeepResearchInvocation(
+	t *testing.T,
+	server *support.FunctionalAPIServer,
+	factoryDir string,
+	args map[string]any,
+) factoryapi.FactorySessionSyncExecutionResponse {
+	t.Helper()
+
+	factory := support.GetJSON[factoryapi.Factory](t, server.URL()+"/factory-sessions/~default/factory")
+	workflowFile := filepath.Join(factoryDir, "scripts", "deep-research.workflow.js")
+	return postJSON[factoryapi.FactorySessionSyncExecutionResponse](
+		t,
+		server.URL()+"/factory-sessions/sync",
+		factoryapi.FactorySessionExecutionRequest{
+			RequestId: "packaged-deep-research-required-input",
+			Source: factoryapi.FactorySessionExecutionSource{
+				Kind:         factoryapi.FactorySessionExecutionSourceKindWorkflowFile,
+				WorkflowFile: &workflowFile,
+			},
+			Args:         &args,
+			Orchestrator: factory.Orchestrator,
+		},
+		"start packaged deep-research invocation",
+	)
+}
+
+func postJSON[T any](t *testing.T, endpoint string, request any, failurePrefix string) T {
+	t.Helper()
+	encoded, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("%s: marshal request: %v", failurePrefix, err)
+	}
+	response, err := http.Post(endpoint, "application/json", bytes.NewReader(encoded))
+	if err != nil {
+		t.Fatalf("%s: POST %s: %v", failurePrefix, endpoint, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		var payload bytes.Buffer
+		_, _ = payload.ReadFrom(response.Body)
+		t.Fatalf("%s: POST %s status = %d, want success: %s", failurePrefix, endpoint, response.StatusCode, payload.String())
+	}
+	var decoded T
+	if err := json.NewDecoder(response.Body).Decode(&decoded); err != nil {
+		t.Fatalf("%s: decode %s response: %v", failurePrefix, endpoint, err)
+	}
+	return decoded
+}
+
+func listFactorySessionDispatches(
+	t *testing.T,
+	serverURL, sessionID string,
+) factoryapi.ListFactorySessionDispatchesResponse {
+	t.Helper()
+	response, err := http.Get(strings.TrimSuffix(serverURL, "/") + "/factory-sessions/" + sessionID + "/dispatches")
+	if err != nil {
+		t.Fatalf("GET /factory-sessions/%s/dispatches: %v", sessionID, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		var payload bytes.Buffer
+		_, _ = payload.ReadFrom(response.Body)
+		t.Fatalf(
+			"GET /factory-sessions/%s/dispatches status = %d, want 200: %s",
+			sessionID,
+			response.StatusCode,
+			payload.String(),
+		)
+	}
+	var decoded factoryapi.ListFactorySessionDispatchesResponse
+	if err := json.NewDecoder(response.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode dispatch list: %v", err)
+	}
+	return decoded
+}

--- a/tests/functional/factory/packaged/deep_research/invocation_test.go
+++ b/tests/functional/factory/packaged/deep_research/invocation_test.go
@@ -2,7 +2,9 @@ package deep_research
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -10,7 +12,10 @@ import (
 	"testing"
 	"time"
 
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
@@ -198,6 +203,94 @@ func TestPackagedDeepResearchOptionalInputsReachWorkers(t *testing.T) {
 	}
 	if labels["research-specialist-tradeoffs"] {
 		t.Fatalf("dispatch labels = %#v, want tradeoffs specialist omitted when maxSubagents is 1", labels)
+	}
+}
+
+// TestPackagedDeepResearchWorkerFailureReturnsFailedOutcome proves that a
+// configured mock-worker rejection during packaged @you/deep-research invocation
+// returns a failed public terminal outcome without a completed success primary
+// result attributable to the failing run.
+func TestPackagedDeepResearchWorkerFailureReturnsFailedOutcome(t *testing.T) {
+	topic := fmt.Sprintf(
+		"functional packaged deep research worker failure %d",
+		time.Now().UnixNano(),
+	)
+
+	factoryDir := support.InstallPackagedFactory(
+		t,
+		t.TempDir(),
+		factorydefinitions.PackagedDeepResearchFactoryName,
+	)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                factoryDir,
+		UseMockWorkers:            true,
+		MockWorkersConfig:         packagedDeepResearchRejectingMockWorkersConfig(),
+		WaitForServiceModeRuntime: true,
+		Edges: serviceedges.Edges{
+			ProviderCommandRunner: packagedDeepResearchFailingCommandRunner{},
+		},
+	})
+
+	args := map[string]any{
+		"topic":        topic,
+		"maxSubagents": 0,
+	}
+	response := startPackagedDeepResearchInvocation(
+		t,
+		server,
+		factoryDir,
+		"packaged-deep-research-worker-failure",
+		args,
+	)
+	if response.Status != factoryapi.FactorySessionDurableLifecycleStatusFailed {
+		t.Fatalf("session status = %q, want FAILED; response = %#v", response.Status, response)
+	}
+	if response.Result != nil && response.Result.PrimaryResult != nil && len(*response.Result.PrimaryResult) > 0 {
+		t.Fatalf("primary result = %#v, want no completed success primary result after worker failure", response.Result)
+	}
+	if strings.TrimSpace(response.SessionId) == "" {
+		t.Fatal("sessionId is empty, want durable JavaScript session ID")
+	}
+
+	dispatches := listFactorySessionDispatches(t, server.URL(), response.SessionId)
+	if len(dispatches.Dispatches) != 1 {
+		t.Fatalf(
+			"dispatch count = %d, want one lead synthesis dispatch when maxSubagents is 0",
+			len(dispatches.Dispatches),
+		)
+	}
+	dispatch := dispatches.Dispatches[0]
+	if dispatch.Label == nil || *dispatch.Label != "lead-research-synthesis" {
+		t.Fatalf("dispatch label = %#v, want lead-research-synthesis", dispatch.Label)
+	}
+	if dispatch.Status != factoryapi.FactoryDispatchStatusFAILED {
+		t.Fatalf("dispatch status = %q, want FAILED", dispatch.Status)
+	}
+	if dispatch.FailureDetail == nil || strings.TrimSpace(dispatch.FailureDetail.Message) == "" {
+		t.Fatalf("dispatch failureDetail = %#v, want stable public failure record", dispatch.FailureDetail)
+	}
+}
+
+type packagedDeepResearchFailingCommandRunner struct{}
+
+func (packagedDeepResearchFailingCommandRunner) Run(
+	_ context.Context,
+	_ platformprocess.CommandRequest,
+) (platformprocess.CommandResult, error) {
+	return platformprocess.CommandResult{}, errors.New("packaged deep research provider failure")
+}
+
+func packagedDeepResearchRejectingMockWorkersConfig() *workers.MockWorkersConfig {
+	exitCode := 7
+	return &workers.MockWorkersConfig{
+		UnmatchedDispatchPolicy: workers.MockWorkerUnmatchedDispatchPolicyPassthrough,
+		MockWorkers: []workers.MockWorkerConfig{{
+			RunType: workers.MockWorkerRunTypeReject,
+			RejectConfig: &workers.MockWorkerRejectConfig{
+				Stderr:   "packaged deep research mock worker failure",
+				ExitCode: &exitCode,
+			},
+		}},
 	}
 }
 

--- a/tests/functional/factory/packaged/deep_research/invocation_test.go
+++ b/tests/functional/factory/packaged/deep_research/invocation_test.go
@@ -38,7 +38,13 @@ func TestPackagedDeepResearchRequiredInputCompletes(t *testing.T) {
 	})
 
 	args := map[string]any{"topic": topic}
-	response := startPackagedDeepResearchInvocation(t, server, factoryDir, args)
+	response := startPackagedDeepResearchInvocation(
+		t,
+		server,
+		factoryDir,
+		"packaged-deep-research-required-input",
+		args,
+	)
 	if response.Status != factoryapi.FactorySessionDurableLifecycleStatusSucceeded {
 		t.Fatalf("session status = %q, want SUCCEEDED; response = %#v", response.Status, response)
 	}
@@ -93,10 +99,113 @@ func TestPackagedDeepResearchRequiredInputCompletes(t *testing.T) {
 	}
 }
 
+// TestPackagedDeepResearchOptionalInputsReachWorkers proves that optional
+// deep-research overrides such as research depth, specialist cap, and approved
+// model execution selection reach mock workers and are observable on dispatch
+// execution selection and the primary synthesis result.
+func TestPackagedDeepResearchOptionalInputsReachWorkers(t *testing.T) {
+	topic := fmt.Sprintf(
+		"functional packaged deep research optional overrides %d with enough breadth for specialist delegation",
+		time.Now().UnixNano(),
+	)
+
+	factoryDir := support.InstallPackagedFactory(
+		t,
+		t.TempDir(),
+		factorydefinitions.PackagedDeepResearchFactoryName,
+	)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                factoryDir,
+		UseMockWorkers:            true,
+		WaitForServiceModeRuntime: true,
+	})
+
+	args := map[string]any{
+		"topic":           topic,
+		"researchDepth":   3,
+		"maxSubagents":    1,
+		"modelProvider":   "CODEX",
+		"model":           "gpt-5",
+		"reasoningEffort": "medium",
+	}
+	response := startPackagedDeepResearchInvocation(
+		t,
+		server,
+		factoryDir,
+		"packaged-deep-research-optional-inputs",
+		args,
+	)
+	if response.Status != factoryapi.FactorySessionDurableLifecycleStatusSucceeded {
+		t.Fatalf("session status = %q, want SUCCEEDED; response = %#v", response.Status, response)
+	}
+	if response.Result == nil || response.Result.PrimaryResult == nil || len(*response.Result.PrimaryResult) != 1 {
+		t.Fatalf("primary result = %#v, want one synthesized result part", response.Result)
+	}
+	if strings.TrimSpace(response.SessionId) == "" {
+		t.Fatal("sessionId is empty, want durable JavaScript session ID")
+	}
+
+	primary, err := json.Marshal((*response.Result.PrimaryResult)[0])
+	if err != nil {
+		t.Fatalf("marshal primary result: %v", err)
+	}
+	primaryText := string(primary)
+	for _, want := range []string{
+		topic,
+		`"researchDepth":3`,
+		`"maxSubagents":1`,
+		`"modelProvider":"CODEX"`,
+		`"model":"gpt-5"`,
+		`"reasoningEffort":"medium"`,
+		"research-specialist-technical",
+	} {
+		if !strings.Contains(primaryText, want) {
+			t.Fatalf("primary result = %s, want substring %q", primaryText, want)
+		}
+	}
+
+	dispatches := listFactorySessionDispatches(t, server.URL(), response.SessionId)
+	if len(dispatches.Dispatches) != 2 {
+		t.Fatalf(
+			"dispatch count = %d, want one bounded specialist dispatch and one lead synthesis",
+			len(dispatches.Dispatches),
+		)
+	}
+	labels := make(map[string]bool)
+	for _, dispatch := range dispatches.Dispatches {
+		if dispatch.Label != nil {
+			labels[*dispatch.Label] = true
+		}
+		if dispatch.Status != factoryapi.FactoryDispatchStatusCOMPLETED {
+			t.Fatalf("dispatch status = %q, want COMPLETED", dispatch.Status)
+		}
+		if dispatch.ModelProvider == nil || *dispatch.ModelProvider != "CODEX" ||
+			dispatch.Model == nil || *dispatch.Model != "gpt-5" ||
+			dispatch.ReasoningEffort == nil || *dispatch.ReasoningEffort != "medium" {
+			t.Fatalf(
+				"dispatch execution selection = provider=%#v model=%#v reasoning=%#v, want approved overrides",
+				dispatch.ModelProvider,
+				dispatch.Model,
+				dispatch.ReasoningEffort,
+			)
+		}
+	}
+	if !labels["research-specialist-technical"] || !labels["lead-research-synthesis"] {
+		t.Fatalf(
+			"dispatch labels = %#v, want technical specialist and lead synthesis",
+			labels,
+		)
+	}
+	if labels["research-specialist-tradeoffs"] {
+		t.Fatalf("dispatch labels = %#v, want tradeoffs specialist omitted when maxSubagents is 1", labels)
+	}
+}
+
 func startPackagedDeepResearchInvocation(
 	t *testing.T,
 	server *support.FunctionalAPIServer,
 	factoryDir string,
+	requestID string,
 	args map[string]any,
 ) factoryapi.FactorySessionSyncExecutionResponse {
 	t.Helper()
@@ -107,7 +216,7 @@ func startPackagedDeepResearchInvocation(
 		t,
 		server.URL()+"/factory-sessions/sync",
 		factoryapi.FactorySessionExecutionRequest{
-			RequestId: "packaged-deep-research-required-input",
+			RequestId: requestID,
 			Source: factoryapi.FactorySessionExecutionSource{
 				Kind:         factoryapi.FactorySessionExecutionSourceKindWorkflowFile,
 				WorkflowFile: &workflowFile,


### PR DESCRIPTION
{
  "project": "Packaged Deep Research Factory Invocation Functional Coverage",
  "branchName": "ft-wave2-factory-deep-research-invocation",
  "description": "Implement only tests/functional/factory/packaged/deep_research/invocation_test.go so public CLI/API packaged-factory invocation with mock workers proves @you/deep-research required-topic completion (dispatch sequence and primary result), optional inputs reaching workers, and worker failure returning a failed public outcome—consuming the three mapped migration-ledger rows without inventing unrelated deletion obligations.",
  "context": {
    "customerAsk": "Implement only tests/functional/factory/packaged/deep_research/invocation_test.go. Through public CLI/API packaged-factory invocation with mock workers, prove: (1) TestPackagedDeepResearchRequiredInputCompletes; (2) TestPackagedDeepResearchOptionalInputsReachWorkers; (3) TestPackagedDeepResearchWorkerFailureReturnsFailedOutcome. Consume the three mapped migration-ledger rows. Avoid service/internal Petri imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for packaged @you/deep-research invocation does not exist yet. Related proofs remain in smoke/runtime_api catch-alls, so maintainers lack a factory-owned cell that jointly proves required-input completion, optional-input reachability, and worker-failure failed outcome independently of goal/ and other packaged factories. Three migration-ledger rows already map here and must be consumed without inventing deletion-batch work (deletion batch n/a).",
    "solution": "Implement the three checklist scenarios in tests/functional/factory/packaged/deep_research/invocation_test.go through the public CLI/API packaged-factory invocation boundary with mock workers and customer-readable Go docs on every top-level Test. Assert required-topic completion with dispatch sequence and primary result, optional override reachability on workers/dispatches/results, and failed public terminal outcome on worker failure; consume the three mapped migration-ledger rows; apply only narrowly coupled ownership/coverage/catalog/migration metadata; and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/factory/packaged/deep_research/invocation_test.go exists as the factory-owned functional cell and covers required-input completion, optional-input reachability, and worker-failure failed outcome.",
    "Through public CLI/API packaged-factory invocation with mock workers, a required-topic @you/deep-research run completes with the expected dispatch sequence and a completed primary result reflecting the topic / lead synthesis.",
    "Through public CLI/API packaged-factory invocation with mock workers, optional deep_research inputs reach workers and are observable on dispatch execution selection and/or primary result.",
    "Through public CLI/API packaged-factory invocation with mock workers, a forced worker failure returns a failed public terminal outcome (no completed success primary result attributable to that failing run).",
    "The three mapped migration-ledger rows for this destination are consumed; no unrelated deletion obligations are invented (deletion batch n/a); only narrowly coupled ownership/coverage/catalog/migration metadata for this cell are updated.",
    "Coverage uses the public CLI/API packaged-factory invocation boundary / approved helpers and does not import service implementations or internal Petri primitives as the proof owner, with customer-readable Go docs on every top-level Test*.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave2-factory-deep-research-invocation-001",
      "title": "Prove required topic completes",
      "description": "As a customer invoking @you/deep-research with a required topic, I want the packaged Factory to complete under mock workers with the expected specialist/lead dispatch sequence and primary synthesis so I can rely on the packaged deep-research happy path.",
      "acceptanceCriteria": [
        "tests/functional/factory/packaged/deep_research/invocation_test.go includes TestPackagedDeepResearchRequiredInputCompletes (or equivalent top-level name matching the checklist intent).",
        "Through the public CLI and/or API packaged-factory invocation boundary with mock workers, invoking @you/deep-research with a required topic reaches a completed / succeeded terminal public status.",
        "Observable evidence proves the expected dispatch sequence for the chosen topic shape (lead synthesis present; specialist dispatches when the packaged workflow would delegate) and a primary result that reflects the submitted topic / lead-research synthesis.",
        "Assertions stay on required-input completion for deep_research and do not re-own packaged catalog discovery, goal routing, or other packaged factory packages.",
        "The top-level test has a customer-readable Go doc comment describing the observable required-input completion behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-deep-research-invocation-002",
      "title": "Prove optional inputs reach workers",
      "description": "As a customer configuring deep-research breadth and execution selection, I want optional inputs such as research depth, specialist cap, and approved model flags to reach workers so bounded research overrides are honored end to end.",
      "acceptanceCriteria": [
        "The deep_research invocation cell includes TestPackagedDeepResearchOptionalInputsReachWorkers (or equivalent top-level name matching the checklist intent).",
        "Through the public CLI and/or API packaged-factory invocation boundary with mock workers, an @you/deep-research invocation supplies optional overrides (at least the packaged supported set such as researchDepth, maxSubagents, and approved model provider/model/reasoning effort).",
        "Observable evidence proves those optional values reach workers / dispatches and appear in public outcome surfaces (dispatch execution selection and/or primary result fields reflecting the overrides).",
        "Assertions remain on optional-input reachability for deep_research and do not widen into catalog required-input rejection matrices or other packaged factory packages.",
        "The top-level test has a customer-readable Go doc comment describing the observable optional-input-to-worker behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-deep-research-invocation-003",
      "title": "Prove worker failure returns failed outcome",
      "description": "As a customer or automation handling a failing deep-research run, I want a worker failure during packaged @you/deep-research invocation to return a failed public terminal outcome so scripts do not treat failed research as successful completion.",
      "acceptanceCriteria": [
        "The deep_research invocation cell includes TestPackagedDeepResearchWorkerFailureReturnsFailedOutcome (or equivalent top-level name matching the checklist intent).",
        "Through the public CLI and/or API packaged-factory invocation boundary with mock workers, a deep_research run is configured so a worker/dispatch fails (mock-worker failure fixture or equivalent public harness control).",
        "Observable evidence proves the public terminal outcome is failed / non-success for that invocation and does not present a completed success primary result attributable to the failing run.",
        "Assertions remain on failed public outcome for deep_research worker failure and do not re-own transport stdout/stderr shaping, full exit-code taxonomy, or other packaged factory failure matrices.",
        "The top-level test has a customer-readable Go doc comment describing the observable failed-outcome-on-worker-failure contract.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-deep-research-invocation-004",
      "title": "Consume ledger rows and close verification gates",
      "description": "As a maintainer executing Wave 2 functional-test expansion, I want the three mapped deep_research migration-ledger rows consumed with only narrowly coupled metadata updates and passing focused boundary/viz gates so this independent packaged cell can terminal-complete without inventing deletion-batch work.",
      "acceptanceCriteria": [
        "The three mapped migration-ledger rows destined for tests/functional/factory/packaged/deep_research/invocation_test.go are consumed (ownership/coverage/catalog/migration metadata updated for this destination as required by Wave expansion process).",
        "No unrelated deletion obligations are invented for this cell (deletion batch n/a); source smoke/runtime_api files are not broadly rewritten beyond what narrow metadata coupling requires.",
        "Only narrowly coupled ownership, coverage, catalog, or migration metadata required for this cell are updated; sibling packaged factories (goal/, fusion, quorum, review, subagent, tts, cross) and catalog cells are not implemented or rewritten.",
        "Focused package tests for tests/functional/factory/packaged/deep_research pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as factory/packaged/deep_research).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)