### PR TITLE
ft-wave2-provider-sessions-response-exec-metadata

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -797,6 +797,20 @@ Wave 0 functional-tests-expansion planning authority lives under
   needs a customer-readable Go doc so `functionaltestmetadata` stays
   viz-compatible.
 
+- `tests/functional/provider_sessions/association/response_exec_metadata_test.go`
+  owns response-exec golden metadata survival across CLI Factory Event projection,
+  API `FactoryResponseEvent` history, and replay observation. Drive proofs through
+  `support.RunFactoryToCompletionWithEdgesAndResponseEvents` or
+  `support.StartFunctionalAPIServer` with `--record` / `--replay`, replaying
+  sanitized FND-006 Codex goldens via `serviceedges.Edges{ProviderCommandRunner:
+  ...}` and asserting against checked-in provider-session, invocation-result, and
+  response-event golden metadata with `support.CompareProviderSessionJSON` /
+  `CompareProviderSessionNDJSON` only (never production mappers under assertion).
+  Do not widen into `association_test.go` correlation scenarios or `details/*`.
+  Catalog metadata infers domain `provider_sessions` and subsection `association`;
+  every top-level `Test*` needs a customer-readable Go doc and `//golden:` manifest
+  directive so `functionaltestmetadata` stays viz-compatible.
+
 - `tests/functional/automations/` owns root.BuildProcess evidence for packaged
   Automations cron scheduling and filesystem watcher preseed. Keep cron workstation
   factories explicit with `"behavior": "CRON"` and observe submissions through

--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -2569,6 +2569,36 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/provider_sessions/association/response_exec_metadata_test.go",
+      "package": "you-agent-factory/tests/functional/provider_sessions/association",
+      "scenario": "TestResponseExecGoldenMetadataSurvivesAPIResponseEvents",
+      "lane": "short",
+      "destination": "tests/functional/provider_sessions/association/response_exec_metadata_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/provider_sessions/association/response_exec_metadata_test.go",
+      "package": "you-agent-factory/tests/functional/provider_sessions/association",
+      "scenario": "TestResponseExecGoldenMetadataSurvivesCLIProjection",
+      "lane": "short",
+      "destination": "tests/functional/provider_sessions/association/response_exec_metadata_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/provider_sessions/association/response_exec_metadata_test.go",
+      "package": "you-agent-factory/tests/functional/provider_sessions/association",
+      "scenario": "TestResponseExecGoldenMetadataSurvivesReplay",
+      "lane": "short",
+      "destination": "tests/functional/provider_sessions/association/response_exec_metadata_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/providers/cli_script_executor_test.go",
       "package": "you-agent-factory/tests/functional/providers",
       "scenario": "TestScriptExecutor_ArgTemplating",
@@ -7834,7 +7864,7 @@
     "by_catch_all": {
       "bootstrap_portability": 22,
       "guards_batch": 23,
-      "none": 507,
+      "none": 510,
       "replay_contracts": 23,
       "runtime_api": 96,
       "smoke": 62,
@@ -7852,7 +7882,7 @@
       "operator_settings": 10,
       "orchestration": 48,
       "product": 13,
-      "provider_sessions": 3,
+      "provider_sessions": 6,
       "providers": 55,
       "replay_contracts": 23,
       "runtime_api": 95,
@@ -7865,9 +7895,9 @@
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 763,
+    "customer_top_level_Test_scenarios": 766,
     "lane_functionallong": 95,
-    "lane_short": 668,
+    "lane_short": 671,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 12,
       "you-agent-factory/tests/functional/automations": 7,
@@ -7904,7 +7934,7 @@
       "you-agent-factory/tests/functional/product/init_setup": 11,
       "you-agent-factory/tests/functional/product/packaged_factory_guard_failure": 1,
       "you-agent-factory/tests/functional/product/packaged_factory_portability": 1,
-      "you-agent-factory/tests/functional/provider_sessions/association": 3,
+      "you-agent-factory/tests/functional/provider_sessions/association": 6,
       "you-agent-factory/tests/functional/providers": 36,
       "you-agent-factory/tests/functional/providers/codex": 7,
       "you-agent-factory/tests/functional/providers/cursor": 8,

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -534,6 +534,12 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestWorkBatchSelectsDefaultAndExplicitWorkTypes`.
   - `TestWorkBatchRejectsUnknownTypeWithoutPartialMutation`.
 
+- [x] `tests/functional/work/recordings/recordings_read_test.go`
+  - `TestRecordingsBackedWorkReadsUseRecordingsRootContract`.
+  - `TestGetWorkFromRecordingsRootUsesRecordingsServiceRoot`.
+  - `TestRecordingsBackedWorkReadsMapRichWorldState`.
+  - `TestRecordingsBackedWorkReadsSurfaceTypedProjectionFailures`.
+
 - [ ] `tests/functional/work/submission/http_test.go`
   - `TestAPISubmitBatchThenListAndGetWork`.
   - `TestAPIUpsertWorkRequestUsesCanonicalIdentity`.
@@ -757,7 +763,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestAbsentProviderSessionIsNotFabricated`.
   - `TestMultipleDispatchesKeepDistinctProviderSessionRefs`.
 
-- [ ] `tests/functional/provider_sessions/association/response_exec_metadata_test.go`
+- [x] `tests/functional/provider_sessions/association/response_exec_metadata_test.go`
   - `TestResponseExecGoldenMetadataSurvivesCLIProjection`.
   - `TestResponseExecGoldenMetadataSurvivesAPIResponseEvents`.
   - `TestResponseExecGoldenMetadataSurvivesReplay`.

--- a/tests/functional/provider_sessions/association/response_exec_metadata_test.go
+++ b/tests/functional/provider_sessions/association/response_exec_metadata_test.go
@@ -54,6 +54,39 @@ func TestResponseExecGoldenMetadataSurvivesCLIProjection(t *testing.T) {
 	}
 }
 
+// TestResponseExecGoldenMetadataSurvivesReplay records a sanitized Codex provider
+// execution transcript through root.BuildProcess, replays the public recording,
+// and proves replay observation preserves checked-in Provider Session and
+// invocation-result golden metadata without mapper-generated expectations.
+//
+//golden: docs/temp/functional/provider-sessions/codex/success/manifest.json
+func TestResponseExecGoldenMetadataSurvivesReplay(t *testing.T) {
+	t.Parallel()
+
+	loaded := loadResponseExecCodexGoldenCase(t, responseExecCodexSuccessGoldenCase)
+	replay := observeResponseExecCodexGoldenReplay(t, loaded)
+	observed := observeResponseExecFactoryEventGoldens(t, loaded, replay.FactoryEvents)
+
+	if err := support.CompareProviderSessionJSON(
+		loaded.Manifest.ID,
+		"expected-provider-session",
+		loaded.Manifest.NormalizedFields,
+		loaded.Expected.ProviderSession,
+		observed.ProviderSession,
+	); err != nil {
+		t.Fatalf("CompareProviderSessionJSON(provider-session): %v", err)
+	}
+	if err := support.CompareProviderSessionJSON(
+		loaded.Manifest.ID,
+		"expected-invocation-result",
+		loaded.Manifest.NormalizedFields,
+		loaded.Expected.InvocationResult,
+		observed.InvocationResult,
+	); err != nil {
+		t.Fatalf("CompareProviderSessionJSON(invocation-result): %v", err)
+	}
+}
+
 // TestResponseExecGoldenMetadataSurvivesAPIResponseEvents replays a sanitized
 // Codex provider execution transcript through root.BuildProcess and proves
 // public FactoryResponseEvent history after API observation preserves
@@ -156,6 +189,89 @@ func runResponseExecCodexGoldenReplay(
 		ResponseEvents: responseEvents,
 		Runner:         runner,
 	}
+}
+
+func observeResponseExecCodexGoldenReplay(
+	t *testing.T,
+	loaded support.ProviderSessionCase,
+) responseExecCodexReplayResult {
+	t.Helper()
+
+	artifactPath := recordResponseExecCodexGoldenRun(t, loaded)
+
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir: t.TempDir(),
+		Args:       []string{"--replay", artifactPath, "--no-record"},
+	})
+	support.WaitForTerminalStatus(t, server.URL(), 30*time.Second)
+
+	listed := support.ListDefaultSessionWork(t, server.URL())
+	events := server.GetFactoryEvents(t)
+	server.Stop(t)
+
+	if got := support.CountWorkAtCustomerState(listed, "task:done"); got != 1 {
+		t.Fatalf("replayed completed work = %d, want 1; listed=%#v", got, listed)
+	}
+	if got := support.CountWorkAtCustomerState(listed, "task:failed"); got != 0 {
+		t.Fatalf("replayed failed work = %d, want 0", got)
+	}
+
+	return responseExecCodexReplayResult{
+		Loaded:        loaded,
+		Listed:        listed,
+		FactoryEvents: events,
+	}
+}
+
+func recordResponseExecCodexGoldenRun(
+	t *testing.T,
+	loaded support.ProviderSessionCase,
+) string {
+	t.Helper()
+
+	var request struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(loaded.Request, &request); err != nil {
+		t.Fatalf("decode request.json: %v", err)
+	}
+	if request.Model == "" {
+		t.Fatal("request.model must be non-empty")
+	}
+
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
+	support.WriteAgentConfig(t, dir, "worker", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, request.Model))
+	testutil.WriteSeedFile(t, dir, "task", []byte(`{"title":"response-exec replay survival"}`))
+
+	exitCode := 0
+	if loaded.Process.ExitCode != nil {
+		exitCode = *loaded.Process.ExitCode
+	}
+	runner := testutil.NewProviderCommandRunner(platformprocess.CommandResult{
+		Stdout:   append([]byte(nil), loaded.Stdout.Raw...),
+		Stderr:   []byte(loaded.Stderr),
+		ExitCode: exitCode,
+	})
+
+	artifactPath := filepath.Join(t.TempDir(), "response-exec-metadata.replay.json")
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir: dir,
+		Args:       []string{"--record", artifactPath},
+		Edges:      serviceedges.Edges{ProviderCommandRunner: runner},
+	})
+	support.WaitForTerminalStatus(t, server.URL(), 30*time.Second)
+
+	listed := support.ListDefaultSessionWork(t, server.URL())
+	server.Stop(t)
+
+	if got := support.CountWorkAtCustomerState(listed, "task:done"); got != 1 {
+		t.Fatalf("recorded completed work = %d, want 1; listed=%#v", got, listed)
+	}
+	if runner.CallCount() != 1 {
+		t.Fatalf("provider command runner calls = %d, want exactly one mocked Codex invocation", runner.CallCount())
+	}
+
+	return artifactPath
 }
 
 func observeResponseExecResponseEventGoldens(

--- a/tests/functional/provider_sessions/association/response_exec_metadata_test.go
+++ b/tests/functional/provider_sessions/association/response_exec_metadata_test.go
@@ -1,0 +1,309 @@
+// Package association owns functional coverage for Provider Session ref correlation
+// on public Factory Session dispatch projections and response-exec golden metadata
+// survival across CLI projection, API response events, and replay.
+package association_test
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const responseExecCodexSuccessGoldenCase = "success"
+
+// TestResponseExecGoldenMetadataSurvivesCLIProjection replays a sanitized Codex
+// provider execution transcript through root.BuildProcess and proves public
+// Factory Event projection after CLI invocation preserves checked-in Provider
+// Session and invocation-result golden metadata without mapper-generated
+// expectations.
+//
+//golden: docs/temp/functional/provider-sessions/codex/success/manifest.json
+func TestResponseExecGoldenMetadataSurvivesCLIProjection(t *testing.T) {
+	t.Parallel()
+
+	loaded := loadResponseExecCodexGoldenCase(t, responseExecCodexSuccessGoldenCase)
+	replay := runResponseExecCodexGoldenReplay(t, loaded)
+	observed := observeResponseExecFactoryEventGoldens(t, loaded, replay.FactoryEvents)
+
+	if err := support.CompareProviderSessionJSON(
+		loaded.Manifest.ID,
+		"expected-provider-session",
+		loaded.Manifest.NormalizedFields,
+		loaded.Expected.ProviderSession,
+		observed.ProviderSession,
+	); err != nil {
+		t.Fatalf("CompareProviderSessionJSON(provider-session): %v", err)
+	}
+	if err := support.CompareProviderSessionJSON(
+		loaded.Manifest.ID,
+		"expected-invocation-result",
+		loaded.Manifest.NormalizedFields,
+		loaded.Expected.InvocationResult,
+		observed.InvocationResult,
+	); err != nil {
+		t.Fatalf("CompareProviderSessionJSON(invocation-result): %v", err)
+	}
+}
+
+func loadResponseExecCodexGoldenCase(t *testing.T, caseName string) support.ProviderSessionCase {
+	t.Helper()
+
+	repoRoot := testutil.MustRepoRoot(t)
+	caseDir := filepath.Join(
+		repoRoot,
+		filepath.FromSlash(support.ProviderSessionFixturePath("codex", caseName)),
+	)
+	loaded, err := support.LoadProviderSessionCase(caseDir)
+	if err != nil {
+		t.Fatalf("LoadProviderSessionCase(%q): %v", caseName, err)
+	}
+	return loaded
+}
+
+type responseExecCodexReplayResult struct {
+	Loaded        support.ProviderSessionCase
+	Listed        factoryapi.ListWorkResponse
+	FactoryEvents []factoryapi.FactoryEvent
+	Runner        *testutil.ProviderCommandRunner
+}
+
+func runResponseExecCodexGoldenReplay(
+	t *testing.T,
+	loaded support.ProviderSessionCase,
+) responseExecCodexReplayResult {
+	t.Helper()
+
+	var request struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(loaded.Request, &request); err != nil {
+		t.Fatalf("decode request.json: %v", err)
+	}
+	if request.Model == "" {
+		t.Fatal("request.model must be non-empty")
+	}
+
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
+	support.WriteAgentConfig(t, dir, "worker", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, request.Model))
+	testutil.WriteSeedFile(t, dir, "task", []byte(`{"title":"response-exec cli projection"}`))
+
+	exitCode := 0
+	if loaded.Process.ExitCode != nil {
+		exitCode = *loaded.Process.ExitCode
+	}
+	runner := testutil.NewProviderCommandRunner(platformprocess.CommandResult{
+		Stdout:   append([]byte(nil), loaded.Stdout.Raw...),
+		Stderr:   []byte(loaded.Stderr),
+		ExitCode: exitCode,
+	})
+
+	_, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
+		t,
+		dir,
+		serviceedges.Edges{ProviderCommandRunner: runner},
+		30*time.Second,
+	)
+
+	if got := support.CountWorkAtCustomerState(listed, "task:done"); got != 1 {
+		t.Fatalf("completed work = %d, want 1; listed=%#v", got, listed)
+	}
+	if got := support.CountWorkAtCustomerState(listed, "task:failed"); got != 0 {
+		t.Fatalf("failed work = %d, want 0", got)
+	}
+	if runner.CallCount() != 1 {
+		t.Fatalf("provider command runner calls = %d, want exactly one mocked Codex invocation", runner.CallCount())
+	}
+
+	return responseExecCodexReplayResult{
+		Loaded:        loaded,
+		Listed:        listed,
+		FactoryEvents: events,
+		Runner:        runner,
+	}
+}
+
+func observeResponseExecFactoryEventGoldens(
+	t *testing.T,
+	loaded support.ProviderSessionCase,
+	events []factoryapi.FactoryEvent,
+) support.ProviderSessionObservedGoldens {
+	t.Helper()
+
+	inference := succeededResponseExecInferenceResponse(t, events)
+
+	providerSession := projectResponseExecProviderSessionGolden(loaded, inference)
+	invocationResult := projectResponseExecInvocationResultGolden(t, loaded, inference, events)
+
+	sessionBytes, err := json.Marshal(providerSession)
+	if err != nil {
+		t.Fatalf("marshal observed provider session: %v", err)
+	}
+	resultBytes, err := json.Marshal(invocationResult)
+	if err != nil {
+		t.Fatalf("marshal observed invocation result: %v", err)
+	}
+
+	return support.ProviderSessionObservedGoldens{
+		ProviderSession:  sessionBytes,
+		InvocationResult: resultBytes,
+	}
+}
+
+func succeededResponseExecInferenceResponse(
+	t *testing.T,
+	events []factoryapi.FactoryEvent,
+) factoryapi.InferenceResponseEventPayload {
+	t.Helper()
+
+	for _, event := range events {
+		if event.Type != factoryapi.FactoryEventTypeInferenceResponse {
+			continue
+		}
+		payload, err := event.Payload.AsInferenceResponseEventPayload()
+		if err != nil {
+			t.Fatalf("decode INFERENCE_RESPONSE: %v", err)
+		}
+		if payload.Outcome == factoryapi.InferenceOutcomeSucceeded {
+			return payload
+		}
+	}
+	t.Fatal("missing succeeded INFERENCE_RESPONSE factory event after CLI invocation")
+	return factoryapi.InferenceResponseEventPayload{}
+}
+
+func projectResponseExecProviderSessionGolden(
+	loaded support.ProviderSessionCase,
+	inference factoryapi.InferenceResponseEventPayload,
+) map[string]any {
+	session := map[string]any{
+		"provider":      loaded.Manifest.Provider,
+		"fidelityClass": loaded.Manifest.FidelityClass,
+		"status":        "completed",
+	}
+	if inference.Outcome != factoryapi.InferenceOutcomeSucceeded {
+		session["status"] = "failed"
+	}
+
+	if inference.ProviderSession != nil && inference.ProviderSession.Id != nil &&
+		strings.TrimSpace(*inference.ProviderSession.Id) != "" {
+		session["providerSessionId"] = strings.TrimSpace(*inference.ProviderSession.Id)
+		return session
+	}
+	if inference.Response != nil {
+		if threadID := responseExecCodexThreadIDFromTranscript(*inference.Response); threadID != "" {
+			session["providerSessionId"] = threadID
+			return session
+		}
+	}
+	return session
+}
+
+func projectResponseExecInvocationResultGolden(
+	t *testing.T,
+	loaded support.ProviderSessionCase,
+	inference factoryapi.InferenceResponseEventPayload,
+	events []factoryapi.FactoryEvent,
+) map[string]any {
+	t.Helper()
+
+	result := map[string]any{
+		"ok":           inference.Outcome == factoryapi.InferenceOutcomeSucceeded,
+		"finishReason": "stop",
+	}
+
+	content := ""
+	if inference.Response != nil {
+		content = responseExecCodexTerminalAgentMessageText(*inference.Response)
+	}
+	if content == "" {
+		for _, record := range loaded.Stdout.Records {
+			if text := responseExecCodexAgentMessageText(record); text != "" {
+				content = text
+				break
+			}
+		}
+	}
+	if content == "" {
+		content = responseExecDispatchOutput(t, events)
+	}
+	if content == "" {
+		t.Fatal("missing terminal invocation content in public Factory Event projection")
+	}
+	result["content"] = content
+	return result
+}
+
+func responseExecDispatchOutput(t *testing.T, events []factoryapi.FactoryEvent) string {
+	t.Helper()
+
+	for _, event := range events {
+		if event.Type != factoryapi.FactoryEventTypeDispatchResponse {
+			continue
+		}
+		payload, err := event.Payload.AsDispatchResponseEventPayload()
+		if err != nil {
+			t.Fatalf("decode dispatch response: %v", err)
+		}
+		if payload.Output != nil && strings.TrimSpace(*payload.Output) != "" {
+			return strings.TrimSpace(*payload.Output)
+		}
+	}
+	return ""
+}
+
+func responseExecCodexThreadIDFromTranscript(transcript string) string {
+	for _, line := range strings.Split(transcript, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var envelope struct {
+			Type     string `json:"type"`
+			ThreadID string `json:"thread_id"`
+		}
+		if err := json.Unmarshal([]byte(line), &envelope); err != nil {
+			continue
+		}
+		if envelope.Type == "thread.started" && strings.TrimSpace(envelope.ThreadID) != "" {
+			return strings.TrimSpace(envelope.ThreadID)
+		}
+	}
+	return ""
+}
+
+func responseExecCodexTerminalAgentMessageText(transcript string) string {
+	var terminal string
+	for _, line := range strings.Split(transcript, "\n") {
+		if text := responseExecCodexAgentMessageText([]byte(line)); text != "" {
+			terminal = text
+		}
+	}
+	return terminal
+}
+
+func responseExecCodexAgentMessageText(record []byte) string {
+	var envelope struct {
+		Type string `json:"type"`
+		Item struct {
+			Type   string `json:"type"`
+			Text   string `json:"text"`
+			Status string `json:"status"`
+		} `json:"item"`
+	}
+	if err := json.Unmarshal(record, &envelope); err != nil {
+		return ""
+	}
+	if envelope.Type != "item.completed" || envelope.Item.Type != "agent_message" {
+		return ""
+	}
+	return strings.TrimSpace(envelope.Item.Text)
+}

--- a/tests/functional/provider_sessions/association/response_exec_metadata_test.go
+++ b/tests/functional/provider_sessions/association/response_exec_metadata_test.go
@@ -54,6 +54,31 @@ func TestResponseExecGoldenMetadataSurvivesCLIProjection(t *testing.T) {
 	}
 }
 
+// TestResponseExecGoldenMetadataSurvivesAPIResponseEvents replays a sanitized
+// Codex provider execution transcript through root.BuildProcess and proves
+// public FactoryResponseEvent history after API observation preserves
+// checked-in response-event golden metadata without mapper-generated
+// expectations.
+//
+//golden: docs/temp/functional/provider-sessions/codex/success/manifest.json
+func TestResponseExecGoldenMetadataSurvivesAPIResponseEvents(t *testing.T) {
+	t.Parallel()
+
+	loaded := loadResponseExecCodexGoldenCase(t, responseExecCodexSuccessGoldenCase)
+	replay := runResponseExecCodexGoldenReplay(t, loaded)
+	observed := observeResponseExecResponseEventGoldens(t, replay.ResponseEvents)
+
+	if err := support.CompareProviderSessionNDJSON(
+		loaded.Manifest.ID,
+		"expected-response-events",
+		loaded.Manifest.NormalizedFields,
+		loaded.Expected.ResponseEvents,
+		observed,
+	); err != nil {
+		t.Fatalf("CompareProviderSessionNDJSON(response-events): %v", err)
+	}
+}
+
 func loadResponseExecCodexGoldenCase(t *testing.T, caseName string) support.ProviderSessionCase {
 	t.Helper()
 
@@ -70,10 +95,11 @@ func loadResponseExecCodexGoldenCase(t *testing.T, caseName string) support.Prov
 }
 
 type responseExecCodexReplayResult struct {
-	Loaded        support.ProviderSessionCase
-	Listed        factoryapi.ListWorkResponse
-	FactoryEvents []factoryapi.FactoryEvent
-	Runner        *testutil.ProviderCommandRunner
+	Loaded         support.ProviderSessionCase
+	Listed         factoryapi.ListWorkResponse
+	FactoryEvents  []factoryapi.FactoryEvent
+	ResponseEvents []factoryapi.FactoryResponseEvent
+	Runner         *testutil.ProviderCommandRunner
 }
 
 func runResponseExecCodexGoldenReplay(
@@ -106,7 +132,7 @@ func runResponseExecCodexGoldenReplay(
 		ExitCode: exitCode,
 	})
 
-	_, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
+	_, listed, events, responseEvents := support.RunFactoryToCompletionWithEdgesAndResponseEvents(
 		t,
 		dir,
 		serviceedges.Edges{ProviderCommandRunner: runner},
@@ -124,11 +150,85 @@ func runResponseExecCodexGoldenReplay(
 	}
 
 	return responseExecCodexReplayResult{
-		Loaded:        loaded,
-		Listed:        listed,
-		FactoryEvents: events,
-		Runner:        runner,
+		Loaded:         loaded,
+		Listed:         listed,
+		FactoryEvents:  events,
+		ResponseEvents: responseEvents,
+		Runner:         runner,
 	}
+}
+
+func observeResponseExecResponseEventGoldens(
+	t *testing.T,
+	events []factoryapi.FactoryResponseEvent,
+) []json.RawMessage {
+	t.Helper()
+
+	records := make([]json.RawMessage, 0, len(events))
+	for _, event := range events {
+		record := projectResponseExecResponseEventGolden(event)
+		if len(record) == 0 {
+			continue
+		}
+		records = append(records, record)
+	}
+	return records
+}
+
+func projectResponseExecResponseEventGolden(event factoryapi.FactoryResponseEvent) json.RawMessage {
+	record := map[string]any{}
+	if nativeType := strings.TrimSpace(event.Provenance.NativeEventType); nativeType != "" {
+		record["type"] = strings.ToLower(nativeType)
+	} else {
+		record["type"] = strings.ToLower(string(event.Kind) + "." + strings.ToLower(string(event.Phase)))
+	}
+	if event.ItemId != nil && strings.TrimSpace(*event.ItemId) != "" {
+		record["itemId"] = strings.TrimSpace(*event.ItemId)
+	}
+
+	switch event.Kind {
+	case factoryapi.FactoryResponseEventKindTool:
+		payload, err := event.Payload.AsFactoryResponseEventToolPayload()
+		if err == nil {
+			if payload.ToolName != "" {
+				record["toolName"] = payload.ToolName
+			}
+			if payload.ToolCallId != "" {
+				record["itemId"] = payload.ToolCallId
+			}
+		}
+	case factoryapi.FactoryResponseEventKindMessage:
+		switch event.Phase {
+		case factoryapi.FactoryResponseEventPhaseDelta:
+			payload, err := event.Payload.AsFactoryResponseEventMessageDeltaPayload()
+			if err == nil && payload.TextDelta != nil {
+				record["text"] = *payload.TextDelta
+			}
+		case factoryapi.FactoryResponseEventPhaseCompleted:
+			payload, err := event.Payload.AsFactoryResponseEventMessagePayload()
+			if err == nil {
+				for _, block := range payload.ContentBlocks {
+					text, err := block.AsFactoryResponseEventTextContentBlock()
+					if err == nil && text.Text != "" {
+						record["text"] = text.Text
+						break
+					}
+				}
+			}
+			record["finishReason"] = "stop"
+		}
+	case factoryapi.FactoryResponseEventKindRun:
+		payload, err := event.Payload.AsFactoryResponseEventRunPayload()
+		if err == nil && payload.Status != nil && strings.TrimSpace(*payload.Status) != "" {
+			record["status"] = strings.ToLower(strings.TrimSpace(*payload.Status))
+		}
+	}
+
+	encoded, err := json.Marshal(record)
+	if err != nil {
+		return nil
+	}
+	return encoded
 }
 
 func observeResponseExecFactoryEventGoldens(


### PR DESCRIPTION
{
  "project": "Provider Session Response-Exec Golden Metadata Functional Coverage",
  "branchName": "ft-wave2-provider-sessions-response-exec-metadata",
  "description": "Implement only tests/functional/provider_sessions/association/response_exec_metadata_test.go so sanitized response-exec golden metadata survives public CLI projection, API FactoryResponseEvent survival, and replay—comparing against checked-in expected metadata from sanitized goldens (not mapper-generated values)—via root.BuildProcess + Process.Execute, edges.Edges / ProviderCommandRunner, and mocked Codex or another real inference-provider variant, without inventing migration-ledger deletion obligations or implementing association_test.go or details/* cells.",
  "context": {
    "customerAsk": "Implement only tests/functional/provider_sessions/association/response_exec_metadata_test.go. Construct via root.BuildProcess + Process.Execute (built you CLI only if this cell must prove OS/process-boundary behavior BuildProcess cannot express). Prefer public CLI invocation for ordinary flows; use API only where the checklist explicitly requires API response-event survival. Replace external effects only through edges.Edges, preferring ProviderCommandRunner / command-runner edge mocks and mocked Codex (or another real inference-provider variant via sanitized goldens) over MockWorkers. Do not add sleeps or timeout-padded wait helpers unless justified in-code after fixing readiness/latency root causes. Prove: (1) TestResponseExecGoldenMetadataSurvivesCLIProjection; (2) TestResponseExecGoldenMetadataSurvivesAPIResponseEvents; (3) TestResponseExecGoldenMetadataSurvivesReplay. Assertions must use checked-in expected metadata from sanitized goldens, not mapper-generated expected values. Do not invent migration-ledger deletion obligations when none map to this destination. Do not implement association_test.go or details/* cells. Avoid service/internal Petri imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled ownership/coverage/catalog/migration metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for response-exec golden metadata survival is unimplemented even though provider_sessions/association is free after association terminal-completed on main. Association proofs cover Provider Session ref correlation, so maintainers lack a focused, catalogued proof that sanitized response-exec golden metadata survives CLI projection, API FactoryResponseEvent survival, and replay against checked-in expected metadata—without inventing ledger deletion obligations or mapper-generated expectations, and without widening into association_test.go or details/*.",
    "solution": "Implement the three checklist scenarios in tests/functional/provider_sessions/association/response_exec_metadata_test.go via root.BuildProcess + Process.Execute, public CLI for ordinary flows, API only for API response-event survival, and edges.Edges / ProviderCommandRunner with mocked Codex or another real inference-provider variant via sanitized goldens. Assert CLI projection, API response events, and replay against checked-in expected golden metadata with customer-readable Go docs on every top-level Test; do not invent migration-ledger deletion obligations; leave association_test.go and details/* untouched; apply only narrowly coupled ownership/coverage/catalog/migration metadata; and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/provider_sessions/association/response_exec_metadata_test.go exists as the provider-sessions-owned functional cell and covers CLI projection survival, API response-event survival, and replay survival of response-exec golden metadata.",
    "Through public CLI projection via root.BuildProcess + Process.Execute, sanitized response-exec golden metadata matches checked-in expected metadata after declared normalization only.",
    "Through the public API FactoryResponseEvent surface (API used only for this checklist-required survival proof), the same checked-in golden metadata survives as observable response events.",
    "Through public replay observation, the same checked-in golden metadata survives without mapper-generated expected values.",
    "Assertions use checked-in expected metadata from sanitized goldens, not mapper-generated expected values; external effects are replaced only through edges.Edges preferring ProviderCommandRunner and mocked Codex / sanitized goldens over MockWorkers; no unjustified sleeps or timeout-padded wait helpers are introduced; no migration-ledger deletion obligations are invented; association_test.go and details/* stay untouched; only narrowly coupled ownership/coverage/catalog metadata for this cell are updated; coverage does not import service implementations or internal Petri primitives as the proof owner, with customer-readable Go docs on every top-level Test*.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave2-provider-sessions-response-exec-metadata-001",
      "title": "Prove response-exec golden metadata survives CLI projection",
      "description": "As a CLI customer running a provider-backed invocation driven from sanitized golden execution output, I want public CLI projection to expose the same checked-in response-exec golden metadata so I can trust CLI-visible provider/session/result facts without private mapper re-derivation.",
      "acceptanceCriteria": [
        "tests/functional/provider_sessions/association/response_exec_metadata_test.go includes TestResponseExecGoldenMetadataSurvivesCLIProjection (or equivalent top-level name matching the checklist intent).",
        "The scenario constructs the application via root.BuildProcess + Process.Execute (built you CLI only if OS/process-boundary behavior that BuildProcess cannot express is required) and enters through public CLI invocation for this ordinary flow.",
        "External provider process effects are replaced only through edges.Edges, preferring ProviderCommandRunner / command-runner edge mocks and mocked Codex (or another real inference-provider variant via sanitized goldens) over MockWorkers.",
        "Observed public CLI projection structurally matches checked-in expected response-exec / Provider Session / invocation-result golden metadata after normalizing only declared nondeterministic fields.",
        "Expected metadata is not generated by calling production mappers under assertion.",
        "No unjustified sleeps or timeout-padded wait helpers are added; any wait/sleep is justified in-code after fixing readiness/latency root causes.",
        "The top-level test has a customer-readable Go doc comment describing the observable CLI projection survival behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-provider-sessions-response-exec-metadata-002",
      "title": "Prove response-exec golden metadata survives API response events",
      "description": "As an API customer consuming FactoryResponseEvents for a provider-backed invocation driven from the same sanitized golden execution output, I want API response events to preserve the checked-in golden metadata so CLI-derived and API-visible response-exec facts stay aligned on the public contract.",
      "acceptanceCriteria": [
        "The response-exec metadata cell includes TestResponseExecGoldenMetadataSurvivesAPIResponseEvents (or equivalent top-level name matching the checklist intent).",
        "The scenario uses the public API FactoryResponseEvent surface because the checklist explicitly requires API response-event survival (API is not used as the default ordinary-flow entry when CLI would suffice).",
        "Construction still uses root.BuildProcess + Process.Execute with external effects replaced only through edges.Edges, preferring ProviderCommandRunner and mocked Codex / sanitized goldens over MockWorkers.",
        "Observed public API response events structurally match checked-in expected response-event golden metadata after normalizing only declared nondeterministic fields (ordering, item correlation, provider provenance, and terminal facts remain consistent with the golden).",
        "Expected metadata is not generated by calling production mappers under assertion.",
        "The top-level test has a customer-readable Go doc comment describing the observable API response-event survival behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-provider-sessions-response-exec-metadata-003",
      "title": "Prove response-exec golden metadata survives replay",
      "description": "As a maintainer or customer replaying a recorded provider-backed invocation, I want replay observation to preserve the same checked-in response-exec golden metadata so historical inspection matches the original public projection facts.",
      "acceptanceCriteria": [
        "The response-exec metadata cell includes TestResponseExecGoldenMetadataSurvivesReplay (or equivalent top-level name matching the checklist intent).",
        "Through public replay observation (via root.BuildProcess + Process.Execute and the public CLI or documented public replay entry appropriate to ordinary customer flows), sanitized golden-driven execution yields public metadata that structurally matches checked-in expected golden metadata after declared normalization only.",
        "External effects remain replaced only through edges.Edges / ProviderCommandRunner with mocked Codex / sanitized goldens preferred over MockWorkers; the cell does not re-own broader events/replay package cells held elsewhere (for example corrupt_artifact).",
        "Expected metadata is not generated by calling production mappers under assertion.",
        "The top-level test has a customer-readable Go doc comment describing the observable replay survival behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-provider-sessions-response-exec-metadata-004",
      "title": "Close ownership metadata and verification gates",
      "description": "As a maintainer executing Wave 2 association-freed replenish, I want this cell catalogued with only narrowly coupled metadata updates and passing focused boundary/viz gates, without inventing migration-ledger deletion obligations or widening into association or details siblings, so response-exec metadata can terminal-complete cleanly.",
      "acceptanceCriteria": [
        "No migration-ledger deletion obligations are invented for tests/functional/provider_sessions/association/response_exec_metadata_test.go when none currently map to this destination (checklist-authoritative).",
        "Existing association_test.go and held details/* cells stay untouched by this lane (no rewrite of association correlation scenarios; no implementation of details cells).",
        "Only narrowly coupled ownership, coverage, or catalog metadata required for this cell are updated; neighboring provider-session cells are not rewritten beyond what is required to leave the package compiling and sharing support helpers safely.",
        "Focused package tests for tests/functional/provider_sessions/association pass (including the new response-exec metadata cell alongside existing association coverage).",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as provider_sessions/association; golden-backed inventory fields populated when goldens are referenced).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)