### PR TITLE
ft-wave2-factory-goal-invocation

### DIFF
--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -7279,6 +7279,46 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/factory/packaged/goal/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/goal",
+      "scenario": "TestPackagedGoalAcceptCompletesWithSummary",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/goal/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/goal/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/goal",
+      "scenario": "TestPackagedGoalRejectRepeatsThenCompletes",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/goal/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/goal/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/goal",
+      "scenario": "TestPackagedGoalUnknownDecisionFails",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/goal/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/goal/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/goal",
+      "scenario": "TestPackagedGoalPausedSubmissionResumes",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/goal/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/workers/inference/claude/conductor_test.go",
       "package": "you-agent-factory/tests/functional/workers/inference/claude",
       "scenario": "TestClaudeConductorSuccessThroughRootBuildProcess",
@@ -7299,12 +7339,12 @@
       "deletion_only_batch": "n/a"
     }
   ],
-  "scanned_at_utc": "2026-07-28T03:45:00Z",
+  "scanned_at_utc": "2026-07-28T04:05:00Z",
   "summary": {
     "by_catch_all": {
       "bootstrap_portability": 22,
       "guards_batch": 23,
-      "none": 444,
+      "none": 448,
       "replay_contracts": 23,
       "runtime_api": 96,
       "smoke": 62,
@@ -7315,7 +7355,7 @@
       "automations": 7,
       "bootstrap_portability": 21,
       "cli": 62,
-      "factory": 7,
+      "factory": 11,
       "guards_batch": 23,
       "models": 5,
       "observability": 9,
@@ -7334,9 +7374,9 @@
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 710,
+    "customer_top_level_Test_scenarios": 714,
     "lane_functionallong": 95,
-    "lane_short": 615,
+    "lane_short": 619,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 12,
       "you-agent-factory/tests/functional/automations": 7,
@@ -7351,6 +7391,7 @@
       "you-agent-factory/tests/functional/cli/session_resume": 6,
       "you-agent-factory/tests/functional/factory/packaged/catalog": 7,
       "you-agent-factory/tests/functional/factory/packaged/deep_research": 3,
+      "you-agent-factory/tests/functional/factory/packaged/goal": 4,
       "you-agent-factory/tests/functional/factory/runtime_lifecycle": 1,
       "you-agent-factory/tests/functional/guards_batch": 23,
       "you-agent-factory/tests/functional/models/model_invoke": 3,

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -659,7 +659,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestPackagedFusionOptionalInputsReachWorkers` covers supported options.
   - `TestPackagedFusionPartialWorkerFailureUsesDocumentedOutcome` covers error.
 
-- [ ] `tests/functional/factory/packaged/goal/invocation_test.go`
+- [x] `tests/functional/factory/packaged/goal/invocation_test.go`
   - `TestPackagedGoalAcceptCompletesWithSummary` covers accepted routing.
   - `TestPackagedGoalRejectRepeatsThenCompletes` covers feedback propagation.
   - `TestPackagedGoalUnknownDecisionFails` covers classifier failure.

--- a/tests/functional/factory/packaged/goal/helpers_test.go
+++ b/tests/functional/factory/packaged/goal/helpers_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
@@ -334,4 +335,117 @@ func primaryResultText(t *testing.T, response factoryapi.InvocationResponse) str
 		t.Fatalf("primaryResult[0] as text part: %v", err)
 	}
 	return part.Text
+}
+
+func startPackagedGoalSessionServer(t *testing.T, factoryDir string) *support.FunctionalAPIServer {
+	t.Helper()
+
+	return support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                factoryDir,
+		UseMockWorkers:            true,
+		WaitForServiceModeRuntime: true,
+	})
+}
+
+func postPackagedGoalJSON[T any](t *testing.T, endpoint string, request any, failurePrefix string) T {
+	t.Helper()
+
+	var body io.Reader
+	if request != nil {
+		encoded, err := json.Marshal(request)
+		if err != nil {
+			t.Fatalf("%s: marshal request: %v", failurePrefix, err)
+		}
+		body = bytes.NewReader(encoded)
+	}
+	resp, err := http.Post(endpoint, "application/json", body)
+	if err != nil {
+		t.Fatalf("%s: POST %s: %v", failurePrefix, endpoint, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("%s: POST %s status = %d, want success: %s", failurePrefix, endpoint, resp.StatusCode, string(payload))
+	}
+	var out T
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("%s: decode %s response: %v", failurePrefix, endpoint, err)
+	}
+	return out
+}
+
+func submitPackagedGoalWork(t *testing.T, baseURL, name, text string) factoryapi.SubmitWorkResponse {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]any{
+		"name":         name,
+		"workTypeName": "goal",
+		"items": []map[string]any{{
+			"type": "text",
+			"text": text,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal packaged goal submit request: %v", err)
+	}
+	resp, err := http.Post(support.DefaultSessionWorkURL(baseURL, "/work"), "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /work goal submit: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("POST /work goal submit status = %d, want 201: %s", resp.StatusCode, string(payload))
+	}
+	var submitted factoryapi.SubmitWorkResponse
+	if err := json.NewDecoder(resp.Body).Decode(&submitted); err != nil {
+		t.Fatalf("decode goal submit response: %v", err)
+	}
+	if strings.TrimSpace(support.StringPointerValue(submitted.WorkId)) == "" {
+		t.Fatalf("goal submit response = %#v, want work id", submitted)
+	}
+	return submitted
+}
+
+func packagedGoalWorkStateName(state *factoryapi.WorkState) string {
+	if state == nil {
+		return ""
+	}
+	return state.Name
+}
+
+func waitForPackagedGoalWorkIDsComplete(
+	t *testing.T,
+	baseURL string,
+	workIDs []string,
+	timeout time.Duration,
+) []factoryapi.Work {
+	t.Helper()
+
+	want := make(map[string]bool, len(workIDs))
+	for _, workID := range workIDs {
+		want[workID] = true
+	}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		listed := support.ListDefaultSessionWork(t, baseURL)
+		found := make(map[string]factoryapi.Work, len(want))
+		for _, item := range listed.Results {
+			workID := support.StringPointerValue(item.WorkId)
+			if want[workID] && packagedGoalWorkStateName(item.State) == "complete" {
+				found[workID] = item
+			}
+		}
+		if len(found) == len(want) {
+			items := make([]factoryapi.Work, 0, len(workIDs))
+			for _, workID := range workIDs {
+				items = append(items, found[workID])
+			}
+			return items
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	listed := support.ListDefaultSessionWork(t, baseURL)
+	t.Fatalf("timed out waiting for completed goal work IDs %v; last work response: %#v", workIDs, listed)
+	return nil
 }

--- a/tests/functional/factory/packaged/goal/helpers_test.go
+++ b/tests/functional/factory/packaged/goal/helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -18,12 +19,13 @@ import (
 )
 
 const (
-	packagedGoalFactoryName            = "@you/goal"
-	packagedGoalPlanWorkstationName    = "plan-goal"
-	packagedGoalExecuteWorkstationName  = "execute-goal"
-	packagedGoalCheckWorkstationName    = "check-goal"
-	packagedGoalReviewWorkstationName   = "review-goal"
-	packagedGoalMockWorkerAcceptedSummary = "mock worker accepted"
+	packagedGoalFactoryName                 = "@you/goal"
+	packagedGoalPlanWorkstationName         = "plan-goal"
+	packagedGoalExecuteWorkstationName        = "execute-goal"
+	packagedGoalCheckWorkstationName          = "check-goal"
+	packagedGoalReviewWorkstationName         = "review-goal"
+	packagedGoalMockWorkerAcceptedSummary     = "mock worker accepted"
+	packagedGoalRejectThenCompleteSummary     = "finished after rejection"
 )
 
 func scaffoldPackagedGoalBuiltInFactory(t *testing.T) string {
@@ -81,6 +83,95 @@ func writePackagedGoalBuiltinMockWorkersConfig(t *testing.T) string {
 	return path
 }
 
+func writePackagedGoalRejectThenAcceptMockWorkersConfig(t *testing.T) (string, string) {
+	t.Helper()
+	return writePackagedGoalSequencedExecutorMockWorkersConfig(
+		t,
+		"goal is not complete yet",
+		"__COMPLETE_WITH_STOP_TOKEN__",
+	)
+}
+
+func writePackagedGoalSequencedExecutorMockWorkersConfig(t *testing.T, executorOutputs ...string) (string, string) {
+	t.Helper()
+
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "goal-executor-sequenced.sh")
+	counterPath := filepath.Join(scriptDir, "goal-executor-sequenced.count")
+	lines := []string{
+		"#!/bin/sh",
+		"count=0",
+		"if [ -f \"" + counterPath + "\" ]; then",
+		"  count=$(cat \"" + counterPath + "\")",
+		"fi",
+		"case \"$count\" in",
+	}
+	for idx, output := range executorOutputs {
+		switch output {
+		case "__COMPLETE_WITH_STOP_TOKEN__":
+			lines = append(lines, "  "+strconv.Itoa(idx)+") printf '%s\\n%s' '"+packagedGoalRejectThenCompleteSummary+"' '<COMPLETE>' ;;")
+		default:
+			lines = append(lines, "  "+strconv.Itoa(idx)+") printf '%s' '"+output+"' ;;")
+		}
+	}
+	fallback := packagedGoalMockWorkerAcceptedSummary
+	if len(executorOutputs) > 0 {
+		last := executorOutputs[len(executorOutputs)-1]
+		if last == "__COMPLETE_WITH_STOP_TOKEN__" {
+			fallback = packagedGoalRejectThenCompleteSummary + "\n<COMPLETE>"
+		} else {
+			fallback = last
+		}
+	}
+	lines = append(lines,
+		"  *) printf '%s' '"+fallback+"' ;;",
+		"esac",
+		"printf '%s' $((count + 1)) > \""+counterPath+"\"",
+	)
+	if err := os.WriteFile(scriptPath, []byte(strings.Join(lines, "\n")+"\n"), 0o755); err != nil {
+		t.Fatalf("write sequenced goal executor script: %v", err)
+	}
+
+	cfg := workers.MockWorkersConfig{
+		MockWorkers: []workers.MockWorkerConfig{
+			{
+				WorkerName:      "goal-executor",
+				WorkstationName: packagedGoalExecuteWorkstationName,
+				RunType:         workers.MockWorkerRunTypeScript,
+				ScriptConfig: &workers.MockWorkerScriptConfig{
+					Command: scriptPath,
+				},
+			},
+		},
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal packaged goal reject-then-accept mock-workers config: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "mock-workers-packaged-goal-reject-then-accept.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write packaged goal reject-then-accept mock-workers config: %v", err)
+	}
+	return path, counterPath
+}
+
+func readPackagedGoalExecutorInvocationCount(t *testing.T, counterPath string) int {
+	t.Helper()
+
+	payload, err := os.ReadFile(counterPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("read executor invocation counter: %v", err)
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(string(payload)))
+	if err != nil {
+		t.Fatalf("parse executor invocation counter %q: %v", string(payload), err)
+	}
+	return count
+}
+
 func startPackagedGoalInvocationServer(t *testing.T, factoryDir, mockWorkersPath string) *support.FunctionalAPIServer {
 	t.Helper()
 
@@ -108,6 +199,18 @@ func postPackagedGoalInvocation(
 ) factoryapi.InvocationResponse {
 	t.Helper()
 
+	_, response := invokePackagedGoal(t, factoryDir, mockWorkersPath, goalText)
+	return response
+}
+
+func invokePackagedGoal(
+	t *testing.T,
+	factoryDir string,
+	mockWorkersPath string,
+	goalText string,
+) (*support.FunctionalAPIServer, factoryapi.InvocationResponse) {
+	t.Helper()
+
 	body := textInvocationRequestBody(goalText)
 	server := startPackagedGoalInvocationServer(t, factoryDir, mockWorkersPath)
 	response, err := http.Post(
@@ -128,7 +231,7 @@ func postPackagedGoalInvocation(
 	if err := json.NewDecoder(response.Body).Decode(&decoded); err != nil {
 		t.Fatalf("decode invocation response: %v", err)
 	}
-	return decoded
+	return server, decoded
 }
 
 func textInvocationRequestBody(goalText string) []byte {

--- a/tests/functional/factory/packaged/goal/helpers_test.go
+++ b/tests/functional/factory/packaged/goal/helpers_test.go
@@ -83,6 +83,32 @@ func writePackagedGoalBuiltinMockWorkersConfig(t *testing.T) string {
 	return path
 }
 
+func writePackagedGoalFailingMockWorkersConfig(t *testing.T) string {
+	t.Helper()
+
+	cfg := workers.MockWorkersConfig{
+		MockWorkers: []workers.MockWorkerConfig{
+			{
+				WorkerName:      "goal-executor",
+				WorkstationName: packagedGoalExecuteWorkstationName,
+				RunType:         workers.MockWorkerRunTypeReject,
+				RejectConfig: &workers.MockWorkerRejectConfig{
+					Stderr: "mock provider failure",
+				},
+			},
+		},
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal packaged goal failing mock-workers config: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "mock-workers-packaged-goal-failing.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write packaged goal failing mock-workers config: %v", err)
+	}
+	return path
+}
+
 func writePackagedGoalRejectThenAcceptMockWorkersConfig(t *testing.T) (string, string) {
 	t.Helper()
 	return writePackagedGoalSequencedExecutorMockWorkersConfig(
@@ -260,6 +286,26 @@ func invocationTextContentPtr(goalText string) *factoryapi.WorkContent {
 	}
 	content := factoryapi.WorkContent{part}
 	return &content
+}
+
+func assertPackagedGoalInvocationFailedWithRuntimeDetails(t *testing.T, response factoryapi.InvocationResponse) {
+	t.Helper()
+
+	if response.Status != factoryapi.InvocationTerminalStatusFailed {
+		t.Fatalf("invocation status = %q, want FAILED; response = %#v", response.Status, response)
+	}
+	if response.ErrorCode == nil || *response.ErrorCode != factoryapi.InvocationResponseErrorCode("INVOCATION_RUNTIME_FAILURE") {
+		t.Fatalf("invocation errorCode = %#v, want INVOCATION_RUNTIME_FAILURE", response.ErrorCode)
+	}
+	if response.Message == nil || !strings.Contains(*response.Message, "invocation failed") || !strings.Contains(*response.Message, `state "goal:failed"`) {
+		t.Fatalf("invocation message = %#v, want failed goal explanation", response.Message)
+	}
+	if response.WorkState == nil || *response.WorkState != "goal:failed" {
+		t.Fatalf("invocation workState = %#v, want goal:failed", response.WorkState)
+	}
+	if response.PrimaryResult != nil {
+		t.Fatalf("invocation primaryResult = %#v, want nil on failed output", response.PrimaryResult)
+	}
 }
 
 func assertPackagedGoalCompletedWithSummary(

--- a/tests/functional/factory/packaged/goal/helpers_test.go
+++ b/tests/functional/factory/packaged/goal/helpers_test.go
@@ -8,11 +8,12 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
@@ -110,95 +111,6 @@ func writePackagedGoalFailingMockWorkersConfig(t *testing.T) string {
 	return path
 }
 
-func writePackagedGoalRejectThenAcceptMockWorkersConfig(t *testing.T) (string, string) {
-	t.Helper()
-	return writePackagedGoalSequencedExecutorMockWorkersConfig(
-		t,
-		"goal is not complete yet",
-		"__COMPLETE_WITH_STOP_TOKEN__",
-	)
-}
-
-func writePackagedGoalSequencedExecutorMockWorkersConfig(t *testing.T, executorOutputs ...string) (string, string) {
-	t.Helper()
-
-	scriptDir := t.TempDir()
-	scriptPath := filepath.Join(scriptDir, "goal-executor-sequenced.sh")
-	counterPath := filepath.Join(scriptDir, "goal-executor-sequenced.count")
-	lines := []string{
-		"#!/bin/sh",
-		"count=0",
-		"if [ -f \"" + counterPath + "\" ]; then",
-		"  count=$(cat \"" + counterPath + "\")",
-		"fi",
-		"case \"$count\" in",
-	}
-	for idx, output := range executorOutputs {
-		switch output {
-		case "__COMPLETE_WITH_STOP_TOKEN__":
-			lines = append(lines, "  "+strconv.Itoa(idx)+") printf '%s\\n%s' '"+packagedGoalRejectThenCompleteSummary+"' '<COMPLETE>' ;;")
-		default:
-			lines = append(lines, "  "+strconv.Itoa(idx)+") printf '%s' '"+output+"' ;;")
-		}
-	}
-	fallback := packagedGoalMockWorkerAcceptedSummary
-	if len(executorOutputs) > 0 {
-		last := executorOutputs[len(executorOutputs)-1]
-		if last == "__COMPLETE_WITH_STOP_TOKEN__" {
-			fallback = packagedGoalRejectThenCompleteSummary + "\n<COMPLETE>"
-		} else {
-			fallback = last
-		}
-	}
-	lines = append(lines,
-		"  *) printf '%s' '"+fallback+"' ;;",
-		"esac",
-		"printf '%s' $((count + 1)) > \""+counterPath+"\"",
-	)
-	if err := os.WriteFile(scriptPath, []byte(strings.Join(lines, "\n")+"\n"), 0o755); err != nil {
-		t.Fatalf("write sequenced goal executor script: %v", err)
-	}
-
-	cfg := workers.MockWorkersConfig{
-		MockWorkers: []workers.MockWorkerConfig{
-			{
-				WorkerName:      "goal-executor",
-				WorkstationName: packagedGoalExecuteWorkstationName,
-				RunType:         workers.MockWorkerRunTypeScript,
-				ScriptConfig: &workers.MockWorkerScriptConfig{
-					Command: scriptPath,
-				},
-			},
-		},
-	}
-	data, err := json.MarshalIndent(cfg, "", "  ")
-	if err != nil {
-		t.Fatalf("marshal packaged goal reject-then-accept mock-workers config: %v", err)
-	}
-	path := filepath.Join(t.TempDir(), "mock-workers-packaged-goal-reject-then-accept.json")
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		t.Fatalf("write packaged goal reject-then-accept mock-workers config: %v", err)
-	}
-	return path, counterPath
-}
-
-func readPackagedGoalExecutorInvocationCount(t *testing.T, counterPath string) int {
-	t.Helper()
-
-	payload, err := os.ReadFile(counterPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return 0
-		}
-		t.Fatalf("read executor invocation counter: %v", err)
-	}
-	count, err := strconv.Atoi(strings.TrimSpace(string(payload)))
-	if err != nil {
-		t.Fatalf("parse executor invocation counter %q: %v", string(payload), err)
-	}
-	return count
-}
-
 func startPackagedGoalInvocationServer(t *testing.T, factoryDir, mockWorkersPath string) *support.FunctionalAPIServer {
 	t.Helper()
 
@@ -238,8 +150,36 @@ func invokePackagedGoal(
 ) (*support.FunctionalAPIServer, factoryapi.InvocationResponse) {
 	t.Helper()
 
-	body := textInvocationRequestBody(goalText)
 	server := startPackagedGoalInvocationServer(t, factoryDir, mockWorkersPath)
+	return server, postPackagedGoalInvocationToServer(t, server, goalText)
+}
+
+func invokePackagedGoalWithProviderRunner(
+	t *testing.T,
+	factoryDir string,
+	runner platformprocess.CommandRunner,
+	goalText string,
+) (*support.FunctionalAPIServer, factoryapi.InvocationResponse) {
+	t.Helper()
+
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                factoryDir,
+		WaitForServiceModeRuntime: true,
+		Edges: serviceedges.Edges{
+			ProviderCommandRunner: runner,
+		},
+	})
+	return server, postPackagedGoalInvocationToServer(t, server, goalText)
+}
+
+func postPackagedGoalInvocationToServer(
+	t *testing.T,
+	server *support.FunctionalAPIServer,
+	goalText string,
+) factoryapi.InvocationResponse {
+	t.Helper()
+
+	body := textInvocationRequestBody(goalText)
 	response, err := http.Post(
 		strings.TrimSuffix(server.URL(), "/")+"/factory-sessions/"+factorysessions.DefaultSessionID+"/invocations",
 		"application/json",
@@ -258,7 +198,7 @@ func invokePackagedGoal(
 	if err := json.NewDecoder(response.Body).Decode(&decoded); err != nil {
 		t.Fatalf("decode invocation response: %v", err)
 	}
-	return server, decoded
+	return decoded
 }
 
 func textInvocationRequestBody(goalText string) []byte {

--- a/tests/functional/factory/packaged/goal/helpers_test.go
+++ b/tests/functional/factory/packaged/goal/helpers_test.go
@@ -1,0 +1,188 @@
+package goal
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	packagedGoalFactoryName            = "@you/goal"
+	packagedGoalPlanWorkstationName    = "plan-goal"
+	packagedGoalExecuteWorkstationName  = "execute-goal"
+	packagedGoalCheckWorkstationName    = "check-goal"
+	packagedGoalReviewWorkstationName   = "review-goal"
+	packagedGoalMockWorkerAcceptedSummary = "mock worker accepted"
+)
+
+func scaffoldPackagedGoalBuiltInFactory(t *testing.T) string {
+	t.Helper()
+	dir := support.InstallPackagedFactory(t, t.TempDir(), packagedGoalFactoryName)
+	if _, err := support.LoadedFactory(t, dir); err != nil {
+		t.Fatalf("LoadRuntimeConfigFromFactoryDir: %v", err)
+	}
+	return dir
+}
+
+func writePackagedGoalBuiltinMockWorkersConfig(t *testing.T) string {
+	t.Helper()
+
+	cfg := workers.MockWorkersConfig{
+		MockWorkers: []workers.MockWorkerConfig{
+			{
+				WorkerName:      "goal-planner",
+				WorkstationName: packagedGoalPlanWorkstationName,
+				RunType:         workers.MockWorkerRunTypeAccept,
+			},
+			{
+				WorkerName:      "goal-executor",
+				WorkstationName: packagedGoalExecuteWorkstationName,
+				RunType:         workers.MockWorkerRunTypeAccept,
+			},
+			{
+				WorkerName:      "goal-checker",
+				WorkstationName: packagedGoalCheckWorkstationName,
+				RunType:         workers.MockWorkerRunTypeScript,
+				ScriptConfig: &workers.MockWorkerScriptConfig{
+					Command: "/bin/echo",
+					Args:    []string{"plain"},
+				},
+			},
+			{
+				WorkerName:      "goal-reviewer",
+				WorkstationName: packagedGoalReviewWorkstationName,
+				RunType:         workers.MockWorkerRunTypeScript,
+				ScriptConfig: &workers.MockWorkerScriptConfig{
+					Command: "/bin/echo",
+					Args:    []string{"accepted"},
+				},
+			},
+		},
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal packaged goal mock-workers config: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "mock-workers-packaged-goal.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write packaged goal mock-workers config: %v", err)
+	}
+	return path
+}
+
+func startPackagedGoalInvocationServer(t *testing.T, factoryDir, mockWorkersPath string) *support.FunctionalAPIServer {
+	t.Helper()
+
+	payload, err := os.ReadFile(mockWorkersPath)
+	if err != nil {
+		t.Fatalf("read customer mock-workers config: %v", err)
+	}
+	var mockWorkersConfig workers.MockWorkersConfig
+	if err := json.Unmarshal(payload, &mockWorkersConfig); err != nil {
+		t.Fatalf("decode customer mock-workers config: %v", err)
+	}
+
+	return support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                factoryDir,
+		WaitForServiceModeRuntime: true,
+		MockWorkersConfig:         &mockWorkersConfig,
+	})
+}
+
+func postPackagedGoalInvocation(
+	t *testing.T,
+	factoryDir string,
+	mockWorkersPath string,
+	goalText string,
+) factoryapi.InvocationResponse {
+	t.Helper()
+
+	body := textInvocationRequestBody(goalText)
+	server := startPackagedGoalInvocationServer(t, factoryDir, mockWorkersPath)
+	response, err := http.Post(
+		strings.TrimSuffix(server.URL(), "/")+"/factory-sessions/"+factorysessions.DefaultSessionID+"/invocations",
+		"application/json",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("POST /factory-sessions/~default/invocations: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(response.Body)
+		t.Fatalf("POST /factory-sessions/~default/invocations status = %d, want 200: %s", response.StatusCode, string(payload))
+	}
+
+	var decoded factoryapi.InvocationResponse
+	if err := json.NewDecoder(response.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode invocation response: %v", err)
+	}
+	return decoded
+}
+
+func textInvocationRequestBody(goalText string) []byte {
+	body, err := json.Marshal(factoryapi.InvocationRequest{
+		SourceKind: invocationTextSourceKindPtr(),
+		Content:    invocationTextContentPtr(goalText),
+	})
+	if err != nil {
+		panic(fmt.Sprintf("marshal invocation request: %v", err))
+	}
+	return body
+}
+
+func invocationTextSourceKindPtr() *factoryapi.InvocationInputSourceKind {
+	sourceKind := factoryapi.InvocationInputSourceKindText
+	return &sourceKind
+}
+
+func invocationTextContentPtr(goalText string) *factoryapi.WorkContent {
+	var part factoryapi.WorkContentPart
+	if err := part.FromWorkTextContentPart(factoryapi.WorkTextContentPart{
+		Type: factoryapi.WorkContentPartTypeText,
+		Text: goalText,
+	}); err != nil {
+		panic(fmt.Sprintf("build invocation text content: %v", err))
+	}
+	content := factoryapi.WorkContent{part}
+	return &content
+}
+
+func assertPackagedGoalCompletedWithSummary(
+	t *testing.T,
+	response factoryapi.InvocationResponse,
+	wantSummary string,
+) {
+	t.Helper()
+
+	if response.Status != factoryapi.InvocationTerminalStatusCompleted {
+		t.Fatalf("invocation status = %q, want COMPLETED; response = %#v", response.Status, response)
+	}
+	if got := primaryResultText(t, response); got != wantSummary {
+		t.Fatalf("primaryResult text = %q, want %q", got, wantSummary)
+	}
+}
+
+func primaryResultText(t *testing.T, response factoryapi.InvocationResponse) string {
+	t.Helper()
+
+	if response.PrimaryResult == nil || len(*response.PrimaryResult) != 1 {
+		t.Fatalf("invocation primaryResult = %#v, want one text part", response.PrimaryResult)
+	}
+	part, err := (*response.PrimaryResult)[0].AsWorkTextContentPart()
+	if err != nil {
+		t.Fatalf("primaryResult[0] as text part: %v", err)
+	}
+	return part.Text
+}

--- a/tests/functional/factory/packaged/goal/invocation_test.go
+++ b/tests/functional/factory/packaged/goal/invocation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
@@ -31,14 +32,15 @@ func TestPackagedGoalAcceptCompletesWithSummary(t *testing.T) {
 // the post-reject primary result.
 func TestPackagedGoalRejectRepeatsThenCompletes(t *testing.T) {
 	dir := scaffoldPackagedGoalBuiltInFactory(t)
-	mockWorkersPath, executorCounterPath := writePackagedGoalRejectThenAcceptMockWorkersConfig(t)
+	runner := support.NewShapedProviderCommandRunner(
+		platformprocess.CommandResult{Stdout: []byte("goal is not complete yet")},
+		platformprocess.CommandResult{Stdout: []byte(packagedGoalRejectThenCompleteSummary + "\n<COMPLETE>")},
+	)
 
-	_, response := invokePackagedGoal(t, dir, mockWorkersPath, "invoke packaged goal after reject")
+	_, response := invokePackagedGoalWithProviderRunner(t, dir, runner, "invoke packaged goal after reject")
 	assertPackagedGoalCompletedWithSummary(t, response, packagedGoalRejectThenCompleteSummary)
-
-	executorInvocations := readPackagedGoalExecutorInvocationCount(t, executorCounterPath)
-	if executorInvocations < 2 {
-		t.Fatalf("executor invocation count = %d, want at least 2 after reject-then-complete", executorInvocations)
+	if got := runner.CallCount(); got < 2 {
+		t.Fatalf("provider invocation count = %d, want at least 2 after reject-then-complete", got)
 	}
 }
 

--- a/tests/functional/factory/packaged/goal/invocation_test.go
+++ b/tests/functional/factory/packaged/goal/invocation_test.go
@@ -18,3 +18,20 @@ func TestPackagedGoalAcceptCompletesWithSummary(t *testing.T) {
 		t.Fatal("primaryResult echoed submitted goal text")
 	}
 }
+
+// TestPackagedGoalRejectRepeatsThenCompletes proves a packaged @you/goal reject
+// decision feeds back through the public session invocation API, triggers another
+// executor dispatch on the built-in repeater workstation, and then completes with
+// the post-reject primary result.
+func TestPackagedGoalRejectRepeatsThenCompletes(t *testing.T) {
+	dir := scaffoldPackagedGoalBuiltInFactory(t)
+	mockWorkersPath, executorCounterPath := writePackagedGoalRejectThenAcceptMockWorkersConfig(t)
+
+	_, response := invokePackagedGoal(t, dir, mockWorkersPath, "invoke packaged goal after reject")
+	assertPackagedGoalCompletedWithSummary(t, response, packagedGoalRejectThenCompleteSummary)
+
+	executorInvocations := readPackagedGoalExecutorInvocationCount(t, executorCounterPath)
+	if executorInvocations < 2 {
+		t.Fatalf("executor invocation count = %d, want at least 2 after reject-then-complete", executorInvocations)
+	}
+}

--- a/tests/functional/factory/packaged/goal/invocation_test.go
+++ b/tests/functional/factory/packaged/goal/invocation_test.go
@@ -35,3 +35,15 @@ func TestPackagedGoalRejectRepeatsThenCompletes(t *testing.T) {
 		t.Fatalf("executor invocation count = %d, want at least 2 after reject-then-complete", executorInvocations)
 	}
 }
+
+// TestPackagedGoalUnknownDecisionFails proves packaged @you/goal invocation through
+// the public session invocation API fails with stable runtime-failure details and no
+// success primary result when mock workers surface an invalid worker outcome on the
+// built-in execute-goal topology.
+func TestPackagedGoalUnknownDecisionFails(t *testing.T) {
+	dir := scaffoldPackagedGoalBuiltInFactory(t)
+	mockWorkersPath := writePackagedGoalFailingMockWorkersConfig(t)
+
+	response := postPackagedGoalInvocation(t, dir, mockWorkersPath, "invoke packaged goal with failing worker")
+	assertPackagedGoalInvocationFailedWithRuntimeDetails(t, response)
+}

--- a/tests/functional/factory/packaged/goal/invocation_test.go
+++ b/tests/functional/factory/packaged/goal/invocation_test.go
@@ -1,7 +1,13 @@
 package goal
 
 import (
+	"strings"
 	"testing"
+	"time"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
 // TestPackagedGoalAcceptCompletesWithSummary proves packaged @you/goal invocation
@@ -46,4 +52,71 @@ func TestPackagedGoalUnknownDecisionFails(t *testing.T) {
 
 	response := postPackagedGoalInvocation(t, dir, mockWorkersPath, "invoke packaged goal with failing worker")
 	assertPackagedGoalInvocationFailedWithRuntimeDetails(t, response)
+}
+
+// TestPackagedGoalPausedSubmissionResumes proves packaged @you/goal work submitted
+// while the Factory Session is paused stays buffered through the public pause/resume
+// control boundary and reaches the completed goal state only after resume.
+func TestPackagedGoalPausedSubmissionResumes(t *testing.T) {
+	dir := scaffoldPackagedGoalBuiltInFactory(t)
+	server := startPackagedGoalSessionServer(t, dir)
+	baseURL := strings.TrimSuffix(server.URL(), "/")
+	sessionPath := "/factory-sessions/" + factorysessions.DefaultSessionID
+
+	pause := postPackagedGoalJSON[factoryapi.FactorySessionLifecycleControlResponse](
+		t,
+		baseURL+sessionPath+"/pause",
+		factoryapi.FactorySessionLifecycleControlRequest{},
+		"pause packaged goal session",
+	)
+	if pause.Operation != factoryapi.FactorySessionLifecycleControlKindPause ||
+		pause.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
+		t.Fatalf("pause response = %#v, want accepted pause", pause)
+	}
+	pauseNoOp := postPackagedGoalJSON[factoryapi.FactorySessionLifecycleControlResponse](
+		t,
+		baseURL+sessionPath+"/pause",
+		factoryapi.FactorySessionLifecycleControlRequest{},
+		"repeat pause packaged goal session",
+	)
+	if pauseNoOp.Operation != factoryapi.FactorySessionLifecycleControlKindPause ||
+		pauseNoOp.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeNoOp {
+		t.Fatalf("repeat pause response = %#v, want no-op pause", pauseNoOp)
+	}
+
+	submitted := submitPackagedGoalWork(t, baseURL, "paused-goal-submit", "customer goal request text")
+	workID := support.StringPointerValue(submitted.WorkId)
+	listed := support.ListDefaultSessionWork(t, baseURL)
+	if support.HasWorkAtCustomerState(listed, workID, "goal:init") {
+		t.Fatalf("paused submit reached goal:init while session was paused: %#v", listed.Results)
+	}
+	if support.HasWorkAtCustomerState(listed, workID, "goal:complete") {
+		t.Fatalf("paused submit reached goal:complete before resume: %#v", listed.Results)
+	}
+
+	resume := postPackagedGoalJSON[factoryapi.FactorySessionLifecycleControlResponse](
+		t,
+		baseURL+sessionPath+"/resume",
+		factoryapi.FactorySessionLifecycleControlRequest{},
+		"resume packaged goal session",
+	)
+	if resume.Operation != factoryapi.FactorySessionLifecycleControlKindResume ||
+		resume.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
+		t.Fatalf("resume response = %#v, want accepted resume", resume)
+	}
+	resumeNoOp := postPackagedGoalJSON[factoryapi.FactorySessionLifecycleControlResponse](
+		t,
+		baseURL+sessionPath+"/resume",
+		factoryapi.FactorySessionLifecycleControlRequest{},
+		"repeat resume packaged goal session",
+	)
+	if resumeNoOp.Operation != factoryapi.FactorySessionLifecycleControlKindResume ||
+		resumeNoOp.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeNoOp {
+		t.Fatalf("repeat resume response = %#v, want no-op resume", resumeNoOp)
+	}
+
+	completed := waitForPackagedGoalWorkIDsComplete(t, baseURL, []string{workID}, 15*time.Second)
+	if len(completed) != 1 || packagedGoalWorkStateName(completed[0].State) != "complete" {
+		t.Fatalf("completed work = %#v, want one completed goal after resume", completed)
+	}
 }

--- a/tests/functional/factory/packaged/goal/invocation_test.go
+++ b/tests/functional/factory/packaged/goal/invocation_test.go
@@ -1,0 +1,20 @@
+package goal
+
+import (
+	"testing"
+)
+
+// TestPackagedGoalAcceptCompletesWithSummary proves packaged @you/goal invocation
+// completes through the public session invocation API with an explicit summary
+// primary result distinct from the submitted goal text.
+func TestPackagedGoalAcceptCompletesWithSummary(t *testing.T) {
+	dir := scaffoldPackagedGoalBuiltInFactory(t)
+	mockWorkersPath := writePackagedGoalBuiltinMockWorkersConfig(t)
+
+	submitted := "customer goal request text"
+	response := postPackagedGoalInvocation(t, dir, mockWorkersPath, submitted)
+	assertPackagedGoalCompletedWithSummary(t, response, packagedGoalMockWorkerAcceptedSummary)
+	if primaryResultText(t, response) == submitted {
+		t.Fatal("primaryResult echoed submitted goal text")
+	}
+}


### PR DESCRIPTION
{
  "project": "Packaged Goal Factory Invocation Functional Coverage",
  "branchName": "ft-wave2-factory-goal-invocation",
  "description": "Implement only tests/functional/factory/packaged/goal/invocation_test.go to prove packaged @you/goal accept-with-summary, reject-then-complete, unknown-decision failure, and paused-submission resume through public CLI/API invocation with mock workers, consuming mapped migration-ledger rows while preserving specialty bindings and without implementing sibling packaged-factory packages.",
  "context": {
    "customerAsk": "Implement only tests/functional/factory/packaged/goal/invocation_test.go. Through public CLI/API packaged-factory invocation with mock workers, prove: (1) TestPackagedGoalAcceptCompletesWithSummary; (2) TestPackagedGoalRejectRepeatsThenCompletes; (3) TestPackagedGoalUnknownDecisionFails; (4) TestPackagedGoalPausedSubmissionResumes. Consume the mapped migration-ledger rows while preserving specialty bindings. Do not implement other packaged-factory packages. Avoid service/internal Petri imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for packaged goal Factory invocation does not exist, while mapped legacy scenarios remain scattered across runtime_api, smoke, acceptance, and cli/named_invocation catch-all coverage. Maintainers lack a focused, catalogued factory proof for accept-with-summary, reject-then-complete, unknown-decision failure, and paused-submission resume at the public packaged-factory invocation boundary. Sibling packaged factories (deep_research, fusion, quorum, review, subagent, tts, cross) are separate packages and must not be absorbed here.",
    "solution": "Implement the four checklist scenarios in tests/functional/factory/packaged/goal/invocation_test.go through public CLI/API packaged-factory invocation with mock workers, with customer-readable Go docs on every top-level Test. Consume every migration-ledger row whose destination is this cell, preserve specialty bindings including test-built-cli-acceptance, apply only narrowly coupled metadata updates for this destination, leave sibling packaged-factory packages untouched, and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/factory/packaged/goal/invocation_test.go exists as the factory-owned functional cell and covers accept-with-summary, reject-then-complete, unknown-decision failure, and paused-submission resume.",
    "Success and failure paths exercise public CLI and/or API packaged-factory invocation with mock workers and produce observable invocation status, primary-result, or failure diagnostics without asserting Petri markings or service internals.",
    "Accept completion returns an explicit summary primary result distinct from the submitted goal text; reject paths repeat then complete; unknown-decision / worker-failure / invalid-topology obligations fail without a success primary result; paused submit does not advance to completion until resume.",
    "Coverage stays on packaged @you/goal invocation product behavior and does not implement deep_research, fusion, quorum, review, subagent, tts, or cross cells, nor own work/routing classifier-only smoke destinations.",
    "Every migration-ledger row whose destination is tests/functional/factory/packaged/goal/invocation_test.go is consumed as applicable; specialty bindings including test-built-cli-acceptance are preserved; only narrowly coupled ownership/coverage/catalog/migration metadata for this cell are updated; sibling packaged-factory and unrelated delete-batch destinations stay untouched.",
    "Every top-level Test* has a customer-readable Go doc comment whose first sentence describes the observable CLI/API packaged-goal behavior.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave2-factory-goal-invocation-001",
      "title": "Prove packaged goal accept completes with summary",
      "description": "As an agent or operator, I want packaged @you/goal invocation to accept work and complete with an explicit summary primary result, so that I can trust the public CLI/API outcome is the documented goal summary rather than an echo of my submitted text.",
      "acceptanceCriteria": [
        "tests/functional/factory/packaged/goal/invocation_test.go includes TestPackagedGoalAcceptCompletesWithSummary as a top-level test.",
        "The test invokes packaged @you/goal through the public CLI and/or API invocation boundary with mock workers configured for an accept / complete path.",
        "The invocation reaches a completed terminal status and returns an explicit summary primary result (for example the documented mock accepted summary), and that result is not merely the submitted goal text.",
        "Customer-facing obligations from mapped accept/summary ledger rows are absorbed as applicable (including API explicit-summary completion, CLI batch primary-result-on-stdout / exit-after-batch-completion without continuous mode, hermetic named invocation success, continue-then-complete before summary when required, repeated named-run distinct invocation identity / installed-copy reuse, and named/explicit effective-signature equivalence or compatibility-input preservation when those map to this destination).",
        "Assertions stay on public packaged-goal invocation outcomes and do not import service implementations or internal Petri packages.",
        "The top-level test has a customer-readable Go doc comment describing the accept-with-summary behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-goal-invocation-002",
      "title": "Prove packaged goal reject repeats then completes",
      "description": "As an agent or operator, I want a packaged @you/goal reject decision to feed back, cause another worker invocation, and then complete, so that reject/retry feedback is observable through the public invocation surface.",
      "acceptanceCriteria": [
        "The cell includes TestPackagedGoalRejectRepeatsThenCompletes as a top-level test.",
        "The test invokes packaged @you/goal through the public CLI and/or API boundary with mock workers that first reject (or otherwise require a repeat) and then complete.",
        "The invocation eventually reaches completed terminal status with the post-reject completion primary result, and the mock worker / provider is observed to have been invoked more than once before completion.",
        "Customer-facing obligations from mapped reject-repeat ledger rows (including API reject-repeats-before-completion) are absorbed as applicable.",
        "The top-level test has a customer-readable Go doc comment describing the reject-then-complete feedback behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-goal-invocation-003",
      "title": "Prove packaged goal unknown decision fails",
      "description": "As an operator scripting against packaged @you/goal, I want unknown or invalid decision outcomes to fail with stable public failure details, so that automation can detect classifier/worker failure without treating the run as success.",
      "acceptanceCriteria": [
        "The cell includes TestPackagedGoalUnknownDecisionFails as a top-level test.",
        "The test invokes packaged @you/goal through the public CLI and/or API boundary with mock workers (or an invalid packaged-goal topology fixture) that produce an unknown/invalid decision or worker failure.",
        "The invocation reaches a failed terminal status with stable, customer-safe failure details (error code / message / work state as documented for the packaged-goal failure path) and does not emit a success primary result.",
        "Customer-facing obligations from mapped failure ledger rows are absorbed as applicable (including API worker-failure failed-status details, invalid topology documented graph-reference rejection, and schema/preparation failures that stop before execution side effects when those map to this destination).",
        "Coverage proves packaged-goal invocation failure semantics only; it does not take ownership of work/routing classifier-only smoke destinations mapped to tests/functional/work/routing/classifier_test.go.",
        "The top-level test has a customer-readable Go doc comment describing the unknown-decision / failure behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-goal-invocation-004",
      "title": "Prove paused packaged-goal submission resumes",
      "description": "As an operator controlling a Factory Session, I want work submitted to packaged @you/goal while the session is paused to remain buffered and complete only after resume, so that session control is honored for packaged goal topology locally in this cell.",
      "acceptanceCriteria": [
        "The cell includes TestPackagedGoalPausedSubmissionResumes as a top-level test.",
        "The test uses the public Factory Session pause/resume control boundary together with packaged @you/goal work submission / invocation on a built-in packaged-goal topology.",
        "While paused, submitted goal work does not reach completion (and does not advance into the documented in-progress init/complete states prematurely).",
        "After an accepted resume, the buffered work reaches the documented completed goal state within the test's readiness wait.",
        "Customer-facing obligations from the mapped paused-submit-resume ledger row (TestPackagedGoalBuiltInTopology_SubmitWhilePausedResumesThroughSessionControl) are absorbed as applicable; full sessions/controls matrix ownership remains outside this cell.",
        "The top-level test has a customer-readable Go doc comment describing the paused-submission resume behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-goal-invocation-005",
      "title": "Consume migration obligations and close verification gates",
      "description": "As a maintainer executing Wave 2 migration, I want this cell to absorb the mapped packaged-goal ledger rows, preserve specialty bindings, and pass focused boundary/metadata gates, so the destination is catalogued correctly without implementing sibling packaged-factory packages.",
      "acceptanceCriteria": [
        "Every migration-ledger mapping whose destination is tests/functional/factory/packaged/goal/invocation_test.go is consumed by this cell's coverage (accept/summary, reject-repeat, unknown/failure, and paused-resume obligations), including rows currently tagged runtime_api-delete-05-factory-packaged, smoke-delete-05-factory-packaged, test-built-cli-acceptance, and deletion_only_batch n/a named-invocation rows.",
        "Specialty bindings are preserved (notably test-built-cli-acceptance for mapped acceptance scenarios); only narrowly coupled ownership, coverage, catalog, or migration metadata required for this cell are updated; sibling packaged-factory packages (deep_research, fusion, quorum, review, subagent, tts, cross) and unrelated delete-batch destinations are left alone.",
        "Focused package tests for tests/functional/factory/packaged/goal pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as factory/packaged/goal).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)