### PR TITLE
ft-wave2-factory-definitions-defaults

### DIFF
--- a/docs/internal/baselines/functional-undocumented-tests.json
+++ b/docs/internal/baselines/functional-undocumented-tests.json
@@ -411,6 +411,42 @@
       "name": "TestOperatorConfigCore_PromptedAndPresuppliedUpdatesShareAtomicBehavior"
     },
     {
+      "file": "operator_settings/servicewire/servicewire_composition_test.go",
+      "name": "TestRegisterDefaultsResolutionFromHomeRestoresAdapterOwnership"
+    },
+    {
+      "file": "operator_settings/servicewire/servicewire_composition_test.go",
+      "name": "TestResolveFromHomeFallbackPreservesAcceptedSemantics"
+    },
+    {
+      "file": "operator_settings/servicewire/servicewire_composition_test.go",
+      "name": "TestResolveFromHomeRejectsMissingFilesystemPorts"
+    },
+    {
+      "file": "operator_settings/servicewire/servicewire_composition_test.go",
+      "name": "TestResolveFromHomeUsesSettingsAdapterOwnershipPath"
+    },
+    {
+      "file": "operator_settings/servicewire/servicewire_composition_test.go",
+      "name": "TestServiceFromConfigDocumentConstructsFromDocumentPorts"
+    },
+    {
+      "file": "operator_settings/servicewire/servicewire_composition_test.go",
+      "name": "TestServiceFromConfigDocumentRejectsMissingDocumentPorts"
+    },
+    {
+      "file": "operator_settings/servicewire/servicewire_composition_test.go",
+      "name": "TestServiceFromHomePortsConstructsSettingsRoot"
+    },
+    {
+      "file": "operator_settings/servicewire/servicewire_composition_test.go",
+      "name": "TestServiceFromHomePortsRejectsMissingPorts"
+    },
+    {
+      "file": "operator_settings/servicewire/servicewire_composition_test.go",
+      "name": "TestServiceWireCompositionRootServesDocumentAndResolutionOperations"
+    },
+    {
       "file": "providers/cli_script_executor_test.go",
       "name": "TestScriptExecutor_ArgTemplating"
     },
@@ -1261,6 +1297,18 @@
     {
       "file": "smoke/verify_fast_command_smoke_test.go",
       "name": "TestVerifyPRInferenceCommandSmoke_StaysOutsideRequiredPRAndExtendedTiers"
+    },
+    {
+      "file": "work/recordings/recordings_read_test.go",
+      "name": "TestGetWorkFromRecordingsRootUsesRecordingsServiceRoot"
+    },
+    {
+      "file": "work/recordings/recordings_read_test.go",
+      "name": "TestRecordingsBackedWorkReadsMapRichWorldState"
+    },
+    {
+      "file": "work/recordings/recordings_read_test.go",
+      "name": "TestRecordingsBackedWorkReadsSurfaceTypedProjectionFailures"
     },
     {
       "file": "workflow/code_review_loop_long_test.go",

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -489,6 +489,13 @@ Wave 0 functional-tests-expansion planning authority lives under
   `support.RunFactoryToCompletionWithEdgesAndWork` and terminal assertions via
   `support.CountWorkAtCustomerState`; catalog metadata infers domain
   `factory/definitions`.
+  `tests/functional/factory/definitions/defaults_test.go` owns operator
+  default provider/model supply, Factory-authored override precedence, and
+  single-discovered-provider fallback through `support.BuildProcess` +
+  `support.StartProcessCommand` with operator `HOME` global config or
+  `edges.WorkersExecutableLocator`, asserting resolved selection via
+  `support.NewShapedProviderCommandRunner` call records; catalog metadata
+  infers domain `factory/definitions`.
   `make pkg-structure` enforces the domain-mirrored functional layout
   `tests/functional/<domain>/<subsection>/...`: new shallow, catch-all, or
   unclassified scenario packages are blocking, while existing nonconforming

--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -1189,31 +1189,31 @@
       "deletion_only_batch": "n/a"
     },
     {
-      "source_path": "tests/functional/factory/packaged/catalog/discovery_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/catalog",
-      "scenario": "TestFactoryListHonorsPreCanceledContextAtomically",
+      "source_path": "tests/functional/factory/definitions/defaults_test.go",
+      "package": "you-agent-factory/tests/functional/factory/definitions",
+      "scenario": "TestExplicitFactoryConfigOverridesGlobalDefaults",
       "lane": "short",
-      "destination": "tests/functional/factory/packaged/catalog/discovery_test.go",
+      "destination": "tests/functional/factory/definitions/defaults_test.go",
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
     },
     {
-      "source_path": "tests/functional/factory/packaged/catalog/discovery_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/catalog",
-      "scenario": "TestFactoryListProjectsEffectiveCatalogWithoutInitialization",
+      "source_path": "tests/functional/factory/definitions/defaults_test.go",
+      "package": "you-agent-factory/tests/functional/factory/definitions",
+      "scenario": "TestGlobalConfigSuppliesDefaultProviderAndModel",
       "lane": "short",
-      "destination": "tests/functional/factory/packaged/catalog/discovery_test.go",
+      "destination": "tests/functional/factory/definitions/defaults_test.go",
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
     },
     {
-      "source_path": "tests/functional/factory/packaged/catalog/discovery_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/catalog",
-      "scenario": "TestFactoryListReportsCatalogDiscoveryFailuresAtomically",
+      "source_path": "tests/functional/factory/definitions/defaults_test.go",
+      "package": "you-agent-factory/tests/functional/factory/definitions",
+      "scenario": "TestSingleDiscoveredProviderIsUsedWhenNoDefaultExists",
       "lane": "short",
-      "destination": "tests/functional/factory/packaged/catalog/discovery_test.go",
+      "destination": "tests/functional/factory/definitions/defaults_test.go",
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
@@ -1244,6 +1244,206 @@
       "scenario": "TestFactoryInitIsIdempotent",
       "lane": "short",
       "destination": "tests/functional/factory/definitions/init_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/catalog/discovery_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/catalog",
+      "scenario": "TestFactoryListHonorsPreCanceledContextAtomically",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/catalog/discovery_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/catalog/discovery_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/catalog",
+      "scenario": "TestFactoryListProjectsEffectiveCatalogWithoutInitialization",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/catalog/discovery_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/catalog/discovery_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/catalog",
+      "scenario": "TestFactoryListReportsCatalogDiscoveryFailuresAtomically",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/catalog/discovery_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/catalog/discovery_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/catalog",
+      "scenario": "TestNewEmbeddedFactoryRequiresFunctionalMatrixEntry",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/catalog/discovery_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/catalog/discovery_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/catalog",
+      "scenario": "TestPackagedFactoriesAPI_ReturnsPublishedCatalog",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/catalog/discovery_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/catalog/discovery_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/catalog",
+      "scenario": "TestPackagedFactoryCatalogHasUniqueStableNames",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/catalog/discovery_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/catalog/discovery_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/catalog",
+      "scenario": "TestPackagedFactoryCatalogListsEveryEmbeddedFactory",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/catalog/discovery_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/deep_research/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/deep_research",
+      "scenario": "TestPackagedDeepResearchOptionalInputsReachWorkers",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/deep_research/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/deep_research/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/deep_research",
+      "scenario": "TestPackagedDeepResearchRequiredInputCompletes",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/deep_research/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/deep_research/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/deep_research",
+      "scenario": "TestPackagedDeepResearchWorkerFailureReturnsFailedOutcome",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/deep_research/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/fusion/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/fusion",
+      "scenario": "TestPackagedFusionOptionalInputsReachWorkers",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/fusion/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/fusion/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/fusion",
+      "scenario": "TestPackagedFusionPartialWorkerFailureUsesDocumentedOutcome",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/fusion/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/fusion/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/fusion",
+      "scenario": "TestPackagedFusionRequiredInputCompletes",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/fusion/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/goal/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/goal",
+      "scenario": "TestPackagedGoalAcceptCompletesWithSummary",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/goal/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/goal/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/goal",
+      "scenario": "TestPackagedGoalPausedSubmissionResumes",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/goal/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/goal/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/goal",
+      "scenario": "TestPackagedGoalRejectRepeatsThenCompletes",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/goal/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/goal/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/goal",
+      "scenario": "TestPackagedGoalUnknownDecisionFails",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/goal/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/subagent/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/subagent",
+      "scenario": "TestPackagedSubagentChildFailureReturnsStableFailure",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/subagent/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/subagent/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/subagent",
+      "scenario": "TestPackagedSubagentReturnsChildResult",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/subagent/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/subagent/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/subagent",
+      "scenario": "TestPackagedSubagentStreamsChildResponseEvents",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/subagent/invocation_test.go",
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
@@ -1639,6 +1839,96 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
+      "scenario": "TestRegisterDefaultsResolutionFromHomeRestoresAdapterOwnership",
+      "lane": "short",
+      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
+      "scenario": "TestResolveFromHomeFallbackPreservesAcceptedSemantics",
+      "lane": "short",
+      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
+      "scenario": "TestResolveFromHomeRejectsMissingFilesystemPorts",
+      "lane": "short",
+      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
+      "scenario": "TestResolveFromHomeUsesSettingsAdapterOwnershipPath",
+      "lane": "short",
+      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
+      "scenario": "TestServiceFromConfigDocumentConstructsFromDocumentPorts",
+      "lane": "short",
+      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
+      "scenario": "TestServiceFromConfigDocumentRejectsMissingDocumentPorts",
+      "lane": "short",
+      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
+      "scenario": "TestServiceFromHomePortsConstructsSettingsRoot",
+      "lane": "short",
+      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
+      "scenario": "TestServiceFromHomePortsRejectsMissingPorts",
+      "lane": "short",
+      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
+      "scenario": "TestServiceWireCompositionRootServesDocumentAndResolutionOperations",
+      "lane": "short",
+      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/orchestration/javascript/composition/agent_test.go",
       "package": "you-agent-factory/tests/functional/orchestration/javascript/composition",
       "scenario": "TestJavaScriptAgentFailureReturnsStableFailureRecord",
@@ -1971,7 +2261,7 @@
     {
       "source_path": "tests/functional/orchestration/javascript/loading/typescript_test.go",
       "package": "you-agent-factory/tests/functional/orchestration/javascript/loading",
-      "scenario": "TestTypeScriptTypeOrSyntaxFailureReturnsCustomerDiagnostic",
+      "scenario": "TestTypeScriptSourceMapReportsAuthoredLocation",
       "lane": "short",
       "destination": "tests/functional/orchestration/javascript/loading/typescript_test.go",
       "catch_all": "none",
@@ -1981,7 +2271,7 @@
     {
       "source_path": "tests/functional/orchestration/javascript/loading/typescript_test.go",
       "package": "you-agent-factory/tests/functional/orchestration/javascript/loading",
-      "scenario": "TestTypeScriptSourceMapReportsAuthoredLocation",
+      "scenario": "TestTypeScriptTypeOrSyntaxFailureReturnsCustomerDiagnostic",
       "lane": "short",
       "destination": "tests/functional/orchestration/javascript/loading/typescript_test.go",
       "catch_all": "none",
@@ -2119,16 +2409,6 @@
       "deletion_only_batch": "n/a"
     },
     {
-      "source_path": "tests/functional/product/packaged_factory_guard_failure/packaged_factory_guard_failure_test.go",
-      "package": "you-agent-factory/tests/functional/product/packaged_factory_guard_failure",
-      "scenario": "TestInitUnknownPackagedFactoryFailsClosedWithCatalogInventory",
-      "lane": "short",
-      "destination": "tests/functional/product/packaged_factory_guard_failure/packaged_factory_guard_failure_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
       "source_path": "tests/functional/product/init_setup/init_setup_test.go",
       "package": "you-agent-factory/tests/functional/product/init_setup",
       "scenario": "TestInitInteractiveContextCancellationAtModelDoesNotWrite",
@@ -2239,6 +2519,16 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/product/packaged_factory_guard_failure/packaged_factory_guard_failure_test.go",
+      "package": "you-agent-factory/tests/functional/product/packaged_factory_guard_failure",
+      "scenario": "TestInitUnknownPackagedFactoryFailsClosedWithCatalogInventory",
+      "lane": "short",
+      "destination": "tests/functional/product/packaged_factory_guard_failure/packaged_factory_guard_failure_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/product/packaged_factory_portability/packaged_factory_portability_test.go",
       "package": "you-agent-factory/tests/functional/product/packaged_factory_portability",
       "scenario": "TestPackagedFactoryInitMaterialization_InvokesOutsideRepositoryWithBootstrapParity",
@@ -2247,6 +2537,36 @@
       "catch_all": "bootstrap_portability",
       "specialty_targets": "none",
       "deletion_only_batch": "bootstrap_portability-delete-05-factory-current"
+    },
+    {
+      "source_path": "tests/functional/provider_sessions/association/association_test.go",
+      "package": "you-agent-factory/tests/functional/provider_sessions/association",
+      "scenario": "TestAbsentProviderSessionIsNotFabricated",
+      "lane": "short",
+      "destination": "tests/functional/provider_sessions/association/association_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/provider_sessions/association/association_test.go",
+      "package": "you-agent-factory/tests/functional/provider_sessions/association",
+      "scenario": "TestMultipleDispatchesKeepDistinctProviderSessionRefs",
+      "lane": "short",
+      "destination": "tests/functional/provider_sessions/association/association_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/provider_sessions/association/association_test.go",
+      "package": "you-agent-factory/tests/functional/provider_sessions/association",
+      "scenario": "TestProviderSessionRefAssociatesWithOwningDispatchAndFactorySession",
+      "lane": "short",
+      "destination": "tests/functional/provider_sessions/association/association_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
     },
     {
       "source_path": "tests/functional/providers/cli_script_executor_test.go",
@@ -4129,6 +4449,56 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/sessions/controls/pause_resume_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/controls",
+      "scenario": "TestAPIInvalidLifecycleTransitionReturnsConflict",
+      "lane": "short",
+      "destination": "tests/functional/sessions/controls/pause_resume_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/sessions/controls/pause_resume_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/controls",
+      "scenario": "TestAPIPauseResumeCancelAndTerminateFactorySession",
+      "lane": "short",
+      "destination": "tests/functional/sessions/controls/pause_resume_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/sessions/controls/pause_resume_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/controls",
+      "scenario": "TestPauseResumeEmitsDurableLifecycleEvents",
+      "lane": "short",
+      "destination": "tests/functional/sessions/controls/pause_resume_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/sessions/controls/pause_resume_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/controls",
+      "scenario": "TestPausedFactorySessionBuffersSubmittedWork",
+      "lane": "short",
+      "destination": "tests/functional/sessions/controls/pause_resume_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/sessions/controls/pause_resume_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/controls",
+      "scenario": "TestResumedFactorySessionDrainsBufferedWorkInOrder",
+      "lane": "short",
+      "destination": "tests/functional/sessions/controls/pause_resume_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/sessions/execution/results_dispatches_test.go",
       "package": "you-agent-factory/tests/functional/sessions/execution",
       "scenario": "TestAPIDispatchListAndDetailExposePublicCorrelation",
@@ -4167,6 +4537,76 @@
       "catch_all": "runtime_api",
       "specialty_targets": "none",
       "deletion_only_batch": "runtime_api-delete-04-sessions"
+    },
+    {
+      "source_path": "tests/functional/sessions/mcp/controls_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/mcp",
+      "scenario": "TestMCPAsyncCancellationIsVisibleThroughAPI",
+      "lane": "short",
+      "destination": "tests/functional/sessions/mcp/controls_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/sessions/mcp/controls_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/mcp",
+      "scenario": "TestMCPAsyncFactorySessionCanBePolledToFailure",
+      "lane": "short",
+      "destination": "tests/functional/sessions/mcp/controls_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/sessions/mcp/controls_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/mcp",
+      "scenario": "TestMCPAsyncFactorySessionCanBePolledToSuccess",
+      "lane": "short",
+      "destination": "tests/functional/sessions/mcp/controls_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/sessions/mcp/controls_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/mcp",
+      "scenario": "TestMCPControlledSessionIsReadableThroughAPI",
+      "lane": "short",
+      "destination": "tests/functional/sessions/mcp/controls_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/sessions/mcp/controls_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/mcp",
+      "scenario": "TestMCPPauseResumeAndCancelTargetCanonicalFactorySession",
+      "lane": "short",
+      "destination": "tests/functional/sessions/mcp/controls_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/sessions/mcp/controls_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/mcp",
+      "scenario": "TestMCPSynchronousFactorySessionReturnsTerminalResult",
+      "lane": "short",
+      "destination": "tests/functional/sessions/mcp/controls_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/sessions/mcp/controls_test.go",
+      "package": "you-agent-factory/tests/functional/sessions/mcp",
+      "scenario": "TestMCPSynchronousFailureReturnsStructuredFailure",
+      "lane": "short",
+      "destination": "tests/functional/sessions/mcp/controls_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
     },
     {
       "source_path": "tests/functional/sessions/restart/logical_identity_test.go",
@@ -5339,6 +5779,176 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/transport/cli/process/context_cancellation_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLIContextCancellationEmitsNoSuccessResult",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/context_cancellation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/context_cancellation_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLIContextCancellationStopsExternalWork",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/context_cancellation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/exit_codes_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLIInterruptedExitCode",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/exit_codes_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/exit_codes_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLISuccessExitCode",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/exit_codes_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/exit_codes_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLIValidationFailureExitCode",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/exit_codes_test.go",
+      "catch_all": "none",
+      "specialty_targets": "test-built-cli-acceptance",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/exit_codes_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLIWorkerFailureExitCode",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/exit_codes_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/help_and_version_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLIHelpListsPublicCommandFamilies",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/help_and_version_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/help_and_version_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLISubcommandHelpUsesStableUsageAndExitZero",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/help_and_version_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/help_and_version_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLIVersionWritesOneMachineReadableVersion",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/help_and_version_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/stdin_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLIEmptyRequiredStdinFailsWithoutDispatch",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/stdin_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/stdin_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestRunReadsPromptFromStdin",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/stdin_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/stdin_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestSubmitBatchReadsJSONFromStdin",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/stdin_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/stdout_stderr_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLIFailureWritesDiagnosticToStderr",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/stdout_stderr_test.go",
+      "catch_all": "none",
+      "specialty_targets": "test-built-cli-acceptance",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/stdout_stderr_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLIQuietModeSuppressesNonResultNoise",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/stdout_stderr_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/stdout_stderr_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLISuccessWritesPrimaryResultOnlyToStdout",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/stdout_stderr_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/unknown_command_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLIUnknownCommandReturnsUsageExitCode",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/unknown_command_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/cli/process/unknown_command_test.go",
+      "package": "you-agent-factory/tests/functional/transport/cli/process",
+      "scenario": "TestCLIUnknownCommandWritesActionableStderr",
+      "lane": "short",
+      "destination": "tests/functional/transport/cli/process/unknown_command_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/transport/docs/topic_inventory_test.go",
       "package": "you-agent-factory/tests/functional/transport/docs",
       "scenario": "TestDocsTopicInventory_AliasesRemainQueryableThroughPackagedSurface",
@@ -5349,11 +5959,21 @@
       "deletion_only_batch": "n/a"
     },
     {
-      "source_path": "tests/functional/factory/packaged/catalog/discovery_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/catalog",
-      "scenario": "TestPackagedFactoriesAPI_ReturnsPublishedCatalog",
+      "source_path": "tests/functional/transport/http/server/concurrent_requests_test.go",
+      "package": "you-agent-factory/tests/functional/transport/http/server",
+      "scenario": "TestAPICancelledRequestDoesNotCancelUnrelatedSession",
       "lane": "short",
-      "destination": "tests/functional/factory/packaged/catalog/discovery_test.go",
+      "destination": "tests/functional/transport/http/server/concurrent_requests_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/http/server/concurrent_requests_test.go",
+      "package": "you-agent-factory/tests/functional/transport/http/server",
+      "scenario": "TestAPIConcurrentSessionRequestsRemainIsolated",
+      "lane": "short",
+      "destination": "tests/functional/transport/http/server/concurrent_requests_test.go",
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
@@ -5389,21 +6009,31 @@
       "deletion_only_batch": "n/a"
     },
     {
-      "source_path": "tests/functional/transport/http/server/concurrent_requests_test.go",
+      "source_path": "tests/functional/transport/http/server/generated_client_test.go",
       "package": "you-agent-factory/tests/functional/transport/http/server",
-      "scenario": "TestAPICancelledRequestDoesNotCancelUnrelatedSession",
+      "scenario": "TestGeneratedClientAndServerSchemaStayAligned",
       "lane": "short",
-      "destination": "tests/functional/transport/http/server/concurrent_requests_test.go",
+      "destination": "tests/functional/transport/http/server/generated_client_test.go",
+      "catch_all": "none",
+      "specialty_targets": "api-smoke,artifact-contract-closeout",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/transport/http/server/generated_client_test.go",
+      "package": "you-agent-factory/tests/functional/transport/http/server",
+      "scenario": "TestGeneratedClientDecodesRepresentativeStructuredError",
+      "lane": "short",
+      "destination": "tests/functional/transport/http/server/generated_client_test.go",
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
     },
     {
-      "source_path": "tests/functional/transport/http/server/concurrent_requests_test.go",
+      "source_path": "tests/functional/transport/http/server/generated_client_test.go",
       "package": "you-agent-factory/tests/functional/transport/http/server",
-      "scenario": "TestAPIConcurrentSessionRequestsRemainIsolated",
+      "scenario": "TestGeneratedClientStatusAndSessionRoundTrip",
       "lane": "short",
-      "destination": "tests/functional/transport/http/server/concurrent_requests_test.go",
+      "destination": "tests/functional/transport/http/server/generated_client_test.go",
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
@@ -5699,11 +6329,131 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/work/recordings/recordings_read_test.go",
+      "package": "you-agent-factory/tests/functional/work/recordings",
+      "lane": "short",
+      "destination": "wrong-layer: pss-cut-work-rec recordings-backed Work read coverage not yet catalogued in test-file-checklist. Replacement evidence owner: tests/functional/work/recordings/recordings_read_test.go.",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a",
+      "scenario": "TestGetWorkFromRecordingsRootUsesRecordingsServiceRoot"
+    },
+    {
+      "source_path": "tests/functional/work/recordings/recordings_read_test.go",
+      "package": "you-agent-factory/tests/functional/work/recordings",
+      "lane": "short",
+      "destination": "wrong-layer: pss-cut-work-rec recordings-backed Work read coverage not yet catalogued in test-file-checklist. Replacement evidence owner: tests/functional/work/recordings/recordings_read_test.go.",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a",
+      "scenario": "TestRecordingsBackedWorkReadsMapRichWorldState"
+    },
+    {
+      "source_path": "tests/functional/work/recordings/recordings_read_test.go",
+      "package": "you-agent-factory/tests/functional/work/recordings",
+      "lane": "short",
+      "destination": "wrong-layer: pss-cut-work-rec recordings-backed Work read coverage not yet catalogued in test-file-checklist. Replacement evidence owner: tests/functional/work/recordings/recordings_read_test.go.",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a",
+      "scenario": "TestRecordingsBackedWorkReadsSurfaceTypedProjectionFailures"
+    },
+    {
+      "source_path": "tests/functional/work/recordings/recordings_read_test.go",
+      "package": "you-agent-factory/tests/functional/work/recordings",
+      "lane": "short",
+      "destination": "wrong-layer: pss-cut-work-rec recordings-backed Work read coverage not yet catalogued in test-file-checklist. Replacement evidence owner: tests/functional/work/recordings/recordings_read_test.go.",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a",
+      "scenario": "TestRecordingsBackedWorkReadsUseRecordingsRootContract"
+    },
+    {
+      "source_path": "tests/functional/work/recovery/manual_move_test.go",
+      "package": "you-agent-factory/tests/functional/work/recovery",
+      "scenario": "TestAPIInvalidMoveReturnsConflictWithoutMutation",
+      "lane": "short",
+      "destination": "tests/functional/work/recovery/manual_move_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/work/recovery/manual_move_test.go",
+      "package": "you-agent-factory/tests/functional/work/recovery",
+      "scenario": "TestAPIMoveWorkResumesRecoverableFlow",
+      "lane": "short",
+      "destination": "tests/functional/work/recovery/manual_move_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/work/recovery/manual_move_test.go",
+      "package": "you-agent-factory/tests/functional/work/recovery",
+      "scenario": "TestFailedCascadeCanBeRecoveredByPublicWorkMove",
+      "lane": "short",
+      "destination": "tests/functional/work/recovery/manual_move_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/work/recovery/manual_move_test.go",
+      "package": "you-agent-factory/tests/functional/work/recovery",
+      "scenario": "TestTerminalFailedWorkCannotBeRedispatchedIllegally",
+      "lane": "short",
+      "destination": "tests/functional/work/recovery/manual_move_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/work/submission/batch_inputs_test.go",
+      "package": "you-agent-factory/tests/functional/work/submission",
+      "scenario": "TestWorkBatchAcceptsInlineFileAndStdinShapes",
+      "lane": "short",
+      "destination": "tests/functional/work/submission/batch_inputs_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/work/submission/batch_inputs_test.go",
+      "package": "you-agent-factory/tests/functional/work/submission",
+      "scenario": "TestWorkBatchRejectsUnknownTypeWithoutPartialMutation",
+      "lane": "short",
+      "destination": "tests/functional/work/submission/batch_inputs_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/work/submission/batch_inputs_test.go",
+      "package": "you-agent-factory/tests/functional/work/submission",
+      "scenario": "TestWorkBatchSelectsDefaultAndExplicitWorkTypes",
+      "lane": "short",
+      "destination": "tests/functional/work/submission/batch_inputs_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/work/visualization/dependency_graph_test.go",
       "package": "you-agent-factory/tests/functional/work/visualization",
       "scenario": "TestWorkVisualizeProducesDeterministicGraph",
       "lane": "short",
       "destination": "tests/functional/work/visualization/dependency_graph_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/workers/agent/root_build_test.go",
+      "package": "you-agent-factory/tests/functional/workers/agent",
+      "scenario": "TestAgentRunnerDeliveryRemainsInertThroughRootBuildProcessConstruction",
+      "lane": "short",
+      "destination": "wrong-layer: package-integration \u2014 root.BuildProcess and Providers wire composition smoke without proving a customer product scenario. Replacement evidence owner: pkg/root and pkg/services/providers/wire package-integration tests.",
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
@@ -5734,6 +6484,26 @@
       "scenario": "TestAgyGoldenTimeout",
       "lane": "short",
       "destination": "tests/functional/workers/inference/agy/golden_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/workers/inference/claude/conductor_test.go",
+      "package": "you-agent-factory/tests/functional/workers/inference/claude",
+      "scenario": "TestClaudeCommandCancellationThroughRootBuildProcessIsCanonical",
+      "lane": "short",
+      "destination": "tests/functional/workers/inference/claude/conductor_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/workers/inference/claude/conductor_test.go",
+      "package": "you-agent-factory/tests/functional/workers/inference/claude",
+      "scenario": "TestClaudeConductorSuccessThroughRootBuildProcess",
+      "lane": "short",
+      "destination": "tests/functional/workers/inference/claude/conductor_test.go",
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
@@ -5774,26 +6544,6 @@
       "scenario": "TestClaudeGoldenToolLifecycleAndSessionIdentity",
       "lane": "functionallong",
       "destination": "tests/functional/workers/inference/claude/golden_success_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/workers/inference/claude/conductor_test.go",
-      "package": "you-agent-factory/tests/functional/workers/inference/claude",
-      "scenario": "TestClaudeCommandCancellationThroughRootBuildProcessIsCanonical",
-      "lane": "short",
-      "destination": "tests/functional/workers/inference/claude/conductor_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/workers/inference/claude/conductor_test.go",
-      "package": "you-agent-factory/tests/functional/workers/inference/claude",
-      "scenario": "TestClaudeConductorSuccessThroughRootBuildProcess",
-      "lane": "short",
-      "destination": "tests/functional/workers/inference/claude/conductor_test.go",
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
@@ -5869,26 +6619,6 @@
       "deletion_only_batch": "n/a"
     },
     {
-      "source_path": "tests/functional/workers/inference/flags_test.go",
-      "package": "you-agent-factory/tests/functional/workers/inference",
-      "scenario": "TestProviderPermissionWorktreeAndModelFlagsMapToCommand",
-      "lane": "short",
-      "destination": "tests/functional/workers/inference/flags_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/workers/inference/flags_test.go",
-      "package": "you-agent-factory/tests/functional/workers/inference",
-      "scenario": "TestUnsupportedProviderFlagReturnsCapabilityError",
-      "lane": "short",
-      "destination": "tests/functional/workers/inference/flags_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
       "source_path": "tests/functional/workers/inference/cursor/golden_failure_test.go",
       "package": "you-agent-factory/tests/functional/workers/inference/cursor",
       "scenario": "TestCursorGoldenMalformedRecordReturnsStableDiagnostic",
@@ -5959,41 +6689,21 @@
       "deletion_only_batch": "n/a"
     },
     {
-      "source_path": "tests/functional/workers/inference/stream_fidelity_test.go",
+      "source_path": "tests/functional/workers/inference/flags_test.go",
       "package": "you-agent-factory/tests/functional/workers/inference",
-      "scenario": "TestProviderFullStreamClaimsDeltasAndSnapshotsTruthfully",
+      "scenario": "TestProviderPermissionWorktreeAndModelFlagsMapToCommand",
       "lane": "short",
-      "destination": "tests/functional/workers/inference/stream_fidelity_test.go",
+      "destination": "tests/functional/workers/inference/flags_test.go",
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
     },
     {
-      "source_path": "tests/functional/workers/inference/stream_fidelity_test.go",
+      "source_path": "tests/functional/workers/inference/flags_test.go",
       "package": "you-agent-factory/tests/functional/workers/inference",
-      "scenario": "TestProviderPartialStreamDoesNotFabricateMissingDeltas",
+      "scenario": "TestUnsupportedProviderFlagReturnsCapabilityError",
       "lane": "short",
-      "destination": "tests/functional/workers/inference/stream_fidelity_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/workers/inference/stream_fidelity_test.go",
-      "package": "you-agent-factory/tests/functional/workers/inference",
-      "scenario": "TestProviderSnapshotOnlyEmitsCompletedSnapshotsOnly",
-      "lane": "short",
-      "destination": "tests/functional/workers/inference/stream_fidelity_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/workers/inference/stream_fidelity_test.go",
-      "package": "you-agent-factory/tests/functional/workers/inference",
-      "scenario": "TestProviderFinalOnlyEmitsTerminalMessageOnly",
-      "lane": "short",
-      "destination": "tests/functional/workers/inference/stream_fidelity_test.go",
+      "destination": "tests/functional/workers/inference/flags_test.go",
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
@@ -6274,6 +6984,46 @@
       "scenario": "TestWorkerProviderOverridesGlobalDefault",
       "lane": "short",
       "destination": "tests/functional/workers/inference/selection_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/workers/inference/stream_fidelity_test.go",
+      "package": "you-agent-factory/tests/functional/workers/inference",
+      "scenario": "TestProviderFinalOnlyEmitsTerminalMessageOnly",
+      "lane": "short",
+      "destination": "tests/functional/workers/inference/stream_fidelity_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/workers/inference/stream_fidelity_test.go",
+      "package": "you-agent-factory/tests/functional/workers/inference",
+      "scenario": "TestProviderFullStreamClaimsDeltasAndSnapshotsTruthfully",
+      "lane": "short",
+      "destination": "tests/functional/workers/inference/stream_fidelity_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/workers/inference/stream_fidelity_test.go",
+      "package": "you-agent-factory/tests/functional/workers/inference",
+      "scenario": "TestProviderPartialStreamDoesNotFabricateMissingDeltas",
+      "lane": "short",
+      "destination": "tests/functional/workers/inference/stream_fidelity_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/workers/inference/stream_fidelity_test.go",
+      "package": "you-agent-factory/tests/functional/workers/inference",
+      "scenario": "TestProviderSnapshotOnlyEmitsCompletedSnapshotsOnly",
+      "lane": "short",
+      "destination": "tests/functional/workers/inference/stream_fidelity_test.go",
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
@@ -6819,6 +7569,16 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/workstations/poller/build_process_test.go",
+      "package": "you-agent-factory/tests/functional/workstations/poller",
+      "scenario": "TestScriptPollerAutomationRemainsInertThroughRootBuildProcessConstruction",
+      "lane": "short",
+      "destination": "tests/functional/workstations/poller/build_process_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/workstations/poller/poller_test.go",
       "package": "you-agent-factory/tests/functional/workstations/poller",
       "scenario": "TestPollerCreatesWorkFromExternalItems",
@@ -6844,16 +7604,6 @@
       "scenario": "TestPollerRecoverableFailureRetriesWithoutDuplicates",
       "lane": "short",
       "destination": "tests/functional/workstations/poller/poller_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/workstations/poller/build_process_test.go",
-      "package": "you-agent-factory/tests/functional/workstations/poller",
-      "scenario": "TestScriptPollerAutomationRemainsInertThroughRootBuildProcessConstruction",
-      "lane": "short",
-      "destination": "tests/functional/workstations/poller/build_process_test.go",
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
@@ -7077,734 +7827,14 @@
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/cli/process/exit_codes_test.go",
-      "package": "you-agent-factory/tests/functional/transport/cli/process",
-      "scenario": "TestCLIInterruptedExitCode",
-      "lane": "short",
-      "destination": "tests/functional/transport/cli/process/exit_codes_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/cli/process/exit_codes_test.go",
-      "package": "you-agent-factory/tests/functional/transport/cli/process",
-      "scenario": "TestCLISuccessExitCode",
-      "lane": "short",
-      "destination": "tests/functional/transport/cli/process/exit_codes_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/cli/process/exit_codes_test.go",
-      "package": "you-agent-factory/tests/functional/transport/cli/process",
-      "scenario": "TestCLIValidationFailureExitCode",
-      "lane": "short",
-      "destination": "tests/functional/transport/cli/process/exit_codes_test.go",
-      "catch_all": "none",
-      "specialty_targets": "test-built-cli-acceptance",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/cli/process/exit_codes_test.go",
-      "package": "you-agent-factory/tests/functional/transport/cli/process",
-      "scenario": "TestCLIWorkerFailureExitCode",
-      "lane": "short",
-      "destination": "tests/functional/transport/cli/process/exit_codes_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/http/server/generated_client_test.go",
-      "package": "you-agent-factory/tests/functional/transport/http/server",
-      "scenario": "TestGeneratedClientAndServerSchemaStayAligned",
-      "lane": "short",
-      "destination": "tests/functional/transport/http/server/generated_client_test.go",
-      "catch_all": "none",
-      "specialty_targets": "api-smoke,artifact-contract-closeout",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/http/server/generated_client_test.go",
-      "package": "you-agent-factory/tests/functional/transport/http/server",
-      "scenario": "TestGeneratedClientDecodesRepresentativeStructuredError",
-      "lane": "short",
-      "destination": "tests/functional/transport/http/server/generated_client_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/http/server/generated_client_test.go",
-      "package": "you-agent-factory/tests/functional/transport/http/server",
-      "scenario": "TestGeneratedClientStatusAndSessionRoundTrip",
-      "lane": "short",
-      "destination": "tests/functional/transport/http/server/generated_client_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/cli/process/help_and_version_test.go",
-      "package": "you-agent-factory/tests/functional/transport/cli/process",
-      "scenario": "TestCLIHelpListsPublicCommandFamilies",
-      "lane": "short",
-      "destination": "tests/functional/transport/cli/process/help_and_version_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/cli/process/help_and_version_test.go",
-      "package": "you-agent-factory/tests/functional/transport/cli/process",
-      "scenario": "TestCLISubcommandHelpUsesStableUsageAndExitZero",
-      "lane": "short",
-      "destination": "tests/functional/transport/cli/process/help_and_version_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/cli/process/help_and_version_test.go",
-      "package": "you-agent-factory/tests/functional/transport/cli/process",
-      "scenario": "TestCLIVersionWritesOneMachineReadableVersion",
-      "lane": "short",
-      "destination": "tests/functional/transport/cli/process/help_and_version_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/cli/process/unknown_command_test.go",
-      "package": "you-agent-factory/tests/functional/transport/cli/process",
-      "scenario": "TestCLIUnknownCommandWritesActionableStderr",
-      "lane": "short",
-      "destination": "tests/functional/transport/cli/process/unknown_command_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/cli/process/unknown_command_test.go",
-      "package": "you-agent-factory/tests/functional/transport/cli/process",
-      "scenario": "TestCLIUnknownCommandReturnsUsageExitCode",
-      "lane": "short",
-      "destination": "tests/functional/transport/cli/process/unknown_command_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/workers/agent/root_build_test.go",
-      "package": "you-agent-factory/tests/functional/workers/agent",
-      "scenario": "TestAgentRunnerDeliveryRemainsInertThroughRootBuildProcessConstruction",
-      "lane": "short",
-      "destination": "wrong-layer: package-integration \u2014 root.BuildProcess and Providers wire composition smoke without proving a customer product scenario. Replacement evidence owner: pkg/root and pkg/services/providers/wire package-integration tests.",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/cli/process/stdin_test.go",
-      "package": "you-agent-factory/tests/functional/transport/cli/process",
-      "scenario": "TestRunReadsPromptFromStdin",
-      "lane": "short",
-      "destination": "tests/functional/transport/cli/process/stdin_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/cli/process/stdin_test.go",
-      "package": "you-agent-factory/tests/functional/transport/cli/process",
-      "scenario": "TestSubmitBatchReadsJSONFromStdin",
-      "lane": "short",
-      "destination": "tests/functional/transport/cli/process/stdin_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/cli/process/stdin_test.go",
-      "package": "you-agent-factory/tests/functional/transport/cli/process",
-      "scenario": "TestCLIEmptyRequiredStdinFailsWithoutDispatch",
-      "lane": "short",
-      "destination": "tests/functional/transport/cli/process/stdin_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/cli/process/stdout_stderr_test.go",
-      "package": "you-agent-factory/tests/functional/transport/cli/process",
-      "scenario": "TestCLISuccessWritesPrimaryResultOnlyToStdout",
-      "lane": "short",
-      "destination": "tests/functional/transport/cli/process/stdout_stderr_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/cli/process/stdout_stderr_test.go",
-      "package": "you-agent-factory/tests/functional/transport/cli/process",
-      "scenario": "TestCLIFailureWritesDiagnosticToStderr",
-      "lane": "short",
-      "destination": "tests/functional/transport/cli/process/stdout_stderr_test.go",
-      "catch_all": "none",
-      "specialty_targets": "test-built-cli-acceptance",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/cli/process/stdout_stderr_test.go",
-      "package": "you-agent-factory/tests/functional/transport/cli/process",
-      "scenario": "TestCLIQuietModeSuppressesNonResultNoise",
-      "lane": "short",
-      "destination": "tests/functional/transport/cli/process/stdout_stderr_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/cli/process/context_cancellation_test.go",
-      "package": "you-agent-factory/tests/functional/transport/cli/process",
-      "scenario": "TestCLIContextCancellationStopsExternalWork",
-      "lane": "short",
-      "destination": "tests/functional/transport/cli/process/context_cancellation_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/transport/cli/process/context_cancellation_test.go",
-      "package": "you-agent-factory/tests/functional/transport/cli/process",
-      "scenario": "TestCLIContextCancellationEmitsNoSuccessResult",
-      "lane": "short",
-      "destination": "tests/functional/transport/cli/process/context_cancellation_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory/packaged/deep_research/invocation_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/deep_research",
-      "scenario": "TestPackagedDeepResearchRequiredInputCompletes",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/deep_research/invocation_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory/packaged/deep_research/invocation_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/deep_research",
-      "scenario": "TestPackagedDeepResearchOptionalInputsReachWorkers",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/deep_research/invocation_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory/packaged/deep_research/invocation_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/deep_research",
-      "scenario": "TestPackagedDeepResearchWorkerFailureReturnsFailedOutcome",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/deep_research/invocation_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory/packaged/catalog/discovery_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/catalog",
-      "scenario": "TestNewEmbeddedFactoryRequiresFunctionalMatrixEntry",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/catalog/discovery_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory/packaged/catalog/discovery_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/catalog",
-      "scenario": "TestPackagedFactoryCatalogHasUniqueStableNames",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/catalog/discovery_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory/packaged/catalog/discovery_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/catalog",
-      "scenario": "TestPackagedFactoryCatalogListsEveryEmbeddedFactory",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/catalog/discovery_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory/packaged/fusion/invocation_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/fusion",
-      "scenario": "TestPackagedFusionRequiredInputCompletes",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/fusion/invocation_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory/packaged/fusion/invocation_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/fusion",
-      "scenario": "TestPackagedFusionOptionalInputsReachWorkers",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/fusion/invocation_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory/packaged/fusion/invocation_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/fusion",
-      "scenario": "TestPackagedFusionPartialWorkerFailureUsesDocumentedOutcome",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/fusion/invocation_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory/packaged/goal/invocation_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/goal",
-      "scenario": "TestPackagedGoalAcceptCompletesWithSummary",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/goal/invocation_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory/packaged/goal/invocation_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/goal",
-      "scenario": "TestPackagedGoalRejectRepeatsThenCompletes",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/goal/invocation_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory/packaged/goal/invocation_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/goal",
-      "scenario": "TestPackagedGoalUnknownDecisionFails",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/goal/invocation_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory/packaged/goal/invocation_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/goal",
-      "scenario": "TestPackagedGoalPausedSubmissionResumes",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/goal/invocation_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory/packaged/subagent/invocation_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/subagent",
-      "scenario": "TestPackagedSubagentReturnsChildResult",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/subagent/invocation_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory/packaged/subagent/invocation_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/subagent",
-      "scenario": "TestPackagedSubagentStreamsChildResponseEvents",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/subagent/invocation_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory/packaged/subagent/invocation_test.go",
-      "package": "you-agent-factory/tests/functional/factory/packaged/subagent",
-      "scenario": "TestPackagedSubagentChildFailureReturnsStableFailure",
-      "lane": "short",
-      "destination": "tests/functional/factory/packaged/subagent/invocation_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/sessions/mcp/controls_test.go",
-      "package": "you-agent-factory/tests/functional/sessions/mcp",
-      "scenario": "TestMCPPauseResumeAndCancelTargetCanonicalFactorySession",
-      "lane": "short",
-      "destination": "tests/functional/sessions/mcp/controls_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/sessions/mcp/controls_test.go",
-      "package": "you-agent-factory/tests/functional/sessions/mcp",
-      "scenario": "TestMCPControlledSessionIsReadableThroughAPI",
-      "lane": "short",
-      "destination": "tests/functional/sessions/mcp/controls_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/sessions/mcp/controls_test.go",
-      "package": "you-agent-factory/tests/functional/sessions/mcp",
-      "scenario": "TestMCPSynchronousFactorySessionReturnsTerminalResult",
-      "lane": "short",
-      "destination": "tests/functional/sessions/mcp/controls_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/sessions/mcp/controls_test.go",
-      "package": "you-agent-factory/tests/functional/sessions/mcp",
-      "scenario": "TestMCPSynchronousFailureReturnsStructuredFailure",
-      "lane": "short",
-      "destination": "tests/functional/sessions/mcp/controls_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/sessions/mcp/controls_test.go",
-      "package": "you-agent-factory/tests/functional/sessions/mcp",
-      "scenario": "TestMCPAsyncFactorySessionCanBePolledToSuccess",
-      "lane": "short",
-      "destination": "tests/functional/sessions/mcp/controls_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/sessions/mcp/controls_test.go",
-      "package": "you-agent-factory/tests/functional/sessions/mcp",
-      "scenario": "TestMCPAsyncFactorySessionCanBePolledToFailure",
-      "lane": "short",
-      "destination": "tests/functional/sessions/mcp/controls_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/sessions/mcp/controls_test.go",
-      "package": "you-agent-factory/tests/functional/sessions/mcp",
-      "scenario": "TestMCPAsyncCancellationIsVisibleThroughAPI",
-      "lane": "short",
-      "destination": "tests/functional/sessions/mcp/controls_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/provider_sessions/association/association_test.go",
-      "package": "you-agent-factory/tests/functional/provider_sessions/association",
-      "scenario": "TestProviderSessionRefAssociatesWithOwningDispatchAndFactorySession",
-      "lane": "short",
-      "destination": "tests/functional/provider_sessions/association/association_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/provider_sessions/association/association_test.go",
-      "package": "you-agent-factory/tests/functional/provider_sessions/association",
-      "scenario": "TestAbsentProviderSessionIsNotFabricated",
-      "lane": "short",
-      "destination": "tests/functional/provider_sessions/association/association_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/provider_sessions/association/association_test.go",
-      "package": "you-agent-factory/tests/functional/provider_sessions/association",
-      "scenario": "TestMultipleDispatchesKeepDistinctProviderSessionRefs",
-      "lane": "short",
-      "destination": "tests/functional/provider_sessions/association/association_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/sessions/controls/pause_resume_test.go",
-      "package": "you-agent-factory/tests/functional/sessions/controls",
-      "scenario": "TestPausedFactorySessionBuffersSubmittedWork",
-      "lane": "short",
-      "destination": "tests/functional/sessions/controls/pause_resume_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/sessions/controls/pause_resume_test.go",
-      "package": "you-agent-factory/tests/functional/sessions/controls",
-      "scenario": "TestResumedFactorySessionDrainsBufferedWorkInOrder",
-      "lane": "short",
-      "destination": "tests/functional/sessions/controls/pause_resume_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/sessions/controls/pause_resume_test.go",
-      "package": "you-agent-factory/tests/functional/sessions/controls",
-      "scenario": "TestPauseResumeEmitsDurableLifecycleEvents",
-      "lane": "short",
-      "destination": "tests/functional/sessions/controls/pause_resume_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/sessions/controls/pause_resume_test.go",
-      "package": "you-agent-factory/tests/functional/sessions/controls",
-      "scenario": "TestAPIPauseResumeCancelAndTerminateFactorySession",
-      "lane": "short",
-      "destination": "tests/functional/sessions/controls/pause_resume_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/sessions/controls/pause_resume_test.go",
-      "package": "you-agent-factory/tests/functional/sessions/controls",
-      "scenario": "TestAPIInvalidLifecycleTransitionReturnsConflict",
-      "lane": "short",
-      "destination": "tests/functional/sessions/controls/pause_resume_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
-      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
-      "scenario": "TestRegisterDefaultsResolutionFromHomeRestoresAdapterOwnership",
-      "lane": "short",
-      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
-      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
-      "scenario": "TestResolveFromHomeFallbackPreservesAcceptedSemantics",
-      "lane": "short",
-      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
-      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
-      "scenario": "TestResolveFromHomeRejectsMissingFilesystemPorts",
-      "lane": "short",
-      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
-      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
-      "scenario": "TestResolveFromHomeUsesSettingsAdapterOwnershipPath",
-      "lane": "short",
-      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
-      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
-      "scenario": "TestServiceFromConfigDocumentConstructsFromDocumentPorts",
-      "lane": "short",
-      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
-      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
-      "scenario": "TestServiceFromConfigDocumentRejectsMissingDocumentPorts",
-      "lane": "short",
-      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
-      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
-      "scenario": "TestServiceFromHomePortsConstructsSettingsRoot",
-      "lane": "short",
-      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
-      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
-      "scenario": "TestServiceFromHomePortsRejectsMissingPorts",
-      "lane": "short",
-      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
-      "package": "you-agent-factory/tests/functional/operator_settings/servicewire",
-      "scenario": "TestServiceWireCompositionRootServesDocumentAndResolutionOperations",
-      "lane": "short",
-      "destination": "tests/functional/operator_settings/servicewire/servicewire_composition_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/work/submission/batch_inputs_test.go",
-      "package": "you-agent-factory/tests/functional/work/submission",
-      "scenario": "TestWorkBatchAcceptsInlineFileAndStdinShapes",
-      "lane": "short",
-      "destination": "tests/functional/work/submission/batch_inputs_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/work/submission/batch_inputs_test.go",
-      "package": "you-agent-factory/tests/functional/work/submission",
-      "scenario": "TestWorkBatchSelectsDefaultAndExplicitWorkTypes",
-      "lane": "short",
-      "destination": "tests/functional/work/submission/batch_inputs_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/work/submission/batch_inputs_test.go",
-      "package": "you-agent-factory/tests/functional/work/submission",
-      "scenario": "TestWorkBatchRejectsUnknownTypeWithoutPartialMutation",
-      "lane": "short",
-      "destination": "tests/functional/work/submission/batch_inputs_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/work/recovery/manual_move_test.go",
-      "package": "you-agent-factory/tests/functional/work/recovery",
-      "scenario": "TestFailedCascadeCanBeRecoveredByPublicWorkMove",
-      "lane": "short",
-      "destination": "tests/functional/work/recovery/manual_move_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/work/recovery/manual_move_test.go",
-      "package": "you-agent-factory/tests/functional/work/recovery",
-      "scenario": "TestTerminalFailedWorkCannotBeRedispatchedIllegally",
-      "lane": "short",
-      "destination": "tests/functional/work/recovery/manual_move_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/work/recovery/manual_move_test.go",
-      "package": "you-agent-factory/tests/functional/work/recovery",
-      "scenario": "TestAPIMoveWorkResumesRecoverableFlow",
-      "lane": "short",
-      "destination": "tests/functional/work/recovery/manual_move_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/work/recovery/manual_move_test.go",
-      "package": "you-agent-factory/tests/functional/work/recovery",
-      "scenario": "TestAPIInvalidMoveReturnsConflictWithoutMutation",
-      "lane": "short",
-      "destination": "tests/functional/work/recovery/manual_move_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/work/recordings/recordings_read_test.go",
-      "package": "you-agent-factory/tests/functional/work/recordings",
-      "lane": "short",
-      "destination": "wrong-layer: pss-cut-work-rec recordings-backed Work read coverage not yet catalogued in test-file-checklist. Replacement evidence owner: tests/functional/work/recordings/recordings_read_test.go.",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a",
-      "scenario": "TestRecordingsBackedWorkReadsUseRecordingsRootContract"
-    },
-    {
-      "source_path": "tests/functional/work/recordings/recordings_read_test.go",
-      "package": "you-agent-factory/tests/functional/work/recordings",
-      "lane": "short",
-      "destination": "wrong-layer: pss-cut-work-rec recordings-backed Work read coverage not yet catalogued in test-file-checklist. Replacement evidence owner: tests/functional/work/recordings/recordings_read_test.go.",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a",
-      "scenario": "TestGetWorkFromRecordingsRootUsesRecordingsServiceRoot"
-    },
-    {
-      "source_path": "tests/functional/work/recordings/recordings_read_test.go",
-      "package": "you-agent-factory/tests/functional/work/recordings",
-      "lane": "short",
-      "destination": "wrong-layer: pss-cut-work-rec recordings-backed Work read coverage not yet catalogued in test-file-checklist. Replacement evidence owner: tests/functional/work/recordings/recordings_read_test.go.",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a",
-      "scenario": "TestRecordingsBackedWorkReadsMapRichWorldState"
-    },
-    {
-      "source_path": "tests/functional/work/recordings/recordings_read_test.go",
-      "package": "you-agent-factory/tests/functional/work/recordings",
-      "lane": "short",
-      "destination": "wrong-layer: pss-cut-work-rec recordings-backed Work read coverage not yet catalogued in test-file-checklist. Replacement evidence owner: tests/functional/work/recordings/recordings_read_test.go.",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a",
-      "scenario": "TestRecordingsBackedWorkReadsSurfaceTypedProjectionFailures"
     }
   ],
-  "scanned_at_utc": "2026-07-28T06:30:00Z",
+  "scanned_at_utc": "2026-07-28T06:44:16Z",
   "summary": {
     "by_catch_all": {
       "bootstrap_portability": 22,
       "guards_batch": 23,
-      "none": 504,
+      "none": 507,
       "replay_contracts": 23,
       "runtime_api": 96,
       "smoke": 62,
@@ -7815,7 +7845,7 @@
       "automations": 7,
       "bootstrap_portability": 21,
       "cli": 59,
-      "factory": 24,
+      "factory": 27,
       "guards_batch": 23,
       "models": 5,
       "observability": 9,
@@ -7830,14 +7860,14 @@
       "sessions": 21,
       "smoke": 62,
       "transport": 106,
-      "work": 5,
+      "work": 13,
       "workers": 74,
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 760,
+    "customer_top_level_Test_scenarios": 763,
     "lane_functionallong": 95,
-    "lane_short": 665,
+    "lane_short": 668,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 12,
       "you-agent-factory/tests/functional/automations": 7,
@@ -7850,7 +7880,7 @@
       "you-agent-factory/tests/functional/cli/named_invocation": 6,
       "you-agent-factory/tests/functional/cli/root_discovery": 9,
       "you-agent-factory/tests/functional/cli/session_resume": 6,
-      "you-agent-factory/tests/functional/factory/definitions": 3,
+      "you-agent-factory/tests/functional/factory/definitions": 6,
       "you-agent-factory/tests/functional/factory/packaged/catalog": 7,
       "you-agent-factory/tests/functional/factory/packaged/deep_research": 3,
       "you-agent-factory/tests/functional/factory/packaged/fusion": 3,
@@ -7904,6 +7934,8 @@
       "you-agent-factory/tests/functional/transport/shell_completion": 1,
       "you-agent-factory/tests/functional/transport/submit": 2,
       "you-agent-factory/tests/functional/work/cli": 1,
+      "you-agent-factory/tests/functional/work/recordings": 4,
+      "you-agent-factory/tests/functional/work/recovery": 4,
       "you-agent-factory/tests/functional/work/submission": 3,
       "you-agent-factory/tests/functional/work/visualization": 1,
       "you-agent-factory/tests/functional/workers/agent": 1,

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -570,6 +570,12 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
 - [x] `tests/functional/work/visualization/dependency_graph_test.go`
   - `TestWorkVisualizeProducesDeterministicGraph`.
 
+- [x] `tests/functional/work/recordings/recordings_read_test.go`
+  - `TestRecordingsBackedWorkReadsUseRecordingsRootContract`.
+  - `TestGetWorkFromRecordingsRootUsesRecordingsServiceRoot`.
+  - `TestRecordingsBackedWorkReadsMapRichWorldState`.
+  - `TestRecordingsBackedWorkReadsSurfaceTypedProjectionFailures`.
+
 ## Wave 2 — sessions
 
 - [ ] `tests/functional/sessions/lifecycle/crud_test.go`
@@ -629,7 +635,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestAPIPreviewFactoryReturnsPublicTopology`.
   - `TestAPIPreviewDoesNotStartWorkersOrSessions`.
 
-- [ ] `tests/functional/factory/definitions/defaults_test.go`
+- [x] `tests/functional/factory/definitions/defaults_test.go`
   - `TestGlobalConfigSuppliesDefaultProviderAndModel`.
   - `TestExplicitFactoryConfigOverridesGlobalDefaults`.
   - `TestSingleDiscoveredProviderIsUsedWhenNoDefaultExists`.

--- a/tests/functional/factory/definitions/defaults_test.go
+++ b/tests/functional/factory/definitions/defaults_test.go
@@ -17,6 +17,8 @@ import (
 const (
 	globalDefaultsProviderAlias = "codex"
 	globalDefaultsModel         = "operator-default-model"
+	factoryOverrideProvider     = modelprovider.ProviderClaude
+	factoryOverrideModel        = "factory-authored-model"
 )
 
 // TestGlobalConfigSuppliesDefaultProviderAndModel proves workers that omit
@@ -60,6 +62,55 @@ Process the input task.
 		t.Fatalf("command = %q, want global default provider %q", call.Command, modelprovider.ProviderCodex)
 	}
 	support.AssertArgsContainSequence(t, call.Args, []string{"--model", globalDefaultsModel})
+}
+
+// TestExplicitFactoryConfigOverridesGlobalDefaults proves Factory-authored
+// provider and model on a worker win over operator global defaults at run time
+// and dispatch through the resolved provider-process edge with the authored
+// model selection.
+func TestExplicitFactoryConfigOverridesGlobalDefaults(t *testing.T) {
+	dir := support.ScaffoldFactory(t, defaultsFactoryConfig())
+	support.WriteAgentConfig(
+		t,
+		dir,
+		"worker-a",
+		support.BuildModelWorkerConfig(factoryOverrideProvider, factoryOverrideModel),
+	)
+	testutil.WriteSeedFile(t, dir, "task", []byte(`{"title":"explicit factory config overrides global defaults"}`))
+
+	homeDir := writeOperatorGlobalDefaultsConfig(t, globalDefaultsProviderAlias, globalDefaultsModel)
+	runner := support.NewShapedProviderCommandRunner(platformprocess.CommandResult{
+		Stdout: support.ClaudeSuccessStdout("Done. COMPLETE"),
+	})
+
+	_, listed := runFactoryWithOperatorHome(
+		t,
+		dir,
+		homeDir,
+		serviceedges.Edges{ProviderCommandRunner: runner},
+		15*time.Second,
+	)
+
+	if got := support.CountWorkAtCustomerState(listed, "task:complete"); got != 1 {
+		t.Fatalf("completed work tokens = %d, want 1; listed=%#v", got, listed)
+	}
+	if got := support.CountWorkAtCustomerState(listed, "task:failed"); got != 0 {
+		t.Fatalf("failed work tokens = %d, want 0", got)
+	}
+	if runner.CallCount() != 1 {
+		t.Fatalf("provider command runner calls = %d, want 1", runner.CallCount())
+	}
+
+	call := runner.LastRequest()
+	if call.Command != string(factoryOverrideProvider) {
+		t.Fatalf(
+			"command = %q, want factory-authored provider %q (not global default %q)",
+			call.Command,
+			factoryOverrideProvider,
+			modelprovider.ProviderCodex,
+		)
+	}
+	support.AssertArgsContainSequence(t, call.Args, []string{"--model", factoryOverrideModel})
 }
 
 func defaultsFactoryConfig() map[string]any {

--- a/tests/functional/factory/definitions/defaults_test.go
+++ b/tests/functional/factory/definitions/defaults_test.go
@@ -1,6 +1,7 @@
 package definitions
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
@@ -113,6 +115,59 @@ func TestExplicitFactoryConfigOverridesGlobalDefaults(t *testing.T) {
 	support.AssertArgsContainSequence(t, call.Args, []string{"--model", factoryOverrideModel})
 }
 
+// TestSingleDiscoveredProviderIsUsedWhenNoDefaultExists proves that when no
+// operator or Factory default provider is configured and exactly one supported
+// provider is discoverable, model-backed Work dispatches through that provider.
+func TestSingleDiscoveredProviderIsUsedWhenNoDefaultExists(t *testing.T) {
+	t.Setenv(operatorsettings.EnvDefaultWorkerModelProvider, "")
+	t.Setenv(operatorsettings.EnvDefaultWorkerModel, "")
+
+	dir := support.ScaffoldFactory(t, defaultsFactoryConfig())
+	support.WriteAgentConfig(t, dir, "worker-a", `---
+type: MODEL_WORKER
+stopToken: COMPLETE
+---
+Process the input task.
+`)
+	testutil.WriteSeedFile(t, dir, "task", []byte(`{"title":"single discovered provider when no default exists"}`))
+
+	homeDir := t.TempDir()
+	discoveredProvider := string(modelprovider.ProviderCodex)
+	codexPath := writeFixtureExecutable(t, discoveredProvider)
+	runner := support.NewShapedProviderCommandRunner(platformprocess.CommandResult{
+		Stdout: support.CodexSuccessStdout("Done. COMPLETE"),
+	})
+
+	_, listed := runFactoryWithOperatorHome(
+		t,
+		dir,
+		homeDir,
+		serviceedges.Edges{
+			ProviderCommandRunner: runner,
+			WorkersExecutableLocator: singleCommandExecutableLocator{
+				command: discoveredProvider,
+				path:    codexPath,
+			},
+		},
+		15*time.Second,
+	)
+
+	if got := support.CountWorkAtCustomerState(listed, "task:complete"); got != 1 {
+		t.Fatalf("completed work tokens = %d, want 1; listed=%#v", got, listed)
+	}
+	if got := support.CountWorkAtCustomerState(listed, "task:failed"); got != 0 {
+		t.Fatalf("failed work tokens = %d, want 0", got)
+	}
+	if runner.CallCount() != 1 {
+		t.Fatalf("provider command runner calls = %d, want 1", runner.CallCount())
+	}
+
+	call := runner.LastRequest()
+	if call.Command != discoveredProvider {
+		t.Fatalf("command = %q, want discovered provider %q", call.Command, discoveredProvider)
+	}
+}
+
 func defaultsFactoryConfig() map[string]any {
 	return map[string]any{
 		"workTypes": []map[string]any{
@@ -191,4 +246,26 @@ func runFactoryWithOperatorHome(
 	work := support.ListDefaultSessionWork(t, baseURL)
 	daemon.Stop(t)
 	return session, work
+}
+
+type singleCommandExecutableLocator struct {
+	command string
+	path    string
+}
+
+func (l singleCommandExecutableLocator) LookPath(file string) (string, error) {
+	if file == l.command {
+		return l.path, nil
+	}
+	return "", fmt.Errorf("executable %q not found", file)
+}
+
+func writeFixtureExecutable(t *testing.T, name string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(name+"-fixture-executable\n"), 0o755); err != nil {
+		t.Fatalf("write %s fixture executable: %v", name, err)
+	}
+	return path
 }

--- a/tests/functional/factory/definitions/defaults_test.go
+++ b/tests/functional/factory/definitions/defaults_test.go
@@ -1,0 +1,143 @@
+package definitions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	globalDefaultsProviderAlias = "codex"
+	globalDefaultsModel         = "operator-default-model"
+)
+
+// TestGlobalConfigSuppliesDefaultProviderAndModel proves workers that omit
+// provider and model inherit operator global defaults at run time and dispatch
+// through the resolved provider-process edge with the configured default model.
+func TestGlobalConfigSuppliesDefaultProviderAndModel(t *testing.T) {
+	dir := support.ScaffoldFactory(t, defaultsFactoryConfig())
+	support.WriteAgentConfig(t, dir, "worker-a", `---
+type: MODEL_WORKER
+stopToken: COMPLETE
+---
+Process the input task.
+`)
+	testutil.WriteSeedFile(t, dir, "task", []byte(`{"title":"global defaults supply provider and model"}`))
+
+	homeDir := writeOperatorGlobalDefaultsConfig(t, globalDefaultsProviderAlias, globalDefaultsModel)
+	runner := support.NewShapedProviderCommandRunner(platformprocess.CommandResult{
+		Stdout: support.CodexSuccessStdout("Done. COMPLETE"),
+	})
+
+	_, listed := runFactoryWithOperatorHome(
+		t,
+		dir,
+		homeDir,
+		serviceedges.Edges{ProviderCommandRunner: runner},
+		15*time.Second,
+	)
+
+	if got := support.CountWorkAtCustomerState(listed, "task:complete"); got != 1 {
+		t.Fatalf("completed work tokens = %d, want 1; listed=%#v", got, listed)
+	}
+	if got := support.CountWorkAtCustomerState(listed, "task:failed"); got != 0 {
+		t.Fatalf("failed work tokens = %d, want 0", got)
+	}
+	if runner.CallCount() != 1 {
+		t.Fatalf("provider command runner calls = %d, want 1", runner.CallCount())
+	}
+
+	call := runner.LastRequest()
+	if call.Command != string(modelprovider.ProviderCodex) {
+		t.Fatalf("command = %q, want global default provider %q", call.Command, modelprovider.ProviderCodex)
+	}
+	support.AssertArgsContainSequence(t, call.Args, []string{"--model", globalDefaultsModel})
+}
+
+func defaultsFactoryConfig() map[string]any {
+	return map[string]any{
+		"workTypes": []map[string]any{
+			{
+				"name": "task",
+				"states": []map[string]string{
+					{"name": "init", "type": "INITIAL"},
+					{"name": "complete", "type": "TERMINAL"},
+					{"name": "failed", "type": "FAILED"},
+				},
+			},
+		},
+		"workers": []map[string]string{
+			{"name": "worker-a"},
+		},
+		"workstations": []map[string]any{
+			{
+				"name":      "process",
+				"worker":    "worker-a",
+				"inputs":    []map[string]string{{"workType": "task", "state": "init"}},
+				"outputs":   []map[string]string{{"workType": "task", "state": "complete"}},
+				"onFailure": []map[string]string{{"workType": "task", "state": "failed"}},
+			},
+		},
+	}
+}
+
+func writeOperatorGlobalDefaultsConfig(t *testing.T, providerAlias, model string) string {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	configDir := filepath.Join(homeDir, ".you-agent-factory")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatalf("mkdir global config directory: %v", err)
+	}
+	config := []byte(`{
+  "defaults": {
+    "workerModelProvider": "` + providerAlias + `",
+    "workerModel": "` + model + `"
+  }
+}`)
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), config, 0o600); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+	return homeDir
+}
+
+func runFactoryWithOperatorHome(
+	t *testing.T,
+	dir string,
+	homeDir string,
+	overrides serviceedges.Edges,
+	timeout time.Duration,
+) (factoryapi.FactorySession, factoryapi.ListWorkResponse) {
+	t.Helper()
+
+	server := support.NewProcessAPIServer()
+	overrides.APIServerStarter = server.Start
+	process := support.BuildProcess(t, overrides)
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "run",
+		"--dir", dir,
+		"--continuously",
+		"--with-server",
+		"--server", "http://127.0.0.1:1",
+		"--quiet",
+		"--no-record",
+	})
+	inputs.Input.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	inputs.Input.WorkingDirectory = dir
+	daemon := support.StartProcessCommand(t, process, inputs.Input)
+	baseURL := server.WaitForURL(t)
+	support.WaitForTerminalStatus(t, baseURL, timeout)
+
+	session := support.GetDefaultSession(t, baseURL)
+	work := support.ListDefaultSessionWork(t, baseURL)
+	daemon.Stop(t)
+	return session, work
+}


### PR DESCRIPTION
{
  "project": "Factory Definition Defaults Functional Coverage",
  "branchName": "ft-wave2-factory-definitions-defaults",
  "description": "Implement only tests/functional/factory/definitions/defaults_test.go to prove operator global defaults supply omitted worker provider/model, explicit Factory config overrides those defaults, and a single discovered provider is used when no default exists, via root.BuildProcess + Process.Execute with CLI-preferred flows and edges.Edges mocks, consuming the two mapped migration-ledger rows and preserving smoke-delete-03-factory-definitions ownership without implementing validation or import_export siblings.",
  "context": {
    "customerAsk": "Implement only tests/functional/factory/definitions/defaults_test.go. Construct via root.BuildProcess + Process.Execute (built you CLI only if OS/process-boundary proof requires it). Prefer public CLI over HTTP/API for ordinary flows. Replace external effects only through edges.Edges, preferring ProviderCommandRunner / command-runner edge mocks and mocked Codex over MockWorkers. Do not add sleeps or timeout-padded wait helpers unless justified in-code after RC fixes. Prove: (1) TestGlobalConfigSuppliesDefaultProviderAndModel; (2) TestExplicitFactoryConfigOverridesGlobalDefaults; (3) TestSingleDiscoveredProviderIsUsedWhenNoDefaultExists. Consume the two mapped migration-ledger rows and preserve smoke-delete-03-factory-definitions ownership. Do not implement validation_test.go or import_export_test.go. Avoid service/internal Petri imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for Factory definition defaults does not exist, while two mapped migration-ledger rows still point at this cell under shared deletion-batch smoke-delete-03-factory-definitions. Legacy smoke proofs mix global-default and loaded-config behavior in catch-all packages, leaving no definitions-owned proof that operator defaults supply omitted provider/model, Factory-authored values override globals, and a single discovered provider is used when no default exists. Held siblings validation_test.go and import_export_test.go must not be widened into this lane, and shared deletion-batch ownership must not be dropped.",
    "solution": "Implement the three checklist scenarios in tests/functional/factory/definitions/defaults_test.go through root.BuildProcess + Process.Execute, preferring public CLI over HTTP/API, replacing external effects only through edges.Edges with ProviderCommandRunner / mocked Codex preferred over MockWorkers, and adding customer-readable Go docs on every top-level Test. Consume the two mapped migration-ledger defaults/loaded-config obligations, preserve smoke-delete-03-factory-definitions ownership shared with held validation, apply only narrowly coupled metadata/deletion updates for this destination, leave held siblings untouched, and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/factory/definitions/defaults_test.go exists as the factory/definitions-owned functional cell and covers global defaults supply, explicit Factory override, and single discovered provider when no default exists.",
    "Global-default success exercises root.BuildProcess + Process.Execute (built CLI only if OS/process-boundary proof requires it), prefers public CLI over HTTP/API for ordinary flows, and proves omitted worker provider/model resolve from operator global config without asserting Petri markings or importing service/internal Petri packages.",
    "Explicit Factory-authored provider/model values win over operator global defaults on the same public observation surface used by the global-defaults proof.",
    "With no configured default and exactly one discoverable provider, that provider is selected for model-backed execution and is observable at the public boundary.",
    "The two mapped migration-ledger rows whose destination is this cell are consumed; named deletion-batch smoke-delete-03-factory-definitions is preserved (shared with held validation); only narrowly coupled ownership/deletion/coverage/catalog metadata for this cell are updated; held siblings validation_test.go and import_export_test.go stay untouched.",
    "Every top-level Test* has a customer-readable Go doc comment whose first sentence describes the observable defaults/precedence behavior; external effects use edges.Edges with preferred ProviderCommandRunner / mocked Codex patterns; no unjustified sleeps or timeout-padded wait helpers.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave2-factory-definitions-defaults-001",
      "title": "Prove global config supplies default provider and model",
      "passes": true
    },
    {
      "id": "ft-wave2-factory-definitions-defaults-002",
      "title": "Prove explicit Factory config overrides global defaults",
      "passes": true
    },
    {
      "id": "ft-wave2-factory-definitions-defaults-003",
      "title": "Prove single discovered provider is used when no default exists",
      "passes": true
    },
    {
      "id": "ft-wave2-factory-definitions-defaults-004",
      "title": "Consume migration obligation and close verification gates",
      "passes": true
    }
  ]
}

## Test plan
- [x] `go test ./tests/functional/factory/definitions/...`
- [x] `go run ./cmd/migrationledgercheck`
- [x] `make functional-boundary-check`
- [x] `go test ./internal/functionaltestmetadata/... ./internal/functionaltestviz/...`


Made with [Cursor](https://cursor.com)