### PR TITLE
ft-wave2-provider-sessions-association

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -778,7 +778,10 @@ Wave 0 functional-tests-expansion planning authority lives under
   `GET /factory-sessions/{session_id}/dispatches` and
   `GET /factory-sessions/{session_id}/dispatches/{dispatch_id}` only:
   `providerSessionRefs`, owning dispatch `id`, and list/detail `sessionId`
-  correlation. Do not invent provider metadata or widen into `details/*` or
+  correlation. Use a successful fake child for present-ref association and a
+  deterministic `fail:` fake-child prompt for absent-ref non-fabrication (nil or
+  empty `providerSessionRefs` on list/detail, not `fake-provider-session-1`).
+  Do not invent provider metadata or widen into `details/*` or
   `response_exec_metadata_test.go`. Catalog metadata infers domain
   `provider_sessions` and subsection `association`; every top-level `Test*`
   needs a customer-readable Go doc so `functionaltestmetadata` stays

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -778,10 +778,13 @@ Wave 0 functional-tests-expansion planning authority lives under
   `GET /factory-sessions/{session_id}/dispatches` and
   `GET /factory-sessions/{session_id}/dispatches/{dispatch_id}` only:
   `providerSessionRefs`, owning dispatch `id`, and list/detail `sessionId`
-  correlation. Use a successful fake child for present-ref association and a
+  correlation.   Use a successful fake child for present-ref association and a
   deterministic `fail:` fake-child prompt for absent-ref non-fabrication (nil or
   empty `providerSessionRefs` on list/detail, not `fake-provider-session-1`).
-  Do not invent provider metadata or widen into `details/*` or
+  For distinct multi-dispatch refs, run two successful `agent.run` children in
+  one workflow and assert `fake-provider-session-1` / `fake-provider-session-2`
+  join to their owning dispatch ids without collision. Do not invent provider
+  metadata or widen into `details/*` or
   `response_exec_metadata_test.go`. Catalog metadata infers domain
   `provider_sessions` and subsection `association`; every top-level `Test*`
   needs a customer-readable Go doc so `functionaltestmetadata` stays

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -771,6 +771,19 @@ Wave 0 functional-tests-expansion planning authority lives under
   every top-level `Test*` needs a customer-readable Go doc so
   `functionaltestmetadata` stays viz-compatible.
 
+- `tests/functional/provider_sessions/association/association_test.go` owns
+  Provider Session ref correlation on public Factory Session dispatch projections.
+  Drive proofs through `support.StartFunctionalAPIServer` with a JavaScript
+  `agent.run` fake-child workflow (no live provider runner calls), then assert on
+  `GET /factory-sessions/{session_id}/dispatches` and
+  `GET /factory-sessions/{session_id}/dispatches/{dispatch_id}` only:
+  `providerSessionRefs`, owning dispatch `id`, and list/detail `sessionId`
+  correlation. Do not invent provider metadata or widen into `details/*` or
+  `response_exec_metadata_test.go`. Catalog metadata infers domain
+  `provider_sessions` and subsection `association`; every top-level `Test*`
+  needs a customer-readable Go doc so `functionaltestmetadata` stays
+  viz-compatible.
+
 - `tests/functional/automations/` owns root.BuildProcess evidence for packaged
   Automations cron scheduling and filesystem watcher preseed. Keep cron workstation
   factories explicit with `"behavior": "CRON"` and observe submissions through

--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -7487,6 +7487,36 @@
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/provider_sessions/association/association_test.go",
+      "package": "you-agent-factory/tests/functional/provider_sessions/association",
+      "scenario": "TestProviderSessionRefAssociatesWithOwningDispatchAndFactorySession",
+      "lane": "short",
+      "destination": "tests/functional/provider_sessions/association/association_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/provider_sessions/association/association_test.go",
+      "package": "you-agent-factory/tests/functional/provider_sessions/association",
+      "scenario": "TestAbsentProviderSessionIsNotFabricated",
+      "lane": "short",
+      "destination": "tests/functional/provider_sessions/association/association_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/provider_sessions/association/association_test.go",
+      "package": "you-agent-factory/tests/functional/provider_sessions/association",
+      "scenario": "TestMultipleDispatchesKeepDistinctProviderSessionRefs",
+      "lane": "short",
+      "destination": "tests/functional/provider_sessions/association/association_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
     }
   ],
   "scanned_at_utc": "2026-07-28T05:00:00Z",
@@ -7494,7 +7524,7 @@
     "by_catch_all": {
       "bootstrap_portability": 22,
       "guards_batch": 23,
-      "none": 460,
+      "none": 463,
       "replay_contracts": 23,
       "runtime_api": 96,
       "smoke": 62,
@@ -7513,6 +7543,7 @@
       "orchestration": 48,
       "product": 13,
       "providers": 55,
+      "provider_sessions": 3,
       "replay_contracts": 23,
       "runtime_api": 95,
       "sessionparity": 13,
@@ -7524,9 +7555,9 @@
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 729,
+    "customer_top_level_Test_scenarios": 732,
     "lane_functionallong": 95,
-    "lane_short": 634,
+    "lane_short": 637,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 12,
       "you-agent-factory/tests/functional/automations": 7,
@@ -7567,6 +7598,7 @@
       "you-agent-factory/tests/functional/providers/codex": 7,
       "you-agent-factory/tests/functional/providers/cursor": 8,
       "you-agent-factory/tests/functional/providers/kiro": 4,
+      "you-agent-factory/tests/functional/provider_sessions/association": 3,
       "you-agent-factory/tests/functional/replay_contracts": 23,
       "you-agent-factory/tests/functional/runtime_api": 56,
       "you-agent-factory/tests/functional/runtime_api/factory_transformation": 39,
@@ -7610,7 +7642,7 @@
       "you-agent-factory/tests/functional/workstations/watcher": 9,
       "you-agent-factory/tests/functional/sessions/mcp": 7
     },
-    "files_with_customer_Test": 235,
+    "files_with_customer_Test": 238,
     "functional_test_go_files": 251,
     "helper_only_non_customer_files": 51,
     "internal_harness_Test_functions": 15,

--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -7389,36 +7389,6 @@
       "deletion_only_batch": "n/a"
     },
     {
-      "source_path": "tests/functional/factory/packaged/fusion/invocation_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/fusion",
-      "scenario": "TestPackagedFusionRequiredInputCompletes",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/fusion/invocation_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory/packaged/fusion/invocation_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/fusion",
-      "scenario": "TestPackagedFusionOptionalInputsReachWorkers",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/fusion/invocation_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory/packaged/fusion/invocation_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/fusion",
-      "scenario": "TestPackagedFusionPartialWorkerFailureUsesDocumentedOutcome",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/fusion/invocation_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
       "source_path": "tests/functional/factory/packaged/subagent/invocation_test.go",
       "package": "you-agent-factory/tests/functional/factory/packaged/subagent",
       "scenario": "TestPackagedSubagentReturnsChildResult",

--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -7319,6 +7319,36 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/factory/packaged/fusion/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/fusion",
+      "scenario": "TestPackagedFusionRequiredInputCompletes",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/fusion/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/fusion/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/fusion",
+      "scenario": "TestPackagedFusionOptionalInputsReachWorkers",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/fusion/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/fusion/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/fusion",
+      "scenario": "TestPackagedFusionPartialWorkerFailureUsesDocumentedOutcome",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/fusion/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/factory/packaged/goal/invocation_test.go",
       "package": "you-agent-factory/tests/functional/factory/packaged/goal",
       "scenario": "TestPackagedGoalAcceptCompletesWithSummary",
@@ -7524,7 +7554,7 @@
     "by_catch_all": {
       "bootstrap_portability": 22,
       "guards_batch": 23,
-      "none": 463,
+      "none": 466,
       "replay_contracts": 23,
       "runtime_api": 96,
       "smoke": 62,
@@ -7535,7 +7565,7 @@
       "automations": 7,
       "bootstrap_portability": 21,
       "cli": 59,
-      "factory": 12,
+      "factory": 15,
       "guards_batch": 23,
       "models": 5,
       "observability": 9,

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -746,7 +746,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestAPIProviderSessionRejectsRawFilesystemPathInput`.
   - `TestAPIUnsupportedProviderSessionKindReturnsTypedError`.
 
-- [ ] `tests/functional/provider_sessions/association/association_test.go`
+- [x] `tests/functional/provider_sessions/association/association_test.go`
   - `TestProviderSessionRefAssociatesWithOwningDispatchAndFactorySession`.
   - `TestAbsentProviderSessionIsNotFabricated`.
   - `TestMultipleDispatchesKeepDistinctProviderSessionRefs`.

--- a/tests/functional/provider_sessions/association/association_test.go
+++ b/tests/functional/provider_sessions/association/association_test.go
@@ -26,6 +26,16 @@ const (
   });
   return { child };
 })();`
+
+	absentProviderSessionChildLabel  = "association-no-provider-child"
+	absentProviderSessionChildPrompt = "fail:association-absent-provider-session"
+	absentProviderSessionWorkflow    = `return (async function () {
+  const child = await agent.run({
+    prompt: "` + absentProviderSessionChildPrompt + `",
+    label: "` + absentProviderSessionChildLabel + `",
+  });
+  return { child };
+})();`
 )
 
 // TestProviderSessionRefAssociatesWithOwningDispatchAndFactorySession proves that
@@ -111,6 +121,155 @@ func TestProviderSessionRefAssociatesWithOwningDispatchAndFactorySession(t *test
 			"dispatch detail providerSessionRef id = %q, want same ref %q from listing",
 			detailRef.Id,
 			providerRef.Id,
+		)
+	}
+}
+
+// TestAbsentProviderSessionIsNotFabricated proves that when a Factory Session
+// dispatch completes without establishing a Provider Session, the public dispatch
+// listing and dispatch detail surfaces omit fabricated providerSessionRefs rather
+// than inventing a synthetic session identity customers could treat as real.
+func TestAbsentProviderSessionIsNotFabricated(t *testing.T) {
+	t.Parallel()
+
+	dir := scaffoldAbsentProviderSessionWorkflow(t)
+	runner := support.NewRecordingCommandRunner("unexpected live provider execution")
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		WaitForServiceModeRuntime: true,
+		UseMockWorkers:            true,
+		Edges:                     serviceedges.Edges{ProviderCommandRunner: runner},
+	})
+	t.Cleanup(func() { server.Stop(t) })
+
+	executed := startAbsentProviderSessionWorkflow(t, server.URL(), dir)
+	if executed.Status != factoryapi.FactorySessionDurableLifecycleStatusFailed {
+		t.Fatalf("session status = %q, want FAILED", executed.Status)
+	}
+	if strings.TrimSpace(executed.SessionId) == "" {
+		t.Fatal("sessionId unexpectedly empty")
+	}
+	if runner.CallCount() != 0 {
+		t.Fatalf("provider command runner call count = %d, want 0 for fake child failure edge", runner.CallCount())
+	}
+
+	listed := listAssociationDispatches(t, server.URL(), executed.SessionId)
+	if listed.SessionId != executed.SessionId {
+		t.Fatalf(
+			"dispatch list sessionId = %q, want owning Factory Session %q",
+			listed.SessionId,
+			executed.SessionId,
+		)
+	}
+	if len(listed.Dispatches) != 1 {
+		t.Fatalf("dispatch count = %d, want exactly one child dispatch without a Provider Session", len(listed.Dispatches))
+	}
+
+	summary := listed.Dispatches[0]
+	if strings.TrimSpace(summary.Id) == "" {
+		t.Fatal("dispatch id unexpectedly empty on public dispatch summary")
+	}
+	if summary.Status != factoryapi.FactoryDispatchStatusFAILED {
+		t.Fatalf("dispatch status = %q, want FAILED", summary.Status)
+	}
+	if summary.Label == nil || *summary.Label != absentProviderSessionChildLabel {
+		t.Fatalf("dispatch label = %#v, want %q", summary.Label, absentProviderSessionChildLabel)
+	}
+	assertAbsentProviderSessionRefsOnDispatchSummary(t, summary)
+
+	detail := getAssociationDispatchDetail(t, server.URL(), executed.SessionId, summary.Id)
+	if detail.SessionId != executed.SessionId {
+		t.Fatalf(
+			"dispatch detail sessionId = %q, want owning Factory Session %q",
+			detail.SessionId,
+			executed.SessionId,
+		)
+	}
+	if detail.Id != summary.Id {
+		t.Fatalf(
+			"dispatch detail id = %q, want same owning dispatch %q from listing",
+			detail.Id,
+			summary.Id,
+		)
+	}
+	assertAbsentProviderSessionRefsOnDispatchDetail(t, detail)
+}
+
+func scaffoldAbsentProviderSessionWorkflow(t *testing.T) string {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, map[string]any{"name": "provider-session-association-absent"})
+	if err := os.WriteFile(filepath.Join(dir, "workflow.js"), []byte(absentProviderSessionWorkflow), 0o600); err != nil {
+		t.Fatalf("write absent provider session workflow: %v", err)
+	}
+	return dir
+}
+
+func startAbsentProviderSessionWorkflow(
+	t *testing.T,
+	serverURL string,
+	dir string,
+) factoryapi.FactorySessionSyncExecutionResponse {
+	t.Helper()
+
+	workflowPath := filepath.Join(dir, "workflow.js")
+	payload, err := json.Marshal(factoryapi.FactorySessionExecutionRequest{
+		RequestId: "provider-session-association-absent",
+		Source: factoryapi.FactorySessionExecutionSource{
+			Kind:         factoryapi.FactorySessionExecutionSourceKindWorkflowFile,
+			WorkflowFile: &workflowPath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal absent provider session workflow request: %v", err)
+	}
+	endpoint := strings.TrimSuffix(serverURL, "/") + "/factory-sessions/sync"
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("build absent provider session workflow request: %v", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("start absent provider session workflow: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		var body bytes.Buffer
+		_, _ = body.ReadFrom(response.Body)
+		t.Fatalf("start absent provider session workflow status = %d: %s", response.StatusCode, body.String())
+	}
+	var executed factoryapi.FactorySessionSyncExecutionResponse
+	if err := json.NewDecoder(response.Body).Decode(&executed); err != nil {
+		t.Fatalf("decode absent provider session workflow response: %v", err)
+	}
+	return executed
+}
+
+func assertAbsentProviderSessionRefsOnDispatchSummary(
+	t *testing.T,
+	summary factoryapi.FactorySessionDispatchSummary,
+) {
+	t.Helper()
+
+	if summary.ProviderSessionRefs != nil && len(*summary.ProviderSessionRefs) > 0 {
+		t.Fatalf(
+			"providerSessionRefs = %#v, want absent public refs without fabricated session identity",
+			summary.ProviderSessionRefs,
+		)
+	}
+}
+
+func assertAbsentProviderSessionRefsOnDispatchDetail(
+	t *testing.T,
+	detail factoryapi.FactoryDispatch,
+) {
+	t.Helper()
+
+	if detail.ProviderSessionRefs != nil && len(*detail.ProviderSessionRefs) > 0 {
+		t.Fatalf(
+			"providerSessionRefs = %#v, want absent public refs without fabricated session identity",
+			detail.ProviderSessionRefs,
 		)
 	}
 }

--- a/tests/functional/provider_sessions/association/association_test.go
+++ b/tests/functional/provider_sessions/association/association_test.go
@@ -36,6 +36,22 @@ const (
   });
   return { child };
 })();`
+
+	multiDispatchFirstChildLabel  = "association-multi-first"
+	multiDispatchFirstChildPrompt = "associate-multi-first-provider-session"
+	multiDispatchSecondChildLabel  = "association-multi-second"
+	multiDispatchSecondChildPrompt = "associate-multi-second-provider-session"
+	multiDispatchWorkflow          = `return (async function () {
+  const first = await agent.run({
+    prompt: "` + multiDispatchFirstChildPrompt + `",
+    label: "` + multiDispatchFirstChildLabel + `",
+  });
+  const second = await agent.run({
+    prompt: "` + multiDispatchSecondChildPrompt + `",
+    label: "` + multiDispatchSecondChildLabel + `",
+  });
+  return { first, second };
+})();`
 )
 
 // TestProviderSessionRefAssociatesWithOwningDispatchAndFactorySession proves that
@@ -195,6 +211,91 @@ func TestAbsentProviderSessionIsNotFabricated(t *testing.T) {
 	assertAbsentProviderSessionRefsOnDispatchDetail(t, detail)
 }
 
+// TestMultipleDispatchesKeepDistinctProviderSessionRefs proves that when a
+// Factory Session produces multiple provider-backed child dispatches, each
+// dispatch keeps its own providerSessionRef on public listing and detail
+// surfaces without colliding or sharing a single fabricated identity, and each
+// ref continues to join to its owning dispatch and the same Factory Session.
+func TestMultipleDispatchesKeepDistinctProviderSessionRefs(t *testing.T) {
+	t.Parallel()
+
+	dir := scaffoldMultiDispatchWorkflow(t)
+	runner := support.NewRecordingCommandRunner("unexpected live provider execution")
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		WaitForServiceModeRuntime: true,
+		UseMockWorkers:            true,
+		Edges:                     serviceedges.Edges{ProviderCommandRunner: runner},
+	})
+	t.Cleanup(func() { server.Stop(t) })
+
+	executed := startMultiDispatchWorkflow(t, server.URL(), dir)
+	if executed.Status != factoryapi.FactorySessionDurableLifecycleStatusSucceeded {
+		t.Fatalf("session status = %q, want SUCCEEDED", executed.Status)
+	}
+	if strings.TrimSpace(executed.SessionId) == "" {
+		t.Fatal("sessionId unexpectedly empty")
+	}
+	if runner.CallCount() != 0 {
+		t.Fatalf("provider command runner call count = %d, want 0 for fake child execution", runner.CallCount())
+	}
+
+	listed := listAssociationDispatches(t, server.URL(), executed.SessionId)
+	if listed.SessionId != executed.SessionId {
+		t.Fatalf(
+			"dispatch list sessionId = %q, want owning Factory Session %q",
+			listed.SessionId,
+			executed.SessionId,
+		)
+	}
+	if len(listed.Dispatches) != 2 {
+		t.Fatalf("dispatch count = %d, want exactly two provider-backed child dispatches", len(listed.Dispatches))
+	}
+
+	firstSummary, secondSummary := findMultiDispatchSummaries(t, listed.Dispatches)
+	firstRef := requireProviderSessionRefOnDispatchSummary(t, firstSummary)
+	secondRef := requireProviderSessionRefOnDispatchSummary(t, secondSummary)
+	if firstRef.Id == secondRef.Id {
+		t.Fatalf(
+			"providerSessionRef ids collided = %q for dispatches %q and %q",
+			firstRef.Id,
+			firstSummary.Id,
+			secondSummary.Id,
+		)
+	}
+	if firstRef.Id != "fake-provider-session-1" {
+		t.Fatalf(
+			"first dispatch providerSessionRef id = %q, want runtime-produced fake-provider-session-1",
+			firstRef.Id,
+		)
+	}
+	if secondRef.Id != "fake-provider-session-2" {
+		t.Fatalf(
+			"second dispatch providerSessionRef id = %q, want runtime-produced fake-provider-session-2",
+			secondRef.Id,
+		)
+	}
+	assertProviderSessionRefKind(t, firstRef)
+	assertProviderSessionRefKind(t, secondRef)
+
+	firstDetail := getAssociationDispatchDetail(t, server.URL(), executed.SessionId, firstSummary.Id)
+	secondDetail := getAssociationDispatchDetail(t, server.URL(), executed.SessionId, secondSummary.Id)
+	assertDispatchOwnsProviderSessionRef(
+		t,
+		executed.SessionId,
+		firstSummary.Id,
+		firstDetail,
+		firstRef,
+	)
+	assertDispatchOwnsProviderSessionRef(
+		t,
+		executed.SessionId,
+		secondSummary.Id,
+		secondDetail,
+		secondRef,
+	)
+}
+
 func scaffoldAbsentProviderSessionWorkflow(t *testing.T) string {
 	t.Helper()
 
@@ -270,6 +371,145 @@ func assertAbsentProviderSessionRefsOnDispatchDetail(
 		t.Fatalf(
 			"providerSessionRefs = %#v, want absent public refs without fabricated session identity",
 			detail.ProviderSessionRefs,
+		)
+	}
+}
+
+func scaffoldMultiDispatchWorkflow(t *testing.T) string {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, map[string]any{"name": "provider-session-association-multi"})
+	if err := os.WriteFile(filepath.Join(dir, "workflow.js"), []byte(multiDispatchWorkflow), 0o600); err != nil {
+		t.Fatalf("write multi-dispatch workflow: %v", err)
+	}
+	return dir
+}
+
+func startMultiDispatchWorkflow(
+	t *testing.T,
+	serverURL string,
+	dir string,
+) factoryapi.FactorySessionSyncExecutionResponse {
+	t.Helper()
+
+	workflowPath := filepath.Join(dir, "workflow.js")
+	payload, err := json.Marshal(factoryapi.FactorySessionExecutionRequest{
+		RequestId: "provider-session-association-multi",
+		Source: factoryapi.FactorySessionExecutionSource{
+			Kind:         factoryapi.FactorySessionExecutionSourceKindWorkflowFile,
+			WorkflowFile: &workflowPath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal multi-dispatch workflow request: %v", err)
+	}
+	endpoint := strings.TrimSuffix(serverURL, "/") + "/factory-sessions/sync"
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("build multi-dispatch workflow request: %v", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("start multi-dispatch workflow: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		var body bytes.Buffer
+		_, _ = body.ReadFrom(response.Body)
+		t.Fatalf("start multi-dispatch workflow status = %d: %s", response.StatusCode, body.String())
+	}
+	var executed factoryapi.FactorySessionSyncExecutionResponse
+	if err := json.NewDecoder(response.Body).Decode(&executed); err != nil {
+		t.Fatalf("decode multi-dispatch workflow response: %v", err)
+	}
+	return executed
+}
+
+func findMultiDispatchSummaries(
+	t *testing.T,
+	dispatches []factoryapi.FactorySessionDispatchSummary,
+) (factoryapi.FactorySessionDispatchSummary, factoryapi.FactorySessionDispatchSummary) {
+	t.Helper()
+
+	var firstSummary factoryapi.FactorySessionDispatchSummary
+	var secondSummary factoryapi.FactorySessionDispatchSummary
+	foundFirst := false
+	foundSecond := false
+	for _, summary := range dispatches {
+		if summary.Label == nil {
+			t.Fatalf("dispatch %q label unexpectedly nil", summary.Id)
+		}
+		switch *summary.Label {
+		case multiDispatchFirstChildLabel:
+			if foundFirst {
+				t.Fatalf("found duplicate first multi-dispatch label %q", multiDispatchFirstChildLabel)
+			}
+			firstSummary = summary
+			foundFirst = true
+		case multiDispatchSecondChildLabel:
+			if foundSecond {
+				t.Fatalf("found duplicate second multi-dispatch label %q", multiDispatchSecondChildLabel)
+			}
+			secondSummary = summary
+			foundSecond = true
+		default:
+			t.Fatalf("dispatch label = %q, want %q or %q", *summary.Label, multiDispatchFirstChildLabel, multiDispatchSecondChildLabel)
+		}
+		if strings.TrimSpace(summary.Id) == "" {
+			t.Fatal("dispatch id unexpectedly empty on public dispatch summary")
+		}
+		if summary.Status != factoryapi.FactoryDispatchStatusCOMPLETED {
+			t.Fatalf("dispatch %q status = %q, want COMPLETED", summary.Id, summary.Status)
+		}
+	}
+	if !foundFirst || !foundSecond {
+		t.Fatalf(
+			"multi-dispatch summaries incomplete: foundFirst=%t foundSecond=%t",
+			foundFirst,
+			foundSecond,
+		)
+	}
+	return firstSummary, secondSummary
+}
+
+func assertProviderSessionRefKind(t *testing.T, ref factoryapi.LoadableProviderSessionRef) {
+	t.Helper()
+
+	if ref.Kind != factoryapi.LoadableProviderSessionKindSessionID {
+		t.Fatalf("providerSessionRef kind = %q, want session_id", ref.Kind)
+	}
+}
+
+func assertDispatchOwnsProviderSessionRef(
+	t *testing.T,
+	factorySessionID string,
+	dispatchID string,
+	detail factoryapi.FactoryDispatch,
+	expectedRef factoryapi.LoadableProviderSessionRef,
+) {
+	t.Helper()
+
+	if detail.SessionId != factorySessionID {
+		t.Fatalf(
+			"dispatch detail sessionId = %q, want owning Factory Session %q",
+			detail.SessionId,
+			factorySessionID,
+		)
+	}
+	if detail.Id != dispatchID {
+		t.Fatalf(
+			"dispatch detail id = %q, want same owning dispatch %q from listing",
+			detail.Id,
+			dispatchID,
+		)
+	}
+	detailRef := requireProviderSessionRefOnDispatchDetail(t, detail)
+	if detailRef.Id != expectedRef.Id {
+		t.Fatalf(
+			"dispatch detail providerSessionRef id = %q, want same ref %q from listing",
+			detailRef.Id,
+			expectedRef.Id,
 		)
 	}
 }

--- a/tests/functional/provider_sessions/association/association_test.go
+++ b/tests/functional/provider_sessions/association/association_test.go
@@ -1,0 +1,226 @@
+// Package association owns functional coverage for Provider Session ref correlation
+// on public Factory Session dispatch projections.
+package association_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	associationChildLabel  = "association-child"
+	associationChildPrompt = "associate-provider-session"
+	associationWorkflow    = `return (async function () {
+  const child = await agent.run({
+    prompt: "` + associationChildPrompt + `",
+    label: "` + associationChildLabel + `",
+  });
+  return { child };
+})();`
+)
+
+// TestProviderSessionRefAssociatesWithOwningDispatchAndFactorySession proves that
+// after a Factory Session produces a provider-backed child dispatch, the public
+// dispatch listing and dispatch detail surfaces expose providerSessionRefs that
+// join to the owning dispatch identifier and the same Factory Session identifier.
+func TestProviderSessionRefAssociatesWithOwningDispatchAndFactorySession(t *testing.T) {
+	t.Parallel()
+
+	dir := scaffoldAssociationWorkflow(t)
+	runner := support.NewRecordingCommandRunner("unexpected live provider execution")
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		WaitForServiceModeRuntime: true,
+		UseMockWorkers:            true,
+		Edges:                     serviceedges.Edges{ProviderCommandRunner: runner},
+	})
+	t.Cleanup(func() { server.Stop(t) })
+
+	executed := startAssociationWorkflow(t, server.URL(), dir)
+	if executed.Status != factoryapi.FactorySessionDurableLifecycleStatusSucceeded {
+		t.Fatalf("session status = %q, want SUCCEEDED", executed.Status)
+	}
+	if strings.TrimSpace(executed.SessionId) == "" {
+		t.Fatal("sessionId unexpectedly empty")
+	}
+	if runner.CallCount() != 0 {
+		t.Fatalf("provider command runner call count = %d, want 0 for fake child execution", runner.CallCount())
+	}
+
+	listed := listAssociationDispatches(t, server.URL(), executed.SessionId)
+	if listed.SessionId != executed.SessionId {
+		t.Fatalf(
+			"dispatch list sessionId = %q, want owning Factory Session %q",
+			listed.SessionId,
+			executed.SessionId,
+		)
+	}
+	if len(listed.Dispatches) != 1 {
+		t.Fatalf("dispatch count = %d, want exactly one provider-backed child dispatch", len(listed.Dispatches))
+	}
+
+	summary := listed.Dispatches[0]
+	if strings.TrimSpace(summary.Id) == "" {
+		t.Fatal("dispatch id unexpectedly empty on public dispatch summary")
+	}
+	if summary.Status != factoryapi.FactoryDispatchStatusCOMPLETED {
+		t.Fatalf("dispatch status = %q, want COMPLETED", summary.Status)
+	}
+	if summary.Label == nil || *summary.Label != associationChildLabel {
+		t.Fatalf("dispatch label = %#v, want %q", summary.Label, associationChildLabel)
+	}
+
+	providerRef := requireProviderSessionRefOnDispatchSummary(t, summary)
+	if providerRef.Id != "fake-provider-session-1" {
+		t.Fatalf(
+			"providerSessionRef id = %q, want runtime-produced fake-provider-session-1",
+			providerRef.Id,
+		)
+	}
+	if providerRef.Kind != factoryapi.LoadableProviderSessionKindSessionID {
+		t.Fatalf("providerSessionRef kind = %q, want session_id", providerRef.Kind)
+	}
+
+	detail := getAssociationDispatchDetail(t, server.URL(), executed.SessionId, summary.Id)
+	if detail.SessionId != executed.SessionId {
+		t.Fatalf(
+			"dispatch detail sessionId = %q, want owning Factory Session %q",
+			detail.SessionId,
+			executed.SessionId,
+		)
+	}
+	if detail.Id != summary.Id {
+		t.Fatalf(
+			"dispatch detail id = %q, want same owning dispatch %q from listing",
+			detail.Id,
+			summary.Id,
+		)
+	}
+	detailRef := requireProviderSessionRefOnDispatchDetail(t, detail)
+	if detailRef.Id != providerRef.Id {
+		t.Fatalf(
+			"dispatch detail providerSessionRef id = %q, want same ref %q from listing",
+			detailRef.Id,
+			providerRef.Id,
+		)
+	}
+}
+
+func scaffoldAssociationWorkflow(t *testing.T) string {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, map[string]any{"name": "provider-session-association"})
+	if err := os.WriteFile(filepath.Join(dir, "workflow.js"), []byte(associationWorkflow), 0o600); err != nil {
+		t.Fatalf("write association workflow: %v", err)
+	}
+	return dir
+}
+
+func startAssociationWorkflow(
+	t *testing.T,
+	serverURL string,
+	dir string,
+) factoryapi.FactorySessionSyncExecutionResponse {
+	t.Helper()
+
+	workflowPath := filepath.Join(dir, "workflow.js")
+	payload, err := json.Marshal(factoryapi.FactorySessionExecutionRequest{
+		RequestId: "provider-session-association",
+		Source: factoryapi.FactorySessionExecutionSource{
+			Kind:         factoryapi.FactorySessionExecutionSourceKindWorkflowFile,
+			WorkflowFile: &workflowPath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal association workflow request: %v", err)
+	}
+	endpoint := strings.TrimSuffix(serverURL, "/") + "/factory-sessions/sync"
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("build association workflow request: %v", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("start association workflow: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		var body bytes.Buffer
+		_, _ = body.ReadFrom(response.Body)
+		t.Fatalf("start association workflow status = %d: %s", response.StatusCode, body.String())
+	}
+	var executed factoryapi.FactorySessionSyncExecutionResponse
+	if err := json.NewDecoder(response.Body).Decode(&executed); err != nil {
+		t.Fatalf("decode association workflow response: %v", err)
+	}
+	return executed
+}
+
+func listAssociationDispatches(
+	t *testing.T,
+	serverURL string,
+	sessionID string,
+) factoryapi.ListFactorySessionDispatchesResponse {
+	t.Helper()
+
+	return support.GetJSON[factoryapi.ListFactorySessionDispatchesResponse](
+		t,
+		strings.TrimSuffix(serverURL, "/")+"/factory-sessions/"+sessionID+"/dispatches",
+	)
+}
+
+func getAssociationDispatchDetail(
+	t *testing.T,
+	serverURL string,
+	sessionID string,
+	dispatchID string,
+) factoryapi.FactoryDispatch {
+	t.Helper()
+
+	return support.GetJSON[factoryapi.FactoryDispatch](
+		t,
+		strings.TrimSuffix(serverURL, "/")+"/factory-sessions/"+sessionID+"/dispatches/"+dispatchID,
+	)
+}
+
+func requireProviderSessionRefOnDispatchSummary(
+	t *testing.T,
+	summary factoryapi.FactorySessionDispatchSummary,
+) factoryapi.LoadableProviderSessionRef {
+	t.Helper()
+
+	if summary.ProviderSessionRefs == nil || len(*summary.ProviderSessionRefs) != 1 {
+		t.Fatalf("providerSessionRefs = %#v, want exactly one public ref", summary.ProviderSessionRefs)
+	}
+	ref := (*summary.ProviderSessionRefs)[0]
+	if strings.TrimSpace(ref.Id) == "" {
+		t.Fatalf("providerSessionRef = %#v, want non-empty public session identity", ref)
+	}
+	return ref
+}
+
+func requireProviderSessionRefOnDispatchDetail(
+	t *testing.T,
+	detail factoryapi.FactoryDispatch,
+) factoryapi.LoadableProviderSessionRef {
+	t.Helper()
+
+	if detail.ProviderSessionRefs == nil || len(*detail.ProviderSessionRefs) != 1 {
+		t.Fatalf("providerSessionRefs = %#v, want exactly one public ref", detail.ProviderSessionRefs)
+	}
+	ref := (*detail.ProviderSessionRefs)[0]
+	if strings.TrimSpace(ref.Id) == "" {
+		t.Fatalf("providerSessionRef = %#v, want non-empty public session identity", ref)
+	}
+	return ref
+}


### PR DESCRIPTION
{
  "project": "Provider Session Association Functional Coverage",
  "branchName": "ft-wave2-provider-sessions-association",
  "description": "Implement only tests/functional/provider_sessions/association/association_test.go so public Provider Session association / dispatch projection boundaries prove a Provider Session ref associates with its owning dispatch and Factory Session, an absent Provider Session is not fabricated, and multiple dispatches keep distinct Provider Session refs—without inventing migration-ledger deletion obligations or provider metadata, and without implementing response_exec_metadata_test.go or details/* cells.",
  "context": {
    "customerAsk": "Implement only tests/functional/provider_sessions/association/association_test.go. Through public Provider Session association / dispatch projection boundaries, prove: (1) TestProviderSessionRefAssociatesWithOwningDispatchAndFactorySession; (2) TestAbsentProviderSessionIsNotFabricated; (3) TestMultipleDispatchesKeepDistinctProviderSessionRefs. Do not invent migration-ledger deletion obligations when none map to this destination. Do not invent provider metadata; do not implement response_exec_metadata_test.go or details/* cells. Avoid service/internal Petri imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for Provider Session association does not exist yet even though provider_sessions/association is free while details/codex remains mid-pipeline elsewhere. Nearby planned cells prove provider details and response-exec golden metadata, so maintainers lack a focused, catalogued association proof that public projections bind a Provider Session ref to its owning dispatch and Factory Session, omit fabricated sessions when absent, and keep distinct refs across multiple dispatches—without inventing ledger deletion obligations or provider metadata, and without widening into held response_exec_metadata_test.go.",
    "solution": "Implement the three checklist scenarios in tests/functional/provider_sessions/association/association_test.go through public Provider Session association / dispatch projection boundaries with customer-readable Go docs on every top-level Test. Assert owning-dispatch and Factory Session correlation for a present ref, non-fabrication when absent, and distinct refs across multiple dispatches; do not invent migration-ledger deletion obligations or provider metadata; leave held response_exec_metadata_test.go and details/* untouched; apply only narrowly coupled ownership/coverage/catalog/migration metadata; and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/provider_sessions/association/association_test.go exists as the provider-sessions-owned functional cell and covers owning-dispatch/Factory Session association, non-fabrication of absent Provider Sessions, and distinct refs across multiple dispatches.",
    "Through public Provider Session association / dispatch projection boundaries, a present Provider Session ref associates with its owning dispatch and Factory Session (public correlation fields join correctly).",
    "Through those same public surfaces, an absent Provider Session is not fabricated (no invented session identity / detail when the fixture does not supply one).",
    "Through those same public surfaces, multiple dispatches keep distinct Provider Session refs (refs attributable to different dispatches do not collide or share a fabricated identity).",
    "No migration-ledger deletion obligations are invented for this destination when none currently map to it (checklist-authoritative); provider metadata is not invented; held sibling response_exec_metadata_test.go and details/* cells stay untouched; only narrowly coupled ownership/coverage/catalog metadata for this cell are updated; coverage uses public association / dispatch projection boundaries / approved helpers and does not import service implementations or internal Petri primitives as the proof owner, with customer-readable Go docs on every top-level Test*.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave2-provider-sessions-association-001",
      "title": "Prove Provider Session ref associates with owning dispatch and Factory Session",
      "description": "As an API or CLI customer inspecting a Factory Session that produced a provider-backed dispatch, I want the public Provider Session ref on association / dispatch projections to join to the owning dispatch and Factory Session so I can correlate provider activity without private runtime handles.",
      "acceptanceCriteria": [
        "tests/functional/provider_sessions/association/association_test.go includes TestProviderSessionRefAssociatesWithOwningDispatchAndFactorySession (or equivalent top-level name matching the checklist intent).",
        "Through public Provider Session association / dispatch projection boundaries, after a session produces at least one dispatch with a present Provider Session ref (minimal fixture that supplies a real public ref, not invented mapper-expected detail), the projected providerSessionRefs (or equivalent public association surface) joins to the owning dispatch identifier and the owning Factory Session identifier.",
        "Observable public correlation is sufficient for a customer to join the Provider Session ref to that same dispatch and Factory Session without scraping private runtime state.",
        "Assertions stay on association / projection correlation at the public boundary and do not invent provider metadata, re-own provider detail loading (details/*), or response-exec golden survival (response_exec_metadata_test.go).",
        "The top-level test has a customer-readable Go doc comment describing the observable owning-dispatch and Factory Session association behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-provider-sessions-association-002",
      "title": "Prove absent Provider Session is not fabricated",
      "description": "As an API or CLI customer inspecting a dispatch that did not produce a Provider Session, I want public association / dispatch projections to omit fabricated Provider Session identity so clients do not treat missing provider sessions as real ones.",
      "acceptanceCriteria": [
        "The association cell includes TestAbsentProviderSessionIsNotFabricated (or equivalent top-level name matching the checklist intent).",
        "Through public Provider Session association / dispatch projection boundaries, a fixture path that does not supply a Provider Session yields no fabricated Provider Session ref / identity on the public projection (absent or empty public refs rather than an invented session id or detail payload).",
        "The absent path does not invent provider metadata (no mapper-generated expected session detail, no synthetic session identity presented as a real associated Provider Session).",
        "Assertions remain on non-fabrication at the public association / dispatch projection boundary and do not widen into provider detail loading (details/*) or response-exec golden metadata ownership.",
        "The top-level test has a customer-readable Go doc comment describing the observable absent-session non-fabrication contract.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-provider-sessions-association-003",
      "title": "Prove multiple dispatches keep distinct Provider Session refs",
      "description": "As an API or CLI customer inspecting a Factory Session with multiple provider-backed dispatches, I want each dispatch’s public Provider Session ref to remain distinct so I can correlate provider activity per dispatch without colliding identities.",
      "acceptanceCriteria": [
        "The association cell includes TestMultipleDispatchesKeepDistinctProviderSessionRefs (or equivalent top-level name matching the checklist intent).",
        "Through public Provider Session association / dispatch projection boundaries, a session that produces at least two dispatches with present Provider Session refs projects distinct refs attributable to those different dispatches (refs do not collide and are not replaced by a single shared fabricated identity).",
        "Each projected ref continues to associate with its own owning dispatch (and the shared Factory Session) without cross-dispatch ref swap.",
        "Assertions remain on distinct multi-dispatch ref projection at the public boundary and do not invent provider metadata or widen into details / response-exec golden cells.",
        "The top-level test has a customer-readable Go doc comment describing the observable distinct multi-dispatch Provider Session ref contract.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-provider-sessions-association-004",
      "title": "Close ownership metadata and verification gates",
      "description": "As a maintainer executing Wave 2 package-freed replenish, I want this cell catalogued with only narrowly coupled metadata updates and passing focused boundary/viz gates, without inventing migration-ledger deletion obligations or widening into held siblings, so association can terminal-complete cleanly while response_exec_metadata_test.go remains held.",
      "acceptanceCriteria": [
        "No migration-ledger deletion obligations are invented for tests/functional/provider_sessions/association/association_test.go when none currently map to this destination (checklist-authoritative).",
        "Provider metadata is not invented; held sibling response_exec_metadata_test.go and mid-pipeline details/* cells stay untouched.",
        "Only narrowly coupled ownership, coverage, or catalog metadata required for this cell are updated; neighboring provider-session cells are not rewritten beyond what is required to leave the package compiling and sharing support helpers safely.",
        "Focused package tests for tests/functional/provider_sessions/association pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as provider_sessions/association).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)