### PR TITLE
pss-mcp-prov-adapter

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -2195,6 +2195,16 @@
       }
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/transports/mcp",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/wire",
       "exception": {
         "kind": "measurement",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1805,6 +1805,10 @@
       "minimum": 85.86
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/transports/mcp",
+      "minimum": 75.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/wire",
       "minimum": 87.50
     },

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -4678,6 +4678,12 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/providers/transports/mcp",
+      "disposition": "retain",
+      "destination": "providers",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/providers/wire",
       "disposition": "retain",
       "destination": "providers",

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -396,6 +396,7 @@
     "pkg/services/providers/internal/services/execution/internal/service",
     "pkg/services/providers/internal/services/execution/wire",
     "pkg/services/providers/internal/testutil/execution",
+    "pkg/services/providers/transports/mcp",
     "pkg/services/providers/wire",
     "pkg/services/recordings",
     "pkg/services/recordings/artifacts",
@@ -2373,6 +2374,11 @@
     },
     {
       "packagePath": "pkg/services/providers/internal/testutil/execution",
+      "disposition": "retain",
+      "destination": "providers"
+    },
+    {
+      "packagePath": "pkg/services/providers/transports/mcp",
       "disposition": "retain",
       "destination": "providers"
     },

--- a/pkg/services/providers/transports/mcp/bind_test.go
+++ b/pkg/services/providers/transports/mcp/bind_test.go
@@ -1,0 +1,181 @@
+package providersmcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"testing"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	providersmcp "github.com/portpowered/infinite-you/pkg/services/providers/transports/mcp"
+)
+
+func TestBind_FakeRootInvokedThroughListProvidersTool(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := fakeProvidersRoot{
+		invoked: &invoked,
+		listProviders: func(context.Context, providers.ListProvidersRequest) (providers.ListProvidersResult, error) {
+			return providers.ListProvidersResult{
+				Providers: []providers.Descriptor{{
+					ID:          providers.IDCodex,
+					DisplayName: "Codex",
+				}},
+			}, nil
+		},
+	}
+	operation := providersmcp.Bind(providersmcp.RootDependencies{Providers: fake})
+	raw, err := operation(
+		context.Background(),
+		providersmcp.ToolListProviders,
+		json.RawMessage(`{}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(list_providers) error = %v", err)
+	}
+	if !invoked {
+		t.Fatal("fake Providers root was not invoked")
+	}
+	var response providersmcp.ToolResponse[providers.ListProvidersResult]
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode tool response: %v", err)
+	}
+	if response.Error != nil || response.Result == nil {
+		t.Fatalf("CallTool(list_providers) = %s, want success", raw)
+	}
+	if len(response.Result.Providers) != 1 || response.Result.Providers[0].ID != providers.IDCodex {
+		t.Fatalf("providers = %#v, want one codex descriptor", response.Result.Providers)
+	}
+}
+
+func TestNewFromRoot_FakeRootInvokedThroughListProvidersTool(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	fake := fakeProvidersRoot{
+		invoked: &invoked,
+		listProviders: func(context.Context, providers.ListProvidersRequest) (providers.ListProvidersResult, error) {
+			return providers.ListProvidersResult{}, nil
+		},
+	}
+	operation := providersmcp.NewFromRoot(providersmcp.RootDependencies{Providers: fake})
+	_, err := operation(
+		context.Background(),
+		providersmcp.ToolListProviders,
+		json.RawMessage(`{}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(list_providers) error = %v", err)
+	}
+	if !invoked {
+		t.Fatal("fake Providers root was not invoked through NewFromRoot binding")
+	}
+}
+
+func TestBind_UnsupportedToolReturnsStableErrorWithoutInvokingFakeRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	operation := providersmcp.Bind(providersmcp.RootDependencies{
+		Providers: fakeProvidersRoot{invoked: &invoked},
+	})
+	_, err := operation(context.Background(), "you.provider.unknown", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("CallTool(unknown) error = nil, want unsupported tool error")
+	}
+	if !strings.Contains(err.Error(), "unsupported tool") {
+		t.Fatalf("CallTool(unknown) error = %v, want unsupported tool error", err)
+	}
+	if invoked {
+		t.Fatal("fake Providers root was invoked for unknown tool")
+	}
+}
+
+func TestBind_ToolOperationRejectsMissingContext(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	operation := providersmcp.BindToolOperation(fakeProvidersRoot{invoked: &invoked})
+	_, err := operation(nil, providersmcp.ToolListProviders, json.RawMessage(`{}`))
+	if err == nil || !strings.Contains(err.Error(), "MCP request context is required") {
+		t.Fatalf("ToolOperation(nil context) error = %v, want required-context error", err)
+	}
+	if invoked {
+		t.Fatal("fake Providers root was invoked for nil context")
+	}
+}
+
+func TestPackageBoundary_DoesNotImportProvidersInternal(t *testing.T) {
+	t.Parallel()
+
+	forbidden := "github.com/portpowered/infinite-you/pkg/services/providers/internal"
+	packagePath := "github.com/portpowered/infinite-you/pkg/services/providers/transports/mcp"
+	assertPackageDirectImportsForbidden(t, packagePath, []string{forbidden})
+}
+
+type fakeProvidersRoot struct {
+	providers.Service
+	invoked       *bool
+	listProviders func(context.Context, providers.ListProvidersRequest) (providers.ListProvidersResult, error)
+	getProvider   func(context.Context, providers.GetProviderRequest) (providers.GetProviderResult, error)
+	execute       func(context.Context, providers.ExecuteRequest) (providers.ExecuteResult, error)
+}
+
+func (fake fakeProvidersRoot) markInvoked() {
+	if fake.invoked != nil {
+		*fake.invoked = true
+	}
+}
+
+func (fake fakeProvidersRoot) ListProviders(
+	ctx context.Context,
+	request providers.ListProvidersRequest,
+) (providers.ListProvidersResult, error) {
+	fake.markInvoked()
+	if fake.listProviders == nil {
+		panic("unexpected ListProviders on fake Providers root")
+	}
+	return fake.listProviders(ctx, request)
+}
+
+func (fake fakeProvidersRoot) GetProvider(
+	ctx context.Context,
+	request providers.GetProviderRequest,
+) (providers.GetProviderResult, error) {
+	fake.markInvoked()
+	if fake.getProvider == nil {
+		panic("unexpected GetProvider on fake Providers root")
+	}
+	return fake.getProvider(ctx, request)
+}
+
+func (fake fakeProvidersRoot) Execute(
+	ctx context.Context,
+	request providers.ExecuteRequest,
+) (providers.ExecuteResult, error) {
+	fake.markInvoked()
+	if fake.execute == nil {
+		panic("unexpected Execute on fake Providers root")
+	}
+	return fake.execute(ctx, request)
+}
+
+func assertPackageDirectImportsForbidden(t *testing.T, packagePath string, forbiddenRoots []string) {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", "-f", "{{.Imports}}", packagePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list imports for %s: %v\n%s", packagePath, err, output)
+	}
+	imports := strings.Fields(strings.Trim(string(output), "[]"))
+	for _, importPath := range imports {
+		for _, forbidden := range forbiddenRoots {
+			if importPath == forbidden || strings.HasPrefix(importPath, forbidden+"/") {
+				t.Fatalf("%s must not import forbidden ownership %s; found direct import %s", packagePath, forbidden, importPath)
+			}
+		}
+	}
+}

--- a/pkg/services/providers/transports/mcp/client.go
+++ b/pkg/services/providers/transports/mcp/client.go
@@ -1,0 +1,106 @@
+package providersmcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+var errMissingRequestContext = errors.New("MCP request context is required")
+
+// ToolOperation is the single injected execution role used by every MCP
+// protocol server. Production binds its Providers dependencies once; protocol
+// tests replace this exact function role.
+type ToolOperation func(context.Context, string, json.RawMessage) (json.RawMessage, error)
+
+// Bind constructs the canonical ToolOperation from explicit Providers root
+// dependencies. Adapter tests replace Providers with a root-shaped fake without
+// constructing real catalog, execution, or service-local Wire graphs.
+func Bind(deps RootDependencies) ToolOperation {
+	return func(ctx context.Context, name string, input json.RawMessage) (json.RawMessage, error) {
+		return CallTool(ctx, deps.Providers, name, input)
+	}
+}
+
+// BindToolOperation binds the canonical tool registry to an explicit Providers
+// Service root without constructing an alternate MCP client.
+func BindToolOperation(service providers.Service) ToolOperation {
+	return Bind(RootDependencies{Providers: service})
+}
+
+func callToolJSON[Input any, Output any](
+	input json.RawMessage,
+	decodeErr string,
+	handler func(Input) ToolResponse[Output],
+) (json.RawMessage, error) {
+	var request Input
+	if err := json.Unmarshal(input, &request); err != nil {
+		envelope := decodeInputErrorEnvelope(decodeErr, err)
+		return json.Marshal(ToolResponse[Output]{Error: &envelope})
+	}
+	return json.Marshal(handler(request))
+}
+
+type canonicalToolHandler func(
+	context.Context,
+	providers.Service,
+	json.RawMessage,
+) (json.RawMessage, error)
+
+var canonicalToolHandlers = map[string]canonicalToolHandler{
+	ToolListProviders: handleListProviders,
+	ToolGetProvider:   handleGetProvider,
+	ToolExecute:       handleExecute,
+}
+
+func handleListProviders(
+	ctx context.Context,
+	service providers.Service,
+	input json.RawMessage,
+) (json.RawMessage, error) {
+	return callToolJSON(input, "decode list providers input", func(request ListProvidersInput) ToolResponse[providers.ListProvidersResult] {
+		return ListProviders(ctx, service, request)
+	})
+}
+
+func handleGetProvider(
+	ctx context.Context,
+	service providers.Service,
+	input json.RawMessage,
+) (json.RawMessage, error) {
+	return callToolJSON(input, "decode get provider input", func(request GetProviderInput) ToolResponse[providers.GetProviderResult] {
+		return GetProvider(ctx, service, request)
+	})
+}
+
+func handleExecute(
+	ctx context.Context,
+	service providers.Service,
+	input json.RawMessage,
+) (json.RawMessage, error) {
+	return callToolJSON(input, "decode execute input", func(request ExecuteInput) ToolResponse[providers.ExecuteResult] {
+		return Execute(ctx, service, request)
+	})
+}
+
+// CallTool invokes one Providers tool against an explicitly supplied Service root.
+// Protocol servers receive the bound ToolOperation rather than choosing between
+// construction paths.
+func CallTool(
+	ctx context.Context,
+	service providers.Service,
+	name string,
+	input json.RawMessage,
+) (json.RawMessage, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("call MCP tool: %w", errMissingRequestContext)
+	}
+	handler, ok := canonicalToolHandlers[name]
+	if !ok {
+		return nil, fmt.Errorf("unsupported tool %q", name)
+	}
+	return handler(ctx, service, input)
+}

--- a/pkg/services/providers/transports/mcp/errors.go
+++ b/pkg/services/providers/transports/mcp/errors.go
@@ -4,15 +4,23 @@ import (
 	"context"
 	"errors"
 	"strings"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
 const (
 	errorCodeBadRequest         = "BAD_REQUEST"
-	errorCodeServiceUnavailable = "provider.service.unavailable"
-	errorCodeInternalExecution  = "provider.execution.internal"
-	errorCodeRequestCanceled    = "provider.request.canceled"
-	errorCodeRequestTimedOut    = "provider.request.timed_out"
+	errorCodeServiceUnavailable    = "provider.service.unavailable"
+	errorCodeIdentityInvalid       = "provider.identity.invalid"
+	errorCodeCatalogUnknown        = "provider.catalog.unknown"
+	errorCodeCatalogUnavailable    = "provider.catalog.unavailable"
+	errorCodeInternalExecution     = "provider.execution.internal"
+	errorCodeRequestCanceled       = "provider.request.canceled"
+	errorCodeRequestTimedOut       = "provider.request.timed_out"
 	errorMessageServiceUnavailable = "providers service is unavailable"
+	errorMessageIdentityInvalid    = "provider id is invalid"
+	errorMessageCatalogUnknown     = "provider is unknown"
+	errorMessageCatalogUnavailable = "provider is unavailable"
 	errorMessageRequestCanceled    = "providers request was canceled"
 	errorMessageRequestTimedOut    = "providers request timed out"
 	errorMessageInternalExecution  = "providers execution failed"
@@ -82,6 +90,43 @@ func unavailableServiceErrorEnvelope() ToolErrorEnvelope {
 		Code:      errorCodeServiceUnavailable,
 		Message:   errorMessageServiceUnavailable,
 		Retryable: false,
+	}
+}
+
+func getProviderErrorEnvelope(err error) ToolErrorEnvelope {
+	if envelope, ok := contextRequestErrorEnvelope(err); ok {
+		return envelope
+	}
+	switch {
+	case errors.Is(err, providers.ErrInvalidID):
+		return ToolErrorEnvelope{
+			Code:      errorCodeIdentityInvalid,
+			Message:   errorMessageIdentityInvalid,
+			Retryable: false,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	case errors.Is(err, providers.ErrUnknownProvider):
+		return ToolErrorEnvelope{
+			Code:      errorCodeCatalogUnknown,
+			Message:   errorMessageCatalogUnknown,
+			Retryable: false,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	case errors.Is(err, providers.ErrProviderUnavailable):
+		return ToolErrorEnvelope{
+			Code:      errorCodeCatalogUnavailable,
+			Message:   errorMessageCatalogUnavailable,
+			Retryable: true,
+			Details: map[string]any{
+				"reason": err.Error(),
+			},
+		}
+	default:
+		return executionErrorEnvelope(err)
 	}
 }
 

--- a/pkg/services/providers/transports/mcp/errors.go
+++ b/pkg/services/providers/transports/mcp/errors.go
@@ -14,16 +14,30 @@ const (
 	errorCodeIdentityInvalid       = "provider.identity.invalid"
 	errorCodeCatalogUnknown        = "provider.catalog.unknown"
 	errorCodeCatalogUnavailable    = "provider.catalog.unavailable"
-	errorCodeInternalExecution     = "provider.execution.internal"
-	errorCodeRequestCanceled       = "provider.request.canceled"
-	errorCodeRequestTimedOut       = "provider.request.timed_out"
-	errorMessageServiceUnavailable = "providers service is unavailable"
-	errorMessageIdentityInvalid    = "provider id is invalid"
-	errorMessageCatalogUnknown     = "provider is unknown"
-	errorMessageCatalogUnavailable = "provider is unavailable"
-	errorMessageRequestCanceled    = "providers request was canceled"
-	errorMessageRequestTimedOut    = "providers request timed out"
-	errorMessageInternalExecution  = "providers execution failed"
+	errorCodeInternalExecution          = "provider.execution.internal"
+	errorCodeExecutionCanceled          = "provider.execution.canceled"
+	errorCodeExecutionTimedOut          = "provider.execution.timed_out"
+	errorCodeExecutionAuthentication    = "provider.execution.authentication"
+	errorCodeExecutionInvalidRequest    = "provider.execution.invalid_request"
+	errorCodeExecutionThrottled         = "provider.execution.throttled"
+	errorCodeExecutionDependency        = "provider.execution.dependency"
+	errorCodeExecutionUnknown           = "provider.execution.unknown"
+	errorCodeRequestCanceled            = "provider.request.canceled"
+	errorCodeRequestTimedOut            = "provider.request.timed_out"
+	errorMessageServiceUnavailable      = "providers service is unavailable"
+	errorMessageIdentityInvalid         = "provider id is invalid"
+	errorMessageCatalogUnknown          = "provider is unknown"
+	errorMessageCatalogUnavailable      = "provider is unavailable"
+	errorMessageExecutionCanceled       = "provider execution was canceled"
+	errorMessageExecutionTimedOut       = "provider execution timed out"
+	errorMessageExecutionAuthentication = "provider authentication failed"
+	errorMessageExecutionInvalidRequest = "provider execution request is invalid"
+	errorMessageExecutionThrottled      = "provider execution was throttled"
+	errorMessageExecutionDependency     = "provider execution dependency failed"
+	errorMessageExecutionUnknown        = "provider execution failed"
+	errorMessageRequestCanceled         = "providers request was canceled"
+	errorMessageRequestTimedOut         = "providers request timed out"
+	errorMessageInternalExecution       = "providers execution failed"
 )
 
 func requestContextErrorResponse[T any](ctx context.Context) (ToolResponse[T], bool) {
@@ -93,10 +107,7 @@ func unavailableServiceErrorEnvelope() ToolErrorEnvelope {
 	}
 }
 
-func getProviderErrorEnvelope(err error) ToolErrorEnvelope {
-	if envelope, ok := contextRequestErrorEnvelope(err); ok {
-		return envelope
-	}
+func catalogErrorEnvelope(err error) (ToolErrorEnvelope, bool) {
 	switch {
 	case errors.Is(err, providers.ErrInvalidID):
 		return ToolErrorEnvelope{
@@ -106,7 +117,7 @@ func getProviderErrorEnvelope(err error) ToolErrorEnvelope {
 			Details: map[string]any{
 				"reason": err.Error(),
 			},
-		}
+		}, true
 	case errors.Is(err, providers.ErrUnknownProvider):
 		return ToolErrorEnvelope{
 			Code:      errorCodeCatalogUnknown,
@@ -115,7 +126,7 @@ func getProviderErrorEnvelope(err error) ToolErrorEnvelope {
 			Details: map[string]any{
 				"reason": err.Error(),
 			},
-		}
+		}, true
 	case errors.Is(err, providers.ErrProviderUnavailable):
 		return ToolErrorEnvelope{
 			Code:      errorCodeCatalogUnavailable,
@@ -124,9 +135,113 @@ func getProviderErrorEnvelope(err error) ToolErrorEnvelope {
 			Details: map[string]any{
 				"reason": err.Error(),
 			},
-		}
+		}, true
 	default:
-		return executionErrorEnvelope(err)
+		return ToolErrorEnvelope{}, false
+	}
+}
+
+func getProviderErrorEnvelope(err error) ToolErrorEnvelope {
+	if envelope, ok := contextRequestErrorEnvelope(err); ok {
+		return envelope
+	}
+	if envelope, ok := catalogErrorEnvelope(err); ok {
+		return envelope
+	}
+	return executionErrorEnvelope(err)
+}
+
+func executeErrorEnvelope(err error) ToolErrorEnvelope {
+	if err == nil {
+		return opaqueExecutionErrorEnvelope()
+	}
+	if envelope, ok := contextRequestErrorEnvelope(err); ok {
+		return envelope
+	}
+	if envelope, ok := catalogErrorEnvelope(err); ok {
+		return envelope
+	}
+	var failure providers.ExecuteFailure
+	if errors.As(err, &failure) {
+		return executeFailureErrorEnvelope(failure, err)
+	}
+	if errors.Is(err, providers.ErrExecuteCancelled) {
+		return executeCanceledErrorEnvelope(err)
+	}
+	if errors.Is(err, providers.ErrExecuteTimeout) {
+		return executeTimedOutErrorEnvelope(err)
+	}
+	return executionErrorEnvelope(err)
+}
+
+func executeFailureErrorEnvelope(failure providers.ExecuteFailure, err error) ToolErrorEnvelope {
+	code, message, retryable := executeFailurePresentation(failure)
+	if trimmed := strings.TrimSpace(failure.Message); trimmed != "" {
+		message = trimmed
+	}
+	return ToolErrorEnvelope{
+		Code:      code,
+		Message:   message,
+		Retryable: retryable,
+		Details:   executeFailureDetails(failure, err),
+	}
+}
+
+func executeFailurePresentation(failure providers.ExecuteFailure) (code string, message string, retryable bool) {
+	switch failure.Kind {
+	case providers.ExecuteFailureKindCanceled:
+		return errorCodeExecutionCanceled, errorMessageExecutionCanceled, false
+	case providers.ExecuteFailureKindTimeout:
+		return errorCodeExecutionTimedOut, errorMessageExecutionTimedOut, true
+	case providers.ExecuteFailureKindAuthentication:
+		return errorCodeExecutionAuthentication, errorMessageExecutionAuthentication, false
+	case providers.ExecuteFailureKindInvalidRequest:
+		return errorCodeExecutionInvalidRequest, errorMessageExecutionInvalidRequest, false
+	case providers.ExecuteFailureKindThrottled:
+		return errorCodeExecutionThrottled, errorMessageExecutionThrottled, true
+	case providers.ExecuteFailureKindDependency:
+		return errorCodeExecutionDependency, errorMessageExecutionDependency, true
+	default:
+		return errorCodeExecutionUnknown, errorMessageExecutionUnknown, false
+	}
+}
+
+func executeFailureDetails(failure providers.ExecuteFailure, err error) map[string]any {
+	details := map[string]any{
+		"kind":   string(failure.Kind),
+		"reason": err.Error(),
+	}
+	if failure.SessionRef != nil {
+		details["sessionRef"] = map[string]any{
+			"provider": string(failure.SessionRef.Provider),
+			"kind":     failure.SessionRef.Kind,
+			"id":       failure.SessionRef.ID,
+		}
+	}
+	return details
+}
+
+func executeCanceledErrorEnvelope(err error) ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeExecutionCanceled,
+		Message:   errorMessageExecutionCanceled,
+		Retryable: false,
+		Details: map[string]any{
+			"kind":   string(providers.ExecuteFailureKindCanceled),
+			"reason": err.Error(),
+		},
+	}
+}
+
+func executeTimedOutErrorEnvelope(err error) ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeExecutionTimedOut,
+		Message:   errorMessageExecutionTimedOut,
+		Retryable: true,
+		Details: map[string]any{
+			"kind":   string(providers.ExecuteFailureKindTimeout),
+			"reason": err.Error(),
+		},
 	}
 }
 

--- a/pkg/services/providers/transports/mcp/errors.go
+++ b/pkg/services/providers/transports/mcp/errors.go
@@ -1,0 +1,104 @@
+package providersmcp
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+const (
+	errorCodeBadRequest         = "BAD_REQUEST"
+	errorCodeServiceUnavailable = "provider.service.unavailable"
+	errorCodeInternalExecution  = "provider.execution.internal"
+	errorCodeRequestCanceled    = "provider.request.canceled"
+	errorCodeRequestTimedOut    = "provider.request.timed_out"
+	errorMessageServiceUnavailable = "providers service is unavailable"
+	errorMessageRequestCanceled    = "providers request was canceled"
+	errorMessageRequestTimedOut    = "providers request timed out"
+	errorMessageInternalExecution  = "providers execution failed"
+)
+
+func requestContextErrorResponse[T any](ctx context.Context) (ToolResponse[T], bool) {
+	if envelope, ok := contextRequestErrorEnvelope(ctx.Err()); ok {
+		return ToolResponse[T]{Error: &envelope}, true
+	}
+	return ToolResponse[T]{}, false
+}
+
+func contextRequestErrorEnvelope(err error) (ToolErrorEnvelope, bool) {
+	if err == nil {
+		return ToolErrorEnvelope{}, false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return contextDeadlineExceededErrorEnvelope(), true
+	}
+	if errors.Is(err, context.Canceled) {
+		return contextCanceledErrorEnvelope(), true
+	}
+	return ToolErrorEnvelope{}, false
+}
+
+func contextCanceledErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeRequestCanceled,
+		Message:   errorMessageRequestCanceled,
+		Retryable: false,
+		Details: map[string]any{
+			"reason": "CANCELED",
+		},
+	}
+}
+
+func contextDeadlineExceededErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeRequestTimedOut,
+		Message:   errorMessageRequestTimedOut,
+		Retryable: true,
+		Details: map[string]any{
+			"reason": "TIMED_OUT",
+		},
+	}
+}
+
+func decodeInputErrorEnvelope(operation string, err error) ToolErrorEnvelope {
+	message := operation
+	details := map[string]any{}
+	if err != nil {
+		if trimmed := strings.TrimSpace(err.Error()); trimmed != "" {
+			message = operation + ": " + trimmed
+		}
+		details["reason"] = err.Error()
+	}
+	return ToolErrorEnvelope{
+		Code:      errorCodeBadRequest,
+		Message:   message,
+		Retryable: false,
+		Details:   details,
+	}
+}
+
+func unavailableServiceErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeServiceUnavailable,
+		Message:   errorMessageServiceUnavailable,
+		Retryable: false,
+	}
+}
+
+func executionErrorEnvelope(err error) ToolErrorEnvelope {
+	if err == nil {
+		return opaqueExecutionErrorEnvelope()
+	}
+	if envelope, ok := contextRequestErrorEnvelope(err); ok {
+		return envelope
+	}
+	return opaqueExecutionErrorEnvelope()
+}
+
+func opaqueExecutionErrorEnvelope() ToolErrorEnvelope {
+	return ToolErrorEnvelope{
+		Code:      errorCodeInternalExecution,
+		Message:   errorMessageInternalExecution,
+		Retryable: false,
+	}
+}

--- a/pkg/services/providers/transports/mcp/execute.go
+++ b/pkg/services/providers/transports/mcp/execute.go
@@ -82,7 +82,7 @@ func Execute(
 	}
 	result, err := service.Execute(ctx, input.executeRequest())
 	if err != nil {
-		envelope := executionErrorEnvelope(err)
+		envelope := executeErrorEnvelope(err)
 		return ToolResponse[providers.ExecuteResult]{Error: &envelope}
 	}
 	return ToolResponse[providers.ExecuteResult]{Result: &result}

--- a/pkg/services/providers/transports/mcp/execute.go
+++ b/pkg/services/providers/transports/mcp/execute.go
@@ -1,0 +1,89 @@
+package providersmcp
+
+import (
+	"context"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+// SessionRefInput is the MCP request shape for a detached provider session ref.
+type SessionRefInput struct {
+	Provider string `json:"provider"`
+	Kind     string `json:"kind"`
+	ID       string `json:"id"`
+}
+
+func (input SessionRefInput) sessionRef() *providers.SessionRef {
+	if input.Provider == "" && input.Kind == "" && input.ID == "" {
+		return nil
+	}
+	return &providers.SessionRef{
+		Provider: providers.ID(input.Provider),
+		Kind:     input.Kind,
+		ID:       input.ID,
+	}
+}
+
+// ExecuteInput is the MCP request shape for you.provider.execute.
+type ExecuteInput struct {
+	Provider           string            `json:"provider"`
+	AttemptID          string            `json:"attemptId"`
+	WorkerType         string            `json:"workerType,omitempty"`
+	WorkstationName    string            `json:"workstationName,omitempty"`
+	Model              string            `json:"model,omitempty"`
+	SkipPermissions    bool              `json:"skipPermissions,omitempty"`
+	SystemPrompt       string            `json:"systemPrompt,omitempty"`
+	UserMessage        string            `json:"userMessage,omitempty"`
+	InputTokens        []any             `json:"inputTokens,omitempty"`
+	OutputSchema       string            `json:"outputSchema,omitempty"`
+	ResumeSession      *SessionRefInput  `json:"resumeSession,omitempty"`
+	WorkingDirectory   string            `json:"workingDirectory,omitempty"`
+	Worktree           string            `json:"worktree,omitempty"`
+	EnvVars            map[string]string `json:"envVars,omitempty"`
+	ProcessEnvironment []string          `json:"processEnvironment,omitempty"`
+}
+
+func (input ExecuteInput) executeRequest() providers.ExecuteRequest {
+	request := providers.ExecuteRequest{
+		Provider:           providers.ID(input.Provider),
+		AttemptID:          input.AttemptID,
+		WorkerType:         input.WorkerType,
+		WorkstationName:    input.WorkstationName,
+		Model:              input.Model,
+		SkipPermissions:    input.SkipPermissions,
+		SystemPrompt:       input.SystemPrompt,
+		UserMessage:        input.UserMessage,
+		InputTokens:        input.InputTokens,
+		OutputSchema:       input.OutputSchema,
+		WorkingDirectory:   input.WorkingDirectory,
+		Worktree:           input.Worktree,
+		EnvVars:            input.EnvVars,
+		ProcessEnvironment: input.ProcessEnvironment,
+	}
+	if input.ResumeSession != nil {
+		request.ResumeSession = input.ResumeSession.sessionRef()
+	}
+	return request
+}
+
+// Execute performs one normalized provider attempt through the you.provider.execute
+// MCP tool.
+func Execute(
+	ctx context.Context,
+	service providers.Service,
+	input ExecuteInput,
+) ToolResponse[providers.ExecuteResult] {
+	if response, done := requestContextErrorResponse[providers.ExecuteResult](ctx); done {
+		return response
+	}
+	if service == nil {
+		envelope := unavailableServiceErrorEnvelope()
+		return ToolResponse[providers.ExecuteResult]{Error: &envelope}
+	}
+	result, err := service.Execute(ctx, input.executeRequest())
+	if err != nil {
+		envelope := executionErrorEnvelope(err)
+		return ToolResponse[providers.ExecuteResult]{Error: &envelope}
+	}
+	return ToolResponse[providers.ExecuteResult]{Result: &result}
+}

--- a/pkg/services/providers/transports/mcp/execute_test.go
+++ b/pkg/services/providers/transports/mcp/execute_test.go
@@ -1,0 +1,453 @@
+package providersmcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	providersmcp "github.com/portpowered/infinite-you/pkg/services/providers/transports/mcp"
+)
+
+const testExecuteInputJSON = `{
+	"provider":"codex",
+	"attemptId":"attempt-1",
+	"workerType":"agent",
+	"workstationName":"ws-1",
+	"model":"gpt-test",
+	"skipPermissions":true,
+	"systemPrompt":"system",
+	"userMessage":"hello",
+	"outputSchema":"{}",
+	"resumeSession":{"provider":"codex","kind":"session_id","id":"session-1"},
+	"workingDirectory":"/tmp/work",
+	"worktree":"/tmp/worktree",
+	"envVars":{"KEY":"value"},
+	"processEnvironment":["PATH=/bin"]
+}`
+
+func TestBind_ExecuteSuccessReturnsDetachedResultFromInjectedRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	wantResult := providers.ExecuteResult{
+		Content: "hello-result",
+		SessionRef: &providers.SessionRef{
+			Provider: providers.IDCodex,
+			Kind:     "session_id",
+			ID:       "session-attempt-1",
+		},
+		Diagnostics: &providers.ExecuteDiagnostics{
+			DurationMillis: 42,
+			Progress: []providers.ExecuteProgress{{
+				Phase:  "running",
+				Detail: "thinking",
+			}},
+			Metadata: map[string]string{"attempt": "attempt-1"},
+		},
+	}
+	fake := fakeProvidersRoot{
+		invoked: &invoked,
+		execute: func(
+			_ context.Context,
+			request providers.ExecuteRequest,
+		) (providers.ExecuteResult, error) {
+			if request.Provider != providers.IDCodex {
+				t.Fatalf("provider = %q, want %q", request.Provider, providers.IDCodex)
+			}
+			if request.AttemptID != "attempt-1" {
+				t.Fatalf("attempt id = %q, want attempt-1", request.AttemptID)
+			}
+			if request.WorkerType != "agent" ||
+				request.WorkstationName != "ws-1" ||
+				request.Model != "gpt-test" ||
+				!request.SkipPermissions ||
+				request.SystemPrompt != "system" ||
+				request.UserMessage != "hello" ||
+				request.OutputSchema != "{}" ||
+				request.WorkingDirectory != "/tmp/work" ||
+				request.Worktree != "/tmp/worktree" {
+				t.Fatalf("execute request = %#v, want mapped MCP fields", request)
+			}
+			if request.ResumeSession == nil ||
+				request.ResumeSession.Provider != providers.IDCodex ||
+				request.ResumeSession.Kind != "session_id" ||
+				request.ResumeSession.ID != "session-1" {
+				t.Fatalf("resume session = %#v, want codex session_id session-1", request.ResumeSession)
+			}
+			if request.EnvVars["KEY"] != "value" {
+				t.Fatalf("env vars = %#v, want KEY=value", request.EnvVars)
+			}
+			if len(request.ProcessEnvironment) != 1 || request.ProcessEnvironment[0] != "PATH=/bin" {
+				t.Fatalf("process environment = %#v, want PATH=/bin", request.ProcessEnvironment)
+			}
+			return wantResult.Clone(), nil
+		},
+	}
+	operation := providersmcp.Bind(providersmcp.RootDependencies{Providers: fake})
+	raw, err := operation(
+		context.Background(),
+		providersmcp.ToolExecute,
+		json.RawMessage(testExecuteInputJSON),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(execute) transport error = %v, want typed tool response", err)
+	}
+	if !invoked {
+		t.Fatal("fake Providers root was not invoked")
+	}
+	var response providersmcp.ToolResponse[providers.ExecuteResult]
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode tool response: %v", err)
+	}
+	if response.Error != nil || response.Result == nil {
+		t.Fatalf("tool response = %s, want success envelope", raw)
+	}
+	got := response.Result
+	if got.Content != wantResult.Content {
+		t.Fatalf("content = %q, want %q", got.Content, wantResult.Content)
+	}
+	if got.SessionRef == nil ||
+		got.SessionRef.Provider != wantResult.SessionRef.Provider ||
+		got.SessionRef.Kind != wantResult.SessionRef.Kind ||
+		got.SessionRef.ID != wantResult.SessionRef.ID {
+		t.Fatalf("session ref = %#v, want %#v", got.SessionRef, wantResult.SessionRef)
+	}
+	if got.Diagnostics == nil ||
+		got.Diagnostics.DurationMillis != wantResult.Diagnostics.DurationMillis ||
+		len(got.Diagnostics.Progress) != 1 ||
+		got.Diagnostics.Progress[0].Phase != "running" {
+		t.Fatalf("diagnostics = %#v, want %#v", got.Diagnostics, wantResult.Diagnostics)
+	}
+}
+
+func TestDiscoverTools_ExecuteDiscoveryMatchesHandlerRegistration(t *testing.T) {
+	t.Parallel()
+
+	tool, ok := providersmcp.ToolByName(providersmcp.ToolExecute)
+	if !ok {
+		t.Fatal("ToolByName(execute) ok = false, want true")
+	}
+	if tool.Name != providersmcp.ToolExecute {
+		t.Fatalf("discovered name = %q, want %q", tool.Name, providersmcp.ToolExecute)
+	}
+	if !providersmcp.IsCanonicalToolHandlerRegistered(providersmcp.ToolExecute) {
+		t.Fatal("execute handler is not registered on canonical CallTool path")
+	}
+	for _, field := range []string{
+		"result.Content",
+		"result.SessionRef",
+		"result.Diagnostics",
+	} {
+		if !containsString(tool.SuccessStableFields, field) {
+			t.Fatalf("success stable fields = %#v, want %q", tool.SuccessStableFields, field)
+		}
+	}
+	properties, ok := tool.InputSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("execute input schema properties = %#v, want object map", tool.InputSchema["properties"])
+	}
+	for _, field := range []string{"provider", "attemptId"} {
+		if _, ok := properties[field]; !ok {
+			t.Fatalf("execute input schema missing %q property", field)
+		}
+	}
+	resultSchema, ok := tool.OutputSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("execute output schema properties missing")
+	}
+	if _, ok := resultSchema["result"]; !ok {
+		t.Fatal("execute output schema missing result envelope")
+	}
+}
+
+func TestBind_ExecuteFailuresReturnTypedErrorEnvelopes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		rootErr       error
+		wantCode      string
+		wantMessage   string
+		wantRetryable bool
+		wantKind      string
+	}{
+		{
+			name:          "invalid provider id",
+			rootErr:       providers.ErrInvalidID,
+			wantCode:      "provider.identity.invalid",
+			wantMessage:   "provider id is invalid",
+			wantRetryable: false,
+		},
+		{
+			name:          "unknown provider",
+			rootErr:       providers.ErrUnknownProvider,
+			wantCode:      "provider.catalog.unknown",
+			wantMessage:   "provider is unknown",
+			wantRetryable: false,
+		},
+		{
+			name:          "execute canceled sentinel",
+			rootErr:       providers.ErrExecuteCancelled,
+			wantCode:      "provider.execution.canceled",
+			wantMessage:   "provider execution was canceled",
+			wantRetryable: false,
+			wantKind:      "canceled",
+		},
+		{
+			name:          "execute timeout sentinel",
+			rootErr:       providers.ErrExecuteTimeout,
+			wantCode:      "provider.execution.timed_out",
+			wantMessage:   "provider execution timed out",
+			wantRetryable: true,
+			wantKind:      "timeout",
+		},
+		{
+			name: "execute failure canceled",
+			rootErr: providers.ExecuteFailure{
+				Kind:    providers.ExecuteFailureKindCanceled,
+				Message: "attempt canceled by provider",
+			},
+			wantCode:      "provider.execution.canceled",
+			wantMessage:   "attempt canceled by provider",
+			wantRetryable: false,
+			wantKind:      "canceled",
+		},
+		{
+			name: "execute failure timeout",
+			rootErr: providers.ExecuteFailure{
+				Kind:    providers.ExecuteFailureKindTimeout,
+				Message: "attempt exceeded deadline",
+			},
+			wantCode:      "provider.execution.timed_out",
+			wantMessage:   "attempt exceeded deadline",
+			wantRetryable: true,
+			wantKind:      "timeout",
+		},
+		{
+			name: "execute failure authentication",
+			rootErr: providers.ExecuteFailure{
+				Kind:    providers.ExecuteFailureKindAuthentication,
+				Message: "invalid credentials",
+			},
+			wantCode:      "provider.execution.authentication",
+			wantMessage:   "invalid credentials",
+			wantRetryable: false,
+			wantKind:      "authentication",
+		},
+		{
+			name: "execute failure invalid request",
+			rootErr: providers.ExecuteFailure{
+				Kind:    providers.ExecuteFailureKindInvalidRequest,
+				Message: "missing user message",
+			},
+			wantCode:      "provider.execution.invalid_request",
+			wantMessage:   "missing user message",
+			wantRetryable: false,
+			wantKind:      "invalid_request",
+		},
+		{
+			name: "execute failure throttled",
+			rootErr: providers.ExecuteFailure{
+				Kind:    providers.ExecuteFailureKindThrottled,
+				Message: "rate limited",
+			},
+			wantCode:      "provider.execution.throttled",
+			wantMessage:   "rate limited",
+			wantRetryable: true,
+			wantKind:      "throttled",
+		},
+		{
+			name: "execute failure dependency",
+			rootErr: providers.ExecuteFailure{
+				Kind:    providers.ExecuteFailureKindDependency,
+				Message: "provider binary missing",
+			},
+			wantCode:      "provider.execution.dependency",
+			wantMessage:   "provider binary missing",
+			wantRetryable: true,
+			wantKind:      "dependency",
+		},
+		{
+			name: "execute failure unknown",
+			rootErr: providers.ExecuteFailure{
+				Kind:    providers.ExecuteFailureKindUnknown,
+				Message: "unexpected provider exit",
+			},
+			wantCode:      "provider.execution.unknown",
+			wantMessage:   "unexpected provider exit",
+			wantRetryable: false,
+			wantKind:      "unknown",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := mustCallExecute(t, fakeProvidersRoot{
+				execute: func(context.Context, providers.ExecuteRequest) (providers.ExecuteResult, error) {
+					return providers.ExecuteResult{}, tc.rootErr
+				},
+			})
+			envelope := assertTypedToolErrorEnvelope(t, raw, tc.wantCode, tc.wantRetryable)
+			if envelope.Message != tc.wantMessage {
+				t.Fatalf("error.message = %q, want %q; envelope = %#v", envelope.Message, tc.wantMessage, envelope)
+			}
+			if tc.wantKind != "" {
+				kind, ok := envelope.Details["kind"].(string)
+				if !ok || kind != tc.wantKind {
+					t.Fatalf("error.details.kind = %#v, want %q; envelope = %#v", envelope.Details["kind"], tc.wantKind, envelope)
+				}
+			}
+		})
+	}
+}
+
+func TestBind_ExecuteFailureCodesAreDistinct(t *testing.T) {
+	t.Parallel()
+
+	throttledRaw := mustCallExecute(t, fakeProvidersRoot{
+		execute: func(context.Context, providers.ExecuteRequest) (providers.ExecuteResult, error) {
+			return providers.ExecuteResult{}, providers.ExecuteFailure{Kind: providers.ExecuteFailureKindThrottled}
+		},
+	})
+	canceledRaw := mustCallExecute(t, fakeProvidersRoot{
+		execute: func(context.Context, providers.ExecuteRequest) (providers.ExecuteResult, error) {
+			return providers.ExecuteResult{}, providers.ExecuteFailure{Kind: providers.ExecuteFailureKindCanceled}
+		},
+	})
+	unknownRaw := mustCallExecute(t, fakeProvidersRoot{
+		execute: func(context.Context, providers.ExecuteRequest) (providers.ExecuteResult, error) {
+			return providers.ExecuteResult{}, providers.ErrUnknownProvider
+		},
+	})
+
+	throttled := assertTypedToolErrorEnvelope(t, throttledRaw, "provider.execution.throttled", true)
+	canceled := assertTypedToolErrorEnvelope(t, canceledRaw, "provider.execution.canceled", false)
+	unknown := assertTypedToolErrorEnvelope(t, unknownRaw, "provider.catalog.unknown", false)
+
+	if throttled.Code == canceled.Code || throttled.Code == unknown.Code || canceled.Code == unknown.Code {
+		t.Fatalf(
+			"execute failure codes must be distinct: throttled=%q canceled=%q unknown=%q",
+			throttled.Code,
+			canceled.Code,
+			unknown.Code,
+		)
+	}
+}
+
+func TestBind_ExecuteNilServiceReturnsUnavailableEnvelope(t *testing.T) {
+	t.Parallel()
+
+	operation := providersmcp.Bind(providersmcp.RootDependencies{Providers: nil})
+	raw, err := operation(
+		context.Background(),
+		providersmcp.ToolExecute,
+		json.RawMessage(`{"provider":"codex","attemptId":"attempt-1"}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(execute) transport error = %v, want typed tool response", err)
+	}
+	envelope := assertTypedToolErrorEnvelope(
+		t,
+		raw,
+		"provider.service.unavailable",
+		false,
+	)
+	if envelope.Message != "providers service is unavailable" {
+		t.Fatalf("error.message = %q, want unavailable message; envelope = %#v", envelope.Message, envelope)
+	}
+}
+
+func TestBind_ExecuteMalformedJSONReturnsDecodeErrorWithoutInvokingRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	operation := providersmcp.Bind(providersmcp.RootDependencies{
+		Providers: fakeProvidersRoot{invoked: &invoked},
+	})
+	raw, err := operation(
+		context.Background(),
+		providersmcp.ToolExecute,
+		json.RawMessage(`{`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(execute) transport error = %v, want typed tool response", err)
+	}
+	envelope := assertTypedToolErrorEnvelope(t, raw, "BAD_REQUEST", false)
+	if !strings.Contains(envelope.Message, "decode execute input") {
+		t.Fatalf("error.message = %q, want decode execute input context", envelope.Message)
+	}
+	if invoked {
+		t.Fatal("fake Providers root was invoked for malformed JSON")
+	}
+}
+
+func TestBind_ExecuteWrappedFailuresPreserveTypedCodes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		rootErr  error
+		wantCode string
+	}{
+		{
+			name:     "wrapped canceled",
+			rootErr:  fmt.Errorf("provider attempt: %w", providers.ErrExecuteCancelled),
+			wantCode: "provider.execution.canceled",
+		},
+		{
+			name:     "wrapped timeout",
+			rootErr:  fmt.Errorf("provider attempt: %w", providers.ErrExecuteTimeout),
+			wantCode: "provider.execution.timed_out",
+		},
+		{
+			name: "wrapped execute failure",
+			rootErr: fmt.Errorf("provider attempt: %w", providers.ExecuteFailure{
+				Kind: providers.ExecuteFailureKindAuthentication,
+			}),
+			wantCode: "provider.execution.authentication",
+		},
+		{
+			name:     "wrapped unknown provider",
+			rootErr:  fmt.Errorf("lookup provider: %w", providers.ErrUnknownProvider),
+			wantCode: "provider.catalog.unknown",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := mustCallExecute(t, fakeProvidersRoot{
+				execute: func(context.Context, providers.ExecuteRequest) (providers.ExecuteResult, error) {
+					return providers.ExecuteResult{}, tc.rootErr
+				},
+			})
+			assertTypedToolErrorEnvelope(t, raw, tc.wantCode, tc.wantCode == "provider.execution.timed_out")
+		})
+	}
+}
+
+func mustCallExecute(t *testing.T, fake fakeProvidersRoot) json.RawMessage {
+	t.Helper()
+
+	var invoked bool
+	fake.invoked = &invoked
+	operation := providersmcp.Bind(providersmcp.RootDependencies{Providers: fake})
+	raw, err := operation(
+		context.Background(),
+		providersmcp.ToolExecute,
+		json.RawMessage(`{"provider":"codex","attemptId":"attempt-1"}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(execute) transport error = %v, want typed tool response", err)
+	}
+	if !invoked {
+		t.Fatal("fake Providers root was not invoked")
+	}
+	return raw
+}

--- a/pkg/services/providers/transports/mcp/get_provider.go
+++ b/pkg/services/providers/transports/mcp/get_provider.go
@@ -1,0 +1,36 @@
+package providersmcp
+
+import (
+	"context"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+// GetProviderInput is the MCP request shape for you.provider.get_provider.
+type GetProviderInput struct {
+	ID string `json:"id"`
+}
+
+// GetProvider returns one detached catalog descriptor through the
+// you.provider.get_provider MCP tool.
+func GetProvider(
+	ctx context.Context,
+	service providers.Service,
+	input GetProviderInput,
+) ToolResponse[providers.GetProviderResult] {
+	if response, done := requestContextErrorResponse[providers.GetProviderResult](ctx); done {
+		return response
+	}
+	if service == nil {
+		envelope := unavailableServiceErrorEnvelope()
+		return ToolResponse[providers.GetProviderResult]{Error: &envelope}
+	}
+	result, err := service.GetProvider(ctx, providers.GetProviderRequest{
+		ID: providers.ID(input.ID),
+	})
+	if err != nil {
+		envelope := executionErrorEnvelope(err)
+		return ToolResponse[providers.GetProviderResult]{Error: &envelope}
+	}
+	return ToolResponse[providers.GetProviderResult]{Result: &result}
+}

--- a/pkg/services/providers/transports/mcp/get_provider.go
+++ b/pkg/services/providers/transports/mcp/get_provider.go
@@ -29,7 +29,7 @@ func GetProvider(
 		ID: providers.ID(input.ID),
 	})
 	if err != nil {
-		envelope := executionErrorEnvelope(err)
+		envelope := getProviderErrorEnvelope(err)
 		return ToolResponse[providers.GetProviderResult]{Error: &envelope}
 	}
 	return ToolResponse[providers.GetProviderResult]{Result: &result}

--- a/pkg/services/providers/transports/mcp/get_provider_test.go
+++ b/pkg/services/providers/transports/mcp/get_provider_test.go
@@ -1,0 +1,330 @@
+package providersmcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	providersmcp "github.com/portpowered/infinite-you/pkg/services/providers/transports/mcp"
+)
+
+func TestBind_GetProviderSuccessReturnsDetachedDescriptorFromInjectedRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	wantDescriptor := providers.Descriptor{
+		ID:           providers.IDCodex,
+		Aliases:      []string{"openai-codex"},
+		DisplayName:  "Codex",
+		Availability: providers.AvailabilitySelectable,
+		Readiness:    providers.ReadinessReady,
+		Capabilities: []providers.Capability{
+			providers.CapabilityPromptSubmission,
+			providers.CapabilityNativeStreaming,
+		},
+	}
+	fake := fakeProvidersRoot{
+		invoked: &invoked,
+		getProvider: func(
+			_ context.Context,
+			request providers.GetProviderRequest,
+		) (providers.GetProviderResult, error) {
+			if request.ID != providers.IDCodex {
+				t.Fatalf("provider id = %q, want %q", request.ID, providers.IDCodex)
+			}
+			return providers.GetProviderResult{
+				Provider: wantDescriptor.Clone(),
+			}, nil
+		},
+	}
+	operation := providersmcp.Bind(providersmcp.RootDependencies{Providers: fake})
+	raw, err := operation(
+		context.Background(),
+		providersmcp.ToolGetProvider,
+		json.RawMessage(`{"id":"codex"}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(get_provider) transport error = %v, want typed tool response", err)
+	}
+	if !invoked {
+		t.Fatal("fake Providers root was not invoked")
+	}
+	var response providersmcp.ToolResponse[providers.GetProviderResult]
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode tool response: %v", err)
+	}
+	if response.Error != nil || response.Result == nil {
+		t.Fatalf("tool response = %s, want success envelope", raw)
+	}
+	got := response.Result.Provider
+	if got.ID != wantDescriptor.ID ||
+		got.DisplayName != wantDescriptor.DisplayName ||
+		got.Availability != wantDescriptor.Availability ||
+		got.Readiness != wantDescriptor.Readiness {
+		t.Fatalf("descriptor = %#v, want %#v", got, wantDescriptor)
+	}
+	if len(got.Capabilities) != len(wantDescriptor.Capabilities) {
+		t.Fatalf("capabilities = %#v, want %#v", got.Capabilities, wantDescriptor.Capabilities)
+	}
+	for i, capability := range got.Capabilities {
+		if capability != wantDescriptor.Capabilities[i] {
+			t.Fatalf("capabilities[%d] = %q, want %q", i, capability, wantDescriptor.Capabilities[i])
+		}
+	}
+}
+
+func TestDiscoverTools_GetProviderDiscoveryMatchesHandlerRegistration(t *testing.T) {
+	t.Parallel()
+
+	tool, ok := providersmcp.ToolByName(providersmcp.ToolGetProvider)
+	if !ok {
+		t.Fatal("ToolByName(get_provider) ok = false, want true")
+	}
+	if tool.Name != providersmcp.ToolGetProvider {
+		t.Fatalf("discovered name = %q, want %q", tool.Name, providersmcp.ToolGetProvider)
+	}
+	if !providersmcp.IsCanonicalToolHandlerRegistered(providersmcp.ToolGetProvider) {
+		t.Fatal("get_provider handler is not registered on canonical CallTool path")
+	}
+	if len(tool.SuccessStableFields) == 0 {
+		t.Fatal("get_provider success stable fields are required")
+	}
+	for _, field := range []string{
+		"result.Provider",
+		"result.Provider.ID",
+		"result.Provider.DisplayName",
+		"result.Provider.Availability",
+		"result.Provider.Readiness",
+		"result.Provider.Capabilities",
+	} {
+		if !containsString(tool.SuccessStableFields, field) {
+			t.Fatalf("success stable fields = %#v, want %q", tool.SuccessStableFields, field)
+		}
+	}
+	properties, ok := tool.InputSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("get_provider input schema properties = %#v, want object map", tool.InputSchema["properties"])
+	}
+	if _, ok := properties["id"]; !ok {
+		t.Fatal("get_provider input schema missing id property")
+	}
+	resultSchema, ok := tool.OutputSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("get_provider output schema properties missing")
+	}
+	if _, ok := resultSchema["result"]; !ok {
+		t.Fatal("get_provider output schema missing result envelope")
+	}
+}
+
+func TestBind_GetProviderCatalogFailuresReturnTypedErrorEnvelopes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		rootErr       error
+		wantCode      string
+		wantMessage   string
+		wantRetryable bool
+	}{
+		{
+			name:          "invalid provider id",
+			rootErr:       providers.ErrInvalidID,
+			wantCode:      "provider.identity.invalid",
+			wantMessage:   "provider id is invalid",
+			wantRetryable: false,
+		},
+		{
+			name:          "unknown provider",
+			rootErr:       providers.ErrUnknownProvider,
+			wantCode:      "provider.catalog.unknown",
+			wantMessage:   "provider is unknown",
+			wantRetryable: false,
+		},
+		{
+			name:          "unavailable provider",
+			rootErr:       providers.ErrProviderUnavailable,
+			wantCode:      "provider.catalog.unavailable",
+			wantMessage:   "provider is unavailable",
+			wantRetryable: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var invoked bool
+			fake := fakeProvidersRoot{
+				invoked: &invoked,
+				getProvider: func(
+					_ context.Context,
+					request providers.GetProviderRequest,
+				) (providers.GetProviderResult, error) {
+					if request.ID != providers.IDCodex {
+						t.Fatalf("provider id = %q, want %q", request.ID, providers.IDCodex)
+					}
+					return providers.GetProviderResult{}, tc.rootErr
+				},
+			}
+			operation := providersmcp.Bind(providersmcp.RootDependencies{Providers: fake})
+			raw, err := operation(
+				context.Background(),
+				providersmcp.ToolGetProvider,
+				json.RawMessage(`{"id":"codex"}`),
+			)
+			if err != nil {
+				t.Fatalf("CallTool(get_provider) transport error = %v, want typed tool response", err)
+			}
+			if !invoked {
+				t.Fatal("fake Providers root was not invoked")
+			}
+			envelope := assertTypedToolErrorEnvelope(t, raw, tc.wantCode, tc.wantRetryable)
+			if envelope.Message != tc.wantMessage {
+				t.Fatalf("error.message = %q, want %q; envelope = %#v", envelope.Message, tc.wantMessage, envelope)
+			}
+		})
+	}
+}
+
+func TestBind_GetProviderCatalogFailuresAreDistinct(t *testing.T) {
+	t.Parallel()
+
+	invalidRaw := mustCallGetProvider(t, fakeProvidersRoot{
+		getProvider: func(context.Context, providers.GetProviderRequest) (providers.GetProviderResult, error) {
+			return providers.GetProviderResult{}, providers.ErrInvalidID
+		},
+	})
+	unknownRaw := mustCallGetProvider(t, fakeProvidersRoot{
+		getProvider: func(context.Context, providers.GetProviderRequest) (providers.GetProviderResult, error) {
+			return providers.GetProviderResult{}, providers.ErrUnknownProvider
+		},
+	})
+	unavailableRaw := mustCallGetProvider(t, fakeProvidersRoot{
+		getProvider: func(context.Context, providers.GetProviderRequest) (providers.GetProviderResult, error) {
+			return providers.GetProviderResult{}, providers.ErrProviderUnavailable
+		},
+	})
+
+	invalid := assertTypedToolErrorEnvelope(t, invalidRaw, "provider.identity.invalid", false)
+	unknown := assertTypedToolErrorEnvelope(t, unknownRaw, "provider.catalog.unknown", false)
+	unavailable := assertTypedToolErrorEnvelope(t, unavailableRaw, "provider.catalog.unavailable", true)
+
+	if invalid.Code == unknown.Code || invalid.Code == unavailable.Code || unknown.Code == unavailable.Code {
+		t.Fatalf(
+			"catalog failure codes must be distinct: invalid=%q unknown=%q unavailable=%q",
+			invalid.Code,
+			unknown.Code,
+			unavailable.Code,
+		)
+	}
+}
+
+func TestBind_GetProviderNilServiceReturnsUnavailableEnvelope(t *testing.T) {
+	t.Parallel()
+
+	operation := providersmcp.Bind(providersmcp.RootDependencies{Providers: nil})
+	raw, err := operation(
+		context.Background(),
+		providersmcp.ToolGetProvider,
+		json.RawMessage(`{"id":"codex"}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(get_provider) transport error = %v, want typed tool response", err)
+	}
+	envelope := assertTypedToolErrorEnvelope(
+		t,
+		raw,
+		"provider.service.unavailable",
+		false,
+	)
+	if envelope.Message != "providers service is unavailable" {
+		t.Fatalf("error.message = %q, want unavailable message; envelope = %#v", envelope.Message, envelope)
+	}
+}
+
+func TestBind_GetProviderMalformedJSONReturnsDecodeErrorWithoutInvokingRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	operation := providersmcp.Bind(providersmcp.RootDependencies{
+		Providers: fakeProvidersRoot{invoked: &invoked},
+	})
+	raw, err := operation(
+		context.Background(),
+		providersmcp.ToolGetProvider,
+		json.RawMessage(`{`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(get_provider) transport error = %v, want typed tool response", err)
+	}
+	envelope := assertTypedToolErrorEnvelope(t, raw, "BAD_REQUEST", false)
+	if !strings.Contains(envelope.Message, "decode get provider input") {
+		t.Fatalf("error.message = %q, want decode get provider input context", envelope.Message)
+	}
+	if invoked {
+		t.Fatal("fake Providers root was invoked for malformed JSON")
+	}
+}
+
+func TestBind_GetProviderWrappedCatalogErrorsPreserveTypedCodes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		rootErr  error
+		wantCode string
+	}{
+		{
+			name:     "wrapped invalid id",
+			rootErr:  fmt.Errorf("lookup provider: %w", providers.ErrInvalidID),
+			wantCode: "provider.identity.invalid",
+		},
+		{
+			name:     "wrapped unknown provider",
+			rootErr:  fmt.Errorf("lookup provider: %w", providers.ErrUnknownProvider),
+			wantCode: "provider.catalog.unknown",
+		},
+		{
+			name:     "wrapped unavailable provider",
+			rootErr:  fmt.Errorf("lookup provider: %w", providers.ErrProviderUnavailable),
+			wantCode: "provider.catalog.unavailable",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := mustCallGetProvider(t, fakeProvidersRoot{
+				getProvider: func(context.Context, providers.GetProviderRequest) (providers.GetProviderResult, error) {
+					return providers.GetProviderResult{}, tc.rootErr
+				},
+			})
+			assertTypedToolErrorEnvelope(t, raw, tc.wantCode, tc.wantCode == "provider.catalog.unavailable")
+		})
+	}
+}
+
+func mustCallGetProvider(t *testing.T, fake fakeProvidersRoot) json.RawMessage {
+	t.Helper()
+
+	var invoked bool
+	fake.invoked = &invoked
+	operation := providersmcp.Bind(providersmcp.RootDependencies{Providers: fake})
+	raw, err := operation(
+		context.Background(),
+		providersmcp.ToolGetProvider,
+		json.RawMessage(`{"id":"codex"}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(get_provider) transport error = %v, want typed tool response", err)
+	}
+	if !invoked {
+		t.Fatal("fake Providers root was not invoked")
+	}
+	return raw
+}

--- a/pkg/services/providers/transports/mcp/list_providers.go
+++ b/pkg/services/providers/transports/mcp/list_providers.go
@@ -1,0 +1,32 @@
+package providersmcp
+
+import (
+	"context"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+// ListProvidersInput is the MCP request shape for you.provider.list_providers.
+type ListProvidersInput struct{}
+
+// ListProviders returns detached catalog descriptors through the
+// you.provider.list_providers MCP tool.
+func ListProviders(
+	ctx context.Context,
+	service providers.Service,
+	_ ListProvidersInput,
+) ToolResponse[providers.ListProvidersResult] {
+	if response, done := requestContextErrorResponse[providers.ListProvidersResult](ctx); done {
+		return response
+	}
+	if service == nil {
+		envelope := unavailableServiceErrorEnvelope()
+		return ToolResponse[providers.ListProvidersResult]{Error: &envelope}
+	}
+	result, err := service.ListProviders(ctx, providers.ListProvidersRequest{})
+	if err != nil {
+		envelope := executionErrorEnvelope(err)
+		return ToolResponse[providers.ListProvidersResult]{Error: &envelope}
+	}
+	return ToolResponse[providers.ListProvidersResult]{Result: &result}
+}

--- a/pkg/services/providers/transports/mcp/list_providers_test.go
+++ b/pkg/services/providers/transports/mcp/list_providers_test.go
@@ -1,0 +1,212 @@
+package providersmcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	providersmcp "github.com/portpowered/infinite-you/pkg/services/providers/transports/mcp"
+)
+
+func TestBind_ListProvidersSuccessReturnsDetachedCatalogFromInjectedRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	wantDescriptor := providers.Descriptor{
+		ID:           providers.IDCodex,
+		Aliases:      []string{"openai-codex"},
+		DisplayName:  "Codex",
+		Availability: providers.AvailabilitySelectable,
+		Readiness:    providers.ReadinessReady,
+		Capabilities: []providers.Capability{
+			providers.CapabilityPromptSubmission,
+			providers.CapabilityNativeStreaming,
+		},
+	}
+	fake := fakeProvidersRoot{
+		invoked: &invoked,
+		listProviders: func(
+			_ context.Context,
+			request providers.ListProvidersRequest,
+		) (providers.ListProvidersResult, error) {
+			if request != (providers.ListProvidersRequest{}) {
+				t.Fatalf("list request = %#v, want empty request", request)
+			}
+			return providers.ListProvidersResult{
+				Providers: []providers.Descriptor{wantDescriptor.Clone()},
+			}, nil
+		},
+	}
+	operation := providersmcp.Bind(providersmcp.RootDependencies{Providers: fake})
+	raw, err := operation(
+		context.Background(),
+		providersmcp.ToolListProviders,
+		json.RawMessage(`{}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(list_providers) transport error = %v, want typed tool response", err)
+	}
+	if !invoked {
+		t.Fatal("fake Providers root was not invoked")
+	}
+	var response providersmcp.ToolResponse[providers.ListProvidersResult]
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode tool response: %v", err)
+	}
+	if response.Error != nil || response.Result == nil {
+		t.Fatalf("tool response = %s, want success envelope", raw)
+	}
+	if len(response.Result.Providers) != 1 {
+		t.Fatalf("providers = %#v, want one descriptor", response.Result.Providers)
+	}
+	got := response.Result.Providers[0]
+	if got.ID != wantDescriptor.ID ||
+		got.DisplayName != wantDescriptor.DisplayName ||
+		got.Availability != wantDescriptor.Availability ||
+		got.Readiness != wantDescriptor.Readiness {
+		t.Fatalf("descriptor = %#v, want %#v", got, wantDescriptor)
+	}
+	if len(got.Capabilities) != len(wantDescriptor.Capabilities) {
+		t.Fatalf("capabilities = %#v, want %#v", got.Capabilities, wantDescriptor.Capabilities)
+	}
+	for i, capability := range got.Capabilities {
+		if capability != wantDescriptor.Capabilities[i] {
+			t.Fatalf("capabilities[%d] = %q, want %q", i, capability, wantDescriptor.Capabilities[i])
+		}
+	}
+}
+
+func TestDiscoverTools_ListProvidersDiscoveryMatchesHandlerRegistration(t *testing.T) {
+	t.Parallel()
+
+	tool, ok := providersmcp.ToolByName(providersmcp.ToolListProviders)
+	if !ok {
+		t.Fatal("ToolByName(list_providers) ok = false, want true")
+	}
+	if tool.Name != providersmcp.ToolListProviders {
+		t.Fatalf("discovered name = %q, want %q", tool.Name, providersmcp.ToolListProviders)
+	}
+	if !providersmcp.IsCanonicalToolHandlerRegistered(providersmcp.ToolListProviders) {
+		t.Fatal("list_providers handler is not registered on canonical CallTool path")
+	}
+	if len(tool.SuccessStableFields) == 0 {
+		t.Fatal("list_providers success stable fields are required")
+	}
+	for _, field := range []string{
+		"result.Providers",
+		"result.Providers[].ID",
+		"result.Providers[].DisplayName",
+		"result.Providers[].Availability",
+		"result.Providers[].Readiness",
+		"result.Providers[].Capabilities",
+	} {
+		if !containsString(tool.SuccessStableFields, field) {
+			t.Fatalf("success stable fields = %#v, want %q", tool.SuccessStableFields, field)
+		}
+	}
+	properties, ok := tool.InputSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("list_providers input schema properties = %#v, want object map", tool.InputSchema["properties"])
+	}
+	if len(properties) != 0 {
+		t.Fatalf("list_providers input properties = %#v, want empty object input", properties)
+	}
+	resultSchema, ok := tool.OutputSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("list_providers output schema properties missing")
+	}
+	if _, ok := resultSchema["result"]; !ok {
+		t.Fatal("list_providers output schema missing result envelope")
+	}
+}
+
+func TestBind_ListProvidersNilServiceReturnsUnavailableEnvelope(t *testing.T) {
+	t.Parallel()
+
+	operation := providersmcp.Bind(providersmcp.RootDependencies{Providers: nil})
+	raw, err := operation(
+		context.Background(),
+		providersmcp.ToolListProviders,
+		json.RawMessage(`{}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(list_providers) transport error = %v, want typed tool response", err)
+	}
+	envelope := assertTypedToolErrorEnvelope(
+		t,
+		raw,
+		"provider.service.unavailable",
+		false,
+	)
+	if envelope.Message != "providers service is unavailable" {
+		t.Fatalf("error.message = %q, want unavailable message; envelope = %#v", envelope.Message, envelope)
+	}
+}
+
+func TestBind_ListProvidersMalformedJSONReturnsDecodeErrorWithoutInvokingRoot(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	operation := providersmcp.Bind(providersmcp.RootDependencies{
+		Providers: fakeProvidersRoot{invoked: &invoked},
+	})
+	raw, err := operation(
+		context.Background(),
+		providersmcp.ToolListProviders,
+		json.RawMessage(`{`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(list_providers) transport error = %v, want typed tool response", err)
+	}
+	envelope := assertTypedToolErrorEnvelope(t, raw, "BAD_REQUEST", false)
+	if !strings.Contains(envelope.Message, "decode list providers input") {
+		t.Fatalf("error.message = %q, want decode list providers input context", envelope.Message)
+	}
+	if invoked {
+		t.Fatal("fake Providers root was invoked for malformed JSON")
+	}
+}
+
+func assertTypedToolErrorEnvelope(
+	t *testing.T,
+	raw json.RawMessage,
+	wantCode string,
+	wantRetryable bool,
+) *providersmcp.ToolErrorEnvelope {
+	t.Helper()
+
+	var response struct {
+		Result *json.RawMessage              `json:"result"`
+		Error  *providersmcp.ToolErrorEnvelope `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode tool response: %v", err)
+	}
+	if response.Result != nil {
+		t.Fatalf("tool response result = %s, want error envelope only", raw)
+	}
+	if response.Error == nil {
+		t.Fatalf("tool response = %s, want typed error envelope", raw)
+	}
+	if response.Error.Code != wantCode {
+		t.Fatalf("error.code = %q, want %q; envelope = %#v", response.Error.Code, wantCode, response.Error)
+	}
+	if response.Error.Retryable != wantRetryable {
+		t.Fatalf("error.retryable = %v, want %v; envelope = %#v", response.Error.Retryable, wantRetryable, response.Error)
+	}
+	if strings.TrimSpace(response.Error.Message) == "" {
+		t.Fatalf("error.message is required; envelope = %#v", response.Error)
+	}
+	return response.Error
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/services/providers/transports/mcp/manifest_registration_test.go
+++ b/pkg/services/providers/transports/mcp/manifest_registration_test.go
@@ -1,0 +1,153 @@
+package providersmcp_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/ownershipinventory"
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+const (
+	mcpAdapterPackagePath = "pkg/services/providers/transports/mcp"
+	mcpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/providers/transports/mcp"
+	providersOwner        = "providers"
+)
+
+type coverageMinimumManifest struct {
+	Lane     string `json:"lane"`
+	Packages []struct {
+		Package   string  `json:"package"`
+		Minimum   float64 `json:"minimum"`
+		Exception *struct {
+			Kind string `json:"kind"`
+		} `json:"exception"`
+	} `json:"packages"`
+}
+
+func TestManifestRegistration_MCPAdapterPackageIsRegistered(t *testing.T) {
+	t.Helper()
+
+	assertPackageTargetManifestRegistration(t)
+	assertOwnershipInventoryRegistration(t)
+	assertCoverageMinimumRegistration(t, "unit", "docs/internal/baselines/go-unit-coverage-package-minimums.json")
+	assertCoverageMinimumRegistration(t, "functional", "docs/internal/baselines/go-functional-coverage-package-minimums.json")
+}
+
+func assertPackageTargetManifestRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, "docs/internal/packaged-service-structure/package-target-manifest.json"))
+	if err != nil {
+		t.Fatalf("read package-target manifest: %v", err)
+	}
+
+	var manifest struct {
+		Inventory []string `json:"inventory"`
+		Packages  []struct {
+			PackagePath string `json:"packagePath"`
+			Disposition string `json:"disposition"`
+			Destination string `json:"destination"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode package-target manifest: %v", err)
+	}
+
+	foundInventory := false
+	for _, packagePath := range manifest.Inventory {
+		if packagePath == mcpAdapterPackagePath {
+			foundInventory = true
+			break
+		}
+	}
+	if !foundInventory {
+		t.Fatalf("package-target manifest inventory missing %q", mcpAdapterPackagePath)
+	}
+
+	for _, row := range manifest.Packages {
+		if row.PackagePath != mcpAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("package-target manifest disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != providersOwner {
+			t.Fatalf("package-target manifest destination = %q, want %q", row.Destination, providersOwner)
+		}
+		return
+	}
+	t.Fatalf("package-target manifest packages missing %q", mcpAdapterPackagePath)
+}
+
+func assertOwnershipInventoryRegistration(t *testing.T) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, ownershipinventory.InventoryRelativePath))
+	if err != nil {
+		t.Fatalf("read ownership inventory: %v", err)
+	}
+
+	var inventory struct {
+		Packages []ownershipinventory.PackageRow `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		t.Fatalf("decode ownership inventory: %v", err)
+	}
+
+	for _, row := range inventory.Packages {
+		if row.PackagePath != mcpAdapterPackagePath {
+			continue
+		}
+		if row.Disposition != ownershipinventory.DispositionRetain {
+			t.Fatalf("ownership inventory disposition = %q, want %q", row.Disposition, ownershipinventory.DispositionRetain)
+		}
+		if row.Destination != providersOwner {
+			t.Fatalf("ownership inventory destination = %q, want %q", row.Destination, providersOwner)
+		}
+		if row.DestinationKind != ownershipinventory.DestinationKindOwner {
+			t.Fatalf(
+				"ownership inventory destinationKind = %q, want %q",
+				row.DestinationKind,
+				ownershipinventory.DestinationKindOwner,
+			)
+		}
+		return
+	}
+	t.Fatalf("ownership inventory packages missing %q", mcpAdapterPackagePath)
+}
+
+func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(testutil.MustRepoPath(t, relativePath))
+	if err != nil {
+		t.Fatalf("read %s coverage manifest: %v", lane, err)
+	}
+
+	var manifest coverageMinimumManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode %s coverage manifest: %v", lane, err)
+	}
+	if manifest.Lane != lane {
+		t.Fatalf("%s coverage manifest lane = %q, want %q", relativePath, manifest.Lane, lane)
+	}
+
+	for _, entry := range manifest.Packages {
+		if entry.Package != mcpAdapterImportPath {
+			continue
+		}
+		if entry.Exception != nil {
+			if entry.Exception.Kind != "measurement" {
+				t.Fatalf("%s coverage exception kind for %q = %q, want measurement", lane, mcpAdapterImportPath, entry.Exception.Kind)
+			}
+			return
+		}
+		if entry.Minimum < 0 {
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterImportPath)
+		}
+		return
+	}
+	t.Fatalf("%s coverage manifest missing %q", lane, mcpAdapterImportPath)
+}

--- a/pkg/services/providers/transports/mcp/registry.go
+++ b/pkg/services/providers/transports/mcp/registry.go
@@ -1,0 +1,92 @@
+package providersmcp
+
+// DiscoverTools returns the canonical Providers MCP tool catalog in stable
+// discovery order. Schemas mirror accepted Providers root request contracts.
+func DiscoverTools() []ToolDefinition {
+	return []ToolDefinition{
+		listProvidersTool(),
+		getProviderTool(),
+		executeTool(),
+	}
+}
+
+// ToolNames returns stable canonical tool names in discovery order.
+func ToolNames() []string {
+	tools := DiscoverTools()
+	names := make([]string, len(tools))
+	for i, tool := range tools {
+		names[i] = tool.Name
+	}
+	return names
+}
+
+// ToolByName returns one canonical tool definition by stable name.
+func ToolByName(name string) (ToolDefinition, bool) {
+	for _, tool := range DiscoverTools() {
+		if tool.Name == name {
+			return tool, true
+		}
+	}
+	return ToolDefinition{}, false
+}
+
+// IsCanonicalToolHandlerRegistered reports whether the live CallTool path
+// registers a handler for one canonical Providers tool name.
+func IsCanonicalToolHandlerRegistered(name string) bool {
+	_, ok := canonicalToolHandlers[name]
+	return ok
+}
+
+func listProvidersTool() ToolDefinition {
+	return ToolDefinition{
+		Name: ToolListProviders,
+		Description: "List detached provider catalog descriptors through the accepted " +
+			"Providers root without constructing Providers internals.",
+		InputSchema:  listProvidersInputSchema(),
+		OutputSchema: toolResponseSchema(listProvidersResultSchema()),
+		SuccessStableFields: []string{
+			"result.Providers",
+			"result.Providers[].ID",
+			"result.Providers[].DisplayName",
+			"result.Providers[].Availability",
+			"result.Providers[].Readiness",
+			"result.Providers[].Capabilities",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}
+
+func getProviderTool() ToolDefinition {
+	return ToolDefinition{
+		Name: ToolGetProvider,
+		Description: "Look up one detached provider catalog descriptor by Providers-owned " +
+			"identity through the accepted Providers root without constructing Providers internals.",
+		InputSchema:  getProviderInputSchema(),
+		OutputSchema: toolResponseSchema(getProviderResultSchema()),
+		SuccessStableFields: []string{
+			"result.Provider",
+			"result.Provider.ID",
+			"result.Provider.DisplayName",
+			"result.Provider.Availability",
+			"result.Provider.Readiness",
+			"result.Provider.Capabilities",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}
+
+func executeTool() ToolDefinition {
+	return ToolDefinition{
+		Name: ToolExecute,
+		Description: "Perform exactly one normalized provider execution attempt through the " +
+			"accepted Providers root and return detached content and optional session facts.",
+		InputSchema:  executeInputSchema(),
+		OutputSchema: toolResponseSchema(executeResultSchema()),
+		SuccessStableFields: []string{
+			"result.Content",
+			"result.SessionRef",
+			"result.Diagnostics",
+		},
+		ErrorStableFields: sharedErrorStableFields,
+	}
+}

--- a/pkg/services/providers/transports/mcp/registry_test.go
+++ b/pkg/services/providers/transports/mcp/registry_test.go
@@ -1,0 +1,152 @@
+package providersmcp_test
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+
+	providersmcp "github.com/portpowered/infinite-you/pkg/services/providers/transports/mcp"
+)
+
+func TestDiscoverTools_ExposesExpectedProvidersTools(t *testing.T) {
+	t.Parallel()
+
+	tools := providersmcp.DiscoverTools()
+	if len(tools) != 3 {
+		t.Fatalf("tool count = %d, want 3", len(tools))
+	}
+
+	wantNames := []string{
+		providersmcp.ToolListProviders,
+		providersmcp.ToolGetProvider,
+		providersmcp.ToolExecute,
+	}
+	gotNames := providersmcp.ToolNames()
+	if !slices.Equal(gotNames, wantNames) {
+		t.Fatalf("tool names = %#v, want %#v", gotNames, wantNames)
+	}
+	for _, name := range wantNames {
+		if !providersmcp.IsCanonicalToolHandlerRegistered(name) {
+			t.Fatalf("canonical handler missing for %q", name)
+		}
+	}
+}
+
+func TestDiscoverTools_EachToolHasSchemasDescriptionsAndStableFields(t *testing.T) {
+	t.Parallel()
+
+	for _, tool := range providersmcp.DiscoverTools() {
+		if strings.TrimSpace(tool.Name) == "" {
+			t.Fatal("tool name is required")
+		}
+		if strings.TrimSpace(tool.Description) == "" {
+			t.Fatalf("tool %q description is required", tool.Name)
+		}
+		if len(tool.InputSchema) == 0 {
+			t.Fatalf("tool %q input schema is required", tool.Name)
+		}
+		if schemaType, _ := tool.InputSchema["type"].(string); schemaType != "object" {
+			t.Fatalf("tool %q input schema type = %q, want object", tool.Name, schemaType)
+		}
+		additional, ok := tool.InputSchema["additionalProperties"].(bool)
+		if !ok || additional {
+			t.Fatalf("tool %q input schema additionalProperties = %v, want false", tool.Name, tool.InputSchema["additionalProperties"])
+		}
+		if len(tool.OutputSchema) == 0 {
+			t.Fatalf("tool %q output schema is required", tool.Name)
+		}
+		if len(tool.SuccessStableFields) == 0 {
+			t.Fatalf("tool %q success stable fields are required", tool.Name)
+		}
+		if len(tool.ErrorStableFields) == 0 {
+			t.Fatalf("tool %q error stable fields are required", tool.Name)
+		}
+	}
+}
+
+func TestDiscoverTools_RepresentativeSchemaFields(t *testing.T) {
+	t.Parallel()
+
+	byName := toolDefinitionsByName(t)
+
+	getProps := byName[providersmcp.ToolGetProvider].InputSchema["properties"].(map[string]any)
+	if _, ok := getProps["id"]; !ok {
+		t.Fatal("get provider input missing id")
+	}
+
+	executeProps := byName[providersmcp.ToolExecute].InputSchema["properties"].(map[string]any)
+	for _, field := range []string{"provider", "attemptId"} {
+		if _, ok := executeProps[field]; !ok {
+			t.Fatalf("execute input missing %q", field)
+		}
+	}
+}
+
+func TestDiscoverTools_OutputSchemasDocumentSharedErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	for _, tool := range providersmcp.DiscoverTools() {
+		properties, ok := tool.OutputSchema["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("tool %q output schema properties missing", tool.Name)
+		}
+		errorSchema, ok := properties["error"].(map[string]any)
+		if !ok {
+			t.Fatalf("tool %q output schema missing error envelope", tool.Name)
+		}
+		errorProps, ok := errorSchema["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("tool %q error envelope properties missing", tool.Name)
+		}
+		for _, field := range []string{"code", "message", "retryable"} {
+			if _, ok := errorProps[field]; !ok {
+				t.Fatalf("tool %q error envelope missing %q", tool.Name, field)
+			}
+		}
+	}
+}
+
+func TestDiscoverTools_RepeatDiscoveryIsStable(t *testing.T) {
+	t.Parallel()
+
+	first, err := json.Marshal(providersmcp.DiscoverTools())
+	if err != nil {
+		t.Fatalf("marshal first discovery: %v", err)
+	}
+	second, err := json.Marshal(providersmcp.DiscoverTools())
+	if err != nil {
+		t.Fatalf("marshal second discovery: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Fatalf("repeat discovery differs:\nfirst=%s\nsecond=%s", first, second)
+	}
+}
+
+func TestToolByName_ReturnsCanonicalDefinitions(t *testing.T) {
+	t.Parallel()
+
+	for _, want := range providersmcp.DiscoverTools() {
+		got, ok := providersmcp.ToolByName(want.Name)
+		if !ok {
+			t.Fatalf("ToolByName(%q) ok = false, want true", want.Name)
+		}
+		if got.Name != want.Name || got.Description != want.Description {
+			t.Fatalf("ToolByName(%q) = %#v, want %#v", want.Name, got, want)
+		}
+	}
+
+	if _, ok := providersmcp.ToolByName("you.provider.unknown"); ok {
+		t.Fatal("ToolByName(unknown) ok = true, want false")
+	}
+}
+
+func toolDefinitionsByName(t *testing.T) map[string]providersmcp.ToolDefinition {
+	t.Helper()
+
+	byName := make(map[string]providersmcp.ToolDefinition, len(providersmcp.DiscoverTools()))
+	for _, tool := range providersmcp.DiscoverTools() {
+		byName[tool.Name] = tool
+	}
+	return byName
+}

--- a/pkg/services/providers/transports/mcp/request_context_test.go
+++ b/pkg/services/providers/transports/mcp/request_context_test.go
@@ -1,0 +1,124 @@
+package providersmcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	providersmcp "github.com/portpowered/infinite-you/pkg/services/providers/transports/mcp"
+)
+
+func TestBind_ListProvidersContextCanceledBeforeRootReturnsDocumentedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	operation := providersmcp.Bind(providersmcp.RootDependencies{
+		Providers: fakeProvidersRoot{invoked: &invoked},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	raw, err := operation(
+		ctx,
+		providersmcp.ToolListProviders,
+		json.RawMessage(`{}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(list_providers) transport error = %v, want typed tool response", err)
+	}
+	if invoked {
+		t.Fatal("fake Providers root was invoked for pre-canceled context")
+	}
+	envelope := assertTypedToolErrorEnvelope(
+		t,
+		raw,
+		"provider.request.canceled",
+		false,
+	)
+	if envelope.Message != "providers request was canceled" {
+		t.Fatalf("error.message = %q, want canceled request message; envelope = %#v", envelope.Message, envelope)
+	}
+}
+
+func TestBind_ListProvidersContextCanceledDuringRootReturnsDocumentedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	entered := make(chan struct{})
+	var enteredOnce sync.Once
+	fake := fakeProvidersRoot{
+		listProviders: func(ctx context.Context, _ providers.ListProvidersRequest) (providers.ListProvidersResult, error) {
+			enteredOnce.Do(func() { close(entered) })
+			<-ctx.Done()
+			return providers.ListProvidersResult{}, ctx.Err()
+		},
+	}
+	operation := providersmcp.Bind(providersmcp.RootDependencies{Providers: fake})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	var raw json.RawMessage
+	var callErr error
+	go func() {
+		defer close(done)
+		raw, callErr = operation(
+			ctx,
+			providersmcp.ToolListProviders,
+			json.RawMessage(`{}`),
+		)
+	}()
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fake Providers root did not start before cancellation")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("CallTool(list_providers) hung after cancellation")
+	}
+	if callErr != nil {
+		t.Fatalf("CallTool(list_providers) transport error = %v, want typed tool response", callErr)
+	}
+	envelope := assertTypedToolErrorEnvelope(
+		t,
+		raw,
+		"provider.request.canceled",
+		false,
+	)
+	if envelope.Message != "providers request was canceled" {
+		t.Fatalf("error.message = %q, want canceled request message; envelope = %#v", envelope.Message, envelope)
+	}
+}
+
+func TestBind_ListProvidersContextDeadlineExceededDuringRootReturnsDocumentedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeProvidersRoot{
+		listProviders: func(ctx context.Context, _ providers.ListProvidersRequest) (providers.ListProvidersResult, error) {
+			<-ctx.Done()
+			return providers.ListProvidersResult{}, ctx.Err()
+		},
+	}
+	operation := providersmcp.Bind(providersmcp.RootDependencies{Providers: fake})
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	raw, err := operation(
+		ctx,
+		providersmcp.ToolListProviders,
+		json.RawMessage(`{}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(list_providers) transport error = %v, want typed tool response", err)
+	}
+	envelope := assertTypedToolErrorEnvelope(
+		t,
+		raw,
+		"provider.request.timed_out",
+		true,
+	)
+	if envelope.Message != "providers request timed out" {
+		t.Fatalf("error.message = %q, want timed out request message; envelope = %#v", envelope.Message, envelope)
+	}
+}

--- a/pkg/services/providers/transports/mcp/request_context_test.go
+++ b/pkg/services/providers/transports/mcp/request_context_test.go
@@ -122,3 +122,115 @@ func TestBind_ListProvidersContextDeadlineExceededDuringRootReturnsDocumentedEnv
 		t.Fatalf("error.message = %q, want timed out request message; envelope = %#v", envelope.Message, envelope)
 	}
 }
+
+func TestBind_ExecuteContextCanceledBeforeRootReturnsDocumentedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	var invoked bool
+	operation := providersmcp.Bind(providersmcp.RootDependencies{
+		Providers: fakeProvidersRoot{invoked: &invoked},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	raw, err := operation(
+		ctx,
+		providersmcp.ToolExecute,
+		json.RawMessage(`{"provider":"codex","attemptId":"attempt-1"}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(execute) transport error = %v, want typed tool response", err)
+	}
+	if invoked {
+		t.Fatal("fake Providers root was invoked for pre-canceled context")
+	}
+	envelope := assertTypedToolErrorEnvelope(
+		t,
+		raw,
+		"provider.request.canceled",
+		false,
+	)
+	if envelope.Message != "providers request was canceled" {
+		t.Fatalf("error.message = %q, want canceled request message; envelope = %#v", envelope.Message, envelope)
+	}
+}
+
+func TestBind_ExecuteContextCanceledDuringRootReturnsDocumentedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	entered := make(chan struct{})
+	var enteredOnce sync.Once
+	fake := fakeProvidersRoot{
+		execute: func(ctx context.Context, _ providers.ExecuteRequest) (providers.ExecuteResult, error) {
+			enteredOnce.Do(func() { close(entered) })
+			<-ctx.Done()
+			return providers.ExecuteResult{}, ctx.Err()
+		},
+	}
+	operation := providersmcp.Bind(providersmcp.RootDependencies{Providers: fake})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	var raw json.RawMessage
+	var callErr error
+	go func() {
+		defer close(done)
+		raw, callErr = operation(
+			ctx,
+			providersmcp.ToolExecute,
+			json.RawMessage(`{"provider":"codex","attemptId":"attempt-1"}`),
+		)
+	}()
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fake Providers root did not start before cancellation")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("CallTool(execute) hung after cancellation")
+	}
+	if callErr != nil {
+		t.Fatalf("CallTool(execute) transport error = %v, want typed tool response", callErr)
+	}
+	envelope := assertTypedToolErrorEnvelope(
+		t,
+		raw,
+		"provider.request.canceled",
+		false,
+	)
+	if envelope.Message != "providers request was canceled" {
+		t.Fatalf("error.message = %q, want canceled request message; envelope = %#v", envelope.Message, envelope)
+	}
+}
+
+func TestBind_ExecuteContextDeadlineExceededDuringRootReturnsDocumentedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	fake := fakeProvidersRoot{
+		execute: func(ctx context.Context, _ providers.ExecuteRequest) (providers.ExecuteResult, error) {
+			<-ctx.Done()
+			return providers.ExecuteResult{}, ctx.Err()
+		},
+	}
+	operation := providersmcp.Bind(providersmcp.RootDependencies{Providers: fake})
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	raw, err := operation(
+		ctx,
+		providersmcp.ToolExecute,
+		json.RawMessage(`{"provider":"codex","attemptId":"attempt-1"}`),
+	)
+	if err != nil {
+		t.Fatalf("CallTool(execute) transport error = %v, want typed tool response", err)
+	}
+	envelope := assertTypedToolErrorEnvelope(
+		t,
+		raw,
+		"provider.request.timed_out",
+		true,
+	)
+	if envelope.Message != "providers request timed out" {
+		t.Fatalf("error.message = %q, want timed out request message; envelope = %#v", envelope.Message, envelope)
+	}
+}

--- a/pkg/services/providers/transports/mcp/root_binding.go
+++ b/pkg/services/providers/transports/mcp/root_binding.go
@@ -1,0 +1,23 @@
+package providersmcp
+
+import (
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+// ProvidersRoot is the accepted Providers root contract used by the MCP adapter.
+// Adapter-owned operations invoke this surface rather than Providers internal packages.
+type ProvidersRoot = providers.Service
+
+// RootDependencies are the accepted Providers root roles consumed by the MCP adapter.
+// Providers is the singular Service root; transports inject an implementation or
+// test fake rather than importing Providers internals or constructing canonical state.
+type RootDependencies struct {
+	Providers ProvidersRoot
+}
+
+// NewFromRoot constructs an MCP tool operation that calls through the supplied
+// Providers root binding. Tests inject focused fakes without constructing real
+// catalog, execution, or service-local Wire graphs.
+func NewFromRoot(deps RootDependencies) ToolOperation {
+	return Bind(deps)
+}

--- a/pkg/services/providers/transports/mcp/schemas.go
+++ b/pkg/services/providers/transports/mcp/schemas.go
@@ -1,0 +1,173 @@
+package providersmcp
+
+func objectSchema(properties map[string]any, required ...string) map[string]any {
+	schema := map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties":           properties,
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+func stringProperty(description string) map[string]any {
+	return map[string]any{
+		"type":        "string",
+		"description": description,
+	}
+}
+
+func booleanProperty(description string) map[string]any {
+	return map[string]any{
+		"type":        "boolean",
+		"description": description,
+	}
+}
+
+func toolResponseSchema(resultSchema map[string]any) map[string]any {
+	return objectSchema(map[string]any{
+		"result": resultSchema,
+		"error":  toolErrorEnvelopeSchema(),
+	})
+}
+
+func toolErrorEnvelopeSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"code":      stringProperty("Stable machine-readable failure code."),
+		"message":   stringProperty("Human-readable failure summary for MCP hosts."),
+		"retryable": map[string]any{"type": "boolean", "description": "Whether the caller should retry the same request later."},
+		"details": map[string]any{
+			"type":                 "object",
+			"additionalProperties": true,
+			"description":          "Optional structured diagnostics such as validation issues or availability hints.",
+		},
+	}, "code", "message", "retryable")
+}
+
+func prerequisiteSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"Kind":        stringProperty("Prerequisite kind such as configuration, credential, or dependency."),
+		"Name":        stringProperty("Prerequisite name."),
+		"Status":      stringProperty("Whether the prerequisite is satisfied or missing."),
+		"Description": stringProperty("Bounded setup guidance for the prerequisite."),
+	})
+}
+
+func providerDescriptorSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"ID":            stringProperty("Providers-owned canonical provider identity."),
+		"Aliases":       map[string]any{"type": "array", "items": stringProperty("Alternate provider identity string.")},
+		"DisplayName":   stringProperty("Human-readable provider display name."),
+		"Availability":  stringProperty("Catalog availability posture for the provider."),
+		"Readiness":     stringProperty("Current provider readiness outcome."),
+		"Prerequisites": map[string]any{"type": "array", "items": prerequisiteSchema()},
+		"Capabilities":  map[string]any{"type": "array", "items": stringProperty("Provider-neutral capability identifier.")},
+	})
+}
+
+func sessionRefSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"Provider": stringProperty("Providers-owned provider identity for the session ref."),
+		"Kind":     stringProperty("Session ref kind such as session_id."),
+		"ID":       stringProperty("Detached provider session identifier."),
+	}, "Provider", "Kind", "ID")
+}
+
+func executeProgressSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"Phase":    stringProperty("Bounded in-flight progress phase."),
+		"Detail":   stringProperty("Bounded progress detail."),
+		"Metadata": map[string]any{"type": "object", "additionalProperties": map[string]any{"type": "string"}},
+	})
+}
+
+func executeDiagnosticsSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"DurationMillis": integerProperty("Sanitized attempt duration in milliseconds."),
+		"Progress":       map[string]any{"type": "array", "items": executeProgressSchema()},
+		"Metadata":       map[string]any{"type": "object", "additionalProperties": map[string]any{"type": "string"}},
+	})
+}
+
+func integerProperty(description string) map[string]any {
+	return map[string]any{
+		"type":        "integer",
+		"description": description,
+	}
+}
+
+func listProvidersInputSchema() map[string]any {
+	return objectSchema(map[string]any{})
+}
+
+func listProvidersResultSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"Providers": map[string]any{
+			"type":        "array",
+			"description": "Detached provider catalog descriptors.",
+			"items":       providerDescriptorSchema(),
+		},
+	})
+}
+
+func getProviderInputSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"id": stringProperty("Providers-owned canonical provider identity."),
+	}, "id")
+}
+
+func getProviderResultSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"Provider": providerDescriptorSchema(),
+	})
+}
+
+func executeInputSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"provider":           stringProperty("Providers-owned canonical provider identity."),
+		"attemptId":          stringProperty("Caller-owned attempt identifier for one normalized execution."),
+		"workerType":         stringProperty("Optional worker type context for the attempt."),
+		"workstationName":    stringProperty("Optional workstation name context for the attempt."),
+		"model":              stringProperty("Optional model identifier for the attempt."),
+		"skipPermissions":    booleanProperty("Whether provider permission prompts should be skipped."),
+		"systemPrompt":       stringProperty("Optional system prompt for the attempt."),
+		"userMessage":        stringProperty("Optional user message for the attempt."),
+		"inputTokens": map[string]any{
+			"type":        "array",
+			"description": "Optional structured input tokens for the attempt.",
+			"items":       map[string]any{},
+		},
+		"outputSchema":       stringProperty("Optional structured output schema for the attempt."),
+		"resumeSession":      sessionRefInputSchema(),
+		"workingDirectory":   stringProperty("Optional working directory for the attempt."),
+		"worktree":           stringProperty("Optional worktree path for the attempt."),
+		"envVars": map[string]any{
+			"type":                 "object",
+			"additionalProperties": map[string]any{"type": "string"},
+			"description":          "Optional environment variables for the attempt.",
+		},
+		"processEnvironment": map[string]any{
+			"type":        "array",
+			"description": "Optional process environment entries for the attempt.",
+			"items":       stringProperty("Process environment entry."),
+		},
+	}, "provider", "attemptId")
+}
+
+func sessionRefInputSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"provider": stringProperty("Providers-owned provider identity for the session ref."),
+		"kind":     stringProperty("Session ref kind such as session_id."),
+		"id":       stringProperty("Detached provider session identifier."),
+	})
+}
+
+func executeResultSchema() map[string]any {
+	return objectSchema(map[string]any{
+		"Content":     stringProperty("Detached provider attempt content."),
+		"SessionRef":  sessionRefSchema(),
+		"Diagnostics": executeDiagnosticsSchema(),
+	})
+}

--- a/pkg/services/providers/transports/mcp/tool.go
+++ b/pkg/services/providers/transports/mcp/tool.go
@@ -1,0 +1,51 @@
+// Package providersmcp exposes MCP tool operations for Providers service root
+// contracts backed by an injected Providers Service root.
+package providersmcp
+
+import "encoding/json"
+
+// Tool names use Providers vocabulary and align with accepted root operations.
+const (
+	ToolListProviders = "you.provider.list_providers"
+	ToolGetProvider   = "you.provider.get_provider"
+	ToolExecute       = "you.provider.execute"
+)
+
+// Stable error envelope fields shared by every Providers MCP tool.
+var sharedErrorStableFields = []string{
+	"error.code",
+	"error.message",
+	"error.retryable",
+	"error.details",
+}
+
+// ToolErrorEnvelope is the stable MCP failure shape for Providers tools.
+type ToolErrorEnvelope struct {
+	Code      string         `json:"code"`
+	Message   string         `json:"message"`
+	Retryable bool           `json:"retryable"`
+	Details   map[string]any `json:"details,omitempty"`
+}
+
+// ToolResponse wraps one tool outcome with either a typed result or a stable error.
+type ToolResponse[T any] struct {
+	Result *T                 `json:"result,omitempty"`
+	Error  *ToolErrorEnvelope `json:"error,omitempty"`
+}
+
+// ToolDefinition is one discoverable MCP tool with typed schemas and documented
+// stable response fields for success and error envelopes.
+type ToolDefinition struct {
+	Name                string         `json:"name"`
+	Description         string         `json:"description"`
+	InputSchema         map[string]any `json:"inputSchema"`
+	OutputSchema        map[string]any `json:"outputSchema"`
+	SuccessStableFields []string       `json:"successStableFields"`
+	ErrorStableFields   []string       `json:"errorStableFields"`
+}
+
+// MarshalJSON encodes one tool definition for MCP hosts and mock clients.
+func (t ToolDefinition) MarshalJSON() ([]byte, error) {
+	type alias ToolDefinition
+	return json.Marshal(alias(t))
+}


### PR DESCRIPTION
{
  "project": "PSS MCP-PROV Providers Owner-Local MCP Adapter",
  "branchName": "pss-mcp-prov-adapter",
  "description": "Package the Providers service-owned MCP adapter under pkg/services/providers/transports/mcp so ListProviders/GetProvider/Execute are exposed as owner-local MCP tools over the accepted providers.Service root with discovery/result/error parity, without PSS-I04 shared MCP registry/server fan-in or HTTP/CLI Providers transport work.",
  "context": {
    "customerAsk": "After Factory-terminal LWR-PROV, package the Providers service-owned MCP adapter under pkg/services/providers/transports/mcp so ListProviders/GetProvider/Execute are exposed as owner-local MCP tools/handlers over the accepted Providers root with discovery/result/error parity — without PSS-I04 shared MCP registry/server fan-in.",
    "problem": "Providers already publishes a sealed providers.Service root and peer owners already ship owner-local MCP adapters, but Providers has no transports/mcp package yet, so MCP hosts cannot discover or call Providers operations through the same pattern without reaching into providers/internal or waiting on shared MCP registry composition.",
    "solution": "Implement MCP-PROV as an inert, Providers-owned MCP adapter that binds only to providers.Service, exposes stable list/get/execute tools with discovery/result/typed-error parity proven through a fake root, reconciles shared package manifests, and leaves PSS-I04 shared MCP fan-in plus HTTP/CLI Providers transports to their own packets."
  },
  "acceptanceCriteria": [
    "Providers MCP adapter lives under pkg/services/providers/transports/mcp and depends only on published Providers root contracts (no providers/internal imports)",
    "ListProviders/GetProvider/Execute tool mapping and typed-error/result parity are proven through a fake Providers root",
    "Cancel/timeout/typed-error translation is proven at the MCP adapter boundary for Execute and request-context failures",
    "PSS-I04 shared MCP registry/server composition is untouched; HTTP-PROV and CLI-PROV paths are untouched",
    "Shared coverage/ownership/package-target manifests are reconciled for the new adapter package on the merged head",
    "Quality checks pass (typecheck, lint, tests)",
    "Delivery loop continues until required CI is terminal green, every blocking PR conversation comment is addressed, merge conflicts and shared-file churn are reconciled, and the PR is merged (opening/green/approved without merge is not complete)"
  ],
  "userStories": [
    {
      "id": "pss-mcp-prov-adapter-001",
      "title": "Scaffold owner-local Providers MCP adapter over published root",
      "description": "As a maintainer, I want a Providers-owned MCP adapter package that binds only to providers.Service so MCP tooling can depend on Providers without importing internals or composing shared MCP servers.",
      "acceptanceCriteria": [
        "Package exists at pkg/services/providers/transports/mcp as the sole Providers MCP adapter owner",
        "Adapter construction is inert (Bind / NewFromRoot / equivalent) and accepts an injected Providers root only",
        "Adapter import graph depends on published Providers root contracts and does not import providers/internal",
        "Stable tool-name constants exist for list, get, and execute operations following the you.provider.* naming pattern used by peer adapters",
        "DiscoverTools (or equivalent) returns those three tools in stable discovery order with input/output schemas and shared error stable fields",
        "No PSS-I04 shared MCP registry/server fan-in and no HTTP-PROV/CLI-PROV path edits occur in this story",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-prov-adapter-002",
      "title": "Expose ListProviders as MCP tool with fake-root parity",
      "description": "As an MCP host, I want a discoverable Providers list tool that returns detached catalog descriptors through the accepted Providers root so I can enumerate providers without constructing Providers internals.",
      "acceptanceCriteria": [
        "Calling the list tool through the bound adapter invokes providers.Service.ListProviders on the injected root",
        "Successful tool responses project detached catalog descriptors with stable success fields aligned to published list-result vocabulary",
        "Tool discovery advertises the list tool schema and registered handler name consistently",
        "Focused tests use a fake Providers root (not Wire/live adapters) to prove discovery/result parity for list",
        "Missing request context and nil-service cases return stable MCP error envelopes rather than panicking",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-prov-adapter-003",
      "title": "Expose GetProvider as MCP tool with typed catalog-error parity",
      "description": "As an MCP host, I want a Providers get tool that looks up one provider identity and translates Providers-owned catalog failures into stable MCP error envelopes so clients can branch on invalid, unknown, and unavailable outcomes.",
      "acceptanceCriteria": [
        "Calling the get tool through the bound adapter invokes providers.Service.GetProvider with the requested Providers-owned ID",
        "Successful responses return a detached provider descriptor with stable success fields",
        "Typed Providers catalog failures (ErrInvalidID, ErrUnknownProvider, ErrProviderUnavailable) translate to stable MCP error codes/messages/details at the adapter boundary",
        "Malformed tool input returns a stable decode/bad-request MCP error envelope",
        "Focused fake-root tests prove success and typed-error parity for get",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-prov-adapter-004",
      "title": "Expose Execute as MCP tool with cancel/timeout/typed-error parity",
      "description": "As an MCP host, I want a Providers execute tool that performs exactly one normalized attempt through the accepted root and preserves cancel, timeout, and typed execute-failure semantics so clients observe the same failure categories as other Providers peers.",
      "acceptanceCriteria": [
        "Calling the execute tool through the bound adapter invokes providers.Service.Execute once with mapped request fields from the MCP input",
        "Successful responses project detached execute results (content and optional session/diagnostic facts) with stable success fields",
        "Request-context cancel and deadline-exceeded paths produce stable MCP cancel/timeout error envelopes at the adapter boundary",
        "Providers-owned execute failures (ErrExecuteCancelled, ErrExecuteTimeout, ExecuteFailure kinds, ErrUnknownProvider, invalid identity) translate to stable MCP error envelopes without losing branchable kind/code information",
        "Focused fake-root tests prove success, cancel, timeout, and typed-error/result parity for execute",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-prov-adapter-005",
      "title": "Reconcile shared package manifests for Providers MCP adapter",
      "description": "As a maintainer, I want the new Providers MCP package registered in shared coverage, ownership, and package-target manifests so package-boundary and coverage gates remain truthful on the merged head.",
      "acceptanceCriteria": [
        "Package-target manifest inventory/registration includes pkg/services/providers/transports/mcp with Providers ownership disposition consistent with peer MCP adapters",
        "Ownership inventory registers the MCP adapter package under the Providers owner",
        "Unit and functional coverage-minimum manifests include the adapter package (or an explicit allowed exception matching peer adapter practice)",
        "Focused manifest-registration tests (peer pattern) pass against the reconciled manifests",
        "No PSS-I04 shared MCP registry/server composition changes are introduced while reconciling manifests",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-mcp-prov-adapter-006",
      "title": "Deliver through review, CI, conflict reconciliation, and merge",
      "description": "As a Factory operator, I want the MCP-PROV change set reviewed, CI-terminal, conflict-reconciled, and merged so the packet is Factory-complete rather than merely PR-ready.",
      "acceptanceCriteria": [
        "Implementation PR for pss-mcp-prov-adapter is opened against the integration base with the owner-local Providers MCP adapter and focused fake-root evidence",
        "Required CI checks are terminal and passing on the PR head",
        "Every blocking PR conversation comment is explicitly addressed",
        "Merge conflicts and shared-file churn (including coverage/ownership/package-target manifests) are rebased/reconciled on the merged head",
        "HTTP-PROV, CLI-PROV, PSS-I04 shared MCP fan-in, and LWR/IMP-PROV ownership remain untouched beyond unavoidable shared-manifest reconciliation",
        "The PR is merged; Factory work completes only after merge evidence exists",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": false,
      "notes": ""
    }
  ]
}
