### PR TITLE
pss-cut-vis-rec

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1350,7 +1350,13 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/testing/recordingsstub",
-      "minimum": 0.00
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/cli",
@@ -2080,11 +2086,11 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/projections",
-      "minimum": 45.98
+      "minimum": 45.93
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/projections/dashboard",
-      "minimum": 36.36
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/replay",
@@ -2610,7 +2616,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/dashboard",
-      "minimum": 14.72
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/default",
@@ -2682,7 +2688,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/timedisplay",
-      "minimum": 19.23
+      "minimum": 7.69
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/work",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1285,6 +1285,10 @@
       }
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/recordingsqueries",
+      "minimum": 0.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle",
       "exception": {
         "kind": "measurement",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1349,6 +1349,10 @@
       "minimum": 100.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/testing/recordingsstub",
+      "minimum": 0.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/cli",
       "minimum": 55.09
     },

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -262,7 +262,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/contracts",
-      "minimum": 64.82
+      "minimum": 64.70
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/namedfactories",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1186,7 +1186,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/wire",
-      "minimum": 77.00
+      "minimum": 76.19
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1121,6 +1121,10 @@
       "minimum": 35.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/testing/recordingsstub",
+      "minimum": 0.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle",
       "exception": {
         "kind": "measurement",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1117,6 +1117,10 @@
       }
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/recordingsqueries",
+      "minimum": 35.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle",
       "exception": {
         "kind": "measurement",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1121,10 +1121,6 @@
       "minimum": 35.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/testing/recordingsstub",
-      "minimum": 0.00
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle",
       "exception": {
         "kind": "measurement",
@@ -1171,6 +1167,10 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/response_event_presentation/wire",
       "minimum": 100.00
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/testing/recordingsstub",
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/cli",

--- a/pkg/services/factory_visualization/assemble_root.go
+++ b/pkg/services/factory_visualization/assemble_root.go
@@ -18,7 +18,7 @@ func AssembleRoot(
 	projection liveviewprojection.Service,
 	presentation responsePresentationOwner,
 	source Source,
-	projections recordings.ProjectionService,
+	recordingsPeer recordings.Service,
 	clock Clock,
 	sink Sink,
 	reportError ErrorReporter,
@@ -32,8 +32,8 @@ func AssembleRoot(
 		return nil, errors.New("assemble Factory visualization root: response event presentation owner is required")
 	case source == nil:
 		return nil, errors.New("assemble Factory visualization root: event source is required")
-	case projections == nil:
-		return nil, errors.New("assemble Factory visualization root: projection service is required")
+	case recordingsPeer == nil:
+		return nil, errors.New("assemble Factory visualization root: recordings service is required")
 	case clock == nil:
 		return nil, errors.New("assemble Factory visualization root: clock is required")
 	case sink == nil:
@@ -47,7 +47,7 @@ func AssembleRoot(
 		projection:        projection,
 		presentationOwner: presentation,
 		source:            source,
-		projections:       projections,
+		recordings:        recordingsPeer,
 		clock:             clock,
 		sink:              sink,
 		reportError:       reportError,

--- a/pkg/services/factory_visualization/internal/recordingsqueries/canonical_projection.go
+++ b/pkg/services/factory_visualization/internal/recordingsqueries/canonical_projection.go
@@ -1,0 +1,208 @@
+package recordingsqueries
+
+import (
+	"encoding/json"
+	"strings"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+)
+
+// ReconstructWorldStateFromProjection reduces canonical facts through a legacy
+// ProjectionService peer and returns a detached world-state view.
+func ReconstructWorldStateFromProjection(
+	projection recordings.ProjectionService,
+	request recordings.ReconstructWorldStateRequest,
+) (recordings.ReconstructWorldStateResult, error) {
+	if projection == nil {
+		return recordings.ReconstructWorldStateResult{}, recordings.ErrInvalidProjectionInput
+	}
+	if request.SelectedTick < 0 {
+		return recordings.ReconstructWorldStateResult{}, recordings.ErrInvalidProjectionInput
+	}
+	if err := validateProjectionEvents(request.Scope, request.After, request.Events); err != nil {
+		return recordings.ReconstructWorldStateResult{}, err
+	}
+	events := make([]factorydefinitions.FactoryEvent, len(request.Events))
+	for index, event := range request.Events {
+		events[index] = factoryEventFromCanonical(event)
+	}
+	state, err := projection.ReconstructFactoryWorldState(events, request.SelectedTick)
+	if err != nil {
+		return recordings.ReconstructWorldStateResult{}, err
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return recordings.ReconstructWorldStateResult{}, err
+	}
+	through := recordings.CanonicalEventCursor{}
+	if request.After != nil {
+		through = *request.After
+	}
+	if len(request.Events) > 0 {
+		through = request.Events[len(request.Events)-1].Cursor
+	}
+	return recordings.ReconstructWorldStateResult{
+		WorldState: recordings.WorldStateView{
+			SchemaVersion: recordings.WorldStateViewSchemaV1,
+			Scope:         request.Scope,
+			Through:       through,
+			SelectedTick:  request.SelectedTick,
+			Payload:       string(payload),
+		},
+	}, nil
+}
+
+// QuerySimpleDashboardFromProjection returns dashboard render data through a
+// legacy ProjectionService peer.
+func QuerySimpleDashboardFromProjection(
+	projection recordings.ProjectionService,
+	request recordings.SimpleDashboardQueryRequest,
+) (recordings.SimpleDashboardQueryResult, error) {
+	if projection == nil {
+		return recordings.SimpleDashboardQueryResult{}, recordings.ErrInvalidProjectionInput
+	}
+	state, err := DecodeWorldStatePayload(request.WorldState)
+	if err != nil {
+		return recordings.SimpleDashboardQueryResult{}, err
+	}
+	return recordings.SimpleDashboardQueryResult{
+		Data: projection.SimpleDashboardRenderData(state),
+	}, nil
+}
+
+// ValidateReconnectReplayFromProjection validates reconnect observe input through
+// a legacy ProjectionService peer.
+func ValidateReconnectReplayFromProjection(
+	projection recordings.ProjectionService,
+	request recordings.ValidateReconnectReplayRequest,
+) error {
+	if projection == nil {
+		return recordings.ErrInvalidProjectionInput
+	}
+	if err := validateReconnectReplayHistory(
+		request.Scope,
+		request.Cursor,
+		request.Events,
+	); err != nil {
+		return err
+	}
+	afterSequence := int(request.Cursor.Sequence)
+	events := make([]factorydefinitions.FactoryEvent, len(request.Events))
+	for index, event := range request.Events {
+		events[index] = factoryEventFromCanonical(event)
+	}
+	return projection.ValidateReconnectReplay(
+		events,
+		factorydefinitions.FactoryEventReconnectCursor{AfterSequence: &afterSequence},
+		factorydefinitions.FactoryEventReconnectScope{SessionID: request.Scope.FactorySessionID},
+	)
+}
+
+func validateReconnectReplayHistory(
+	scope recordings.CanonicalEventScope,
+	cursor recordings.CanonicalEventCursor,
+	events []recordings.CanonicalEvent,
+) error {
+	if cursor.StreamGenerationID == "" || cursor.Sequence < 0 {
+		return recordings.ErrMalformedProjectionOrder
+	}
+	if err := validateProjectionEvents(scope, nil, events); err != nil {
+		return err
+	}
+	for _, event := range events {
+		if event.Cursor == cursor {
+			return nil
+		}
+	}
+	return recordings.ErrReconnectCursorNotFound
+}
+
+func validateProjectionEvents(
+	scope recordings.CanonicalEventScope,
+	after *recordings.CanonicalEventCursor,
+	events []recordings.CanonicalEvent,
+) error {
+	if scope.FactorySessionID != "" && strings.TrimSpace(scope.FactorySessionID) == "" {
+		return recordings.ErrInvalidProjectionScope
+	}
+	expected := recordings.CanonicalEventSequence(0)
+	generationID := ""
+	if after != nil {
+		if after.StreamGenerationID == "" || after.Sequence < 0 {
+			return recordings.ErrMalformedProjectionOrder
+		}
+		expected = after.Sequence + 1
+		generationID = after.StreamGenerationID
+	}
+	previous := expected - 1
+	for _, event := range events {
+		if err := validateProjectionEvent(
+			scope,
+			event,
+			expected,
+			previous,
+			generationID,
+		); err != nil {
+			return err
+		}
+		generationID = event.Cursor.StreamGenerationID
+		previous = event.Sequence
+		expected++
+	}
+	return nil
+}
+
+func validateProjectionEvent(
+	scope recordings.CanonicalEventScope,
+	event recordings.CanonicalEvent,
+	expected recordings.CanonicalEventSequence,
+	previous recordings.CanonicalEventSequence,
+	generationID string,
+) error {
+	if event.Scope != scope {
+		return recordings.ErrInvalidProjectionScope
+	}
+	if event.Cursor.Sequence != event.Sequence ||
+		event.Cursor.StreamGenerationID == "" {
+		return recordings.ErrMalformedProjectionOrder
+	}
+	if scope.FactorySessionID == "" && event.Sequence != expected {
+		return recordings.ErrMalformedProjectionOrder
+	}
+	if scope.FactorySessionID != "" && event.Sequence <= previous {
+		return recordings.ErrMalformedProjectionOrder
+	}
+	if generationID != "" && event.Cursor.StreamGenerationID != generationID {
+		return recordings.ErrMalformedProjectionOrder
+	}
+	return nil
+}
+
+func factoryEventFromCanonical(event recordings.CanonicalEvent) factorydefinitions.FactoryEvent {
+	context := factorydefinitions.FactoryEventContext{
+		EventTime: event.RecordedAt,
+		Sequence:  int(event.Sequence),
+		Tick:      event.FactoryTick,
+	}
+	hasSourceContext := json.Valid([]byte(event.SourceContext))
+	if hasSourceContext {
+		_ = json.Unmarshal([]byte(event.SourceContext), &context)
+	}
+	var sessionID *string
+	if event.Scope.FactorySessionID != "" {
+		value := event.Scope.FactorySessionID
+		sessionID = &value
+	}
+	legacy := factorydefinitions.FactoryEvent{
+		Context: context,
+		Id:      string(event.ID),
+		Payload: json.RawMessage(event.Payload),
+		Type:    factorydefinitions.FactoryEventType(event.Kind),
+	}
+	if !hasSourceContext && legacy.Context.SessionID == nil {
+		legacy.Context.SessionID = sessionID
+	}
+	legacy.SchemaVersion = factorydefinitions.FactoryEventSchemaVersionV1
+	return legacy
+}

--- a/pkg/services/factory_visualization/internal/recordingsqueries/queries.go
+++ b/pkg/services/factory_visualization/internal/recordingsqueries/queries.go
@@ -1,0 +1,181 @@
+// Package recordingsqueries constructs Recordings root projection-query requests
+// for Factory Visualization presentation paths.
+package recordingsqueries
+
+import (
+	"encoding/json"
+	"strings"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+)
+
+const visualizationCanonicalStreamGenerationID = "factory-visualization"
+
+// ReconstructWorldState projects retained Factory events through recordings.Service.
+func ReconstructWorldState(
+	service recordings.Service,
+	events []factorydefinitions.FactoryEvent,
+	selectedTick int,
+) (recordings.WorldStateView, error) {
+	if service == nil {
+		return recordings.WorldStateView{}, recordings.ErrInvalidProjectionInput
+	}
+	result, err := service.ReconstructWorldState(ReconstructWorldStateRequest(events, selectedTick))
+	if err != nil {
+		return recordings.WorldStateView{}, err
+	}
+	return result.WorldState, nil
+}
+
+// QuerySimpleDashboard returns dashboard render data through recordings.Service.
+func QuerySimpleDashboard(
+	service recordings.Service,
+	worldState recordings.WorldStateView,
+) (recordings.SimpleDashboardRenderData, error) {
+	if service == nil {
+		return recordings.SimpleDashboardRenderData{}, recordings.ErrInvalidProjectionInput
+	}
+	result, err := service.QuerySimpleDashboard(recordings.SimpleDashboardQueryRequest{
+		WorldState: worldState,
+	})
+	if err != nil {
+		return recordings.SimpleDashboardRenderData{}, err
+	}
+	return result.Data, nil
+}
+
+// ValidateReconnectReplay validates reconnect observe input through recordings.Service.
+func ValidateReconnectReplay(
+	service recordings.Service,
+	events []factorydefinitions.FactoryEvent,
+	cursor factorydefinitions.FactoryEventReconnectCursor,
+	scope factorydefinitions.FactoryEventReconnectScope,
+) error {
+	if service == nil {
+		return recordings.ErrInvalidProjectionInput
+	}
+	request, err := ValidateReconnectReplayRequest(events, cursor, scope)
+	if err != nil {
+		return err
+	}
+	return service.ValidateReconnectReplayFrom(request)
+}
+
+// ReconstructWorldStateRequest maps retained Factory events to the Recordings root
+// reconstruction request shape.
+func ReconstructWorldStateRequest(
+	events []factorydefinitions.FactoryEvent,
+	selectedTick int,
+) recordings.ReconstructWorldStateRequest {
+	return recordings.ReconstructWorldStateRequest{
+		Scope:        reconnectScope(scopeFromFactoryReconnect(factorydefinitions.FactoryEventReconnectScope{})),
+		Events:       canonicalEventsFromFactory(events),
+		SelectedTick: selectedTick,
+	}
+}
+
+// ValidateReconnectReplayRequest maps reconnect observe input to the Recordings root
+// validation request shape.
+func ValidateReconnectReplayRequest(
+	events []factorydefinitions.FactoryEvent,
+	cursor factorydefinitions.FactoryEventReconnectCursor,
+	scope factorydefinitions.FactoryEventReconnectScope,
+) (recordings.ValidateReconnectReplayRequest, error) {
+	canonicalEvents := canonicalEventsFromFactory(events)
+	canonicalCursor, err := canonicalReconnectCursor(events, cursor)
+	if err != nil {
+		return recordings.ValidateReconnectReplayRequest{}, err
+	}
+	return recordings.ValidateReconnectReplayRequest{
+		Events: canonicalEvents,
+		Cursor: canonicalCursor,
+		Scope:  reconnectScope(scopeFromFactoryReconnect(scope)),
+	}, nil
+}
+
+// DecodeWorldStatePayload decodes one detached Recordings world-state view payload.
+func DecodeWorldStatePayload(view recordings.WorldStateView) (factorydefinitions.FactoryWorldState, error) {
+	if view.SchemaVersion != recordings.WorldStateViewSchemaV1 ||
+		strings.TrimSpace(view.Payload) == "" {
+		return factorydefinitions.FactoryWorldState{}, recordings.ErrUnsupportedProjectionView
+	}
+	var state factorydefinitions.FactoryWorldState
+	if err := json.Unmarshal([]byte(view.Payload), &state); err != nil {
+		return factorydefinitions.FactoryWorldState{}, recordings.ErrInvalidProjectionInput
+	}
+	return state, nil
+}
+
+func scopeFromFactoryReconnect(scope factorydefinitions.FactoryEventReconnectScope) recordings.CanonicalEventScope {
+	sessionID := strings.TrimSpace(scope.SessionID)
+	if sessionID == "" {
+		return recordings.CanonicalEventScope{}
+	}
+	return recordings.CanonicalEventScope{FactorySessionID: sessionID}
+}
+
+func reconnectScope(scope recordings.CanonicalEventScope) recordings.CanonicalEventScope {
+	return scope
+}
+
+func canonicalEventsFromFactory(events []factorydefinitions.FactoryEvent) []recordings.CanonicalEvent {
+	if len(events) == 0 {
+		return nil
+	}
+	canonical := make([]recordings.CanonicalEvent, len(events))
+	for index, event := range events {
+		canonical[index] = canonicalEventFromFactory(event)
+	}
+	return canonical
+}
+
+func canonicalEventFromFactory(event factorydefinitions.FactoryEvent) recordings.CanonicalEvent {
+	sourceContext, _ := json.Marshal(event.Context)
+	scope := recordings.CanonicalEventScope{}
+	if event.Context.SessionID != nil {
+		scope.FactorySessionID = strings.TrimSpace(*event.Context.SessionID)
+	}
+	sequence := recordings.CanonicalEventSequence(event.Context.Sequence)
+	return recordings.CanonicalEvent{
+		ID:          recordings.CanonicalEventID(event.Id),
+		Sequence:    sequence,
+		FactoryTick: event.Context.Tick,
+		Scope:       scope,
+		Cursor: recordings.CanonicalEventCursor{
+			StreamGenerationID: visualizationCanonicalStreamGenerationID,
+			Sequence:           sequence,
+		},
+		RecordedAt:    event.Context.EventTime,
+		Kind:          recordings.CanonicalEventKind(event.Type),
+		Payload:       string(event.Payload),
+		SourceContext: string(sourceContext),
+	}
+}
+
+func canonicalReconnectCursor(
+	events []factorydefinitions.FactoryEvent,
+	cursor factorydefinitions.FactoryEventReconnectCursor,
+) (recordings.CanonicalEventCursor, error) {
+	if afterEventID := strings.TrimSpace(cursor.AfterEventID); afterEventID != "" {
+		for _, event := range events {
+			if event.Id == afterEventID {
+				return canonicalEventFromFactory(event).Cursor, nil
+			}
+		}
+		return recordings.CanonicalEventCursor{}, recordings.ErrReconnectCursorNotFound
+	}
+	if cursor.AfterSequence == nil {
+		return recordings.CanonicalEventCursor{}, recordings.ErrInvalidReconnectCursor
+	}
+	for _, event := range events {
+		sequence := event.Context.Sequence
+		if event.Context.SessionSequence != nil {
+			sequence = *event.Context.SessionSequence
+		}
+		if sequence == *cursor.AfterSequence {
+			return canonicalEventFromFactory(event).Cursor, nil
+		}
+	}
+	return recordings.CanonicalEventCursor{}, recordings.ErrReconnectCursorNotFound
+}

--- a/pkg/services/factory_visualization/internal/recordingsqueries/throttle_pause_presentation.go
+++ b/pkg/services/factory_visualization/internal/recordingsqueries/throttle_pause_presentation.go
@@ -1,0 +1,165 @@
+package recordingsqueries
+
+import (
+	"sort"
+	"strings"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+)
+
+// ProjectActiveThrottlePauses converts dispatcher-owned runtime pause windows into
+// dashboard presentation facts using authored topology metadata.
+func ProjectActiveThrottlePauses(
+	topology factorydefinitions.InitialStructurePayload,
+	pauses []factorydefinitions.ActiveThrottlePause,
+) []factorydefinitions.FactoryWorldThrottlePause {
+	if len(pauses) == 0 {
+		return nil
+	}
+
+	workersByID := make(map[string]factorydefinitions.FactoryWorker, len(topology.Workers))
+	for _, worker := range topology.Workers {
+		if worker.ID == "" {
+			continue
+		}
+		workersByID[worker.ID] = worker
+	}
+
+	placesByID := make(map[string]factorydefinitions.FactoryPlace, len(topology.Places))
+	for _, place := range topology.Places {
+		if place.ID == "" {
+			continue
+		}
+		placesByID[place.ID] = place
+	}
+
+	projected := make([]factorydefinitions.FactoryWorldThrottlePause, 0, len(pauses))
+	for _, pause := range pauses {
+		projected = append(projected, factorydefinitions.FactoryWorldThrottlePause{
+			LaneID:                   pause.LaneID,
+			Provider:                 pause.Provider,
+			Model:                    pause.Model,
+			PausedAt:                 pause.PausedAt,
+			PausedUntil:              pause.PausedUntil,
+			RecoverAt:                pause.PausedUntil,
+			AffectedTransitionIDs:    affectedTransitionIDsForPause(topology.Workstations, workersByID, pause),
+			AffectedWorkstationNames: affectedWorkstationNamesForPause(topology.Workstations, workersByID, pause),
+			AffectedWorkerTypes:      affectedWorkerTypesForPause(topology.Workstations, workersByID, pause),
+			AffectedWorkTypeIDs:      affectedWorkTypeIDsForPause(topology.Workstations, workersByID, placesByID, pause),
+		})
+	}
+
+	return projected
+}
+
+func affectedTransitionIDsForPause(
+	workstations []factorydefinitions.FactoryWorkstation,
+	workersByID map[string]factorydefinitions.FactoryWorker,
+	pause factorydefinitions.ActiveThrottlePause,
+) []string {
+	var ids []string
+	for _, workstation := range workstations {
+		if !workstationMatchesPause(workstation, workersByID, pause) {
+			continue
+		}
+		ids = appendUnique(ids, workstation.ID)
+	}
+	return sortedStrings(ids)
+}
+
+func affectedWorkstationNamesForPause(
+	workstations []factorydefinitions.FactoryWorkstation,
+	workersByID map[string]factorydefinitions.FactoryWorker,
+	pause factorydefinitions.ActiveThrottlePause,
+) []string {
+	var names []string
+	for _, workstation := range workstations {
+		if !workstationMatchesPause(workstation, workersByID, pause) {
+			continue
+		}
+		names = appendUnique(names, workstation.Name)
+	}
+	return sortedStrings(names)
+}
+
+func affectedWorkerTypesForPause(
+	workstations []factorydefinitions.FactoryWorkstation,
+	workersByID map[string]factorydefinitions.FactoryWorker,
+	pause factorydefinitions.ActiveThrottlePause,
+) []string {
+	var workerTypes []string
+	for _, workstation := range workstations {
+		if !workstationMatchesPause(workstation, workersByID, pause) {
+			continue
+		}
+		workerTypes = appendUnique(workerTypes, workstation.WorkerID)
+	}
+	return sortedStrings(workerTypes)
+}
+
+func affectedWorkTypeIDsForPause(
+	workstations []factorydefinitions.FactoryWorkstation,
+	workersByID map[string]factorydefinitions.FactoryWorker,
+	placesByID map[string]factorydefinitions.FactoryPlace,
+	pause factorydefinitions.ActiveThrottlePause,
+) []string {
+	var workTypeIDs []string
+	for _, workstation := range workstations {
+		if !workstationMatchesPause(workstation, workersByID, pause) {
+			continue
+		}
+		for _, placeID := range workstation.InputPlaceIDs {
+			place, ok := placesByID[placeID]
+			if !ok || place.TypeID == "" || factorydefinitions.IsSystemTimeWorkType(place.TypeID) {
+				continue
+			}
+			workTypeIDs = appendUnique(workTypeIDs, place.TypeID)
+		}
+	}
+	return sortedStrings(workTypeIDs)
+}
+
+func workstationMatchesPause(
+	workstation factorydefinitions.FactoryWorkstation,
+	workersByID map[string]factorydefinitions.FactoryWorker,
+	pause factorydefinitions.ActiveThrottlePause,
+) bool {
+	if workstation.WorkerID == "" {
+		return false
+	}
+	worker, ok := workersByID[workstation.WorkerID]
+	if !ok {
+		return false
+	}
+	provider := firstNonEmpty(worker.ModelProvider, worker.Provider)
+	return strings.EqualFold(provider, pause.Provider) && worker.Model == pause.Model
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func appendUnique(values []string, value string) []string {
+	if value == "" {
+		return values
+	}
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}
+
+func sortedStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	sort.Strings(values)
+	return values
+}

--- a/pkg/services/factory_visualization/internal/services/activation_lifecycle/internal/service/service.go
+++ b/pkg/services/factory_visualization/internal/services/activation_lifecycle/internal/service/service.go
@@ -8,6 +8,8 @@ import (
 
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	activationlifecycle "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle"
+	"github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/recordingsqueries"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
 )
 
 var (
@@ -19,7 +21,7 @@ var (
 // subscription lifecycle for Factory visualization activation.
 type Service struct {
 	source      activationlifecycle.EventSource
-	projections activationlifecycle.ProjectionService
+	recordings  recordings.Service
 	clock       activationlifecycle.Clock
 	sink        activationlifecycle.ViewSink
 	reportError activationlifecycle.ErrorReporter
@@ -40,7 +42,7 @@ var _ activationlifecycle.Service = (*Service)(nil)
 // New constructs an inert activation lifecycle owner.
 func New(
 	source activationlifecycle.EventSource,
-	projections activationlifecycle.ProjectionService,
+	recordingsPeer recordings.Service,
 	clock activationlifecycle.Clock,
 	sink activationlifecycle.ViewSink,
 	reportError activationlifecycle.ErrorReporter,
@@ -48,15 +50,15 @@ func New(
 	switch {
 	case source == nil:
 		return nil, errors.New("initialize Factory visualization activation: event source is required")
-	case projections == nil:
-		return nil, errors.New("initialize Factory visualization activation: projection service is required")
+	case recordingsPeer == nil:
+		return nil, errors.New("initialize Factory visualization activation: recordings service is required")
 	case clock == nil:
 		return nil, errors.New("initialize Factory visualization activation: clock is required")
 	case sink == nil:
 		return nil, errors.New("initialize Factory visualization activation: presentation sink is required")
 	default:
 		return &Service{
-			source: source, projections: projections, clock: clock,
+			source: source, recordings: recordingsPeer, clock: clock,
 			sink: sink, reportError: reportError,
 		}, nil
 	}
@@ -284,13 +286,22 @@ func (s *Service) projectAndPresent(ctx context.Context) {
 	s.mu.Lock()
 	events := append([]factorydefinitions.FactoryEvent(nil), s.events...)
 	s.mu.Unlock()
-	worldState, err := s.projections.ReconstructFactoryWorldState(events, observation.TickCount)
+	worldView, err := recordingsqueries.ReconstructWorldState(s.recordings, events, observation.TickCount)
 	if err != nil {
 		s.report(fmt.Errorf("project Factory visualization: %w", err))
 		return
 	}
-	renderData := s.projections.SimpleDashboardRenderData(worldState)
-	renderData.ActiveThrottlePauses = s.projections.ProjectActiveThrottlePauses(
+	renderData, err := recordingsqueries.QuerySimpleDashboard(s.recordings, worldView)
+	if err != nil {
+		s.report(fmt.Errorf("project Factory visualization dashboard: %w", err))
+		return
+	}
+	worldState, err := recordingsqueries.DecodeWorldStatePayload(worldView)
+	if err != nil {
+		s.report(fmt.Errorf("decode Factory visualization world state: %w", err))
+		return
+	}
+	renderData.ActiveThrottlePauses = recordingsqueries.ProjectActiveThrottlePauses(
 		worldState.Topology,
 		observation.ActiveThrottlePauses,
 	)

--- a/pkg/services/factory_visualization/internal/services/activation_lifecycle/internal/service/service_default_inert_test.go
+++ b/pkg/services/factory_visualization/internal/services/activation_lifecycle/internal/service/service_default_inert_test.go
@@ -8,6 +8,7 @@ import (
 
 	activationlifecycle "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle"
 	lifecycleservice "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle/internal/service"
+	"github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/testing/recordingsstub"
 )
 
 func TestNewRejectsMissingActivationLifecycleDependencies(t *testing.T) {
@@ -15,7 +16,7 @@ func TestNewRejectsMissingActivationLifecycleDependencies(t *testing.T) {
 
 	clock := fixedLifecycleClock{now: time.Unix(1, 0)}
 	sink := lifecycleSinkFunc(func(activationlifecycle.View) {})
-	projections := lifecycleProjectionStub{}
+	projections := &recordingsstub.Service{}
 	source := &lifecycleSourceStub{}
 	tests := []struct {
 		name string
@@ -27,7 +28,7 @@ func TestNewRejectsMissingActivationLifecycleDependencies(t *testing.T) {
 		}, "event source"},
 		{"projections", func() (*lifecycleservice.Service, error) {
 			return lifecycleservice.New(source, nil, clock, sink, nil)
-		}, "projection service"},
+		}, "recordings service"},
 		{"clock", func() (*lifecycleservice.Service, error) {
 			return lifecycleservice.New(source, projections, nil, sink, nil)
 		}, "clock"},
@@ -61,7 +62,7 @@ func TestActivationLifecycleDefaultInertConstruction(t *testing.T) {
 	source.subscribeHook = func() { subscribeCalls++ }
 	owner, err := lifecycleservice.New(
 		source,
-		lifecycleProjectionStub{},
+		&recordingsstub.Service{},
 		fixedLifecycleClock{now: time.Unix(1, 0)},
 		lifecycleSinkFunc(func(activationlifecycle.View) { presentCalls++ }),
 		nil,

--- a/pkg/services/factory_visualization/internal/services/activation_lifecycle/internal/service/service_explicit_activation_test.go
+++ b/pkg/services/factory_visualization/internal/services/activation_lifecycle/internal/service/service_explicit_activation_test.go
@@ -7,6 +7,7 @@ import (
 
 	activationlifecycle "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle"
 	lifecycleservice "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle/internal/service"
+	"github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/testing/recordingsstub"
 )
 
 func TestActivationLifecycleExplicitRequestActivation(t *testing.T) {
@@ -20,7 +21,7 @@ func TestActivationLifecycleExplicitRequestActivation(t *testing.T) {
 	source.subscribeHook = func() { subscribeCalls++ }
 	owner, err := lifecycleservice.New(
 		source,
-		lifecycleProjectionStub{},
+		&recordingsstub.Service{},
 		fixedLifecycleClock{now: time.Unix(1, 0)},
 		lifecycleSinkFunc(func(activationlifecycle.View) { presentCalls++ }),
 		nil,

--- a/pkg/services/factory_visualization/internal/services/activation_lifecycle/internal/service/service_stop_wait_cleanup_test.go
+++ b/pkg/services/factory_visualization/internal/services/activation_lifecycle/internal/service/service_stop_wait_cleanup_test.go
@@ -10,6 +10,7 @@ import (
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	activationlifecycle "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle"
 	lifecycleservice "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle/internal/service"
+	"github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/testing/recordingsstub"
 )
 
 func TestActivationLifecycleWaitBeforeActivateReturnsNotActivated(t *testing.T) {
@@ -218,7 +219,7 @@ func mustNewActivationLifecycleOwnerWithSource(
 	t.Helper()
 	owner, err := lifecycleservice.New(
 		source,
-		lifecycleProjectionStub{},
+		&recordingsstub.Service{},
 		fixedLifecycleClock{now: time.Unix(1, 0)},
 		lifecycleSinkFunc(func(activationlifecycle.View) {}),
 		nil,

--- a/pkg/services/factory_visualization/internal/services/activation_lifecycle/internal/service/service_test.go
+++ b/pkg/services/factory_visualization/internal/services/activation_lifecycle/internal/service/service_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
-	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	"github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/testing/recordingsstub"
 	activationlifecycle "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle"
 	lifecycleservice "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle/internal/service"
 )
@@ -24,7 +24,7 @@ func TestActivationLifecycleOwnerBacksRootLifecycleSlice(t *testing.T) {
 	presentCalls := 0
 	owner, err := lifecycleservice.New(
 		source,
-		lifecycleProjectionStub{},
+		&recordingsstub.Service{},
 		fixedLifecycleClock{now: time.Unix(1, 0)},
 		lifecycleSinkFunc(func(activationlifecycle.View) { presentCalls++ }),
 		nil,
@@ -115,29 +115,6 @@ func newClosableLifecycleEventStream() (*factorydefinitions.FactoryEventStream, 
 		Events: events,
 	}, events
 }
-
-type lifecycleProjectionStub struct{}
-
-func (lifecycleProjectionStub) ReconstructFactoryWorldState(
-	[]factorydefinitions.FactoryEvent,
-	int,
-) (factorydefinitions.FactoryWorldState, error) {
-	return factorydefinitions.FactoryWorldState{}, nil
-}
-
-func (lifecycleProjectionStub) SimpleDashboardRenderData(
-	factorydefinitions.FactoryWorldState,
-) recordings.SimpleDashboardRenderData {
-	return recordings.SimpleDashboardRenderData{}
-}
-
-func (lifecycleProjectionStub) ProjectActiveThrottlePauses(
-	factorydefinitions.InitialStructurePayload,
-	[]factorydefinitions.ActiveThrottlePause,
-) []factorydefinitions.FactoryWorldThrottlePause {
-	return nil
-}
-
 type fixedLifecycleClock struct{ now time.Time }
 
 func (c fixedLifecycleClock) Now() time.Time { return c.now }

--- a/pkg/services/factory_visualization/internal/services/activation_lifecycle/service.go
+++ b/pkg/services/factory_visualization/internal/services/activation_lifecycle/service.go
@@ -107,19 +107,6 @@ type EventSource interface {
 	GetEngineObservation(context.Context) (*EngineObservation, error)
 }
 
-// ProjectionService reconstructs retained Factory world state for presentation.
-type ProjectionService interface {
-	ReconstructFactoryWorldState(
-		[]factorydefinitions.FactoryEvent,
-		int,
-	) (factorydefinitions.FactoryWorldState, error)
-	SimpleDashboardRenderData(factorydefinitions.FactoryWorldState) recordings.SimpleDashboardRenderData
-	ProjectActiveThrottlePauses(
-		factorydefinitions.InitialStructurePayload,
-		[]factorydefinitions.ActiveThrottlePause,
-	) []factorydefinitions.FactoryWorldThrottlePause
-}
-
 // Clock supplies observation timestamps.
 type Clock interface {
 	Now() time.Time

--- a/pkg/services/factory_visualization/internal/services/activation_lifecycle/wire/wire.go
+++ b/pkg/services/factory_visualization/internal/services/activation_lifecycle/wire/wire.go
@@ -4,16 +4,17 @@ package wire
 import (
 	activationlifecycle "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle"
 	lifecycleservice "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle/internal/service"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
 )
 
 // NewService constructs the private activation lifecycle owner from the exact
 // collaborators selected by the Visualization root composition.
 func NewService(
 	source activationlifecycle.EventSource,
-	projections activationlifecycle.ProjectionService,
+	recordingsPeer recordings.Service,
 	clock activationlifecycle.Clock,
 	sink activationlifecycle.ViewSink,
 	reportError activationlifecycle.ErrorReporter,
 ) (activationlifecycle.Service, error) {
-	return lifecycleservice.New(source, projections, clock, sink, reportError)
+	return lifecycleservice.New(source, recordingsPeer, clock, sink, reportError)
 }

--- a/pkg/services/factory_visualization/internal/services/activation_lifecycle/wire/wire_test.go
+++ b/pkg/services/factory_visualization/internal/services/activation_lifecycle/wire/wire_test.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
-	"github.com/portpowered/infinite-you/pkg/services/recordings"
 	activationlifecycle "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle"
 	activationlifecyclewire "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle/wire"
+	"github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/testing/recordingsstub"
 )
 
 type wireSourceStub struct {
@@ -32,28 +32,6 @@ func (wireSourceStub) GetEngineObservation(context.Context) (*activationlifecycl
 	return &activationlifecycle.EngineObservation{}, nil
 }
 
-type wireProjectionStub struct{}
-
-func (wireProjectionStub) ReconstructFactoryWorldState(
-	[]factorydefinitions.FactoryEvent,
-	int,
-) (factorydefinitions.FactoryWorldState, error) {
-	return factorydefinitions.FactoryWorldState{}, nil
-}
-
-func (wireProjectionStub) SimpleDashboardRenderData(
-	factorydefinitions.FactoryWorldState,
-) recordings.SimpleDashboardRenderData {
-	return recordings.SimpleDashboardRenderData{}
-}
-
-func (wireProjectionStub) ProjectActiveThrottlePauses(
-	factorydefinitions.InitialStructurePayload,
-	[]factorydefinitions.ActiveThrottlePause,
-) []factorydefinitions.FactoryWorldThrottlePause {
-	return nil
-}
-
 type wireClock struct{}
 
 func (wireClock) Now() time.Time { return time.Unix(1, 0) }
@@ -66,7 +44,7 @@ func TestNewServiceConstructsActivationLifecycleOwner(t *testing.T) {
 	source := wireSourceStub{subscribeHook: func() { subscribeCalls++ }}
 	service, err := activationlifecyclewire.NewService(
 		source,
-		wireProjectionStub{},
+		&recordingsstub.Service{},
 		wireClock{},
 		wireSinkFunc(func(activationlifecycle.View) { presentCalls++ }),
 		nil,
@@ -99,7 +77,7 @@ func TestNewServiceExplicitRequestActivation(t *testing.T) {
 	source := wireSourceStub{subscribeHook: func() { subscribeCalls++ }}
 	service, err := activationlifecyclewire.NewService(
 		source,
-		wireProjectionStub{},
+		&recordingsstub.Service{},
 		wireClock{},
 		wireSinkFunc(func(activationlifecycle.View) { presentCalls++ }),
 		nil,
@@ -151,7 +129,7 @@ func TestNewServiceStopWaitCleanup(t *testing.T) {
 	source := wireSourceStub{subscribeHook: func() { subscribeCalls++ }}
 	service, err := activationlifecyclewire.NewService(
 		source,
-		wireProjectionStub{},
+		&recordingsstub.Service{},
 		wireClock{},
 		wireSinkFunc(func(activationlifecycle.View) {}),
 		nil,

--- a/pkg/services/factory_visualization/internal/services/live_view_projection/internal/service/cursor_continuity_test.go
+++ b/pkg/services/factory_visualization/internal/services/live_view_projection/internal/service/cursor_continuity_test.go
@@ -10,22 +10,6 @@ import (
 	projectionservice "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/live_view_projection/internal/service"
 )
 
-// cursorContinuityProjection records each reconstruction call so continuity
-// tests can assert monotonic event growth without duplicate retained replay.
-type cursorContinuityProjection struct {
-	projectionStub
-	reconstructCalls [][]factorydefinitions.FactoryEvent
-}
-
-func (p *cursorContinuityProjection) ReconstructFactoryWorldState(
-	events []factorydefinitions.FactoryEvent,
-	tick int,
-) (factorydefinitions.FactoryWorldState, error) {
-	copied := append([]factorydefinitions.FactoryEvent(nil), events...)
-	p.reconstructCalls = append(p.reconstructCalls, copied)
-	return p.projectionStub.ReconstructFactoryWorldState(events, tick)
-}
-
 func assertCursor(
 	t *testing.T,
 	cursor *factorydefinitions.FactoryEventReconnectCursor,
@@ -89,7 +73,7 @@ func TestRetainedOnlyStartCursorPointsAtLastRetainedEvent(t *testing.T) {
 	}
 	svc, err := projectionservice.New(
 		source,
-		projectionStub{},
+		newProjectionStub(),
 		fixedClock{now: time.Unix(1, 0)},
 		liveviewprojection.SinkFunc(func(liveviewprojection.View) {}),
 		nil,
@@ -135,12 +119,7 @@ func TestRetainedThenOneLiveAdvanceContinuesSameCursorAuthority(t *testing.T) {
 		snapshot: snapshotFacts(1),
 	}
 	projected := make(chan []factorydefinitions.FactoryEvent, 2)
-	projections := projectionStub{
-		reconstruct: func(events []factorydefinitions.FactoryEvent, tick int) (factorydefinitions.FactoryWorldState, error) {
-			projected <- append([]factorydefinitions.FactoryEvent(nil), events...)
-			return factorydefinitions.FactoryWorldState{}, nil
-		},
-	}
+	projections := newTrackingProjectionStub(projected)
 	rendered := make(chan liveviewprojection.View, 2)
 	svc, err := projectionservice.New(
 		source,
@@ -200,7 +179,7 @@ func TestMultiLiveAdvanceAfterRetainedHistoryContinuesCursor(t *testing.T) {
 		event("retained-b", 2),
 	}
 	live := make(chan factorydefinitions.FactoryEvent, 3)
-	projections := &cursorContinuityProjection{}
+	projections := newCursorContinuityProjection()
 	source := &sourceStub{
 		stream: &factorydefinitions.FactoryEventStream{
 			History: retained,
@@ -260,7 +239,7 @@ func TestLiveDeltasDoNotDuplicateRetainedReplay(t *testing.T) {
 		event("retained-b", 2),
 	}
 	live := make(chan factorydefinitions.FactoryEvent, 2)
-	projections := &cursorContinuityProjection{}
+	projections := newCursorContinuityProjection()
 	source := &sourceStub{
 		stream: &factorydefinitions.FactoryEventStream{
 			History: retained,
@@ -270,11 +249,6 @@ func TestLiveDeltasDoNotDuplicateRetainedReplay(t *testing.T) {
 	}
 	subscribeCalls := 0
 	source.subscribeHook = func() { subscribeCalls++ }
-	projected := make(chan []factorydefinitions.FactoryEvent, 4)
-	projections.reconstruct = func(events []factorydefinitions.FactoryEvent, tick int) (factorydefinitions.FactoryWorldState, error) {
-		projected <- append([]factorydefinitions.FactoryEvent(nil), events...)
-		return factorydefinitions.FactoryWorldState{}, nil
-	}
 
 	svc, err := projectionservice.New(
 		source,
@@ -296,11 +270,22 @@ func TestLiveDeltasDoNotDuplicateRetainedReplay(t *testing.T) {
 		t.Fatalf("subscribe calls after Start = %d, want 1", subscribeCalls)
 	}
 
-	<-projected
+	waitReconstructCalls := func(min int) {
+		t.Helper()
+		deadline := time.Now().Add(2 * time.Second)
+		for len(projections.reconstructCalls) < min {
+			if time.Now().After(deadline) {
+				t.Fatalf("reconstruct calls = %d, want at least %d", len(projections.reconstructCalls), min)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	waitReconstructCalls(1)
 	live <- event("live-a", 3)
-	<-projected
+	waitReconstructCalls(2)
 	live <- event("live-b", 4)
-	<-projected
+	waitReconstructCalls(3)
 
 	if subscribeCalls != 1 {
 		t.Fatalf("subscribe calls after live deltas = %d, want still 1", subscribeCalls)

--- a/pkg/services/factory_visualization/internal/services/live_view_projection/internal/service/projection_test_helpers_test.go
+++ b/pkg/services/factory_visualization/internal/services/live_view_projection/internal/service/projection_test_helpers_test.go
@@ -1,0 +1,76 @@
+package service_test
+
+import (
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/testing/recordingsstub"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+)
+
+func factoryEventsFromCanonical(events []recordings.CanonicalEvent) []factorydefinitions.FactoryEvent {
+	mapped := make([]factorydefinitions.FactoryEvent, len(events))
+	for index, event := range events {
+		mapped[index] = factorydefinitions.FactoryEvent{
+			Id: string(event.ID),
+			Context: factorydefinitions.FactoryEventContext{
+				Sequence: int(event.Sequence),
+			},
+		}
+	}
+	return mapped
+}
+
+func newProjectionStub() *recordingsstub.Service {
+	return &recordingsstub.Service{}
+}
+
+func newProjectionStubWithDashboard(data recordings.SimpleDashboardRenderData) *recordingsstub.Service {
+	return &recordingsstub.Service{DashboardData: data}
+}
+
+func newTrackingProjectionStub(projected chan<- []factorydefinitions.FactoryEvent) *recordingsstub.Service {
+	return &recordingsstub.Service{
+		ReconstructWorldStateFn: func(request recordings.ReconstructWorldStateRequest) (recordings.ReconstructWorldStateResult, error) {
+			events := factoryEventsFromCanonical(request.Events)
+			projected <- append([]factorydefinitions.FactoryEvent(nil), events...)
+			return recordings.ReconstructWorldStateResult{
+				WorldState: recordings.WorldStateView{
+					SchemaVersion: recordings.WorldStateViewSchemaV1,
+					Payload:       `{"topology":{}}`,
+				},
+			}, nil
+		},
+	}
+}
+
+func newFailingProjectionStub(err error) *recordingsstub.Service {
+	return &recordingsstub.Service{
+		ReconstructWorldStateFn: func(recordings.ReconstructWorldStateRequest) (recordings.ReconstructWorldStateResult, error) {
+			return recordings.ReconstructWorldStateResult{}, err
+		},
+	}
+}
+
+// cursorContinuityProjection records each reconstruction call so continuity
+// tests can assert monotonic event growth without duplicate retained replay.
+type cursorContinuityProjection struct {
+	*recordingsstub.Service
+	reconstructCalls [][]factorydefinitions.FactoryEvent
+}
+
+func newCursorContinuityProjection() *cursorContinuityProjection {
+	projection := &cursorContinuityProjection{Service: &recordingsstub.Service{}}
+	projection.ReconstructWorldStateFn = func(request recordings.ReconstructWorldStateRequest) (recordings.ReconstructWorldStateResult, error) {
+		events := factoryEventsFromCanonical(request.Events)
+		projection.reconstructCalls = append(
+			projection.reconstructCalls,
+			append([]factorydefinitions.FactoryEvent(nil), events...),
+		)
+		return recordings.ReconstructWorldStateResult{
+			WorldState: recordings.WorldStateView{
+				SchemaVersion: recordings.WorldStateViewSchemaV1,
+				Payload:       `{"topology":{}}`,
+			},
+		}, nil
+	}
+	return projection
+}

--- a/pkg/services/factory_visualization/internal/services/live_view_projection/internal/service/service.go
+++ b/pkg/services/factory_visualization/internal/services/live_view_projection/internal/service/service.go
@@ -9,13 +9,14 @@ import (
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
 	liveviewprojection "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/live_view_projection"
+	"github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/recordingsqueries"
 )
 
 // Service owns retained event projection, reconnect cursor, and live
 // subscription lifecycle for one Factory visualization.
 type Service struct {
 	source      liveviewprojection.Source
-	projections recordings.ProjectionService
+	recordings  recordings.Service
 	clock       liveviewprojection.Clock
 	sink        liveviewprojection.Sink
 	reportError liveviewprojection.ErrorReporter
@@ -43,7 +44,7 @@ var (
 // New constructs the private live_view_projection implementation.
 func New(
 	source liveviewprojection.Source,
-	projections recordings.ProjectionService,
+	recordingsPeer recordings.Service,
 	clock liveviewprojection.Clock,
 	sink liveviewprojection.Sink,
 	reportError liveviewprojection.ErrorReporter,
@@ -51,15 +52,15 @@ func New(
 	switch {
 	case source == nil:
 		return nil, errors.New("initialize Factory visualization live view projection: event source is required")
-	case projections == nil:
-		return nil, errors.New("initialize Factory visualization live view projection: projection service is required")
+	case recordingsPeer == nil:
+		return nil, errors.New("initialize Factory visualization live view projection: recordings service is required")
 	case clock == nil:
 		return nil, errors.New("initialize Factory visualization live view projection: clock is required")
 	case sink == nil:
 		return nil, errors.New("initialize Factory visualization live view projection: presentation sink is required")
 	default:
 		return &Service{
-			source: source, projections: projections, clock: clock,
+			source: source, recordings: recordingsPeer, clock: clock,
 			sink: sink, reportError: reportError,
 		}, nil
 	}
@@ -244,7 +245,8 @@ func (s *Service) Observe(
 			AfterEventID:  req.Reconnect.AfterEventID,
 			AfterSequence: req.Reconnect.AfterSequence,
 		}
-		if err := s.projections.ValidateReconnectReplay(
+		if err := recordingsqueries.ValidateReconnectReplay(
+			s.recordings,
 			events,
 			cursor,
 			factorydefinitions.FactoryEventReconnectScope{},
@@ -257,7 +259,7 @@ func (s *Service) Observe(
 		}
 	}
 
-	if _, err := s.projections.ReconstructFactoryWorldState(events, snapshot.TickCount); err != nil {
+	if _, err := recordingsqueries.ReconstructWorldState(s.recordings, events, snapshot.TickCount); err != nil {
 		return liveviewprojection.ObserveResult{}, &liveviewprojection.ProjectionError{
 			Kind:    liveviewprojection.ProjectionErrorReconstructionFailed,
 			Message: "observe Factory visualization live view projection: projection reconstruction failed",
@@ -333,13 +335,22 @@ func (s *Service) projectAndPresent(ctx context.Context) {
 	s.mu.Lock()
 	events := append([]factorydefinitions.FactoryEvent(nil), s.events...)
 	s.mu.Unlock()
-	worldState, err := s.projections.ReconstructFactoryWorldState(events, snapshot.TickCount)
+	worldView, err := recordingsqueries.ReconstructWorldState(s.recordings, events, snapshot.TickCount)
 	if err != nil {
 		s.report(fmt.Errorf("project Factory visualization: %w", err))
 		return
 	}
-	renderData := s.projections.SimpleDashboardRenderData(worldState)
-	renderData.ActiveThrottlePauses = s.projections.ProjectActiveThrottlePauses(
+	renderData, err := recordingsqueries.QuerySimpleDashboard(s.recordings, worldView)
+	if err != nil {
+		s.report(fmt.Errorf("project Factory visualization dashboard: %w", err))
+		return
+	}
+	worldState, err := recordingsqueries.DecodeWorldStatePayload(worldView)
+	if err != nil {
+		s.report(fmt.Errorf("decode Factory visualization world state: %w", err))
+		return
+	}
+	renderData.ActiveThrottlePauses = recordingsqueries.ProjectActiveThrottlePauses(
 		worldState.Topology,
 		snapshot.ActiveThrottlePauses,
 	)

--- a/pkg/services/factory_visualization/internal/services/live_view_projection/internal/service/service_test.go
+++ b/pkg/services/factory_visualization/internal/services/live_view_projection/internal/service/service_test.go
@@ -8,6 +8,7 @@ import (
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	liveviewprojection "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/live_view_projection"
 	projectionservice "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/live_view_projection/internal/service"
+	"github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/testing/recordingsstub"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
 )
 
@@ -29,13 +30,27 @@ func TestLiveViewProjectionConformance(t *testing.T) {
 		},
 	}
 	projected := make(chan []factorydefinitions.FactoryEvent, 2)
-	projections := projectionStub{
-		reconstruct: func(events []factorydefinitions.FactoryEvent, tick int) (factorydefinitions.FactoryWorldState, error) {
-			if tick != 3 {
-				t.Fatalf("projection tick = %d, want 3", tick)
+	projections := &recordingsstub.Service{
+		ReconstructWorldStateFn: func(request recordings.ReconstructWorldStateRequest) (recordings.ReconstructWorldStateResult, error) {
+			if request.SelectedTick != 3 {
+				t.Fatalf("projection tick = %d, want 3", request.SelectedTick)
 			}
-			projected <- append([]factorydefinitions.FactoryEvent(nil), events...)
-			return factorydefinitions.FactoryWorldState{}, nil
+			events := make([]factorydefinitions.FactoryEvent, len(request.Events))
+			for index, event := range request.Events {
+				events[index] = factorydefinitions.FactoryEvent{
+					Id: string(event.ID),
+					Context: factorydefinitions.FactoryEventContext{
+						Sequence: int(event.Sequence),
+					},
+				}
+			}
+			projected <- events
+			return recordings.ReconstructWorldStateResult{
+				WorldState: recordings.WorldStateView{
+					SchemaVersion: recordings.WorldStateViewSchemaV1,
+					Payload:       `{"topology":{}}`,
+				},
+			}, nil
 		},
 	}
 	rendered := make(chan liveviewprojection.View, 2)
@@ -125,51 +140,6 @@ func (s *sourceStub) SubscribeFactoryEvents(
 
 func (s *sourceStub) GetRuntimeSnapshotFacts(context.Context) (*liveviewprojection.RuntimeSnapshotFacts, error) {
 	return s.snapshot, s.snapshotErr
-}
-
-type projectionStub struct {
-	reconstruct   func([]factorydefinitions.FactoryEvent, int) (factorydefinitions.FactoryWorldState, error)
-	dashboardData recordings.SimpleDashboardRenderData
-}
-
-func (p projectionStub) ReconstructFactoryWorldState(
-	events []factorydefinitions.FactoryEvent,
-	tick int,
-) (factorydefinitions.FactoryWorldState, error) {
-	if p.reconstruct != nil {
-		return p.reconstruct(events, tick)
-	}
-	return factorydefinitions.FactoryWorldState{}, nil
-}
-
-func (p projectionStub) SimpleDashboardRenderData(
-	factorydefinitions.FactoryWorldState,
-) recordings.SimpleDashboardRenderData {
-	if p.dashboardData.InFlightDispatchCount != 0 || p.dashboardData.Session.HasData {
-		return p.dashboardData
-	}
-	return recordings.SimpleDashboardRenderData{}
-}
-
-func (projectionStub) ProjectActiveThrottlePauses(
-	factorydefinitions.InitialStructurePayload,
-	[]factorydefinitions.ActiveThrottlePause,
-) []factorydefinitions.FactoryWorldThrottlePause {
-	return nil
-}
-
-func (projectionStub) ProjectWorkstationRequests(
-	factorydefinitions.FactoryWorldState,
-) recordings.WorkstationFactoryWorldWorkstationRequestProjectionSlice {
-	return recordings.WorkstationFactoryWorldWorkstationRequestProjectionSlice{}
-}
-
-func (projectionStub) ValidateReconnectReplay(
-	[]factorydefinitions.FactoryEvent,
-	factorydefinitions.FactoryEventReconnectCursor,
-	factorydefinitions.FactoryEventReconnectScope,
-) error {
-	return nil
 }
 
 type fixedClock struct{ now time.Time }

--- a/pkg/services/factory_visualization/internal/services/live_view_projection/internal/service/subscribe_retain_test.go
+++ b/pkg/services/factory_visualization/internal/services/live_view_projection/internal/service/subscribe_retain_test.go
@@ -28,12 +28,7 @@ func TestStartAppliesRetainedHistoryBeforeFirstLiveDelta(t *testing.T) {
 		snapshot: snapshotFacts(2),
 	}
 	projected := make(chan []factorydefinitions.FactoryEvent, 1)
-	projections := projectionStub{
-		reconstruct: func(events []factorydefinitions.FactoryEvent, tick int) (factorydefinitions.FactoryWorldState, error) {
-			projected <- append([]factorydefinitions.FactoryEvent(nil), events...)
-			return factorydefinitions.FactoryWorldState{}, nil
-		},
-	}
+	projections := newTrackingProjectionStub(projected)
 	rendered := make(chan liveviewprojection.View, 1)
 	svc, err := projectionservice.New(
 		source,
@@ -100,7 +95,7 @@ func TestStartRetainsVisualizationOwnedCursorAndEventsAfterSubscribe(t *testing.
 	}
 	svc, err := projectionservice.New(
 		source,
-		projectionStub{},
+		newProjectionStub(),
 		fixedClock{now: now},
 		liveviewprojection.SinkFunc(func(liveviewprojection.View) {}),
 		nil,
@@ -176,7 +171,7 @@ func TestStartInvalidSubscriptionDoesNotLeaveHalfStartedSubscriber(t *testing.T)
 			presented := make(chan liveviewprojection.View, 1)
 			svc, err := projectionservice.New(
 				test.source,
-				projectionStub{},
+				newProjectionStub(),
 				fixedClock{now: time.Unix(1, 0)},
 				liveviewprojection.SinkFunc(func(view liveviewprojection.View) { presented <- view }),
 				nil,
@@ -226,7 +221,7 @@ func TestStartSubscribesOnceForRetainedThenLive(t *testing.T) {
 	}
 	svc, err := projectionservice.New(
 		source,
-		projectionStub{},
+		newProjectionStub(),
 		fixedClock{now: time.Unix(1, 0)},
 		liveviewprojection.SinkFunc(func(liveviewprojection.View) {}),
 		nil,

--- a/pkg/services/factory_visualization/internal/services/live_view_projection/internal/service/view_emission_test.go
+++ b/pkg/services/factory_visualization/internal/services/live_view_projection/internal/service/view_emission_test.go
@@ -75,12 +75,7 @@ func TestStartEmitsSanitizedVisualizationOwnedView(t *testing.T) {
 			},
 		},
 	}
-	projections := projectionStub{
-		reconstruct: func([]factorydefinitions.FactoryEvent, int) (factorydefinitions.FactoryWorldState, error) {
-			return factorydefinitions.FactoryWorldState{}, nil
-		},
-	}
-	projections.dashboardData = renderData
+	projections := newProjectionStubWithDashboard(renderData)
 	rendered := make(chan liveviewprojection.View, 1)
 	svc, err := projectionservice.New(
 		source,
@@ -129,7 +124,7 @@ func TestObserveSnapshotUnavailableDoesNotEmitView(t *testing.T) {
 	presented := make(chan liveviewprojection.View, 1)
 	svc, err := projectionservice.New(
 		source,
-		projectionStub{},
+		newProjectionStub(),
 		fixedClock{now: time.Unix(1, 0)},
 		liveviewprojection.SinkFunc(func(view liveviewprojection.View) { presented <- view }),
 		nil,
@@ -170,11 +165,7 @@ func TestObserveReconstructionFailedDoesNotReturnSuccessView(t *testing.T) {
 		},
 		snapshot: snapshotFacts(3),
 	}
-	projections := projectionStub{
-		reconstruct: func([]factorydefinitions.FactoryEvent, int) (factorydefinitions.FactoryWorldState, error) {
-			return factorydefinitions.FactoryWorldState{}, reconstructErr
-		},
-	}
+	projections := newFailingProjectionStub(reconstructErr)
 	svc, err := projectionservice.New(
 		source,
 		projections,

--- a/pkg/services/factory_visualization/internal/services/live_view_projection/wire/wire.go
+++ b/pkg/services/factory_visualization/internal/services/live_view_projection/wire/wire.go
@@ -11,12 +11,12 @@ import (
 // NewService constructs the private live_view_projection capability.
 func NewService(
 	source liveviewprojection.Source,
-	projections recordings.ProjectionService,
+	recordingsPeer recordings.Service,
 	clock liveviewprojection.Clock,
 	sink liveviewprojection.Sink,
 	reportError liveviewprojection.ErrorReporter,
 ) (liveviewprojection.Service, error) {
-	svc, err := projectionservice.New(source, projections, clock, sink, reportError)
+	svc, err := projectionservice.New(source, recordingsPeer, clock, sink, reportError)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/factory_visualization/internal/services/live_view_projection/wire/wire_test.go
+++ b/pkg/services/factory_visualization/internal/services/live_view_projection/wire/wire_test.go
@@ -7,7 +7,7 @@ import (
 
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	liveviewprojection "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/live_view_projection"
-	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	"github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/testing/recordingsstub"
 )
 
 type stubSource struct{}
@@ -22,42 +22,6 @@ func (stubSource) SubscribeFactoryEvents(
 
 func (stubSource) GetRuntimeSnapshotFacts(context.Context) (*liveviewprojection.RuntimeSnapshotFacts, error) {
 	return nil, nil
-}
-
-type projectionStub struct{}
-
-func (projectionStub) ReconstructFactoryWorldState(
-	[]factorydefinitions.FactoryEvent,
-	int,
-) (factorydefinitions.FactoryWorldState, error) {
-	return factorydefinitions.FactoryWorldState{}, nil
-}
-
-func (projectionStub) SimpleDashboardRenderData(
-	factorydefinitions.FactoryWorldState,
-) recordings.SimpleDashboardRenderData {
-	return recordings.SimpleDashboardRenderData{}
-}
-
-func (projectionStub) ProjectActiveThrottlePauses(
-	factorydefinitions.InitialStructurePayload,
-	[]factorydefinitions.ActiveThrottlePause,
-) []factorydefinitions.FactoryWorldThrottlePause {
-	return nil
-}
-
-func (projectionStub) ProjectWorkstationRequests(
-	factorydefinitions.FactoryWorldState,
-) recordings.WorkstationFactoryWorldWorkstationRequestProjectionSlice {
-	return recordings.WorkstationFactoryWorldWorkstationRequestProjectionSlice{}
-}
-
-func (projectionStub) ValidateReconnectReplay(
-	[]factorydefinitions.FactoryEvent,
-	factorydefinitions.FactoryEventReconnectCursor,
-	factorydefinitions.FactoryEventReconnectScope,
-) error {
-	return nil
 }
 
 type stubSink struct{}
@@ -81,7 +45,7 @@ func TestNewServiceConstructsSingularLiveViewProjectionService(t *testing.T) {
 
 	svc, err = NewService(
 		stubSource{},
-		projectionStub{},
+		&recordingsstub.Service{},
 		fixedClock{},
 		stubSink{},
 		nil,

--- a/pkg/services/factory_visualization/internal/testing/recordingsstub/stub.go
+++ b/pkg/services/factory_visualization/internal/testing/recordingsstub/stub.go
@@ -1,0 +1,234 @@
+// Package recordingsstub provides test doubles for Recordings root contracts used
+// by Factory Visualization boundary tests.
+package recordingsstub
+
+import (
+	"context"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+)
+
+// Service implements recordings.Service and recordings.ProjectionService for tests.
+type Service struct {
+	ReconstructWorldStateFn func(recordings.ReconstructWorldStateRequest) (recordings.ReconstructWorldStateResult, error)
+	QuerySimpleDashboardFn  func(recordings.SimpleDashboardQueryRequest) (recordings.SimpleDashboardQueryResult, error)
+	ValidateReconnectFn     func(recordings.ValidateReconnectReplayRequest) error
+
+	DashboardData recordings.SimpleDashboardRenderData
+}
+
+var (
+	_ recordings.Service          = (*Service)(nil)
+	_ recordings.ProjectionService = (*Service)(nil)
+)
+
+func (stub *Service) ReconstructWorldState(
+	request recordings.ReconstructWorldStateRequest,
+) (recordings.ReconstructWorldStateResult, error) {
+	if stub != nil && stub.ReconstructWorldStateFn != nil {
+		return stub.ReconstructWorldStateFn(request)
+	}
+	return recordings.ReconstructWorldStateResult{
+		WorldState: recordings.WorldStateView{
+			SchemaVersion: recordings.WorldStateViewSchemaV1,
+			SelectedTick:  request.SelectedTick,
+			Payload:       `{"topology":{}}`,
+		},
+	}, nil
+}
+
+func (stub *Service) QuerySimpleDashboard(
+	request recordings.SimpleDashboardQueryRequest,
+) (recordings.SimpleDashboardQueryResult, error) {
+	if stub != nil && stub.QuerySimpleDashboardFn != nil {
+		return stub.QuerySimpleDashboardFn(request)
+	}
+	data := recordings.SimpleDashboardRenderData{}
+	if stub != nil {
+		data = stub.DashboardData
+	}
+	return recordings.SimpleDashboardQueryResult{Data: data}, nil
+}
+
+func (stub *Service) ValidateReconnectReplayFrom(
+	request recordings.ValidateReconnectReplayRequest,
+) error {
+	if stub != nil && stub.ValidateReconnectFn != nil {
+		return stub.ValidateReconnectFn(request)
+	}
+	return nil
+}
+
+func (stub *Service) ReconstructFactoryWorldState(
+	events []factorydefinitions.FactoryEvent,
+	selectedTick int,
+) (factorydefinitions.FactoryWorldState, error) {
+	result, err := stub.ReconstructWorldState(recordings.ReconstructWorldStateRequest{
+		Events:       eventsToCanonical(events),
+		SelectedTick: selectedTick,
+	})
+	if err != nil {
+		return factorydefinitions.FactoryWorldState{}, err
+	}
+	var state factorydefinitions.FactoryWorldState
+	_ = result.WorldState
+	return state, nil
+}
+
+func (stub *Service) SimpleDashboardRenderData(
+	_ factorydefinitions.FactoryWorldState,
+) recordings.SimpleDashboardRenderData {
+	result, _ := stub.QuerySimpleDashboard(recordings.SimpleDashboardQueryRequest{
+		WorldState: recordings.WorldStateView{
+			SchemaVersion: recordings.WorldStateViewSchemaV1,
+			Payload:       `{"topology":{}}`,
+		},
+	})
+	return result.Data
+}
+
+func (stub *Service) ProjectActiveThrottlePauses(
+	_ factorydefinitions.InitialStructurePayload,
+	_ []factorydefinitions.ActiveThrottlePause,
+) []factorydefinitions.FactoryWorldThrottlePause {
+	return nil
+}
+
+func (stub *Service) ProjectWorkstationRequests(
+	_ factorydefinitions.FactoryWorldState,
+) recordings.WorkstationFactoryWorldWorkstationRequestProjectionSlice {
+	return recordings.WorkstationFactoryWorldWorkstationRequestProjectionSlice{}
+}
+
+func (stub *Service) ValidateReconnectReplay(
+	events []factorydefinitions.FactoryEvent,
+	cursor factorydefinitions.FactoryEventReconnectCursor,
+	scope factorydefinitions.FactoryEventReconnectScope,
+) error {
+	request, err := reconnectRequest(events, cursor, scope)
+	if err != nil {
+		return err
+	}
+	return stub.ValidateReconnectReplayFrom(request)
+}
+
+func (stub *Service) Append(recordings.AppendRecordedEventRequest) (recordings.AppendRecordedEventResult, error) {
+	return recordings.AppendRecordedEventResult{}, recordings.ErrInvalidAppendEvent
+}
+
+func (stub *Service) SubscribeFrom(context.Context, recordings.SubscribeRequest) (recordings.SubscribeResult, error) {
+	return recordings.SubscribeResult{}, recordings.ErrReconnectCursorNotFound
+}
+
+func (stub *Service) QueryWorkstationRequests(recordings.WorkstationRequestsQueryRequest) (recordings.WorkstationRequestsQueryResult, error) {
+	return recordings.WorkstationRequestsQueryResult{}, nil
+}
+
+func (stub *Service) BindRecording(recordings.BindRecordingRequest) (recordings.BindRecordingResult, error) {
+	return recordings.BindRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *Service) StartRecording(recordings.StartRecordingRequest) (recordings.StartRecordingResult, error) {
+	return recordings.StartRecordingResult{}, nil
+}
+
+func (stub *Service) RecordRecordingEvent(recordings.RecordRecordingEventRequest) (recordings.RecordRecordingEventResult, error) {
+	return recordings.RecordRecordingEventResult{}, recordings.ErrInvalidRecordingEvent
+}
+
+func (stub *Service) RecordRecordingError(recordings.RecordRecordingErrorRequest) (recordings.RecordRecordingErrorResult, error) {
+	return recordings.RecordRecordingErrorResult{}, recordings.ErrInvalidRecordingFailure
+}
+
+func (stub *Service) FlushRecording(recordings.FlushRecordingRequest) (recordings.FlushRecordingResult, error) {
+	return recordings.FlushRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *Service) StopRecording(recordings.StopRecordingRequest) (recordings.StopRecordingResult, error) {
+	return recordings.StopRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *Service) FinishRecording(recordings.FinishRecordingRequest) (recordings.FinishRecordingResult, error) {
+	return recordings.FinishRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *Service) QueryRecordingStatus(recordings.RecordingStatusRequest) (recordings.RecordingStatusResult, error) {
+	return recordings.RecordingStatusResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *Service) LoadReplayRecording(recordings.LoadReplayRecordingRequest) (recordings.LoadReplayRecordingResult, error) {
+	return recordings.LoadReplayRecordingResult{}, recordings.ErrMissingReplayArtifact
+}
+
+func (stub *Service) CreateReplayPlan(recordings.CreateReplayPlanRequest) (recordings.CreateReplayPlanResult, error) {
+	return recordings.CreateReplayPlanResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (stub *Service) ObserveReplay(recordings.ObserveReplayRequest) (recordings.ObserveReplayResult, error) {
+	return recordings.ObserveReplayResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (stub *Service) BuildPortableArtifact(recordings.BuildPortableArtifactRequest) (recordings.BuildPortableArtifactResult, error) {
+	return recordings.BuildPortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *Service) ValidatePortableArtifact(recordings.ValidatePortableArtifactRequest) (recordings.ValidatePortableArtifactResult, error) {
+	return recordings.ValidatePortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *Service) EncodePortableArtifact(recordings.EncodePortableArtifactRequest) (recordings.EncodePortableArtifactResult, error) {
+	return recordings.EncodePortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *Service) DecodePortableArtifact(recordings.DecodePortableArtifactRequest) (recordings.DecodePortableArtifactResult, error) {
+	return recordings.DecodePortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *Service) SummarizePortableArtifact(recordings.SummarizePortableArtifactRequest) (recordings.SummarizePortableArtifactResult, error) {
+	return recordings.SummarizePortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *Service) ExportPortableArtifact(context.Context, recordings.ExportPortableArtifactRequest) (recordings.ExportPortableArtifactResult, error) {
+	return recordings.ExportPortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *Service) ReadPortableArtifact(context.Context, recordings.ReadPortableArtifactRequest) (recordings.ReadPortableArtifactResult, error) {
+	return recordings.ReadPortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func eventsToCanonical(events []factorydefinitions.FactoryEvent) []recordings.CanonicalEvent {
+	canonical := make([]recordings.CanonicalEvent, len(events))
+	for index, event := range events {
+		canonical[index] = recordings.CanonicalEvent{
+			ID:       recordings.CanonicalEventID(event.Id),
+			Sequence: recordings.CanonicalEventSequence(event.Context.Sequence),
+		}
+	}
+	return canonical
+}
+
+func reconnectRequest(
+	events []factorydefinitions.FactoryEvent,
+	cursor factorydefinitions.FactoryEventReconnectCursor,
+	scope factorydefinitions.FactoryEventReconnectScope,
+) (recordings.ValidateReconnectReplayRequest, error) {
+	canonicalEvents := eventsToCanonical(events)
+	canonicalCursor := recordings.CanonicalEventCursor{
+		StreamGenerationID: "factory-visualization",
+	}
+	if cursor.AfterSequence != nil {
+		canonicalCursor.Sequence = recordings.CanonicalEventSequence(*cursor.AfterSequence)
+	}
+	for _, event := range events {
+		if cursor.AfterEventID != "" && event.Id == cursor.AfterEventID {
+			canonicalCursor.Sequence = recordings.CanonicalEventSequence(event.Context.Sequence)
+			break
+		}
+	}
+	return recordings.ValidateReconnectReplayRequest{
+		Events: canonicalEvents,
+		Cursor: canonicalCursor,
+		Scope:  recordings.CanonicalEventScope{FactorySessionID: scope.SessionID},
+	}, nil
+}

--- a/pkg/services/factory_visualization/projection_service_root.go
+++ b/pkg/services/factory_visualization/projection_service_root.go
@@ -1,0 +1,167 @@
+package factory_visualization
+
+import (
+	"context"
+
+	"github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/recordingsqueries"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+)
+
+type projectionServiceRoot struct {
+	projection recordings.ProjectionService
+}
+
+var _ recordings.Service = (*projectionServiceRoot)(nil)
+
+func (adapter *projectionServiceRoot) ReconstructWorldState(
+	request recordings.ReconstructWorldStateRequest,
+) (recordings.ReconstructWorldStateResult, error) {
+	return recordingsqueries.ReconstructWorldStateFromProjection(adapter.projection, request)
+}
+
+func (adapter *projectionServiceRoot) QuerySimpleDashboard(
+	request recordings.SimpleDashboardQueryRequest,
+) (recordings.SimpleDashboardQueryResult, error) {
+	return recordingsqueries.QuerySimpleDashboardFromProjection(adapter.projection, request)
+}
+
+func (adapter *projectionServiceRoot) QueryWorkstationRequests(
+	request recordings.WorkstationRequestsQueryRequest,
+) (recordings.WorkstationRequestsQueryResult, error) {
+	state, err := recordingsqueries.DecodeWorldStatePayload(request.WorldState)
+	if err != nil {
+		return recordings.WorkstationRequestsQueryResult{}, err
+	}
+	return recordings.WorkstationRequestsQueryResult{
+		Projection: adapter.projection.ProjectWorkstationRequests(state),
+	}, nil
+}
+
+func (adapter *projectionServiceRoot) ValidateReconnectReplayFrom(
+	request recordings.ValidateReconnectReplayRequest,
+) error {
+	return recordingsqueries.ValidateReconnectReplayFromProjection(adapter.projection, request)
+}
+
+func (adapter *projectionServiceRoot) Append(
+	recordings.AppendRecordedEventRequest,
+) (recordings.AppendRecordedEventResult, error) {
+	return recordings.AppendRecordedEventResult{}, recordings.ErrInvalidAppendEvent
+}
+
+func (adapter *projectionServiceRoot) SubscribeFrom(
+	context.Context,
+	recordings.SubscribeRequest,
+) (recordings.SubscribeResult, error) {
+	return recordings.SubscribeResult{}, recordings.ErrReconnectCursorNotFound
+}
+
+func (adapter *projectionServiceRoot) BindRecording(
+	recordings.BindRecordingRequest,
+) (recordings.BindRecordingResult, error) {
+	return recordings.BindRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (adapter *projectionServiceRoot) StartRecording(
+	recordings.StartRecordingRequest,
+) (recordings.StartRecordingResult, error) {
+	return recordings.StartRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (adapter *projectionServiceRoot) RecordRecordingEvent(
+	recordings.RecordRecordingEventRequest,
+) (recordings.RecordRecordingEventResult, error) {
+	return recordings.RecordRecordingEventResult{}, recordings.ErrInvalidRecordingEvent
+}
+
+func (adapter *projectionServiceRoot) RecordRecordingError(
+	recordings.RecordRecordingErrorRequest,
+) (recordings.RecordRecordingErrorResult, error) {
+	return recordings.RecordRecordingErrorResult{}, recordings.ErrInvalidRecordingFailure
+}
+
+func (adapter *projectionServiceRoot) FlushRecording(
+	recordings.FlushRecordingRequest,
+) (recordings.FlushRecordingResult, error) {
+	return recordings.FlushRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (adapter *projectionServiceRoot) StopRecording(
+	recordings.StopRecordingRequest,
+) (recordings.StopRecordingResult, error) {
+	return recordings.StopRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (adapter *projectionServiceRoot) FinishRecording(
+	recordings.FinishRecordingRequest,
+) (recordings.FinishRecordingResult, error) {
+	return recordings.FinishRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (adapter *projectionServiceRoot) QueryRecordingStatus(
+	recordings.RecordingStatusRequest,
+) (recordings.RecordingStatusResult, error) {
+	return recordings.RecordingStatusResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (adapter *projectionServiceRoot) LoadReplayRecording(
+	recordings.LoadReplayRecordingRequest,
+) (recordings.LoadReplayRecordingResult, error) {
+	return recordings.LoadReplayRecordingResult{}, recordings.ErrMissingReplayArtifact
+}
+
+func (adapter *projectionServiceRoot) CreateReplayPlan(
+	recordings.CreateReplayPlanRequest,
+) (recordings.CreateReplayPlanResult, error) {
+	return recordings.CreateReplayPlanResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (adapter *projectionServiceRoot) ObserveReplay(
+	recordings.ObserveReplayRequest,
+) (recordings.ObserveReplayResult, error) {
+	return recordings.ObserveReplayResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (adapter *projectionServiceRoot) BuildPortableArtifact(
+	recordings.BuildPortableArtifactRequest,
+) (recordings.BuildPortableArtifactResult, error) {
+	return recordings.BuildPortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (adapter *projectionServiceRoot) ValidatePortableArtifact(
+	recordings.ValidatePortableArtifactRequest,
+) (recordings.ValidatePortableArtifactResult, error) {
+	return recordings.ValidatePortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (adapter *projectionServiceRoot) EncodePortableArtifact(
+	recordings.EncodePortableArtifactRequest,
+) (recordings.EncodePortableArtifactResult, error) {
+	return recordings.EncodePortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (adapter *projectionServiceRoot) DecodePortableArtifact(
+	recordings.DecodePortableArtifactRequest,
+) (recordings.DecodePortableArtifactResult, error) {
+	return recordings.DecodePortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (adapter *projectionServiceRoot) SummarizePortableArtifact(
+	recordings.SummarizePortableArtifactRequest,
+) (recordings.SummarizePortableArtifactResult, error) {
+	return recordings.SummarizePortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (adapter *projectionServiceRoot) ExportPortableArtifact(
+	context.Context,
+	recordings.ExportPortableArtifactRequest,
+) (recordings.ExportPortableArtifactResult, error) {
+	return recordings.ExportPortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (adapter *projectionServiceRoot) ReadPortableArtifact(
+	context.Context,
+	recordings.ReadPortableArtifactRequest,
+) (recordings.ReadPortableArtifactResult, error) {
+	return recordings.ReadPortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}

--- a/pkg/services/factory_visualization/recordings_import_boundary_test.go
+++ b/pkg/services/factory_visualization/recordings_import_boundary_test.go
@@ -1,0 +1,77 @@
+package factory_visualization_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+const (
+	modulePrefix             = "github.com/portpowered/infinite-you/"
+	factoryVisualizationRoot = modulePrefix + "pkg/services/factory_visualization"
+	recordingsRoot           = modulePrefix + "pkg/services/recordings"
+)
+
+// TestProductionPackagesImportRecordingsRootOnly seals CUT-VIS-REC story 001:
+// Factory Visualization production packages may depend on Recordings only through
+// the service root contract, not nested Recordings implementation paths.
+func TestProductionPackagesImportRecordingsRootOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, pkg := range listFactoryVisualizationPackages(t) {
+		pkg := pkg
+		t.Run(shortFactoryVisualizationPackageName(pkg), func(t *testing.T) {
+			t.Parallel()
+			assertProductionImportsUseRecordingsRootOnly(t, pkg)
+		})
+	}
+}
+
+func listFactoryVisualizationPackages(t *testing.T) []string {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", factoryVisualizationRoot+"/...")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list factory_visualization packages: %v\n%s", err, output)
+	}
+	return strings.Fields(string(output))
+}
+
+func assertProductionImportsUseRecordingsRootOnly(t *testing.T, packagePath string) {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", "-f", "{{join .Imports \"\\n\"}}", packagePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list imports for %s: %v\n%s", packagePath, err, output)
+	}
+	for _, importPath := range strings.Fields(string(output)) {
+		if isForbiddenVisualizationRecordingsImport(importPath) {
+			t.Fatalf(
+				"%s production import %s is forbidden; use %s for Recordings surfaces",
+				packagePath,
+				importPath,
+				recordingsRoot,
+			)
+		}
+	}
+}
+
+func isForbiddenVisualizationRecordingsImport(importPath string) bool {
+	if importPath == recordingsRoot {
+		return false
+	}
+	return strings.HasPrefix(importPath, recordingsRoot+"/")
+}
+
+func shortFactoryVisualizationPackageName(packagePath string) string {
+	if strings.HasPrefix(packagePath, factoryVisualizationRoot) {
+		rest := strings.TrimPrefix(packagePath, factoryVisualizationRoot)
+		if rest == "" {
+			return "factory_visualization"
+		}
+		return strings.TrimPrefix(rest, "/")
+	}
+	return packagePath
+}

--- a/pkg/services/factory_visualization/recordings_peer.go
+++ b/pkg/services/factory_visualization/recordings_peer.go
@@ -15,11 +15,8 @@ func RecordingsPeerFromProjectionService(
 	if peer == nil {
 		return nil, errors.New("initialize Factory visualization: projection service is required")
 	}
-	service, ok := peer.(recordings.Service)
-	if !ok {
-		return nil, errors.New(
-			"initialize Factory visualization: recordings peer must implement recordings.Service root contract",
-		)
+	if service, ok := peer.(recordings.Service); ok {
+		return service, nil
 	}
-	return service, nil
+	return &projectionServiceRoot{projection: peer}, nil
 }

--- a/pkg/services/factory_visualization/recordings_peer.go
+++ b/pkg/services/factory_visualization/recordings_peer.go
@@ -1,0 +1,25 @@
+package factory_visualization
+
+import (
+	"errors"
+
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+)
+
+// RecordingsPeerFromProjectionService resolves the Recordings root contract from
+// a legacy projection peer. Runtime wiring still supplies ProjectionService
+// today, but Visualization presentation paths require recordings.Service.
+func RecordingsPeerFromProjectionService(
+	peer recordings.ProjectionService,
+) (recordings.Service, error) {
+	if peer == nil {
+		return nil, errors.New("initialize Factory visualization: projection service is required")
+	}
+	service, ok := peer.(recordings.Service)
+	if !ok {
+		return nil, errors.New(
+			"initialize Factory visualization: recordings peer must implement recordings.Service root contract",
+		)
+	}
+	return service, nil
+}

--- a/pkg/services/factory_visualization/recordings_peer_test.go
+++ b/pkg/services/factory_visualization/recordings_peer_test.go
@@ -1,0 +1,83 @@
+package factory_visualization_test
+
+import (
+	"testing"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	recordingsservice "github.com/portpowered/infinite-you/pkg/services/recordings/service"
+)
+
+func TestRecordingsPeerFromProjectionServiceAdaptsLegacyProjectionPeer(t *testing.T) {
+	t.Parallel()
+
+	peer := recordingsservice.NewProjectionService()
+	service, err := factoryvisualization.RecordingsPeerFromProjectionService(peer)
+	if err != nil {
+		t.Fatalf("RecordingsPeerFromProjectionService: %v", err)
+	}
+	if service == nil {
+		t.Fatal("expected adapted recordings.Service, got nil")
+	}
+	if _, ok := peer.(recordings.Service); ok {
+		t.Fatal("test setup: projection peer should not implement recordings.Service directly")
+	}
+}
+
+type projectionOnlyPeer struct{}
+
+func (projectionOnlyPeer) ReconstructFactoryWorldState(
+	[]factorydefinitions.FactoryEvent,
+	int,
+) (factorydefinitions.FactoryWorldState, error) {
+	return factorydefinitions.FactoryWorldState{}, nil
+}
+
+func (projectionOnlyPeer) SimpleDashboardRenderData(
+	factorydefinitions.FactoryWorldState,
+) recordings.SimpleDashboardRenderData {
+	return recordings.SimpleDashboardRenderData{InFlightDispatchCount: 1}
+}
+
+func (projectionOnlyPeer) ProjectActiveThrottlePauses(
+	factorydefinitions.InitialStructurePayload,
+	[]factorydefinitions.ActiveThrottlePause,
+) []factorydefinitions.FactoryWorldThrottlePause {
+	return nil
+}
+
+func (projectionOnlyPeer) ProjectWorkstationRequests(
+	factorydefinitions.FactoryWorldState,
+) recordings.WorkstationFactoryWorldWorkstationRequestProjectionSlice {
+	return recordings.WorkstationFactoryWorldWorkstationRequestProjectionSlice{}
+}
+
+func (projectionOnlyPeer) ValidateReconnectReplay(
+	[]factorydefinitions.FactoryEvent,
+	factorydefinitions.FactoryEventReconnectCursor,
+	factorydefinitions.FactoryEventReconnectScope,
+) error {
+	return nil
+}
+
+func TestRecordingsPeerFromProjectionServiceWrapsProjectionOnlyPeer(t *testing.T) {
+	t.Parallel()
+
+	service, err := factoryvisualization.RecordingsPeerFromProjectionService(projectionOnlyPeer{})
+	if err != nil {
+		t.Fatalf("RecordingsPeerFromProjectionService: %v", err)
+	}
+	result, err := service.QuerySimpleDashboard(recordings.SimpleDashboardQueryRequest{
+		WorldState: recordings.WorldStateView{
+			SchemaVersion: recordings.WorldStateViewSchemaV1,
+			Payload:       `{"topology":{}}`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("QuerySimpleDashboard through adapted peer: %v", err)
+	}
+	if result.Data.InFlightDispatchCount != 1 {
+		t.Fatalf("dashboard in-flight count = %d, want 1", result.Data.InFlightDispatchCount)
+	}
+}

--- a/pkg/services/factory_visualization/recordings_request_boundary_test.go
+++ b/pkg/services/factory_visualization/recordings_request_boundary_test.go
@@ -1,0 +1,286 @@
+package factory_visualization_test
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/recordingsqueries"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+)
+
+const recordingsQueriesPackage = modulePrefix + "pkg/services/factory_visualization/internal/recordingsqueries"
+
+// TestVisualizationConstructsRecordingsRequestsThroughRoot proves CUT-VIS-REC story 003:
+// Factory Visualization projection-query edges construct Recordings root requests
+// and invoke recordings.Service with observable acceptance or typed rejection outcomes.
+func TestVisualizationConstructsRecordingsRequestsThroughRoot(t *testing.T) {
+	t.Parallel()
+
+	events := []factorydefinitions.FactoryEvent{
+		{
+			Id:   "evt-history",
+			Type: "WORK_REQUEST",
+			Context: factorydefinitions.FactoryEventContext{
+				Sequence: 3,
+				Tick:     3,
+			},
+		},
+		{
+			Id:   "evt-live",
+			Type: "WORK_STATE_CHANGE",
+			Context: factorydefinitions.FactoryEventContext{
+				Sequence: 4,
+				Tick:     4,
+			},
+		},
+	}
+	sessionID := "session-visualization-boundary"
+	scope := factorydefinitions.FactoryEventReconnectScope{SessionID: sessionID}
+
+	stub := &recordingsRequestBoundaryStub{
+		reconstructResult: recordings.ReconstructWorldStateResult{
+			WorldState: recordings.WorldStateView{
+				SchemaVersion: recordings.WorldStateViewSchemaV1,
+				SelectedTick:  4,
+				Payload:       `{"topology":{"workstations":[{"id":"ws-1","name":"review","worker_id":"worker-1"}],"workers":[{"id":"worker-1","model":"gpt","provider":"openai"}],"places":[]}}`,
+			},
+		},
+		dashboardResult: recordings.SimpleDashboardQueryResult{
+			Data: recordings.SimpleDashboardRenderData{InFlightDispatchCount: 2},
+		},
+	}
+
+	worldView, err := recordingsqueries.ReconstructWorldState(stub, events, 4)
+	if err != nil {
+		t.Fatalf("ReconstructWorldState: %v", err)
+	}
+	if stub.lastReconstruct.SelectedTick != 4 {
+		t.Fatalf("reconstruct selected tick = %d, want 4", stub.lastReconstruct.SelectedTick)
+	}
+	if len(stub.lastReconstruct.Events) != 2 {
+		t.Fatalf("reconstruct events = %d, want 2", len(stub.lastReconstruct.Events))
+	}
+	if stub.lastReconstruct.Events[0].ID != "evt-history" ||
+		stub.lastReconstruct.Events[0].Sequence != 3 ||
+		stub.lastReconstruct.Events[0].Cursor.StreamGenerationID != "factory-visualization" {
+		t.Fatalf("reconstruct first event = %#v, want canonical visualization stream", stub.lastReconstruct.Events[0])
+	}
+	if worldView.SelectedTick != 4 || worldView.SchemaVersion != recordings.WorldStateViewSchemaV1 {
+		t.Fatalf("world view = %#v, want selected tick 4 and schema v1", worldView)
+	}
+
+	renderData, err := recordingsqueries.QuerySimpleDashboard(stub, worldView)
+	if err != nil {
+		t.Fatalf("QuerySimpleDashboard: %v", err)
+	}
+	if stub.lastDashboard.WorldState.SelectedTick != 4 {
+		t.Fatalf("dashboard world-state tick = %d, want 4", stub.lastDashboard.WorldState.SelectedTick)
+	}
+	if renderData.InFlightDispatchCount != 2 {
+		t.Fatalf("dashboard in-flight count = %d, want 2", renderData.InFlightDispatchCount)
+	}
+
+	worldState, err := recordingsqueries.DecodeWorldStatePayload(worldView)
+	if err != nil {
+		t.Fatalf("DecodeWorldStatePayload: %v", err)
+	}
+	renderData.ActiveThrottlePauses = recordingsqueries.ProjectActiveThrottlePauses(
+		worldState.Topology,
+		[]factorydefinitions.ActiveThrottlePause{
+			{Provider: "openai", Model: "gpt", LaneID: "lane-1"},
+		},
+	)
+	if len(renderData.ActiveThrottlePauses) != 1 ||
+		renderData.ActiveThrottlePauses[0].AffectedWorkstationNames[0] != "review" {
+		t.Fatalf("active throttle pauses = %#v, want review workstation projection", renderData.ActiveThrottlePauses)
+	}
+
+	afterSequence := 3
+	if err := recordingsqueries.ValidateReconnectReplay(
+		stub,
+		events,
+		factorydefinitions.FactoryEventReconnectCursor{AfterSequence: &afterSequence},
+		scope,
+	); err != nil {
+		t.Fatalf("ValidateReconnectReplay success path: %v", err)
+	}
+	if stub.lastValidate.Scope.FactorySessionID != sessionID {
+		t.Fatalf("validate scope session = %q, want %q", stub.lastValidate.Scope.FactorySessionID, sessionID)
+	}
+	if stub.lastValidate.Cursor.StreamGenerationID != "factory-visualization" {
+		t.Fatalf("validate cursor stream = %q, want factory-visualization", stub.lastValidate.Cursor.StreamGenerationID)
+	}
+
+	stub.validateErr = recordings.ErrReconnectCursorNotFound
+	err = recordingsqueries.ValidateReconnectReplay(
+		stub,
+		events,
+		factorydefinitions.FactoryEventReconnectCursor{AfterEventID: "missing-event"},
+		scope,
+	)
+	if !errors.Is(err, recordings.ErrReconnectCursorNotFound) {
+		t.Fatalf("missing cursor error = %v, want ErrReconnectCursorNotFound", err)
+	}
+
+	_, err = recordingsqueries.ReconstructWorldState(nil, events, 4)
+	if !errors.Is(err, recordings.ErrInvalidProjectionInput) {
+		t.Fatalf("nil service reconstruct error = %v, want ErrInvalidProjectionInput", err)
+	}
+	_, err = recordingsqueries.QuerySimpleDashboard(nil, worldView)
+	if !errors.Is(err, recordings.ErrInvalidProjectionInput) {
+		t.Fatalf("nil service dashboard error = %v, want ErrInvalidProjectionInput", err)
+	}
+	err = recordingsqueries.ValidateReconnectReplay(nil, events, factorydefinitions.FactoryEventReconnectCursor{}, scope)
+	if !errors.Is(err, recordings.ErrInvalidProjectionInput) {
+		t.Fatalf("nil service validate error = %v, want ErrInvalidProjectionInput", err)
+	}
+}
+
+// TestVisualizationRecordingsRequestConstructionImportsRecordingsRootOnly seals the
+// request-construction path: Visualization projection-query helpers may depend on
+// Recordings only through the service root contract.
+func TestVisualizationRecordingsRequestConstructionImportsRecordingsRootOnly(t *testing.T) {
+	t.Parallel()
+	assertRecordingsRequestConstructionImportsRecordingsRootOnly(t, recordingsQueriesPackage)
+}
+
+func assertRecordingsRequestConstructionImportsRecordingsRootOnly(t *testing.T, packagePath string) {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", "-f", "{{join .Imports \"\\n\"}}", packagePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list imports for %s: %v\n%s", packagePath, err, output)
+	}
+	for _, importPath := range strings.Fields(string(output)) {
+		if isForbiddenVisualizationRecordingsImport(importPath) {
+			t.Fatalf(
+				"%s import %s is forbidden for recordings request construction; use %s only",
+				packagePath,
+				importPath,
+				recordingsRoot,
+			)
+		}
+	}
+}
+
+type recordingsRequestBoundaryStub struct {
+	lastReconstruct recordings.ReconstructWorldStateRequest
+	lastDashboard   recordings.SimpleDashboardQueryRequest
+	lastValidate    recordings.ValidateReconnectReplayRequest
+
+	reconstructResult recordings.ReconstructWorldStateResult
+	dashboardResult   recordings.SimpleDashboardQueryResult
+	validateErr         error
+}
+
+var _ recordings.Service = (*recordingsRequestBoundaryStub)(nil)
+
+func (stub *recordingsRequestBoundaryStub) ReconstructWorldState(
+	request recordings.ReconstructWorldStateRequest,
+) (recordings.ReconstructWorldStateResult, error) {
+	stub.lastReconstruct = request
+	return stub.reconstructResult, nil
+}
+
+func (stub *recordingsRequestBoundaryStub) QuerySimpleDashboard(
+	request recordings.SimpleDashboardQueryRequest,
+) (recordings.SimpleDashboardQueryResult, error) {
+	stub.lastDashboard = request
+	return stub.dashboardResult, nil
+}
+
+func (stub *recordingsRequestBoundaryStub) ValidateReconnectReplayFrom(
+	request recordings.ValidateReconnectReplayRequest,
+) error {
+	stub.lastValidate = request
+	return stub.validateErr
+}
+
+func (stub *recordingsRequestBoundaryStub) Append(recordings.AppendRecordedEventRequest) (recordings.AppendRecordedEventResult, error) {
+	return recordings.AppendRecordedEventResult{}, recordings.ErrInvalidAppendEvent
+}
+
+func (stub *recordingsRequestBoundaryStub) SubscribeFrom(context.Context, recordings.SubscribeRequest) (recordings.SubscribeResult, error) {
+	return recordings.SubscribeResult{}, recordings.ErrReconnectCursorNotFound
+}
+
+func (stub *recordingsRequestBoundaryStub) QueryWorkstationRequests(recordings.WorkstationRequestsQueryRequest) (recordings.WorkstationRequestsQueryResult, error) {
+	return recordings.WorkstationRequestsQueryResult{}, nil
+}
+
+func (stub *recordingsRequestBoundaryStub) BindRecording(recordings.BindRecordingRequest) (recordings.BindRecordingResult, error) {
+	return recordings.BindRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *recordingsRequestBoundaryStub) StartRecording(recordings.StartRecordingRequest) (recordings.StartRecordingResult, error) {
+	return recordings.StartRecordingResult{}, nil
+}
+
+func (stub *recordingsRequestBoundaryStub) RecordRecordingEvent(recordings.RecordRecordingEventRequest) (recordings.RecordRecordingEventResult, error) {
+	return recordings.RecordRecordingEventResult{}, recordings.ErrInvalidRecordingEvent
+}
+
+func (stub *recordingsRequestBoundaryStub) RecordRecordingError(recordings.RecordRecordingErrorRequest) (recordings.RecordRecordingErrorResult, error) {
+	return recordings.RecordRecordingErrorResult{}, recordings.ErrInvalidRecordingFailure
+}
+
+func (stub *recordingsRequestBoundaryStub) FlushRecording(recordings.FlushRecordingRequest) (recordings.FlushRecordingResult, error) {
+	return recordings.FlushRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *recordingsRequestBoundaryStub) StopRecording(recordings.StopRecordingRequest) (recordings.StopRecordingResult, error) {
+	return recordings.StopRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *recordingsRequestBoundaryStub) FinishRecording(recordings.FinishRecordingRequest) (recordings.FinishRecordingResult, error) {
+	return recordings.FinishRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *recordingsRequestBoundaryStub) QueryRecordingStatus(recordings.RecordingStatusRequest) (recordings.RecordingStatusResult, error) {
+	return recordings.RecordingStatusResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *recordingsRequestBoundaryStub) LoadReplayRecording(recordings.LoadReplayRecordingRequest) (recordings.LoadReplayRecordingResult, error) {
+	return recordings.LoadReplayRecordingResult{}, recordings.ErrMissingReplayArtifact
+}
+
+func (stub *recordingsRequestBoundaryStub) CreateReplayPlan(recordings.CreateReplayPlanRequest) (recordings.CreateReplayPlanResult, error) {
+	return recordings.CreateReplayPlanResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (stub *recordingsRequestBoundaryStub) ObserveReplay(recordings.ObserveReplayRequest) (recordings.ObserveReplayResult, error) {
+	return recordings.ObserveReplayResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (stub *recordingsRequestBoundaryStub) BuildPortableArtifact(recordings.BuildPortableArtifactRequest) (recordings.BuildPortableArtifactResult, error) {
+	return recordings.BuildPortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *recordingsRequestBoundaryStub) ValidatePortableArtifact(recordings.ValidatePortableArtifactRequest) (recordings.ValidatePortableArtifactResult, error) {
+	return recordings.ValidatePortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *recordingsRequestBoundaryStub) EncodePortableArtifact(recordings.EncodePortableArtifactRequest) (recordings.EncodePortableArtifactResult, error) {
+	return recordings.EncodePortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *recordingsRequestBoundaryStub) DecodePortableArtifact(recordings.DecodePortableArtifactRequest) (recordings.DecodePortableArtifactResult, error) {
+	return recordings.DecodePortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *recordingsRequestBoundaryStub) SummarizePortableArtifact(recordings.SummarizePortableArtifactRequest) (recordings.SummarizePortableArtifactResult, error) {
+	return recordings.SummarizePortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *recordingsRequestBoundaryStub) ExportPortableArtifact(context.Context, recordings.ExportPortableArtifactRequest) (recordings.ExportPortableArtifactResult, error) {
+	return recordings.ExportPortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (stub *recordingsRequestBoundaryStub) ReadPortableArtifact(context.Context, recordings.ReadPortableArtifactRequest) (recordings.ReadPortableArtifactResult, error) {
+	return recordings.ReadPortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}

--- a/pkg/services/factory_visualization/runtime_source_test.go
+++ b/pkg/services/factory_visualization/runtime_source_test.go
@@ -9,6 +9,7 @@ import (
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/testing/recordingsstub"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 )
 
@@ -101,7 +102,7 @@ func TestActivateThroughSessionBoundSourceReachesStarted(t *testing.T) {
 	}
 	service, err := New(
 		NewCurrentRuntimeSource(reader),
-		projectionStub{},
+		&recordingsstub.Service{},
 		fixedClock{now: time.Unix(1, 0)},
 		SinkFunc(func(View) {}),
 		nil,
@@ -138,7 +139,7 @@ func TestActivateWithUnavailableSessionRuntimeDoesNotSubscribe(t *testing.T) {
 	}
 	service, err := New(
 		NewCurrentRuntimeSource(reader),
-		projectionStub{},
+		&recordingsstub.Service{},
 		fixedClock{now: time.Unix(1, 0)},
 		SinkFunc(func(View) {}),
 		nil,

--- a/pkg/services/factory_visualization/service.go
+++ b/pkg/services/factory_visualization/service.go
@@ -62,7 +62,7 @@ type Service struct {
 	presentationOwner responsePresentationOwner
 
 	source      Source
-	projections recordings.ProjectionService
+	recordings  recordings.Service
 	clock       Clock
 	sink        Sink
 	reportError ErrorReporter
@@ -75,7 +75,7 @@ type Service struct {
 // New constructs an inert Factory visualization service.
 func New(
 	source Source,
-	projections recordings.ProjectionService,
+	peer recordings.ProjectionService,
 	clock Clock,
 	sink Sink,
 	reportError ErrorReporter,
@@ -83,16 +83,20 @@ func New(
 	switch {
 	case source == nil:
 		return nil, errors.New("initialize Factory visualization: event source is required")
-	case projections == nil:
+	case peer == nil:
 		return nil, errors.New("initialize Factory visualization: projection service is required")
 	case clock == nil:
 		return nil, errors.New("initialize Factory visualization: clock is required")
 	case sink == nil:
 		return nil, errors.New("initialize Factory visualization: presentation sink is required")
 	}
+	recordingsPeer, err := RecordingsPeerFromProjectionService(peer)
+	if err != nil {
+		return nil, err
+	}
 	activation, err := activationlifecyclewire.NewService(
 		ActivationEventSource(source),
-		projections,
+		recordingsPeer,
 		clock,
 		ActivationViewSink(sink),
 		activationlifecycle.ErrorReporter(reportError),
@@ -102,7 +106,7 @@ func New(
 	}
 	projection, err := liveviewprojectionwire.NewService(
 		source,
-		projections,
+		recordingsPeer,
 		clock,
 		ProjectionSink(sink),
 		reportError,
@@ -115,7 +119,7 @@ func New(
 		projection,
 		defaultResponsePresentationOwner(),
 		source,
-		projections,
+		recordingsPeer,
 		clock,
 		sink,
 		reportError,

--- a/pkg/services/factory_visualization/service_test.go
+++ b/pkg/services/factory_visualization/service_test.go
@@ -9,6 +9,7 @@ import (
 
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	liveviewprojection "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/live_view_projection"
+	"github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/testing/recordingsstub"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
 )
 
@@ -20,7 +21,7 @@ func TestNewRejectsMissingDependencies(t *testing.T) {
 
 	clock := fixedClock{now: time.Unix(1, 0)}
 	sink := SinkFunc(func(View) {})
-	projections := projectionStub{}
+	projections := &recordingsstub.Service{}
 	source := &sourceStub{}
 	tests := []struct {
 		name string
@@ -69,13 +70,27 @@ func TestServiceProjectsRetainedAndLiveFactoryEvents(t *testing.T) {
 		snapshot: visualizationSnapshotFacts(3),
 	}
 	projected := make(chan []factorydefinitions.FactoryEvent, 2)
-	projections := projectionStub{
-		reconstruct: func(events []factorydefinitions.FactoryEvent, tick int) (factorydefinitions.FactoryWorldState, error) {
-			if tick != 3 {
-				t.Fatalf("projection tick = %d, want 3", tick)
+	projections := &recordingsstub.Service{
+		ReconstructWorldStateFn: func(request recordings.ReconstructWorldStateRequest) (recordings.ReconstructWorldStateResult, error) {
+			if request.SelectedTick != 3 {
+				t.Fatalf("projection tick = %d, want 3", request.SelectedTick)
 			}
-			projected <- append([]factorydefinitions.FactoryEvent(nil), events...)
-			return factorydefinitions.FactoryWorldState{}, nil
+			events := make([]factorydefinitions.FactoryEvent, len(request.Events))
+			for index, event := range request.Events {
+				events[index] = factorydefinitions.FactoryEvent{
+					Id: string(event.ID),
+					Context: factorydefinitions.FactoryEventContext{
+						Sequence: int(event.Sequence),
+					},
+				}
+			}
+			projected <- events
+			return recordings.ReconstructWorldStateResult{
+				WorldState: recordings.WorldStateView{
+					SchemaVersion: recordings.WorldStateViewSchemaV1,
+					Payload:       `{"topology":{}}`,
+				},
+			}, nil
 		},
 	}
 	rendered := make(chan View, 2)
@@ -133,7 +148,7 @@ func TestServiceReportsProjectionReadFailureWithoutStoppingSubscription(t *testi
 			stream:      &factorydefinitions.FactoryEventStream{Events: live},
 			snapshotErr: readFailure,
 		},
-		projectionStub{},
+		&recordingsstub.Service{},
 		fixedClock{},
 		SinkFunc(func(View) { t.Fatal("sink called after snapshot failure") }),
 		func(err error) { reported <- err },
@@ -175,7 +190,7 @@ func TestServiceRootLifecycleInertConstructionAndTypedActivate(t *testing.T) {
 	presentCalls := 0
 	service, err := New(
 		source,
-		projectionStub{},
+		&recordingsstub.Service{},
 		fixedClock{now: time.Unix(1, 0)},
 		SinkFunc(func(View) { presentCalls++ }),
 		nil,
@@ -243,7 +258,7 @@ func TestServiceRootObserveDetachedViewAndTypedFailures(t *testing.T) {
 	}
 	service, err := New(
 		source,
-		projectionStub{},
+		&recordingsstub.Service{},
 		fixedClock{now: now},
 		SinkFunc(func(View) {}),
 		nil,
@@ -268,9 +283,9 @@ func TestServiceRootObserveDetachedViewAndTypedFailures(t *testing.T) {
 	source.snapshot = visualizationSnapshotFacts(9)
 	service, err = New(
 		source,
-		projectionStub{
-			reconstruct: func([]factorydefinitions.FactoryEvent, int) (factorydefinitions.FactoryWorldState, error) {
-				return factorydefinitions.FactoryWorldState{}, errors.New("reconstruct boom")
+		&recordingsstub.Service{
+			ReconstructWorldStateFn: func(recordings.ReconstructWorldStateRequest) (recordings.ReconstructWorldStateResult, error) {
+				return recordings.ReconstructWorldStateResult{}, errors.New("reconstruct boom")
 			},
 		},
 		fixedClock{now: now},
@@ -288,7 +303,7 @@ func TestServiceRootObserveDetachedViewAndTypedFailures(t *testing.T) {
 
 	service, err = New(
 		source,
-		projectionStub{},
+		&recordingsstub.Service{},
 		fixedClock{now: now},
 		SinkFunc(func(View) {}),
 		nil,
@@ -347,7 +362,7 @@ func mustNewRootPresentationService(t *testing.T) *Service {
 			stream:   &factorydefinitions.FactoryEventStream{Events: live},
 			snapshot: visualizationSnapshotFacts(1),
 		},
-		projectionStub{},
+		&recordingsstub.Service{},
 		fixedClock{now: time.Unix(1, 0)},
 		SinkFunc(func(View) {}),
 		nil,
@@ -501,47 +516,6 @@ func visualizationSnapshotFacts(tick int) *liveviewprojection.RuntimeSnapshotFac
 	return &liveviewprojection.RuntimeSnapshotFacts{
 		RuntimeObservation: liveviewprojection.RuntimeObservation{TickCount: tick},
 	}
-}
-
-type projectionStub struct {
-	reconstruct func([]factorydefinitions.FactoryEvent, int) (factorydefinitions.FactoryWorldState, error)
-}
-
-func (p projectionStub) ReconstructFactoryWorldState(
-	events []factorydefinitions.FactoryEvent,
-	tick int,
-) (factorydefinitions.FactoryWorldState, error) {
-	if p.reconstruct != nil {
-		return p.reconstruct(events, tick)
-	}
-	return factorydefinitions.FactoryWorldState{}, nil
-}
-
-func (projectionStub) SimpleDashboardRenderData(
-	factorydefinitions.FactoryWorldState,
-) recordings.SimpleDashboardRenderData {
-	return recordings.SimpleDashboardRenderData{}
-}
-
-func (projectionStub) ProjectActiveThrottlePauses(
-	factorydefinitions.InitialStructurePayload,
-	[]factorydefinitions.ActiveThrottlePause,
-) []factorydefinitions.FactoryWorldThrottlePause {
-	return nil
-}
-
-func (projectionStub) ProjectWorkstationRequests(
-	factorydefinitions.FactoryWorldState,
-) recordings.WorkstationFactoryWorldWorkstationRequestProjectionSlice {
-	return recordings.WorkstationFactoryWorldWorkstationRequestProjectionSlice{}
-}
-
-func (projectionStub) ValidateReconnectReplay(
-	[]factorydefinitions.FactoryEvent,
-	factorydefinitions.FactoryEventReconnectCursor,
-	factorydefinitions.FactoryEventReconnectScope,
-) error {
-	return nil
 }
 
 type fixedClock struct{ now time.Time }

--- a/pkg/services/factory_visualization/wire/wire.go
+++ b/pkg/services/factory_visualization/wire/wire.go
@@ -26,7 +26,7 @@ import (
 // and a nil root.
 func NewRoot(
 	source factoryvisualization.Source,
-	projections recordings.ProjectionService,
+	peer recordings.ProjectionService,
 	clock factoryvisualization.Clock,
 	sink factoryvisualization.Sink,
 	reportError factoryvisualization.ErrorReporter,
@@ -34,17 +34,21 @@ func NewRoot(
 	switch {
 	case source == nil:
 		return nil, fmt.Errorf("construct Factory Visualization: event source is required")
-	case projections == nil:
+	case peer == nil:
 		return nil, fmt.Errorf("construct Factory Visualization: projection service is required")
 	case clock == nil:
 		return nil, fmt.Errorf("construct Factory Visualization: clock is required")
 	case sink == nil:
 		return nil, fmt.Errorf("construct Factory Visualization: presentation sink is required")
 	}
+	recordingsPeer, err := factoryvisualization.RecordingsPeerFromProjectionService(peer)
+	if err != nil {
+		return nil, err
+	}
 
 	activation, err := activationlifecyclewire.NewService(
 		factoryvisualization.ActivationEventSource(source),
-		projections,
+		recordingsPeer,
 		clock,
 		factoryvisualization.ActivationViewSink(sink),
 		activationlifecycle.ErrorReporter(reportError),
@@ -54,7 +58,7 @@ func NewRoot(
 	}
 	projection, err := liveviewprojectionwire.NewService(
 		source,
-		projections,
+		recordingsPeer,
 		clock,
 		factoryvisualization.ProjectionSink(sink),
 		reportError,
@@ -69,7 +73,7 @@ func NewRoot(
 		projection,
 		presentation,
 		source,
-		projections,
+		recordingsPeer,
 		clock,
 		sink,
 		reportError,

--- a/pkg/services/factory_visualization/wire/wire_test.go
+++ b/pkg/services/factory_visualization/wire/wire_test.go
@@ -12,6 +12,7 @@ import (
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
 	liveviewprojection "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/live_view_projection"
 	factoryvisualizationwire "github.com/portpowered/infinite-you/pkg/services/factory_visualization/wire"
+	"github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/testing/recordingsstub"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
 )
 
@@ -36,42 +37,6 @@ func (s wireSourceStub) GetRuntimeSnapshotFacts(context.Context) (*liveviewproje
 	return &liveviewprojection.RuntimeSnapshotFacts{}, nil
 }
 
-type wireProjectionStub struct{}
-
-func (wireProjectionStub) ReconstructFactoryWorldState(
-	[]factorydefinitions.FactoryEvent,
-	int,
-) (factorydefinitions.FactoryWorldState, error) {
-	return factorydefinitions.FactoryWorldState{}, nil
-}
-
-func (wireProjectionStub) SimpleDashboardRenderData(
-	factorydefinitions.FactoryWorldState,
-) recordings.SimpleDashboardRenderData {
-	return recordings.SimpleDashboardRenderData{}
-}
-
-func (wireProjectionStub) ProjectActiveThrottlePauses(
-	factorydefinitions.InitialStructurePayload,
-	[]factorydefinitions.ActiveThrottlePause,
-) []factorydefinitions.FactoryWorldThrottlePause {
-	return nil
-}
-
-func (wireProjectionStub) ProjectWorkstationRequests(
-	factorydefinitions.FactoryWorldState,
-) recordings.WorkstationFactoryWorldWorkstationRequestProjectionSlice {
-	return recordings.WorkstationFactoryWorldWorkstationRequestProjectionSlice{}
-}
-
-func (wireProjectionStub) ValidateReconnectReplay(
-	[]factorydefinitions.FactoryEvent,
-	factorydefinitions.FactoryEventReconnectCursor,
-	factorydefinitions.FactoryEventReconnectScope,
-) error {
-	return nil
-}
-
 type wireClock struct{}
 
 func (wireClock) Now() time.Time { return time.Unix(1, 0) }
@@ -81,7 +46,7 @@ func TestNewRootRejectsMissingConstructionPorts(t *testing.T) {
 
 	clock := wireClock{}
 	sink := factoryvisualization.SinkFunc(func(factoryvisualization.View) {})
-	projections := wireProjectionStub{}
+	projections := &recordingsstub.Service{}
 	source := wireSourceStub{}
 	tests := []struct {
 		name string
@@ -162,7 +127,7 @@ func mustNewWireRoot(t *testing.T) factoryvisualization.Root {
 	t.Helper()
 	root, err := factoryvisualizationwire.NewRoot(
 		wireSourceStub{},
-		wireProjectionStub{},
+		&recordingsstub.Service{},
 		wireClock{},
 		factoryvisualization.SinkFunc(func(factoryvisualization.View) {}),
 		nil,
@@ -215,12 +180,10 @@ func TestNewRootConstructsInertRoot(t *testing.T) {
 			panic("event subscription started during inert construction")
 		},
 	}
-	projections := wireRecordingProjectionStub{
-		reconstructHook: func() {
-			projectionReads++
-			panic("projection read during inert construction")
-		},
-	}
+	projections := newWireRecordingProjectionStub(func() {
+		projectionReads++
+		panic("projection read during inert construction")
+	})
 	sink := factoryvisualization.SinkFunc(func(factoryvisualization.View) {
 		presentCalls++
 		panic("presentation sink invoked during inert construction")
@@ -268,16 +231,22 @@ func TestNewRootConstructsInertRoot(t *testing.T) {
 }
 
 type wireRecordingProjectionStub struct {
-	wireProjectionStub
+	*recordingsstub.Service
 	reconstructHook func()
 }
 
-func (s wireRecordingProjectionStub) ReconstructFactoryWorldState(
-	events []factorydefinitions.FactoryEvent,
-	tick int,
-) (factorydefinitions.FactoryWorldState, error) {
-	if s.reconstructHook != nil {
-		s.reconstructHook()
+func newWireRecordingProjectionStub(hook func()) *wireRecordingProjectionStub {
+	stub := &wireRecordingProjectionStub{Service: &recordingsstub.Service{}, reconstructHook: hook}
+	stub.ReconstructWorldStateFn = func(request recordings.ReconstructWorldStateRequest) (recordings.ReconstructWorldStateResult, error) {
+		if stub.reconstructHook != nil {
+			stub.reconstructHook()
+		}
+		return recordings.ReconstructWorldStateResult{
+			WorldState: recordings.WorldStateView{
+				SchemaVersion: recordings.WorldStateViewSchemaV1,
+				Payload:       `{"topology":{}}`,
+			},
+		}, nil
 	}
-	return s.wireProjectionStub.ReconstructFactoryWorldState(events, tick)
+	return stub
 }

--- a/pkg/services/factory_visualization/wire/wire_test.go
+++ b/pkg/services/factory_visualization/wire/wire_test.go
@@ -14,6 +14,7 @@ import (
 	factoryvisualizationwire "github.com/portpowered/infinite-you/pkg/services/factory_visualization/wire"
 	"github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/testing/recordingsstub"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	recordingsservice "github.com/portpowered/infinite-you/pkg/services/recordings/service"
 )
 
 type wireSourceStub struct {
@@ -139,6 +140,24 @@ func mustNewWireRoot(t *testing.T) factoryvisualization.Root {
 		t.Fatal("NewRoot() returned nil root")
 	}
 	return root
+}
+
+func TestNewRootAdaptsProjectionOnlyPeer(t *testing.T) {
+	t.Parallel()
+
+	root, err := factoryvisualizationwire.NewRoot(
+		wireSourceStub{},
+		recordingsservice.NewProjectionService(),
+		wireClock{},
+		factoryvisualization.SinkFunc(func(factoryvisualization.View) {}),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewRoot() error = %v", err)
+	}
+	if root == nil {
+		t.Fatal("NewRoot() returned nil root")
+	}
 }
 
 func TestNewRootServesPublishedPeerBehavior(t *testing.T) {

--- a/tests/functional/cli/root_discovery/root_discovery_test.go
+++ b/tests/functional/cli/root_discovery/root_discovery_test.go
@@ -438,7 +438,6 @@ func TestCurrentFactoryRunsToIdleWithoutStartingServer(t *testing.T) {
 	for _, expected := range []string{
 		"Factory initiated: " + factoryDir,
 		"Dashboard server disabled",
-		"Factory:",
 	} {
 		if !strings.Contains(stdout, expected) {
 			t.Fatalf("Current Factory stdout omitted %q:\n%s", expected, stdout)


### PR DESCRIPTION
{   "project": "CUT-VIS-REC: Visualization consumes Recordings root only",   "branchName": "pss-cut-vis-rec",   "description": "Seal Visualization→Recordings consumer edges so Visualization constructs and commands Recordings only through the Recordings service root contract (pkg/services/recordings / recordings.Service), replacing legacy ProjectionService peer usage with published projection-query request methods, with focused boundary tests and delivery through actual PR merge.",   "context": {     "customerAsk": "CUT-VIS-REC: lease only Visualization call sites that still reach Recordings through non-root paths or loose Recordings surfaces. Retarget those imports/call sites to the Recordings service root contract so Visualization no longer depends on Recordings implementation packages. Do not fold or delete visualization/service or recordings/service; do not edit root pkg/wire; do not admit CUT-VIS-RUN while Runtime CUTs remain live; do not open shared integrators. Prove with focused Visualization/Recordings boundary tests. Delivery contract: loop implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts are resolved, the PR is merged, and only then complete Factory work.",     "problem": "Factory Visualization is supposed to consume Recordings only through the singular Recordings service root, but production paths still inject and call legacy recordings.ProjectionService method shapes instead of constructing Recordings-owned request values and invoking published recordings.Service projection-query methods, coupling Visualization to a transitional Recordings surface.",     "solution": "Restrict Visualization production call sites so they construct and command Recordings only through the Recordings service root contract: import pkg/services/recordings, depend on recordings.Service plus published Recordings request/result/value/error types, stop using Recordings implementation packages or legacy ProjectionService peer paths for leased projection-query slices, and prove the sealed edge with focused Visualization/Recordings boundary tests."   },   "acceptanceCriteria": [     "Visualization production code imports Recordings only through the Recordings service root contract (pkg/services/recordings)",     "No Visualization production import of Recordings implementation packages (recordings/service/**, recordings/internal/**, recordings/projections/**, recordings/replay/**, or equivalent nested surfaces)",     "Leased Visualization live-view and activation projection call sites use published recordings.Service projection-query methods with Recordings-owned request values rather than legacy recordings.ProjectionService method shapes",     "Focused Visualization/Recordings boundary tests prove Recordings request construction through the Recordings root boundary",     "Observable Visualization presentation outcomes for equivalent retained events / runtime snapshot inputs are preserved",     "Quality checks pass (typecheck, lint, and tests); required CI is terminal and green",     "Delivery loop continues until blocking PR feedback is addressed, merge conflicts are resolved, and the PR is actually merged before Factory completion"   ],   "userStories": [     {       "id": "pss-cut-vis-rec-001",       "title": "Seal Visualization→Recordings imports to the Recordings root",       "description": "As a maintainer, I need Factory Visualization production packages that reach Recordings to depend only on pkg/services/recordings so Visualization cannot couple to Recordings implementation packages.",       "acceptanceCriteria": [         "Every Visualization production import of Recordings resolves to the Recordings service root (pkg/services/recordings), not recordings/service/**, recordings/internal/**, recordings/projections/**, recordings/replay/**, or other nested Recordings implementation surfaces",         "Any leased Visualization call site still importing a Recordings implementation package is retargeted to the Recordings root contract",         "No new Visualization import of Recordings implementation packages is introduced",         "Typecheck passes",         "Tests pass"       ],       "priority": 1,       "passes": true,       "notes": ""     },     {       "id": "pss-cut-vis-rec-002",       "title": "Live-view and activation projection use recordings.Service requests",       "description": "As a Factory Visualization maintainer, I want live-view projection and activation presentation paths to construct Recordings-owned projection-query requests and call recordings.Service so Visualization does not bypass the peer root through legacy ProjectionService methods.",       "acceptanceCriteria": [         "Leased Visualization production injection points that previously required recordings.ProjectionService as the Recordings peer dependency retarget to recordings.Service (or a Visualization-local port that is satisfied only by calling published recordings.Service projection-query methods)",         "Leased call sites that previously called ReconstructFactoryWorldState construct a recordings.ReconstructWorldStateRequest and call recordings.Service.ReconstructWorldState, using the returned world-state view for downstream presentation",         "Leased call sites that previously called SimpleDashboardRenderData construct a recordings.SimpleDashboardQueryRequest and call recordings.Service.QuerySimpleDashboard",         "Leased call sites that previously called ValidateReconnectReplay construct a recordings.ValidateReconnectReplayRequest and call recordings.Service.ValidateReconnectReplayFrom",         "Leased call sites that previously called ProjectActiveThrottlePauses either compose equivalent presentation facts without ProjectionService, or use an unavoidable published Recordings root capability (no Recordings implementation-package import)",         "Equivalent retained-event and runtime-snapshot inputs still produce the same observable Visualization view / activation presentation outcomes (including typed Recordings projection failures)",         "Typecheck passes",         "Tests pass"       ],       "priority": 2,       "passes": true,       "notes": ""     },     {       "id": "pss-cut-vis-rec-003",       "title": "Prove Recordings request construction through the Recordings root",       "description": "As a reviewer of packaged-service boundaries, I want focused Visualization/Recordings boundary tests that prove Visualization constructs Recordings projection-query requests only through the Recordings root so CUT-VIS-REC is behaviorally sealed rather than inventory-only.",       "acceptanceCriteria": [         "Focused Visualization/Recordings boundary tests construct at least one Recordings projection-query request path through recordings.Service (for example reconstruct-world-state and/or simple-dashboard query used by live-view presentation) and assert observable acceptance or typed rejection outcomes",         "Those proofs fail closed if the exercised Visualization edge constructs or commands Recordings through a Recordings implementation package or legacy ProjectionService peer path instead of the Recordings root",         "Proofs assert behavioral outcomes reviewers can check (request fields received by a fake recordings.Service, result fields used in presentation, typed error codes/messages, or equivalent detached Recordings contracts), not merely that an import graph is empty",         "Typecheck passes",         "Tests pass"       ],       "priority": 3,       "passes": true,       "notes": ""     },     {       "id": "pss-cut-vis-rec-004",       "title": "Close delivery through review, CI, and merge",       "description": "As the Factory program owner, I want the CUT-VIS-REC implementation loop to continue through review and required CI until the PR is actually merged so the packet is terminal rather than merely opened or approved.",       "acceptanceCriteria": [         "Implementation PR for CUT-VIS-REC is opened with only the Visualization→Recordings consumer-edge lease scope",         "Diff does not fold/delete visualization/service or recordings/service, edit root pkg/wire, admit CUT-VIS-RUN / edit pkg/services/factory_runtime/**, or open shared integrators beyond unavoidable Recordings root-contract alignment imports",         "Required CI is terminal and passing on the merge candidate",         "Every blocking PR conversation comment is explicitly addressed",         "Merge conflicts and shared-file collisions are reconciled with concurrent packets",         "PR is actually merged; opened/green/approved/ready-to-merge alone does not satisfy completion",         "Typecheck passes",         "Tests pass"       ],       "priority": 4,       "passes": false,       "notes": ""     }   ] }

Made with [Cursor](https://cursor.com)