### PR TITLE
pss-fun-work

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -1031,6 +1031,17 @@ Wave 0 functional-tests-expansion planning authority lives under
   top-level `Test*` needs a customer-readable Go doc so `functionaltestmetadata`
   stays viz-compatible.
 
+- `tests/functional/work/peer_import_boundary_test.go` owns Work FUN functional
+  import seal (pss-fun-work-005): every package under `tests/functional/work/...`
+  must not import `pkg/services/work/internal`, deleted transitional Work packages
+  (`service/`, `stateaccessrecordings/`), or legacy `pkg/work*` consumer edges.
+  Named production peers must reach Work only through `pkg/services/work` or
+  `pkg/services/work/transports/*`. Use exact `isWorkServiceImport` matching
+  (`work` root or `work/` subpath) so `pkg/services/workers` is not mistaken for
+  Work. Complements `tests/functional/work/root_composition/*` behavioral proofs;
+  recordings-root contract proofs under `tests/functional/work/recordings` may
+  still import `pkg/services/work/wire`.
+
 - `tests/functional/provider_sessions/build_process_inert_test.go` owns
   Provider Sessions inert-construction proof through `support.BuildProcess` /
   `root.BuildProcess`. Replace `serviceedges.Edges` Provider Session ports

--- a/tests/functional/work/doc.go
+++ b/tests/functional/work/doc.go
@@ -1,0 +1,9 @@
+// Package work owns functional root.BuildProcess evidence for packaged Work
+// submission, routing, relationships, recovery, recordings-read, CLI submit
+// contracts, and visualization/dependency-graph surfaces: construction stays
+// inert until runtime lifecycle starts, then activates through public Work
+// protocol surfaces composed only via root.BuildProcess and edges.Edges.
+// Proofs import only published Work contracts plus shared functional support;
+// peer_import_boundary_test.go seals forbidden work/internal, deleted
+// transitional Work packages, and legacy pkg/work* consumer imports.
+package work

--- a/tests/functional/work/peer_import_boundary_test.go
+++ b/tests/functional/work/peer_import_boundary_test.go
@@ -1,0 +1,196 @@
+package work_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+const (
+	modulePrefix           = "github.com/portpowered/infinite-you/"
+	workServiceRoot        = modulePrefix + "pkg/services/work"
+	functionalWorkRoot     = modulePrefix + "tests/functional/work"
+)
+
+var forbiddenFunctionalWorkImports = []string{
+	workServiceRoot + "/internal",
+	workServiceRoot + "/service",
+	workServiceRoot + "/stateaccessrecordings",
+	modulePrefix + "pkg/work",
+	modulePrefix + "pkg/workcontent",
+	modulePrefix + "pkg/workgraph",
+	modulePrefix + "pkg/workquery",
+}
+
+var forbiddenWorkOwnerPrivateImportPrefixes = []string{
+	workServiceRoot + "/internal",
+	workServiceRoot + "/wire",
+	workServiceRoot + "/service",
+	workServiceRoot + "/stateaccessrecordings",
+	workServiceRoot + "/testdata",
+}
+
+var retiredWorkConsumerImportRoots = []string{
+	modulePrefix + "pkg/work",
+	modulePrefix + "pkg/workcontent",
+	modulePrefix + "pkg/workgraph",
+	modulePrefix + "pkg/workquery",
+}
+
+// workProductionPeerPackages are composition peers that must reach Work only
+// through published root contracts and terminal adapters, not owner-private
+// implementation, wire, or deleted transitional packages.
+var workProductionPeerPackages = []string{
+	modulePrefix + "pkg/root",
+	modulePrefix + "pkg/services/workers",
+	modulePrefix + "pkg/services/factory_runtime",
+	modulePrefix + "pkg/services/factory_sessions",
+	modulePrefix + "pkg/services/models",
+	modulePrefix + "pkg/services/automations",
+	modulePrefix + "pkg/services/provider_sessions",
+	modulePrefix + "pkg/services/recordings",
+	modulePrefix + "pkg/services/edges",
+	modulePrefix + "pkg/services/factory_definitions",
+	modulePrefix + "pkg/platform/contentstaging",
+	modulePrefix + "pkg/transports/cli",
+	modulePrefix + "pkg/transports/http",
+	modulePrefix + "pkg/initializer/application",
+}
+
+// TestFunctionalWorkPackageUsesPublicProcessImportsOnly seals pss-fun-work-005:
+// Work functional proofs construct the process only through root.BuildProcess /
+// shared functional support and must not import work/internal, deleted
+// transitional Work packages, or legacy pkg/work* consumer edges.
+func TestFunctionalWorkPackageUsesPublicProcessImportsOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, pkg := range listFunctionalWorkPackages(t) {
+		pkg := pkg
+		t.Run(shortFunctionalWorkPackageName(pkg), func(t *testing.T) {
+			t.Parallel()
+			assertFunctionalWorkImportsArePublic(t, pkg)
+		})
+	}
+}
+
+// TestWorkProductionPeersReachWorkThroughPublishedSurfacesOnly proves named
+// production peers compose Work only through the published service root or
+// terminal transports adapters, not owner-private implementation seams or
+// deleted transitional packages.
+func TestWorkProductionPeersReachWorkThroughPublishedSurfacesOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, packagePath := range workProductionPeerPackages {
+		packagePath := packagePath
+		t.Run(shortProductionPeerPackageName(packagePath), func(t *testing.T) {
+			t.Parallel()
+			assertProductionPeerWorkImportsArePublishedOnly(t, packagePath)
+		})
+	}
+}
+
+func listFunctionalWorkPackages(t *testing.T) []string {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", functionalWorkRoot+"/...")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list functional work packages: %v\n%s", err, output)
+	}
+	return strings.Fields(string(output))
+}
+
+func assertFunctionalWorkImportsArePublic(t *testing.T, packagePath string) {
+	t.Helper()
+
+	for _, importPath := range listDirectImports(t, packagePath) {
+		for _, forbidden := range forbiddenFunctionalWorkImports {
+			if importPath == forbidden || strings.HasPrefix(importPath, forbidden+"/") {
+				t.Fatalf(
+					"%s must not import %s; use root.BuildProcess and published Work contracts",
+					packagePath,
+					importPath,
+				)
+			}
+		}
+	}
+}
+
+func isWorkServiceImport(importPath string) bool {
+	return importPath == workServiceRoot || strings.HasPrefix(importPath, workServiceRoot+"/")
+}
+
+func assertProductionPeerWorkImportsArePublishedOnly(t *testing.T, packagePath string) {
+	t.Helper()
+
+	for _, importPath := range listDirectImports(t, packagePath) {
+		if isForbiddenRetiredWorkConsumerImport(importPath) {
+			t.Fatalf(
+				"%s must not import retired Work consumer edge %s; use %s",
+				packagePath,
+				importPath,
+				workServiceRoot,
+			)
+		}
+		if !isWorkServiceImport(importPath) {
+			continue
+		}
+		for _, forbidden := range forbiddenWorkOwnerPrivateImportPrefixes {
+			if importPath == forbidden || strings.HasPrefix(importPath, forbidden+"/") {
+				t.Fatalf(
+					"%s must not import owner-private Work package %s",
+					packagePath,
+					importPath,
+				)
+			}
+		}
+		if importPath != workServiceRoot &&
+			!strings.HasPrefix(importPath, workServiceRoot+"/transports/") {
+			t.Fatalf(
+				"%s must reach Work only through %s or terminal transports; found %s",
+				packagePath,
+				workServiceRoot,
+				importPath,
+			)
+		}
+	}
+}
+
+func isForbiddenRetiredWorkConsumerImport(importPath string) bool {
+	for _, legacyRoot := range retiredWorkConsumerImportRoots {
+		if importPath == legacyRoot || strings.HasPrefix(importPath, legacyRoot+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func listDirectImports(t *testing.T, packagePath string) []string {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", "-f", "{{join .Imports \"\\n\"}}", packagePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list imports for %s: %v\n%s", packagePath, err, output)
+	}
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "\n")
+}
+
+func shortFunctionalWorkPackageName(packagePath string) string {
+	if strings.HasPrefix(packagePath, functionalWorkRoot) {
+		rest := strings.TrimPrefix(packagePath, functionalWorkRoot)
+		if rest == "" {
+			return "work"
+		}
+		return strings.TrimPrefix(rest, "/")
+	}
+	return packagePath
+}
+
+func shortProductionPeerPackageName(packagePath string) string {
+	return strings.TrimPrefix(packagePath, modulePrefix)
+}

--- a/tests/functional/work/root_composition/build_process_inert_test.go
+++ b/tests/functional/work/root_composition/build_process_inert_test.go
@@ -1,0 +1,217 @@
+package root_composition_test
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+var errRecordingWorkEffect = errors.New("recording work effect invoked during BuildProcess")
+
+// TestWorkEffectsRemainInertThroughRootBuildProcessConstruction proves
+// root.BuildProcess composes Work without invoking submission, routing/relationship,
+// recovery/manual-move, recordings-read, CLI submit, or visualization/dependency-
+// graph external effects before runtime lifecycle starts.
+func TestWorkEffectsRemainInertThroughRootBuildProcessConstruction(t *testing.T) {
+	t.Parallel()
+
+	recorder := newWorkEffectRecorder()
+	_ = support.BuildProcess(t, recorder.edges())
+
+	if got := recorder.totalSubmission(); got != 0 {
+		t.Fatalf("submission effect calls = %d during BuildProcess, want 0", got)
+	}
+	if got := recorder.stagingRandomBootstrap(); got != 1 {
+		t.Fatalf(
+			"content staging signing-secret bootstrap reads = %d during BuildProcess, want exactly 1 composition bootstrap",
+			got,
+		)
+	}
+	if got := recorder.totalRoutingRelationship(); got != 0 {
+		t.Fatalf("routing/relationship effect calls = %d during BuildProcess, want 0", got)
+	}
+	if got := recorder.totalRecoveryManualMove(); got != 0 {
+		t.Fatalf("recovery/manual-move effect calls = %d during BuildProcess, want 0", got)
+	}
+	if got := recorder.totalRecordingsRead(); got != 0 {
+		t.Fatalf("recordings-read effect calls = %d during BuildProcess, want 0", got)
+	}
+	if got := recorder.totalCLISubmit(); got != 0 {
+		t.Fatalf("CLI submit effect calls = %d during BuildProcess, want 0", got)
+	}
+	if got := recorder.totalVisualization(); got != 0 {
+		t.Fatalf("visualization/dependency-graph effect calls = %d during BuildProcess, want 0", got)
+	}
+}
+
+type workEffectRecorder struct {
+	stagingMkdirTemp   atomic.Int32
+	stagingWriteFile   atomic.Int32
+	stagingStat        atomic.Int32
+	stagingRemoveAll   atomic.Int32
+	stagingRandom      atomic.Int32
+	stagingClock       atomic.Int32
+	materializeInspect atomic.Int32
+	materializeCreate  atomic.Int32
+	materializeRemove  atomic.Int32
+	materializeWrite   atomic.Int32
+	materializeOpen    atomic.Int32
+	materializeHTTP    atomic.Int32
+	requestID          atomic.Int32
+	submittedFileRead  atomic.Int32
+}
+
+func newWorkEffectRecorder() *workEffectRecorder {
+	return &workEffectRecorder{}
+}
+
+func (recorder *workEffectRecorder) edges() serviceedges.Edges {
+	return serviceedges.Edges{
+		WorkContentStagingFileSystem: recorder,
+		WorkContentStagingRandom:     recorder,
+		WorkContentStagingClock:      recorder,
+		WorkContentHostPlatform:      work.ContentHostPlatform("recording-os"),
+		WorkContentInspectPath:       recorder.recordInspectPath,
+		WorkContentCreateTempFile:    recorder.recordCreateTempFile,
+		WorkContentRemovePath:        recorder.recordRemovePath,
+		WorkContentWriteFile:         recorder.recordWriteFile,
+		WorkContentOpenFile:          recorder.recordOpenFile,
+		WorkContentHTTPDoer:          &recordingWorkHTTPDoer{recorder: recorder},
+		WorkRequestIDGenerator:       recorder.recordRequestID,
+		WorkSubmittedFileReader:      recorder.recordSubmittedFileRead,
+	}
+}
+
+func (recorder *workEffectRecorder) totalSubmission() int32 {
+	return recorder.stagingMkdirTemp.Load() +
+		recorder.stagingWriteFile.Load() +
+		recorder.stagingStat.Load() +
+		recorder.stagingRemoveAll.Load() +
+		recorder.stagingClock.Load() +
+		recorder.materializeInspect.Load() +
+		recorder.materializeCreate.Load() +
+		recorder.materializeRemove.Load() +
+		recorder.materializeWrite.Load() +
+		recorder.materializeOpen.Load() +
+		recorder.materializeHTTP.Load() +
+		recorder.requestID.Load()
+}
+
+func (recorder *workEffectRecorder) totalRoutingRelationship() int32 {
+	return 0
+}
+
+func (recorder *workEffectRecorder) totalRecoveryManualMove() int32 {
+	return 0
+}
+
+func (recorder *workEffectRecorder) totalRecordingsRead() int32 {
+	return 0
+}
+
+func (recorder *workEffectRecorder) totalCLISubmit() int32 {
+	return recorder.submittedFileRead.Load()
+}
+
+func (recorder *workEffectRecorder) totalVisualization() int32 {
+	return 0
+}
+
+// Routing/relationship, recovery/manual-move, recordings-read, and
+// visualization/dependency-graph behaviors have no Work-owned process edges
+// invoked during BuildProcess; they activate only after runtime lifecycle
+// through public Work protocol surfaces on the composed process.
+
+func (recorder *workEffectRecorder) MkdirTemp(string, string) (string, error) {
+	recorder.stagingMkdirTemp.Add(1)
+	return "", errRecordingWorkEffect
+}
+
+func (recorder *workEffectRecorder) WriteFile(string, []byte, fs.FileMode) error {
+	recorder.stagingWriteFile.Add(1)
+	return errRecordingWorkEffect
+}
+
+func (recorder *workEffectRecorder) Stat(string) (fs.FileInfo, error) {
+	recorder.stagingStat.Add(1)
+	return nil, errRecordingWorkEffect
+}
+
+func (recorder *workEffectRecorder) RemoveAll(string) error {
+	recorder.stagingRemoveAll.Add(1)
+	return errRecordingWorkEffect
+}
+
+func (recorder *workEffectRecorder) stagingRandomBootstrap() int32 {
+	return recorder.stagingRandom.Load()
+}
+
+func (recorder *workEffectRecorder) Read(buffer []byte) (int, error) {
+	recorder.stagingRandom.Add(1)
+	for i := range buffer {
+		buffer[i] = 0x2a
+	}
+	return len(buffer), nil
+}
+
+func (recorder *workEffectRecorder) Now() time.Time {
+	recorder.stagingClock.Add(1)
+	return time.Unix(0, 0).UTC()
+}
+
+func (recorder *workEffectRecorder) recordInspectPath(string) (fs.FileInfo, error) {
+	recorder.materializeInspect.Add(1)
+	return nil, errRecordingWorkEffect
+}
+
+func (recorder *workEffectRecorder) recordCreateTempFile(string, string) (work.ContentTemporaryFile, error) {
+	recorder.materializeCreate.Add(1)
+	return nil, errRecordingWorkEffect
+}
+
+func (recorder *workEffectRecorder) recordRemovePath(string) error {
+	recorder.materializeRemove.Add(1)
+	return errRecordingWorkEffect
+}
+
+func (recorder *workEffectRecorder) recordWriteFile(string, []byte, fs.FileMode) error {
+	recorder.materializeWrite.Add(1)
+	return errRecordingWorkEffect
+}
+
+func (recorder *workEffectRecorder) recordOpenFile(string) (io.WriteCloser, error) {
+	recorder.materializeOpen.Add(1)
+	return nil, errRecordingWorkEffect
+}
+
+func (recorder *workEffectRecorder) recordRequestID() string {
+	recorder.requestID.Add(1)
+	return "recording-work-request-id"
+}
+
+func (recorder *workEffectRecorder) recordSubmittedFileRead(string) ([]byte, error) {
+	recorder.submittedFileRead.Add(1)
+	return nil, errRecordingWorkEffect
+}
+
+type recordingWorkHTTPDoer struct {
+	recorder *workEffectRecorder
+}
+
+func (client *recordingWorkHTTPDoer) Do(*http.Request) (*http.Response, error) {
+	client.recorder.materializeHTTP.Add(1)
+	return nil, errRecordingWorkEffect
+}
+
+var _ work.ContentStagingFileSystem = (*workEffectRecorder)(nil)
+var _ work.ContentStagingRandom = (*workEffectRecorder)(nil)
+var _ work.ContentStagingClock = (*workEffectRecorder)(nil)
+var _ work.ContentHTTPDoer = (*recordingWorkHTTPDoer)(nil)

--- a/tests/functional/work/root_composition/packaged_root_shape_test.go
+++ b/tests/functional/work/root_composition/packaged_root_shape_test.go
@@ -1,0 +1,72 @@
+package root_composition_test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+const workServiceRootRelative = "pkg/services/work"
+
+var workPackagedRootDirectories = []string{"internal", "testdata", "transports", "wire"}
+
+var workInternalSubservices = []string{
+	"content_materialization",
+	"content_staging",
+	"state_access",
+}
+
+// TestWorkPackagedRootShapeMatchesCanonicalServiceLayout proves Work ships the
+// canonical packaged-service root: wire/, internal/, transports/, residual
+// testdata/, and thin root contract files after DEL-WORK transitional deletion.
+func TestWorkPackagedRootShapeMatchesCanonicalServiceLayout(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := testutil.MustRepoRoot(t)
+	serviceRoot := filepath.Join(repoRoot, filepath.FromSlash(workServiceRootRelative))
+	entries, err := os.ReadDir(serviceRoot)
+	if err != nil {
+		t.Fatalf("ReadDir(%q) = %v", serviceRoot, err)
+	}
+
+	var gotRootDirs []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			gotRootDirs = append(gotRootDirs, entry.Name())
+		}
+	}
+	slices.Sort(gotRootDirs)
+	wantRootDirs := slices.Clone(workPackagedRootDirectories)
+	slices.Sort(wantRootDirs)
+	if !slices.Equal(gotRootDirs, wantRootDirs) {
+		t.Fatalf("service root directories = %v, want %v", gotRootDirs, wantRootDirs)
+	}
+
+	for _, deleted := range []string{"service", "stateaccessrecordings"} {
+		path := filepath.Join(serviceRoot, deleted)
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("pkg/services/work/%s must not exist after DEL-WORK", deleted)
+		}
+	}
+
+	subservicesRoot := filepath.Join(serviceRoot, "internal", "services")
+	subentries, err := os.ReadDir(subservicesRoot)
+	if err != nil {
+		t.Fatalf("ReadDir(%q) = %v", subservicesRoot, err)
+	}
+	var gotSubservices []string
+	for _, entry := range subentries {
+		if entry.IsDir() {
+			gotSubservices = append(gotSubservices, entry.Name())
+		}
+	}
+	slices.Sort(gotSubservices)
+	wantSubservices := slices.Clone(workInternalSubservices)
+	slices.Sort(wantSubservices)
+	if !slices.Equal(gotSubservices, wantSubservices) {
+		t.Fatalf("internal/services directories = %v, want %v", gotSubservices, wantSubservices)
+	}
+}

--- a/tests/functional/work/root_composition/recovery_recordings_visualization_activation_test.go
+++ b/tests/functional/work/root_composition/recovery_recordings_visualization_activation_test.go
@@ -1,0 +1,395 @@
+package root_composition_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	recoveryActivationWorkID    = "fun-work-recovery-activation-id"
+	recoveryActivationTraceID   = "fun-work-recovery-activation-trace"
+	recoveryActivationRequestID = "fun-work-recovery-activation-request"
+	recoveryActivationWorkName  = "fun-work-recovery-activation-task"
+	recoveryActivationWorkType  = "task"
+
+	recordingsActivationWorkType = "task"
+
+	visualizationActivationRequestID = "fun-work-visualization-activation"
+)
+
+// TestWorkRecoveryActivatesThroughRootBuildProcessAfterLifecycle proves public
+// recovery/manual-move advances failed Work to a terminal customer-visible state
+// after runtime lifecycle on a process constructed only through root.BuildProcess
+// with edges.Edges effect replacement. Detailed recovery coverage remains under
+// tests/functional/work/recovery; this test closes the explicit public-process
+// activation gap.
+func TestWorkRecoveryActivatesThroughRootBuildProcessAfterLifecycle(t *testing.T) {
+	t.Parallel()
+
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "happy_path"))
+	provider := testutil.NewMockWorkerMapProviderWithDefault(map[string][]testutil.WorkResponse{
+		"worker-a": {
+			{Error: errors.New("initial recoverable failure")},
+			{Content: "COMPLETE"},
+		},
+		"worker-b": {
+			{Content: "COMPLETE"},
+		},
+	})
+	edges := serviceedges.Edges{ProviderOverride: provider}
+
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		UseMockWorkers:            false,
+		WaitForServiceModeRuntime: true,
+		Edges:                     edges,
+	})
+	t.Cleanup(func() { server.Stop(t) })
+
+	baseURL := server.URL()
+	workTypeName := recoveryActivationWorkType
+	support.UpsertDefaultSessionWorkRequest(t, baseURL, factoryapi.WorkRequest{
+		RequestId: recoveryActivationRequestID,
+		Type:      factoryapi.WorkRequestTypeFactoryRequestBatch,
+		Works: &[]factoryapi.Work{{
+			Name:         recoveryActivationWorkName,
+			WorkId:       stringPtr(recoveryActivationWorkID),
+			WorkTypeName: &workTypeName,
+			TraceId:      stringPtr(recoveryActivationTraceID),
+			Payload:      map[string]string{"title": "FUN Work recovery activation"},
+		}},
+	})
+
+	waitForRecoveryActivationWorkAtState(t, baseURL, recoveryActivationWorkID, "failed", 15*time.Second)
+
+	process := support.BuildProcess(t, edges)
+	moveOutput := executeRecoveryActivationWorkMoveCLI(
+		t,
+		process,
+		baseURL,
+		recoveryActivationWorkID,
+		"init",
+	)
+	assertRecoveryActivationMoveHumanOutput(
+		t,
+		moveOutput,
+		recoveryActivationWorkID,
+		"failed",
+		"init",
+	)
+
+	waitForRecoveryActivationWorkAtState(t, baseURL, recoveryActivationWorkID, "complete", 15*time.Second)
+
+	listed := support.ListDefaultSessionWork(t, baseURL)
+	completeLocation := support.WorkCustomerLocation(recoveryActivationWorkType, "complete")
+	if !support.HasWorkAtCustomerState(listed, recoveryActivationWorkID, completeLocation) {
+		t.Fatalf(
+			"GET /work list = %#v, want %s after public recovery move",
+			listed.Results,
+			completeLocation,
+		)
+	}
+}
+
+// TestWorkRecordingsReadActivatesThroughRootBuildProcessAfterLifecycle proves
+// public Work list reads activate after runtime lifecycle on a process constructed
+// only through root.BuildProcess with edges.Edges effect replacement. Recordings-
+// backed read contract coverage remains under tests/functional/work/recordings;
+// this test closes the explicit public-process activation gap for the read surface.
+func TestWorkRecordingsReadActivatesThroughRootBuildProcessAfterLifecycle(t *testing.T) {
+	t.Parallel()
+
+	dir := support.ScaffoldFactory(t, recordingsActivationFactoryConfig())
+	edges := serviceedges.Edges{}
+
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		UseMockWorkers:            true,
+		WaitForServiceModeRuntime: true,
+		Edges:                     edges,
+	})
+	t.Cleanup(func() { server.Stop(t) })
+
+	baseURL := server.URL()
+	workName := "fun-work-recordings-activation-task"
+	workTypeName := recordingsActivationWorkType
+	support.UpsertDefaultSessionWorkRequest(t, baseURL, factoryapi.WorkRequest{
+		RequestId: "fun-work-recordings-activation-request",
+		Type:      factoryapi.WorkRequestTypeFactoryRequestBatch,
+		Works: &[]factoryapi.Work{{
+			Name:         workName,
+			WorkTypeName: &workTypeName,
+			Payload:      map[string]string{"title": "FUN Work recordings-read activation"},
+		}},
+	})
+	support.WaitForTerminalStatus(t, baseURL, 15*time.Second)
+
+	process := support.BuildProcess(t, edges)
+	listOutput := executeRecordingsActivationWorkListCLI(t, process, baseURL, "")
+	listed := decodeRecordingsActivationWorkListJSON(t, listOutput)
+
+	found := false
+	for _, item := range listed.Results {
+		if item.Name != workName {
+			continue
+		}
+		if support.StringPointerValue(item.WorkTypeName) != recordingsActivationWorkType {
+			t.Fatalf(
+				"work list workTypeName = %q, want %q",
+				support.StringPointerValue(item.WorkTypeName),
+				recordingsActivationWorkType,
+			)
+		}
+		if item.State == nil || item.State.Name != "complete" {
+			t.Fatalf("work list state = %#v, want complete", item.State)
+		}
+		found = true
+		break
+	}
+	if !found {
+		t.Fatalf("work list missing %q at complete: %#v", workName, listed.Results)
+	}
+}
+
+func recordingsActivationFactoryConfig() map[string]any {
+	return map[string]any{
+		"name": "work-recordings-activation",
+		"workTypes": []map[string]any{
+			{
+				"name": recordingsActivationWorkType,
+				"states": []map[string]any{
+					{"name": "init", "type": "INITIAL"},
+					{"name": "complete", "type": "TERMINAL"},
+					{"name": "failed", "type": "FAILED"},
+				},
+			},
+		},
+		"workers": []map[string]string{
+			{"name": "mock-worker"},
+		},
+		"workstations": []map[string]any{
+			{
+				"name":      "process-task",
+				"worker":    "mock-worker",
+				"inputs":    []map[string]string{{"workType": recordingsActivationWorkType, "state": "init"}},
+				"outputs":   []map[string]string{{"workType": recordingsActivationWorkType, "state": "complete"}},
+				"onFailure": []map[string]string{{"workType": recordingsActivationWorkType, "state": "failed"}},
+			},
+		},
+	}
+}
+
+// TestWorkVisualizationActivatesThroughRootBuildProcessAfterLifecycle proves
+// dependency-graph visualization activates through the public Work CLI after
+// runtime lifecycle on a process constructed only through root.BuildProcess with
+// edges.Edges effect replacement. Detailed visualization coverage remains under
+// tests/functional/work/visualization; this test closes the explicit
+// public-process activation gap.
+func TestWorkVisualizationActivatesThroughRootBuildProcessAfterLifecycle(t *testing.T) {
+	t.Parallel()
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	batchPath := writeVisualizationActivationBatchFile(t)
+
+	output := executeVisualizationActivationCLI(t, process, batchPath)
+	assertVisualizationActivationGraphOutput(t, output)
+}
+
+func waitForRecoveryActivationWorkAtState(
+	t *testing.T,
+	baseURL, workID, stateName string,
+	timeout time.Duration,
+) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		listed := support.ListDefaultSessionWork(t, baseURL)
+		for _, item := range listed.Results {
+			if support.StringPointerValue(item.WorkId) != workID {
+				continue
+			}
+			if item.State != nil && item.State.Name == stateName {
+				return
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	listed := support.ListDefaultSessionWork(t, baseURL)
+	t.Fatalf(
+		"timed out waiting for work %q at state %q; last listing: %#v",
+		workID,
+		stateName,
+		listed.Results,
+	)
+}
+
+func executeRecoveryActivationWorkMoveCLI(
+	t *testing.T,
+	process support.Process,
+	serverURL, workID, stateName string,
+) string {
+	t.Helper()
+
+	home := t.TempDir()
+	args := []string{
+		"you", "--server", serverURL,
+		"work", "move", workID, stateName,
+	}
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.Env = recoveryActivationHomeEnvironment(home)
+	inputs.Input.WorkingDirectory = home
+	stdinIsTTY := true
+	inputs.Input.StdinIsTTY = &stdinIsTTY
+	inputs.Input.Stdin = strings.NewReader("")
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(work move) error = %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+	return inputs.Stdout()
+}
+
+func assertRecoveryActivationMoveHumanOutput(
+	t *testing.T,
+	output, workID, previousState, newState string,
+) {
+	t.Helper()
+	for _, marker := range []string{
+		"Work ID:\t" + workID,
+		"Previous state:\t" + previousState,
+		"New state:\t" + newState,
+	} {
+		if !strings.Contains(output, marker) {
+			t.Fatalf("work move output missing %q:\n%s", marker, output)
+		}
+	}
+}
+
+func executeRecordingsActivationWorkListCLI(
+	t *testing.T,
+	process support.Process,
+	serverURL, sessionID string,
+) string {
+	t.Helper()
+
+	home := t.TempDir()
+	args := []string{
+		"you", "--server", serverURL, "--json",
+		"work", "list",
+		"--name", "fun-work-recordings-activation-task",
+	}
+	if sessionID != "" {
+		args = append(args, "--session", sessionID)
+	}
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.Env = recoveryActivationHomeEnvironment(home)
+	inputs.Input.WorkingDirectory = home
+	stdinIsTTY := true
+	inputs.Input.StdinIsTTY = &stdinIsTTY
+	inputs.Input.Stdin = strings.NewReader("")
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(work list) error = %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+	return inputs.Stdout()
+}
+
+func decodeRecordingsActivationWorkListJSON(t *testing.T, output string) factoryapi.ListWorkResponse {
+	t.Helper()
+
+	var listed factoryapi.ListWorkResponse
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &listed); err != nil {
+		t.Fatalf("decode work list JSON: %v\noutput:\n%s", err, output)
+	}
+	return listed
+}
+
+func writeVisualizationActivationBatchFile(t *testing.T) string {
+	t.Helper()
+
+	batchPath := filepath.Join(t.TempDir(), "fun-work-visualize-activation.json")
+	content := fmt.Sprintf(`{
+  "requestId": %q,
+  "type": "FACTORY_REQUEST_BATCH",
+  "works": [
+    {"name": "plan", "workTypeName": "task"},
+    {"name": "ship-release", "workTypeName": "task"}
+  ],
+  "relations": [
+    {"type": "DEPENDS_ON", "sourceWorkName": "ship-release", "targetWorkName": "plan"}
+  ]
+}`, visualizationActivationRequestID)
+	if err := os.WriteFile(batchPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write visualize batch file: %v", err)
+	}
+	return batchPath
+}
+
+func executeVisualizationActivationCLI(t *testing.T, process support.Process, batchPath string) string {
+	t.Helper()
+
+	home := t.TempDir()
+	args := []string{"you", "work", "visualize", batchPath}
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.Env = recoveryActivationHomeEnvironment(home)
+	inputs.Input.WorkingDirectory = home
+	stdinIsTTY := true
+	inputs.Input.StdinIsTTY = &stdinIsTTY
+	inputs.Input.Stdin = strings.NewReader("")
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(work visualize) error = %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+	return inputs.Stdout()
+}
+
+func assertVisualizationActivationGraphOutput(t *testing.T, output string) {
+	t.Helper()
+
+	if !strings.HasPrefix(output, "flowchart TD\n") {
+		t.Fatalf("visualize output missing flowchart header:\n%s", output)
+	}
+	for _, want := range []string{
+		`plan["plan"]`,
+		`"ship-release"["ship-release"]`,
+		`"ship-release" --> plan`,
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("visualize output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func recoveryActivationHomeEnvironment(home string) []string {
+	if runtime.GOOS == "windows" {
+		return []string{"USERPROFILE=" + home}
+	}
+	if runtime.GOOS == "plan9" {
+		return []string{"home=" + home}
+	}
+	return []string{"HOME=" + home}
+}

--- a/tests/functional/work/root_composition/routing_relationship_activation_test.go
+++ b/tests/functional/work/root_composition/routing_relationship_activation_test.go
@@ -1,0 +1,670 @@
+package root_composition_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	routingActivationRouterWorkstation = "router"
+
+	relationshipActivationRequiredState = "complete"
+	relationshipActivationStartWS       = "start"
+	relationshipActivationFinishWS      = "finish"
+
+	relationshipActivationPrerequisiteID = "fun-work-prerequisite-a"
+	relationshipActivationDependentID    = "fun-work-dependent-b"
+
+	parentChildActivationRequestID = "fun-work-parent-child-request"
+	parentChildActivationParentID  = "fun-work-parent-id"
+	parentChildActivationChildID   = "fun-work-child-id"
+	parentChildActivationParent    = "fun-work-parent"
+	parentChildActivationChild     = "fun-work-child"
+	parentChildActivationWorkType  = "task"
+)
+
+// TestWorkRoutingActivatesThroughRootBuildProcessAfterLifecycle proves logical-move
+// routing advances Work to an observable public outcome after runtime lifecycle on a
+// process constructed only through root.BuildProcess with edges.Edges effect
+// replacement. Detailed classifier and logical-move coverage remains under
+// tests/functional/work/routing; this test closes the explicit public-process
+// activation gap.
+func TestWorkRoutingActivatesThroughRootBuildProcessAfterLifecycle(t *testing.T) {
+	t.Parallel()
+
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "logical_move_dir"))
+	configureRoutingActivationLogicalMoveWorkstation(t, dir, routingActivationRouterWorkstation)
+	testutil.WriteSeedFile(t, dir, "task", []byte("fun-work-logical-move-payload"))
+
+	provider := testutil.NewMockProvider()
+	_, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
+		t,
+		dir,
+		serviceedges.Edges{ProviderOverride: provider},
+		10*time.Second,
+	)
+
+	if provider.CallCount() != 0 {
+		t.Fatalf(
+			"provider call count = %d after logical-move routing, want 0 workerless routing",
+			provider.CallCount(),
+		)
+	}
+	doneLocation := support.WorkCustomerLocation("task", "done")
+	if got := support.CountWorkAtCustomerState(listed, doneLocation); got != 1 {
+		t.Fatalf("%s work count = %d, want 1 after logical move; listed=%#v", doneLocation, got, listed)
+	}
+	initLocation := support.WorkCustomerLocation("task", "init")
+	if got := support.CountWorkAtCustomerState(listed, initLocation); got != 0 {
+		t.Fatalf("%s work count = %d, want 0 after logical move; listed=%#v", initLocation, got, listed)
+	}
+
+	dispatches := support.ObserveDispatchEvents(t, events)
+	logicalMoveDispatches := filterRoutingActivationWorkstationDispatches(
+		dispatches,
+		routingActivationRouterWorkstation,
+	)
+	if len(logicalMoveDispatches) == 0 {
+		t.Fatalf("no dispatch events at logical-move workstation %q", routingActivationRouterWorkstation)
+	}
+	for _, dispatch := range logicalMoveDispatches {
+		if dispatch.Response == nil {
+			continue
+		}
+		if dispatch.Response.Outcome != factoryapi.WorkOutcomeAccepted {
+			t.Fatalf(
+				"logical-move dispatch %q outcome = %s, want ACCEPTED",
+				dispatch.DispatchID,
+				dispatch.Response.Outcome,
+			)
+		}
+		if dispatch.Response.ProviderFailure != nil {
+			t.Fatalf(
+				"logical-move dispatch %q providerFailure = %#v, want no provider invocation",
+				dispatch.DispatchID,
+				dispatch.Response.ProviderFailure,
+			)
+		}
+	}
+}
+
+// TestWorkRelationshipsActivateThroughRootBuildProcessAfterLifecycle proves
+// DEPENDS_ON and PARENT_CHILD relationship outcomes are observable through public
+// Work surfaces after runtime lifecycle on processes built only via root.BuildProcess
+// and edges.Edges. Detailed relationship coverage remains under
+// tests/functional/work/relationships; this test closes the explicit public-process
+// activation gap.
+func TestWorkRelationshipsActivateThroughRootBuildProcessAfterLifecycle(t *testing.T) {
+	t.Parallel()
+
+	t.Run("depends_on", func(t *testing.T) {
+		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "dependency_tracking_dir"))
+
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			WorkTypeID: "task",
+			WorkID:     relationshipActivationPrerequisiteID,
+			Payload:    []byte("fun-work prerequisite"),
+		})
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			WorkTypeID: "task",
+			WorkID:     relationshipActivationDependentID,
+			Payload:    []byte("fun-work dependent"),
+			Relations: []work.Relation{
+				{
+					Type:          work.RelationDependsOn,
+					TargetWorkID:  relationshipActivationPrerequisiteID,
+					RequiredState: relationshipActivationRequiredState,
+				},
+			},
+		})
+
+		runner := testutil.NewProviderCommandRunner(
+			relationshipActivationProviderSuccess(),
+			relationshipActivationProviderSuccess(),
+			relationshipActivationProviderSuccess(),
+			relationshipActivationProviderSuccess(),
+		)
+
+		session, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
+			t,
+			dir,
+			serviceedges.Edges{ProviderCommandRunner: runner},
+			15*time.Second,
+		)
+
+		completeLocation := support.WorkCustomerLocation("task", relationshipActivationRequiredState)
+		if !support.HasWorkAtCustomerState(listed, relationshipActivationPrerequisiteID, completeLocation) {
+			t.Fatalf(
+				"prerequisite %q not at %q in public listing: %#v",
+				relationshipActivationPrerequisiteID,
+				relationshipActivationRequiredState,
+				listed,
+			)
+		}
+		if !support.HasWorkAtCustomerState(listed, relationshipActivationDependentID, completeLocation) {
+			t.Fatalf(
+				"dependent %q not at %q in public listing: %#v",
+				relationshipActivationDependentID,
+				relationshipActivationRequiredState,
+				listed,
+			)
+		}
+		if runner.CallCount() != 4 {
+			t.Fatalf(
+				"provider command runner calls = %d, want 4 starter and finisher invocations",
+				runner.CallCount(),
+			)
+		}
+
+		prerequisiteCompleteSequence, dependentStartSequence := relationshipActivationDependsOnDispatchOrdering(
+			t,
+			events,
+			relationshipActivationPrerequisiteID,
+			relationshipActivationDependentID,
+		)
+		if dependentStartSequence <= prerequisiteCompleteSequence {
+			t.Fatalf(
+				"dependent %q dispatch sequence = %d, want after prerequisite %q complete sequence %d",
+				relationshipActivationDependentID,
+				dependentStartSequence,
+				relationshipActivationPrerequisiteID,
+				prerequisiteCompleteSequence,
+			)
+		}
+
+		if session.Runtime.Progress.Categories.Terminal != 2 || session.Runtime.Progress.Categories.Failed != 0 {
+			t.Fatalf(
+				"session progress categories = %+v, want two terminal and zero failed",
+				session.Runtime.Progress.Categories,
+			)
+		}
+	})
+
+	t.Run("parent_child", func(t *testing.T) {
+		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "dependency_tracking_dir"))
+
+		provider := testutil.NewMockProvider(
+			workerexecution.InferenceResponse{Content: "COMPLETE"},
+			workerexecution.InferenceResponse{Content: "COMPLETE"},
+			workerexecution.InferenceResponse{Content: "COMPLETE"},
+			workerexecution.InferenceResponse{Content: "COMPLETE"},
+		)
+		edges := serviceedges.Edges{ProviderOverride: provider}
+
+		server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+			FactoryDir:                dir,
+			WaitForServiceModeRuntime: true,
+			Edges:                     edges,
+		})
+		t.Cleanup(func() { server.Stop(t) })
+
+		baseURL := server.URL()
+		process := support.BuildProcess(t, edges)
+
+		batchOutput := executeRelationshipActivationBatchSubmitCLI(
+			t,
+			process,
+			baseURL,
+			relationshipActivationParentChildBatchJSON(),
+		)
+		decodeRelationshipActivationBatchSubmitJSON(t, batchOutput, parentChildActivationRequestID)
+
+		support.WaitForTerminalStatus(t, baseURL, 15*time.Second)
+
+		listed := support.ListDefaultSessionWork(t, baseURL)
+		assertRelationshipActivationParentChildInListing(
+			t,
+			listed,
+			parentChildActivationChildID,
+			parentChildActivationParentID,
+		)
+
+		events := server.GetFactoryEvents(t)
+		assertRelationshipActivationParentChildInFactoryEvents(
+			t,
+			events,
+			parentChildActivationRequestID,
+			parentChildActivationChild,
+			parentChildActivationParent,
+			parentChildActivationParentID,
+		)
+
+		assertRelationshipActivationParentChildOnChildDispatch(
+			t,
+			provider,
+			parentChildActivationChildID,
+			parentChildActivationParentID,
+		)
+	})
+}
+
+func configureRoutingActivationLogicalMoveWorkstation(t *testing.T, dir, workstationName string) {
+	t.Helper()
+
+	path := filepath.Join(dir, "factory.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read factory config: %v", err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("decode factory config: %v", err)
+	}
+	for _, raw := range config["workstations"].([]any) {
+		workstation := raw.(map[string]any)
+		if workstation["name"] == workstationName {
+			workstation["type"] = "LOGICAL_MOVE"
+			workstation["worker"] = ""
+		}
+	}
+	updated, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		t.Fatalf("encode factory config: %v", err)
+	}
+	if err := os.WriteFile(path, updated, 0o644); err != nil {
+		t.Fatalf("write factory config: %v", err)
+	}
+
+	workstationConfigPath := filepath.Join(dir, "workstations", workstationName, "AGENTS.md")
+	if err := os.WriteFile(workstationConfigPath, []byte("---\ntype: LOGICAL_MOVE\n---\n"), 0o644); err != nil {
+		t.Fatalf("write logical workstation config: %v", err)
+	}
+}
+
+func filterRoutingActivationWorkstationDispatches(
+	dispatches []support.DispatchEventObservation,
+	workstation string,
+) []support.DispatchEventObservation {
+	filtered := make([]support.DispatchEventObservation, 0, len(dispatches))
+	for _, dispatch := range dispatches {
+		if dispatch.Request.TransitionId != workstation {
+			continue
+		}
+		filtered = append(filtered, dispatch)
+	}
+	return filtered
+}
+
+func relationshipActivationProviderSuccess() platformprocess.CommandResult {
+	return platformprocess.CommandResult{Stdout: support.CodexSuccessStdout("COMPLETE")}
+}
+
+func relationshipActivationDependsOnDispatchOrdering(
+	t *testing.T,
+	events []factoryapi.FactoryEvent,
+	prerequisiteWorkID, dependentWorkID string,
+) (prerequisiteCompleteSequence, dependentStartSequence int) {
+	t.Helper()
+
+	prerequisiteCompleteSequence = -1
+	dependentStartSequence = -1
+
+	for _, event := range events {
+		switch event.Type {
+		case factoryapi.FactoryEventTypeDispatchResponse:
+			payload, err := event.Payload.AsDispatchResponseEventPayload()
+			if err != nil {
+				continue
+			}
+			if payload.Outcome != factoryapi.WorkOutcomeAccepted || payload.TransitionId != relationshipActivationFinishWS {
+				continue
+			}
+			if !relationshipActivationDispatchEventIncludesWork(event.Context.WorkIds, prerequisiteWorkID) {
+				continue
+			}
+			prerequisiteCompleteSequence = event.Context.Sequence
+		case factoryapi.FactoryEventTypeDispatchRequest:
+			payload, err := event.Payload.AsDispatchRequestEventPayload()
+			if err != nil {
+				continue
+			}
+			if payload.TransitionId != relationshipActivationStartWS {
+				continue
+			}
+			if !relationshipActivationDispatchRequestIncludesWork(payload, dependentWorkID) {
+				continue
+			}
+			if prerequisiteCompleteSequence < 0 {
+				t.Fatalf(
+					"dependent %q received %q dispatch before prerequisite %q reached %q",
+					dependentWorkID,
+					relationshipActivationStartWS,
+					prerequisiteWorkID,
+					relationshipActivationRequiredState,
+				)
+			}
+			if dependentStartSequence < 0 {
+				dependentStartSequence = event.Context.Sequence
+			}
+		}
+	}
+
+	if prerequisiteCompleteSequence < 0 {
+		t.Fatalf(
+			"prerequisite %q never reached %q through public dispatch",
+			prerequisiteWorkID,
+			relationshipActivationRequiredState,
+		)
+	}
+	if dependentStartSequence < 0 {
+		t.Fatalf(
+			"dependent %q never received public %q dispatch",
+			dependentWorkID,
+			relationshipActivationStartWS,
+		)
+	}
+	return prerequisiteCompleteSequence, dependentStartSequence
+}
+
+func relationshipActivationDispatchRequestIncludesWork(
+	payload factoryapi.DispatchRequestEventPayload,
+	workID string,
+) bool {
+	for _, input := range payload.Inputs {
+		if input.WorkId == workID {
+			return true
+		}
+	}
+	return false
+}
+
+func relationshipActivationDispatchEventIncludesWork(workIDs *[]string, workID string) bool {
+	if workIDs == nil {
+		return false
+	}
+	for _, candidate := range *workIDs {
+		if candidate == workID {
+			return true
+		}
+	}
+	return false
+}
+
+func executeRelationshipActivationBatchSubmitCLI(
+	t *testing.T,
+	process support.Process,
+	serverURL string,
+	batchJSON string,
+) string {
+	t.Helper()
+
+	home := t.TempDir()
+	args := []string{
+		"you", "--server", serverURL, "--json",
+		"submit", "batch", batchJSON,
+	}
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.Env = relationshipActivationHomeEnvironment(home)
+	inputs.Input.WorkingDirectory = home
+	stdinIsTTY := true
+	inputs.Input.StdinIsTTY = &stdinIsTTY
+	inputs.Input.Stdin = strings.NewReader("")
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(batch submit) error = %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+	return inputs.Stdout()
+}
+
+type relationshipActivationBatchSubmitJSON struct {
+	RequestID string `json:"requestId"`
+	TraceID   string `json:"traceId"`
+	WorkCount int    `json:"workCount"`
+}
+
+func decodeRelationshipActivationBatchSubmitJSON(
+	t *testing.T,
+	output string,
+	requestID string,
+) relationshipActivationBatchSubmitJSON {
+	t.Helper()
+
+	var submitted relationshipActivationBatchSubmitJSON
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &submitted); err != nil {
+		t.Fatalf("decode batch submit JSON: %v\noutput:\n%s", err, output)
+	}
+	if submitted.RequestID != requestID {
+		t.Fatalf("batch submit requestId = %q, want %q", submitted.RequestID, requestID)
+	}
+	if strings.TrimSpace(submitted.TraceID) == "" || submitted.WorkCount != 2 {
+		t.Fatalf("batch submit response missing trace or work count: %#v", submitted)
+	}
+	return submitted
+}
+
+func relationshipActivationParentChildBatchJSON() string {
+	return `{
+		"requestId": "` + parentChildActivationRequestID + `",
+		"type": "FACTORY_REQUEST_BATCH",
+		"works": [
+			{
+				"name": "` + parentChildActivationParent + `",
+				"workId": "` + parentChildActivationParentID + `",
+				"workTypeName": "` + parentChildActivationWorkType + `",
+				"payload": {"role": "parent"}
+			},
+			{
+				"name": "` + parentChildActivationChild + `",
+				"workId": "` + parentChildActivationChildID + `",
+				"workTypeName": "` + parentChildActivationWorkType + `",
+				"payload": {"role": "child"}
+			}
+		],
+		"relations": [
+			{
+				"type": "PARENT_CHILD",
+				"sourceWorkName": "` + parentChildActivationChild + `",
+				"targetWorkName": "` + parentChildActivationParent + `"
+			}
+		]
+	}`
+}
+
+func relationshipActivationHomeEnvironment(home string) []string {
+	if runtime.GOOS == "windows" {
+		return []string{"USERPROFILE=" + home}
+	}
+	if runtime.GOOS == "plan9" {
+		return []string{"home=" + home}
+	}
+	return []string{"HOME=" + home}
+}
+
+func assertRelationshipActivationParentChildInListing(
+	t *testing.T,
+	listed factoryapi.ListWorkResponse,
+	childWorkID, parentWorkID string,
+) {
+	t.Helper()
+
+	for _, item := range listed.Results {
+		if support.StringPointerValue(item.WorkId) != childWorkID {
+			continue
+		}
+		assertRelationshipActivationParentChildRelationOnWork(t, item, parentWorkID)
+		return
+	}
+	t.Fatalf("public work list missing child %q: %#v", childWorkID, listed.Results)
+}
+
+func assertRelationshipActivationParentChildRelationOnWork(
+	t *testing.T,
+	item factoryapi.Work,
+	parentWorkID string,
+) {
+	t.Helper()
+
+	if item.Relations == nil || len(*item.Relations) == 0 {
+		t.Fatalf(
+			"work %q missing relations in public listing: %#v",
+			support.StringPointerValue(item.WorkId),
+			item,
+		)
+	}
+	for _, relation := range *item.Relations {
+		if relation.Type != factoryapi.RelationTypeParentChild {
+			continue
+		}
+		if relation.TargetWorkId != nil && *relation.TargetWorkId == parentWorkID {
+			return
+		}
+	}
+	t.Fatalf(
+		"work %q missing PARENT_CHILD relation to parent %q: relations=%#v",
+		support.StringPointerValue(item.WorkId),
+		parentWorkID,
+		*item.Relations,
+	)
+}
+
+func assertRelationshipActivationParentChildInFactoryEvents(
+	t *testing.T,
+	events []factoryapi.FactoryEvent,
+	requestID, childWorkName, parentWorkName, parentWorkID string,
+) {
+	t.Helper()
+
+	foundWorkRequest := false
+	foundRelationshipChange := false
+
+	for _, event := range events {
+		if support.StringPointerValue(event.Context.RequestId) != requestID {
+			continue
+		}
+		switch event.Type {
+		case factoryapi.FactoryEventTypeWorkRequest:
+			foundWorkRequest = true
+			payload, err := event.Payload.AsWorkRequestEventPayload()
+			if err != nil {
+				t.Fatalf("decode WORK_REQUEST event: %v", err)
+			}
+			if payload.Relations == nil {
+				t.Fatalf("WORK_REQUEST payload missing relations: %#v", payload)
+			}
+			if !relationshipActivationFactoryEventRelationsIncludeParentChild(
+				payload.Relations,
+				childWorkName,
+				parentWorkName,
+			) {
+				t.Fatalf(
+					"WORK_REQUEST relations = %#v, want PARENT_CHILD from %q to %q",
+					payload.Relations,
+					childWorkName,
+					parentWorkName,
+				)
+			}
+		case factoryapi.FactoryEventTypeRelationshipChangeRequest:
+			foundRelationshipChange = true
+			payload, err := event.Payload.AsRelationshipChangeRequestEventPayload()
+			if err != nil {
+				t.Fatalf("decode RELATIONSHIP_CHANGE_REQUEST event: %v", err)
+			}
+			if payload.Relation.Type != factoryapi.RelationTypeParentChild {
+				t.Fatalf("relationship change type = %q, want PARENT_CHILD", payload.Relation.Type)
+			}
+			if payload.Relation.SourceWorkName != childWorkName || payload.Relation.TargetWorkName != parentWorkName {
+				t.Fatalf(
+					"relationship change = %#v, want %q PARENT_CHILD %q",
+					payload.Relation,
+					childWorkName,
+					parentWorkName,
+				)
+			}
+			if support.StringPointerValue(payload.Relation.TargetWorkId) != parentWorkID {
+				t.Fatalf(
+					"relationship target work id = %q, want %q",
+					support.StringPointerValue(payload.Relation.TargetWorkId),
+					parentWorkID,
+				)
+			}
+		}
+	}
+
+	if !foundWorkRequest {
+		t.Fatalf("Factory Event history missing WORK_REQUEST for request %q", requestID)
+	}
+	if !foundRelationshipChange {
+		t.Fatalf("Factory Event history missing RELATIONSHIP_CHANGE_REQUEST for request %q", requestID)
+	}
+}
+
+func relationshipActivationFactoryEventRelationsIncludeParentChild(
+	relations *[]factoryapi.Relation,
+	childWorkName, parentWorkName string,
+) bool {
+	if relations == nil {
+		return false
+	}
+	for _, relation := range *relations {
+		if relation.Type == factoryapi.RelationTypeParentChild &&
+			relation.SourceWorkName == childWorkName &&
+			relation.TargetWorkName == parentWorkName {
+			return true
+		}
+	}
+	return false
+}
+
+func assertRelationshipActivationParentChildOnChildDispatch(
+	t *testing.T,
+	provider *testutil.MockProvider,
+	childWorkID, parentWorkID string,
+) {
+	t.Helper()
+
+	for _, call := range provider.Calls() {
+		token := relationshipActivationFirstDispatchToken(call.InputTokens)
+		if token.Color.WorkID != childWorkID {
+			continue
+		}
+		for _, relation := range token.Color.Relations {
+			if relation.Type == work.RelationParentChild && relation.TargetWorkID == parentWorkID {
+				return
+			}
+		}
+		t.Fatalf(
+			"child dispatch token relations = %#v, want PARENT_CHILD target %q",
+			token.Color.Relations,
+			parentWorkID,
+		)
+	}
+	t.Fatalf("provider dispatch history missing child work %q", childWorkID)
+}
+
+func relationshipActivationFirstDispatchToken(rawTokens any) workerexecution.Token {
+	switch tokens := rawTokens.(type) {
+	case []any:
+		if len(tokens) == 0 {
+			return workerexecution.Token{}
+		}
+		token, ok := tokens[0].(workerexecution.Token)
+		if !ok {
+			return workerexecution.Token{}
+		}
+		return token
+	case []workerexecution.Token:
+		if len(tokens) == 0 {
+			return workerexecution.Token{}
+		}
+		return tokens[0]
+	default:
+		return workerexecution.Token{}
+	}
+}

--- a/tests/functional/work/root_composition/submission_activation_test.go
+++ b/tests/functional/work/root_composition/submission_activation_test.go
@@ -1,0 +1,386 @@
+package root_composition_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	submissionActivationWorkType = "task"
+
+	submissionActivationHTTPBatchRequestID = "fun-work-submission-http-batch"
+	submissionActivationHTTPBatchWorkName  = "fun-work-http-batch-task"
+	submissionActivationHTTPBatchWorkID    = "fun-work-http-batch-id"
+
+	submissionActivationHTTPUnaryWorkName = "fun-work-http-unary-task"
+
+	submissionActivationCLIUnaryWorkName = "fun-work-cli-unary-task"
+	submissionActivationCLIBatchRequestID  = "fun-work-cli-batch"
+	submissionActivationCLIBatchWorkName   = "fun-work-cli-batch-task"
+)
+
+// TestWorkSubmissionAndCLISubmitActivateThroughRootBuildProcessAfterLifecycle
+// proves Work HTTP submission (batch and unary) and CLI submit contracts activate
+// through public surfaces after runtime lifecycle on a process constructed only
+// through root.BuildProcess with edges.Edges effect replacement. Behavioral
+// coverage under tests/functional/work/submission and
+// tests/functional/work/transports/cli/submit retains the detailed contract
+// proofs; this test closes the explicit public-process activation gap.
+func TestWorkSubmissionAndCLISubmitActivateThroughRootBuildProcessAfterLifecycle(t *testing.T) {
+	t.Parallel()
+
+	recorder := newWorkSubmissionActivationRecorder()
+	edges := recorder.edges()
+
+	dir := support.ScaffoldFactory(t, submissionActivationFactoryConfig())
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		UseMockWorkers:            true,
+		WaitForServiceModeRuntime: true,
+		Edges:                     edges,
+	})
+	t.Cleanup(func() { server.Stop(t) })
+
+	baseURL := server.URL()
+	requestIDsBefore := recorder.requestIDs()
+
+	workTypeName := submissionActivationWorkType
+	batchSubmitted := support.UpsertDefaultSessionWorkRequest(t, baseURL, factoryapi.WorkRequest{
+		RequestId: submissionActivationHTTPBatchRequestID,
+		Type:      factoryapi.WorkRequestTypeFactoryRequestBatch,
+		Works: &[]factoryapi.Work{{
+			Name:         submissionActivationHTTPBatchWorkName,
+			WorkId:       stringPtr(submissionActivationHTTPBatchWorkID),
+			WorkTypeName: &workTypeName,
+			Payload:      map[string]string{"title": "FUN Work HTTP batch activation"},
+		}},
+	})
+	if batchSubmitted.RequestId != submissionActivationHTTPBatchRequestID {
+		t.Fatalf(
+			"PUT /work-requests requestId = %q, want %q",
+			batchSubmitted.RequestId,
+			submissionActivationHTTPBatchRequestID,
+		)
+	}
+	assertSubmissionActivationWorkListed(
+		t,
+		baseURL,
+		submissionActivationHTTPBatchWorkName,
+		submissionActivationHTTPBatchWorkID,
+	)
+
+	unarySubmitted := support.SubmitDefaultSessionWork(t, baseURL, factoryapi.SubmitWorkRequest{
+		Name:         stringPtr(submissionActivationHTTPUnaryWorkName),
+		WorkTypeName: submissionActivationWorkType,
+		Payload:      map[string]string{"title": "FUN Work HTTP unary activation"},
+	})
+	unaryWorkID := support.StringPointerValue(unarySubmitted.WorkId)
+	if unaryWorkID == "" {
+		t.Fatalf("POST /work workId is empty, want customer-visible work identity")
+	}
+	assertSubmissionActivationWorkListed(
+		t,
+		baseURL,
+		submissionActivationHTTPUnaryWorkName,
+		unaryWorkID,
+	)
+
+	process := support.BuildProcess(t, edges)
+	payloadPath := writeSubmissionActivationPayloadFile(t, "# FUN Work CLI unary activation\n")
+
+	cliUnaryOutput := executeSubmissionActivationUnarySubmitCLI(
+		t,
+		process,
+		baseURL,
+		submissionActivationCLIUnaryWorkName,
+		payloadPath,
+	)
+	cliUnarySubmitted := decodeSubmissionActivationUnarySubmitJSON(
+		t,
+		cliUnaryOutput,
+		submissionActivationCLIUnaryWorkName,
+	)
+	assertSubmissionActivationWorkListed(
+		t,
+		baseURL,
+		submissionActivationCLIUnaryWorkName,
+		*cliUnarySubmitted.WorkID,
+	)
+
+	cliBatchOutput := executeSubmissionActivationBatchSubmitCLI(
+		t,
+		process,
+		baseURL,
+		submissionActivationInlineBatchJSON(),
+	)
+	cliBatchSubmitted := decodeSubmissionActivationBatchSubmitJSON(t, cliBatchOutput)
+	if cliBatchSubmitted.RequestID != submissionActivationCLIBatchRequestID {
+		t.Fatalf(
+			"CLI submit batch requestId = %q, want %q",
+			cliBatchSubmitted.RequestID,
+			submissionActivationCLIBatchRequestID,
+		)
+	}
+	assertSubmissionActivationWorkListed(
+		t,
+		baseURL,
+		submissionActivationCLIBatchWorkName,
+		cliBatchSubmitted.Works[0].WorkID,
+	)
+
+	if got := recorder.requestIDs() - requestIDsBefore; got <= 0 {
+		t.Fatalf(
+			"WorkRequestIDGenerator calls after public submission = %d, want > 0 via edges",
+			got,
+		)
+	}
+}
+
+type workSubmissionActivationRecorder struct {
+	requestID atomic.Int32
+}
+
+func newWorkSubmissionActivationRecorder() *workSubmissionActivationRecorder {
+	return &workSubmissionActivationRecorder{}
+}
+
+func (recorder *workSubmissionActivationRecorder) edges() serviceedges.Edges {
+	return serviceedges.Edges{
+		WorkRequestIDGenerator: recorder.generateRequestID,
+	}
+}
+
+func (recorder *workSubmissionActivationRecorder) requestIDs() int32 {
+	return recorder.requestID.Load()
+}
+
+func (recorder *workSubmissionActivationRecorder) generateRequestID() string {
+	next := recorder.requestID.Add(1)
+	return fmt.Sprintf("fun-work-submission-request-%d", next)
+}
+
+func submissionActivationFactoryConfig() map[string]any {
+	return map[string]any{
+		"name": "work-submission-activation",
+		"workTypes": []map[string]any{
+			{
+				"name": submissionActivationWorkType,
+				"states": []map[string]any{
+					{"name": "init", "type": "INITIAL"},
+					{"name": "complete", "type": "TERMINAL"},
+					{"name": "failed", "type": "FAILED"},
+				},
+			},
+		},
+		"workers": []map[string]string{
+			{"name": "mock-worker"},
+		},
+		"workstations": []map[string]any{
+			{
+				"name":      "process-task",
+				"worker":    "mock-worker",
+				"inputs":    []map[string]string{{"workType": submissionActivationWorkType, "state": "init"}},
+				"outputs":   []map[string]string{{"workType": submissionActivationWorkType, "state": "complete"}},
+				"onFailure": []map[string]string{{"workType": submissionActivationWorkType, "state": "failed"}},
+			},
+		},
+	}
+}
+
+func assertSubmissionActivationWorkListed(t *testing.T, baseURL, workName, workID string) {
+	t.Helper()
+
+	listed := support.ListDefaultSessionWork(t, baseURL)
+	for _, item := range listed.Results {
+		if item.Name != workName {
+			continue
+		}
+		if support.StringPointerValue(item.WorkId) == workID {
+			if support.StringPointerValue(item.WorkTypeName) != submissionActivationWorkType {
+				t.Fatalf(
+					"GET /work list workTypeName = %q, want %q for name=%q workId=%q",
+					support.StringPointerValue(item.WorkTypeName),
+					submissionActivationWorkType,
+					workName,
+					workID,
+				)
+			}
+			return
+		}
+	}
+	t.Fatalf(
+		"GET /work list missing submitted work name=%q workId=%q: %#v",
+		workName,
+		workID,
+		listed.Results,
+	)
+}
+
+func writeSubmissionActivationPayloadFile(t *testing.T, content string) string {
+	t.Helper()
+	payloadPath := filepath.Join(t.TempDir(), "request.md")
+	if err := os.WriteFile(payloadPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write unary payload file: %v", err)
+	}
+	return payloadPath
+}
+
+func executeSubmissionActivationUnarySubmitCLI(
+	t *testing.T,
+	process support.Process,
+	serverURL string,
+	workName string,
+	payloadPath string,
+) string {
+	t.Helper()
+
+	home := t.TempDir()
+	args := []string{
+		"you", "--server", serverURL, "--json",
+		"submit",
+		"--name", workName,
+		"--work-type-name", submissionActivationWorkType,
+		"--payload", payloadPath,
+	}
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.Env = submissionActivationHomeEnvironment(home)
+	inputs.Input.WorkingDirectory = home
+	stdinIsTTY := true
+	inputs.Input.StdinIsTTY = &stdinIsTTY
+	inputs.Input.Stdin = strings.NewReader("")
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(unary submit) error = %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+	return inputs.Stdout()
+}
+
+func executeSubmissionActivationBatchSubmitCLI(
+	t *testing.T,
+	process support.Process,
+	serverURL string,
+	batchJSON string,
+) string {
+	t.Helper()
+
+	home := t.TempDir()
+	args := []string{
+		"you", "--server", serverURL, "--json",
+		"submit", "batch", batchJSON,
+	}
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.Env = submissionActivationHomeEnvironment(home)
+	inputs.Input.WorkingDirectory = home
+	stdinIsTTY := true
+	inputs.Input.StdinIsTTY = &stdinIsTTY
+	inputs.Input.Stdin = strings.NewReader("")
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(batch submit) error = %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+	return inputs.Stdout()
+}
+
+type submissionActivationUnarySubmitJSON struct {
+	TraceID string  `json:"traceId"`
+	WorkID  *string `json:"workId"`
+	Name    string  `json:"name"`
+}
+
+type submissionActivationBatchSubmitJSON struct {
+	RequestID string `json:"requestId"`
+	TraceID   string `json:"traceId"`
+	WorkCount int    `json:"workCount"`
+	Works     []struct {
+		Name   string `json:"name"`
+		WorkID string `json:"workId"`
+	} `json:"works"`
+}
+
+func decodeSubmissionActivationUnarySubmitJSON(
+	t *testing.T,
+	output string,
+	workName string,
+) submissionActivationUnarySubmitJSON {
+	t.Helper()
+
+	var submitted submissionActivationUnarySubmitJSON
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &submitted); err != nil {
+		t.Fatalf("decode unary submit JSON: %v\noutput:\n%s", err, output)
+	}
+	if submitted.TraceID == "" {
+		t.Fatalf("unary submit response missing traceId: %#v", submitted)
+	}
+	if submitted.WorkID == nil || strings.TrimSpace(*submitted.WorkID) == "" {
+		t.Fatalf("unary submit response missing workId: %#v", submitted)
+	}
+	if submitted.Name != workName {
+		t.Fatalf("unary submit response name = %q, want %q", submitted.Name, workName)
+	}
+	return submitted
+}
+
+func decodeSubmissionActivationBatchSubmitJSON(
+	t *testing.T,
+	output string,
+) submissionActivationBatchSubmitJSON {
+	t.Helper()
+
+	var submitted submissionActivationBatchSubmitJSON
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &submitted); err != nil {
+		t.Fatalf("decode batch submit JSON: %v\noutput:\n%s", err, output)
+	}
+	if submitted.WorkCount != 1 || len(submitted.Works) != 1 || strings.TrimSpace(submitted.Works[0].WorkID) == "" {
+		t.Fatalf("batch submit response missing accepted work identity: %#v", submitted)
+	}
+	if strings.TrimSpace(submitted.RequestID) == "" || strings.TrimSpace(submitted.TraceID) == "" {
+		t.Fatalf("batch submit response missing request or trace identity: %#v", submitted)
+	}
+	return submitted
+}
+
+func submissionActivationInlineBatchJSON() string {
+	return `{
+		"requestId": "` + submissionActivationCLIBatchRequestID + `",
+		"type": "FACTORY_REQUEST_BATCH",
+		"works": [
+			{
+				"name": "` + submissionActivationCLIBatchWorkName + `",
+				"workTypeName": "` + submissionActivationWorkType + `",
+				"payload": {"title": "FUN Work CLI batch activation"}
+			}
+		]
+	}`
+}
+
+func submissionActivationHomeEnvironment(home string) []string {
+	if runtime.GOOS == "windows" {
+		return []string{"USERPROFILE=" + home}
+	}
+	if runtime.GOOS == "plan9" {
+		return []string{"home=" + home}
+	}
+	return []string{"HOME=" + home}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}

--- a/tests/functional/work/transports/cli/submit/unary_contract/unary_contract_test.go
+++ b/tests/functional/work/transports/cli/submit/unary_contract/unary_contract_test.go
@@ -150,3 +150,23 @@ func TestCLISubmitUnaryStructuredFailurePreservesPublicMessage(t *testing.T) {
 	assertRequest(t)
 	assertUnarySubmitStructuredFailurePreservesPublicMessage(t, inputs)
 }
+
+// TestCLISubmitUnaryContractHarnessExecutesThroughRootBuildProcess proves the
+// Work-owned unary_contract cell constructs a customer process through
+// root.BuildProcess, invokes public you submit through Process.Execute, and
+// replaces external effects only through edges.Edges.
+func TestCLISubmitUnaryContractHarnessExecutesThroughRootBuildProcess(t *testing.T) {
+	server, assertRequest := newUnaryStructuredFailureServer(t)
+	process := buildUnaryContractProcess(t, serviceedges.Edges{})
+	payloadPath := writeUnaryContractPayloadFile(t, "# Harness\n\nStructured failure.")
+
+	inputs := executeUnarySubmitExpectingFailure(
+		t,
+		process,
+		server.URL,
+		unaryContractStructuredFailureWorkName,
+		payloadPath,
+	)
+	assertRequest(t)
+	assertUnarySubmitStructuredFailurePreservesPublicMessage(t, inputs)
+}


### PR DESCRIPTION
{
  "project": "FUN-work: public-process proof for Work after INV→CLN→DEL vertical completion",
  "branchName": "pss-fun-work",
  "description": "Prove Work as a packaged service through public process composition only: root.BuildProcess, public Work protocol surfaces (HTTP/CLI/MCP adapters already terminal), and edges.Edges effect replacement. Validate and, only where needed, extend focused functional proofs under tests/functional/work so submission (unary/batch/HTTP), routing/classifier/logical-move, relationships, recovery/manual-move, recordings-read, CLI submit contracts, and visualization/dependency-graph remain inert until runtime lifecycle starts, then exercise public Work behavior without importing work/internal or deleted transitional Work packages (service/, stateaccessrecordings/, legacy pkg/work public roots) from outside the owner and without inventing pkg/root or pkg/wire test-only composition helpers.",
  "context": {
    "customerAsk": "After INV-WORK-TOPLEVEL, CLN-WORK-FOLD-SERVICE, CLN-WORK-LEGACY-PACKAGES, CLN-WORK-CONTRACT-ROOTS, and DEL-WORK Factory completion, prove from an external-user perspective that Work still works: submission (unary/batch/HTTP), routing/classifier/logical-move, relationships (DEPENDS_ON/PARENT_CHILD), recovery/manual-move, recordings-read, CLI submit contracts, and visualization/dependency-graph surfaces remain inert until runtime lifecycle, then activate through public Work protocol surfaces constructed only via root.BuildProcess and edges.Edges—without inventing root/wire test subsystems or peer-importing work/internal or deleted transitional Work packages (service/, stateaccessrecordings/, legacy pkg/work public roots).",
    "problem": "INV→CLN→DEL for Work is Factory-terminal and the live Work package already has the packaged root shape (wire/, internal/, transports/ plus residual unexpected testdata/), with service/ and stateaccessrecordings/ deleted and packaged_root_shape / del_work_* gates locking deletion. Existing tests/functional/work covers submission, routing, relationships, recovery, recordings-read, CLI submit contracts, and visualization, but the Work vertical still lacks an explicit public-process proof that composition goes only through root.BuildProcess + edges.Edges, that those surfaces stay inert before runtime lifecycle and activate afterward through public surfaces, and that owner-private imports and deleted transitional packages stay sealed. Treating DEL merge, packaged_root_shape, or del_work_* unit gates as sufficient would close FUN without external lifecycle behavior.",
    "solution": "Validate existing tests/functional/work proofs first; add only missing external proofs for inert construction and post-lifecycle activation through public Work surfaces. Construct only via root.BuildProcess, replace effects only via edges.Edges, and seal functional/production-peer imports away from work/internal and deleted transitional Work packages—without inventing root/wire test helpers (including WorkRootFromEdges), protocol adapters, package folds/deletes (including residual testdata/), or a second suite topology. Deliver through merge."
  },
  "acceptanceCriteria": [
    "Submission, routing/relationships, recovery/manual-move, recordings-read, CLI submit contracts, and visualization/dependency-graph surfaces have external functional proof of inert construction and post-lifecycle activation through public Work surfaces (behavioral)",
    "No functional-suite or production peer import of deleted Work transitional packages (service/, stateaccessrecordings/, legacy pkg/work public roots) or work/internal from outside the Work owner",
    "Packaged Work root remains wire/, internal/, transports/ plus thin root contracts (testdata/ may remain as committed unexpected move debt only)",
    "Quality checks pass (typecheck, lint, and required tests/CI are terminal green)",
    "Delivery loop continues until required CI is terminal and passing, all blocking PR conversation feedback is addressed, merge conflicts and shared-file churn are reconciled, and the PR is actually merged (opened/green/approved/ready-to-merge alone is not complete)"
  ],
  "userStories": [
    {
      "id": "pss-fun-work-001",
      "title": "Prove Work remains inert through root.BuildProcess",
      "description": "As a maintainer, I want focused functional proof that root.BuildProcess composes Work without invoking submission, routing/relationship, recovery/manual-move, recordings-read, CLI submit, or visualization/dependency-graph external effects before runtime lifecycle starts, so packaged construction matches peer FUN inertness.",
      "acceptanceCriteria": [
        "A functional proof under tests/functional/work constructs the process only through root.BuildProcess / shared functional support (not a new pkg/root or pkg/wire Work helper, and not a WorkRootFromEdges-style test subsystem)",
        "Instrumented Work-relevant edges.Edges replacements report zero invocations for submission, routing/relationship, recovery/manual-move, recordings-read, CLI submit, and visualization/dependency-graph external effects during BuildProcess before runtime lifecycle starts",
        "The proof does not treat packaged_root_shape, del_work_* unit gates, peer-import scanners, or unit-only thin-root proofs as a substitute for this inert-construction behavior",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-fun-work-002",
      "title": "Activate submission and CLI submit contracts through public surfaces after lifecycle",
      "description": "As an external user of the public process, I want Work submission (unary/batch/HTTP) and CLI submit contract behavior to activate only after runtime lifecycle and remain observable through public Work protocol surfaces on a process composed only via root.BuildProcess and edges.Edges.",
      "acceptanceCriteria": [
        "First validate whether existing proofs under tests/functional/work/submission and tests/functional/work/transports/cli/submit already exercise unary/batch/HTTP submission and CLI submit contracts through root.BuildProcess + edges.Edges; retain and tighten those proofs rather than inventing a parallel suite topology",
        "After runtime lifecycle starts, unary and/or batch submission produces an observable public Work outcome through an already-terminal public surface (HTTP and/or CLI)",
        "After runtime lifecycle starts, CLI submit contract proofs (unary and/or batch) execute through Process.Execute on a process built only via root.BuildProcess, with external effects replaced only via edges.Edges",
        "Effect replacement uses only edges.Edges; proofs do not import work/internal or deleted transitional Work packages (service/, stateaccessrecordings/, legacy pkg/work public roots)",
        "Add only missing external assertions required for explicit post-lifecycle public-surface proof",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-fun-work-003",
      "title": "Activate routing and relationships through public surfaces after lifecycle",
      "description": "As an external user, I want Work routing (classifier/logical-move) and relationships (DEPENDS_ON/PARENT_CHILD) to activate after runtime lifecycle on the same public-process composition path, without inventing adapters or a second suite topology.",
      "acceptanceCriteria": [
        "First validate whether existing proofs under tests/functional/work/routing and tests/functional/work/relationships already exercise classifier/logical-move and DEPENDS_ON/PARENT_CHILD through root.BuildProcess + edges.Edges; retain and tighten rather than inventing a second suite",
        "After lifecycle, at least one classifier or logical-move path produces an observable public routing outcome through the public process",
        "After lifecycle, at least one DEPENDS_ON relationship outcome and at least one PARENT_CHILD relationship outcome are observable through public Work surfaces on the public process",
        "Proofs construct only through public process composition and do not invent Work HTTP/CLI/MCP adapters or reopen accepted Schema-Driven/Clean CLI UX",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-fun-work-004",
      "title": "Activate recovery, recordings-read, and visualization through public surfaces after lifecycle",
      "description": "As an external user, I want recovery/manual-move, recordings-read, and visualization/dependency-graph surfaces to activate after runtime lifecycle through public Work (and already-terminal public visualization) surfaces on the same root.BuildProcess + edges.Edges path.",
      "acceptanceCriteria": [
        "First validate whether existing proofs under tests/functional/work/recovery, tests/functional/work/recordings, and tests/functional/work/visualization already exercise those behaviors through root.BuildProcess + edges.Edges; retain and tighten rather than inventing a second suite topology",
        "After lifecycle, a public recovery/manual-move path produces an observable Work state/placement outcome through the public process",
        "After lifecycle, a public recordings-read path produces an observable read outcome for Work-related recordings through the public process",
        "After lifecycle, a public visualization/dependency-graph path produces an observable graph/dependency outcome through the public process",
        "Proofs do not import work/internal or deleted transitional Work packages; do not invent Work protocol adapters; do not take FUN-visualization or CUT-VIS-* implementation leases beyond proving Work-owned visualization coverage already under tests/functional/work",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-fun-work-005",
      "title": "Seal functional suite against internal and deleted transitional Work imports",
      "description": "As a maintainer, I want the Work functional suite (and named production peers outside the Work owner) to import only public process construction and published Work root contracts so FUN proofs cannot reach work/internal or deleted transitional Work packages.",
      "acceptanceCriteria": [
        "Packages under tests/functional/work/... do not import pkg/services/work/internal (or any subpath), deleted transitional packages (service/, stateaccessrecordings/), or legacy pkg/work public roots",
        "A focused functional seal (peer-import style, following Automations/Models/Provider Sessions/Sessions FUN seals) fails if those forbidden imports reappear in the FUN proof surface",
        "Named production peer packages that compose Work import published Work root contracts only — not work/internal or deleted transitional Work packages",
        "This seal complements, and does not replace, the inert-construction and post-lifecycle behavioral proofs in stories 001–004",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-fun-work-006",
      "title": "Confirm packaged root shape and deliver through merge",
      "description": "As a Factory operator, I want the packaged Work root to remain wire/, internal/, transports/ plus thin root contracts (with residual testdata/ left as inventory debt), and the FUN PR merged with terminal CI, so FUN-work is Factory-complete without folds, deletes, adapter invention, or absorbing adjacent owner leases.",
      "acceptanceCriteria": [
        "Packaged Work root directories remain wire/, internal/, and transports/ plus thin root contract/test files; residual public testdata/ may remain but is not folded or deleted under this lease; deleted transitional public packages do not reappear",
        "This packet does not invent pkg/root/pkg/wire Work helpers solely for tests, does not open PSS-I0*, does not invent Work HTTP/CLI/MCP adapters, does not reopen accepted Schema-Driven/Clean CLI UX, and does not take Providers CLI adapter, WRK/REC/SET/DEF residual CLN/DEL, FUN-runtime, or CUT-RUN-REC leases",
        "Changed paths stay within the FUN-work lease: tests/functional/work/**, and Work root contract/characterization tests only when required for public-process proof gaps",
        "Required CI is terminal green; blocking PR conversation comments are addressed; merge conflicts/shared-file churn are reconciled; the PR is merged (opening or greening a PR without merge is not completion)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    }
  ]
}
