### PR TITLE
ft-wave2-provider-sessions-details-http

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -847,6 +847,19 @@ Wave 0 functional-tests-expansion planning authority lives under
   every top-level `Test*` needs a customer-readable Go doc and `//golden:` manifest
   directive so `functionaltestmetadata` stays viz-compatible.
 
+- `tests/functional/provider_sessions/details/http_test.go` owns HTTP/API Provider
+  Session detail contracts through the public `GET /provider-sessions/detail` boundary
+  via `support.StartFunctionalAPIServer` (root.BuildProcess + Process.Execute) with
+  `ProviderSessionResolveHomeDirectory` edge override and without MockWorkers when
+  sanitized on-disk fixtures suffice. Prove golden-backed detail matches checked-in
+  expected metadata (`//golden:` on the success load test), reject raw filesystem path
+  input with typed `BAD_REQUEST` errors, and return typed `BAD_REQUEST` for unsupported
+  provider session kinds without fabricating detail bodies. Reuse same-package Codex/Cursor
+  fixture helpers from sibling cells; do not widen into `codex_details_test.go` or
+  `cursor_details_test.go`. Close catalog metadata with `test-file-checklist.md`,
+  `migration-ledger-inventory.json`, and customer-readable Go docs so
+  `functionaltestmetadata` stays viz-compatible.
+
 - `tests/functional/provider_sessions/details/cursor_details_test.go` owns Cursor
   Provider Session detail inspection through the public `GET /provider-sessions/detail`
   boundary via `support.StartFunctionalAPIServer` with

--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -3169,6 +3169,36 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/provider_sessions/details/http_test.go",
+      "package": "you-agent-factory/tests/functional/provider_sessions/details",
+      "scenario": "TestAPIProviderSessionDetailsUseGoldenExpectedMetadata",
+      "lane": "short",
+      "destination": "tests/functional/provider_sessions/details/http_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/provider_sessions/details/http_test.go",
+      "package": "you-agent-factory/tests/functional/provider_sessions/details",
+      "scenario": "TestAPIProviderSessionRejectsRawFilesystemPathInput",
+      "lane": "short",
+      "destination": "tests/functional/provider_sessions/details/http_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/provider_sessions/details/http_test.go",
+      "package": "you-agent-factory/tests/functional/provider_sessions/details",
+      "scenario": "TestAPIUnsupportedProviderSessionKindReturnsTypedError",
+      "lane": "short",
+      "destination": "tests/functional/provider_sessions/details/http_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/provider_sessions/details/cursor_details_test.go",
       "package": "you-agent-factory/tests/functional/provider_sessions/details",
       "scenario": "TestCursorProviderSessionUnavailableContentRemainsInspectable",
@@ -9093,7 +9123,7 @@
       "operator_settings": 10,
       "orchestration": 48,
       "product": 13,
-      "provider_sessions": 9,
+      "provider_sessions": 12,
       "providers": 64,
       "replay_contracts": 23,
       "runtime_api": 105,
@@ -9106,9 +9136,9 @@
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 887,
+    "customer_top_level_Test_scenarios": 890,
     "lane_functionallong": 95,
-    "lane_short": 792,
+    "lane_short": 795,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 12,
       "you-agent-factory/tests/functional/automations": 14,
@@ -9152,7 +9182,7 @@
       "you-agent-factory/tests/functional/product/packaged_factory_guard_failure": 1,
       "you-agent-factory/tests/functional/product/packaged_factory_portability": 1,
       "you-agent-factory/tests/functional/provider_sessions/association": 6,
-      "you-agent-factory/tests/functional/provider_sessions/details": 3,
+      "you-agent-factory/tests/functional/provider_sessions/details": 6,
       "you-agent-factory/tests/functional/providers": 36,
       "you-agent-factory/tests/functional/providers/codex": 7,
       "you-agent-factory/tests/functional/providers/cursor": 8,
@@ -9211,8 +9241,8 @@
       "you-agent-factory/tests/functional/workstations/repeater": 13,
       "you-agent-factory/tests/functional/workstations/watcher": 9
     },
-    "files_with_customer_Test": 253,
-    "functional_test_go_files": 252,
+    "files_with_customer_Test": 254,
+    "functional_test_go_files": 253,
     "helper_only_non_customer_files": 51,
     "internal_harness_Test_functions": 15,
     "internal_harness_test_files": 5

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -796,7 +796,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
     partial data.
   - `TestCursorProviderSessionMissingIDReturnsNotFound`.
 
-- [ ] `tests/functional/provider_sessions/details/http_test.go`
+- [x] `tests/functional/provider_sessions/details/http_test.go`
   - `TestAPIProviderSessionDetailsUseGoldenExpectedMetadata`.
   - `TestAPIProviderSessionRejectsRawFilesystemPathInput`.
   - `TestAPIUnsupportedProviderSessionKindReturnsTypedError`.

--- a/tests/functional/provider_sessions/details/http_test.go
+++ b/tests/functional/provider_sessions/details/http_test.go
@@ -3,8 +3,10 @@ package details
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/portpowered/infinite-you/internal/testutil"
@@ -76,6 +78,71 @@ func TestAPIProviderSessionDetailsUseGoldenExpectedMetadata(t *testing.T) {
 			t.Fatalf("%v", err)
 		}
 		t.Fatalf("compareOrUpdateCodexProviderSessionDetailGolden: %v", err)
+	}
+}
+
+// TestAPIProviderSessionRejectsRawFilesystemPathInput proves the public HTTP/API
+// Provider Session detail endpoint rejects raw filesystem path input instead of
+// treating host paths as session locators or returning fabricated detail from
+// path traversal.
+func TestAPIProviderSessionRejectsRawFilesystemPathInput(t *testing.T) {
+	repoRoot := testutil.MustRepoRoot(t)
+	caseDir := filepath.Join(repoRoot, filepath.FromSlash(support.ProviderSessionFixturePath("codex", "success")))
+	rolloutPath := filepath.Join(caseDir, codexGoldenRolloutFile)
+	rolloutContent, err := os.ReadFile(rolloutPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", codexGoldenRolloutFile, err)
+	}
+
+	homeDir := t.TempDir()
+	validSessionID := "session_fixture_codex_api_path_rejection"
+	writeCodexGoldenRolloutFixture(t, codexSessionsRoot(homeDir), validSessionID, string(rolloutContent))
+	rolloutAbsolutePath := filepath.Join(
+		codexSessionsRoot(homeDir),
+		"2026",
+		"07",
+		"27",
+		"rollout-"+validSessionID+".jsonl",
+	)
+
+	server := startAPIProviderSessionDetailServer(t, homeDir, serviceedges.Edges{})
+	defer server.Stop(t)
+
+	for _, test := range []struct {
+		name string
+		id   string
+	}{
+		{name: "absolute host path", id: "/tmp/rollout-session.jsonl"},
+		{name: "relative traversal", id: "../secret"},
+		{name: "stored rollout absolute path", id: rolloutAbsolutePath},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			body := getCodexProviderSessionDetailErrorBody(
+				t,
+				server.URL(),
+				test.id,
+				http.StatusBadRequest,
+			)
+			if !strings.Contains(body, "path separators") {
+				t.Fatalf("error body = %q, want path-separator rejection diagnostic", body)
+			}
+
+			var failure factoryapi.ErrorResponse
+			if err := json.Unmarshal([]byte(body), &failure); err != nil {
+				t.Fatalf("decode error response: %v", err)
+			}
+			if failure.Code != factoryapi.ErrorResponseCodeBADREQUEST {
+				t.Fatalf("error code = %q, want BAD_REQUEST", failure.Code)
+			}
+			if failure.Message == "" {
+				t.Fatal("error message is empty, want customer-readable validation diagnostic")
+			}
+			if strings.Contains(body, `"transcript"`) || strings.Contains(body, `"providerSession"`) {
+				t.Fatalf("validation error fabricated provider session detail: %s", body)
+			}
+
+			assertCodexProviderSessionErrorBodySafe(t, "api-path-rejection", body, homeDir)
+		})
 	}
 }
 

--- a/tests/functional/provider_sessions/details/http_test.go
+++ b/tests/functional/provider_sessions/details/http_test.go
@@ -3,7 +3,9 @@ package details
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -144,6 +146,98 @@ func TestAPIProviderSessionRejectsRawFilesystemPathInput(t *testing.T) {
 			assertCodexProviderSessionErrorBodySafe(t, "api-path-rejection", body, homeDir)
 		})
 	}
+}
+
+// TestAPIUnsupportedProviderSessionKindReturnsTypedError proves the public HTTP/API
+// Provider Session detail endpoint rejects unsupported provider session kinds with
+// a typed BAD_REQUEST error instead of opaque server failures or fabricated detail
+// bodies that invent session identity or transcript content.
+func TestAPIUnsupportedProviderSessionKindReturnsTypedError(t *testing.T) {
+	homeDir := t.TempDir()
+	server := startAPIProviderSessionDetailServer(t, homeDir, serviceedges.Edges{})
+	defer server.Stop(t)
+
+	for _, test := range []struct {
+		name     string
+		provider string
+		kind     string
+		id       string
+	}{
+		{
+			name:     "codex unsupported kind",
+			provider: string(factoryapi.Codex),
+			kind:     "path",
+			id:       "sess-unsupported-kind-codex",
+		},
+		{
+			name:     "cursor unsupported kind",
+			provider: string(factoryapi.Cursor),
+			kind:     "path",
+			id:       "sess-unsupported-kind-cursor",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			body := getAPIProviderSessionDetailErrorBody(
+				t,
+				server.URL(),
+				test.provider,
+				test.kind,
+				test.id,
+				http.StatusBadRequest,
+			)
+
+			var failure factoryapi.ErrorResponse
+			if err := json.Unmarshal([]byte(body), &failure); err != nil {
+				t.Fatalf("decode error response: %v", err)
+			}
+			if failure.Code != factoryapi.ErrorResponseCodeBADREQUEST {
+				t.Fatalf("error code = %q, want BAD_REQUEST", failure.Code)
+			}
+			if failure.Message == "" {
+				t.Fatal("error message is empty, want customer-readable validation diagnostic")
+			}
+			if strings.Contains(body, `"transcript"`) || strings.Contains(body, `"providerSession"`) {
+				t.Fatalf("unsupported kind error fabricated provider session detail: %s", body)
+			}
+
+			assertCodexProviderSessionErrorBodySafe(t, "api-unsupported-kind", body, homeDir)
+		})
+	}
+}
+
+func providerSessionDetailURL(baseURL, provider, kind, id string) string {
+	query := url.Values{}
+	query.Set("provider", provider)
+	query.Set("kind", kind)
+	query.Set("id", id)
+	return strings.TrimSuffix(baseURL, "/") + "/provider-sessions/detail?" + query.Encode()
+}
+
+func getAPIProviderSessionDetailErrorBody(
+	t *testing.T,
+	baseURL, provider, kind, id string,
+	wantStatus int,
+) string {
+	t.Helper()
+
+	response, err := http.Get(providerSessionDetailURL(baseURL, provider, kind, id))
+	if err != nil {
+		t.Fatalf("GET provider session detail: %v", err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read provider session detail body: %v", err)
+	}
+	if response.StatusCode != wantStatus {
+		t.Fatalf(
+			"GET provider session detail status = %d, want %d: %s",
+			response.StatusCode,
+			wantStatus,
+			strings.TrimSpace(string(body)),
+		)
+	}
+	return string(body)
 }
 
 func startAPIProviderSessionDetailServer(

--- a/tests/functional/provider_sessions/details/http_test.go
+++ b/tests/functional/provider_sessions/details/http_test.go
@@ -1,0 +1,99 @@
+package details
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+// TestAPIProviderSessionDetailsUseGoldenExpectedMetadata loads a sanitized Codex
+// Provider Session through the public HTTP/API detail endpoint served by
+// root.BuildProcess + Process.Execute and proves the response structurally
+// matches checked-in expected Provider Session metadata.
+//golden: docs/temp/functional/provider-sessions/codex/success/manifest.json
+func TestAPIProviderSessionDetailsUseGoldenExpectedMetadata(t *testing.T) {
+	repoRoot := testutil.MustRepoRoot(t)
+	caseDir := filepath.Join(repoRoot, filepath.FromSlash(support.ProviderSessionFixturePath("codex", "success")))
+
+	loaded, err := support.LoadProviderSessionCase(caseDir)
+	if err != nil {
+		t.Fatalf("LoadProviderSessionCase: %v", err)
+	}
+	if loaded.Manifest.ID != "codex-message-tool-success" {
+		t.Fatalf("manifest.ID = %q, want codex-message-tool-success", loaded.Manifest.ID)
+	}
+
+	var request struct {
+		SessionID string `json:"session_id"`
+	}
+	if err := json.Unmarshal(loaded.Request, &request); err != nil {
+		t.Fatalf("decode request.json: %v", err)
+	}
+	if request.SessionID == "" {
+		t.Fatal("request.session_id must be non-empty")
+	}
+
+	rolloutPath := filepath.Join(caseDir, codexGoldenRolloutFile)
+	rolloutContent, err := os.ReadFile(rolloutPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", codexGoldenRolloutFile, err)
+	}
+
+	homeDir := t.TempDir()
+	writeCodexGoldenRolloutFixture(t, codexSessionsRoot(homeDir), request.SessionID, string(rolloutContent))
+
+	server := startAPIProviderSessionDetailServer(t, homeDir, serviceedges.Edges{})
+	defer server.Stop(t)
+
+	detail := support.GetJSON[factoryapi.ProviderSessionDetailResponse](
+		t,
+		codexProviderSessionDetailURL(server.URL(), request.SessionID),
+	)
+	if detail.ProviderSession.Id != request.SessionID {
+		t.Fatalf("detail provider session id = %q, want %q", detail.ProviderSession.Id, request.SessionID)
+	}
+	if detail.ProviderSession.Provider != factoryapi.Codex {
+		t.Fatalf("detail provider = %q, want codex", detail.ProviderSession.Provider)
+	}
+	if detail.ProviderSession.Kind != factoryapi.LoadableProviderSessionKindSessionID {
+		t.Fatalf("detail kind = %q, want session_id", detail.ProviderSession.Kind)
+	}
+	if len(detail.Transcript) == 0 {
+		t.Fatal("provider session detail transcript is empty, want readable success-session content")
+	}
+
+	observed := observeCodexProviderSessionDetailGolden(detail)
+	if err := compareOrUpdateCodexProviderSessionDetailGolden(loaded, observed); err != nil {
+		var updated *support.ProviderSessionGoldensUpdatedError
+		if errors.As(err, &updated) {
+			t.Fatalf("%v", err)
+		}
+		t.Fatalf("compareOrUpdateCodexProviderSessionDetailGolden: %v", err)
+	}
+}
+
+func startAPIProviderSessionDetailServer(
+	t *testing.T,
+	homeDir string,
+	edges serviceedges.Edges,
+) *support.FunctionalAPIServer {
+	t.Helper()
+
+	if edges.ProviderSessionResolveHomeDirectory == nil {
+		edges.ProviderSessionResolveHomeDirectory = func() (string, error) { return homeDir, nil }
+	}
+	dir := support.ScaffoldSingleStepFactory(t, "api-provider-session-detail")
+	return support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		WaitForServiceModeRuntime: true,
+		Edges:                     edges,
+		Env:                       []string{"HOME=" + homeDir, "USERPROFILE=" + homeDir},
+	})
+}


### PR DESCRIPTION
{
  "project": "Provider Session Details HTTP/API Functional Coverage",
  "branchName": "ft-wave2-provider-sessions-details-http",
  "description": "Implement only tests/functional/provider_sessions/details/http_test.go (plus narrowly coupled sanitized fixtures) to prove Provider Session detail contracts through the public HTTP/API via root.BuildProcess + Process.Execute: golden-backed detail matching checked-in expected metadata, rejection of raw filesystem path input, and typed error for unsupported Provider Session kind—without inventing ledger deletions or expected provider metadata, and without modifying terminal codex_details or cursor_details sibling cells.",
  "context": {
    "customerAsk": "Implement only tests/functional/provider_sessions/details/http_test.go. Construct via root.BuildProcess + Process.Execute (built you CLI only if this cell must prove OS/process-boundary behavior BuildProcess cannot express). This cell owns HTTP/API Provider Session detail contracts, so prefer the public API surface for the stated proofs; keep CLI out unless a narrow cross-surface fact is required by the checklist. Replace external effects only through edges.Edges, preferring ProviderCommandRunner / command-runner edge mocks and mocked Codex/Cursor (or another real inference-provider variant via sanitized goldens) over --with-mock-workers / MockWorkers. Do not invent expected provider metadata — assert against checked-in golden expected metadata. Do not add sleeps or timeout-padded wait helpers unless justified in-code after fixing readiness/latency root causes. Prove: (1) TestAPIProviderSessionDetailsUseGoldenExpectedMetadata; (2) TestAPIProviderSessionRejectsRawFilesystemPathInput; (3) TestAPIUnsupportedProviderSessionKindReturnsTypedError. Do not invent migration-ledger deletion obligations when none map to this destination. Do not implement cursor_details_test.go or codex_details_test.go. Avoid service/internal Petri imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled ownership/coverage/catalog/migration metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "HTTP/API Provider Session detail contracts are not proven at the Wave 2 provider_sessions/details destination cell even though Codex and Cursor details siblings are terminal and have freed the package. Without golden-backed public API proofs, reviewers cannot trust that Provider Session detail responses match checked-in expected metadata, that raw filesystem path input is rejected rather than accepted as a session locator, or that an unsupported Provider Session kind returns a typed public error instead of an opaque failure or fabricated detail. No migration-ledger rows map to this destination; inventing unrelated ledger deletion obligations would create false ownership work.",
    "solution": "Author the HTTP/API details functional cell under tests/functional/provider_sessions/details/. Reuse or extend only the narrowly coupled sanitized Codex/Cursor (or other real inference-provider) golden / fixture material required by the three checklist scenarios. Drive proofs through root.BuildProcess + Process.Execute on the public HTTP/API Provider Session detail surface. Replace only external effects through edges.Edges (home/session-root resolution, filesystem, and ProviderCommandRunner / command-runner mocks as needed). Prefer mocked Codex/Cursor / sanitized goldens over MockWorkers. Compare successful detail output to checked-in expected Provider Session metadata; assert rejection of raw filesystem path input; assert typed error for unsupported kind. Skip inventing ledger deletions. Close with customer-readable Go docs plus focused package, boundary-check, and viz-compatible metadata verification."
  },
  "acceptanceCriteria": [
    "tests/functional/provider_sessions/details/http_test.go exists as the sole new functional cell for this work and is owned by the provider_sessions/details domain for HTTP/API proofs only.",
    "Through the public HTTP/API Provider Session detail boundary (root.BuildProcess + Process.Execute), loading a Provider Session backed by sanitized golden fixtures returns detail that structurally matches checked-in expected Provider Session metadata after declared normalization only.",
    "Through the same public API boundary, a request that supplies a raw filesystem path as Provider Session input is rejected (typed client / validation error; not accepted as a session locator and not returning fabricated detail from host path traversal).",
    "Through the same public API boundary, requesting details for an unsupported Provider Session kind returns a distinguishable typed public error (not an opaque 500 / unstructured failure and not a fabricated detail body).",
    "Construction replaces external effects only through edges.Edges, prefers ProviderCommandRunner / command-runner mocks and mocked Codex/Cursor / sanitized goldens over MockWorkers, prefers the public API surface, and does not add sleeps or timeout-padded wait helpers unless justified in-code after fixing readiness/latency root causes. Expected provider metadata is never invented by calling production mappers under test. No migration-ledger deletion obligations are invented for this cell.",
    "codex_details_test.go and cursor_details_test.go are not modified by this work; every top-level Test* has a customer-readable Go doc comment; only narrowly coupled ownership / coverage / catalog / migration metadata for this cell are updated; tests avoid service/internal Petri imports.",
    "Quality gate passes: focused package tests for the new cell, make functional-boundary-check, functional-test metadata / viz-compatible verification for touched catalog surfaces, plus typecheck, lint, and tests for touched surfaces."
  ],
  "userStories": [
    {
      "id": "ft-wave2-provider-sessions-details-http-001",
      "title": "Prove API details use golden expected metadata",
      "description": "As a customer or maintainer, I want a provider-session-owned functional test that loads Provider Session details through the public HTTP/API detail boundary against sanitized golden fixtures so I can trust public API detail matches checked-in expected metadata.",
      "acceptanceCriteria": [
        "tests/functional/provider_sessions/details/http_test.go is created under provider_sessions/details ownership.",
        "Narrowly coupled sanitized Provider Session golden / fixture material is available for the proof (reuse existing Codex/Cursor / real inference-provider goldens and their checked-in expected metadata when sufficient, or add only the minimal tracked case needed) and loads through the existing Provider Session golden harness without shared-harness API changes.",
        "TestAPIProviderSessionDetailsUseGoldenExpectedMetadata exists with a customer-readable Go doc comment describing the observable API detail-load behavior.",
        "The scenario constructs via root.BuildProcess + Process.Execute on the public HTTP/API Provider Session detail surface, replacing external effects only through edges.Edges.",
        "Observed public Provider Session detail structurally matches the checked-in expected Provider Session metadata after normalizing only declared nondeterministic fields; provider/kind/id (and other fields declared by the golden) are present as declared.",
        "Expected metadata is not generated by calling production mappers under assertion; MockWorkers / --with-mock-workers are not used when ProviderCommandRunner / command-runner mocks or sanitized goldens suffice.",
        "The test package does not import service/internal Petri packages; no sleeps or timeout-padded wait helpers are added unless justified in-code after fixing readiness/latency root causes; CLI is not used unless a narrow cross-surface fact is required by the checklist.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-provider-sessions-details-http-002",
      "title": "Prove API rejects raw filesystem path input",
      "description": "As a customer or client calling the Provider Session detail API, I want raw filesystem path input rejected so host paths cannot be used as session locators and the API never fabricates detail from arbitrary path traversal.",
      "acceptanceCriteria": [
        "TestAPIProviderSessionRejectsRawFilesystemPathInput exists with a customer-readable Go doc comment describing the observable path-rejection behavior.",
        "Through the same public HTTP/API Provider Session detail boundary as story 001, a request that supplies a raw filesystem path (for example an absolute host path where a session id / public locator is required) is rejected.",
        "Observable evidence proves a typed client / validation error outcome appropriate to the public API (not success with fabricated detail, and not an opaque 500 / unstructured failure that implies path acceptance).",
        "Public error diagnostics do not include secrets, unsanitized absolute host path leakage beyond what is required to identify the rejected input, or other unsanitized host material.",
        "Assertions remain on path-input rejection at the public HTTP detail boundary and do not widen into Codex/Cursor sibling detail matrices or association cells.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-provider-sessions-details-http-003",
      "title": "Prove unsupported Provider Session kind returns typed error",
      "description": "As a customer or client requesting Provider Session details, I want an unsupported Provider Session kind to fail with a typed public error so callers can distinguish unsupported kind from missing sessions and server faults.",
      "acceptanceCriteria": [
        "TestAPIUnsupportedProviderSessionKindReturnsTypedError exists with a customer-readable Go doc comment describing the observable typed unsupported-kind error behavior.",
        "Through the same public HTTP/API Provider Session detail boundary as story 001, requesting details with an unsupported Provider Session kind returns a distinguishable typed public error outcome (structured typed error / status class appropriate to the public API)—not an opaque 500 or unstructured failure body.",
        "The response does not invent Provider Session identity, transcript entries, or expected metadata for the unsupported kind.",
        "Assertions remain on typed unsupported-kind error at the public HTTP detail boundary and do not widen into Codex/Cursor sibling proofs or association cells.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-provider-sessions-details-http-004",
      "title": "Close catalog metadata and verification gates",
      "description": "As a maintainer, I want narrowly coupled catalog metadata updated and verified for this HTTP/API details cell so the destination is visible in functional coverage without inventing ledger deletions or modifying terminal Codex/Cursor siblings.",
      "acceptanceCriteria": [
        "No migration-ledger deletion obligations are invented for http_test.go when none map to this destination.",
        "Only narrowly coupled ownership, coverage, catalog, and related metadata required for this HTTP/API details cell are updated.",
        "Checklist / catalog visibility reflects the three top-level Tests and provider_sessions/details HTTP/API ownership; existing codex_details_test.go and cursor_details_test.go are left unchanged.",
        "Focused tests for the details package (HTTP cell) pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test metadata verification (viz-compatible catalog/metadata checks) accepts the cell without requiring broad unrelated inventory cleanup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)