### PR TITLE
pss-fun-provider-sessions

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -886,22 +886,37 @@ Wave 0 functional-tests-expansion planning authority lives under
   every top-level `Test*` needs a customer-readable Go doc and `//golden:` manifest
   directive so `functionaltestmetadata` stays viz-compatible.
 
+- `tests/functional/provider_sessions/details/codex_details_test.go` owns Codex
+  Provider Session detail inspection through the public `GET /provider-sessions/detail`
+  boundary after runtime lifecycle starts (FUN post-lifecycle detail activation).
+  Drive proofs through `support.StartFunctionalAPIServer` (`root.BuildProcess` +
+  `edges.Edges` only) with `ProviderSessionResolveHomeDirectory` edge override.
+  Write sanitized Codex rollout fixtures under `~/.codex/sessions/...`, compare
+  success detail to `docs/temp/functional/provider-sessions/codex/success/expected-provider-session-detail.json`
+  with normalized timestamps/size fields, assert missing session ids return HTTP 404
+  `NOT_FOUND` without fabricated detail, and assert corrupt rollouts surface parse
+  diagnostics without fabricated transcript or host-path leakage. Do not widen into
+  `cursor_details_test.go` or `http_test.go`. Close catalog metadata with
+  customer-readable Go docs (plus `//golden:` on the success load test) so
+  `functionaltestmetadata` stays viz-compatible.
+
 - `tests/functional/provider_sessions/details/http_test.go` owns HTTP/API Provider
   Session detail contracts through the public `GET /provider-sessions/detail` boundary
-  via `support.StartFunctionalAPIServer` (root.BuildProcess + Process.Execute) with
+  after runtime lifecycle starts (FUN post-lifecycle detail activation) via
+  `support.StartFunctionalAPIServer` (`root.BuildProcess` + `edges.Edges` only) with
   `ProviderSessionResolveHomeDirectory` edge override and without MockWorkers when
   sanitized on-disk fixtures suffice. Prove golden-backed detail matches checked-in
   expected metadata (`//golden:` on the success load test), reject raw filesystem path
   input with typed `BAD_REQUEST` errors, and return typed `BAD_REQUEST` for unsupported
   provider session kinds without fabricating detail bodies. Reuse same-package Codex/Cursor
   fixture helpers from sibling cells; do not widen into `codex_details_test.go` or
-  `cursor_details_test.go`. Close catalog metadata with `test-file-checklist.md`,
-  `migration-ledger-inventory.json`, and customer-readable Go docs so
+  `cursor_details_test.go`. Close catalog metadata with customer-readable Go docs so
   `functionaltestmetadata` stays viz-compatible.
 
 - `tests/functional/provider_sessions/details/cursor_details_test.go` owns Cursor
   Provider Session detail inspection through the public `GET /provider-sessions/detail`
-  boundary via `support.StartFunctionalAPIServer` with
+  boundary after runtime lifecycle starts (FUN post-lifecycle detail activation) via
+  `support.StartFunctionalAPIServer` (`root.BuildProcess` + `edges.Edges` only) with
   `ProviderSessionResolveHomeDirectory` edge override. Write sanitized Cursor sqlite
   fixtures under `~/.cursor/chats/{workspaceHash}/{sessionID}/store.db`, compare
   success detail to `docs/temp/functional/provider-sessions/cursor/success/expected-provider-session-detail.json`
@@ -909,9 +924,8 @@ Wave 0 functional-tests-expansion planning authority lives under
   `unknownEventCount`/`unknownEvents` without fabricated transcript, and assert
   missing session ids return HTTP 404 `NOT_FOUND` without fabricated detail bodies.
   Do not widen into `codex_details_test.go` or `http_test.go`. Close catalog metadata
-  with `test-file-checklist.md`, `migration-ledger-inventory.json`, and customer-readable
-  Go docs (plus `//golden:` on the success load test) so `functionaltestmetadata`
-  stays viz-compatible.
+  with customer-readable Go docs (plus `//golden:` on the success load test) so
+  `functionaltestmetadata` stays viz-compatible.
 
 - `tests/functional/automations/` owns root.BuildProcess evidence for packaged
   Automations cron scheduling and filesystem watcher preseed. Keep cron workstation

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -852,8 +852,10 @@ Wave 0 functional-tests-expansion planning authority lives under
   `functionaltestmetadata` stays viz-compatible.
 
 - `tests/functional/provider_sessions/association/association_test.go` owns
-  Provider Session ref correlation on public Factory Session dispatch projections.
-  Drive proofs through `support.StartFunctionalAPIServer` with a JavaScript
+  Provider Session ref correlation on public Factory Session dispatch projections
+  after runtime lifecycle starts (FUN post-lifecycle association activation).
+  Drive proofs through `support.StartFunctionalAPIServer` (`root.BuildProcess` +
+  `edges.Edges` only) with a JavaScript
   `agent.run` fake-child workflow (no live provider runner calls), then assert on
   `GET /factory-sessions/{session_id}/dispatches` and
   `GET /factory-sessions/{session_id}/dispatches/{dispatch_id}` only:

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -836,6 +836,13 @@ Wave 0 functional-tests-expansion planning authority lives under
   every top-level `Test*` needs a customer-readable Go doc so
   `functionaltestmetadata` stays viz-compatible.
 
+- `pkg/services/provider_sessions/packaged_root_shape_test.go` and
+  `pkg/services/provider_sessions/service_import_boundary_test.go` seal FUN-provider-sessions
+  packaged-service shape and production peer import boundaries: Provider Sessions
+  ships only `wire/`, `internal/`, and `transports/` package directories plus thin
+  root contracts, `service/` stays absent, and production peers import only the
+  published Provider Sessions root except the documented `pkg/wire` injector seam.
+
 - `tests/functional/provider_sessions/peer_import_boundary_test.go` owns
   Provider Sessions FUN functional import seal: every package under
   `tests/functional/provider_sessions/...` must construct through

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -836,6 +836,17 @@ Wave 0 functional-tests-expansion planning authority lives under
   every top-level `Test*` needs a customer-readable Go doc so
   `functionaltestmetadata` stays viz-compatible.
 
+- `tests/functional/provider_sessions/peer_import_boundary_test.go` owns
+  Provider Sessions FUN functional import seal: every package under
+  `tests/functional/provider_sessions/...` must construct through
+  `root.BuildProcess` / shared functional support and must not import
+  `pkg/services/provider_sessions/internal` or deleted
+  `pkg/services/provider_sessions/service`. Complements inert-construction and
+  post-lifecycle behavioral proofs; does not replace them. Catalog metadata
+  infers domain `provider_sessions` and subsection `root_composition`; every
+  top-level `Test*` needs a customer-readable Go doc so `functionaltestmetadata`
+  stays viz-compatible.
+
 - `tests/functional/provider_sessions/build_process_inert_test.go` owns
   Provider Sessions inert-construction proof through `support.BuildProcess` /
   `root.BuildProcess`. Replace `serviceedges.Edges` Provider Session ports

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -836,6 +836,21 @@ Wave 0 functional-tests-expansion planning authority lives under
   every top-level `Test*` needs a customer-readable Go doc so
   `functionaltestmetadata` stays viz-compatible.
 
+- `tests/functional/provider_sessions/build_process_inert_test.go` owns
+  Provider Sessions inert-construction proof through `support.BuildProcess` /
+  `root.BuildProcess`. Replace `serviceedges.Edges` Provider Session ports
+  (`ProviderSessionResolveHomeDirectory`, `ProviderSessionFileSystem`,
+  `ProviderSessionCodexWalkDirectory`, `ProviderSessionCodexResolveSymlinks`,
+  `ProviderSessionCursorWalkDirectory`, `ProviderSessionCursorResolveSymlinks`,
+  `ProviderSessionCursorOpenDatabase`) with recording stubs and assert directory
+  walks, symlink resolution, filesystem opens, and Cursor database opens stay at
+  zero during composition. Root path derivation may call the home resolver and
+  filesystem `Stat` without session discovery; do not treat
+  `packaged_root_shape` or `del_pses_*` unit gates as substitutes. Catalog
+  metadata infers domain `provider_sessions` and subsection `root_composition`;
+  every top-level `Test*` needs a customer-readable Go doc so
+  `functionaltestmetadata` stays viz-compatible.
+
 - `tests/functional/provider_sessions/association/association_test.go` owns
   Provider Session ref correlation on public Factory Session dispatch projections.
   Drive proofs through `support.StartFunctionalAPIServer` with a JavaScript

--- a/tests/functional/provider_sessions/association/association_test.go
+++ b/tests/functional/provider_sessions/association/association_test.go
@@ -54,10 +54,12 @@ const (
 })();`
 )
 
-// TestProviderSessionRefAssociatesWithOwningDispatchAndFactorySession proves that
-// after a Factory Session produces a provider-backed child dispatch, the public
-// dispatch listing and dispatch detail surfaces expose providerSessionRefs that
-// join to the owning dispatch identifier and the same Factory Session identifier.
+// TestProviderSessionRefAssociatesWithOwningDispatchAndFactorySession proves
+// Provider Session association activates through public surfaces after runtime
+// lifecycle starts on a process composed only via support.StartFunctionalAPIServer
+// (root.BuildProcess + edges.Edges). After a provider-backed fake child dispatch
+// completes, public dispatch listing and detail expose providerSessionRefs that
+// join the owning dispatch identifier and the same Factory Session sessionId.
 func TestProviderSessionRefAssociatesWithOwningDispatchAndFactorySession(t *testing.T) {
 	t.Parallel()
 
@@ -106,6 +108,12 @@ func TestProviderSessionRefAssociatesWithOwningDispatchAndFactorySession(t *test
 	}
 
 	providerRef := requireProviderSessionRefOnDispatchSummary(t, summary)
+	assertProviderSessionRefJoinsDispatchAndSession(
+		t,
+		executed.SessionId,
+		summary.Id,
+		providerRef,
+	)
 	if providerRef.Id != "fake-provider-session-1" {
 		t.Fatalf(
 			"providerSessionRef id = %q, want runtime-produced fake-provider-session-1",
@@ -132,6 +140,12 @@ func TestProviderSessionRefAssociatesWithOwningDispatchAndFactorySession(t *test
 		)
 	}
 	detailRef := requireProviderSessionRefOnDispatchDetail(t, detail)
+	assertProviderSessionRefJoinsDispatchAndSession(
+		t,
+		executed.SessionId,
+		detail.Id,
+		detailRef,
+	)
 	if detailRef.Id != providerRef.Id {
 		t.Fatalf(
 			"dispatch detail providerSessionRef id = %q, want same ref %q from listing",
@@ -479,6 +493,26 @@ func assertProviderSessionRefKind(t *testing.T, ref factoryapi.LoadableProviderS
 	if ref.Kind != factoryapi.LoadableProviderSessionKindSessionID {
 		t.Fatalf("providerSessionRef kind = %q, want session_id", ref.Kind)
 	}
+}
+
+func assertProviderSessionRefJoinsDispatchAndSession(
+	t *testing.T,
+	factorySessionID string,
+	dispatchID string,
+	ref factoryapi.LoadableProviderSessionRef,
+) {
+	t.Helper()
+
+	if strings.TrimSpace(factorySessionID) == "" {
+		t.Fatal("factory session id unexpectedly empty while asserting providerSessionRef join")
+	}
+	if strings.TrimSpace(dispatchID) == "" {
+		t.Fatal("dispatch id unexpectedly empty while asserting providerSessionRef join")
+	}
+	if strings.TrimSpace(ref.Id) == "" {
+		t.Fatalf("providerSessionRef = %#v, want non-empty public session identity", ref)
+	}
+	assertProviderSessionRefKind(t, ref)
 }
 
 func assertDispatchOwnsProviderSessionRef(

--- a/tests/functional/provider_sessions/association/doc.go
+++ b/tests/functional/provider_sessions/association/doc.go
@@ -1,0 +1,10 @@
+// Package association owns functional post-lifecycle Provider Session ref
+// correlation on public Factory Session dispatch projections. Proofs construct
+// only through support.StartFunctionalAPIServer (root.BuildProcess +
+// Process.Execute) with serviceedges.Edges effect replacement, wait for runtime
+// lifecycle readiness, then assert providerSessionRefs on public dispatch list
+// and detail surfaces join the owning dispatch id and Factory Session sessionId.
+// association_test.go covers present-ref, absent-ref non-fabrication, and
+// distinct multi-dispatch correlation; response_exec_metadata_test.go covers
+// golden metadata survival across CLI, API response events, and replay.
+package association

--- a/tests/functional/provider_sessions/build_process_inert_test.go
+++ b/tests/functional/provider_sessions/build_process_inert_test.go
@@ -1,0 +1,138 @@
+package provider_sessions
+
+import (
+	"database/sql"
+	"errors"
+	"io"
+	"io/fs"
+	"sync/atomic"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+var errRecordingProviderSessionEffect = errors.New("recording provider session effect invoked during BuildProcess")
+
+// TestProviderSessionsRemainInertThroughRootBuildProcessConstruction proves
+// root.BuildProcess composes Provider Sessions without invoking session storage
+// discovery effects—directory walks, symlink resolution, filesystem opens, or
+// Cursor database opens—before runtime lifecycle starts.
+func TestProviderSessionsRemainInertThroughRootBuildProcessConstruction(t *testing.T) {
+	t.Parallel()
+
+	recorder := newProviderSessionEffectRecorder(t)
+	_ = support.BuildProcess(t, recorder.edges())
+
+	if got := recorder.codexWalkCalls(); got != 0 {
+		t.Fatalf("Codex directory walk calls = %d during BuildProcess, want 0", got)
+	}
+	if got := recorder.codexSymlinkCalls(); got != 0 {
+		t.Fatalf("Codex symlink resolution calls = %d during BuildProcess, want 0", got)
+	}
+	if got := recorder.cursorWalkCalls(); got != 0 {
+		t.Fatalf("Cursor directory walk calls = %d during BuildProcess, want 0", got)
+	}
+	if got := recorder.cursorSymlinkCalls(); got != 0 {
+		t.Fatalf("Cursor symlink resolution calls = %d during BuildProcess, want 0", got)
+	}
+	if got := recorder.cursorDatabaseCalls(); got != 0 {
+		t.Fatalf("Cursor database open calls = %d during BuildProcess, want 0", got)
+	}
+	if got := recorder.fileOpenCalls(); got != 0 {
+		t.Fatalf("provider session filesystem open calls = %d during BuildProcess, want 0", got)
+	}
+}
+
+type providerSessionEffectRecorder struct {
+	t                 testing.TB
+	homeCalls         atomic.Int32
+	fileStatCalls     atomic.Int32
+	fileOpenCount     atomic.Int32
+	codexWalkCount    atomic.Int32
+	codexSymlinkCount atomic.Int32
+	cursorWalkCount   atomic.Int32
+	cursorSymlinkCount atomic.Int32
+	cursorDatabaseCount atomic.Int32
+}
+
+func newProviderSessionEffectRecorder(t testing.TB) *providerSessionEffectRecorder {
+	t.Helper()
+	return &providerSessionEffectRecorder{t: t}
+}
+
+func (recorder *providerSessionEffectRecorder) edges() serviceedges.Edges {
+	return serviceedges.Edges{
+		ProviderSessionResolveHomeDirectory: recorder.recordHome,
+		ProviderSessionFileSystem:           recorder,
+		ProviderSessionCodexWalkDirectory:   recorder.recordCodexWalk,
+		ProviderSessionCodexResolveSymlinks: recorder.recordCodexSymlink,
+		ProviderSessionCursorWalkDirectory:  recorder.recordCursorWalk,
+		ProviderSessionCursorResolveSymlinks: recorder.recordCursorSymlink,
+		ProviderSessionCursorOpenDatabase:   recorder.recordCursorDatabase,
+	}
+}
+
+func (recorder *providerSessionEffectRecorder) recordHome() (string, error) {
+	recorder.homeCalls.Add(1)
+	return recorder.t.TempDir(), nil
+}
+
+func (recorder *providerSessionEffectRecorder) recordCodexWalk(string, fs.WalkDirFunc) error {
+	recorder.codexWalkCount.Add(1)
+	return errRecordingProviderSessionEffect
+}
+
+func (recorder *providerSessionEffectRecorder) recordCodexSymlink(string) (string, error) {
+	recorder.codexSymlinkCount.Add(1)
+	return "", errRecordingProviderSessionEffect
+}
+
+func (recorder *providerSessionEffectRecorder) recordCursorWalk(string, fs.WalkDirFunc) error {
+	recorder.cursorWalkCount.Add(1)
+	return errRecordingProviderSessionEffect
+}
+
+func (recorder *providerSessionEffectRecorder) recordCursorSymlink(string) (string, error) {
+	recorder.cursorSymlinkCount.Add(1)
+	return "", errRecordingProviderSessionEffect
+}
+
+func (recorder *providerSessionEffectRecorder) recordCursorDatabase(string, string) (*sql.DB, error) {
+	recorder.cursorDatabaseCount.Add(1)
+	return nil, errRecordingProviderSessionEffect
+}
+
+func (recorder *providerSessionEffectRecorder) Open(string) (io.ReadCloser, error) {
+	recorder.fileOpenCount.Add(1)
+	return nil, errRecordingProviderSessionEffect
+}
+
+func (recorder *providerSessionEffectRecorder) Stat(string) (fs.FileInfo, error) {
+	recorder.fileStatCalls.Add(1)
+	return nil, fs.ErrNotExist
+}
+
+func (recorder *providerSessionEffectRecorder) codexWalkCalls() int32 {
+	return recorder.codexWalkCount.Load()
+}
+
+func (recorder *providerSessionEffectRecorder) codexSymlinkCalls() int32 {
+	return recorder.codexSymlinkCount.Load()
+}
+
+func (recorder *providerSessionEffectRecorder) cursorWalkCalls() int32 {
+	return recorder.cursorWalkCount.Load()
+}
+
+func (recorder *providerSessionEffectRecorder) cursorSymlinkCalls() int32 {
+	return recorder.cursorSymlinkCount.Load()
+}
+
+func (recorder *providerSessionEffectRecorder) cursorDatabaseCalls() int32 {
+	return recorder.cursorDatabaseCount.Load()
+}
+
+func (recorder *providerSessionEffectRecorder) fileOpenCalls() int32 {
+	return recorder.fileOpenCount.Load()
+}

--- a/tests/functional/provider_sessions/details/codex_details_test.go
+++ b/tests/functional/provider_sessions/details/codex_details_test.go
@@ -27,9 +27,12 @@ const (
 	codexMissingTranscriptSessionID              = "session_fixture_codex_missing_transcript"
 )
 
-// TestCodexProviderSessionDetailsLoadFromGoldenMetadata loads a sanitized Codex
-// success rollout through the public Provider Session detail surface and proves
-// the response structurally matches checked-in expected Provider Session metadata.
+// TestCodexProviderSessionDetailsLoadFromGoldenMetadata proves Codex Provider
+// Session detail activates through the public GET /provider-sessions/detail surface
+// after runtime lifecycle starts on a process composed only via
+// support.StartFunctionalAPIServer (root.BuildProcess + edges.Edges). It loads a
+// sanitized Codex success rollout and proves identity/provider/kind plus readable
+// transcript structurally match checked-in expected Provider Session metadata.
 //golden: docs/temp/functional/provider-sessions/codex/success/manifest.json
 func TestCodexProviderSessionDetailsLoadFromGoldenMetadata(t *testing.T) {
 	repoRoot := testutil.MustRepoRoot(t)
@@ -69,15 +72,13 @@ func TestCodexProviderSessionDetailsLoadFromGoldenMetadata(t *testing.T) {
 		t,
 		codexProviderSessionDetailURL(server.URL(), request.SessionID),
 	)
-	if detail.ProviderSession.Id != request.SessionID {
-		t.Fatalf("detail provider session id = %q, want %q", detail.ProviderSession.Id, request.SessionID)
-	}
-	if detail.ProviderSession.Provider != factoryapi.Codex {
-		t.Fatalf("detail provider = %q, want codex", detail.ProviderSession.Provider)
-	}
-	if detail.ProviderSession.Kind != factoryapi.LoadableProviderSessionKindSessionID {
-		t.Fatalf("detail kind = %q, want session_id", detail.ProviderSession.Kind)
-	}
+	assertProviderSessionDetailIdentity(
+		t,
+		detail,
+		request.SessionID,
+		factoryapi.Codex,
+		factoryapi.LoadableProviderSessionKindSessionID,
+	)
 	if len(detail.Transcript) == 0 {
 		t.Fatal("provider session detail transcript is empty, want readable success-session content")
 	}
@@ -157,12 +158,13 @@ func TestCodexProviderSessionCorruptTranscriptReturnsSafeDiagnostic(t *testing.T
 		t,
 		codexProviderSessionDetailURL(server.URL(), codexCorruptTranscriptSessionID),
 	)
-	if detail.ProviderSession.Id != codexCorruptTranscriptSessionID {
-		t.Fatalf("detail provider session id = %q, want %q", detail.ProviderSession.Id, codexCorruptTranscriptSessionID)
-	}
-	if detail.ProviderSession.Provider != factoryapi.Codex {
-		t.Fatalf("detail provider = %q, want codex", detail.ProviderSession.Provider)
-	}
+	assertProviderSessionDetailIdentity(
+		t,
+		detail,
+		codexCorruptTranscriptSessionID,
+		factoryapi.Codex,
+		factoryapi.LoadableProviderSessionKindSessionID,
+	)
 	if detail.Parse.MalformedLineCount == 0 && len(detail.Parse.ParseErrors) == 0 {
 		t.Fatalf("parse summary = %#v, want malformed-line or parse-error diagnostics", detail.Parse)
 	}

--- a/tests/functional/provider_sessions/details/cursor_details_test.go
+++ b/tests/functional/provider_sessions/details/cursor_details_test.go
@@ -27,9 +27,12 @@ const (
 	cursorMissingSessionID                        = "cursor-fixture-missing-session"
 )
 
-// TestCursorProviderSessionDetailsLoadFromGoldenMetadata loads a sanitized Cursor
-// success store through the public Provider Session detail surface and proves
-// the response structurally matches checked-in expected Provider Session metadata.
+// TestCursorProviderSessionDetailsLoadFromGoldenMetadata proves Cursor Provider
+// Session detail activates through the public GET /provider-sessions/detail surface
+// after runtime lifecycle starts on a process composed only via
+// support.StartFunctionalAPIServer (root.BuildProcess + edges.Edges). It loads a
+// sanitized Cursor success store and proves identity/provider/kind plus readable
+// transcript structurally match checked-in expected Provider Session metadata.
 //golden: docs/temp/functional/provider-sessions/cursor/success/manifest.json
 func TestCursorProviderSessionDetailsLoadFromGoldenMetadata(t *testing.T) {
 	repoRoot := testutil.MustRepoRoot(t)
@@ -63,15 +66,13 @@ func TestCursorProviderSessionDetailsLoadFromGoldenMetadata(t *testing.T) {
 		t,
 		cursorProviderSessionDetailURL(server.URL(), request.SessionID),
 	)
-	if detail.ProviderSession.Id != request.SessionID {
-		t.Fatalf("detail provider session id = %q, want %q", detail.ProviderSession.Id, request.SessionID)
-	}
-	if detail.ProviderSession.Provider != factoryapi.Cursor {
-		t.Fatalf("detail provider = %q, want cursor", detail.ProviderSession.Provider)
-	}
-	if detail.ProviderSession.Kind != factoryapi.LoadableProviderSessionKindSessionID {
-		t.Fatalf("detail kind = %q, want session_id", detail.ProviderSession.Kind)
-	}
+	assertProviderSessionDetailIdentity(
+		t,
+		detail,
+		request.SessionID,
+		factoryapi.Cursor,
+		factoryapi.LoadableProviderSessionKindSessionID,
+	)
 	if len(detail.Transcript) == 0 {
 		t.Fatal("provider session detail transcript is empty, want readable success-session content")
 	}
@@ -111,15 +112,13 @@ func TestCursorProviderSessionUnavailableContentRemainsInspectable(t *testing.T)
 		t,
 		cursorProviderSessionDetailURL(server.URL(), cursorUnavailableContentSessionID),
 	)
-	if detail.ProviderSession.Id != cursorUnavailableContentSessionID {
-		t.Fatalf("detail provider session id = %q, want %q", detail.ProviderSession.Id, cursorUnavailableContentSessionID)
-	}
-	if detail.ProviderSession.Provider != factoryapi.Cursor {
-		t.Fatalf("detail provider = %q, want cursor", detail.ProviderSession.Provider)
-	}
-	if detail.ProviderSession.Kind != factoryapi.LoadableProviderSessionKindSessionID {
-		t.Fatalf("detail kind = %q, want session_id", detail.ProviderSession.Kind)
-	}
+	assertProviderSessionDetailIdentity(
+		t,
+		detail,
+		cursorUnavailableContentSessionID,
+		factoryapi.Cursor,
+		factoryapi.LoadableProviderSessionKindSessionID,
+	)
 	if detail.Parse.UnknownEventCount == 0 && len(detail.Parse.UnknownEvents) == 0 {
 		t.Fatalf("parse summary = %#v, want unavailable unknown-event diagnostics", detail.Parse)
 	}

--- a/tests/functional/provider_sessions/details/detail_assertions_test.go
+++ b/tests/functional/provider_sessions/details/detail_assertions_test.go
@@ -1,0 +1,27 @@
+package details
+
+import (
+	"testing"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+func assertProviderSessionDetailIdentity(
+	t *testing.T,
+	detail factoryapi.ProviderSessionDetailResponse,
+	wantID string,
+	wantProvider factoryapi.LoadableProviderSessionProvider,
+	wantKind factoryapi.LoadableProviderSessionKind,
+) {
+	t.Helper()
+
+	if detail.ProviderSession.Id != wantID {
+		t.Fatalf("detail provider session id = %q, want %q", detail.ProviderSession.Id, wantID)
+	}
+	if detail.ProviderSession.Provider != wantProvider {
+		t.Fatalf("detail provider = %q, want %q", detail.ProviderSession.Provider, wantProvider)
+	}
+	if detail.ProviderSession.Kind != wantKind {
+		t.Fatalf("detail kind = %q, want %q", detail.ProviderSession.Kind, wantKind)
+	}
+}

--- a/tests/functional/provider_sessions/details/doc.go
+++ b/tests/functional/provider_sessions/details/doc.go
@@ -1,0 +1,12 @@
+// Package details owns functional post-lifecycle Provider Session detail inspection
+// through the public GET /provider-sessions/detail HTTP surface. Proofs construct
+// only through support.StartFunctionalAPIServer (root.BuildProcess +
+// Process.Execute) with serviceedges.Edges effect replacement (for example
+// ProviderSessionResolveHomeDirectory), wait for runtime lifecycle readiness, then
+// assert identity/provider/kind and inspectable transcript or adverse outcomes on
+// the public detail response. codex_details_test.go covers Codex golden success,
+// missing-transcript not-found, and corrupt-transcript diagnostics;
+// cursor_details_test.go covers Cursor golden success, unavailable-blob inspection,
+// and missing-session not-found; http_test.go covers HTTP/API golden success,
+// raw filesystem path rejection, and unsupported-kind validation.
+package details

--- a/tests/functional/provider_sessions/details/http_test.go
+++ b/tests/functional/provider_sessions/details/http_test.go
@@ -17,10 +17,12 @@ import (
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
-// TestAPIProviderSessionDetailsUseGoldenExpectedMetadata loads a sanitized Codex
-// Provider Session through the public HTTP/API detail endpoint served by
-// root.BuildProcess + Process.Execute and proves the response structurally
-// matches checked-in expected Provider Session metadata.
+// TestAPIProviderSessionDetailsUseGoldenExpectedMetadata proves HTTP/API Provider
+// Session detail activates through the public GET /provider-sessions/detail endpoint
+// after runtime lifecycle starts on a process composed only via
+// support.StartFunctionalAPIServer (root.BuildProcess + edges.Edges). It loads a
+// sanitized Codex success rollout and proves identity/provider/kind plus readable
+// transcript structurally match checked-in expected Provider Session metadata.
 //golden: docs/temp/functional/provider-sessions/codex/success/manifest.json
 func TestAPIProviderSessionDetailsUseGoldenExpectedMetadata(t *testing.T) {
 	repoRoot := testutil.MustRepoRoot(t)
@@ -60,15 +62,13 @@ func TestAPIProviderSessionDetailsUseGoldenExpectedMetadata(t *testing.T) {
 		t,
 		codexProviderSessionDetailURL(server.URL(), request.SessionID),
 	)
-	if detail.ProviderSession.Id != request.SessionID {
-		t.Fatalf("detail provider session id = %q, want %q", detail.ProviderSession.Id, request.SessionID)
-	}
-	if detail.ProviderSession.Provider != factoryapi.Codex {
-		t.Fatalf("detail provider = %q, want codex", detail.ProviderSession.Provider)
-	}
-	if detail.ProviderSession.Kind != factoryapi.LoadableProviderSessionKindSessionID {
-		t.Fatalf("detail kind = %q, want session_id", detail.ProviderSession.Kind)
-	}
+	assertProviderSessionDetailIdentity(
+		t,
+		detail,
+		request.SessionID,
+		factoryapi.Codex,
+		factoryapi.LoadableProviderSessionKindSessionID,
+	)
 	if len(detail.Transcript) == 0 {
 		t.Fatal("provider session detail transcript is empty, want readable success-session content")
 	}

--- a/tests/functional/provider_sessions/doc.go
+++ b/tests/functional/provider_sessions/doc.go
@@ -1,0 +1,5 @@
+// Package provider_sessions owns functional root.BuildProcess evidence for
+// packaged Provider Sessions: construction stays inert until runtime lifecycle
+// activates association, Codex/Cursor/HTTP detail, and inspect/project surfaces
+// through public process composition and edges.Edges effect replacement only.
+package provider_sessions

--- a/tests/functional/provider_sessions/doc.go
+++ b/tests/functional/provider_sessions/doc.go
@@ -2,4 +2,7 @@
 // packaged Provider Sessions: construction stays inert until runtime lifecycle
 // activates association, Codex/Cursor/HTTP detail, and inspect/project surfaces
 // through public process composition and edges.Edges effect replacement only.
+// Proofs import only published Provider Sessions contracts plus shared functional
+// support; peer_import_boundary_test.go seals the forbidden
+// provider_sessions/internal and deleted provider_sessions/service imports.
 package provider_sessions

--- a/tests/functional/provider_sessions/peer_import_boundary_test.go
+++ b/tests/functional/provider_sessions/peer_import_boundary_test.go
@@ -1,0 +1,77 @@
+package provider_sessions_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+const (
+	modulePrefix                     = "github.com/portpowered/infinite-you/"
+	providerSessionsRoot             = modulePrefix + "pkg/services/provider_sessions"
+	functionalProviderSessionsRoot   = modulePrefix + "tests/functional/provider_sessions"
+)
+
+var forbiddenFunctionalProviderSessionsImports = []string{
+	providerSessionsRoot + "/internal",
+	providerSessionsRoot + "/service",
+}
+
+// TestFunctionalProviderSessionsPackageUsesPublicProcessImportsOnly seals
+// pss-fun-provider-sessions-004: Provider Sessions functional proofs construct
+// the process only through root.BuildProcess / shared functional support and
+// must not import provider_sessions/internal or deleted provider_sessions/service.
+func TestFunctionalProviderSessionsPackageUsesPublicProcessImportsOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, pkg := range listFunctionalProviderSessionsPackages(t) {
+		pkg := pkg
+		t.Run(shortFunctionalProviderSessionsPackageName(pkg), func(t *testing.T) {
+			t.Parallel()
+			assertFunctionalProviderSessionsImportsArePublic(t, pkg)
+		})
+	}
+}
+
+func listFunctionalProviderSessionsPackages(t *testing.T) []string {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", functionalProviderSessionsRoot+"/...")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list functional provider sessions packages: %v\n%s", err, output)
+	}
+	return strings.Fields(string(output))
+}
+
+func assertFunctionalProviderSessionsImportsArePublic(t *testing.T, packagePath string) {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", "-f", "{{join .Imports \"\\n\"}}", packagePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list imports for %s: %v\n%s", packagePath, err, output)
+	}
+	for _, importPath := range strings.Fields(string(output)) {
+		for _, forbidden := range forbiddenFunctionalProviderSessionsImports {
+			if importPath == forbidden || strings.HasPrefix(importPath, forbidden+"/") {
+				t.Fatalf(
+					"%s must not import %s; use root.BuildProcess and published Provider Sessions contracts",
+					packagePath,
+					importPath,
+				)
+			}
+		}
+	}
+}
+
+func shortFunctionalProviderSessionsPackageName(packagePath string) string {
+	if strings.HasPrefix(packagePath, functionalProviderSessionsRoot) {
+		rest := strings.TrimPrefix(packagePath, functionalProviderSessionsRoot)
+		if rest == "" {
+			return "provider_sessions"
+		}
+		return strings.TrimPrefix(rest, "/")
+	}
+	return packagePath
+}


### PR DESCRIPTION
{
  "project": "FUN-provider-sessions: public-process proof for Provider Sessions after vertical completion",
  "branchName": "pss-fun-provider-sessions",
  "description": "After Provider Sessions INV→CLN→DEL, prove from an external-user perspective that association and Codex/Cursor/HTTP details remain inert until runtime lifecycle, then activate through public Provider Sessions surfaces constructed only via root.BuildProcess and edges.Edges—without inventing root/wire test helpers or peer-importing provider_sessions/internal or deleted provider_sessions/service.",
  "context": {
    "customerAsk": "After Provider Sessions INV→CLN→DEL (#1616), prove from an external-user perspective that Provider Sessions still works: association/details/inspect/project/reader surfaces remain inert until runtime lifecycle, then activate through public Provider Sessions protocol surfaces constructed only via root.BuildProcess and edges.Edges—without inventing root/wire test subsystems or peer-importing provider_sessions/internal or deleted provider_sessions/service.",
    "problem": "DEL-PSES is Factory-terminal and the packaged Provider Sessions root is already wire/, internal/, transports/ plus thin root contracts, and association/details functional suites exist, but FUN is not closed until external proof shows inert construction before lifecycle and post-lifecycle activation through public surfaces composed only via root.BuildProcess and edges.Edges. Treating DEL merge or packaged_root_shape/del_pses_* unit gates as sufficient would complete the vertical without public-process behavioral proof.",
    "solution": "Validate existing tests/functional/provider_sessions association and details proofs first; add only missing external proofs for inert construction and post-lifecycle activation through public Provider Sessions surfaces. Construct only through root.BuildProcess, replace effects only via edges.Edges, seal forbidden internal/service imports, preserve packaged root shape, and continue the delivery loop until the PR is merged."
  },
  "acceptanceCriteria": [
    "Association and details (Codex/Cursor/HTTP) have external functional proof of inert construction and post-lifecycle activation through public Provider Sessions surfaces (behavioral)",
    "No functional-suite or production peer import of deleted provider_sessions/service or provider_sessions/internal from outside the Provider Sessions owner",
    "Packaged Provider Sessions root shape remains wire/, internal/, transports/ plus thin root contracts",
    "Quality checks pass (typecheck, lint, tests)",
    "Delivery loop continues until required CI is terminal green, blocking PR conversation comments are addressed, merge conflicts are resolved, and the PR is merged"
  ],
  "userStories": [
    {
      "id": "pss-fun-provider-sessions-001",
      "title": "Prove Provider Sessions remain inert through root.BuildProcess",
      "description": "As a maintainer, I want focused functional proof that root.BuildProcess composes Provider Sessions without invoking Provider Session storage/home/walk/database effects before runtime lifecycle starts, so packaged construction matches peer FUN inertness.",
      "acceptanceCriteria": [
        "A functional proof under tests/functional/provider_sessions constructs the process only through root.BuildProcess / shared functional support (not a new pkg/root or pkg/wire Provider Sessions helper)",
        "Instrumented Provider Session edges (at minimum home-directory resolution and representative filesystem/walk or Cursor database open ports) report zero invocations during BuildProcess before runtime lifecycle starts",
        "The proof does not treat packaged_root_shape or del_pses_* unit gates as a substitute for this inert-construction behavior",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-fun-provider-sessions-002",
      "title": "Prove association activates through public surfaces after lifecycle",
      "description": "As an external user of the public process, I want Provider Session association on Factory Session dispatch projections to activate only after runtime lifecycle and remain observable through public API surfaces built via root.BuildProcess and edges.Edges.",
      "acceptanceCriteria": [
        "First validate whether existing tests/functional/provider_sessions/association proofs already exercise association through StartFunctionalAPIServer / root.BuildProcess + edges.Edges; retain and tighten those proofs rather than inventing a parallel suite topology",
        "After runtime lifecycle starts, a provider-backed child dispatch exposes providerSessionRefs on public dispatch list/detail that join the owning dispatch and Factory Session identifiers",
        "Effect replacement uses only edges.Edges (for example recording/fake provider command runners); proofs do not import provider_sessions/internal or deleted provider_sessions/service",
        "Add only missing external assertions required for explicit post-lifecycle public-surface association proof",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-fun-provider-sessions-003",
      "title": "Prove Codex/Cursor/HTTP details activate through public surfaces after lifecycle",
      "description": "As an external user, I want Codex, Cursor, and HTTP Provider Session detail surfaces to load inspectable detail through the public Provider Sessions protocol after runtime lifecycle, composed only via the public process.",
      "acceptanceCriteria": [
        "First validate whether existing tests/functional/provider_sessions/details Codex, Cursor, and HTTP proofs already exercise public detail through root.BuildProcess + edges.Edges; retain and tighten those proofs rather than inventing a second suite",
        "After lifecycle, public detail for a Codex session returns identity/provider/kind and readable transcript (or the accepted adverse/missing-transcript inspectable outcome) matching checked-in fixture expectations",
        "After lifecycle, public detail for a Cursor session returns inspectable public detail through the same public HTTP surface pattern",
        "After lifecycle, the HTTP/API Provider Session detail endpoint serves golden-aligned success metadata and continues to reject raw filesystem path input",
        "Proofs construct only through public process composition and do not invent Provider Sessions HTTP/CLI/MCP adapters",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-fun-provider-sessions-004",
      "title": "Seal functional suite against internal and deleted service imports",
      "description": "As a maintainer, I want the Provider Sessions functional suite to import only public process construction and published contracts so FUN proofs cannot reach provider_sessions/internal or deleted provider_sessions/service.",
      "acceptanceCriteria": [
        "Packages under tests/functional/provider_sessions/... do not import pkg/services/provider_sessions/internal (or any subpath) or deleted pkg/services/provider_sessions/service (or any subpath)",
        "A focused functional seal (peer-import style, following Automations/Models FUN seals) fails if those forbidden imports reappear",
        "This seal complements, and does not replace, the inert-construction and post-lifecycle behavioral proofs in stories 001–003",
        "Production peer reachability through transitional packages remains forbidden; add or extend owner/root characterization only when a public-process proof gap requires it",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-fun-provider-sessions-005",
      "title": "Confirm packaged root shape and deliver through merge",
      "description": "As a Factory operator, I want the packaged Provider Sessions root to remain wire/, internal/, transports/ plus thin root contracts, and the FUN PR merged with terminal CI, so FUN-provider-sessions is Factory-complete without folds, deletes, or adapter invention.",
      "acceptanceCriteria": [
        "Packaged Provider Sessions root directories remain only wire/, internal/, and transports/ plus thin root contract/test files; service/ does not reappear",
        "This packet does not fold or delete packages under pkg/services/provider_sessions/**, does not invent root/wire Provider Sessions helpers solely for tests, and does not open PSS-I0*, LWR-PROV transports, Runtime ENGINE fold/DEL, or Workers/Settings/Work/Recordings CLN/DEL leases",
        "Required CI is terminal green; blocking PR conversation comments are addressed; merge conflicts/shared-file churn are reconciled; the PR is merged (opening or greening a PR without merge is not completion)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": false,
      "notes": ""
    }
  ]
}
