### PR TITLE
ft-depth-workers-transports-cli-run-help

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -306,6 +306,19 @@
   Catalog metadata infers domain `workers` and subsection `mock` from the path;
   every top-level `Test*` needs a customer-readable Go doc so
   `functionaltestmetadata` stays viz-compatible.
+  Workers CLI run invocation-help functional coverage belongs in
+  `tests/functional/workers/transports/cli/run/help/invocation_help_test.go`:
+  prove Factory invocation signature help for `you run --named <factory> --help`
+  through `support.BuildProcess` + `support.FakeInputs` with
+  `HOME`/`USERPROFILE` pinned to the seeded named-factory catalog; prove
+  required vs optional parameter labels and usage tokens from observable stdout
+  only; prove read-only help with
+  `serviceedges.Edges{ProviderCommandRunner: testutil.NewProviderCommandRunner()}`
+  and zero provider dispatch. Substitute external effects only through
+  `edges.Edges`; do not use `--with-mock-workers` for this cell. Catalog
+  metadata infers domain `workers` and subsection `transports` from the path;
+  every top-level `Test*` needs a customer-readable Go doc so
+  `functionaltestmetadata` stays viz-compatible.
   Packaged `@you/subagent` invocation functional coverage belongs in
   `tests/functional/factory/packaged/subagent/invocation_test.go`: prove child
   primary-result return through public CLI JSON and hermetic no-server named

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -1954,6 +1954,16 @@ response-stream output.
   Keep usage lines, parameter descriptions, defaults, accepted values, output
   hints, and example rendering derived from `interfaces.InvocationSignatureConfig`
   instead of hard-coding packaged-factory argument inventories in CLI help.
+- Functional ownership for Factory-aware `you run` invocation help belongs in
+  `tests/functional/workers/transports/cli/run/help/invocation_help_test.go`:
+  prove named-Factory signature help, required vs optional parameter distinction,
+  and read-only no-dispatch guarantees through `support.BuildProcess` +
+  `Process.Execute` on `you run --named <factory> --help`; seed factories with
+  `support.ScaffoldFactory` and `support.CreateNamedFactory`; install
+  `testutil.NewProviderCommandRunner` via `serviceedges.Edges` for no-dispatch
+  proofs. Do not place this coverage under root `pkg/transports/cli` or catch-all
+  `tests/functional/cli/`; package-level renderer regressions remain in
+  `pkg/transports/cli/run/run_invocation_test.go`.
 - `docs/reference/run.md` (`you docs run`) owns supported `@you/fusion`
   invocation and signature-aware help. Factory materialization, examples, and
   edit-after-materialize behavior belong in

--- a/tests/functional/workers/transports/cli/run/help/doc.go
+++ b/tests/functional/workers/transports/cli/run/help/doc.go
@@ -1,0 +1,3 @@
+// Package help owns functional coverage for Factory-aware you run invocation
+// help through the public CLI and root.BuildProcess customer process boundary.
+package help

--- a/tests/functional/workers/transports/cli/run/help/invocation_help_test.go
+++ b/tests/functional/workers/transports/cli/run/help/invocation_help_test.go
@@ -76,6 +76,139 @@ func TestCLIRunHelpShowsInvocationSignatureForNamedFactory(t *testing.T) {
 	}
 }
 
+// TestCLIRunHelpDistinguishesRequiredAndOptionalParameters proves you run --named
+// <factory> --help visibly marks required and optional invocationSignature
+// parameters so operators know which arguments they must supply before a run.
+func TestCLIRunHelpDistinguishesRequiredAndOptionalParameters(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	workingDirectory := t.TempDir()
+	sourceDir := support.ScaffoldFactory(t, invocationHelpFactoryConfig())
+	support.CreateNamedFactory(
+		t,
+		homeDir,
+		workingDirectory,
+		invocationHelpNamedFactoryName,
+		filepath.Join(sourceDir, interfaces.FactoryConfigFile),
+	)
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "run",
+		"--named", invocationHelpNamedFactoryName,
+		"--help",
+	})
+	inputs.Input.Env = append(inputs.Input.Env, "HOME="+homeDir, "USERPROFILE="+homeDir)
+	inputs.Input.WorkingDirectory = workingDirectory
+
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(run --named %s --help) error = %v\nstdout:\n%s\nstderr:\n%s",
+			invocationHelpNamedFactoryName,
+			err,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+
+	got := inputs.Stdout()
+	usageLine := invocationHelpUsageLine(t, got)
+	if !strings.Contains(usageLine, "<"+invocationHelpRequiredParameter+">") {
+		t.Fatalf("usage line missing required token %q:\n%s", invocationHelpRequiredParameter, usageLine)
+	}
+	if strings.Contains(usageLine, "[<"+invocationHelpRequiredParameter+">]") {
+		t.Fatalf("required parameter %q must not be bracketed in usage:\n%s", invocationHelpRequiredParameter, usageLine)
+	}
+	for _, optionalParameter := range []string{
+		invocationHelpOptionalParameter,
+		invocationHelpOptionalPathParameter,
+	} {
+		if !strings.Contains(usageLine, "[--"+optionalParameter) {
+			t.Fatalf("usage line missing bracketed optional token for %q:\n%s", optionalParameter, usageLine)
+		}
+	}
+
+	assertInvocationHelpParameterRequirement(t, got, invocationHelpRequiredParameter, true)
+	assertInvocationHelpParameterRequirement(t, got, invocationHelpOptionalParameter, false)
+	assertInvocationHelpParameterRequirement(t, got, invocationHelpOptionalPathParameter, false)
+}
+
+func invocationHelpUsageLine(t *testing.T, help string) string {
+	t.Helper()
+
+	const usagePrefix = "Usage:\n  "
+	start := strings.Index(help, usagePrefix)
+	if start < 0 {
+		t.Fatalf("help missing usage section:\n%s", help)
+	}
+	rest := help[start+len(usagePrefix):]
+	end := strings.Index(rest, "\n")
+	if end < 0 {
+		return rest
+	}
+	return rest[:end]
+}
+
+func assertInvocationHelpParameterRequirement(t *testing.T, help, parameter string, required bool) {
+	t.Helper()
+
+	marker := "Factory-defined arguments:"
+	start := strings.Index(help, marker)
+	if start < 0 {
+		t.Fatalf("help missing %q section:\n%s", marker, help)
+	}
+	argumentsSection := help[start+len(marker):]
+	if end := strings.Index(argumentsSection, "\n\n"); end >= 0 {
+		argumentsSection = argumentsSection[:end]
+	}
+
+	parameterSection, ok := invocationHelpParameterSection(argumentsSection, parameter)
+	if !ok {
+		t.Fatalf("help missing parameter %q:\n%s", parameter, help)
+	}
+
+	if required {
+		if !strings.Contains(parameterSection, "Required.") {
+			t.Fatalf("parameter %q missing Required. label:\n%s", parameter, parameterSection)
+		}
+		if strings.Contains(parameterSection, "\n    Optional.") {
+			t.Fatalf("parameter %q incorrectly marked optional:\n%s", parameter, parameterSection)
+		}
+		return
+	}
+	if !strings.Contains(parameterSection, "Optional.") {
+		t.Fatalf("parameter %q missing Optional. label:\n%s", parameter, parameterSection)
+	}
+}
+
+func invocationHelpParameterSection(argumentsSection, parameter string) (string, bool) {
+	lines := strings.Split(argumentsSection, "\n")
+	for index, line := range lines {
+		if !strings.HasPrefix(line, "  ") || strings.HasPrefix(line, "    ") {
+			continue
+		}
+		if !invocationHelpParameterHeaderMatches(line, parameter) {
+			continue
+		}
+		block := []string{line}
+		for _, detail := range lines[index+1:] {
+			if strings.HasPrefix(detail, "  ") && !strings.HasPrefix(detail, "    ") {
+				break
+			}
+			block = append(block, detail)
+		}
+		return strings.Join(block, "\n"), true
+	}
+	return "", false
+}
+
+func invocationHelpParameterHeaderMatches(headerLine, parameter string) bool {
+	return strings.Contains(headerLine, "<"+parameter+">") ||
+		strings.Contains(headerLine, "--"+parameter+" ") ||
+		strings.Contains(headerLine, "--"+parameter+"|")
+}
+
 func invocationHelpFactoryConfig() map[string]any {
 	return map[string]any{
 		"name": invocationHelpFactoryConfigName,

--- a/tests/functional/workers/transports/cli/run/help/invocation_help_test.go
+++ b/tests/functional/workers/transports/cli/run/help/invocation_help_test.go
@@ -1,0 +1,151 @@
+package help_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	invocationHelpNamedFactoryName    = "invocation-help-alpha"
+	invocationHelpFactoryConfigName   = "invocation-help-portable"
+	invocationHelpWorkTypeName        = "help-task"
+	invocationHelpRequiredParameter   = "input"
+	invocationHelpOptionalParameter   = "mode"
+	invocationHelpOptionalPathParameter = "artifact"
+)
+
+// TestCLIRunHelpShowsInvocationSignatureForNamedFactory proves you run --named
+// <factory> --help prints Factory invocation help for the selected named Factory,
+// including signature usage and the factory-defined argument surface customers
+// use to compose a run command without starting Work.
+func TestCLIRunHelpShowsInvocationSignatureForNamedFactory(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	workingDirectory := t.TempDir()
+	sourceDir := support.ScaffoldFactory(t, invocationHelpFactoryConfig())
+	support.CreateNamedFactory(
+		t,
+		homeDir,
+		workingDirectory,
+		invocationHelpNamedFactoryName,
+		filepath.Join(sourceDir, interfaces.FactoryConfigFile),
+	)
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "run",
+		"--named", invocationHelpNamedFactoryName,
+		"--help",
+	})
+	inputs.Input.Env = append(inputs.Input.Env, "HOME="+homeDir, "USERPROFILE="+homeDir)
+	inputs.Input.WorkingDirectory = workingDirectory
+
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(run --named %s --help) error = %v\nstdout:\n%s\nstderr:\n%s",
+			invocationHelpNamedFactoryName,
+			err,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+
+	got := inputs.Stdout()
+	for _, want := range []string{
+		"Factory invocation help",
+		"Selected factory: " + invocationHelpFactoryConfigName + " (named factory " + invocationHelpNamedFactoryName + ")",
+		"Usage:\n  you run --named " + invocationHelpNamedFactoryName + " <" + invocationHelpRequiredParameter + "> [--" + invocationHelpOptionalPathParameter + " <file-path>] [--" + invocationHelpOptionalParameter + " <value>]",
+		"Factory-defined arguments:",
+		invocationHelpRequiredParameter,
+		invocationHelpOptionalParameter,
+		invocationHelpOptionalPathParameter,
+		"you run --named " + invocationHelpNamedFactoryName + " 'Fix the lint issues' --" + invocationHelpOptionalPathParameter + " report.md --" + invocationHelpOptionalParameter + " safe",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("run --named %s --help missing %q:\n%s", invocationHelpNamedFactoryName, want, got)
+		}
+	}
+	if strings.Contains(got, "Load workflow and run the factory engine") {
+		t.Fatalf("expected signature-aware help instead of generic Cobra help:\n%s", got)
+	}
+}
+
+func invocationHelpFactoryConfig() map[string]any {
+	return map[string]any{
+		"name": invocationHelpFactoryConfigName,
+		"invocationSignature": map[string]any{
+			"parameters": []any{
+				map[string]any{
+					"name":        invocationHelpRequiredParameter,
+					"description": "Primary text input for the portable factory.",
+					"required":    true,
+					"bindings": []any{
+						map[string]any{"kind": "POSITIONAL", "position": 1},
+						map[string]any{"kind": "STDIN"},
+					},
+				},
+				map[string]any{
+					"name":         invocationHelpOptionalParameter,
+					"description":  "Execution mode for the portable factory.",
+					"choices":        []any{"fast", "safe"},
+					"defaultValue": "safe",
+					"bindings":     []any{map[string]any{"kind": "NAMED"}},
+				},
+				map[string]any{
+					"name":        invocationHelpOptionalPathParameter,
+					"description": "Optional output file path.",
+					"aliases":     []any{"out"},
+					"typeHint":    "FILE_PATH",
+					"bindings":    []any{map[string]any{"kind": "NAMED"}},
+				},
+			},
+			"outputContract": map[string]any{
+				"mode":          "FILE",
+				"pathParameter": invocationHelpOptionalPathParameter,
+				"contentType":   "text/plain",
+				"fileExtension": ".txt",
+			},
+			"examples": []any{
+				map[string]any{
+					"name": "positional-input",
+					"argv": []any{
+						"Fix the lint issues",
+						"--" + invocationHelpOptionalParameter,
+						"safe",
+						"--" + invocationHelpOptionalPathParameter,
+						"report.md",
+					},
+				},
+			},
+		},
+		"workTypes": []any{
+			map[string]any{
+				"name":             invocationHelpWorkTypeName,
+				"handlingBehavior": []any{"DEFAULT"},
+				"states": []any{
+					map[string]any{"name": "init", "type": "INITIAL"},
+					map[string]any{"name": "complete", "type": "TERMINAL"},
+					map[string]any{"name": "failed", "type": "FAILED"},
+				},
+			},
+		},
+		"workers": []any{
+			map[string]any{"name": "mock-worker"},
+		},
+		"workstations": []map[string]any{
+			{
+				"name":      "process-prompt",
+				"worker":    "mock-worker",
+				"inputs":    []any{map[string]any{"workType": invocationHelpWorkTypeName, "state": "init"}},
+				"outputs":   []any{map[string]any{"workType": invocationHelpWorkTypeName, "state": "complete"}},
+				"onFailure": []any{map[string]any{"workType": invocationHelpWorkTypeName, "state": "failed"}},
+			},
+		},
+	}
+}

--- a/tests/functional/workers/transports/cli/run/help/invocation_help_test.go
+++ b/tests/functional/workers/transports/cli/run/help/invocation_help_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/portpowered/infinite-you/internal/testutil"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
@@ -132,6 +133,60 @@ func TestCLIRunHelpDistinguishesRequiredAndOptionalParameters(t *testing.T) {
 	assertInvocationHelpParameterRequirement(t, got, invocationHelpRequiredParameter, true)
 	assertInvocationHelpParameterRequirement(t, got, invocationHelpOptionalParameter, false)
 	assertInvocationHelpParameterRequirement(t, got, invocationHelpOptionalPathParameter, false)
+}
+
+// TestCLIRunHelpDoesNotDispatchExternalWork proves you run --named <factory>
+// --help completes as read-only Factory invocation discovery without invoking
+// external provider command execution or worker dispatch.
+func TestCLIRunHelpDoesNotDispatchExternalWork(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	workingDirectory := t.TempDir()
+	sourceDir := support.ScaffoldFactory(t, invocationHelpFactoryConfig())
+	support.CreateNamedFactory(
+		t,
+		homeDir,
+		workingDirectory,
+		invocationHelpNamedFactoryName,
+		filepath.Join(sourceDir, interfaces.FactoryConfigFile),
+	)
+
+	runner := testutil.NewProviderCommandRunner()
+	process := support.BuildProcess(t, serviceedges.Edges{
+		ProviderCommandRunner: runner,
+	})
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "run",
+		"--named", invocationHelpNamedFactoryName,
+		"--help",
+	})
+	inputs.Input.Env = append(inputs.Input.Env, "HOME="+homeDir, "USERPROFILE="+homeDir)
+	inputs.Input.WorkingDirectory = workingDirectory
+
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(run --named %s --help) error = %v\nstdout:\n%s\nstderr:\n%s",
+			invocationHelpNamedFactoryName,
+			err,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+	if runner.CallCount() != 0 {
+		t.Fatalf(
+			"provider command runner call count = %d, want 0 for read-only run help",
+			runner.CallCount(),
+		)
+	}
+
+	got := inputs.Stdout()
+	if !strings.Contains(got, "Factory invocation help") {
+		t.Fatalf("run --named %s --help missing Factory invocation help:\n%s", invocationHelpNamedFactoryName, got)
+	}
+	if !strings.Contains(got, "Selected factory: "+invocationHelpFactoryConfigName+" (named factory "+invocationHelpNamedFactoryName+")") {
+		t.Fatalf("run --named %s --help missing selected factory line:\n%s", invocationHelpNamedFactoryName, got)
+	}
 }
 
 func invocationHelpUsageLine(t *testing.T, help string) string {


### PR DESCRIPTION
{
  "project": "Workers Run CLI Invocation Help Depth",
  "branchName": "ft-depth-workers-transports-cli-run-help",
  "description": "Implement only tests/functional/workers/transports/cli/run/help/invocation_help_test.go to prove you run --named … --help renders Factory invocation signature help, distinguishes required vs optional parameters, and does not dispatch external work, via root.BuildProcess + Process.Execute under workers service-mirrored ownership.",
  "context": {
    "customerAsk": "Read and follow docs/temp/functional-tests-expansion/cli-run-submit-factory-petri-depth-plan.md. Implement only tests/functional/workers/transports/cli/run/help/invocation_help_test.go (not root transport/cli). Construct via root.BuildProcess + Process.Execute; prefer public CLI; ProviderCommandRunner / mocked Codex over MockWorkers. Prove: (1) TestCLIRunHelpShowsInvocationSignatureForNamedFactory; (2) TestCLIRunHelpDistinguishesRequiredAndOptionalParameters; (3) TestCLIRunHelpDoesNotDispatchExternalWork. Do not implement run/modes. No sleeps unless RC-justified. Go docs on every Test*; focused tests + functional-boundary-check + viz metadata.",
    "problem": "Wave 1 run_wiring covers path/named/invalid Factory selection only, while pkg/transports/cli/run still has thin help/signature coverage. Maintainers lack a functional cell under the workers service-mirrored tree that proves Factory-aware invocation help through BuildProcess/Process.Execute, including required/optional distinction and a no-dispatch guarantee. Sibling run/modes must not be widened into this lane.",
    "solution": "Implement the three named scenarios in tests/functional/workers/transports/cli/run/help/invocation_help_test.go through the public you run CLI boundary via root.BuildProcess + Process.Execute. Seed a named Factory with required and optional invocationSignature parameters; assert customer-visible Factory invocation help; prove help does not invoke a failing ProviderCommandRunner / mocked-Codex edge; add customer-readable Go docs; verify focused package tests, functional-boundary-check, and viz-compatible metadata without implementing run/modes."
  },
  "acceptanceCriteria": [
    "tests/functional/workers/transports/cli/run/help/invocation_help_test.go exists under the workers service-mirrored tree (not root transport/cli) and covers the three named scenarios.",
    "Named-Factory help through the public CLI prints Factory invocation help that includes the selected named Factory and its invocation signature usage/parameter surface.",
    "Help output visibly marks required vs optional parameters for a Factory whose signature includes both kinds.",
    "Help completes without invoking the installed ProviderCommandRunner / mocked-Codex edge (no external work dispatch).",
    "Construction uses root.BuildProcess + Process.Execute; external effects are replaced only via edges.Edges; no MockWorkers / --with-mock-workers for this cell; no sleeps unless an in-code RC justification is present; run/modes is not implemented.",
    "Every top-level Test* has a customer-readable Go doc comment whose first sentence describes the observable CLI behavior.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-depth-workers-transports-cli-run-help-001",
      "title": "Prove named-Factory invocation signature help",
      "description": "As an operator or agent, I want you run --named <factory> --help to show the Factory’s invocation signature, so that I can compose a correct run command without starting Work.",
      "acceptanceCriteria": [
        "tests/functional/workers/transports/cli/run/help/invocation_help_test.go includes TestCLIRunHelpShowsInvocationSignatureForNamedFactory.",
        "The test constructs the process via root.BuildProcess + Process.Execute and invokes the public CLI you run --named <factory> --help against a seeded named Factory with an invocationSignature.",
        "Observable stdout includes Factory invocation help for the selected named Factory and renders the signature usage / factory-defined argument surface customers use to compose the run (for example parameter names and usage tokens present in the signature).",
        "Assertions stay on public CLI help outcomes; they do not import service implementations or internal Petri packages, and they do not claim run/modes ownership.",
        "The top-level test has a customer-readable Go doc comment describing the named-Factory invocation-signature help behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-depth-workers-transports-cli-run-help-002",
      "title": "Prove required vs optional parameter distinction",
      "description": "As an operator reading Factory-aware help, I want required and optional parameters to be visibly distinguished, so that I know which arguments I must supply before a successful run.",
      "acceptanceCriteria": [
        "The cell includes TestCLIRunHelpDistinguishesRequiredAndOptionalParameters.",
        "The scenario uses a named Factory whose invocationSignature includes at least one required and one optional parameter, invoked through root.BuildProcess + Process.Execute on the public CLI help path.",
        "Help output visibly marks the required parameter as required and the optional parameter as optional (customer-visible labels and/or required vs bracketed optional usage tokens consistent with public help rendering).",
        "Assertions prove the distinction from observable help text only; they do not scan source inventories or enforce command-registration tables.",
        "The top-level test has a customer-readable Go doc comment describing the required/optional distinction behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-depth-workers-transports-cli-run-help-003",
      "title": "Prove help does not dispatch external work",
      "description": "As a maintainer trusting help as a read-only discovery path, I want you run --named … --help to complete without calling external providers or workers, so that help never incurs side effects or provider spend.",
      "acceptanceCriteria": [
        "The cell includes TestCLIRunHelpDoesNotDispatchExternalWork.",
        "The test installs a ProviderCommandRunner / mocked-Codex edge via edges.Edges that fails the test if invoked (prefer command-runner edge mocks over MockWorkers / --with-mock-workers).",
        "Executing you run --named <factory> --help through root.BuildProcess + Process.Execute succeeds with Factory invocation help on stdout and does not invoke the provider command-runner edge.",
        "No wall-clock sleeps or timeout-padded wait helpers are introduced unless an in-code RC justification is present.",
        "The top-level test has a customer-readable Go doc comment describing the no-dispatch help guarantee.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-depth-workers-transports-cli-run-help-004",
      "title": "Close ownership and verification gates",
      "description": "As a maintainer executing the CLI run/submit/factory + Petri depth cohort, I want this help cell owned under workers/transports/cli/run/help and verified with focused boundary/viz gates, so the destination is catalogued correctly without implementing run/modes or root transport/cli ownership.",
      "acceptanceCriteria": [
        "New coverage lives only under tests/functional/workers/transports/cli/run/help/; no new ownership under root transport/cli or catch-all cli/; run/modes is not implemented in this task.",
        "Focused package tests for ./tests/functional/workers/transports/cli/run/help/... pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership under workers/transports/cli/run).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)