### PR TITLE
ft-wave2-factory-subagent-invocation

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -306,6 +306,17 @@
   Catalog metadata infers domain `workers` and subsection `mock` from the path;
   every top-level `Test*` needs a customer-readable Go doc so
   `functionaltestmetadata` stays viz-compatible.
+  Packaged `@you/subagent` invocation functional coverage belongs in
+  `tests/functional/factory/packaged/subagent/invocation_test.go`: prove child
+  primary-result return through public CLI JSON and hermetic no-server named
+  invocation, child Factory Response Event streaming on
+  `GET /factory-sessions/~default/response-events`, and stable child failure
+  through CLI JSON plus API invocation with rejecting mock workers. Drive proofs
+  through `support.InstallPackagedFactory`, `support.WriteMockWorkersConfig`,
+  `support.BuildProcess`, and `support.StartFunctionalAPIServer` without
+  service-internal Petri imports. Catalog metadata infers domain `factory` and
+  subsection `packaged/subagent` from the path; every top-level `Test*` needs a
+  customer-readable Go doc so `functionaltestmetadata` stays viz-compatible.
   CLI single-JSON result functional coverage belongs in
   `tests/functional/transport/cli/output/json_result_test.go`: invoke
   `support.BuildProcess(t, serviceedges.Edges{}).Execute` with global `--json`

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -1758,7 +1758,14 @@ response-stream output.
 - `pkg/services/factory_definitions/packages/subagent/` retains only packaged
   subagent metadata and response-shaping behavior; shared catalog validation,
   installation tests, and public functional outcomes own definition evidence.
-- Hermetic no-server named `@you/subagent` package proof lives in
+- Packaged `@you/subagent` invocation functional coverage lives in
+  `tests/functional/factory/packaged/subagent/invocation_test.go` for child
+  primary-result return, child Factory Response Event streaming, and stable child
+  failure through public CLI/API boundaries with mock workers. The mapped
+  `test-built-cli-acceptance` specialty binding for
+  `TestSubagentInvocation_SuccessfulNamedRun_ReturnsAuthoritativePrimaryResultJSON`
+  remains in `tests/functional/acceptance/invoke_repeat_subagent_outcomes_test.go`.
+- Hermetic no-server named `@you/subagent` package proof also lives in
   `pkg/transports/cli/run/run_invocation_test.go`
   (`TestRun_NamedSubagentHermeticInvocationSucceedsWithoutListeningServer`,
   `TestRun_NamedSubagentNoServerBootstrap_TextPrimaryResultIsAgentResponse`,

--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -7289,6 +7289,36 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/factory/packaged/subagent/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/subagent",
+      "scenario": "TestPackagedSubagentReturnsChildResult",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/subagent/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/subagent/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/subagent",
+      "scenario": "TestPackagedSubagentStreamsChildResponseEvents",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/subagent/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/subagent/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/subagent",
+      "scenario": "TestPackagedSubagentChildFailureReturnsStableFailure",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/subagent/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/sessions/mcp/controls_test.go",
       "package": "you-agent-factory/tests/functional/sessions/mcp",
       "scenario": "TestMCPPauseResumeAndCancelTargetCanonicalFactorySession",
@@ -7399,12 +7429,12 @@
       "deletion_only_batch": "n/a"
     }
   ],
-  "scanned_at_utc": "2026-07-28T04:35:00Z",
+  "scanned_at_utc": "2026-07-28T05:00:00Z",
   "summary": {
     "by_catch_all": {
       "bootstrap_portability": 22,
       "guards_batch": 23,
-      "none": 457,
+      "none": 460,
       "replay_contracts": 23,
       "runtime_api": 96,
       "smoke": 62,
@@ -7415,7 +7445,7 @@
       "automations": 7,
       "bootstrap_portability": 21,
       "cli": 59,
-      "factory": 11,
+      "factory": 12,
       "guards_batch": 23,
       "models": 5,
       "observability": 9,
@@ -7434,9 +7464,9 @@
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 720,
+    "customer_top_level_Test_scenarios": 723,
     "lane_functionallong": 95,
-    "lane_short": 625,
+    "lane_short": 628,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 12,
       "you-agent-factory/tests/functional/automations": 7,
@@ -7452,6 +7482,7 @@
       "you-agent-factory/tests/functional/factory/packaged/catalog": 7,
       "you-agent-factory/tests/functional/factory/packaged/deep_research": 3,
       "you-agent-factory/tests/functional/factory/packaged/goal": 4,
+      "you-agent-factory/tests/functional/factory/packaged/subagent": 3,
       "you-agent-factory/tests/functional/factory/runtime_lifecycle": 1,
       "you-agent-factory/tests/functional/guards_batch": 23,
       "you-agent-factory/tests/functional/models/model_invoke": 3,

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -684,7 +684,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestPackagedReviewRejectionCarriesFeedback` covers retry context.
   - `TestPackagedReviewRetryExhaustionFails` covers bounded failure.
 
-- [ ] `tests/functional/factory/packaged/subagent/invocation_test.go`
+- [x] `tests/functional/factory/packaged/subagent/invocation_test.go`
   - `TestPackagedSubagentReturnsChildResult` covers basic dispatch.
   - `TestPackagedSubagentStreamsChildResponseEvents` covers observation.
   - `TestPackagedSubagentChildFailureReturnsStableFailure` covers error.

--- a/tests/functional/factory/packaged/subagent/invocation_test.go
+++ b/tests/functional/factory/packaged/subagent/invocation_test.go
@@ -79,6 +79,42 @@ func TestPackagedSubagentStreamsChildResponseEvents(t *testing.T) {
 	assertPackagedSubagentChildResponseEvents(t, responseEvents)
 }
 
+// TestPackagedSubagentChildFailureReturnsStableFailure proves that packaged
+// @you/subagent invocation returns a stable failed public terminal outcome when
+// the child worker rejects, without emitting a success primary result for the
+// failing run.
+func TestPackagedSubagentChildFailureReturnsStableFailure(t *testing.T) {
+	t.Run("CLI JSON returns stable failed terminal outcome", func(t *testing.T) {
+		requestText := fmt.Sprintf("functional-packaged-subagent-failure-%d", time.Now().UnixNano())
+		response, stderr, execErr := runPackagedSubagentCLIJSONFailureInvocation(t, requestText)
+
+		if execErr == nil {
+			t.Fatal("Process.Execute error = nil, want terminal packaged-subagent child failure")
+		}
+		assertPackagedSubagentStableFailureInvocation(t, response)
+		assertPackagedSubagentStableFailureErrorResponse(t, response, stderr)
+		if invocationPrimaryResultPresent(response) {
+			t.Fatalf("primaryResult = %#v, want no success primary result after child worker failure", response.PrimaryResult)
+		}
+		if strings.Contains(invocationResponseJSON(t, response), packagedSubagentChildPrimaryResult) {
+			t.Fatal("failed invocation JSON contained child success primary result text")
+		}
+		if strings.Contains(invocationResponseJSON(t, response), requestText) {
+			t.Fatalf("failed invocation JSON echoed submitted request text %q", requestText)
+		}
+	})
+
+	t.Run("API returns stable failed terminal outcome", func(t *testing.T) {
+		requestText := fmt.Sprintf("functional-packaged-subagent-api-failure-%d", time.Now().UnixNano())
+		response := runPackagedSubagentAPIFailureInvocation(t, requestText)
+
+		assertPackagedSubagentStableFailureInvocation(t, response)
+		if invocationPrimaryResultPresent(response) {
+			t.Fatalf("primaryResult = %#v, want no success primary result after child worker failure", response.PrimaryResult)
+		}
+	})
+}
+
 func runPackagedSubagentAPIInvocationWithResponseEvents(
 	t *testing.T,
 	requestText string,
@@ -274,6 +310,113 @@ func packagedSubagentAcceptMockWorkersConfig() *workers.MockWorkersConfig {
 			RunType:         workers.MockWorkerRunTypeAccept,
 		}},
 	}
+}
+
+func packagedSubagentRejectingMockWorkersConfig() *workers.MockWorkersConfig {
+	exitCode := 7
+	return &workers.MockWorkersConfig{
+		UnmatchedDispatchPolicy: workers.MockWorkerUnmatchedDispatchPolicyPassthrough,
+		MockWorkers: []workers.MockWorkerConfig{{
+			WorkerName:      factorydefinitions.PackagedSubagentWorkerName,
+			WorkstationName: factorydefinitions.PackagedSubagentRunWorkstationName,
+			RunType:         workers.MockWorkerRunTypeReject,
+			RejectConfig: &workers.MockWorkerRejectConfig{
+				Stderr:   "packaged subagent mock worker failure",
+				ExitCode: &exitCode,
+			},
+		}},
+	}
+}
+
+func runPackagedSubagentCLIJSONFailureInvocation(
+	t *testing.T,
+	requestText string,
+) (factoryapi.InvocationResponse, string, error) {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	support.InstallPackagedFactory(t, homeDir, factorydefinitions.PackagedSubagentFactoryName)
+	mockWorkersPath := support.WriteMockWorkersConfig(t, packagedSubagentRejectingMockWorkersConfig())
+
+	args := []string{
+		"you", "--json", "run",
+		"--named", factorydefinitions.PackagedSubagentFactoryName,
+		"--with-mock-workers", mockWorkersPath,
+		"--no-record",
+		requestText,
+	}
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	inputs.Input.WorkingDirectory = t.TempDir()
+	execErr := support.BuildProcess(t, serviceedges.Edges{}).Execute(inputs.Input)
+
+	var response factoryapi.InvocationResponse
+	if decodeErr := json.Unmarshal([]byte(strings.TrimSpace(inputs.Stdout())), &response); decodeErr != nil {
+		t.Fatalf("decode invocation JSON stdout: %v\nstdout:\n%s", decodeErr, inputs.Stdout())
+	}
+	return response, inputs.Stderr(), execErr
+}
+
+func runPackagedSubagentAPIFailureInvocation(
+	t *testing.T,
+	requestText string,
+) factoryapi.InvocationResponse {
+	t.Helper()
+
+	factoryDir := support.InstallPackagedFactory(t, t.TempDir(), factorydefinitions.PackagedSubagentFactoryName)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:        factoryDir,
+		UseMockWorkers:    true,
+		MockWorkersConfig: packagedSubagentRejectingMockWorkersConfig(),
+	})
+	return postPackagedSubagentInvocation(t, server.URL(), requestText)
+}
+
+func assertPackagedSubagentStableFailureInvocation(
+	t *testing.T,
+	response factoryapi.InvocationResponse,
+) {
+	t.Helper()
+
+	if response.Status != factoryapi.InvocationTerminalStatusFailed {
+		t.Fatalf("status = %q, want FAILED; response = %#v", response.Status, response)
+	}
+	if response.ErrorCode == nil || strings.TrimSpace(string(*response.ErrorCode)) == "" {
+		t.Fatalf("errorCode = %#v, want stable public failure code", response.ErrorCode)
+	}
+	if response.Message == nil || strings.TrimSpace(*response.Message) == "" {
+		t.Fatalf("message = %#v, want stable public failure message", response.Message)
+	}
+}
+
+func assertPackagedSubagentStableFailureErrorResponse(
+	t *testing.T,
+	response factoryapi.InvocationResponse,
+	stderr string,
+) {
+	t.Helper()
+
+	decoder := json.NewDecoder(strings.NewReader(stderr))
+	var errorResponse factoryapi.ErrorResponse
+	if err := decoder.Decode(&errorResponse); err != nil {
+		t.Fatalf("decode ErrorResponse: %v\nstderr:\n%s", err, stderr)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		t.Fatalf("stderr contains data after ErrorResponse: %v\nstderr:\n%s", err, stderr)
+	}
+	if errorResponse.Code != factoryapi.ErrorResponseCode(*response.ErrorCode) {
+		t.Fatalf("ErrorResponse code = %q, want %q", errorResponse.Code, *response.ErrorCode)
+	}
+	if errorResponse.Family != factoryapi.ErrorFamilyInternalServerError {
+		t.Fatalf("ErrorResponse family = %q, want INTERNAL_SERVER_ERROR", errorResponse.Family)
+	}
+	if !strings.HasPrefix(errorResponse.Message, *response.Message) {
+		t.Fatalf("ErrorResponse message = %q, want prefix %q", errorResponse.Message, *response.Message)
+	}
+}
+
+func invocationPrimaryResultPresent(response factoryapi.InvocationResponse) bool {
+	return response.PrimaryResult != nil && len(*response.PrimaryResult) > 0
 }
 
 func invocationPrimaryResultText(t *testing.T, response factoryapi.InvocationResponse) string {

--- a/tests/functional/factory/packaged/subagent/invocation_test.go
+++ b/tests/functional/factory/packaged/subagent/invocation_test.go
@@ -1,10 +1,13 @@
 package subagent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"strings"
 	"sync/atomic"
@@ -14,6 +17,7 @@ import (
 	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
 	"github.com/portpowered/infinite-you/pkg/root"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
@@ -56,6 +60,145 @@ func TestPackagedSubagentReturnsChildResult(t *testing.T) {
 			t.Fatalf("HTTP listener start calls = %d, want 0", listenerStarts)
 		}
 	})
+}
+
+// TestPackagedSubagentStreamsChildResponseEvents proves that packaged
+// @you/subagent invocation publishes child Factory Response Events on the public
+// Factory Session response-event stream, not only the terminal invocation
+// primary result returned by the invocation API.
+func TestPackagedSubagentStreamsChildResponseEvents(t *testing.T) {
+	requestText := fmt.Sprintf("functional-packaged-subagent-stream-%d", time.Now().UnixNano())
+	response, responseEvents := runPackagedSubagentAPIInvocationWithResponseEvents(t, requestText)
+
+	if response.Status != factoryapi.InvocationTerminalStatusCompleted {
+		t.Fatalf("invocation status = %q, want COMPLETED; response = %#v", response.Status, response)
+	}
+	if got := invocationPrimaryResultText(t, response); got != packagedSubagentChildPrimaryResult {
+		t.Fatalf("primaryResult = %q, want %q", got, packagedSubagentChildPrimaryResult)
+	}
+	assertPackagedSubagentChildResponseEvents(t, responseEvents)
+}
+
+func runPackagedSubagentAPIInvocationWithResponseEvents(
+	t *testing.T,
+	requestText string,
+) (factoryapi.InvocationResponse, []factoryapi.FactoryResponseEvent) {
+	t.Helper()
+
+	factoryDir := support.InstallPackagedFactory(t, t.TempDir(), factorydefinitions.PackagedSubagentFactoryName)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:        factoryDir,
+		UseMockWorkers:    true,
+		MockWorkersConfig: packagedSubagentAcceptMockWorkersConfig(),
+	})
+
+	response := postPackagedSubagentInvocation(t, server.URL(), requestText)
+	responseEvents := support.GetFactoryResponseEventsAt(t, server.URL(), factorysessions.DefaultSessionID)
+	return response, responseEvents
+}
+
+func postPackagedSubagentInvocation(
+	t *testing.T,
+	serverURL string,
+	requestText string,
+) factoryapi.InvocationResponse {
+	t.Helper()
+
+	body, err := json.Marshal(packagedSubagentTextInvocationRequest(requestText))
+	if err != nil {
+		t.Fatalf("marshal invocation request: %v", err)
+	}
+	endpoint := strings.TrimSuffix(serverURL, "/") +
+		"/factory-sessions/" + factorysessions.DefaultSessionID + "/invocations"
+	response, err := http.Post(endpoint, "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST %s: %v", endpoint, err)
+	}
+	defer response.Body.Close()
+	payload, readErr := io.ReadAll(response.Body)
+	if readErr != nil {
+		t.Fatalf("read invocation response: %v", readErr)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("POST %s status = %d, want 200: %s", endpoint, response.StatusCode, string(payload))
+	}
+
+	var decoded factoryapi.InvocationResponse
+	if decodeErr := json.Unmarshal(payload, &decoded); decodeErr != nil {
+		t.Fatalf("decode invocation response: %v\npayload:\n%s", decodeErr, string(payload))
+	}
+	return decoded
+}
+
+func packagedSubagentTextInvocationRequest(requestText string) factoryapi.InvocationRequest {
+	var part factoryapi.WorkContentPart
+	if err := part.FromWorkTextContentPart(factoryapi.WorkTextContentPart{
+		Type: factoryapi.WorkContentPartTypeText,
+		Text: requestText,
+	}); err != nil {
+		panic(fmt.Sprintf("build invocation text content: %v", err))
+	}
+	sourceKind := factoryapi.InvocationInputSourceKindText
+	content := factoryapi.WorkContent{part}
+	return factoryapi.InvocationRequest{
+		SourceKind: &sourceKind,
+		Content:    &content,
+	}
+}
+
+func assertPackagedSubagentChildResponseEvents(
+	t *testing.T,
+	events []factoryapi.FactoryResponseEvent,
+) {
+	t.Helper()
+
+	if len(events) == 0 {
+		t.Fatal("response events are empty, want child Factory Response Events on the public stream surface")
+	}
+
+	var dispatchID string
+	for index, event := range events {
+		if event.DispatchId == nil || strings.TrimSpace(*event.DispatchId) == "" {
+			t.Fatalf("response event[%d] = %#v, want child dispatch correlation", index, event)
+		}
+		if dispatchID == "" {
+			dispatchID = *event.DispatchId
+		}
+		if *event.DispatchId != dispatchID {
+			t.Fatalf("response event[%d] dispatch = %q, want %q", index, *event.DispatchId, dispatchID)
+		}
+		if event.Kind != factoryapi.FactoryResponseEventKindMessage {
+			t.Fatalf("response event[%d] kind = %q, want MESSAGE child progress", index, event.Kind)
+		}
+		if event.Phase != factoryapi.FactoryResponseEventPhaseCompleted {
+			t.Fatalf("response event[%d] phase = %q, want COMPLETED child message", index, event.Phase)
+		}
+		if event.SchemaVersion == "" || event.EventId == "" {
+			t.Fatalf("response event[%d] = %#v, want public response-event contract fields", index, event)
+		}
+	}
+
+	finalEvent := events[len(events)-1]
+	payload, err := finalEvent.Payload.AsFactoryResponseEventMessagePayload()
+	if err != nil {
+		t.Fatalf("decode final child response event payload: %v", err)
+	}
+	if got := responseEventMessageText(payload); got != packagedSubagentChildPrimaryResult {
+		t.Fatalf("final child response event text = %q, want %q", got, packagedSubagentChildPrimaryResult)
+	}
+}
+
+func responseEventMessageText(payload factoryapi.FactoryResponseEventMessagePayload) string {
+	for _, block := range payload.ContentBlocks {
+		text, err := block.AsFactoryResponseEventTextContentBlock()
+		if err != nil {
+			continue
+		}
+		if text.Text != "" {
+			return text.Text
+		}
+	}
+	return ""
 }
 
 func runPackagedSubagentCLIJSONInvocation(t *testing.T, requestText string) factoryapi.InvocationResponse {

--- a/tests/functional/factory/packaged/subagent/invocation_test.go
+++ b/tests/functional/factory/packaged/subagent/invocation_test.go
@@ -1,0 +1,169 @@
+package subagent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
+	"github.com/portpowered/infinite-you/pkg/root"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const packagedSubagentChildPrimaryResult = "mock worker accepted"
+
+// TestPackagedSubagentReturnsChildResult proves that packaged @you/subagent
+// invocation through the public CLI completes with the child's authoritative
+// primary agent response instead of echoing the submitted request text,
+// including hermetic no-server success without starting an HTTP listener.
+func TestPackagedSubagentReturnsChildResult(t *testing.T) {
+	t.Run("CLI JSON returns authoritative child primary result", func(t *testing.T) {
+		requestText := fmt.Sprintf("functional-packaged-subagent-primary-%d", time.Now().UnixNano())
+		response := runPackagedSubagentCLIJSONInvocation(t, requestText)
+
+		if response.Status != factoryapi.InvocationTerminalStatusCompleted {
+			t.Fatalf("status = %q, want COMPLETED; response = %#v", response.Status, response)
+		}
+		if got := invocationPrimaryResultText(t, response); got != packagedSubagentChildPrimaryResult {
+			t.Fatalf("primaryResult = %q, want %q", got, packagedSubagentChildPrimaryResult)
+		}
+		if strings.Contains(invocationResponseJSON(t, response), requestText) {
+			t.Fatalf("invocation JSON echoed submitted request text %q", requestText)
+		}
+	})
+
+	t.Run("hermetic named invocation succeeds without listening server", func(t *testing.T) {
+		requestText := "hermetic no-server packaged subagent prompt"
+		stdout, listenerStarts := runHermeticPackagedSubagentInvocation(t, requestText)
+
+		if stdout != packagedSubagentChildPrimaryResult {
+			t.Fatalf("stdout = %q, want child primary result %q", stdout, packagedSubagentChildPrimaryResult)
+		}
+		if stdout == requestText {
+			t.Fatal("stdout echoed submitted request text instead of child agent response")
+		}
+		if listenerStarts != 0 {
+			t.Fatalf("HTTP listener start calls = %d, want 0", listenerStarts)
+		}
+	})
+}
+
+func runPackagedSubagentCLIJSONInvocation(t *testing.T, requestText string) factoryapi.InvocationResponse {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	support.InstallPackagedFactory(t, homeDir, factorydefinitions.PackagedSubagentFactoryName)
+	mockWorkersPath := support.WriteMockWorkersConfig(t, packagedSubagentAcceptMockWorkersConfig())
+
+	args := []string{
+		"you", "--json", "run",
+		"--named", factorydefinitions.PackagedSubagentFactoryName,
+		"--with-mock-workers", mockWorkersPath,
+		"--no-record",
+		requestText,
+	}
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	inputs.Input.WorkingDirectory = t.TempDir()
+	if err := support.BuildProcess(t, serviceedges.Edges{}).Execute(inputs.Input); err != nil {
+		t.Fatalf("Process.Execute(%v) error = %v\nstdout:\n%s\nstderr:\n%s", args, err, inputs.Stdout(), inputs.Stderr())
+	}
+	if inputs.Stderr() != "" {
+		t.Fatalf("stderr = %q, want empty successful-run stderr", inputs.Stderr())
+	}
+
+	var response factoryapi.InvocationResponse
+	if decodeErr := json.Unmarshal([]byte(strings.TrimSpace(inputs.Stdout())), &response); decodeErr != nil {
+		t.Fatalf("decode invocation JSON stdout: %v\nstdout:\n%s", decodeErr, inputs.Stdout())
+	}
+	return response
+}
+
+func runHermeticPackagedSubagentInvocation(t *testing.T, requestText string) (string, int) {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	workingDirectory := t.TempDir()
+	listenerStarts := &listenerStartObservation{}
+	process, err := root.BuildProcess(t.Context(), serviceedges.Edges{
+		APIServerStarter: listenerStarts.Start,
+	})
+	if err != nil {
+		t.Fatalf("BuildProcess() error = %v", err)
+	}
+
+	environment := append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	mockWorkersPath := support.WriteMockWorkersConfig(t, packagedSubagentAcceptMockWorkersConfig())
+	args := []string{
+		"you", "run",
+		"--named", factorydefinitions.PackagedSubagentFactoryName,
+		"--with-mock-workers", "--no-record", "--quiet",
+		mockWorkersPath, requestText,
+	}
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.Env = environment
+	inputs.Input.WorkingDirectory = workingDirectory
+	if execErr := process.Execute(inputs.Input); execErr != nil {
+		t.Fatalf("Process.Execute(%v) error = %v\nstdout:\n%s\nstderr:\n%s", args, execErr, inputs.Stdout(), inputs.Stderr())
+	}
+	if inputs.Stderr() != "" {
+		t.Fatalf("named invocation stderr = %q, want empty; stdout=%s", inputs.Stderr(), inputs.Stdout())
+	}
+	return strings.TrimSpace(inputs.Stdout()), int(listenerStarts.calls.Load())
+}
+
+func packagedSubagentAcceptMockWorkersConfig() *workers.MockWorkersConfig {
+	return &workers.MockWorkersConfig{
+		UnmatchedDispatchPolicy: workers.MockWorkerUnmatchedDispatchPolicyPassthrough,
+		MockWorkers: []workers.MockWorkerConfig{{
+			WorkerName:      factorydefinitions.PackagedSubagentWorkerName,
+			WorkstationName: factorydefinitions.PackagedSubagentRunWorkstationName,
+			RunType:         workers.MockWorkerRunTypeAccept,
+		}},
+	}
+}
+
+func invocationPrimaryResultText(t *testing.T, response factoryapi.InvocationResponse) string {
+	t.Helper()
+
+	if response.PrimaryResult == nil || len(*response.PrimaryResult) != 1 {
+		t.Fatalf("primaryResult = %#v, want one text part", response.PrimaryResult)
+	}
+	part, err := (*response.PrimaryResult)[0].AsWorkTextContentPart()
+	if err != nil {
+		t.Fatalf("primaryResult[0] as text part: %v", err)
+	}
+	return part.Text
+}
+
+func invocationResponseJSON(t *testing.T, response factoryapi.InvocationResponse) string {
+	t.Helper()
+
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal invocation response: %v", err)
+	}
+	return string(encoded)
+}
+
+type listenerStartObservation struct {
+	calls atomic.Int32
+}
+
+func (observation *listenerStartObservation) Start(
+	_ context.Context,
+	_ platformhttpserver.StartRequest,
+) error {
+	observation.calls.Add(1)
+	return errors.New("hermetic packaged subagent invocation attempted to start an HTTP listener")
+}


### PR DESCRIPTION
{
  "project": "Packaged Subagent Factory Invocation Functional Coverage",
  "branchName": "ft-wave2-factory-subagent-invocation",
  "description": "Implement only tests/functional/factory/packaged/subagent/invocation_test.go to prove packaged @you/subagent child-result return, child response-event streaming, and child-failure stable failure through public CLI/API invocation with mock workers, consuming the two mapped migration-ledger rows while preserving specialty binding test-built-cli-acceptance and without implementing sibling packaged-factory packages.",
  "context": {
    "customerAsk": "Implement only tests/functional/factory/packaged/subagent/invocation_test.go. Through public CLI/API packaged-factory invocation with mock workers, prove: (1) TestPackagedSubagentReturnsChildResult; (2) TestPackagedSubagentStreamsChildResponseEvents; (3) TestPackagedSubagentChildFailureReturnsStableFailure. Consume the two mapped migration-ledger rows while preserving specialty binding test-built-cli-acceptance. Do not implement other packaged-factory packages. Avoid service/internal Petri imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for packaged subagent Factory invocation does not exist, while mapped legacy scenarios remain in acceptance and cli/named_invocation catch-all coverage. Maintainers lack a focused, catalogued factory proof for child-result return, child response-event streaming, and child-failure stable failure at the public packaged-factory invocation boundary. Sibling packaged factories (goal, deep_research, fusion, quorum, review, tts, cross) and still-active goal/catalog packages are separate and must not be absorbed here.",
    "solution": "Implement the three checklist scenarios in tests/functional/factory/packaged/subagent/invocation_test.go through public CLI/API packaged-factory invocation with mock workers, with customer-readable Go docs on every top-level Test. Consume both migration-ledger rows whose destination is this cell, preserve specialty binding test-built-cli-acceptance, leave deletion batch n/a without inventing deletions, apply only narrowly coupled metadata updates for this destination, leave sibling packaged-factory packages untouched, and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/factory/packaged/subagent/invocation_test.go exists as the factory-owned functional cell and covers child-result return, child response-event streaming, and child-failure stable failure.",
    "Success and failure paths exercise public CLI and/or API packaged-factory invocation with mock workers and produce observable invocation status, primary-result, streamed response events, or failure diagnostics without asserting Petri markings or service internals.",
    "Successful child completion returns an authoritative child primary result distinct from the submitted request text; streaming proves child response events are observable on the public stream surface; child failure reaches a stable failed terminal status without a success primary result.",
    "Coverage stays on packaged @you/subagent invocation product behavior and does not implement goal, deep_research, fusion, quorum, review, tts, or cross cells, nor still-active goal/catalog packages.",
    "Both migration-ledger rows whose destination is tests/functional/factory/packaged/subagent/invocation_test.go are consumed as applicable; specialty binding test-built-cli-acceptance is preserved; deletion batch remains n/a with no invented deletion obligations; only narrowly coupled ownership/coverage/catalog/migration metadata for this cell are updated; sibling packaged-factory destinations stay untouched.",
    "Every top-level Test* has a customer-readable Go doc comment whose first sentence describes the observable CLI/API packaged-subagent behavior.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave2-factory-subagent-invocation-001",
      "title": "Prove packaged subagent returns child result",
      "description": "As an agent or operator, I want packaged @you/subagent invocation to complete with the child's authoritative primary result, so that I can trust the public CLI/API outcome is the child agent response rather than an echo of my submitted request text.",
      "acceptanceCriteria": [
        "tests/functional/factory/packaged/subagent/invocation_test.go includes TestPackagedSubagentReturnsChildResult as a top-level test.",
        "The test invokes packaged @you/subagent through the public CLI and/or API invocation boundary with mock workers configured for a successful child accept / complete path.",
        "The invocation reaches a completed terminal status and returns an authoritative child primary result (for example the documented mock accepted agent response), and that result is not merely the submitted request text.",
        "Customer-facing obligations from the mapped successful named-run / hermetic named-invocation ledger rows are absorbed as applicable (TestSubagentInvocation_SuccessfulNamedRun_ReturnsAuthoritativePrimaryResultJSON and TestRun_NamedSubagentHermeticInvocationSucceedsWithoutListeningServer), including hermetic no-server success when proven through this cell's public boundary.",
        "Assertions stay on public packaged-subagent invocation outcomes and do not import service implementations or internal Petri packages.",
        "The top-level test has a customer-readable Go doc comment describing the child-result return behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-subagent-invocation-002",
      "title": "Prove packaged subagent streams child response events",
      "description": "As an operator observing a packaged @you/subagent run, I want child Factory Response Events to stream on the public observation surface, so that I can watch child progress without waiting only for the terminal primary result.",
      "acceptanceCriteria": [
        "The cell includes TestPackagedSubagentStreamsChildResponseEvents as a top-level test.",
        "The test invokes packaged @you/subagent through the public CLI and/or API stream / response-event observation boundary with mock workers that produce observable child response activity before terminal completion.",
        "Observable evidence proves one or more child Factory Response Events are delivered on the public stream surface for the invocation (event kinds / payloads consistent with the public response-event contract for child agent progress), not only a terminal primary-result payload.",
        "Assertions remain on packaged-subagent stream observation and do not re-own transport-only stream fidelity cells or other packaged-factory packages.",
        "The top-level test has a customer-readable Go doc comment describing the child response-event streaming behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-subagent-invocation-003",
      "title": "Prove child failure returns stable failure",
      "description": "As an operator scripting against packaged @you/subagent, I want a failing child worker to produce a stable public failure outcome, so that automation can detect child failure without treating the run as success.",
      "acceptanceCriteria": [
        "The cell includes TestPackagedSubagentChildFailureReturnsStableFailure as a top-level test.",
        "The test invokes packaged @you/subagent through the public CLI and/or API boundary with mock workers configured so the child worker / dispatch fails.",
        "The invocation reaches a failed terminal status with stable, customer-safe failure details (error code / message / status as documented for the packaged-subagent failure path) and does not emit a success primary result attributable to that failing run.",
        "Assertions prove packaged-subagent child-failure semantics only and do not widen into unrelated transport exit-code matrices or sibling packaged factories.",
        "The top-level test has a customer-readable Go doc comment describing the child-failure stable-failure behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-subagent-invocation-004",
      "title": "Consume migration obligations and close verification gates",
      "description": "As a maintainer executing Wave 2 migration, I want this cell to absorb the two mapped packaged-subagent ledger rows, preserve specialty binding test-built-cli-acceptance, and pass focused boundary/metadata gates, so the destination is catalogued correctly without implementing sibling packaged-factory packages.",
      "acceptanceCriteria": [
        "Both migration-ledger mappings whose destination is tests/functional/factory/packaged/subagent/invocation_test.go are consumed by this cell's coverage (successful named primary-result JSON and hermetic named subagent invocation), with deletion_only_batch n/a and no invented deletion obligations.",
        "Specialty binding test-built-cli-acceptance is preserved for the mapped acceptance scenario; only narrowly coupled ownership, coverage, catalog, or migration metadata required for this cell are updated; sibling packaged-factory packages (goal, deep_research, fusion, quorum, review, tts, cross) and still-active goal/catalog packages are left alone.",
        "Focused package tests for tests/functional/factory/packaged/subagent pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as factory/packaged/subagent).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)