### PR TITLE
ft-wave2-factory-review-invocation

### DIFF
--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -1896,6 +1896,13 @@ response-stream output.
   approval. Run the same gate for default configuration, edited materialized
   worker configuration, and `--default-worker-model-provider` /
   `--default-worker-model` operator overrides.
+- Factory-owned packaged `@you/review` invocation coverage lives in
+  `tests/functional/factory/packaged/review/invocation_test.go`. Prefer
+  `root.BuildProcess` + `Process.Execute` with `you --json run --named @you/review`
+  and `edges.Edges.ProviderCommandRunner` mocks shaped through
+  `support.NewShapedProviderCommandRunner` (work stdout then reviewer decision
+  envelope JSON) over `--with-mock-workers` when proving approval, rejection
+  feedback retry context, and bounded failure.
 - Named `@you/goal` operator-control smoke coverage lives in
   `tests/functional/smoke/cli_named_goal_operator_controls_smoke_test.go`,
   proving API and CLI pause/resume buffering, ordered post-resume drain via

--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -1449,6 +1449,36 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/factory/packaged/review/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/review",
+      "scenario": "TestPackagedReviewApprovalCompletes",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/review/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/review/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/review",
+      "scenario": "TestPackagedReviewRejectionCarriesFeedback",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/review/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/packaged/review/invocation_test.go",
+      "package": "you-agent-factory/tests/functional/factory/packaged/review",
+      "scenario": "TestPackagedReviewRetryExhaustionFails",
+      "lane": "short",
+      "destination": "tests/functional/factory/packaged/review/invocation_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/factory/packaged/subagent/invocation_test.go",
       "package": "you-agent-factory/tests/functional/factory/packaged/subagent",
       "scenario": "TestPackagedSubagentChildFailureReturnsStableFailure",
@@ -7995,9 +8025,9 @@
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 770,
+    "customer_top_level_Test_scenarios": 779,
     "lane_functionallong": 95,
-    "lane_short": 675,
+    "lane_short": 684,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 12,
       "you-agent-factory/tests/functional/automations": 7,

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -716,7 +716,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestPackagedQuorumOptionalMemberSettingsReachWorkers` covers overrides.
   - `TestPackagedQuorumInsufficientSuccessfulMembersFails` covers failure.
 
-- [ ] `tests/functional/factory/packaged/review/invocation_test.go`
+- [x] `tests/functional/factory/packaged/review/invocation_test.go`
   - `TestPackagedReviewApprovalCompletes` covers first-pass approval.
   - `TestPackagedReviewRejectionCarriesFeedback` covers retry context.
   - `TestPackagedReviewRetryExhaustionFails` covers bounded failure.

--- a/tests/functional/factory/packaged/review/helpers_test.go
+++ b/tests/functional/factory/packaged/review/helpers_test.go
@@ -1,0 +1,87 @@
+package review
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+func runPackagedReviewCLIJSONInvocation(
+	t *testing.T,
+	runner platformprocess.CommandRunner,
+	requestText string,
+	extraArgs ...string,
+) factoryapi.InvocationResponse {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	support.InstallPackagedFactory(t, homeDir, factorydefinitions.PackagedReviewFactoryName)
+
+	args := []string{
+		"you", "--json", "run",
+		"--named", factorydefinitions.PackagedReviewFactoryName,
+		"--no-record",
+	}
+	args = append(args, extraArgs...)
+	args = append(args, requestText)
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	inputs.Input.WorkingDirectory = t.TempDir()
+
+	process := support.BuildProcess(t, serviceedges.Edges{
+		ProviderCommandRunner: runner,
+	})
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(%v) error = %v\nstdout:\n%s\nstderr:\n%s",
+			args,
+			err,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+	if inputs.Stderr() != "" {
+		t.Fatalf("stderr = %q, want empty successful-run stderr", inputs.Stderr())
+	}
+
+	var response factoryapi.InvocationResponse
+	if decodeErr := json.Unmarshal([]byte(strings.TrimSpace(inputs.Stdout())), &response); decodeErr != nil {
+		t.Fatalf("decode invocation JSON stdout: %v\nstdout:\n%s", decodeErr, inputs.Stdout())
+	}
+	return response
+}
+
+func assertPackagedReviewCompletedWithText(
+	t *testing.T,
+	response factoryapi.InvocationResponse,
+	want string,
+) {
+	t.Helper()
+
+	if response.Status != factoryapi.InvocationTerminalStatusCompleted {
+		t.Fatalf("invocation status = %q, want COMPLETED; response = %#v", response.Status, response)
+	}
+	if got := invocationPrimaryResultText(t, response); got != want {
+		t.Fatalf("primaryResult text = %q, want %q", got, want)
+	}
+}
+
+func invocationPrimaryResultText(t *testing.T, response factoryapi.InvocationResponse) string {
+	t.Helper()
+
+	if response.PrimaryResult == nil || len(*response.PrimaryResult) != 1 {
+		t.Fatalf("primaryResult = %#v, want one text part", response.PrimaryResult)
+	}
+	part, err := (*response.PrimaryResult)[0].AsWorkTextContentPart()
+	if err != nil {
+		t.Fatalf("primaryResult[0] as text part: %v", err)
+	}
+	return part.Text
+}

--- a/tests/functional/factory/packaged/review/helpers_test.go
+++ b/tests/functional/factory/packaged/review/helpers_test.go
@@ -1,7 +1,9 @@
 package review
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -56,6 +58,69 @@ func runPackagedReviewCLIJSONInvocation(
 		t.Fatalf("decode invocation JSON stdout: %v\nstdout:\n%s", decodeErr, inputs.Stdout())
 	}
 	return response
+}
+
+func runPackagedReviewCLIJSONFailureInvocation(
+	t *testing.T,
+	runner platformprocess.CommandRunner,
+	requestText string,
+	extraArgs ...string,
+) (factoryapi.InvocationResponse, string, error) {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	support.InstallPackagedFactory(t, homeDir, factorydefinitions.PackagedReviewFactoryName)
+
+	args := []string{
+		"you", "--json", "run",
+		"--named", factorydefinitions.PackagedReviewFactoryName,
+		"--no-record",
+	}
+	args = append(args, extraArgs...)
+	args = append(args, requestText)
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	inputs.Input.WorkingDirectory = t.TempDir()
+
+	process := support.BuildProcess(t, serviceedges.Edges{
+		ProviderCommandRunner: runner,
+	})
+	execErr := process.Execute(inputs.Input)
+
+	var response factoryapi.InvocationResponse
+	if decodeErr := json.Unmarshal([]byte(strings.TrimSpace(inputs.Stdout())), &response); decodeErr != nil {
+		t.Fatalf("decode invocation JSON stdout: %v\nstdout:\n%s", decodeErr, inputs.Stdout())
+	}
+	return response, inputs.Stderr(), execErr
+}
+
+type packagedReviewFailingCommandRunner struct{}
+
+func (packagedReviewFailingCommandRunner) Run(
+	_ context.Context,
+	_ platformprocess.CommandRequest,
+) (platformprocess.CommandResult, error) {
+	return platformprocess.CommandResult{}, errors.New("mock provider failure")
+}
+
+func assertPackagedReviewBoundedFailureFailed(
+	t *testing.T,
+	response factoryapi.InvocationResponse,
+) {
+	t.Helper()
+
+	if response.Status != factoryapi.InvocationTerminalStatusFailed {
+		t.Fatalf("invocation status = %q, want FAILED; response = %#v", response.Status, response)
+	}
+	if response.PrimaryResult != nil {
+		t.Fatalf(
+			"primaryResult = %#v, want no completed success primary result after bounded review failure",
+			response.PrimaryResult,
+		)
+	}
+	if response.WorkState == nil || *response.WorkState != "reviewable-work:failed" {
+		t.Fatalf("workState = %#v, want reviewable-work:failed", response.WorkState)
+	}
 }
 
 func assertPackagedReviewCompletedWithText(

--- a/tests/functional/factory/packaged/review/helpers_test.go
+++ b/tests/functional/factory/packaged/review/helpers_test.go
@@ -73,6 +73,13 @@ func assertPackagedReviewCompletedWithText(
 	}
 }
 
+func providerCommandPrompt(request platformprocess.CommandRequest) string {
+	if len(request.Stdin) > 0 {
+		return string(request.Stdin)
+	}
+	return strings.Join(request.Args, " ")
+}
+
 func invocationPrimaryResultText(t *testing.T, response factoryapi.InvocationResponse) string {
 	t.Helper()
 

--- a/tests/functional/factory/packaged/review/invocation_test.go
+++ b/tests/functional/factory/packaged/review/invocation_test.go
@@ -1,0 +1,29 @@
+package review
+
+import (
+	"testing"
+
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+// TestPackagedReviewApprovalCompletes proves packaged @you/review invocation
+// completes through the public CLI under edge-mocked Codex providers when the
+// independent reviewer accepts on the first pass, dispatches work then review,
+// and returns the approved candidate output as the primary result.
+func TestPackagedReviewApprovalCompletes(t *testing.T) {
+	submitted := "customer request"
+	runner := support.NewShapedProviderCommandRunner(
+		platformprocess.CommandResult{Stdout: []byte("candidate work")},
+		platformprocess.CommandResult{Stdout: []byte(`{"decision":"ACCEPTED","output":"approved candidate work"}`)},
+	)
+
+	response := runPackagedReviewCLIJSONInvocation(t, runner, submitted)
+	assertPackagedReviewCompletedWithText(t, response, "approved candidate work")
+	if invocationPrimaryResultText(t, response) == submitted {
+		t.Fatal("primaryResult echoed submitted request text")
+	}
+	if got := runner.CallCount(); got != 2 {
+		t.Fatalf("provider invocation count = %d, want work then review", got)
+	}
+}

--- a/tests/functional/factory/packaged/review/invocation_test.go
+++ b/tests/functional/factory/packaged/review/invocation_test.go
@@ -1,6 +1,7 @@
 package review
 
 import (
+	"strings"
 	"testing"
 
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
@@ -25,5 +26,42 @@ func TestPackagedReviewApprovalCompletes(t *testing.T) {
 	}
 	if got := runner.CallCount(); got != 2 {
 		t.Fatalf("provider invocation count = %d, want work then review", got)
+	}
+}
+
+// TestPackagedReviewRejectionCarriesFeedback proves packaged @you/review
+// invocation carries the original request, rejected prior candidate, and
+// reviewer feedback into the revised work attempt after a first-pass rejection,
+// then completes with the later approved candidate as the primary result.
+func TestPackagedReviewRejectionCarriesFeedback(t *testing.T) {
+	submitted := "write release notes"
+	runner := support.NewShapedProviderCommandRunner(
+		platformprocess.CommandResult{Stdout: []byte("first candidate")},
+		platformprocess.CommandResult{Stdout: []byte(`{"decision":"REJECTED","feedback":"add the missing release date"}`)},
+		platformprocess.CommandResult{Stdout: []byte("revised candidate")},
+		platformprocess.CommandResult{Stdout: []byte(`{"decision":"ACCEPTED","output":"approved revised candidate"}`)},
+	)
+
+	response := runPackagedReviewCLIJSONInvocation(t, runner, submitted)
+	assertPackagedReviewCompletedWithText(t, response, "approved revised candidate")
+	if invocationPrimaryResultText(t, response) == submitted {
+		t.Fatal("primaryResult echoed submitted request text")
+	}
+	if got := runner.CallCount(); got != 4 {
+		t.Fatalf("provider invocation count = %d, want work, review, revised work, review", got)
+	}
+
+	requests := runner.Requests()
+	if len(requests) != 4 {
+		t.Fatalf("recorded provider requests = %d, want 4", len(requests))
+	}
+	secondWorkPrompt := providerCommandPrompt(requests[2])
+	if !strings.Contains(secondWorkPrompt, submitted) ||
+		!strings.Contains(secondWorkPrompt, "first candidate") ||
+		!strings.Contains(secondWorkPrompt, "add the missing release date") {
+		t.Fatalf(
+			"revised work prompt = %q, want request, rejected candidate, and review feedback",
+			secondWorkPrompt,
+		)
 	}
 }

--- a/tests/functional/factory/packaged/review/invocation_test.go
+++ b/tests/functional/factory/packaged/review/invocation_test.go
@@ -65,3 +65,18 @@ func TestPackagedReviewRejectionCarriesFeedback(t *testing.T) {
 		)
 	}
 }
+
+// TestPackagedReviewRetryExhaustionFails proves packaged @you/review invocation
+// returns a failed public terminal outcome with no completed success primary
+// result when the edge-mocked provider cannot satisfy the packaged approval gate,
+// for example because work dispatch fails before review can approve output.
+func TestPackagedReviewRetryExhaustionFails(t *testing.T) {
+	submitted := "customer request"
+	runner := packagedReviewFailingCommandRunner{}
+
+	response, _, execErr := runPackagedReviewCLIJSONFailureInvocation(t, runner, submitted)
+	if execErr == nil {
+		t.Fatal("Process.Execute error = nil, want terminal packaged-review provider failure")
+	}
+	assertPackagedReviewBoundedFailureFailed(t, response)
+}


### PR DESCRIPTION
{
  "project": "Packaged Review Factory Invocation Functional Coverage",
  "branchName": "ft-wave2-factory-review-invocation",
  "description": "Implement only tests/functional/factory/packaged/review/invocation_test.go so root.BuildProcess + Process.Execute public CLI packaged-factory invocation with edges.Edges ProviderCommandRunner / mocked Codex proves @you/review first-pass approval completion, rejection feedback carried into retry work before later approval, and bounded failure without a success primary result—while consuming the five mapped migration-ledger rows and preserving runtime_api-delete-05-factory-packaged, smoke-delete-05-factory-packaged, and workflow-delete-01-orchestration-dispatch ownership for review-mapped rows and held siblings.",
  "context": {
    "customerAsk": "Implement only tests/functional/factory/packaged/review/invocation_test.go. Construct via root.BuildProcess + Process.Execute (built you CLI only if this cell must prove OS/process-boundary behavior BuildProcess cannot express). Prefer public CLI over HTTP/API for ordinary packaged-factory invocation. Replace external effects only through edges.Edges, preferring ProviderCommandRunner / command-runner edge mocks and mocked Codex (or another real inference-provider variant via sanitized goldens) over --with-mock-workers / MockWorkers. Do not add sleeps or timeout-padded wait helpers unless justified in-code after fixing readiness/latency root causes. Prove: (1) TestPackagedReviewApprovalCompletes; (2) TestPackagedReviewRejectionCarriesFeedback; (3) TestPackagedReviewRetryExhaustionFails. Consume the five mapped migration-ledger rows and preserve runtime_api-delete-05-factory-packaged, smoke-delete-05-factory-packaged, and workflow-delete-01-orchestration-dispatch ownership for review-mapped rows. Do not implement quorum, goal, deep_research, fusion, subagent, tts, cross, or classifier cells. Avoid service/internal Petri imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled ownership/coverage/catalog/migration metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for packaged @you/review invocation does not exist yet. Existing proofs live under catch-all runtime_api, smoke, and workflow suites, so maintainers lack a factory-owned cell that jointly proves first-pass approval completion, rejection-feedback retry context, and bounded failure. Five migration-ledger rows map here under shared deletion batches that must keep ownership for held siblings (especially classifier on smoke-delete-05).",
    "solution": "Implement the three checklist scenarios in tests/functional/factory/packaged/review/invocation_test.go via root.BuildProcess + Process.Execute, preferring public CLI and replacing external effects only through edges.Edges with ProviderCommandRunner / mocked Codex preferred over MockWorkers. Assert first-pass approval with approved-candidate primary result, reject-then-approve with request/prior-candidate/feedback in revised work, and failed public terminal outcome with no success primary result on bounded failure; consume the five mapped migration-ledger rows while preserving shared deletion-batch ownership; apply only narrowly coupled metadata; and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/factory/packaged/review/invocation_test.go exists as the factory-owned functional cell and covers first-pass approval completion, rejection-feedback retry context, and bounded failure.",
    "Through root.BuildProcess + Process.Execute and public CLI packaged-factory invocation with edges.Edges provider/command-runner mocks, a first-pass approved @you/review run completes with the approved candidate text as the primary result (work then review, two provider invocations).",
    "Through the same construction/entry preferences, a reject-then-approve path carries request, prior candidate, and reviewer feedback into the revised work attempt and completes with the later approved candidate as the primary result.",
    "Through the same construction/entry preferences, a forced bounded-failure condition yields the documented public failed terminal outcome with no successful primary result attributable to that failing run.",
    "The five mapped migration-ledger rows for this destination are consumed; runtime_api-delete-05-factory-packaged, smoke-delete-05-factory-packaged, and workflow-delete-01-orchestration-dispatch ownership is preserved for review-mapped rows and held siblings; only narrowly coupled ownership/coverage/catalog/migration metadata for this cell are updated.",
    "Coverage constructs via root.BuildProcess + Process.Execute, prefers public CLI, replaces external effects only through edges.Edges (ProviderCommandRunner / mocked Codex preferred over MockWorkers), does not import service implementations or internal Petri primitives as the proof owner, and gives every top-level Test* a customer-readable Go doc comment.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave2-factory-review-invocation-001",
      "title": "Prove first-pass approval completes",
      "description": "As a customer invoking @you/review with a required text request, I want the packaged Factory to complete under edge-mocked providers when the independent reviewer accepts on the first pass so I can rely on the packaged review happy path.",
      "acceptanceCriteria": [
        "tests/functional/factory/packaged/review/invocation_test.go includes TestPackagedReviewApprovalCompletes as a top-level test.",
        "The test constructs the process via root.BuildProcess + Process.Execute (built you CLI only if this scenario must prove OS/process-boundary behavior BuildProcess cannot express) and prefers public CLI packaged-factory invocation over HTTP/API.",
        "External provider/process effects are replaced only through edges.Edges, preferring ProviderCommandRunner / command-runner edge mocks and mocked Codex (or another real inference-provider variant via sanitized goldens) over --with-mock-workers / MockWorkers.",
        "Invoking @you/review with a required request reaches a completed / succeeded terminal public status.",
        "Observable evidence proves work-then-review dispatch (two provider invocations) and that the public primary result is the approved candidate output (not merely the submitted request text), absorbing customer-facing obligations of mapped ledger scenarios such as TestSessionInvocationAPI_PackagedReviewReturnsApprovedCandidate.",
        "Assertions stay on first-pass approval completion for review and do not re-own quorum, goal, deep_research, fusion, catalog discovery, or other packaged factory packages.",
        "The top-level test has a customer-readable Go doc comment describing the observable first-pass approval completion behavior.",
        "No unjustified sleeps or timeout-padded wait helpers are introduced (any wait helper is justified in-code after readiness/latency root-cause consideration).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-review-invocation-002",
      "title": "Prove rejection carries feedback into retry work",
      "description": "As a customer whose first review pass is rejected, I want actionable reviewer feedback and the prior candidate to reach the next work attempt so a later approval can complete with the revised approved output.",
      "acceptanceCriteria": [
        "The review invocation cell includes TestPackagedReviewRejectionCarriesFeedback as a top-level test.",
        "Construction and entry follow the same preferences as story 001 (root.BuildProcess + Process.Execute, public CLI preferred, edges.Edges ProviderCommandRunner / mocked Codex preferred over MockWorkers).",
        "An @you/review invocation is driven so the reviewer rejects first (decision envelope with actionable feedback), work revises, and a later review accepts.",
        "Observable evidence proves the revised work provider prompt / input carries the original request, the rejected prior candidate, and the reviewer feedback; the invocation completes with the later approved candidate as the primary result (absorbing customer-facing obligations of mapped ledger scenarios such as TestSessionInvocationAPI_PackagedReviewRejectsThenApprovesRevision, smoke TestNamedReviewInvocationVariants_RealCLIRequireApprovalAfterRejection, and workflow TestCodeReviewLoop feedback-on-retry).",
        "Assertions remain on rejection-feedback retry context for review and do not widen into guard-owned global retry-loop-breaker matrices, catalog required-input rejection matrices, or other packaged factory packages.",
        "The top-level test has a customer-readable Go doc comment describing the observable rejection-feedback retry behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-review-invocation-003",
      "title": "Prove bounded review failure fails without success primary result",
      "description": "As a customer or automation handling a failing review run, I want bounded packaged @you/review failure (worker/review failure or retry exhaustion as expressed by the packaged approval-gate contract) to yield a failed public outcome with no successful primary result so scripts do not treat an unapproved run as completion.",
      "acceptanceCriteria": [
        "The review invocation cell includes TestPackagedReviewRetryExhaustionFails as a top-level test.",
        "Construction and entry follow the same preferences as story 001 (root.BuildProcess + Process.Execute, public CLI preferred, edges.Edges ProviderCommandRunner / mocked Codex preferred over MockWorkers).",
        "A review run is configured so the packaged approval gate cannot produce an approved primary result (for example work or review worker failure via command-runner edge mock / sanitized-golden failure fixture, or exhaustion of the reject-retry path within the packaged contract) while preserving enough context to observe the documented failure path.",
        "Observable evidence proves the public terminal outcome is failed / non-success, that no completed success primary result is attributable to that failing run, and that work state reflects the packaged failed place when applicable (for example reviewable-work:failed), absorbing customer-facing obligations of mapped ledger scenarios such as TestSessionInvocationAPI_PackagedReviewWorkerFailureReturnsFailedStatus.",
        "Assertions remain on bounded packaged-review failure and do not re-own transport stdout/stderr shaping, full exit-code taxonomy, guard-owned global retry-loop-breaker suites, or other packaged factory failure matrices.",
        "The top-level test has a customer-readable Go doc comment describing the observable bounded-failure contract.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-review-invocation-004",
      "title": "Consume mapped ledger rows and close verification gates",
      "description": "As a maintainer executing Wave 2 functional-test expansion, I want the five mapped migration-ledger rows consumed with shared deletion-batch ownership preserved, and focused boundary/viz gates passing, so review can terminal-complete without stranding classifier or inventing unrelated deletion work.",
      "acceptanceCriteria": [
        "The five mapped migration-ledger rows destined for tests/functional/factory/packaged/review/invocation_test.go are consumed: runtime_api TestSessionInvocationAPI_PackagedReviewReturnsApprovedCandidate (runtime_api-delete-05-factory-packaged); runtime_api TestSessionInvocationAPI_PackagedReviewRejectsThenApprovesRevision (runtime_api-delete-05-factory-packaged); runtime_api TestSessionInvocationAPI_PackagedReviewWorkerFailureReturnsFailedStatus (runtime_api-delete-05-factory-packaged); smoke TestNamedReviewInvocationVariants_RealCLIRequireApprovalAfterRejection (smoke-delete-05-factory-packaged); workflow TestCodeReviewLoop (workflow-delete-01-orchestration-dispatch).",
        "runtime_api-delete-05-factory-packaged, smoke-delete-05-factory-packaged, and workflow-delete-01-orchestration-dispatch ownership is preserved for review-mapped rows and held siblings (especially classifier on smoke-delete-05 and remaining orchestration/petri rows on workflow-delete-01); this cell does not execute those shared deletion batches wholesale.",
        "Only narrowly coupled ownership, coverage, catalog, or migration metadata required for this cell are updated; sibling packaged factories (quorum, goal, deep_research, fusion, subagent, tts, cross) and classifier are not implemented or rewritten.",
        "Focused package tests for tests/functional/factory/packaged/review pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as factory/packaged/review).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)