### PR TITLE
pss-cut-run-rec

### DIFF
--- a/docs/internal/processes/runtime-cleanup-relevant-files.md
+++ b/docs/internal/processes/runtime-cleanup-relevant-files.md
@@ -992,7 +992,13 @@ in `pkg/services/factory_runtime` (`interfaces.go`) plus root typed errors in
 `pkg/services/factory_runtime` (not `factory_runtime/javascript`, deleted
 `factory_runtime/service`, `engine`, or other nested Runtime paths); lock this with
 `pkg/services/factory_sessions/runtime_consumer_import_boundary_test.go` and
-`cmd/pkgboundarycheck` peer-subpackage rules. After DEL-RUN-SERVICE deletes the
+`cmd/pkgboundarycheck` peer-subpackage rules. CUT-RUN-REC seals Factory Runtime
+production Recordings imports to the service root only via
+`pkg/services/factory_runtime/recordings_import_boundary_test.go`
+(`TestProductionPackagesImportRecordingsRootOnly`); mirror
+`pkg/services/work/recordings_import_boundary_test.go` and
+`pkg/services/recordings/runtime_import_boundary_test.go` for the reverse edge.
+After DEL-RUN-SERVICE deletes the
 transitional `factory_runtime/service` tree, lock the deletion with
 `pkg/services/factory_runtime/wire/service_deletion_proof_test.go` (filesystem,
 module import scan, ownership-inventory absence, wire construction, and pipeline

--- a/docs/internal/processes/runtime-cleanup-relevant-files.md
+++ b/docs/internal/processes/runtime-cleanup-relevant-files.md
@@ -995,7 +995,11 @@ in `pkg/services/factory_runtime` (`interfaces.go`) plus root typed errors in
 `cmd/pkgboundarycheck` peer-subpackage rules. CUT-RUN-REC seals Factory Runtime
 production Recordings imports to the service root only via
 `pkg/services/factory_runtime/recordings_import_boundary_test.go`
-(`TestProductionPackagesImportRecordingsRootOnly`); mirror
+(`TestProductionPackagesImportRecordingsRootOnly`) and behavioral construction
+proof in `pkg/services/factory_runtime/recordings_request_boundary_test.go`
+(`TestRuntimeConstructsRecordingsCapabilitiesThroughRoot`) plus
+`pkg/services/factory_runtime/internal/build_test.go`
+(`TestBuild_ConstructsRecordingsRootLedgerAndHostingCapabilities`); mirror
 `pkg/services/work/recordings_import_boundary_test.go` and
 `pkg/services/recordings/runtime_import_boundary_test.go` for the reverse edge.
 After DEL-RUN-SERVICE deletes the

--- a/docs/internal/processes/runtime-cleanup-relevant-files.md
+++ b/docs/internal/processes/runtime-cleanup-relevant-files.md
@@ -999,7 +999,13 @@ production Recordings imports to the service root only via
 proof in `pkg/services/factory_runtime/recordings_request_boundary_test.go`
 (`TestRuntimeConstructsRecordingsCapabilitiesThroughRoot`) plus
 `pkg/services/factory_runtime/internal/build_test.go`
-(`TestBuild_ConstructsRecordingsRootLedgerAndHostingCapabilities`); mirror
+(`TestBuild_ConstructsRecordingsRootLedgerAndHostingCapabilities`); behavior
+preservation after the cut is locked in
+`pkg/services/factory_runtime/recordings_consumer_behavior_preservation_test.go`
+(`TestRuntimeRecordingsConsumerBehaviorPreserved`) alongside existing host,
+assembly, replay, and execution suites under `internal/host`,
+`internal/build_test.go`, `internal/services/instance_host/internal/service`,
+and `internal/services/orchestration/runtime`; mirror
 `pkg/services/work/recordings_import_boundary_test.go` and
 `pkg/services/recordings/runtime_import_boundary_test.go` for the reverse edge.
 After DEL-RUN-SERVICE deletes the

--- a/pkg/services/factory_runtime/internal/build_test.go
+++ b/pkg/services/factory_runtime/internal/build_test.go
@@ -21,6 +21,59 @@ import (
 	"go.uber.org/zap"
 )
 
+func TestBuild_ConstructsRecordingsRootLedgerAndHostingCapabilities(t *testing.T) {
+	dir := t.TempDir()
+	factoryfixtures.WriteFactoryJSON(t, dir, factoryfixtures.MinimalFactoryConfig())
+
+	loaded, err := loadedFactoryFixture(dir)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfigFromFactoryDir: %v", err)
+	}
+
+	ledger := &recordingfixtures.ScriptedRuntimeLedger{GenerationID: "runtime-recordings-root"}
+	var capturedSource recordings.InitialStructureSource
+	ledgerFactory := factory.RuntimeLedgerFactory(func(
+		source recordings.InitialStructureSource,
+		_ func() time.Time,
+		_ interfaces.RuntimeDefinitionLookup,
+	) recordings.RuntimeEventLedger {
+		capturedSource = source
+		return ledger
+	})
+	recorder := &runtimeRecordingsRecorderStub{}
+
+	bundle, err := testRuntimeFactory().Build(
+		context.Background(), dir, dir, "~default",
+		"", interfaces.RuntimeModeBatch, false, nil, nil, nil, false, nil, nil,
+		"", factory.RuntimeLogStorageConfig{},
+		factoryinternal.RuntimeFileLoggingPolicyDisabled,
+		factoryinternal.RuntimeMetricsPolicyDisabled, "", factory.RuntimeMetricsStorageConfig{},
+		loaded, zap.NewNop(), "runtime-recordings-root", "", clockwork.NewFakeClock(),
+		"/recordings/session.json", recorder, nil, nil, nil, nil, nil,
+		ledgerFactory,
+		func(recordings.WorkerEventRecorder, *zap.Logger) (map[string]workers.WorkerExecutor, error) {
+			return nil, nil
+		},
+		testRuntimeWorkers{},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if capturedSource == nil {
+		t.Fatal("ledger factory InitialStructureSource = nil")
+	}
+	if bundle.RecordingLedger() != ledger {
+		t.Fatalf("RecordingLedger = %T, want injected root ledger", bundle.RecordingLedger())
+	}
+	if bundle.Recording != recorder {
+		t.Fatalf("Recording = %T, want injected RuntimeRecorder", bundle.Recording)
+	}
+	if bundle.StreamGeneration() != "runtime-recordings-root" {
+		t.Fatalf("stream generation = %q, want runtime-recordings-root", bundle.StreamGeneration())
+	}
+}
+
 func TestBuild_ConstructsRunnableBundleWithoutRootService(t *testing.T) {
 	dir := t.TempDir()
 	factoryfixtures.WriteFactoryJSON(t, dir, factoryfixtures.MinimalFactoryConfig())
@@ -269,3 +322,23 @@ func testRuntimeMetricsFactory(root string) factory.RuntimeMetricsSinkFactory {
 		}}, nil
 	}
 }
+
+type runtimeRecordingsRecorderStub struct{}
+
+func (*runtimeRecordingsRecorderStub) BindRecordingService(
+	recordings.Service,
+	recordings.CanonicalEventScope,
+) error {
+	return nil
+}
+
+func (*runtimeRecordingsRecorderStub) Start(context.Context)               {}
+func (*runtimeRecordingsRecorderStub) Stop()                               {}
+func (*runtimeRecordingsRecorderStub) RecordEvent(interfaces.FactoryEvent) {}
+func (*runtimeRecordingsRecorderStub) RecordError(error)                   {}
+func (*runtimeRecordingsRecorderStub) Finish(time.Time)                    {}
+func (*runtimeRecordingsRecorderStub) Flush() error                        { return nil }
+func (*runtimeRecordingsRecorderStub) Err() error                          { return nil }
+func (*runtimeRecordingsRecorderStub) Finalize(time.Time) error            { return nil }
+
+var _ recordings.RuntimeRecorder = (*runtimeRecordingsRecorderStub)(nil)

--- a/pkg/services/factory_runtime/recordings_consumer_behavior_preservation_test.go
+++ b/pkg/services/factory_runtime/recordings_consumer_behavior_preservation_test.go
@@ -1,0 +1,204 @@
+package factory_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/portpowered/infinite-you/internal/testutil/recordingfixtures"
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryhost "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/host"
+	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/replayhooks"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	"go.uber.org/zap"
+)
+
+var (
+	_ factoryruntime.HostedInstance = (*factoryhost.Bundle)(nil)
+	_ factoryruntime.HostedLedger     = (*recordingfixtures.ScriptedRuntimeLedger)(nil)
+)
+
+// TestRuntimeRecordingsConsumerBehaviorPreserved proves CUT-RUN-REC story 004:
+// hosting, replay, and execution paths that depend on Recordings keep working
+// through root contracts and Runtime root aliases without deep Recordings imports.
+func TestRuntimeRecordingsConsumerBehaviorPreserved(t *testing.T) {
+	t.Parallel()
+
+	testHostedRuntimeExposesRecordingsRootCapabilities(t)
+	testHostingStopFinalizesRecordingsRootRecorder(t)
+	testReplayExecutionHandoffConsumesRecordingsRootVocabulary(t)
+	testExecutionCompletionPlannerAcceptsRecordingsRootAlias(t)
+}
+
+func testHostedRuntimeExposesRecordingsRootCapabilities(t *testing.T) {
+	t.Helper()
+
+	ledger := &recordingfixtures.ScriptedRuntimeLedger{GenerationID: "preserve-hosted-ledger"}
+	recorder := &runtimeRecordingsRecorderStub{}
+	bundle := factoryhost.NewBundle(
+		"/runtime",
+		"/factory",
+		"runtime-preserve",
+		"backend-preserve",
+		time.Date(2026, 7, 28, 15, 0, 0, 0, time.UTC),
+		ledger,
+		nil,
+		nil,
+		zap.NewNop(),
+		nil,
+		nil,
+		recorder,
+		"/recordings/preserve.json",
+		nil,
+	)
+
+	var hosted factoryruntime.HostedInstance = bundle
+	if hosted.RecordingLedger() != ledger {
+		t.Fatalf("RecordingLedger = %T, want root ledger fake", hosted.RecordingLedger())
+	}
+	if hosted.StreamGeneration() != "preserve-hosted-ledger" {
+		t.Fatalf("stream generation = %q, want preserve-hosted-ledger", hosted.StreamGeneration())
+	}
+
+	var rootLedger recordings.Ledger = hosted.RecordingLedger()
+	if rootLedger.StreamGenerationID() != "preserve-hosted-ledger" {
+		t.Fatalf("ledger stream generation = %q, want preserve-hosted-ledger", rootLedger.StreamGenerationID())
+	}
+}
+
+func testHostingStopFinalizesRecordingsRootRecorder(t *testing.T) {
+	t.Helper()
+
+	finishedAt := time.Date(2026, 7, 28, 15, 5, 0, 0, time.UTC)
+	recording := &preservedTerminalRecording{}
+	handle := &factoryhost.Handle{
+		Bundle:  &factoryhost.Bundle{Recording: recording},
+		RunDone: make(chan struct{}),
+	}
+	handle.SetRunResult(nil)
+
+	if err := factoryhost.Stop(handle, clockwork.NewFakeClockAt(finishedAt)); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if recording.finalizeCalls != 1 || !recording.finishedAt.Equal(finishedAt) {
+		t.Fatalf(
+			"recording finalization = (%d, %s), want one call at %s",
+			recording.finalizeCalls,
+			recording.finishedAt,
+			finishedAt,
+		)
+	}
+}
+
+func testReplayExecutionHandoffConsumesRecordingsRootVocabulary(t *testing.T) {
+	t.Helper()
+
+	submissionHook := &preservedReplayHook{name: factoryruntime.ReplaySubmissionHookName}
+	workStateHook := &preservedReplayHook{name: factoryruntime.ReplayWorkStateChangeHookName}
+	var capturedArtifact *recordings.ReplayArtifact
+
+	var replayFactory recordings.ReplayExecutionFactory = func(
+		artifact *recordings.ReplayArtifact,
+	) (
+		workers.Provider,
+		workers.CommandRunner,
+		[]recordings.ReplayHook,
+		recordings.CompletionDeliveryPlanner,
+		error,
+	) {
+		capturedArtifact = artifact
+		return nil, nil, []recordings.ReplayHook{submissionHook, workStateHook}, &runtimeReplayPlannerStub{}, nil
+	}
+
+	rootFactory := factoryruntime.ReplayExecutionFactory(replayFactory)
+	_, _, hooks, _, err := rootFactory(&recordings.ReplayArtifact{SchemaVersion: "1"})
+	if err != nil {
+		t.Fatalf("ReplayExecutionFactory: %v", err)
+	}
+	if capturedArtifact == nil || capturedArtifact.SchemaVersion != "1" {
+		t.Fatalf("captured artifact = %#v, want schema version 1", capturedArtifact)
+	}
+
+	adapted := replayhooks.Adapt(hooks)
+	if len(adapted) != 2 {
+		t.Fatalf("adapted hooks = %d, want 2", len(adapted))
+	}
+	if adapted[0].Name() != factoryruntime.ReplaySubmissionHookName {
+		t.Fatalf("submission hook name = %q, want %q", adapted[0].Name(), factoryruntime.ReplaySubmissionHookName)
+	}
+	if adapted[1].Name() != factoryruntime.ReplayWorkStateChangeHookName {
+		t.Fatalf(
+			"work-state hook name = %q, want %q",
+			adapted[1].Name(),
+			factoryruntime.ReplayWorkStateChangeHookName,
+		)
+	}
+
+	var runtimeHook factoryruntime.ReplayHook = submissionHook
+	if runtimeHook.Name() != factoryruntime.ReplaySubmissionHookName {
+		t.Fatalf("root ReplayHook alias name = %q, want %q", runtimeHook.Name(), factoryruntime.ReplaySubmissionHookName)
+	}
+}
+
+func testExecutionCompletionPlannerAcceptsRecordingsRootAlias(t *testing.T) {
+	t.Helper()
+
+	planner := &runtimeReplayPlannerStub{}
+	var recordingsPlanner recordings.CompletionDeliveryPlanner = planner
+	var runtimePlanner factoryruntime.CompletionDeliveryPlanner = recordingsPlanner
+
+	deliveryTick, keepAlive, err := runtimePlanner.DeliveryTickForDispatch(work.WorkDispatch{DispatchID: "dispatch-preserve"})
+	if err != nil {
+		t.Fatalf("DeliveryTickForDispatch: %v", err)
+	}
+	if deliveryTick != 7 || !keepAlive {
+		t.Fatalf("delivery tick = (%d, %v), want (7, true)", deliveryTick, keepAlive)
+	}
+}
+
+type preservedTerminalRecording struct {
+	finalizeCalls int
+	finishedAt    time.Time
+}
+
+func (*preservedTerminalRecording) BindRecordingService(
+	recordings.Service,
+	recordings.CanonicalEventScope,
+) error {
+	return nil
+}
+func (*preservedTerminalRecording) Start(context.Context)               {}
+func (*preservedTerminalRecording) Stop()                               {}
+func (*preservedTerminalRecording) RecordEvent(interfaces.FactoryEvent) {}
+func (*preservedTerminalRecording) RecordError(error)                   {}
+func (*preservedTerminalRecording) Finish(time.Time)                    {}
+func (*preservedTerminalRecording) Flush() error                        { return nil }
+func (*preservedTerminalRecording) Err() error                          { return nil }
+func (r *preservedTerminalRecording) Finalize(finishedAt time.Time) error {
+	r.finalizeCalls++
+	r.finishedAt = finishedAt
+	return nil
+}
+
+var _ recordings.RuntimeRecorder = (*preservedTerminalRecording)(nil)
+
+type preservedReplayHook struct {
+	name string
+}
+
+func (hook *preservedReplayHook) Name() string { return hook.name }
+func (hook *preservedReplayHook) Priority() int {
+	return 0
+}
+func (hook *preservedReplayHook) OnTick(
+	context.Context,
+	recordings.ReplaySnapshot,
+) (recordings.ReplayHookResult, error) {
+	return recordings.ReplayHookResult{}, nil
+}
+
+var _ recordings.ReplayHook = (*preservedReplayHook)(nil)

--- a/pkg/services/factory_runtime/recordings_import_boundary_test.go
+++ b/pkg/services/factory_runtime/recordings_import_boundary_test.go
@@ -1,0 +1,77 @@
+package factory_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+const (
+	factoryRuntimeRoot = "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	recordingsRoot     = "github.com/portpowered/infinite-you/pkg/services/recordings"
+)
+
+// TestProductionPackagesImportRecordingsRootOnly seals CUT-RUN-REC story 002:
+// Factory Runtime production packages may depend on Recordings only through the
+// service root contract, not nested Recordings implementation packages or
+// transitional public dirs.
+func TestProductionPackagesImportRecordingsRootOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, pkg := range listFactoryRuntimePackages(t) {
+		pkg := pkg
+		t.Run(shortFactoryRuntimePackageName(pkg), func(t *testing.T) {
+			t.Parallel()
+			assertProductionImportsUseRecordingsRootOnly(t, pkg)
+		})
+	}
+}
+
+func listFactoryRuntimePackages(t *testing.T) []string {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", factoryRuntimeRoot+"/...")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list factory runtime packages: %v\n%s", err, output)
+	}
+	return strings.Fields(string(output))
+}
+
+func assertProductionImportsUseRecordingsRootOnly(t *testing.T, packagePath string) {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", "-f", "{{join .Imports \"\\n\"}}", packagePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list imports for %s: %v\n%s", packagePath, err, output)
+	}
+	for _, importPath := range strings.Fields(string(output)) {
+		if isForbiddenFactoryRuntimeRecordingsImport(importPath) {
+			t.Fatalf(
+				"%s production import %s is forbidden; use %s for Recordings surfaces",
+				packagePath,
+				importPath,
+				recordingsRoot,
+			)
+		}
+	}
+}
+
+func isForbiddenFactoryRuntimeRecordingsImport(importPath string) bool {
+	if importPath == recordingsRoot {
+		return false
+	}
+	return strings.HasPrefix(importPath, recordingsRoot+"/")
+}
+
+func shortFactoryRuntimePackageName(packagePath string) string {
+	if strings.HasPrefix(packagePath, factoryRuntimeRoot) {
+		rest := strings.TrimPrefix(packagePath, factoryRuntimeRoot)
+		if rest == "" {
+			return "factory_runtime"
+		}
+		return strings.TrimPrefix(rest, "/")
+	}
+	return packagePath
+}

--- a/pkg/services/factory_runtime/recordings_request_boundary_test.go
+++ b/pkg/services/factory_runtime/recordings_request_boundary_test.go
@@ -1,0 +1,252 @@
+package factory_test
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil/recordingfixtures"
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/petri"
+	factoryhost "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/host"
+	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/replayhooks"
+	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/state"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	"go.uber.org/zap"
+)
+
+const (
+	runtimeReplayhooksPackage = factoryRuntimeRoot + "/internal/services/orchestration/replayhooks"
+	runtimeHostPackage        = factoryRuntimeRoot + "/internal/host"
+)
+
+// TestRuntimeConstructsRecordingsCapabilitiesThroughRoot proves CUT-RUN-REC story 003:
+// Factory Runtime constructs ledger, replay, and hosting Recordings capabilities
+// only through the published Recordings service root contract.
+func TestRuntimeConstructsRecordingsCapabilitiesThroughRoot(t *testing.T) {
+	t.Parallel()
+
+	testRuntimeAdaptsRecordingsReplayHooksThroughRoot(t)
+	testRuntimeHostingExposesRecordingsRootCapabilities(t)
+}
+
+func testRuntimeAdaptsRecordingsReplayHooksThroughRoot(t *testing.T) {
+	t.Helper()
+
+	stubHook := &runtimeReplayHookStub{
+		name:     factoryruntime.ReplaySubmissionHookName,
+		priority: -100,
+	}
+	replayFactory := factoryruntime.ReplayExecutionFactory(func(
+		artifact *recordings.ReplayArtifact,
+	) (
+		workers.Provider,
+		workers.CommandRunner,
+		[]recordings.ReplayHook,
+		recordings.CompletionDeliveryPlanner,
+		error,
+	) {
+		if artifact == nil {
+			t.Fatal("replay artifact = nil")
+		}
+		return nil, nil, []recordings.ReplayHook{stubHook}, &runtimeReplayPlannerStub{}, nil
+	})
+
+	_, _, hooks, planner, err := replayFactory(&recordings.ReplayArtifact{})
+	if err != nil {
+		t.Fatalf("ReplayExecutionFactory: %v", err)
+	}
+	if planner == nil {
+		t.Fatal("completion planner = nil")
+	}
+	if len(hooks) != 1 {
+		t.Fatalf("replay hooks = %d, want 1", len(hooks))
+	}
+
+	adapted := replayhooks.Adapt(hooks)
+	if len(adapted) != 1 {
+		t.Fatalf("adapted hooks = %d, want 1", len(adapted))
+	}
+	if adapted[0].Name() != factoryruntime.ReplaySubmissionHookName {
+		t.Fatalf("adapted hook name = %q, want %q", adapted[0].Name(), factoryruntime.ReplaySubmissionHookName)
+	}
+	if adapted[0].Priority() != -100 {
+		t.Fatalf("adapted hook priority = %d, want -100", adapted[0].Priority())
+	}
+
+	_, err = adapted[0].OnTick(
+		context.Background(),
+		interfaces.SubmissionHookContext[interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]]{
+			Snapshot: interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{
+				TickCount: 4,
+				Marking: petri.MarkingSnapshot{
+					Tokens: map[string]*workers.Token{
+						"token-1": {
+							PlaceID: "place-review",
+							Color: workers.Color{
+								WorkID:   "work-story",
+								DataType: workers.DataTypeWork,
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("adapted hook OnTick: %v", err)
+	}
+	if stubHook.lastSnapshot.Tick != 4 {
+		t.Fatalf("replay snapshot tick = %d, want 4", stubHook.lastSnapshot.Tick)
+	}
+	token, ok := stubHook.lastSnapshot.TokenByWorkID["work-story"]
+	if !ok || token.PlaceID != "place-review" || token.TokenID != "token-1" {
+		t.Fatalf("replay snapshot tokens = %#v, want work-story at place-review", stubHook.lastSnapshot.TokenByWorkID)
+	}
+
+	deliveryTick, keepAlive, err := planner.DeliveryTickForDispatch(work.WorkDispatch{DispatchID: "dispatch-1"})
+	if err != nil {
+		t.Fatalf("DeliveryTickForDispatch: %v", err)
+	}
+	if deliveryTick != 7 || !keepAlive {
+		t.Fatalf("delivery tick = (%d, %v), want (7, true)", deliveryTick, keepAlive)
+	}
+}
+
+func testRuntimeHostingExposesRecordingsRootCapabilities(t *testing.T) {
+	t.Helper()
+
+	ledger := &recordingfixtures.ScriptedRuntimeLedger{GenerationID: "hosted-recordings-root"}
+	recorder := &runtimeRecordingsRecorderStub{}
+	bundle := factoryhost.NewBundle(
+		"/runtime",
+		"/factory",
+		"runtime-1",
+		"backend-1",
+		time.Date(2026, 7, 28, 14, 0, 0, 0, time.UTC),
+		ledger,
+		nil,
+		nil,
+		zap.NewNop(),
+		nil,
+		nil,
+		recorder,
+		"/recordings/session.json",
+		nil,
+	)
+	if bundle.RecordingLedger() != ledger {
+		t.Fatalf("RecordingLedger = %T, want injected root ledger", bundle.RecordingLedger())
+	}
+	if bundle.Recording != recorder {
+		t.Fatalf("Recording = %T, want injected RuntimeRecorder", bundle.Recording)
+	}
+	if bundle.StreamGeneration() != "hosted-recordings-root" {
+		t.Fatalf("stream generation = %q, want hosted-recordings-root", bundle.StreamGeneration())
+	}
+}
+
+// TestRuntimeRecordingsRequestConstructionImportsRecordingsRootOnly seals the
+// request-construction path: Runtime boundary tests may depend on Recordings
+// only through the service root contract.
+func TestRuntimeRecordingsRequestConstructionImportsRecordingsRootOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, packagePath := range []string{runtimeReplayhooksPackage, runtimeHostPackage} {
+		packagePath := packagePath
+		t.Run(shortRuntimePackageName(packagePath), func(t *testing.T) {
+			t.Parallel()
+			assertRecordingsRequestConstructionImportsRecordingsRootOnly(t, packagePath)
+		})
+	}
+}
+
+func assertRecordingsRequestConstructionImportsRecordingsRootOnly(t *testing.T, packagePath string) {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", "-f", "{{join .Imports \"\\n\"}}", packagePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list imports for %s: %v\n%s", packagePath, err, output)
+	}
+	for _, importPath := range strings.Fields(string(output)) {
+		if isForbiddenFactoryRuntimeRecordingsImport(importPath) {
+			t.Fatalf(
+				"%s import %s is forbidden for recordings request construction; use %s only",
+				packagePath,
+				importPath,
+				recordingsRoot,
+			)
+		}
+	}
+}
+
+func shortRuntimePackageName(packagePath string) string {
+	prefix := factoryRuntimeRoot + "/"
+	if strings.HasPrefix(packagePath, prefix) {
+		return strings.TrimPrefix(packagePath, prefix)
+	}
+	return packagePath
+}
+
+type runtimeReplayHookStub struct {
+	name         string
+	priority     int
+	lastSnapshot recordings.ReplaySnapshot
+}
+
+func (stub *runtimeReplayHookStub) Name() string {
+	return stub.name
+}
+
+func (stub *runtimeReplayHookStub) Priority() int {
+	return stub.priority
+}
+
+func (stub *runtimeReplayHookStub) OnTick(
+	_ context.Context,
+	snapshot recordings.ReplaySnapshot,
+) (recordings.ReplayHookResult, error) {
+	stub.lastSnapshot = snapshot
+	return recordings.ReplayHookResult{KeepAlive: true}, nil
+}
+
+type runtimeReplayPlannerStub struct{}
+
+func (stub *runtimeReplayPlannerStub) DeliveryTickForDispatch(
+	work.WorkDispatch,
+) (int, bool, error) {
+	return 7, true, nil
+}
+
+type runtimeRecordingsRecorderStub struct {
+	recordedEvents int
+}
+
+func (*runtimeRecordingsRecorderStub) BindRecordingService(
+	recordings.Service,
+	recordings.CanonicalEventScope,
+) error {
+	return nil
+}
+
+func (*runtimeRecordingsRecorderStub) Start(context.Context) {}
+func (*runtimeRecordingsRecorderStub) Stop()                 {}
+
+func (stub *runtimeRecordingsRecorderStub) RecordEvent(interfaces.FactoryEvent) {
+	stub.recordedEvents++
+}
+
+func (*runtimeRecordingsRecorderStub) RecordError(error) {}
+func (*runtimeRecordingsRecorderStub) Finish(time.Time)  {}
+func (*runtimeRecordingsRecorderStub) Flush() error      { return nil }
+func (*runtimeRecordingsRecorderStub) Err() error        { return nil }
+func (*runtimeRecordingsRecorderStub) Finalize(time.Time) error {
+	return nil
+}
+
+var _ recordings.RuntimeRecorder = (*runtimeRecordingsRecorderStub)(nil)


### PR DESCRIPTION
{
  "project": "CUT-RUN-REC: Factory Runtime consumes Recordings root only",
  "branchName": "pss-cut-run-rec",
  "description": "After Runtime CLN folds and DEL-RUN SERVICE+ENGINE are Factory-complete, cut Factory Runtime's Recordings consumer edge so Runtime reaches Recordings only through the Recordings service root contract—no implementation packages, transitional public dirs, or loose helper surfaces—and prove the boundary with focused Runtime/Recordings tests while preserving hosting/replay/execution behavior.",
  "context": {
    "customerAsk": "After Runtime CLN-RUN-FOLD-SERVICE/ENGINE and DEL-RUN SERVICE+ENGINE are Factory-terminal, cut Factory Runtime's Recordings consumer edge so Runtime reaches Recordings only through the Recordings service root contract—no Recordings implementation packages, transitional public dirs, or loose helper surfaces—and prove the boundary with focused Runtime/Recordings tests.",
    "problem": "CUT-REC-RUN (Recordings→Runtime) is already Factory-terminal, but the Runtime→Recordings consumer edge is still open. Any remaining deep or transitional Recordings imports from Factory Runtime production code would leave hosting/replay/execution Recordings dependencies unsealed and allow regressions into recordings/internal or transitional public Recordings dirs.",
    "solution": "Audit and retarget Factory Runtime Recordings-edge call sites to the Recordings service root, seal the root-only import boundary with focused Runtime-owned tests, prove ledger/replay/hosting construction through the Recordings root, and preserve existing Runtime hosting/replay/execution behavior without folding/deleting packages or implementing FUN-runtime under this lease."
  },
  "acceptanceCriteria": [
    "Factory Runtime production code imports Recordings only through the Recordings service root contract (github.com/portpowered/infinite-you/pkg/services/recordings)",
    "No Factory Runtime production imports of Recordings implementation packages (internal/), transitional public dirs (artifacts, replay, projections, wire, or other non-root Recordings paths), or loose helper surfaces outside the root contract",
    "Focused Runtime/Recordings boundary tests prove ledger, replay, and hosting Recordings construction through the Recordings root boundary",
    "Observable Runtime hosting, replay, and execution behavior that depends on Recordings ledgers and hooks remains preserved",
    "Quality checks pass (typecheck, lint, tests)",
    "Delivery loop continues until required CI is terminal and passing, all blocking PR conversation feedback is addressed, merge conflicts/shared-file churn are reconciled, and the PR is actually merged (opened/green/approved alone is not complete)"
  ],
  "userStories": [
    {
      "id": "pss-cut-run-rec-001",
      "title": "Retarget Runtime Recordings call sites to the service root",
      "description": "As a Factory Runtime maintainer, I need every Runtime production Recordings dependency to use the Recordings service root contract so Runtime no longer reaches Recordings implementation packages or transitional public dirs.",
      "acceptanceCriteria": [
        "Audit pkg/services/factory_runtime/** production packages for any import of pkg/services/recordings/... other than the exact root package path",
        "Retarget any non-root Recordings call sites to root-published types and constructors (recordings.Ledger, recordings.Service, recordings.RuntimeRecorder / RuntimeRecorderFactory, recordings.ReplayHook / ReplayExecutionFactory, recordings.RuntimeEventLedger, related root request/result vocabulary)",
        "After retarget, Runtime hosting/assembly/replay paths still obtain Recordings capabilities only as root contract values (no deep-package construction from Runtime production code)",
        "Do not fold or delete factory_runtime or recordings packages; do not edit Recordings fold/delete/CONTRACT residual implementation; do not reopen CUT-REC-RUN",
        "Narrow pkg/services/recordings/** edits are allowed only if a root-facing seam must accept a retargeted contract; pkg/wire edits only if an unavoidable Runtime→Recordings import retarget is required",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Audit complete 2026-07-28: all factory_runtime production packages already import only pkg/services/recordings root; no retargeting required."
    },
    {
      "id": "pss-cut-run-rec-002",
      "title": "Seal Runtime→Recordings root-only import boundary",
      "description": "As a Factory Runtime maintainer, I want a focused compile/import proof that Factory Runtime production packages may depend on Recordings only through the service root, so future deep imports fail immediately.",
      "acceptanceCriteria": [
        "Add or extend a focused Factory Runtime owner-local boundary test (prefer near existing Runtime import-boundary suites) that lists Runtime production packages and asserts Recordings imports are exactly the Recordings root",
        "The test fails when any Runtime production package imports pkg/services/recordings/internal/..., .../artifacts, .../replay, .../projections, .../wire, or any other non-root Recordings path",
        "The sealed boundary allows the Recordings root import and does not forbid Runtime's own internal packages",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added recordings_import_boundary_test.go: go list scan of all factory_runtime packages asserts Recordings imports are exactly pkg/services/recordings root."
    },
    {
      "id": "pss-cut-run-rec-003",
      "title": "Prove ledger/replay/hosting construction through Recordings root",
      "description": "As a Factory Runtime maintainer, I need behavioral proof that Runtime constructs ledger, replay, and hosting Recordings requests/capabilities through the Recordings root contract, so the consumer edge is sealed by observable construction—not only by import scanning.",
      "acceptanceCriteria": [
        "Add or extend focused Runtime/Recordings boundary tests near the cut (owner-local factory_runtime tests and/or existing recordings/runtime boundary suites)",
        "Tests construct or exercise ledger/replay/hosting Recordings surfaces using only Recordings root types (for example root Ledger / RuntimeEventLedger, ReplayHook / ReplayExecutionFactory, and hosting-facing recording/ledger vocabulary published at the root)",
        "A fake or stub that implements the Recordings root seam receives the constructed requests/capabilities and asserts expected root fields/outcomes (behavioral, not source-inventory)",
        "FUN-runtime public-process suites are not used as a substitute for this consumer-edge proof",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added recordings_request_boundary_test.go (replay hook adaptation + hosting bundle) and build_test.go ledger/hosting construction proof through Recordings root types."
    },
    {
      "id": "pss-cut-run-rec-004",
      "title": "Preserve Runtime hosting/replay/execution Recordings behavior",
      "description": "As a Factory Runtime maintainer, I want existing hosting, replay, and execution behavior that depends on Recordings to keep working after the consumer-edge cut so the boundary change does not alter Runtime outcomes.",
      "acceptanceCriteria": [
        "Existing focused Runtime host/assembly/replay/execution tests that cover Recordings-dependent paths continue to pass without changing product outcomes",
        "Hosted Runtime still exposes Recordings ledger/recording capabilities through root contracts used by hosting (RecordingLedger() / hosted ledger vocabulary remains Recordings-root typed)",
        "Replay hook adaptation and execution handoff still consume Recordings root replay vocabulary (or Runtime root aliases of those root types) without requiring Recordings implementation packages",
        "No FUN-runtime suite expansion is introduced under this lease",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Added recordings_consumer_behavior_preservation_test.go; ran go test ./pkg/services/factory_runtime/... — all host/assembly/replay/execution suites pass."
    }
  ]
}
