### PR TITLE
ft-wave2-factory-definitions-import-export

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -678,6 +678,11 @@ Wave 0 functional-tests-expansion planning authority lives under
   `factory_definitions` and subsection `transports/cli` from the path; every
   top-level `Test*` needs a customer-readable Go doc so `functionaltestmetadata`
   stays viz-compatible.
+  `tests/functional/factory/definitions/import_export_test.go` owns export→import→run,
+  nested docs/scripts/metadata preservation, and invalid-import Current Factory
+  safety through `support.BuildProcess` + `support.FlattenFactoryConfig` /
+  `support.CreateNamedFactory` CLI round-trips with `support.RunFactoryToCompletionWithEdgesAndWork`
+  for terminal run proofs; catalog metadata infers domain `factory/definitions`.
   `make pkg-structure` enforces the domain-mirrored functional layout
   `tests/functional/<domain>/<subsection>/...`: new shallow, catch-all, or
   unclassified scenario packages are blocking, while existing nonconforming

--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -1399,6 +1399,36 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/factory_definitions/transports/cli/named_lifecycle/named_lifecycle_test.go",
+      "package": "you-agent-factory/tests/functional/factory_definitions/transports/cli/named_lifecycle",
+      "scenario": "TestCLIFactoryDeleteMissingReturnsActionableFailure",
+      "lane": "short",
+      "destination": "tests/functional/factory_definitions/transports/cli/named_lifecycle/named_lifecycle_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory_definitions/transports/cli/named_lifecycle/named_lifecycle_test.go",
+      "package": "you-agent-factory/tests/functional/factory_definitions/transports/cli/named_lifecycle",
+      "scenario": "TestCLIFactoryListReflectsCreateAndDelete",
+      "lane": "short",
+      "destination": "tests/functional/factory_definitions/transports/cli/named_lifecycle/named_lifecycle_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory_definitions/transports/cli/named_lifecycle/named_lifecycle_test.go",
+      "package": "you-agent-factory/tests/functional/factory_definitions/transports/cli/named_lifecycle",
+      "scenario": "TestCLIFactoryNamedCreateListUpdateDelete",
+      "lane": "short",
+      "destination": "tests/functional/factory_definitions/transports/cli/named_lifecycle/named_lifecycle_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/factory/definitions/defaults_test.go",
       "package": "you-agent-factory/tests/functional/factory/definitions",
       "scenario": "TestExplicitFactoryConfigOverridesGlobalDefaults",
@@ -1454,6 +1484,36 @@
       "scenario": "TestFactoryInitIsIdempotent",
       "lane": "short",
       "destination": "tests/functional/factory/definitions/init_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/definitions/import_export_test.go",
+      "package": "you-agent-factory/tests/functional/factory/definitions",
+      "scenario": "TestExportedFactoryCanBeImportedAndRun",
+      "lane": "short",
+      "destination": "tests/functional/factory/definitions/import_export_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/definitions/import_export_test.go",
+      "package": "you-agent-factory/tests/functional/factory/definitions",
+      "scenario": "TestImportExportPreservesNestedDocsScriptsAndMetadata",
+      "lane": "short",
+      "destination": "tests/functional/factory/definitions/import_export_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory/definitions/import_export_test.go",
+      "package": "you-agent-factory/tests/functional/factory/definitions",
+      "scenario": "TestInvalidImportDoesNotReplaceCurrentFactory",
+      "lane": "short",
+      "destination": "tests/functional/factory/definitions/import_export_test.go",
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
@@ -7849,6 +7909,36 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/workers/transports/cli/run/help/invocation_help_test.go",
+      "package": "you-agent-factory/tests/functional/workers/transports/cli/run/help",
+      "scenario": "TestCLIRunHelpDistinguishesRequiredAndOptionalParameters",
+      "lane": "short",
+      "destination": "tests/functional/workers/transports/cli/run/help/invocation_help_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/workers/transports/cli/run/help/invocation_help_test.go",
+      "package": "you-agent-factory/tests/functional/workers/transports/cli/run/help",
+      "scenario": "TestCLIRunHelpDoesNotDispatchExternalWork",
+      "lane": "short",
+      "destination": "tests/functional/workers/transports/cli/run/help/invocation_help_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/workers/transports/cli/run/help/invocation_help_test.go",
+      "package": "you-agent-factory/tests/functional/workers/transports/cli/run/help",
+      "scenario": "TestCLIRunHelpShowsInvocationSignatureForNamedFactory",
+      "lane": "short",
+      "destination": "tests/functional/workers/transports/cli/run/help/invocation_help_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/workers/agent/root_build_test.go",
       "package": "you-agent-factory/tests/functional/workers/agent",
       "scenario": "TestAgentRunnerDeliveryRemainsInertThroughRootBuildProcessConstruction",
@@ -9387,7 +9477,7 @@
       "you-agent-factory/tests/functional/events/factory_events": 5,
       "you-agent-factory/tests/functional/factory/current": 6,
       "you-agent-factory/tests/functional/factory/definition_activation": 3,
-      "you-agent-factory/tests/functional/factory/definitions": 11,
+      "you-agent-factory/tests/functional/factory/definitions": 14,
       "you-agent-factory/tests/functional/factory/packaged/catalog": 10,
       "you-agent-factory/tests/functional/factory/packaged/catalog/required_inputs_test": 2,
       "you-agent-factory/tests/functional/factory/packaged/cross": 2,

--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -1489,106 +1489,6 @@
       "deletion_only_batch": "n/a"
     },
     {
-      "source_path": "tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go",
-      "package": "you-agent-factory/tests/functional/factory_definitions/transports/cli/validate_persist",
-      "scenario": "TestCLIFactoryValidateRejectsInvalidDefinitionActionably",
-      "lane": "short",
-      "destination": "tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go",
-      "package": "you-agent-factory/tests/functional/factory_definitions/transports/cli/validate_persist",
-      "scenario": "TestCLIFactoryValidateDoesNotMutateOnFailure",
-      "lane": "short",
-      "destination": "tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go",
-      "package": "you-agent-factory/tests/functional/factory_definitions/transports/cli/validate_persist",
-      "scenario": "TestCLIFactoryPersistFromFileThenRunSucceeds",
-      "lane": "short",
-      "destination": "tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go",
-      "package": "you-agent-factory/tests/functional/factory_runtime/orchestrators/petri/guards",
-      "scenario": "TestPetriAuthoredEligibilityGuardBlocksDispatchUntilSatisfied",
-      "lane": "short",
-      "destination": "tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go",
-      "package": "you-agent-factory/tests/functional/factory_runtime/orchestrators/petri/guards",
-      "scenario": "TestPetriParentOrSameNameGuardReleasesExpectedWork",
-      "lane": "short",
-      "destination": "tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go",
-      "package": "you-agent-factory/tests/functional/factory_runtime/orchestrators/petri/guards",
-      "scenario": "TestPetriVisitOrMatchGuardFailureIsVisibleInPublicWorkState",
-      "lane": "short",
-      "destination": "tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/provider_sessions/build_process_inert_test.go",
-      "package": "you-agent-factory/tests/functional/provider_sessions",
-      "scenario": "TestProviderSessionsRemainInertThroughRootBuildProcessConstruction",
-      "lane": "short",
-      "destination": "tests/functional/provider_sessions/build_process_inert_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/provider_sessions/peer_import_boundary_test.go",
-      "package": "you-agent-factory/tests/functional/provider_sessions",
-      "scenario": "TestFunctionalProviderSessionsPackageUsesPublicProcessImportsOnly",
-      "lane": "short",
-      "destination": "tests/functional/provider_sessions/peer_import_boundary_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/workers/transports/cli/run/modes/output_modes_test.go",
-      "package": "you-agent-factory/tests/functional/workers/transports/cli/run/modes",
-      "scenario": "TestCLIRunSuccessPrimaryResultTextJSONAndNDJSON",
-      "lane": "short",
-      "destination": "tests/functional/workers/transports/cli/run/modes/output_modes_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/workers/transports/cli/run/modes/output_modes_test.go",
-      "package": "you-agent-factory/tests/functional/workers/transports/cli/run/modes",
-      "scenario": "TestCLIRunFailureOmitsFalseSuccessPrimaryResult",
-      "lane": "short",
-      "destination": "tests/functional/workers/transports/cli/run/modes/output_modes_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
       "source_path": "tests/functional/factory/definitions/validation_test.go",
       "package": "you-agent-factory/tests/functional/factory/definitions",
       "scenario": "TestAPIPreviewDoesNotStartWorkersOrSessions",
@@ -8829,36 +8729,6 @@
       "deletion_only_batch": "n/a"
     },
     {
-      "source_path": "tests/functional/workers/transports/cli/run/help/invocation_help_test.go",
-      "package": "you-agent-factory/tests/functional/workers/transports/cli/run/help",
-      "scenario": "TestCLIRunHelpDistinguishesRequiredAndOptionalParameters",
-      "lane": "short",
-      "destination": "tests/functional/workers/transports/cli/run/help/invocation_help_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/workers/transports/cli/run/help/invocation_help_test.go",
-      "package": "you-agent-factory/tests/functional/workers/transports/cli/run/help",
-      "scenario": "TestCLIRunHelpDoesNotDispatchExternalWork",
-      "lane": "short",
-      "destination": "tests/functional/workers/transports/cli/run/help/invocation_help_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/workers/transports/cli/run/help/invocation_help_test.go",
-      "package": "you-agent-factory/tests/functional/workers/transports/cli/run/help",
-      "scenario": "TestCLIRunHelpShowsInvocationSignatureForNamedFactory",
-      "lane": "short",
-      "destination": "tests/functional/workers/transports/cli/run/help/invocation_help_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
       "source_path": "tests/functional/workers/transports/cli/run/modes/output_modes_test.go",
       "package": "you-agent-factory/tests/functional/workers/transports/cli/run/modes",
       "scenario": "TestCLIRunFailureOmitsFalseSuccessPrimaryResult",
@@ -9559,9 +9429,9 @@
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 913,
+    "customer_top_level_Test_scenarios": 919,
     "lane_functionallong": 95,
-    "lane_short": 818,
+    "lane_short": 824,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 12,
       "you-agent-factory/tests/functional/automations": 14,
@@ -9592,9 +9462,6 @@
       "you-agent-factory/tests/functional/factory_definitions/transports/cli/validate_persist": 3,
       "you-agent-factory/tests/functional/factory_runtime/orchestrators/petri/guards": 3,
       "you-agent-factory/tests/functional/factory_runtime/orchestrators/petri/routing": 3,
-      "you-agent-factory/tests/functional/factory_runtime/orchestrators/petri/guards": 3,
-      "you-agent-factory/tests/functional/factory_definitions/transports/cli/named_lifecycle": 3,
-      "you-agent-factory/tests/functional/factory_definitions/transports/cli/validate_persist": 3,
       "you-agent-factory/tests/functional/factory_visualization": 6,
       "you-agent-factory/tests/functional/guards_batch": 15,
       "you-agent-factory/tests/functional/models/model_invoke": 4,
@@ -9618,7 +9485,6 @@
       "you-agent-factory/tests/functional/provider_sessions": 2,
       "you-agent-factory/tests/functional/provider_sessions/association": 6,
       "you-agent-factory/tests/functional/provider_sessions/details": 9,
-      "you-agent-factory/tests/functional/provider_sessions": 2,
       "you-agent-factory/tests/functional/providers": 36,
       "you-agent-factory/tests/functional/providers/agy": 4,
       "you-agent-factory/tests/functional/providers/codex": 7,
@@ -9757,21 +9623,21 @@
     }
   },
   "completeness_audit": {
-    "audited_at_utc": "2026-07-28T13:53:41Z",
-    "story": "ft-wave2-work-relationships-parent-child-003",
-    "live_customer_scenarios": 913,
-    "ledger_rows": 913,
+    "audited_at_utc": "2026-07-28T14:30:00Z",
+    "story": "ft-wave2-factory-definitions-import-export-mergeability-5",
+    "live_customer_scenarios": 919,
+    "ledger_rows": 919,
     "unmapped_scenarios": 0,
-    "checklist_destinations": 441,
+    "checklist_destinations": 442,
     "wrong_layer_destinations": 69,
     "invalid_destinations": 0,
-    "lane_short": 818,
+    "lane_short": 824,
     "lane_functionallong": 95,
     "specialty_targets_documented": 11,
     "deletion_only_batches": 51,
     "validator": "go run ./cmd/migrationledgercheck",
-    "row_count": 913,
-    "short_lane_rows": 818,
+    "row_count": 919,
+    "short_lane_rows": 824,
     "functionallong_lane_rows": 95
   }
 }

--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -1399,36 +1399,6 @@
       "deletion_only_batch": "n/a"
     },
     {
-      "source_path": "tests/functional/factory_definitions/transports/cli/named_lifecycle/named_lifecycle_test.go",
-      "package": "you-agent-factory/tests/functional/factory_definitions/transports/cli/named_lifecycle",
-      "scenario": "TestCLIFactoryDeleteMissingReturnsActionableFailure",
-      "lane": "short",
-      "destination": "tests/functional/factory_definitions/transports/cli/named_lifecycle/named_lifecycle_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory_definitions/transports/cli/named_lifecycle/named_lifecycle_test.go",
-      "package": "you-agent-factory/tests/functional/factory_definitions/transports/cli/named_lifecycle",
-      "scenario": "TestCLIFactoryListReflectsCreateAndDelete",
-      "lane": "short",
-      "destination": "tests/functional/factory_definitions/transports/cli/named_lifecycle/named_lifecycle_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
-      "source_path": "tests/functional/factory_definitions/transports/cli/named_lifecycle/named_lifecycle_test.go",
-      "package": "you-agent-factory/tests/functional/factory_definitions/transports/cli/named_lifecycle",
-      "scenario": "TestCLIFactoryNamedCreateListUpdateDelete",
-      "lane": "short",
-      "destination": "tests/functional/factory_definitions/transports/cli/named_lifecycle/named_lifecycle_test.go",
-      "catch_all": "none",
-      "specialty_targets": "none",
-      "deletion_only_batch": "n/a"
-    },
-    {
       "source_path": "tests/functional/factory/definitions/defaults_test.go",
       "package": "you-agent-factory/tests/functional/factory/definitions",
       "scenario": "TestExplicitFactoryConfigOverridesGlobalDefaults",
@@ -1514,6 +1484,106 @@
       "scenario": "TestInvalidImportDoesNotReplaceCurrentFactory",
       "lane": "short",
       "destination": "tests/functional/factory/definitions/import_export_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go",
+      "package": "you-agent-factory/tests/functional/factory_definitions/transports/cli/validate_persist",
+      "scenario": "TestCLIFactoryValidateRejectsInvalidDefinitionActionably",
+      "lane": "short",
+      "destination": "tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go",
+      "package": "you-agent-factory/tests/functional/factory_definitions/transports/cli/validate_persist",
+      "scenario": "TestCLIFactoryValidateDoesNotMutateOnFailure",
+      "lane": "short",
+      "destination": "tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go",
+      "package": "you-agent-factory/tests/functional/factory_definitions/transports/cli/validate_persist",
+      "scenario": "TestCLIFactoryPersistFromFileThenRunSucceeds",
+      "lane": "short",
+      "destination": "tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go",
+      "package": "you-agent-factory/tests/functional/factory_runtime/orchestrators/petri/guards",
+      "scenario": "TestPetriAuthoredEligibilityGuardBlocksDispatchUntilSatisfied",
+      "lane": "short",
+      "destination": "tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go",
+      "package": "you-agent-factory/tests/functional/factory_runtime/orchestrators/petri/guards",
+      "scenario": "TestPetriParentOrSameNameGuardReleasesExpectedWork",
+      "lane": "short",
+      "destination": "tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go",
+      "package": "you-agent-factory/tests/functional/factory_runtime/orchestrators/petri/guards",
+      "scenario": "TestPetriVisitOrMatchGuardFailureIsVisibleInPublicWorkState",
+      "lane": "short",
+      "destination": "tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/provider_sessions/build_process_inert_test.go",
+      "package": "you-agent-factory/tests/functional/provider_sessions",
+      "scenario": "TestProviderSessionsRemainInertThroughRootBuildProcessConstruction",
+      "lane": "short",
+      "destination": "tests/functional/provider_sessions/build_process_inert_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/provider_sessions/peer_import_boundary_test.go",
+      "package": "you-agent-factory/tests/functional/provider_sessions",
+      "scenario": "TestFunctionalProviderSessionsPackageUsesPublicProcessImportsOnly",
+      "lane": "short",
+      "destination": "tests/functional/provider_sessions/peer_import_boundary_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/workers/transports/cli/run/modes/output_modes_test.go",
+      "package": "you-agent-factory/tests/functional/workers/transports/cli/run/modes",
+      "scenario": "TestCLIRunSuccessPrimaryResultTextJSONAndNDJSON",
+      "lane": "short",
+      "destination": "tests/functional/workers/transports/cli/run/modes/output_modes_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/workers/transports/cli/run/modes/output_modes_test.go",
+      "package": "you-agent-factory/tests/functional/workers/transports/cli/run/modes",
+      "scenario": "TestCLIRunFailureOmitsFalseSuccessPrimaryResult",
+      "lane": "short",
+      "destination": "tests/functional/workers/transports/cli/run/modes/output_modes_test.go",
       "catch_all": "none",
       "specialty_targets": "none",
       "deletion_only_batch": "n/a"
@@ -7899,6 +7969,36 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/work/transports/cli/submit/unary_contract/unary_contract_test.go",
+      "package": "you-agent-factory/tests/functional/work/transports/cli/submit/unary_contract",
+      "scenario": "TestCLISubmitUnaryDefaultAndExplicitSessionTargeting",
+      "lane": "short",
+      "destination": "tests/functional/work/transports/cli/submit/unary_contract/unary_contract_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/work/transports/cli/submit/unary_contract/unary_contract_test.go",
+      "package": "you-agent-factory/tests/functional/work/transports/cli/submit/unary_contract",
+      "scenario": "TestCLISubmitUnaryFileAndStdinReachWork",
+      "lane": "short",
+      "destination": "tests/functional/work/transports/cli/submit/unary_contract/unary_contract_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/work/transports/cli/submit/unary_contract/unary_contract_test.go",
+      "package": "you-agent-factory/tests/functional/work/transports/cli/submit/unary_contract",
+      "scenario": "TestCLISubmitUnaryStructuredFailurePreservesPublicMessage",
+      "lane": "short",
+      "destination": "tests/functional/work/transports/cli/submit/unary_contract/unary_contract_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/work/visualization/dependency_graph_test.go",
       "package": "you-agent-factory/tests/functional/work/visualization",
       "scenario": "TestWorkVisualizeProducesDeterministicGraph",
@@ -9492,6 +9592,9 @@
       "you-agent-factory/tests/functional/factory_definitions/transports/cli/validate_persist": 3,
       "you-agent-factory/tests/functional/factory_runtime/orchestrators/petri/guards": 3,
       "you-agent-factory/tests/functional/factory_runtime/orchestrators/petri/routing": 3,
+      "you-agent-factory/tests/functional/factory_runtime/orchestrators/petri/guards": 3,
+      "you-agent-factory/tests/functional/factory_definitions/transports/cli/named_lifecycle": 3,
+      "you-agent-factory/tests/functional/factory_definitions/transports/cli/validate_persist": 3,
       "you-agent-factory/tests/functional/factory_visualization": 6,
       "you-agent-factory/tests/functional/guards_batch": 15,
       "you-agent-factory/tests/functional/models/model_invoke": 4,
@@ -9515,6 +9618,7 @@
       "you-agent-factory/tests/functional/provider_sessions": 2,
       "you-agent-factory/tests/functional/provider_sessions/association": 6,
       "you-agent-factory/tests/functional/provider_sessions/details": 9,
+      "you-agent-factory/tests/functional/provider_sessions": 2,
       "you-agent-factory/tests/functional/providers": 36,
       "you-agent-factory/tests/functional/providers/agy": 4,
       "you-agent-factory/tests/functional/providers/codex": 7,
@@ -9577,8 +9681,8 @@
       "you-agent-factory/tests/functional/workstations/repeater": 13,
       "you-agent-factory/tests/functional/workstations/watcher": 9
     },
-    "files_with_customer_Test": 254,
-    "functional_test_go_files": 253,
+    "files_with_customer_Test": 259,
+    "functional_test_go_files": 258,
     "helper_only_non_customer_files": 51,
     "internal_harness_Test_functions": 15,
     "internal_harness_test_files": 5

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -750,16 +750,31 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestImportExportPreservesNestedDocsScriptsAndMetadata`.
   - `TestInvalidImportDoesNotReplaceCurrentFactory`.
 
+
+- [x] `tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go`
+  - `TestCLIFactoryValidateRejectsInvalidDefinitionActionably`.
+  - `TestCLIFactoryValidateDoesNotMutateOnFailure`.
+  - `TestCLIFactoryPersistFromFileThenRunSucceeds`.
+
 - [x] `tests/functional/work/transports/cli/submit/batch_contract/batch_contract_test.go`
   - `TestCLISubmitBatchDryRunEmitsSummaryWithoutMutation`.
   - `TestCLISubmitBatchSuccessHumanAndJSONShapes`.
   - `TestCLISubmitBatchInvalidJSONFailsBeforeUpsert`.
   - `TestCLISubmitBatchContractHarnessExecutesThroughRootBuildProcess`.
 
+- [x] `tests/functional/work/transports/cli/submit/unary_contract/unary_contract_test.go`
+  - `TestCLISubmitUnaryFileAndStdinReachWork`.
+  - `TestCLISubmitUnaryDefaultAndExplicitSessionTargeting`.
+  - `TestCLISubmitUnaryStructuredFailurePreservesPublicMessage`.
+
 - [x] `tests/functional/workers/transports/cli/run/help/invocation_help_test.go`
   - `TestCLIRunHelpShowsInvocationSignatureForNamedFactory`.
   - `TestCLIRunHelpDistinguishesRequiredAndOptionalParameters`.
   - `TestCLIRunHelpDoesNotDispatchExternalWork`.
+
+- [x] `tests/functional/workers/transports/cli/run/modes/output_modes_test.go`
+  - `TestCLIRunSuccessPrimaryResultTextJSONAndNDJSON`.
+  - `TestCLIRunFailureOmitsFalseSuccessPrimaryResult`.
 
 ### Factory visualization
 
@@ -924,6 +939,12 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestCursorHistoricalInspectionThroughRootBuildProcess_ReturnsDeterministicNormalizedDetail`.
   - `TestCursorHistoricalInspectionThroughRootBuildProcess_PropagatesMissingAndContainmentFailures`.
   - `TestCursorHistoricalInspectionThroughRootBuildProcess_DegradesAdverseNativeDataSafely`.
+
+- [x] `tests/functional/provider_sessions/build_process_inert_test.go`
+  - `TestProviderSessionsRemainInertThroughRootBuildProcessConstruction`.
+
+- [x] `tests/functional/provider_sessions/peer_import_boundary_test.go`
+  - `TestFunctionalProviderSessionsPackageUsesPublicProcessImportsOnly`.
 
 - [x] `tests/functional/provider_sessions/details/codex_details_test.go`
   - `TestCodexProviderSessionDetailsLoadFromGoldenMetadata` covers API detail.

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -745,10 +745,21 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestCLIFactoryValidateDoesNotMutateOnFailure`.
   - `TestCLIFactoryPersistFromFileThenRunSucceeds`.
 
-- [ ] `tests/functional/factory/definitions/import_export_test.go`
+- [x] `tests/functional/factory/definitions/import_export_test.go`
   - `TestExportedFactoryCanBeImportedAndRun`.
   - `TestImportExportPreservesNestedDocsScriptsAndMetadata`.
   - `TestInvalidImportDoesNotReplaceCurrentFactory`.
+
+- [x] `tests/functional/work/transports/cli/submit/batch_contract/batch_contract_test.go`
+  - `TestCLISubmitBatchDryRunEmitsSummaryWithoutMutation`.
+  - `TestCLISubmitBatchSuccessHumanAndJSONShapes`.
+  - `TestCLISubmitBatchInvalidJSONFailsBeforeUpsert`.
+  - `TestCLISubmitBatchContractHarnessExecutesThroughRootBuildProcess`.
+
+- [x] `tests/functional/workers/transports/cli/run/help/invocation_help_test.go`
+  - `TestCLIRunHelpShowsInvocationSignatureForNamedFactory`.
+  - `TestCLIRunHelpDistinguishesRequiredAndOptionalParameters`.
+  - `TestCLIRunHelpDoesNotDispatchExternalWork`.
 
 ### Factory visualization
 

--- a/tests/functional/factory/definitions/import_export_test.go
+++ b/tests/functional/factory/definitions/import_export_test.go
@@ -1,8 +1,10 @@
 package definitions
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,6 +21,7 @@ const (
 	importExportSourceName      = "export-source"
 	importExportImportedName    = "imported-roundtrip"
 	importExportPortableName    = "imported-portable"
+	importExportCurrentName     = "current-safe"
 	importExportWorkerName      = "worker-a"
 	importExportWorkstationName = "process"
 
@@ -195,6 +198,261 @@ func TestImportExportPreservesNestedDocsScriptsAndMetadata(t *testing.T) {
 	assertImportExportPortableLayoutNote(t, importedFactory, "imported factory")
 }
 
+// TestInvalidImportDoesNotReplaceCurrentFactory proves an invalid import through
+// the public update path is rejected with a customer-visible failure and leaves
+// the prior Current Factory definition unchanged on public readback.
+func TestInvalidImportDoesNotReplaceCurrentFactory(t *testing.T) {
+	runner := support.NewRecordingCommandRunner("runtime must not execute during invalid import")
+	edges := serviceedges.Edges{ProviderCommandRunner: runner}
+
+	homeDir := t.TempDir()
+	workingDir := t.TempDir()
+	env := append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	namedFactoriesRoot := initializeImportExportCustomerHome(t, env, workingDir)
+
+	sourceDir := support.ScaffoldFactory(t, importExportCurrentFactoryConfig())
+	support.WriteAgentConfig(
+		t,
+		sourceDir,
+		importExportWorkerName,
+		support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"),
+	)
+	sourcePath := filepath.Join(sourceDir, "factory.json")
+
+	factoryDir := createImportExportActivatedNamedFactory(
+		t,
+		env,
+		workingDir,
+		namedFactoriesRoot,
+		importExportCurrentName,
+		sourcePath,
+	)
+
+	baselineFactory, err := support.LoadedFactory(t, filepath.Join(factoryDir, "factory.json"))
+	if err != nil {
+		t.Fatalf("load baseline current factory: %v", err)
+	}
+	if baselineFactory.Name != factoryapi.FactoryName(importExportCurrentName) {
+		t.Fatalf(
+			"baseline factory name = %q, want %q",
+			baselineFactory.Name,
+			importExportCurrentName,
+		)
+	}
+
+	invalidDir := support.ScaffoldFactory(t, importExportInvalidImportFactoryConfig())
+	invalidPath := filepath.Join(invalidDir, "factory.json")
+
+	updateInputs := support.FakeInputs(t.Context(), []string{
+		"you",
+		"factory",
+		"update",
+		importExportCurrentName,
+		"--from",
+		invalidPath,
+		"--dir",
+		namedFactoriesRoot,
+	})
+	updateInputs.Input.Env = env
+	updateInputs.Input.WorkingDirectory = workingDir
+	updateErr := support.BuildProcess(t, edges).Execute(updateInputs.Input)
+	if updateErr == nil {
+		t.Fatalf(
+			"Process.Execute(factory update invalid import) error = nil, want customer-visible failure; stdout=%q stderr=%q",
+			updateInputs.Stdout(),
+			updateInputs.Stderr(),
+		)
+	}
+	diagnostic := updateErr.Error() + "\n" + updateInputs.Stdout() + "\n" + updateInputs.Stderr()
+	if !strings.Contains(diagnostic, "invalid factory config") {
+		t.Fatalf("diagnostic missing invalid import marker:\n%s", diagnostic)
+	}
+	if !strings.Contains(diagnostic, validationCodeDanglingWorkerReference) {
+		t.Fatalf(
+			"diagnostic missing validation code %q:\n%s",
+			validationCodeDanglingWorkerReference,
+			diagnostic,
+		)
+	}
+
+	reloadedFactory, err := support.LoadedFactory(t, filepath.Join(factoryDir, "factory.json"))
+	if err != nil {
+		t.Fatalf("reload current factory after rejected import: %v", err)
+	}
+	assertImportExportCurrentFactoryUnchanged(t, baselineFactory, reloadedFactory)
+
+	listInputs := support.FakeInputs(t.Context(), []string{"you", "--json", "factory", "list"})
+	listInputs.Input.Env = env
+	listInputs.Input.WorkingDirectory = workingDir
+	if err := support.BuildProcess(t, edges).Execute(listInputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(factory list) error = %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			listInputs.Stdout(),
+			listInputs.Stderr(),
+		)
+	}
+	var listEntries []importExportFactoryListEntry
+	if err := json.Unmarshal([]byte(listInputs.Stdout()), &listEntries); err != nil {
+		t.Fatalf("decode factory list: %v\n%s", err, listInputs.Stdout())
+	}
+	foundCurrent := false
+	for _, entry := range listEntries {
+		if entry.Name != importExportCurrentName {
+			continue
+		}
+		foundCurrent = true
+		if entry.FactoryDirectory != factoryDir {
+			t.Fatalf(
+				"current factory directory = %q, want %q",
+				entry.FactoryDirectory,
+				factoryDir,
+			)
+		}
+		if !entry.Current {
+			t.Fatalf("factory list current flag = false, want true for %q", importExportCurrentName)
+		}
+	}
+	if !foundCurrent {
+		t.Fatalf("factory list missing current factory %q; entries=%#v", importExportCurrentName, listEntries)
+	}
+
+	if runner.CallCount() != 0 {
+		t.Fatalf("provider command runner calls = %d, want 0 during rejected import", runner.CallCount())
+	}
+}
+
+type importExportFactoryListEntry struct {
+	Name             string `json:"name"`
+	FactoryDirectory string `json:"factoryDirectory"`
+	Current          bool   `json:"current"`
+}
+
+func initializeImportExportCustomerHome(t *testing.T, env []string, workingDirectory string) string {
+	t.Helper()
+
+	homeDir := importExportEnvironmentHome(env)
+	namedFactoriesRoot := filepath.Join(homeDir, ".you-agent-factory", "factories")
+	missingFactory := filepath.Join(workingDirectory, "missing-initialization-factory.json")
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "run", "--factory", missingFactory,
+	})
+	inputs.Input.Env = env
+	inputs.Input.WorkingDirectory = workingDirectory
+	err := support.BuildProcess(t, serviceedges.Edges{}).Execute(inputs.Input)
+	if err == nil || !strings.Contains(err.Error(), filepath.Base(missingFactory)) {
+		t.Fatalf(
+			"Process.Execute(run missing Factory) error = %v, want missing Factory diagnostic\nstdout:\n%s\nstderr:\n%s",
+			err,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+	return namedFactoriesRoot
+}
+
+func createImportExportActivatedNamedFactory(
+	t *testing.T,
+	env []string,
+	workingDirectory string,
+	namedFactoriesRoot string,
+	name string,
+	factoryConfigPath string,
+) string {
+	t.Helper()
+
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you",
+		"--json",
+		"factory",
+		"create",
+		name,
+		"--from",
+		factoryConfigPath,
+		"--dir",
+		namedFactoriesRoot,
+		"--set-current",
+	})
+	inputs.Input.Env = env
+	inputs.Input.WorkingDirectory = workingDirectory
+	if err := support.BuildProcess(t, serviceedges.Edges{}).Execute(inputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(factory create %q --set-current) error = %v\nstdout:\n%s\nstderr:\n%s",
+			name,
+			err,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+
+	var result struct {
+		FactoryDir string `json:"factoryDir"`
+	}
+	if err := json.Unmarshal([]byte(inputs.Stdout()), &result); err != nil {
+		t.Fatalf("decode factory create result: %v\nstdout:\n%s", err, inputs.Stdout())
+	}
+	if _, err := os.Stat(filepath.Join(result.FactoryDir, "factory.json")); err != nil {
+		t.Fatalf(
+			"activated named Factory %q missing factory.json at %s: %v",
+			name,
+			result.FactoryDir,
+			err,
+		)
+	}
+	return result.FactoryDir
+}
+
+func importExportEnvironmentHome(env []string) string {
+	for index := len(env) - 1; index >= 0; index-- {
+		item := env[index]
+		if strings.HasPrefix(item, "HOME=") {
+			return strings.TrimPrefix(item, "HOME=")
+		}
+		if strings.HasPrefix(item, "USERPROFILE=") {
+			return strings.TrimPrefix(item, "USERPROFILE=")
+		}
+	}
+	return ""
+}
+
+func assertImportExportCurrentFactoryUnchanged(
+	t *testing.T,
+	baseline factoryapi.Factory,
+	reloaded factoryapi.Factory,
+) {
+	t.Helper()
+
+	if reloaded.Name != baseline.Name {
+		t.Fatalf("reloaded factory name = %q, want unchanged %q", reloaded.Name, baseline.Name)
+	}
+	if reloaded.Id == nil || baseline.Id == nil || *reloaded.Id != *baseline.Id {
+		t.Fatalf("reloaded factory id = %#v, want unchanged %#v", reloaded.Id, baseline.Id)
+	}
+	if baseline.Version != nil && reloaded.Version != nil && *reloaded.Version != *baseline.Version {
+		t.Fatalf("reloaded factory version = %#v, want unchanged %#v", reloaded.Version, baseline.Version)
+	}
+	assertImportExportWorkTypePresent(t, reloaded, importExportWorkType, "reloaded current factory")
+}
+
+func assertImportExportWorkTypePresent(
+	t *testing.T,
+	factory factoryapi.Factory,
+	workType string,
+	contextLabel string,
+) {
+	t.Helper()
+
+	if factory.WorkTypes == nil {
+		t.Fatalf("%s workTypes = nil, want %q", contextLabel, workType)
+	}
+	for _, candidate := range *factory.WorkTypes {
+		if candidate.Name == workType {
+			return
+		}
+	}
+	t.Fatalf("%s missing work type %q in %#v", contextLabel, workType, factory.WorkTypes)
+}
+
 func seedImportExportPortableFilesOnDisk(t *testing.T, factoryDir string) {
 	t.Helper()
 
@@ -308,6 +566,42 @@ func findImportExportBundledFileByTargetPath(
 		}
 	}
 	return factoryapi.BundledFile{}, false
+}
+
+func importExportCurrentFactoryConfig() map[string]any {
+	cfg := importExportFactoryConfig()
+	cfg["name"] = importExportCurrentName
+	cfg["id"] = importExportCurrentName
+	return cfg
+}
+
+func importExportInvalidImportFactoryConfig() map[string]any {
+	return map[string]any{
+		"name": "invalid-import-payload",
+		"id":   "invalid-import-payload",
+		"workTypes": []map[string]any{
+			{
+				"name": importExportWorkType,
+				"states": []map[string]string{
+					{"name": "init", "type": "INITIAL"},
+					{"name": "complete", "type": "TERMINAL"},
+					{"name": "failed", "type": "FAILED"},
+				},
+			},
+		},
+		"workers": []map[string]string{
+			{"name": importExportWorkerName},
+		},
+		"workstations": []map[string]any{
+			{
+				"name":      importExportWorkstationName,
+				"worker":    "missing-worker",
+				"inputs":    []map[string]string{{"workType": importExportWorkType, "state": "init"}},
+				"outputs":   []map[string]string{{"workType": importExportWorkType, "state": "complete"}},
+				"onFailure": []map[string]string{{"workType": importExportWorkType, "state": "failed"}},
+			},
+		},
+	}
 }
 
 func importExportFactoryConfig() map[string]any {

--- a/tests/functional/factory/definitions/import_export_test.go
+++ b/tests/functional/factory/definitions/import_export_test.go
@@ -1,0 +1,126 @@
+package definitions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	importExportWorkType       = "task"
+	importExportSourceName     = "export-source"
+	importExportImportedName   = "imported-roundtrip"
+	importExportWorkerName     = "worker-a"
+	importExportWorkstationName = "process"
+)
+
+// TestExportedFactoryCanBeImportedAndRun proves a valid Factory exported through
+// the public flatten path can be imported through factory create and then run to
+// a customer-visible terminal success outcome.
+func TestExportedFactoryCanBeImportedAndRun(t *testing.T) {
+	sourceDir := support.ScaffoldFactory(t, importExportFactoryConfig())
+	support.WriteAgentConfig(
+		t,
+		sourceDir,
+		importExportWorkerName,
+		support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"),
+	)
+
+	exported, err := support.FlattenFactoryConfig(t, filepath.Join(sourceDir, "factory.json"))
+	if err != nil {
+		t.Fatalf("FlattenFactoryConfig(export source): %v", err)
+	}
+	if len(exported) == 0 {
+		t.Fatal("exported factory payload is empty")
+	}
+
+	exportPath := filepath.Join(t.TempDir(), "exported-factory.json")
+	if err := os.WriteFile(exportPath, exported, 0o644); err != nil {
+		t.Fatalf("write exported factory payload: %v", err)
+	}
+
+	homeDir := t.TempDir()
+	workingDir := t.TempDir()
+	importedDir := support.CreateNamedFactory(
+		t,
+		homeDir,
+		workingDir,
+		importExportImportedName,
+		exportPath,
+	)
+
+	if _, err := os.Stat(filepath.Join(importedDir, "factory.json")); err != nil {
+		t.Fatalf("imported factory.json missing at %s: %v", importedDir, err)
+	}
+	importedFactory, err := support.LoadedFactory(t, filepath.Join(importedDir, "factory.json"))
+	if err != nil {
+		t.Fatalf("load imported factory through public flatten readback: %v", err)
+	}
+	if importedFactory.Name == "" {
+		t.Fatalf("imported factory name = %q, want non-empty customer-visible identity", importedFactory.Name)
+	}
+
+	testutil.WriteSeedFile(
+		t,
+		importedDir,
+		importExportWorkType,
+		[]byte(`{"title":"exported factory imported and run"}`),
+	)
+
+	runner := support.NewShapedProviderCommandRunner(platformprocess.CommandResult{
+		Stdout: support.CodexSuccessStdout("Done. COMPLETE"),
+	})
+	edges := serviceedges.Edges{ProviderCommandRunner: runner}
+
+	_, listed := support.RunFactoryToCompletionWithEdgesAndWork(
+		t,
+		importedDir,
+		edges,
+		15*time.Second,
+	)
+
+	if got := support.CountWorkAtCustomerState(listed, importExportWorkType+":complete"); got != 1 {
+		t.Fatalf("completed work tokens = %d, want 1; listed=%#v", got, listed)
+	}
+	if got := support.CountWorkAtCustomerState(listed, importExportWorkType+":failed"); got != 0 {
+		t.Fatalf("failed work tokens = %d, want 0", got)
+	}
+	if runner.CallCount() != 1 {
+		t.Fatalf("provider command runner calls = %d, want 1", runner.CallCount())
+	}
+}
+
+func importExportFactoryConfig() map[string]any {
+	return map[string]any{
+		"name": importExportSourceName,
+		"workTypes": []map[string]any{
+			{
+				"name": importExportWorkType,
+				"states": []map[string]string{
+					{"name": "init", "type": "INITIAL"},
+					{"name": "complete", "type": "TERMINAL"},
+					{"name": "failed", "type": "FAILED"},
+				},
+			},
+		},
+		"workers": []map[string]string{
+			{"name": importExportWorkerName},
+		},
+		"workstations": []map[string]any{
+			{
+				"name":      importExportWorkstationName,
+				"worker":    importExportWorkerName,
+				"inputs":    []map[string]string{{"workType": importExportWorkType, "state": "init"}},
+				"outputs":   []map[string]string{{"workType": importExportWorkType, "state": "complete"}},
+				"onFailure": []map[string]string{{"workType": importExportWorkType, "state": "failed"}},
+			},
+		},
+	}
+}

--- a/tests/functional/factory/definitions/import_export_test.go
+++ b/tests/functional/factory/definitions/import_export_test.go
@@ -10,15 +10,23 @@ import (
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
 const (
-	importExportWorkType       = "task"
-	importExportSourceName     = "export-source"
-	importExportImportedName   = "imported-roundtrip"
-	importExportWorkerName     = "worker-a"
+	importExportWorkType        = "task"
+	importExportSourceName      = "export-source"
+	importExportImportedName    = "imported-roundtrip"
+	importExportPortableName    = "imported-portable"
+	importExportWorkerName      = "worker-a"
 	importExportWorkstationName = "process"
+
+	importExportPortableDocPath    = "factory/docs/standards/review.md"
+	importExportPortableDocBody   = "# Review standards\n"
+	importExportPortableScriptPath = "factory/scripts/execute-task.sh"
+	importExportPortableScriptBody = "#!/bin/sh\necho 'portable script'\n"
+	importExportPortableNoteBody   = "Portable guidance remains literal."
 )
 
 // TestExportedFactoryCanBeImportedAndRun proves a valid Factory exported through
@@ -97,6 +105,211 @@ func TestExportedFactoryCanBeImportedAndRun(t *testing.T) {
 	}
 }
 
+// TestImportExportPreservesNestedDocsScriptsAndMetadata proves nested docs,
+// scripts, and portable layout metadata authored with a Factory survive export
+// and import through the public flatten and create customer paths.
+func TestImportExportPreservesNestedDocsScriptsAndMetadata(t *testing.T) {
+	sourceDir := support.ScaffoldFactory(t, importExportPortableFactoryConfig())
+	support.WriteAgentConfig(
+		t,
+		sourceDir,
+		importExportWorkerName,
+		support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"),
+	)
+	seedImportExportPortableFilesOnDisk(t, sourceDir)
+
+	exported, err := support.FlattenFactoryConfig(t, filepath.Join(sourceDir, "factory.json"))
+	if err != nil {
+		t.Fatalf("FlattenFactoryConfig(export source): %v", err)
+	}
+	if len(exported) == 0 {
+		t.Fatal("exported factory payload is empty")
+	}
+
+	exportedFactory, err := support.DecodeFactoryDefinition(exported)
+	if err != nil {
+		t.Fatalf("decode exported factory payload: %v", err)
+	}
+	assertImportExportPortableBundledFileInline(
+		t,
+		exportedFactory,
+		factoryapi.BundledFileTypeDOC,
+		importExportPortableDocPath,
+		importExportPortableDocBody,
+		"exported factory",
+	)
+	assertImportExportPortableBundledFileInline(
+		t,
+		exportedFactory,
+		factoryapi.BundledFileTypeSCRIPT,
+		importExportPortableScriptPath,
+		importExportPortableScriptBody,
+		"exported factory",
+	)
+	assertImportExportPortableLayoutNote(t, exportedFactory, "exported factory")
+
+	exportPath := filepath.Join(t.TempDir(), "exported-portable-factory.json")
+	if err := os.WriteFile(exportPath, exported, 0o644); err != nil {
+		t.Fatalf("write exported factory payload: %v", err)
+	}
+
+	homeDir := t.TempDir()
+	workingDir := t.TempDir()
+	importedDir := support.CreateNamedFactory(
+		t,
+		homeDir,
+		workingDir,
+		importExportPortableName,
+		exportPath,
+	)
+
+	assertImportExportPortableFileOnDisk(
+		t,
+		filepath.Join(importedDir, "docs", "standards", "review.md"),
+		importExportPortableDocBody,
+	)
+	assertImportExportPortableFileOnDisk(
+		t,
+		filepath.Join(importedDir, "scripts", "execute-task.sh"),
+		importExportPortableScriptBody,
+	)
+
+	importedFactory, err := support.LoadedFactory(t, filepath.Join(importedDir, "factory.json"))
+	if err != nil {
+		t.Fatalf("load imported factory through public flatten readback: %v", err)
+	}
+	assertImportExportPortableBundledFile(
+		t,
+		importedFactory,
+		factoryapi.BundledFileTypeDOC,
+		importExportPortableDocPath,
+		"imported factory",
+	)
+	assertImportExportPortableBundledFile(
+		t,
+		importedFactory,
+		factoryapi.BundledFileTypeSCRIPT,
+		importExportPortableScriptPath,
+		"imported factory",
+	)
+	assertImportExportPortableLayoutNote(t, importedFactory, "imported factory")
+}
+
+func seedImportExportPortableFilesOnDisk(t *testing.T, factoryDir string) {
+	t.Helper()
+
+	docPath := filepath.Join(factoryDir, "docs", "standards", "review.md")
+	if err := os.MkdirAll(filepath.Dir(docPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(docPath), err)
+	}
+	if err := os.WriteFile(docPath, []byte(importExportPortableDocBody), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", docPath, err)
+	}
+
+	scriptPath := filepath.Join(factoryDir, "scripts", "execute-task.sh")
+	if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(scriptPath), err)
+	}
+	if err := os.WriteFile(scriptPath, []byte(importExportPortableScriptBody), 0o755); err != nil {
+		t.Fatalf("WriteFile(%s): %v", scriptPath, err)
+	}
+}
+
+func assertImportExportPortableFileOnDisk(t *testing.T, path, want string) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	if string(data) != want {
+		t.Fatalf("file %s = %q, want %q", path, string(data), want)
+	}
+}
+
+func assertImportExportPortableBundledFile(
+	t *testing.T,
+	factory factoryapi.Factory,
+	wantType factoryapi.BundledFileType,
+	targetPath string,
+	contextLabel string,
+) {
+	t.Helper()
+
+	bundledFile, ok := findImportExportBundledFileByTargetPath(factory, targetPath)
+	if !ok {
+		t.Fatalf("%s missing bundled file target %q", contextLabel, targetPath)
+	}
+	if bundledFile.Type != wantType {
+		t.Fatalf(
+			"%s bundled file %q type = %q, want %q",
+			contextLabel,
+			targetPath,
+			bundledFile.Type,
+			wantType,
+		)
+	}
+}
+
+func assertImportExportPortableBundledFileInline(
+	t *testing.T,
+	factory factoryapi.Factory,
+	wantType factoryapi.BundledFileType,
+	targetPath string,
+	wantInline string,
+	contextLabel string,
+) {
+	t.Helper()
+
+	assertImportExportPortableBundledFile(t, factory, wantType, targetPath, contextLabel)
+
+	bundledFile, _ := findImportExportBundledFileByTargetPath(factory, targetPath)
+	if bundledFile.Content.Inline != wantInline {
+		t.Fatalf(
+			"%s bundled file %q inline = %q, want %q",
+			contextLabel,
+			targetPath,
+			bundledFile.Content.Inline,
+			wantInline,
+		)
+	}
+}
+
+func assertImportExportPortableLayoutNote(t *testing.T, factory factoryapi.Factory, contextLabel string) {
+	t.Helper()
+
+	if factory.Layout == nil || factory.Layout.Annotations == nil {
+		t.Fatalf("%s missing portable layout annotations", contextLabel)
+	}
+	for _, annotation := range *factory.Layout.Annotations {
+		if annotation.Kind != factoryapi.FactoryLayoutAnnotationKindNOTE {
+			continue
+		}
+		if annotation.Note == nil {
+			continue
+		}
+		if annotation.Note.Body == importExportPortableNoteBody {
+			return
+		}
+	}
+	t.Fatalf("%s missing portable layout note %q", contextLabel, importExportPortableNoteBody)
+}
+
+func findImportExportBundledFileByTargetPath(
+	factory factoryapi.Factory,
+	targetPath string,
+) (factoryapi.BundledFile, bool) {
+	if factory.SupportingFiles == nil || factory.SupportingFiles.BundledFiles == nil {
+		return factoryapi.BundledFile{}, false
+	}
+	for _, bundledFile := range *factory.SupportingFiles.BundledFiles {
+		if bundledFile.TargetPath == targetPath {
+			return bundledFile, true
+		}
+	}
+	return factoryapi.BundledFile{}, false
+}
+
 func importExportFactoryConfig() map[string]any {
 	return map[string]any{
 		"name": importExportSourceName,
@@ -123,4 +336,49 @@ func importExportFactoryConfig() map[string]any {
 			},
 		},
 	}
+}
+
+func importExportPortableFactoryConfig() map[string]any {
+	cfg := importExportFactoryConfig()
+	cfg["name"] = importExportSourceName
+	cfg["supportingFiles"] = map[string]any{
+		"bundledFiles": []map[string]any{
+			{
+				"id":         importExportPortableDocPath,
+				"type":       "DOC",
+				"targetPath": importExportPortableDocPath,
+				"content": map[string]any{
+					"encoding": "utf-8",
+					"inline":   importExportPortableDocBody,
+				},
+			},
+			{
+				"id":         importExportPortableScriptPath,
+				"type":       "SCRIPT",
+				"targetPath": importExportPortableScriptPath,
+				"content": map[string]any{
+					"encoding": "utf-8",
+					"inline":   importExportPortableScriptBody,
+				},
+			},
+		},
+	}
+	cfg["layout"] = map[string]any{
+		"schemaVersion": 1,
+		"nodes": []map[string]any{{
+			"id":       "workstation:" + importExportWorkstationName,
+			"position": map[string]any{"x": 128, "y": 256},
+		}},
+		"annotations": []map[string]any{{
+			"id":       "portable-note",
+			"kind":     "NOTE",
+			"position": map[string]any{"x": -80, "y": 120},
+			"note": map[string]any{
+				"body": importExportPortableNoteBody,
+				"tone": "INFO",
+			},
+		}},
+		"viewport": map[string]any{"x": 40, "y": 60, "zoom": 0.9},
+	}
+	return cfg
 }


### PR DESCRIPTION
{
  "project": "Factory Definition Import/Export Round-Trip Functional Coverage",
  "branchName": "ft-wave2-factory-definitions-import-export",
  "description": "Implement only tests/functional/factory/definitions/import_export_test.go to prove export→import→run, nested docs/scripts/metadata preservation, and invalid-import Current Factory safety via root.BuildProcess + Process.Execute with CLI-preferred ordinary export/import/run flows and API only for explicit export/import contract proofs, consuming the twenty-one mapped migration-ledger rows and preserving bootstrap_portability-delete-03-factory-definitions-import-export, bootstrap_portability-delete-04-portable-config, and runtime_api-delete-06-factory-current ownership without implementing validation, defaults, init, or depth factory_definitions/transports/cli siblings.",
  "context": {
    "customerAsk": "Implement only tests/functional/factory/definitions/import_export_test.go. Construct via root.BuildProcess + Process.Execute (built you CLI only if this cell must prove OS/process-boundary behavior BuildProcess cannot express). Prefer public CLI over HTTP/API for ordinary export/import/run flows; use API where the checklist explicitly requires export/import contract proofs. Replace external effects only through edges.Edges, preferring ProviderCommandRunner / command-runner edge mocks and mocked Codex (or another real inference-provider variant via sanitized goldens) over --with-mock-workers / MockWorkers. Do not add sleeps or timeout-padded wait helpers unless justified in-code after fixing readiness/latency root causes. Prove: (1) TestExportedFactoryCanBeImportedAndRun; (2) TestImportExportPreservesNestedDocsScriptsAndMetadata; (3) TestInvalidImportDoesNotReplaceCurrentFactory. Consume the twenty-one mapped migration-ledger rows and preserve bootstrap_portability-delete-03-factory-definitions-import-export, bootstrap_portability-delete-04-portable-config, and runtime_api-delete-06-factory-current ownership for import_export-mapped rows. Do not implement validation_test.go, defaults_test.go, init_test.go, or depth factory_definitions/transports/cli cells. Avoid service/internal Petri imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled ownership/coverage/catalog/migration metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for Factory definition import/export round-trips does not exist, while twenty-one mapped migration-ledger rows still point at this cell under bootstrap_portability-delete-03-factory-definitions-import-export, bootstrap_portability-delete-04-portable-config, and runtime_api-delete-06-factory-current. Legacy proofs for export→import→activate/run, nested docs preservation, portable flatten/expand readiness, canonical export/import contracts, and named/replace-current portable layout live in catch-all packages, leaving no definitions-owned proof of the three checklist behaviors. Sibling validation/defaults/init/depth-CLI cells must not be widened into this lane, held delete-03/04 must not be deleted by the ready-only bootstrap_portability migrator, and named deletion-batch ownership must not be dropped.",
    "solution": "Implement the three checklist scenarios in tests/functional/factory/definitions/import_export_test.go through root.BuildProcess + Process.Execute, preferring public CLI for ordinary export/import/run flows and using the public export/import API only for explicit contract proofs, replacing external effects only through edges.Edges with ProviderCommandRunner / mocked Codex preferred over MockWorkers, and adding customer-readable Go docs on every top-level Test. Consume the twenty-one mapped migration-ledger import/export and portable-layout obligations, preserve the three named deletion-batch ownerships for import_export-mapped rows, apply only narrowly coupled metadata/deletion updates for this destination, leave sibling cells untouched, keep held delete-03/04 out of the ready-only migrator, and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/factory/definitions/import_export_test.go exists as the factory/definitions-owned functional cell and covers exported Factory can be imported and run, nested docs/scripts/metadata survive import/export, and invalid import does not replace Current Factory.",
    "CLI-preferred export/import/run flows exercise root.BuildProcess + Process.Execute (built CLI only if OS/process-boundary proof requires it) and prove round-trip + run without asserting Petri markings or importing service/internal Petri packages.",
    "Nested docs, scripts, and portable metadata remain present and usable after export→import (customer-visible paths/content or equivalent public readback).",
    "An invalid import attempt leaves the prior Current Factory definition observable and unchanged; rejection is customer-visible.",
    "The twenty-one mapped migration-ledger rows whose destination is this cell are consumed; named deletion-batches bootstrap_portability-delete-03-factory-definitions-import-export, bootstrap_portability-delete-04-portable-config, and runtime_api-delete-06-factory-current are preserved for import_export-mapped rows; only narrowly coupled ownership/deletion/coverage/catalog metadata for this cell are updated; sibling validation/defaults/init/depth-CLI cells stay untouched; held delete-03/04 rows are not deleted by the ready-only bootstrap_portability migrator.",
    "Every top-level Test* has a customer-readable Go doc comment whose first sentence describes the observable import/export behavior; external effects use edges.Edges with preferred ProviderCommandRunner / mocked Codex patterns; no unjustified sleeps or timeout-padded wait helpers.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave2-factory-definitions-import-export-001",
      "title": "Prove exported Factory can be imported and run",
      "description": "As a Factory author moving a definition between environments, I want an exported Factory to import cleanly through the public customer path and then run work, so that portability is proven end-to-end—not just as a file copy.",
      "acceptanceCriteria": [
        "tests/functional/factory/definitions/import_export_test.go includes TestExportedFactoryCanBeImportedAndRun.",
        "The test constructs the process via root.BuildProcess + Process.Execute (built you CLI only if OS/process-boundary proof requires it) and prefers public CLI over HTTP/API for the ordinary export/import/run flow.",
        "A valid Factory is exported, imported through the public customer path, and a subsequent run against the imported Factory completes with a customer-observable success outcome.",
        "Assertions stay on public export/import/run outcomes and do not inspect Petri markings or import service/internal Petri packages.",
        "External effects are replaced only through edges.Edges, preferring ProviderCommandRunner / command-runner mocks and mocked Codex over MockWorkers; no unjustified sleeps or timeout-padded wait helpers.",
        "The top-level test has a customer-readable Go doc comment describing the export→import→run behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-definitions-import-export-002",
      "title": "Prove import/export preserves nested docs, scripts, and metadata",
      "description": "As a Factory author who ships nested docs, scripts, and portable metadata with a definition, I want those artifacts to survive export→import, so that shared Factories remain complete after transfer.",
      "acceptanceCriteria": [
        "The cell includes TestImportExportPreservesNestedDocsScriptsAndMetadata.",
        "The test uses the same public process-construction boundary as the round-trip proof (root.BuildProcess + Process.Execute, CLI preferred for ordinary flow; API only if an explicit export/import contract proof requires it).",
        "A Factory authored with nested docs and/or scripts (and related portable metadata) is exported and imported; after import, nested docs, scripts, and metadata remain present via customer-visible paths, content, or public readback.",
        "Coverage absorbs the customer-facing nested-docs and portable-layout obligations mapped to this destination without owning Current Factory read/save success paths already covered by terminal read_save, or depth factory_definitions/transports/cli cells.",
        "External effects use edges.Edges with preferred ProviderCommandRunner / mocked Codex patterns; no unjustified sleeps.",
        "The top-level test has a customer-readable Go doc comment describing the nested docs/scripts/metadata preservation behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-definitions-import-export-003",
      "title": "Prove invalid import does not replace Current Factory",
      "description": "As an operator importing a Factory definition, I want an invalid import to fail without replacing my Current Factory, so that a bad payload cannot silently destroy the active definition.",
      "acceptanceCriteria": [
        "The cell includes TestInvalidImportDoesNotReplaceCurrentFactory.",
        "The test constructs via root.BuildProcess + Process.Execute and prefers public CLI for the ordinary invalid-import safety flow (API only if an explicit contract proof requires it).",
        "A known-good Current Factory is established; an invalid import attempt is rejected with a customer-visible failure outcome.",
        "After the failed import, public observations show the prior Current Factory definition remains unchanged (identity/content/readback equivalence sufficient for reviewer verification).",
        "Assertions do not take ownership of validation multi-error matrices, defaults, init, or depth CLI validate/persist cells.",
        "External effects use edges.Edges with preferred ProviderCommandRunner / mocked Codex patterns; no unjustified sleeps.",
        "The top-level test has a customer-readable Go doc comment describing the invalid-import Current Factory safety behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-factory-definitions-import-export-004",
      "title": "Consume migration obligation and close verification gates",
      "description": "As a maintainer executing Wave 2 migration, I want this cell to absorb the twenty-one mapped import/export ledger rows and pass focused boundary/metadata gates, so the destination is catalogued correctly without implementing sibling cells or dropping shared deletion-batch ownership.",
      "acceptanceCriteria": [
        "Migration-ledger mappings whose destination is tests/functional/factory/definitions/import_export_test.go are consumed by this cell's coverage for export→import→run, nested docs/scripts/metadata preservation, portable flatten/expand readiness, canonical export/import contracts, and related customer-facing import/export obligations (twenty-one rows under bootstrap_portability-delete-03-factory-definitions-import-export, bootstrap_portability-delete-04-portable-config, and runtime_api-delete-06-factory-current); specialty bindings remain as recorded (none or artifact-contract-closeout).",
        "Named deletion-batches bootstrap_portability-delete-03-factory-definitions-import-export, bootstrap_portability-delete-04-portable-config, and runtime_api-delete-06-factory-current ownership is preserved for import_export-mapped rows; held delete-03/04 batches are not deleted by the ready-only bootstrap_portability migrator (delete-05/06 only); batches are not reassigned solely because this cell lands.",
        "Only narrowly coupled ownership, deletion-only migration, coverage, or catalog metadata required for this cell are updated; siblings validation_test.go, defaults_test.go, init_test.go, and depth factory_definitions/transports/cli cells are left alone.",
        "Focused package tests for tests/functional/factory/definitions (import_export cell) pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as factory/definitions).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)