### PR TITLE
ft-wave2-factory-current-read-save

### DIFF
--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -7827,14 +7827,44 @@
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/current/read_save_test.go",
+      "package": "you-agent-factory/tests/functional/factory/current",
+      "scenario": "TestAPIGetAndSaveCurrentFactoryWithinOneSession",
+      "lane": "short",
+      "destination": "tests/functional/factory/current/read_save_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/current/read_save_test.go",
+      "package": "you-agent-factory/tests/functional/factory/current",
+      "scenario": "TestAPISaveCurrentFactoryValidatesBeforePersistence",
+      "lane": "short",
+      "destination": "tests/functional/factory/current/read_save_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/current/read_save_test.go",
+      "package": "you-agent-factory/tests/functional/factory/current",
+      "scenario": "TestAPICurrentFactoriesRemainSessionScoped",
+      "lane": "short",
+      "destination": "tests/functional/factory/current/read_save_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
     }
   ],
-  "scanned_at_utc": "2026-07-28T06:44:16Z",
+  "scanned_at_utc": "2026-07-28T07:03:39Z",
   "summary": {
     "by_catch_all": {
       "bootstrap_portability": 22,
       "guards_batch": 23,
-      "none": 507,
+      "none": 510,
       "replay_contracts": 23,
       "runtime_api": 96,
       "smoke": 62,
@@ -7845,7 +7875,7 @@
       "automations": 7,
       "bootstrap_portability": 21,
       "cli": 59,
-      "factory": 27,
+      "factory": 30,
       "guards_batch": 23,
       "models": 5,
       "observability": 9,
@@ -7865,9 +7895,9 @@
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 763,
+    "customer_top_level_Test_scenarios": 766,
     "lane_functionallong": 95,
-    "lane_short": 668,
+    "lane_short": 671,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 12,
       "you-agent-factory/tests/functional/automations": 7,
@@ -7880,6 +7910,7 @@
       "you-agent-factory/tests/functional/cli/named_invocation": 6,
       "you-agent-factory/tests/functional/cli/root_discovery": 9,
       "you-agent-factory/tests/functional/cli/session_resume": 6,
+      "you-agent-factory/tests/functional/factory/current": 3,
       "you-agent-factory/tests/functional/factory/definitions": 6,
       "you-agent-factory/tests/functional/factory/packaged/catalog": 7,
       "you-agent-factory/tests/functional/factory/packaged/deep_research": 3,

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -709,7 +709,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
 
 ### Current factory
 
-- [ ] `tests/functional/factory/current/read_save_test.go`
+- [x] `tests/functional/factory/current/read_save_test.go`
   - `TestAPIGetAndSaveCurrentFactoryWithinOneSession`.
   - `TestAPISaveCurrentFactoryValidatesBeforePersistence`.
   - `TestAPICurrentFactoriesRemainSessionScoped`.

--- a/tests/functional/factory/current/helpers_test.go
+++ b/tests/functional/factory/current/helpers_test.go
@@ -203,3 +203,14 @@ func versionDocument(version factoryapi.HybridLogicalTimestamp) map[string]strin
 		"physical": version.Physical.UTC().Format(time.RFC3339Nano),
 	}
 }
+
+const factoryValidationCodeDanglingPlaceReference = "factory.route.danglingPlaceReference"
+
+func hasValidationTargetCode(targets []factoryapi.FactoryValidationTarget, code string) bool {
+	for _, target := range targets {
+		if target.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/functional/factory/current/helpers_test.go
+++ b/tests/functional/factory/current/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -35,6 +36,79 @@ func seedNamedFactoryRoot(t *testing.T, rootDir, name, workType string) {
 		t.Fatalf("write customer Factory source %s: %v", name, err)
 	}
 	support.CreateAndActivateNamedFactoryAtRoot(t, sourceDir, rootDir, name, sourcePath)
+}
+
+func createNamedFactoryFixture(t *testing.T, rootDir, name string, payload []byte) string {
+	t.Helper()
+
+	sourceDir := t.TempDir()
+	sourcePath := filepath.Join(sourceDir, interfaces.FactoryConfigFile)
+	if err := os.WriteFile(sourcePath, payload, 0o600); err != nil {
+		t.Fatalf("write customer Factory source %s: %v", name, err)
+	}
+	return support.CreateNamedFactoryAtRoot(t, sourceDir, rootDir, name, sourcePath)
+}
+
+func openNamedFactorySession(t *testing.T, serverURL, folderPath, name string) string {
+	t.Helper()
+	body, err := json.Marshal(factoryapi.OpenFactorySessionRequest{
+		FolderPath: folderPath,
+		Target: &factoryapi.FactorySessionTargetRef{
+			Kind: factoryapi.FactorySessionTargetRefKindNamed,
+			Name: &name,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal open factory session request: %v", err)
+	}
+	resp, err := http.Post(serverURL+"/factory-sessions", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /factory-sessions: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		t.Fatalf("POST /factory-sessions status = %d, want 200", resp.StatusCode)
+	}
+	var opened factoryapi.OpenFactorySessionResponse
+	decodeJSONResponse(t, resp, &opened, "decode open factory session response")
+	if opened.Session == nil || opened.Session.Id == "" {
+		t.Fatalf("open factory session response = %#v, want session id", opened)
+	}
+	return opened.Session.Id
+}
+
+func getCurrentFactoryForSession(t *testing.T, serverURL, sessionID string) factoryapi.Factory {
+	t.Helper()
+	resp, err := http.Get(sessionFactoryURL(serverURL, sessionID))
+	if err != nil {
+		t.Fatalf("GET /factory-sessions/%s/factory: %v", sessionID, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		t.Fatalf("GET /factory-sessions/%s/factory status = %d, want 200", sessionID, resp.StatusCode)
+	}
+	var current factoryapi.Factory
+	decodeJSONResponse(t, resp, &current, "decode session current factory response")
+	return current
+}
+
+func saveCurrentFactoryForSession(t *testing.T, serverURL, sessionID, body string) factoryapi.Factory {
+	t.Helper()
+	resp := putFactoryForSessionRequestExpectStatusWithClient(
+		t,
+		http.DefaultClient,
+		serverURL,
+		"/factory-sessions/"+sessionID+"/factory",
+		saveFactoryForSessionRequestBody(body),
+		http.StatusOK,
+	)
+	var saved factoryapi.Factory
+	decodeJSONResponse(t, resp, &saved, "decode session current factory save response")
+	return saved
+}
+
+func sessionFactoryURL(serverURL, sessionID string) string {
+	return serverURL + "/factory-sessions/" + url.PathEscape(sessionID) + "/factory"
 }
 
 func getCurrentFactory(t *testing.T, serverURL string) factoryapi.Factory {

--- a/tests/functional/factory/current/helpers_test.go
+++ b/tests/functional/factory/current/helpers_test.go
@@ -1,0 +1,205 @@
+package current
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+func startCurrentFactoryServer(t *testing.T, rootDir string) *support.FunctionalAPIServer {
+	t.Helper()
+	return support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                rootDir,
+		UseMockWorkers:            true,
+		WaitForServiceModeRuntime: true,
+	})
+}
+
+func seedNamedFactoryRoot(t *testing.T, rootDir, name, workType string) {
+	t.Helper()
+
+	sourceDir := t.TempDir()
+	sourcePath := filepath.Join(sourceDir, interfaces.FactoryConfigFile)
+	if err := os.WriteFile(sourcePath, functionalNamedFactoryPayloadWithWorkType(t, name, workType), 0o600); err != nil {
+		t.Fatalf("write customer Factory source %s: %v", name, err)
+	}
+	support.CreateAndActivateNamedFactoryAtRoot(t, sourceDir, rootDir, name, sourcePath)
+}
+
+func getCurrentFactory(t *testing.T, serverURL string) factoryapi.Factory {
+	t.Helper()
+	resp, err := http.Get(serverURL + "/factory-sessions/~default/factory")
+	if err != nil {
+		t.Fatalf("GET /factory-sessions/~default/factory: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		t.Fatalf("GET /factory-sessions/~default/factory status = %d, want 200", resp.StatusCode)
+	}
+	var current factoryapi.Factory
+	decodeJSONResponse(t, resp, &current, "decode current factory response")
+	return current
+}
+
+func saveCurrentFactoryDefinition(t *testing.T, serverURL, body string) factoryapi.Factory {
+	t.Helper()
+
+	resp := saveCurrentFactoryDefinitionExpectStatus(t, serverURL, body, http.StatusOK)
+	var saved factoryapi.Factory
+	decodeJSONResponse(t, resp, &saved, "decode current factory save response")
+	return saved
+}
+
+func saveCurrentFactoryDefinitionExpectStatus(t *testing.T, serverURL, body string, wantStatus int) *http.Response {
+	t.Helper()
+	return putFactoryForSessionRequestExpectStatusWithClient(
+		t,
+		http.DefaultClient,
+		serverURL,
+		"/factory-sessions/~default/factory",
+		saveFactoryForSessionRequestBody(body),
+		wantStatus,
+	)
+}
+
+func saveFactoryForSessionRequestBody(factoryJSON string) string {
+	return fmt.Sprintf(`{"factory":%s}`, factoryJSON)
+}
+
+func putFactoryForSessionRequestExpectStatusWithClient(
+	t *testing.T,
+	client *http.Client,
+	serverURL,
+	path string,
+	body string,
+	wantStatus int,
+) *http.Response {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodPut, serverURL+path, bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("new factory session save request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("PUT %s: %v", path, err)
+	}
+	if resp.StatusCode != wantStatus {
+		payload, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("PUT %s status = %d, want %d: %s", path, resp.StatusCode, wantStatus, payload)
+	}
+	return resp
+}
+
+func decodeJSONResponse(t *testing.T, resp *http.Response, target any, message string) {
+	t.Helper()
+	defer resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+		t.Fatalf("%s: %v", message, err)
+	}
+}
+
+func assertFactoryWorkType(t *testing.T, factory factoryapi.Factory, want string, contextLabel string) {
+	t.Helper()
+	if factory.WorkTypes == nil || len(*factory.WorkTypes) != 1 || (*factory.WorkTypes)[0].Name != want {
+		t.Fatalf("%s work types = %#v, want %s", contextLabel, factory.WorkTypes, want)
+	}
+}
+
+func functionalNamedFactoryPayloadWithWorkType(t *testing.T, name, workType string) []byte {
+	t.Helper()
+	return []byte(functionalNamedFactoryPayloadJSON(name, workType))
+}
+
+func functionalNamedFactoryBody(name, workType string, version ...factoryapi.HybridLogicalTimestamp) string {
+	if len(version) == 0 {
+		return functionalNamedFactoryPayloadJSON(name, workType)
+	}
+	return currentFactorySaveDocument(nil, name, workType, versionDocument(version[0]))
+}
+
+func functionalNamedFactoryPayloadJSON(name, workType string) string {
+	return `{
+		"name":"` + name + `",
+		"id":"` + name + `",
+		"workTypes":[{"name":"` + workType + `","states":[{"name":"init","type":"INITIAL"},{"name":"done","type":"TERMINAL"},{"name":"failed","type":"FAILED"}]}],
+		"workers":[{"name":"planner","type":"MODEL_WORKER","modelProvider":"CLAUDE","executorProvider":"SCRIPT_WRAP","model":"claude-sonnet-4-20250514"}],
+		"workstations":[{"name":"plan-task","behavior":"STANDARD","type":"MODEL_WORKSTATION","worker":"planner","inputs":[{"workType":"` + workType + `","state":"init"}],"outputs":[{"workType":"` + workType + `","state":"done"}]}]
+	}`
+}
+
+func currentFactorySaveDocument(t *testing.T, name, workType string, version any) string {
+	if t != nil {
+		t.Helper()
+	}
+	document := map[string]any{
+		"name": name,
+		"id":   name,
+		"workTypes": []map[string]any{{
+			"name": workType,
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "done", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []map[string]string{{
+			"name":             "planner",
+			"type":             "MODEL_WORKER",
+			"modelProvider":    "CLAUDE",
+			"executorProvider": "SCRIPT_WRAP",
+			"model":            "claude-sonnet-4-20250514",
+		}},
+		"workstations": []map[string]any{{
+			"name":     "plan-task",
+			"behavior": "STANDARD",
+			"type":     "MODEL_WORKSTATION",
+			"worker":   "planner",
+			"inputs":   []map[string]string{{"workType": workType, "state": "init"}},
+			"outputs":  []map[string]string{{"workType": workType, "state": "done"}},
+		}},
+	}
+	if version != nil {
+		document["version"] = version
+	}
+	body, err := json.Marshal(document)
+	if err != nil {
+		if t != nil {
+			t.Fatalf("marshal current factory save document: %v", err)
+		}
+		panic(err)
+	}
+	return string(body)
+}
+
+func advancedFactoryVersion(t *testing.T, version *factoryapi.HybridLogicalTimestamp) factoryapi.HybridLogicalTimestamp {
+	t.Helper()
+	if version == nil {
+		t.Fatal("factory version = nil, want version metadata")
+	}
+	return factoryapi.HybridLogicalTimestamp{
+		Logical:  version.Logical + 1,
+		Physical: version.Physical.UTC().Add(time.Nanosecond),
+	}
+}
+
+func versionDocument(version factoryapi.HybridLogicalTimestamp) map[string]string {
+	return map[string]string{
+		"logical":  strconv.FormatInt(version.Logical.Int64(), 10),
+		"physical": version.Physical.UTC().Format(time.RFC3339Nano),
+	}
+}

--- a/tests/functional/factory/current/read_save_test.go
+++ b/tests/functional/factory/current/read_save_test.go
@@ -1,0 +1,38 @@
+package current
+
+import (
+	"testing"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+// TestAPIGetAndSaveCurrentFactoryWithinOneSession proves that a Factory Session
+// can read its Current Factory, save a valid updated definition through the
+// public session API, and read back the saved customer-visible topology within
+// the same session.
+func TestAPIGetAndSaveCurrentFactoryWithinOneSession(t *testing.T) {
+	rootDir := t.TempDir()
+	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
+
+	server := startCurrentFactoryServer(t, rootDir)
+	defer server.Stop(t)
+
+	current := getCurrentFactory(t, server.URL())
+	if current.Name != factoryapi.FactoryName("alpha") {
+		t.Fatalf("current factory name = %q, want alpha", current.Name)
+	}
+	assertFactoryWorkType(t, current, "alpha-task", "initial current factory")
+
+	saved := saveCurrentFactoryDefinition(
+		t,
+		server.URL(),
+		functionalNamedFactoryBody("alpha", "story", advancedFactoryVersion(t, current.Version)),
+	)
+	assertFactoryWorkType(t, saved, "story", "save response")
+
+	reloaded := getCurrentFactory(t, server.URL())
+	if reloaded.Name != factoryapi.FactoryName("alpha") {
+		t.Fatalf("reloaded current factory name = %q, want alpha", reloaded.Name)
+	}
+	assertFactoryWorkType(t, reloaded, "story", "subsequent get within session")
+}

--- a/tests/functional/factory/current/read_save_test.go
+++ b/tests/functional/factory/current/read_save_test.go
@@ -88,3 +88,45 @@ func TestAPISaveCurrentFactoryValidatesBeforePersistence(t *testing.T) {
 	}
 	assertFactoryWorkType(t, reloaded, "alpha-task", "current factory after rejected save")
 }
+
+// TestAPICurrentFactoriesRemainSessionScoped proves that Current Factory saves stay
+// isolated across Factory Sessions so a valid save in one session updates that
+// session's readback while another session's Current Factory remains unchanged.
+func TestAPICurrentFactoriesRemainSessionScoped(t *testing.T) {
+	rootDir := t.TempDir()
+	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
+	createNamedFactoryFixture(
+		t,
+		rootDir,
+		"beta",
+		functionalNamedFactoryPayloadWithWorkType(t, "beta", "beta-task"),
+	)
+
+	server := startCurrentFactoryServer(t, rootDir)
+	defer server.Stop(t)
+
+	betaSessionID := openNamedFactorySession(t, server.URL(), rootDir, "beta")
+
+	sessionCurrent := getCurrentFactoryForSession(t, server.URL(), betaSessionID)
+	if sessionCurrent.Name != factoryapi.FactoryName("beta") {
+		t.Fatalf("session current factory name = %q, want beta", sessionCurrent.Name)
+	}
+	assertFactoryWorkType(t, sessionCurrent, "beta-task", "beta session current factory before save")
+
+	saved := saveCurrentFactoryForSession(
+		t,
+		server.URL(),
+		betaSessionID,
+		functionalNamedFactoryBody("beta", "story", advancedFactoryVersion(t, sessionCurrent.Version)),
+	)
+	assertFactoryWorkType(t, saved, "story", "beta session save response")
+
+	reloaded := getCurrentFactoryForSession(t, server.URL(), betaSessionID)
+	assertFactoryWorkType(t, reloaded, "story", "beta session current factory after save")
+
+	defaultCurrent := getCurrentFactory(t, server.URL())
+	if defaultCurrent.Name != factoryapi.FactoryName("alpha") {
+		t.Fatalf("default current factory name = %q, want alpha", defaultCurrent.Name)
+	}
+	assertFactoryWorkType(t, defaultCurrent, "alpha-task", "default session current factory after beta session save")
+}

--- a/tests/functional/factory/current/read_save_test.go
+++ b/tests/functional/factory/current/read_save_test.go
@@ -1,7 +1,10 @@
 package current
 
 import (
+	"net/http"
+	"strconv"
 	"testing"
+	"time"
 
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 )
@@ -35,4 +38,53 @@ func TestAPIGetAndSaveCurrentFactoryWithinOneSession(t *testing.T) {
 		t.Fatalf("reloaded current factory name = %q, want alpha", reloaded.Name)
 	}
 	assertFactoryWorkType(t, reloaded, "story", "subsequent get within session")
+}
+
+// TestAPISaveCurrentFactoryValidatesBeforePersistence proves that an invalid Current
+// Factory save is rejected through the public session API before persistence, returns
+// a structured validation error, and leaves the prior Current Factory unchanged on
+// subsequent readback within the same session.
+func TestAPISaveCurrentFactoryValidatesBeforePersistence(t *testing.T) {
+	rootDir := t.TempDir()
+	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
+
+	server := startCurrentFactoryServer(t, rootDir)
+	defer server.Stop(t)
+
+	current := getCurrentFactory(t, server.URL())
+	if current.Version == nil {
+		t.Fatal("current factory version = nil, want version metadata for save")
+	}
+	assertFactoryWorkType(t, current, "alpha-task", "initial current factory")
+
+	advanced := advancedFactoryVersion(t, current.Version)
+	body := `{
+		"name":"alpha",
+		"version":{"physical":"` + advanced.Physical.UTC().Format(time.RFC3339Nano) + `","logical":"` + strconv.FormatInt(advanced.Logical.Int64(), 10) + `"},
+		"workTypes":[{"name":"story","states":[{"name":"queued","type":"INITIAL"}]}],
+		"workers":[{"name":"worker-a","type":"MODEL_WORKER","modelProvider":"CLAUDE","executorProvider":"SCRIPT_WRAP","model":"claude-sonnet-4-20250514"}],
+		"workstations":[{"name":"process","behavior":"STANDARD","type":"MODEL_WORKSTATION","worker":"worker-a","inputs":[{"workType":"story","state":"queued"}],"outputs":[{"workType":"story","state":"missing-state"}]}]
+	}`
+
+	resp := saveCurrentFactoryDefinitionExpectStatus(t, server.URL(), body, http.StatusBadRequest)
+	var errResp factoryapi.ErrorResponse
+	decodeJSONResponse(t, resp, &errResp, "decode invalid current factory save response")
+	if errResp.Code != factoryapi.ErrorResponseCodeINVALIDFACTORY {
+		t.Fatalf("error code = %q, want INVALID_FACTORY", errResp.Code)
+	}
+	if errResp.Family != factoryapi.ErrorFamilyBadRequest {
+		t.Fatalf("error family = %q, want BAD_REQUEST", errResp.Family)
+	}
+	if errResp.Targets == nil || len(*errResp.Targets) == 0 {
+		t.Fatalf("error targets = %#v, want topology validation targets", errResp.Targets)
+	}
+	if !hasValidationTargetCode(*errResp.Targets, factoryValidationCodeDanglingPlaceReference) {
+		t.Fatalf("error targets = %#v, want dangling place reference target", errResp.Targets)
+	}
+
+	reloaded := getCurrentFactory(t, server.URL())
+	if reloaded.Version == nil || *reloaded.Version != *current.Version {
+		t.Fatalf("reloaded version = %#v, want unchanged %#v", reloaded.Version, current.Version)
+	}
+	assertFactoryWorkType(t, reloaded, "alpha-task", "current factory after rejected save")
 }


### PR DESCRIPTION
{
  "project": "Current Factory Read/Save Functional Coverage",
  "branchName": "ft-wave2-factory-current-read-save",
  "description": "Implement only tests/functional/factory/current/read_save_test.go so the public Current Factory API/session boundary proves in-session get/save, validate-before-persist rejection without mutation, and session-scoped Current Factory isolation—consuming mapped migration-ledger rows and preserving bootstrap_portability-delete-05-factory-current, runtime_api-delete-06-factory-current, workflow-delete-07-factory-current, and current-factory-watcher-switch-smoke while holding prompt_template_test.go.",
  "context": {
    "customerAsk": "Implement only tests/functional/factory/current/read_save_test.go. Through the public current-Factory API/session boundary, prove: (1) TestAPIGetAndSaveCurrentFactoryWithinOneSession; (2) TestAPISaveCurrentFactoryValidatesBeforePersistence; (3) TestAPICurrentFactoriesRemainSessionScoped. Consume mapped migration-ledger rows and preserve named deletion-batch / specialty bindings (bootstrap_portability-delete-05-factory-current, runtime_api-delete-06-factory-current, workflow-delete-07-factory-current, current-factory-watcher-switch-smoke). Do not implement prompt_template_test.go. Avoid service/internal Petri imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for Current Factory read/save does not exist yet. Maintainers lack a factory/current-owned cell that jointly proves in-session get/save round-trip, pre-persist validation failure, and cross-session isolation. Legacy proofs are scattered across bootstrap_portability, runtime_api transformation, and workflow sources mapped to this cell; without a destination-owned implementation that preserves named deletion-batch and specialty bindings, Wave 2 coverage and shared workflow-delete-07-factory-current ownership with held prompt_template_test.go can strand or collide.",
    "solution": "Implement the three checklist scenarios in tests/functional/factory/current/read_save_test.go through the public Current Factory API/session boundary with customer-readable Go docs on every top-level Test. Assert in-session get/save readback, invalid-save rejection before persistence with unchanged subsequent get, and session-scoped isolation across Factory Sessions; consume mapped migration-ledger rows; preserve bootstrap_portability-delete-05-factory-current, runtime_api-delete-06-factory-current, workflow-delete-07-factory-current, and current-factory-watcher-switch-smoke; leave prompt_template_test.go held; apply only narrowly coupled metadata; and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/factory/current/read_save_test.go exists as the factory/current-owned functional cell and covers in-session get/save, validate-before-persist, and session-scoped isolation.",
    "Through the public Current Factory API/session boundary, a Factory Session can get its Current Factory, save a valid updated definition, and read back the saved definition within that same session.",
    "Through the public Current Factory API/session boundary, an invalid save is rejected with a public validation/error outcome before persistence, and a subsequent get shows the prior Current Factory unchanged.",
    "Through the public Current Factory API/session boundary, Current Factory saves remain isolated per Factory Session (one session's save does not rewrite another session's Current Factory).",
    "Mapped migration-ledger rows whose destination is this cell are consumed as applicable; named deletion batches bootstrap_portability-delete-05-factory-current, runtime_api-delete-06-factory-current, and workflow-delete-07-factory-current, plus specialty current-factory-watcher-switch-smoke, are preserved; only narrowly coupled ownership/deletion/coverage/catalog metadata for this cell are updated; held sibling prompt_template_test.go stays untouched.",
    "Coverage uses the public Current Factory API/session boundary / approved helpers and does not import service implementations or internal Petri primitives as the proof owner, with customer-readable Go docs on every top-level Test*.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave2-factory-current-read-save-001",
      "title": "Prove get and save succeed within one session",
      "description": "As a customer editing the active Factory in a Factory Session, I want to get and save the Current Factory through the public API so that my edits persist and remain visible on readback inside that same session.",
      "acceptanceCriteria": [
        "tests/functional/factory/current/read_save_test.go includes TestAPIGetAndSaveCurrentFactoryWithinOneSession (or equivalent top-level name matching the checklist intent).",
        "Through the public Current Factory API/session boundary, the test opens or uses one Factory Session, gets the Current Factory, saves a valid updated definition (for example a customer-visible work-type or topology edit with a valid advanced save version), and gets again.",
        "Observable evidence proves the saved definition is returned by the save response and by a subsequent get within the same session (customer-visible fields such as name/work types match the saved payload).",
        "Assertions stay on in-session get/save/readback for Current Factory and do not re-own prompt-template validation, packaged-factory invocation, or Factory-init scaffold proofs.",
        "The top-level test has a customer-readable Go doc comment describing the observable in-session Current Factory get/save behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-current-read-save-002",
      "title": "Prove invalid saves validate before persistence",
      "description": "As a customer or editor submitting a malformed Current Factory definition, I want the public save path to reject invalid input before persistence so that a bad save cannot corrupt the active Factory for the session.",
      "acceptanceCriteria": [
        "The Current Factory read/save cell includes TestAPISaveCurrentFactoryValidatesBeforePersistence (or equivalent top-level name matching the checklist intent).",
        "Through the public Current Factory API/session boundary, the test gets a readable Current Factory, then attempts a save that is invalid under the public Current Factory contract (for example topology/validation failure, invalid bundled-doc target, or stale/non-advanced version—whichever is the smallest stable public invalidation already supported by the API).",
        "Observable evidence proves the save fails with a public non-success validation/error outcome (structured error/targets or equivalent public failure shape) and that a subsequent get returns the prior Current Factory unchanged.",
        "Assertions remain on pre-persist validation for Current Factory save and do not widen into full Factory-definition validation matrices owned by other cells or prompt-template ownership.",
        "The top-level test has a customer-readable Go doc comment describing the observable validate-before-persist Current Factory save behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-current-read-save-003",
      "title": "Prove Current Factories remain session-scoped",
      "description": "As a customer running multiple Factory Sessions, I want each session's Current Factory to stay isolated so that edits in one session do not silently rewrite another session's active Factory.",
      "acceptanceCriteria": [
        "The Current Factory read/save cell includes TestAPICurrentFactoriesRemainSessionScoped (or equivalent top-level name matching the checklist intent).",
        "Through the public Current Factory API/session boundary, the test uses at least two Factory Session contexts (for example a default/current session and a second named-factory session, or two distinct session IDs) with distinguishable Current Factory definitions.",
        "A valid save performed in one session updates that session's Current Factory readback while the other session's Current Factory remains the prior distinguishable definition.",
        "Assertions remain on session-scoped Current Factory isolation and do not re-own Factory Session lifecycle CRUD, watcher specialty smoke implementation beyond preserving the binding, or prompt-template proofs.",
        "The top-level test has a customer-readable Go doc comment describing the observable session-scoped Current Factory isolation behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-current-read-save-004",
      "title": "Consume migration obligation and close verification gates",
      "description": "As a maintainer executing Wave 2 functional-test expansion, I want this cell to absorb the mapped Current Factory read/save ledger rows, preserve named deletion-batch and specialty bindings, and pass focused boundary/metadata gates so factory/current can terminal-complete without implementing held prompt_template_test.go.",
      "acceptanceCriteria": [
        "Migration-ledger mappings whose destination is tests/functional/factory/current/read_save_test.go are consumed by this cell's coverage for in-session get/save, validate-before-persist, and session-scoped isolation obligations (thirty-four mapped scenarios collapsed into the three checklist behaviors as applicable).",
        "Named deletion batches bootstrap_portability-delete-05-factory-current, runtime_api-delete-06-factory-current, and workflow-delete-07-factory-current, plus specialty binding current-factory-watcher-switch-smoke, are preserved for this destination; shared workflow-delete-07-factory-current ownership with held prompt_template_test.go is not casually reassigned or exclusively claimed in a way that strands the sibling.",
        "Only narrowly coupled ownership, deletion-only migration, coverage, or catalog metadata required for this cell are updated; prompt_template_test.go is not implemented or rewritten.",
        "Focused package tests for tests/functional/factory/current (read/save cell) pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as factory/current).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)