### PR TITLE
ft-wave2-factory-quorum-invocation

### DIFF
--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -1419,6 +1419,36 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/factory/packaged/quorum/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/quorum",
+      "scenario": "TestPackagedQuorumRequiredInputCompletes",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/quorum/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/quorum/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/quorum",
+      "scenario": "TestPackagedQuorumOptionalMemberSettingsReachWorkers",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/quorum/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/quorum/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/quorum",
+      "scenario": "TestPackagedQuorumInsufficientSuccessfulMembersFails",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/quorum/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/factory/packaged/subagent/invocation_test.go",
       "package": "you-agent-factory/tests/functional/factory/packaged/subagent",
       "scenario": "TestPackagedSubagentChildFailureReturnsStableFailure",
@@ -7865,9 +7895,9 @@
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 763,
+    "customer_top_level_Test_scenarios": 766,
     "lane_functionallong": 95,
-    "lane_short": 668,
+    "lane_short": 671,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 12,
       "you-agent-factory/tests/functional/automations": 7,

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -567,6 +567,12 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestAPIMoveWorkResumesRecoverableFlow`.
   - `TestAPIInvalidMoveReturnsConflictWithoutMutation`.
 
+- [x] `tests/functional/work/recordings/recordings_read_test.go`
+  - `TestRecordingsBackedWorkReadsUseRecordingsRootContract`.
+  - `TestGetWorkFromRecordingsRootUsesRecordingsServiceRoot`.
+  - `TestRecordingsBackedWorkReadsMapRichWorldState`.
+  - `TestRecordingsBackedWorkReadsSurfaceTypedProjectionFailures`.
+
 - [x] `tests/functional/work/visualization/dependency_graph_test.go`
   - `TestWorkVisualizeProducesDeterministicGraph`.
 
@@ -679,7 +685,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestPackagedGoalUnknownDecisionFails` covers classifier failure.
   - `TestPackagedGoalPausedSubmissionResumes` covers session control locally.
 
-- [ ] `tests/functional/factory/packaged/quorum/invocation_test.go`
+- [x] `tests/functional/factory/packaged/quorum/invocation_test.go`
   - `TestPackagedQuorumRequiredInputCompletes` covers member dispatch and final
     result.
   - `TestPackagedQuorumOptionalMemberSettingsReachWorkers` covers overrides.

--- a/pkg/services/factory_sessions/internal/invocation/session_owner_test.go
+++ b/pkg/services/factory_sessions/internal/invocation/session_owner_test.go
@@ -523,6 +523,28 @@ func TestSessionOwnerWait_PreservesTerminalFailureClassifications(t *testing.T) 
 	}
 }
 
+func TestSessionOwnerWait_ReturnsFailedWhileActiveWorkHasScopedFailure(t *testing.T) {
+	observation := activeSessionInvocationObservation()
+	failedChild := invocationWorkItem("work-branch-b", "quorum-branch-b", "failed", "Branch B", "quorum-branch-b:failed")
+	observation.WorldState.WorkStateChangesByWorkID[failedChild.ID] = []interfaces.FactoryWorldWorkStateChangeRecord{{
+		WorkID:       failedChild.ID,
+		WorkTypeName: failedChild.WorkTypeID,
+		ToState:      "failed",
+		ToPlaceID:    failedChild.PlaceID,
+		RequestID:    "request-1",
+	}}
+	observation.WorldState.FailedWorkItemsByID[failedChild.ID] = failedChild
+
+	result := waitForSessionOwnerObservation(t, observation, &interfaces.InvocationReturnConfig{
+		Policy:        work.ReturnPolicyExplicit,
+		WorkTypeName:  "quorum-merge",
+		TerminalState: "complete",
+	})
+	assertSessionOwnerEqual(t, "status", result.Status, interfaces.InvocationTerminalStatusFailed)
+	assertSessionOwnerEqual(t, "error code", result.ErrorCode, string(work.PrimaryResultErrorCodeFailed))
+	assertSessionOwnerEqual(t, "work state", result.WorkState, "quorum-branch-b:failed")
+}
+
 func waitForSessionOwnerObservation(t *testing.T, observation SessionInvocationObservation, policy *interfaces.InvocationReturnConfig) FactoryInvocationResult {
 	t.Helper()
 	owner := newTestSessionOwner(sessionOwnerFixture{Observe: func(context.Context, string, SessionInvocationWaitInput) (SessionInvocationObservation, error) {

--- a/pkg/services/factory_sessions/internal/invocation/session_owner_test.go
+++ b/pkg/services/factory_sessions/internal/invocation/session_owner_test.go
@@ -545,6 +545,48 @@ func TestSessionOwnerWait_ReturnsFailedWhileActiveWorkHasScopedFailure(t *testin
 	assertSessionOwnerEqual(t, "work state", result.WorkState, "quorum-branch-b:failed")
 }
 
+func TestSessionOwnerWait_DefaultWaitNextPollsUntilCompletion(t *testing.T) {
+	observations := 0
+	owner := newTestSessionOwner(sessionOwnerFixture{Observe: func(context.Context, string, SessionInvocationWaitInput) (SessionInvocationObservation, error) {
+		observations++
+		if observations == 1 {
+			return activeSessionInvocationObservation(), nil
+		}
+		return completedSessionInvocationObservation("request-1", "trace-1", "done"), nil
+	}})
+	result, err := owner.waitForResult(context.Background(), "session-1", sessionWaitInput(nil))
+	if err != nil {
+		t.Fatalf("waitForResult: %v", err)
+	}
+	if observations < 2 {
+		t.Fatalf("observe calls = %d, want at least 2", observations)
+	}
+	assertSessionOwnerEqual(t, "status", result.Status, interfaces.InvocationTerminalStatusCompleted)
+	assertSessionOwnerEqual(t, "primary result", result.PrimaryResult[0].Text, "done")
+}
+
+func TestSessionOwnerWait_ReturnsFailedFromStoppedScopedFailure(t *testing.T) {
+	observation := stoppedSessionInvocationObservation()
+	failedChild := invocationWorkItem("work-branch-b", "quorum-branch-b", "failed", "Branch B", "quorum-branch-b:failed")
+	observation.WorldState.WorkStateChangesByWorkID[failedChild.ID] = []interfaces.FactoryWorldWorkStateChangeRecord{{
+		WorkID:       failedChild.ID,
+		WorkTypeName: failedChild.WorkTypeID,
+		ToState:      "failed",
+		ToPlaceID:    failedChild.PlaceID,
+		RequestID:    "request-1",
+	}}
+	observation.WorldState.FailedWorkItemsByID[failedChild.ID] = failedChild
+
+	result := waitForSessionOwnerObservation(t, observation, &interfaces.InvocationReturnConfig{
+		Policy:        work.ReturnPolicyExplicit,
+		WorkTypeName:  "quorum-merge",
+		TerminalState: "complete",
+	})
+	assertSessionOwnerEqual(t, "status", result.Status, interfaces.InvocationTerminalStatusFailed)
+	assertSessionOwnerEqual(t, "error code", result.ErrorCode, string(work.PrimaryResultErrorCodeFailed))
+	assertSessionOwnerEqual(t, "work state", result.WorkState, "quorum-branch-b:failed")
+}
+
 func waitForSessionOwnerObservation(t *testing.T, observation SessionInvocationObservation, policy *interfaces.InvocationReturnConfig) FactoryInvocationResult {
 	t.Helper()
 	owner := newTestSessionOwner(sessionOwnerFixture{Observe: func(context.Context, string, SessionInvocationWaitInput) (SessionInvocationObservation, error) {

--- a/pkg/services/factory_sessions/internal/invocation/session_wait.go
+++ b/pkg/services/factory_sessions/internal/invocation/session_wait.go
@@ -96,6 +96,9 @@ func (o *SessionOwner) resolveObservation(
 	if classified, ok := work.ClassifyMissingPrimaryResult(selectionInput); ok {
 		return o.failedResult(sessionID, input, classified), true, nil
 	}
+	if classified, ok := work.ClassifyFailedInvocation(sessionID, selectionInput); ok {
+		return o.failedResult(sessionID, input, classified), true, nil
+	}
 	if _, exists := observation.WorldState.WorkRequestsByID[input.RequestID]; !exists || observation.ActiveWork {
 		return FactoryInvocationResult{}, false, nil
 	}

--- a/tests/functional/factory/packaged/quorum/helpers_test.go
+++ b/tests/functional/factory/packaged/quorum/helpers_test.go
@@ -1,0 +1,188 @@
+package quorum
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	packagedQuorumBranchAWorkstation = "run-quorum-branch-a"
+	packagedQuorumBranchBWorkstation = "run-quorum-branch-b"
+	packagedQuorumMergeWorkstation   = "merge-quorum"
+)
+
+type packagedQuorumCommandRunner struct {
+	mu               sync.Mutex
+	callCounts       map[string]int
+	capturedMergePromptText string
+}
+
+func newPackagedQuorumCommandRunner() *packagedQuorumCommandRunner {
+	return &packagedQuorumCommandRunner{
+		callCounts: make(map[string]int),
+	}
+}
+
+func (runner *packagedQuorumCommandRunner) Run(
+	_ context.Context,
+	request platformprocess.CommandRequest,
+) (platformprocess.CommandResult, error) {
+	lane := packagedQuorumRequestLane(request)
+	runner.mu.Lock()
+	runner.callCounts[lane]++
+	runner.mu.Unlock()
+
+	switch lane {
+	case packagedQuorumBranchAWorkstation:
+		return packagedQuorumCodexResult("branch A COMPLETE"), nil
+	case packagedQuorumBranchBWorkstation:
+		return packagedQuorumCodexResult("branch B COMPLETE"), nil
+	case packagedQuorumMergeWorkstation:
+		prompt := packagedQuorumCommandPrompt(request)
+		runner.mu.Lock()
+		runner.capturedMergePromptText = prompt
+		runner.mu.Unlock()
+		return packagedQuorumCodexResult("merged quorum response:\n" + prompt + "\nCOMPLETE"), nil
+	default:
+		return platformprocess.CommandResult{}, nil
+	}
+}
+
+func packagedQuorumCodexResult(result string) platformprocess.CommandResult {
+	return platformprocess.CommandResult{Stdout: support.CodexSuccessStdout(result)}
+}
+
+func packagedQuorumCommandPrompt(request platformprocess.CommandRequest) string {
+	if len(request.Stdin) > 0 {
+		return string(request.Stdin)
+	}
+	if len(request.Args) > 0 {
+		return request.Args[len(request.Args)-1]
+	}
+	return ""
+}
+
+func packagedQuorumRequestLane(request platformprocess.CommandRequest) string {
+	prompt := packagedQuorumCommandPrompt(request)
+	switch {
+	case strings.Contains(prompt, "Produce branch A's independent assessment"):
+		return packagedQuorumBranchAWorkstation
+	case strings.Contains(prompt, "Produce branch B's independent assessment"):
+		return packagedQuorumBranchBWorkstation
+	case strings.Contains(prompt, "Synthesize the two quorum assessments"):
+		return packagedQuorumMergeWorkstation
+	default:
+		return "unknown"
+	}
+}
+
+func (runner *packagedQuorumCommandRunner) callCount(workstation string) int {
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+	return runner.callCounts[workstation]
+}
+
+func (runner *packagedQuorumCommandRunner) capturedMergePrompt() string {
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+	return runner.capturedMergePromptText
+}
+
+func runPackagedQuorumCLIJSONInvocation(
+	t *testing.T,
+	runner platformprocess.CommandRunner,
+	requestText string,
+) factoryapi.InvocationResponse {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	support.InstallPackagedFactory(t, homeDir, factorydefinitions.PackagedQuorumFactoryName)
+
+	args := []string{
+		"you", "--json", "run",
+		"--named", factorydefinitions.PackagedQuorumFactoryName,
+		"--no-record",
+		requestText,
+	}
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	inputs.Input.WorkingDirectory = t.TempDir()
+
+	process := support.BuildProcess(t, serviceedges.Edges{
+		ProviderCommandRunner: runner,
+	})
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(%v) error = %v\nstdout:\n%s\nstderr:\n%s",
+			args,
+			err,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+	if inputs.Stderr() != "" {
+		t.Fatalf("stderr = %q, want empty successful-run stderr", inputs.Stderr())
+	}
+
+	var response factoryapi.InvocationResponse
+	if decodeErr := json.Unmarshal([]byte(strings.TrimSpace(inputs.Stdout())), &response); decodeErr != nil {
+		t.Fatalf("decode invocation JSON stdout: %v\nstdout:\n%s", decodeErr, inputs.Stdout())
+	}
+	return response
+}
+
+func invocationPrimaryResultText(t *testing.T, response factoryapi.InvocationResponse) string {
+	t.Helper()
+
+	if response.PrimaryResult == nil || len(*response.PrimaryResult) != 1 {
+		t.Fatalf("primaryResult = %#v, want one text part", response.PrimaryResult)
+	}
+	part, err := (*response.PrimaryResult)[0].AsWorkTextContentPart()
+	if err != nil {
+		t.Fatalf("primaryResult[0] as text part: %v", err)
+	}
+	return part.Text
+}
+
+func assertMergedQuorumPrimaryResult(t *testing.T, result, originalRequest string) {
+	t.Helper()
+	assertPromptIncludes(
+		t,
+		result,
+		"Original request:\n",
+		originalRequest,
+		"Branch A output:\n",
+		"branch A",
+		"Branch B output:\n",
+		"branch B",
+	)
+}
+
+func assertPromptIncludes(t *testing.T, text string, values ...string) {
+	t.Helper()
+	lastIndex := 0
+	for _, value := range values {
+		nextIndex := strings.Index(text[lastIndex:], value)
+		if nextIndex < 0 {
+			t.Fatalf("text = %q, missing %q", text, value)
+		}
+		lastIndex += nextIndex + len(value)
+	}
+}
+
+func packagedQuorumRequestText(t *testing.T) string {
+	t.Helper()
+	return fmt.Sprintf("functional packaged quorum required input %d", time.Now().UnixNano())
+}

--- a/tests/functional/factory/packaged/quorum/helpers_test.go
+++ b/tests/functional/factory/packaged/quorum/helpers_test.go
@@ -3,6 +3,7 @@ package quorum
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -35,6 +36,42 @@ func newPackagedQuorumCommandRunner() *packagedQuorumCommandRunner {
 		callCounts: make(map[string]int),
 		requests:   make(map[string]platformprocess.CommandRequest),
 	}
+}
+
+func newPackagedQuorumBranchBFailingCommandRunner() *packagedQuorumBranchBFailingCommandRunner {
+	return &packagedQuorumBranchBFailingCommandRunner{
+		callCounts: make(map[string]int),
+	}
+}
+
+type packagedQuorumBranchBFailingCommandRunner struct {
+	mu         sync.Mutex
+	callCounts map[string]int
+}
+
+func (runner *packagedQuorumBranchBFailingCommandRunner) Run(
+	_ context.Context,
+	request platformprocess.CommandRequest,
+) (platformprocess.CommandResult, error) {
+	lane := packagedQuorumRequestLane(request)
+	runner.mu.Lock()
+	runner.callCounts[lane]++
+	runner.mu.Unlock()
+
+	switch lane {
+	case packagedQuorumBranchAWorkstation:
+		return packagedQuorumCodexResult("branch A COMPLETE"), nil
+	case packagedQuorumBranchBWorkstation:
+		return platformprocess.CommandResult{}, errors.New("packaged quorum branch B provider failure")
+	default:
+		return platformprocess.CommandResult{}, nil
+	}
+}
+
+func (runner *packagedQuorumBranchBFailingCommandRunner) callCount(workstation string) int {
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+	return runner.callCounts[workstation]
 }
 
 func (runner *packagedQuorumCommandRunner) Run(
@@ -179,6 +216,66 @@ func runPackagedQuorumCLIJSONInvocation(
 		t.Fatalf("decode invocation JSON stdout: %v\nstdout:\n%s", decodeErr, inputs.Stdout())
 	}
 	return response
+}
+
+func runPackagedQuorumCLIJSONFailureInvocation(
+	t *testing.T,
+	runner platformprocess.CommandRunner,
+	requestText string,
+	extraArgs ...string,
+) (factoryapi.InvocationResponse, string, error) {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	support.InstallPackagedFactory(t, homeDir, factorydefinitions.PackagedQuorumFactoryName)
+
+	args := []string{
+		"you", "--json", "run",
+		"--named", factorydefinitions.PackagedQuorumFactoryName,
+		"--no-record",
+	}
+	args = append(args, extraArgs...)
+	args = append(args, requestText)
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	inputs.Input.WorkingDirectory = t.TempDir()
+
+	process := support.BuildProcess(t, serviceedges.Edges{
+		ProviderCommandRunner: runner,
+	})
+	execErr := process.Execute(inputs.Input)
+
+	var response factoryapi.InvocationResponse
+	if decodeErr := json.Unmarshal([]byte(strings.TrimSpace(inputs.Stdout())), &response); decodeErr != nil {
+		t.Fatalf("decode invocation JSON stdout: %v\nstdout:\n%s", decodeErr, inputs.Stdout())
+	}
+	return response, inputs.Stderr(), execErr
+}
+
+func assertPackagedQuorumInsufficientSuccessfulMembersFailed(
+	t *testing.T,
+	response factoryapi.InvocationResponse,
+) {
+	t.Helper()
+
+	if response.Status != factoryapi.InvocationTerminalStatusFailed {
+		t.Fatalf("invocation status = %q, want FAILED; response = %#v", response.Status, response)
+	}
+	if response.PrimaryResult != nil {
+		t.Fatalf(
+			"primary result = %#v, want no completed success primary result after insufficient successful members",
+			response.PrimaryResult,
+		)
+	}
+	if response.WorkState == nil || !strings.Contains(*response.WorkState, ":failed") {
+		t.Fatalf("invocation workState = %#v, want a failed quorum member state", response.WorkState)
+	}
+	if response.ErrorCode == nil || strings.TrimSpace(string(*response.ErrorCode)) == "" {
+		t.Fatalf("errorCode = %#v, want stable public failure code", response.ErrorCode)
+	}
+	if response.Message == nil || strings.TrimSpace(*response.Message) == "" {
+		t.Fatalf("message = %#v, want stable public failure message", response.Message)
+	}
 }
 
 func invocationPrimaryResultText(t *testing.T, response factoryapi.InvocationResponse) string {

--- a/tests/functional/factory/packaged/quorum/helpers_test.go
+++ b/tests/functional/factory/packaged/quorum/helpers_test.go
@@ -24,14 +24,16 @@ const (
 )
 
 type packagedQuorumCommandRunner struct {
-	mu               sync.Mutex
-	callCounts       map[string]int
+	mu                      sync.Mutex
+	callCounts              map[string]int
+	requests                map[string]platformprocess.CommandRequest
 	capturedMergePromptText string
 }
 
 func newPackagedQuorumCommandRunner() *packagedQuorumCommandRunner {
 	return &packagedQuorumCommandRunner{
 		callCounts: make(map[string]int),
+		requests:   make(map[string]platformprocess.CommandRequest),
 	}
 }
 
@@ -42,6 +44,7 @@ func (runner *packagedQuorumCommandRunner) Run(
 	lane := packagedQuorumRequestLane(request)
 	runner.mu.Lock()
 	runner.callCounts[lane]++
+	runner.requests[lane] = request
 	runner.mu.Unlock()
 
 	switch lane {
@@ -100,10 +103,44 @@ func (runner *packagedQuorumCommandRunner) capturedMergePrompt() string {
 	return runner.capturedMergePromptText
 }
 
+func (runner *packagedQuorumCommandRunner) assertProviderModel(
+	t *testing.T,
+	workstation, provider, model string,
+) {
+	t.Helper()
+
+	runner.mu.Lock()
+	request, ok := runner.requests[workstation]
+	runner.mu.Unlock()
+	if !ok {
+		t.Fatalf("no command request for %s", workstation)
+	}
+	if request.Command != provider || !packagedQuorumContainsArgumentPair(request.Args, "--model", model) {
+		t.Fatalf(
+			"%s command = %q %#v, want %s provider with model %q",
+			workstation,
+			request.Command,
+			request.Args,
+			provider,
+			model,
+		)
+	}
+}
+
+func packagedQuorumContainsArgumentPair(args []string, name, value string) bool {
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] == name && args[index+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
 func runPackagedQuorumCLIJSONInvocation(
 	t *testing.T,
 	runner platformprocess.CommandRunner,
 	requestText string,
+	extraArgs ...string,
 ) factoryapi.InvocationResponse {
 	t.Helper()
 
@@ -114,8 +151,9 @@ func runPackagedQuorumCLIJSONInvocation(
 		"you", "--json", "run",
 		"--named", factorydefinitions.PackagedQuorumFactoryName,
 		"--no-record",
-		requestText,
 	}
+	args = append(args, extraArgs...)
+	args = append(args, requestText)
 	inputs := support.FakeInputs(t.Context(), args)
 	inputs.Input.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
 	inputs.Input.WorkingDirectory = t.TempDir()

--- a/tests/functional/factory/packaged/quorum/invocation_test.go
+++ b/tests/functional/factory/packaged/quorum/invocation_test.go
@@ -1,0 +1,44 @@
+package quorum
+
+import (
+	"testing"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+// TestPackagedQuorumRequiredInputCompletes proves that invoking the packaged
+// @you/quorum Factory with only the required text request completes through the
+// public CLI under edge-mocked Codex providers, dispatches both independent
+// branch members, and returns one merged primary result reflecting the
+// submitted request.
+func TestPackagedQuorumRequiredInputCompletes(t *testing.T) {
+	requestText := packagedQuorumRequestText(t)
+	runner := newPackagedQuorumCommandRunner()
+
+	response := runPackagedQuorumCLIJSONInvocation(t, runner, requestText)
+	if response.Status != factoryapi.InvocationTerminalStatusCompleted {
+		t.Fatalf("invocation status = %q, want COMPLETED; response = %#v", response.Status, response)
+	}
+
+	for _, workstation := range []string{
+		packagedQuorumBranchAWorkstation,
+		packagedQuorumBranchBWorkstation,
+		packagedQuorumMergeWorkstation,
+	} {
+		if got := runner.callCount(workstation); got != 1 {
+			t.Fatalf("%s provider call count = %d, want one quorum dispatch", workstation, got)
+		}
+	}
+
+	assertMergedQuorumPrimaryResult(t, invocationPrimaryResultText(t, response), requestText)
+	assertPromptIncludes(
+		t,
+		runner.capturedMergePrompt(),
+		"Original request:\n",
+		requestText,
+		"Branch A output:\n",
+		"branch A",
+		"Branch B output:\n",
+		"branch B",
+	)
+}

--- a/tests/functional/factory/packaged/quorum/invocation_test.go
+++ b/tests/functional/factory/packaged/quorum/invocation_test.go
@@ -92,3 +92,28 @@ func TestPackagedQuorumOptionalMemberSettingsReachWorkers(t *testing.T) {
 	runner.assertProviderModel(t, packagedQuorumBranchBWorkstation, codex, "gpt-5.1")
 	runner.assertProviderModel(t, packagedQuorumMergeWorkstation, codex, "gpt-5.2")
 }
+
+// TestPackagedQuorumInsufficientSuccessfulMembersFails proves that packaged
+// @you/quorum invocation returns a failed public terminal outcome when fewer
+// than the required branch members succeed, without emitting a completed success
+// primary result for the failing run.
+func TestPackagedQuorumInsufficientSuccessfulMembersFails(t *testing.T) {
+	requestText := "functional packaged quorum insufficient successful members request"
+	runner := newPackagedQuorumBranchBFailingCommandRunner()
+
+	response, _, execErr := runPackagedQuorumCLIJSONFailureInvocation(t, runner, requestText)
+	if execErr == nil {
+		t.Fatal("Process.Execute error = nil, want terminal packaged-quorum branch failure")
+	}
+	assertPackagedQuorumInsufficientSuccessfulMembersFailed(t, response)
+
+	if got := runner.callCount(packagedQuorumBranchAWorkstation); got != 1 {
+		t.Fatalf("%s provider call count = %d, want one successful branch dispatch", packagedQuorumBranchAWorkstation, got)
+	}
+	if got := runner.callCount(packagedQuorumBranchBWorkstation); got < 1 {
+		t.Fatalf("%s provider call count = %d, want at least one failing branch dispatch", packagedQuorumBranchBWorkstation, got)
+	}
+	if got := runner.callCount(packagedQuorumMergeWorkstation); got != 0 {
+		t.Fatalf("%s provider call count = %d, want no merge dispatch before both branches succeed", packagedQuorumMergeWorkstation, got)
+	}
+}

--- a/tests/functional/factory/packaged/quorum/invocation_test.go
+++ b/tests/functional/factory/packaged/quorum/invocation_test.go
@@ -3,6 +3,7 @@ package quorum
 import (
 	"testing"
 
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 )
 
@@ -41,4 +42,53 @@ func TestPackagedQuorumRequiredInputCompletes(t *testing.T) {
 		"Branch B output:\n",
 		"branch B",
 	)
+}
+
+// TestPackagedQuorumOptionalMemberSettingsReachWorkers proves that optional
+// branch and merge provider/model settings supplied through the public CLI
+// reach the quorum branch and merge workers under edge-mocked Codex providers
+// and complete with a merged primary result reflecting the submitted request.
+func TestPackagedQuorumOptionalMemberSettingsReachWorkers(t *testing.T) {
+	requestText := "configured quorum optional member settings request"
+	runner := newPackagedQuorumCommandRunner()
+
+	response := runPackagedQuorumCLIJSONInvocation(
+		t,
+		runner,
+		requestText,
+		"--branch-provider", "CODEX",
+		"--branch-model", "gpt-5.1",
+		"--merge-provider", "CODEX",
+		"--merge-model", "gpt-5.2",
+	)
+	if response.Status != factoryapi.InvocationTerminalStatusCompleted {
+		t.Fatalf("invocation status = %q, want COMPLETED; response = %#v", response.Status, response)
+	}
+
+	for _, workstation := range []string{
+		packagedQuorumBranchAWorkstation,
+		packagedQuorumBranchBWorkstation,
+		packagedQuorumMergeWorkstation,
+	} {
+		if got := runner.callCount(workstation); got != 1 {
+			t.Fatalf("%s provider call count = %d, want one configured quorum dispatch", workstation, got)
+		}
+	}
+
+	assertMergedQuorumPrimaryResult(t, invocationPrimaryResultText(t, response), requestText)
+	assertPromptIncludes(
+		t,
+		runner.capturedMergePrompt(),
+		"Original request:\n",
+		requestText,
+		"Branch A output:\n",
+		"branch A",
+		"Branch B output:\n",
+		"branch B",
+	)
+
+	codex := string(modelprovider.ProviderCodex)
+	runner.assertProviderModel(t, packagedQuorumBranchAWorkstation, codex, "gpt-5.1")
+	runner.assertProviderModel(t, packagedQuorumBranchBWorkstation, codex, "gpt-5.1")
+	runner.assertProviderModel(t, packagedQuorumMergeWorkstation, codex, "gpt-5.2")
 }


### PR DESCRIPTION
{
  "project": "Packaged Quorum Factory Invocation Functional Coverage",
  "branchName": "ft-wave2-factory-quorum-invocation",
  "description": "Implement only tests/functional/factory/packaged/quorum/invocation_test.go so root.BuildProcess + Process.Execute public CLI packaged-factory invocation with edges.Edges ProviderCommandRunner / mocked Codex proves @you/quorum required-input member dispatch and merge completion, optional member settings reaching workers, and insufficient successful members failing—while consuming the three mapped migration-ledger rows and preserving runtime_api-delete-05-factory-packaged and smoke-delete-05-factory-packaged ownership for held siblings.",
  "context": {
    "customerAsk": "Implement only tests/functional/factory/packaged/quorum/invocation_test.go. Construct via root.BuildProcess + Process.Execute (built you CLI only if OS/process-boundary proof requires it). Prefer public CLI over HTTP/API for ordinary packaged-factory invocation. Replace external effects only through edges.Edges, preferring ProviderCommandRunner / command-runner edge mocks and mocked Codex (or another real inference-provider variant via sanitized goldens) over --with-mock-workers / MockWorkers. Do not add sleeps or timeout-padded wait helpers unless justified in-code after RC fixes. Prove: (1) TestPackagedQuorumRequiredInputCompletes; (2) TestPackagedQuorumOptionalMemberSettingsReachWorkers; (3) TestPackagedQuorumInsufficientSuccessfulMembersFails. Consume the three mapped migration-ledger rows and preserve runtime_api-delete-05-factory-packaged and smoke-delete-05-factory-packaged ownership. Do not implement review, goal, deep_research, fusion, subagent, tts, cross, or classifier cells. Avoid service/internal Petri imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for packaged @you/quorum invocation does not exist yet. Existing proofs live under catch-all runtime_api and smoke suites, so maintainers lack a factory-owned cell that jointly proves required-input member dispatch + merge completion, optional member-setting reachability, and insufficient-successful-members failure. Three migration-ledger rows map here under shared deletion batches that must keep ownership for held siblings (especially review).",
    "solution": "Implement the three checklist scenarios in tests/functional/factory/packaged/quorum/invocation_test.go via root.BuildProcess + Process.Execute, preferring public CLI and replacing external effects only through edges.Edges with ProviderCommandRunner / mocked Codex preferred over MockWorkers. Assert required-input branch+merge completion with primary result, optional branch/merge provider-model reachability on edge captures, and failed public terminal outcome when too few members succeed; consume the three mapped migration-ledger rows while preserving shared deletion-batch ownership; apply only narrowly coupled metadata; and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/factory/packaged/quorum/invocation_test.go exists as the factory-owned functional cell and covers required-input member dispatch + merge completion, optional member-setting reachability, and insufficient-successful-members failure.",
    "Through root.BuildProcess + Process.Execute and public CLI packaged-factory invocation with edges.Edges provider/command-runner mocks, a required-input @you/quorum run completes both branch members and the final merge with a completed primary result reflecting the submitted request.",
    "Through the same construction/entry preferences, optional branchProvider/branchModel/mergeProvider/mergeModel settings reach workers and are observable on command-runner edge captures and/or public primary-result surfaces.",
    "Through the same construction/entry preferences, a forced insufficient-successful-members condition yields the documented public failed terminal outcome (no completed success primary result attributable to that failing run).",
    "The three mapped migration-ledger rows for this destination are consumed; runtime_api-delete-05-factory-packaged and smoke-delete-05-factory-packaged ownership is preserved for held siblings; only narrowly coupled ownership/coverage/catalog/migration metadata for this cell are updated.",
    "Coverage constructs via root.BuildProcess + Process.Execute, prefers public CLI, replaces external effects only through edges.Edges (ProviderCommandRunner / mocked Codex preferred over MockWorkers), does not import service implementations or internal Petri primitives as the proof owner, and gives every top-level Test* a customer-readable Go doc comment.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave2-factory-quorum-invocation-001",
      "title": "Prove required input completes via member dispatch and merge",
      "description": "As a customer invoking @you/quorum with a required text request, I want the packaged Factory to complete under edge-mocked providers through both independent branch members and a final merge result so I can rely on the packaged quorum happy path.",
      "acceptanceCriteria": [
        "tests/functional/factory/packaged/quorum/invocation_test.go includes TestPackagedQuorumRequiredInputCompletes as a top-level test.",
        "The test constructs the process via root.BuildProcess + Process.Execute (built you CLI only if this scenario must prove OS/process-boundary behavior BuildProcess cannot express) and prefers public CLI packaged-factory invocation over HTTP/API.",
        "External provider/process effects are replaced only through edges.Edges, preferring ProviderCommandRunner / command-runner edge mocks and mocked Codex (or another real inference-provider variant via sanitized goldens) over --with-mock-workers / MockWorkers.",
        "Invoking @you/quorum with a required input reaches a completed / succeeded terminal public status.",
        "Observable evidence proves both branch members dispatch and the final merge produces one primary result reflecting the submitted request (absorbing customer-facing obligations of mapped ledger scenarios such as merge gated until both branches complete and one merge result).",
        "Assertions stay on required-input completion for quorum and do not re-own review, goal, deep_research, fusion, catalog discovery, or other packaged factory packages.",
        "The top-level test has a customer-readable Go doc comment describing the observable required-input member-dispatch-and-merge completion behavior.",
        "No unjustified sleeps or timeout-padded wait helpers are introduced (any wait helper is justified in-code after readiness/latency root-cause consideration).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-quorum-invocation-002",
      "title": "Prove optional member settings reach workers",
      "description": "As a customer configuring branch and merge providers/models, I want optional quorum member settings to reach the branch and merge workers so supported role overrides are honored end to end.",
      "acceptanceCriteria": [
        "The quorum invocation cell includes TestPackagedQuorumOptionalMemberSettingsReachWorkers as a top-level test.",
        "Construction and entry follow the same preferences as story 001 (root.BuildProcess + Process.Execute, public CLI preferred, edges.Edges ProviderCommandRunner / mocked Codex preferred over MockWorkers).",
        "An @you/quorum invocation supplies optional member settings from the packaged supported set (branchProvider/branchModel and mergeProvider/mergeModel, including CLI forms such as --branch-provider, --branch-model, --merge-provider, --merge-model).",
        "Observable evidence proves those optional values reach workers / provider command invocations (for example command-runner edge captures showing branch vs merge provider/model selection) and appear in public outcome surfaces as applicable.",
        "Assertions absorb customer-facing obligations of the mapped role-arguments ledger row without widening into catalog required-input rejection matrices or other packaged factory packages.",
        "The top-level test has a customer-readable Go doc comment describing the observable optional-member-settings-to-worker behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-quorum-invocation-003",
      "title": "Prove insufficient successful members fails",
      "description": "As a customer or automation handling a failing quorum run, I want insufficient successful members during packaged @you/quorum invocation to yield a failed public outcome so scripts do not treat a broken branch fan-in as successful completion.",
      "acceptanceCriteria": [
        "The quorum invocation cell includes TestPackagedQuorumInsufficientSuccessfulMembersFails as a top-level test.",
        "Construction and entry follow the same preferences as story 001 (root.BuildProcess + Process.Execute, public CLI preferred, edges.Edges ProviderCommandRunner / mocked Codex preferred over MockWorkers).",
        "A quorum run is configured so fewer than the required successful members complete (for example one branch member fails via command-runner edge mock / sanitized-golden failure fixture) while preserving enough context to observe the documented failure path.",
        "Observable evidence proves the public terminal outcome is failed / non-success and that no completed success primary result is attributable to that failing run.",
        "Assertions remain on insufficient-successful-members failure for quorum and do not re-own transport stdout/stderr shaping, full exit-code taxonomy, review retry exhaustion, or other packaged factory failure matrices.",
        "The top-level test has a customer-readable Go doc comment describing the observable insufficient-successful-members failure contract.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-quorum-invocation-004",
      "title": "Consume mapped ledger rows and close verification gates",
      "description": "As a maintainer executing Wave 2 functional-test expansion, I want the three mapped migration-ledger rows consumed with shared deletion-batch ownership preserved, and focused boundary/viz gates passing, so quorum can terminal-complete without stranding review or inventing unrelated deletion work.",
      "acceptanceCriteria": [
        "The three mapped migration-ledger rows destined for tests/functional/factory/packaged/quorum/invocation_test.go are consumed: runtime_api TestSessionInvocationAPI_PackagedQuorumAppliesRoleArguments (runtime_api-delete-05-factory-packaged); runtime_api TestSessionInvocationAPI_PackagedQuorumGatesMergeUntilBothBranchesComplete (runtime_api-delete-05-factory-packaged); smoke TestNamedQuorumRun_RealCLIAcceptsRoleFlagsAndReturnsOneMergeResult (smoke-delete-05-factory-packaged).",
        "runtime_api-delete-05-factory-packaged and smoke-delete-05-factory-packaged ownership is preserved for held siblings (especially review); this cell does not execute those shared deletion batches wholesale.",
        "Only narrowly coupled ownership, coverage, catalog, or migration metadata required for this cell are updated; sibling packaged factories (review, goal, deep_research, fusion, subagent, tts, cross) and classifier are not implemented or rewritten.",
        "Focused package tests for tests/functional/factory/packaged/quorum pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as factory/packaged/quorum).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)