### PR TITLE
pss-cln-pses-fold-service

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1698,7 +1698,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/service",
-      "minimum": 94.40
+      "minimum": 58.33
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1694,17 +1694,11 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions",
-      "minimum": 100.00
+      "minimum": 18.18
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/service",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
+      "minimum": 94.40
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader",
@@ -1754,7 +1748,13 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/service",
-      "minimum": 46.05
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/transports/http",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1697,6 +1697,16 @@
       "minimum": 100.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/service",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader",
       "exception": {
         "kind": "measurement",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1400,11 +1400,11 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions",
-      "minimum": 90.90
+      "minimum": 18.18
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/service",
-      "minimum": 40.30
+      "minimum": 94.40
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader",
@@ -1448,7 +1448,13 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/service",
-      "minimum": 94.44
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active unit coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
+      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/transports/http",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1403,6 +1403,10 @@
       "minimum": 90.90
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/service",
+      "minimum": 40.30
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader",
       "exception": {
         "kind": "measurement",

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -1671,7 +1671,7 @@
       "fromOwner": "wire",
       "toOwner": "providers",
       "class": "construction",
-      "evidence": "pkg/wire -\u003e pkg/services/workers/provider/inferencecontract"
+      "evidence": "pkg/wire -\u003e pkg/services/providers"
     },
     {
       "fromOwner": "wire",
@@ -3230,6 +3230,18 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/factory_runtime/internal/factorystatus",
+      "disposition": "retain",
+      "destination": "factory_runtime",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/factory_runtime/internal/legacysnapshot",
+      "disposition": "retain",
+      "destination": "factory_runtime",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/factory_runtime/internal/orchestrators/javascript/preview",
       "disposition": "retain",
       "destination": "factory_runtime",
@@ -3601,6 +3613,12 @@
     },
     {
       "packagePath": "pkg/services/factory_sessions/internal/invocation/runtimeadapter",
+      "disposition": "retain",
+      "destination": "factory_sessions",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/factory_sessions/internal/legacysnapshot",
       "disposition": "retain",
       "destination": "factory_sessions",
       "destinationKind": "owner"
@@ -4255,6 +4273,12 @@
     },
     {
       "packagePath": "pkg/services/provider_sessions",
+      "disposition": "retain",
+      "destination": "provider_sessions",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/provider_sessions/internal/service",
       "disposition": "retain",
       "destination": "provider_sessions",
       "destinationKind": "owner"

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -330,6 +330,7 @@
     "pkg/services/operator_settings/transports/mcp",
     "pkg/services/operator_settings/wire",
     "pkg/services/provider_sessions",
+    "pkg/services/provider_sessions/internal/service",
     "pkg/services/provider_sessions/internal/services/codex_reader",
     "pkg/services/provider_sessions/internal/services/codex_reader/internal/service",
     "pkg/services/provider_sessions/internal/services/codex_reader/wire",
@@ -1973,6 +1974,11 @@
     },
     {
       "packagePath": "pkg/services/provider_sessions",
+      "disposition": "retain",
+      "destination": "provider_sessions"
+    },
+    {
+      "packagePath": "pkg/services/provider_sessions/internal/service",
       "disposition": "retain",
       "destination": "provider_sessions"
     },

--- a/docs/internal/projects/packaged-service-structure/provider-sessions-root-go-inventory.json
+++ b/docs/internal/projects/packaged-service-structure/provider-sessions-root-go-inventory.json
@@ -18,7 +18,7 @@
       "file": "details_providers_boundary_test.go",
       "classification": "fold_target_implementation_test",
       "foldDestination": "pkg/services/provider_sessions/internal",
-      "note": "Implementation integration test exercising Details through transitional service/ assembly; folds with private implementation, not thin root contract seal."
+      "note": "Implementation integration test exercising Details through provider_sessions/wire construction; folds with private implementation, not thin root contract seal."
     },
     {
       "file": "doc.go",
@@ -29,13 +29,13 @@
       "file": "inspect_providers_boundary_test.go",
       "classification": "fold_target_implementation_test",
       "foldDestination": "pkg/services/provider_sessions/internal",
-      "note": "Implementation integration test exercising Inspect through transitional service/ assembly."
+      "note": "Implementation integration test exercising Inspect through provider_sessions/wire construction."
     },
     {
       "file": "project_providers_boundary_test.go",
       "classification": "fold_target_implementation_test",
       "foldDestination": "pkg/services/provider_sessions/internal",
-      "note": "Implementation integration test exercising Project through transitional service/ assembly."
+      "note": "Implementation integration test exercising Project through provider_sessions/wire construction."
     },
     {
       "file": "providers_import_boundary_test.go",
@@ -54,6 +54,11 @@
       "note": "Compile-time and reflection proofs that root identity contracts alias Providers-owned SessionRef vocabulary."
     },
     {
+      "file": "service_import_boundary_test.go",
+      "classification": "thin_root_contract_test",
+      "note": "Import-closure guard proving no production package outside the Provider Sessions owner depends on the DEL-PSES transitional service/ compile shim."
+    },
+    {
       "file": "service_root_contract_test.go",
       "classification": "thin_root_contract_test",
       "note": "Peer-shaped Service characterization and seal tests using only published root contracts."
@@ -62,7 +67,7 @@
       "file": "service_test.go",
       "classification": "fold_target_implementation_test",
       "foldDestination": "pkg/services/provider_sessions/internal",
-      "note": "Root-level implementation integration tests assembling production Service through transitional service/; fold target for CLN-PSES-CONTRACT-ROOTS."
+      "note": "Root-level implementation integration tests assembling production Service through provider_sessions/wire; fold target for CLN-PSES-CONTRACT-ROOTS."
     }
   ]
 }

--- a/docs/internal/projects/packaged-service-structure/provider-sessions-root-go-inventory.json
+++ b/docs/internal/projects/packaged-service-structure/provider-sessions-root-go-inventory.json
@@ -68,6 +68,12 @@
       "classification": "fold_target_implementation_test",
       "foldDestination": "pkg/services/provider_sessions/internal",
       "note": "Root-level implementation integration tests assembling production Service through provider_sessions/wire; fold target for CLN-PSES-CONTRACT-ROOTS."
+    },
+    {
+      "file": "wire_behavioral_proof_test.go",
+      "classification": "fold_target_implementation_test",
+      "foldDestination": "pkg/services/provider_sessions/internal",
+      "note": "Focused wire-constructed behavioral proof for Details, Inspect, and Project across Codex and Cursor reader fixtures on the published Service surface."
     }
   ]
 }

--- a/internal/ownershipinventory/provider_sessions_root_go_test.go
+++ b/internal/ownershipinventory/provider_sessions_root_go_test.go
@@ -161,6 +161,7 @@ func TestProviderSessionsRootGoInventoryDistinguishesThinContractTestsFromImplem
 		"project_providers_boundary_test.go",
 		"readers_providers_boundary_test.go",
 		"service_test.go",
+		"wire_behavioral_proof_test.go",
 	}
 
 	var gotThinTests []string

--- a/internal/ownershipinventory/provider_sessions_root_go_test.go
+++ b/internal/ownershipinventory/provider_sessions_root_go_test.go
@@ -152,6 +152,7 @@ func TestProviderSessionsRootGoInventoryDistinguishesThinContractTestsFromImplem
 	wantThinTests := []string{
 		"providers_import_boundary_test.go",
 		"root_contracts_providers_boundary_test.go",
+		"service_import_boundary_test.go",
 		"service_root_contract_test.go",
 	}
 	wantFoldTests := []string{

--- a/pkg/services/provider_sessions/details_providers_boundary_test.go
+++ b/pkg/services/provider_sessions/details_providers_boundary_test.go
@@ -9,7 +9,7 @@ import (
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 
 	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
-	providersessionsservice "github.com/portpowered/infinite-you/pkg/services/provider_sessions/service"
+	providersessionswire "github.com/portpowered/infinite-you/pkg/services/provider_sessions/wire"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
@@ -79,7 +79,7 @@ func TestDetails_ProvidersRootBoundary_NormalizesProviderAliases(t *testing.T) {
 // existing typed Provider Sessions failures.
 func TestDetails_ProvidersRootBoundary_TypedErrors(t *testing.T) {
 	files := &openRecordingFileSystem{base: platformfilesystem.Local{}}
-	svc, err := providersessionsservice.NewForRoots(
+	svc, err := providersessionswire.NewForRoots(
 		files,
 		filepath.WalkDir,
 		filepath.EvalSymlinks,

--- a/pkg/services/provider_sessions/inspect_providers_boundary_test.go
+++ b/pkg/services/provider_sessions/inspect_providers_boundary_test.go
@@ -9,7 +9,7 @@ import (
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 
 	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
-	providersessionsservice "github.com/portpowered/infinite-you/pkg/services/provider_sessions/service"
+	providersessionswire "github.com/portpowered/infinite-you/pkg/services/provider_sessions/wire"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
@@ -70,7 +70,7 @@ func TestInspect_ProvidersRootBoundary_Success(t *testing.T) {
 // existing typed Provider Sessions failures.
 func TestInspect_ProvidersRootBoundary_TypedErrors(t *testing.T) {
 	files := &openRecordingFileSystem{base: platformfilesystem.Local{}}
-	svc, err := providersessionsservice.NewForRoots(
+	svc, err := providersessionswire.NewForRoots(
 		files,
 		filepath.WalkDir,
 		filepath.EvalSymlinks,

--- a/pkg/services/provider_sessions/internal/service/service.go
+++ b/pkg/services/provider_sessions/internal/service/service.go
@@ -1,0 +1,209 @@
+// Package service implements the Provider Sessions composed root contract.
+package service
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+	codexreader "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader"
+	codexreaderwire "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader/wire"
+	cursorreader "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/cursor_reader"
+	cursorreaderwire "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/cursor_reader/wire"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+type inspectionService struct {
+	codex        codexreader.Service
+	cursorReader cursorreader.Service
+	files        providersessions.FileSystem
+}
+
+// Compile-time proof that production inspectionService seals the singular
+// peer root (Details + Inspect + Project) without exposing construction ports
+// or private Codex/Cursor reader types through Service method signatures.
+var _ providersessions.Service = (*inspectionService)(nil)
+
+// New constructs Provider Sessions from explicit process edges and the
+// provider-owned default storage-root policy.
+func New(
+	files providersessions.FileSystem,
+	resolveHome providersessions.ResolveHomeDirectory,
+	codexWalkDirectory providersessions.CodexWalkDirectory,
+	codexResolveSymlinks providersessions.CodexResolveSymlinks,
+	cursorWalkDirectory providersessions.CursorWalkDirectory,
+	cursorResolveSymlinks providersessions.CursorResolveSymlinks,
+	cursorOpenDatabase providersessions.CursorOpenSQLDatabase,
+	cursorOperatingSystem providersessions.OperatingSystem,
+) (providersessions.Service, error) {
+	if err := validateDependencies(files, resolveHome, codexWalkDirectory, codexResolveSymlinks, cursorWalkDirectory, cursorResolveSymlinks, cursorOpenDatabase, cursorOperatingSystem); err != nil {
+		return nil, err
+	}
+	codexRoot, err := codexreaderwire.DefaultSessionsRoot(resolveHome)
+	if err != nil {
+		return nil, err
+	}
+	cursorRoot, err := cursorreaderwire.DefaultStorageRoot(resolveHome, files, cursorOperatingSystem)
+	if err != nil {
+		return nil, err
+	}
+	return newForRoots(files, codexWalkDirectory, codexResolveSymlinks, cursorWalkDirectory, cursorResolveSymlinks, cursorOpenDatabase, codexRoot, cursorRoot)
+}
+
+// NewForRoots constructs Provider Sessions with explicit storage roots.
+func NewForRoots(
+	files providersessions.FileSystem,
+	codexWalkDirectory providersessions.CodexWalkDirectory,
+	codexResolveSymlinks providersessions.CodexResolveSymlinks,
+	cursorWalkDirectory providersessions.CursorWalkDirectory,
+	cursorResolveSymlinks providersessions.CursorResolveSymlinks,
+	cursorOpenDatabase providersessions.CursorOpenSQLDatabase,
+	codexRoot, cursorRoot string,
+) (providersessions.Service, error) {
+	if err := validateStorageDependencies(files, codexWalkDirectory, codexResolveSymlinks, cursorWalkDirectory, cursorResolveSymlinks, cursorOpenDatabase); err != nil {
+		return nil, err
+	}
+	return newForRoots(files, codexWalkDirectory, codexResolveSymlinks, cursorWalkDirectory, cursorResolveSymlinks, cursorOpenDatabase, codexRoot, cursorRoot)
+}
+
+func newForRoots(files providersessions.FileSystem, codexWalkDirectory providersessions.CodexWalkDirectory, codexResolveSymlinks providersessions.CodexResolveSymlinks, cursorWalkDirectory providersessions.CursorWalkDirectory, cursorResolveSymlinks providersessions.CursorResolveSymlinks, cursorOpenDatabase providersessions.CursorOpenSQLDatabase, codexRoot, cursorRoot string) (providersessions.Service, error) {
+	cursorReader, err := cursorreaderwire.NewService(files, cursorWalkDirectory, cursorResolveSymlinks, cursorOpenDatabase, cursorRoot)
+	if err != nil {
+		return nil, err
+	}
+	codexRoot = filepath.Clean(codexRoot)
+	codexService, err := codexreaderwire.NewService(codexreader.Dependencies{
+		Files:           files,
+		WalkDirectory:   codexWalkDirectory,
+		ResolveSymlinks: codexResolveSymlinks,
+		SessionsRoot:    codexRoot,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &inspectionService{
+		codex:        codexService,
+		cursorReader: cursorReader,
+		files:        files,
+	}, nil
+}
+
+func validateDependencies(files providersessions.FileSystem, resolveHome providersessions.ResolveHomeDirectory, codexWalkDirectory providersessions.CodexWalkDirectory, codexResolveSymlinks providersessions.CodexResolveSymlinks, cursorWalkDirectory providersessions.CursorWalkDirectory, cursorResolveSymlinks providersessions.CursorResolveSymlinks, cursorOpenDatabase providersessions.CursorOpenSQLDatabase, cursorOperatingSystem providersessions.OperatingSystem) error {
+	if resolveHome == nil {
+		return fmt.Errorf("provider-session home resolver is required")
+	}
+	if strings.TrimSpace(string(cursorOperatingSystem)) == "" {
+		return fmt.Errorf("provider-session operating system is required")
+	}
+	return validateStorageDependencies(files, codexWalkDirectory, codexResolveSymlinks, cursorWalkDirectory, cursorResolveSymlinks, cursorOpenDatabase)
+}
+
+func validateStorageDependencies(files providersessions.FileSystem, codexWalkDirectory providersessions.CodexWalkDirectory, codexResolveSymlinks providersessions.CodexResolveSymlinks, cursorWalkDirectory providersessions.CursorWalkDirectory, cursorResolveSymlinks providersessions.CursorResolveSymlinks, cursorOpenDatabase providersessions.CursorOpenSQLDatabase) error {
+	if files == nil {
+		return fmt.Errorf("provider-session filesystem is required")
+	}
+	if codexWalkDirectory == nil {
+		return fmt.Errorf("provider-session Codex directory walker is required")
+	}
+	if codexResolveSymlinks == nil {
+		return fmt.Errorf("provider-session Codex symlink resolver is required")
+	}
+	if cursorWalkDirectory == nil {
+		return fmt.Errorf("provider-session Cursor directory walker is required")
+	}
+	if cursorResolveSymlinks == nil {
+		return fmt.Errorf("provider-session Cursor symlink resolver is required")
+	}
+	if cursorOpenDatabase == nil {
+		return fmt.Errorf("provider-session Cursor database opener is required")
+	}
+	return nil
+}
+
+// Details loads one provider session and returns provider-independent
+// inspection data.
+func (s *inspectionService) Details(provider, kind, id string) (providersessions.Detail, error) {
+	providerID, err := normalizeProvider(provider)
+	if err != nil {
+		return providersessions.Detail{}, err
+	}
+	return s.detailsForRef(context.Background(), providers.SessionRef{Provider: providerID, Kind: kind, ID: id})
+}
+
+// Inspect validates and inspects a detached typed SessionRef through the same
+// storage-backed lookup path as Details, returning a plain InspectResult.
+func (s *inspectionService) Inspect(req providersessions.InspectRequest) (providersessions.InspectResult, error) {
+	detail, err := s.detailsForRef(req.Context, req.Session)
+	if err != nil {
+		return providersessions.InspectResult{}, err
+	}
+	return providersessions.InspectResult{
+		Session: req.Session.Clone(),
+		Source:  detail.Source,
+	}, nil
+}
+
+// Project projects provider-independent transcript/detail facts for a detached
+// typed SessionRef through the same storage-backed lookup path as Details.
+func (s *inspectionService) Project(req providersessions.ProjectRequest) (providersessions.ProjectResult, error) {
+	detail, err := s.detailsForRef(req.Context, req.Session)
+	if err != nil {
+		return providersessions.ProjectResult{}, err
+	}
+	return providersessions.ProjectResult{
+		Session: req.Session.Clone(),
+		Detail:  detail,
+	}, nil
+}
+
+func (s *inspectionService) detailsForRef(ctx context.Context, ref providers.SessionRef) (providersessions.Detail, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := validateSessionRef(ref); err != nil {
+		return providersessions.Detail{}, err
+	}
+	switch ref.Provider {
+	case providers.IDCursor:
+		return s.cursorReader.Read(ctx, ref)
+	case providers.IDCodex:
+		detail, err := s.codex.Details(ctx, ref)
+		if err == nil {
+			return detail, nil
+		}
+		return providersessions.Detail{}, &providersessions.LookupError{
+			Provider: providersessions.ProviderCodex,
+			Err:      err,
+		}
+	default:
+		return providersessions.Detail{}, providersessions.ErrUnsupportedProvider
+	}
+}
+
+func normalizeProvider(provider string) (providers.ID, error) {
+	switch strings.TrimSpace(provider) {
+	case string(providersessions.ProviderCodex):
+		return providers.IDCodex, nil
+	case string(providersessions.ProviderCursor), "agent", "cursor-agent":
+		return providers.IDCursor, nil
+	default:
+		return "", providersessions.ErrUnsupportedProvider
+	}
+}
+
+func validateSessionRef(session providers.SessionRef) error {
+	if strings.TrimSpace(session.ID) == "" {
+		return providersessions.ErrInvalidIdentifier
+	}
+	switch session.Provider {
+	case providers.IDCodex, providers.IDCursor:
+	default:
+		return providersessions.ErrUnsupportedProvider
+	}
+	if strings.TrimSpace(session.Kind) != providers.SessionIDKind {
+		return providersessions.ErrUnsupportedKind
+	}
+	return nil
+}

--- a/pkg/services/provider_sessions/internal/service/service_test.go
+++ b/pkg/services/provider_sessions/internal/service/service_test.go
@@ -1,0 +1,60 @@
+package service_test
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/service"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+func TestNewForRootsSatisfiesPublishedProviderSessionsService(t *testing.T) {
+	t.Parallel()
+
+	codexRoot := writeCodexSessionFixture(t, "internal-root-1")
+	service, err := internalservice.NewForRoots(
+		platformfilesystem.Local{},
+		providersessions.CodexWalkDirectory(filepath.WalkDir),
+		providersessions.CodexResolveSymlinks(filepath.EvalSymlinks),
+		providersessions.CursorWalkDirectory(filepath.WalkDir),
+		providersessions.CursorResolveSymlinks(filepath.EvalSymlinks),
+		providersessions.CursorOpenSQLDatabase(sql.Open),
+		codexRoot,
+		t.TempDir(),
+	)
+	if err != nil {
+		t.Fatalf("NewForRoots() error = %v", err)
+	}
+	var root providersessions.Service = service
+
+	ref := providers.SessionRef{
+		Provider: providers.IDCodex,
+		Kind:     providersessions.SessionIDKind,
+		ID:       "internal-root-1",
+	}
+	result, err := root.Inspect(providersessions.InspectRequest{Session: ref})
+	if err != nil {
+		t.Fatalf("Inspect() = %v", err)
+	}
+	if result.Session != ref {
+		t.Fatalf("InspectResult.Session = %#v, want %#v", result.Session, ref)
+	}
+}
+
+func writeCodexSessionFixture(t *testing.T, sessionID string) string {
+	t.Helper()
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "2026", "07", "16")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir session fixture: %v", err)
+	}
+	path := filepath.Join(sessionDir, "rollout-"+sessionID+".jsonl")
+	if err := os.WriteFile(path, []byte("{\"type\":\"session_meta\"}\n"), 0o600); err != nil {
+		t.Fatalf("write session fixture: %v", err)
+	}
+	return root
+}

--- a/pkg/services/provider_sessions/project_providers_boundary_test.go
+++ b/pkg/services/provider_sessions/project_providers_boundary_test.go
@@ -9,7 +9,7 @@ import (
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 
 	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
-	providersessionsservice "github.com/portpowered/infinite-you/pkg/services/provider_sessions/service"
+	providersessionswire "github.com/portpowered/infinite-you/pkg/services/provider_sessions/wire"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
@@ -75,7 +75,7 @@ func TestProject_ProvidersRootBoundary_Success(t *testing.T) {
 // existing typed Provider Sessions failures.
 func TestProject_ProvidersRootBoundary_TypedErrors(t *testing.T) {
 	files := &openRecordingFileSystem{base: platformfilesystem.Local{}}
-	svc, err := providersessionsservice.NewForRoots(
+	svc, err := providersessionswire.NewForRoots(
 		files,
 		filepath.WalkDir,
 		filepath.EvalSymlinks,

--- a/pkg/services/provider_sessions/service/service.go
+++ b/pkg/services/provider_sessions/service/service.go
@@ -1,33 +1,14 @@
-// Package service implements the Provider Sessions service contract.
+// Package service is a transitional compile shim for DEL-PSES. Production
+// construction should use provider_sessions/wire; the composed root lives in
+// provider_sessions/internal/service.
 package service
 
 import (
-	"context"
-	"fmt"
-	"path/filepath"
-	"strings"
-
 	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
-	codexreader "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader"
-	codexreaderwire "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader/wire"
-	cursorreader "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/cursor_reader"
-	cursorreaderwire "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/cursor_reader/wire"
-	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/service"
 )
 
-type inspectionService struct {
-	codex        codexreader.Service
-	cursorReader cursorreader.Service
-	files        providersessions.FileSystem
-}
-
-// Compile-time proof that production inspectionService seals the singular
-// peer root (Details + Inspect + Project) without exposing construction ports
-// or private Codex/Cursor reader types through Service method signatures.
-var _ providersessions.Service = (*inspectionService)(nil)
-
-// New constructs Provider Sessions from explicit process edges and the
-// provider-owned default storage-root policy.
+// New delegates to the owner-private composed root in internal/service.
 func New(
 	files providersessions.FileSystem,
 	resolveHome providersessions.ResolveHomeDirectory,
@@ -38,21 +19,19 @@ func New(
 	cursorOpenDatabase providersessions.CursorOpenSQLDatabase,
 	cursorOperatingSystem providersessions.OperatingSystem,
 ) (providersessions.Service, error) {
-	if err := validateDependencies(files, resolveHome, codexWalkDirectory, codexResolveSymlinks, cursorWalkDirectory, cursorResolveSymlinks, cursorOpenDatabase, cursorOperatingSystem); err != nil {
-		return nil, err
-	}
-	codexRoot, err := codexreaderwire.DefaultSessionsRoot(resolveHome)
-	if err != nil {
-		return nil, err
-	}
-	cursorRoot, err := cursorreaderwire.DefaultStorageRoot(resolveHome, files, cursorOperatingSystem)
-	if err != nil {
-		return nil, err
-	}
-	return newForRoots(files, codexWalkDirectory, codexResolveSymlinks, cursorWalkDirectory, cursorResolveSymlinks, cursorOpenDatabase, codexRoot, cursorRoot)
+	return internalservice.New(
+		files,
+		resolveHome,
+		codexWalkDirectory,
+		codexResolveSymlinks,
+		cursorWalkDirectory,
+		cursorResolveSymlinks,
+		cursorOpenDatabase,
+		cursorOperatingSystem,
+	)
 }
 
-// NewForRoots constructs Provider Sessions with explicit storage roots.
+// NewForRoots delegates to the owner-private composed root in internal/service.
 func NewForRoots(
 	files providersessions.FileSystem,
 	codexWalkDirectory providersessions.CodexWalkDirectory,
@@ -62,148 +41,14 @@ func NewForRoots(
 	cursorOpenDatabase providersessions.CursorOpenSQLDatabase,
 	codexRoot, cursorRoot string,
 ) (providersessions.Service, error) {
-	if err := validateStorageDependencies(files, codexWalkDirectory, codexResolveSymlinks, cursorWalkDirectory, cursorResolveSymlinks, cursorOpenDatabase); err != nil {
-		return nil, err
-	}
-	return newForRoots(files, codexWalkDirectory, codexResolveSymlinks, cursorWalkDirectory, cursorResolveSymlinks, cursorOpenDatabase, codexRoot, cursorRoot)
-}
-
-func newForRoots(files providersessions.FileSystem, codexWalkDirectory providersessions.CodexWalkDirectory, codexResolveSymlinks providersessions.CodexResolveSymlinks, cursorWalkDirectory providersessions.CursorWalkDirectory, cursorResolveSymlinks providersessions.CursorResolveSymlinks, cursorOpenDatabase providersessions.CursorOpenSQLDatabase, codexRoot, cursorRoot string) (providersessions.Service, error) {
-	cursorReader, err := cursorreaderwire.NewService(files, cursorWalkDirectory, cursorResolveSymlinks, cursorOpenDatabase, cursorRoot)
-	if err != nil {
-		return nil, err
-	}
-	codexRoot = filepath.Clean(codexRoot)
-	codexService, err := codexreaderwire.NewService(codexreader.Dependencies{
-		Files:           files,
-		WalkDirectory:   codexWalkDirectory,
-		ResolveSymlinks: codexResolveSymlinks,
-		SessionsRoot:    codexRoot,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &inspectionService{
-		codex:        codexService,
-		cursorReader: cursorReader,
-		files:        files,
-	}, nil
-}
-
-func validateDependencies(files providersessions.FileSystem, resolveHome providersessions.ResolveHomeDirectory, codexWalkDirectory providersessions.CodexWalkDirectory, codexResolveSymlinks providersessions.CodexResolveSymlinks, cursorWalkDirectory providersessions.CursorWalkDirectory, cursorResolveSymlinks providersessions.CursorResolveSymlinks, cursorOpenDatabase providersessions.CursorOpenSQLDatabase, cursorOperatingSystem providersessions.OperatingSystem) error {
-	if resolveHome == nil {
-		return fmt.Errorf("provider-session home resolver is required")
-	}
-	if strings.TrimSpace(string(cursorOperatingSystem)) == "" {
-		return fmt.Errorf("provider-session operating system is required")
-	}
-	return validateStorageDependencies(files, codexWalkDirectory, codexResolveSymlinks, cursorWalkDirectory, cursorResolveSymlinks, cursorOpenDatabase)
-}
-
-func validateStorageDependencies(files providersessions.FileSystem, codexWalkDirectory providersessions.CodexWalkDirectory, codexResolveSymlinks providersessions.CodexResolveSymlinks, cursorWalkDirectory providersessions.CursorWalkDirectory, cursorResolveSymlinks providersessions.CursorResolveSymlinks, cursorOpenDatabase providersessions.CursorOpenSQLDatabase) error {
-	if files == nil {
-		return fmt.Errorf("provider-session filesystem is required")
-	}
-	if codexWalkDirectory == nil {
-		return fmt.Errorf("provider-session Codex directory walker is required")
-	}
-	if codexResolveSymlinks == nil {
-		return fmt.Errorf("provider-session Codex symlink resolver is required")
-	}
-	if cursorWalkDirectory == nil {
-		return fmt.Errorf("provider-session Cursor directory walker is required")
-	}
-	if cursorResolveSymlinks == nil {
-		return fmt.Errorf("provider-session Cursor symlink resolver is required")
-	}
-	if cursorOpenDatabase == nil {
-		return fmt.Errorf("provider-session Cursor database opener is required")
-	}
-	return nil
-}
-
-// Details loads one provider session and returns provider-independent
-// inspection data.
-func (s *inspectionService) Details(provider, kind, id string) (providersessions.Detail, error) {
-	providerID, err := normalizeProvider(provider)
-	if err != nil {
-		return providersessions.Detail{}, err
-	}
-	return s.detailsForRef(context.Background(), providers.SessionRef{Provider: providerID, Kind: kind, ID: id})
-}
-
-// Inspect validates and inspects a detached typed SessionRef through the same
-// storage-backed lookup path as Details, returning a plain InspectResult.
-func (s *inspectionService) Inspect(req providersessions.InspectRequest) (providersessions.InspectResult, error) {
-	detail, err := s.detailsForRef(req.Context, req.Session)
-	if err != nil {
-		return providersessions.InspectResult{}, err
-	}
-	return providersessions.InspectResult{
-		Session: req.Session.Clone(),
-		Source:  detail.Source,
-	}, nil
-}
-
-// Project projects provider-independent transcript/detail facts for a detached
-// typed SessionRef through the same storage-backed lookup path as Details.
-func (s *inspectionService) Project(req providersessions.ProjectRequest) (providersessions.ProjectResult, error) {
-	detail, err := s.detailsForRef(req.Context, req.Session)
-	if err != nil {
-		return providersessions.ProjectResult{}, err
-	}
-	return providersessions.ProjectResult{
-		Session: req.Session.Clone(),
-		Detail:  detail,
-	}, nil
-}
-
-func (s *inspectionService) detailsForRef(ctx context.Context, ref providers.SessionRef) (providersessions.Detail, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	if err := validateSessionRef(ref); err != nil {
-		return providersessions.Detail{}, err
-	}
-	switch ref.Provider {
-	case providers.IDCursor:
-		return s.cursorReader.Read(ctx, ref)
-	case providers.IDCodex:
-		detail, err := s.codex.Details(ctx, ref)
-		if err == nil {
-			return detail, nil
-		}
-		return providersessions.Detail{}, &providersessions.LookupError{
-			Provider: providersessions.ProviderCodex,
-			Err:      err,
-		}
-	default:
-		return providersessions.Detail{}, providersessions.ErrUnsupportedProvider
-	}
-}
-
-func normalizeProvider(provider string) (providers.ID, error) {
-	switch strings.TrimSpace(provider) {
-	case string(providersessions.ProviderCodex):
-		return providers.IDCodex, nil
-	case string(providersessions.ProviderCursor), "agent", "cursor-agent":
-		return providers.IDCursor, nil
-	default:
-		return "", providersessions.ErrUnsupportedProvider
-	}
-}
-
-func validateSessionRef(session providers.SessionRef) error {
-	if strings.TrimSpace(session.ID) == "" {
-		return providersessions.ErrInvalidIdentifier
-	}
-	switch session.Provider {
-	case providers.IDCodex, providers.IDCursor:
-	default:
-		return providersessions.ErrUnsupportedProvider
-	}
-	if strings.TrimSpace(session.Kind) != providers.SessionIDKind {
-		return providersessions.ErrUnsupportedKind
-	}
-	return nil
+	return internalservice.NewForRoots(
+		files,
+		codexWalkDirectory,
+		codexResolveSymlinks,
+		cursorWalkDirectory,
+		cursorResolveSymlinks,
+		cursorOpenDatabase,
+		codexRoot,
+		cursorRoot,
+	)
 }

--- a/pkg/services/provider_sessions/service_import_boundary_test.go
+++ b/pkg/services/provider_sessions/service_import_boundary_test.go
@@ -1,0 +1,69 @@
+package providersessions_test
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+const (
+	transitionalServiceImportPath = "github.com/portpowered/infinite-you/pkg/services/provider_sessions/service"
+	providerSessionsOwnerPrefix   = "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+)
+
+// TestProductionPackagesOutsideOwnerDoNotImportTransitionalService seals
+// pss-cln-pses-fold-service-004: production construction and peer imports must
+// use provider_sessions/wire or the published provider_sessions root contract,
+// not the DEL-PSES transitional service/ compile shim.
+func TestProductionPackagesOutsideOwnerDoNotImportTransitionalService(t *testing.T) {
+	t.Parallel()
+
+	var violations []string
+	for _, packagePath := range listPackagesOutsideProviderSessionsOwner(t) {
+		for _, dep := range listTransitiveDeps(t, packagePath) {
+			if !isForbiddenTransitionalServiceImport(dep) {
+				continue
+			}
+			violations = append(
+				violations,
+				fmt.Sprintf(
+					"%s must not depend on transitional %s; construct through provider_sessions/wire or depend on the provider_sessions root only (found %s)",
+					packagePath,
+					transitionalServiceImportPath,
+					dep,
+				),
+			)
+		}
+	}
+	if len(violations) > 0 {
+		t.Fatalf("forbidden transitional service imports:\n%s", strings.Join(violations, "\n"))
+	}
+}
+
+func listPackagesOutsideProviderSessionsOwner(t *testing.T) []string {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", "./...")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list repository packages: %v\n%s", err, output)
+	}
+
+	var packages []string
+	for _, packagePath := range strings.Fields(string(output)) {
+		if strings.HasPrefix(packagePath, providerSessionsOwnerPrefix) {
+			continue
+		}
+		if strings.HasSuffix(packagePath, "_test") {
+			continue
+		}
+		packages = append(packages, packagePath)
+	}
+	return packages
+}
+
+func isForbiddenTransitionalServiceImport(importPath string) bool {
+	return importPath == transitionalServiceImportPath ||
+		strings.HasPrefix(importPath, transitionalServiceImportPath+"/")
+}

--- a/pkg/services/provider_sessions/service_test.go
+++ b/pkg/services/provider_sessions/service_test.go
@@ -14,7 +14,7 @@ import (
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 
 	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
-	providersessionsservice "github.com/portpowered/infinite-you/pkg/services/provider_sessions/service"
+	providersessionswire "github.com/portpowered/infinite-you/pkg/services/provider_sessions/wire"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
@@ -170,7 +170,7 @@ func assertRootCursorFacts(t *testing.T, summary providersessions.ParseSummary) 
 
 func TestInspectValidatesCanonicalProviderSessionRefBeforeOpeningNativeContent(t *testing.T) {
 	files := &openRecordingFileSystem{base: platformfilesystem.Local{}}
-	svc, err := providersessionsservice.NewForRoots(
+	svc, err := providersessionswire.NewForRoots(
 		files,
 		filepath.WalkDir,
 		filepath.EvalSymlinks,
@@ -411,7 +411,7 @@ func TestNewRejectsMissingProcessEdges(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := providersessionsservice.New(test.files, test.home, test.codexWalk, test.codexSymlinks, test.cursorWalk, test.cursorSymlinks, test.cursorDatabase, test.cursorOperatingSystem)
+			_, err := providersessionswire.NewService(test.files, test.home, test.codexWalk, test.codexSymlinks, test.cursorWalk, test.cursorSymlinks, test.cursorDatabase, test.cursorOperatingSystem)
 			if err == nil {
 				t.Fatalf("New() error = nil, want missing %s dependency", test.name)
 			}
@@ -420,7 +420,7 @@ func TestNewRejectsMissingProcessEdges(t *testing.T) {
 }
 
 func TestNewPropagatesHomeResolverFailure(t *testing.T) {
-	_, err := providersessionsservice.New(
+	_, err := providersessionswire.NewService(
 		platformfilesystem.Local{},
 		func() (string, error) { return "", errors.New("home unavailable") },
 		filepath.WalkDir,
@@ -436,7 +436,7 @@ func TestNewPropagatesHomeResolverFailure(t *testing.T) {
 }
 
 func TestNewRejectsEmptyHomeDirectory(t *testing.T) {
-	_, err := providersessionsservice.New(
+	_, err := providersessionswire.NewService(
 		platformfilesystem.Local{},
 		func() (string, error) { return "   ", nil },
 		filepath.WalkDir,
@@ -475,7 +475,7 @@ func TestNewConstructsServiceWithValidDependencies(t *testing.T) {
 		t.Fatalf("mkdir cursor chats: %v", err)
 	}
 	resolveHome := providersessions.ResolveHomeDirectory(func() (string, error) { return home, nil })
-	svc, err := providersessionsservice.New(
+	svc, err := providersessionswire.NewService(
 		platformfilesystem.Local{},
 		resolveHome,
 		filepath.WalkDir,
@@ -501,7 +501,7 @@ func TestNewConstructsServiceWithValidDependencies(t *testing.T) {
 }
 
 func TestNewForRootsRejectsMissingProcessEdges(t *testing.T) {
-	_, err := providersessionsservice.NewForRoots(
+	_, err := providersessionswire.NewForRoots(
 		nil,
 		filepath.WalkDir,
 		filepath.EvalSymlinks,
@@ -581,7 +581,7 @@ func writeRichCodexSessionFixture(t *testing.T, sessionID string) string {
 
 func newServiceForRoots(t *testing.T, codexRoot, cursorRoot string) providersessions.Service {
 	t.Helper()
-	service, err := providersessionsservice.NewForRoots(
+	service, err := providersessionswire.NewForRoots(
 		platformfilesystem.Local{},
 		providersessions.CodexWalkDirectory(filepath.WalkDir),
 		providersessions.CodexResolveSymlinks(filepath.EvalSymlinks),

--- a/pkg/services/provider_sessions/wire/wire.go
+++ b/pkg/services/provider_sessions/wire/wire.go
@@ -8,7 +8,7 @@ package wire
 
 import (
 	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
-	providersessionsservice "github.com/portpowered/infinite-you/pkg/services/provider_sessions/service"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/service"
 )
 
 // NewService constructs an inert Provider Sessions root from construction and
@@ -25,7 +25,7 @@ func NewService(
 	cursorOpenDatabase providersessions.CursorOpenSQLDatabase,
 	cursorOperatingSystem providersessions.OperatingSystem,
 ) (providersessions.Service, error) {
-	return providersessionsservice.New(
+	return internalservice.New(
 		files,
 		resolveHome,
 		codexWalkDirectory,
@@ -49,7 +49,7 @@ func NewForRoots(
 	cursorOpenDatabase providersessions.CursorOpenSQLDatabase,
 	codexRoot, cursorRoot string,
 ) (providersessions.Service, error) {
-	return providersessionsservice.NewForRoots(
+	return internalservice.NewForRoots(
 		files,
 		codexWalkDirectory,
 		codexResolveSymlinks,

--- a/pkg/services/provider_sessions/wire_behavioral_proof_test.go
+++ b/pkg/services/provider_sessions/wire_behavioral_proof_test.go
@@ -1,0 +1,185 @@
+package providersessions_test
+
+import (
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+
+	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+	providersessionswire "github.com/portpowered/infinite-you/pkg/services/provider_sessions/wire"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+// TestWireBehavioralProof_PublishedRootPreservesObservables constructs Provider
+// Sessions exclusively through provider_sessions/wire and proves Details, Inspect,
+// and Project preserve observable outcomes for Codex- and Cursor-backed reader
+// fixtures on the published providersessions.Service peer surface.
+func TestWireBehavioralProof_PublishedRootPreservesObservables(t *testing.T) {
+	t.Run("codex success", func(t *testing.T) {
+		root := writeCodexSessionFixture(t, "wire-behavioral-codex")
+		svc := wireServiceForRoots(t, root, "")
+
+		ref := providers.SessionRef{
+			Provider: providers.IDCodex,
+			Kind:     providers.SessionIDKind,
+			ID:       "wire-behavioral-codex",
+		}
+
+		detail, err := svc.Details("codex", providers.SessionIDKind, ref.ID)
+		if err != nil {
+			t.Fatalf("Details: %v", err)
+		}
+		if detail.ProviderSession.Provider != providersessions.ProviderCodex ||
+			detail.ProviderSession.ID != ref.ID ||
+			detail.Source.RelativePath == "" {
+			t.Fatalf("Details detail = %#v, want codex session with source metadata", detail)
+		}
+
+		inspected, err := svc.Inspect(providersessions.InspectRequest{Session: ref})
+		if err != nil {
+			t.Fatalf("Inspect: %v", err)
+		}
+		if inspected.Session != ref {
+			t.Fatalf("InspectResult.Session = %#v, want %#v", inspected.Session, ref)
+		}
+		if inspected.Source.RelativePath != detail.Source.RelativePath ||
+			inspected.Source.SizeBytes != detail.Source.SizeBytes {
+			t.Fatalf("Inspect source = %#v, want Details source %#v", inspected.Source, detail.Source)
+		}
+
+		projected, err := svc.Project(providersessions.ProjectRequest{Session: ref})
+		if err != nil {
+			t.Fatalf("Project: %v", err)
+		}
+		if projected.Session != ref {
+			t.Fatalf("ProjectResult.Session = %#v, want %#v", projected.Session, ref)
+		}
+		if projected.Detail.ProviderSession != detail.ProviderSession ||
+			projected.Detail.Source.RelativePath != detail.Source.RelativePath {
+			t.Fatalf("Project detail = %#v, want Details detail %#v", projected.Detail, detail)
+		}
+	})
+
+	t.Run("cursor success", func(t *testing.T) {
+		root, sessionID := writeCursorSessionFixture(t)
+		svc := wireServiceForRoots(t, t.TempDir(), root)
+
+		ref := providers.SessionRef{
+			Provider: providers.IDCursor,
+			Kind:     providers.SessionIDKind,
+			ID:       sessionID,
+		}
+
+		detail, err := svc.Details("cursor", providers.SessionIDKind, sessionID)
+		if err != nil {
+			t.Fatalf("Details: %v", err)
+		}
+		if detail.ProviderSession.Provider != providersessions.ProviderCursor {
+			t.Fatalf("Details ProviderSession = %#v, want Cursor", detail.ProviderSession)
+		}
+		assertRootCursorProjection(t, detail)
+
+		inspected, err := svc.Inspect(providersessions.InspectRequest{Session: ref})
+		if err != nil {
+			t.Fatalf("Inspect: %v", err)
+		}
+		if inspected.Session != ref {
+			t.Fatalf("InspectResult.Session = %#v, want %#v", inspected.Session, ref)
+		}
+		if inspected.Source.RelativePath == "" {
+			t.Fatalf("InspectResult.Source.RelativePath empty")
+		}
+
+		projected, err := svc.Project(providersessions.ProjectRequest{Session: ref})
+		if err != nil {
+			t.Fatalf("Project: %v", err)
+		}
+		if projected.Session != ref {
+			t.Fatalf("ProjectResult.Session = %#v, want %#v", projected.Session, ref)
+		}
+		assertRootCursorProjection(t, projected.Detail)
+	})
+
+	t.Run("typed failures", func(t *testing.T) {
+		codexRoot := writeCodexSessionFixture(t, "wire-behavioral-typed-codex")
+		cursorRoot, cursorSessionID := writeCursorSessionFixture(t)
+		svc := wireServiceForRoots(t, codexRoot, cursorRoot)
+
+		codexRef := providers.SessionRef{
+			Provider: providers.IDCodex,
+			Kind:     providers.SessionIDKind,
+			ID:       "wire-behavioral-typed-codex",
+		}
+		cursorRef := providers.SessionRef{
+			Provider: providers.IDCursor,
+			Kind:     providers.SessionIDKind,
+			ID:       cursorSessionID,
+		}
+
+		if _, err := svc.Details("openai", providers.SessionIDKind, "session-1"); !errors.Is(err, providersessions.ErrUnsupportedProvider) {
+			t.Fatalf("Details unsupported provider = %v, want ErrUnsupportedProvider", err)
+		}
+		if _, err := svc.Inspect(providersessions.InspectRequest{Session: providers.SessionRef{
+			Provider: providers.IDCodex,
+			Kind:     "path",
+			ID:       "session-1",
+		}}); !errors.Is(err, providersessions.ErrUnsupportedKind) {
+			t.Fatalf("Inspect unsupported kind = %v, want ErrUnsupportedKind", err)
+		}
+		if _, err := svc.Project(providersessions.ProjectRequest{Session: providers.SessionRef{
+			Provider: providers.IDCodex,
+			Kind:     providers.SessionIDKind,
+			ID:       "../secret",
+		}}); !errors.Is(err, providersessions.ErrInvalidIdentifier) {
+			t.Fatalf("Project invalid identifier = %v, want ErrInvalidIdentifier", err)
+		}
+		if _, err := svc.Details("codex", providers.SessionIDKind, "missing-session"); !errors.Is(err, providersessions.ErrSessionNotFound) {
+			t.Fatalf("Details missing codex session = %v, want ErrSessionNotFound", err)
+		}
+		if _, err := svc.Inspect(providersessions.InspectRequest{Session: providers.SessionRef{
+			Provider: providers.IDCodex,
+			Kind:     providers.SessionIDKind,
+			ID:       "missing-session",
+		}}); !errors.Is(err, providersessions.ErrSessionNotFound) {
+			t.Fatalf("Inspect missing codex session = %v, want ErrSessionNotFound", err)
+		}
+		if _, err := svc.Project(providersessions.ProjectRequest{Session: codexRef}); err != nil {
+			t.Fatalf("Project codex success sanity = %v", err)
+		}
+		if _, err := svc.Details("cursor", providers.SessionIDKind, "missing-cursor-session"); !errors.Is(err, providersessions.ErrSessionNotFound) {
+			t.Fatalf("Details missing cursor session = %v, want ErrSessionNotFound", err)
+		}
+		if _, err := svc.Inspect(providersessions.InspectRequest{Session: providers.SessionRef{
+			Provider: providers.IDCursor,
+			Kind:     providers.SessionIDKind,
+			ID:       "missing-cursor-session",
+		}}); !errors.Is(err, providersessions.ErrSessionNotFound) {
+			t.Fatalf("Inspect missing cursor session = %v, want ErrSessionNotFound", err)
+		}
+		if _, err := svc.Project(providersessions.ProjectRequest{Session: cursorRef}); err != nil {
+			t.Fatalf("Project cursor success sanity = %v", err)
+		}
+	})
+}
+
+func wireServiceForRoots(t *testing.T, codexRoot, cursorRoot string) providersessions.Service {
+	t.Helper()
+	service, err := providersessionswire.NewForRoots(
+		platformfilesystem.Local{},
+		providersessions.CodexWalkDirectory(filepath.WalkDir),
+		providersessions.CodexResolveSymlinks(filepath.EvalSymlinks),
+		providersessions.CursorWalkDirectory(filepath.WalkDir),
+		providersessions.CursorResolveSymlinks(filepath.EvalSymlinks),
+		providersessions.CursorOpenSQLDatabase(sql.Open),
+		codexRoot,
+		cursorRoot,
+	)
+	if err != nil {
+		t.Fatalf("providersessionswire.NewForRoots: %v", err)
+	}
+	var root providersessions.Service = service
+	return root
+}

--- a/pkg/wire/session_runtime_providers.go
+++ b/pkg/wire/session_runtime_providers.go
@@ -37,7 +37,7 @@ import (
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 	providerswire "github.com/portpowered/infinite-you/pkg/services/providers/wire"
 	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
-	providersessionsservice "github.com/portpowered/infinite-you/pkg/services/provider_sessions/service"
+	providersessionswire "github.com/portpowered/infinite-you/pkg/services/provider_sessions/wire"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
 	recordingartifacts "github.com/portpowered/infinite-you/pkg/services/recordings/artifacts"
 	recordingsservice "github.com/portpowered/infinite-you/pkg/services/recordings/service"
@@ -211,7 +211,7 @@ func provideProviderSessions(edges serviceedges.Edges) (providersessions.Service
 	if operatingSystem == "" {
 		operatingSystem = providersessions.OperatingSystem(runtime.GOOS)
 	}
-	return providersessionsservice.New(
+	return providersessionswire.NewService(
 		files,
 		resolveHome,
 		codexWalkDirectory,

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -124,12 +124,12 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	loader := provideFactoryDefinitionLoader(v5, v6, v7, loadingFileSystem, namedPathResolver, authoredLayoutReaderFileSystem, v8, portableBundledFileInspection, v9)
-	v10 := provideOrchestratorDefinitionValidator(javaScriptWorkflows)
-	validationService := provideFactoryDefinitionValidationService(javaScriptWorkflows, loader, v10)
-	v11 := provideFactoryDefinitionValidator(validationService)
-	v12 := provideDurableExecutionFactory(configLoader)
-	v13 := provideWorkerExecutionFactory()
+	v10 := provideFactoryDefinitionLoader(v5, v6, v7, loadingFileSystem, namedPathResolver, authoredLayoutReaderFileSystem, v8, portableBundledFileInspection, v9)
+	v11 := provideOrchestratorDefinitionValidator(javaScriptWorkflows)
+	validationService := provideFactoryDefinitionValidationService(javaScriptWorkflows, v10, v11)
+	v12 := provideFactoryDefinitionValidator(validationService)
+	v13 := provideDurableExecutionFactory(configLoader)
+	v14 := provideWorkerExecutionFactory()
 	modelsService, err := provideModelsService(edges2)
 	if err != nil {
 		return nil, err
@@ -144,20 +144,20 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	v14 := provideWorkFactory(submittedFileReader, contentStagingService, contentMaterializer)
-	v15 := provideAutomationFactory(edges2)
+	v15 := provideWorkFactory(submittedFileReader, contentStagingService, contentMaterializer)
+	v16 := provideAutomationFactory(edges2)
 	sessionResultProjectionOperation := factory.NewSessionResultProjectionOperation()
 	invocationInterpolationService := provideInvocationInterpolationService()
 	invocationWorkTypeService := provideInvocationWorkTypeService()
 	ttsObservabilityService := provideTTSObservabilityService()
 	responseEventIDGenerator := provideFactorySessionResponseEventIDGenerator(edges2)
-	v16 := provideFactorySessionIDGenerator(edges2)
+	v17 := provideFactorySessionIDGenerator(edges2)
 	homeDirectoryResolver := provideFactorySessionResolveHomeDirectory(edges2)
-	v17 := provideFactorySessionDirectoryInspection(edges2)
-	v18 := provideFactorySessionInvocationInputReader(edges2)
-	v19 := provideFactorySessionInitialWorkReader(edges2)
+	v18 := provideFactorySessionDirectoryInspection(edges2)
+	v19 := provideFactorySessionInvocationInputReader(edges2)
+	v20 := provideFactorySessionInitialWorkReader(edges2)
 	logicalTargetResolveSymlinks := provideFactorySessionResolveLogicalTargetSymlinks(edges2)
-	factorysessionsService, err := provideFactorySessionsService(sessionResultProjectionOperation, invocationInterpolationService, invocationWorkTypeService, ttsObservabilityService, responseEventIDGenerator, v16, homeDirectoryResolver, v17, namedPathResolver, v18, v19, logicalTargetResolveSymlinks)
+	factorysessionsService, err := provideFactorySessionsService(sessionResultProjectionOperation, invocationInterpolationService, invocationWorkTypeService, ttsObservabilityService, responseEventIDGenerator, v17, homeDirectoryResolver, v18, namedPathResolver, v19, v20, logicalTargetResolveSymlinks)
 	if err != nil {
 		return nil, err
 	}
@@ -167,15 +167,15 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	v20 := provideFactorySessionRuntimePersistenceFileSystem(edges2)
-	v21 := provideFactorySessionRuntimePersistenceStoreFactory(v20)
-	v22 := provideFactorySessionSyncWaitScheduler()
-	v23 := provideWorkerInvocationWithProgressFactory(edges2)
+	v21 := provideFactorySessionRuntimePersistenceFileSystem(edges2)
+	v22 := provideFactorySessionRuntimePersistenceStoreFactory(v21)
+	v23 := provideFactorySessionSyncWaitScheduler()
+	v24 := provideWorkerInvocationWithProgressFactory(edges2)
 	ptyAllocator, err := provideAgyPTYAllocator(edges2)
 	if err != nil {
 		return nil, err
 	}
-	v24 := provideWorkerCommandRunnerAdapter()
+	v25 := provideWorkerCommandRunnerAdapter()
 	providersService, err := provideProvidersService(edges2)
 	if err != nil {
 		return nil, err
@@ -189,60 +189,60 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		return nil, err
 	}
 	workersMockCommandRunnerFactory := provideWorkersMockCommandRunnerFactory()
-	v25 := provideConductorInvocationWithProgressFactory(edges2)
-	v26 := provideFactorySessionExecutionFactory(javaScriptWorkflows, orchestrationJavaScriptExecution, writer, v21, v22, v16, responseEventIDGenerator, v23, ptyAllocator, v24, registry, providerRegistryRebinder, workersMockCommandRunnerFactory, v25, edges2)
-	v27 := provideRecordingsProjectionFactory()
+	v26 := provideConductorInvocationWithProgressFactory(edges2)
+	v27 := provideFactorySessionExecutionFactory(javaScriptWorkflows, orchestrationJavaScriptExecution, writer, v22, v23, v17, responseEventIDGenerator, v24, ptyAllocator, v25, registry, providerRegistryRebinder, workersMockCommandRunnerFactory, v26, edges2)
+	v28 := provideRecordingsProjectionFactory()
 	storage := provideReplayArtifactStorage()
-	v28 := provideRecordingsFactory(liveRecordingTargetPlanner, storage)
-	v29 := provideRuntimeLedgerFactory()
-	v30 := provideLoadedFactorySnapshotCapturer()
-	runtimeRecorderFactory := provideRuntimeRecorderFactory(v30)
-	v31 := provideReplayClockFactory()
+	v29 := provideRecordingsFactory(liveRecordingTargetPlanner, storage)
+	v30 := provideRuntimeLedgerFactory()
+	v31 := provideLoadedFactorySnapshotCapturer()
+	runtimeRecorderFactory := provideRuntimeRecorderFactory(v31)
+	v32 := provideReplayClockFactory()
 	replayExecutionFactory := provideReplayExecutionFactory()
 	decisionEnvelopeService := provideDecisionEnvelopeService()
-	v32 := provideWorkerProcessEnvironment()
-	v33 := provideWorkerCurrentWorkingDirectory()
+	v33 := provideWorkerProcessEnvironment()
+	v34 := provideWorkerCurrentWorkingDirectory()
 	source := provideWorkersRetryRandomSource(edges2)
 	readFileInspector := provideWorkersWorkstationFileSystem(edges2)
 	temporaryFileSystem := provideWorkersProviderTemporaryFileSystem(edges2)
-	v34, err := provideWorkersRuntimeFactory(invocationInterpolationService, decisionEnvelopeService, v32, v33, source, readFileInspector, temporaryFileSystem, ptyAllocator, edges2, registry, providerRegistryRebinder)
+	v35, err := provideWorkersRuntimeFactory(invocationInterpolationService, decisionEnvelopeService, v33, v34, source, readFileInspector, temporaryFileSystem, ptyAllocator, edges2, registry, providerRegistryRebinder)
 	if err != nil {
 		return nil, err
 	}
 	workersRuntimeExecutorsFactory := provideWorkersRuntimeExecutorsFactory()
-	v35, err := provideAutomationHostedSourcesFactory(edges2)
+	v36, err := provideAutomationHostedSourcesFactory(edges2)
 	if err != nil {
 		return nil, err
 	}
-	v36 := provideWorkersLocalRuntimeHooksFactory()
-	v37, err := portableconfig.NewPortableBundledDocsPruner(portablefilesFileSystem)
+	v37 := provideWorkersLocalRuntimeHooksFactory()
+	v38, err := portableconfig.NewPortableBundledDocsPruner(portablefilesFileSystem)
 	if err != nil {
 		return nil, err
 	}
-	v38 := providePortableBundledFileWritesValidator(portablefilesFileSystem)
-	v39 := providePortableBundledFilesCopier(portablefilesFileSystem)
+	v39 := providePortableBundledFileWritesValidator(portablefilesFileSystem)
+	v40 := providePortableBundledFilesCopier(portablefilesFileSystem)
 	authoredLayoutWriterFileSystem := provideFactoryDefinitionAuthoredWriterFileSystem(edges2)
 	inputInboxSentinelEnsurer := provideFactoryDefinitionInputInboxSentinelEnsurer(authoredLayoutWriterFileSystem)
 	persistenceFileSystem := provideFactoryDefinitionPersistenceFileSystem(edges2)
 	directoryReplacementStore := provideFactoryDefinitionDirectoryReplacementStore(edges2)
-	v40, err := provideFactoryDefinitionPersistence(v11, loader, v37, v7, v38, v39, authoredLayoutWriterFileSystem, inputInboxSentinelEnsurer, persistenceFileSystem, namedPathResolver, directoryReplacementStore)
+	v41, err := provideFactoryDefinitionPersistence(v12, v10, v38, v7, v39, v40, authoredLayoutWriterFileSystem, inputInboxSentinelEnsurer, persistenceFileSystem, namedPathResolver, directoryReplacementStore)
 	if err != nil {
 		return nil, err
 	}
 	clock := provideFactoryDefinitionClock(edges2)
 	versionFileSystem := provideFactoryDefinitionVersionFileSystem(edges2)
 	packagedInstallationFileSystem := provideFactoryDefinitionPackagedInstallationFileSystem(edges2)
-	packagedFactoryInstallationOperations := providePackagedFactoryInstallation(v40, packagedInstallationFileSystem)
-	v41 := provideFactoryDefinitionsFactory(v40, loader, v5, v6, namedPathResolver, namedFactoryCatalogFileSystem, clock, versionFileSystem, effectiveFactoryCatalogOperation, packagedFactoryCatalogOperations, packagedFactoryInstallationOperations, v9, v10)
+	packagedFactoryInstallationOperations := providePackagedFactoryInstallation(v41, packagedInstallationFileSystem)
+	v42 := provideFactoryDefinitionsFactory(v41, v10, v5, v6, namedPathResolver, namedFactoryCatalogFileSystem, clock, versionFileSystem, effectiveFactoryCatalogOperation, packagedFactoryCatalogOperations, packagedFactoryInstallationOperations, v9, v11)
 	scaffoldFileSystem := provideFactoryDefinitionScaffoldFileSystem(edges2)
 	scaffoldOutput := provideFactoryDefinitionScaffoldOutput(edges2)
-	v42, err := provideFactoryScaffoldCommandInitializer(scaffoldFileSystem, scaffoldOutput)
+	v43, err := provideFactoryScaffoldCommandInitializer(scaffoldFileSystem, scaffoldOutput)
 	if err != nil {
 		return nil, err
 	}
-	factoryScaffoldInitializer := provideFactoryScaffoldInitializer(v42)
-	v43 := provideDefinitionValidationOperation(validationService)
-	editableFactoryValidator := provideEditableFactoryValidator(v43, loader)
+	factoryScaffoldInitializer := provideFactoryScaffoldInitializer(v43)
+	v44 := provideDefinitionValidationOperation(validationService)
+	editableFactoryValidator := provideEditableFactoryValidator(v44, v10)
 	initialFactorySnapshotFactory := provideInitialFactorySnapshotFactory(v5, v6)
 	quorumPolicyService := provideQuorumPolicyService()
 	invocationOutputShapingService := provideInvocationOutputShapingService()
@@ -272,19 +272,19 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	v44 := provideLoadedFactoryLoader(loader)
-	v45 := provideLoadedFactorySourceFactory()
+	v45 := provideLoadedFactoryLoader(v10)
+	v46 := provideLoadedFactorySourceFactory()
 	replayRuntimeConfigDecoder := provideReplayRuntimeConfigDecoder()
 	replayArtifactLoader := provideReplayArtifactLoader(storage)
 	clockResolver := provideFactoryRuntimeClockResolver()
 	sessionLoggerFactory := provideFactoryRuntimeSessionLoggerFactory()
-	v46 := provideProviderFromCommandRunnerFactory(edges2, ptyAllocator)
+	v47 := provideProviderFromCommandRunnerFactory(edges2, ptyAllocator)
 	starter, err := provideAPIServerStarter(edges2)
 	if err != nil {
 		return nil, err
 	}
-	v47 := provideRuntimeHostOperation(starter)
-	v48, err := provideProcessRuntimeFactory(v47)
+	v48 := provideRuntimeHostOperation(starter)
+	v49, err := provideProcessRuntimeFactory(v48)
 	if err != nil {
 		return nil, err
 	}
@@ -293,73 +293,73 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	configEncoder := provideOperatorConfigEncoder()
 	backendScopeEnsurer := provideOperatorBackendScopeEnsurer(fileSystem, createTemporaryFile, operatorsettingsIDGenerator, configDecoder, configEncoder)
 	runtimeInstanceIDGenerator := provideFactorySessionRuntimeInstanceIDGenerator(edges2)
-	v49 := provideFactorySessionReplayRecordingReader(edges2)
+	v50 := provideFactorySessionReplayRecordingReader(edges2)
 	providerIdentityResolver := provideFactorySessionProviderIdentityResolver(registry)
 	runtimeOpeningDependencies := wire.RuntimeOpeningDependencies{
 		ProviderSessions:                 providersessionsService,
 		FactoryWorkflows:                 javaScriptWorkflowDefinitions,
 		WorkflowPreview:                  workflowPreviewOperation,
-		FactoryDefinitionValidator:       v11,
+		FactoryDefinitionValidator:       v12,
 		NamedPaths:                       namedPathResolver,
-		DurableExecutionFactory:          v12,
-		WorkerExecutionFactory:           v13,
+		DurableExecutionFactory:          v13,
+		WorkerExecutionFactory:           v14,
 		ModelService:                     modelsService,
-		WorkFactory:                      v14,
-		AutomationFactory:                v15,
+		WorkFactory:                      v15,
+		AutomationFactory:                v16,
 		FactorySessionsService:           factorysessionsService,
-		FactorySessionExecutionFactory:   v26,
-		RecordingsProjectionFactory:      v27,
-		RecordingsFactory:                v28,
-		RuntimeLedgerFactory:             v29,
+		FactorySessionExecutionFactory:   v27,
+		RecordingsProjectionFactory:      v28,
+		RecordingsFactory:                v29,
+		RuntimeLedgerFactory:             v30,
 		RuntimeRecorderFactory:           runtimeRecorderFactory,
-		ReplayClockFactory:               v31,
+		ReplayClockFactory:               v32,
 		ReplayExecutionFactory:           replayExecutionFactory,
-		WorkersRuntimeFactory:            v34,
+		WorkersRuntimeFactory:            v35,
 		WorkersRuntimeExecutorsFactory:   workersRuntimeExecutorsFactory,
 		WorkersMockCommandRunnerFactory:  workersMockCommandRunnerFactory,
-		AutomationHostedSourcesFactory:   v35,
-		WorkersLocalRuntimeHooksFactory:  v36,
-		FactoryDefinitionsFactory:        v41,
+		AutomationHostedSourcesFactory:   v36,
+		WorkersLocalRuntimeHooksFactory:  v37,
+		FactoryDefinitionsFactory:        v42,
 		FactoryScaffoldInitializer:       factoryScaffoldInitializer,
 		EditableFactoryValidator:         editableFactoryValidator,
 		InitialFactorySnapshotFactory:    initialFactorySnapshotFactory,
 		FactoryRuntimeAssembler:          assembly,
 		ContentMaterializer:              contentMaterializer,
-		LoadFactory:                      v44,
-		NewLoadedFactory:                 v45,
+		LoadFactory:                      v45,
+		NewLoadedFactory:                 v46,
 		DecodeReplayConfig:               replayRuntimeConfigDecoder,
 		LoadReplay:                       replayArtifactLoader,
-		CaptureLoadedFactorySnapshot:     v30,
+		CaptureLoadedFactorySnapshot:     v31,
 		ResolveClock:                     clockResolver,
 		NewSessionLogger:                 sessionLoggerFactory,
-		AdaptWorkerCommandRunner:         v24,
-		ProviderFromCommandRunnerFactory: v46,
-		ProcessRuntimeFactory:            v48,
+		AdaptWorkerCommandRunner:         v25,
+		ProviderFromCommandRunnerFactory: v47,
+		ProcessRuntimeFactory:            v49,
 		EnsureOperatorBackendScope:       backendScopeEnsurer,
 		GenerateRuntimeInstanceID:        runtimeInstanceIDGenerator,
 		ResolveHome:                      homeDirectoryResolver,
-		ReplayFiles:                      v49,
+		ReplayFiles:                      v50,
 		ProviderIdentities:               providerIdentityResolver,
 	}
-	v50, err := wire.NewRuntimeOpeningFactory(runtimeOpeningDependencies)
+	v51, err := wire.NewRuntimeOpeningFactory(runtimeOpeningDependencies)
 	if err != nil {
 		return nil, err
 	}
-	v51 := provideFactorySessionContractFixtureReader(edges2)
-	v52 := provideStandaloneSessionExecutionFactory(javaScriptWorkflows, orchestrationJavaScriptExecution, writer, v21, v22, v16, v51)
-	v53 := provideWorkerInvocationFactory(edges2)
+	v52 := provideFactorySessionContractFixtureReader(edges2)
+	v53 := provideStandaloneSessionExecutionFactory(javaScriptWorkflows, orchestrationJavaScriptExecution, writer, v22, v23, v17, v52)
+	v54 := provideWorkerInvocationFactory(edges2)
 	runtimeArtifactRootResolver := provideRuntimeArtifactRootResolver()
-	v54 := provideFactorySessionExecutionOpeningFileSystem(edges2)
+	v55 := provideFactorySessionExecutionOpeningFileSystem(edges2)
 	logger, err := logging.NewDefaultLogger()
 	if err != nil {
 		return nil, err
 	}
-	v55, err := provideSessionExecutionOpeningFactory(v50, edges2, v52, v53, clockResolver, runtimeArtifactRootResolver, v24, v54, ptyAllocator, logger)
+	v56, err := provideSessionExecutionOpeningFactory(v51, edges2, v53, v54, clockResolver, runtimeArtifactRootResolver, v25, v55, ptyAllocator, logger)
 	if err != nil {
 		return nil, err
 	}
-	v56 := wire.NewExecutionServiceBuilder(v55)
-	executionServiceBuilder := provideCLIExecutionServiceBuilder(v56)
+	v57 := wire.NewExecutionServiceBuilder(v56)
+	executionServiceBuilder := provideCLIExecutionServiceBuilder(v57)
 	wireStandardCLIHTTPProtocol, err := provideStandardCLIHTTPProtocol()
 	if err != nil {
 		return nil, err
@@ -370,14 +370,14 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		return nil, err
 	}
 	modelInvocationTimeout := provideModelInvocationTimeout()
-	v57, err := provideInvocationOperation(v50, edges2, workingDirectory, v3, invocationArtifactExporter, modelInvocationTimeout, runtimeArtifactRootResolver, v16)
+	v58, err := provideInvocationOperation(v51, edges2, workingDirectory, v3, invocationArtifactExporter, modelInvocationTimeout, runtimeArtifactRootResolver, v17)
 	if err != nil {
 		return nil, err
 	}
-	invocationOperation := provideModelsCLIInvocationOperation(v57)
+	invocationOperation := provideModelsCLIInvocationOperation(v58)
 	cliService := provideModelsCLIService(wireStandardCLIHTTPProtocol, invocationOperation)
-	v58 := wire.NewRequestPreparation()
-	sessionService := provideSessionsCLIService(wireStandardCLIHTTPProtocol, v58)
+	v59 := wire.NewRequestPreparation()
+	sessionService := provideSessionsCLIService(wireStandardCLIHTTPProtocol, v59)
 	payloadFileReader := provideSubmitPayloadReader()
 	wireExtendedCLIHTTPProtocol, err := provideExtendedCLIHTTPProtocol()
 	if err != nil {
@@ -386,22 +386,22 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	submitWorkOperation := provideSubmitWorkOperation(payloadFileReader, wireExtendedCLIHTTPProtocol)
 	factoryRequestBatchPreparation := work.NewFactoryRequestBatchPreparation()
 	submitBatchOperation := provideSubmitBatchOperation(wireExtendedCLIHTTPProtocol, factoryRequestBatchPreparation)
-	flattenFactoryConfigOperation := provideFlattenFactoryConfigOperation(v40)
-	expandFactoryConfigOperation := provideExpandFactoryConfigOperation(v40)
+	flattenFactoryConfigOperation := provideFlattenFactoryConfigOperation(v41)
+	expandFactoryConfigOperation := provideExpandFactoryConfigOperation(v41)
 	providerCatalog := provideOperatorSettingsProviderCatalog(registry)
 	configDocumentService := provideOperatorConfigDocumentService(fileSystem, createTemporaryFile, providerCatalog, configDecoder, configEncoder)
 	configureInitOperation := provideConfigureInitOperation(configDocumentService)
 	installPackagedFactoryOperation := provideInstallPackagedFactoryOperation(packagedFactoryCatalogOperations, packagedFactoryInstallationOperations)
 	cliInstallPackagedFactoryOperation := provideInstallPackagedFactoryCLI(installPackagedFactoryOperation)
 	queryFactoryOperation := provideQueryFactoryOperation(wireStandardCLIHTTPProtocol)
-	v59 := provideCurrentFactoryPointerReader(namedPathResolver)
-	listFactoriesOperation := provideListFactoriesOperation(effectiveCatalogService, v59)
-	v60 := provideSubmittedDefinitionValidationOperation(validationService)
-	validateFactoryOperation := provideValidateFactoryOperation(v60, authoredFactorySourceLoader)
-	v61 := provideNamedFactoryPersistenceOperation(v40)
-	createFactoryFromFileOperation := provideCreateFactoryFromFileOperation(v61, authoredFactorySourceLoader)
+	v60 := provideCurrentFactoryPointerReader(namedPathResolver)
+	listFactoriesOperation := provideListFactoriesOperation(effectiveCatalogService, v60)
+	v61 := provideSubmittedDefinitionValidationOperation(validationService)
+	validateFactoryOperation := provideValidateFactoryOperation(v61, authoredFactorySourceLoader)
+	v62 := provideNamedFactoryPersistenceOperation(v41)
+	createFactoryFromFileOperation := provideCreateFactoryFromFileOperation(v62, authoredFactorySourceLoader)
 	replaceFactoryCurrentOperation := provideReplaceFactoryCurrentOperation(wireStandardCLIHTTPProtocol)
-	updateFactoryFromFileOperation := provideUpdateFactoryFromFileOperation(v61, authoredFactorySourceLoader)
+	updateFactoryFromFileOperation := provideUpdateFactoryFromFileOperation(v62, authoredFactorySourceLoader)
 	deleteFactoryOperation := provideDeleteFactoryOperation(v)
 	listRequestPreparation := work.NewListRequestPreparation()
 	listWorkOperation := provideListWorkOperation(wireStandardCLIHTTPProtocol, listRequestPreparation)
@@ -422,8 +422,8 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	v62 := provideRuntimeInputResolver(edges2, clockResolver)
-	v63 := provideRuntimeOpener(v50)
+	v63 := provideRuntimeInputResolver(edges2, clockResolver)
+	v64 := provideRuntimeOpener(v51)
 	factory_visualizationRuntimeFactory := provideFactoryVisualizationFactory()
 	factoryStatusProjector := factory.NewFactoryStatusProjector()
 	contentPreparation := work.NewContentPreparation()
@@ -435,36 +435,36 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	requestPreparation := provideFactorySessionHTTPRequestPreparation(v58)
-	handler, err := application2.NewHandler(httpBinder, contentPreparation, v60, contentStagingService, requestPreparationService, requestPreparation)
+	requestPreparation := provideFactorySessionHTTPRequestPreparation(v59)
+	handler, err := application2.NewHandler(httpBinder, contentPreparation, v61, contentStagingService, requestPreparationService, requestPreparation)
 	if err != nil {
 		return nil, err
 	}
 	runnerFactory := provideLifecycleRunnerFactory()
-	v64, err := provideApplicationRuntimeAdapter(factory_visualizationRuntimeFactory, handler, runnerFactory)
+	v65, err := provideApplicationRuntimeAdapter(factory_visualizationRuntimeFactory, handler, runnerFactory)
 	if err != nil {
 		return nil, err
 	}
-	v65 := wire.NewLifecyclePlanOperation()
-	v66, err := wire.NewApplicationService(v62, v63, v64, v65)
+	v66 := wire.NewLifecyclePlanOperation()
+	v67, err := wire.NewApplicationService(v63, v64, v65, v66)
 	if err != nil {
 		return nil, err
 	}
-	runRuntimeRunnerBuilder, err := provideRunRuntimeRunnerBuilder(runtimeRunnerBuilder, v66)
+	runRuntimeRunnerBuilder, err := provideRunRuntimeRunnerBuilder(runtimeRunnerBuilder, v67)
 	if err != nil {
 		return nil, err
 	}
 	responsePresentation := provideResponsePresentation()
-	v67 := provideDirectJavaScriptSyncRunner()
+	v68 := provideDirectJavaScriptSyncRunner()
 	directJavaScriptHostAdapter, err := provideDirectJavaScriptHostAdapter(handler, starter, runnerFactory)
 	if err != nil {
 		return nil, err
 	}
-	v68, err := wire.NewDirectJavaScriptRunOperation(v56, v67, v16, directJavaScriptHostAdapter)
+	v69, err := wire.NewDirectJavaScriptRunOperation(v57, v68, v17, directJavaScriptHostAdapter)
 	if err != nil {
 		return nil, err
 	}
-	selectionFactory, err := provideRunSelectionFactory(runOpener, runRuntimeRunnerBuilder, v57, responsePresentation, v68, runtimeRunnerBuilder)
+	selectionFactory, err := provideRunSelectionFactory(runOpener, runRuntimeRunnerBuilder, v58, responsePresentation, v69, runtimeRunnerBuilder)
 	if err != nil {
 		return nil, err
 	}
@@ -495,7 +495,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		SubmitBatch:                       submitBatchOperation,
 		FlattenFactoryConfig:              flattenFactoryConfigOperation,
 		ExpandFactoryConfig:               expandFactoryConfigOperation,
-		InitFactory:                       v42,
+		InitFactory:                       v43,
 		ConfigureInit:                     configureInitOperation,
 		InstallPackagedFactory:            cliInstallPackagedFactoryOperation,
 		QueryFactory:                      queryFactoryOperation,
@@ -517,23 +517,23 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		return nil, err
 	}
 	stdioOpener := stdio.NewOpener()
-	v69 := provideFixtureStdioApplicationBuilder(stdioRunnerBuilder, runnerFactory, stdioOpener, v58, workflowPreviewOperation)
+	v70 := provideFixtureStdioApplicationBuilder(stdioRunnerBuilder, runnerFactory, stdioOpener, v59, workflowPreviewOperation)
 	openedStdioRunnerBuilder, err := application.NewOpenedStdioRunnerBuilder(managedRunnerFactory)
 	if err != nil {
 		return nil, err
 	}
-	v70 := provideRuntimeStdioApplicationBuilder(openedStdioRunnerBuilder, runnerFactory, stdioOpener, v58)
-	v71, err := wire.NewStdioOpeningService(v55, v69, v70)
+	v71 := provideRuntimeStdioApplicationBuilder(openedStdioRunnerBuilder, runnerFactory, stdioOpener, v59)
+	v72, err := wire.NewStdioOpeningService(v56, v70, v71)
 	if err != nil {
 		return nil, err
 	}
-	processStdioApplicationOpener, err := provideStdioApplicationOpener(v71)
+	processStdioApplicationOpener, err := provideStdioApplicationOpener(v72)
 	if err != nil {
 		return nil, err
 	}
 	inspectPath := provideSystemInitializationInspectPath(edges2)
 	legacyFactoryMigrationFileSystem := provideSystemInitializationLegacyFactoryMigrationFileSystem(edges2)
-	systeminitializationService, err := provideSystemInitializationService(v40, packagedInstallationFileSystem, packagedFactoryCatalogOperations, configLoader, backendScopeEnsurer, inspectPath, legacyFactoryMigrationFileSystem)
+	systeminitializationService, err := provideSystemInitializationService(v41, packagedInstallationFileSystem, packagedFactoryCatalogOperations, configLoader, backendScopeEnsurer, inspectPath, legacyFactoryMigrationFileSystem)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
{
  "project": "CLN-PSES-FOLD-SERVICE: fold provider_sessions/service into internal",
  "branchName": "pss-cln-pses-fold-service",
  "description": "Fold transitional pkg/services/provider_sessions/service implementation into provider_sessions/internal, make provider_sessions/wire the sole public construction bridge returning the Provider Sessions root from internal implementation, retarget root pkg/wire away from provider_sessions/service, preserve observable Details/Inspect/Project/reader behavior, and deliver through required CI and actual PR merge without deleting the residual service path (DEL-PSES).",
  "context": {
    "customerAsk": "Fold transitional pkg/services/provider_sessions/service implementation into pkg/services/provider_sessions/internal (keeping planned parent-private subservices under internal/services/* including existing codex_reader and cursor_reader). Retarget provider_sessions/wire so it is the sole public construction bridge returning the Provider Sessions root from internal implementation. Retarget the narrow root pkg/wire Provider Sessions construction call away from provider_sessions/service so it uses provider_sessions/wire only. Prefer zero remaining production imports of provider_sessions/service. Do not delete the emptied path yet (DEL-PSES). Do not invent Provider Sessions protocol adapters. Prove with focused Provider Sessions root-contract and behavioral/reader proofs that observable provider-session inspect/details/project/read behavior is preserved. Delivery contract: loop implementation and review until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn (including pkg/wire) are reconciled, the PR is merged, and only then complete Factory work.",
    "problem": "Provider Sessions still has a transitional public service package that owns the composed root implementation. provider_sessions/wire and root pkg/wire construct through that transitional surface, so the Packaged Service Structure target shape (wire + internal + transports) is incomplete and later DEL-PSES cannot safely delete the path.",
    "solution": "Move the composed Provider Sessions root into provider_sessions/internal while keeping Codex/Cursor readers parent-private under internal/services/*, make provider_sessions/wire the only public construction bridge returning providersessions.Service, retarget root pkg/wire to owner wire only, leave residual service for DEL-PSES, and prove Details/Inspect/Project/reader behavior through wire-constructed roots before merging."
  },
  "acceptanceCriteria": [
    "provider_sessions/wire constructs the Provider Sessions root from internal implementation without exporting internal types on the peer surface",
    "Root pkg/wire no longer imports pkg/services/provider_sessions/service",
    "No production package outside the Provider Sessions owner imports provider_sessions/service",
    "Observable Provider Sessions inspect/details/project/reader behavior is preserved (behavioral proof through a wire-constructed root)",
    "Quality checks pass (typecheck, lint, tests)",
    "Implementation/review loop continues until required CI is terminal green, all blocking PR conversation feedback is addressed, merge conflicts (including shared pkg/wire churn) are reconciled, and the PR is actually merged"
  ],
  "userStories": [
    {
      "id": "pss-cln-pses-fold-service-001",
      "title": "Fold composed root into owner-private internal",
      "description": "As a maintainer, I want the real Provider Sessions composed-root implementation to live under provider_sessions/internal (with Codex/Cursor readers remaining parent-private under internal/services/*) so the transitional public service package is no longer the implementation home.",
      "acceptanceCriteria": [
        "Composed Provider Sessions root implementation used in production construction lives under pkg/services/provider_sessions/internal (not as the real body of provider_sessions/service)",
        "Existing parent-private codex_reader and cursor_reader remain under provider_sessions/internal/services/* (no protocol-adapter invention; no relocation outside the owner)",
        "A wire-or-internal constructed Provider Sessions root still satisfies providersessions.Service and can serve Details/Inspect/Project for a deterministic fixture or test double path",
        "No facade that leaves provider_sessions/service as the real implementation while claiming the fold is complete",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cln-pses-fold-service-002",
      "title": "Retarget owner wire as sole public construction bridge",
      "description": "As a maintainer, I want provider_sessions/wire to construct the Provider Sessions root exclusively from internal implementation and return only the published providersessions.Service peer surface so peers never depend on internal types or the transitional service package for construction.",
      "acceptanceCriteria": [
        "provider_sessions/wire construction functions compose the root from provider_sessions/internal (or internal construction helpers) rather than from provider_sessions/service as the real implementation",
        "Returned value is the singular published providersessions.Service root; method signatures and return types do not export owner-internal implementation types",
        "Missing required construction ports still fail with a deterministic construction error and a nil service",
        "Owner wire tests construct through provider_sessions/wire and exercise at least one successful root-surface call (Details, Inspect, or Project) or a deterministic construction-failure case",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cln-pses-fold-service-003",
      "title": "Retarget root pkg/wire Provider Sessions construction",
      "description": "As a process integrator, I want root pkg/wire to construct Provider Sessions only through provider_sessions/wire so the application injector no longer depends on the transitional provider_sessions/service package.",
      "acceptanceCriteria": [
        "Root pkg/wire Provider Sessions construction calls provider_sessions/wire only",
        "Root pkg/wire no longer imports pkg/services/provider_sessions/service",
        "Process construction still yields a usable Provider Sessions root for the same injected edges/ports previously accepted by the transitional constructor",
        "Shared-file churn on pkg/wire is reconciled by rebase/merge in this lane (do not hold waiting for Automations or other owners' DEL packets)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cln-pses-fold-service-004",
      "title": "Clear production imports of transitional service",
      "description": "As a maintainer, I want zero remaining production imports of provider_sessions/service outside the Provider Sessions owner so the folded shape is real, while leaving the path present for later DEL-PSES deletion.",
      "acceptanceCriteria": [
        "No production package outside the Provider Sessions owner imports pkg/services/provider_sessions/service",
        "Residual provider_sessions/service path is not deleted in this packet (DEL-PSES owns deletion); a transitional compile shim is acceptable only if production construction does not use it as the real implementation",
        "Boundary or import-proof coverage fails if a forbidden production import of provider_sessions/service is reintroduced",
        "Ownership / package-target / coverage manifests are updated only as required by this fold (no unrelated inventory rewrite)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cln-pses-fold-service-005",
      "title": "Prove inspect/details/project/reader behavior is preserved",
      "description": "As a Provider Sessions consumer, I want wire-constructed roots to preserve observable Details, Inspect, Project, and reader-backed session outcomes so the fold does not change product behavior.",
      "acceptanceCriteria": [
        "Focused behavioral proof constructs Provider Sessions exclusively through provider_sessions/wire (not through transitional service as the production path)",
        "Proof covers Details, Inspect, and Project success and/or typed-failure outcomes on the published root for at least one Codex- and one Cursor-backed fixture path (or equivalent deterministic reader-backed fixtures already used by owner tests)",
        "Existing Provider Sessions root-contract expectations remain satisfied for the published peer surface",
        "No invented Provider Sessions protocol adapters; no IMP-PROV-04/05 adapter redesign",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-cln-pses-fold-service-006",
      "title": "Close delivery through required CI and PR merge",
      "description": "As a Factory operator, I want this packet to remain open through review and CI until the PR is actually merged so Factory completion reflects integrated mainline state, not a ready-but-unmerged branch.",
      "acceptanceCriteria": [
        "Required CI is terminal and passing on the PR",
        "Every blocking PR conversation comment is explicitly addressed",
        "Merge conflicts and shared-file churn (including pkg/wire) are reconciled",
        "PR is merged to the target branch",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": false,
      "notes": ""
    }
  ]
}
