### PR TITLE
ft-depth-workers-transports-cli-run-modes

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -778,6 +778,18 @@ Wave 0 functional-tests-expansion planning authority lives under
   metadata infers domain `workers` and subsection `inference` from the path;
   every top-level `Test*` needs a customer-readable Go doc so
   `functionaltestmetadata` stays viz-compatible.
+- Workers-owned CLI run output-mode functional coverage belongs in
+  `tests/functional/workers/transports/cli/run/modes/output_modes_test.go`:
+  drive public `you run` through `support.BuildProcess` + `support.FakeInputs`
+  with `serviceedges.Edges` populated via `support.ConfigureWorkerCommands` and
+  `support.NewStaticSuccessCommandRunner` (preferred over `--with-mock-workers`);
+  scaffold a minimal model-worker factory with `support.ScaffoldFactory` and
+  `support.BuildModelWorkerConfig`; prove quiet text, single-JSON, and NDJSON
+  (`--json --output response-stream`) primary-result fidelity on stdout only.
+  Place `--quiet` and `--output` on the `run` subcommand, not as global flags.
+  Catalog metadata infers domain `workers` and subsection
+  `transports/cli/run/modes` from the path; every top-level `Test*` needs a
+  customer-readable Go doc so `functionaltestmetadata` stays viz-compatible.
 - Packaged `@you/tts` invocation functional coverage belongs in
   `tests/functional/factory/packaged/tts/invocation_test.go`: prove required-text
   audio artifact metadata, optional voice/format reachability on fake provider

--- a/tests/functional/internal/support/process_api_server.go
+++ b/tests/functional/internal/support/process_api_server.go
@@ -61,6 +61,19 @@ func (server *ProcessAPIServer) Start(
 	return nil
 }
 
+// BaseURL returns the bound httptest URL after Ready has been signaled.
+func (server *ProcessAPIServer) BaseURL() (string, bool) {
+	if server == nil {
+		return "", false
+	}
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if server.url == "" {
+		return "", false
+	}
+	return server.url, true
+}
+
 // Ready is closed after the httptest server is accepting requests.
 func (server *ProcessAPIServer) Ready() <-chan struct{} {
 	if server == nil {
@@ -89,4 +102,21 @@ func (server *ProcessAPIServer) WaitForURL(t testing.TB) string {
 		t.Fatal("process API server became ready without a URL")
 	}
 	return server.url
+}
+
+// WaitForBaseURL waits for the injected transport to start and returns its URL
+// or an error. It is safe to call from background goroutines.
+func (server *ProcessAPIServer) WaitForBaseURL(timeout time.Duration) (string, error) {
+	if server == nil {
+		return "", fmt.Errorf("process API server is required")
+	}
+	select {
+	case <-server.ready:
+	case <-time.After(timeout):
+		return "", fmt.Errorf("timed out waiting for process API server")
+	}
+	if baseURL, ok := server.BaseURL(); ok {
+		return baseURL, nil
+	}
+	return "", fmt.Errorf("process API server became ready without a URL")
 }

--- a/tests/functional/sessions/execution/helpers_test.go
+++ b/tests/functional/sessions/execution/helpers_test.go
@@ -754,6 +754,81 @@ func assertTerminalWorkPrimaryText(
 	}
 }
 
+// tryWaitForTerminalWorkPrimaryTextDuringInvocation polls /work until terminal
+// primary text is visible or the hosted CLI invocation completes. When the
+// invocation finishes first, one final read is attempted so callers fail fast
+// instead of waiting on a torn-down one-shot server.
+func tryWaitForTerminalWorkPrimaryTextDuringInvocation(
+	serverURL, wantText string,
+	timeout time.Duration,
+	invocationDone <-chan struct{},
+) error {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	var lastDiagnostic string
+	for {
+		ok, diagnostic := tryReadTerminalWorkPrimaryText(serverURL, wantText)
+		if ok {
+			return nil
+		}
+		lastDiagnostic = diagnostic
+
+		select {
+		case <-invocationDone:
+			ok, finalDiagnostic := tryReadTerminalWorkPrimaryText(serverURL, wantText)
+			if ok {
+				return nil
+			}
+			return fmt.Errorf(
+				"CLI invocation completed before terminal work with text %q was visible at %s: %s",
+				wantText,
+				serverURL,
+				finalDiagnostic,
+			)
+		default:
+		}
+
+		select {
+		case <-ticker.C:
+		case <-invocationDone:
+			ok, finalDiagnostic := tryReadTerminalWorkPrimaryText(serverURL, wantText)
+			if ok {
+				return nil
+			}
+			return fmt.Errorf(
+				"CLI invocation completed before terminal work with text %q was visible at %s: %s",
+				wantText,
+				serverURL,
+				finalDiagnostic,
+			)
+		case <-deadline.C:
+			return fmt.Errorf(
+				"timed out waiting for terminal work with text %q at %s: %s",
+				wantText,
+				serverURL,
+				lastDiagnostic,
+			)
+		}
+	}
+}
+
+// waitForTerminalWorkPrimaryTextDuringInvocation polls /work until terminal
+// primary text is visible or the hosted CLI invocation completes.
+func waitForTerminalWorkPrimaryTextDuringInvocation(
+	t *testing.T,
+	serverURL, wantText string,
+	timeout time.Duration,
+	invocationDone <-chan struct{},
+) {
+	t.Helper()
+	if err := tryWaitForTerminalWorkPrimaryTextDuringInvocation(serverURL, wantText, timeout, invocationDone); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // waitForTerminalWorkPrimaryText polls the public /work surface until one
 // terminal work item exposes the expected primary text, or times out. Hosted
 // CLI invocations complete asynchronously relative to the first successful

--- a/tests/functional/sessions/execution/visibility_test.go
+++ b/tests/functional/sessions/execution/visibility_test.go
@@ -40,6 +40,22 @@ func TestCLIInvocationIsVisibleThroughAPISessionAndWorkReads(t *testing.T) {
 	inputs.WorkingDirectory = dir
 
 	command := support.StartProcessCommand(t, process, inputs.Input)
+
+	workReady := make(chan error, 1)
+	go func() {
+		baseURL, err := api.WaitForBaseURL(5 * time.Second)
+		if err != nil {
+			workReady <- err
+			return
+		}
+		workReady <- tryWaitForTerminalWorkPrimaryTextDuringInvocation(
+			baseURL,
+			terminalSuccessPrimaryResult,
+			15*time.Second,
+			command.Done(),
+		)
+	}()
+
 	baseURL := api.WaitForURL(t)
 
 	sessionDuring := support.GetDefaultSession(t, baseURL)
@@ -50,7 +66,9 @@ func TestCLIInvocationIsVisibleThroughAPISessionAndWorkReads(t *testing.T) {
 		t.Fatalf("session runtime status during CLI invocation = %#v, want observable lifecycle status", sessionDuring.Runtime)
 	}
 
-	waitForTerminalWorkPrimaryText(t, baseURL, terminalSuccessPrimaryResult, 15*time.Second)
+	if workErr := <-workReady; workErr != nil {
+		t.Fatal(workErr)
+	}
 
 	<-command.Done()
 	if err := command.Err(); err != nil {

--- a/tests/functional/workers/transports/cli/run/modes/output_modes_test.go
+++ b/tests/functional/workers/transports/cli/run/modes/output_modes_test.go
@@ -1,0 +1,202 @@
+package modes_test
+
+import (
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	wantPrimaryResult        = "deterministic workers primary COMPLETE"
+	factoryEventRecordType   = "factory_event"
+	invocationResultType     = "invocation_result"
+)
+
+// TestCLIRunSuccessPrimaryResultTextJSONAndNDJSON proves a successful public
+// you run invocation writes the same deterministic primary result across quiet
+// text, single-JSON, and NDJSON response-stream presentations at the CLI boundary.
+func TestCLIRunSuccessPrimaryResultTextJSONAndNDJSON(t *testing.T) {
+	t.Run("quiet text primary result", func(t *testing.T) {
+		result := executeSuccessfulRun(t, nil, []string{"--quiet"})
+		if strings.TrimSpace(result.stdout) != wantPrimaryResult {
+			t.Fatalf("stdout = %q, want raw primary result %q", result.stdout, wantPrimaryResult)
+		}
+		assertSuccessfulRunStderrEmpty(t, result.stderr)
+	})
+
+	t.Run("single JSON InvocationResponse", func(t *testing.T) {
+		result := executeSuccessfulRun(t, []string{"--json"}, nil)
+		response := decodeSingleInvocationResponse(t, result.stdout)
+		if response.Status != factoryapi.InvocationTerminalStatusCompleted {
+			t.Fatalf("status = %q, want %q", response.Status, factoryapi.InvocationTerminalStatusCompleted)
+		}
+		assertInvocationPrimaryResultText(t, response, wantPrimaryResult)
+		assertSuccessfulRunStderrEmpty(t, result.stderr)
+	})
+
+	t.Run("NDJSON response-stream invocation_result", func(t *testing.T) {
+		result := executeSuccessfulRun(t, []string{"--json"}, []string{"--output", "response-stream"})
+		terminal := decodeTerminalNDJSONInvocationResult(t, result.stdout)
+		if terminal.RecordType != invocationResultType {
+			t.Fatalf("terminal recordType = %q, want %q", terminal.RecordType, invocationResultType)
+		}
+		if terminal.Response.Status != factoryapi.InvocationTerminalStatusCompleted {
+			t.Fatalf("status = %q, want %q", terminal.Response.Status, factoryapi.InvocationTerminalStatusCompleted)
+		}
+		assertInvocationPrimaryResultText(t, terminal.Response, wantPrimaryResult)
+		assertSuccessfulRunStderrEmpty(t, result.stderr)
+	})
+}
+
+type successfulRunResult struct {
+	stdout string
+	stderr string
+}
+
+func executeSuccessfulRun(t *testing.T, globalArgs, runArgs []string) successfulRunResult {
+	t.Helper()
+
+	factoryDir := scaffoldProviderBackedFactory(t)
+	factoryPath := filepath.Join(factoryDir, interfaces.FactoryConfigFile)
+
+	edges := serviceedges.Edges{}
+	support.ConfigureWorkerCommands(t, &edges, support.NewStaticSuccessCommandRunner(wantPrimaryResult), nil)
+
+	args := []string{"you"}
+	args = append(args, globalArgs...)
+	args = append(args,
+		"run",
+		"--factory", factoryPath,
+		"--no-record",
+	)
+	args = append(args, runArgs...)
+	args = append(args, "prove workers-owned output modes")
+
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.WorkingDirectory = factoryDir
+	if err := support.BuildProcess(t, edges).Execute(inputs.Input); err != nil {
+		t.Fatalf("Process.Execute(%v) error = %v\nstdout:\n%s\nstderr:\n%s", args, err, inputs.Stdout(), inputs.Stderr())
+	}
+	return successfulRunResult{stdout: inputs.Stdout(), stderr: inputs.Stderr()}
+}
+
+func scaffoldProviderBackedFactory(t *testing.T) string {
+	t.Helper()
+
+	cfg := map[string]any{
+		"workTypes": []map[string]any{{
+			"name": "task",
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "complete", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+			"handlingBehavior": []string{"DEFAULT"},
+		}},
+		"workers": []map[string]string{{"name": "worker-a"}},
+		"workstations": []map[string]any{{
+			"name":      "process",
+			"worker":    "worker-a",
+			"inputs":    []map[string]string{{"workType": "task", "state": "init"}},
+			"outputs":   []map[string]string{{"workType": "task", "state": "complete"}},
+			"onFailure": []map[string]string{{"workType": "task", "state": "failed"}},
+		}},
+	}
+	dir := support.ScaffoldFactory(t, cfg)
+	support.WriteAgentConfig(t, dir, "worker-a", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"))
+	return dir
+}
+
+func assertSuccessfulRunStderrEmpty(t *testing.T, stderr string) {
+	t.Helper()
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty successful-run stderr", stderr)
+	}
+}
+
+func decodeSingleInvocationResponse(t *testing.T, stdout string) factoryapi.InvocationResponse {
+	t.Helper()
+	decoder := json.NewDecoder(strings.NewReader(stdout))
+	var response factoryapi.InvocationResponse
+	if err := decoder.Decode(&response); err != nil {
+		t.Fatalf("decode InvocationResponse: %v\nstdout:\n%s", err, stdout)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		t.Fatalf("stdout contains data after InvocationResponse: %v\nstdout:\n%s", err, stdout)
+	}
+	return response
+}
+
+type ndjsonTerminalInvocationResult struct {
+	RecordType string
+	Response   factoryapi.InvocationResponse
+}
+
+func decodeTerminalNDJSONInvocationResult(t *testing.T, stdout string) ndjsonTerminalInvocationResult {
+	t.Helper()
+	lines := nonEmptyLines(stdout)
+	if len(lines) == 0 {
+		t.Fatalf("stdout empty, want NDJSON stream ending in invocation_result\nstdout:\n%s", stdout)
+	}
+
+	var terminal ndjsonTerminalInvocationResult
+	for index, line := range lines {
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(line), &fields); err != nil {
+			t.Fatalf("decode NDJSON record %d: %v\nline: %s", index, err, line)
+		}
+		var recordType string
+		if err := json.Unmarshal(fields["recordType"], &recordType); err != nil {
+			t.Fatalf("decode recordType for record %d: %v\nline: %s", index, err, line)
+		}
+		if recordType != invocationResultType {
+			if recordType != factoryEventRecordType {
+				t.Fatalf("record %d recordType = %q, want %q or %q", index, recordType, factoryEventRecordType, invocationResultType)
+			}
+			continue
+		}
+		if index != len(lines)-1 {
+			t.Fatalf("invocation_result record index = %d, want terminal index %d", index, len(lines)-1)
+		}
+		if err := json.Unmarshal(fields["response"], &terminal.Response); err != nil {
+			t.Fatalf("decode terminal invocation result %d: %v\nline: %s", index, err, line)
+		}
+		terminal.RecordType = recordType
+	}
+	if terminal.RecordType == "" {
+		t.Fatalf("stdout missing terminal invocation_result\nstdout:\n%s", stdout)
+	}
+	return terminal
+}
+
+func assertInvocationPrimaryResultText(t *testing.T, response factoryapi.InvocationResponse, want string) {
+	t.Helper()
+	if response.PrimaryResult == nil || len(*response.PrimaryResult) != 1 {
+		t.Fatalf("primaryResult = %#v, want one text content part", response.PrimaryResult)
+	}
+	part, err := (*response.PrimaryResult)[0].AsWorkTextContentPart()
+	if err != nil {
+		t.Fatalf("primaryResult[0] as text content: %v", err)
+	}
+	if part.Text != want {
+		t.Fatalf("primaryResult text = %q, want %q", part.Text, want)
+	}
+}
+
+func nonEmptyLines(value string) []string {
+	var lines []string
+	for _, line := range strings.Split(value, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}

--- a/tests/functional/workers/transports/cli/run/modes/output_modes_test.go
+++ b/tests/functional/workers/transports/cli/run/modes/output_modes_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
@@ -15,9 +16,11 @@ import (
 )
 
 const (
-	wantPrimaryResult        = "deterministic workers primary COMPLETE"
-	factoryEventRecordType   = "factory_event"
-	invocationResultType     = "invocation_result"
+	wantPrimaryResult                 = "deterministic workers primary COMPLETE"
+	deterministicProviderFailureExit  = 7
+	deterministicProviderFailureStderr = "deterministic provider rejection"
+	factoryEventRecordType            = "factory_event"
+	invocationResultType              = "invocation_result"
 )
 
 // TestCLIRunSuccessPrimaryResultTextJSONAndNDJSON proves a successful public
@@ -56,6 +59,54 @@ func TestCLIRunSuccessPrimaryResultTextJSONAndNDJSON(t *testing.T) {
 	})
 }
 
+// TestCLIRunFailureOmitsFalseSuccessPrimaryResult proves a failed public you run
+// invocation never writes a completed-success primary result to stdout in quiet
+// text or machine-readable presentations, while stderr still follows the documented
+// structured failure contract for JSON modes.
+func TestCLIRunFailureOmitsFalseSuccessPrimaryResult(t *testing.T) {
+	t.Run("quiet text omits success primary result", func(t *testing.T) {
+		result, err := executeFailedRun(t, nil, []string{"--quiet"})
+		if err == nil {
+			t.Fatal("Process.Execute error = nil, want terminal invocation failure")
+		}
+		if strings.TrimSpace(result.stdout) != "" {
+			t.Fatalf("stdout = %q, want empty quiet failure stdout without false primary result", result.stdout)
+		}
+		if strings.TrimSpace(result.stderr) == "" {
+			t.Fatal("stderr was empty; want actionable failure diagnostic without stdout noise")
+		}
+	})
+
+	t.Run("single JSON failed InvocationResponse", func(t *testing.T) {
+		result, err := executeFailedRun(t, []string{"--json"}, nil)
+		if err == nil {
+			t.Fatal("Process.Execute error = nil, want terminal invocation failure")
+		}
+		response := decodeSingleInvocationResponse(t, result.stdout)
+		assertFailedInvocationResponse(t, response)
+		assertFailedRunErrorResponse(t, result.stderr, response)
+		if invocationPrimaryResultPresent(response) {
+			t.Fatalf("primaryResult = %#v, want no success primary result on terminal failure", response.PrimaryResult)
+		}
+	})
+
+	t.Run("NDJSON response-stream failed invocation_result", func(t *testing.T) {
+		result, err := executeFailedRun(t, []string{"--json"}, []string{"--output", "response-stream"})
+		if err == nil {
+			t.Fatal("Process.Execute error = nil, want terminal invocation failure")
+		}
+		terminal := decodeTerminalNDJSONInvocationResult(t, result.stdout)
+		if terminal.RecordType != invocationResultType {
+			t.Fatalf("terminal recordType = %q, want %q", terminal.RecordType, invocationResultType)
+		}
+		assertFailedInvocationResponse(t, terminal.Response)
+		assertFailedRunErrorResponse(t, result.stderr, terminal.Response)
+		if invocationPrimaryResultPresent(terminal.Response) {
+			t.Fatalf("primaryResult = %#v, want no success primary result on terminal failure", terminal.Response.PrimaryResult)
+		}
+	})
+}
+
 type successfulRunResult struct {
 	stdout string
 	stderr string
@@ -86,6 +137,40 @@ func executeSuccessfulRun(t *testing.T, globalArgs, runArgs []string) successful
 		t.Fatalf("Process.Execute(%v) error = %v\nstdout:\n%s\nstderr:\n%s", args, err, inputs.Stdout(), inputs.Stderr())
 	}
 	return successfulRunResult{stdout: inputs.Stdout(), stderr: inputs.Stderr()}
+}
+
+type failedRunResult struct {
+	stdout string
+	stderr string
+}
+
+func executeFailedRun(t *testing.T, globalArgs, runArgs []string) (failedRunResult, error) {
+	t.Helper()
+
+	factoryDir := scaffoldProviderBackedFactory(t)
+	factoryPath := filepath.Join(factoryDir, interfaces.FactoryConfigFile)
+
+	runner := support.NewShapedProviderCommandRunner(platformprocess.CommandResult{
+		ExitCode: deterministicProviderFailureExit,
+		Stderr:   []byte(deterministicProviderFailureStderr),
+	})
+	edges := serviceedges.Edges{}
+	support.ConfigureWorkerCommands(t, &edges, runner, nil)
+
+	args := []string{"you"}
+	args = append(args, globalArgs...)
+	args = append(args,
+		"run",
+		"--factory", factoryPath,
+		"--no-record",
+	)
+	args = append(args, runArgs...)
+	args = append(args, "prove workers-owned failure output modes")
+
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.WorkingDirectory = factoryDir
+	err := support.BuildProcess(t, edges).Execute(inputs.Input)
+	return failedRunResult{stdout: inputs.Stdout(), stderr: inputs.Stderr()}, err
 }
 
 func scaffoldProviderBackedFactory(t *testing.T) string {
@@ -175,6 +260,47 @@ func decodeTerminalNDJSONInvocationResult(t *testing.T, stdout string) ndjsonTer
 		t.Fatalf("stdout missing terminal invocation_result\nstdout:\n%s", stdout)
 	}
 	return terminal
+}
+
+func assertFailedInvocationResponse(t *testing.T, response factoryapi.InvocationResponse) {
+	t.Helper()
+	if response.Status != factoryapi.InvocationTerminalStatusFailed {
+		t.Fatalf("status = %q, want %q", response.Status, factoryapi.InvocationTerminalStatusFailed)
+	}
+	if response.ErrorCode == nil || response.Message == nil {
+		t.Fatalf("failed InvocationResponse lacks error detail: %#v", response)
+	}
+}
+
+func assertFailedRunErrorResponse(
+	t *testing.T,
+	stderr string,
+	response factoryapi.InvocationResponse,
+) {
+	t.Helper()
+	errorResponse := decodeSingleErrorResponse(t, stderr)
+	if errorResponse.Code != factoryapi.ErrorResponseCode(*response.ErrorCode) ||
+		errorResponse.Family != factoryapi.ErrorFamilyInternalServerError ||
+		!strings.HasPrefix(errorResponse.Message, *response.Message) {
+		t.Fatalf("ErrorResponse = %#v, want code %s and message prefix %q", errorResponse, *response.ErrorCode, *response.Message)
+	}
+}
+
+func decodeSingleErrorResponse(t *testing.T, stderr string) factoryapi.ErrorResponse {
+	t.Helper()
+	decoder := json.NewDecoder(strings.NewReader(stderr))
+	var response factoryapi.ErrorResponse
+	if err := decoder.Decode(&response); err != nil {
+		t.Fatalf("decode ErrorResponse: %v\nstderr:\n%s", err, stderr)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		t.Fatalf("stderr contains data after ErrorResponse: %v\nstderr:\n%s", err, stderr)
+	}
+	return response
+}
+
+func invocationPrimaryResultPresent(response factoryapi.InvocationResponse) bool {
+	return response.PrimaryResult != nil && len(*response.PrimaryResult) > 0
 }
 
 func assertInvocationPrimaryResultText(t *testing.T, response factoryapi.InvocationResponse, want string) {


### PR DESCRIPTION
{
  "project": "Workers Run CLI Output Modes Depth",
  "branchName": "ft-depth-workers-transports-cli-run-modes",
  "description": "Implement the workers-owned functional cell at tests/functional/workers/transports/cli/run/modes/output_modes_test.go so successful you run invocations prove primary-result fidelity across text, single-JSON, and NDJSON presentations, and failed invocations omit false-success primary results, migrating strengthened intent from legacy cli/factory_run/output without owning run/help or yaml_io_parity.",
  "context": {
    "customerAsk": "Read and follow docs/temp/functional-tests-expansion/cli-run-submit-factory-petri-depth-plan.md. Implement only tests/functional/workers/transports/cli/run/modes/output_modes_test.go (not root transport/cli or legacy cli/factory_run as owner). Construct via root.BuildProcess + Process.Execute; prefer public CLI; ProviderCommandRunner / mocked Codex over MockWorkers. Prove: (1) TestCLIRunSuccessPrimaryResultTextJSONAndNDJSON; (2) TestCLIRunFailureOmitsFalseSuccessPrimaryResult. May strengthen/migrate behavioral intent from tests/functional/cli/factory_run/output/ without expanding scope to yaml_io_parity. Do not implement run/help. No sleeps unless RC-justified. Go docs on every Test*; focused tests + functional-boundary-check + viz metadata.",
    "problem": "Legacy cli/factory_run/output holds run output-mode behavior in a CLI-rooted catch-all, while pkg/transports/cli/run coverage is thin relative to the documented you docs run presentation contract. Maintainers lack an independent workers-owned cell proving success primary-result fidelity across text/JSON/NDJSON and failure omission of false-success primary results without colliding with run/help.",
    "solution": "Add tests/functional/workers/transports/cli/run/modes/output_modes_test.go under the service-mirrored workers owner. Drive public you run through root.BuildProcess + Process.Execute, replace external effects via edges.Edges with ProviderCommandRunner / mocked Codex preferred over MockWorkers, prove the two named Test* behaviors (strengthening legacy output intent as needed), keep run/help and yaml_io_parity out of scope, and close focused package tests plus functional-boundary-check and viz-compatible metadata."
  },
  "acceptanceCriteria": [
    "tests/functional/workers/transports/cli/run/modes/output_modes_test.go exists as the workers-owned functional cell and contains TestCLIRunSuccessPrimaryResultTextJSONAndNDJSON and TestCLIRunFailureOmitsFalseSuccessPrimaryResult (or stronger equivalents of those named intents).",
    "A successful public you run proves primary-result fidelity across text (default and/or quiet raw), single-JSON (--json without --output response-stream), and NDJSON (--json --output response-stream) presentations, matching the documented contract in you docs run.",
    "A failed public you run omits any false-success primary result: terminal failure does not emit a completed-success primary payload, and quiet failure writes no success terminal value; stderr still follows the documented structured failure contract.",
    "Coverage constructs via root.BuildProcess + Process.Execute, prefers public CLI, replaces external effects only through edges.Edges with ProviderCommandRunner / mocked Codex preferred over MockWorkers, and asserts public CLI / Work / Factory Session / Factory Event outcomes only (no service-implementation or internal Petri-net imports as proof owners).",
    "Every top-level Test* has a customer-readable Go doc comment; the cell does not implement run/help, does not expand into yaml_io_parity, and uses no sleeps unless an RC justifies them.",
    "Focused package tests for tests/functional/workers/transports/cli/run/modes, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-depth-workers-transports-cli-run-modes-001",
      "title": "Prove success primary result across text, JSON, and NDJSON",
      "description": "As an automation customer or maintainer, I want a workers-owned functional proof that a successful you run emits the Factory's primary result correctly in text, single-JSON, and NDJSON modes, so scripts and humans can rely on a stable presentation contract at the public CLI boundary.",
      "acceptanceCriteria": [
        "tests/functional/workers/transports/cli/run/modes/output_modes_test.go includes TestCLIRunSuccessPrimaryResultTextJSONAndNDJSON (or a stronger top-level equivalent preserving that intent).",
        "The test constructs the process via root.BuildProcess / Process.Execute (or the public functional support wrapper for that path) and invokes public you run args.",
        "External effects are replaced only through edges.Edges, preferring ProviderCommandRunner / mocked Codex over --with-mock-workers / MockWorkers.",
        "Default/text success path writes the deterministic primary result to stdout per the documented primary-result contract (quiet raw primary result may be used as the text presentation proof).",
        "Single-JSON success (--json without --output response-stream) writes exactly one InvocationResponse with completed terminal status whose public primary result matches the same deterministic value; a second decode reaches EOF.",
        "NDJSON success (--json --output response-stream) ends with a terminal recordType=invocation_result whose nested response is completed and carries the same public primary result.",
        "Successful paths under test leave stderr empty (or otherwise free of structured error responses).",
        "Assertions use public CLI / contract outcomes only and do not import service implementations or internal Petri packages as the proof owner.",
        "The top-level test has a customer-readable Go doc comment whose first sentence describes the observable multi-mode success behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-depth-workers-transports-cli-run-modes-002",
      "title": "Prove failure omits false-success primary result",
      "description": "As an automation customer handling failed runs, I want proof that a failed you run never presents a false-success primary result, so downstream scripts do not treat a failed invocation as a successful terminal value.",
      "acceptanceCriteria": [
        "The modes cell includes TestCLIRunFailureOmitsFalseSuccessPrimaryResult (or a stronger top-level equivalent preserving that intent).",
        "Through the public CLI/Process.Execute boundary with ProviderCommandRunner / mocked Codex preferred over MockWorkers, a deterministic terminal (or equivalent) run failure exits unsuccessfully.",
        "Quiet / primary-result presentation on failure writes no success terminal primary-result value to stdout.",
        "Structured JSON and/or NDJSON failure presentation (at least one machine-readable mode covered by this cell) does not emit a completed success InvocationResponse primary-result payload; when a terminal failed InvocationResponse is written, its status is failed and it is not treated as success primary output.",
        "Failure still writes exactly one stderr ErrorResponse JSON object per the documented invocation-failure contract for the exercised mode(s).",
        "Behavioral intent may be strengthened or migrated from legacy tests/functional/cli/factory_run/output/ failure scenarios, but ownership remains under workers/transports/cli/run/modes/ and does not expand into yaml_io_parity, human lifecycle catalog ownership, or run/help.",
        "The top-level test has a customer-readable Go doc comment describing the observable false-success omission behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-depth-workers-transports-cli-run-modes-003",
      "title": "Close modes-cell verification and ownership gates",
      "description": "As a maintainer executing the CLI run/submit/factory + Petri depth cohort, I want the workers run modes cell to pass focused package, boundary, and viz-metadata gates under the correct owner path, so the depth cohort catalog stays accurate without colliding with run/help or legacy CLI catch-alls.",
      "acceptanceCriteria": [
        "The destination package lives only under tests/functional/workers/transports/cli/run/modes/ (no new ownership under root transport/cli or catch-all cli/).",
        "run/help is not implemented in this lane; yaml_io_parity and other held replenishes remain out of scope.",
        "Any migration/strengthen steps from tests/functional/cli/factory_run/output/ leave unmigrated legacy neighbors compiling and do not delete unrelated obligations.",
        "No sleeps or timeout-padded wait helpers are introduced unless an RC justifies them.",
        "Focused package tests for ./tests/functional/workers/transports/cli/run/modes/... pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred under workers/transports/cli/run/modes).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)