### PR TITLE
ft-wave2-sessions-results-dispatches

### DIFF
--- a/contracts/functional-scenario-evidence.json
+++ b/contracts/functional-scenario-evidence.json
@@ -20,6 +20,13 @@
       ]
     },
     {
+      "test": "tests/functional/sessions/execution/results_dispatches_test.go::TestAPIDispatchListAndDetailExposePublicCorrelation",
+      "stableIds": [
+        "rest/getFactorySessionDispatch",
+        "rest/listFactorySessionDispatches"
+      ]
+    },
+    {
       "test": "tests/functional/sessions/execution/results_dispatches_test.go::TestAPIResultAndResultsExposeTerminalInvocationData",
       "stableIds": [
         "rest/getFactorySessionResults",

--- a/contracts/functional-scenario-evidence.json
+++ b/contracts/functional-scenario-evidence.json
@@ -14,12 +14,6 @@
       ]
     },
     {
-      "test": "tests/functional/runtime_api/api_session_invocation_test.go::TestSessionInvocationAPI_ReturnsPrimaryResult",
-      "stableIds": [
-        "rest/invokeFactorySessionBySessionId"
-      ]
-    },
-    {
       "test": "tests/functional/sessions/execution/results_dispatches_test.go::TestAPIDispatchListAndDetailExposePublicCorrelation",
       "stableIds": [
         "rest/getFactorySessionDispatch",

--- a/contracts/functional-scenario-evidence.json
+++ b/contracts/functional-scenario-evidence.json
@@ -20,6 +20,13 @@
       ]
     },
     {
+      "test": "tests/functional/sessions/execution/results_dispatches_test.go::TestAPIResultAndResultsExposeTerminalInvocationData",
+      "stableIds": [
+        "rest/getFactorySessionResults",
+        "rest/invokeFactorySessionBySessionId"
+      ]
+    },
+    {
       "test": "tests/functional/transport/cli/commands/run_wiring_test.go::TestCLIRunFactoryByPath",
       "stableIds": [
         "cli/you.run"

--- a/contracts/functional-scenarios.json
+++ b/contracts/functional-scenarios.json
@@ -249,7 +249,7 @@
       "status": "missing",
       "lane": "short",
       "executionClass": "deterministic",
-      "reviewedReason": "The manifest-owned server command surface is present, but lifecycle behavior remains assigned to its dedicated PRD story and does not yet have qualifying customer-boundary functional evidence."
+      "reviewedReason": "No qualifying repository-owned functional test currently invokes and observes this component through its customer boundary."
     },
     {
       "stableId": "cli/you.session",
@@ -612,10 +612,15 @@
       "name": "getFactorySessionDispatch",
       "interface": "rest",
       "classification": "operation",
-      "status": "missing",
-      "lane": "short",
+      "status": "covered",
+      "lane": "long",
       "executionClass": "deterministic",
-      "reviewedReason": "No qualifying repository-owned functional test currently invokes and observes this component through its customer boundary."
+      "evidence": [
+        {
+          "test": "tests/functional/sessions/execution/results_dispatches_test.go::TestAPIDispatchListAndDetailExposePublicCorrelation",
+          "boundary": "rest"
+        }
+      ]
     },
     {
       "stableId": "rest/getFactorySessionPartialResult",
@@ -642,10 +647,15 @@
       "name": "getFactorySessionResults",
       "interface": "rest",
       "classification": "operation",
-      "status": "missing",
-      "lane": "short",
+      "status": "covered",
+      "lane": "long",
       "executionClass": "deterministic",
-      "reviewedReason": "No qualifying repository-owned functional test currently invokes and observes this component through its customer boundary."
+      "evidence": [
+        {
+          "test": "tests/functional/sessions/execution/results_dispatches_test.go::TestAPIResultAndResultsExposeTerminalInvocationData",
+          "boundary": "rest"
+        }
+      ]
     },
     {
       "stableId": "rest/getFactorySessionSyncPreflightBySessionId",
@@ -732,7 +742,7 @@
       "executionClass": "deterministic",
       "evidence": [
         {
-          "test": "tests/functional/runtime_api/api_session_invocation_test.go::TestSessionInvocationAPI_ReturnsPrimaryResult",
+          "test": "tests/functional/sessions/execution/results_dispatches_test.go::TestAPIResultAndResultsExposeTerminalInvocationData",
           "boundary": "rest"
         }
       ]
@@ -762,10 +772,15 @@
       "name": "listFactorySessionDispatches",
       "interface": "rest",
       "classification": "operation",
-      "status": "missing",
-      "lane": "short",
+      "status": "covered",
+      "lane": "long",
       "executionClass": "deterministic",
-      "reviewedReason": "No qualifying repository-owned functional test currently invokes and observes this component through its customer boundary."
+      "evidence": [
+        {
+          "test": "tests/functional/sessions/execution/results_dispatches_test.go::TestAPIDispatchListAndDetailExposePublicCorrelation",
+          "boundary": "rest"
+        }
+      ]
     },
     {
       "stableId": "rest/listFactorySessions",

--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -4099,6 +4099,36 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/sessions/execution/results_dispatches_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/execution",
+      "scenario": "TestAPIDispatchListAndDetailExposePublicCorrelation",
+      "lane": "short",
+      "destination": "tests/functional/sessions/execution/results_dispatches_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/sessions/execution/results_dispatches_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/execution",
+      "scenario": "TestAPIPartialResultIsAvailableBeforeTerminalCompletion",
+      "lane": "short",
+      "destination": "tests/functional/sessions/execution/results_dispatches_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/sessions/execution/results_dispatches_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/execution",
+      "scenario": "TestAPIResultAndResultsExposeTerminalInvocationData",
+      "lane": "short",
+      "destination": "tests/functional/sessions/execution/results_dispatches_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/sessions/live_runtime_build_process_test.go",
       "package": "you-agent-factory/tests/functional/sessions",
       "scenario": "TestBuildProcessRoutesLiveOpenListControlAndCloseThroughFactorySessionsRoot",
@@ -7510,6 +7540,7 @@
       "you-agent-factory/tests/functional/sessionparity": 13,
       "you-agent-factory/tests/functional/sessions": 1,
       "you-agent-factory/tests/functional/sessions/cli": 2,
+      "you-agent-factory/tests/functional/sessions/execution": 3,
       "you-agent-factory/tests/functional/sessions/restart": 3,
       "you-agent-factory/tests/functional/smoke": 62,
       "you-agent-factory/tests/functional/transport/cli/commands": 20,

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -590,7 +590,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestAPIPauseResumeCancelAndTerminateFactorySession`.
   - `TestAPIInvalidLifecycleTransitionReturnsConflict`.
 
-- [ ] `tests/functional/sessions/execution/results_dispatches_test.go`
+- [x] `tests/functional/sessions/execution/results_dispatches_test.go`
   - `TestAPIResultAndResultsExposeTerminalInvocationData`.
   - `TestAPIDispatchListAndDetailExposePublicCorrelation`.
   - `TestAPIPartialResultIsAvailableBeforeTerminalCompletion`.

--- a/internal/functionalscenarios/manifest.go
+++ b/internal/functionalscenarios/manifest.go
@@ -123,8 +123,12 @@ func applyReviewedEvidence(scenario *Scenario) {
 		markCovered(scenario, LaneLong, "tests/functional/runtime_api/api_generated_smoke_test.go::TestGeneratedAPIIntegrationSmoke_BatchUpsertAcceptsWorksContent", InterfaceREST)
 	case "rest/moveWorkBySessionId":
 		markCovered(scenario, LaneLong, "tests/functional/runtime_api/api_manual_work_recovery_test.go::TestManualWorkRecovery_CascadeFailureThenAPIMovesResumeProgress", InterfaceREST)
+	case "rest/getFactorySessionDispatch", "rest/listFactorySessionDispatches":
+		markCovered(scenario, LaneLong, "tests/functional/sessions/execution/results_dispatches_test.go::TestAPIDispatchListAndDetailExposePublicCorrelation", InterfaceREST)
+	case "rest/getFactorySessionResults":
+		markCovered(scenario, LaneLong, "tests/functional/sessions/execution/results_dispatches_test.go::TestAPIResultAndResultsExposeTerminalInvocationData", InterfaceREST)
 	case "rest/invokeFactorySessionBySessionId":
-		markCovered(scenario, LaneLong, "tests/functional/runtime_api/api_session_invocation_test.go::TestSessionInvocationAPI_ReturnsPrimaryResult", InterfaceREST)
+		markCovered(scenario, LaneLong, "tests/functional/sessions/execution/results_dispatches_test.go::TestAPIResultAndResultsExposeTerminalInvocationData", InterfaceREST)
 	case "rest/getEventsBySessionId":
 		scenario.Status = StatusPartial
 		scenario.Lane = LaneLong

--- a/pkg/services/factory_sessions/internal/execution/fake_service_runtime_test.go
+++ b/pkg/services/factory_sessions/internal/execution/fake_service_runtime_test.go
@@ -2940,6 +2940,106 @@ func TestValidateCheckpointSummaryForResume_RejectsInvalidMetadata(t *testing.T)
 	}
 }
 
+func TestApplyRuntimeCheckpointPartialProjection_SurfacesPartialResultWhileRunning(t *testing.T) {
+	t.Parallel()
+	const sessionID = "dur-sess-checkpoint-partial-001"
+	state := &runtimeSessionState{
+		session: SessionReadResult{
+			SessionID: sessionID,
+			Status:    LifecycleStatusRunning,
+		},
+		artifacts: []ArtifactSummary{{ID: "artifact-checkpoint-1", Kind: "text"}},
+	}
+	checkpoint := &factory.JavaScriptCheckpointRecord{
+		ID:    "checkpoint-1",
+		Label: "after-step-one",
+		State: map[string]any{"text": "checkpoint partial output"},
+	}
+
+	applyRuntimeCheckpointPartialProjection(state, checkpoint)
+
+	if state.session.ResultSummary == nil || state.session.ResultSummary.ResultStatus != string(ResultStatusPartial) {
+		t.Fatalf("result summary = %#v, want PARTIAL", state.session.ResultSummary)
+	}
+	if state.result.ResultStatus != ResultStatusPartial {
+		t.Fatalf("result status = %q, want PARTIAL", state.result.ResultStatus)
+	}
+	if state.result.Mode != ResultModePartial {
+		t.Fatalf("result mode = %q, want partial", state.result.Mode)
+	}
+	if state.result.SessionStatus != LifecycleStatusRunning {
+		t.Fatalf("session status = %q, want RUNNING", state.result.SessionStatus)
+	}
+	if len(state.result.PrimaryResult) == 0 {
+		t.Fatal("primary result missing")
+	}
+	if len(state.result.ArtifactIDs) != 1 || state.result.ArtifactIDs[0] != "artifact-checkpoint-1" {
+		t.Fatalf("artifact IDs = %#v, want checkpoint artifact", state.result.ArtifactIDs)
+	}
+}
+
+func TestApplyRuntimeCheckpointPartialProjection_NoopsForTerminalOrEmptyCheckpoint(t *testing.T) {
+	t.Parallel()
+	checkpoint := &factory.JavaScriptCheckpointRecord{
+		ID:    "checkpoint-1",
+		Label: "after-step-one",
+		State: map[string]any{"text": "checkpoint partial output"},
+	}
+	running := &runtimeSessionState{
+		session: SessionReadResult{SessionID: "dur-sess-checkpoint-partial-002", Status: LifecycleStatusRunning},
+		result:  ResultReadResult{SessionID: "dur-sess-checkpoint-partial-002", ResultStatus: ResultStatusNotReady},
+	}
+	terminal := &runtimeSessionState{
+		session: SessionReadResult{SessionID: "dur-sess-checkpoint-partial-003", Status: LifecycleStatusSucceeded},
+		result:  ResultReadResult{SessionID: "dur-sess-checkpoint-partial-003", ResultStatus: ResultStatusFinal},
+	}
+
+	applyRuntimeCheckpointPartialProjection(nil, checkpoint)
+	applyRuntimeCheckpointPartialProjection(running, nil)
+	applyRuntimeCheckpointPartialProjection(terminal, checkpoint)
+	applyRuntimeCheckpointPartialProjection(running, &factory.JavaScriptCheckpointRecord{ID: "checkpoint-empty"})
+
+	if running.result.ResultStatus != ResultStatusNotReady {
+		t.Fatalf("running result status = %q, want NOT_READY", running.result.ResultStatus)
+	}
+	if terminal.result.ResultStatus != ResultStatusFinal {
+		t.Fatalf("terminal result status = %q, want FINAL", terminal.result.ResultStatus)
+	}
+}
+
+func TestJavaScriptRuntimeService_ApplyRunningRuntimeRecord_CheckpointProjectsPartialResult(t *testing.T) {
+	t.Parallel()
+	const sessionID = "dur-sess-checkpoint-running-record-001"
+	service := newConfiguredJavaScriptRuntimeService(javaScriptRuntimeServiceConfig{ProjectRoot: t.TempDir()})
+	if err := seedRuntimeSessionWithRunningDispatch(service, sessionID, "dispatch-1", "step-one"); err != nil {
+		t.Fatalf("seedRuntimeSessionWithRunningDispatch: %v", err)
+	}
+
+	service.applyRunningRuntimeRecord(sessionID, factory.JavaScriptRuntimeRecord{
+		Sequence: 2,
+		Kind:     factory.JavaScriptRecordKindCheckpoint,
+		Checkpoint: &factory.JavaScriptCheckpointRecord{
+			ID:    "checkpoint-1",
+			Label: "after-step-one",
+			State: map[string]any{"text": "checkpoint partial output"},
+		},
+	})
+
+	result, err := service.GetResult(context.Background(), sessionID, ResultRequest{Mode: ResultModePartial})
+	if err != nil {
+		t.Fatalf("GetResult partial: %v", err)
+	}
+	if result.ResultStatus != ResultStatusPartial {
+		t.Fatalf("partial status = %q, want PARTIAL", result.ResultStatus)
+	}
+	if len(result.PrimaryResult) == 0 {
+		t.Fatal("partial primaryResult missing")
+	}
+	if result.SessionStatus != LifecycleStatusRunning {
+		t.Fatalf("session status = %q, want RUNNING", result.SessionStatus)
+	}
+}
+
 func TestFinalizeInterruptedTerminalSession_PreservesPartialAndUnavailableResults(t *testing.T) {
 	t.Parallel()
 	sessionID := "dur-sess-interrupted-finalize-001"

--- a/pkg/services/factory_sessions/internal/execution/prepare_start.go
+++ b/pkg/services/factory_sessions/internal/execution/prepare_start.go
@@ -818,6 +818,7 @@ func (s *JavaScriptRuntimeService) applyRunningRuntimeRecord(sessionID string, r
 			CheckpointState: record.Checkpoint.State,
 			Records:         state.runtimeRecords,
 		})
+		applyRuntimeCheckpointPartialProjection(state, record.Checkpoint)
 	}
 	state.dispatches = cloneDispatchSummaries(projection.Dispatches)
 	state.dispatchJavaScript = cloneDispatchJavaScriptProjections(projection.DispatchJavaScript)

--- a/pkg/services/factory_sessions/internal/execution/resume.go
+++ b/pkg/services/factory_sessions/internal/execution/resume.go
@@ -682,6 +682,46 @@ func applyRuntimeSuccessProjection(
 	state.result = projected
 }
 
+func applyRuntimeCheckpointPartialProjection(
+	state *runtimeSessionState,
+	checkpoint *workflowresult.JavaScriptCheckpointRecord,
+) {
+	if state == nil || checkpoint == nil || IsTerminalLifecycleStatus(state.session.Status) {
+		return
+	}
+	if len(checkpoint.State) == 0 {
+		return
+	}
+	encoded, err := json.Marshal(checkpoint.State)
+	if err != nil || len(encoded) == 0 {
+		return
+	}
+	parts, validation := workflowresult.ProjectPrimaryResult(
+		state.session.SessionID,
+		workflowresult.TypedValue{JSON: encoded},
+		artifactStatesFromSummaries(state.artifacts),
+	)
+	if validation.HasIssues() || len(parts) == 0 {
+		return
+	}
+	primaryJSON := workContentJSONFromParts(parts)
+	if len(primaryJSON) == 0 {
+		return
+	}
+	state.session.ResultSummary = &ResultSummary{
+		ResultStatus: string(ResultStatusPartial),
+		Summary:      resultSummaryTextFromParts(parts),
+	}
+	state.result = ResultReadResult{
+		SessionID:     state.session.SessionID,
+		ResultStatus:  ResultStatusPartial,
+		SessionStatus: state.session.Status,
+		Mode:          ResultModePartial,
+		PrimaryResult: primaryJSON,
+		ArtifactIDs:   artifactIDsFromSummaries(state.artifacts),
+	}
+}
+
 func projectRuntimeSuccessResult(
 	sessionID string,
 	value workflowresult.TypedValue,

--- a/tests/functional/runtime_api/api_session_invocation_test.go
+++ b/tests/functional/runtime_api/api_session_invocation_test.go
@@ -18,7 +18,6 @@ import (
 	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
-	"github.com/portpowered/infinite-you/tests/internal/functionalevidence"
 )
 
 func TestSessionInvocationAPI_ReturnsPrimaryResult(t *testing.T) {
@@ -46,7 +45,6 @@ func TestSessionInvocationAPI_ReturnsPrimaryResult(t *testing.T) {
 	recorder.assertContainsMetric(t, "invocation.fallback_policy_used", map[string]string{"input_source": "COMPATIBILITY_CONTENT"})
 	recorder.assertContainsMetric(t, "invocation.success", map[string]string{"input_source": "COMPATIBILITY_CONTENT"})
 	recorder.assertContainsMetric(t, "invocation.result_type", map[string]string{"input_source": "COMPATIBILITY_CONTENT", "result_type": "text"})
-	functionalevidence.Covers(t, "rest/invokeFactorySessionBySessionId")
 }
 
 func TestSessionInvocationAPI_RejectsWhitespaceOnlyText(t *testing.T) {

--- a/tests/functional/sessions/execution/helpers_test.go
+++ b/tests/functional/sessions/execution/helpers_test.go
@@ -47,6 +47,22 @@ func newPartialResultBlockingProvider(workflowName string) *partialResultBlockin
 	return &partialResultBlockingProvider{workflowName: workflowName}
 }
 
+func (p *partialResultBlockingProvider) waitForCanceledInfer(t *testing.T, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		p.mu.Lock()
+		canceled := p.contextCanceled
+		p.mu.Unlock()
+		if canceled > 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("provider Infer did not observe canceled workflow context")
+}
+
 func (p *partialResultBlockingProvider) Infer(
 	ctx context.Context,
 	_ workerexecution.ProviderInferenceRequest,
@@ -581,23 +597,55 @@ func waitForDurablePartialResult(
 	return partial
 }
 
-func terminateDurableSession(t *testing.T, serverURL, sessionID string) {
+func interruptFactoryDispatch(
+	t *testing.T,
+	serverURL, sessionID, dispatchID, reason string,
+) {
 	t.Helper()
 
-	endpoint := strings.TrimSuffix(serverURL, "/") + "/factory-sessions/" + sessionID + "/terminate"
-	request, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, http.NoBody)
+	payload, err := json.Marshal(factoryapi.FactorySessionInterruptDispatchRequest{
+		DispatchId: dispatchID,
+		Reason:     &reason,
+	})
 	if err != nil {
-		t.Fatalf("build terminate request: %v", err)
+		t.Fatalf("marshal interrupt dispatch request: %v", err)
 	}
+
+	endpoint := strings.TrimSuffix(serverURL, "/") + "/factory-sessions/" + sessionID + "/interrupt-dispatch"
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("build interrupt dispatch request: %v", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {
 		t.Fatalf("POST %s: %v", endpoint, err)
 	}
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
-		payload, _ := io.ReadAll(response.Body)
-		t.Fatalf("POST %s status = %d, want 200: %s", endpoint, response.StatusCode, strings.TrimSpace(string(payload)))
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("POST %s status = %d, want 200: %s", endpoint, response.StatusCode, strings.TrimSpace(string(body)))
 	}
+}
+
+func releaseBlockedPartialResultSession(
+	t *testing.T,
+	serverURL string,
+	provider *partialResultBlockingProvider,
+	sessionID string,
+) {
+	t.Helper()
+
+	reason := "results dispatches partial result cleanup"
+	interruptFactoryDispatch(t, serverURL, sessionID, partialResultSecondDispatchID, reason)
+	provider.waitForCanceledInfer(t, 5*time.Second)
+	waitForDurableSessionStatus(
+		t,
+		serverURL,
+		sessionID,
+		factoryapi.FactorySessionDurableLifecycleStatusInterrupted,
+		5*time.Second,
+	)
 }
 
 func assertInvocationPrimaryResultText(

--- a/tests/functional/sessions/execution/helpers_test.go
+++ b/tests/functional/sessions/execution/helpers_test.go
@@ -21,9 +21,20 @@ import (
 )
 
 const (
-	terminalSuccessPrimaryResult      = "primary result COMPLETE"
-	inlineJavaScriptWorkflowFileName  = "results-dispatches.workflow.js"
+	terminalSuccessPrimaryResult         = "primary result COMPLETE"
+	inlineJavaScriptWorkflowFileName     = "results-dispatches.workflow.js"
+	dispatchCorrelationWorkflowFileName  = "results-dispatches-correlation.workflow.js"
+	dispatchCorrelationChildLabel        = "dispatch-correlation-child"
+	dispatchCorrelationChildPrompt       = "prove-dispatch-correlation"
 )
+
+var dispatchCorrelationWorkflow = `return (async function () {
+  const child = await agent.run({
+    prompt: "` + dispatchCorrelationChildPrompt + `",
+    label: "` + dispatchCorrelationChildLabel + `",
+  });
+  return { child };
+})();`
 
 type blockingInvocationRunner struct {
 	started chan struct{}
@@ -80,6 +91,20 @@ func scaffoldInvocationFactory(t *testing.T, overrides map[string]any) string {
 	}
 	dir := support.ScaffoldFactory(t, cfg)
 	support.WriteAgentConfig(t, dir, "worker-a", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"))
+	return dir
+}
+
+func scaffoldDispatchCorrelationFactory(t *testing.T) string {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, map[string]any{"name": "results-dispatches-correlation"})
+	if err := os.WriteFile(
+		filepath.Join(dir, dispatchCorrelationWorkflowFileName),
+		[]byte(dispatchCorrelationWorkflow),
+		0o600,
+	); err != nil {
+		t.Fatalf("write dispatch correlation workflow: %v", err)
+	}
 	return dir
 }
 
@@ -172,6 +197,71 @@ func postInvocation(t *testing.T, serverURL string, request factoryapi.Invocatio
 		t.Fatalf("decode invocation response: %v", err)
 	}
 	return decoded
+}
+
+func startDispatchCorrelationSync(
+	t *testing.T,
+	serverURL, factoryDir string,
+) factoryapi.FactorySessionSyncExecutionResponse {
+	t.Helper()
+
+	workflowPath := filepath.Join(factoryDir, dispatchCorrelationWorkflowFileName)
+	payload, err := json.Marshal(factoryapi.FactorySessionExecutionRequest{
+		RequestId: "results-dispatches-correlation-sync",
+		Source: factoryapi.FactorySessionExecutionSource{
+			Kind:         factoryapi.FactorySessionExecutionSourceKindWorkflowFile,
+			WorkflowFile: &workflowPath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal dispatch correlation sync request: %v", err)
+	}
+
+	endpoint := strings.TrimSuffix(serverURL, "/") + "/factory-sessions/sync"
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("build dispatch correlation sync request: %v", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("POST %s: %v", endpoint, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(response.Body)
+		t.Fatalf("POST %s status = %d, want 200: %s", endpoint, response.StatusCode, strings.TrimSpace(string(payload)))
+	}
+
+	var result factoryapi.FactorySessionSyncExecutionResponse
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		t.Fatalf("decode dispatch correlation sync response: %v", err)
+	}
+	return result
+}
+
+func listFactorySessionDispatches(
+	t *testing.T,
+	serverURL, sessionID string,
+) factoryapi.ListFactorySessionDispatchesResponse {
+	t.Helper()
+
+	return support.GetJSON[factoryapi.ListFactorySessionDispatchesResponse](
+		t,
+		strings.TrimSuffix(serverURL, "/")+"/factory-sessions/"+sessionID+"/dispatches",
+	)
+}
+
+func getFactorySessionDispatch(
+	t *testing.T,
+	serverURL, sessionID, dispatchID string,
+) factoryapi.FactoryDispatch {
+	t.Helper()
+
+	return support.GetJSON[factoryapi.FactoryDispatch](
+		t,
+		strings.TrimSuffix(serverURL, "/")+"/factory-sessions/"+sessionID+"/dispatches/"+dispatchID,
+	)
 }
 
 func startInlineJavaScriptSync(
@@ -306,6 +396,69 @@ func generatedWorkStateType(state *factoryapi.WorkState) factoryapi.WorkStateTyp
 		return ""
 	}
 	return state.Type
+}
+
+func assertDispatchListDetailPublicCorrelation(
+	t *testing.T,
+	sessionID string,
+	summary factoryapi.FactorySessionDispatchSummary,
+	detail factoryapi.FactoryDispatch,
+) {
+	t.Helper()
+
+	if strings.TrimSpace(summary.Id) == "" {
+		t.Fatal("dispatch summary id is empty, want public dispatch identifier")
+	}
+	if detail.Id != summary.Id {
+		t.Fatalf("dispatch detail id = %q, want list summary id %q", detail.Id, summary.Id)
+	}
+	if detail.SessionId != sessionID {
+		t.Fatalf("dispatch detail sessionId = %q, want %q", detail.SessionId, sessionID)
+	}
+	if detail.Status != summary.Status {
+		t.Fatalf("dispatch detail status = %q, want list summary status %q", detail.Status, summary.Status)
+	}
+	if detail.DispatchKind != summary.DispatchKind {
+		t.Fatalf("dispatch detail dispatchKind = %q, want list summary dispatchKind %q", detail.DispatchKind, summary.DispatchKind)
+	}
+	if detail.OrchestratorKind != factoryapi.JAVASCRIPT {
+		t.Fatalf("dispatch detail orchestratorKind = %q, want JAVASCRIPT", detail.OrchestratorKind)
+	}
+	if summary.Label == nil || detail.Label == nil || *detail.Label != *summary.Label {
+		t.Fatalf("dispatch detail label = %#v, want list summary label %#v", detail.Label, summary.Label)
+	}
+	if summary.ProviderSessionRefs != nil && len(*summary.ProviderSessionRefs) > 0 {
+		if detail.ProviderSessionRefs == nil {
+			t.Fatalf("dispatch detail providerSessionRefs = nil, want list summary refs %#v", summary.ProviderSessionRefs)
+		}
+		if len(*detail.ProviderSessionRefs) != len(*summary.ProviderSessionRefs) {
+			t.Fatalf(
+				"dispatch detail providerSessionRefs count = %d, want %d from list summary",
+				len(*detail.ProviderSessionRefs),
+				len(*summary.ProviderSessionRefs),
+			)
+		}
+		for i := range *summary.ProviderSessionRefs {
+			summaryRef := (*summary.ProviderSessionRefs)[i]
+			detailRef := (*detail.ProviderSessionRefs)[i]
+			if detailRef.Id != summaryRef.Id {
+				t.Fatalf(
+					"providerSessionRefs[%d].id = %q, want list summary ref %q",
+					i,
+					detailRef.Id,
+					summaryRef.Id,
+				)
+			}
+			if detailRef.Provider != summaryRef.Provider {
+				t.Fatalf(
+					"providerSessionRefs[%d].provider = %q, want list summary ref %q",
+					i,
+					detailRef.Provider,
+					summaryRef.Provider,
+				)
+			}
+		}
+	}
 }
 
 func waitForBlockingInvocationStart(t *testing.T, blocking *blockingInvocationRunner) {

--- a/tests/functional/sessions/execution/helpers_test.go
+++ b/tests/functional/sessions/execution/helpers_test.go
@@ -251,6 +251,44 @@ func textInvocationRequest(t *testing.T, text string, timeoutMillis *int64) fact
 	}
 }
 
+func postInvocationExpectStatus(
+	t *testing.T,
+	serverURL string,
+	request factoryapi.InvocationRequest,
+	wantStatus int,
+) factoryapi.ErrorResponse {
+	t.Helper()
+
+	body, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("marshal invocation request: %v", err)
+	}
+	response, err := http.Post(
+		strings.TrimSuffix(serverURL, "/")+"/factory-sessions/"+factorysessions.DefaultSessionID+"/invocations",
+		"application/json",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("POST /factory-sessions/~default/invocations: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != wantStatus {
+		payload, _ := io.ReadAll(response.Body)
+		t.Fatalf(
+			"POST /factory-sessions/~default/invocations status = %d, want %d: %s",
+			response.StatusCode,
+			wantStatus,
+			strings.TrimSpace(string(payload)),
+		)
+	}
+
+	var decoded factoryapi.ErrorResponse
+	if err := json.NewDecoder(response.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode invocation error response: %v", err)
+	}
+	return decoded
+}
+
 func postInvocation(t *testing.T, serverURL string, request factoryapi.InvocationRequest) factoryapi.InvocationResponse {
 	t.Helper()
 

--- a/tests/functional/sessions/execution/helpers_test.go
+++ b/tests/functional/sessions/execution/helpers_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,6 +18,7 @@ import (
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
@@ -24,9 +27,68 @@ const (
 	terminalSuccessPrimaryResult         = "primary result COMPLETE"
 	inlineJavaScriptWorkflowFileName     = "results-dispatches.workflow.js"
 	dispatchCorrelationWorkflowFileName  = "results-dispatches-correlation.workflow.js"
+	partialResultWorkflowName              = "resumable-two-step-fake-children"
 	dispatchCorrelationChildLabel        = "dispatch-correlation-child"
 	dispatchCorrelationChildPrompt       = "prove-dispatch-correlation"
+	partialResultCheckpointLabel         = "after-step-one"
+	partialResultFirstDispatchID         = "dispatch-1"
+	partialResultSecondDispatchID        = "dispatch-2"
 )
+
+type partialResultBlockingProvider struct {
+	mu              sync.Mutex
+	calls           int
+	blockedOnce     bool
+	contextCanceled int
+	workflowName    string
+}
+
+func newPartialResultBlockingProvider(workflowName string) *partialResultBlockingProvider {
+	return &partialResultBlockingProvider{workflowName: workflowName}
+}
+
+func (p *partialResultBlockingProvider) Infer(
+	ctx context.Context,
+	_ workerexecution.ProviderInferenceRequest,
+) (workerexecution.InferenceResponse, error) {
+	p.mu.Lock()
+	p.calls++
+	call := p.calls
+	alreadyBlocked := p.blockedOnce
+	p.mu.Unlock()
+
+	if call == 1 {
+		return workerexecution.InferenceResponse{
+			Content: fmt.Sprintf(`{"text":"live:%s:step-one:step-one:workflows","label":"step-one"}`, p.workflowName),
+			ProviderSession: &workerexecution.ProviderSessionMetadata{
+				Provider: "mock",
+				Kind:     "session_id",
+				ID:       "partial-result-provider-session-1",
+			},
+		}, nil
+	}
+
+	if !alreadyBlocked {
+		p.mu.Lock()
+		p.blockedOnce = true
+		p.mu.Unlock()
+
+		<-ctx.Done()
+		p.mu.Lock()
+		p.contextCanceled++
+		p.mu.Unlock()
+		return workerexecution.InferenceResponse{}, ctx.Err()
+	}
+
+	return workerexecution.InferenceResponse{
+		Content: fmt.Sprintf(`{"text":"live:%s:step-two:step-two:workflows","label":"step-two"}`, p.workflowName),
+		ProviderSession: &workerexecution.ProviderSessionMetadata{
+			Provider: "mock",
+			Kind:     "session_id",
+			ID:       "partial-result-provider-session-2",
+		},
+	}, nil
+}
 
 var dispatchCorrelationWorkflow = `return (async function () {
   const child = await agent.run({
@@ -104,6 +166,28 @@ func scaffoldDispatchCorrelationFactory(t *testing.T) string {
 		0o600,
 	); err != nil {
 		t.Fatalf("write dispatch correlation workflow: %v", err)
+	}
+	return dir
+}
+
+func scaffoldPartialResultFactory(t *testing.T) string {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, map[string]any{"name": "results-dispatches-partial"})
+	workflowDir := filepath.Join(dir, ".claude", "workflows")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("mkdir workflows: %v", err)
+	}
+	fixturePath := support.AgentFactoryPath(
+		t,
+		filepath.Join("tests", "fixtures", "javascript_runtime", partialResultWorkflowName+".workflow.js"),
+	)
+	raw, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("read workflow fixture %s: %v", fixturePath, err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, partialResultWorkflowName+".js"), raw, 0o600); err != nil {
+		t.Fatalf("write partial result workflow: %v", err)
 	}
 	return dir
 }
@@ -311,10 +395,171 @@ func readDurableSessionResult(
 ) factoryapi.FactorySessionResult {
 	t.Helper()
 
+	return readDurableSessionResultWithMode(t, serverURL, sessionID, "final")
+}
+
+func readDurableSessionResultWithMode(
+	t *testing.T,
+	serverURL, sessionID, mode string,
+) factoryapi.FactorySessionResult {
+	t.Helper()
+
 	return support.GetJSON[factoryapi.FactorySessionResult](
 		t,
-		strings.TrimSuffix(serverURL, "/")+"/factory-sessions/"+sessionID+"/results?mode=final",
+		strings.TrimSuffix(serverURL, "/")+"/factory-sessions/"+sessionID+"/results?mode="+mode,
 	)
+}
+
+func readDurableSession(
+	t *testing.T,
+	serverURL, sessionID string,
+) factoryapi.FactorySessionDurableReadModel {
+	t.Helper()
+
+	response := support.GetJSON[factoryapi.FactorySessionGetResponse](
+		t,
+		strings.TrimSuffix(serverURL, "/")+"/factory-sessions/"+sessionID,
+	)
+	session, err := response.AsFactorySessionDurableReadModel()
+	if err != nil {
+		t.Fatalf("decode durable session %s: %v", sessionID, err)
+	}
+	if session.SessionId != sessionID {
+		t.Fatalf("durable session id = %q, want %q", session.SessionId, sessionID)
+	}
+	return session
+}
+
+func startPartialResultAsync(
+	t *testing.T,
+	serverURL string,
+) factoryapi.FactorySessionExecutionResponse {
+	t.Helper()
+
+	workflowName := partialResultWorkflowName
+	payload, err := json.Marshal(factoryapi.FactorySessionExecutionRequest{
+		RequestId: "results-dispatches-partial-async",
+		Source: factoryapi.FactorySessionExecutionSource{
+			Kind:         factoryapi.FactorySessionExecutionSourceKindWorkflowName,
+			WorkflowName: &workflowName,
+		},
+		Args: &map[string]any{
+			"subject": "workflows",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal partial result async request: %v", err)
+	}
+
+	endpoint := strings.TrimSuffix(serverURL, "/") + "/factory-sessions/async"
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("build partial result async request: %v", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("POST %s: %v", endpoint, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(response.Body)
+		t.Fatalf("POST %s status = %d, want 200: %s", endpoint, response.StatusCode, strings.TrimSpace(string(payload)))
+	}
+
+	var started factoryapi.FactorySessionExecutionResponse
+	if err := json.NewDecoder(response.Body).Decode(&started); err != nil {
+		t.Fatalf("decode partial result async response: %v", err)
+	}
+	return started
+}
+
+func waitForDurableSessionStatus(
+	t *testing.T,
+	serverURL, sessionID string,
+	want factoryapi.FactorySessionDurableLifecycleStatus,
+	timeout time.Duration,
+) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		session := readDurableSession(t, serverURL, sessionID)
+		if session.Status == want {
+			return
+		}
+		time.Sleep(15 * time.Millisecond)
+	}
+	session := readDurableSession(t, serverURL, sessionID)
+	t.Fatalf("durable session %s status = %q, want %q within %s", sessionID, session.Status, want, timeout)
+}
+
+func waitForFactoryDispatchStatus(
+	t *testing.T,
+	serverURL, sessionID, dispatchID string,
+	want factoryapi.FactoryDispatchStatus,
+	timeout time.Duration,
+) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		listed := listFactorySessionDispatches(t, serverURL, sessionID)
+		for _, dispatch := range listed.Dispatches {
+			if dispatch.Id != dispatchID {
+				continue
+			}
+			if dispatch.Status == want {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("dispatch %s did not reach %s within %s", dispatchID, want, timeout)
+}
+
+func waitForDurablePartialResult(
+	t *testing.T,
+	serverURL, sessionID string,
+	timeout time.Duration,
+) factoryapi.FactorySessionResult {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		partial := readDurableSessionResultWithMode(t, serverURL, sessionID, "partial")
+		if partial.ResultStatus == factoryapi.FactorySessionResultStatusPartial &&
+			partial.PrimaryResult != nil && len(*partial.PrimaryResult) > 0 {
+			return partial
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	partial := readDurableSessionResultWithMode(t, serverURL, sessionID, "partial")
+	t.Fatalf(
+		"partial result = %#v, want PARTIAL status with primaryResult before %s",
+		partial,
+		timeout,
+	)
+	return partial
+}
+
+func terminateDurableSession(t *testing.T, serverURL, sessionID string) {
+	t.Helper()
+
+	endpoint := strings.TrimSuffix(serverURL, "/") + "/factory-sessions/" + sessionID + "/terminate"
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, http.NoBody)
+	if err != nil {
+		t.Fatalf("build terminate request: %v", err)
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("POST %s: %v", endpoint, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(response.Body)
+		t.Fatalf("POST %s status = %d, want 200: %s", endpoint, response.StatusCode, strings.TrimSpace(string(payload)))
+	}
 }
 
 func assertInvocationPrimaryResultText(
@@ -458,6 +703,32 @@ func assertDispatchListDetailPublicCorrelation(
 				)
 			}
 		}
+	}
+}
+
+func assertPartialResultObservableBeforeTerminal(
+	t *testing.T,
+	partial factoryapi.FactorySessionResult,
+) {
+	t.Helper()
+
+	if partial.ResultStatus != factoryapi.FactorySessionResultStatusPartial {
+		t.Fatalf("resultStatus = %q, want PARTIAL", partial.ResultStatus)
+	}
+	if partial.PrimaryResult == nil || len(*partial.PrimaryResult) == 0 {
+		t.Fatalf("primaryResult = %#v, want observable partial content", partial.PrimaryResult)
+	}
+	part, err := (*partial.PrimaryResult)[0].AsWorkJsonContentPart()
+	if err != nil {
+		t.Fatalf("primaryResult[0] as json part: %v", err)
+	}
+	payload, ok := part.Json.(map[string]any)
+	if !ok {
+		t.Fatalf("primaryResult json = %#v, want object", part.Json)
+	}
+	step, ok := payload["step"].(float64)
+	if !ok || int(step) != 1 {
+		t.Fatalf("primaryResult step = %#v, want checkpoint step 1", payload["step"])
 	}
 }
 

--- a/tests/functional/sessions/execution/helpers_test.go
+++ b/tests/functional/sessions/execution/helpers_test.go
@@ -1,0 +1,319 @@
+package execution_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	terminalSuccessPrimaryResult      = "primary result COMPLETE"
+	inlineJavaScriptWorkflowFileName  = "results-dispatches.workflow.js"
+)
+
+type blockingInvocationRunner struct {
+	started chan struct{}
+}
+
+func newBlockingInvocationRunner() *blockingInvocationRunner {
+	return &blockingInvocationRunner{started: make(chan struct{}, 1)}
+}
+
+func (r *blockingInvocationRunner) Run(ctx context.Context, _ platformprocess.CommandRequest) (platformprocess.CommandResult, error) {
+	select {
+	case r.started <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	return platformprocess.CommandResult{}, ctx.Err()
+}
+
+var _ platformprocess.CommandRunner = (*blockingInvocationRunner)(nil)
+
+func simplePipelineConfig() map[string]any {
+	return map[string]any{
+		"workTypes": []map[string]any{{
+			"name": "task",
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "complete", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []map[string]string{{"name": "worker-a"}},
+		"workstations": []map[string]any{{
+			"name":      "process",
+			"worker":    "worker-a",
+			"inputs":    []map[string]string{{"workType": "task", "state": "init"}},
+			"outputs":   []map[string]string{{"workType": "task", "state": "complete"}},
+			"onFailure": []map[string]string{{"workType": "task", "state": "failed"}},
+		}},
+	}
+}
+
+func scaffoldInvocationFactory(t *testing.T, overrides map[string]any) string {
+	t.Helper()
+
+	cfg := simplePipelineConfig()
+	for key, value := range overrides {
+		cfg[key] = value
+	}
+	workTypes := cfg["workTypes"].([]map[string]any)
+	for i := range workTypes {
+		if name, _ := workTypes[i]["name"].(string); name == "task" {
+			workTypes[i]["handlingBehavior"] = []string{"DEFAULT"}
+		}
+	}
+	dir := support.ScaffoldFactory(t, cfg)
+	support.WriteAgentConfig(t, dir, "worker-a", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"))
+	return dir
+}
+
+func scaffoldInlineJavaScriptFactory(t *testing.T) string {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, map[string]any{
+		"orchestrator": map[string]any{
+			"kind": "JAVASCRIPT",
+			"javascript": map[string]any{
+				"inlineSource": map[string]any{
+					"encoding": "utf-8",
+					"inline":   `workflow.final("` + terminalSuccessPrimaryResult + `");`,
+				},
+			},
+		},
+	})
+	if err := os.WriteFile(
+		filepath.Join(dir, inlineJavaScriptWorkflowFileName),
+		[]byte(`workflow.final("`+terminalSuccessPrimaryResult+`");`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write inline JavaScript workflow: %v", err)
+	}
+	return dir
+}
+
+func startInvocationServer(
+	t *testing.T,
+	factoryDir string,
+	providerRunner, scriptRunner platformprocess.CommandRunner,
+) *support.FunctionalAPIServer {
+	t.Helper()
+
+	edges := serviceedges.Edges{}
+	support.ConfigureWorkerCommands(t, &edges, providerRunner, scriptRunner)
+	return support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                factoryDir,
+		WaitForServiceModeRuntime: true,
+		Edges:                     edges,
+	})
+}
+
+func textInvocationRequest(t *testing.T, text string, timeoutMillis *int64) factoryapi.InvocationRequest {
+	t.Helper()
+
+	var part factoryapi.WorkContentPart
+	if err := part.FromWorkTextContentPart(factoryapi.WorkTextContentPart{
+		Type: factoryapi.WorkContentPartTypeText,
+		Text: text,
+	}); err != nil {
+		t.Fatalf("build invocation text content: %v", err)
+	}
+	sourceKind := factoryapi.InvocationInputSourceKindText
+	content := factoryapi.WorkContent{part}
+	return factoryapi.InvocationRequest{
+		SourceKind:    &sourceKind,
+		Content:       &content,
+		TimeoutMillis: timeoutMillis,
+	}
+}
+
+func postInvocation(t *testing.T, serverURL string, request factoryapi.InvocationRequest) factoryapi.InvocationResponse {
+	t.Helper()
+
+	body, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("marshal invocation request: %v", err)
+	}
+	response, err := http.Post(
+		strings.TrimSuffix(serverURL, "/")+"/factory-sessions/"+factorysessions.DefaultSessionID+"/invocations",
+		"application/json",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("POST /factory-sessions/~default/invocations: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(response.Body)
+		t.Fatalf(
+			"POST /factory-sessions/~default/invocations status = %d: %s",
+			response.StatusCode,
+			strings.TrimSpace(string(payload)),
+		)
+	}
+
+	var decoded factoryapi.InvocationResponse
+	if err := json.NewDecoder(response.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode invocation response: %v", err)
+	}
+	return decoded
+}
+
+func startInlineJavaScriptSync(
+	t *testing.T,
+	serverURL, factoryDir string,
+) factoryapi.FactorySessionSyncExecutionResponse {
+	t.Helper()
+
+	workflowPath := filepath.Join(factoryDir, inlineJavaScriptWorkflowFileName)
+	payload, err := json.Marshal(factoryapi.FactorySessionExecutionRequest{
+		RequestId: "results-dispatches-inline-js-sync",
+		Source: factoryapi.FactorySessionExecutionSource{
+			Kind:         factoryapi.FactorySessionExecutionSourceKindWorkflowFile,
+			WorkflowFile: &workflowPath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal sync execution request: %v", err)
+	}
+
+	endpoint := strings.TrimSuffix(serverURL, "/") + "/factory-sessions/sync"
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("build sync execution request: %v", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("POST %s: %v", endpoint, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(response.Body)
+		t.Fatalf("POST %s status = %d, want 200: %s", endpoint, response.StatusCode, strings.TrimSpace(string(payload)))
+	}
+
+	var result factoryapi.FactorySessionSyncExecutionResponse
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		t.Fatalf("decode sync execution response: %v", err)
+	}
+	return result
+}
+
+func readDurableSessionResult(
+	t *testing.T,
+	serverURL, sessionID string,
+) factoryapi.FactorySessionResult {
+	t.Helper()
+
+	return support.GetJSON[factoryapi.FactorySessionResult](
+		t,
+		strings.TrimSuffix(serverURL, "/")+"/factory-sessions/"+sessionID+"/results?mode=final",
+	)
+}
+
+func assertInvocationPrimaryResultText(
+	t *testing.T,
+	response factoryapi.InvocationResponse,
+	wantText string,
+) {
+	t.Helper()
+
+	if response.Status != factoryapi.InvocationTerminalStatusCompleted {
+		t.Fatalf("invocation status = %q, want COMPLETED", response.Status)
+	}
+	if response.PrimaryResult == nil || len(*response.PrimaryResult) != 1 {
+		t.Fatalf("invocation primaryResult = %#v, want one text part", response.PrimaryResult)
+	}
+	part, err := (*response.PrimaryResult)[0].AsWorkTextContentPart()
+	if err != nil {
+		t.Fatalf("primaryResult[0] as text part: %v", err)
+	}
+	if part.Text != wantText {
+		t.Fatalf("primaryResult text = %q, want %q", part.Text, wantText)
+	}
+}
+
+func assertFactorySessionResultPrimaryText(
+	t *testing.T,
+	result factoryapi.FactorySessionResult,
+	wantText string,
+) {
+	t.Helper()
+
+	if result.ResultStatus != factoryapi.FactorySessionResultStatusFinal {
+		t.Fatalf("resultStatus = %q, want FINAL", result.ResultStatus)
+	}
+	if result.PrimaryResult == nil || len(*result.PrimaryResult) != 1 {
+		t.Fatalf("primaryResult = %#v, want one content part", result.PrimaryResult)
+	}
+	part, err := (*result.PrimaryResult)[0].AsWorkJsonContentPart()
+	if err != nil {
+		t.Fatalf("primaryResult[0] as json part: %v", err)
+	}
+	got, ok := part.Json.(string)
+	if !ok || got != wantText {
+		t.Fatalf("primaryResult json = %#v, want string %q", part.Json, wantText)
+	}
+}
+
+func assertTerminalWorkPrimaryText(
+	t *testing.T,
+	serverURL, wantText string,
+) {
+	t.Helper()
+
+	listed := support.GetJSON[factoryapi.ListWorkResponse](
+		t,
+		support.DefaultSessionWorkURL(serverURL, "/work"),
+	)
+	if len(listed.Results) != 1 {
+		t.Fatalf("listed work count = %d, want 1; listed=%#v", len(listed.Results), listed.Results)
+	}
+	item := listed.Results[0]
+	if item.State == nil || generatedWorkStateType(item.State) != factoryapi.WorkStateTypeTERMINAL {
+		t.Fatalf("work state = %#v, want TERMINAL", item.State)
+	}
+	if item.Content == nil || len(*item.Content) != 1 {
+		t.Fatalf("work content = %#v, want one text part", item.Content)
+	}
+	part, err := (*item.Content)[0].AsWorkTextContentPart()
+	if err != nil {
+		t.Fatalf("work content[0] as text part: %v", err)
+	}
+	if part.Text != wantText {
+		t.Fatalf("work content text = %q, want %q", part.Text, wantText)
+	}
+}
+
+func generatedWorkStateType(state *factoryapi.WorkState) factoryapi.WorkStateType {
+	if state == nil {
+		return ""
+	}
+	return state.Type
+}
+
+func waitForBlockingInvocationStart(t *testing.T, blocking *blockingInvocationRunner) {
+	t.Helper()
+
+	select {
+	case <-blocking.started:
+	case <-time.After(time.Second):
+		t.Fatal("blocking invocation did not start")
+	}
+}

--- a/tests/functional/sessions/execution/results_dispatches_test.go
+++ b/tests/functional/sessions/execution/results_dispatches_test.go
@@ -1,11 +1,17 @@
 package execution_test
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
 
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 	"github.com/portpowered/infinite-you/tests/internal/functionalevidence"
@@ -13,7 +19,9 @@ import (
 
 // TestAPIResultAndResultsExposeTerminalInvocationData proves terminal invocation
 // and durable session result reads expose success primary-result content plus
-// typed non-success terminal statuses through the public Factory Session API.
+// typed non-success terminal statuses, invalid invocation inputs are rejected
+// with typed public errors, and canceled request context stops in-flight
+// invocations without fabricating terminal success results.
 func TestAPIResultAndResultsExposeTerminalInvocationData(t *testing.T) {
 	t.Run("successfulInvocationExposesPrimaryResultOnInvocationAndWorkReads", func(t *testing.T) {
 		dir := scaffoldInvocationFactory(t, nil)
@@ -85,6 +93,117 @@ func TestAPIResultAndResultsExposeTerminalInvocationData(t *testing.T) {
 			t.Fatalf("invocation primaryResult = %#v, want nil on timeout", response.PrimaryResult)
 		}
 		waitForBlockingInvocationStart(t, blocking)
+	})
+
+	t.Run("rejectsWhitespaceOnlyTextWithTypedPublicError", func(t *testing.T) {
+		dir := scaffoldInvocationFactory(t, nil)
+		server := startInvocationServer(
+			t,
+			dir,
+			support.NewStaticSuccessCommandRunner(terminalSuccessPrimaryResult),
+			nil,
+		)
+
+		response := postInvocationExpectStatus(
+			t,
+			server.URL(),
+			textInvocationRequest(t, "   ", nil),
+			http.StatusBadRequest,
+		)
+		if string(response.Code) != "INVOCATION_INPUT_EMPTY" {
+			t.Fatalf("invocation error code = %q, want INVOCATION_INPUT_EMPTY", response.Code)
+		}
+	})
+
+	t.Run("rejectsArgsWithoutActiveSignatureWithTypedPublicError", func(t *testing.T) {
+		dir := scaffoldInvocationFactory(t, nil)
+		server := startInvocationServer(
+			t,
+			dir,
+			support.NewStaticSuccessCommandRunner(terminalSuccessPrimaryResult),
+			nil,
+		)
+
+		response := postInvocationExpectStatus(
+			t,
+			server.URL(),
+			factoryapi.InvocationRequest{
+				Args: &map[string]any{"input": "hello"},
+			},
+			http.StatusBadRequest,
+		)
+		if string(response.Code) != "INVOCATION_ARGUMENT_INVALID_ACTIVE_SIGNATURE" {
+			t.Fatalf(
+				"invocation error code = %q, want INVOCATION_ARGUMENT_INVALID_ACTIVE_SIGNATURE",
+				response.Code,
+			)
+		}
+	})
+
+	t.Run("rejectsInvalidStructuredArgValueShapeWithTypedPublicError", func(t *testing.T) {
+		dir := scaffoldInvocationFactory(t, nil)
+		server := startInvocationServer(
+			t,
+			dir,
+			support.NewStaticSuccessCommandRunner(terminalSuccessPrimaryResult),
+			nil,
+		)
+
+		response := postInvocationExpectStatus(
+			t,
+			server.URL(),
+			factoryapi.InvocationRequest{
+				Args: &map[string]any{"input": 7},
+			},
+			http.StatusBadRequest,
+		)
+		if string(response.Code) != "BAD_REQUEST" {
+			t.Fatalf("invocation error code = %q, want BAD_REQUEST", response.Code)
+		}
+	})
+
+	t.Run("canceledRequestContextStopsInFlightInvocation", func(t *testing.T) {
+		dir := scaffoldInvocationFactory(t, nil)
+		blocking := newBlockingInvocationRunner()
+		server := startInvocationServer(t, dir, blocking, nil)
+
+		body, err := json.Marshal(textInvocationRequest(t, "invoke this", nil))
+		if err != nil {
+			t.Fatalf("marshal invocation request: %v", err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		request, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodPost,
+			server.URL()+"/factory-sessions/"+factorysessions.DefaultSessionID+"/invocations",
+			bytes.NewReader(body),
+		)
+		if err != nil {
+			cancel()
+			t.Fatalf("build invocation request: %v", err)
+		}
+		request.Header.Set("Content-Type", "application/json")
+		errCh := make(chan error, 1)
+		go func() {
+			response, requestErr := http.DefaultClient.Do(request)
+			if response != nil {
+				_ = response.Body.Close()
+			}
+			errCh <- requestErr
+		}()
+
+		<-blocking.started
+		cancel()
+
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("canceled invocation request error = %v, want context.Canceled", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("canceled invocation request did not return")
+		}
 	})
 
 	t.Run("durableResultsReadExposesFinalPrimaryResult", func(t *testing.T) {

--- a/tests/functional/sessions/execution/results_dispatches_test.go
+++ b/tests/functional/sessions/execution/results_dispatches_test.go
@@ -1,0 +1,116 @@
+package execution_test
+
+import (
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+	"github.com/portpowered/infinite-you/tests/internal/functionalevidence"
+)
+
+// TestAPIResultAndResultsExposeTerminalInvocationData proves terminal invocation
+// and durable session result reads expose success primary-result content plus
+// typed non-success terminal statuses through the public Factory Session API.
+func TestAPIResultAndResultsExposeTerminalInvocationData(t *testing.T) {
+	t.Run("successfulInvocationExposesPrimaryResultOnInvocationAndWorkReads", func(t *testing.T) {
+		dir := scaffoldInvocationFactory(t, nil)
+		server := startInvocationServer(
+			t,
+			dir,
+			support.NewStaticSuccessCommandRunner(terminalSuccessPrimaryResult),
+			nil,
+		)
+
+		response := postInvocation(t, server.URL(), textInvocationRequest(t, "invoke this", nil))
+		assertInvocationPrimaryResultText(t, response, terminalSuccessPrimaryResult)
+		assertTerminalWorkPrimaryText(t, server.URL(), terminalSuccessPrimaryResult)
+	})
+
+	t.Run("unresolvedPrimaryResultReturnsFailedTerminalStatus", func(t *testing.T) {
+		dir := scaffoldInvocationFactory(t, map[string]any{
+			"invocationReturn": map[string]any{
+				"policy":        "EXPLICIT",
+				"workTypeName":  "summary",
+				"terminalState": "complete",
+			},
+			"workTypes": append(simplePipelineConfig()["workTypes"].([]map[string]any), map[string]any{
+				"name": "summary",
+				"states": []map[string]string{
+					{"name": "init", "type": "INITIAL"},
+					{"name": "complete", "type": "TERMINAL"},
+					{"name": "failed", "type": "FAILED"},
+				},
+			}),
+		})
+		server := startInvocationServer(
+			t,
+			dir,
+			support.NewStaticSuccessCommandRunner("task output COMPLETE"),
+			nil,
+		)
+
+		response := postInvocation(t, server.URL(), textInvocationRequest(t, "invoke this", nil))
+		if response.Status != factoryapi.InvocationTerminalStatusFailed {
+			t.Fatalf("invocation status = %q, want FAILED", response.Status)
+		}
+		if response.ErrorCode == nil || *response.ErrorCode != factoryapi.INVOCATIONPRIMARYRESULTUNRESOLVED {
+			t.Fatalf("invocation errorCode = %#v, want INVOCATION_PRIMARY_RESULT_UNRESOLVED", response.ErrorCode)
+		}
+		if response.PrimaryResult != nil {
+			t.Fatalf("invocation primaryResult = %#v, want nil on unresolved output", response.PrimaryResult)
+		}
+	})
+
+	t.Run("timeoutReturnsTimedOutTerminalStatus", func(t *testing.T) {
+		dir := scaffoldInvocationFactory(t, nil)
+		blocking := newBlockingInvocationRunner()
+		server := startInvocationServer(t, dir, blocking, nil)
+
+		timeoutMillis := int64(10)
+		response := postInvocation(
+			t,
+			server.URL(),
+			textInvocationRequest(t, "invoke this", &timeoutMillis),
+		)
+		if response.Status != factoryapi.InvocationTerminalStatusTimedOut {
+			t.Fatalf("invocation status = %q, want TIMED_OUT", response.Status)
+		}
+		if response.ErrorCode == nil || *response.ErrorCode != factoryapi.INVOCATIONTIMEDOUT {
+			t.Fatalf("invocation errorCode = %#v, want INVOCATION_TIMED_OUT", response.ErrorCode)
+		}
+		if response.PrimaryResult != nil {
+			t.Fatalf("invocation primaryResult = %#v, want nil on timeout", response.PrimaryResult)
+		}
+		waitForBlockingInvocationStart(t, blocking)
+	})
+
+	t.Run("durableResultsReadExposesFinalPrimaryResult", func(t *testing.T) {
+		dir := scaffoldInlineJavaScriptFactory(t)
+		server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+			FactoryDir:                dir,
+			WaitForServiceModeRuntime: true,
+			UseMockWorkers:            true,
+			Edges: serviceedges.Edges{
+				ProviderCommandRunner: support.NewRecordingCommandRunner("unexpected live provider execution"),
+			},
+		})
+
+		started := startInlineJavaScriptSync(t, server.URL(), dir)
+		if started.Status != factoryapi.FactorySessionDurableLifecycleStatusSucceeded {
+			t.Fatalf("session status = %q, want SUCCEEDED", started.Status)
+		}
+		if started.Result == nil {
+			t.Fatal("sync result = nil, want FINAL primary outcome")
+		}
+		assertFactorySessionResultPrimaryText(t, *started.Result, terminalSuccessPrimaryResult)
+
+		finalResult := readDurableSessionResult(t, server.URL(), started.SessionId)
+		if finalResult.SessionId != started.SessionId {
+			t.Fatalf("result sessionId = %q, want %q", finalResult.SessionId, started.SessionId)
+		}
+		assertFactorySessionResultPrimaryText(t, finalResult, terminalSuccessPrimaryResult)
+	})
+
+	functionalevidence.Covers(t, "rest/getFactorySessionResults", "rest/invokeFactorySessionBySessionId")
+}

--- a/tests/functional/sessions/execution/results_dispatches_test.go
+++ b/tests/functional/sessions/execution/results_dispatches_test.go
@@ -309,7 +309,8 @@ func TestAPIPartialResultIsAvailableBeforeTerminalCompletion(t *testing.T) {
 		t.Fatal("sessionId is empty, want durable Factory Session identifier")
 	}
 	t.Cleanup(func() {
-		terminateDurableSession(t, server.URL(), started.SessionId)
+		releaseBlockedPartialResultSession(t, server.URL(), provider, started.SessionId)
+		server.Stop(t)
 	})
 
 	waitForDurableSessionStatus(

--- a/tests/functional/sessions/execution/results_dispatches_test.go
+++ b/tests/functional/sessions/execution/results_dispatches_test.go
@@ -3,6 +3,7 @@ package execution_test
 import (
 	"strings"
 	"testing"
+	"time"
 
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
@@ -169,4 +170,84 @@ func TestAPIDispatchListAndDetailExposePublicCorrelation(t *testing.T) {
 	}
 
 	functionalevidence.Covers(t, "rest/getFactorySessionDispatch", "rest/listFactorySessionDispatches")
+}
+
+// TestAPIPartialResultIsAvailableBeforeTerminalCompletion proves a durable
+// Factory Session exposes an observable partial-result projection through the
+// public results read surface while the session is still non-terminal and
+// before final completion is available.
+func TestAPIPartialResultIsAvailableBeforeTerminalCompletion(t *testing.T) {
+	dir := scaffoldPartialResultFactory(t)
+	provider := newPartialResultBlockingProvider(partialResultWorkflowName)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		WaitForServiceModeRuntime: true,
+		Edges:                     serviceedges.Edges{ProviderOverride: provider},
+	})
+
+	started := startPartialResultAsync(t, server.URL())
+	if strings.TrimSpace(started.SessionId) == "" {
+		t.Fatal("sessionId is empty, want durable Factory Session identifier")
+	}
+	t.Cleanup(func() {
+		terminateDurableSession(t, server.URL(), started.SessionId)
+	})
+
+	waitForDurableSessionStatus(
+		t,
+		server.URL(),
+		started.SessionId,
+		factoryapi.FactorySessionDurableLifecycleStatusRunning,
+		5*time.Second,
+	)
+	waitForFactoryDispatchStatus(
+		t,
+		server.URL(),
+		started.SessionId,
+		partialResultFirstDispatchID,
+		factoryapi.FactoryDispatchStatusCOMPLETED,
+		5*time.Second,
+	)
+	waitForFactoryDispatchStatus(
+		t,
+		server.URL(),
+		started.SessionId,
+		partialResultSecondDispatchID,
+		factoryapi.FactoryDispatchStatusRUNNING,
+		5*time.Second,
+	)
+
+	partial := waitForDurablePartialResult(t, server.URL(), started.SessionId, 5*time.Second)
+	if partial.SessionId != started.SessionId {
+		t.Fatalf("partial result sessionId = %q, want %q", partial.SessionId, started.SessionId)
+	}
+	if partial.SessionStatus == nil || *partial.SessionStatus != factoryapi.FactorySessionDurableLifecycleStatusRunning {
+		t.Fatalf("partial result sessionStatus = %#v, want RUNNING", partial.SessionStatus)
+	}
+	if partial.Mode == nil || *partial.Mode != factoryapi.FactorySessionResultModePartial {
+		t.Fatalf("partial result mode = %#v, want partial", partial.Mode)
+	}
+	assertPartialResultObservableBeforeTerminal(t, partial)
+
+	session := readDurableSession(t, server.URL(), started.SessionId)
+	if session.Status != factoryapi.FactorySessionDurableLifecycleStatusRunning {
+		t.Fatalf("session status = %q, want RUNNING before terminal completion", session.Status)
+	}
+	if session.ResultSummary != nil &&
+		session.ResultSummary.ResultStatus == factoryapi.FactorySessionResultStatusFinal {
+		t.Fatalf("resultSummary = %#v, want no FINAL summary before terminal completion", session.ResultSummary)
+	}
+	if session.LatestCheckpoint == nil || session.LatestCheckpoint.Label == nil ||
+		*session.LatestCheckpoint.Label != partialResultCheckpointLabel {
+		t.Fatalf("latestCheckpoint = %#v, want label %q", session.LatestCheckpoint, partialResultCheckpointLabel)
+	}
+
+	final := readDurableSessionResultWithMode(t, server.URL(), started.SessionId, "final")
+	if final.ResultStatus != factoryapi.FactorySessionResultStatusNotReady {
+		t.Fatalf("final-mode resultStatus = %q, want NOT_READY while session is running", final.ResultStatus)
+	}
+	if final.Availability == nil || final.Availability.Reason == nil ||
+		*final.Availability.Reason != "RESULT_NOT_READY" {
+		t.Fatalf("final-mode availability = %#v, want RESULT_NOT_READY", final.Availability)
+	}
 }

--- a/tests/functional/sessions/execution/results_dispatches_test.go
+++ b/tests/functional/sessions/execution/results_dispatches_test.go
@@ -1,6 +1,7 @@
 package execution_test
 
 import (
+	"strings"
 	"testing"
 
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
@@ -113,4 +114,59 @@ func TestAPIResultAndResultsExposeTerminalInvocationData(t *testing.T) {
 	})
 
 	functionalevidence.Covers(t, "rest/getFactorySessionResults", "rest/invokeFactorySessionBySessionId")
+}
+
+// TestAPIDispatchListAndDetailExposePublicCorrelation proves durable Factory
+// Session dispatch list and detail reads expose the same public dispatch
+// identifier and compatible correlation fields so customers can join summaries
+// to detail without private runtime handles.
+func TestAPIDispatchListAndDetailExposePublicCorrelation(t *testing.T) {
+	dir := scaffoldDispatchCorrelationFactory(t)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		WaitForServiceModeRuntime: true,
+		UseMockWorkers:            true,
+		Edges: serviceedges.Edges{
+			ProviderCommandRunner: support.NewRecordingCommandRunner("unexpected live provider execution"),
+		},
+	})
+
+	started := startDispatchCorrelationSync(t, server.URL(), dir)
+	if started.Status != factoryapi.FactorySessionDurableLifecycleStatusSucceeded {
+		t.Fatalf("session status = %q, want SUCCEEDED", started.Status)
+	}
+	if strings.TrimSpace(started.SessionId) == "" {
+		t.Fatal("sessionId is empty, want durable Factory Session identifier")
+	}
+
+	listed := listFactorySessionDispatches(t, server.URL(), started.SessionId)
+	if len(listed.Dispatches) == 0 {
+		t.Fatalf("dispatch list is empty, want at least one public dispatch summary")
+	}
+	if listed.SessionId != started.SessionId {
+		t.Fatalf("dispatch list sessionId = %q, want %q", listed.SessionId, started.SessionId)
+	}
+
+	var matched bool
+	for _, summary := range listed.Dispatches {
+		if summary.Label == nil || *summary.Label != dispatchCorrelationChildLabel {
+			continue
+		}
+		if summary.Status != factoryapi.FactoryDispatchStatusCOMPLETED {
+			t.Fatalf("dispatch summary status = %q, want COMPLETED", summary.Status)
+		}
+		detail := getFactorySessionDispatch(t, server.URL(), started.SessionId, summary.Id)
+		assertDispatchListDetailPublicCorrelation(t, started.SessionId, summary, detail)
+		matched = true
+		break
+	}
+	if !matched {
+		t.Fatalf(
+			"dispatch list = %#v, want one completed dispatch labeled %q",
+			listed.Dispatches,
+			dispatchCorrelationChildLabel,
+		)
+	}
+
+	functionalevidence.Covers(t, "rest/getFactorySessionDispatch", "rest/listFactorySessionDispatches")
 }


### PR DESCRIPTION
{
  "project": "Session Results and Dispatch Reads Functional Coverage",
  "branchName": "ft-wave2-sessions-results-dispatches",
  "description": "Implement only tests/functional/sessions/execution/results_dispatches_test.go so the public API session/execution read surfaces prove terminal result/results expose invocation data, dispatch list/detail expose public correlation, and partial results are available before terminal completion—consuming the seven mapped migration-ledger rows from api_session_invocation_test.go without inventing unrelated deletion obligations or implementing visibility_test.go.",
  "context": {
    "customerAsk": "Implement only tests/functional/sessions/execution/results_dispatches_test.go. Through the public API session/execution read surfaces, prove: (1) TestAPIResultAndResultsExposeTerminalInvocationData; (2) TestAPIDispatchListAndDetailExposePublicCorrelation; (3) TestAPIPartialResultIsAvailableBeforeTerminalCompletion. Consume the seven mapped migration-ledger rows. Do not implement visibility_test.go. Avoid service/internal Petri imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for session results and dispatch reads does not exist yet even though Wave 2 is opening and seven invocation/result scenarios already map here. Legacy runtime_api coverage in api_session_invocation_test.go proves invocation POST outcomes under a catch-all package, so maintainers lack a focused, catalogued sessions/execution proof that terminal result/results reads expose invocation data, dispatch list/detail expose public correlation, and partial results are available before terminal completion.",
    "solution": "Implement the three checklist scenarios in tests/functional/sessions/execution/results_dispatches_test.go through the public Factory Session API session/execution read surfaces with customer-readable Go docs on every top-level Test. Consume the seven checklist-authoritative migration-ledger rows from api_session_invocation_test.go (later deletion-batch tag runtime_api-delete-04-sessions preserved as metadata only; do not delete legacy sources in this cell); apply only narrowly coupled ownership/coverage/catalog/migration metadata; leave held execution sibling visibility_test.go untouched; and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/sessions/execution/results_dispatches_test.go exists as the sessions-owned functional cell and covers terminal result/results reads, dispatch list/detail public correlation, and pre-terminal partial-result availability.",
    "Through the public API session/execution read surfaces, terminal invocation/session data is exposed on result and results reads (success primary-result facts and non-success terminal statuses as required to absorb mapped ledger obligations).",
    "Through the public API session/execution read surfaces, dispatch list and dispatch detail expose public correlation identifiers that match for the same dispatch.",
    "Through the public API session/execution read surfaces, a partial result is available before terminal completion (observable partial payload/status distinct from final terminal completion).",
    "The seven checklist-authoritative migration-ledger rows whose destination is this cell are consumed as applicable; only narrowly coupled ownership/coverage/catalog/migration metadata for this cell are updated; no unrelated deletion-batch destinations are invented or executed in this cell; coverage uses the public API session/execution read surfaces / approved helpers and does not import service implementations or internal Petri primitives as the proof owner, with customer-readable Go docs on every top-level Test*; held sibling visibility_test.go stays untouched.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave2-sessions-results-dispatches-001",
      "title": "Prove result and results expose terminal invocation data",
      "description": "As an API customer inspecting a finished Factory Session, I want terminal invocation/session outcome data on the public result and results reads so I can retrieve success primary-result content or typed terminal failure/timeout facts without scraping events.",
      "acceptanceCriteria": [
        "tests/functional/sessions/execution/results_dispatches_test.go includes TestAPIResultAndResultsExposeTerminalInvocationData (or equivalent top-level name matching the checklist intent).",
        "Through the public API session/execution read surfaces, after a successful public invocation/session run (minimal Factory/worker fixture), GET /factory-sessions/{session_id}/result and/or /factory-sessions/{session_id}/results expose the terminal success primary-result data customers expect (absorbing the mapped TestSessionInvocationAPI_ReturnsPrimaryResult customer-facing obligation as applicable).",
        "Through the same public read surfaces, non-success terminal outcomes required by mapped ledger ownership are observable as typed terminal statuses/error facts rather than fabricated success primary results (absorbing unresolved-primary-result failed status and timed-out status obligations as applicable).",
        "Assertions stay on terminal result/results readability at the public API boundary and do not re-own pause/resume controls, restart identity, MCP controls, or CLI/API visibility parity belonging to held/sibling cells.",
        "The top-level test has a customer-readable Go doc comment describing the observable terminal result/results behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-sessions-results-dispatches-002",
      "title": "Prove dispatch list and detail expose public correlation",
      "description": "As an API customer correlating worker/dispatch activity for a Factory Session, I want list and detail dispatch reads to expose stable public correlation identifiers so I can join summaries to detail without private runtime handles.",
      "acceptanceCriteria": [
        "The results/dispatches cell includes TestAPIDispatchListAndDetailExposePublicCorrelation (or equivalent top-level name matching the checklist intent).",
        "Through the public API session/execution read surfaces, after a session has produced at least one dispatch, GET /factory-sessions/{session_id}/dispatches returns a dispatch summary that includes a public dispatch identifier (and public provider-session correlation refs when the fixture produces them).",
        "GET /factory-sessions/{session_id}/dispatches/{dispatch_id} for that same identifier returns detail whose public correlation identity matches the list entry (same dispatch id; compatible public correlation fields).",
        "Assertions remain on public dispatch correlation at the API boundary and do not widen into event-stream ordering ownership, artifact-body reads, or held visibility_test.go CLI/API parity proofs.",
        "The top-level test has a customer-readable Go doc comment describing the observable dispatch list/detail public correlation contract.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-sessions-results-dispatches-003",
      "title": "Prove partial result is available before terminal completion",
      "description": "As an API customer polling an in-flight Factory Session, I want a partial result before terminal completion so I can observe progress without waiting for the final terminal outcome.",
      "acceptanceCriteria": [
        "The results/dispatches cell includes TestAPIPartialResultIsAvailableBeforeTerminalCompletion (or equivalent top-level name matching the checklist intent).",
        "Through the public API session/execution read surfaces, while a session is still non-terminal (for example a blocking/slow worker fixture), GET /factory-sessions/{session_id}/partial-result and/or results with partial mode returns an observable partial-result projection before terminal completion.",
        "The partial-result response is distinguishable from a final terminal success completion (partial/in-progress facts present; session not yet treated as finally completed in that read).",
        "Assertions remain on pre-terminal partial-result availability at the public API boundary and do not widen into pause/resume buffering ownership or held visibility parity proofs.",
        "The top-level test has a customer-readable Go doc comment describing the observable pre-terminal partial-result contract.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-sessions-results-dispatches-004",
      "title": "Consume mapped ledger rows and close verification gates",
      "description": "As a maintainer executing Wave 2 migration, I want this cell to absorb the seven checklist-authoritative migration-ledger rows and pass focused boundary/metadata gates so the destination is catalogued correctly without inventing unrelated deletion obligations or widening into the held sibling.",
      "acceptanceCriteria": [
        "Migration-ledger mappings whose destination is tests/functional/sessions/execution/results_dispatches_test.go are consumed by this cell’s coverage for all seven source scenarios from tests/functional/runtime_api/api_session_invocation_test.go: TestSessionInvocationAPI_CanceledRequestContextStopsRequest, TestSessionInvocationAPI_RejectsArgsWithoutActiveSignature, TestSessionInvocationAPI_RejectsInvalidStructuredArgValueShape, TestSessionInvocationAPI_RejectsWhitespaceOnlyText, TestSessionInvocationAPI_ReturnsPrimaryResult, TestSessionInvocationAPI_TimeoutReturnsTimedOutStatus, and TestSessionInvocationAPI_UnresolvedPrimaryResultReturnsFailedStatus (catch-all runtime_api, specialty none, later deletion-only batch tag runtime_api-delete-04-sessions preserved as metadata ownership only).",
        "Customer-facing obligations from those rows are absorbed as applicable into the cell’s public API proofs: successful terminal primary-result readability; unresolved primary result and timeout as typed non-success terminals; invalid invocation inputs rejected with typed public errors without fabricating terminal success results/dispatches; canceled request context stops the in-flight request without a false terminal success result — without inventing unrelated deletion-batch work and without deleting legacy runtime_api sources in this cell.",
        "Only narrowly coupled ownership, coverage, or catalog metadata required for this cell are updated; held Wave 2 sibling visibility_test.go stays untouched.",
        "Neighboring sessions lifecycle/controls/restart/mcp cells are not rewritten beyond what is required to leave shared support helpers compiling safely.",
        "Focused package tests for tests/functional/sessions/execution pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as sessions/execution).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)