### PR TITLE
pss-cut-vis-run

### DIFF
--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -647,6 +647,13 @@ response-stream output.
   event subscription. Behavioral proof:
   `pkg/services/factory_visualization/runtime_observation_boundary_test.go`
   (`TestRuntimeObservationUsesRootServiceObserve`).
+- CLI visualization presentation maps dashboard header facts from
+  Visualization-owned `RuntimeObservation` fields through
+  `dashboard.SimpleDashboardHeader` instead of Petri-shaped
+  `RuntimeEngineStateSnapshot` aliases. The leased CLI transport package does
+  not import Factory Runtime. Proof:
+  `pkg/services/factory_visualization/transports/cli/presentation_runtime_snapshot_boundary_test.go`
+  (`TestPresentationSinkUsesVisualizationOwnedRuntimeFacts`).
 - Shared ordered output serialization and final-once terminal write helpers
   (transport-shaped, non-authority):
   `pkg/services/factory_visualization/factory_event_stream.go`,

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -640,6 +640,13 @@ response-stream output.
   Petri, and legacy helper paths are forbidden. Inventory proof:
   `pkg/services/factory_visualization/runtime_import_boundary_test.go`
   (`TestProductionPackagesImportFactoryRuntimeRootOnly`).
+- Session-bound Visualization observation flows through
+  `pkg/services/factory_visualization/runtime_source.go`, which constructs
+  root `factory_runtime.ObserveRequest` values and calls `Service.Observe`
+  for snapshot facts while retaining migration-only `APIFactory` casts for
+  event subscription. Behavioral proof:
+  `pkg/services/factory_visualization/runtime_observation_boundary_test.go`
+  (`TestRuntimeObservationUsesRootServiceObserve`).
 - Shared ordered output serialization and final-once terminal write helpers
   (transport-shaped, non-authority):
   `pkg/services/factory_visualization/factory_event_stream.go`,

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -635,6 +635,11 @@ response-stream output.
   `io.Writer`, queue capacity, backpressure, or final-write ordering as their
   policy source of truth on that seam. Characterization proof:
   `TestRootContractInvariants_AllSlicesThroughSingularRoot`.
+- Factory Visualization production packages may import Factory Runtime only
+  through `pkg/services/factory_runtime`; nested Runtime implementation,
+  Petri, and legacy helper paths are forbidden. Inventory proof:
+  `pkg/services/factory_visualization/runtime_import_boundary_test.go`
+  (`TestProductionPackagesImportFactoryRuntimeRootOnly`).
 - Shared ordered output serialization and final-once terminal write helpers
   (transport-shaped, non-authority):
   `pkg/services/factory_visualization/factory_event_stream.go`,

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -654,6 +654,12 @@ response-stream output.
   not import Factory Runtime. Proof:
   `pkg/services/factory_visualization/transports/cli/presentation_runtime_snapshot_boundary_test.go`
   (`TestPresentationSinkUsesVisualizationOwnedRuntimeFacts`).
+- CUT-VIS-RUN story 004 consumer-edge proofs exercise session-bound
+  activation, detached `Observe`, and snapshot-fact reads only through root
+  `Service.Observe`, fail closed without Petri snapshot helpers, and propagate
+  typed observe failures. Behavioral proof:
+  `pkg/services/factory_visualization/runtime_consumer_boundary_test.go`
+  (`TestVisualizationConsumerObservationExercisesRuntimeRoot`).
 - Shared ordered output serialization and final-once terminal write helpers
   (transport-shaped, non-authority):
   `pkg/services/factory_visualization/factory_event_stream.go`,

--- a/pkg/services/factory_visualization/runtime_consumer_boundary_test.go
+++ b/pkg/services/factory_visualization/runtime_consumer_boundary_test.go
@@ -1,0 +1,231 @@
+package factory_visualization
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+)
+
+// TestVisualizationConsumerObservationExercisesRuntimeRoot proves CUT-VIS-RUN story 004:
+// leased session-bound activation and detached Observe paths reach Factory Runtime
+// only through root Service.Observe, mapping returned observation facts into
+// activation/view outcomes reviewers can verify.
+func TestVisualizationConsumerObservationExercisesRuntimeRoot(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 28, 7, 55, 0, 0, time.UTC)
+	uptime := 17 * time.Second
+	history := event("retained", 1)
+	runtimeFactory := &sessionBoundRuntimeFactory{
+		stream: &factorydefinitions.FactoryEventStream{
+			History: []factorydefinitions.FactoryEvent{history},
+			Events:  make(chan factorydefinitions.FactoryEvent),
+		},
+		observation: factoryruntime.Observation{
+			Status: factoryruntime.ObservationStatusActive,
+			Progress: factoryruntime.ObservationProgress{
+				TickCount: 13,
+			},
+			Health: factoryruntime.ObservationHealth{
+				FactoryState: "RUNNING",
+				Uptime:       uptime,
+			},
+		},
+	}
+	reader := sessionRuntimeReaderStub{
+		withRuntimeRead: func(fn func(*factorysessions.LiveRuntime) error) error {
+			return fn(&factorysessions.LiveRuntime{Factory: runtimeFactory})
+		},
+	}
+	emitted := make([]View, 0, 2)
+	service, err := New(
+		NewCurrentRuntimeSource(reader),
+		projectionStub{},
+		fixedClock{now: now},
+		SinkFunc(func(view View) {
+			emitted = append(emitted, view)
+		}),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("New() with session-bound runtime source: %v", err)
+	}
+	var root Root = service
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if _, err := root.Activate(ctx, ActivateRequest{Mode: ActivateModeRetainedThenLive}); err != nil {
+		t.Fatalf("Activate through session-bound runtime: %v", err)
+	}
+
+	result, err := root.Observe(context.Background(), ObserveRequest{Mode: ObserveModeRetainedThenLive})
+	if err != nil {
+		t.Fatalf("Observe after Activate: %v", err)
+	}
+	if len(runtimeFactory.observeRequests) == 0 {
+		t.Fatal("detached Observe did not exercise root Service.Observe")
+	}
+	lastObserve := runtimeFactory.observeRequests[len(runtimeFactory.observeRequests)-1]
+	if lastObserve.Scope != factoryruntime.ObservationScopeFull {
+		t.Fatalf("observe scope = %q, want %q", lastObserve.Scope, factoryruntime.ObservationScopeFull)
+	}
+	if result.View.TickCount != 13 {
+		t.Fatalf("Observe TickCount = %d, want 13 from root observation facts", result.View.TickCount)
+	}
+	if result.View.RetainedEventCount != 1 {
+		t.Fatalf("Observe RetainedEventCount = %d, want 1", result.View.RetainedEventCount)
+	}
+	if !result.View.ObservedAt.Equal(now) {
+		t.Fatalf("Observe ObservedAt = %v, want %v", result.View.ObservedAt, now)
+	}
+
+	facts, err := NewCurrentRuntimeSource(reader).GetRuntimeSnapshotFacts(context.Background())
+	if err != nil {
+		t.Fatalf("GetRuntimeSnapshotFacts after Observe: %v", err)
+	}
+	if facts.FactoryState != "RUNNING" {
+		t.Fatalf("snapshot factory state = %q, want RUNNING", facts.FactoryState)
+	}
+	if facts.RuntimeStatus != factorydefinitions.RuntimeStatusActive {
+		t.Fatalf("snapshot runtime status = %q, want ACTIVE", facts.RuntimeStatus)
+	}
+	if facts.Uptime != uptime {
+		t.Fatalf("snapshot uptime = %v, want %v", facts.Uptime, uptime)
+	}
+
+	foundActivationTick := false
+	for _, view := range emitted {
+		if view.Runtime.TickCount == 13 {
+			foundActivationTick = true
+			break
+		}
+	}
+	if !foundActivationTick {
+		t.Fatalf("activation views = %#v, want tick count from root observation facts", emitted)
+	}
+}
+
+// TestVisualizationConsumerObservationFailsClosedWithoutPetriSnapshot proves the
+// leased observation path does not require Petri-shaped GetEngineStateSnapshot or
+// RuntimeEngineStateSnapshot aliases. A root Service-only runtime still supplies
+// snapshot facts through Service.Observe.
+func TestVisualizationConsumerObservationFailsClosedWithoutPetriSnapshot(t *testing.T) {
+	t.Parallel()
+
+	runtimeFactory := &rootObservationOnlyFactory{
+		sessionBoundRuntimeFactory: sessionBoundRuntimeFactory{
+			observation: factoryruntime.Observation{
+				Status: factoryruntime.ObservationStatusActive,
+				Progress: factoryruntime.ObservationProgress{TickCount: 4},
+				Health: factoryruntime.ObservationHealth{
+					FactoryState: "RUNNING",
+				},
+			},
+		},
+	}
+	reader := sessionRuntimeReaderStub{
+		withRuntimeRead: func(fn func(*factorysessions.LiveRuntime) error) error {
+			return fn(&factorysessions.LiveRuntime{Factory: runtimeFactory})
+		},
+	}
+	source := NewCurrentRuntimeSource(reader)
+
+	facts, err := source.GetRuntimeSnapshotFacts(context.Background())
+	if err != nil {
+		t.Fatalf("GetRuntimeSnapshotFacts through root Service-only runtime: %v", err)
+	}
+	if facts == nil || facts.TickCount != 4 {
+		t.Fatalf("snapshot facts = %#v, want tick 4 from root Observe", facts)
+	}
+	if runtimeFactory.snapshotAccessAttempts != 0 {
+		t.Fatalf(
+			"legacy snapshot access attempts = %d, want 0; observation must not use Petri snapshots",
+			runtimeFactory.snapshotAccessAttempts,
+		)
+	}
+	if len(runtimeFactory.observeRequests) != 1 {
+		t.Fatalf("observe calls = %d, want 1 root observation path", len(runtimeFactory.observeRequests))
+	}
+}
+
+// TestVisualizationConsumerDetachedObservePropagatesRootObserveFailure proves typed
+// Runtime observation failures propagate through detached Observe as
+// Visualization-owned projection failures with the root cause attached.
+func TestVisualizationConsumerDetachedObservePropagatesRootObserveFailure(t *testing.T) {
+	t.Parallel()
+
+	wantErr := factoryruntime.ErrNotRunning
+	runtimeFactory := &sessionBoundRuntimeFactory{
+		stream: &factorydefinitions.FactoryEventStream{
+			Events: make(chan factorydefinitions.FactoryEvent),
+		},
+		observeErr: wantErr,
+	}
+	reader := sessionRuntimeReaderStub{
+		withRuntimeRead: func(fn func(*factorysessions.LiveRuntime) error) error {
+			return fn(&factorysessions.LiveRuntime{Factory: runtimeFactory})
+		},
+	}
+	service, err := New(
+		NewCurrentRuntimeSource(reader),
+		projectionStub{},
+		fixedClock{now: time.Unix(1, 0)},
+		SinkFunc(func(View) {}),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("New() with failing runtime observe: %v", err)
+	}
+
+	_, err = service.Observe(context.Background(), ObserveRequest{Mode: ObserveModeRetainedThenLive})
+	var projErr *ProjectionError
+	if !errors.As(err, &projErr) || projErr.Kind != ProjectionErrorSnapshotUnavailable {
+		t.Fatalf("Observe error = %v, want ProjectionErrorSnapshotUnavailable", err)
+	}
+	if !errors.Is(projErr.Cause, wantErr) {
+		t.Fatalf("Observe cause = %v, want %v", projErr.Cause, wantErr)
+	}
+}
+
+// TestVisualizationRuntimeSourceDoesNotReferencePetriSnapshotHelpers seals the
+// production observation adapter against Petri-shaped snapshot helper names.
+func TestVisualizationRuntimeSourceDoesNotReferencePetriSnapshotHelpers(t *testing.T) {
+	t.Parallel()
+
+	forbidden := []string{
+		"GetEngineStateSnapshot",
+		"RuntimeEngineStateSnapshot",
+		"StateSnapshot",
+	}
+	source, err := os.ReadFile(filepath.Join("runtime_source.go"))
+	if err != nil {
+		t.Fatalf("read runtime_source.go: %v", err)
+	}
+	content := string(source)
+	for _, needle := range forbidden {
+		if strings.Contains(content, needle) {
+			t.Fatalf("runtime_source.go contains forbidden Petri snapshot reference %q", needle)
+		}
+	}
+}
+
+// rootObservationOnlyFactory embeds the session-bound Service stub and records
+// legacy snapshot access attempts so tests fail closed when a consumer edge
+// reaches for Petri-shaped snapshot helpers instead of Service.Observe.
+type rootObservationOnlyFactory struct {
+	sessionBoundRuntimeFactory
+	snapshotAccessAttempts int
+}
+
+func (f *rootObservationOnlyFactory) GetEngineStateSnapshot(context.Context) (any, error) {
+	f.snapshotAccessAttempts++
+	return nil, errors.New("petri snapshot access is forbidden on Visualization consumer edges")
+}

--- a/pkg/services/factory_visualization/runtime_import_boundary_test.go
+++ b/pkg/services/factory_visualization/runtime_import_boundary_test.go
@@ -1,0 +1,91 @@
+package factory_visualization_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+const (
+	modulePrefix            = "github.com/portpowered/infinite-you/"
+	factoryRuntimeRoot      = modulePrefix + "pkg/services/factory_runtime"
+	factoryVisualizationRoot = modulePrefix + "pkg/services/factory_visualization"
+)
+
+// TestProductionPackagesImportFactoryRuntimeRootOnly seals CUT-VIS-RUN story 001:
+// Factory Visualization production packages may depend on Factory Runtime only
+// through the service root contract, not nested Runtime implementation, Petri,
+// or legacy helper paths.
+func TestProductionPackagesImportFactoryRuntimeRootOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, pkg := range listFactoryVisualizationPackages(t) {
+		pkg := pkg
+		t.Run(shortFactoryVisualizationPackageName(pkg), func(t *testing.T) {
+			t.Parallel()
+			assertProductionImportsUseRuntimeRootOnly(t, pkg)
+		})
+	}
+}
+
+func listFactoryVisualizationPackages(t *testing.T) []string {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", factoryVisualizationRoot+"/...")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list factory visualization packages: %v\n%s", err, output)
+	}
+	return strings.Fields(string(output))
+}
+
+func assertProductionImportsUseRuntimeRootOnly(t *testing.T, packagePath string) {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", "-f", "{{join .Imports \"\\n\"}}", packagePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list imports for %s: %v\n%s", packagePath, err, output)
+	}
+	for _, importPath := range strings.Fields(string(output)) {
+		if isForbiddenFactoryVisualizationRuntimeImport(importPath) {
+			t.Fatalf(
+				"%s production import %s is forbidden; use %s for Factory Runtime surfaces",
+				packagePath,
+				importPath,
+				factoryRuntimeRoot,
+			)
+		}
+	}
+}
+
+func isForbiddenFactoryVisualizationRuntimeImport(importPath string) bool {
+	if importPath == factoryRuntimeRoot {
+		return false
+	}
+	if strings.HasPrefix(importPath, factoryRuntimeRoot+"/") {
+		return true
+	}
+	if importPath == modulePrefix+"pkg/factory" ||
+		strings.HasPrefix(importPath, modulePrefix+"pkg/factory/") {
+		return true
+	}
+	if strings.HasPrefix(importPath, modulePrefix+"pkg/services/factory_runtime/internal/orchestrators/petri") {
+		return true
+	}
+	if strings.HasPrefix(importPath, modulePrefix+"pkg/transports/mapping/factory") {
+		return true
+	}
+	return false
+}
+
+func shortFactoryVisualizationPackageName(packagePath string) string {
+	if strings.HasPrefix(packagePath, factoryVisualizationRoot) {
+		rest := strings.TrimPrefix(packagePath, factoryVisualizationRoot)
+		if rest == "" {
+			return "factory_visualization"
+		}
+		return strings.TrimPrefix(rest, "/")
+	}
+	return packagePath
+}

--- a/pkg/services/factory_visualization/runtime_observation_boundary_test.go
+++ b/pkg/services/factory_visualization/runtime_observation_boundary_test.go
@@ -1,0 +1,162 @@
+package factory_visualization
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+)
+
+// TestRuntimeObservationUsesRootServiceObserve proves CUT-VIS-RUN story 002:
+// leased Visualization observation paths construct root ObserveRequest values
+// and call Service.Observe, mapping returned observation facts into
+// Visualization-owned runtime snapshot fields.
+func TestRuntimeObservationUsesRootServiceObserve(t *testing.T) {
+	t.Parallel()
+
+	uptime := 42 * time.Second
+	runtimeFactory := &sessionBoundRuntimeFactory{
+		stream: &factorydefinitions.FactoryEventStream{
+			Events: make(chan factorydefinitions.FactoryEvent),
+		},
+		observation: factoryruntime.Observation{
+			Status: factoryruntime.ObservationStatusActive,
+			Progress: factoryruntime.ObservationProgress{
+				TickCount: 7,
+			},
+			Health: factoryruntime.ObservationHealth{
+				FactoryState: "RUNNING",
+				Uptime:       uptime,
+				ActiveThrottlePauses: []factorydefinitions.ActiveThrottlePause{
+					{Provider: "provider-a", Model: "model-a"},
+				},
+			},
+		},
+	}
+	reader := sessionRuntimeReaderStub{
+		withRuntimeRead: func(fn func(*factorysessions.LiveRuntime) error) error {
+			return fn(&factorysessions.LiveRuntime{Factory: runtimeFactory})
+		},
+	}
+	source := NewCurrentRuntimeSource(reader)
+
+	facts, err := source.GetRuntimeSnapshotFacts(context.Background())
+	if err != nil {
+		t.Fatalf("GetRuntimeSnapshotFacts: %v", err)
+	}
+	if len(runtimeFactory.observeRequests) != 1 {
+		t.Fatalf("observe calls = %d, want 1 root observation path", len(runtimeFactory.observeRequests))
+	}
+	if runtimeFactory.observeRequests[0].Scope != factoryruntime.ObservationScopeFull {
+		t.Fatalf(
+			"observe scope = %q, want %q",
+			runtimeFactory.observeRequests[0].Scope,
+			factoryruntime.ObservationScopeFull,
+		)
+	}
+	if facts == nil {
+		t.Fatal("GetRuntimeSnapshotFacts returned nil facts")
+	}
+	if facts.TickCount != 7 {
+		t.Fatalf("tick count = %d, want 7", facts.TickCount)
+	}
+	if facts.FactoryState != "RUNNING" {
+		t.Fatalf("factory state = %q, want RUNNING", facts.FactoryState)
+	}
+	if facts.RuntimeStatus != factorydefinitions.RuntimeStatusActive {
+		t.Fatalf("runtime status = %q, want ACTIVE", facts.RuntimeStatus)
+	}
+	if facts.Uptime != uptime {
+		t.Fatalf("uptime = %v, want %v", facts.Uptime, uptime)
+	}
+	if len(facts.ActiveThrottlePauses) != 1 ||
+		facts.ActiveThrottlePauses[0].Provider != "provider-a" ||
+		facts.ActiveThrottlePauses[0].Model != "model-a" {
+		t.Fatalf("active throttle pauses = %#v, want provider-a/model-a", facts.ActiveThrottlePauses)
+	}
+}
+
+func TestRuntimeObservationPropagatesRootObserveFailure(t *testing.T) {
+	t.Parallel()
+
+	wantErr := factoryruntime.ErrNotRunning
+	runtimeFactory := &sessionBoundRuntimeFactory{
+		stream: &factorydefinitions.FactoryEventStream{
+			Events: make(chan factorydefinitions.FactoryEvent),
+		},
+		observeErr: wantErr,
+	}
+	reader := sessionRuntimeReaderStub{
+		withRuntimeRead: func(fn func(*factorysessions.LiveRuntime) error) error {
+			return fn(&factorysessions.LiveRuntime{Factory: runtimeFactory})
+		},
+	}
+	source := NewCurrentRuntimeSource(reader)
+
+	_, err := source.GetRuntimeSnapshotFacts(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("GetRuntimeSnapshotFacts error = %v, want %v", err, wantErr)
+	}
+	if len(runtimeFactory.observeRequests) != 1 {
+		t.Fatalf("observe calls = %d, want 1 before failure propagation", len(runtimeFactory.observeRequests))
+	}
+}
+
+func TestRuntimeObservationUnavailableRuntimeDoesNotCallObserve(t *testing.T) {
+	t.Parallel()
+
+	observeCalls := 0
+	runtimeFactory := &sessionBoundRuntimeFactory{
+		observeRequests: make([]factoryruntime.ObserveRequest, 0),
+	}
+	reader := sessionRuntimeReaderStub{
+		withRuntimeRead: func(func(*factorysessions.LiveRuntime) error) error {
+			return factorysessions.ErrRuntimeNotAvailable
+		},
+	}
+	source := NewCurrentRuntimeSource(reader)
+
+	_, err := source.GetRuntimeSnapshotFacts(context.Background())
+	if !errors.Is(err, factorysessions.ErrRuntimeNotAvailable) {
+		t.Fatalf("GetRuntimeSnapshotFacts error = %v, want ErrRuntimeNotAvailable", err)
+	}
+	observeCalls = len(runtimeFactory.observeRequests)
+	if observeCalls != 0 {
+		t.Fatalf("observe calls = %d, want 0 when runtime is unavailable", observeCalls)
+	}
+}
+
+func TestRuntimeSubscribeUsesMigrationOnlyAPIFactoryCast(t *testing.T) {
+	t.Parallel()
+
+	runtimeFactory := &sessionBoundRuntimeFactory{
+		stream: &factorydefinitions.FactoryEventStream{
+			Events: make(chan factorydefinitions.FactoryEvent),
+		},
+	}
+	reader := sessionRuntimeReaderStub{
+		withRuntimeRead: func(fn func(*factorysessions.LiveRuntime) error) error {
+			return fn(&factorysessions.LiveRuntime{Factory: runtimeFactory})
+		},
+	}
+	source := NewCurrentRuntimeSource(reader)
+
+	stream, err := source.SubscribeFactoryEvents(
+		context.Background(),
+		nil,
+		factorydefinitions.FactoryEventReconnectScope{},
+	)
+	if err != nil {
+		t.Fatalf("SubscribeFactoryEvents: %v", err)
+	}
+	if stream == nil || stream.Events == nil {
+		t.Fatal("SubscribeFactoryEvents returned invalid stream")
+	}
+	if len(runtimeFactory.observeRequests) != 0 {
+		t.Fatalf("observe calls during subscribe = %d, want 0", len(runtimeFactory.observeRequests))
+	}
+}

--- a/pkg/services/factory_visualization/runtime_source_test.go
+++ b/pkg/services/factory_visualization/runtime_source_test.go
@@ -176,9 +176,11 @@ func (s sessionRuntimeReaderStub) WithRuntimeRead(
 
 type sessionBoundRuntimeFactory struct {
 	factoryruntime.Service
-	subscribeHook func()
-	stream        *factorydefinitions.FactoryEventStream
-	observation   factoryruntime.Observation
+	subscribeHook   func()
+	stream          *factorydefinitions.FactoryEventStream
+	observation     factoryruntime.Observation
+	observeRequests []factoryruntime.ObserveRequest
+	observeErr      error
 }
 
 func (f *sessionBoundRuntimeFactory) SubmitWorkRequest(
@@ -200,8 +202,12 @@ func (f *sessionBoundRuntimeFactory) SubscribeFactoryEvents(
 }
 
 func (f *sessionBoundRuntimeFactory) Observe(
-	context.Context,
-	factoryruntime.ObserveRequest,
+	_ context.Context,
+	req factoryruntime.ObserveRequest,
 ) (factoryruntime.ObserveResult, error) {
+	f.observeRequests = append(f.observeRequests, req)
+	if f.observeErr != nil {
+		return factoryruntime.ObserveResult{}, f.observeErr
+	}
 	return factoryruntime.ObserveResult{Observation: f.observation}, nil
 }

--- a/pkg/services/factory_visualization/transports/cli/presentation_runtime_snapshot_boundary_test.go
+++ b/pkg/services/factory_visualization/transports/cli/presentation_runtime_snapshot_boundary_test.go
@@ -1,0 +1,62 @@
+package cli_test
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	visualizationcli "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/cli"
+)
+
+// TestPresentationSinkUsesVisualizationOwnedRuntimeFacts proves CUT-VIS-RUN story 003:
+// the CLI visualization sink maps dashboard header facts from Visualization-owned
+// RuntimeObservation fields instead of Petri-shaped RuntimeEngineStateSnapshot aliases.
+func TestPresentationSinkUsesVisualizationOwnedRuntimeFacts(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService()
+	var output bytes.Buffer
+	sink := service.BuildVisualizationSink(visualizationcli.SinkConfig{Output: &output})
+	if sink == nil {
+		t.Fatal("sink = nil, want dashboard sink")
+	}
+
+	sink.PresentFactoryView(factoryvisualization.View{
+		Runtime: factoryvisualization.RuntimeObservation{
+			TickCount:     9,
+			FactoryState:  "RUNNING",
+			RuntimeStatus: interfaces.RuntimeStatusActive,
+			Uptime:        42 * time.Second,
+		},
+		ObservedAt: time.Unix(100, 0).UTC(),
+	})
+
+	got := output.String()
+	for _, want := range []string{"Factory: RUNNING", "Runtime: ACTIVE", "Tick: 9", "42s"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("dashboard output = %q, want %q", got, want)
+		}
+	}
+}
+
+// TestPresentationSinkPackageDoesNotImportFactoryRuntime proves the leased CLI
+// presentation sink no longer depends on Factory Runtime snapshot aliases.
+func TestPresentationSinkPackageDoesNotImportFactoryRuntime(t *testing.T) {
+	t.Parallel()
+
+	const packagePath = "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/cli"
+	cmd := exec.Command("go", "list", "-f", "{{join .Imports \"\\n\"}}", packagePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list imports for %s: %v\n%s", packagePath, err, output)
+	}
+	for _, importPath := range strings.Fields(string(output)) {
+		if importPath == "github.com/portpowered/infinite-you/pkg/services/factory_runtime" {
+			t.Fatalf("%s must not import Factory Runtime; use Visualization-owned RuntimeObservation facts", packagePath)
+		}
+	}
+}

--- a/pkg/services/factory_visualization/transports/cli/visualization_sink.go
+++ b/pkg/services/factory_visualization/transports/cli/visualization_sink.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 
-	state "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
 	"github.com/portpowered/infinite-you/pkg/transports/cli/dashboard"
 )
@@ -30,19 +29,13 @@ func (s *service) BuildVisualizationSink(cfg SinkConfig) factoryvisualization.Si
 
 func renderSimpleDashboard(output io.Writer, input factoryvisualization.View) {
 	fmt.Fprint(output, dashboard.FormatSimpleDashboardWithRenderData(
-		dashboardEngineSnapshotHeader(input.Runtime),
+		dashboard.SimpleDashboardHeader{
+			TickCount:     input.Runtime.TickCount,
+			FactoryState:  input.Runtime.FactoryState,
+			RuntimeStatus: input.Runtime.RuntimeStatus,
+			Uptime:        input.Runtime.Uptime,
+		},
 		input.RenderData,
 		input.ObservedAt,
 	))
-}
-
-func dashboardEngineSnapshotHeader(
-	runtime factoryvisualization.RuntimeObservation,
-) state.RuntimeEngineStateSnapshot {
-	return state.RuntimeEngineStateSnapshot{
-		TickCount:     runtime.TickCount,
-		FactoryState:  runtime.FactoryState,
-		RuntimeStatus: runtime.RuntimeStatus,
-		Uptime:        runtime.Uptime,
-	}
 }

--- a/pkg/services/recordings/projections/projectiontests/selected_tick_cross_boundary_smoke_test.go
+++ b/pkg/services/recordings/projections/projectiontests/selected_tick_cross_boundary_smoke_test.go
@@ -9,7 +9,6 @@ import (
 	factoryeventprojection "github.com/portpowered/infinite-you/pkg/transports/mapping/factoryeventprojection"
 
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
-	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
 	recordingprojections "github.com/portpowered/infinite-you/pkg/services/recordings/projections"
 	"github.com/portpowered/infinite-you/pkg/services/recordings/projections/dashboard"
@@ -44,12 +43,12 @@ func TestSelectedTickCrossBoundarySmoke_ReconstructsCanonicalStateAcrossSupporte
 
 	now := t0.Add(12 * time.Second)
 	output := dashboard.FormatSimpleDashboardWithRenderData(
-		factoryruntime.DashboardEngineStateSnapshot(
-			"RUNNING",
-			interfaces.RuntimeStatusActive,
-			11,
-			11*time.Second,
-		),
+		dashboard.SimpleDashboardHeader{
+			FactoryState:  "RUNNING",
+			RuntimeStatus: interfaces.RuntimeStatusActive,
+			TickCount:     11,
+			Uptime:        11 * time.Second,
+		},
 		projections.SimpleDashboardRenderDataFromWorldState(worldState),
 		now,
 	)

--- a/pkg/transports/cli/dashboard/dashboard.go
+++ b/pkg/transports/cli/dashboard/dashboard.go
@@ -12,6 +12,15 @@ import (
 	"time"
 )
 
+// SimpleDashboardHeader carries orchestration-neutral dashboard header facts
+// for simple-dashboard rendering without Petri-shaped snapshot aliases.
+type SimpleDashboardHeader struct {
+	FactoryState  string
+	RuntimeStatus interfaces.RuntimeStatus
+	TickCount     int
+	Uptime        time.Duration
+}
+
 // FormatSimpleDashboard renders the snapshot-only dashboard shell. Session
 // accounting requires FormatSimpleDashboardWithRenderData.
 func FormatSimpleDashboard(
@@ -34,12 +43,12 @@ func FormatSimpleDashboard(
 // FormatSimpleDashboardWithRenderData renders a dashboard using the dedicated
 // simple-dashboard render DTO for session accounting.
 func FormatSimpleDashboardWithRenderData(
-	es state.RuntimeEngineStateSnapshot,
+	header SimpleDashboardHeader,
 	renderData recordings.SimpleDashboardRenderData,
 	now time.Time,
 ) string {
 	return formatSimpleDashboardHeader(
-		es,
+		header,
 		now,
 		dashboardActiveViewFromRenderData(renderData),
 		dashboardQueueCountViewsFromRenderData(renderData),
@@ -50,7 +59,7 @@ func FormatSimpleDashboardWithRenderData(
 }
 
 func formatSimpleDashboardHeader(
-	es state.RuntimeEngineStateSnapshot,
+	header SimpleDashboardHeader,
 	now time.Time,
 	active dashboardActiveView,
 	queueCounts []dashboardQueueCountView,
@@ -62,9 +71,9 @@ func formatSimpleDashboardHeader(
 
 	b.WriteString("╔══════════════════════════════════════════╗\n")
 	fmt.Fprintf(&b, "║  Factory: %-10s  Runtime: %-8s  ║\n",
-		es.FactoryState, es.RuntimeStatus)
+		header.FactoryState, header.RuntimeStatus)
 	fmt.Fprintf(&b, "║  Uptime:  %-10s  Tick: %-11d  ║\n",
-		FormatDuration(es.Uptime.Truncate(time.Second)), es.TickCount)
+		FormatDuration(header.Uptime.Truncate(time.Second)), header.TickCount)
 	b.WriteString("╚══════════════════════════════════════════╝\n")
 
 	renderActiveWorkstations(&b, active, now)
@@ -73,7 +82,7 @@ func formatSimpleDashboardHeader(
 	renderCompletedWorkstations(&b, completedHistory)
 
 	if summary.HasData {
-		renderSessionMetrics(&b, summary, dashboardSessionStartTime(es.Uptime, now))
+		renderSessionMetrics(&b, summary, dashboardSessionStartTime(header.Uptime, now))
 	}
 
 	return b.String()
@@ -93,7 +102,7 @@ func formatSimpleDashboard(
 		topology = es.Topology
 	}
 	return formatSimpleDashboardHeader(
-		state.RuntimeEngineStateSnapshot{
+		SimpleDashboardHeader{
 			FactoryState:  es.FactoryState,
 			RuntimeStatus: es.RuntimeStatus,
 			TickCount:     es.TickCount,

--- a/pkg/transports/cli/dashboard/dashboard_test.go
+++ b/pkg/transports/cli/dashboard/dashboard_test.go
@@ -98,8 +98,8 @@ func activeRawEngineSnapshotForDashboardTest(now time.Time, topology *factoryrun
 
 func dashboardHeaderFromEngineSnapshot(
 	es interfaces.EngineStateSnapshot[factoryruntime.PetriMarkingSnapshot, *factoryruntime.Net],
-) factoryruntime.RuntimeEngineStateSnapshot {
-	return factoryruntime.RuntimeEngineStateSnapshot{
+) SimpleDashboardHeader {
+	return SimpleDashboardHeader{
 		FactoryState:  es.FactoryState,
 		RuntimeStatus: es.RuntimeStatus,
 		TickCount:     es.TickCount,
@@ -160,7 +160,7 @@ func TestFormatSimpleDashboardWithRenderData_MapsSystemTimeCompatibilityAtCliBou
 	now := time.Date(2026, 4, 3, 12, 0, 0, 0, time.Local)
 
 	output := FormatSimpleDashboardWithRenderData(
-		factoryruntime.RuntimeEngineStateSnapshot{
+		SimpleDashboardHeader{
 			FactoryState:  "RUNNING",
 			RuntimeStatus: interfaces.RuntimeStatusIdle,
 			Uptime:        2 * time.Minute,
@@ -213,7 +213,7 @@ func TestFormatSimpleDashboardWithRenderData_RendersUnavailableTimes(t *testing.
 	now := time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC)
 
 	output := FormatSimpleDashboardWithRenderData(
-		factoryruntime.RuntimeEngineStateSnapshot{
+		SimpleDashboardHeader{
 			FactoryState:  "RUNNING",
 			RuntimeStatus: interfaces.RuntimeStatusActive,
 		},
@@ -263,7 +263,7 @@ func TestDashboardSessionViewFromRenderData_FallsBackToDispatchHistoryWorkItems(
 	assertDispatchHistoryFallbackView(t, view)
 
 	output := FormatSimpleDashboardWithRenderData(
-		factoryruntime.RuntimeEngineStateSnapshot{
+		SimpleDashboardHeader{
 			FactoryState:  "RUNNING",
 			RuntimeStatus: interfaces.RuntimeStatusIdle,
 			Uptime:        5 * time.Minute,
@@ -276,10 +276,10 @@ func TestDashboardSessionViewFromRenderData_FallsBackToDispatchHistoryWorkItems(
 }
 
 func buildTerminalProviderRenderFixture(now time.Time) (
-	factoryruntime.RuntimeEngineStateSnapshot,
+	SimpleDashboardHeader,
 	recordings.SimpleDashboardRenderData,
 ) {
-	return factoryruntime.RuntimeEngineStateSnapshot{
+	return SimpleDashboardHeader{
 			FactoryState:  "RUNNING",
 			RuntimeStatus: interfaces.RuntimeStatusIdle,
 			Uptime:        20 * time.Minute,
@@ -529,7 +529,7 @@ func TestFormatSimpleDashboardWithRenderData_RendersWorkTypeCountBreakdown(t *te
 	now := time.Date(2026, 4, 3, 12, 0, 0, 0, time.Local)
 
 	output := FormatSimpleDashboardWithRenderData(
-		factoryruntime.RuntimeEngineStateSnapshot{
+		SimpleDashboardHeader{
 			FactoryState:  "RUNNING",
 			RuntimeStatus: interfaces.RuntimeStatusIdle,
 			Uptime:        time.Minute,


### PR DESCRIPTION
{
  "project": "CUT-VIS-RUN: Visualization consumes Factory Runtime root only",
  "branchName": "pss-cut-vis-run",
  "description": "Seal Visualization→Factory Runtime consumer edges so Visualization imports and invokes Runtime only through the Runtime service root contract (pkg/services/factory_runtime / Service.Observe and published root control surfaces), removes Petri-shaped GetEngineStateSnapshot / StateSnapshot production dependencies and non-root Runtime package imports, proves the boundary with focused Visualization/Runtime tests, and delivers through actual PR merge without folding packages or reopening Recordings / Runtime fold / integrator leases.",
  "context": {
    "customerAsk": "CUT-VIS-RUN: lease only Factory Visualization call sites that still reach Factory Runtime through non-root paths (service/host, engine, runtime, javascript, hosting bundles, GetEngineStateSnapshot, or other implementation packages). Retarget those imports/call sites to the Factory Runtime service root contract (Service.Observe / root control surfaces) so Visualization no longer depends on Runtime implementation packages or Petri-shaped observation helpers. Do not fold or delete visualization or factory_runtime packages. Do not edit root pkg/wire except a narrow Visualization→Runtime import retarget if unavoidable. Do not open CUT-RUN-REC, IMP-RUN-04, or shared integrators; do not reopen CUT-VIS-REC / Recordings edges. Prove with focused Visualization/Runtime boundary tests. Delivery contract: loop implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts are resolved, the PR is merged, and only then complete Factory work.",
    "problem": "Visualization still risks coupling to Factory Runtime through non-root implementation packages or Petri-shaped GetEngineStateSnapshot / StateSnapshot observation helpers instead of the singular Runtime root Service observation/control contract, which leaks Runtime ownership into Visualization and blocks later Runtime fold/delete sequencing while CUT-VIS-REC and Runtime folds remain separately owned.",
    "solution": "Restrict Visualization production call sites so they import and invoke Factory Runtime only through pkg/services/factory_runtime, retarget leased observation/control onto Service.Observe and published root control surfaces, remove Petri-shaped GetEngineStateSnapshot / StateSnapshot production dependencies and nested Runtime imports, and prove the sealed edge with focused Visualization/Runtime boundary tests while leaving fold/delete, Recordings edges, IMP-RUN-04, and shared integrators to other packets."
  },
  "acceptanceCriteria": [
    "Visualization production code imports Factory Runtime only through the Runtime service root contract (pkg/services/factory_runtime)",
    "No new Visualization imports of Runtime implementation packages (factory_runtime/service/**, factory_runtime/engine/**, factory_runtime/runtime/**, factory_runtime/javascript/**, hosting bundles, or equivalent nested Runtime packages)",
    "No Visualization production dependency on Petri-shaped GetEngineStateSnapshot / StateSnapshot aliases",
    "Focused Visualization/Runtime boundary tests prove Runtime observation/control through the Runtime root boundary",
    "Observable Visualization activation/view behavior is preserved for equivalent inputs",
    "Quality checks pass (typecheck, lint, and tests); required CI is terminal and green",
    "Delivery loop continues until blocking PR feedback is addressed, merge conflicts are resolved, and the PR is actually merged before Factory completion"
  ],
  "userStories": [
    {
      "id": "pss-cut-vis-run-001",
      "title": "Seal Visualization→Runtime imports to the Runtime root",
      "description": "As a maintainer, I need Factory Visualization production packages that reach Factory Runtime to depend only on pkg/services/factory_runtime so Visualization cannot couple to Runtime implementation packages.",
      "acceptanceCriteria": [
        "Every Visualization production import of Factory Runtime resolves to the Runtime service root (pkg/services/factory_runtime), not factory_runtime/service/** (including service/host), factory_runtime/engine/**, factory_runtime/runtime/**, factory_runtime/javascript/**, hosting/orchestration bundles, or other nested Runtime packages",
        "Any leased Visualization call site still importing a Runtime implementation package is retargeted to the Runtime root contract",
        "No new Visualization import of Runtime implementation packages is introduced",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cut-vis-run-002",
      "title": "Live observation and control use Runtime root Service",
      "description": "As a Factory Visualization maintainer, I want leased live-runtime observation and control paths to invoke Factory Runtime only through root Service methods and root request/result types so Visualization does not bypass the peer root through GetEngineStateSnapshot, Petri StateSnapshot aliases, or nested Runtime packages.",
      "acceptanceCriteria": [
        "Leased Visualization production observation paths construct factory_runtime.ObserveRequest (or equivalent root observation request alias) and call root Service.Observe, using returned root observation facts for activation/live-view presentation",
        "Leased Visualization production control paths that need Runtime control invoke published root control surfaces rather than Runtime implementation packages",
        "Visualization production code does not call GetEngineStateSnapshot and does not depend on Petri-shaped StateSnapshot aliases for leased observation behavior",
        "Remaining migration-only root peer casts (for example event-subscribe surfaces still published only on root APIFactory) stay on Runtime root imports only and are not used as a substitute for Service.Observe observation facts",
        "Equivalent session-bound runtime inputs still produce the same observable Visualization activation/view outcomes (including typed Runtime-unavailable / observation failures)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cut-vis-run-003",
      "title": "Presentation edges drop Petri-shaped Runtime snapshot aliases",
      "description": "As a Factory Visualization presentation owner, I want CLI/live-view presentation adapters under this lease to consume Visualization-owned runtime observation facts or root Observe-derived vocabulary so Visualization presentation does not reintroduce Petri-shaped GetEngineStateSnapshot / StateSnapshot dependencies.",
      "acceptanceCriteria": [
        "Leased Visualization presentation/sink paths that previously depended on Petri-shaped GetEngineStateSnapshot / StateSnapshot aliases map dashboard/header facts from Visualization-owned runtime observation fields or from root Observe-derived / root-published neutral observation vocabulary instead",
        "Those presentation paths do not import Runtime implementation packages and do not call GetEngineStateSnapshot",
        "Equivalent projected view inputs still produce the same observable dashboard/view presentation outcomes for activation and live view",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cut-vis-run-004",
      "title": "Prove Runtime observation/control through the Runtime root",
      "description": "As a reviewer of packaged-service boundaries, I want focused Visualization/Runtime boundary tests that prove Visualization exercises Runtime observation/control only through the Runtime root so CUT-VIS-RUN is behaviorally sealed rather than inventory-only.",
      "acceptanceCriteria": [
        "Focused Visualization/Runtime boundary tests construct at least one Runtime root observation path through Service.Observe / ObserveRequest (for example session-bound runtime source snapshot facts used by live-view activation) and assert observable acceptance or typed rejection outcomes",
        "Where a leased control surface exists under Visualization, proofs also exercise at least one published root control path; otherwise observation proof alone is sufficient for this consumer edge",
        "Those proofs fail closed if the exercised Visualization edge obtains observation/control through a Runtime implementation package or Petri-shaped GetEngineStateSnapshot / StateSnapshot path instead of the Runtime root",
        "Proofs assert behavioral outcomes reviewers can check (request scope/fields received by a fake Runtime Service, observation fields used in activation/view facts, typed error codes/messages, or equivalent detached Runtime contracts), not merely that an import graph is empty",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cut-vis-run-005",
      "title": "Close delivery through review, CI, and merge",
      "description": "As the Factory program owner, I want the CUT-VIS-RUN implementation loop to continue through review and required CI until the PR is actually merged so the packet is terminal rather than merely opened or approved.",
      "acceptanceCriteria": [
        "Implementation PR for CUT-VIS-RUN is opened with only the Visualization→Runtime consumer-edge lease scope",
        "Diff does not fold/delete visualization or factory_runtime packages, reopen CUT-VIS-REC / Recordings edges, admit CUT-RUN-REC or IMP-RUN-04, open shared integrators, or edit root pkg/wire beyond an unavoidable Visualization→Runtime import retarget",
        "Required CI is terminal and passing on the merge candidate",
        "Every blocking PR conversation comment is explicitly addressed",
        "Merge conflicts and shared-file collisions are reconciled with concurrent packets",
        "PR is actually merged; opened/green/approved/ready-to-merge alone does not satisfy completion",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": false,
      "notes": ""
    }
  ]
}
