### PR TITLE
ft-depth-factory-runtime-petri-routing-multi-transition

### DIFF
--- a/docs/internal/baselines/package-structure-baseline.json
+++ b/docs/internal/baselines/package-structure-baseline.json
@@ -933,6 +933,21 @@
       "target": "bootstrap_portability"
     },
     {
+      "rule": "functional-test-unclassified-domain",
+      "filePath": "tests/functional/factory_runtime/orchestrators/petri/routing/doc.go",
+      "target": "factory_runtime"
+    },
+    {
+      "rule": "functional-test-unclassified-domain",
+      "filePath": "tests/functional/factory_runtime/orchestrators/petri/routing/helpers_test.go",
+      "target": "factory_runtime"
+    },
+    {
+      "rule": "functional-test-unclassified-domain",
+      "filePath": "tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go",
+      "target": "factory_runtime"
+    },
+    {
       "rule": "functional-test-missing-subsection",
       "filePath": "tests/functional/factory_visualization/activation_lifecycle_test.go",
       "target": "factory_visualization"

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -874,6 +874,15 @@ Wave 0 functional-tests-expansion planning authority lives under
   Go docs (plus `//golden:` on the success load test) so `functionaltestmetadata`
   stays viz-compatible.
 
+- `tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go`
+  owns service-mirrored Factory Runtime Petri multi-transition routing depth
+  through `support.RunFactoryToCompletionWithEdgesAndWork` and public Work /
+  session / Factory Event assertions only. Close catalog metadata with
+  `test-file-checklist.md`, `migration-ledger-inventory.json`,
+  `package-structure-baseline.json` entries for the `factory_runtime` domain
+  noun, and customer-readable Go docs on every top-level `Test*` so
+  `functionaltestmetadata` stays viz-compatible.
+
 - `tests/functional/automations/` owns root.BuildProcess evidence for packaged
   Automations cron scheduling and filesystem watcher preseed. Keep cron workstation
   factories explicit with `"behavior": "CRON"` and observe submissions through

--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -1909,6 +1909,36 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go",
+      "package": "you-agent-factory/tests/functional/factory_runtime/orchestrators/petri/routing",
+      "scenario": "TestPetriFailureRoutesToDocumentedFailedPlace",
+      "lane": "short",
+      "destination": "tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go",
+      "package": "you-agent-factory/tests/functional/factory_runtime/orchestrators/petri/routing",
+      "scenario": "TestPetriMultiStagePipelineCompletesAtPublicTerminals",
+      "lane": "short",
+      "destination": "tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go",
+      "package": "you-agent-factory/tests/functional/factory_runtime/orchestrators/petri/routing",
+      "scenario": "TestPetriMultiTransitionPreservesWorkCorrelation",
+      "lane": "short",
+      "destination": "tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/guards_batch/cascading_failure_test.go",
       "package": "you-agent-factory/tests/functional/guards_batch",
       "scenario": "TestCascadingFailure_CompletedNotCascaded",
@@ -3566,6 +3596,46 @@
       "destination": "tests/functional/workers/inference/process_cleanup_test.go",
       "catch_all": "none",
       "specialty_targets": "script-timeout-companion-smoke-100",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/providers/agy/process_harness_test.go",
+      "package": "you-agent-factory/tests/functional/providers/agy",
+      "scenario": "TestAgyCommandCancellationThroughRootBuildProcessIsCanonical",
+      "lane": "short",
+      "destination": "tests/functional/providers/agy/process_harness_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/providers/agy/process_harness_test.go",
+      "package": "you-agent-factory/tests/functional/providers/agy",
+      "scenario": "TestAgyConductorSuccessThroughRootBuildProcess",
+      "lane": "short",
+      "destination": "tests/functional/providers/agy/process_harness_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/providers/agy/process_harness_test.go",
+      "package": "you-agent-factory/tests/functional/providers/agy",
+      "scenario": "TestAgyNativeFailureThroughRootBuildProcessIsSafe",
+      "lane": "short",
+      "destination": "tests/functional/providers/agy/process_harness_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/providers/agy/process_harness_test.go",
+      "package": "you-agent-factory/tests/functional/providers/agy",
+      "scenario": "TestAgyTimeoutFailureThroughRootBuildProcess",
+      "lane": "short",
+      "destination": "tests/functional/providers/agy/process_harness_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
       "deletion_only_batch": "n/a"
     },
     {
@@ -9189,7 +9259,7 @@
       "deletion_only_batch": "n/a"
     }
   ],
-  "scanned_at_utc": "2026-07-28T12:30:00Z",
+  "scanned_at_utc": "2026-07-28T12:55:00Z",
   "summary": {
     "by_catch_all": {
       "bootstrap_portability": 22,
@@ -9207,6 +9277,7 @@
       "cli": 59,
       "events": 5,
       "factory": 56,
+      "factory_runtime": 3,
       "factory_visualization": 6,
       "guards_batch": 23,
       "models": 25,
@@ -9215,7 +9286,7 @@
       "orchestration": 48,
       "product": 13,
       "provider_sessions": 15,
-      "providers": 64,
+      "providers": 68,
       "replay_contracts": 23,
       "runtime_api": 105,
       "sessionparity": 13,
@@ -9227,9 +9298,9 @@
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 899,
+    "customer_top_level_Test_scenarios": 906,
     "lane_functionallong": 95,
-    "lane_short": 804,
+    "lane_short": 811,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 12,
       "you-agent-factory/tests/functional/automations": 14,
@@ -9255,6 +9326,7 @@
       "you-agent-factory/tests/functional/factory/packaged/review": 3,
       "you-agent-factory/tests/functional/factory/packaged/subagent": 3,
       "you-agent-factory/tests/functional/factory/packaged/tts": 3,
+      "you-agent-factory/tests/functional/factory_runtime/orchestrators/petri/routing": 3,
       "you-agent-factory/tests/functional/factory_visualization": 6,
       "you-agent-factory/tests/functional/guards_batch": 23,
       "you-agent-factory/tests/functional/models/model_invoke": 4,
@@ -9277,6 +9349,7 @@
       "you-agent-factory/tests/functional/provider_sessions/association": 6,
       "you-agent-factory/tests/functional/provider_sessions/details": 9,
       "you-agent-factory/tests/functional/providers": 36,
+      "you-agent-factory/tests/functional/providers/agy": 4,
       "you-agent-factory/tests/functional/providers/codex": 7,
       "you-agent-factory/tests/functional/providers/cursor": 8,
       "you-agent-factory/tests/functional/providers/gemini": 4,

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -727,6 +727,13 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
 - [x] `tests/functional/factory_visualization/response_presentation_test.go`
   - `TestVisualizationResponsePresentationThroughPublicRootAfterLifecycle`.
 
+### Factory runtime (service-mirrored Petri depth)
+
+- [x] `tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go`
+  - `TestPetriMultiStagePipelineCompletesAtPublicTerminals`.
+  - `TestPetriFailureRoutesToDocumentedFailedPlace`.
+  - `TestPetriMultiTransitionPreservesWorkCorrelation`.
+
 ### Packaged factories
 
 - [x] `tests/functional/factory/packaged/catalog/discovery_test.go`
@@ -821,6 +828,11 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
 
 ## Wave 2 — provider sessions
 
+- [x] `tests/functional/providers/agy/process_harness_test.go`
+  - `TestAgyConductorSuccessThroughRootBuildProcess`.
+  - `TestAgyNativeFailureThroughRootBuildProcessIsSafe`.
+  - `TestAgyTimeoutFailureThroughRootBuildProcess`.
+  - `TestAgyCommandCancellationThroughRootBuildProcessIsCanonical`.
 - [x] `tests/functional/providers/codex/process_harness_test.go`
   - `TestCodexHistoricalInspectionSuccessThroughRootBuildProcess`.
   - `TestCodexHistoricalInspectionDetachedRepeatedRunsThroughRootBuildProcess`.

--- a/tests/functional/factory_runtime/orchestrators/petri/routing/doc.go
+++ b/tests/functional/factory_runtime/orchestrators/petri/routing/doc.go
@@ -1,0 +1,4 @@
+// Package routing contains functional proofs that multi-transition Petri Factory
+// routing reaches documented public Work terminals through root.BuildProcess and
+// Process.Execute without importing internal Petri-net marking packages.
+package routing

--- a/tests/functional/factory_runtime/orchestrators/petri/routing/helpers_test.go
+++ b/tests/functional/factory_runtime/orchestrators/petri/routing/helpers_test.go
@@ -95,6 +95,61 @@ func assertQuiescentSession(t *testing.T, session factoryapi.FactorySession, wan
 	}
 }
 
+func assertListedWorkStateTrace(
+	t *testing.T,
+	response factoryapi.ListWorkResponse,
+	workType, state, traceID string,
+) {
+	t.Helper()
+	for _, item := range response.Results {
+		if item.WorkTypeName == nil || *item.WorkTypeName != workType || item.State == nil || item.State.Name != state {
+			continue
+		}
+		if item.TraceId == nil || *item.TraceId != traceID {
+			t.Errorf("%s:%s trace ID = %#v, want %q", workType, state, item.TraceId, traceID)
+		}
+		return
+	}
+	t.Errorf("listed Work missing %s:%s", workType, state)
+}
+
+func assertDispatchEventsReferenceTerminalWork(
+	t *testing.T,
+	events []factoryapi.FactoryEvent,
+	listed factoryapi.ListWorkResponse,
+	terminalLocation string,
+	traceIDs []string,
+) {
+	t.Helper()
+	terminalWorkIDs := map[string]string{}
+	for _, item := range listed.Results {
+		if support.WorkItemCustomerLocation(item) != terminalLocation {
+			continue
+		}
+		if item.TraceId == nil || item.WorkId == nil {
+			continue
+		}
+		terminalWorkIDs[*item.TraceId] = *item.WorkId
+	}
+	for _, traceID := range traceIDs {
+		workID, ok := terminalWorkIDs[traceID]
+		if !ok {
+			t.Errorf("missing terminal Work ID for trace %q", traceID)
+			continue
+		}
+		referenced := false
+		for _, dispatch := range support.ObserveDispatchEvents(t, events) {
+			if support.DispatchObservationIncludesWork(dispatch, workID) {
+				referenced = true
+				break
+			}
+		}
+		if !referenced {
+			t.Errorf("dispatch events missing public Work ID %q for trace %q", workID, traceID)
+		}
+	}
+}
+
 func assertTerminalWorkCorrelatesToTraceIDs(
 	t *testing.T,
 	listed factoryapi.ListWorkResponse,

--- a/tests/functional/factory_runtime/orchestrators/petri/routing/helpers_test.go
+++ b/tests/functional/factory_runtime/orchestrators/petri/routing/helpers_test.go
@@ -1,0 +1,72 @@
+package routing
+
+import (
+	"testing"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+func assertWorkAtCustomerStates(t *testing.T, listed factoryapi.ListWorkResponse, wants map[string]int) {
+	t.Helper()
+	for location, want := range wants {
+		if got := support.CountWorkAtCustomerState(listed, location); got != want {
+			t.Errorf("%s Work count = %d, want %d", location, got, want)
+		}
+	}
+}
+
+func assertQuiescentSession(t *testing.T, session factoryapi.FactorySession, wantTerminal, wantFailed int) {
+	t.Helper()
+	categories := session.Runtime.Progress.Categories
+	if categories.Initial != 0 || categories.Processing != 0 {
+		t.Errorf(
+			"session still has in-progress Work: initial=%d processing=%d",
+			categories.Initial,
+			categories.Processing,
+		)
+	}
+	if categories.Terminal != wantTerminal {
+		t.Errorf("session terminal count = %d, want %d", categories.Terminal, wantTerminal)
+	}
+	if categories.Failed != wantFailed {
+		t.Errorf("session failed count = %d, want %d", categories.Failed, wantFailed)
+	}
+}
+
+func assertTerminalWorkCorrelatesToTraceIDs(
+	t *testing.T,
+	listed factoryapi.ListWorkResponse,
+	terminalLocation string,
+	traceIDs []string,
+) {
+	t.Helper()
+	wants := make(map[string]bool, len(traceIDs))
+	for _, traceID := range traceIDs {
+		wants[traceID] = true
+	}
+	found := map[string]bool{}
+	for _, item := range listed.Results {
+		if support.WorkItemCustomerLocation(item) != terminalLocation {
+			continue
+		}
+		if item.TraceId == nil || !wants[*item.TraceId] {
+			t.Errorf("unexpected %s trace ID %#v", terminalLocation, item.TraceId)
+			continue
+		}
+		if item.WorkId == nil || *item.WorkId == "" {
+			t.Errorf("terminal Work at %s missing workId for trace %q", terminalLocation, *item.TraceId)
+			continue
+		}
+		if found[*item.TraceId] {
+			t.Errorf("duplicate terminal Work for trace %q at %s", *item.TraceId, terminalLocation)
+			continue
+		}
+		found[*item.TraceId] = true
+	}
+	for traceID := range wants {
+		if !found[traceID] {
+			t.Errorf("listed Work missing %s trace %q", terminalLocation, traceID)
+		}
+	}
+}

--- a/tests/functional/factory_runtime/orchestrators/petri/routing/helpers_test.go
+++ b/tests/functional/factory_runtime/orchestrators/petri/routing/helpers_test.go
@@ -7,6 +7,67 @@ import (
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
+func workIDAtCustomerState(
+	t *testing.T,
+	listed factoryapi.ListWorkResponse,
+	location string,
+	traceID string,
+) (string, bool) {
+	t.Helper()
+	for _, item := range listed.Results {
+		if support.WorkItemCustomerLocation(item) != location {
+			continue
+		}
+		if item.TraceId == nil || *item.TraceId != traceID {
+			continue
+		}
+		if item.WorkId == nil || *item.WorkId == "" {
+			t.Fatalf("work at %s for trace %q missing workId", location, traceID)
+		}
+		return *item.WorkId, true
+	}
+	return "", false
+}
+
+func assertTraceAbsentAtCustomerState(
+	t *testing.T,
+	listed factoryapi.ListWorkResponse,
+	location string,
+	traceID string,
+) {
+	t.Helper()
+	for _, item := range listed.Results {
+		if support.WorkItemCustomerLocation(item) != location {
+			continue
+		}
+		if item.TraceId != nil && *item.TraceId == traceID {
+			t.Errorf("trace %q should not be at %s", traceID, location)
+		}
+	}
+}
+
+func assertFailedDispatchForWork(
+	t *testing.T,
+	dispatches []support.DispatchEventObservation,
+	workID string,
+) {
+	t.Helper()
+
+	for _, dispatch := range dispatches {
+		if !support.DispatchObservationIncludesWork(dispatch, workID) {
+			continue
+		}
+		if dispatch.Response == nil {
+			continue
+		}
+		if dispatch.Response.Outcome != factoryapi.WorkOutcomeFailed {
+			continue
+		}
+		return
+	}
+	t.Fatalf("no failed dispatch observation for work %q", workID)
+}
+
 func assertWorkAtCustomerStates(t *testing.T, listed factoryapi.ListWorkResponse, wants map[string]int) {
 	t.Helper()
 	for location, want := range wants {

--- a/tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go
+++ b/tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go
@@ -1,10 +1,12 @@
 package routing
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/portpowered/infinite-you/internal/testutil"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
@@ -138,6 +140,151 @@ func TestPetriMultiStagePipelineCompletesAtPublicTerminals(t *testing.T) {
 		assertQuiescentSession(t, session, 1, 0)
 		if runner.CallCount() != 3 {
 			t.Errorf("provider command call count = %d, want 3", runner.CallCount())
+		}
+	})
+}
+
+// TestPetriFailureRoutesToDocumentedFailedPlace proves worker or provider
+// failures in multi-transition Petri Factory routing project Work to the
+// Factory-documented failed place on public Work / session surfaces. Failed
+// dispatch outcomes are asserted on Factory Events when that is the natural
+// observation surface, without routing the same Work to success terminals or
+// inspecting internal Petri markings.
+func TestPetriFailureRoutesToDocumentedFailedPlace(t *testing.T) {
+	t.Run("two_stage_service_simple_second_stage_exit_routes_to_failed", func(t *testing.T) {
+		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "service_simple"))
+		traceID := "trace-two-stage-failure"
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			WorkTypeID: "task",
+			TraceID:    traceID,
+			Payload:    []byte(`{"title":"two-stage failure routing"}`),
+		})
+
+		runner := testutil.NewProviderCommandRunner(
+			platformprocess.CommandResult{Stdout: support.CodexSuccessStdout("Done. COMPLETE")},
+			platformprocess.CommandResult{
+				Stderr:   []byte("stage-two provider unavailable"),
+				ExitCode: 1,
+			},
+		)
+		session, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
+			t,
+			dir,
+			serviceedges.Edges{ProviderCommandRunner: runner},
+			10*time.Second,
+		)
+
+		failedTerminal := support.WorkCustomerLocation("task", "failed")
+		successTerminal := support.WorkCustomerLocation("task", "complete")
+		assertWorkAtCustomerStates(t, listed, map[string]int{
+			failedTerminal: 1,
+			successTerminal: 0,
+			support.WorkCustomerLocation("task", "init"):        0,
+			support.WorkCustomerLocation("task", "processing"): 0,
+		})
+		assertTerminalWorkCorrelatesToTraceIDs(t, listed, failedTerminal, []string{traceID})
+		assertTraceAbsentAtCustomerState(t, listed, successTerminal, traceID)
+		assertQuiescentSession(t, session, 0, 1)
+
+		failedWorkID, ok := workIDAtCustomerState(t, listed, failedTerminal, traceID)
+		if !ok {
+			t.Fatalf("missing failed Work for trace %q at %s", traceID, failedTerminal)
+		}
+		assertFailedDispatchForWork(t, support.ObserveDispatchEvents(t, events), failedWorkID)
+		if runner.CallCount() != 2 {
+			t.Errorf("provider command call count = %d, want 2", runner.CallCount())
+		}
+	})
+
+	t.Run("cross_work_type_dispatcher_executor_exit_routes_prd_to_failed", func(t *testing.T) {
+		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "dispatcher_workflow"))
+		traceID := "trace-dispatcher-executor-failure"
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			WorkTypeID: "idea",
+			TraceID:    traceID,
+			Payload:    []byte(`{"title":"dispatcher failure routing"}`),
+		})
+
+		runner := testutil.NewProviderCommandRunner(
+			platformprocess.CommandResult{Stdout: support.CodexSuccessStdout("Done. COMPLETE")},
+			platformprocess.CommandResult{
+				Stderr:   []byte("executor subprocess failed"),
+				ExitCode: 1,
+			},
+		)
+		session, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
+			t,
+			dir,
+			serviceedges.Edges{ProviderCommandRunner: runner},
+			15*time.Second,
+		)
+
+		failedTerminal := support.WorkCustomerLocation("prd", "failed")
+		successTerminal := support.WorkCustomerLocation("prd", "complete")
+		assertWorkAtCustomerStates(t, listed, map[string]int{
+			failedTerminal: 1,
+			successTerminal: 0,
+			support.WorkCustomerLocation("idea", "init"):        0,
+			support.WorkCustomerLocation("prd", "init"):         0,
+			support.WorkCustomerLocation("prd", "in-review"):      0,
+		})
+		assertTerminalWorkCorrelatesToTraceIDs(t, listed, failedTerminal, []string{traceID})
+		assertTraceAbsentAtCustomerState(t, listed, successTerminal, traceID)
+		assertQuiescentSession(t, session, 0, 1)
+
+		failedWorkID, ok := workIDAtCustomerState(t, listed, failedTerminal, traceID)
+		if !ok {
+			t.Fatalf("missing failed Work for trace %q at %s", traceID, failedTerminal)
+		}
+		assertFailedDispatchForWork(t, support.ObserveDispatchEvents(t, events), failedWorkID)
+		if runner.CallCount() != 2 {
+			t.Errorf("provider command call count = %d, want 2", runner.CallCount())
+		}
+	})
+
+	t.Run("code_review_reviewer_error_routes_to_failed", func(t *testing.T) {
+		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "code_review"))
+		traceID := "trace-code-review-failure"
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			WorkTypeID: "code-change",
+			TraceID:    traceID,
+			Payload:    []byte(`{"task":"routing failure review"}`),
+		})
+
+		provider := testutil.NewMockWorkerMapProviderWithDefault(map[string][]testutil.WorkResponse{
+			"swe":      {{Content: "Done. COMPLETE"}},
+			"reviewer": {{Content: "", Error: errors.New("reviewer inference failed")}},
+		})
+		session, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
+			t,
+			dir,
+			serviceedges.Edges{ProviderOverride: provider},
+			15*time.Second,
+		)
+
+		failedTerminal := support.WorkCustomerLocation("code-change", "failed")
+		successTerminal := support.WorkCustomerLocation("code-change", "complete")
+		assertWorkAtCustomerStates(t, listed, map[string]int{
+			failedTerminal:  1,
+			successTerminal: 0,
+			support.WorkCustomerLocation("code-change", "init"):      0,
+			support.WorkCustomerLocation("code-change", "in-review"): 0,
+		})
+		assertTerminalWorkCorrelatesToTraceIDs(t, listed, failedTerminal, []string{traceID})
+		assertTraceAbsentAtCustomerState(t, listed, successTerminal, traceID)
+		assertQuiescentSession(t, session, 0, 1)
+
+		failedWorkID, ok := workIDAtCustomerState(t, listed, failedTerminal, traceID)
+		if !ok {
+			t.Fatalf("missing failed Work for trace %q at %s", traceID, failedTerminal)
+		}
+		assertFailedDispatchForWork(t, support.ObserveDispatchEvents(t, events), failedWorkID)
+		if provider.CallCount("swe") != 1 || provider.CallCount("reviewer") != 1 {
+			t.Errorf(
+				"provider calls = swe:%d reviewer:%d, want swe:1 reviewer:1",
+				provider.CallCount("swe"),
+				provider.CallCount("reviewer"),
+			)
 		}
 	})
 }

--- a/tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go
+++ b/tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go
@@ -288,3 +288,106 @@ func TestPetriFailureRoutesToDocumentedFailedPlace(t *testing.T) {
 		}
 	})
 }
+
+// TestPetriMultiTransitionPreservesWorkCorrelation proves a known public Work
+// identity submitted through multi-transition Petri Factory routing remains
+// attributable on public Work listings and Factory Event projections after
+// routing completes or lands at the documented failed place, without
+// inspecting internal Petri markings.
+func TestPetriMultiTransitionPreservesWorkCorrelation(t *testing.T) {
+	t.Run("cross_work_type_dispatcher_preserves_origin_trace_through_stages", func(t *testing.T) {
+		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "dispatcher_workflow"))
+		originTraceID := "trace-correlation-dispatcher"
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			WorkTypeID: "idea",
+			TraceID:    originTraceID,
+			Payload:    []byte(`{"title":"correlation across dispatcher stages"}`),
+		})
+
+		runner := testutil.NewProviderCommandRunner(support.AcceptedCommandResults(3)...)
+		_, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
+			t,
+			dir,
+			serviceedges.Edges{ProviderCommandRunner: runner},
+			10*time.Second,
+		)
+
+		terminal := support.WorkCustomerLocation("prd", "complete")
+		assertWorkAtCustomerStates(t, listed, map[string]int{
+			terminal: 1,
+			support.WorkCustomerLocation("idea", "init"): 0,
+			support.WorkCustomerLocation("prd", "init"):  0,
+		})
+		assertListedWorkStateTrace(t, listed, "prd", "complete", originTraceID)
+		assertTerminalWorkCorrelatesToTraceIDs(t, listed, terminal, []string{originTraceID})
+		assertDispatchEventsReferenceTerminalWork(t, events, listed, terminal, []string{originTraceID})
+	})
+
+	t.Run("three_stage_ideation_correlates_trace_on_terminal_and_events", func(t *testing.T) {
+		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "full_ideation_pipeline"))
+		originTraceID := "trace-correlation-ideation"
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			WorkTypeID: "idea",
+			TraceID:    originTraceID,
+			Payload:    []byte(`{"title":"correlation across ideation stages"}`),
+		})
+
+		provider := testutil.NewMockProvider(
+			workerexecution.InferenceResponse{Content: "PRD created. COMPLETE"},
+			workerexecution.InferenceResponse{Content: "Code written. COMPLETE"},
+			workerexecution.InferenceResponse{Content: "Looks good. ACCEPTED"},
+		)
+		_, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
+			t,
+			dir,
+			serviceedges.Edges{ProviderOverride: provider},
+			15*time.Second,
+		)
+
+		terminal := support.WorkCustomerLocation("story", "complete")
+		assertWorkAtCustomerStates(t, listed, map[string]int{
+			terminal: 1,
+			support.WorkCustomerLocation("idea", "init"):       0,
+			support.WorkCustomerLocation("prd", "init"):        0,
+			support.WorkCustomerLocation("story", "init"):      0,
+			support.WorkCustomerLocation("story", "in-review"): 0,
+			support.WorkCustomerLocation("story", "executing"): 0,
+		})
+		assertListedWorkStateTrace(t, listed, "story", "complete", originTraceID)
+		assertTerminalWorkCorrelatesToTraceIDs(t, listed, terminal, []string{originTraceID})
+		assertDispatchEventsReferenceTerminalWork(t, events, listed, terminal, []string{originTraceID})
+	})
+
+	t.Run("failure_routing_preserves_origin_trace_at_failed_place", func(t *testing.T) {
+		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "service_simple"))
+		originTraceID := "trace-correlation-failure"
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			WorkTypeID: "task",
+			TraceID:    originTraceID,
+			Payload:    []byte(`{"title":"correlation on failure routing"}`),
+		})
+
+		runner := testutil.NewProviderCommandRunner(
+			platformprocess.CommandResult{Stdout: support.CodexSuccessStdout("Done. COMPLETE")},
+			platformprocess.CommandResult{
+				Stderr:   []byte("stage-two provider unavailable"),
+				ExitCode: 1,
+			},
+		)
+		_, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
+			t,
+			dir,
+			serviceedges.Edges{ProviderCommandRunner: runner},
+			10*time.Second,
+		)
+
+		failedTerminal := support.WorkCustomerLocation("task", "failed")
+		assertWorkAtCustomerStates(t, listed, map[string]int{
+			failedTerminal: 1,
+			support.WorkCustomerLocation("task", "complete"): 0,
+		})
+		assertListedWorkStateTrace(t, listed, "task", "failed", originTraceID)
+		assertTerminalWorkCorrelatesToTraceIDs(t, listed, failedTerminal, []string{originTraceID})
+		assertDispatchEventsReferenceTerminalWork(t, events, listed, failedTerminal, []string{originTraceID})
+	})
+}

--- a/tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go
+++ b/tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go
@@ -1,0 +1,143 @@
+package routing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+// TestPetriMultiStagePipelineCompletesAtPublicTerminals proves multi-transition
+// Petri Factory routing started through root.BuildProcess reaches the documented
+// public success terminal location(s) at quiescence. Scenarios cover two-stage
+// same-work-type pipelines, cross-work-type dispatcher flows, and three-stage
+// ideation pipelines without inspecting internal Petri markings.
+func TestPetriMultiStagePipelineCompletesAtPublicTerminals(t *testing.T) {
+	t.Run("two_stage_service_simple_completes_at_terminal", func(t *testing.T) {
+		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "service_simple"))
+		traceID := "trace-two-stage-service-simple"
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			WorkTypeID: "task",
+			TraceID:    traceID,
+			Payload:    []byte(`{"title":"two-stage routing depth"}`),
+		})
+
+		runner := testutil.NewProviderCommandRunner(support.AcceptedCommandResults(2)...)
+		session, listed := support.RunFactoryToCompletionWithEdgesAndWork(t, dir, serviceedges.Edges{
+			ProviderCommandRunner: runner,
+		}, 10*time.Second)
+
+		terminal := support.WorkCustomerLocation("task", "complete")
+		assertWorkAtCustomerStates(t, listed, map[string]int{
+			terminal: 1,
+			support.WorkCustomerLocation("task", "init"):        0,
+			support.WorkCustomerLocation("task", "processing"): 0,
+			support.WorkCustomerLocation("task", "failed"):    0,
+		})
+		assertTerminalWorkCorrelatesToTraceIDs(t, listed, terminal, []string{traceID})
+		assertQuiescentSession(t, session, 1, 0)
+		if runner.CallCount() != 2 {
+			t.Errorf("provider command call count = %d, want 2", runner.CallCount())
+		}
+	})
+
+	t.Run("code_review_multi_stage_completes", func(t *testing.T) {
+		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "code_review"))
+		traceID := "trace-code-review-routing"
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			WorkTypeID: "code-change",
+			TraceID:    traceID,
+			Payload:    []byte(`{"task":"routing depth review"}`),
+		})
+
+		provider := testutil.NewMockWorkerMapProvider(map[string][]workerexecution.InferenceResponse{
+			"swe":      {{Content: "Done. COMPLETE"}},
+			"reviewer": {{Content: "Done. COMPLETE"}},
+		})
+		session, listed := support.RunFactoryToCompletionWithEdgesAndWork(t, dir, serviceedges.Edges{
+			ProviderOverride: provider,
+		}, 15*time.Second)
+
+		terminal := support.WorkCustomerLocation("code-change", "complete")
+		assertWorkAtCustomerStates(t, listed, map[string]int{
+			terminal: 1,
+			support.WorkCustomerLocation("code-change", "init"):      0,
+			support.WorkCustomerLocation("code-change", "in-review"): 0,
+			support.WorkCustomerLocation("code-change", "failed"):    0,
+		})
+		assertTerminalWorkCorrelatesToTraceIDs(t, listed, terminal, []string{traceID})
+		assertQuiescentSession(t, session, 1, 0)
+		if provider.CallCount("swe") != 1 || provider.CallCount("reviewer") != 1 {
+			t.Errorf(
+				"provider calls = swe:%d reviewer:%d, want swe:1 reviewer:1",
+				provider.CallCount("swe"),
+				provider.CallCount("reviewer"),
+			)
+		}
+	})
+
+	t.Run("three_stage_ideation_reaches_story_complete", func(t *testing.T) {
+		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "full_ideation_pipeline"))
+		traceID := "trace-ideation-multi-stage"
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			WorkTypeID: "idea",
+			TraceID:    traceID,
+			Payload:    []byte(`{"title":"multi-transition ideation depth"}`),
+		})
+
+		provider := testutil.NewMockProvider(
+			workerexecution.InferenceResponse{Content: "PRD created. COMPLETE"},
+			workerexecution.InferenceResponse{Content: "Code written. COMPLETE"},
+			workerexecution.InferenceResponse{Content: "Looks good. ACCEPTED"},
+		)
+		session, listed := support.RunFactoryToCompletionWithEdgesAndWork(t, dir, serviceedges.Edges{
+			ProviderOverride: provider,
+		}, 15*time.Second)
+
+		terminal := support.WorkCustomerLocation("story", "complete")
+		assertWorkAtCustomerStates(t, listed, map[string]int{
+			terminal: 1,
+			support.WorkCustomerLocation("idea", "init"):       0,
+			support.WorkCustomerLocation("prd", "init"):        0,
+			support.WorkCustomerLocation("story", "init"):      0,
+			support.WorkCustomerLocation("story", "in-review"): 0,
+			support.WorkCustomerLocation("story", "executing"): 0,
+		})
+		assertTerminalWorkCorrelatesToTraceIDs(t, listed, terminal, []string{traceID})
+		assertQuiescentSession(t, session, 1, 0)
+		if provider.CallCount() != 3 {
+			t.Errorf("provider call count = %d, want 3", provider.CallCount())
+		}
+	})
+
+	t.Run("cross_work_type_dispatcher_reaches_prd_complete", func(t *testing.T) {
+		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "dispatcher_workflow"))
+		traceID := "trace-dispatcher-multi-transition"
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			WorkTypeID: "idea",
+			TraceID:    traceID,
+			Payload:    []byte(`{"title":"dispatcher routing depth"}`),
+		})
+
+		runner := testutil.NewProviderCommandRunner(support.AcceptedCommandResults(3)...)
+		session, listed := support.RunFactoryToCompletionWithEdgesAndWork(t, dir, serviceedges.Edges{
+			ProviderCommandRunner: runner,
+		}, 10*time.Second)
+
+		terminal := support.WorkCustomerLocation("prd", "complete")
+		assertWorkAtCustomerStates(t, listed, map[string]int{
+			terminal: 1,
+			support.WorkCustomerLocation("idea", "init"): 0,
+			support.WorkCustomerLocation("prd", "init"):  0,
+		})
+		assertTerminalWorkCorrelatesToTraceIDs(t, listed, terminal, []string{traceID})
+		assertQuiescentSession(t, session, 1, 0)
+		if runner.CallCount() != 3 {
+			t.Errorf("provider command call count = %d, want 3", runner.CallCount())
+		}
+	})
+}


### PR DESCRIPTION
{
  "project": "Factory Runtime Petri Multi-Transition Routing Depth",
  "branchName": "ft-depth-factory-runtime-petri-routing-multi-transition",
  "description": "Implement only tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go so factory_runtime Petri multi-transition routing is proven through root.BuildProcess + Process.Execute and public Work/session outcomes: multi-stage pipelines complete at documented public terminals, failures route to the documented failed place, and Work identity stays correlated across transitions—without internal Petri marking imports or opening the sibling guards/eligibility cell.",
  "context": {
    "customerAsk": "Read and follow docs/temp/functional-tests-expansion/cli-run-submit-factory-petri-depth-plan.md. Implement only tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go. Construct via root.BuildProcess + Process.Execute; prefer public CLI for ordinary flows; ProviderCommandRunner / mocked Codex over MockWorkers and over ProviderOverride mocks when a command-runner edge proves the path. Prove public Work/session outcomes only (no internal Petri marking imports): (1) TestPetriMultiStagePipelineCompletesAtPublicTerminals; (2) TestPetriFailureRoutesToDocumentedFailedPlace; (3) TestPetriMultiTransitionPreservesWorkCorrelation. Do not implement guards/eligibility. No sleeps unless RC-justified. Go docs on every Test*; focused tests + functional-boundary-check + viz metadata.",
    "problem": "Wave 1 orchestration/petri/dispatch covers simple and concurrent dispatch, but pkg/services/factory_runtime/internal/orchestrators/petri remains ~39.1% and no focused multi-transition routing depth cell exists under the service-mirrored factory_runtime/orchestrators/petri tree. Multi-stage completion, documented failure routing, and Work-identity correlation across transitions are not catalogued as an independent public-outcome routing proof, so regressions can hide behind catch-alls or internal marking tests.",
    "solution": "Implement tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go with TestPetriMultiStagePipelineCompletesAtPublicTerminals, TestPetriFailureRoutesToDocumentedFailedPlace, and TestPetriMultiTransitionPreservesWorkCorrelation via root.BuildProcess + Process.Execute, preferring public CLI and ProviderCommandRunner / mocked Codex edges. Assert only public Work / Factory Session / Factory Event outcomes; add customer-readable Go docs on every top-level Test*; update only narrowly coupled ownership/coverage/catalog/migration metadata; verify focused package tests plus functional-boundary-check and viz-compatible metadata checks. Do not implement guards/eligibility."
  },
  "acceptanceCriteria": [
    "tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go exists as the factory_runtime Petri routing-owned functional cell and contains TestPetriMultiStagePipelineCompletesAtPublicTerminals, TestPetriFailureRoutesToDocumentedFailedPlace, and TestPetriMultiTransitionPreservesWorkCorrelation.",
    "All scenarios construct via root.BuildProcess + Process.Execute (or approved support wrapper), prefer public CLI for ordinary flows, and replace external effects through edges.Edges preferring ProviderCommandRunner / mocked Codex over MockWorkers and over ProviderOverride when a command-runner edge proves the path.",
    "Success coverage proves a multi-stage pipeline reaches the documented public success terminal(s) with session quiescence observable from public Work / session surfaces, without wall-clock time.Sleep synchronization unless RC-justified and documented.",
    "Failure coverage proves worker/provider failure projects Work at the Factory-documented failed place on public Work / session surfaces (and failed dispatch outcome on public Factory Events when that surface is the natural observation).",
    "Correlation coverage proves the same public Work identity remains attributable across multi-transition routing (WorkID / TraceID / equivalent public correlation fields on listed Work and/or Factory Events).",
    "Assertions use public Work / Factory Session / Factory Event outcomes only; the cell does not import internal Petri-net marking packages as the proof owner; every top-level Test* has a customer-readable Go doc comment; guards/eligibility is not implemented.",
    "Quality gate: typecheck, lint, and tests pass — focused package tests for the new routing cell, make functional-boundary-check, and functional-test-viz-compatible metadata checks for touched surfaces."
  ],
  "userStories": [
    {
      "id": "ft-depth-factory-runtime-petri-routing-multi-transition-001",
      "title": "Prove multi-stage pipeline completes at public terminals",
      "description": "As a maintainer, I want a customer functional scenario that starts a multi-stage Petri Factory through root.BuildProcess, submits Work via the public CLI (or equivalent public process entry), and proves Work reaches the documented public success terminal location(s) at quiescence, so multi-transition happy-path routing regressions are caught from public Work / session projections.",
      "acceptanceCriteria": [
        "tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go defines TestPetriMultiStagePipelineCompletesAtPublicTerminals with a customer-readable Go doc comment describing multi-stage completion at public terminals.",
        "The scenario builds the application through root.BuildProcess + Process.Execute / approved support harness and prefers public CLI for ordinary submit/run flows.",
        "External effects are replaced via edges.Edges, preferring ProviderCommandRunner / mocked Codex over MockWorkers and over ProviderOverride when a command-runner edge proves the path.",
        "After deterministic quiescence, public Work projections show submitted Work at the documented success terminal location(s) for the multi-stage Factory, with no leftover in-progress Work for that run attributable to the scenario.",
        "Assertions stay on public Work / session outcomes and do not import internal Petri markings or implement guards/eligibility behavior.",
        "No wall-clock time.Sleep synchronization unless RC-justified and documented in the test.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-depth-factory-runtime-petri-routing-multi-transition-002",
      "title": "Prove failure routes to documented failed place",
      "description": "As a maintainer, I want a customer functional scenario that forces a worker/provider failure in a multi-transition Petri Factory and proves Work lands at the Factory-documented failed place on public Work / session surfaces, so failure routing regressions are visible without inspecting internal nets.",
      "acceptanceCriteria": [
        "The routing cell includes TestPetriFailureRoutesToDocumentedFailedPlace with a customer-readable Go doc comment describing failure routing to the documented failed place.",
        "The scenario constructs via root.BuildProcess + Process.Execute / approved harness, prefers public CLI for ordinary flows, and injects failure through edges.Edges (ProviderCommandRunner / mocked Codex preferred).",
        "After deterministic observation, public Work projections show Work at the Factory-documented failed place (customer-facing failed state / location), not at the success terminal for that run.",
        "When Factory Events are the natural observation surface, a failed dispatch / execution outcome attributable to that Work is visible on public events; assertions do not inspect internal Petri markings.",
        "Scope stays on failure routing for multi-transition Petri; guards / eligibility and Wave 3 guards/resources cells are not implemented.",
        "No wall-clock time.Sleep synchronization unless RC-justified and documented in the test.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-depth-factory-runtime-petri-routing-multi-transition-003",
      "title": "Prove multi-transition preserves Work correlation",
      "description": "As a maintainer, I want a customer functional scenario that submits Work with a known public identity through a multi-transition Petri pipeline and proves that identity remains correlated on public Work / session / event surfaces after routing completes, so lineage regressions across stages are caught without internal marking inspection.",
      "acceptanceCriteria": [
        "The routing cell includes TestPetriMultiTransitionPreservesWorkCorrelation with a customer-readable Go doc comment describing Work-identity preservation across multi-transition routing.",
        "The scenario constructs via root.BuildProcess + Process.Execute / approved harness and prefers public CLI for ordinary flows, with external effects replaced via preferred command-runner / mocked Codex edges.",
        "Submitted Work carries a known public identity (WorkID and/or TraceID / equivalent public correlation fields) that remains attributable on public Work listings and/or Factory Event projections after multi-transition completion (or documented failure routing when that path is used for correlation proof).",
        "Assertions prove correlation on public surfaces only and do not import internal Petri markings or widen into guards/eligibility proofs.",
        "No wall-clock time.Sleep synchronization unless RC-justified and documented in the test.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-depth-factory-runtime-petri-routing-multi-transition-004",
      "title": "Close ownership metadata and verification gates",
      "description": "As a maintainer executing the CLI run/submit/factory + Petri depth cohort, I want this routing cell catalogued under the service-mirrored factory_runtime/orchestrators/petri/routing ownership with passing focused boundary/viz gates, so the depth cell can terminal-complete cleanly without opening the sibling guards package.",
      "acceptanceCriteria": [
        "Ownership remains under tests/functional/factory_runtime/orchestrators/petri/routing/; no new ownership is introduced under root orchestration/ or catch-all cli/.",
        "Only narrowly coupled ownership, coverage, catalog, or migration metadata required for this cell are updated; the sibling factory_runtime/orchestrators/petri/guards/eligibility cell is not implemented or rewritten as part of this work.",
        "Focused package tests for tests/functional/factory_runtime/orchestrators/petri/routing pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as factory_runtime/orchestrators/petri/routing).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)