### PR TITLE
ft-depth-factory-runtime-petri-guards-eligibility

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -293,6 +293,17 @@
   Catalog metadata infers domain `workstations` and subsection `poller` from
   the path; every top-level `Test*` needs a customer-readable Go doc so
   `functionaltestmetadata` stays viz-compatible.
+  Factory_runtime Petri authored eligibility guard functional coverage belongs
+  in `tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go`:
+  prove VISIT_COUNT block-until-satisfied, SAME_NAME correlated release, and
+  VISIT_COUNT/MATCHES_FIELDS failure visibility through public Factory Event
+  dispatch ordering, Work listings, and API status observation via
+  `support.RunFactoryToCompletionWithEdgesAndObservations`,
+  `support.StartFunctionalAPIServer`, and `support.NewShapedProviderCommandRunner`
+  without service-internal Petri imports. Catalog metadata infers domain
+  `factory_runtime` and subsection `orchestrators/petri/guards` from the path;
+  every top-level `Test*` needs a customer-readable Go doc so
+  `functionaltestmetadata` stays viz-compatible.
   Mock-worker replacement functional coverage belongs in
   `tests/functional/workers/mock/replacement_test.go`: prove named-only
   `--with-mock-workers` replacement through

--- a/tests/functional/factory_runtime/orchestrators/petri/guards/doc.go
+++ b/tests/functional/factory_runtime/orchestrators/petri/guards/doc.go
@@ -1,0 +1,3 @@
+// Package guards owns factory_runtime Petri authored eligibility guard coverage
+// through public Work, Factory Session, and CLI outcomes only.
+package guards

--- a/tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go
+++ b/tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go
@@ -1,0 +1,192 @@
+package guards
+
+import (
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+// TestPetriAuthoredEligibilityGuardBlocksDispatchUntilSatisfied proves a
+// workstation-level VISIT_COUNT eligibility guard keeps the guarded
+// completion workstation from dispatching until the watched workstation has
+// visited the shared Work enough times, then releases the expected public
+// terminal Work outcome after the guard becomes satisfied.
+func TestPetriAuthoredEligibilityGuardBlocksDispatchUntilSatisfied(t *testing.T) {
+	dir := support.ScaffoldFactory(t, visitGuardedCompletionFactoryConfig())
+	support.WriteAgentConfig(t, dir, "executor", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"))
+	support.WriteAgentConfig(t, dir, "loop-reviewer", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"))
+	support.WriteAgentConfig(t, dir, "gate-reviewer", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"))
+
+	traceID := "trace-visit-guard-eligibility"
+	testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+		WorkTypeID: "story",
+		TraceID:    traceID,
+		Payload:    []byte(`{"title":"visit-guard eligibility proof"}`),
+	})
+
+	runner := support.NewShapedProviderCommandRunner(
+		codexCommandResult("Done. COMPLETE"),
+		codexCommandResult("needs more work"),
+		codexCommandResult("Done. COMPLETE"),
+		codexCommandResult("Done. COMPLETE"),
+	)
+
+	session, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
+		t,
+		dir,
+		serviceedges.Edges{ProviderCommandRunner: runner},
+		15*time.Second,
+	)
+
+	executeIndexes := dispatchResponseIndexesForTransition(t, events, "execute-story")
+	secondPassIndexes := dispatchResponseIndexesForTransition(t, events, "second-pass-review")
+	reviewIndexes := dispatchResponseIndexesForTransition(t, events, "review-story")
+	if len(executeIndexes) < 2 {
+		t.Fatalf("execute-story dispatch count = %d, want at least 2 before guarded completion", len(executeIndexes))
+	}
+	if len(reviewIndexes) < 2 {
+		t.Fatalf("review-story dispatch count = %d, want at least 2 while the guard blocks the gated workstation", len(reviewIndexes))
+	}
+	for _, index := range secondPassIndexes {
+		if index < executeIndexes[1] {
+			t.Fatalf(
+				"second-pass-review dispatch index = %d, want after second execute-story dispatch index %d while the guard is unsatisfied",
+				index,
+				executeIndexes[1],
+			)
+		}
+	}
+	if got := support.CountWorkAtCustomerState(listed, support.WorkCustomerLocation("story", "complete")); got != 1 {
+		t.Fatalf("complete work count = %d, want 1; listed=%#v", got, listed)
+	}
+	if got := support.CountWorkAtCustomerState(listed, support.WorkCustomerLocation("story", "init")); got != 0 {
+		t.Fatalf("init work count after completion = %d, want 0", got)
+	}
+	assertTerminalWorkCorrelatesToTraceID(t, listed, traceID)
+	assertQuiescentSession(t, session, 1, 0)
+	if runner.CallCount() != 4 {
+		t.Fatalf("provider command calls = %d, want 4 (execute, review reject, execute, review complete)", runner.CallCount())
+	}
+}
+
+func visitGuardedCompletionFactoryConfig() map[string]any {
+	return map[string]any{
+		"name": "visit-guard-eligibility",
+		"workTypes": []map[string]any{{
+			"name": "story",
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "in-review", "type": "PROCESSING"},
+				{"name": "complete", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []map[string]string{
+			{"name": "executor"},
+			{"name": "loop-reviewer"},
+			{"name": "gate-reviewer"},
+		},
+		"workstations": []map[string]any{
+			{
+				"name":      "execute-story",
+				"worker":    "executor",
+				"inputs":    []map[string]string{{"workType": "story", "state": "init"}},
+				"outputs":   []map[string]string{{"workType": "story", "state": "in-review"}},
+				"onFailure": []map[string]string{{"workType": "story", "state": "failed"}},
+			},
+			{
+				"name":        "review-story",
+				"worker":      "loop-reviewer",
+				"inputs":      []map[string]string{{"workType": "story", "state": "in-review"}},
+				"onFailure":   []map[string]string{{"workType": "story", "state": "failed"}},
+				"onRejection": []map[string]string{{"workType": "story", "state": "init"}},
+				"outputs":     []map[string]string{{"workType": "story", "state": "complete"}},
+			},
+			{
+				"name":   "second-pass-review",
+				"worker": "gate-reviewer",
+				"inputs": []map[string]string{{"workType": "story", "state": "in-review"}},
+				"outputs": []map[string]string{
+					{"workType": "story", "state": "complete"},
+				},
+				"onFailure": []map[string]string{{"workType": "story", "state": "failed"}},
+				"guards": []map[string]any{{
+					"type":        "VISIT_COUNT",
+					"workstation": "execute-story",
+					"maxVisits":   float64(2),
+				}},
+			},
+		},
+	}
+}
+
+func codexCommandResult(stdout string) platformprocess.CommandResult {
+	return platformprocess.CommandResult{Stdout: support.CodexSuccessStdout(stdout)}
+}
+
+func dispatchResponseIndexesForTransition(
+	t *testing.T,
+	events []factoryapi.FactoryEvent,
+	transitionID string,
+) []int {
+	t.Helper()
+
+	var indexes []int
+	for index, event := range events {
+		if event.Type != factoryapi.FactoryEventTypeDispatchResponse {
+			continue
+		}
+		payload, err := event.Payload.AsDispatchResponseEventPayload()
+		if err != nil {
+			t.Fatalf("decode dispatch response: %v", err)
+		}
+		if payload.TransitionId == transitionID {
+			indexes = append(indexes, index)
+		}
+	}
+	return indexes
+}
+
+func assertTerminalWorkCorrelatesToTraceID(
+	t *testing.T,
+	listed factoryapi.ListWorkResponse,
+	traceID string,
+) {
+	t.Helper()
+
+	for _, item := range listed.Results {
+		if item.State == nil || item.State.Name != "complete" {
+			continue
+		}
+		if item.TraceId == nil || *item.TraceId != traceID {
+			t.Fatalf("complete work trace ID = %#v, want %q", item.TraceId, traceID)
+		}
+		return
+	}
+	t.Fatalf("listed work missing story:complete for trace %q", traceID)
+}
+
+func assertQuiescentSession(t *testing.T, session factoryapi.FactorySession, wantTerminal, wantFailed int) {
+	t.Helper()
+	categories := session.Runtime.Progress.Categories
+	if categories.Initial != 0 || categories.Processing != 0 {
+		t.Errorf(
+			"session still has in-progress Work: initial=%d processing=%d",
+			categories.Initial,
+			categories.Processing,
+		)
+	}
+	if categories.Terminal != wantTerminal {
+		t.Errorf("session terminal count = %d, want %d", categories.Terminal, wantTerminal)
+	}
+	if categories.Failed != wantFailed {
+		t.Errorf("session failed count = %d, want %d", categories.Failed, wantFailed)
+	}
+}

--- a/tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go
+++ b/tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go
@@ -17,9 +17,10 @@ import (
 // workstation-level VISIT_COUNT eligibility guard keeps the guarded
 // completion workstation from dispatching until the watched workstation has
 // visited the shared Work enough times, then releases the expected public
-// terminal Work outcome after the guard becomes satisfied.
+// terminal Work outcome through the guarded second-pass-review dispatch.
 func TestPetriAuthoredEligibilityGuardBlocksDispatchUntilSatisfied(t *testing.T) {
 	dir := support.ScaffoldFactory(t, visitGuardedCompletionFactoryConfig())
+	support.WriteWorkstationConfig(t, dir, "advance-to-gate", "---\ntype: LOGICAL_MOVE\n---\n")
 	support.WriteAgentConfig(t, dir, "executor", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"))
 	support.WriteAgentConfig(t, dir, "loop-reviewer", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"))
 	support.WriteAgentConfig(t, dir, "gate-reviewer", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"))
@@ -48,11 +49,12 @@ func TestPetriAuthoredEligibilityGuardBlocksDispatchUntilSatisfied(t *testing.T)
 	executeIndexes := dispatchResponseIndexesForTransition(t, events, "execute-story")
 	secondPassIndexes := dispatchResponseIndexesForTransition(t, events, "second-pass-review")
 	reviewIndexes := dispatchResponseIndexesForTransition(t, events, "review-story")
+	advanceIndexes := dispatchResponseIndexesForTransition(t, events, "advance-to-gate")
 	if len(executeIndexes) < 2 {
 		t.Fatalf("execute-story dispatch count = %d, want at least 2 before guarded completion", len(executeIndexes))
 	}
-	if len(reviewIndexes) < 2 {
-		t.Fatalf("review-story dispatch count = %d, want at least 2 while the guard blocks the gated workstation", len(reviewIndexes))
+	if len(reviewIndexes) != 1 {
+		t.Fatalf("review-story dispatch count = %d, want 1 while the guard blocks the gated workstation", len(reviewIndexes))
 	}
 	for _, index := range secondPassIndexes {
 		if index < executeIndexes[1] {
@@ -63,6 +65,26 @@ func TestPetriAuthoredEligibilityGuardBlocksDispatchUntilSatisfied(t *testing.T)
 			)
 		}
 	}
+	if len(secondPassIndexes) < 1 {
+		t.Fatalf("second-pass-review dispatch count = %d, want at least 1 after the guard is satisfied", len(secondPassIndexes))
+	}
+	if len(advanceIndexes) != 1 {
+		t.Fatalf("advance-to-gate dispatch count = %d, want 1 after execute-story satisfies the visit guard", len(advanceIndexes))
+	}
+	if advanceIndexes[0] < executeIndexes[1] {
+		t.Fatalf(
+			"advance-to-gate dispatch index = %d, want after second execute-story dispatch index %d",
+			advanceIndexes[0],
+			executeIndexes[1],
+		)
+	}
+	if secondPassIndexes[0] <= advanceIndexes[0] {
+		t.Fatalf(
+			"second-pass-review dispatch index = %d, want after advance-to-gate dispatch index %d",
+			secondPassIndexes[0],
+			advanceIndexes[0],
+		)
+	}
 	if got := support.CountWorkAtCustomerState(listed, support.WorkCustomerLocation("story", "complete")); got != 1 {
 		t.Fatalf("complete work count = %d, want 1; listed=%#v", got, listed)
 	}
@@ -72,7 +94,7 @@ func TestPetriAuthoredEligibilityGuardBlocksDispatchUntilSatisfied(t *testing.T)
 	assertTerminalWorkCorrelatesToTraceID(t, listed, traceID)
 	assertQuiescentSession(t, session, 1, 0)
 	if runner.CallCount() != 4 {
-		t.Fatalf("provider command calls = %d, want 4 (execute, review reject, execute, review complete)", runner.CallCount())
+		t.Fatalf("provider command calls = %d, want 4 (execute, review reject, execute, guarded second-pass-review)", runner.CallCount())
 	}
 }
 
@@ -480,6 +502,7 @@ func visitGuardedCompletionFactoryConfig() map[string]any {
 			"states": []map[string]string{
 				{"name": "init", "type": "INITIAL"},
 				{"name": "in-review", "type": "PROCESSING"},
+				{"name": "gate-ready", "type": "PROCESSING"},
 				{"name": "complete", "type": "TERMINAL"},
 				{"name": "failed", "type": "FAILED"},
 			},
@@ -503,21 +526,29 @@ func visitGuardedCompletionFactoryConfig() map[string]any {
 				"inputs":      []map[string]string{{"workType": "story", "state": "in-review"}},
 				"onFailure":   []map[string]string{{"workType": "story", "state": "failed"}},
 				"onRejection": []map[string]string{{"workType": "story", "state": "init"}},
-				"outputs":     []map[string]string{{"workType": "story", "state": "complete"}},
+				"outputs":     []map[string]string{{"workType": "story", "state": "gate-ready"}},
 			},
 			{
-				"name":   "second-pass-review",
-				"worker": "gate-reviewer",
+				"name":   "advance-to-gate",
+				"type":   "LOGICAL_MOVE",
 				"inputs": []map[string]string{{"workType": "story", "state": "in-review"}},
 				"outputs": []map[string]string{
-					{"workType": "story", "state": "complete"},
+					{"workType": "story", "state": "gate-ready"},
 				},
-				"onFailure": []map[string]string{{"workType": "story", "state": "failed"}},
 				"guards": []map[string]any{{
 					"type":        "VISIT_COUNT",
 					"workstation": "execute-story",
 					"maxVisits":   float64(2),
 				}},
+			},
+			{
+				"name":   "second-pass-review",
+				"worker": "gate-reviewer",
+				"inputs": []map[string]string{{"workType": "story", "state": "gate-ready"}},
+				"outputs": []map[string]string{
+					{"workType": "story", "state": "complete"},
+				},
+				"onFailure": []map[string]string{{"workType": "story", "state": "failed"}},
 			},
 		},
 	}

--- a/tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go
+++ b/tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go
@@ -76,6 +76,178 @@ func TestPetriAuthoredEligibilityGuardBlocksDispatchUntilSatisfied(t *testing.T)
 	}
 }
 
+// TestPetriParentOrSameNameGuardReleasesExpectedWork proves a SAME_NAME input
+// guard dispatches only when peer Work names correlate, releasing the expected
+// matched Work to its public terminal state while mismatched peers remain idle
+// without the guarded workstation's success outcome.
+func TestPetriParentOrSameNameGuardReleasesExpectedWork(t *testing.T) {
+	t.Run("matching peer names release correlated work", func(t *testing.T) {
+		dir := support.ScaffoldFactory(t, sameNameGuardFactoryConfig())
+		support.WriteAgentConfig(t, dir, "matcher", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"))
+
+		const (
+			matchedPlanWorkID = "plan-alpha"
+			matchedTaskWorkID = "task-alpha"
+			matchedName       = "alpha"
+			matchTraceID      = "trace-same-name-match"
+		)
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			Name:       matchedName,
+			WorkID:     matchedPlanWorkID,
+			WorkTypeID: "plan",
+			TraceID:    matchTraceID,
+			Payload:    []byte(`{"role":"plan"}`),
+		})
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			Name:       matchedName,
+			WorkID:     matchedTaskWorkID,
+			WorkTypeID: "task",
+			TraceID:    matchTraceID,
+			Payload:    []byte(`{"role":"task"}`),
+		})
+
+		runner := support.NewShapedProviderCommandRunner(
+			codexCommandResult("Done. COMPLETE"),
+		)
+		session, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
+			t,
+			dir,
+			serviceedges.Edges{ProviderCommandRunner: runner},
+			15*time.Second,
+		)
+
+		matchIndexes := dispatchResponseIndexesForTransition(t, events, "match-items")
+		if len(matchIndexes) != 1 {
+			t.Fatalf("match-items dispatch count = %d, want 1 for correlated peer names", len(matchIndexes))
+		}
+		if got := support.CountWorkAtCustomerState(listed, support.WorkCustomerLocation("task", "matched")); got != 1 {
+			t.Fatalf("matched task count = %d, want 1; listed=%#v", got, listed)
+		}
+		if !support.HasWorkAtCustomerState(listed, matchedTaskWorkID, support.WorkCustomerLocation("task", "matched")) {
+			t.Fatalf("task %q missing public matched outcome; listed=%#v", matchedTaskWorkID, listed)
+		}
+		if support.HasWorkAtCustomerState(listed, matchedTaskWorkID, support.WorkCustomerLocation("task", "ready")) {
+			t.Fatalf("task %q still at ready after SAME_NAME guard released correlated work", matchedTaskWorkID)
+		}
+		assertQuiescentSession(t, session, 1, 0)
+		if runner.CallCount() != 1 {
+			t.Fatalf("provider command calls = %d, want 1 for the correlated match-items dispatch", runner.CallCount())
+		}
+	})
+
+	t.Run("mismatched peer names keep guarded workstation idle", func(t *testing.T) {
+		dir := support.ScaffoldFactory(t, sameNameGuardFactoryConfig())
+		support.WriteAgentConfig(t, dir, "matcher", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"))
+
+		const (
+			mismatchedPlanWorkID = "plan-beta"
+			mismatchedTaskWorkID = "task-gamma"
+			mismatchTraceID      = "trace-same-name-mismatch"
+		)
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			Name:       "beta",
+			WorkID:     mismatchedPlanWorkID,
+			WorkTypeID: "plan",
+			TraceID:    mismatchTraceID,
+			Payload:    []byte(`{"role":"plan"}`),
+		})
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			Name:       "gamma",
+			WorkID:     mismatchedTaskWorkID,
+			WorkTypeID: "task",
+			TraceID:    mismatchTraceID,
+			Payload:    []byte(`{"role":"task"}`),
+		})
+
+		runner := support.NewShapedProviderCommandRunner(
+			codexCommandResult("Done. COMPLETE"),
+		)
+		server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+			FactoryDir: dir,
+			Edges: serviceedges.Edges{
+				ProviderCommandRunner: runner,
+			},
+		})
+		defer server.Stop(t)
+
+		baseURL := server.URL()
+		waitForMinimumWorkAtCustomerState(
+			t,
+			baseURL,
+			support.WorkCustomerLocation("plan", "ready"),
+			1,
+			10*time.Second,
+		)
+		waitForMinimumWorkAtCustomerState(
+			t,
+			baseURL,
+			support.WorkCustomerLocation("task", "ready"),
+			1,
+			10*time.Second,
+		)
+		waitForBlockedSameNameGuardObservation(t, baseURL, 10*time.Second)
+
+		listed := support.ListDefaultSessionWork(t, baseURL)
+		if got := support.CountWorkAtCustomerState(listed, support.WorkCustomerLocation("task", "matched")); got != 0 {
+			t.Fatalf("matched task count = %d, want 0 for mismatched peer names; listed=%#v", got, listed)
+		}
+		if !support.HasWorkAtCustomerState(listed, mismatchedTaskWorkID, support.WorkCustomerLocation("task", "ready")) {
+			t.Fatalf("task %q missing public ready state; listed=%#v", mismatchedTaskWorkID, listed)
+		}
+
+		events := server.GetFactoryEvents(t)
+		if indexes := dispatchResponseIndexesForTransition(t, events, "match-items"); len(indexes) != 0 {
+			t.Fatalf("match-items dispatch count = %d, want 0 while peer names mismatch", len(indexes))
+		}
+		if runner.CallCount() != 0 {
+			t.Fatalf("provider command calls = %d, want 0 while SAME_NAME guard blocks mismatched peers", runner.CallCount())
+		}
+	})
+}
+
+func sameNameGuardFactoryConfig() map[string]any {
+	return map[string]any{
+		"name": "same-name-guard-eligibility",
+		"workTypes": []map[string]any{
+			{
+				"name": "plan",
+				"states": []map[string]string{
+					{"name": "ready", "type": "INITIAL"},
+				},
+			},
+			{
+				"name": "task",
+				"states": []map[string]string{
+					{"name": "ready", "type": "INITIAL"},
+					{"name": "matched", "type": "TERMINAL"},
+				},
+			},
+		},
+		"workers": []map[string]string{
+			{"name": "matcher"},
+		},
+		"workstations": []map[string]any{
+			{
+				"name":   "match-items",
+				"worker": "matcher",
+				"inputs": []map[string]any{
+					{"workType": "plan", "state": "ready"},
+					{
+						"workType": "task",
+						"state":    "ready",
+						"guards": []map[string]string{
+							{"type": "SAME_NAME", "matchInput": "plan"},
+						},
+					},
+				},
+				"outputs": []map[string]string{
+					{"workType": "task", "state": "matched"},
+				},
+			},
+		},
+	}
+}
+
 func visitGuardedCompletionFactoryConfig() map[string]any {
 	return map[string]any{
 		"name": "visit-guard-eligibility",
@@ -171,6 +343,45 @@ func assertTerminalWorkCorrelatesToTraceID(
 		return
 	}
 	t.Fatalf("listed work missing story:complete for trace %q", traceID)
+}
+
+func waitForBlockedSameNameGuardObservation(t *testing.T, baseURL string, timeout time.Duration) {
+	t.Helper()
+
+	support.WaitForStatus(t, baseURL, timeout, func(status factoryapi.StatusResponse) bool {
+		return status.Categories.Initial == 2 &&
+			status.Categories.Processing == 0 &&
+			status.Categories.Terminal == 0
+	})
+}
+
+func waitForMinimumWorkAtCustomerState(
+	t *testing.T,
+	baseURL string,
+	location string,
+	want int,
+	timeout time.Duration,
+) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		listed := support.ListDefaultSessionWork(t, baseURL)
+		if support.CountWorkAtCustomerState(listed, location) >= want {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	listed := support.ListDefaultSessionWork(t, baseURL)
+	t.Fatalf(
+		"%s work count = %d, want at least %d within %s; listed=%#v",
+		location,
+		support.CountWorkAtCustomerState(listed, location),
+		want,
+		timeout,
+		listed,
+	)
 }
 
 func assertQuiescentSession(t *testing.T, session factoryapi.FactorySession, wantTerminal, wantFailed int) {

--- a/tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go
+++ b/tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go
@@ -205,6 +205,230 @@ func TestPetriParentOrSameNameGuardReleasesExpectedWork(t *testing.T) {
 	})
 }
 
+// TestPetriVisitOrMatchGuardFailureIsVisibleInPublicWorkState proves
+// VISIT_COUNT and MATCHES_FIELDS eligibility guard failures are observable
+// through public Work and Factory Session surfaces without inspecting internal
+// Petri markings.
+func TestPetriVisitOrMatchGuardFailureIsVisibleInPublicWorkState(t *testing.T) {
+	t.Run("visit count loop breaker routes over-limit work to failed", func(t *testing.T) {
+		dir := support.ScaffoldFactory(t, visitCountLoopBreakerFactoryConfig())
+		support.WriteAgentConfig(t, dir, "executor", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"))
+		support.WriteAgentConfig(t, dir, "reviewer", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"))
+		support.WriteWorkstationConfig(t, dir, "review-loop-breaker", "---\ntype: LOGICAL_MOVE\n---\n")
+
+		const traceID = "trace-visit-count-guard-failure"
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			WorkTypeID: "story",
+			TraceID:    traceID,
+			Payload:    []byte(`{"title":"visit-count guard failure proof"}`),
+		})
+
+		runner := support.NewShapedProviderCommandRunner(
+			codexCommandResult("Done. COMPLETE"),
+			codexCommandResult("needs more work"),
+			codexCommandResult("Done. COMPLETE"),
+			codexCommandResult("needs more work"),
+		)
+		session, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
+			t,
+			dir,
+			serviceedges.Edges{ProviderCommandRunner: runner},
+			15*time.Second,
+		)
+
+		for placeID, want := range map[string]int{
+			support.WorkCustomerLocation("story", "failed"):    1,
+			support.WorkCustomerLocation("story", "init"):      0,
+			support.WorkCustomerLocation("story", "in-review"): 0,
+			support.WorkCustomerLocation("story", "complete"):  0,
+		} {
+			if got := support.CountWorkAtCustomerState(listed, placeID); got != want {
+				t.Fatalf("%s work count = %d, want %d; listed=%#v", placeID, got, want, listed)
+			}
+		}
+		loopBreakerIndexes := dispatchResponseIndexesForTransition(t, events, "review-loop-breaker")
+		if len(loopBreakerIndexes) != 1 {
+			t.Fatalf("review-loop-breaker dispatch count = %d, want 1 after visit-count guard failure", len(loopBreakerIndexes))
+		}
+		assertQuiescentSession(t, session, 0, 1)
+		assertTerminalWorkCorrelatesToTraceID(t, listed, traceID)
+		if runner.CallCount() != 4 {
+			t.Fatalf("provider command calls = %d, want 4 (execute, review reject, execute, review reject)", runner.CallCount())
+		}
+	})
+
+	t.Run("matches fields guard blocks mismatched inputs", func(t *testing.T) {
+		dir := support.ScaffoldFactory(t, matchesFieldsGuardFactoryConfig())
+		support.WriteAgentConfig(t, dir, "matcher", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"))
+
+		const (
+			mismatchedPlanWorkID = "plan-alpha"
+			mismatchedTaskWorkID = "task-beta"
+			mismatchTraceID      = "trace-matches-fields-mismatch"
+		)
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			Name:       "flavor-a",
+			WorkID:     mismatchedPlanWorkID,
+			WorkTypeID: "plan",
+			TraceID:    mismatchTraceID,
+			Payload:    []byte(`{"role":"plan"}`),
+		})
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			Name:       "flavor-b",
+			WorkID:     mismatchedTaskWorkID,
+			WorkTypeID: "task",
+			TraceID:    mismatchTraceID,
+			Payload:    []byte(`{"role":"task"}`),
+		})
+
+		runner := support.NewShapedProviderCommandRunner(
+			codexCommandResult("Done. COMPLETE"),
+		)
+		server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+			FactoryDir: dir,
+			Edges: serviceedges.Edges{
+				ProviderCommandRunner: runner,
+			},
+		})
+		defer server.Stop(t)
+
+		baseURL := server.URL()
+		waitForMinimumWorkAtCustomerState(
+			t,
+			baseURL,
+			support.WorkCustomerLocation("plan", "ready"),
+			1,
+			10*time.Second,
+		)
+		waitForMinimumWorkAtCustomerState(
+			t,
+			baseURL,
+			support.WorkCustomerLocation("task", "ready"),
+			1,
+			10*time.Second,
+		)
+		waitForBlockedMatchesFieldsGuardObservation(t, baseURL, 10*time.Second)
+
+		listed := support.ListDefaultSessionWork(t, baseURL)
+		if got := support.CountWorkAtCustomerState(listed, support.WorkCustomerLocation("plan", "matched")); got != 0 {
+			t.Fatalf("matched plan count = %d, want 0 for mismatched field values; listed=%#v", got, listed)
+		}
+		if got := support.CountWorkAtCustomerState(listed, support.WorkCustomerLocation("task", "matched")); got != 0 {
+			t.Fatalf("matched task count = %d, want 0 for mismatched field values; listed=%#v", got, listed)
+		}
+		for workID, location := range map[string]string{
+			mismatchedPlanWorkID: support.WorkCustomerLocation("plan", "ready"),
+			mismatchedTaskWorkID: support.WorkCustomerLocation("task", "ready"),
+		} {
+			if !support.HasWorkAtCustomerState(listed, workID, location) {
+				t.Fatalf("work %q missing public %s state; listed=%#v", workID, location, listed)
+			}
+		}
+
+		events := server.GetFactoryEvents(t)
+		if indexes := dispatchResponseIndexesForTransition(t, events, "pair-items"); len(indexes) != 0 {
+			t.Fatalf("pair-items dispatch count = %d, want 0 while MATCHES_FIELDS guard blocks mismatched names", len(indexes))
+		}
+		if runner.CallCount() != 0 {
+			t.Fatalf("provider command calls = %d, want 0 while MATCHES_FIELDS guard blocks mismatched inputs", runner.CallCount())
+		}
+	})
+}
+
+func visitCountLoopBreakerFactoryConfig() map[string]any {
+	return map[string]any{
+		"name": "visit-count-guard-failure",
+		"workTypes": []map[string]any{{
+			"name": "story",
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "in-review", "type": "PROCESSING"},
+				{"name": "complete", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []map[string]string{
+			{"name": "executor"},
+			{"name": "reviewer"},
+		},
+		"workstations": []map[string]any{
+			{
+				"name":      "execute-story",
+				"worker":    "executor",
+				"inputs":    []map[string]string{{"workType": "story", "state": "init"}},
+				"outputs":   []map[string]string{{"workType": "story", "state": "in-review"}},
+				"onFailure": []map[string]string{{"workType": "story", "state": "failed"}},
+			},
+			{
+				"name":        "review-story",
+				"worker":      "reviewer",
+				"inputs":      []map[string]string{{"workType": "story", "state": "in-review"}},
+				"onFailure":   []map[string]string{{"workType": "story", "state": "failed"}},
+				"onRejection": []map[string]string{{"workType": "story", "state": "init"}},
+				"outputs":     []map[string]string{{"workType": "story", "state": "complete"}},
+			},
+			{
+				"name":   "review-loop-breaker",
+				"type":   "LOGICAL_MOVE",
+				"inputs": []map[string]string{{"workType": "story", "state": "init"}},
+				"outputs": []map[string]string{
+					{"workType": "story", "state": "failed"},
+				},
+				"guards": []map[string]any{{
+					"type":        "VISIT_COUNT",
+					"workstation": "review-story",
+					"maxVisits":   float64(2),
+				}},
+			},
+		},
+	}
+}
+
+func matchesFieldsGuardFactoryConfig() map[string]any {
+	return map[string]any{
+		"name": "matches-fields-guard-eligibility",
+		"workTypes": []map[string]any{
+			{
+				"name": "plan",
+				"states": []map[string]string{
+					{"name": "ready", "type": "INITIAL"},
+					{"name": "matched", "type": "TERMINAL"},
+				},
+			},
+			{
+				"name": "task",
+				"states": []map[string]string{
+					{"name": "ready", "type": "INITIAL"},
+					{"name": "matched", "type": "TERMINAL"},
+				},
+			},
+		},
+		"workers": []map[string]string{
+			{"name": "matcher"},
+		},
+		"workstations": []map[string]any{
+			{
+				"name":   "pair-items",
+				"worker": "matcher",
+				"inputs": []map[string]string{
+					{"workType": "plan", "state": "ready"},
+					{"workType": "task", "state": "ready"},
+				},
+				"outputs": []map[string]string{
+					{"workType": "plan", "state": "matched"},
+					{"workType": "task", "state": "matched"},
+				},
+				"guards": []map[string]any{{
+					"type": "MATCHES_FIELDS",
+					"matchConfig": map[string]string{
+						"inputKey": ".Name",
+					},
+				}},
+			},
+		},
+	}
+}
+
 func sameNameGuardFactoryConfig() map[string]any {
 	return map[string]any{
 		"name": "same-name-guard-eligibility",
@@ -334,15 +558,20 @@ func assertTerminalWorkCorrelatesToTraceID(
 	t.Helper()
 
 	for _, item := range listed.Results {
-		if item.State == nil || item.State.Name != "complete" {
+		if item.State == nil {
+			continue
+		}
+		switch item.State.Name {
+		case "complete", "failed":
+		default:
 			continue
 		}
 		if item.TraceId == nil || *item.TraceId != traceID {
-			t.Fatalf("complete work trace ID = %#v, want %q", item.TraceId, traceID)
+			t.Fatalf("%s work trace ID = %#v, want %q", item.State.Name, item.TraceId, traceID)
 		}
 		return
 	}
-	t.Fatalf("listed work missing story:complete for trace %q", traceID)
+	t.Fatalf("listed work missing terminal story outcome for trace %q", traceID)
 }
 
 func waitForBlockedSameNameGuardObservation(t *testing.T, baseURL string, timeout time.Duration) {
@@ -352,6 +581,17 @@ func waitForBlockedSameNameGuardObservation(t *testing.T, baseURL string, timeou
 		return status.Categories.Initial == 2 &&
 			status.Categories.Processing == 0 &&
 			status.Categories.Terminal == 0
+	})
+}
+
+func waitForBlockedMatchesFieldsGuardObservation(t *testing.T, baseURL string, timeout time.Duration) {
+	t.Helper()
+
+	support.WaitForStatus(t, baseURL, timeout, func(status factoryapi.StatusResponse) bool {
+		return status.Categories.Initial == 2 &&
+			status.Categories.Processing == 0 &&
+			status.Categories.Terminal == 0 &&
+			status.Categories.Failed == 0
 	})
 }
 


### PR DESCRIPTION
{
  "project": "Deepen factory_runtime Petri authored eligibility guards",
  "branchName": "ft-depth-factory-runtime-petri-guards-eligibility",
  "description": "Add a domain-owned functional package under tests/functional/factory_runtime/orchestrators/petri/guards that proves authored Petri eligibility guards (block-until-satisfied, parent/same-name release, and visit/match failure visibility) through public Work, Factory Session, and CLI outcomes only—using root.BuildProcess + Process.Execute, public CLI, and ProviderCommandRunner/mocked Codex—without implementing routing/multi_transition or Wave 3 guards/resources.",
  "context": {
    "customerAsk": "Read and follow docs/temp/functional-tests-expansion/cli-run-submit-factory-petri-depth-plan.md. Implement only tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go. Construct via root.BuildProcess + Process.Execute; prefer public CLI; ProviderCommandRunner / mocked Codex over MockWorkers. Prove public Work/session outcomes only (no internal Petri imports): (1) TestPetriAuthoredEligibilityGuardBlocksDispatchUntilSatisfied; (2) TestPetriParentOrSameNameGuardReleasesExpectedWork; (3) TestPetriVisitOrMatchGuardFailureIsVisibleInPublicWorkState. Do not implement routing/multi_transition or Wave 3 guards/resources cells. No sleeps unless RC-justified. Go docs on every Test*; focused tests + functional-boundary-check + viz metadata.",
    "problem": "Authored eligibility guards (SameName/parent/visit-count style) are largely absent from domain-owned Petri functional cells, so maintainers cannot rely on a focused factory_runtime package to prove public block-until-satisfied, correlated release, and visible guard-failure behavior without inspecting internal Petri markings. Wave 3 guards/resources remain deferred.",
    "solution": "Create an independent Go functional package at tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go that constructs via root.BuildProcess + Process.Execute, prefers public CLI, replaces external effects through edges.Edges with ProviderCommandRunner/mocked Codex, and asserts only public Work/session/CLI/event outcomes for the three named eligibility behaviors—without importing internal Petri packages or expanding into routing or Wave 3 cells."
  },
  "acceptanceCriteria": [
    "Destination package exists at tests/functional/factory_runtime/orchestrators/petri/guards/ with eligibility_test.go owning the three listed Test* behaviors (or stronger public equivalents with the same intent).",
    "TestPetriAuthoredEligibilityGuardBlocksDispatchUntilSatisfied proves an authored eligibility guard keeps the guarded workstation from producing its public success outcome until the condition is satisfied, then allows expected public Work/session progress after satisfaction.",
    "TestPetriParentOrSameNameGuardReleasesExpectedWork proves a parent-aware or SAME_NAME input guard releases/dispatches the expected correlated Work and does not release mismatched peers.",
    "TestPetriVisitOrMatchGuardFailureIsVisibleInPublicWorkState proves a VISIT_COUNT or MATCHES_FIELDS style failure/non-progress outcome is observable in public Work/Factory Session state, not only through internal Petri markings.",
    "Harness conventions hold: root.BuildProcess + Process.Execute; public CLI preferred; ProviderCommandRunner/mocked Codex over MockWorkers; no internal Petri imports; no sleeps unless readiness RC is justified in-code; customer-readable Go docs on every top-level Test*.",
    "Focused package tests pass, make functional-boundary-check passes, and functional-test-viz-compatible metadata remains valid for the new cell.",
    "Typecheck, lint, and focused/required tests pass for the changed surface with no unrelated cleanup bundled into this lane."
  ],
  "userStories": [
    {
      "id": "ft-depth-factory-runtime-petri-guards-eligibility-001",
      "title": "Authored eligibility guard blocks dispatch until satisfied",
      "description": "As a maintainer, I want a functional proof that an authored workstation eligibility guard prevents public dispatch success until the condition is met, so customers can trust that guarded workstations stay idle until eligibility is true.",
      "acceptanceCriteria": [
        "TestPetriAuthoredEligibilityGuardBlocksDispatchUntilSatisfied exists in tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go",
        "When the authored eligibility condition is false, the guarded workstation does not produce its public success/terminal Work outcome for the submitted work",
        "After the eligibility condition becomes satisfied through public Work/session progress, the same factory path produces the expected public success/progressed Work outcome",
        "Assertions use only public CLI, Work, Factory Session, or Factory Event surfaces — no internal Petri-net package imports",
        "Process is constructed via root.BuildProcess + Process.Execute; external effects replaced through edges.Edges preferring ProviderCommandRunner/mocked Codex over MockWorkers",
        "Top-level test has a customer-readable Go doc comment",
        "No sleeps or timeout-padded wait helpers unless an RC is justified in-code",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-depth-factory-runtime-petri-guards-eligibility-002",
      "title": "Parent or same-name guard releases expected work",
      "description": "As a maintainer, I want a functional proof that parent-aware or SAME_NAME input guards release only the expected correlated Work, so join and fan-in eligibility stays correct at the public surface.",
      "acceptanceCriteria": [
        "TestPetriParentOrSameNameGuardReleasesExpectedWork exists in the eligibility package",
        "A factory authored with a parent-aware or SAME_NAME input guard dispatches/releases the expected correlated Work when peer/parent conditions match",
        "Mismatched peer names or incomplete parent/child conditions do not produce the guarded workstation's public success outcome for the wrong Work",
        "Public CLI/Work/session outcomes are the sole proof surface; no internal Petri imports",
        "Harness uses root.BuildProcess + Process.Execute and ProviderCommandRunner/mocked Codex over MockWorkers",
        "Top-level test has a customer-readable Go doc comment",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-depth-factory-runtime-petri-guards-eligibility-003",
      "title": "Visit or match guard failure is visible in public Work state",
      "description": "As a maintainer, I want a functional proof that visit-count or field-match eligibility failure surfaces in public Work/Factory Session state, so customers and operators can observe blocked or failed guard outcomes without inspecting internal Petri markings.",
      "acceptanceCriteria": [
        "TestPetriVisitOrMatchGuardFailureIsVisibleInPublicWorkState exists in the eligibility package",
        "When a VISIT_COUNT or MATCHES_FIELDS style authored condition keeps work from progressing (or routes it to a documented failed/terminal public state), that outcome is visible via public Work/session/CLI inspection",
        "The test does not assert internal markings, transition tables, or Petri package types",
        "Harness uses root.BuildProcess + Process.Execute and ProviderCommandRunner/mocked Codex over MockWorkers",
        "Top-level test has a customer-readable Go doc comment",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-depth-factory-runtime-petri-guards-eligibility-004",
      "title": "Package boundary and cohort verification",
      "description": "As a maintainer, I want the new eligibility cell to satisfy cohort ownership and verification gates so it remains a durable, service-mirrored functional package without leaking into deferred Wave 3 or routing cells.",
      "acceptanceCriteria": [
        "New tests live only under tests/functional/factory_runtime/orchestrators/petri/guards/ (not under root transport/cli, catch-all cli/, or historical tests/functional/orchestration/petri as owner)",
        "Routing/multi_transition and Wave 3 guards/resources cells are not implemented or expanded by this work",
        "go test ./tests/functional/factory_runtime/orchestrators/petri/guards/... passes",
        "make functional-boundary-check passes",
        "Functional-test-viz-compatible metadata for the cell remains valid",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)