### PR TITLE
ft-wave2-provider-sessions-cursor-details

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -840,6 +840,20 @@ Wave 0 functional-tests-expansion planning authority lives under
   every top-level `Test*` needs a customer-readable Go doc and `//golden:` manifest
   directive so `functionaltestmetadata` stays viz-compatible.
 
+- `tests/functional/provider_sessions/details/cursor_details_test.go` owns Cursor
+  Provider Session detail inspection through the public `GET /provider-sessions/detail`
+  boundary via `support.StartFunctionalAPIServer` with
+  `ProviderSessionResolveHomeDirectory` edge override. Write sanitized Cursor sqlite
+  fixtures under `~/.cursor/chats/{workspaceHash}/{sessionID}/store.db`, compare
+  success detail to `docs/temp/functional/provider-sessions/cursor/success/expected-provider-session-detail.json`
+  with `modifiedAt` and `sizeBytes` normalized, assert unavailable blobs surface
+  `unknownEventCount`/`unknownEvents` without fabricated transcript, and assert
+  missing session ids return HTTP 404 `NOT_FOUND` without fabricated detail bodies.
+  Do not widen into `codex_details_test.go` or `http_test.go`. Close catalog metadata
+  with `test-file-checklist.md`, `migration-ledger-inventory.json`, and customer-readable
+  Go docs (plus `//golden:` on the success load test) so `functionaltestmetadata`
+  stays viz-compatible.
+
 - `tests/functional/automations/` owns root.BuildProcess evidence for packaged
   Automations cron scheduling and filesystem watcher preseed. Keep cron workstation
   factories explicit with `"behavior": "CRON"` and observe submissions through

--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -3149,6 +3149,36 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/provider_sessions/details/cursor_details_test.go",
+      "package": "you-agent-factory/tests/functional/provider_sessions/details",
+      "scenario": "TestCursorProviderSessionDetailsLoadFromGoldenMetadata",
+      "lane": "short",
+      "destination": "tests/functional/provider_sessions/details/cursor_details_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/provider_sessions/details/cursor_details_test.go",
+      "package": "you-agent-factory/tests/functional/provider_sessions/details",
+      "scenario": "TestCursorProviderSessionMissingIDReturnsNotFound",
+      "lane": "short",
+      "destination": "tests/functional/provider_sessions/details/cursor_details_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/provider_sessions/details/cursor_details_test.go",
+      "package": "you-agent-factory/tests/functional/provider_sessions/details",
+      "scenario": "TestCursorProviderSessionUnavailableContentRemainsInspectable",
+      "lane": "short",
+      "destination": "tests/functional/provider_sessions/details/cursor_details_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/providers/cli_script_executor_test.go",
       "package": "you-agent-factory/tests/functional/providers",
       "scenario": "TestScriptExecutor_ArgTemplating",
@@ -8977,6 +9007,66 @@
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory_visualization/activation_lifecycle_test.go",
+      "package": "you-agent-factory/tests/functional/factory_visualization",
+      "scenario": "TestVisualizationActivatesThroughPublicRootAfterLifecycle",
+      "lane": "short",
+      "destination": "wrong-layer: factory visualization root composition not yet catalogued in test-file-checklist. Replacement evidence owner: tests/functional/factory_visualization/activation_lifecycle_test.go.",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory_visualization/inert_construction_test.go",
+      "package": "you-agent-factory/tests/functional/factory_visualization",
+      "scenario": "TestVisualizationRemainsInertThroughRootBuildProcessConstruction",
+      "lane": "short",
+      "destination": "wrong-layer: factory visualization root composition not yet catalogued in test-file-checklist. Replacement evidence owner: tests/functional/factory_visualization/inert_construction_test.go.",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory_visualization/observe_live_view_test.go",
+      "package": "you-agent-factory/tests/functional/factory_visualization",
+      "scenario": "TestVisualizationObserveThroughPublicRootAfterLifecycle",
+      "lane": "short",
+      "destination": "wrong-layer: factory visualization root composition not yet catalogued in test-file-checklist. Replacement evidence owner: tests/functional/factory_visualization/observe_live_view_test.go.",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory_visualization/peer_import_boundary_test.go",
+      "package": "you-agent-factory/tests/functional/factory_visualization",
+      "scenario": "TestFunctionalProofsImportOnlyPublishedVisualizationSurfaces",
+      "lane": "short",
+      "destination": "wrong-layer: factory visualization root composition not yet catalogued in test-file-checklist. Replacement evidence owner: tests/functional/factory_visualization/peer_import_boundary_test.go.",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory_visualization/peer_import_boundary_test.go",
+      "package": "you-agent-factory/tests/functional/factory_visualization",
+      "scenario": "TestProductionPeersReachVisualizationThroughPublishedSurfacesOnly",
+      "lane": "short",
+      "destination": "wrong-layer: factory visualization root composition not yet catalogued in test-file-checklist. Replacement evidence owner: tests/functional/factory_visualization/peer_import_boundary_test.go.",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory_visualization/response_presentation_test.go",
+      "package": "you-agent-factory/tests/functional/factory_visualization",
+      "scenario": "TestVisualizationResponsePresentationThroughPublicRootAfterLifecycle",
+      "lane": "short",
+      "destination": "wrong-layer: factory visualization root composition not yet catalogued in test-file-checklist. Replacement evidence owner: tests/functional/factory_visualization/response_presentation_test.go.",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
     }
   ],
   "scanned_at_utc": "2026-07-28T09:30:00Z",
@@ -9016,9 +9106,9 @@
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 878,
+    "customer_top_level_Test_scenarios": 887,
     "lane_functionallong": 95,
-    "lane_short": 783,
+    "lane_short": 792,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 12,
       "you-agent-factory/tests/functional/automations": 14,

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -789,7 +789,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestCodexProviderSessionMissingTranscriptReturnsNotFound` covers absence.
   - `TestCodexProviderSessionCorruptTranscriptReturnsSafeDiagnostic`.
 
-- [ ] `tests/functional/provider_sessions/details/cursor_details_test.go`
+- [x] `tests/functional/provider_sessions/details/cursor_details_test.go`
   - `TestCursorProviderSessionDetailsLoadFromGoldenMetadata` covers readable
     transcript data.
   - `TestCursorProviderSessionUnavailableContentRemainsInspectable` covers

--- a/tests/functional/automations/hosted_sources_root_composition_test.go
+++ b/tests/functional/automations/hosted_sources_root_composition_test.go
@@ -39,6 +39,8 @@ func TestBuildProcessRemainsHostedSourcesInertBeforeRuntimeLifecycle(t *testing.
 	}
 }
 
+// TestAutomationsHostedSourcesActivateThroughRuntimeLifecycle proves hosted automation
+// sources admit Work through the runtime lifecycle after BuildProcess composition.
 func TestAutomationsHostedSourcesActivateThroughRuntimeLifecycle(t *testing.T) {
 	linearServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/tests/functional/automations/reconciliation_root_composition_test.go
+++ b/tests/functional/automations/reconciliation_root_composition_test.go
@@ -18,6 +18,8 @@ const (
 	reconciliationSourceKind   = "schedule"
 )
 
+// TestBuildProcessRemainsReconciliationInertBeforeExplicitRootInvocation proves
+// BuildProcess does not reconcile automation sources before explicit Root invocation.
 func TestBuildProcessRemainsReconciliationInertBeforeExplicitRootInvocation(t *testing.T) {
 	t.Parallel()
 
@@ -43,6 +45,8 @@ func TestBuildProcessRemainsReconciliationInertBeforeExplicitRootInvocation(t *t
 	}
 }
 
+// TestAutomationsReconciliationAdmitsThroughPublishedRootAfterComposition proves
+// published Automations Root reconciliation converges matching observed instances.
 func TestAutomationsReconciliationAdmitsThroughPublishedRootAfterComposition(t *testing.T) {
 	t.Parallel()
 
@@ -87,6 +91,8 @@ func TestAutomationsReconciliationAdmitsThroughPublishedRootAfterComposition(t *
 	}
 }
 
+// TestAutomationsReconcileAdmitsAbsentSourceThroughPublishedRootAfterComposition proves
+// published Automations Root reconciliation admits absent desired sources safely.
 func TestAutomationsReconcileAdmitsAbsentSourceThroughPublishedRootAfterComposition(t *testing.T) {
 	t.Parallel()
 

--- a/tests/functional/automations/script_poller_root_composition_test.go
+++ b/tests/functional/automations/script_poller_root_composition_test.go
@@ -23,6 +23,8 @@ const (
 	scriptPollerWorkerName        = "script-poller"
 )
 
+// TestBuildProcessRemainsScriptPollerInertBeforeRuntimeLifecycle proves BuildProcess
+// does not invoke script poller commands before the runtime lifecycle starts.
 func TestBuildProcessRemainsScriptPollerInertBeforeRuntimeLifecycle(t *testing.T) {
 	t.Parallel()
 
@@ -38,6 +40,8 @@ func TestBuildProcessRemainsScriptPollerInertBeforeRuntimeLifecycle(t *testing.T
 	}
 }
 
+// TestAutomationsScriptPollerAdmitsWorkThroughRuntimeLifecycle proves script poller
+// workstations admit Work through the runtime lifecycle after BuildProcess composition.
 func TestAutomationsScriptPollerAdmitsWorkThroughRuntimeLifecycle(t *testing.T) {
 	dir := support.ScaffoldFactory(t, scriptPollerFactoryConfig())
 	support.ClearSeedInputs(t, dir)

--- a/tests/functional/provider_sessions/details/cursor_details_test.go
+++ b/tests/functional/provider_sessions/details/cursor_details_test.go
@@ -1,0 +1,290 @@
+package details
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+	_ "modernc.org/sqlite"
+)
+
+const (
+	cursorGoldenSuccessWorkspaceHash             = "cursor-fixture-workspace"
+	cursorGoldenExpectedProviderSessionDetailFile = "expected-provider-session-detail.json"
+)
+
+// TestCursorProviderSessionDetailsLoadFromGoldenMetadata loads a sanitized Cursor
+// success store through the public Provider Session detail surface and proves
+// the response structurally matches checked-in expected Provider Session metadata.
+//golden: docs/temp/functional/provider-sessions/cursor/success/manifest.json
+func TestCursorProviderSessionDetailsLoadFromGoldenMetadata(t *testing.T) {
+	repoRoot := testutil.MustRepoRoot(t)
+	caseDir := filepath.Join(repoRoot, filepath.FromSlash(support.ProviderSessionFixturePath("cursor", "success")))
+
+	loaded, err := support.LoadProviderSessionCase(caseDir)
+	if err != nil {
+		t.Fatalf("LoadProviderSessionCase: %v", err)
+	}
+	if loaded.Manifest.ID != "cursor-text-success" {
+		t.Fatalf("manifest.ID = %q, want cursor-text-success", loaded.Manifest.ID)
+	}
+
+	var request struct {
+		SessionID string `json:"session_id"`
+	}
+	if err := json.Unmarshal(loaded.Request, &request); err != nil {
+		t.Fatalf("decode request.json: %v", err)
+	}
+	if request.SessionID == "" {
+		t.Fatal("request.session_id must be non-empty")
+	}
+
+	homeDir := t.TempDir()
+	writeCursorGoldenSuccessStorageFixture(t, homeDir, request.SessionID)
+
+	server := startCursorProviderSessionDetailServer(t, homeDir, serviceedges.Edges{})
+	defer server.Stop(t)
+
+	detail := support.GetJSON[factoryapi.ProviderSessionDetailResponse](
+		t,
+		cursorProviderSessionDetailURL(server.URL(), request.SessionID),
+	)
+	if detail.ProviderSession.Id != request.SessionID {
+		t.Fatalf("detail provider session id = %q, want %q", detail.ProviderSession.Id, request.SessionID)
+	}
+	if detail.ProviderSession.Provider != factoryapi.Cursor {
+		t.Fatalf("detail provider = %q, want cursor", detail.ProviderSession.Provider)
+	}
+	if detail.ProviderSession.Kind != factoryapi.LoadableProviderSessionKindSessionID {
+		t.Fatalf("detail kind = %q, want session_id", detail.ProviderSession.Kind)
+	}
+	if len(detail.Transcript) == 0 {
+		t.Fatal("provider session detail transcript is empty, want readable success-session content")
+	}
+	hasReadableText := false
+	for _, entry := range detail.Transcript {
+		if entry.Text != nil && strings.TrimSpace(*entry.Text) != "" {
+			hasReadableText = true
+			break
+		}
+	}
+	if !hasReadableText {
+		t.Fatalf("provider session detail transcript = %#v, want readable text", detail.Transcript)
+	}
+
+	observed := observeCursorProviderSessionDetailGolden(detail)
+	if err := compareOrUpdateCursorProviderSessionDetailGolden(loaded, observed); err != nil {
+		var updated *support.ProviderSessionGoldensUpdatedError
+		if errors.As(err, &updated) {
+			t.Fatalf("%v", err)
+		}
+		t.Fatalf("compareOrUpdateCursorProviderSessionDetailGolden: %v", err)
+	}
+}
+
+func startCursorProviderSessionDetailServer(
+	t *testing.T,
+	homeDir string,
+	edges serviceedges.Edges,
+) *support.FunctionalAPIServer {
+	t.Helper()
+
+	if edges.ProviderSessionResolveHomeDirectory == nil {
+		edges.ProviderSessionResolveHomeDirectory = func() (string, error) { return homeDir, nil }
+	}
+	dir := support.ScaffoldSingleStepFactory(t, "cursor-provider-session-detail")
+	return support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		UseMockWorkers:            true,
+		WaitForServiceModeRuntime: true,
+		Edges:                     edges,
+		Env:                       []string{"HOME=" + homeDir, "USERPROFILE=" + homeDir},
+	})
+}
+
+func cursorProviderSessionDetailURL(baseURL, sessionID string) string {
+	query := url.Values{}
+	query.Set("provider", string(factoryapi.Cursor))
+	query.Set("kind", string(factoryapi.LoadableProviderSessionKindSessionID))
+	query.Set("id", sessionID)
+	return strings.TrimSuffix(baseURL, "/") + "/provider-sessions/detail?" + query.Encode()
+}
+
+func writeCursorGoldenSuccessStorageFixture(t *testing.T, homeDir, sessionID string) {
+	t.Helper()
+
+	chatsRoot := filepath.Join(homeDir, ".cursor", "chats")
+	dbPath := filepath.Join(chatsRoot, cursorGoldenSuccessWorkspaceHash, sessionID, "store.db")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("mkdir cursor storage: %v", err)
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open cursor storage sqlite: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	schema := `
+CREATE TABLE blobs (key TEXT PRIMARY KEY, value TEXT);
+CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);`
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatalf("create cursor storage tables: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO blobs (key, value) VALUES (?, ?)`,
+		"bubble-success",
+		`{"bubbleId":"bubble-success","chatId":"chat-success","text":"Cursor fixture answer COMPLETE","timestamp":1000,"type":1}`,
+	); err != nil {
+		t.Fatalf("insert cursor storage bubble: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO meta (key, value) VALUES (?, ?)`,
+		"0",
+		`{"createdAt":1000,"agentId":"`+sessionID+`","name":"Cursor golden success fixture session"}`,
+	); err != nil {
+		t.Fatalf("insert cursor storage meta: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO meta (key, value) VALUES (?, ?)`,
+		"1",
+		`{"usage":{"inputTokens":12,"outputTokens":34,"cacheReadTokens":5,"cacheWriteTokens":2}}`,
+	); err != nil {
+		t.Fatalf("insert cursor storage usage meta: %v", err)
+	}
+}
+
+func observeCursorProviderSessionDetailGolden(
+	detail factoryapi.ProviderSessionDetailResponse,
+) json.RawMessage {
+	transcript := make([]map[string]any, 0, len(detail.Transcript))
+	for _, entry := range detail.Transcript {
+		record := map[string]any{
+			"order": entry.Order,
+			"type":  string(entry.Type),
+		}
+		if entry.SourceType != nil {
+			record["sourceType"] = *entry.SourceType
+		}
+		if entry.Text != nil {
+			record["text"] = *entry.Text
+		}
+		if entry.Timestamp != nil {
+			record["timestamp"] = entry.Timestamp.UTC().Format(time.RFC3339Nano)
+		}
+		transcript = append(transcript, record)
+	}
+
+	var tokenUsage map[string]any
+	if detail.Parse.TokenUsage != nil {
+		tokenUsage = map[string]any{}
+		if detail.Parse.TokenUsage.InputTokens != nil {
+			tokenUsage["inputTokens"] = *detail.Parse.TokenUsage.InputTokens
+		}
+		if detail.Parse.TokenUsage.OutputTokens != nil {
+			tokenUsage["outputTokens"] = *detail.Parse.TokenUsage.OutputTokens
+		}
+		if detail.Parse.TokenUsage.CachedInputTokens != nil {
+			tokenUsage["cachedInputTokens"] = *detail.Parse.TokenUsage.CachedInputTokens
+		}
+		if detail.Parse.TokenUsage.CacheWriteTokens != nil {
+			tokenUsage["cacheWriteTokens"] = *detail.Parse.TokenUsage.CacheWriteTokens
+		}
+		if detail.Parse.TokenUsage.TotalTokens != nil {
+			tokenUsage["totalTokens"] = *detail.Parse.TokenUsage.TotalTokens
+		}
+	}
+
+	record := map[string]any{
+		"providerSession": map[string]any{
+			"provider": string(detail.ProviderSession.Provider),
+			"kind":     string(detail.ProviderSession.Kind),
+			"id":       detail.ProviderSession.Id,
+		},
+		"source": map[string]any{
+			"relativePath": detail.Source.RelativePath,
+			"sizeBytes":    detail.Source.SizeBytes,
+		},
+		"parse": map[string]any{
+			"eventCount": detail.Parse.EventCount,
+			"lineCount":  detail.Parse.LineCount,
+		},
+		"transcript": transcript,
+	}
+	if detail.Source.ModifiedAt != nil {
+		record["source"].(map[string]any)["modifiedAt"] = detail.Source.ModifiedAt.UTC().Format(time.RFC3339Nano)
+	}
+	if tokenUsage != nil {
+		record["parse"].(map[string]any)["tokenUsage"] = tokenUsage
+	}
+	return mustMarshalJSON(record)
+}
+
+func compareOrUpdateCursorProviderSessionDetailGolden(
+	loaded support.ProviderSessionCase,
+	observed json.RawMessage,
+) error {
+	expectedPath := filepath.Join(loaded.CaseDir, cursorGoldenExpectedProviderSessionDetailFile)
+	expected, err := os.ReadFile(expectedPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		if !support.ProviderSessionFunctionalGoldensUpdateEnabled() {
+			return &support.ProviderSessionLoadError{
+				CaseID: loaded.Manifest.ID,
+				Role:   "expected-provider-session-detail",
+				Path:   expectedPath,
+				Detail: "required expected-provider-session-detail fixture is missing",
+			}
+		}
+		encoded, err := json.MarshalIndent(json.RawMessage(observed), "", "  ")
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(expectedPath, append(encoded, '\n'), 0o644); err != nil {
+			return err
+		}
+		return &support.ProviderSessionGoldensUpdatedError{
+			CaseID: loaded.Manifest.ID,
+			Paths:  []string{cursorGoldenExpectedProviderSessionDetailFile},
+		}
+	}
+
+	normalizedFields := append([]string(nil), loaded.Manifest.NormalizedFields...)
+	normalizedFields = append(normalizedFields, "modifiedAt", "sizeBytes")
+
+	err = support.CompareProviderSessionJSON(
+		loaded.Manifest.ID,
+		"expected-provider-session-detail",
+		normalizedFields,
+		expected,
+		observed,
+	)
+	if err == nil {
+		return nil
+	}
+	if !support.ProviderSessionFunctionalGoldensUpdateEnabled() {
+		return err
+	}
+	encoded, marshalErr := json.MarshalIndent(json.RawMessage(observed), "", "  ")
+	if marshalErr != nil {
+		return marshalErr
+	}
+	if writeErr := os.WriteFile(expectedPath, append(encoded, '\n'), 0o644); writeErr != nil {
+		return writeErr
+	}
+	return &support.ProviderSessionGoldensUpdatedError{
+		CaseID: loaded.Manifest.ID,
+		Paths:  []string{cursorGoldenExpectedProviderSessionDetailFile},
+	}
+}

--- a/tests/functional/provider_sessions/details/cursor_details_test.go
+++ b/tests/functional/provider_sessions/details/cursor_details_test.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -22,6 +24,7 @@ const (
 	cursorGoldenSuccessWorkspaceHash              = "cursor-fixture-workspace"
 	cursorGoldenExpectedProviderSessionDetailFile = "expected-provider-session-detail.json"
 	cursorUnavailableContentSessionID             = "cursor-fixture-unavailable-content"
+	cursorMissingSessionID                        = "cursor-fixture-missing-session"
 )
 
 // TestCursorProviderSessionDetailsLoadFromGoldenMetadata loads a sanitized Cursor
@@ -133,6 +136,42 @@ func TestCursorProviderSessionUnavailableContentRemainsInspectable(t *testing.T)
 	assertCursorProviderSessionDetailBodySafe(t, "unavailable-content", string(encoded), homeDir)
 }
 
+// TestCursorProviderSessionMissingIDReturnsNotFound proves that requesting
+// Cursor Provider Session details for a session_id that does not exist returns
+// a distinguishable not-found outcome instead of fabricating session detail.
+func TestCursorProviderSessionMissingIDReturnsNotFound(t *testing.T) {
+	homeDir := t.TempDir()
+
+	server := startCursorProviderSessionDetailServer(t, homeDir, serviceedges.Edges{})
+	defer server.Stop(t)
+
+	body := getCursorProviderSessionDetailErrorBody(
+		t,
+		server.URL(),
+		cursorMissingSessionID,
+		http.StatusNotFound,
+	)
+	if !strings.Contains(body, "provider session not found") {
+		t.Fatalf("error body = %q, want not-found message", body)
+	}
+
+	var failure factoryapi.ErrorResponse
+	if err := json.Unmarshal([]byte(body), &failure); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if failure.Code != factoryapi.ErrorResponseCodeNOTFOUND {
+		t.Fatalf("error code = %q, want NOT_FOUND", failure.Code)
+	}
+	if failure.Message == "" {
+		t.Fatal("error message is empty, want customer-readable not-found diagnostic")
+	}
+	if strings.Contains(body, `"transcript"`) || strings.Contains(body, `"providerSession"`) {
+		t.Fatalf("not-found response fabricated provider session detail: %s", body)
+	}
+
+	assertCursorProviderSessionDetailBodySafe(t, "missing-session", body, homeDir)
+}
+
 func startCursorProviderSessionDetailServer(
 	t *testing.T,
 	homeDir string,
@@ -151,6 +190,33 @@ func startCursorProviderSessionDetailServer(
 		Edges:                     edges,
 		Env:                       []string{"HOME=" + homeDir, "USERPROFILE=" + homeDir},
 	})
+}
+
+func getCursorProviderSessionDetailErrorBody(
+	t *testing.T,
+	baseURL, sessionID string,
+	wantStatus int,
+) string {
+	t.Helper()
+
+	response, err := http.Get(cursorProviderSessionDetailURL(baseURL, sessionID))
+	if err != nil {
+		t.Fatalf("GET provider session detail: %v", err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read provider session detail body: %v", err)
+	}
+	if response.StatusCode != wantStatus {
+		t.Fatalf(
+			"GET provider session detail status = %d, want %d: %s",
+			response.StatusCode,
+			wantStatus,
+			strings.TrimSpace(string(body)),
+		)
+	}
+	return string(body)
 }
 
 func cursorProviderSessionDetailURL(baseURL, sessionID string) string {

--- a/tests/functional/provider_sessions/details/cursor_details_test.go
+++ b/tests/functional/provider_sessions/details/cursor_details_test.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	cursorGoldenSuccessWorkspaceHash             = "cursor-fixture-workspace"
+	cursorGoldenSuccessWorkspaceHash              = "cursor-fixture-workspace"
 	cursorGoldenExpectedProviderSessionDetailFile = "expected-provider-session-detail.json"
+	cursorUnavailableContentSessionID             = "cursor-fixture-unavailable-content"
 )
 
 // TestCursorProviderSessionDetailsLoadFromGoldenMetadata loads a sanitized Cursor
@@ -92,6 +93,46 @@ func TestCursorProviderSessionDetailsLoadFromGoldenMetadata(t *testing.T) {
 	}
 }
 
+// TestCursorProviderSessionUnavailableContentRemainsInspectable proves that a
+// Cursor Provider Session whose store contains encrypted or otherwise unavailable
+// blob content still returns an inspectable public detail response with identity
+// and unavailable parse facts instead of fabricated plaintext transcript.
+func TestCursorProviderSessionUnavailableContentRemainsInspectable(t *testing.T) {
+	homeDir := t.TempDir()
+	writeCursorUnavailableContentStorageFixture(t, homeDir, cursorUnavailableContentSessionID)
+
+	server := startCursorProviderSessionDetailServer(t, homeDir, serviceedges.Edges{})
+	defer server.Stop(t)
+
+	detail := support.GetJSON[factoryapi.ProviderSessionDetailResponse](
+		t,
+		cursorProviderSessionDetailURL(server.URL(), cursorUnavailableContentSessionID),
+	)
+	if detail.ProviderSession.Id != cursorUnavailableContentSessionID {
+		t.Fatalf("detail provider session id = %q, want %q", detail.ProviderSession.Id, cursorUnavailableContentSessionID)
+	}
+	if detail.ProviderSession.Provider != factoryapi.Cursor {
+		t.Fatalf("detail provider = %q, want cursor", detail.ProviderSession.Provider)
+	}
+	if detail.ProviderSession.Kind != factoryapi.LoadableProviderSessionKindSessionID {
+		t.Fatalf("detail kind = %q, want session_id", detail.ProviderSession.Kind)
+	}
+	if detail.Parse.UnknownEventCount == 0 && len(detail.Parse.UnknownEvents) == 0 {
+		t.Fatalf("parse summary = %#v, want unavailable unknown-event diagnostics", detail.Parse)
+	}
+	for _, entry := range detail.Transcript {
+		if entry.Text != nil && strings.TrimSpace(*entry.Text) != "" {
+			t.Fatalf("transcript entry = %#v, want no fabricated plaintext from unavailable blobs", entry)
+		}
+	}
+
+	encoded, err := json.Marshal(detail)
+	if err != nil {
+		t.Fatalf("marshal detail: %v", err)
+	}
+	assertCursorProviderSessionDetailBodySafe(t, "unavailable-content", string(encoded), homeDir)
+}
+
 func startCursorProviderSessionDetailServer(
 	t *testing.T,
 	homeDir string,
@@ -160,6 +201,43 @@ CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);`
 		`{"usage":{"inputTokens":12,"outputTokens":34,"cacheReadTokens":5,"cacheWriteTokens":2}}`,
 	); err != nil {
 		t.Fatalf("insert cursor storage usage meta: %v", err)
+	}
+}
+
+func writeCursorUnavailableContentStorageFixture(t *testing.T, homeDir, sessionID string) {
+	t.Helper()
+
+	chatsRoot := filepath.Join(homeDir, ".cursor", "chats")
+	dbPath := filepath.Join(chatsRoot, cursorGoldenSuccessWorkspaceHash, sessionID, "store.db")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("mkdir cursor storage: %v", err)
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open cursor storage sqlite: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.Exec(`CREATE TABLE blobs (key TEXT PRIMARY KEY, value TEXT)`); err != nil {
+		t.Fatalf("create cursor storage blobs table: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO blobs (key, value) VALUES (?, ?)`,
+		"encrypted-blob",
+		string([]byte{0x00, 0x01, 0x02, 0x03, 0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa}),
+	); err != nil {
+		t.Fatalf("insert encrypted cursor storage blob: %v", err)
+	}
+}
+
+func assertCursorProviderSessionDetailBodySafe(t *testing.T, caseID, body, homeDir string) {
+	t.Helper()
+	if err := support.ValidateProviderSessionFixtureContent(caseID, "provider-session-detail", []byte(body)); err != nil {
+		t.Fatalf("provider session response leaked forbidden material: %v\nbody=%s", err, body)
+	}
+	cursorChatsRoot := filepath.Join(homeDir, ".cursor", "chats")
+	if strings.Contains(body, homeDir) || strings.Contains(body, cursorChatsRoot) {
+		t.Fatalf("provider session response leaked configured host path: %s", body)
 	}
 }
 


### PR DESCRIPTION
{
  "project": "Cursor Provider Session Details Functional Coverage",
  "branchName": "ft-wave2-provider-sessions-cursor-details",
  "description": "Implement only tests/functional/provider_sessions/details/cursor_details_test.go (plus narrowly coupled sanitized Cursor fixtures) to prove Cursor Provider Session inspection through the public detail boundary via root.BuildProcess + Process.Execute: golden-backed detail load with readable transcript matching checked-in expected metadata, unavailable/partial content remaining inspectable without fabricated plaintext, and missing session id not-found—without inventing ledger deletions or expected provider metadata, and without modifying codex_details or implementing held http sibling cells.",
  "context": {
    "customerAsk": "Implement only tests/functional/provider_sessions/details/cursor_details_test.go. Construct via root.BuildProcess + Process.Execute (built you CLI only if this cell must prove OS/process-boundary behavior BuildProcess cannot express). Prefer public CLI over HTTP/API for ordinary Provider Session detail flows; use API only where the checklist explicitly requires API detail facts. Replace external effects only through edges.Edges, preferring ProviderCommandRunner / command-runner edge mocks and mocked Cursor/Codex (or another real inference-provider variant via sanitized goldens) over --with-mock-workers / MockWorkers. Do not add sleeps or timeout-padded wait helpers unless justified in-code after fixing readiness/latency root causes. Prove: (1) TestCursorProviderSessionDetailsLoadFromGoldenMetadata; (2) TestCursorProviderSessionUnavailableContentRemainsInspectable; (3) TestCursorProviderSessionMissingIDReturnsNotFound. Do not invent migration-ledger deletion obligations when none map to this destination. Do not implement codex_details_test.go or details/http_test.go. Avoid service/internal Petri imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled ownership/coverage/catalog/migration metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "Cursor Provider Session detail inspection is not proven at the Wave 2 provider_sessions/details destination cell. Without golden-backed public inspection proofs, reviewers cannot trust that Cursor detail responses match checked-in expected metadata with readable transcript data, that unavailable / encrypted / partial content remains inspectable without fabricating plaintext, or that a missing session id surfaces as not-found rather than a fabricated session. The same-package HTTP details sibling must stay held; inventing unrelated ledger deletion obligations would create false ownership work.",
    "solution": "Author the Cursor details functional cell under tests/functional/provider_sessions/details/. Reuse or extend only the narrowly coupled sanitized Cursor golden / fixture material required by the three checklist scenarios. Drive proofs through root.BuildProcess + Process.Execute, preferring public CLI observation when expressible and otherwise the established public Provider Session detail surface. Replace only external effects through edges.Edges (home/session-root resolution, filesystem, and ProviderCommandRunner / command-runner mocks as needed). Prefer mocked Cursor / sanitized goldens over MockWorkers. Compare successful detail output to checked-in expected Provider Session metadata; assert inspectable partial-content outcomes for unavailable content; assert typed not-found for a missing id. Skip inventing ledger deletions. Close with customer-readable Go docs plus focused package, boundary-check, and viz-compatible metadata verification."
  },
  "acceptanceCriteria": [
    "tests/functional/provider_sessions/details/cursor_details_test.go exists as the sole new functional cell for this work and is owned by the provider_sessions/details domain for Cursor proofs only.",
    "Through the public Provider Session inspection boundary (root.BuildProcess + Process.Execute, preferring CLI when expressible, otherwise public detail observation), loading a Cursor session backed by sanitized golden fixtures returns detail that structurally matches checked-in expected Provider Session metadata after declared normalization only, including readable transcript data.",
    "Through the same boundary, a Cursor session with unavailable / partial content remains inspectable: public identity and parse/unavailable facts are present, and plaintext transcript is not fabricated from unavailable blobs.",
    "Through the same boundary, requesting details for a missing Cursor session id returns a distinguishable not-found outcome (no fabricated session detail).",
    "Construction replaces external effects only through edges.Edges, prefers ProviderCommandRunner / command-runner mocks and mocked Cursor / sanitized goldens over MockWorkers, and does not add sleeps or timeout-padded wait helpers unless justified in-code after fixing readiness/latency root causes. Expected provider metadata is never invented by calling production mappers under test. No migration-ledger deletion obligations are invented for this cell.",
    "codex_details_test.go is not modified by this work; http_test.go remains unimplemented; every top-level Test* has a customer-readable Go doc comment; only narrowly coupled ownership / coverage / catalog / migration metadata for this cell are updated; tests avoid service/internal Petri imports.",
    "Quality gate passes: focused package tests for the new cell, make functional-boundary-check, functional-test metadata / viz-compatible verification for touched catalog surfaces, plus typecheck, lint, and tests for touched surfaces."
  ],
  "userStories": [
    {
      "id": "ft-wave2-provider-sessions-cursor-details-001",
      "title": "Prove Cursor details load from sanitized golden metadata",
      "description": "As a customer or maintainer, I want a provider-session-owned functional test that loads Cursor Provider Session details from sanitized golden fixtures through the public inspection boundary so I can trust public detail matches checked-in expected metadata with readable transcript data.",
      "acceptanceCriteria": [
        "tests/functional/provider_sessions/details/cursor_details_test.go is created under provider_sessions/details ownership.",
        "Narrowly coupled sanitized Cursor golden / fixture material exists under docs/temp/functional/provider-sessions/cursor/ (reuse cursor/success and its expected-provider-session-detail.json when sufficient, or add only the minimal tracked Cursor case needed) and loads through the existing Provider Session golden harness without shared-harness API changes.",
        "TestCursorProviderSessionDetailsLoadFromGoldenMetadata exists with a customer-readable Go doc comment describing the observable detail-load behavior.",
        "The scenario constructs via root.BuildProcess + Process.Execute (prefer public CLI observation when a detail CLI path can express the outcome; otherwise the established public Provider Session detail surface), replacing external effects only through edges.Edges.",
        "Observed public Provider Session detail structurally matches the checked-in expected Provider Session metadata after normalizing only declared nondeterministic fields; provider/kind/id and readable transcript data are present as declared by the golden.",
        "Expected metadata is not generated by calling production mappers under assertion; MockWorkers / --with-mock-workers are not used when ProviderCommandRunner / command-runner mocks or sanitized Cursor goldens suffice.",
        "The test package does not import service/internal Petri packages; no sleeps or timeout-padded wait helpers are added unless justified in-code after fixing readiness/latency root causes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-provider-sessions-cursor-details-002",
      "title": "Prove unavailable Cursor content remains inspectable",
      "description": "As a customer or maintainer, I want a functional proof that a Cursor Provider Session whose content is unavailable or only partially readable still returns an inspectable public detail response so operators can see identity and unavailable/parse facts without fabricated plaintext transcript.",
      "acceptanceCriteria": [
        "Narrowly coupled sanitized unavailable / partial-content Cursor fixture material is available for the proof (checked-in under the Cursor golden root or package-local fixture construction mirroring product Cursor storage), without inventing expected metadata via production mappers.",
        "TestCursorProviderSessionUnavailableContentRemainsInspectable exists with a customer-readable Go doc comment describing the observable partial-data inspectability behavior.",
        "Through the same public Provider Session inspection boundary as story 001, loading the unavailable / partial Cursor session returns an inspectable detail response (not a not-found / hard failure for an existing session id).",
        "Public detail exposes Cursor provider/kind/id and parse/unavailable facts (for example non-zero unknown/unavailable event counts or equivalent public unavailable markers); plaintext transcript entries are absent or empty rather than fabricated from unavailable blobs.",
        "Public diagnostics do not include secrets, absolute host paths, raw filesystem path acceptance, or other unsanitized host material.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-provider-sessions-cursor-details-003",
      "title": "Prove missing Cursor session id returns not-found",
      "description": "As a customer or maintainer, I want a functional proof that requesting Cursor Provider Session details for a missing session id returns a distinguishable not-found outcome so absence is never fabricated into a session.",
      "acceptanceCriteria": [
        "TestCursorProviderSessionMissingIDReturnsNotFound exists with a customer-readable Go doc comment describing the observable not-found behavior.",
        "Through the same public Provider Session inspection boundary as story 001, requesting details for a Cursor session_id that does not exist returns a distinguishable not-found outcome (for example CLI not-found signaling or HTTP 404 / typed session-not-found), not a fabricated detail body.",
        "The response does not invent Provider Session identity, transcript entries, or expected metadata for the missing session.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-provider-sessions-cursor-details-004",
      "title": "Close catalog metadata and verification gates",
      "description": "As a maintainer, I want narrowly coupled catalog metadata updated and verified for this Cursor details cell so the destination is visible in functional coverage without inventing ledger deletions or implementing held siblings.",
      "acceptanceCriteria": [
        "No migration-ledger deletion obligations are invented for cursor_details_test.go when none map to this destination.",
        "Only narrowly coupled ownership, coverage, catalog, and related metadata required for this Cursor details cell are updated.",
        "Checklist / catalog visibility reflects the three top-level Tests and provider_sessions/details Cursor ownership; existing codex_details_test.go is left unchanged and http_test.go remains out of scope for this work.",
        "Focused tests for the details package (Cursor cell) pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test metadata verification (viz-compatible catalog/metadata checks) accepts the cell without requiring broad unrelated inventory cleanup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)