### PR TITLE
ft-wave2-factory-fusion-invocation

### DIFF
--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -2007,6 +2007,15 @@ response-stream output.
   source together with its source identity, args schema, agents, and default
   policy; resolving its scoped name again from the session directory loses the
   materialized named-factory context.
+- Functional coverage for packaged `@you/fusion` Petri invocation belongs in
+  `tests/functional/factory/packaged/fusion/invocation_test.go`. Exercise
+  `POST /factory-sessions/~default/invocations` with `InvocationRequest.Args`,
+  observe multi-worker merge order through public factory dispatch events
+  (`draft-fusion` then `refine-fusion`), and correlate optional overrides from
+  `MODEL_REQUEST`, `INFERENCE_RESPONSE`, and `AGENT_RUN_RESPONSE` on the
+  factory event stream. Durable-session `GET /factory-sessions/{id}/dispatches`
+  is for JavaScript workflow sessions such as deep-research, not Petri
+  invocation-only runs.
 - Functional coverage for `@you/deep-research` belongs in
   `tests/functional/smoke/cli_named_deep_research_smoke_test.go` and
   `tests/functional/runtime_api/api_packaged_deep_research_invocation_test.go`.

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -654,7 +654,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestPackagedDeepResearchOptionalInputsReachWorkers` covers overrides.
   - `TestPackagedDeepResearchWorkerFailureReturnsFailedOutcome` covers failure.
 
-- [ ] `tests/functional/factory/packaged/fusion/invocation_test.go`
+- [x] `tests/functional/factory/packaged/fusion/invocation_test.go`
   - `TestPackagedFusionRequiredInputCompletes` verifies its multi-worker merge.
   - `TestPackagedFusionOptionalInputsReachWorkers` covers supported options.
   - `TestPackagedFusionPartialWorkerFailureUsesDocumentedOutcome` covers error.

--- a/tests/functional/factory/packaged/fusion/invocation_test.go
+++ b/tests/functional/factory/packaged/fusion/invocation_test.go
@@ -1,0 +1,135 @@
+package fusion
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+// TestPackagedFusionRequiredInputCompletes proves that invoking the packaged
+// @you/fusion Factory with only the required input completes under mock
+// workers, runs the drafter then refiner dispatch sequence, and returns a
+// primary result reflecting the refined fusion outcome for the submitted request.
+func TestPackagedFusionRequiredInputCompletes(t *testing.T) {
+	input := fmt.Sprintf(
+		"functional packaged fusion required input %d",
+		time.Now().UnixNano(),
+	)
+
+	factoryDir := support.InstallPackagedFactory(
+		t,
+		t.TempDir(),
+		factorydefinitions.PackagedFusionFactoryName,
+	)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                factoryDir,
+		UseMockWorkers:            true,
+		WaitForServiceModeRuntime: true,
+	})
+
+	response := startPackagedFusionInvocation(
+		t,
+		server,
+		"packaged-fusion-required-input",
+		map[string]any{"input": input},
+	)
+	if response.Status != factoryapi.InvocationTerminalStatusCompleted {
+		t.Fatalf("invocation status = %q, want COMPLETED; response = %#v", response.Status, response)
+	}
+	if response.PrimaryResult == nil || len(*response.PrimaryResult) != 1 {
+		t.Fatalf("primary result = %#v, want one refined result part", response.PrimaryResult)
+	}
+	primaryText := invocationPrimaryResultText(t, response)
+	if !strings.Contains(primaryText, "mock worker accepted") {
+		t.Fatalf("primary result = %q, want refined mock-worker outcome", primaryText)
+	}
+	if strings.Contains(primaryText, input) {
+		t.Fatalf("primary result = %q, want refined output rather than raw submitted input echo", primaryText)
+	}
+
+	dispatches := support.ObserveDispatchEvents(t, server.GetFactoryEvents(t))
+	if len(dispatches) != 2 {
+		t.Fatalf(
+			"dispatch count = %d, want drafter and refiner dispatches",
+			len(dispatches),
+		)
+	}
+	wantWorkstations := []string{"draft-fusion", "refine-fusion"}
+	for index, dispatch := range dispatches {
+		if dispatch.Response == nil {
+			t.Fatalf("dispatch[%d] = %#v, want completed public dispatch response", index, dispatch)
+		}
+		if dispatch.Response.Outcome != factoryapi.WorkOutcomeAccepted {
+			t.Fatalf("dispatch[%d] outcome = %q, want ACCEPTED", index, dispatch.Response.Outcome)
+		}
+		if dispatch.Request.TransitionId != wantWorkstations[index] {
+			t.Fatalf(
+				"dispatch[%d] transition = %q, want %q in documented order",
+				index,
+				dispatch.Request.TransitionId,
+				wantWorkstations[index],
+			)
+		}
+	}
+}
+
+func startPackagedFusionInvocation(
+	t *testing.T,
+	server *support.FunctionalAPIServer,
+	requestID string,
+	args map[string]any,
+) factoryapi.InvocationResponse {
+	t.Helper()
+
+	return postJSON[factoryapi.InvocationResponse](
+		t,
+		server.URL()+"/factory-sessions/"+factorysessions.DefaultSessionID+"/invocations",
+		factoryapi.InvocationRequest{
+			RequestId: &requestID,
+			Args:      &args,
+		},
+		"start packaged fusion invocation",
+	)
+}
+
+func invocationPrimaryResultText(t *testing.T, response factoryapi.InvocationResponse) string {
+	t.Helper()
+
+	part, err := (*response.PrimaryResult)[0].AsWorkTextContentPart()
+	if err != nil {
+		t.Fatalf("primaryResult[0] as text part: %v", err)
+	}
+	return part.Text
+}
+
+func postJSON[T any](t *testing.T, endpoint string, request any, failurePrefix string) T {
+	t.Helper()
+	encoded, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("%s: marshal request: %v", failurePrefix, err)
+	}
+	response, err := http.Post(endpoint, "application/json", bytes.NewReader(encoded))
+	if err != nil {
+		t.Fatalf("%s: POST %s: %v", failurePrefix, endpoint, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		payload, _ := io.ReadAll(response.Body)
+		t.Fatalf("%s: POST %s status = %d, want success: %s", failurePrefix, endpoint, response.StatusCode, string(payload))
+	}
+	var decoded T
+	if err := json.NewDecoder(response.Body).Decode(&decoded); err != nil {
+		t.Fatalf("%s: decode %s response: %v", failurePrefix, endpoint, err)
+	}
+	return decoded
+}

--- a/tests/functional/factory/packaged/fusion/invocation_test.go
+++ b/tests/functional/factory/packaged/fusion/invocation_test.go
@@ -12,6 +12,7 @@ import (
 
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
@@ -181,6 +182,99 @@ func TestPackagedFusionOptionalInputsReachWorkers(t *testing.T) {
 			"refiner agent-run system summary = %q, want secondEffort override",
 			effortByDispatch[dispatches[1].DispatchID],
 		)
+	}
+}
+
+// TestPackagedFusionPartialWorkerFailureUsesDocumentedOutcome proves that a
+// configured mock-worker rejection during one fusion stage returns a failed
+// public terminal invocation outcome without a completed success primary
+// result attributable to the failing run.
+func TestPackagedFusionPartialWorkerFailureUsesDocumentedOutcome(t *testing.T) {
+	input := fmt.Sprintf(
+		"functional packaged fusion partial worker failure %d",
+		time.Now().UnixNano(),
+	)
+
+	factoryDir := support.InstallPackagedFactory(
+		t,
+		t.TempDir(),
+		factorydefinitions.PackagedFusionFactoryName,
+	)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                factoryDir,
+		UseMockWorkers:            true,
+		MockWorkersConfig:         packagedFusionRejectingDrafterMockWorkersConfig(),
+		WaitForServiceModeRuntime: true,
+	})
+
+	response := startPackagedFusionInvocation(
+		t,
+		server,
+		"packaged-fusion-partial-worker-failure",
+		map[string]any{"input": input},
+	)
+	if response.Status != factoryapi.InvocationTerminalStatusFailed {
+		t.Fatalf("invocation status = %q, want FAILED; response = %#v", response.Status, response)
+	}
+	if response.PrimaryResult != nil {
+		t.Fatalf(
+			"primary result = %#v, want no completed success primary result after worker failure",
+			response.PrimaryResult,
+		)
+	}
+	if response.WorkState == nil || *response.WorkState != "task:failed" {
+		t.Fatalf("invocation workState = %#v, want task:failed", response.WorkState)
+	}
+
+	dispatches := support.ObserveDispatchEvents(t, server.GetFactoryEvents(t))
+	if len(dispatches) == 0 {
+		t.Fatal("dispatch observations missing, want at least one draft-fusion failure")
+	}
+	var failedDraftDispatches int
+	for _, dispatch := range dispatches {
+		if dispatch.Request.TransitionId == "refine-fusion" {
+			t.Fatalf(
+				"dispatch transition = %q, want no refiner dispatch after draft-stage failure",
+				dispatch.Request.TransitionId,
+			)
+		}
+		if dispatch.Request.TransitionId != "draft-fusion" {
+			t.Fatalf(
+				"dispatch transition = %q, want only draft-fusion dispatches",
+				dispatch.Request.TransitionId,
+			)
+		}
+		if dispatch.Response == nil {
+			t.Fatalf("draft-fusion dispatch response missing: %#v", dispatch)
+		}
+		if dispatch.Response.Outcome != factoryapi.WorkOutcomeFailed {
+			t.Fatalf(
+				"draft-fusion outcome = %q, want FAILED",
+				dispatch.Response.Outcome,
+			)
+		}
+		if dispatch.Response.Error == nil || strings.TrimSpace(*dispatch.Response.Error) == "" {
+			t.Fatalf("dispatch error = %#v, want stable public failure record", dispatch.Response.Error)
+		}
+		failedDraftDispatches++
+	}
+	if failedDraftDispatches == 0 {
+		t.Fatal("failed draft-fusion dispatch count = 0, want at least one")
+	}
+}
+
+func packagedFusionRejectingDrafterMockWorkersConfig() *workers.MockWorkersConfig {
+	exitCode := 7
+	return &workers.MockWorkersConfig{
+		MockWorkers: []workers.MockWorkerConfig{{
+			WorkerName:      "fusion-drafter",
+			WorkstationName: "draft-fusion",
+			RunType:         workers.MockWorkerRunTypeReject,
+			RejectConfig: &workers.MockWorkerRejectConfig{
+				Stderr:   "packaged fusion mock worker failure",
+				ExitCode: &exitCode,
+			},
+		}},
 	}
 }
 

--- a/tests/functional/factory/packaged/fusion/invocation_test.go
+++ b/tests/functional/factory/packaged/fusion/invocation_test.go
@@ -83,6 +83,241 @@ func TestPackagedFusionRequiredInputCompletes(t *testing.T) {
 	}
 }
 
+// TestPackagedFusionOptionalInputsReachWorkers proves that optional fusion
+// provider, model, and effort overrides reach the drafter and refiner workers
+// and are observable on public dispatch execution selection and agent-run
+// diagnostics when invoking @you/fusion through the packaged invocation API.
+func TestPackagedFusionOptionalInputsReachWorkers(t *testing.T) {
+	input := fmt.Sprintf(
+		"functional packaged fusion optional overrides %d",
+		time.Now().UnixNano(),
+	)
+
+	factoryDir := support.InstallPackagedFactory(
+		t,
+		t.TempDir(),
+		factorydefinitions.PackagedFusionFactoryName,
+	)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                factoryDir,
+		UseMockWorkers:            true,
+		WaitForServiceModeRuntime: true,
+	})
+
+	args := map[string]any{
+		"input":           input,
+		"firstProvider":   "CLAUDE",
+		"secondProvider":  "CODEX",
+		"firstModel":      "claude-sonnet-4-20250514",
+		"secondModel":     "gpt-5",
+		"firstEffort":     "low",
+		"secondEffort":    "high",
+		"output":          "fusion-optional-overrides.md",
+	}
+	response := startPackagedFusionInvocation(
+		t,
+		server,
+		"packaged-fusion-optional-inputs",
+		args,
+	)
+	if response.Status != factoryapi.InvocationTerminalStatusCompleted {
+		t.Fatalf("invocation status = %q, want COMPLETED; response = %#v", response.Status, response)
+	}
+	if response.PrimaryResult == nil || len(*response.PrimaryResult) != 1 {
+		t.Fatalf("primary result = %#v, want one refined result part", response.PrimaryResult)
+	}
+
+	dispatches := support.ObserveDispatchEvents(t, server.GetFactoryEvents(t))
+	if len(dispatches) != 2 {
+		t.Fatalf("dispatch count = %d, want drafter and refiner dispatches", len(dispatches))
+	}
+	wantWorkstations := []string{"draft-fusion", "refine-fusion"}
+	for index, dispatch := range dispatches {
+		if dispatch.Request.TransitionId != wantWorkstations[index] {
+			t.Fatalf(
+				"dispatch[%d] transition = %q, want %q in documented order",
+				index,
+				dispatch.Request.TransitionId,
+				wantWorkstations[index],
+			)
+		}
+	}
+
+	events := server.GetFactoryEvents(t)
+	modelRequests := modelRequestsByWorker(t, events)
+	assertFusionModelRequest(
+		t,
+		modelRequests,
+		"fusion-drafter",
+		"claude-sonnet-4-20250514",
+	)
+	assertFusionModelRequest(t, modelRequests, "fusion-refiner", "gpt-5")
+
+	providersByDispatch := inferenceProvidersByDispatchID(t, events)
+	assertFusionInferenceProvider(
+		t,
+		providersByDispatch,
+		dispatches[0].DispatchID,
+		"draft-fusion",
+		"claude",
+	)
+	assertFusionInferenceProvider(
+		t,
+		providersByDispatch,
+		dispatches[1].DispatchID,
+		"refine-fusion",
+		"codex",
+	)
+
+	effortByDispatch := agentRunSystemSummariesByDispatchID(t, events)
+	if !strings.Contains(effortByDispatch[dispatches[0].DispatchID], "Reasoning effort: low") {
+		t.Fatalf(
+			"drafter agent-run system summary = %q, want firstEffort override",
+			effortByDispatch[dispatches[0].DispatchID],
+		)
+	}
+	if !strings.Contains(effortByDispatch[dispatches[1].DispatchID], "Reasoning effort: high") {
+		t.Fatalf(
+			"refiner agent-run system summary = %q, want secondEffort override",
+			effortByDispatch[dispatches[1].DispatchID],
+		)
+	}
+}
+
+func modelRequestsByWorker(
+	t *testing.T,
+	events []factoryapi.FactoryEvent,
+) map[string]factoryapi.ModelRequestEventPayload {
+	t.Helper()
+
+	requests := make(map[string]factoryapi.ModelRequestEventPayload)
+	for _, event := range events {
+		if event.Type != factoryapi.FactoryEventTypeModelRequest {
+			continue
+		}
+		payload, err := event.Payload.AsModelRequestEventPayload()
+		if err != nil {
+			t.Fatalf("decode MODEL_REQUEST: %v", err)
+		}
+		requests[payload.Worker] = payload
+	}
+	return requests
+}
+
+func inferenceProvidersByDispatchID(
+	t *testing.T,
+	events []factoryapi.FactoryEvent,
+) map[string]string {
+	t.Helper()
+
+	providers := make(map[string]string)
+	for _, event := range events {
+		if event.Type != factoryapi.FactoryEventTypeInferenceResponse {
+			continue
+		}
+		if event.Context.DispatchId == nil || *event.Context.DispatchId == "" {
+			continue
+		}
+		payload, err := event.Payload.AsInferenceResponseEventPayload()
+		if err != nil {
+			t.Fatalf("decode INFERENCE_RESPONSE: %v", err)
+		}
+		if payload.Diagnostics == nil || payload.Diagnostics.Provider == nil ||
+			payload.Diagnostics.Provider.Provider == nil {
+			t.Fatalf(
+				"INFERENCE_RESPONSE for dispatch %q missing provider diagnostics: %#v",
+				*event.Context.DispatchId,
+				payload,
+			)
+		}
+		providers[*event.Context.DispatchId] = *payload.Diagnostics.Provider.Provider
+	}
+	return providers
+}
+
+func agentRunSystemSummariesByDispatchID(
+	t *testing.T,
+	events []factoryapi.FactoryEvent,
+) map[string]string {
+	t.Helper()
+
+	summaries := make(map[string]string)
+	for _, event := range events {
+		if event.Type != factoryapi.FactoryEventTypeAgentRunResponse {
+			continue
+		}
+		if event.Context.DispatchId == nil || *event.Context.DispatchId == "" {
+			continue
+		}
+		payload, err := event.Payload.AsAgentRunResponseEventPayload()
+		if err != nil {
+			t.Fatalf("decode AGENT_RUN_RESPONSE: %v", err)
+		}
+		if payload.Diagnostics == nil || payload.Diagnostics.AgentRun == nil ||
+			payload.Diagnostics.AgentRun.Transcript == nil {
+			t.Fatalf(
+				"AGENT_RUN_RESPONSE for dispatch %q missing transcript diagnostics: %#v",
+				*event.Context.DispatchId,
+				payload,
+			)
+		}
+		for _, entry := range *payload.Diagnostics.AgentRun.Transcript {
+			if entry.Role != nil && *entry.Role == "system" && entry.Summary != nil {
+				summaries[*event.Context.DispatchId] = *entry.Summary
+				break
+			}
+		}
+	}
+	return summaries
+}
+
+func assertFusionModelRequest(
+	t *testing.T,
+	requests map[string]factoryapi.ModelRequestEventPayload,
+	workerName, wantModel string,
+) {
+	t.Helper()
+
+	payload, ok := requests[workerName]
+	if !ok {
+		t.Fatalf("model requests = %#v, want %q MODEL_REQUEST", requests, workerName)
+	}
+	if payload.Model != wantModel {
+		t.Fatalf(
+			"%s model request model = %q, want override %q",
+			workerName,
+			payload.Model,
+			wantModel,
+		)
+	}
+}
+
+func assertFusionInferenceProvider(
+	t *testing.T,
+	providersByDispatch map[string]string,
+	dispatchID, workstationName, wantProvider string,
+) {
+	t.Helper()
+
+	gotProvider, ok := providersByDispatch[dispatchID]
+	if !ok {
+		t.Fatalf(
+			"inference providers = %#v, want provider diagnostics for %q dispatch %q",
+			providersByDispatch,
+			workstationName,
+			dispatchID,
+		)
+	}
+	if gotProvider != wantProvider {
+		t.Fatalf(
+			"%s inference provider = %q, want override %q",
+			workstationName,
+			gotProvider,
+			wantProvider,
+		)
+	}
+}
+
 func startPackagedFusionInvocation(
 	t *testing.T,
 	server *support.FunctionalAPIServer,


### PR DESCRIPTION
{
  "project": "Packaged Fusion Factory Invocation Functional Coverage",
  "branchName": "ft-wave2-factory-fusion-invocation",
  "description": "Implement only tests/functional/factory/packaged/fusion/invocation_test.go so public CLI/API packaged-factory invocation with mock workers proves @you/fusion required-input completion through the two-stage multi-worker merge, optional inputs reaching workers, and partial worker failure using the documented public failed outcome—without inventing migration-ledger deletion obligations when none map to this destination.",
  "context": {
    "customerAsk": "Implement only tests/functional/factory/packaged/fusion/invocation_test.go. Through public CLI/API packaged-factory invocation with mock workers, prove: (1) TestPackagedFusionRequiredInputCompletes; (2) TestPackagedFusionOptionalInputsReachWorkers; (3) TestPackagedFusionPartialWorkerFailureUsesDocumentedOutcome. Do not invent migration-ledger deletion obligations when none map to this destination. Do not implement quorum, review, goal, deep_research, subagent, tts, or cross cells. Avoid service/internal Petri imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled ownership/coverage/catalog/migration metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for packaged @you/fusion invocation does not exist yet. Maintainers lack a factory-owned cell that jointly proves required-input multi-worker merge completion, optional-input reachability, and partial-worker-failure documented outcome independently of goal, deep_research, quorum, review, and other packaged factories. No migration-ledger inventory rows map here, so inventing deletion-batch work would incorrectly couple this free cell to held shared batches.",
    "solution": "Implement the three checklist scenarios in tests/functional/factory/packaged/fusion/invocation_test.go through the public CLI/API packaged-factory invocation boundary with mock workers and customer-readable Go docs on every top-level Test. Assert required-input drafter→refiner merge completion with primary result, optional override reachability on workers/dispatches/results, and documented failed public terminal outcome on partial worker failure; do not invent migration-ledger deletion obligations; apply only narrowly coupled ownership/coverage/catalog/migration metadata; and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/factory/packaged/fusion/invocation_test.go exists as the factory-owned functional cell and covers required-input multi-worker merge completion, optional-input reachability, and partial-worker-failure documented outcome.",
    "Through public CLI/API packaged-factory invocation with mock workers, a required-input @you/fusion run completes the drafter→refiner merge with a completed primary / refined result reflecting the submitted request.",
    "Through public CLI/API packaged-factory invocation with mock workers, optional fusion inputs reach workers and are observable on dispatch execution selection and/or primary result.",
    "Through public CLI/API packaged-factory invocation with mock workers, a forced partial worker failure uses the documented public failed terminal outcome (no completed success primary result attributable to that failing run).",
    "No migration-ledger deletion obligations are invented for this destination; only narrowly coupled ownership/coverage/catalog/migration metadata for this cell are updated.",
    "Coverage uses the public CLI/API packaged-factory invocation boundary / approved helpers and does not import service implementations or internal Petri primitives as the proof owner, with customer-readable Go docs on every top-level Test*.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave2-factory-fusion-invocation-001",
      "title": "Prove required input completes via multi-worker merge",
      "description": "As a customer invoking @you/fusion with a required text request, I want the packaged Factory to complete under mock workers through the two-stage drafter→refiner multi-worker merge with a refined primary result so I can rely on the packaged fusion happy path.",
      "acceptanceCriteria": [
        "tests/functional/factory/packaged/fusion/invocation_test.go includes TestPackagedFusionRequiredInputCompletes (or equivalent top-level name matching the checklist intent).",
        "Through the public CLI and/or API packaged-factory invocation boundary with mock workers, invoking @you/fusion with a required input reaches a completed / succeeded terminal public status.",
        "Observable evidence proves the multi-worker merge path for the chosen request (draft-stage then refine-stage dispatches / workers present in the documented order) and a primary result that reflects the refined fusion outcome for the submitted input.",
        "Assertions stay on required-input completion for fusion and do not re-own packaged catalog discovery, goal routing, deep_research, or other packaged factory packages.",
        "The top-level test has a customer-readable Go doc comment describing the observable required-input multi-worker merge completion behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-fusion-invocation-002",
      "title": "Prove optional inputs reach workers",
      "description": "As a customer configuring per-pass fusion providers, models, or effort hints, I want optional inputs to reach the drafter and refiner workers so supported overrides are honored end to end.",
      "acceptanceCriteria": [
        "The fusion invocation cell includes TestPackagedFusionOptionalInputsReachWorkers (or equivalent top-level name matching the checklist intent).",
        "Through the public CLI and/or API packaged-factory invocation boundary with mock workers, an @you/fusion invocation supplies optional overrides from the packaged supported set (at least one of firstProvider/secondProvider, firstModel/secondModel, firstEffort/secondEffort, and optionally output when asserting file-oriented contract visibility).",
        "Observable evidence proves those optional values reach workers / dispatches and appear in public outcome surfaces (dispatch execution selection and/or primary result fields reflecting the overrides).",
        "Assertions remain on optional-input reachability for fusion and do not widen into catalog required-input rejection matrices or other packaged factory packages.",
        "The top-level test has a customer-readable Go doc comment describing the observable optional-input-to-worker behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-fusion-invocation-003",
      "title": "Prove partial worker failure uses documented outcome",
      "description": "As a customer or automation handling a failing fusion run, I want a partial worker failure during packaged @you/fusion invocation to use the documented public failed outcome so scripts do not treat a failed draft or refine pass as successful completion.",
      "acceptanceCriteria": [
        "The fusion invocation cell includes TestPackagedFusionPartialWorkerFailureUsesDocumentedOutcome (or equivalent top-level name matching the checklist intent).",
        "Through the public CLI and/or API packaged-factory invocation boundary with mock workers, a fusion run is configured so one stage's worker/dispatch fails (mock-worker failure fixture or equivalent public harness control) while preserving enough context to observe the documented failure path.",
        "Observable evidence proves the public terminal outcome matches the documented fusion failure contract (failed / non-success terminal status; no completed success primary result attributable to the failing run).",
        "Assertions remain on documented failed outcome for fusion partial worker failure and do not re-own transport stdout/stderr shaping, full exit-code taxonomy, or other packaged factory failure matrices.",
        "The top-level test has a customer-readable Go doc comment describing the observable documented-outcome-on-partial-worker-failure contract.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-fusion-invocation-004",
      "title": "Close metadata and verification gates without invented deletions",
      "description": "As a maintainer executing Wave 2 functional-test expansion, I want only narrowly coupled metadata updates and passing focused boundary/viz gates for the fusion cell so this independent packaged package can terminal-complete without inventing migration-ledger deletion work when none map here.",
      "acceptanceCriteria": [
        "No migration-ledger deletion obligations are invented for tests/functional/factory/packaged/fusion/invocation_test.go (none currently map; checklist behaviors remain authoritative).",
        "Only narrowly coupled ownership, coverage, catalog, or migration metadata required for this cell are updated; sibling packaged factories (quorum, review, goal, deep_research, subagent, tts, cross) are not implemented or rewritten.",
        "Shared held deletion batches (runtime_api-delete-05-factory-packaged, smoke-delete-05-factory-packaged) are not claimed or executed from this cell.",
        "Focused package tests for tests/functional/factory/packaged/fusion pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as factory/packaged/fusion).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)