### PR TITLE
ft-encode-functional-test-preferences-standards

### DIFF
--- a/docs/internal/standards/code/code-review-standards.md
+++ b/docs/internal/standards/code/code-review-standards.md
@@ -2,7 +2,7 @@
 
 ---
 author: andreas abdi
-last modified: 2026, april, 18
+last modified: 2026, july, 28
 doc-id: STD-015
 ---
 
@@ -23,6 +23,12 @@ Every contributor **MUST** review this standard before conducting or requesting 
 - Reject feature PRs that include generated one-off artifacts or prohibited task-management files.
 - Request changes when new user-facing production UI copy bypasses the feature-owned localization catalog path or the repo's hardcoded-copy quality gate without a documented exception.
 - Request changes for unexplained stateful helper paths, hidden side effects, special-case subsystem dispatch, dead code, or Go functions longer than 80 lines without a documented exception.
+- Request changes when a functional-test PR violates any of the five functional-test construction preferences in [general-backend-standards.md §6](./general-backend-standards.md#6-testing-strategy-and-test-pyramid) without a documented, in-scope exception.
+- Request changes when functional tests bypass `root.BuildProcess` + `Process.Execute` by default or invoke a built `you` CLI without proving OS/process-boundary behavior that `BuildProcess` cannot express.
+- Request changes when functional tests use HTTP/API for ordinary customer flows without an API-owned contract or explicit CLI+API parity justification.
+- Request changes when functional tests replace external effects outside `edges.Edges` or prefer custom in-process provider fakes over `ProviderCommandRunner` and other command-runner edge mocks.
+- Request changes when functional tests use `--with-mock-workers` / `MockWorkers` outside `tests/functional/workers/mock/...` cells that own the workers/mock feature.
+- Request changes when functional tests add sleeps or timeout-padded wait helpers as the default synchronization strategy without in-code justification for why deterministic observation or edge mocking cannot substitute.
 
 ## Review Checklist
 
@@ -35,6 +41,7 @@ Before approval, reviewers **SHOULD** confirm:
 - New or changed behavior has appropriate tests.
 - Review comments are clearly marked as blocking or non-blocking.
 - AI-generated code, if present, has been checked against real APIs, real behavior, and project conventions.
+- For PRs that change functional tests under `tests/functional/...`, the five construction preferences from [general-backend-standards.md §6](./general-backend-standards.md#6-testing-strategy-and-test-pyramid) are satisfied: `root.BuildProcess` + `Process.Execute` by default (built CLI only for OS/process-boundary proof), CLI-over-API for ordinary flows, external effects replaced only through `edges.Edges` with `ProviderCommandRunner`/command-runner edge mocks preferred, mocked Codex over MockWorkers except in workers/mock feature cells, and RC-fix over sleeps or timeout-padded wait helpers unless justified in-code.
 
 ## Regulations
 
@@ -69,3 +76,13 @@ A reviewer **MUST** approve when the change is correct, well-tested, and conform
 ### 8. Apply Additional Scrutiny to AI-Generated Code
 
 AI-generated code **MUST** receive the same or greater scrutiny as human-written code, especially for hallucinated APIs, stale patterns, hidden side effects, and subtle edge-case bugs.
+
+### 9. Enforce Functional-Test Construction Preferences
+
+When a PR changes functional tests, a reviewer **MUST** request changes if any of the five construction preferences in [general-backend-standards.md §6](./general-backend-standards.md#6-testing-strategy-and-test-pyramid) is violated without a documented, in-scope exception:
+
+1. Functional application tests **MUST** construct through `root.BuildProcess` and execute through `Process.Execute` by default. A built `you` CLI **MAY** be used only when the cell must prove OS/process-boundary behavior that `BuildProcess` cannot express.
+2. Functional tests **MUST** prefer public CLI invocation over HTTP/API for ordinary customer flows. HTTP or API entry **MAY** be used only for API-owned contracts or explicit CLI+API parity cells.
+3. External effects **MUST** be replaced only through `edges.Edges`. Functional tests **MUST** prefer `ProviderCommandRunner` and other command-runner edge mocks over custom in-process provider fakes.
+4. Functional tests **MUST** prefer mocked Codex or another real inference-provider variant through the command-runner edge and sanitized goldens over `--with-mock-workers` / `MockWorkers`, except for cells under `tests/functional/workers/mock/...` that own the workers/mock feature.
+5. Functional tests **MUST NOT** add sleeps or timeout-padded wait helpers as the default synchronization strategy. Any sleep, polling loop, or timeout-padded wait helper **MUST** include an in-code justification for why deterministic observation or edge mocking cannot substitute.

--- a/docs/internal/standards/code/general-backend-standards.md
+++ b/docs/internal/standards/code/general-backend-standards.md
@@ -2,7 +2,7 @@
 
 ---
 author: andreas abdi
-last modified: 2026, may, 27
+last modified: 2026, july, 27
 doc-id: STD-017
 ---
 
@@ -271,6 +271,25 @@ Rules:
   internal engine-state snapshot through functional support. Assertions
   **MUST** use public CLI, HTTP, MCP, Factory Session, Work, and Factory Event
   contracts or observations made by the injected external-effect edge.
+- Functional application tests **MUST** execute scenarios through
+  `Process.Execute` by default after constructing through `root.BuildProcess`.
+  They **MAY** invoke a built `you` CLI binary only when the cell must prove
+  OS/process-boundary behavior that `BuildProcess` cannot express.
+- Functional tests **MUST** prefer public CLI invocation over HTTP/API for
+  ordinary customer flows. HTTP or API entry **MAY** be used only for
+  API-owned contracts or explicit CLI+API parity cells.
+- External effects **MUST** be replaced only through `edges.Edges`. Functional
+  tests **MUST** prefer `ProviderCommandRunner` and other command-runner edge
+  mocks over custom in-process provider fakes.
+- Functional tests **MUST** prefer mocked Codex or another real
+  inference-provider variant through the command-runner edge and sanitized
+  goldens over `--with-mock-workers` / `MockWorkers`, except for cells under
+  `tests/functional/workers/mock/...` that own the workers/mock feature.
+- Functional tests **MUST NOT** add sleeps or timeout-padded wait helpers as the
+  default synchronization strategy. Prefer fixing readiness or latency root
+  causes first. Any sleep, polling loop, or timeout-padded wait helper **MUST**
+  include an in-code justification for why deterministic observation or edge
+  mocking cannot substitute.
 - Functional test sources **MUST** live under
   `tests/functional/<domain>/<subsection>/...`, where `<domain>` is a durable
   product-domain noun such as `transport`, `workers`, `orchestration`,

--- a/factory/workstations/review/AGENTS.md
+++ b/factory/workstations/review/AGENTS.md
@@ -21,6 +21,12 @@ You are processing work item {{ (index .Inputs 0).WorkID }} of type {{ (index .I
    - treat hallucinated APIs, stale patterns, hidden side effects, and subtle edge cases in AI-authored code as high-risk review targets
    - request changes for correctness issues, security issues, missing required tests, prompt-rule violations, hidden side effects, dead code, or oversized unclear helpers
    - approve only when the change is correct, adequately tested, and within the defined expectations
+   - for PRs that change functional tests under `tests/functional/...`, apply the five construction preferences from [general-backend-standards.md §6](../../../docs/internal/standards/code/general-backend-standards.md#6-testing-strategy-and-test-pyramid) and request changes (`BLOCKING`) when any preference is violated without a documented, in-scope exception:
+     - functional tests **MUST** construct through `root.BuildProcess` + `Process.Execute` by default; a built `you` CLI **MAY** be used only when the cell must prove OS/process-boundary behavior that `BuildProcess` cannot express
+     - functional tests **MUST** prefer public CLI invocation over HTTP/API for ordinary customer flows; HTTP or API entry **MAY** be used only for API-owned contracts or explicit CLI+API parity cells
+     - external effects **MUST** be replaced only through `edges.Edges`; functional tests **MUST** prefer `ProviderCommandRunner` and other command-runner edge mocks over custom in-process provider fakes
+     - functional tests **MUST** prefer mocked Codex or another real inference-provider variant through the command-runner edge and sanitized goldens over `--with-mock-workers` / `MockWorkers`, except for cells under `tests/functional/workers/mock/...` that own the workers/mock feature
+     - functional tests **MUST NOT** add sleeps or timeout-padded wait helpers as the default synchronization strategy; any sleep, polling loop, or timeout-padded wait helper **MUST** include an in-code justification for why deterministic observation or edge mocking cannot substitute
 4. Run: gh pr diff $prNumber  — to see the full diff
 5. Read the changed files to understand the implementation in full
 6. Read surrounding codebase code (the code the PR touches) to check for pattern conformance


### PR DESCRIPTION
{
  "project": "Encode Functional-Test Preferences into Backend and Review Standards",
  "branchName": "ft-encode-functional-test-preferences-standards",
  "description": "Encode five normative functional-test preferences (BuildProcess-first, CLI-over-API, ProviderCommandRunner/edge mocks, mocked Codex over MockWorkers, RC-fix over sleeps) as MUST rules in backend testing standards and as blocking review checks in code-review standards and the review workstation agent, docs-only for the three target files.",
  "context": {
    "customerAsk": "Update docs/internal/standards/code/general-backend-standards.md testing strategy so functional tests MUST follow five preferences: BuildProcess-first (built CLI only when required), CLI-over-API for ordinary flows, ProviderCommandRunner/edge mocks over custom provider fakes, mocked Codex over MockWorkers except workers/mock cells, and RC-fix over sleeps/timeout helpers. Mirror the same five preferences as blocking review checks in docs/internal/standards/code/code-review-standards.md and factory/workstations/review/AGENTS.md. Keep the change docs-only for these three files; update last-modified metadata; do not rewrite Wave 2 functional test cells.",
    "problem": "Backend testing standards only partially encode the functional-test contract (BuildProcess and edges.Edges exist; CLI preference, command-runner mocking, Codex-over-MockWorkers, and no-sleep rules do not). Code-review standards and the review workstation do not treat the five preferences as blocking checks, so functional-test PRs can still ship non-compliant harnesses while Wave 2 expansion continues.",
    "solution": "Extend general-backend-standards.md §6 with the five MUST preferences and exceptions; mirror them as blocking Quick Rules/Review Checklist items in code-review-standards.md; add matching Step 1 request-changes rules in factory/workstations/review/AGENTS.md; update last-modified metadata; leave tests/functional untouched."
  },
  "acceptanceCriteria": [
    "general-backend-standards.md testing strategy states all five functional-test preferences as MUST rules with the agreed exceptions (built CLI only for OS/process-boundary proof; API only for API-owned or CLI+API parity cells; MockWorkers only for workers/mock feature cells; any sleep/timeout helper justified in-code)",
    "code-review-standards.md Quick Rules and/or Review Checklist treat violations of those five preferences on functional-test PRs as request-changes / blocking review outcomes",
    "factory/workstations/review/AGENTS.md Step 1 review rules instruct the reviewer agent to request changes when functional-test PRs violate any of the five preferences",
    "Last-modified metadata is updated on edited standards documents that carry that frontmatter",
    "Diff is limited to the three target files; no Wave 2 / tests/functional cell rewrites or unrelated cleanup",
    "A maintainer reading the three updated files can identify the same five preferences in backend standards and both review surfaces",
    "Typecheck, lint, and relevant tests pass for the docs-only change set (or are explicitly N/A where no code/test surface changed)"
  ],
  "userStories": [
    {
      "id": "ft-encode-functional-test-preferences-standards-001",
      "title": "Encode five preferences in backend testing standards",
      "description": "As a backend author, I want general-backend-standards.md testing strategy to state the five functional-test preferences as MUST rules so new functional cells follow the expansion contract by default.",
      "acceptanceCriteria": [
        "§6 (or adjacent testing-strategy rules) states functional tests MUST construct via root.BuildProcess + Process.Execute by default, and MAY use a built you CLI only when the cell must prove OS/process-boundary behavior BuildProcess cannot express",
        "Functional tests MUST prefer public CLI invocation over HTTP/API for ordinary customer flows; HTTP/API is allowed only for API-owned contracts or explicit CLI+API parity cells",
        "External effects MUST be replaced only through edges.Edges, preferring ProviderCommandRunner / command-runner edge mocks over custom in-process provider fakes",
        "Functional tests MUST prefer mocked Codex (or another real inference-provider variant via the command-runner edge / sanitized goldens) over --with-mock-workers / MockWorkers, except for cells that own the workers/mock feature",
        "Functional tests MUST NOT add sleeps or timeout-padded wait helpers as the default synchronization strategy; prefer fixing readiness/latency root causes, and any sleep/helper MUST be justified in-code",
        "Existing BuildProcess / edges.Edges requirements remain intact and are not weakened",
        "Document last-modified metadata is updated",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-encode-functional-test-preferences-standards-002",
      "title": "Mirror preferences as blocking code-review checks",
      "description": "As a code reviewer, I want code-review-standards.md to treat violations of the five functional-test preferences as blocking so functional-test PRs cannot be approved while ignoring the backend testing contract.",
      "acceptanceCriteria": [
        "Quick Rules and/or Review Checklist explicitly cover the five preferences for functional-test changes",
        "Review guidance states reviewers MUST request changes when a functional-test PR violates any of the five preferences without a documented, in-scope exception",
        "The review wording stays aligned with the backend-standards encoding (same exceptions: OS/process-boundary CLI, API-owned/parity cells, workers/mock feature cells, justified sleep/helper)",
        "Document last-modified metadata is updated",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-encode-functional-test-preferences-standards-003",
      "title": "Mirror preferences in review workstation Step 1 rules",
      "description": "As the review workstation agent, I want Step 1 review rules in factory/workstations/review/AGENTS.md to require request-changes when functional-test PRs violate the five preferences so automated review enforces the same contract as human reviewers.",
      "acceptanceCriteria": [
        "Step 1 review rules list the five functional-test preferences as checks to apply when the PR changes functional tests",
        "The rules instruct the agent to request changes (blocking) when any preference is violated without a documented, in-scope exception",
        "The agent guidance stays aligned with backend and code-review standards wording for the five preferences and exceptions",
        "No unrelated review-workflow rewrite beyond adding these functional-test preference checks",
        "Typecheck passes"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-encode-functional-test-preferences-standards-004",
      "title": "Confirm docs-only scope and cross-file preference parity",
      "description": "As a maintainer, I want the finished change set limited to the three target guidance files and to show the same five preferences on all three surfaces so Wave 2 work is unaffected and review/author guidance cannot drift.",
      "acceptanceCriteria": [
        "Diff touches only docs/internal/standards/code/general-backend-standards.md, docs/internal/standards/code/code-review-standards.md, and factory/workstations/review/AGENTS.md",
        "No tests/functional cell, harness, or Wave 2 batch file is rewritten in this task",
        "A reader can identify all five preferences in each of the three updated files",
        "Preference exceptions are consistent across the three files",
        "Typecheck passes"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)