### PR TITLE
pss-cut-def-run

### DIFF
--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -146,7 +146,12 @@ Use this map when changing the public REST contract.
   orchestrator implementation paths. Orchestration-specific semantic validation stays on the
   injected `OrchestratorDefinitionValidator` port; the nested validation
   subservice additionally forbids direct Runtime imports in
-  `internal/services/validation/boundary_test.go`.
+  `internal/services/validation/boundary_test.go`. Prove the sealed semantic
+  validation edge with
+  `pkg/services/factory_definitions/orchestration_semantic_validation_boundary_test.go`:
+  Definitions-owned strategy checks without a Runtime port, orchestration-invalid
+  targets through the injected port, and import guards on the validation and
+  orchestrator packages.
 - Factory Visualization HTTP decoding, root contract mapping, typed error
   translation, and cancel/timeout handling live in
   `pkg/services/factory_visualization/transports/http`. HTTP-VIS proves

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -157,6 +157,12 @@ Use this map when changing the public REST contract.
   import guards on the public `validation` package, AST checks on
   `validation_contract.go` and `contracts/validation.go`, and behavioral proofs
   that validation targets use Definitions-owned code/severity/subject vocabulary.
+  Prove typed invalid-topology, required-tool, and orchestrator/strategy cases on
+  the sealed public validation path with
+  `pkg/services/factory_definitions/sealed_validation_path_boundary_test.go`:
+  `validation.Service.ValidateTopology` and `Validate` behavioral proofs with
+  code/severity/subject or rule/path assertions, plus import guards on the
+  validation package for the Runtime semantic-validation edge.
 - Factory Visualization HTTP decoding, root contract mapping, typed error
   translation, and cancel/timeout handling live in
   `pkg/services/factory_visualization/transports/http`. HTTP-VIS proves

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -138,6 +138,15 @@ Use this map when changing the public REST contract.
   `pkg/transports/http` server composes injected service-owned adapters; HTTP-DEF
   proves fake-root parity at the adapter edge without importing Definitions
   internals.
+  CUT-DEF-RUN seals Factory Definitions production imports of Factory Runtime to
+  the service root only (`pkg/services/factory_runtime`) for orchestration
+  semantic-validation edges; the lease-wide guard is
+  `pkg/services/factory_definitions/runtime_import_boundary_test.go` and fails
+  closed on nested `factory_runtime/**`, legacy `pkg/factory/**`, and Petri
+  orchestrator implementation paths. Orchestration-specific semantic validation stays on the
+  injected `OrchestratorDefinitionValidator` port; the nested validation
+  subservice additionally forbids direct Runtime imports in
+  `internal/services/validation/boundary_test.go`.
 - Factory Visualization HTTP decoding, root contract mapping, typed error
   translation, and cancel/timeout handling live in
   `pkg/services/factory_visualization/transports/http`. HTTP-VIS proves

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -151,7 +151,12 @@ Use this map when changing the public REST contract.
   `pkg/services/factory_definitions/orchestration_semantic_validation_boundary_test.go`:
   Definitions-owned strategy checks without a Runtime port, orchestration-invalid
   targets through the injected port, and import guards on the validation and
-  orchestrator packages.
+  orchestrator packages. Keep Petri engine types off the Definitions validation
+  peer surface with
+  `pkg/services/factory_definitions/validation_peer_surface_boundary_test.go`:
+  import guards on the public `validation` package, AST checks on
+  `validation_contract.go` and `contracts/validation.go`, and behavioral proofs
+  that validation targets use Definitions-owned code/severity/subject vocabulary.
 - Factory Visualization HTTP decoding, root contract mapping, typed error
   translation, and cancel/timeout handling live in
   `pkg/services/factory_visualization/transports/http`. HTTP-VIS proves

--- a/pkg/services/factory_definitions/orchestration_semantic_validation_boundary_test.go
+++ b/pkg/services/factory_definitions/orchestration_semantic_validation_boundary_test.go
@@ -1,0 +1,169 @@
+package factorydefinitions_test
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	factorycontracts "github.com/portpowered/infinite-you/pkg/services/factory_definitions/contracts"
+	factoryvalidation "github.com/portpowered/infinite-you/pkg/services/factory_definitions/validation"
+)
+
+var orchestrationSemanticValidationPackages = []string{
+	factoryDefinitionsRoot + "/validation",
+	factoryDefinitionsRoot + "/internal/services/validation/internal/orchestrator",
+}
+
+// TestOrchestrationSemanticValidationPackagesImportNoRuntimeImplementation seals
+// CUT-DEF-RUN story 002: orchestration-specific semantic validation under
+// Factory Definitions may reach Factory Runtime only through the injected
+// OrchestratorDefinitionValidator port, not nested Runtime implementation paths.
+func TestOrchestrationSemanticValidationPackagesImportNoRuntimeImplementation(t *testing.T) {
+	t.Parallel()
+
+	for _, pkg := range orchestrationSemanticValidationPackages {
+		pkg := pkg
+		t.Run(shortFactoryDefinitionsPackageName(pkg), func(t *testing.T) {
+			t.Parallel()
+			assertProductionImportsUseRuntimeRootOnly(t, pkg)
+		})
+	}
+}
+
+// TestOrchestrationSemanticValidation_DefinitionsOwnedStrategyCheckWithoutRuntimePort
+// proves Definitions-owned orchestrator/strategy checks remain on Definitions
+// vocabulary and do not require a Runtime-backed validator.
+func TestOrchestrationSemanticValidation_DefinitionsOwnedStrategyCheckWithoutRuntimePort(t *testing.T) {
+	t.Parallel()
+
+	validator := factoryvalidation.New(nil)
+	cfg := &factorycontracts.FactoryConfig{
+		Name: "unsupported-orchestrator",
+		Orchestrator: &factorycontracts.FactoryOrchestratorConfig{
+			Kind: "LEGACY",
+		},
+	}
+
+	result := validator.Validate(context.Background(), cfg, nil)
+	found := false
+	for _, target := range result.Targets {
+		if target.Code == factoryvalidation.CodeOrchestratorUnsupportedKind &&
+			target.Severity == factorycontracts.ValidationSeverityError &&
+			target.Subject.Type == factorycontracts.ValidationSubjectTypeFactory &&
+			target.Subject.Location == factorycontracts.ValidationSubjectLocationDefinition {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("validation targets = %#v, want Definitions-owned unsupported orchestrator kind target", result.Targets)
+	}
+}
+
+// TestOrchestrationSemanticValidation_InvalidOrchestrationReturnsDefinitionsOwnedTargets
+// proves orchestration-invalid definitions yield Definitions-owned validation
+// targets (code, severity, subject) through the sealed Runtime semantic-validation
+// port without Definitions importing Runtime implementation packages.
+func TestOrchestrationSemanticValidation_InvalidOrchestrationReturnsDefinitionsOwnedTargets(t *testing.T) {
+	t.Parallel()
+
+	cfg := validJavaScriptOrchestratorConfig()
+	validator := factoryvalidation.New(runtimeSemanticValidationStub{targets: []factorycontracts.ValidationTarget{{
+		Code:     "workflow.source.syntaxError",
+		Severity: factorycontracts.ValidationSeverityError,
+		Message:  "unexpected token",
+		Path:     "factory.orchestrator.javascript.inlineSource",
+		Subject: factorycontracts.ValidationSubject{
+			Type:     factorycontracts.ValidationSubjectTypeFactory,
+			ID:       "factory",
+			Location: factorycontracts.ValidationSubjectLocationDefinition,
+		},
+	}}})
+
+	result := validator.Validate(context.Background(), cfg, nil)
+	found := false
+	for _, target := range result.Targets {
+		if target.Code == "workflow.source.syntaxError" &&
+			target.Severity == factorycontracts.ValidationSeverityError &&
+			target.Subject.Type == factorycontracts.ValidationSubjectTypeFactory &&
+			target.Subject.ID == "factory" &&
+			target.Subject.Location == factorycontracts.ValidationSubjectLocationDefinition &&
+			target.Path == "factory.orchestrator.javascript.inlineSource" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("validation targets = %#v, want orchestration-invalid runtime semantic target", result.Targets)
+	}
+}
+
+// TestOrchestrationSemanticValidation_ValidOrchestrationProducesNoRuntimeTargets
+// proves equivalent orchestration-valid inputs still produce no runtime-owned
+// semantic validation findings when the sealed port reports success.
+func TestOrchestrationSemanticValidation_ValidOrchestrationProducesNoRuntimeTargets(t *testing.T) {
+	t.Parallel()
+
+	cfg := validJavaScriptOrchestratorConfig()
+	validator := factoryvalidation.New(runtimeSemanticValidationStub{})
+
+	result := validator.Validate(context.Background(), cfg, nil)
+	for _, target := range result.Targets {
+		if strings.HasPrefix(target.Code, "workflow.") ||
+			strings.HasPrefix(target.Code, "JAVASCRIPT_") {
+			t.Fatalf("validation targets = %#v, want no runtime semantic validation findings", result.Targets)
+		}
+	}
+}
+
+// TestOrchestrationSemanticValidationPortContractUsesDefinitionsVocabularyOnly
+// proves the OrchestratorDefinitionValidator port surface stays on
+// Definitions-owned contracts and does not pull Runtime implementation types
+// into the orchestration semantic validation packages.
+func TestOrchestrationSemanticValidationPortContractUsesDefinitionsVocabularyOnly(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command(
+		"go",
+		"list",
+		"-f",
+		"{{join .Imports \"\\n\"}}",
+		factoryDefinitionsRoot+"/contracts",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list imports for contracts: %v\n%s", err, output)
+	}
+	for _, importPath := range strings.Fields(string(output)) {
+		if isForbiddenFactoryDefinitionsRuntimeImport(importPath) {
+			t.Fatalf(
+				"contracts import %s is forbidden on OrchestratorDefinitionValidator port; use Definitions vocabulary only",
+				importPath,
+			)
+		}
+	}
+}
+
+func validJavaScriptOrchestratorConfig() *factorycontracts.FactoryConfig {
+	return &factorycontracts.FactoryConfig{
+		Name: "javascript-orchestrator",
+		Orchestrator: &factorycontracts.FactoryOrchestratorConfig{
+			Kind: factorycontracts.OrchestratorKindJavaScript,
+			JavaScript: &factorycontracts.FactoryOrchestratorJavaScriptConfig{
+				SourceRef:  "factory/workflows/review.js",
+				Entrypoint: "main",
+			},
+		},
+	}
+}
+
+type runtimeSemanticValidationStub struct {
+	targets []factorycontracts.ValidationTarget
+}
+
+func (s runtimeSemanticValidationStub) ValidateJavaScriptFactoryDefinition(
+	_ context.Context,
+	_ *factorycontracts.FactoryOrchestratorJavaScriptConfig,
+	_ factorycontracts.WorkflowSourceReader,
+) []factorycontracts.ValidationTarget {
+	return append([]factorycontracts.ValidationTarget(nil), s.targets...)
+}

--- a/pkg/services/factory_definitions/runtime_import_boundary_test.go
+++ b/pkg/services/factory_definitions/runtime_import_boundary_test.go
@@ -1,0 +1,88 @@
+package factorydefinitions_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+const (
+	modulePrefix          = "github.com/portpowered/infinite-you/"
+	factoryRuntimeRoot    = modulePrefix + "pkg/services/factory_runtime"
+	factoryDefinitionsRoot = modulePrefix + "pkg/services/factory_definitions"
+)
+
+// TestProductionPackagesImportFactoryRuntimeRootOnly seals CUT-DEF-RUN story 001:
+// Factory Definitions production packages may depend on Factory Runtime only
+// through the service root contract, not nested Runtime implementation, Petri,
+// or legacy helper paths.
+func TestProductionPackagesImportFactoryRuntimeRootOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, pkg := range listFactoryDefinitionsPackages(t) {
+		pkg := pkg
+		t.Run(shortFactoryDefinitionsPackageName(pkg), func(t *testing.T) {
+			t.Parallel()
+			assertProductionImportsUseRuntimeRootOnly(t, pkg)
+		})
+	}
+}
+
+func listFactoryDefinitionsPackages(t *testing.T) []string {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", factoryDefinitionsRoot+"/...")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list factory definitions packages: %v\n%s", err, output)
+	}
+	return strings.Fields(string(output))
+}
+
+func assertProductionImportsUseRuntimeRootOnly(t *testing.T, packagePath string) {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", "-f", "{{join .Imports \"\\n\"}}", packagePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list imports for %s: %v\n%s", packagePath, err, output)
+	}
+	for _, importPath := range strings.Fields(string(output)) {
+		if isForbiddenFactoryDefinitionsRuntimeImport(importPath) {
+			t.Fatalf(
+				"%s production import %s is forbidden; use %s or a Definitions-owned injected port backed by Runtime root capability",
+				packagePath,
+				importPath,
+				factoryRuntimeRoot,
+			)
+		}
+	}
+}
+
+func isForbiddenFactoryDefinitionsRuntimeImport(importPath string) bool {
+	if importPath == factoryRuntimeRoot {
+		return false
+	}
+	if strings.HasPrefix(importPath, factoryRuntimeRoot+"/") {
+		return true
+	}
+	if importPath == modulePrefix+"pkg/factory" ||
+		strings.HasPrefix(importPath, modulePrefix+"pkg/factory/") {
+		return true
+	}
+	if strings.HasPrefix(importPath, modulePrefix+"pkg/services/factory_runtime/internal/orchestrators/petri") {
+		return true
+	}
+	return false
+}
+
+func shortFactoryDefinitionsPackageName(packagePath string) string {
+	if strings.HasPrefix(packagePath, factoryDefinitionsRoot) {
+		rest := strings.TrimPrefix(packagePath, factoryDefinitionsRoot)
+		if rest == "" {
+			return "factory_definitions"
+		}
+		return strings.TrimPrefix(rest, "/")
+	}
+	return packagePath
+}

--- a/pkg/services/factory_definitions/sealed_validation_path_boundary_test.go
+++ b/pkg/services/factory_definitions/sealed_validation_path_boundary_test.go
@@ -1,0 +1,199 @@
+package factorydefinitions_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	factorycontracts "github.com/portpowered/infinite-you/pkg/services/factory_definitions/contracts"
+	factoryvalidation "github.com/portpowered/infinite-you/pkg/services/factory_definitions/validation"
+	workerconfig "github.com/portpowered/infinite-you/pkg/services/factory_definitions/workers"
+)
+
+var sealedValidationPathPackages = []string{
+	factoryDefinitionsRoot + "/validation",
+}
+
+// TestSealedValidationPathPackagesImportNoRuntimeImplementation seals CUT-DEF-RUN
+// story 004: the public validation service may reach Factory Runtime only through
+// the injected OrchestratorDefinitionValidator port, not nested Runtime paths.
+func TestSealedValidationPathPackagesImportNoRuntimeImplementation(t *testing.T) {
+	t.Parallel()
+
+	for _, pkg := range sealedValidationPathPackages {
+		pkg := pkg
+		t.Run(shortFactoryDefinitionsPackageName(pkg), func(t *testing.T) {
+			t.Parallel()
+			assertProductionImportsUseRuntimeRootOnly(t, pkg)
+		})
+	}
+}
+
+// TestSealedValidationPath_InvalidTopologyReturnsTypedTarget proves an
+// invalid-topology case through the public validation service boundary with
+// observable Definitions-owned code, severity, and path fields.
+func TestSealedValidationPath_InvalidTopologyReturnsTypedTarget(t *testing.T) {
+	t.Parallel()
+
+	cfg := sealedValidationPathPetriFactoryConfig()
+	cfg.Workstations[0].Outputs = []factorycontracts.IOConfig{{
+		WorkTypeName: "task",
+		StateName:    "bogus",
+	}}
+
+	validator := factoryvalidation.New(nil)
+	result := validator.ValidateTopology(context.Background(), cfg, nil)
+	if !result.HasErrors() {
+		t.Fatal("expected blocking topology findings")
+	}
+
+	found := false
+	for _, finding := range result.Findings {
+		if finding.Rule == factoryvalidation.CodeDanglingPlaceReference &&
+			finding.Severity == factorycontracts.ValidationSeverityError &&
+			finding.Path != "" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("topology findings = %#v, want typed dangling place topology finding", result.Findings)
+	}
+}
+
+// TestSealedValidationPath_InvalidRequiredToolReturnsTypedTarget proves an
+// invalid/missing required-tool case through the public validation service
+// boundary with observable Definitions-owned rule, severity, and path fields.
+func TestSealedValidationPath_InvalidRequiredToolReturnsTypedTarget(t *testing.T) {
+	t.Parallel()
+
+	cfg := sealedValidationPathPetriFactoryConfig()
+	cfg.ResourceManifest = &factorycontracts.PortableResourceManifestConfig{
+		RequiredTools: []factorycontracts.RequiredToolConfig{{
+			Name:    "Missing helper",
+			Command: "missing-tool",
+		}},
+	}
+	checker := sealedValidationPathRequiredToolChecker{
+		"missing-tool": {
+			FailureKind: factorycontracts.RequiredToolFailureKindMissing,
+			Err:         errors.New(`required tool "Missing helper" command "missing-tool" was not found on PATH`),
+		},
+	}
+
+	validator := factoryvalidation.New(nil)
+	result := validator.ValidateTopology(context.Background(), cfg, checker)
+	if !result.HasErrors() {
+		t.Fatal("expected blocking required-tool findings")
+	}
+
+	found := false
+	for _, finding := range result.Findings {
+		if finding.Rule == "required-tool-missing" &&
+			finding.Severity == factorycontracts.ValidationSeverityError &&
+			finding.Path == "resourceManifest.requiredTools[0].command" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("topology findings = %#v, want typed missing required-tool finding", result.Findings)
+	}
+}
+
+// TestSealedValidationPath_InvalidOrchestratorStrategyReturnsTypedTarget proves
+// an invalid orchestrator/strategy case through the public validation service
+// boundary with observable Definitions-owned code, severity, and subject fields.
+func TestSealedValidationPath_InvalidOrchestratorStrategyReturnsTypedTarget(t *testing.T) {
+	t.Parallel()
+
+	cfg := sealedValidationPathPetriFactoryConfig()
+	cfg.Orchestrator = &factorycontracts.FactoryOrchestratorConfig{Kind: "LEGACY"}
+
+	validator := factoryvalidation.New(nil)
+	result := validator.Validate(context.Background(), cfg, nil)
+	if !result.HasBlockingTargets() {
+		t.Fatal("expected blocking orchestrator strategy targets")
+	}
+
+	found := false
+	for _, target := range result.Targets {
+		assertValidationTargetUsesDefinitionsVocabulary(t, target)
+		if target.Code == factoryvalidation.CodeOrchestratorUnsupportedKind &&
+			target.Severity == factorycontracts.ValidationSeverityError &&
+			target.Subject.Type == factorycontracts.ValidationSubjectTypeFactory &&
+			target.Subject.Location == factorycontracts.ValidationSubjectLocationDefinition {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("validation targets = %#v, want typed unsupported orchestrator strategy target", result.Targets)
+	}
+}
+
+// TestSealedValidationPath_RuntimeSemanticValidationThroughSealedPort proves
+// orchestration-invalid semantic validation still flows through the injected
+// Runtime root port on the public validation service without Definitions
+// importing Runtime implementation packages.
+func TestSealedValidationPath_RuntimeSemanticValidationThroughSealedPort(t *testing.T) {
+	t.Parallel()
+
+	cfg := validJavaScriptOrchestratorConfig()
+	validator := factoryvalidation.New(runtimeSemanticValidationStub{targets: []factorycontracts.ValidationTarget{{
+		Code:     "workflow.source.syntaxError",
+		Severity: factorycontracts.ValidationSeverityError,
+		Message:  "unexpected token",
+		Path:     "factory.orchestrator.javascript.inlineSource",
+		Subject: factorycontracts.ValidationSubject{
+			Type:     factorycontracts.ValidationSubjectTypeFactory,
+			ID:       "factory",
+			Location: factorycontracts.ValidationSubjectLocationDefinition,
+		},
+	}}})
+
+	result := validator.Validate(context.Background(), cfg, nil)
+	found := false
+	for _, target := range result.Targets {
+		assertValidationTargetUsesDefinitionsVocabulary(t, target)
+		if target.Code == "workflow.source.syntaxError" &&
+			target.Severity == factorycontracts.ValidationSeverityError &&
+			target.Subject.Type == factorycontracts.ValidationSubjectTypeFactory &&
+			target.Path == "factory.orchestrator.javascript.inlineSource" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("validation targets = %#v, want orchestration-invalid runtime semantic target through sealed port", result.Targets)
+	}
+}
+
+func sealedValidationPathPetriFactoryConfig() *factorycontracts.FactoryConfig {
+	return &factorycontracts.FactoryConfig{
+		Name: "sealed-validation-path",
+		WorkTypes: []factorycontracts.WorkTypeConfig{{
+			Name: "task",
+			States: []factorycontracts.StateConfig{
+				{Name: "init", Type: factorycontracts.StateTypeInitial},
+				{Name: "done", Type: factorycontracts.StateTypeTerminal},
+				{Name: "failed", Type: factorycontracts.StateTypeFailed},
+			},
+		}},
+		Workers: []workerconfig.Config{{Name: "worker-a"}},
+		Workstations: []factorycontracts.FactoryWorkstationConfig{{
+			Name:           "process",
+			WorkerTypeName: "worker-a",
+			Inputs:         []factorycontracts.IOConfig{{WorkTypeName: "task", StateName: "init"}},
+			Outputs:        []factorycontracts.IOConfig{{WorkTypeName: "task", StateName: "done"}},
+			OnFailure:      []factorycontracts.IOConfig{{WorkTypeName: "task", StateName: "failed"}},
+		}},
+	}
+}
+
+type sealedValidationPathRequiredToolChecker map[string]factorycontracts.RequiredToolCheckResult
+
+func (s sealedValidationPathRequiredToolChecker) Check(
+	tool factorycontracts.RequiredToolConfig,
+) factorycontracts.RequiredToolCheckResult {
+	if result, ok := s[tool.Command]; ok {
+		return result
+	}
+	return factorycontracts.RequiredToolCheckResult{}
+}

--- a/pkg/services/factory_definitions/validation_peer_surface_boundary_test.go
+++ b/pkg/services/factory_definitions/validation_peer_surface_boundary_test.go
@@ -1,0 +1,260 @@
+package factorydefinitions_test
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	factorycontracts "github.com/portpowered/infinite-you/pkg/services/factory_definitions/contracts"
+	factoryvalidation "github.com/portpowered/infinite-you/pkg/services/factory_definitions/validation"
+	workerconfig "github.com/portpowered/infinite-you/pkg/services/factory_definitions/workers"
+)
+
+var validationPeerSurfacePackages = []string{
+	factoryDefinitionsRoot + "/validation",
+}
+
+var validationPeerSurfaceSourceFiles = []string{
+	"validation_contract.go",
+	filepath.Join("contracts", "validation.go"),
+}
+
+// prohibitedValidationPeerPetriEngineSymbols maps raw Petri live-engine symbols
+// that must not appear on the Definitions validation peer surface. Authored
+// Factory Definition orchestrator.kind = PETRI configuration remains allowed.
+var prohibitedValidationPeerPetriEngineSymbols = map[string]struct{}{
+	"Net":                    {},
+	"RuntimeNet":             {},
+	"PetriMarking":           {},
+	"PetriMarkingSnapshot":   {},
+	"RuntimeToken":           {},
+	"RuntimeTokenColor":      {},
+	"PetriTransition":        {},
+	"EnabledTransition":      {},
+	"EngineStateSnapshot":    {},
+	"StateSnapshot":          {},
+	"NewEngineStateSnapshot": {},
+	"MarkingMutation":        {},
+}
+
+var forbiddenValidationPeerImportPrefixes = []string{
+	modulePrefix + "pkg/services/factory_runtime",
+	modulePrefix + "pkg/factory",
+	modulePrefix + "pkg/orchestrators/petri",
+	modulePrefix + "pkg/petri",
+}
+
+// TestValidationPeerSurfacePackagesImportNoPetriEngineOrRuntimeInternals seals
+// CUT-DEF-RUN story 003: the public validation package may not import Factory
+// Runtime, Petri engine, or legacy factory helper packages.
+func TestValidationPeerSurfacePackagesImportNoPetriEngineOrRuntimeInternals(t *testing.T) {
+	t.Parallel()
+
+	for _, pkg := range validationPeerSurfacePackages {
+		pkg := pkg
+		t.Run(shortFactoryDefinitionsPackageName(pkg), func(t *testing.T) {
+			t.Parallel()
+			assertValidationPeerSurfaceImportsForbidden(t, pkg)
+		})
+	}
+}
+
+// TestValidationPeerSurfaceContractsDeclareOnlyDefinitionsValidationVocabulary
+// fails closed when validation peer contract sources export Petri engine types
+// or require Runtime/Petri implementation packages.
+func TestValidationPeerSurfaceContractsDeclareOnlyDefinitionsValidationVocabulary(t *testing.T) {
+	t.Parallel()
+
+	for _, relPath := range validationPeerSurfaceSourceFiles {
+		relPath := relPath
+		t.Run(filepath.ToSlash(relPath), func(t *testing.T) {
+			t.Parallel()
+			assertValidationPeerSurfaceSourceUsesDefinitionsVocabularyOnly(t, relPath)
+		})
+	}
+}
+
+// TestValidationPeerSurface_ReturnsDefinitionsOwnedTargets proves validation
+// results returned through the peer surface use Definitions-owned targets with
+// code, severity, and subject fields rather than Petri-shaped diagnostics.
+func TestValidationPeerSurface_ReturnsDefinitionsOwnedTargets(t *testing.T) {
+	t.Parallel()
+
+	cfg := peerSurfacePetriScopedFactoryConfig()
+	cfg.Workstations[0].Outputs = []factorycontracts.IOConfig{{
+		WorkTypeName: "task",
+		StateName:    "missing-state",
+	}}
+
+	result := factoryvalidation.ValidateGraphTopology(cfg)
+	if !result.HasBlockingTargets() {
+		t.Fatal("expected blocking topology targets")
+	}
+
+	found := false
+	for _, target := range result.Targets {
+		assertValidationTargetUsesDefinitionsVocabulary(t, target)
+		if target.Code == factoryvalidation.CodeDanglingPlaceReference {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("validation targets = %#v, want typed dangling place topology target", result.Targets)
+	}
+}
+
+// TestValidationPeerSurface_PeerConsumesValidationContractsWithoutPetriImports
+// proves a peer-shaped consumer can depend on validation contracts and exercise
+// validation outcomes using only Definitions-owned vocabulary.
+func TestValidationPeerSurface_PeerConsumesValidationContractsWithoutPetriImports(t *testing.T) {
+	t.Parallel()
+
+	var validator factorycontracts.Validator = factoryvalidation.New(nil)
+	cfg := &factorycontracts.FactoryConfig{
+		Name: "unsupported-orchestrator",
+		Orchestrator: &factorycontracts.FactoryOrchestratorConfig{
+			Kind: "LEGACY",
+		},
+	}
+
+	result := validator.Validate(context.Background(), cfg, nil)
+	for _, target := range result.Targets {
+		assertValidationTargetUsesDefinitionsVocabulary(t, target)
+	}
+}
+
+// TestValidationPeerSurfaceScannerFailsClosedOnSyntheticPetriLeak proves the
+// peer-surface guard rejects prohibited Petri engine symbols instead of only
+// passing on the current tree.
+func TestValidationPeerSurfaceScannerFailsClosedOnSyntheticPetriLeak(t *testing.T) {
+	t.Parallel()
+
+	const synthetic = `
+package synthetic
+
+type LeakedValidationSurface struct {
+	Marking PetriMarkingSnapshot
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "synthetic.go", synthetic, 0)
+	if err != nil {
+		t.Fatalf("parse synthetic source: %v", err)
+	}
+	if !validationPeerSurfaceFileDeclaresProhibitedPetriSymbol(file) {
+		t.Fatal("expected synthetic Petri engine symbol to be detected")
+	}
+}
+
+func assertValidationPeerSurfaceImportsForbidden(t *testing.T, packagePath string) {
+	t.Helper()
+	assertProductionImportsUseRuntimeRootOnly(t, packagePath)
+
+	output, err := execListImports(packagePath)
+	if err != nil {
+		t.Fatalf("go list imports for %s: %v\n%s", packagePath, err, output)
+	}
+	for _, importPath := range strings.Fields(output) {
+		for _, forbidden := range forbiddenValidationPeerImportPrefixes {
+			if importPath == forbidden || strings.HasPrefix(importPath, forbidden+"/") {
+				t.Fatalf(
+					"%s validation peer import %s is forbidden; keep Petri engine and Runtime implementation types off the validation peer surface",
+					packagePath,
+					importPath,
+				)
+			}
+		}
+	}
+}
+
+func execListImports(packagePath string) (string, error) {
+	cmd := exec.Command("go", "list", "-f", "{{join .Imports \"\\n\"}}", packagePath)
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func assertValidationPeerSurfaceSourceUsesDefinitionsVocabularyOnly(t *testing.T, relPath string) {
+	t.Helper()
+
+	sourcePath := relPath
+	if _, err := os.Stat(sourcePath); err != nil {
+		t.Fatalf("stat %s: %v", relPath, err)
+	}
+	file, err := parser.ParseFile(token.NewFileSet(), sourcePath, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", relPath, err)
+	}
+	if validationPeerSurfaceFileDeclaresProhibitedPetriSymbol(file) {
+		t.Fatalf("%s exports or references prohibited Petri engine symbols on the validation peer surface", relPath)
+	}
+}
+
+func validationPeerSurfaceFileDeclaresProhibitedPetriSymbol(file *ast.File) bool {
+	found := false
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch typed := node.(type) {
+		case *ast.Ident:
+			if _, prohibited := prohibitedValidationPeerPetriEngineSymbols[typed.Name]; prohibited {
+				found = true
+				return false
+			}
+		case *ast.TypeSpec:
+			if _, prohibited := prohibitedValidationPeerPetriEngineSymbols[typed.Name.Name]; prohibited {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func assertValidationTargetUsesDefinitionsVocabulary(t *testing.T, target factorycontracts.ValidationTarget) {
+	t.Helper()
+
+	if strings.TrimSpace(target.Code) == "" {
+		t.Fatalf("validation target must carry Definitions-owned code: %#v", target)
+	}
+	if target.Severity != factorycontracts.ValidationSeverityError &&
+		target.Severity != factorycontracts.ValidationSeverityWarning &&
+		target.Severity != factorycontracts.ValidationSeverityHint {
+		t.Fatalf("validation target severity = %q, want Definitions-owned severity", target.Severity)
+	}
+	if strings.TrimSpace(string(target.Subject.Type)) == "" {
+		t.Fatalf("validation target must carry Definitions-owned subject type: %#v", target)
+	}
+	if strings.Contains(strings.ToLower(target.Code), "petrimarking") ||
+		strings.Contains(strings.ToLower(target.Code), "runtime.token") ||
+		strings.Contains(strings.ToLower(target.Message), "petri marking") ||
+		strings.Contains(strings.ToLower(target.Message), "enabled transition") {
+		t.Fatalf("validation target leaked Petri engine vocabulary: %#v", target)
+	}
+}
+
+func peerSurfacePetriScopedFactoryConfig() *factorycontracts.FactoryConfig {
+	return &factorycontracts.FactoryConfig{
+		Name: "peer-surface-topology",
+		WorkTypes: []factorycontracts.WorkTypeConfig{{
+			Name: "task",
+			States: []factorycontracts.StateConfig{
+				{Name: "init", Type: factorycontracts.StateTypeInitial},
+				{Name: "done", Type: factorycontracts.StateTypeTerminal},
+				{Name: "failed", Type: factorycontracts.StateTypeFailed},
+			},
+		}},
+		Workers: []workerconfig.Config{{Name: "worker-a"}},
+		Workstations: []factorycontracts.FactoryWorkstationConfig{{
+			Name:           "process",
+			WorkerTypeName: "worker-a",
+			Inputs:         []factorycontracts.IOConfig{{WorkTypeName: "task", StateName: "init"}},
+			Outputs:        []factorycontracts.IOConfig{{WorkTypeName: "task", StateName: "done"}},
+			OnFailure:      []factorycontracts.IOConfig{{WorkTypeName: "task", StateName: "failed"}},
+		}},
+	}
+}


### PR DESCRIPTION
{
  "project": "CUT-DEF-RUN: Definitions consumes Runtime root only for validation edges",
  "branchName": "pss-cut-def-run",
  "description": "Seal the Factory Definitions→Factory Runtime consumer edge so Definitions reaches Runtime only through the Runtime service root contract for orchestration-specific semantic validation, with typed invalid topology/tool/strategy proofs and no Petri exposure on the Definitions peer surface, without reopening IMP-RUN ownership or DEF package folds, and with delivery continuing until required CI is terminal green, blocking feedback is addressed, conflicts are resolved, and the PR is merged.",
  "context": {
    "customerAsk": "CUT-DEF-RUN: lease Factory Definitions call sites that still reach Factory Runtime through non-root paths; retarget them to the Runtime service root contract for orchestration-specific semantic validation only, with typed invalid topology/tool/strategy cases and no Petri exposure on the Definitions surface. Do not reopen IMP-RUN ownership or DEF package folds. Loop until CI is terminal green, blocking feedback is addressed, conflicts are resolved, and the PR is merged.",
    "problem": "Definitions validation is supposed to call Factory Runtime only through the Runtime root for orchestration-specific semantic validation, but legacy edges may still reach Runtime implementation or Petri-shaped surfaces. Those leaks couple Definitions to Runtime ownership internals and block later Definitions fold/delete packets.",
    "solution": "Retarget Definitions→Runtime validation consumer edges to the Runtime service root contract for orchestration-specific semantic validation only, keep Petri types off the Definitions peer surface, prove typed invalid topology/tool/strategy outcomes on the sealed path, and leave IMP-RUN ownership and DEF package folds out of scope."
  },
  "acceptanceCriteria": [
    "Definitions production code reaches Factory Runtime only through the Runtime root contract for orchestration-specific semantic validation",
    "No Petri types appear on the Definitions peer surface used by validation consumers",
    "Focused typed invalid-topology, invalid-tool, and invalid-strategy proofs pass through the sealed validation path",
    "Observable Definitions validation outcomes for equivalent inputs are preserved",
    "Quality checks pass (typecheck, lint, and tests); required CI is terminal and green",
    "Delivery loop completes: blocking PR feedback addressed, merge conflicts resolved, and the PR is merged before Factory completion"
  ],
  "userStories": [
    {
      "id": "pss-cut-def-run-001",
      "title": "Seal Definitions→Runtime imports to the Runtime root",
      "description": "As a maintainer, I need Factory Definitions production packages that reach Factory Runtime for semantic validation to depend only on pkg/services/factory_runtime so Definitions cannot couple to Runtime implementation or Petri/engine packages.",
      "acceptanceCriteria": [
        "Every Definitions production import of Factory Runtime used for validation/semantic-validation edges resolves to the Runtime service root (pkg/services/factory_runtime), not factory_runtime/service/**, factory_runtime/javascript/**, factory_runtime/internal/**, Petri/engine packages, or other nested Runtime surfaces",
        "Any Definitions call site still reaching Runtime through a non-root surface for orchestration-specific semantic validation is retargeted to the Runtime root contract or a Definitions-owned injected port whose concrete Runtime collaborator is constructed only from root-exported capability",
        "No new Definitions import of Runtime implementation or Petri packages is introduced",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cut-def-run-002",
      "title": "Orchestration semantic validation uses Runtime root only",
      "description": "As a Factory Definitions validation owner, I want orchestration-specific semantic validation to invoke Factory Runtime only through the Runtime root contract so Definitions validation stays on Definitions vocabulary while Runtime owns orchestration semantics.",
      "acceptanceCriteria": [
        "Orchestration-specific semantic validation under the Definitions lease invokes Runtime only through the Runtime root contract or a Definitions-owned port (OrchestratorDefinitionValidator / equivalent) whose Runtime-backed implementation is reached from the Runtime root, not nested Runtime packages",
        "Structural, topology, required-tool, and Definitions-owned strategy checks remain on Definitions validation vocabulary and do not import Runtime implementation packages to obtain those outcomes",
        "A focused Definitions/Runtime boundary test shows an orchestration-invalid definition yields Definitions-owned validation targets (code, severity, subject) through the sealed Runtime semantic-validation edge without importing Runtime implementation packages from Definitions",
        "Equivalent orchestration-valid and orchestration-invalid inputs still produce the same observable validation outcomes as before the cut",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cut-def-run-003",
      "title": "Keep Petri types off the Definitions peer surface",
      "description": "As a peer consumer of Factory Definitions, I want the Definitions validation peer surface to expose only Definitions-owned validation vocabulary so callers never depend on Petri/net/engine types from Definitions.",
      "acceptanceCriteria": [
        "Definitions peer validation contracts and public validation surfaces used across the lease do not export or require Petri/net/engine types",
        "Validation results returned to peer callers use Definitions-owned targets/results rather than Petri-shaped diagnostics",
        "A focused boundary characterization or package test fails closed if the Definitions validation peer surface introduces Petri types",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cut-def-run-004",
      "title": "Prove typed invalid topology, tool, and strategy cases",
      "description": "As a reviewer of packaged-service boundaries, I want focused typed invalid topology, required-tool, and strategy proofs on the sealed Definitions validation path so CUT-DEF-RUN is behaviorally sealed rather than inventory-only.",
      "acceptanceCriteria": [
        "Focused validation proofs cover at least one typed invalid-topology case, one typed invalid/missing required-tool case, and one typed invalid orchestrator/strategy case",
        "Each proof asserts observable Definitions-owned fields reviewers can check (validation code, severity, subject type/path or equivalent typed fields), not merely that a type exists or that an import graph is empty",
        "Those proofs exercise the sealed validation path after the Runtime consumer-edge cut and fail closed if the exercised semantic-validation edge leaves the Runtime root",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cut-def-run-005",
      "title": "Close delivery through review, CI, and merge",
      "description": "As the Factory program owner, I want the CUT-DEF-RUN implementation loop to continue through review and required CI until the PR is actually merged so the packet is terminal rather than merely opened or approved.",
      "acceptanceCriteria": [
        "Implementation PR for CUT-DEF-RUN is opened with only the Definitions→Runtime consumer-edge lease scope",
        "Diff does not reopen IMP-RUN ownership, fold/delete DEF packages, open unrelated shared integrators, or edit root pkg/wire beyond an unavoidable Definitions→Runtime import retarget",
        "Required CI is terminal and passing on the merge candidate",
        "Every blocking PR conversation comment is explicitly addressed",
        "Merge conflicts and shared-file collisions are reconciled with concurrent packets",
        "PR is actually merged; opened/green/approved/ready-to-merge alone does not satisfy completion",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": false,
      "notes": ""
    }
  ]
}
