### PR TITLE
ft-wave2-sessions-pause-resume

### DIFF
--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -7597,6 +7597,96 @@
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
+      "scenario": "TestRegisterDefaultsResolutionFromHomeRestoresAdapterOwnership",
+      "lane": "short",
+      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
+      "scenario": "TestResolveFromHomeFallbackPreservesAcceptedSemantics",
+      "lane": "short",
+      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
+      "scenario": "TestResolveFromHomeRejectsMissingFilesystemPorts",
+      "lane": "short",
+      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
+      "scenario": "TestResolveFromHomeUsesSettingsAdapterOwnershipPath",
+      "lane": "short",
+      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
+      "scenario": "TestServiceFromConfigDocumentConstructsFromDocumentPorts",
+      "lane": "short",
+      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
+      "scenario": "TestServiceFromConfigDocumentRejectsMissingDocumentPorts",
+      "lane": "short",
+      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
+      "scenario": "TestServiceFromHomePortsConstructsSettingsRoot",
+      "lane": "short",
+      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
+      "scenario": "TestServiceFromHomePortsRejectsMissingPorts",
+      "lane": "short",
+      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
+      "scenario": "TestServiceWireCompositionRootServesDocumentAndResolutionOperations",
+      "lane": "short",
+      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
     }
   ],
   "scanned_at_utc": "2026-07-28T05:00:00Z",
@@ -7604,7 +7694,7 @@
     "by_catch_all": {
       "bootstrap_portability": 22,
       "guards_batch": 23,
-      "none": 466,
+      "none": 475,
       "replay_contracts": 23,
       "runtime_api": 96,
       "smoke": 62,
@@ -7619,7 +7709,7 @@
       "guards_batch": 23,
       "models": 5,
       "observability": 9,
-      "operator_settings": 1,
+      "operator_settings": 10,
       "orchestration": 48,
       "product": 13,
       "providers": 55,
@@ -7635,9 +7725,9 @@
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 740,
+    "customer_top_level_Test_scenarios": 749,
     "lane_functionallong": 95,
-    "lane_short": 645,
+    "lane_short": 654,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 12,
       "you-agent-factory/tests/functional/automations": 7,
@@ -7663,6 +7753,7 @@
       "you-agent-factory/tests/functional/models/model_list": 2,
       "you-agent-factory/tests/functional/observability/coverage": 9,
       "you-agent-factory/tests/functional/operator_settings/configcore": 1,
+      "you-agent-factory/tests/functional/operator_settings/servicewire": 9,
       "you-agent-factory/tests/functional/orchestration/javascript/composition": 14,
       "you-agent-factory/tests/functional/orchestration/javascript/contracts": 8,
       "you-agent-factory/tests/functional/orchestration/javascript/durability": 3,
@@ -7723,7 +7814,7 @@
       "you-agent-factory/tests/functional/workstations/watcher": 9,
       "you-agent-factory/tests/functional/sessions/mcp": 7
     },
-    "files_with_customer_Test": 238,
+    "files_with_customer_Test": 239,
     "functional_test_go_files": 251,
     "helper_only_non_customer_files": 51,
     "internal_harness_Test_functions": 15,

--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -7547,6 +7547,56 @@
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/sessions/controls/pause_resume_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/controls",
+      "scenario": "TestPausedFactorySessionBuffersSubmittedWork",
+      "lane": "short",
+      "destination": "tests/functional/sessions/controls/pause_resume_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/sessions/controls/pause_resume_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/controls",
+      "scenario": "TestResumedFactorySessionDrainsBufferedWorkInOrder",
+      "lane": "short",
+      "destination": "tests/functional/sessions/controls/pause_resume_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/sessions/controls/pause_resume_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/controls",
+      "scenario": "TestPauseResumeEmitsDurableLifecycleEvents",
+      "lane": "short",
+      "destination": "tests/functional/sessions/controls/pause_resume_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/sessions/controls/pause_resume_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/controls",
+      "scenario": "TestAPIPauseResumeCancelAndTerminateFactorySession",
+      "lane": "short",
+      "destination": "tests/functional/sessions/controls/pause_resume_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/sessions/controls/pause_resume_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/controls",
+      "scenario": "TestAPIInvalidLifecycleTransitionReturnsConflict",
+      "lane": "short",
+      "destination": "tests/functional/sessions/controls/pause_resume_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
     }
   ],
   "scanned_at_utc": "2026-07-28T05:00:00Z",
@@ -7585,9 +7635,9 @@
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 732,
+    "customer_top_level_Test_scenarios": 740,
     "lane_functionallong": 95,
-    "lane_short": 637,
+    "lane_short": 645,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 12,
       "you-agent-factory/tests/functional/automations": 7,

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -583,7 +583,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
 - [ ] `tests/functional/sessions/live_runtime_build_process_test.go`
   - `TestBuildProcessRoutesLiveOpenListControlAndCloseThroughFactorySessionsRoot`.
 
-- [ ] `tests/functional/sessions/controls/pause_resume_test.go`
+- [x] `tests/functional/sessions/controls/pause_resume_test.go`
   - `TestPausedFactorySessionBuffersSubmittedWork`.
   - `TestResumedFactorySessionDrainsBufferedWorkInOrder`.
   - `TestPauseResumeEmitsDurableLifecycleEvents`.

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -872,6 +872,19 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestUnixProviderTimeoutTerminatesProcessGroup`.
   - `TestUnixSignalsMapToInterruptedPublicOutcome`.
 
+## Wave 3 — operator settings
+
+- [x] `tests/functional/operator_settings/servicewire/servicewire_composition_test.go`
+  - `TestServiceWireCompositionRootServesDocumentAndResolutionOperations`.
+  - `TestServiceFromHomePortsConstructsSettingsRoot`.
+  - `TestServiceFromHomePortsRejectsMissingPorts`.
+  - `TestServiceFromConfigDocumentConstructsFromDocumentPorts`.
+  - `TestServiceFromConfigDocumentRejectsMissingDocumentPorts`.
+  - `TestResolveFromHomeUsesSettingsAdapterOwnershipPath`.
+  - `TestResolveFromHomeRejectsMissingFilesystemPorts`.
+  - `TestResolveFromHomeFallbackPreservesAcceptedSemantics`.
+  - `TestRegisterDefaultsResolutionFromHomeRestoresAdapterOwnership`.
+
 ## Completion audit
 
 - [ ] Every checkbox is implemented, linked to an existing equivalent test, or

--- a/tests/functional/sessions/controls/helpers_test.go
+++ b/tests/functional/sessions/controls/helpers_test.go
@@ -120,6 +120,33 @@ func readDurableFactorySession(
 	return session
 }
 
+func waitForDurableFactorySessionTerminal(
+	t *testing.T,
+	baseURL string,
+	sessionID string,
+	timeout time.Duration,
+) factoryapi.FactorySessionDurableLifecycleStatus {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		session := readDurableFactorySession(t, baseURL, sessionID)
+		if session.Status == factoryapi.FactorySessionDurableLifecycleStatusTerminated ||
+			session.Status == factoryapi.FactorySessionDurableLifecycleStatusCanceled {
+			return session.Status
+		}
+		time.Sleep(15 * time.Millisecond)
+	}
+	session := readDurableFactorySession(t, baseURL, sessionID)
+	t.Fatalf(
+		"durable session %s status = %q, want TERMINATED or CANCELED within %s",
+		sessionID,
+		session.Status,
+		timeout,
+	)
+	return ""
+}
+
 func waitForDurableFactorySessionStatus(
 	t *testing.T,
 	baseURL string,
@@ -206,6 +233,84 @@ func postSessionLifecycleControl(
 		factoryapi.FactorySessionLifecycleControlRequest{},
 		"apply Factory Session lifecycle control "+string(operation),
 	)
+}
+
+func postSessionLifecycleControlExpectConflict(
+	t *testing.T,
+	baseURL string,
+	sessionID string,
+	operation factoryapi.FactorySessionLifecycleControlKind,
+) factoryapi.FactorySessionLifecycleControlResponse {
+	t.Helper()
+
+	pathSegment := lifecycleControlPathSegment(operation)
+	endpoint := strings.TrimSuffix(baseURL, "/") + "/factory-sessions/" + sessionID + "/" + pathSegment
+	body, err := json.Marshal(factoryapi.FactorySessionLifecycleControlRequest{})
+	if err != nil {
+		t.Fatalf("marshal lifecycle control request: %v", err)
+	}
+	response, err := http.Post(endpoint, "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST %s: %v", endpoint, err)
+	}
+	defer response.Body.Close()
+	payload, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read POST %s response: %v", endpoint, err)
+	}
+	if response.StatusCode != http.StatusConflict {
+		t.Fatalf(
+			"POST %s status = %d, want 409 conflict: %s",
+			endpoint,
+			response.StatusCode,
+			payload,
+		)
+	}
+	var decoded factoryapi.FactorySessionLifecycleControlResponse
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("decode POST %s response: %v\n%s", endpoint, err, payload)
+	}
+	return decoded
+}
+
+func isRejectedLifecycleControlOutcome(
+	outcome factoryapi.FactorySessionLifecycleControlOutcome,
+) bool {
+	switch outcome {
+	case factoryapi.FactorySessionLifecycleControlOutcomeConflict,
+		factoryapi.FactorySessionLifecycleControlOutcomeInvalidState,
+		factoryapi.FactorySessionLifecycleControlOutcomeTerminalSession:
+		return true
+	default:
+		return false
+	}
+}
+
+func assertRejectedSessionLifecycleControl(
+	t *testing.T,
+	response factoryapi.FactorySessionLifecycleControlResponse,
+	sessionID string,
+	operation factoryapi.FactorySessionLifecycleControlKind,
+	wantStatus factoryapi.FactorySessionDurableLifecycleStatus,
+) {
+	t.Helper()
+
+	if response.Operation != operation {
+		t.Fatalf("lifecycle control operation = %q, want %q", response.Operation, operation)
+	}
+	if !isRejectedLifecycleControlOutcome(response.Outcome) {
+		t.Fatalf(
+			"lifecycle control outcome = %q, want CONFLICT, INVALID_STATE, or TERMINAL_SESSION; response=%#v",
+			response.Outcome,
+			response,
+		)
+	}
+	if response.SessionId != sessionID {
+		t.Fatalf("lifecycle control sessionId = %q, want %q", response.SessionId, sessionID)
+	}
+	if response.Status != wantStatus {
+		t.Fatalf("lifecycle control status = %q, want %q unchanged", response.Status, wantStatus)
+	}
 }
 
 func lifecycleControlPathSegment(operation factoryapi.FactorySessionLifecycleControlKind) string {

--- a/tests/functional/sessions/controls/helpers_test.go
+++ b/tests/functional/sessions/controls/helpers_test.go
@@ -1,0 +1,105 @@
+package sessioncontrols_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+func pauseResumeControlsFactoryConfig() map[string]any {
+	return map[string]any{
+		"name": "sessions-controls-pause-resume",
+		"workTypes": []map[string]any{
+			{
+				"name": "task",
+				"states": []map[string]any{
+					{"name": "init", "type": "INITIAL"},
+					{"name": "complete", "type": "TERMINAL"},
+					{"name": "failed", "type": "FAILED"},
+				},
+			},
+		},
+		"workers": []map[string]string{
+			{"name": "mock-worker"},
+		},
+		"workstations": []map[string]any{
+			{
+				"name":      "process-task",
+				"worker":    "mock-worker",
+				"inputs":    []map[string]string{{"workType": "task", "state": "init"}},
+				"outputs":   []map[string]string{{"workType": "task", "state": "complete"}},
+				"onFailure": []map[string]string{{"workType": "task", "state": "failed"}},
+			},
+		},
+	}
+}
+
+func postSessionLifecycleControl(
+	t *testing.T,
+	baseURL string,
+	sessionID string,
+	operation factoryapi.FactorySessionLifecycleControlKind,
+) factoryapi.FactorySessionLifecycleControlResponse {
+	t.Helper()
+
+	pathSegment := lifecycleControlPathSegment(operation)
+	return postSessionControlJSON[factoryapi.FactorySessionLifecycleControlResponse](
+		t,
+		baseURL+"/factory-sessions/"+sessionID+"/"+pathSegment,
+		factoryapi.FactorySessionLifecycleControlRequest{},
+		"apply Factory Session lifecycle control "+string(operation),
+	)
+}
+
+func lifecycleControlPathSegment(operation factoryapi.FactorySessionLifecycleControlKind) string {
+	switch operation {
+	case factoryapi.FactorySessionLifecycleControlKindPause:
+		return "pause"
+	case factoryapi.FactorySessionLifecycleControlKindResume:
+		return "resume"
+	case factoryapi.FactorySessionLifecycleControlKindCancel:
+		return "cancel"
+	case factoryapi.FactorySessionLifecycleControlKindTerminate:
+		return "terminate"
+	default:
+		return string(operation)
+	}
+}
+
+func postSessionControlJSON[T any](t *testing.T, endpoint string, request any, failurePrefix string) T {
+	t.Helper()
+
+	body, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("%s: marshal request: %v", failurePrefix, err)
+	}
+	response, err := http.Post(endpoint, "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("%s: POST %s: %v", failurePrefix, endpoint, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		payload, _ := io.ReadAll(response.Body)
+		t.Fatalf("%s: POST %s status = %d, want success: %s", failurePrefix, endpoint, response.StatusCode, payload)
+	}
+	var decoded T
+	if err := json.NewDecoder(response.Body).Decode(&decoded); err != nil {
+		t.Fatalf("%s: decode %s response: %v", failurePrefix, endpoint, err)
+	}
+	return decoded
+}
+
+func stringPointer(value string) *string {
+	return &value
+}
+
+func stringPointerValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/tests/functional/sessions/controls/helpers_test.go
+++ b/tests/functional/sessions/controls/helpers_test.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,7 +19,35 @@ import (
 const (
 	pauseResumeProcessTaskWorkstation = "process-task"
 	pauseResumeDrainWaitTimeout       = 30 * time.Second
+	pauseResumeBusyLoopWorkflowName   = "busy-loop"
+	pauseResumeDurableStatusTimeout   = 15 * time.Second
 )
+
+func pauseResumeControlsFactoryDirWithBusyLoop(t *testing.T) string {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, pauseResumeControlsFactoryConfig())
+	workflowDir := filepath.Join(dir, ".claude", "workflows")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("mkdir workflows: %v", err)
+	}
+	fixturePath := support.AgentFactoryPath(
+		t,
+		filepath.Join("tests", "fixtures", "javascript_runtime", pauseResumeBusyLoopWorkflowName+".workflow.js"),
+	)
+	raw, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("read workflow fixture %s: %v", fixturePath, err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(workflowDir, pauseResumeBusyLoopWorkflowName+".js"),
+		raw,
+		0o600,
+	); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	return dir
+}
 
 func pauseResumeControlsFactoryConfig() map[string]any {
 	return map[string]any{
@@ -43,6 +74,120 @@ func pauseResumeControlsFactoryConfig() map[string]any {
 				"onFailure": []map[string]string{{"workType": "task", "state": "failed"}},
 			},
 		},
+	}
+}
+
+func startBusyLoopDurableSession(t *testing.T, baseURL string, requestID string) string {
+	t.Helper()
+
+	workflowName := pauseResumeBusyLoopWorkflowName
+	started := postSessionControlJSON[factoryapi.FactorySessionExecutionResponse](
+		t,
+		strings.TrimSuffix(baseURL, "/")+"/factory-sessions/async",
+		factoryapi.FactorySessionExecutionRequest{
+			RequestId: requestID,
+			Source: factoryapi.FactorySessionExecutionSource{
+				Kind:         factoryapi.FactorySessionExecutionSourceKindWorkflowName,
+				WorkflowName: &workflowName,
+			},
+		},
+		"start busy-loop durable Factory Session",
+	)
+	if started.SessionId == "" {
+		t.Fatalf("async durable session id is empty: %#v", started)
+	}
+	return started.SessionId
+}
+
+func readDurableFactorySession(
+	t *testing.T,
+	baseURL string,
+	sessionID string,
+) factoryapi.FactorySessionDurableReadModel {
+	t.Helper()
+
+	response := support.GetJSON[factoryapi.FactorySessionGetResponse](
+		t,
+		strings.TrimSuffix(baseURL, "/")+"/factory-sessions/"+sessionID,
+	)
+	session, err := response.AsFactorySessionDurableReadModel()
+	if err != nil {
+		t.Fatalf("decode durable session %s: %v", sessionID, err)
+	}
+	if session.SessionId != sessionID {
+		t.Fatalf("durable session id = %q, want %q", session.SessionId, sessionID)
+	}
+	return session
+}
+
+func waitForDurableFactorySessionStatus(
+	t *testing.T,
+	baseURL string,
+	sessionID string,
+	want factoryapi.FactorySessionDurableLifecycleStatus,
+	timeout time.Duration,
+) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		session := readDurableFactorySession(t, baseURL, sessionID)
+		if session.Status == want {
+			return
+		}
+		time.Sleep(15 * time.Millisecond)
+	}
+	session := readDurableFactorySession(t, baseURL, sessionID)
+	t.Fatalf(
+		"durable session %s status = %q, want %q within %s",
+		sessionID,
+		session.Status,
+		want,
+		timeout,
+	)
+}
+
+func assertAcceptedSessionLifecycleControl(
+	t *testing.T,
+	response factoryapi.FactorySessionLifecycleControlResponse,
+	sessionID string,
+	operation factoryapi.FactorySessionLifecycleControlKind,
+	wantStatus factoryapi.FactorySessionDurableLifecycleStatus,
+) {
+	t.Helper()
+
+	if response.Operation != operation {
+		t.Fatalf("lifecycle control operation = %q, want %q", response.Operation, operation)
+	}
+	if response.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
+		t.Fatalf("lifecycle control outcome = %q, want ACCEPTED; response=%#v", response.Outcome, response)
+	}
+	if response.SessionId != sessionID {
+		t.Fatalf("lifecycle control sessionId = %q, want %q", response.SessionId, sessionID)
+	}
+	if response.Status != wantStatus {
+		t.Fatalf("lifecycle control status = %q, want %q", response.Status, wantStatus)
+	}
+}
+
+func assertLiveSessionLifecycleControlStatus(
+	t *testing.T,
+	baseURL string,
+	want factoryapi.FactorySessionDurableLifecycleStatus,
+) {
+	t.Helper()
+
+	session := support.GetDefaultSession(t, baseURL)
+	if session.Runtime.LifecycleControlStatus == nil {
+		t.Fatalf("live session %s lifecycleControlStatus = nil, want %q", session.Id, want)
+	}
+	if *session.Runtime.LifecycleControlStatus != want {
+		t.Fatalf(
+			"live session %s lifecycleControlStatus = %q, want %q",
+			session.Id,
+			*session.Runtime.LifecycleControlStatus,
+			want,
+		)
 	}
 }
 

--- a/tests/functional/sessions/controls/helpers_test.go
+++ b/tests/functional/sessions/controls/helpers_test.go
@@ -230,3 +230,68 @@ func dispatchObservationForWorkAtWorkstation(
 	}
 	return support.DispatchEventObservation{}, false
 }
+
+func filterSessionLifecycleControlEvents(events []factoryapi.FactoryEvent) []factoryapi.FactoryEvent {
+	var lifecycleControls []factoryapi.FactoryEvent
+	for _, event := range events {
+		if event.Type == factoryapi.FactoryEventTypeSessionLifecycleControl {
+			lifecycleControls = append(lifecycleControls, event)
+		}
+	}
+	return lifecycleControls
+}
+
+func assertPauseResumeLifecycleControlEvents(
+	t *testing.T,
+	events []factoryapi.FactoryEvent,
+) {
+	t.Helper()
+
+	lifecycleControls := filterSessionLifecycleControlEvents(events)
+	if len(lifecycleControls) < 2 {
+		t.Fatalf(
+			"SESSION_LIFECYCLE_CONTROL events = %d, want at least pause and resume",
+			len(lifecycleControls),
+		)
+	}
+
+	pauseEvent := lifecycleControls[len(lifecycleControls)-2]
+	resumeEvent := lifecycleControls[len(lifecycleControls)-1]
+	if pauseEvent.Type != factoryapi.FactoryEventTypeSessionLifecycleControl {
+		t.Fatalf("pause event type = %q, want SESSION_LIFECYCLE_CONTROL", pauseEvent.Type)
+	}
+	if resumeEvent.Type != factoryapi.FactoryEventTypeSessionLifecycleControl {
+		t.Fatalf("resume event type = %q, want SESSION_LIFECYCLE_CONTROL", resumeEvent.Type)
+	}
+
+	pausePayload, err := pauseEvent.Payload.AsSessionLifecycleControlEventPayload()
+	if err != nil {
+		t.Fatalf("decode pause lifecycle-control payload: %v", err)
+	}
+	if pausePayload.Operation != factoryapi.FactorySessionLifecycleControlKindPause {
+		t.Fatalf("pause payload operation = %q, want PAUSE", pausePayload.Operation)
+	}
+	if pausePayload.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
+		t.Fatalf("pause payload outcome = %q, want ACCEPTED", pausePayload.Outcome)
+	}
+
+	resumePayload, err := resumeEvent.Payload.AsSessionLifecycleControlEventPayload()
+	if err != nil {
+		t.Fatalf("decode resume lifecycle-control payload: %v", err)
+	}
+	if resumePayload.Operation != factoryapi.FactorySessionLifecycleControlKindResume {
+		t.Fatalf("resume payload operation = %q, want RESUME", resumePayload.Operation)
+	}
+	if resumePayload.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
+		t.Fatalf("resume payload outcome = %q, want ACCEPTED", resumePayload.Outcome)
+	}
+
+	if !pausePayload.OccurredAt.Before(resumePayload.OccurredAt) &&
+		!pausePayload.OccurredAt.Equal(resumePayload.OccurredAt) {
+		t.Fatalf(
+			"lifecycle-control event order = pause@%s resume@%s, want pause before resume",
+			pausePayload.OccurredAt.UTC(),
+			resumePayload.OccurredAt.UTC(),
+		)
+	}
+}

--- a/tests/functional/sessions/controls/helpers_test.go
+++ b/tests/functional/sessions/controls/helpers_test.go
@@ -6,8 +6,16 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
+	"github.com/portpowered/infinite-you/pkg/services/workers"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	pauseResumeProcessTaskWorkstation = "process-task"
+	pauseResumeDrainWaitTimeout       = 30 * time.Second
 )
 
 func pauseResumeControlsFactoryConfig() map[string]any {
@@ -102,4 +110,123 @@ func stringPointerValue(value *string) string {
 		return ""
 	}
 	return *value
+}
+
+func pauseResumeControlsSlowMockWorkersConfig() *workers.MockWorkersConfig {
+	return &workers.MockWorkersConfig{
+		UnmatchedDispatchPolicy: workers.MockWorkerUnmatchedDispatchPolicyPassthrough,
+		MockWorkers: []workers.MockWorkerConfig{
+			{
+				WorkerName:      "mock-worker",
+				WorkstationName: pauseResumeProcessTaskWorkstation,
+				RunType:         workers.MockWorkerRunTypeScript,
+				ScriptConfig: &workers.MockWorkerScriptConfig{
+					Command: "/bin/sh",
+					Args: []string{
+						"-c",
+						"sleep 2 && echo mock worker accepted",
+					},
+				},
+			},
+		},
+	}
+}
+
+func waitForSessionWorkIDsAtCustomerState(
+	t *testing.T,
+	baseURL string,
+	workIDs []string,
+	location string,
+	timeout time.Duration,
+) {
+	t.Helper()
+
+	want := make(map[string]bool, len(workIDs))
+	for _, workID := range workIDs {
+		want[workID] = true
+	}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		listed := support.ListDefaultSessionWork(t, baseURL)
+		found := 0
+		for _, workID := range workIDs {
+			if support.HasWorkAtCustomerState(listed, workID, location) {
+				found++
+			}
+		}
+		if found == len(want) {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	listed := support.ListDefaultSessionWork(t, baseURL)
+	t.Fatalf(
+		"timed out waiting for work IDs %v at %s; listed=%#v",
+		workIDs,
+		location,
+		listed.Results,
+	)
+}
+
+func assertBufferedWorkDrainedInSubmissionOrder(
+	t *testing.T,
+	server *support.FunctionalAPIServer,
+	firstWorkID string,
+	secondWorkID string,
+) {
+	t.Helper()
+
+	waitForSessionWorkIDsAtCustomerState(
+		t,
+		server.URL(),
+		[]string{firstWorkID, secondWorkID},
+		support.WorkCustomerLocation("task", "complete"),
+		pauseResumeDrainWaitTimeout,
+	)
+
+	dispatches := support.ObserveDispatchEvents(t, server.GetFactoryEvents(t))
+	firstDispatch, okFirst := dispatchObservationForWorkAtWorkstation(
+		dispatches,
+		firstWorkID,
+		pauseResumeProcessTaskWorkstation,
+	)
+	secondDispatch, okSecond := dispatchObservationForWorkAtWorkstation(
+		dispatches,
+		secondWorkID,
+		pauseResumeProcessTaskWorkstation,
+	)
+	if !okFirst || !okSecond {
+		t.Fatalf(
+			"dispatch history missing %q dispatches for buffered work %q and %q: %#v",
+			pauseResumeProcessTaskWorkstation,
+			firstWorkID,
+			secondWorkID,
+			dispatches,
+		)
+	}
+	if !firstDispatch.StartedAt.Before(secondDispatch.StartedAt) {
+		t.Fatalf(
+			"dispatch start order = first@%s second@%s for works %q then %q; want first buffered work to start before second",
+			firstDispatch.StartedAt.UTC(),
+			secondDispatch.StartedAt.UTC(),
+			firstWorkID,
+			secondWorkID,
+		)
+	}
+}
+
+func dispatchObservationForWorkAtWorkstation(
+	dispatches []support.DispatchEventObservation,
+	workID string,
+	workstation string,
+) (support.DispatchEventObservation, bool) {
+	for _, dispatch := range dispatches {
+		if dispatch.Request.TransitionId != workstation {
+			continue
+		}
+		if support.DispatchObservationIncludesWork(dispatch, workID) {
+			return dispatch, true
+		}
+	}
+	return support.DispatchEventObservation{}, false
 }

--- a/tests/functional/sessions/controls/pause_resume_test.go
+++ b/tests/functional/sessions/controls/pause_resume_test.go
@@ -65,3 +65,68 @@ func TestPausedFactorySessionBuffersSubmittedWork(t *testing.T) {
 		t.Fatalf("work %q reached task:complete while session was paused: %#v", workID, listed.Results)
 	}
 }
+
+// TestResumedFactorySessionDrainsBufferedWorkInOrder proves resume drains work
+// buffered during pause in submission order through public session-control and
+// dispatch observation boundaries.
+func TestResumedFactorySessionDrainsBufferedWorkInOrder(t *testing.T) {
+	factoryDir := support.ScaffoldFactory(t, pauseResumeControlsFactoryConfig())
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:        factoryDir,
+		MockWorkersConfig: pauseResumeControlsSlowMockWorkersConfig(),
+	})
+	defer server.Stop(t)
+
+	baseURL := server.URL()
+	sessionID := factorysessions.DefaultSessionID
+
+	pause := postSessionLifecycleControl(
+		t,
+		baseURL,
+		sessionID,
+		factoryapi.FactorySessionLifecycleControlKindPause,
+	)
+	if pause.Operation != factoryapi.FactorySessionLifecycleControlKindPause ||
+		pause.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
+		t.Fatalf("pause response = %#v, want accepted pause", pause)
+	}
+
+	first := support.SubmitDefaultSessionWork(t, baseURL, factoryapi.SubmitWorkRequest{
+		Name:         stringPointer("paused-buffered-first"),
+		WorkTypeName: "task",
+		Payload:      map[string]string{"title": "First paused submission"},
+	})
+	second := support.SubmitDefaultSessionWork(t, baseURL, factoryapi.SubmitWorkRequest{
+		Name:         stringPointer("paused-buffered-second"),
+		WorkTypeName: "task",
+		Payload:      map[string]string{"title": "Second paused submission"},
+	})
+	firstID := stringPointerValue(first.WorkId)
+	secondID := stringPointerValue(second.WorkId)
+	if firstID == "" || secondID == "" {
+		t.Fatalf("submit while paused missing work ids: first=%#v second=%#v", first, second)
+	}
+
+	listed := support.ListDefaultSessionWork(t, baseURL)
+	for _, workID := range []string{firstID, secondID} {
+		if support.HasWorkAtCustomerState(listed, workID, support.WorkCustomerLocation("task", "complete")) {
+			t.Fatalf("work %q reached task:complete before resume: %#v", workID, listed.Results)
+		}
+	}
+
+	resume := postSessionLifecycleControl(
+		t,
+		baseURL,
+		sessionID,
+		factoryapi.FactorySessionLifecycleControlKindResume,
+	)
+	if resume.Operation != factoryapi.FactorySessionLifecycleControlKindResume ||
+		resume.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
+		t.Fatalf("resume response = %#v, want accepted resume", resume)
+	}
+	if resume.Status != factoryapi.FactorySessionDurableLifecycleStatusRunning {
+		t.Fatalf("resume status = %q, want RUNNING", resume.Status)
+	}
+
+	assertBufferedWorkDrainedInSubmissionOrder(t, server, firstID, secondID)
+}

--- a/tests/functional/sessions/controls/pause_resume_test.go
+++ b/tests/functional/sessions/controls/pause_resume_test.go
@@ -1,0 +1,67 @@
+package sessioncontrols_test
+
+import (
+	"testing"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+// TestPausedFactorySessionBuffersSubmittedWork proves a paused Factory Session
+// accepts submitted work through the public session-control boundary while
+// keeping that work buffered instead of advancing it into active processing.
+func TestPausedFactorySessionBuffersSubmittedWork(t *testing.T) {
+	factoryDir := support.ScaffoldFactory(t, pauseResumeControlsFactoryConfig())
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:     factoryDir,
+		UseMockWorkers: true,
+	})
+	defer server.Stop(t)
+
+	baseURL := server.URL()
+	sessionID := factorysessions.DefaultSessionID
+
+	pause := postSessionLifecycleControl(
+		t,
+		baseURL,
+		sessionID,
+		factoryapi.FactorySessionLifecycleControlKindPause,
+	)
+	if pause.Operation != factoryapi.FactorySessionLifecycleControlKindPause ||
+		pause.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
+		t.Fatalf("pause response = %#v, want accepted pause", pause)
+	}
+	if pause.Status != factoryapi.FactorySessionDurableLifecycleStatusPaused {
+		t.Fatalf("pause status = %q, want PAUSED", pause.Status)
+	}
+
+	pausedSession := support.GetDefaultSession(t, baseURL)
+	if pausedSession.Runtime.LifecycleControlStatus == nil ||
+		*pausedSession.Runtime.LifecycleControlStatus != factoryapi.FactorySessionDurableLifecycleStatusPaused {
+		t.Fatalf(
+			"session read after pause lifecycleControlStatus = %#v, want %q",
+			pausedSession.Runtime.LifecycleControlStatus,
+			factoryapi.FactorySessionDurableLifecycleStatusPaused,
+		)
+	}
+
+	workName := "paused-buffered-task"
+	submitted := support.SubmitDefaultSessionWork(t, baseURL, factoryapi.SubmitWorkRequest{
+		Name:         stringPointer(workName),
+		WorkTypeName: "task",
+		Payload:      map[string]string{"title": "Submitted while paused"},
+	})
+	workID := stringPointerValue(submitted.WorkId)
+	if workID == "" {
+		t.Fatalf("submit while paused missing work id: %#v", submitted)
+	}
+
+	listed := support.ListDefaultSessionWork(t, baseURL)
+	if support.HasWorkAtCustomerState(listed, workID, support.WorkCustomerLocation("task", "init")) {
+		t.Fatalf("work %q reached task:init while session was paused: %#v", workID, listed.Results)
+	}
+	if support.HasWorkAtCustomerState(listed, workID, support.WorkCustomerLocation("task", "complete")) {
+		t.Fatalf("work %q reached task:complete while session was paused: %#v", workID, listed.Results)
+	}
+}

--- a/tests/functional/sessions/controls/pause_resume_test.go
+++ b/tests/functional/sessions/controls/pause_resume_test.go
@@ -308,3 +308,104 @@ func TestAPIPauseResumeCancelAndTerminateFactorySession(t *testing.T) {
 		)
 	}
 }
+
+// TestAPIInvalidLifecycleTransitionReturnsConflict proves illegal Factory Session
+// lifecycle controls through the public API return HTTP conflict with typed rejection
+// outcomes and leave the session in its prior terminal lifecycle state.
+func TestAPIInvalidLifecycleTransitionReturnsConflict(t *testing.T) {
+	factoryDir := pauseResumeControlsFactoryDirWithBusyLoop(t)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                factoryDir,
+		UseMockWorkers:            true,
+		WaitForServiceModeRuntime: true,
+	})
+	defer server.Stop(t)
+
+	baseURL := server.URL()
+	sessionID := startBusyLoopDurableSession(t, baseURL, "req-sessions-controls-invalid-transition")
+	waitForDurableFactorySessionStatus(
+		t,
+		baseURL,
+		sessionID,
+		factoryapi.FactorySessionDurableLifecycleStatusRunning,
+		pauseResumeDurableStatusTimeout,
+	)
+
+	terminate := postSessionLifecycleControl(
+		t,
+		baseURL,
+		sessionID,
+		factoryapi.FactorySessionLifecycleControlKindTerminate,
+	)
+	assertAcceptedSessionLifecycleControl(
+		t,
+		terminate,
+		sessionID,
+		factoryapi.FactorySessionLifecycleControlKindTerminate,
+		factoryapi.FactorySessionDurableLifecycleStatusTerminated,
+	)
+
+	terminalStatus := waitForDurableFactorySessionTerminal(
+		t,
+		baseURL,
+		sessionID,
+		pauseResumeDurableStatusTimeout,
+	)
+	before := readDurableFactorySession(t, baseURL, sessionID)
+	if before.Status != terminalStatus {
+		t.Fatalf(
+			"pre-invalid-control session %s status = %q, want %q",
+			sessionID,
+			before.Status,
+			terminalStatus,
+		)
+	}
+
+	resume := postSessionLifecycleControlExpectConflict(
+		t,
+		baseURL,
+		sessionID,
+		factoryapi.FactorySessionLifecycleControlKindResume,
+	)
+	assertRejectedSessionLifecycleControl(
+		t,
+		resume,
+		sessionID,
+		factoryapi.FactorySessionLifecycleControlKindResume,
+		terminalStatus,
+	)
+
+	afterResume := readDurableFactorySession(t, baseURL, sessionID)
+	if afterResume.Status != terminalStatus {
+		t.Fatalf(
+			"session %s status after rejected resume = %q, want unchanged %q",
+			sessionID,
+			afterResume.Status,
+			terminalStatus,
+		)
+	}
+
+	pause := postSessionLifecycleControlExpectConflict(
+		t,
+		baseURL,
+		sessionID,
+		factoryapi.FactorySessionLifecycleControlKindPause,
+	)
+	assertRejectedSessionLifecycleControl(
+		t,
+		pause,
+		sessionID,
+		factoryapi.FactorySessionLifecycleControlKindPause,
+		terminalStatus,
+	)
+
+	afterPause := readDurableFactorySession(t, baseURL, sessionID)
+	if afterPause.Status != terminalStatus {
+		t.Fatalf(
+			"session %s status after rejected pause = %q, want unchanged %q",
+			sessionID,
+			afterPause.Status,
+			terminalStatus,
+		)
+	}
+}

--- a/tests/functional/sessions/controls/pause_resume_test.go
+++ b/tests/functional/sessions/controls/pause_resume_test.go
@@ -187,3 +187,124 @@ func TestPauseResumeEmitsDurableLifecycleEvents(t *testing.T) {
 
 	assertPauseResumeLifecycleControlEvents(t, server.GetFactoryEvents(t))
 }
+
+// TestAPIPauseResumeCancelAndTerminateFactorySession proves public API pause,
+// resume, cancel, and terminate controls return typed lifecycle-control outcomes
+// and leave each Factory Session in the expected lifecycle state after control.
+func TestAPIPauseResumeCancelAndTerminateFactorySession(t *testing.T) {
+	factoryDir := pauseResumeControlsFactoryDirWithBusyLoop(t)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                factoryDir,
+		UseMockWorkers:            true,
+		WaitForServiceModeRuntime: true,
+	})
+	defer server.Stop(t)
+
+	baseURL := server.URL()
+	liveSession := support.GetDefaultSession(t, baseURL)
+	liveSessionID := liveSession.Id
+	if liveSessionID == "" {
+		t.Fatal("live Factory Session id is empty")
+	}
+
+	pause := postSessionLifecycleControl(
+		t,
+		baseURL,
+		liveSessionID,
+		factoryapi.FactorySessionLifecycleControlKindPause,
+	)
+	assertAcceptedSessionLifecycleControl(
+		t,
+		pause,
+		liveSessionID,
+		factoryapi.FactorySessionLifecycleControlKindPause,
+		factoryapi.FactorySessionDurableLifecycleStatusPaused,
+	)
+	assertLiveSessionLifecycleControlStatus(
+		t,
+		baseURL,
+		factoryapi.FactorySessionDurableLifecycleStatusPaused,
+	)
+
+	resume := postSessionLifecycleControl(
+		t,
+		baseURL,
+		liveSessionID,
+		factoryapi.FactorySessionLifecycleControlKindResume,
+	)
+	assertAcceptedSessionLifecycleControl(
+		t,
+		resume,
+		liveSessionID,
+		factoryapi.FactorySessionLifecycleControlKindResume,
+		factoryapi.FactorySessionDurableLifecycleStatusRunning,
+	)
+	assertLiveSessionLifecycleControlStatus(
+		t,
+		baseURL,
+		factoryapi.FactorySessionDurableLifecycleStatusRunning,
+	)
+
+	cancelSessionID := startBusyLoopDurableSession(t, baseURL, "req-sessions-controls-cancel")
+	waitForDurableFactorySessionStatus(
+		t,
+		baseURL,
+		cancelSessionID,
+		factoryapi.FactorySessionDurableLifecycleStatusRunning,
+		pauseResumeDurableStatusTimeout,
+	)
+
+	cancel := postSessionLifecycleControl(
+		t,
+		baseURL,
+		cancelSessionID,
+		factoryapi.FactorySessionLifecycleControlKindCancel,
+	)
+	assertAcceptedSessionLifecycleControl(
+		t,
+		cancel,
+		cancelSessionID,
+		factoryapi.FactorySessionLifecycleControlKindCancel,
+		factoryapi.FactorySessionDurableLifecycleStatusCanceling,
+	)
+	waitForDurableFactorySessionStatus(
+		t,
+		baseURL,
+		cancelSessionID,
+		factoryapi.FactorySessionDurableLifecycleStatusCanceled,
+		pauseResumeDurableStatusTimeout,
+	)
+
+	terminateSessionID := startBusyLoopDurableSession(t, baseURL, "req-sessions-controls-terminate")
+	waitForDurableFactorySessionStatus(
+		t,
+		baseURL,
+		terminateSessionID,
+		factoryapi.FactorySessionDurableLifecycleStatusRunning,
+		pauseResumeDurableStatusTimeout,
+	)
+
+	terminate := postSessionLifecycleControl(
+		t,
+		baseURL,
+		terminateSessionID,
+		factoryapi.FactorySessionLifecycleControlKindTerminate,
+	)
+	assertAcceptedSessionLifecycleControl(
+		t,
+		terminate,
+		terminateSessionID,
+		factoryapi.FactorySessionLifecycleControlKindTerminate,
+		factoryapi.FactorySessionDurableLifecycleStatusTerminated,
+	)
+
+	terminated := readDurableFactorySession(t, baseURL, terminateSessionID)
+	if terminated.Status != factoryapi.FactorySessionDurableLifecycleStatusTerminated &&
+		terminated.Status != factoryapi.FactorySessionDurableLifecycleStatusCanceled {
+		t.Fatalf(
+			"durable session %s status after terminate = %q, want TERMINATED or CANCELED",
+			terminateSessionID,
+			terminated.Status,
+		)
+	}
+}

--- a/tests/functional/sessions/controls/pause_resume_test.go
+++ b/tests/functional/sessions/controls/pause_resume_test.go
@@ -130,3 +130,60 @@ func TestResumedFactorySessionDrainsBufferedWorkInOrder(t *testing.T) {
 
 	assertBufferedWorkDrainedInSubmissionOrder(t, server, firstID, secondID)
 }
+
+// TestPauseResumeEmitsDurableLifecycleEvents proves pause and resume through
+// the public session-control boundary leave durable SESSION_LIFECYCLE_CONTROL
+// Factory Events in chronological order with public control operation kinds.
+func TestPauseResumeEmitsDurableLifecycleEvents(t *testing.T) {
+	factoryDir := support.ScaffoldFactory(t, pauseResumeControlsFactoryConfig())
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:     factoryDir,
+		UseMockWorkers: true,
+	})
+	defer server.Stop(t)
+
+	baseURL := server.URL()
+	sessionID := factorysessions.DefaultSessionID
+
+	pause := postSessionLifecycleControl(
+		t,
+		baseURL,
+		sessionID,
+		factoryapi.FactorySessionLifecycleControlKindPause,
+	)
+	if pause.Operation != factoryapi.FactorySessionLifecycleControlKindPause ||
+		pause.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
+		t.Fatalf("pause response = %#v, want accepted pause", pause)
+	}
+
+	submitted := support.SubmitDefaultSessionWork(t, baseURL, factoryapi.SubmitWorkRequest{
+		Name:         stringPointer("lifecycle-event-buffered-task"),
+		WorkTypeName: "task",
+		Payload:      map[string]string{"title": "Submitted between pause and resume"},
+	})
+	workID := stringPointerValue(submitted.WorkId)
+	if workID == "" {
+		t.Fatalf("submit while paused missing work id: %#v", submitted)
+	}
+
+	resume := postSessionLifecycleControl(
+		t,
+		baseURL,
+		sessionID,
+		factoryapi.FactorySessionLifecycleControlKindResume,
+	)
+	if resume.Operation != factoryapi.FactorySessionLifecycleControlKindResume ||
+		resume.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
+		t.Fatalf("resume response = %#v, want accepted resume", resume)
+	}
+
+	waitForSessionWorkIDsAtCustomerState(
+		t,
+		baseURL,
+		[]string{workID},
+		support.WorkCustomerLocation("task", "complete"),
+		pauseResumeDrainWaitTimeout,
+	)
+
+	assertPauseResumeLifecycleControlEvents(t, server.GetFactoryEvents(t))
+}


### PR DESCRIPTION
{
  "project": "Factory Session Pause/Resume Controls Functional Coverage",
  "branchName": "ft-wave2-sessions-pause-resume",
  "description": "Implement only tests/functional/sessions/controls/pause_resume_test.go to prove pause buffers submitted work, resume drains buffered work in order, pause/resume emit durable lifecycle events, API pause/resume/cancel/terminate succeed with typed outcomes, and invalid lifecycle transitions return conflict—through public CLI/API session-control boundaries, consuming the five mapped migration-ledger rows without owning sibling sessions cells or service/internal Petri imports.",
  "context": {
    "customerAsk": "Implement only tests/functional/sessions/controls/pause_resume_test.go. Through public CLI/API session-control boundaries, prove: (1) TestPausedFactorySessionBuffersSubmittedWork; (2) TestResumedFactorySessionDrainsBufferedWorkInOrder; (3) TestPauseResumeEmitsDurableLifecycleEvents; (4) TestAPIPauseResumeCancelAndTerminateFactorySession; (5) TestAPIInvalidLifecycleTransitionReturnsConflict. Consume the five mapped migration-ledger rows. Avoid service/internal Petri imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for Factory Session pause/resume controls does not exist, while mapped legacy scenarios remain split across smoke and runtime_api packages. Maintainers lack a sessions-owned, catalogued proof for buffering, ordered drain, durable lifecycle events, API cancel/terminate, and invalid-transition conflict at the public session-control boundary.",
    "solution": "Implement the five checklist scenarios in tests/functional/sessions/controls/pause_resume_test.go through public CLI/API Factory Session lifecycle-control boundaries, with customer-readable Go docs on every top-level Test. Consume the five mapped ledger obligations, keep specialty bindings as none and destination deletion_only_batch as n/a, apply only narrowly coupled metadata updates for this destination, and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/sessions/controls/pause_resume_test.go exists as the sessions-owned functional cell and covers TestPausedFactorySessionBuffersSubmittedWork, TestResumedFactorySessionDrainsBufferedWorkInOrder, TestPauseResumeEmitsDurableLifecycleEvents, TestAPIPauseResumeCancelAndTerminateFactorySession, and TestAPIInvalidLifecycleTransitionReturnsConflict.",
    "Pause buffering and ordered resume drain are proven through public CLI and/or API session-control and work/session read boundaries without asserting Petri markings or service implementation internals as primary ownership.",
    "Pause/resume emit durable public Factory Events of lifecycle-control kind that remain readable after the controls complete.",
    "API pause, resume, cancel, and terminate succeed with typed FactorySessionLifecycleControlResponse outcomes; invalid transitions return conflict (HTTP conflict and/or typed CONFLICT / INVALID_STATE / TERMINAL_SESSION outcome per public contract) without illegal mutation.",
    "The five mapped migration-ledger rows are consumed for this destination; deletion_only_batch for this work item remains n/a; specialty bindings remain none; only narrowly coupled metadata for this cell are updated.",
    "Every top-level Test* has a customer-readable Go doc comment whose first sentence describes the observable pause/resume control behavior; the cell does not import service/internal Petri packages.",
    "Focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave2-sessions-pause-resume-001",
      "title": "Prove paused session buffers submitted work",
      "description": "As an operator, I want a paused Factory Session to accept submitted work without advancing it while paused, so that I can halt processing without losing or prematurely completing in-flight submissions.",
      "acceptanceCriteria": [
        "tests/functional/sessions/controls/pause_resume_test.go includes TestPausedFactorySessionBuffersSubmittedWork.",
        "Through a public session-control boundary, pause a live Factory Session and receive an accepted pause / paused lifecycle-control outcome.",
        "Work submitted while paused remains buffered: public work/session reads show it has not reached an active-processing or terminal-complete state that would indicate dispatch progressed during pause.",
        "Coverage absorbs the customer-facing pause-buffering obligation of TestNamedGoalOperatorControls_PauseBuffersSubmitUntilResume (and the paused-status customer signal from TestSessionInvocationAPI_PausedSessionReturnsPausedStatus when exercised through the same public control/read surfaces) without asserting Petri place names as primary ownership unless they are the documented public work-state vocabulary for the fixture.",
        "The top-level test has a customer-readable Go doc comment describing paused buffering behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-sessions-pause-resume-002",
      "title": "Prove resume drains buffered work in order",
      "description": "As an operator, I want resume to drain work that was buffered during pause in submission order, so that ordered customer work is not reordered by the pause/resume control cycle.",
      "acceptanceCriteria": [
        "The cell includes TestResumedFactorySessionDrainsBufferedWorkInOrder.",
        "Through a public CLI and/or API session-control boundary, pause a live session, submit at least two distinct work items while paused, then resume with an accepted resume outcome.",
        "After resume, both buffered items reach a public completed (or otherwise successfully processed) terminal observation within the test's readiness wait.",
        "Public dispatch or equivalent ordered observations show the first submitted buffered item begins processing before the second.",
        "Coverage absorbs the customer-facing ordered-drain obligation of TestNamedGoalOperatorControls_ClIPauseResumeDrainsBufferedGoalsInOrder.",
        "The top-level test has a customer-readable Go doc comment describing ordered drain after resume.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-sessions-pause-resume-003",
      "title": "Prove pause/resume emit durable lifecycle events",
      "description": "As an operator or integrator, I want pause and resume to leave durable Factory Events in session history, so that I can audit and replay lifecycle controls after the fact.",
      "acceptanceCriteria": [
        "The cell includes TestPauseResumeEmitsDurableLifecycleEvents.",
        "Through a public session-control boundary, perform pause then resume on a live Factory Session (optionally with a buffered submission between them that completes after resume).",
        "Public Factory Events history includes at least one pause and one resume SESSION_LIFECYCLE_CONTROL (or equivalent documented public lifecycle-control event type) in chronological order.",
        "Event payloads expose the public control operation kinds for pause and resume without requiring service/internal Petri imports.",
        "Coverage absorbs the customer-facing durable-event obligation of TestNamedGoalOperatorControls_PauseResumeRecordsLifecycleControlEventsForReplay.",
        "The top-level test has a customer-readable Go doc comment describing durable lifecycle-control event emission.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-sessions-pause-resume-004",
      "title": "Prove API pause, resume, cancel, and terminate",
      "description": "As an API client, I want pause, resume, cancel, and terminate to succeed through the public Factory Session control endpoints with typed outcomes, so that operators can fully control a session's lifecycle over HTTP.",
      "acceptanceCriteria": [
        "The cell includes TestAPIPauseResumeCancelAndTerminateFactorySession.",
        "Through public API endpoints (POST /factory-sessions/{session_id}/pause|resume|cancel|terminate or the established functional helpers that hit those surfaces), each control returns HTTP success with a typed FactorySessionLifecycleControlResponse whose operation matches the requested control and whose outcome is ACCEPTED (or documented NO_OP only when repeating an already-applied control in a substep that intentionally checks idempotency).",
        "After each successful control, a subsequent public session read reflects the expected lifecycle state for that control (paused after pause; running/active after resume; canceled/terminated terminal state after cancel/terminate as documented by the public contract).",
        "Coverage absorbs the customer-facing control-surface obligations mapped from TestNamedGoalOperatorControls_InterruptedGoalInspectSurfacesDispatchAndStopSummary and TestSessionInvocationAPI_PausedSessionReturnsPausedStatus insofar as they require public pause/cancel/terminate control and readable session lifecycle state—without owning MCP controls or deep inspect matrices belonging to sibling cells.",
        "The top-level test has a customer-readable Go doc comment describing API pause/resume/cancel/terminate control behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-sessions-pause-resume-005",
      "title": "Prove invalid lifecycle transitions return conflict",
      "description": "As an API client, I want illegal Factory Session lifecycle transitions to fail with a public conflict outcome and leave the session unchanged in an illegal way, so that automation can detect bad control sequences safely.",
      "acceptanceCriteria": [
        "The cell includes TestAPIInvalidLifecycleTransitionReturnsConflict.",
        "Through the public API session-control boundary, attempt at least one documented invalid transition (for example resume on an already-terminated session, pause after terminate, or another contract-documented illegal pair).",
        "The response is a public conflict: HTTP 409 and/or typed lifecycle-control outcome CONFLICT / INVALID_STATE / TERMINAL_SESSION per the OpenAPI FactorySessionLifecycleControl* contract, with a customer-safe error body.",
        "A subsequent public session read shows the session did not apply the illegal transition (terminal/canceled/terminated state remains terminal; no silent flip to running/paused contrary to the failed control).",
        "Assertions stay on public API outcomes and do not import service/internal Petri packages.",
        "The top-level test has a customer-readable Go doc comment describing invalid-transition conflict behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-sessions-pause-resume-006",
      "title": "Consume migration obligation and close verification gates",
      "description": "As a maintainer executing Wave 2 migration, I want this cell to absorb the five mapped ledger rows and pass focused boundary/metadata gates, so the destination is catalogued correctly without widening into sibling sessions packages or inventing deletion obligations.",
      "acceptanceCriteria": [
        "The five migration-ledger mappings to tests/functional/sessions/controls/pause_resume_test.go are consumed by this cell's coverage; legacy source scenarios are not deleted by this work item (deletion_only_batch: n/a for the destination work item).",
        "Only narrowly coupled ownership, coverage, or catalog metadata required for this cell are updated; specialty bindings remain none.",
        "The cell does not implement sibling destinations (sessions/lifecycle, sessions/execution, sessions/restart, sessions/mcp, or live_runtime_build_process).",
        "Focused package tests for tests/functional/sessions/controls pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as sessions/controls).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)