### PR TITLE
ft-depth-factory-definitions-transports-cli-validate-persist

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -529,6 +529,19 @@ Wave 0 functional-tests-expansion planning authority lives under
   `factory_definitions` and subsection `transports/cli/named_lifecycle`.
   Every top-level `Test*` needs a customer-readable Go doc so
   `functionaltestmetadata` stays viz-compatible.
+  Factory Definitions CLI validate/persist depth belongs in
+  `tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go`:
+  prove actionable public `you --json factory config validate` rejection before
+  provider dispatch, failed validate non-mutation of durable named Factory state
+  via `factory list` and on-disk `factory.json`, and persist-from-file through
+  `factory create --from` followed by successful `you --json run --named
+  --with-server` with terminal primary results. Drive proofs through
+  `support.BuildProcess` + `Process.Execute`, substituting external effects
+  only through `edges.Edges` with `ProviderCommandRunner` / mocked Codex
+  preferred over `MockWorkers`. Catalog metadata infers domain
+  `factory_definitions` and subsection `transports/cli` from the path; every
+  top-level `Test*` needs a customer-readable Go doc so `functionaltestmetadata`
+  stays viz-compatible.
   `make pkg-structure` enforces the domain-mirrored functional layout
   `tests/functional/<domain>/<subsection>/...`: new shallow, catch-all, or
   unclassified scenario packages are blocking, while existing nonconforming

--- a/tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go
+++ b/tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go
@@ -1,0 +1,105 @@
+package validate_persist
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const invalidFactoryWithDanglingWorker = `{
+	"name":"invalid-validate-persist",
+	"workTypes":[{
+		"name":"task",
+		"states":[
+			{"name":"init","type":"INITIAL"},
+			{"name":"complete","type":"TERMINAL"},
+			{"name":"failed","type":"FAILED"}
+		]
+	}],
+	"workstations":[{
+		"name":"execute",
+		"worker":"missing-worker",
+		"inputs":[{"workType":"task","state":"init"}],
+		"outputs":[{"workType":"task","state":"complete"}],
+		"onFailure":[{"workType":"task","state":"failed"}],
+		"type":"MODEL_WORKSTATION"
+	}]
+}`
+
+// TestCLIFactoryValidateRejectsInvalidDefinitionActionably proves the public
+// Factory CLI validate command rejects an invalid authored definition with
+// actionable diagnostics before runtime execution or persistence side effects.
+func TestCLIFactoryValidateRejectsInvalidDefinitionActionably(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		body    string
+		wants   []string
+	}{
+		{
+			name: "semantic validation failure",
+			body: invalidFactoryWithDanglingWorker,
+			wants: []string{
+				"factory validation found blocking issues",
+				"factory.worker.danglingReference",
+				"missing-worker",
+			},
+		},
+		{
+			name: "parse failure",
+			body: `{"name":["invalid"]}`,
+			wants: []string{
+				"parse factory config",
+				"name",
+				"cannot unmarshal",
+			},
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			sourcePath := writeFactoryFile(t, test.body)
+			assertValidateRejectedActionably(t, sourcePath, test.wants...)
+		})
+	}
+}
+
+func assertValidateRejectedActionably(t *testing.T, factorySource string, wants ...string) {
+	t.Helper()
+
+	runner := support.NewRecordingCommandRunner("runtime must not execute")
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "--json", "factory", "config", "validate", factorySource,
+	})
+	inputs.Input.WorkingDirectory = filepath.Dir(factorySource)
+	err := support.BuildProcess(
+		t,
+		serviceedges.Edges{ProviderCommandRunner: runner},
+	).Execute(inputs.Input)
+	if err == nil {
+		t.Fatal("Process.Execute(factory config validate) error = nil, want rejection")
+	}
+
+	diagnostic := err.Error() + "\n" + inputs.Stdout() + "\n" + inputs.Stderr()
+	for _, want := range wants {
+		if !strings.Contains(diagnostic, want) {
+			t.Fatalf("validate diagnostic missing %q:\n%s", want, diagnostic)
+		}
+	}
+	if runner.CallCount() != 0 {
+		t.Fatalf("provider command runner call count = %d, want 0 before validate completes", runner.CallCount())
+	}
+}
+
+func writeFactoryFile(t *testing.T, body string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "factory.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write factory.json: %v", err)
+	}
+	return path
+}

--- a/tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go
+++ b/tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go
@@ -74,7 +74,7 @@ func TestCLIFactoryValidateRejectsInvalidDefinitionActionably(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			sourcePath := writeFactoryFile(t, test.body)
-			assertValidateRejectedActionably(t, sourcePath, test.wants...)
+			assertValidateRejectedActionably(t, sourcePath, test.wants, validateOptions{})
 		})
 	}
 }
@@ -93,12 +93,21 @@ func TestCLIFactoryValidateDoesNotMutateOnFailure(t *testing.T) {
 		durableBaselineFactoryName,
 		filepath.Join(sourceDir, "factory.json"),
 	)
+	env := customerHomeEnvironment(home)
 	before := captureDurableBaseline(t, home, workingDirectory, factoryDir)
 
 	invalidPath := writeFactoryFile(t, invalidFactoryWithDanglingWorker)
-	assertValidateRejectedActionably(t, invalidPath,
-		"factory validation found blocking issues",
-		"factory.worker.danglingReference",
+	assertValidateRejectedActionably(
+		t,
+		invalidPath,
+		[]string{
+			"factory validation found blocking issues",
+			"factory.worker.danglingReference",
+		},
+		validateOptions{
+			env:              env,
+			workingDirectory: workingDirectory,
+		},
 	)
 
 	after := captureDurableBaseline(t, home, workingDirectory, factoryDir)
@@ -181,14 +190,31 @@ func TestCLIFactoryPersistFromFileThenRunSucceeds(t *testing.T) {
 	}
 }
 
-func assertValidateRejectedActionably(t *testing.T, factorySource string, wants ...string) {
+type validateOptions struct {
+	env              []string
+	workingDirectory string
+}
+
+func assertValidateRejectedActionably(
+	t *testing.T,
+	factorySource string,
+	wants []string,
+	options validateOptions,
+) {
 	t.Helper()
 
 	runner := support.NewRecordingCommandRunner("runtime must not execute")
 	inputs := support.FakeInputs(t.Context(), []string{
 		"you", "--json", "factory", "config", "validate", factorySource,
 	})
-	inputs.Input.WorkingDirectory = filepath.Dir(factorySource)
+	if options.env != nil {
+		inputs.Input.Env = options.env
+	}
+	if options.workingDirectory != "" {
+		inputs.Input.WorkingDirectory = options.workingDirectory
+	} else {
+		inputs.Input.WorkingDirectory = filepath.Dir(factorySource)
+	}
 	err := support.BuildProcess(
 		t,
 		serviceedges.Edges{ProviderCommandRunner: runner},
@@ -211,6 +237,7 @@ func assertValidateRejectedActionably(t *testing.T, factorySource string, wants 
 type durableBaseline struct {
 	factoryJSON []byte
 	factory     factoryapi.Factory
+	listEntries []factoryListEntry
 	listEntry   factoryListEntry
 }
 
@@ -236,11 +263,8 @@ func captureDurableBaseline(
 	if err != nil {
 		t.Fatalf("LoadedFactory(%s): %v", factoryDir, err)
 	}
-	entry, ok := findFactoryListEntry(
-		t,
-		executeFactoryList(t, home, workingDirectory),
-		durableBaselineFactoryName,
-	)
+	listEntries := executeFactoryList(t, home, workingDirectory)
+	entry, ok := findFactoryListEntry(t, listEntries, durableBaselineFactoryName)
 	if !ok {
 		t.Fatalf("factory list missing durable Factory %q", durableBaselineFactoryName)
 	}
@@ -254,6 +278,7 @@ func captureDurableBaseline(
 	return durableBaseline{
 		factoryJSON: append([]byte(nil), factoryJSON...),
 		factory:     factory,
+		listEntries: append([]factoryListEntry(nil), listEntries...),
 		listEntry:   entry,
 	}
 }
@@ -280,6 +305,13 @@ func assertDurableBaselineUnchanged(t *testing.T, before, after durableBaseline)
 			"factory list entry changed after failed validate\nbefore: %#v\nafter: %#v",
 			before.listEntry,
 			after.listEntry,
+		)
+	}
+	if !reflect.DeepEqual(before.listEntries, after.listEntries) {
+		t.Fatalf(
+			"factory list inventory changed after failed validate\nbefore: %#v\nafter: %#v",
+			before.listEntries,
+			after.listEntries,
 		)
 	}
 }

--- a/tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go
+++ b/tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go
@@ -1,14 +1,20 @@
 package validate_persist
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
+
+const durableBaselineFactoryName = "validate-persist-baseline"
 
 const invalidFactoryWithDanglingWorker = `{
 	"name":"invalid-validate-persist",
@@ -66,6 +72,32 @@ func TestCLIFactoryValidateRejectsInvalidDefinitionActionably(t *testing.T) {
 	}
 }
 
+// TestCLIFactoryValidateDoesNotMutateOnFailure proves a failed public Factory
+// CLI validate of an invalid candidate leaves an existing durable Factory
+// definition unchanged on disk and in the public factory list.
+func TestCLIFactoryValidateDoesNotMutateOnFailure(t *testing.T) {
+	home := t.TempDir()
+	workingDirectory := t.TempDir()
+	sourceDir := support.ScaffoldSingleStepFactory(t, durableBaselineFactoryName)
+	factoryDir := support.CreateNamedFactory(
+		t,
+		home,
+		workingDirectory,
+		durableBaselineFactoryName,
+		filepath.Join(sourceDir, "factory.json"),
+	)
+	before := captureDurableBaseline(t, home, workingDirectory, factoryDir)
+
+	invalidPath := writeFactoryFile(t, invalidFactoryWithDanglingWorker)
+	assertValidateRejectedActionably(t, invalidPath,
+		"factory validation found blocking issues",
+		"factory.worker.danglingReference",
+	)
+
+	after := captureDurableBaseline(t, home, workingDirectory, factoryDir)
+	assertDurableBaselineUnchanged(t, before, after)
+}
+
 func assertValidateRejectedActionably(t *testing.T, factorySource string, wants ...string) {
 	t.Helper()
 
@@ -91,6 +123,117 @@ func assertValidateRejectedActionably(t *testing.T, factorySource string, wants 
 	if runner.CallCount() != 0 {
 		t.Fatalf("provider command runner call count = %d, want 0 before validate completes", runner.CallCount())
 	}
+}
+
+type durableBaseline struct {
+	factoryJSON []byte
+	factory     factoryapi.Factory
+	listEntry   factoryListEntry
+}
+
+type factoryListEntry struct {
+	Name             string `json:"name"`
+	FactoryDirectory string `json:"factoryDirectory"`
+	Description      string `json:"description"`
+}
+
+func captureDurableBaseline(
+	t *testing.T,
+	home string,
+	workingDirectory string,
+	factoryDir string,
+) durableBaseline {
+	t.Helper()
+
+	factoryJSON, err := os.ReadFile(filepath.Join(factoryDir, "factory.json"))
+	if err != nil {
+		t.Fatalf("read durable factory.json: %v", err)
+	}
+	factory, err := support.LoadedFactory(t, factoryDir)
+	if err != nil {
+		t.Fatalf("LoadedFactory(%s): %v", factoryDir, err)
+	}
+	entry, ok := findFactoryListEntry(
+		t,
+		executeFactoryList(t, home, workingDirectory),
+		durableBaselineFactoryName,
+	)
+	if !ok {
+		t.Fatalf("factory list missing durable Factory %q", durableBaselineFactoryName)
+	}
+	if entry.FactoryDirectory != factoryDir {
+		t.Fatalf(
+			"factory list directory = %q, want durable directory %q",
+			entry.FactoryDirectory,
+			factoryDir,
+		)
+	}
+	return durableBaseline{
+		factoryJSON: append([]byte(nil), factoryJSON...),
+		factory:     factory,
+		listEntry:   entry,
+	}
+}
+
+func assertDurableBaselineUnchanged(t *testing.T, before, after durableBaseline) {
+	t.Helper()
+
+	if !bytes.Equal(before.factoryJSON, after.factoryJSON) {
+		t.Fatalf(
+			"durable factory.json changed after failed validate\nbefore:\n%s\nafter:\n%s",
+			before.factoryJSON,
+			after.factoryJSON,
+		)
+	}
+	if !reflect.DeepEqual(before.factory, after.factory) {
+		t.Fatalf(
+			"loaded durable Factory changed after failed validate\nbefore: %#v\nafter: %#v",
+			before.factory,
+			after.factory,
+		)
+	}
+	if !reflect.DeepEqual(before.listEntry, after.listEntry) {
+		t.Fatalf(
+			"factory list entry changed after failed validate\nbefore: %#v\nafter: %#v",
+			before.listEntry,
+			after.listEntry,
+		)
+	}
+}
+
+func executeFactoryList(t *testing.T, home, workingDirectory string) []factoryListEntry {
+	t.Helper()
+
+	inputs := support.FakeInputs(t.Context(), []string{"you", "--json", "factory", "list"})
+	inputs.Input.Env = append(os.Environ(), "HOME="+home, "USERPROFILE="+home)
+	inputs.Input.WorkingDirectory = workingDirectory
+	if err := support.BuildProcess(t, serviceedges.Edges{}).Execute(inputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(factory list) error = %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+	var entries []factoryListEntry
+	if err := json.Unmarshal([]byte(inputs.Stdout()), &entries); err != nil {
+		t.Fatalf("decode factory list: %v\n%s", err, inputs.Stdout())
+	}
+	return entries
+}
+
+func findFactoryListEntry(
+	t *testing.T,
+	entries []factoryListEntry,
+	name string,
+) (factoryListEntry, bool) {
+	t.Helper()
+	for _, entry := range entries {
+		if entry.Name == name {
+			return entry, true
+		}
+	}
+	return factoryListEntry{}, false
 }
 
 func writeFactoryFile(t *testing.T, body string) string {

--- a/tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go
+++ b/tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go
@@ -3,6 +3,7 @@ package validate_persist
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -10,11 +11,17 @@ import (
 	"testing"
 
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
-const durableBaselineFactoryName = "validate-persist-baseline"
+const (
+	durableBaselineFactoryName = "validate-persist-baseline"
+	persistThenRunFactoryName  = "validate-persist-run"
+	persistThenRunPrimaryResult = "persist-from-file run COMPLETE"
+)
 
 const invalidFactoryWithDanglingWorker = `{
 	"name":"invalid-validate-persist",
@@ -96,6 +103,82 @@ func TestCLIFactoryValidateDoesNotMutateOnFailure(t *testing.T) {
 
 	after := captureDurableBaseline(t, home, workingDirectory, factoryDir)
 	assertDurableBaselineUnchanged(t, before, after)
+}
+
+// TestCLIFactoryPersistFromFileThenRunSucceeds proves persist-from-file through
+// the public Factory CLI create path produces a durable Factory that succeeds on
+// a subsequent public run invocation with a customer-visible primary result.
+func TestCLIFactoryPersistFromFileThenRunSucceeds(t *testing.T) {
+	home := t.TempDir()
+	workingDirectory := t.TempDir()
+	env := customerHomeEnvironment(home)
+
+	sourceDir := support.ScaffoldSingleStepFactory(t, persistThenRunFactoryName)
+	support.UpdateFactoryConfig(t, sourceDir, func(cfg map[string]any) {
+		workTypes, ok := cfg["workTypes"].([]any)
+		if !ok || len(workTypes) == 0 {
+			t.Fatal("persist-then-run factory missing workTypes")
+		}
+		workType, ok := workTypes[0].(map[string]any)
+		if !ok {
+			t.Fatal("persist-then-run factory workType has unexpected shape")
+		}
+		workType["handlingBehavior"] = []any{"DEFAULT"}
+	})
+	support.WriteAgentConfig(
+		t,
+		sourceDir,
+		"processor",
+		support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"),
+	)
+	sourcePath := filepath.Join(sourceDir, interfaces.FactoryConfigFile)
+
+	factoryDir := support.CreateNamedFactory(
+		t,
+		home,
+		workingDirectory,
+		persistThenRunFactoryName,
+		sourcePath,
+	)
+	if _, err := os.Stat(filepath.Join(factoryDir, interfaces.FactoryConfigFile)); err != nil {
+		t.Fatalf("persisted %s missing after factory create --from: %v", interfaces.FactoryConfigFile, err)
+	}
+
+	providerRunner := support.NewStaticSuccessCommandRunner(persistThenRunPrimaryResult)
+	api := support.NewProcessAPIServer()
+	edges := serviceedges.Edges{APIServerStarter: api.Start}
+	support.ConfigureWorkerCommands(t, &edges, providerRunner, nil)
+	process := support.BuildProcess(t, edges)
+
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "--json", "run",
+		"--named", persistThenRunFactoryName,
+		"--no-record",
+		"--with-server",
+		"prove persist-from-file then run",
+	})
+	inputs.Input.Env = env
+	inputs.Input.WorkingDirectory = workingDirectory
+
+	command := support.StartProcessCommand(t, process, inputs.Input)
+	_ = api.WaitForURL(t)
+	<-command.Done()
+	if err := command.Err(); err != nil {
+		t.Fatalf(
+			"Process.Execute(factory run) error = %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+
+	response := decodeInvocationResponse(t, inputs.Stdout())
+	if response.Status != factoryapi.InvocationTerminalStatusCompleted {
+		t.Fatalf("invocation status = %q, want %q", response.Status, factoryapi.InvocationTerminalStatusCompleted)
+	}
+	if got := invocationPrimaryResultText(t, response); got != persistThenRunPrimaryResult {
+		t.Fatalf("primaryResult = %q, want %q", got, persistThenRunPrimaryResult)
+	}
 }
 
 func assertValidateRejectedActionably(t *testing.T, factorySource string, wants ...string) {
@@ -245,4 +328,35 @@ func writeFactoryFile(t *testing.T, body string) string {
 		t.Fatalf("write factory.json: %v", err)
 	}
 	return path
+}
+
+func customerHomeEnvironment(home string) []string {
+	return append(os.Environ(), "HOME="+home, "USERPROFILE="+home)
+}
+
+func decodeInvocationResponse(t *testing.T, stdout string) factoryapi.InvocationResponse {
+	t.Helper()
+
+	decoder := json.NewDecoder(strings.NewReader(stdout))
+	var response factoryapi.InvocationResponse
+	if err := decoder.Decode(&response); err != nil {
+		t.Fatalf("decode InvocationResponse: %v\nstdout:\n%s", err, stdout)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		t.Fatalf("stdout contains data after InvocationResponse: %v\nstdout:\n%s", err, stdout)
+	}
+	return response
+}
+
+func invocationPrimaryResultText(t *testing.T, response factoryapi.InvocationResponse) string {
+	t.Helper()
+
+	if response.PrimaryResult == nil || len(*response.PrimaryResult) != 1 {
+		t.Fatalf("primaryResult = %#v, want one text content part", response.PrimaryResult)
+	}
+	part, err := (*response.PrimaryResult)[0].AsWorkTextContentPart()
+	if err != nil {
+		t.Fatalf("primaryResult text part: %v", err)
+	}
+	return part.Text
 }


### PR DESCRIPTION
{
  "project": "Factory Definitions CLI Validate/Persist Depth",
  "branchName": "ft-depth-factory-definitions-transports-cli-validate-persist",
  "description": "Implement only tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go to prove public Factory CLI validate rejects invalid definitions actionably, failed validate does not mutate durable Factory definition state, and persist-from-file of a valid definition then succeeds at a subsequent public run—via root.BuildProcess + Process.Execute with public-CLI preference and ProviderCommandRunner / mocked Codex over MockWorkers—without implementing named_lifecycle or Wave 2 factory/definitions validation|import_export cells.",
  "context": {
    "customerAsk": "Read and follow docs/temp/functional-tests-expansion/cli-run-submit-factory-petri-depth-plan.md. Implement only tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go (not root transport/cli). Construct via root.BuildProcess + Process.Execute; prefer public CLI; ProviderCommandRunner / mocked Codex over MockWorkers. Prove: (1) TestCLIFactoryValidateRejectsInvalidDefinitionActionably; (2) TestCLIFactoryPersistFromFileThenRunSucceeds; (3) TestCLIFactoryValidateDoesNotMutateOnFailure. Do not implement named_lifecycle or Wave 2 factory/definitions/validation|import_export cells. No sleeps unless RC-justified. Go docs on every Test*; focused tests + functional-boundary-check + viz metadata.",
    "problem": "Validate-reject and persist-from-file-then-run are thin versus the pkg/transports/cli/factory surface. Wave 1 transport/cli factory_wiring covers init/validate/query and portability at the wiring layer but does not own depth proofs for actionable invalid-definition rejection, failed-validate non-mutation, or persist-from-file followed by a successful public run under the service-mirrored factory_definitions owner. Without a focused validate_persist package, reviewers cannot separately verify those three CLI outcomes from named_lifecycle CRUD depth or Wave 2 factory/definitions validation|import_export cells, and new depth must not reopen root transport/cli ownership.",
    "solution": "Implement the three checklist scenarios in tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go through root.BuildProcess + Process.Execute, preferring public Factory CLI for ordinary flows, replacing external effects only through edges.Edges with ProviderCommandRunner / mocked Codex preferred over MockWorkers, asserting public CLI / Work / Factory Session / Factory Event outcomes only (no service/internal Petri imports), adding customer-readable Go docs on every top-level Test*, leaving named_lifecycle and Wave 2 definitions validation|import_export untouched, and verifying focused package tests plus functional-boundary-check and viz-compatible metadata."
  },
  "acceptanceCriteria": [
    "tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go exists as an independent Go package under the service-mirrored factory_definitions/transports/cli owner (not under root transport/cli or catch-all cli/).",
    "The cell proves invalid Factory validate is rejected with actionable public diagnostics via TestCLIFactoryValidateRejectsInvalidDefinitionActionably.",
    "The cell proves persist-from-file of a valid definition followed by a successful public run via TestCLIFactoryPersistFromFileThenRunSucceeds.",
    "The cell proves failed validate does not mutate durable Factory definition state via TestCLIFactoryValidateDoesNotMutateOnFailure.",
    "Construction uses root.BuildProcess + Process.Execute by default; public CLI is preferred; external effects use edges.Edges with ProviderCommandRunner / mocked Codex preferred over MockWorkers; no unjustified sleeps; no service/internal Petri imports in assertions; sibling named_lifecycle and Wave 2 factory/definitions/validation|import_export cells are not implemented or widened.",
    "Every top-level Test* has a customer-readable Go doc comment whose first sentence describes the observable validate/persist behavior.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-depth-factory-definitions-transports-cli-validate-persist-001",
      "title": "Prove validate rejects invalid definitions actionably",
      "description": "As a Factory author validating a broken definition file, I want the public Factory CLI validate command to reject it with actionable diagnostics, so that I can fix the definition before persist or run.",
      "acceptanceCriteria": [
        "tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go includes TestCLIFactoryValidateRejectsInvalidDefinitionActionably in an independent Go package under factory_definitions/transports/cli (not root transport/cli).",
        "The test constructs the process via root.BuildProcess + Process.Execute and prefers the public Factory CLI validate path over HTTP/API for the ordinary rejection flow.",
        "An invalid authored Factory definition is rejected before runtime execution / successful persist.",
        "Public diagnostics are actionable (customer-visible failure naming the defect class or target in human/JSON CLI output) without inspecting Petri markings or importing service/internal Petri packages.",
        "External effects are replaced only through edges.Edges, preferring ProviderCommandRunner / mocked Codex over MockWorkers; no unjustified sleeps or timeout-padded wait helpers.",
        "The top-level test has a customer-readable Go doc comment whose first sentence describes the observable validate-reject behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-depth-factory-definitions-transports-cli-validate-persist-002",
      "title": "Prove failed validate does not mutate durable state",
      "description": "As an operator who already has a durable Factory definition, I want a failed validate of a bad candidate file to leave existing Factory definition state unchanged, so that validation stays a safe, side-effect-free check.",
      "acceptanceCriteria": [
        "The cell includes TestCLIFactoryValidateDoesNotMutateOnFailure.",
        "The test constructs via root.BuildProcess + Process.Execute and uses the public Factory CLI validate path.",
        "Before validate, a durable Factory definition baseline is observable through a public CLI/list/query/read surface (or equivalent public durable-state observation).",
        "After a failed validate of an invalid candidate, the durable baseline is unchanged (same public identity/content markers; no create/update/delete side effect attributable to the failed validate).",
        "Assertions stay on public non-mutation outcomes and do not take ownership of named-factory CRUD lifecycle or Wave 2 definitions validation/import_export cells.",
        "External effects use edges.Edges with preferred ProviderCommandRunner / mocked Codex patterns; no unjustified sleeps.",
        "The top-level test has a customer-readable Go doc comment describing the failed-validate non-mutation behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-depth-factory-definitions-transports-cli-validate-persist-003",
      "title": "Prove persist-from-file then run succeeds",
      "description": "As a Factory author loading a valid definition from a file, I want persist-from-file through the public CLI to produce a Factory that can be run successfully, so that the authoring path from file to execution is proven end-to-end at the process boundary.",
      "acceptanceCriteria": [
        "The cell includes TestCLIFactoryPersistFromFileThenRunSucceeds.",
        "The test constructs via root.BuildProcess + Process.Execute and prefers public CLI for both persist-from-file and the subsequent run.",
        "A valid Factory definition file is persisted through the public Factory CLI persist-from-file / create-or-update-from-file surface.",
        "A subsequent public run against the persisted Factory succeeds with a customer-observable success outcome (exit success and/or primary result / session completion visible at the public CLI boundary).",
        "External effects for inference/provider work use edges.Edges, preferring ProviderCommandRunner / mocked Codex over MockWorkers; no unjustified sleeps.",
        "Coverage proves persist-then-run only; it does not implement named_lifecycle create/list/update/delete matrix depth or Wave 2 definitions validation/import_export cells.",
        "The top-level test has a customer-readable Go doc comment describing the persist-from-file-then-run behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-depth-factory-definitions-transports-cli-validate-persist-004",
      "title": "Close focused verification and metadata gates",
      "description": "As a maintainer landing this depth cell, I want focused package tests, functional boundary checks, and viz-compatible metadata to pass without widening into sibling packages, so the destination is catalogued correctly under the service-mirrored owner.",
      "acceptanceCriteria": [
        "Focused package tests for ./tests/functional/factory_definitions/transports/cli/validate_persist/... pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (customer-readable Go docs inventoriable; domain ownership inferred under factory_definitions).",
        "No new ownership lands under root transport/cli or catch-all cli/; sibling named_lifecycle and Wave 2 factory/definitions/validation|import_export remain untouched by this lane.",
        "Only narrowly coupled ownership/coverage/catalog metadata required for this cell are updated when metadata updates are needed.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)