### PR TITLE
pss-lwr-prov-service-wire

### DIFF
--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -19,6 +19,14 @@ primary-result behavior.
   through Catalog's side-effect-free canonical identity resolver, reject aliases
   and unknown IDs before publishing the root, and reserve request-time Catalog
   lookup for live readiness/selectability so construction remains inert.
+- Providers owner-local Wire at `pkg/services/providers/wire` must stay
+  registered under destination `providers` in
+  `docs/internal/packaged-service-structure/package-target-manifest.json`,
+  `docs/internal/baselines/ownership-inventory.json`, and both
+  `go-*-coverage-package-minimums.json` baselines; prove registration with
+  `wire/manifest_registration_test.go` rather than re-editing manifests when
+  IMP-PROV already landed the rows. This LWR packet does not introduce
+  `pkg/services/providers/transports/**` protocol adapters.
 - Parent-private Runner implementations that expose subprocess progress should
   consume an injected streaming command capability, serialize publication only
   within each invocation, and build terminal diagnostics from the command

--- a/pkg/services/providers/wire/construction_boundary_test.go
+++ b/pkg/services/providers/wire/construction_boundary_test.go
@@ -1,0 +1,96 @@
+package wire
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+const (
+	modulePrefix              = "github.com/portpowered/infinite-you/"
+	providersWirePackage      = modulePrefix + "pkg/services/providers/wire"
+	catalogWireImport         = modulePrefix + "pkg/services/providers/internal/services/catalog/wire"
+	executionWireImport       = modulePrefix + "pkg/services/providers/internal/services/execution/wire"
+	rootServiceImport         = modulePrefix + "pkg/services/providers/internal/service"
+	executionAdaptersPrefix   = modulePrefix + "pkg/services/providers/internal/services/execution/internal/adapters/"
+	executionInternalService  = modulePrefix + "pkg/services/providers/internal/services/execution/internal/service"
+)
+
+// TestWireConstructionComposesCatalogAndExecutionOwners seals the sole
+// service-local composition path: root wire must assemble Catalog and
+// Execution through their owner wire packages and the published root facade.
+func TestWireConstructionComposesCatalogAndExecutionOwners(t *testing.T) {
+	t.Parallel()
+
+	imports := listDirectImports(t, providersWirePackage)
+	required := []string{
+		catalogWireImport,
+		executionWireImport,
+		rootServiceImport,
+	}
+	for _, importPath := range required {
+		if !containsImport(imports, importPath) {
+			t.Fatalf(
+				"%s must compose through %s; direct imports = %v",
+				providersWirePackage,
+				importPath,
+				imports,
+			)
+		}
+	}
+}
+
+// TestWireConstructionDoesNotImportExecutionAdaptersDirectly seals that root
+// wire composes built-in adapters through execution/wire rather than reaching
+// into adapter packages directly.
+func TestWireConstructionDoesNotImportExecutionAdaptersDirectly(t *testing.T) {
+	t.Parallel()
+
+	for _, importPath := range listDirectImports(t, providersWirePackage) {
+		if strings.HasPrefix(importPath, executionAdaptersPrefix) {
+			t.Fatalf(
+				"%s must not import execution adapter package %s directly",
+				providersWirePackage,
+				importPath,
+			)
+		}
+	}
+}
+
+// TestWireConstructionDoesNotImportExecutionInternalServiceDirectly seals that
+// root wire reaches execution through execution/wire rather than the private
+// execution service package.
+func TestWireConstructionDoesNotImportExecutionInternalServiceDirectly(t *testing.T) {
+	t.Parallel()
+
+	for _, importPath := range listDirectImports(t, providersWirePackage) {
+		if importPath == executionInternalService ||
+			strings.HasPrefix(importPath, executionInternalService+"/") {
+			t.Fatalf(
+				"%s must compose execution through execution/wire, not %s",
+				providersWirePackage,
+				importPath,
+			)
+		}
+	}
+}
+
+func listDirectImports(t *testing.T, packagePath string) []string {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", "-f", "{{.Imports}}", packagePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list imports for %s: %v\n%s", packagePath, err, output)
+	}
+	return strings.Fields(strings.Trim(string(output), "[]"))
+}
+
+func containsImport(imports []string, importPath string) bool {
+	for _, candidate := range imports {
+		if candidate == importPath {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/services/providers/wire/manifest_registration_test.go
+++ b/pkg/services/providers/wire/manifest_registration_test.go
@@ -1,0 +1,144 @@
+package wire_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/ownershipinventory"
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+const (
+	providersWirePackagePath = "pkg/services/providers/wire"
+	providersWireImportPath  = "github.com/portpowered/infinite-you/pkg/services/providers/wire"
+	providersOwner           = "providers"
+)
+
+type coverageMinimumManifest struct {
+	Lane     string `json:"lane"`
+	Packages []struct {
+		Package string  `json:"package"`
+		Minimum float64 `json:"minimum"`
+	} `json:"packages"`
+}
+
+func TestManifestRegistration_ProvidersWirePackageIsRegistered(t *testing.T) {
+	t.Helper()
+
+	assertPackageTargetManifestRegistration(t)
+	assertOwnershipInventoryRegistration(t)
+	assertCoverageMinimumRegistration(t, "unit", "docs/internal/baselines/go-unit-coverage-package-minimums.json")
+	assertCoverageMinimumRegistration(t, "functional", "docs/internal/baselines/go-functional-coverage-package-minimums.json")
+}
+
+func assertPackageTargetManifestRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, "docs/internal/packaged-service-structure/package-target-manifest.json"))
+	if err != nil {
+		t.Fatalf("read package-target manifest: %v", err)
+	}
+
+	var manifest struct {
+		Inventory []string `json:"inventory"`
+		Packages  []struct {
+			PackagePath string `json:"packagePath"`
+			Disposition string `json:"disposition"`
+			Destination string `json:"destination"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode package-target manifest: %v", err)
+	}
+
+	foundInventory := false
+	for _, packagePath := range manifest.Inventory {
+		if packagePath == providersWirePackagePath {
+			foundInventory = true
+			break
+		}
+	}
+	if !foundInventory {
+		t.Fatalf("package-target manifest inventory missing %q", providersWirePackagePath)
+	}
+
+	for _, row := range manifest.Packages {
+		if row.PackagePath != providersWirePackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("package-target manifest disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != providersOwner {
+			t.Fatalf("package-target manifest destination = %q, want %q", row.Destination, providersOwner)
+		}
+		return
+	}
+	t.Fatalf("package-target manifest packages missing %q", providersWirePackagePath)
+}
+
+func assertOwnershipInventoryRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, ownershipinventory.InventoryRelativePath))
+	if err != nil {
+		t.Fatalf("read ownership inventory: %v", err)
+	}
+
+	var inventory struct {
+		Packages []ownershipinventory.PackageRow `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		t.Fatalf("decode ownership inventory: %v", err)
+	}
+
+	for _, row := range inventory.Packages {
+		if row.PackagePath != providersWirePackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("ownership inventory disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != providersOwner {
+			t.Fatalf("ownership inventory destination = %q, want %q", row.Destination, providersOwner)
+		}
+		if row.DestinationKind != ownershipinventory.DestinationKindOwner {
+			t.Fatalf(
+				"ownership inventory destinationKind = %q, want %q",
+				row.DestinationKind,
+				ownershipinventory.DestinationKindOwner,
+			)
+		}
+		return
+	}
+	t.Fatalf("ownership inventory packages missing %q", providersWirePackagePath)
+}
+
+func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, relativePath))
+	if err != nil {
+		t.Fatalf("read %s coverage manifest: %v", lane, err)
+	}
+
+	var manifest coverageMinimumManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode %s coverage manifest: %v", lane, err)
+	}
+	if manifest.Lane != lane {
+		t.Fatalf("%s coverage manifest lane = %q, want %q", relativePath, manifest.Lane, lane)
+	}
+
+	for _, entry := range manifest.Packages {
+		if entry.Package != providersWireImportPath {
+			continue
+		}
+		if entry.Minimum < 0 {
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, providersWireImportPath)
+		}
+		return
+	}
+	t.Fatalf("%s coverage manifest missing %q", lane, providersWireImportPath)
+}

--- a/pkg/services/providers/wire/wire.go
+++ b/pkg/services/providers/wire/wire.go
@@ -3,10 +3,13 @@
 // Wire performs construction only, returns the singular providers.Service root
 // interface, and starts no lifecycle components. Parent-private Catalog and
 // Execution owner wiring stays inside the owner service assembly path; peers
-// depend on Service rather than owner internals or construction ports.
+// depend on Service rather than owner internals or construction ports. Missing
+// required construction ports fail with a deterministic construction error and
+// a nil service.
 package wire
 
 import (
+	"fmt"
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
@@ -120,6 +123,8 @@ func WithAgyPTY(platform AgyPTYPlatformDependencies) Option {
 
 // NewService constructs one inert Providers root over sibling Catalog and
 // Execution capabilities sharing the same private catalog identity authority.
+// Missing required composition inputs fail with a deterministic construction
+// error and a nil service.
 func NewService(options ...Option) (providers.Service, error) {
 	var config wireOptions
 	for _, option := range options {
@@ -147,6 +152,9 @@ func newRoot(
 	cursorPlatform CursorPlatformDependencies,
 	agyPTYPlatform AgyPTYPlatformDependencies,
 ) (providers.Service, error) {
+	if catalogService == nil {
+		return nil, fmt.Errorf("construct Providers: catalog is required")
+	}
 	if workersCommandRunner == nil && commandRunner != nil {
 		workersCommandRunner = workerprocess.AdaptCommandRunner(commandRunner)
 	}

--- a/pkg/services/providers/wire/wire.go
+++ b/pkg/services/providers/wire/wire.go
@@ -1,5 +1,9 @@
-// Package wire constructs the published Providers root Service from the
-// parent-private catalog subservice.
+// Package wire is the Providers service composition boundary.
+//
+// Wire performs construction only, returns the singular providers.Service root
+// interface, and starts no lifecycle components. Parent-private Catalog and
+// Execution owner wiring stays inside the owner service assembly path; peers
+// depend on Service rather than owner internals or construction ports.
 package wire
 
 import (

--- a/pkg/services/providers/wire/wire_test.go
+++ b/pkg/services/providers/wire/wire_test.go
@@ -286,6 +286,109 @@ func TestNewServiceInjectsPlatformDependenciesThroughWireOptions(t *testing.T) {
 	}
 }
 
+func TestNewServiceServesPublishedCatalogAndExecuteCompositionForMigratedIdentities(t *testing.T) {
+	t.Parallel()
+
+	probeCalls := 0
+	root, err := NewService(CatalogOption(catalogwire.WithProbeQuery(func(
+		_ context.Context,
+		descriptor providers.Descriptor,
+	) (catalog.ProbeFacts, error) {
+		probeCalls++
+		return catalog.ProbeFacts{
+			Readiness:     descriptor.Readiness,
+			Prerequisites: descriptor.Prerequisites,
+		}, nil
+	})))
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if probeCalls != 0 {
+		t.Fatalf("construction probe calls = %d, want inert construction", probeCalls)
+	}
+
+	list, err := root.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if err != nil {
+		t.Fatalf("ListProviders() = %v", err)
+	}
+	wantMigratedIDs := []providers.ID{
+		providers.IDAgy,
+		providers.IDClaude,
+		providers.IDCodex,
+		providers.IDCursor,
+		providers.IDGemini,
+		providers.IDKiro,
+		providers.IDOpenCode,
+		providers.IDPi,
+	}
+	byID := indexProvidersByID(list.Providers)
+	for _, id := range wantMigratedIDs {
+		descriptor, ok := byID[id]
+		if !ok {
+			t.Fatalf("ListProviders() missing migrated identity %q", id)
+		}
+		if descriptor.ID != id {
+			t.Fatalf("ListProviders()[%q].ID = %q", id, descriptor.ID)
+		}
+	}
+
+	for _, id := range wantMigratedIDs {
+		got, getErr := root.GetProvider(context.Background(), providers.GetProviderRequest{ID: id})
+		if getErr != nil {
+			t.Fatalf("GetProvider(%q) = %v", id, getErr)
+		}
+		if got.Provider.ID != id {
+			t.Fatalf("GetProvider(%q).Provider.ID = %q", id, got.Provider.ID)
+		}
+	}
+
+	probeCallsBeforeExecute := probeCalls
+	executeTests := []struct {
+		id   providers.ID
+		name string
+	}{
+		{id: providers.IDCodex, name: "Codex"},
+		{id: providers.IDClaude, name: "Claude"},
+		{id: providers.IDCursor, name: "Cursor"},
+		{id: providers.IDAgy, name: "Agy"},
+		{id: providers.IDGemini, name: "Gemini"},
+		{id: providers.IDKiro, name: "Kiro"},
+		{id: providers.IDOpenCode, name: "OpenCode"},
+		{id: providers.IDPi, name: "Pi"},
+	}
+	for _, test := range executeTests {
+		_, executeErr := root.Execute(context.Background(), providers.ExecuteRequest{
+			Provider:  test.id,
+			AttemptID: "migrated-composition-" + string(test.id),
+		})
+		if errors.Is(executeErr, providers.ErrUnknownProvider) {
+			t.Fatalf(
+				"Execute(%q) = %v, want execution bound through published registry",
+				test.id,
+				executeErr,
+			)
+		}
+		var failure providers.ExecuteFailure
+		if !errors.As(executeErr, &failure) ||
+			failure.Kind != providers.ExecuteFailureKindDependency ||
+			!strings.Contains(failure.Message, test.name) {
+			t.Fatalf(
+				"Execute(%q) error = %#v, want dependency failure from bound %s adapter without effects",
+				test.id,
+				executeErr,
+				test.name,
+			)
+		}
+	}
+	if probeCalls <= probeCallsBeforeExecute {
+		t.Fatalf(
+			"execution probe calls = %d before %d after explicit Execute, want catalog probing only after Execute",
+			probeCallsBeforeExecute,
+			probeCalls,
+		)
+	}
+}
+
 func TestNewServiceBindsCodexAndClaudeFromCatalogWithoutEffects(t *testing.T) {
 	t.Parallel()
 
@@ -412,6 +515,14 @@ func (i *inertPathInspector) Stat(string) (fs.FileInfo, error) {
 
 func reflectDeepZeroExecuteResult(result providers.ExecuteResult) bool {
 	return result == providers.ExecuteResult{}
+}
+
+func indexProvidersByID(descriptors []providers.Descriptor) map[providers.ID]providers.Descriptor {
+	byID := make(map[providers.ID]providers.Descriptor, len(descriptors))
+	for _, descriptor := range descriptors {
+		byID[descriptor.ID] = descriptor
+	}
+	return byID
 }
 
 type recordingWorkersCommandRunner struct {

--- a/pkg/services/providers/wire/wire_test.go
+++ b/pkg/services/providers/wire/wire_test.go
@@ -3,12 +3,19 @@ package wire
 import (
 	"context"
 	"errors"
+	"io/fs"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
+	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 	catalog "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog"
 	catalogwire "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/wire"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	"github.com/portpowered/infinite-you/pkg/services/workers/agypty"
 )
 
 func TestNewServiceConstructsPublishedRoot(t *testing.T) {
@@ -87,6 +94,97 @@ func TestNewServiceBuildsUsableRoot(t *testing.T) {
 	}
 }
 
+func TestNewServiceConstructsInertRoot(t *testing.T) {
+	t.Parallel()
+
+	probeCalls := 0
+	platformRunner := &inertPlatformCommandRunner{}
+	workersRunner := &inertWorkersCommandRunner{}
+	cursorTempFiles := &inertTemporaryFileSystem{}
+	agyAllocator := &inertPTYAllocator{}
+	agyLocator := &inertExecutableLocator{}
+	agyInspector := &inertPathInspector{}
+
+	runtime.GC()
+	time.Sleep(20 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	service, err := NewService(
+		CatalogOption(catalogwire.WithProbeQuery(func(
+			_ context.Context,
+			descriptor providers.Descriptor,
+		) (catalog.ProbeFacts, error) {
+			probeCalls++
+			return catalog.ProbeFacts{
+				Readiness:     descriptor.Readiness,
+				Prerequisites: descriptor.Prerequisites,
+			}, nil
+		})),
+		WithCommandRunner(platformRunner),
+		WithWorkersCommandRunner(workersRunner),
+		WithCursorPlatform(CursorPlatformDependencies{
+			OperatingSystem: "windows",
+			TemporaryDir:    t.TempDir(),
+			TemporaryFiles:  cursorTempFiles,
+		}),
+		WithAgyPTY(AgyPTYPlatformDependencies{
+			Allocator: agyAllocator,
+			Locator:   agyLocator,
+			Inspector: agyInspector,
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+	var root providers.Service = service
+	if root == nil {
+		t.Fatal("constructed root is not assignable to providers.Service")
+	}
+
+	if probeCalls != 0 {
+		t.Fatalf("construction probe calls = %d, want 0", probeCalls)
+	}
+	if platformRunner.calls != 0 {
+		t.Fatalf("platform command runner calls = %d, want inert construction", platformRunner.calls)
+	}
+	if workersRunner.calls != 0 {
+		t.Fatalf("workers command runner calls = %d, want inert construction", workersRunner.calls)
+	}
+	if cursorTempFiles.calls != 0 {
+		t.Fatalf("cursor temporary filesystem calls = %d, want inert construction", cursorTempFiles.calls)
+	}
+	if agyAllocator.calls != 0 || agyLocator.calls != 0 || agyInspector.calls != 0 {
+		t.Fatalf(
+			"construction invoked Agy PTY platform effects (allocate=%d lookpath=%d stat=%d), want inert construction",
+			agyAllocator.calls,
+			agyLocator.calls,
+			agyInspector.calls,
+		)
+	}
+
+	runtime.GC()
+	time.Sleep(20 * time.Millisecond)
+	if leaked := runtime.NumGoroutine() - baseline; leaked > 4 {
+		t.Fatalf(
+			"goroutine leak after construction: baseline=%d current=%d delta=%d",
+			baseline,
+			runtime.NumGoroutine(),
+			leaked,
+		)
+	}
+
+	result, listErr := root.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if listErr != nil {
+		t.Fatalf("ListProviders() = %v", listErr)
+	}
+	if len(result.Providers) == 0 {
+		t.Fatalf("ListProviders() = %#v, want non-empty migrated catalog after inert construction", result)
+	}
+}
+
 func TestNewServiceBindsCodexAndClaudeFromCatalogWithoutEffects(t *testing.T) {
 	t.Parallel()
 
@@ -140,4 +238,73 @@ func TestNewRootRejectsMissingCatalog(t *testing.T) {
 	if err == nil || root != nil {
 		t.Fatalf("newRoot(nil) = (%v, %v), want construction error", root, err)
 	}
+}
+
+type inertPlatformCommandRunner struct {
+	calls int
+}
+
+func (r *inertPlatformCommandRunner) Run(
+	_ context.Context,
+	_ platformprocess.CommandRequest,
+) (platformprocess.CommandResult, error) {
+	r.calls++
+	panic("platform command runner invoked during inert construction")
+}
+
+type inertWorkersCommandRunner struct {
+	calls int
+}
+
+func (r *inertWorkersCommandRunner) Run(
+	_ context.Context,
+	_ workers.CommandRequest,
+) (workers.CommandResult, error) {
+	r.calls++
+	panic("workers command runner invoked during inert construction")
+}
+
+type inertTemporaryFileSystem struct {
+	calls int
+}
+
+func (f *inertTemporaryFileSystem) CreateTemp(string, string) (platformfilesystem.TemporaryFile, error) {
+	f.calls++
+	panic("cursor temporary file creation during inert construction")
+}
+
+func (f *inertTemporaryFileSystem) Remove(string) error {
+	f.calls++
+	panic("cursor temporary file remove during inert construction")
+}
+
+type inertPTYAllocator struct {
+	calls int
+}
+
+func (a *inertPTYAllocator) Allocate(
+	_ context.Context,
+	_ agypty.ProcessLaunch,
+	_ agypty.SessionConfig,
+) (agypty.PTYSession, error) {
+	a.calls++
+	panic("agy PTY allocation during inert construction")
+}
+
+type inertExecutableLocator struct {
+	calls int
+}
+
+func (l *inertExecutableLocator) LookPath(string) (string, error) {
+	l.calls++
+	panic("agy executable lookup during inert construction")
+}
+
+type inertPathInspector struct {
+	calls int
+}
+
+func (i *inertPathInspector) Stat(string) (fs.FileInfo, error) {
+	i.calls++
+	panic("agy path inspect during inert construction")
 }

--- a/pkg/services/providers/wire/wire_test.go
+++ b/pkg/services/providers/wire/wire_test.go
@@ -11,6 +11,68 @@ import (
 	catalogwire "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/wire"
 )
 
+func TestNewServiceConstructsPublishedRoot(t *testing.T) {
+	t.Parallel()
+
+	service, err := NewService()
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service")
+	}
+	var root providers.Service = service
+	if root == nil {
+		t.Fatal("constructed root is not assignable to providers.Service")
+	}
+
+	result, err := root.ListProviders(context.Background(), providers.ListProvidersRequest{})
+	if err != nil {
+		t.Fatalf("ListProviders() = %v", err)
+	}
+	if len(result.Providers) == 0 {
+		t.Fatalf("ListProviders() = %#v, want non-empty migrated catalog", result)
+	}
+}
+
+func TestNewServiceComposesCatalogAndExecutionWithSharedCatalogAuthority(t *testing.T) {
+	t.Parallel()
+
+	root, err := NewService()
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	got, err := root.GetProvider(context.Background(), providers.GetProviderRequest{
+		ID: providers.IDCodex,
+	})
+	if err != nil {
+		t.Fatalf("GetProvider(codex) = %v", err)
+	}
+	if got.Provider.ID != providers.IDCodex {
+		t.Fatalf("GetProvider(codex).Provider.ID = %q", got.Provider.ID)
+	}
+
+	_, executeErr := root.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:  providers.IDCodex,
+		AttemptID: "shared-catalog-authority",
+	})
+	if errors.Is(executeErr, providers.ErrUnknownProvider) {
+		t.Fatalf(
+			"Execute(codex) = %v, want execution bound through shared catalog authority",
+			executeErr,
+		)
+	}
+	var failure providers.ExecuteFailure
+	if !errors.As(executeErr, &failure) ||
+		failure.Kind != providers.ExecuteFailureKindDependency {
+		t.Fatalf(
+			"Execute(codex) = %#v, want dependency failure from bound adapter without effects",
+			executeErr,
+		)
+	}
+}
+
 func TestNewServiceBuildsUsableRoot(t *testing.T) {
 	root, err := NewService()
 	if err != nil {

--- a/pkg/services/providers/wire/wire_test.go
+++ b/pkg/services/providers/wire/wire_test.go
@@ -437,10 +437,55 @@ func TestNewServiceBindsCodexAndClaudeFromCatalogWithoutEffects(t *testing.T) {
 	}
 }
 
-func TestNewRootRejectsMissingCatalog(t *testing.T) {
-	root, err := newRoot(nil, nil, nil, CursorPlatformDependencies{}, AgyPTYPlatformDependencies{})
-	if err == nil || root != nil {
-		t.Fatalf("newRoot(nil) = (%v, %v), want construction error", root, err)
+func TestNewServiceRejectsMissingRequiredConstructionPorts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		call func() (providers.Service, error)
+		want string
+	}{
+		{
+			name: "catalog",
+			call: func() (providers.Service, error) {
+				return newRoot(
+					nil,
+					nil,
+					nil,
+					CursorPlatformDependencies{},
+					AgyPTYPlatformDependencies{},
+				)
+			},
+			want: "construct Providers: catalog is required",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			service, err := test.call()
+			if err == nil {
+				t.Fatalf("NewService() error = nil, want missing %s construction port", test.name)
+			}
+			if service != nil {
+				t.Fatalf("NewService() = %#v, want nil service", service)
+			}
+			if !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("NewService() error = %q, want %q", err.Error(), test.want)
+			}
+		})
+	}
+
+	service, err := NewService()
+	if err != nil {
+		t.Fatalf("NewService() error = %v, want successful construction with required ports", err)
+	}
+	if service == nil {
+		t.Fatal("NewService() returned nil service, want non-nil providers.Service")
+	}
+	var root providers.Service = service
+	if root == nil {
+		t.Fatal("constructed root is not assignable to providers.Service")
 	}
 }
 

--- a/pkg/services/providers/wire/wire_test.go
+++ b/pkg/services/providers/wire/wire_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -185,6 +187,105 @@ func TestNewServiceConstructsInertRoot(t *testing.T) {
 	}
 }
 
+func TestNewServiceAgyExecuteFailsClosedWithoutInjectedPTY(t *testing.T) {
+	t.Parallel()
+
+	root, err := NewService()
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	result, executeErr := root.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:  providers.IDAgy,
+		AttemptID: "agy-without-pty-effects",
+	})
+	if !reflectDeepZeroExecuteResult(result) {
+		t.Fatalf("Execute(agy) result = %#v, want zero result on dependency failure", result)
+	}
+	var failure providers.ExecuteFailure
+	if !errors.As(executeErr, &failure) ||
+		failure.Kind != providers.ExecuteFailureKindDependency ||
+		!strings.Contains(failure.Message, "Agy") {
+		t.Fatalf(
+			"Execute(agy) error = %#v, want Agy dependency-normalized failure without injected PTY effects",
+			executeErr,
+		)
+	}
+}
+
+func TestNewServiceInjectsPlatformDependenciesThroughWireOptions(t *testing.T) {
+	t.Parallel()
+
+	cursorTempFiles := newRecordingTemporaryFileSystem(`C:\cursor-temp\cursor_prompt_fixture.md`)
+	workersRunner := &recordingWorkersCommandRunner{}
+	agyAllocator := &recordingPTYAllocator{
+		result: agypty.SessionResult{ExitCode: 0, CleanedText: "agy via wire"},
+	}
+	agyPath := filepath.Join(t.TempDir(), "agy")
+	agyLocator := fakeExecutableLocator{string(providers.IDAgy): agyPath}
+	agyInspector := fakeExecutableInspector{agyPath: fakeExecutableInfo{directory: false}}
+
+	root, err := NewService(
+		WithWorkersCommandRunner(workersRunner),
+		WithCursorPlatform(CursorPlatformDependencies{
+			OperatingSystem: "windows",
+			TemporaryDir:    `C:\cursor-temp`,
+			TemporaryFiles:  cursorTempFiles,
+		}),
+		WithAgyPTY(AgyPTYPlatformDependencies{
+			Allocator: agyAllocator,
+			Locator:   agyLocator,
+			Inspector: agyInspector,
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if cursorTempFiles.created != 0 || workersRunner.calls != 0 || agyAllocator.calls != 0 {
+		t.Fatalf(
+			"construction invoked platform effects (cursor create=%d runner=%d agy allocate=%d), want inert construction",
+			cursorTempFiles.created,
+			workersRunner.calls,
+			agyAllocator.calls,
+		)
+	}
+
+	oversizedPrompt := strings.Repeat("x", 8*1024)
+	_, cursorErr := root.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:    providers.IDCursor,
+		AttemptID:   "cursor-platform-injection",
+		UserMessage: oversizedPrompt,
+	})
+	if cursorErr == nil {
+		t.Fatal("Execute(cursor) error = nil, want failure after oversized prompt materialization")
+	}
+	if cursorTempFiles.created != 1 {
+		t.Fatalf("cursor temporary creates = %d, want injected Cursor platform used on execute", cursorTempFiles.created)
+	}
+	if cursorTempFiles.file.content != oversizedPrompt {
+		t.Fatalf("cursor prompt content = %q, want oversized prompt written through injected platform", cursorTempFiles.file.content)
+	}
+	if workersRunner.calls != 1 {
+		t.Fatalf("workers runner calls = %d, want command dispatch after injected Cursor platform", workersRunner.calls)
+	}
+
+	agyResult, agyErr := root.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:         providers.IDAgy,
+		AttemptID:        "agy-platform-injection",
+		WorkingDirectory: t.TempDir(),
+		UserMessage:      "hello through wire",
+	})
+	if agyErr != nil {
+		t.Fatalf("Execute(agy) error = %v, want success with injected PTY platform", agyErr)
+	}
+	if agyAllocator.calls != 1 {
+		t.Fatalf("agy allocator calls = %d, want injected Agy PTY platform used on execute", agyAllocator.calls)
+	}
+	if agyResult.Content != "agy via wire" {
+		t.Fatalf("Execute(agy) content = %q, want injected allocator output", agyResult.Content)
+	}
+}
+
 func TestNewServiceBindsCodexAndClaudeFromCatalogWithoutEffects(t *testing.T) {
 	t.Parallel()
 
@@ -308,3 +409,126 @@ func (i *inertPathInspector) Stat(string) (fs.FileInfo, error) {
 	i.calls++
 	panic("agy path inspect during inert construction")
 }
+
+func reflectDeepZeroExecuteResult(result providers.ExecuteResult) bool {
+	return result == providers.ExecuteResult{}
+}
+
+type recordingWorkersCommandRunner struct {
+	calls int
+}
+
+func (r *recordingWorkersCommandRunner) Run(
+	_ context.Context,
+	_ workers.CommandRequest,
+) (workers.CommandResult, error) {
+	r.calls++
+	return workers.CommandResult{}, nil
+}
+
+type recordingTemporaryFileSystem struct {
+	mu        sync.Mutex
+	file      *recordingTemporaryFile
+	created   int
+	directory string
+	pattern   string
+	removes   int
+}
+
+func newRecordingTemporaryFileSystem(path string) *recordingTemporaryFileSystem {
+	return &recordingTemporaryFileSystem{
+		file: &recordingTemporaryFile{path: path},
+	}
+}
+
+func (f *recordingTemporaryFileSystem) CreateTemp(directory, pattern string) (platformfilesystem.TemporaryFile, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.created++
+	f.directory = directory
+	f.pattern = pattern
+	return f.file, nil
+}
+
+func (f *recordingTemporaryFileSystem) Remove(path string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.removes++
+	return nil
+}
+
+type recordingTemporaryFile struct {
+	mu      sync.Mutex
+	path    string
+	content string
+	closes  int
+}
+
+func (f *recordingTemporaryFile) Name() string { return f.path }
+
+func (f *recordingTemporaryFile) WriteString(value string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.content = value
+	return len(value), nil
+}
+
+func (f *recordingTemporaryFile) Close() error {
+	f.mu.Lock()
+	f.closes++
+	f.mu.Unlock()
+	return nil
+}
+
+type recordingPTYAllocator struct {
+	calls  int
+	result agypty.SessionResult
+}
+
+func (a *recordingPTYAllocator) Allocate(
+	_ context.Context,
+	_ agypty.ProcessLaunch,
+	_ agypty.SessionConfig,
+) (agypty.PTYSession, error) {
+	a.calls++
+	return &recordingPTYSession{result: a.result}, nil
+}
+
+type recordingPTYSession struct {
+	result agypty.SessionResult
+}
+
+func (s *recordingPTYSession) Run(context.Context) (agypty.SessionResult, error) {
+	return s.result, nil
+}
+
+func (s *recordingPTYSession) Close() error { return nil }
+
+type fakeExecutableLocator map[string]string
+
+func (l fakeExecutableLocator) LookPath(name string) (string, error) {
+	if path, ok := l[name]; ok {
+		return path, nil
+	}
+	return "", fs.ErrNotExist
+}
+
+type fakeExecutableInspector map[string]fakeExecutableInfo
+
+func (i fakeExecutableInspector) Stat(path string) (fs.FileInfo, error) {
+	if info, ok := i[path]; ok {
+		return info, nil
+	}
+	return nil, fs.ErrNotExist
+}
+
+type fakeExecutableInfo struct {
+	directory bool
+}
+
+func (i fakeExecutableInfo) Name() string       { return "agy" }
+func (i fakeExecutableInfo) Size() int64        { return 0 }
+func (i fakeExecutableInfo) Mode() fs.FileMode  { return 0o755 }
+func (i fakeExecutableInfo) ModTime() time.Time { return time.Time{} }
+func (i fakeExecutableInfo) IsDir() bool        { return i.directory }
+func (i fakeExecutableInfo) Sys() any           { return nil }


### PR DESCRIPTION
{
  "project": "PSS LWR-PROV: package Providers service-local Wire to LWR parity after terminal IMP-PROV-06",
  "branchName": "pss-lwr-prov-service-wire",
  "description": "Bring pkg/services/providers/wire to peer-owner LWR parity after Factory-terminal IMP-PROV-06: compose the accepted Providers root from parent-private Catalog + Execution (including Agy/PTY platform injection), prove inert construction and published Catalog/Execute composition, leave HTTP/CLI/MCP transports out, and complete only when the PR is merged.",
  "context": {
    "customerAsk": "After Factory-terminal IMP-PROV-06 (Agy/PTY), complete Providers service-local Wire to the same inert LWR standard used by other owners: compose the accepted Providers root from parent-private Catalog + Execution owners (including all migrated concrete adapters through Agy/PTY platform injection), prove construction starts no lifecycle, and leave HTTP/CLI/MCP protocol adapters out of this packet.",
    "problem": "Every concrete IMP-PROV adapter group is Factory-terminal and pkg/services/providers/wire already constructs the published providers.Service, but that Wire surface is still thinner than peer LWR packets: inert-construction and post-adapter-absorption composition proofs are incomplete relative to the accepted LWR standard, so treating the thin skeleton as LWR-complete would unlock transports on insufficient evidence.",
    "solution": "Bring pkg/services/providers/wire to peer-owner LWR parity without inventing a second root or opening transports. Compose Catalog + Execution with injectable Cursor and Agy/PTY options, prove inert construction and published-contract composition including Agy fail-closed without PTY effects, reconcile shared manifests as required, and continue the delivery loop until the PR is merged."
  },
  "acceptanceCriteria": [
    "Providers root is constructed only through pkg/services/providers/wire (or an explicitly documented equivalent owner-local Wire path) composing Catalog + Execution (behavioral)",
    "Wire construction is inert: no lifecycle start, no probe/process side effects during NewService (behavioral)",
    "Constructed root serves published Providers Catalog/Execute contracts for migrated identities, including Agy fail-closed without injected PTY effects (behavioral)",
    "Agy/PTY and Cursor platform dependencies remain injectable Wire options rather than hidden globals (behavioral)",
    "No Providers HTTP/CLI/MCP transport packages are introduced by this packet",
    "Shared coverage/ownership/package-target manifests are reconciled on the merged head",
    "Quality checks pass (typecheck, lint, tests)",
    "Delivery loop continues until required CI is terminal green, blocking PR conversation comments are addressed, merge conflicts are resolved, and the PR is merged"
  ],
  "userStories": [
    {
      "id": "pss-lwr-prov-service-wire-001",
      "title": "Sole Wire composes Catalog + Execution into published root",
      "description": "As a maintainer, I want Providers roots constructed only through pkg/services/providers/wire from parent-private Catalog and Execution so peers depend on one inert LWR composition path returning the published providers.Service.",
      "acceptanceCriteria": [
        "pkg/services/providers/wire.NewService is the sole service-local construction path that returns the published Providers root (providers.Service); no second Providers root is invented outside this Wire owner",
        "Construction composes parent-private Catalog and Execution owners that share the same private catalog identity authority",
        "A successfully constructed root is assignable to providers.Service and can exercise at least one published Catalog operation (for example ListProviders) with a non-empty migrated catalog result",
        "This story does not author Providers HTTP/CLI/MCP transports and does not reopen concrete adapter packages except unavoidable Wire option/platform-injection plumbing",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-prov-service-wire-002",
      "title": "Prove inert Wire construction",
      "description": "As a maintainer, I want focused proof that Providers Wire construction starts no lifecycle, probes, or provider processes so LWR inertness matches peer owners.",
      "acceptanceCriteria": [
        "Calling NewService (or the accepted equivalent) returns only a constructed providers.Service (or a construction error) and does not start provider processes, PTY allocation, or other lifecycle loops during construction",
        "Instrumented catalog probe queries are not invoked during construction (probe call count remains 0 until an explicit Catalog/Execute path that requires probing)",
        "Injected command runners / Agy PTY platform effects are not invoked during construction when supplied as Wire options",
        "Focused Wire tests assert these inert-construction outcomes as observable behavior, not source-file inventories",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-prov-service-wire-003",
      "title": "Keep Cursor and Agy/PTY platform dependencies injectable",
      "description": "As a process integrator, I want Cursor and Agy/PTY platform facts injected through explicit Providers Wire options so OS/process/PTY effects are not hardcoded inside Wire.",
      "acceptanceCriteria": [
        "Cursor platform dependencies remain injectable through an explicit Wire option (for example WithCursorPlatform) rather than hidden globals inside Wire",
        "Agy/PTY platform dependencies remain injectable through an explicit Wire option (for example WithAgyPTY) rather than hidden globals inside Wire",
        "When Agy/PTY platform effects are not injected, Execute for the Agy catalog identity fails closed with the accepted unavailable/dependency-normalized failure rather than allocating PTY or starting a process",
        "Wire does not hardcode live OS/process/PTY side effects during construction or as default hidden globals",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-prov-service-wire-004",
      "title": "Published Catalog/Execute composition for migrated identities",
      "description": "As a Providers consumer, I want a Wire-constructed root to serve published Catalog and Execute contracts for migrated provider identities so post-IMP-PROV composition is proven at the LWR boundary.",
      "acceptanceCriteria": [
        "A Wire-constructed root serves published Catalog behavior for migrated provider identities (list/get or equivalent accepted catalog surface returns the registered identities)",
        "Execute through the published root binds migrated concrete adapters through the accepted Execution registry for representative identities already absorbed by IMP-PROV (including Agy)",
        "Without injected Agy/PTY effects, Agy Execute fails closed as in story 003; with injected effects available only when explicitly supplied, construction itself still remains inert",
        "Existing Codex/Claude (and peer) composition-without-effects evidence is preserved or extended rather than regressing to a thinner surface",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-prov-service-wire-005",
      "title": "Reject missing required construction ports",
      "description": "As a maintainer, I want clear construction failures when required Catalog/construction ports are missing so invalid Providers roots cannot be published silently.",
      "acceptanceCriteria": [
        "Constructing with a nil catalog (or equivalent missing required catalog construction port) returns a clear construction error and a nil Providers root",
        "Focused Wire tests cover the missing-catalog / missing-required-port failure as an observable construction outcome",
        "Successful construction paths continue to return a non-nil providers.Service only when required composition inputs are present",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-lwr-prov-service-wire-006",
      "title": "Manifest reconciliation and merge delivery without transports",
      "description": "As a maintainer, I want shared manifests reconciled and the PR merged with no Providers transports introduced so LWR-PROV is Factory-complete and protocol adapters remain gated.",
      "acceptanceCriteria": [
        "No Providers HTTP/CLI/MCP transport packages under pkg/services/providers/transports/** (or equivalent protocol-adapter trees) are introduced by this packet",
        "Shared coverage, ownership, and package-target manifests are updated only as required by Wire package registration or proof package moves, then reconciled on the merged head",
        "Package-boundary/file-count checks and relevant unit gates for the Providers Wire surface pass on the merged head",
        "Required CI is terminal green; blocking PR conversation comments are addressed; merge conflicts/shared-file churn are reconciled; the PR is merged (opening or greening a PR without merge is not completion)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": false,
      "notes": ""
    }
  ]
}
