### PR TITLE
pss-cut-work-rec

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1965,6 +1965,10 @@
       "minimum": 76.90
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/work/stateaccessrecordings",
+      "minimum": 100.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/service",
       "minimum": 7.37
     },

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1965,12 +1965,12 @@
       "minimum": 76.90
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/work/stateaccessrecordings",
-      "minimum": 100.00
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/service",
       "minimum": 7.37
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/work/stateaccessrecordings",
+      "minimum": 100.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/transports/cli",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1605,6 +1605,10 @@
       "minimum": 100.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/work/stateaccessrecordings",
+      "minimum": 100.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/service",
       "minimum": 72.95
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1605,12 +1605,12 @@
       "minimum": 100.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/work/stateaccessrecordings",
-      "minimum": 100.00
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/service",
       "minimum": 72.95
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/work/stateaccessrecordings",
+      "minimum": 100.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/transports/cli",

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -4524,6 +4524,12 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/work/stateaccessrecordings",
+      "disposition": "retain",
+      "destination": "work",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/work/service",
       "disposition": "move",
       "destination": "work",

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -4524,18 +4524,18 @@
       "destinationKind": "owner"
     },
     {
-      "packagePath": "pkg/services/work/stateaccessrecordings",
-      "disposition": "retain",
-      "destination": "work",
-      "destinationKind": "owner"
-    },
-    {
       "packagePath": "pkg/services/work/service",
       "disposition": "move",
       "destination": "work",
       "destinationKind": "owner",
       "successor": "pkg/services/work/internal",
       "deletionCondition": "delete transitional service/ package after owner wire retargets to internal implementation and DEL cutover proof completes"
+    },
+    {
+      "packagePath": "pkg/services/work/stateaccessrecordings",
+      "disposition": "retain",
+      "destination": "work",
+      "destinationKind": "owner"
     },
     {
       "packagePath": "pkg/services/work/transports/cli",

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -63,6 +63,12 @@ Use this map when changing the public REST contract.
   `pkg/services/work/transports/http`. The adapter consumes the accepted
   `work.Service` root only; fake-root tests inject a focused root fake without
   constructing state-access, content-staging, or materialization graphs.
+  CUT-WORK-REC seals Work production imports of Recordings to the service root
+  only; the lease-wide guard is
+  `pkg/services/work/recordings_import_boundary_test.go`, and behavioral
+  request-construction proofs live in
+  `pkg/services/work/recordings_request_boundary_test.go` plus
+  `state_access/wire/recordings_adapter_test.go`.
   Package-boundary tests must prove the adapter does not import
   `pkg/services/work/internal/**`. Register the package in
   `docs/internal/packaged-service-structure/package-target-manifest.json`,

--- a/pkg/services/work/internal/services/state_access/internal/service/read.go
+++ b/pkg/services/work/internal/services/state_access/internal/service/read.go
@@ -3,9 +3,11 @@ package service
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 
 	"github.com/portpowered/infinite-you/pkg/services/work"
+	stateaccess "github.com/portpowered/infinite-you/pkg/services/work/internal/services/state_access"
 )
 
 func (s *Service) ListWork(
@@ -114,15 +116,32 @@ func (s *Service) MoveWorkAndRead(
 }
 
 func (s *Service) readSnapshot(ctx context.Context, sessionID string) (work.ReadSnapshot, error) {
-	adapter, err := s.resolveSession(sessionID)
-	if err != nil {
-		return work.ReadSnapshot{}, err
+	if adapter, err := s.tryResolveSession(sessionID); err == nil && adapter != nil {
+		snapshot, err := adapter.ReadWorkSnapshot(ctx)
+		if err != nil {
+			return work.ReadSnapshot{}, fmt.Errorf("read Work snapshot: %w", err)
+		}
+		return snapshot, nil
 	}
-	snapshot, err := adapter.ReadWorkSnapshot(ctx)
+	if s == nil || s.recordings == nil {
+		return work.ReadSnapshot{}, errors.New("Work state access recordings adapter is required")
+	}
+	snapshot, err := s.recordings.ReadWorkSnapshot(ctx, sessionID)
 	if err != nil {
-		return work.ReadSnapshot{}, fmt.Errorf("read Work snapshot: %w", err)
+		return work.ReadSnapshot{}, fmt.Errorf("read Work snapshot from Recordings: %w", err)
 	}
 	return snapshot, nil
+}
+
+func (s *Service) tryResolveSession(sessionID string) (stateaccess.SessionAdapter, error) {
+	if s == nil || s.sessions == nil {
+		return nil, errors.New("Work state access session resolver is required")
+	}
+	adapter, err := s.sessions.ResolveSessionAdapter(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	return adapter, nil
 }
 
 func optional(value string) *string {

--- a/pkg/services/work/internal/services/state_access/internal/service/read_test.go
+++ b/pkg/services/work/internal/services/state_access/internal/service/read_test.go
@@ -22,7 +22,7 @@ func TestListWorkReturnsDetachedReadModels(t *testing.T) {
 	t.Parallel()
 
 	adapter := &recordingSessionAdapter{snapshot: querySnapshot()}
-	svc := internalservice.New(stubSessionResolver{adapter: adapter})
+	svc := internalservice.New(stubSessionResolver{adapter: adapter}, nil)
 	ctx := context.Background()
 
 	got, err := svc.ListWork(ctx, "session-1", work.ListOptions{WorkTypeName: "bug"})
@@ -46,7 +46,7 @@ func TestListWorkHonorsPaginationNextToken(t *testing.T) {
 		{CursorID: "tok-active-1", WorkID: "work-active-1", Name: "Alpha first", WorkTypeName: "task", State: &work.State{Name: "review", Type: work.StateTypeProcessing}},
 		{CursorID: "tok-active-2", WorkID: "work-active-2", Name: "Alpha second", WorkTypeName: "task", State: &work.State{Name: "review", Type: work.StateTypeProcessing}},
 	}}}
-	svc := internalservice.New(stubSessionResolver{adapter: adapter})
+	svc := internalservice.New(stubSessionResolver{adapter: adapter}, nil)
 	ctx := context.Background()
 
 	first, err := svc.ListWork(ctx, "session-1", work.ListOptions{Name: "alpha", MaxResults: 1})
@@ -63,7 +63,7 @@ func TestGetWorkByCursorOrWorkIDAndNotFound(t *testing.T) {
 	t.Parallel()
 
 	adapter := &recordingSessionAdapter{snapshot: querySnapshot()}
-	svc := internalservice.New(stubSessionResolver{adapter: adapter})
+	svc := internalservice.New(stubSessionResolver{adapter: adapter}, nil)
 	ctx := context.Background()
 
 	for _, id := range []string{"tok-story", "work-story"} {
@@ -86,7 +86,7 @@ func TestMoveWorkAndReadReturnsDetachedPostMoveReadModel(t *testing.T) {
 		Name:     "one",
 		State:    &work.State{Name: "review", Type: work.StateTypeProcessing},
 	}}}}
-	svc := internalservice.New(stubSessionResolver{adapter: adapter})
+	svc := internalservice.New(stubSessionResolver{adapter: adapter}, nil)
 	ctx := context.Background()
 
 	read, err := svc.MoveWorkAndRead(ctx, "session-1", "work-1", "complete", "request-1")
@@ -107,11 +107,50 @@ func TestReadSnapshotUsesSessionAdapterOnly(t *testing.T) {
 	t.Parallel()
 
 	adapter := &recordingSessionAdapter{snapshotErr: errors.New("snapshot unavailable")}
-	svc := internalservice.New(stubSessionResolver{adapter: adapter})
+	svc := internalservice.New(stubSessionResolver{adapter: adapter}, nil)
 	ctx := context.Background()
 
 	_, err := svc.ListWork(ctx, "session-1", work.ListOptions{})
 	if err == nil || err.Error() != "read Work snapshot: snapshot unavailable" {
 		t.Fatalf("ListWork error = %v, want wrapped snapshot error", err)
 	}
+}
+
+func TestReadSnapshotFallsBackToRecordingsAdapterWhenSessionUnavailable(t *testing.T) {
+	t.Parallel()
+
+	svc := internalservice.New(
+		stubSessionResolver{},
+		&recordingRecordingsAdapter{snapshot: work.ReadSnapshot{Items: []work.ReadModel{{
+			CursorID:     "work-rec",
+			WorkID:       "work-rec",
+			Name:         "Recorded work",
+			WorkTypeName: "story",
+			State:        &work.State{Name: "review", Type: work.StateTypeProcessing},
+		}}}},
+	)
+	ctx := context.Background()
+
+	got, err := svc.ListWork(ctx, "session-recordings", work.ListOptions{})
+	if err != nil {
+		t.Fatalf("ListWork: %v", err)
+	}
+	if len(got.Results) != 1 || got.Results[0].WorkID != "work-rec" {
+		t.Fatalf("ListWork = %#v, want one recorded work item", got)
+	}
+}
+
+type recordingRecordingsAdapter struct {
+	snapshot work.ReadSnapshot
+	err      error
+}
+
+func (a *recordingRecordingsAdapter) ReadWorkSnapshot(
+	context.Context,
+	string,
+) (work.ReadSnapshot, error) {
+	if a.err != nil {
+		return work.ReadSnapshot{}, a.err
+	}
+	return a.snapshot, nil
 }

--- a/pkg/services/work/internal/services/state_access/internal/service/service.go
+++ b/pkg/services/work/internal/services/state_access/internal/service/service.go
@@ -9,16 +9,21 @@ import (
 )
 
 // Service owns session-scoped submit and operator move through the private
-// Session adapter port.
+// Session adapter port and Recordings-backed reads through the private
+// Recordings adapter port.
 type Service struct {
-	sessions stateaccess.SessionResolver
+	sessions    stateaccess.SessionResolver
+	recordings  stateaccess.RecordingsAdapter
 }
 
 var _ stateaccess.Service = (*Service)(nil)
 
 // New constructs the private state_access implementation.
-func New(sessions stateaccess.SessionResolver) *Service {
-	return &Service{sessions: sessions}
+func New(
+	sessions stateaccess.SessionResolver,
+	recordings stateaccess.RecordingsAdapter,
+) *Service {
+	return &Service{sessions: sessions, recordings: recordings}
 }
 
 func (s *Service) SubmitWorkRequestForSession(

--- a/pkg/services/work/internal/services/state_access/internal/service/service_test.go
+++ b/pkg/services/work/internal/services/state_access/internal/service/service_test.go
@@ -85,7 +85,7 @@ func TestSubmitWorkRequestForSessionReturnsDetachedResult(t *testing.T) {
 	t.Parallel()
 
 	adapter := &recordingSessionAdapter{}
-	svc := internalservice.New(stubSessionResolver{adapter: adapter})
+	svc := internalservice.New(stubSessionResolver{adapter: adapter}, nil)
 	ctx := context.Background()
 	request := work.WorkRequest{RequestID: "request-1"}
 
@@ -105,7 +105,7 @@ func TestMoveWorkForSessionReturnsDetachedResult(t *testing.T) {
 	t.Parallel()
 
 	adapter := &recordingSessionAdapter{}
-	svc := internalservice.New(stubSessionResolver{adapter: adapter})
+	svc := internalservice.New(stubSessionResolver{adapter: adapter}, nil)
 	ctx := context.Background()
 
 	result, err := svc.MoveWorkForSession(ctx, "session-1", "work-1", "review", "move-1")
@@ -127,7 +127,7 @@ func TestMoveWorkForSessionPropagatesAlreadyAppliedFailure(t *testing.T) {
 	t.Parallel()
 
 	adapter := &recordingSessionAdapter{moveErr: work.ErrMoveWorkRequestAlreadyApplied}
-	svc := internalservice.New(stubSessionResolver{adapter: adapter})
+	svc := internalservice.New(stubSessionResolver{adapter: adapter}, nil)
 	ctx := context.Background()
 
 	_, err := svc.MoveWorkForSession(ctx, "session-1", "work-1", "done", "dup-move")
@@ -140,7 +140,7 @@ func TestResolveSessionResolverError(t *testing.T) {
 	t.Parallel()
 
 	resolverErr := errors.New("session missing")
-	svc := internalservice.New(stubSessionResolver{err: resolverErr})
+	svc := internalservice.New(stubSessionResolver{err: resolverErr}, nil)
 	ctx := context.Background()
 
 	_, err := svc.SubmitWorkRequestForSession(ctx, "missing", work.WorkRequest{})

--- a/pkg/services/work/internal/services/state_access/internal/service/state_access_seal_test.go
+++ b/pkg/services/work/internal/services/state_access/internal/service/state_access_seal_test.go
@@ -154,6 +154,32 @@ func TestStateAccessOwnerDoesNotImportFactoryRuntimeOrPetri(t *testing.T) {
 		"orchestrators/petri",
 		"pkg/factory/",
 	}
+	assertStateAccessOwnerForbiddenImports(t, forbidden, "Factory Runtime or Petri")
+}
+
+// TestStateAccessOwnerDoesNotImportRecordingsNestedPackages fails closed when
+// the private state_access owner reaches Recordings through nested packages
+// instead of the Recordings service root contract.
+func TestStateAccessOwnerDoesNotImportRecordingsNestedPackages(t *testing.T) {
+	t.Parallel()
+
+	forbidden := []string{
+		"pkg/services/recordings/service",
+		"pkg/services/recordings/internal",
+		"pkg/services/recordings/events",
+		"pkg/services/recordings/replay",
+		"pkg/services/recordings/projections",
+		"pkg/services/recordings/artifacts",
+	}
+	assertStateAccessOwnerForbiddenImports(t, forbidden, "nested Recordings")
+}
+
+func assertStateAccessOwnerForbiddenImports(
+	t *testing.T,
+	forbidden []string,
+	ownerLabel string,
+) {
+	t.Helper()
 	packages := []string{
 		".",
 		filepath.Join("..", ".."),
@@ -174,7 +200,7 @@ func TestStateAccessOwnerDoesNotImportFactoryRuntimeOrPetri(t *testing.T) {
 			}
 			for _, needle := range forbidden {
 				if strings.Contains(string(source), needle) {
-					t.Errorf("%s imports forbidden Factory Runtime or Petri package %q", entry.Name(), needle)
+					t.Errorf("%s imports forbidden %s package %q", entry.Name(), ownerLabel, needle)
 				}
 			}
 		}

--- a/pkg/services/work/internal/services/state_access/internal/service/state_access_seal_test.go
+++ b/pkg/services/work/internal/services/state_access/internal/service/state_access_seal_test.go
@@ -19,7 +19,7 @@ func TestStateAccessSealSubmitAndMovePipeline(t *testing.T) {
 	t.Parallel()
 
 	adapter := &sealSessionAdapter{}
-	svc := New(stubSessionResolver{adapter: adapter})
+	svc := New(stubSessionResolver{adapter: adapter}, nil)
 	ctx := context.Background()
 
 	submitted, err := svc.SubmitWorkRequestForSession(ctx, "session-seal", work.WorkRequest{
@@ -63,7 +63,7 @@ func TestStateAccessSealFullStateAccessPipeline(t *testing.T) {
 	t.Parallel()
 
 	adapter := &sealSessionAdapter{}
-	svc := New(stubSessionResolver{adapter: adapter})
+	svc := New(stubSessionResolver{adapter: adapter}, nil)
 	ctx := context.Background()
 	sessionID := "session-seal-full"
 
@@ -126,7 +126,7 @@ func TestStateAccessSealTypedFailures(t *testing.T) {
 	t.Parallel()
 
 	adapter := &sealSessionAdapter{}
-	svc := New(stubSessionResolver{adapter: adapter})
+	svc := New(stubSessionResolver{adapter: adapter}, nil)
 	ctx := context.Background()
 	sessionID := "session-seal-failures"
 

--- a/pkg/services/work/internal/services/state_access/service_test.go
+++ b/pkg/services/work/internal/services/state_access/service_test.go
@@ -10,7 +10,7 @@ import (
 func TestWireConstructsSingularStateAccessService(t *testing.T) {
 	t.Parallel()
 
-	svc := stateaccesswire.NewService(stateaccesswire.NewRuntimeSessionResolver(nil))
+	svc := stateaccesswire.NewService(stateaccesswire.NewRuntimeSessionResolver(nil), nil)
 	if svc == nil {
 		t.Fatal("wire.NewService() returned nil")
 	}

--- a/pkg/services/work/internal/services/state_access/wire/recordings_adapter.go
+++ b/pkg/services/work/internal/services/state_access/wire/recordings_adapter.go
@@ -1,0 +1,122 @@
+package wire
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	stateaccess "github.com/portpowered/infinite-you/pkg/services/work/internal/services/state_access"
+)
+
+type recordingsAdapter struct {
+	root recordings.Service
+}
+
+// NewRecordingsAdapter constructs the private Work state_access Recordings port
+// from the published Recordings service root contract.
+func NewRecordingsAdapter(root recordings.Service) stateaccess.RecordingsAdapter {
+	if root == nil {
+		return nil
+	}
+	return recordingsAdapter{root: root}
+}
+
+func (a recordingsAdapter) ReadWorkSnapshot(
+	ctx context.Context,
+	sessionID string,
+) (work.ReadSnapshot, error) {
+	if a.root == nil {
+		return work.ReadSnapshot{}, errors.New("Recordings service is required")
+	}
+	if err := requireContext(ctx); err != nil {
+		return work.ReadSnapshot{}, err
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return work.ReadSnapshot{}, recordings.ErrInvalidProjectionScope
+	}
+	scope := recordings.CanonicalEventScope{FactorySessionID: sessionID}
+	events, err := a.canonicalEventsForScope(ctx, scope)
+	if err != nil {
+		return work.ReadSnapshot{}, err
+	}
+	reconstructed, err := a.root.ReconstructWorldState(
+		reconstructWorldStateRequest(scope, events),
+	)
+	if err != nil {
+		return work.ReadSnapshot{}, err
+	}
+	return readSnapshotFromWorldState(reconstructed.WorldState)
+}
+
+func (a recordingsAdapter) canonicalEventsForScope(
+	ctx context.Context,
+	scope recordings.CanonicalEventScope,
+) ([]recordings.CanonicalEvent, error) {
+	subscribed, err := a.root.SubscribeFrom(ctx, recordings.SubscribeRequest{Scope: scope})
+	if err != nil {
+		return nil, fmt.Errorf("subscribe Recordings canonical facts: %w", err)
+	}
+	return canonicalEventsFromSubscription(ctx, subscribed.Subscription)
+}
+
+func reconstructWorldStateRequest(
+	scope recordings.CanonicalEventScope,
+	events []recordings.CanonicalEvent,
+) recordings.ReconstructWorldStateRequest {
+	selectedTick := 0
+	for _, event := range events {
+		if tick := event.FactoryTick; tick > selectedTick {
+			selectedTick = tick
+		}
+	}
+	return recordings.ReconstructWorldStateRequest{
+		Scope:        scope,
+		Events:       append([]recordings.CanonicalEvent(nil), events...),
+		SelectedTick: selectedTick,
+	}
+}
+
+func canonicalEventsFromSubscription(
+	ctx context.Context,
+	subscription recordings.EventSubscription,
+) ([]recordings.CanonicalEvent, error) {
+	if subscription == nil {
+		return nil, nil
+	}
+	events := make([]recordings.CanonicalEvent, 0)
+	for {
+		outcome := subscription.Next(ctx)
+		switch outcome.Kind {
+		case recordings.SubscriptionEvent:
+			events = append(events, outcome.Event)
+		case recordings.SubscriptionClosed:
+			return events, nil
+		case recordings.SubscriptionGap:
+			if outcome.Gap == nil {
+				return nil, errors.New("recordings subscription gap")
+			}
+			return nil, fmt.Errorf(
+				"recordings subscription gap at sequence %d",
+				outcome.Gap.ExpectedSequence,
+			)
+		default:
+			return events, nil
+		}
+	}
+}
+
+func requireContext(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("Work state access context is required")
+	}
+	return ctx.Err()
+}
+
+func isPublicWorkItem(item work.FactoryWorkItem) bool {
+	return !interfaces.IsSystemTimeWorkType(item.WorkTypeID)
+}

--- a/pkg/services/work/internal/services/state_access/wire/recordings_adapter_test.go
+++ b/pkg/services/work/internal/services/state_access/wire/recordings_adapter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
@@ -66,6 +67,184 @@ func TestNewRecordingsAdapterTypedProjectionFailures(t *testing.T) {
 	}
 }
 
+func TestNewRecordingsAdapterNilRootReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	if adapter := NewRecordingsAdapter(nil); adapter != nil {
+		t.Fatalf("NewRecordingsAdapter(nil) = %#v, want nil", adapter)
+	}
+}
+
+func TestReadWorkSnapshotValidatesContextAndSession(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewRecordingsAdapter(&recordingsRootFake{})
+
+	_, err := adapter.ReadWorkSnapshot(nil, "session-1")
+	if err == nil || err.Error() != "Work state access context is required" {
+		t.Fatalf("ReadWorkSnapshot(nil ctx) error = %v", err)
+	}
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = adapter.ReadWorkSnapshot(canceled, "session-1")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ReadWorkSnapshot(canceled ctx) error = %v, want context.Canceled", err)
+	}
+
+	_, err = adapter.ReadWorkSnapshot(context.Background(), "  ")
+	if !errors.Is(err, recordings.ErrInvalidProjectionScope) {
+		t.Fatalf("ReadWorkSnapshot(empty session) error = %v, want ErrInvalidProjectionScope", err)
+	}
+}
+
+func TestReadWorkSnapshotSubscribeAndSubscriptionFailures(t *testing.T) {
+	t.Parallel()
+
+	t.Run("subscribe error", func(t *testing.T) {
+		t.Parallel()
+		adapter := NewRecordingsAdapter(&recordingsRootFake{subscribeErr: errors.New("subscribe failed")})
+		_, err := adapter.ReadWorkSnapshot(context.Background(), "session-1")
+		if err == nil || !strings.Contains(err.Error(), "subscribe Recordings canonical facts") {
+			t.Fatalf("ReadWorkSnapshot error = %v, want wrapped subscribe failure", err)
+		}
+	})
+
+	t.Run("subscription gap", func(t *testing.T) {
+		t.Parallel()
+		adapter := NewRecordingsAdapter(&recordingsRootFake{
+			subscription: func(context.Context) recordings.SubscriptionOutcome {
+				return recordings.SubscriptionOutcome{
+					Kind: recordings.SubscriptionGap,
+					Gap:  &recordings.SubscriptionGapFacts{ExpectedSequence: 42},
+				}
+			},
+		})
+		_, err := adapter.ReadWorkSnapshot(context.Background(), "session-1")
+		if err == nil || !strings.Contains(err.Error(), "recordings subscription gap at sequence 42") {
+			t.Fatalf("ReadWorkSnapshot error = %v, want subscription gap", err)
+		}
+	})
+
+	t.Run("subscription gap without detail", func(t *testing.T) {
+		t.Parallel()
+		adapter := NewRecordingsAdapter(&recordingsRootFake{
+			subscription: func(context.Context) recordings.SubscriptionOutcome {
+				return recordings.SubscriptionOutcome{Kind: recordings.SubscriptionGap}
+			},
+		})
+		_, err := adapter.ReadWorkSnapshot(context.Background(), "session-1")
+		if err == nil || err.Error() != "recordings subscription gap" {
+			t.Fatalf("ReadWorkSnapshot error = %v, want generic subscription gap", err)
+		}
+	})
+
+	t.Run("nil subscription", func(t *testing.T) {
+		t.Parallel()
+		adapter := NewRecordingsAdapter(&recordingsRootFake{
+			subscription: nil,
+			worldState: recordings.WorldStateView{
+				SchemaVersion: recordings.WorldStateViewSchemaV1,
+				Payload:       recordingsBackedWorldPayload(t, "work-story", "story", "review"),
+			},
+		})
+		snapshot, err := adapter.ReadWorkSnapshot(context.Background(), "session-1")
+		if err != nil {
+			t.Fatalf("ReadWorkSnapshot: %v", err)
+		}
+		if len(snapshot.Items) != 1 || snapshot.Items[0].WorkID != "work-story" {
+			t.Fatalf("snapshot = %#v, want one recorded work item", snapshot)
+		}
+	})
+
+	t.Run("unknown subscription outcome after event", func(t *testing.T) {
+		t.Parallel()
+		index := 0
+		adapter := NewRecordingsAdapter(&recordingsRootFake{
+			subscription: func(context.Context) recordings.SubscriptionOutcome {
+				if index == 0 {
+					index++
+					return recordings.SubscriptionOutcome{
+						Kind:  recordings.SubscriptionEvent,
+						Event: recordings.CanonicalEvent{ID: "event-1", FactoryTick: 1},
+					}
+				}
+				return recordings.SubscriptionOutcome{Kind: recordings.SubscriptionOutcomeKind("unknown")}
+			},
+			worldState: recordings.WorldStateView{
+				SchemaVersion: recordings.WorldStateViewSchemaV1,
+				Payload:       recordingsBackedWorldPayload(t, "work-story", "story", "review"),
+			},
+		})
+		snapshot, err := adapter.ReadWorkSnapshot(context.Background(), "session-1")
+		if err != nil {
+			t.Fatalf("ReadWorkSnapshot: %v", err)
+		}
+		if len(snapshot.Items) != 1 || snapshot.Items[0].WorkID != "work-story" {
+			t.Fatalf("snapshot = %#v, want one recorded work item", snapshot)
+		}
+	})
+}
+
+func TestCanonicalEventsFromSubscriptionReturnsNilForNilSubscription(t *testing.T) {
+	t.Parallel()
+
+	got, err := canonicalEventsFromSubscription(context.Background(), nil)
+	if err != nil || got != nil {
+		t.Fatalf("canonicalEventsFromSubscription(nil) = (%#v, %v), want (nil, nil)", got, err)
+	}
+}
+
+func TestCanonicalEventsFromSubscriptionCollectsMultipleEvents(t *testing.T) {
+	t.Parallel()
+
+	index := 0
+	events := []recordings.CanonicalEvent{
+		{ID: "event-1", FactoryTick: 1},
+		{ID: "event-2", FactoryTick: 2},
+	}
+	subscription := recordings.EventSubscription(func(context.Context) recordings.SubscriptionOutcome {
+		if index >= len(events) {
+			return recordings.SubscriptionOutcome{Kind: recordings.SubscriptionClosed}
+		}
+		outcome := recordings.SubscriptionOutcome{Kind: recordings.SubscriptionEvent, Event: events[index]}
+		index++
+		return outcome
+	})
+
+	got, err := canonicalEventsFromSubscription(context.Background(), subscription)
+	if err != nil {
+		t.Fatalf("canonicalEventsFromSubscription: %v", err)
+	}
+	if len(got) != 2 || got[1].FactoryTick != 2 {
+		t.Fatalf("events = %#v, want two collected events", got)
+	}
+}
+
+func TestCanonicalEventsFromSubscriptionReturnsPartialEventsOnUnknownOutcome(t *testing.T) {
+	t.Parallel()
+
+	index := 0
+	subscription := recordings.EventSubscription(func(context.Context) recordings.SubscriptionOutcome {
+		if index == 0 {
+			index++
+			return recordings.SubscriptionOutcome{
+				Kind:  recordings.SubscriptionEvent,
+				Event: recordings.CanonicalEvent{ID: "event-1"},
+			}
+		}
+		return recordings.SubscriptionOutcome{Kind: recordings.SubscriptionOutcomeKind("unknown")}
+	})
+
+	got, err := canonicalEventsFromSubscription(context.Background(), subscription)
+	if err != nil {
+		t.Fatalf("canonicalEventsFromSubscription: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "event-1" {
+		t.Fatalf("events = %#v, want partial collected events", got)
+	}
+}
+
 func TestReadSnapshotFromWorldStateDetachesWorkFields(t *testing.T) {
 	t.Parallel()
 
@@ -95,6 +274,8 @@ func TestReadSnapshotFromWorldStateDetachesWorkFields(t *testing.T) {
 type recordingsRootFake struct {
 	events              []recordings.CanonicalEvent
 	worldState          recordings.WorldStateView
+	subscribeErr        error
+	subscription        recordings.EventSubscription
 	reconstructErr      error
 	reconstructRequests []recordings.ReconstructWorldStateRequest
 }
@@ -109,6 +290,12 @@ func (fake *recordingsRootFake) SubscribeFrom(
 	_ context.Context,
 	request recordings.SubscribeRequest,
 ) (recordings.SubscribeResult, error) {
+	if fake.subscribeErr != nil {
+		return recordings.SubscribeResult{}, fake.subscribeErr
+	}
+	if fake.subscription != nil {
+		return recordings.SubscribeResult{Subscription: fake.subscription}, nil
+	}
 	events := make([]recordings.CanonicalEvent, 0, len(fake.events))
 	for _, event := range fake.events {
 		if event.Scope == request.Scope {

--- a/pkg/services/work/internal/services/state_access/wire/recordings_adapter_test.go
+++ b/pkg/services/work/internal/services/state_access/wire/recordings_adapter_test.go
@@ -1,0 +1,303 @@
+package wire
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+)
+
+func TestNewRecordingsAdapterConstructsReconstructWorldStateThroughRoot(t *testing.T) {
+	t.Parallel()
+
+	scope := recordings.CanonicalEventScope{FactorySessionID: "session-recordings"}
+	events := []recordings.CanonicalEvent{{
+		ID:          "event-1",
+		Sequence:    0,
+		FactoryTick: 3,
+		Scope:       scope,
+		Kind:        recordings.CanonicalEventKind(interfaces.FactoryEventTypeWorkRequest),
+		Payload:     `{"requestId":"request-1"}`,
+	}}
+	fake := &recordingsRootFake{
+		events: events,
+		worldState: recordings.WorldStateView{
+			SchemaVersion: recordings.WorldStateViewSchemaV1,
+			Scope:         scope,
+			SelectedTick:  3,
+			Payload:       recordingsBackedWorldPayload(t, "work-story", "story", "review"),
+		},
+	}
+	adapter := NewRecordingsAdapter(fake)
+	ctx := context.Background()
+
+	snapshot, err := adapter.ReadWorkSnapshot(ctx, "session-recordings")
+	if err != nil {
+		t.Fatalf("ReadWorkSnapshot: %v", err)
+	}
+	if len(fake.reconstructRequests) != 1 {
+		t.Fatalf("reconstruct requests = %d, want 1", len(fake.reconstructRequests))
+	}
+	request := fake.reconstructRequests[0]
+	if request.Scope != scope || request.SelectedTick != 3 || len(request.Events) != 1 {
+		t.Fatalf("ReconstructWorldStateRequest = %#v, want scoped tick-3 replay", request)
+	}
+	if len(snapshot.Items) != 1 || snapshot.Items[0].WorkID != "work-story" {
+		t.Fatalf("snapshot = %#v, want one story work item", snapshot)
+	}
+	if snapshot.Items[0].State == nil || snapshot.Items[0].State.Name != "review" {
+		t.Fatalf("snapshot state = %#v, want review", snapshot.Items[0].State)
+	}
+}
+
+func TestNewRecordingsAdapterTypedProjectionFailures(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewRecordingsAdapter(&recordingsRootFake{
+		reconstructErr: recordings.ErrInvalidProjectionInput,
+	})
+	_, err := adapter.ReadWorkSnapshot(context.Background(), "session-recordings")
+	if !errors.Is(err, recordings.ErrInvalidProjectionInput) {
+		t.Fatalf("ReadWorkSnapshot error = %v, want ErrInvalidProjectionInput", err)
+	}
+}
+
+func TestReadSnapshotFromWorldStateDetachesWorkFields(t *testing.T) {
+	t.Parallel()
+
+	view := recordings.WorldStateView{
+		SchemaVersion: recordings.WorldStateViewSchemaV1,
+		Payload: recordingsBackedWorldPayload(
+			t,
+			"work-story",
+			"story",
+			"review",
+		),
+	}
+	snapshot, err := readSnapshotFromWorldState(view)
+	if err != nil {
+		t.Fatalf("readSnapshotFromWorldState: %v", err)
+	}
+	if len(snapshot.Items) != 1 {
+		t.Fatalf("snapshot = %#v, want one item", snapshot)
+	}
+	snapshot.Items[0].State.Name = "mutated"
+	second, err := readSnapshotFromWorldState(view)
+	if err != nil || second.Items[0].State.Name != "review" {
+		t.Fatalf("detached snapshot mutated source: %#v, %v", second, err)
+	}
+}
+
+type recordingsRootFake struct {
+	events              []recordings.CanonicalEvent
+	worldState          recordings.WorldStateView
+	reconstructErr      error
+	reconstructRequests []recordings.ReconstructWorldStateRequest
+}
+
+func (fake *recordingsRootFake) Append(
+	recordings.AppendRecordedEventRequest,
+) (recordings.AppendRecordedEventResult, error) {
+	return recordings.AppendRecordedEventResult{}, recordings.ErrInvalidAppendEvent
+}
+
+func (fake *recordingsRootFake) SubscribeFrom(
+	_ context.Context,
+	request recordings.SubscribeRequest,
+) (recordings.SubscribeResult, error) {
+	events := make([]recordings.CanonicalEvent, 0, len(fake.events))
+	for _, event := range fake.events {
+		if event.Scope == request.Scope {
+			events = append(events, event)
+		}
+	}
+	index := 0
+	return recordings.SubscribeResult{
+		Subscription: func(context.Context) recordings.SubscriptionOutcome {
+			if index >= len(events) {
+				return recordings.SubscriptionOutcome{Kind: recordings.SubscriptionClosed}
+			}
+			outcome := recordings.SubscriptionOutcome{
+				Kind:  recordings.SubscriptionEvent,
+				Event: events[index],
+			}
+			index++
+			return outcome
+		},
+	}, nil
+}
+
+func (fake *recordingsRootFake) ReconstructWorldState(
+	request recordings.ReconstructWorldStateRequest,
+) (recordings.ReconstructWorldStateResult, error) {
+	fake.reconstructRequests = append(fake.reconstructRequests, request)
+	if fake.reconstructErr != nil {
+		return recordings.ReconstructWorldStateResult{}, fake.reconstructErr
+	}
+	return recordings.ReconstructWorldStateResult{WorldState: fake.worldState}, nil
+}
+
+func (fake *recordingsRootFake) QuerySimpleDashboard(
+	recordings.SimpleDashboardQueryRequest,
+) (recordings.SimpleDashboardQueryResult, error) {
+	return recordings.SimpleDashboardQueryResult{}, recordings.ErrInvalidProjectionInput
+}
+
+func (fake *recordingsRootFake) QueryWorkstationRequests(
+	recordings.WorkstationRequestsQueryRequest,
+) (recordings.WorkstationRequestsQueryResult, error) {
+	return recordings.WorkstationRequestsQueryResult{}, recordings.ErrInvalidProjectionInput
+}
+
+func (fake *recordingsRootFake) ValidateReconnectReplayFrom(
+	recordings.ValidateReconnectReplayRequest,
+) error {
+	return recordings.ErrInvalidProjectionInput
+}
+
+func (fake *recordingsRootFake) BindRecording(
+	recordings.BindRecordingRequest,
+) (recordings.BindRecordingResult, error) {
+	return recordings.BindRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *recordingsRootFake) StartRecording(
+	recordings.StartRecordingRequest,
+) (recordings.StartRecordingResult, error) {
+	return recordings.StartRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *recordingsRootFake) RecordRecordingEvent(
+	recordings.RecordRecordingEventRequest,
+) (recordings.RecordRecordingEventResult, error) {
+	return recordings.RecordRecordingEventResult{}, recordings.ErrInvalidRecordingEvent
+}
+
+func (fake *recordingsRootFake) RecordRecordingError(
+	recordings.RecordRecordingErrorRequest,
+) (recordings.RecordRecordingErrorResult, error) {
+	return recordings.RecordRecordingErrorResult{}, recordings.ErrInvalidRecordingFailure
+}
+
+func (fake *recordingsRootFake) FlushRecording(
+	recordings.FlushRecordingRequest,
+) (recordings.FlushRecordingResult, error) {
+	return recordings.FlushRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *recordingsRootFake) StopRecording(
+	recordings.StopRecordingRequest,
+) (recordings.StopRecordingResult, error) {
+	return recordings.StopRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *recordingsRootFake) FinishRecording(
+	recordings.FinishRecordingRequest,
+) (recordings.FinishRecordingResult, error) {
+	return recordings.FinishRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *recordingsRootFake) QueryRecordingStatus(
+	recordings.RecordingStatusRequest,
+) (recordings.RecordingStatusResult, error) {
+	return recordings.RecordingStatusResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *recordingsRootFake) LoadReplayRecording(
+	recordings.LoadReplayRecordingRequest,
+) (recordings.LoadReplayRecordingResult, error) {
+	return recordings.LoadReplayRecordingResult{}, recordings.ErrMissingReplayArtifact
+}
+
+func (fake *recordingsRootFake) CreateReplayPlan(
+	recordings.CreateReplayPlanRequest,
+) (recordings.CreateReplayPlanResult, error) {
+	return recordings.CreateReplayPlanResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *recordingsRootFake) ObserveReplay(
+	recordings.ObserveReplayRequest,
+) (recordings.ObserveReplayResult, error) {
+	return recordings.ObserveReplayResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *recordingsRootFake) BuildPortableArtifact(
+	recordings.BuildPortableArtifactRequest,
+) (recordings.BuildPortableArtifactResult, error) {
+	return recordings.BuildPortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *recordingsRootFake) ValidatePortableArtifact(
+	recordings.ValidatePortableArtifactRequest,
+) (recordings.ValidatePortableArtifactResult, error) {
+	return recordings.ValidatePortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *recordingsRootFake) EncodePortableArtifact(
+	recordings.EncodePortableArtifactRequest,
+) (recordings.EncodePortableArtifactResult, error) {
+	return recordings.EncodePortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *recordingsRootFake) DecodePortableArtifact(
+	recordings.DecodePortableArtifactRequest,
+) (recordings.DecodePortableArtifactResult, error) {
+	return recordings.DecodePortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *recordingsRootFake) SummarizePortableArtifact(
+	recordings.SummarizePortableArtifactRequest,
+) (recordings.SummarizePortableArtifactResult, error) {
+	return recordings.SummarizePortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *recordingsRootFake) ExportPortableArtifact(
+	context.Context,
+	recordings.ExportPortableArtifactRequest,
+) (recordings.ExportPortableArtifactResult, error) {
+	return recordings.ExportPortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *recordingsRootFake) ReadPortableArtifact(
+	context.Context,
+	recordings.ReadPortableArtifactRequest,
+) (recordings.ReadPortableArtifactResult, error) {
+	return recordings.ReadPortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func recordingsBackedWorldPayload(
+	t *testing.T,
+	workID string,
+	workTypeID string,
+	stateName string,
+) string {
+	t.Helper()
+	state := interfaces.FactoryWorldState{
+		Topology: interfaces.InitialStructurePayload{
+			WorkTypes: []interfaces.FactoryWorkType{{
+				ID: workTypeID,
+				States: []interfaces.FactoryStateDefinition{
+					{Value: "init", Category: work.StateTypeInitial},
+					{Value: "review", Category: work.StateTypeProcessing},
+				},
+			}},
+		},
+		WorkItemsByID: map[string]work.FactoryWorkItem{
+			workID: {
+				ID:          workID,
+				WorkTypeID:  workTypeID,
+				DisplayName: "Review PRD",
+				State:       stateName,
+			},
+		},
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal world state: %v", err)
+	}
+	return string(payload)
+}

--- a/pkg/services/work/internal/services/state_access/wire/recordings_snapshot.go
+++ b/pkg/services/work/internal/services/state_access/wire/recordings_snapshot.go
@@ -1,0 +1,142 @@
+package wire
+
+import (
+	"encoding/json"
+	"strings"
+
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+)
+
+func readSnapshotFromWorldState(view recordings.WorldStateView) (work.ReadSnapshot, error) {
+	if view.SchemaVersion != recordings.WorldStateViewSchemaV1 ||
+		strings.TrimSpace(view.Payload) == "" {
+		return work.ReadSnapshot{}, recordings.ErrUnsupportedProjectionView
+	}
+	var state interfaces.FactoryWorldState
+	if err := json.Unmarshal([]byte(view.Payload), &state); err != nil {
+		return work.ReadSnapshot{}, recordings.ErrInvalidProjectionInput
+	}
+	return readSnapshotFromFactoryWorldState(state), nil
+}
+
+func readSnapshotFromFactoryWorldState(state interfaces.FactoryWorldState) work.ReadSnapshot {
+	itemsByID := make(map[string]work.FactoryWorkItem, len(state.WorkItemsByID))
+	for id, item := range state.WorkItemsByID {
+		itemsByID[id] = item
+	}
+	for id, item := range state.ActiveWorkItemsByID {
+		itemsByID[id] = item
+	}
+	names := workDisplayNames(itemsByID)
+	activeIDs := activeWorkItemIDs(state.ActiveWorkItemsByID)
+	items := make([]work.ReadModel, 0, len(itemsByID))
+	for _, item := range itemsByID {
+		if !isPublicWorkItem(item) {
+			continue
+		}
+		items = append(items, readModelFromWorkItem(item, state, names, activeIDs))
+	}
+	return work.ReadSnapshot{Items: items}
+}
+
+func readModelFromWorkItem(
+	item work.FactoryWorkItem,
+	state interfaces.FactoryWorldState,
+	names map[string]string,
+	activeIDs map[string]struct{},
+) work.ReadModel {
+	_, inFlight := activeIDs[item.ID]
+	read := work.ReadModel{
+		CursorID:                 item.ID,
+		WorkID:                   item.ID,
+		Name:                     firstNonEmpty(item.DisplayName, names[item.ID], item.ID),
+		WorkTypeName:             item.WorkTypeID,
+		ChainingTraceDepth:       item.ChainingTraceDepth,
+		CurrentChainingTraceID:   item.CurrentChainingTraceID,
+		PreviousChainingTraceIDs: append([]string(nil), item.PreviousChainingTraceIDs...),
+		TraceID:                  item.TraceID,
+		Content:                  work.CloneWorkContentParts(item.Content),
+		Tags:                     work.CloneTags(item.Tags),
+	}
+	read.State = workStateFromItem(item, state, inFlight)
+	for _, relation := range state.RelationsByWorkID[item.ID] {
+		read.Relations = append(read.Relations, work.ReadRelation{
+			Type:           work.RelationType(relation.Type),
+			SourceWorkName: read.Name,
+			TargetWorkName: firstNonEmpty(relation.TargetWorkName, names[relation.TargetWorkID], relation.TargetWorkID),
+			TargetWorkID:   relation.TargetWorkID,
+			RequiredState:  relation.RequiredState,
+		})
+	}
+	return read
+}
+
+func workStateFromItem(
+	item work.FactoryWorkItem,
+	state interfaces.FactoryWorldState,
+	inFlight bool,
+) *work.State {
+	stateName := strings.TrimSpace(item.State)
+	if stateName == "" {
+		return nil
+	}
+	if _, failed := state.FailedWorkItemsByID[item.ID]; failed {
+		return &work.State{Name: stateName, Type: work.StateTypeFailed}
+	}
+	if terminal, ok := state.TerminalWorkByID[item.ID]; ok {
+		stateName = firstNonEmpty(terminal.WorkItem.State, stateName)
+	}
+	category := workStateCategory(state.Topology, item.WorkTypeID, stateName)
+	if inFlight && category != work.StateTypeTerminal && category != work.StateTypeFailed {
+		category = work.StateTypeProcessing
+	}
+	if category == "" {
+		category = work.StateTypeInitial
+	}
+	return &work.State{Name: stateName, Type: category}
+}
+
+func workStateCategory(
+	topology interfaces.InitialStructurePayload,
+	workTypeID string,
+	stateName string,
+) string {
+	for _, workType := range topology.WorkTypes {
+		if workType.ID != workTypeID && workType.Name != workTypeID {
+			continue
+		}
+		for _, state := range workType.States {
+			if state.Value == stateName {
+				return state.Category
+			}
+		}
+	}
+	return ""
+}
+
+func workDisplayNames(items map[string]work.FactoryWorkItem) map[string]string {
+	names := make(map[string]string, len(items))
+	for id, item := range items {
+		names[id] = firstNonEmpty(item.DisplayName, id)
+	}
+	return names
+}
+
+func activeWorkItemIDs(items map[string]work.FactoryWorkItem) map[string]struct{} {
+	active := make(map[string]struct{}, len(items))
+	for id := range items {
+		active[id] = struct{}{}
+	}
+	return active
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/pkg/services/work/internal/services/state_access/wire/recordings_snapshot_test.go
+++ b/pkg/services/work/internal/services/state_access/wire/recordings_snapshot_test.go
@@ -1,0 +1,248 @@
+package wire
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+)
+
+func TestReadSnapshotFromWorldStateRejectsUnsupportedViews(t *testing.T) {
+	t.Parallel()
+
+	for name, view := range map[string]recordings.WorldStateView{
+		"wrong schema": {SchemaVersion: "v0", Payload: `{"workItemsById":{}}`},
+		"empty payload": {SchemaVersion: recordings.WorldStateViewSchemaV1, Payload: "  "},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, err := readSnapshotFromWorldState(view)
+			if !errors.Is(err, recordings.ErrUnsupportedProjectionView) {
+				t.Fatalf("readSnapshotFromWorldState error = %v, want ErrUnsupportedProjectionView", err)
+			}
+		})
+	}
+}
+
+func TestReadSnapshotFromWorldStateRejectsInvalidPayload(t *testing.T) {
+	t.Parallel()
+
+	_, err := readSnapshotFromWorldState(recordings.WorldStateView{
+		SchemaVersion: recordings.WorldStateViewSchemaV1,
+		Payload:       "{not-json",
+	})
+	if !errors.Is(err, recordings.ErrInvalidProjectionInput) {
+		t.Fatalf("readSnapshotFromWorldState error = %v, want ErrInvalidProjectionInput", err)
+	}
+}
+
+func TestReadSnapshotFromFactoryWorldStateMapsActiveFailedTerminalAndRelations(t *testing.T) {
+	t.Parallel()
+
+	state := interfaces.FactoryWorldState{
+		Topology: interfaces.InitialStructurePayload{
+			WorkTypes: []interfaces.FactoryWorkType{{
+				ID: "story",
+				States: []interfaces.FactoryStateDefinition{
+					{Value: "init", Category: work.StateTypeInitial},
+					{Value: "review", Category: work.StateTypeProcessing},
+					{Value: "done", Category: work.StateTypeTerminal},
+				},
+			}},
+		},
+		WorkItemsByID: map[string]work.FactoryWorkItem{
+			interfaces.SystemTimeWorkTypeID: {
+				ID:         interfaces.SystemTimeWorkTypeID,
+				WorkTypeID: interfaces.SystemTimeWorkTypeID,
+				State:      "pending",
+			},
+			"work-active": {
+				ID:          "work-active",
+				WorkTypeID:  "story",
+				DisplayName: "Active story",
+				State:       "review",
+			},
+			"work-failed": {
+				ID:         "work-failed",
+				WorkTypeID: "story",
+				State:      "review",
+			},
+			"work-terminal": {
+				ID:         "work-terminal",
+				WorkTypeID: "story",
+				State:      "init",
+			},
+			"work-empty-state": {
+				ID:         "work-empty-state",
+				WorkTypeID: "story",
+			},
+		},
+		ActiveWorkItemsByID: map[string]work.FactoryWorkItem{
+			"work-active": {
+				ID:         "work-active",
+				WorkTypeID: "story",
+				State:      "review",
+			},
+		},
+		FailedWorkItemsByID: map[string]work.FactoryWorkItem{
+			"work-failed": {
+				ID:         "work-failed",
+				WorkTypeID: "story",
+				State:      "review",
+			},
+		},
+		TerminalWorkByID: map[string]interfaces.FactoryTerminalWork{
+			"work-terminal": {
+				WorkItem: work.FactoryWorkItem{
+					ID:         "work-terminal",
+					WorkTypeID: "story",
+					State:      "done",
+				},
+			},
+		},
+		RelationsByWorkID: map[string][]work.FactoryRelation{
+			"work-active": {{
+				Type:           "depends_on",
+				TargetWorkID:   "work-terminal",
+				TargetWorkName: "Terminal story",
+				RequiredState:  "done",
+			}},
+		},
+	}
+	snapshot := readSnapshotFromFactoryWorldState(state)
+	if len(snapshot.Items) != 4 {
+		t.Fatalf("snapshot items = %d, want 4 public work items", len(snapshot.Items))
+	}
+	byID := make(map[string]work.ReadModel, len(snapshot.Items))
+	for _, item := range snapshot.Items {
+		byID[item.WorkID] = item
+	}
+	if _, ok := byID[interfaces.SystemTimeWorkTypeID]; ok {
+		t.Fatalf("system time work leaked into snapshot: %#v", snapshot)
+	}
+	if byID["work-active"].State == nil || byID["work-active"].State.Type != work.StateTypeProcessing {
+		t.Fatalf("active work state = %#v, want processing", byID["work-active"].State)
+	}
+	if byID["work-failed"].State == nil || byID["work-failed"].State.Type != work.StateTypeFailed {
+		t.Fatalf("failed work state = %#v, want failed", byID["work-failed"].State)
+	}
+	if byID["work-terminal"].State == nil || byID["work-terminal"].State.Name != "done" {
+		t.Fatalf("terminal work state = %#v, want done", byID["work-terminal"].State)
+	}
+	if byID["work-empty-state"].State != nil {
+		t.Fatalf("empty-state work = %#v, want nil state", byID["work-empty-state"].State)
+	}
+	if len(byID["work-active"].Relations) != 1 || byID["work-active"].Relations[0].TargetWorkName != "Terminal story" {
+		t.Fatalf("relations = %#v, want one depends_on relation", byID["work-active"].Relations)
+	}
+}
+
+func TestWorkStateCategoryFallsBackToInitialWhenUnknown(t *testing.T) {
+	t.Parallel()
+
+	state := &work.State{
+		Name: "unknown-state",
+		Type: workStateCategory(interfaces.InitialStructurePayload{}, "story", "unknown-state"),
+	}
+	if state.Type != "" {
+		t.Fatalf("workStateCategory = %q, want empty category", state.Type)
+	}
+	item := workStateFromItem(
+		work.FactoryWorkItem{ID: "work-1", WorkTypeID: "story", State: "unknown-state"},
+		interfaces.FactoryWorldState{},
+		false,
+	)
+	if item == nil || item.Type != work.StateTypeInitial {
+		t.Fatalf("workStateFromItem = %#v, want initial fallback", item)
+	}
+}
+
+func TestReconstructWorldStateRequestSelectsHighestTick(t *testing.T) {
+	t.Parallel()
+
+	scope := recordings.CanonicalEventScope{FactorySessionID: "session-1"}
+	request := reconstructWorldStateRequest(scope, []recordings.CanonicalEvent{
+		{FactoryTick: 1},
+		{FactoryTick: 7},
+		{FactoryTick: 3},
+	})
+	if request.SelectedTick != 7 || request.Scope != scope || len(request.Events) != 3 {
+		t.Fatalf("request = %#v, want tick 7 with copied events", request)
+	}
+	request.Events[0].FactoryTick = 99
+	if request.Events[0].FactoryTick == 99 {
+		// copied slice should be independent from source mutation only if source changed
+	}
+}
+
+func TestFirstNonEmptyReturnsFirstTrimmedValue(t *testing.T) {
+	t.Parallel()
+
+	if got := firstNonEmpty(" ", "", "value", "later"); got != "value" {
+		t.Fatalf("firstNonEmpty = %q, want value", got)
+	}
+	if got := firstNonEmpty(" ", ""); got != "" {
+		t.Fatalf("firstNonEmpty(all empty) = %q, want empty", got)
+	}
+}
+
+func TestReadWorkSnapshotRejectsNilRecordingsRoot(t *testing.T) {
+	t.Parallel()
+
+	adapter := recordingsAdapter{}
+	_, err := adapter.ReadWorkSnapshot(context.Background(), "session-1")
+	if err == nil || err.Error() != "Recordings service is required" {
+		t.Fatalf("ReadWorkSnapshot error = %v, want missing Recordings service", err)
+	}
+}
+
+func TestWorkStateCategoryMatchesWorkTypeName(t *testing.T) {
+	t.Parallel()
+
+	category := workStateCategory(
+		interfaces.InitialStructurePayload{
+			WorkTypes: []interfaces.FactoryWorkType{{
+				Name: "story",
+				States: []interfaces.FactoryStateDefinition{
+					{Value: "review", Category: work.StateTypeProcessing},
+				},
+			}},
+		},
+		"story",
+		"review",
+	)
+	if category != work.StateTypeProcessing {
+		t.Fatalf("workStateCategory = %q, want processing", category)
+	}
+}
+
+func TestWorkStateCategorySkipsNonMatchingWorkTypes(t *testing.T) {
+	t.Parallel()
+
+	category := workStateCategory(
+		interfaces.InitialStructurePayload{
+			WorkTypes: []interfaces.FactoryWorkType{
+				{
+					ID: "bug",
+					States: []interfaces.FactoryStateDefinition{
+						{Value: "triage", Category: work.StateTypeInitial},
+					},
+				},
+				{
+					ID: "story",
+					States: []interfaces.FactoryStateDefinition{
+						{Value: "review", Category: work.StateTypeProcessing},
+					},
+				},
+			},
+		},
+		"story",
+		"review",
+	)
+	if category != work.StateTypeProcessing {
+		t.Fatalf("workStateCategory = %q, want processing", category)
+	}
+}

--- a/pkg/services/work/internal/services/state_access/wire/wire.go
+++ b/pkg/services/work/internal/services/state_access/wire/wire.go
@@ -10,10 +10,13 @@ import (
 )
 
 // NewService constructs the private Work state_access subservice from a
-// session resolver. The resolver adapts Factory Sessions into the parent-private
-// Session adapter port.
-func NewService(sessions stateaccess.SessionResolver) stateaccess.Service {
-	return internalservice.New(sessions)
+// session resolver and optional Recordings adapter. The resolver adapts Factory
+// Sessions into the parent-private Session adapter port.
+func NewService(
+	sessions stateaccess.SessionResolver,
+	recordings stateaccess.RecordingsAdapter,
+) stateaccess.Service {
+	return internalservice.New(sessions, recordings)
 }
 
 type runtimeSessionResolver struct {

--- a/pkg/services/work/internal/services/state_access/wire/wire_test.go
+++ b/pkg/services/work/internal/services/state_access/wire/wire_test.go
@@ -68,7 +68,7 @@ func (r stubRuntimeResolver) ResolveWorkRuntime(string) (work.Runtime, error) {
 func TestNewServiceConstructsStateAccessSubservice(t *testing.T) {
 	t.Parallel()
 
-	if service := NewService(NewRuntimeSessionResolver(stubRuntimeResolver{})); service == nil {
+	if service := NewService(NewRuntimeSessionResolver(stubRuntimeResolver{}), nil); service == nil {
 		t.Fatal("NewService() = nil")
 	}
 }

--- a/pkg/services/work/recordings_import_boundary_test.go
+++ b/pkg/services/work/recordings_import_boundary_test.go
@@ -1,0 +1,77 @@
+package work_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+const (
+	modulePrefix   = "github.com/portpowered/infinite-you/"
+	workRoot       = modulePrefix + "pkg/services/work"
+	recordingsRoot = modulePrefix + "pkg/services/recordings"
+)
+
+// TestProductionPackagesImportRecordingsRootOnly seals CUT-WORK-REC story 001:
+// Work production packages may depend on Recordings only through the service
+// root contract, not nested Recordings implementation packages.
+func TestProductionPackagesImportRecordingsRootOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, pkg := range listWorkPackages(t) {
+		pkg := pkg
+		t.Run(shortWorkPackageName(pkg), func(t *testing.T) {
+			t.Parallel()
+			assertProductionImportsUseRecordingsRootOnly(t, pkg)
+		})
+	}
+}
+
+func listWorkPackages(t *testing.T) []string {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", workRoot+"/...")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list work packages: %v\n%s", err, output)
+	}
+	return strings.Fields(string(output))
+}
+
+func assertProductionImportsUseRecordingsRootOnly(t *testing.T, packagePath string) {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", "-f", "{{join .Imports \"\\n\"}}", packagePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list imports for %s: %v\n%s", packagePath, err, output)
+	}
+	for _, importPath := range strings.Fields(string(output)) {
+		if isForbiddenWorkRecordingsImport(importPath) {
+			t.Fatalf(
+				"%s production import %s is forbidden; use %s for Recordings surfaces",
+				packagePath,
+				importPath,
+				recordingsRoot,
+			)
+		}
+	}
+}
+
+func isForbiddenWorkRecordingsImport(importPath string) bool {
+	if importPath == recordingsRoot {
+		return false
+	}
+	return strings.HasPrefix(importPath, recordingsRoot+"/")
+}
+
+func shortWorkPackageName(packagePath string) string {
+	if strings.HasPrefix(packagePath, workRoot) {
+		rest := strings.TrimPrefix(packagePath, workRoot)
+		if rest == "" {
+			return "work"
+		}
+		return strings.TrimPrefix(rest, "/")
+	}
+	return packagePath
+}

--- a/pkg/services/work/recordings_request_boundary_test.go
+++ b/pkg/services/work/recordings_request_boundary_test.go
@@ -1,0 +1,351 @@
+package work_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	stateaccess "github.com/portpowered/infinite-you/pkg/services/work/internal/services/state_access"
+	stateaccesswire "github.com/portpowered/infinite-you/pkg/services/work/internal/services/state_access/wire"
+)
+
+const stateAccessWireRoot = modulePrefix + "pkg/services/work/internal/services/state_access/wire"
+
+// TestWorkConstructsRecordingsRequestsThroughRoot proves CUT-WORK-REC story 003:
+// leased Work state_access Recordings-backed reads construct Recordings queries
+// only through the published Recordings service root contract.
+func TestWorkConstructsRecordingsRequestsThroughRoot(t *testing.T) {
+	t.Parallel()
+
+	scope := recordings.CanonicalEventScope{FactorySessionID: "session-recordings-root"}
+	events := []recordings.CanonicalEvent{{
+		ID:          "event-1",
+		Sequence:    0,
+		FactoryTick: 3,
+		Scope:       scope,
+		Kind:        recordings.CanonicalEventKind(interfaces.FactoryEventTypeWorkRequest),
+		Payload:     `{"requestId":"request-1"}`,
+	}}
+	fake := &workRecordingsRootFake{
+		events: events,
+		worldState: recordings.WorldStateView{
+			SchemaVersion: recordings.WorldStateViewSchemaV1,
+			Scope:         scope,
+			SelectedTick:  3,
+			Payload:       recordingsBackedWorldPayload(t, "work-story", "story", "review"),
+		},
+	}
+	svc := stateaccesswire.NewService(
+		unavailableSessionResolver{},
+		stateaccesswire.NewRecordingsAdapter(fake),
+	)
+	ctx := context.Background()
+
+	list, err := svc.ListWork(ctx, "session-recordings-root", work.ListOptions{})
+	if err != nil {
+		t.Fatalf("ListWork: %v", err)
+	}
+	if len(list.Results) != 1 || list.Results[0].WorkID != "work-story" {
+		t.Fatalf("ListWork = %#v, want one story work item", list)
+	}
+	if list.Results[0].State == nil || list.Results[0].State.Name != "review" {
+		t.Fatalf("ListWork state = %#v, want review", list.Results[0].State)
+	}
+
+	got, err := svc.GetWork(ctx, "session-recordings-root", "work-story")
+	if err != nil || got.WorkID != "work-story" || got.State.Name != "review" {
+		t.Fatalf("GetWork = %#v, %v", got, err)
+	}
+
+	if len(fake.subscribeRequests) != 2 {
+		t.Fatalf("subscribe requests = %d, want 2 (ListWork and GetWork)", len(fake.subscribeRequests))
+	}
+	for _, request := range fake.subscribeRequests {
+		if request.Scope != scope {
+			t.Fatalf("SubscribeRequest scope = %#v, want %#v", request.Scope, scope)
+		}
+	}
+	if len(fake.reconstructRequests) != 2 {
+		t.Fatalf("reconstruct requests = %d, want 2", len(fake.reconstructRequests))
+	}
+	for _, request := range fake.reconstructRequests {
+		if request.Scope != scope || request.SelectedTick != 3 || len(request.Events) != 1 {
+			t.Fatalf("ReconstructWorldStateRequest = %#v, want scoped tick-3 replay", request)
+		}
+	}
+}
+
+// TestWorkRecordingsTypedProjectionFailuresSurfaceThroughReadEdge proves typed
+// Recordings projection failures propagate through the leased Work read edge.
+func TestWorkRecordingsTypedProjectionFailuresSurfaceThroughReadEdge(t *testing.T) {
+	t.Parallel()
+
+	svc := stateaccesswire.NewService(
+		unavailableSessionResolver{},
+		stateaccesswire.NewRecordingsAdapter(&workRecordingsRootFake{
+			reconstructErr: recordings.ErrInvalidProjectionInput,
+		}),
+	)
+	_, err := svc.ListWork(context.Background(), "session-recordings-root", work.ListOptions{})
+	if err == nil {
+		t.Fatal("ListWork error = nil, want typed projection failure")
+	}
+	if !errors.Is(err, recordings.ErrInvalidProjectionInput) {
+		t.Fatalf("ListWork error = %v, want ErrInvalidProjectionInput", err)
+	}
+}
+
+// TestWorkRecordingsRequestConstructionImportsRecordingsRootOnly seals the
+// request-construction path: Work boundary tests may depend on Recordings query
+// helpers only through the service root contract.
+func TestWorkRecordingsRequestConstructionImportsRecordingsRootOnly(t *testing.T) {
+	t.Parallel()
+	assertRecordingsRequestConstructionImportsRecordingsRootOnly(t, stateAccessWireRoot)
+}
+
+func assertRecordingsRequestConstructionImportsRecordingsRootOnly(
+	t *testing.T,
+	packagePath string,
+) {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", "-f", "{{join .Imports \"\\n\"}}", packagePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list imports for %s: %v\n%s", packagePath, err, output)
+	}
+	for _, importPath := range strings.Fields(string(output)) {
+		if isForbiddenWorkRecordingsImport(importPath) {
+			t.Fatalf(
+				"%s import %s is forbidden for Recordings request construction; use %s only",
+				packagePath,
+				importPath,
+				recordingsRoot,
+			)
+		}
+	}
+}
+
+type unavailableSessionResolver struct{}
+
+func (unavailableSessionResolver) ResolveSessionAdapter(string) (stateaccess.SessionAdapter, error) {
+	return nil, errors.New("session unavailable")
+}
+
+type workRecordingsRootFake struct {
+	events              []recordings.CanonicalEvent
+	worldState          recordings.WorldStateView
+	reconstructErr      error
+	subscribeRequests   []recordings.SubscribeRequest
+	reconstructRequests []recordings.ReconstructWorldStateRequest
+}
+
+func (fake *workRecordingsRootFake) Append(
+	recordings.AppendRecordedEventRequest,
+) (recordings.AppendRecordedEventResult, error) {
+	return recordings.AppendRecordedEventResult{}, recordings.ErrInvalidAppendEvent
+}
+
+func (fake *workRecordingsRootFake) SubscribeFrom(
+	_ context.Context,
+	request recordings.SubscribeRequest,
+) (recordings.SubscribeResult, error) {
+	fake.subscribeRequests = append(fake.subscribeRequests, request)
+	events := make([]recordings.CanonicalEvent, 0, len(fake.events))
+	for _, event := range fake.events {
+		if event.Scope == request.Scope {
+			events = append(events, event)
+		}
+	}
+	index := 0
+	return recordings.SubscribeResult{
+		Subscription: func(context.Context) recordings.SubscriptionOutcome {
+			if index >= len(events) {
+				return recordings.SubscriptionOutcome{Kind: recordings.SubscriptionClosed}
+			}
+			outcome := recordings.SubscriptionOutcome{
+				Kind:  recordings.SubscriptionEvent,
+				Event: events[index],
+			}
+			index++
+			return outcome
+		},
+	}, nil
+}
+
+func (fake *workRecordingsRootFake) ReconstructWorldState(
+	request recordings.ReconstructWorldStateRequest,
+) (recordings.ReconstructWorldStateResult, error) {
+	fake.reconstructRequests = append(fake.reconstructRequests, request)
+	if fake.reconstructErr != nil {
+		return recordings.ReconstructWorldStateResult{}, fake.reconstructErr
+	}
+	return recordings.ReconstructWorldStateResult{WorldState: fake.worldState}, nil
+}
+
+func (fake *workRecordingsRootFake) QuerySimpleDashboard(
+	recordings.SimpleDashboardQueryRequest,
+) (recordings.SimpleDashboardQueryResult, error) {
+	return recordings.SimpleDashboardQueryResult{}, recordings.ErrInvalidProjectionInput
+}
+
+func (fake *workRecordingsRootFake) QueryWorkstationRequests(
+	recordings.WorkstationRequestsQueryRequest,
+) (recordings.WorkstationRequestsQueryResult, error) {
+	return recordings.WorkstationRequestsQueryResult{}, recordings.ErrInvalidProjectionInput
+}
+
+func (fake *workRecordingsRootFake) ValidateReconnectReplayFrom(
+	recordings.ValidateReconnectReplayRequest,
+) error {
+	return recordings.ErrInvalidProjectionInput
+}
+
+func (fake *workRecordingsRootFake) BindRecording(
+	recordings.BindRecordingRequest,
+) (recordings.BindRecordingResult, error) {
+	return recordings.BindRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *workRecordingsRootFake) StartRecording(
+	recordings.StartRecordingRequest,
+) (recordings.StartRecordingResult, error) {
+	return recordings.StartRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *workRecordingsRootFake) RecordRecordingEvent(
+	recordings.RecordRecordingEventRequest,
+) (recordings.RecordRecordingEventResult, error) {
+	return recordings.RecordRecordingEventResult{}, recordings.ErrInvalidRecordingEvent
+}
+
+func (fake *workRecordingsRootFake) RecordRecordingError(
+	recordings.RecordRecordingErrorRequest,
+) (recordings.RecordRecordingErrorResult, error) {
+	return recordings.RecordRecordingErrorResult{}, recordings.ErrInvalidRecordingFailure
+}
+
+func (fake *workRecordingsRootFake) FlushRecording(
+	recordings.FlushRecordingRequest,
+) (recordings.FlushRecordingResult, error) {
+	return recordings.FlushRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *workRecordingsRootFake) StopRecording(
+	recordings.StopRecordingRequest,
+) (recordings.StopRecordingResult, error) {
+	return recordings.StopRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *workRecordingsRootFake) FinishRecording(
+	recordings.FinishRecordingRequest,
+) (recordings.FinishRecordingResult, error) {
+	return recordings.FinishRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *workRecordingsRootFake) QueryRecordingStatus(
+	recordings.RecordingStatusRequest,
+) (recordings.RecordingStatusResult, error) {
+	return recordings.RecordingStatusResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *workRecordingsRootFake) LoadReplayRecording(
+	recordings.LoadReplayRecordingRequest,
+) (recordings.LoadReplayRecordingResult, error) {
+	return recordings.LoadReplayRecordingResult{}, recordings.ErrMissingReplayArtifact
+}
+
+func (fake *workRecordingsRootFake) CreateReplayPlan(
+	recordings.CreateReplayPlanRequest,
+) (recordings.CreateReplayPlanResult, error) {
+	return recordings.CreateReplayPlanResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *workRecordingsRootFake) ObserveReplay(
+	recordings.ObserveReplayRequest,
+) (recordings.ObserveReplayResult, error) {
+	return recordings.ObserveReplayResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *workRecordingsRootFake) BuildPortableArtifact(
+	recordings.BuildPortableArtifactRequest,
+) (recordings.BuildPortableArtifactResult, error) {
+	return recordings.BuildPortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *workRecordingsRootFake) ValidatePortableArtifact(
+	recordings.ValidatePortableArtifactRequest,
+) (recordings.ValidatePortableArtifactResult, error) {
+	return recordings.ValidatePortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *workRecordingsRootFake) EncodePortableArtifact(
+	recordings.EncodePortableArtifactRequest,
+) (recordings.EncodePortableArtifactResult, error) {
+	return recordings.EncodePortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *workRecordingsRootFake) DecodePortableArtifact(
+	recordings.DecodePortableArtifactRequest,
+) (recordings.DecodePortableArtifactResult, error) {
+	return recordings.DecodePortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *workRecordingsRootFake) SummarizePortableArtifact(
+	recordings.SummarizePortableArtifactRequest,
+) (recordings.SummarizePortableArtifactResult, error) {
+	return recordings.SummarizePortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *workRecordingsRootFake) ExportPortableArtifact(
+	context.Context,
+	recordings.ExportPortableArtifactRequest,
+) (recordings.ExportPortableArtifactResult, error) {
+	return recordings.ExportPortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *workRecordingsRootFake) ReadPortableArtifact(
+	context.Context,
+	recordings.ReadPortableArtifactRequest,
+) (recordings.ReadPortableArtifactResult, error) {
+	return recordings.ReadPortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func recordingsBackedWorldPayload(
+	t *testing.T,
+	workID string,
+	workTypeID string,
+	stateName string,
+) string {
+	t.Helper()
+	state := interfaces.FactoryWorldState{
+		Topology: interfaces.InitialStructurePayload{
+			WorkTypes: []interfaces.FactoryWorkType{{
+				ID: workTypeID,
+				States: []interfaces.FactoryStateDefinition{
+					{Value: "init", Category: work.StateTypeInitial},
+					{Value: "review", Category: work.StateTypeProcessing},
+				},
+			}},
+		},
+		WorkItemsByID: map[string]work.FactoryWorkItem{
+			workID: {
+				ID:          workID,
+				WorkTypeID:  workTypeID,
+				DisplayName: "Review PRD",
+				State:       stateName,
+			},
+		},
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal world state: %v", err)
+	}
+	return string(payload)
+}

--- a/pkg/services/work/service/service.go
+++ b/pkg/services/work/service/service.go
@@ -40,6 +40,7 @@ func New(sessions RuntimeResolver) *Service {
 		sessions: sessions,
 		stateAccess: stateaccesswire.NewService(
 			stateaccesswire.NewRuntimeSessionResolver(liveSessionRuntimeResolver{sessions: sessions}),
+			nil,
 		),
 	}
 }
@@ -60,6 +61,7 @@ func NewService(
 		contentMaterializer: contentMaterializer,
 		stateAccess: stateaccesswire.NewService(
 			stateaccesswire.NewRuntimeSessionResolver(runtimes),
+			nil,
 		),
 	}
 }

--- a/pkg/services/work/stateaccessrecordings/exercise.go
+++ b/pkg/services/work/stateaccessrecordings/exercise.go
@@ -12,6 +12,13 @@ import (
 	stateaccesswire "github.com/portpowered/infinite-you/pkg/services/work/internal/services/state_access/wire"
 )
 
+func newRecordingsRootService(root recordings.Service) stateaccess.Service {
+	return stateaccesswire.NewService(
+		nilSessionResolver{},
+		stateaccesswire.NewRecordingsAdapter(root),
+	)
+}
+
 // ListWorkFromRecordingsRoot exercises Recordings-backed Work list reads through
 // the published Recordings service root when no live session adapter is available.
 func ListWorkFromRecordingsRoot(
@@ -20,11 +27,18 @@ func ListWorkFromRecordingsRoot(
 	root recordings.Service,
 	options work.ListOptions,
 ) (work.ListResult, error) {
-	svc := stateaccesswire.NewService(
-		nilSessionResolver{},
-		stateaccesswire.NewRecordingsAdapter(root),
-	)
-	return svc.ListWork(ctx, sessionID, options)
+	return newRecordingsRootService(root).ListWork(ctx, sessionID, options)
+}
+
+// GetWorkFromRecordingsRoot exercises Recordings-backed Work get reads through
+// the published Recordings service root when no live session adapter is available.
+func GetWorkFromRecordingsRoot(
+	ctx context.Context,
+	sessionID string,
+	workID string,
+	root recordings.Service,
+) (work.ReadModel, error) {
+	return newRecordingsRootService(root).GetWork(ctx, sessionID, workID)
 }
 
 type nilSessionResolver struct{}

--- a/pkg/services/work/stateaccessrecordings/exercise.go
+++ b/pkg/services/work/stateaccessrecordings/exercise.go
@@ -1,0 +1,34 @@
+// Package stateaccessrecordings exposes the leased Work state_access
+// Recordings-backed read edge for functional verification without importing
+// Work internal packages from tests/functional.
+package stateaccessrecordings
+
+import (
+	"context"
+
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	stateaccess "github.com/portpowered/infinite-you/pkg/services/work/internal/services/state_access"
+	stateaccesswire "github.com/portpowered/infinite-you/pkg/services/work/internal/services/state_access/wire"
+)
+
+// ListWorkFromRecordingsRoot exercises Recordings-backed Work list reads through
+// the published Recordings service root when no live session adapter is available.
+func ListWorkFromRecordingsRoot(
+	ctx context.Context,
+	sessionID string,
+	root recordings.Service,
+	options work.ListOptions,
+) (work.ListResult, error) {
+	svc := stateaccesswire.NewService(
+		nilSessionResolver{},
+		stateaccesswire.NewRecordingsAdapter(root),
+	)
+	return svc.ListWork(ctx, sessionID, options)
+}
+
+type nilSessionResolver struct{}
+
+func (nilSessionResolver) ResolveSessionAdapter(string) (stateaccess.SessionAdapter, error) {
+	return nil, nil
+}

--- a/pkg/services/work/stateaccessrecordings/exercise_test.go
+++ b/pkg/services/work/stateaccessrecordings/exercise_test.go
@@ -1,0 +1,184 @@
+package stateaccessrecordings_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	"github.com/portpowered/infinite-you/pkg/services/work/stateaccessrecordings"
+)
+
+func TestListWorkFromRecordingsRootUsesRecordingsServiceRoot(t *testing.T) {
+	t.Parallel()
+
+	scope := recordings.CanonicalEventScope{FactorySessionID: "session-recordings-unit"}
+	fake := &recordingsRootFake{
+		events: []recordings.CanonicalEvent{{
+			ID:          "event-1",
+			FactoryTick: 2,
+			Scope:       scope,
+			Kind:        recordings.CanonicalEventKind(interfaces.FactoryEventTypeWorkRequest),
+		}},
+		worldState: recordings.WorldStateView{
+			SchemaVersion: recordings.WorldStateViewSchemaV1,
+			Payload:       recordingsBackedWorldPayload(t, "work-story", "story", "review"),
+		},
+	}
+
+	list, err := stateaccessrecordings.ListWorkFromRecordingsRoot(
+		context.Background(),
+		"session-recordings-unit",
+		fake,
+		work.ListOptions{},
+	)
+	if err != nil {
+		t.Fatalf("ListWorkFromRecordingsRoot: %v", err)
+	}
+	if len(list.Results) != 1 || list.Results[0].WorkID != "work-story" {
+		t.Fatalf("ListWorkFromRecordingsRoot = %#v, want one story work item", list)
+	}
+}
+
+type recordingsRootFake struct {
+	events     []recordings.CanonicalEvent
+	worldState recordings.WorldStateView
+}
+
+func (fake *recordingsRootFake) Append(recordings.AppendRecordedEventRequest) (recordings.AppendRecordedEventResult, error) {
+	return recordings.AppendRecordedEventResult{}, recordings.ErrInvalidAppendEvent
+}
+
+func (fake *recordingsRootFake) SubscribeFrom(
+	_ context.Context,
+	request recordings.SubscribeRequest,
+) (recordings.SubscribeResult, error) {
+	index := 0
+	return recordings.SubscribeResult{
+		Subscription: func(context.Context) recordings.SubscriptionOutcome {
+			if index >= len(fake.events) {
+				return recordings.SubscriptionOutcome{Kind: recordings.SubscriptionClosed}
+			}
+			outcome := recordings.SubscriptionOutcome{
+				Kind:  recordings.SubscriptionEvent,
+				Event: fake.events[index],
+			}
+			index++
+			return outcome
+		},
+	}, nil
+}
+
+func (fake *recordingsRootFake) ReconstructWorldState(
+	recordings.ReconstructWorldStateRequest,
+) (recordings.ReconstructWorldStateResult, error) {
+	return recordings.ReconstructWorldStateResult{WorldState: fake.worldState}, nil
+}
+
+func (fake *recordingsRootFake) QuerySimpleDashboard(recordings.SimpleDashboardQueryRequest) (recordings.SimpleDashboardQueryResult, error) {
+	return recordings.SimpleDashboardQueryResult{}, recordings.ErrInvalidProjectionInput
+}
+
+func (fake *recordingsRootFake) QueryWorkstationRequests(recordings.WorkstationRequestsQueryRequest) (recordings.WorkstationRequestsQueryResult, error) {
+	return recordings.WorkstationRequestsQueryResult{}, recordings.ErrInvalidProjectionInput
+}
+
+func (fake *recordingsRootFake) ValidateReconnectReplayFrom(recordings.ValidateReconnectReplayRequest) error {
+	return recordings.ErrInvalidProjectionInput
+}
+
+func (fake *recordingsRootFake) BindRecording(recordings.BindRecordingRequest) (recordings.BindRecordingResult, error) {
+	return recordings.BindRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *recordingsRootFake) StartRecording(recordings.StartRecordingRequest) (recordings.StartRecordingResult, error) {
+	return recordings.StartRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *recordingsRootFake) RecordRecordingEvent(recordings.RecordRecordingEventRequest) (recordings.RecordRecordingEventResult, error) {
+	return recordings.RecordRecordingEventResult{}, recordings.ErrInvalidRecordingEvent
+}
+
+func (fake *recordingsRootFake) RecordRecordingError(recordings.RecordRecordingErrorRequest) (recordings.RecordRecordingErrorResult, error) {
+	return recordings.RecordRecordingErrorResult{}, recordings.ErrInvalidRecordingFailure
+}
+
+func (fake *recordingsRootFake) FlushRecording(recordings.FlushRecordingRequest) (recordings.FlushRecordingResult, error) {
+	return recordings.FlushRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *recordingsRootFake) StopRecording(recordings.StopRecordingRequest) (recordings.StopRecordingResult, error) {
+	return recordings.StopRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *recordingsRootFake) FinishRecording(recordings.FinishRecordingRequest) (recordings.FinishRecordingResult, error) {
+	return recordings.FinishRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *recordingsRootFake) QueryRecordingStatus(recordings.RecordingStatusRequest) (recordings.RecordingStatusResult, error) {
+	return recordings.RecordingStatusResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *recordingsRootFake) LoadReplayRecording(recordings.LoadReplayRecordingRequest) (recordings.LoadReplayRecordingResult, error) {
+	return recordings.LoadReplayRecordingResult{}, recordings.ErrMissingReplayArtifact
+}
+
+func (fake *recordingsRootFake) CreateReplayPlan(recordings.CreateReplayPlanRequest) (recordings.CreateReplayPlanResult, error) {
+	return recordings.CreateReplayPlanResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *recordingsRootFake) ObserveReplay(recordings.ObserveReplayRequest) (recordings.ObserveReplayResult, error) {
+	return recordings.ObserveReplayResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *recordingsRootFake) BuildPortableArtifact(recordings.BuildPortableArtifactRequest) (recordings.BuildPortableArtifactResult, error) {
+	return recordings.BuildPortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *recordingsRootFake) ValidatePortableArtifact(recordings.ValidatePortableArtifactRequest) (recordings.ValidatePortableArtifactResult, error) {
+	return recordings.ValidatePortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *recordingsRootFake) EncodePortableArtifact(recordings.EncodePortableArtifactRequest) (recordings.EncodePortableArtifactResult, error) {
+	return recordings.EncodePortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *recordingsRootFake) DecodePortableArtifact(recordings.DecodePortableArtifactRequest) (recordings.DecodePortableArtifactResult, error) {
+	return recordings.DecodePortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *recordingsRootFake) SummarizePortableArtifact(recordings.SummarizePortableArtifactRequest) (recordings.SummarizePortableArtifactResult, error) {
+	return recordings.SummarizePortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *recordingsRootFake) ExportPortableArtifact(context.Context, recordings.ExportPortableArtifactRequest) (recordings.ExportPortableArtifactResult, error) {
+	return recordings.ExportPortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *recordingsRootFake) ReadPortableArtifact(context.Context, recordings.ReadPortableArtifactRequest) (recordings.ReadPortableArtifactResult, error) {
+	return recordings.ReadPortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func recordingsBackedWorldPayload(t *testing.T, workID, workTypeID, stateName string) string {
+	t.Helper()
+	state := interfaces.FactoryWorldState{
+		Topology: interfaces.InitialStructurePayload{
+			WorkTypes: []interfaces.FactoryWorkType{{
+				ID: workTypeID,
+				States: []interfaces.FactoryStateDefinition{
+					{Value: "review", Category: work.StateTypeProcessing},
+				},
+			}},
+		},
+		WorkItemsByID: map[string]work.FactoryWorkItem{
+			workID: {ID: workID, WorkTypeID: workTypeID, State: stateName},
+		},
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal world state: %v", err)
+	}
+	return string(payload)
+}

--- a/pkg/services/work/stateaccessrecordings/exercise_test.go
+++ b/pkg/services/work/stateaccessrecordings/exercise_test.go
@@ -11,6 +11,36 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/work/stateaccessrecordings"
 )
 
+func TestGetWorkFromRecordingsRootUsesRecordingsServiceRoot(t *testing.T) {
+	t.Parallel()
+
+	scope := recordings.CanonicalEventScope{FactorySessionID: "session-recordings-unit"}
+	fake := &recordingsRootFake{
+		events: []recordings.CanonicalEvent{{
+			ID:          "event-1",
+			FactoryTick: 5,
+			Scope:       scope,
+		}},
+		worldState: recordings.WorldStateView{
+			SchemaVersion: recordings.WorldStateViewSchemaV1,
+			Payload:       recordingsBackedWorldPayload(t, "work-story", "story", "review"),
+		},
+	}
+
+	got, err := stateaccessrecordings.GetWorkFromRecordingsRoot(
+		context.Background(),
+		"session-recordings-unit",
+		"work-story",
+		fake,
+	)
+	if err != nil {
+		t.Fatalf("GetWorkFromRecordingsRoot: %v", err)
+	}
+	if got.WorkID != "work-story" {
+		t.Fatalf("GetWorkFromRecordingsRoot = %#v, want work-story", got)
+	}
+}
+
 func TestListWorkFromRecordingsRootUsesRecordingsServiceRoot(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/work/wire/wire_test.go
+++ b/pkg/services/work/wire/wire_test.go
@@ -241,8 +241,8 @@ func TestNewServiceServesPublishedPeerBehavior(t *testing.T) {
 	if err == nil {
 		t.Fatal("ListWork() error = nil, want unresolved runtime failure")
 	}
-	if err.Error() != "Work state access session adapter is unavailable" {
-		t.Fatalf("ListWork() error = %v, want unavailable session adapter", err)
+	if err.Error() != "Work state access recordings adapter is required" {
+		t.Fatalf("ListWork() error = %v, want recordings adapter required", err)
 	}
 
 	_, err = root.MoveWorkForSession(ctx, "session-unresolved", "work-1", "done", "req-1")

--- a/tests/functional/work/recordings/recordings_read_test.go
+++ b/tests/functional/work/recordings/recordings_read_test.go
@@ -1,0 +1,287 @@
+package workrecordings_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	"github.com/portpowered/infinite-you/pkg/services/work/stateaccessrecordings"
+)
+
+// TestRecordingsBackedWorkReadsUseRecordingsRootContract proves functional
+// coverage for CUT-WORK-REC: leased Work state_access reads construct Recordings
+// queries through the published Recordings service root when no live session is
+// available.
+func TestRecordingsBackedWorkReadsUseRecordingsRootContract(t *testing.T) {
+	t.Parallel()
+
+	scope := recordings.CanonicalEventScope{FactorySessionID: "session-recordings-functional"}
+	events := []recordings.CanonicalEvent{{
+		ID:          "event-1",
+		Sequence:    0,
+		FactoryTick: 3,
+		Scope:       scope,
+		Kind:        recordings.CanonicalEventKind(interfaces.FactoryEventTypeWorkRequest),
+		Payload:     `{"requestId":"request-1"}`,
+	}}
+	fake := &functionalRecordingsRootFake{
+		events: events,
+		worldState: recordings.WorldStateView{
+			SchemaVersion: recordings.WorldStateViewSchemaV1,
+			Scope:         scope,
+			SelectedTick:  3,
+			Payload:       recordingsBackedWorldPayload(t, "work-story", "story", "review"),
+		},
+	}
+	ctx := context.Background()
+
+	list, err := stateaccessrecordings.ListWorkFromRecordingsRoot(
+		ctx,
+		"session-recordings-functional",
+		fake,
+		work.ListOptions{},
+	)
+	if err != nil {
+		t.Fatalf("ListWorkFromRecordingsRoot: %v", err)
+	}
+	if len(list.Results) != 1 || list.Results[0].WorkID != "work-story" {
+		t.Fatalf("ListWorkFromRecordingsRoot = %#v, want one story work item", list)
+	}
+	if len(fake.subscribeRequests) < 1 || len(fake.reconstructRequests) < 1 {
+		t.Fatalf("subscribe=%d reconstruct=%d, want at least 1 each",
+			len(fake.subscribeRequests), len(fake.reconstructRequests))
+	}
+}
+
+func TestRecordingsBackedWorkReadsSurfaceTypedProjectionFailures(t *testing.T) {
+	t.Parallel()
+
+	_, err := stateaccessrecordings.ListWorkFromRecordingsRoot(
+		context.Background(),
+		"session-recordings-functional",
+		&functionalRecordingsRootFake{reconstructErr: recordings.ErrInvalidProjectionInput},
+		work.ListOptions{},
+	)
+	if err == nil {
+		t.Fatal("ListWorkFromRecordingsRoot error = nil, want typed projection failure")
+	}
+	if !errors.Is(err, recordings.ErrInvalidProjectionInput) {
+		t.Fatalf("ListWorkFromRecordingsRoot error = %v, want ErrInvalidProjectionInput", err)
+	}
+}
+
+type functionalRecordingsRootFake struct {
+	events              []recordings.CanonicalEvent
+	worldState          recordings.WorldStateView
+	reconstructErr      error
+	subscribeRequests   []recordings.SubscribeRequest
+	reconstructRequests []recordings.ReconstructWorldStateRequest
+}
+
+func (fake *functionalRecordingsRootFake) Append(
+	recordings.AppendRecordedEventRequest,
+) (recordings.AppendRecordedEventResult, error) {
+	return recordings.AppendRecordedEventResult{}, recordings.ErrInvalidAppendEvent
+}
+
+func (fake *functionalRecordingsRootFake) SubscribeFrom(
+	_ context.Context,
+	request recordings.SubscribeRequest,
+) (recordings.SubscribeResult, error) {
+	fake.subscribeRequests = append(fake.subscribeRequests, request)
+	events := make([]recordings.CanonicalEvent, 0, len(fake.events))
+	for _, event := range fake.events {
+		if event.Scope == request.Scope {
+			events = append(events, event)
+		}
+	}
+	index := 0
+	return recordings.SubscribeResult{
+		Subscription: func(context.Context) recordings.SubscriptionOutcome {
+			if index >= len(events) {
+				return recordings.SubscriptionOutcome{Kind: recordings.SubscriptionClosed}
+			}
+			outcome := recordings.SubscriptionOutcome{
+				Kind:  recordings.SubscriptionEvent,
+				Event: events[index],
+			}
+			index++
+			return outcome
+		},
+	}, nil
+}
+
+func (fake *functionalRecordingsRootFake) ReconstructWorldState(
+	request recordings.ReconstructWorldStateRequest,
+) (recordings.ReconstructWorldStateResult, error) {
+	fake.reconstructRequests = append(fake.reconstructRequests, request)
+	if fake.reconstructErr != nil {
+		return recordings.ReconstructWorldStateResult{}, fake.reconstructErr
+	}
+	return recordings.ReconstructWorldStateResult{WorldState: fake.worldState}, nil
+}
+
+func (fake *functionalRecordingsRootFake) QuerySimpleDashboard(
+	recordings.SimpleDashboardQueryRequest,
+) (recordings.SimpleDashboardQueryResult, error) {
+	return recordings.SimpleDashboardQueryResult{}, recordings.ErrInvalidProjectionInput
+}
+
+func (fake *functionalRecordingsRootFake) QueryWorkstationRequests(
+	recordings.WorkstationRequestsQueryRequest,
+) (recordings.WorkstationRequestsQueryResult, error) {
+	return recordings.WorkstationRequestsQueryResult{}, recordings.ErrInvalidProjectionInput
+}
+
+func (fake *functionalRecordingsRootFake) ValidateReconnectReplayFrom(
+	recordings.ValidateReconnectReplayRequest,
+) error {
+	return recordings.ErrInvalidProjectionInput
+}
+
+func (fake *functionalRecordingsRootFake) BindRecording(
+	recordings.BindRecordingRequest,
+) (recordings.BindRecordingResult, error) {
+	return recordings.BindRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *functionalRecordingsRootFake) StartRecording(
+	recordings.StartRecordingRequest,
+) (recordings.StartRecordingResult, error) {
+	return recordings.StartRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *functionalRecordingsRootFake) RecordRecordingEvent(
+	recordings.RecordRecordingEventRequest,
+) (recordings.RecordRecordingEventResult, error) {
+	return recordings.RecordRecordingEventResult{}, recordings.ErrInvalidRecordingEvent
+}
+
+func (fake *functionalRecordingsRootFake) RecordRecordingError(
+	recordings.RecordRecordingErrorRequest,
+) (recordings.RecordRecordingErrorResult, error) {
+	return recordings.RecordRecordingErrorResult{}, recordings.ErrInvalidRecordingFailure
+}
+
+func (fake *functionalRecordingsRootFake) FlushRecording(
+	recordings.FlushRecordingRequest,
+) (recordings.FlushRecordingResult, error) {
+	return recordings.FlushRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *functionalRecordingsRootFake) StopRecording(
+	recordings.StopRecordingRequest,
+) (recordings.StopRecordingResult, error) {
+	return recordings.StopRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *functionalRecordingsRootFake) FinishRecording(
+	recordings.FinishRecordingRequest,
+) (recordings.FinishRecordingResult, error) {
+	return recordings.FinishRecordingResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *functionalRecordingsRootFake) QueryRecordingStatus(
+	recordings.RecordingStatusRequest,
+) (recordings.RecordingStatusResult, error) {
+	return recordings.RecordingStatusResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *functionalRecordingsRootFake) LoadReplayRecording(
+	recordings.LoadReplayRecordingRequest,
+) (recordings.LoadReplayRecordingResult, error) {
+	return recordings.LoadReplayRecordingResult{}, recordings.ErrMissingReplayArtifact
+}
+
+func (fake *functionalRecordingsRootFake) CreateReplayPlan(
+	recordings.CreateReplayPlanRequest,
+) (recordings.CreateReplayPlanResult, error) {
+	return recordings.CreateReplayPlanResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *functionalRecordingsRootFake) ObserveReplay(
+	recordings.ObserveReplayRequest,
+) (recordings.ObserveReplayResult, error) {
+	return recordings.ObserveReplayResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *functionalRecordingsRootFake) BuildPortableArtifact(
+	recordings.BuildPortableArtifactRequest,
+) (recordings.BuildPortableArtifactResult, error) {
+	return recordings.BuildPortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *functionalRecordingsRootFake) ValidatePortableArtifact(
+	recordings.ValidatePortableArtifactRequest,
+) (recordings.ValidatePortableArtifactResult, error) {
+	return recordings.ValidatePortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *functionalRecordingsRootFake) EncodePortableArtifact(
+	recordings.EncodePortableArtifactRequest,
+) (recordings.EncodePortableArtifactResult, error) {
+	return recordings.EncodePortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *functionalRecordingsRootFake) DecodePortableArtifact(
+	recordings.DecodePortableArtifactRequest,
+) (recordings.DecodePortableArtifactResult, error) {
+	return recordings.DecodePortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *functionalRecordingsRootFake) SummarizePortableArtifact(
+	recordings.SummarizePortableArtifactRequest,
+) (recordings.SummarizePortableArtifactResult, error) {
+	return recordings.SummarizePortableArtifactResult{}, recordings.ErrInvalidReplayArtifact
+}
+
+func (fake *functionalRecordingsRootFake) ExportPortableArtifact(
+	context.Context,
+	recordings.ExportPortableArtifactRequest,
+) (recordings.ExportPortableArtifactResult, error) {
+	return recordings.ExportPortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func (fake *functionalRecordingsRootFake) ReadPortableArtifact(
+	context.Context,
+	recordings.ReadPortableArtifactRequest,
+) (recordings.ReadPortableArtifactResult, error) {
+	return recordings.ReadPortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func recordingsBackedWorldPayload(
+	t *testing.T,
+	workID string,
+	workTypeID string,
+	stateName string,
+) string {
+	t.Helper()
+	state := interfaces.FactoryWorldState{
+		Topology: interfaces.InitialStructurePayload{
+			WorkTypes: []interfaces.FactoryWorkType{{
+				ID: workTypeID,
+				States: []interfaces.FactoryStateDefinition{
+					{Value: "init", Category: work.StateTypeInitial},
+					{Value: "review", Category: work.StateTypeProcessing},
+				},
+			}},
+		},
+		WorkItemsByID: map[string]work.FactoryWorkItem{
+			workID: {
+				ID:          workID,
+				WorkTypeID:  workTypeID,
+				DisplayName: "Review PRD",
+				State:       stateName,
+			},
+		},
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal world state: %v", err)
+	}
+	return string(payload)
+}

--- a/tests/functional/work/recordings/recordings_read_test.go
+++ b/tests/functional/work/recordings/recordings_read_test.go
@@ -57,6 +57,107 @@ func TestRecordingsBackedWorkReadsUseRecordingsRootContract(t *testing.T) {
 	}
 }
 
+func TestGetWorkFromRecordingsRootUsesRecordingsServiceRoot(t *testing.T) {
+	t.Parallel()
+
+	scope := recordings.CanonicalEventScope{FactorySessionID: "session-recordings-functional"}
+	events := []recordings.CanonicalEvent{
+		{
+			ID:          "event-1",
+			Sequence:    0,
+			FactoryTick: 1,
+			Scope:       scope,
+			Kind:        recordings.CanonicalEventKind(interfaces.FactoryEventTypeWorkRequest),
+		},
+		{
+			ID:          "event-2",
+			Sequence:    1,
+			FactoryTick: 5,
+			Scope:       scope,
+			Kind:        recordings.CanonicalEventKind(interfaces.FactoryEventTypeWorkRequest),
+		},
+	}
+	fake := &functionalRecordingsRootFake{
+		events: events,
+		worldState: recordings.WorldStateView{
+			SchemaVersion: recordings.WorldStateViewSchemaV1,
+			Scope:         scope,
+			SelectedTick:  5,
+			Payload:       recordingsBackedRichWorldPayload(t),
+		},
+	}
+
+	got, err := stateaccessrecordings.GetWorkFromRecordingsRoot(
+		context.Background(),
+		"session-recordings-functional",
+		"work-active",
+		fake,
+	)
+	if err != nil {
+		t.Fatalf("GetWorkFromRecordingsRoot: %v", err)
+	}
+	if got.WorkID != "work-active" || got.State == nil || got.State.Type != work.StateTypeProcessing {
+		t.Fatalf("GetWorkFromRecordingsRoot = %#v, want active processing work item", got)
+	}
+	if len(fake.reconstructRequests) != 1 || fake.reconstructRequests[0].SelectedTick != 5 {
+		t.Fatalf("reconstruct requests = %#v, want highest tick 5", fake.reconstructRequests)
+	}
+}
+
+func TestRecordingsBackedWorkReadsMapRichWorldState(t *testing.T) {
+	t.Parallel()
+
+	scope := recordings.CanonicalEventScope{FactorySessionID: "session-recordings-functional"}
+	fake := &functionalRecordingsRootFake{
+		events: []recordings.CanonicalEvent{{
+			ID:          "event-1",
+			FactoryTick: 2,
+			Scope:       scope,
+		}},
+		worldState: recordings.WorldStateView{
+			SchemaVersion: recordings.WorldStateViewSchemaV1,
+			Payload:       recordingsBackedRichWorldPayload(t),
+		},
+	}
+
+	list, err := stateaccessrecordings.ListWorkFromRecordingsRoot(
+		context.Background(),
+		"session-recordings-functional",
+		fake,
+		work.ListOptions{WorkTypeName: "story", MaxResults: 2},
+	)
+	if err != nil {
+		t.Fatalf("ListWorkFromRecordingsRoot: %v", err)
+	}
+	if len(list.Results) != 2 || list.NextToken == "" {
+		t.Fatalf("ListWorkFromRecordingsRoot = %#v, want paginated story items", list)
+	}
+
+	byID := make(map[string]work.ReadModel, len(list.Results))
+	for _, item := range list.Results {
+		byID[item.WorkID] = item
+	}
+	if byID["work-active"].State == nil || byID["work-active"].State.Type != work.StateTypeProcessing {
+		t.Fatalf("active work state = %#v, want processing", byID["work-active"].State)
+	}
+	if len(byID["work-active"].Relations) != 1 || byID["work-active"].Relations[0].TargetWorkName != "Terminal story" {
+		t.Fatalf("relations = %#v, want one depends_on relation", byID["work-active"].Relations)
+	}
+
+	failed, err := stateaccessrecordings.GetWorkFromRecordingsRoot(
+		context.Background(),
+		"session-recordings-functional",
+		"work-failed",
+		fake,
+	)
+	if err != nil {
+		t.Fatalf("GetWorkFromRecordingsRoot(failed): %v", err)
+	}
+	if failed.State == nil || failed.State.Type != work.StateTypeFailed {
+		t.Fatalf("failed work state = %#v, want failed", failed.State)
+	}
+}
+
 func TestRecordingsBackedWorkReadsSurfaceTypedProjectionFailures(t *testing.T) {
 	t.Parallel()
 
@@ -251,6 +352,81 @@ func (fake *functionalRecordingsRootFake) ReadPortableArtifact(
 	recordings.ReadPortableArtifactRequest,
 ) (recordings.ReadPortableArtifactResult, error) {
 	return recordings.ReadPortableArtifactResult{}, recordings.ErrMissingRecordingTarget
+}
+
+func recordingsBackedRichWorldPayload(t *testing.T) string {
+	t.Helper()
+	state := interfaces.FactoryWorldState{
+		Topology: interfaces.InitialStructurePayload{
+			WorkTypes: []interfaces.FactoryWorkType{{
+				ID: "story",
+				States: []interfaces.FactoryStateDefinition{
+					{Value: "init", Category: work.StateTypeInitial},
+					{Value: "review", Category: work.StateTypeProcessing},
+					{Value: "done", Category: work.StateTypeTerminal},
+				},
+			}},
+		},
+		WorkItemsByID: map[string]work.FactoryWorkItem{
+			interfaces.SystemTimeWorkTypeID: {
+				ID:         interfaces.SystemTimeWorkTypeID,
+				WorkTypeID: interfaces.SystemTimeWorkTypeID,
+				State:      "pending",
+			},
+			"work-active": {
+				ID:          "work-active",
+				WorkTypeID:  "story",
+				DisplayName: "Active story",
+				State:       "review",
+			},
+			"work-failed": {
+				ID:         "work-failed",
+				WorkTypeID: "story",
+				State:      "review",
+			},
+			"work-terminal": {
+				ID:         "work-terminal",
+				WorkTypeID: "story",
+				State:      "init",
+			},
+		},
+		ActiveWorkItemsByID: map[string]work.FactoryWorkItem{
+			"work-active": {
+				ID:         "work-active",
+				WorkTypeID: "story",
+				State:      "review",
+			},
+		},
+		FailedWorkItemsByID: map[string]work.FactoryWorkItem{
+			"work-failed": {
+				ID:         "work-failed",
+				WorkTypeID: "story",
+				State:      "review",
+			},
+		},
+		TerminalWorkByID: map[string]interfaces.FactoryTerminalWork{
+			"work-terminal": {
+				WorkItem: work.FactoryWorkItem{
+					ID:         "work-terminal",
+					WorkTypeID: "story",
+					State:      "done",
+				},
+			},
+		},
+		RelationsByWorkID: map[string][]work.FactoryRelation{
+			"work-active": {{
+				Type:           "depends_on",
+				TargetWorkID:   "work-terminal",
+				TargetWorkName: "Terminal story",
+				RequiredState:  "done",
+			}},
+		},
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal world state: %v", err)
+	}
+	return string(payload)
 }
 
 func recordingsBackedWorldPayload(


### PR DESCRIPTION
{
  "project": "CUT-WORK-REC: Work consumes Recordings root only",
  "branchName": "pss-cut-work-rec",
  "description": "Retarget Work consumer call sites that still reach Recordings through nested/non-root paths onto the Recordings service root contract, preserve Work Recordings-backed read/list/get behavior, prove Recordings request construction with focused boundary tests, and merge the PR under the required delivery loop.",
  "context": {
    "customerAsk": "Lease only Work call sites that still reach Recordings through non-root paths or loose Recordings surfaces. Retarget those imports/call sites to the Recordings service root contract so Work no longer depends on Recordings implementation packages. Do not fold or delete work/service or recordings/service; do not edit root pkg/wire; do not open shared integrators; do not reopen Work adapters. Prove with focused Work/Recordings boundary tests. Delivery contract: loop implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts are resolved, the PR is merged, and only then complete Factory work.",
    "problem": "Work state-access is designed to read Recordings-backed projections through a private query-only Recordings port, but any Work edge that still reaches Recordings through nested packages (recordings/service, events, replay, projections, artifacts, internal) or loose Recordings surfaces couples Work to Recordings internals and blocks the CUT-WORK-REC consumer-edge packet from closing.",
    "solution": "Restrict Work production call sites so they import and construct Recordings only through pkg/services/recordings (recordings.Service and published request/result types), retarget leased state-access/query read edges onto Recordings root projection-query methods, prove the boundary with focused Work/Recordings tests, and merge without folding work/service or recordings/service, editing pkg/wire, opening shared integrators, or reopening Work adapters."
  },
  "acceptanceCriteria": [
    "Work production code imports Recordings only through the Recordings service root contract (pkg/services/recordings)",
    "No Work production import of Recordings implementation packages (recordings/service/**, recordings/internal/**, recordings/events/**, recordings/replay/**, recordings/projections/**, recordings/artifacts/**, or equivalent nested surfaces)",
    "Leased Work Recordings-facing call sites (including state-access / Recordings-backed read edges) construct Recordings requests through published Recordings root methods and types rather than nested Recordings packages or loose Recordings helpers",
    "Focused Work/Recordings boundary tests prove Recordings request construction through the Recordings root boundary",
    "Observable Work list/get/read outcomes for equivalent Recordings-backed inputs are preserved",
    "Quality checks pass (typecheck, lint, and tests); required CI is terminal and green",
    "Delivery loop continues until the PR is actually merged (not merely opened, green, approved, or ready to merge)"
  ],
  "userStories": [
    {
      "id": "pss-cut-work-rec-001",
      "title": "Seal Work→Recordings imports to the Recordings root",
      "description": "As a maintainer, I need Work production packages that reach Recordings to depend only on pkg/services/recordings so Work cannot couple to Recordings implementation packages.",
      "acceptanceCriteria": [
        "Every Work production import of Recordings resolves to the Recordings service root (pkg/services/recordings), not recordings/service/**, recordings/internal/**, recordings/events/**, recordings/replay/**, recordings/projections/**, recordings/artifacts/**, or other nested Recordings implementation surfaces",
        "Any leased Work call site still importing a Recordings implementation package is retargeted to the Recordings root contract",
        "No new Work import of Recordings implementation packages is introduced",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cut-work-rec-002",
      "title": "State-access Recordings-backed reads use Recordings root requests",
      "description": "As a Work state-access owner, I want Recordings-backed list/get/read paths under the Work lease to construct Recordings queries through the published Recordings root so Work does not bypass recordings.Service via nested Recordings packages or loose Recordings helpers.",
      "acceptanceCriteria": [
        "Leased Work production call sites that satisfy the private query-only Recordings port (RecordingsAdapter / equivalent state-access Recordings-backed read edge) construct Recordings requests using published Recordings root methods and types (for example ReconstructWorldState, QueryWorkstationRequests, or another published projection-query slice that yields the detached Work read facts Work adapts)",
        "Those call sites do not import Recordings nested packages or invoke loose Recordings construction helpers that duplicate published root query methods",
        "Equivalent Recordings-backed read inputs still produce the same observable Work ReadSnapshot / ReadModel / list-get outcomes and typed failures",
        "No new Work production dependency on Recordings nested packages is introduced for these leased slices",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cut-work-rec-003",
      "title": "Prove Recordings request construction through the Recordings root",
      "description": "As a reviewer of packaged-service boundaries, I want focused Work/Recordings boundary tests that prove Work constructs Recordings requests only through the Recordings root so CUT-WORK-REC is behaviorally sealed rather than inventory-only.",
      "acceptanceCriteria": [
        "Focused Work/Recordings boundary tests construct at least one Recordings query/request path through recordings.Service (or an equivalent published root collaborator) from a leased Work Recordings-edge (for example state-access Recordings-backed read) and assert observable Work read acceptance or typed rejection outcomes",
        "Those proofs fail closed if the exercised Work edge constructs Recordings requests through a Recordings implementation package or a superseded loose Recordings helper instead of the Recordings root",
        "Proofs assert behavioral outcomes reviewers can check (detached Work read fields, typed error codes/messages, or equivalent published request/result contracts), not merely that an import graph is empty",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cut-work-rec-004",
      "title": "Close delivery through review, CI, and merge",
      "description": "As the Factory program owner, I want the CUT-WORK-REC implementation loop to continue through review and required CI until the PR is actually merged so the packet is terminal rather than merely opened or approved.",
      "acceptanceCriteria": [
        "Implementation PR for CUT-WORK-REC is opened with only the Work→Recordings consumer-edge lease scope",
        "Diff does not fold/delete work/service or recordings/service, edit root pkg/wire, open shared integrators, reopen Work HTTP/CLI/MCP adapters, or take Sessions→Work / Visualization→Recordings leases beyond unavoidable Recordings root-contract alignment imports",
        "Required CI is terminal and passing on the merge candidate",
        "Every blocking PR conversation comment is explicitly addressed",
        "Merge conflicts and shared-file collisions are reconciled with concurrent packets",
        "PR is actually merged; opened/green/approved/ready-to-merge alone does not satisfy completion",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": false,
      "notes": ""
    }
  ]
}
