### PR TITLE
pss-ret-def-root-wire

### DIFF
--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -708,7 +708,13 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/service",
-      "minimum": 61.50
+      "exception": {
+        "kind": "measurement",
+        "justification": "Transitional compile shim; root composition now constructs through factory_definitions/wire and implementation coverage lives under factory_definitions/internal and factory_definitions/wire.",
+        "owner": "factory-definition-maintainers",
+        "deadline": "2027-07-15",
+        "removalGate": "DEL-DEF-RESIDUAL deletes this transitional public package path."
+      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/snapshotcapture",

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -180,11 +180,12 @@ Use this map when changing the public REST contract.
   proves fake-root parity at the adapter edge without importing Definitions
   internals.
   pss-cln-def-fold-toplevel seals non-owner production imports of the transitional
-  `factory_definitions/service` compile shim to the documented Automations-leased
-  `pkg/wire` residual only; the repository-wide guard is
-  `pkg/services/factory_definitions/non_owner_service_import_boundary_test.go`,
+  `factory_definitions/service` compile shim to the Factory Definitions owner only;
+  RET-DEF-ROOT-WIRE retargeted root `pkg/wire` off the shim. The repository-wide
+  guard is `pkg/services/factory_definitions/non_owner_service_import_boundary_test.go`,
   with `pkg/services/factory_definitions/service` registered in
-  `cmd/pkgboundarycheck` converged service subpackage roots.
+  `cmd/pkgboundarycheck` converged service subpackage roots. Root pkg/wire must
+  not reintroduce the transitional import (`root_wire_hold_test.go`).
   DEL-DEF story 001 (`pss-del-def-001`) confirms prerequisite packets are
   Factory-complete before leased deletion begins. Observable gate proofs live in
   `pkg/services/factory_definitions/del_def_prerequisite_gate_test.go` (tree
@@ -199,8 +200,9 @@ Use this map when changing the public REST contract.
   DEL-DEF story 002 (`pss-del-def-002`) deletes emptied transitional DEF
   top-level packages (`authoredlayout`, `portableconfig`, `loading`,
   `runtimeconfig`, `namedfactories`) and retargets owner imports to
-  `internal/services/*` destinations. The `service/` compile shim remains under
-  the Automations-leased `pkg/wire` hold. Import-clearing proof is
+  `internal/services/*` destinations. The `service/` compile shim remains for
+  owner-local transitional construction until DEL-DEF-RESIDUAL deletes it.
+  Import-clearing proof is
   `pkg/services/factory_definitions/del_def_transitional_deletion_test.go`;
   deletion/absence proofs are in `del_def_prerequisite_gate_test.go`. Root
   `pkg/wire` composition ports moved to public exports under

--- a/pkg/services/factory_definitions/del_def_transitional_deletion_test.go
+++ b/pkg/services/factory_definitions/del_def_transitional_deletion_test.go
@@ -20,8 +20,8 @@ var allowedDeletedTransitionalImporterPrefixes = []string{
 
 // TestDelDefTransitionalDeletion_NoImportsOfDeletedPackages proves DEL-DEF
 // story 002 cleared production and test imports of deleted transitional
-// packages, except the documented Automations-leased root pkg/wire residual
-// that still compiles against factory_definitions/service.
+// packages, except the documented root pkg/wire residual for deleted
+// transitional import paths retargeted in later DEF fold work.
 func TestDelDefTransitionalDeletion_NoImportsOfDeletedPackages(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_definitions/non_owner_service_import_boundary_test.go
+++ b/pkg/services/factory_definitions/non_owner_service_import_boundary_test.go
@@ -7,15 +7,14 @@ import (
 )
 
 const (
-	moduleImportPrefix              = "github.com/portpowered/infinite-you/"
-	factoryDefinitionsOwnerPrefix   = moduleImportPrefix + "pkg/services/factory_definitions"
-	rootPkgWireResidualImportPrefix = moduleImportPrefix + "pkg/wire"
+	moduleImportPrefix            = "github.com/portpowered/infinite-you/"
+	factoryDefinitionsOwnerPrefix = moduleImportPrefix + "pkg/services/factory_definitions"
 )
 
 // TestNonOwnerProductionPackages_DoNotImportTransitionalServiceShim seals
-// pss-cln-def-fold-toplevel story 005: only the Factory Definitions owner and
-// the documented Automations-leased root pkg/wire residual may import the
-// transitional factory_definitions/service compile shim.
+// pss-cln-def-fold-toplevel story 005 and RET-DEF-ROOT-WIRE story 004: only the
+// Factory Definitions owner may import the transitional
+// factory_definitions/service compile shim.
 func TestNonOwnerProductionPackages_DoNotImportTransitionalServiceShim(t *testing.T) {
 	t.Parallel()
 
@@ -50,21 +49,16 @@ func TestNonOwnerProductionPackages_DoNotImportTransitionalServiceShim(t *testin
 				continue
 			}
 			t.Fatalf(
-				"%s must not import transitional service shim %s; use %s or the owner wire bridge %s (root pkg/wire residual only)",
+				"%s must not import transitional service shim %s; use %s or factory_definitions/wire",
 				packagePath,
 				importPath,
 				factoryDefinitionsOwnerPrefix,
-				rootPkgWireResidualImportPrefix,
 			)
 		}
 	}
 }
 
 func isAllowedTransitionalServiceImporter(packagePath string) bool {
-	if packagePath == factoryDefinitionsOwnerPrefix ||
-		strings.HasPrefix(packagePath, factoryDefinitionsOwnerPrefix+"/") {
-		return true
-	}
-	return packagePath == rootPkgWireResidualImportPrefix ||
-		strings.HasPrefix(packagePath, rootPkgWireResidualImportPrefix+"/")
+	return packagePath == factoryDefinitionsOwnerPrefix ||
+		strings.HasPrefix(packagePath, factoryDefinitionsOwnerPrefix+"/")
 }

--- a/pkg/services/factory_definitions/non_owner_validation_import_boundary_test.go
+++ b/pkg/services/factory_definitions/non_owner_validation_import_boundary_test.go
@@ -62,12 +62,11 @@ func TestNonOwnerProductionPackages_DoNotImportValidationInternalsOrTransitional
 					continue
 				}
 				t.Fatalf(
-					"%s must not import %s %s; use %s or %s",
+					"%s must not import %s %s; use %s or factory_definitions/wire",
 					packagePath,
 					forbidden.label,
 					importPath,
 					factoryDefinitionsOwnerPrefix,
-					rootPkgWireResidualImportPrefix,
 				)
 			}
 		}

--- a/pkg/services/factory_definitions/root_wire_hold_test.go
+++ b/pkg/services/factory_definitions/root_wire_hold_test.go
@@ -11,11 +11,7 @@ const (
 	factoryDefinitionsInternalImport = "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal"
 	factoryDefinitionsPeerImport       = "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	rootPkgWireImport                  = "github.com/portpowered/infinite-you/pkg/wire"
-
-	// PostAutoDELDefinitionsWireRetargetFollowUp names the Automations-leased
-	// follow-up that must retarget root pkg/wire construction to
-	// factory_definitions/wire after AUTO-DEL completes.
-	PostAutoDELDefinitionsWireRetargetFollowUp = "post-AUTO-DEL: retarget root pkg/wire Factory Definitions construction from factory_definitions/service to factory_definitions/wire only (factory_definition_service_provider.go, cli_commands.go, profiles.go, session_runtime_providers.go)"
+	factoryDefinitionsWireImport       = "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire"
 )
 
 var transitionalServiceForbiddenImports = []string{
@@ -61,16 +57,16 @@ func TestTransitionalServiceShim_ForwardsFromInternalOnly(t *testing.T) {
 	}
 }
 
-func TestRootPkgWire_StillImportsTransitionalServiceResidual(t *testing.T) {
+func TestRootPkgWire_DoesNotImportTransitionalServiceResidual(t *testing.T) {
 	t.Parallel()
 
 	imports := packageImports(t, rootPkgWireImport)
-	if !importsContain(imports, transitionalServiceImport) {
+	if importsContain(imports, transitionalServiceImport) {
 		t.Fatalf(
-			"%s still imports %s under the Automations-leased root wire hold; follow-up %q",
+			"%s must construct Factory Definitions through %s, not transitional service shim %s",
 			rootPkgWireImport,
+			factoryDefinitionsWireImport,
 			transitionalServiceImport,
-			PostAutoDELDefinitionsWireRetargetFollowUp,
 		)
 	}
 }

--- a/pkg/services/factory_definitions/service/transitional_shim_test.go
+++ b/pkg/services/factory_definitions/service/transitional_shim_test.go
@@ -1,0 +1,64 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorydefinitionsservice "github.com/portpowered/infinite-you/pkg/services/factory_definitions/service"
+)
+
+func TestTransitionalShim_ExposesOwnerLocalConstructionHelpers(t *testing.T) {
+	t.Parallel()
+
+	discovery, err := factorydefinitionsservice.NewEffectiveCatalogDiscovery(
+		func(string) ([]factorydefinitions.NamedFactoryListEntry, error) {
+			return nil, nil
+		},
+		func(string) ([]byte, error) { return nil, nil },
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewEffectiveCatalogDiscovery() error = %v", err)
+	}
+	if discovery.ListRoot == nil || discovery.ListPackaged == nil {
+		t.Fatal("NewEffectiveCatalogDiscovery() returned incomplete discovery ports")
+	}
+
+	normalize := func(
+		context.Context,
+		factorydefinitions.EffectiveFactoryCatalogCandidate,
+	) (*factorydefinitions.FactoryConfig, error) {
+		return &factorydefinitions.FactoryConfig{}, nil
+	}
+	catalog, err := factorydefinitionsservice.NewEffectiveCatalog(discovery, normalize)
+	if err != nil {
+		t.Fatalf("NewEffectiveCatalog() error = %v", err)
+	}
+	if catalog == nil {
+		t.Fatal("NewEffectiveCatalog() returned nil operation")
+	}
+
+	effectiveCatalogService, err := factorydefinitionsservice.NewEffectiveCatalogService(catalog)
+	if err != nil {
+		t.Fatalf("NewEffectiveCatalogService() error = %v", err)
+	}
+	if effectiveCatalogService == nil {
+		t.Fatal("NewEffectiveCatalogService() returned nil service")
+	}
+
+	packagedCatalog, err := factorydefinitionsservice.NewPackagedFactoryCatalog(nil)
+	if err != nil {
+		t.Fatalf("NewPackagedFactoryCatalog() error = %v", err)
+	}
+	if packagedCatalog.List == nil || packagedCatalog.Resolve == nil {
+		t.Fatal("NewPackagedFactoryCatalog() returned incomplete catalog operations")
+	}
+
+	installationService := factorydefinitionsservice.NewPackagedFactoryInstallationService(nil, nil)
+	if installationService == nil {
+		t.Fatal("NewPackagedFactoryInstallationService() returned nil service")
+	}
+
+	_ = factorydefinitionsservice.WithDistributionScaffold(nil, nil)
+}

--- a/pkg/services/factory_definitions/wire/construction_ports_test.go
+++ b/pkg/services/factory_definitions/wire/construction_ports_test.go
@@ -1,0 +1,51 @@
+package wire_test
+
+import (
+	"testing"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorydefinitionswire "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire"
+)
+
+func TestPublishedConstructionPorts_ExposeRootCompositionHelpers(t *testing.T) {
+	t.Parallel()
+
+	discovery, err := factorydefinitionswire.NewEffectiveCatalogDiscovery(
+		func(string) ([]factorydefinitions.NamedFactoryListEntry, error) {
+			return nil, nil
+		},
+		func(string) ([]byte, error) { return nil, nil },
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewEffectiveCatalogDiscovery() error = %v", err)
+	}
+	if discovery.ListRoot == nil || discovery.ListPackaged == nil {
+		t.Fatal("NewEffectiveCatalogDiscovery() returned incomplete discovery ports")
+	}
+
+	normalize := factorydefinitionswire.EffectiveFactoryDefinitionNormalizerFromMapper()
+	catalog, err := factorydefinitionswire.NewEffectiveCatalog(discovery, normalize)
+	if err != nil {
+		t.Fatalf("NewEffectiveCatalog() error = %v", err)
+	}
+	if catalog == nil {
+		t.Fatal("NewEffectiveCatalog() returned nil operation")
+	}
+
+	service, err := factorydefinitionswire.NewEffectiveCatalogService(catalog)
+	if err != nil {
+		t.Fatalf("NewEffectiveCatalogService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewEffectiveCatalogService() returned nil service")
+	}
+
+	packagedCatalog, err := factorydefinitionswire.NewPackagedFactoryCatalog(nil)
+	if err != nil {
+		t.Fatalf("NewPackagedFactoryCatalog() error = %v", err)
+	}
+	if packagedCatalog.List == nil || packagedCatalog.Resolve == nil {
+		t.Fatal("NewPackagedFactoryCatalog() returned incomplete catalog operations")
+	}
+}

--- a/pkg/services/factory_definitions/wire/effective_catalog_ports.go
+++ b/pkg/services/factory_definitions/wire/effective_catalog_ports.go
@@ -1,0 +1,36 @@
+package wire
+
+import (
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorydefinitionsinternal "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal"
+)
+
+// EffectiveCatalogService is the read-only Factory Definitions owner used by
+// transports that do not require a Factory Session.
+type EffectiveCatalogService = factorydefinitionsinternal.EffectiveCatalogService
+
+// NewEffectiveCatalog constructs the stateless effective Factory catalog.
+func NewEffectiveCatalog(
+	discovery factorydefinitions.EffectiveFactoryCatalogDiscovery,
+	normalize factorydefinitions.EffectiveFactoryDefinitionNormalizer,
+) (factorydefinitions.EffectiveFactoryCatalogOperation, error) {
+	return factorydefinitionsinternal.NewEffectiveCatalog(discovery, normalize)
+}
+
+// NewEffectiveCatalogService constructs the read-only Factory Definitions
+// service slice used by transports that do not require a Factory Session.
+func NewEffectiveCatalogService(
+	listEffective factorydefinitions.EffectiveFactoryCatalogOperation,
+) (*EffectiveCatalogService, error) {
+	return factorydefinitionsinternal.NewEffectiveCatalogService(listEffective)
+}
+
+// NewEffectiveCatalogDiscovery constructs read-only disk and published-package
+// discovery.
+func NewEffectiveCatalogDiscovery(
+	listRoot factorydefinitions.EffectiveFactoryRootListing,
+	read factorydefinitions.EffectiveFactoryCandidateRead,
+	packaged []factorydefinitions.PackagedDefinition,
+) (factorydefinitions.EffectiveFactoryCatalogDiscovery, error) {
+	return factorydefinitionsinternal.NewEffectiveCatalogDiscovery(listRoot, read, packaged)
+}

--- a/pkg/services/factory_definitions/wire/packaged_catalog_ports.go
+++ b/pkg/services/factory_definitions/wire/packaged_catalog_ports.go
@@ -1,0 +1,33 @@
+package wire
+
+import (
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorydefinitionsinternal "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal"
+	distributionpackagedinstallation "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation"
+)
+
+// NewPackagedFactoryCatalog constructs deterministic packaged Factory catalog
+// operations from validated embedded definitions.
+func NewPackagedFactoryCatalog(
+	definitions []factorydefinitions.PackagedDefinition,
+) (factorydefinitions.PackagedFactoryCatalogOperations, error) {
+	return factorydefinitionsinternal.NewPackagedFactoryCatalog(definitions)
+}
+
+// NewPackagedFactoryInstaller constructs packaged Factory ensure/install
+// operations from exact persistence and filesystem ports.
+func NewPackagedFactoryInstaller(
+	persistence factorydefinitions.Persistence,
+	fileSystem factorydefinitions.PackagedInstallationFileSystem,
+) factorydefinitions.PackagedFactoryInstaller {
+	return factorydefinitionsinternal.NewPackagedFactoryInstaller(persistence, fileSystem)
+}
+
+// NewPackagedFactoryInstallationService constructs the private packaged
+// installation service for composition paths that need the concrete type.
+func NewPackagedFactoryInstallationService(
+	persistence factorydefinitions.Persistence,
+	fileSystem factorydefinitions.PackagedInstallationFileSystem,
+) *distributionpackagedinstallation.Service {
+	return factorydefinitionsinternal.NewPackagedFactoryInstallationService(persistence, fileSystem)
+}

--- a/pkg/services/factory_definitions/wire/snapshots.go
+++ b/pkg/services/factory_definitions/wire/snapshots.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	contracts "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorydefinitionsinternal "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal"
 	compilationloading "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/compilation/loading"
 	snapshotsportabilitycapture "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/snapshots_portability/capture"
 	snapshotsportabilityeditable "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/snapshots_portability/editable"
@@ -36,6 +37,20 @@ func LoadedFactorySnapshotCapturer() contracts.LoadedFactorySnapshotCapturer {
 func FactorySnapshotCapturer() contracts.FactorySnapshotCapturer {
 	return snapshotsportabilitycapture.NewExplicit(
 		factorysnapshot.ObjectFromFactoryConfig,
+	)
+}
+
+// CaptureInitialSnapshot captures the portable Factory Definition stored with
+// a newly created runtime recording.
+func CaptureInitialSnapshot(
+	loaded contracts.LoadedFactorySource,
+	preparePortableFactoryConfig contracts.PortableFactoryConfigPreparer,
+	captureFactorySnapshot contracts.FactorySnapshotCapturer,
+) (*contracts.FactorySnapshot, error) {
+	return factorydefinitionsinternal.CaptureInitialSnapshot(
+		loaded,
+		preparePortableFactoryConfig,
+		captureFactorySnapshot,
 	)
 }
 

--- a/pkg/wire/cli_commands.go
+++ b/pkg/wire/cli_commands.go
@@ -11,7 +11,7 @@ import (
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	platformstdio "github.com/portpowered/infinite-you/pkg/platform/stdio"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
-	factorydefinitionsservice "github.com/portpowered/infinite-you/pkg/services/factory_definitions/service"
+	factorydefinitionswire "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire"
 	sessioncli "github.com/portpowered/infinite-you/pkg/services/factory_sessions/transports/cli/session"
 	factorysessionwire "github.com/portpowered/infinite-you/pkg/services/factory_sessions/wire"
 	modelscli "github.com/portpowered/infinite-you/pkg/services/models/transports/cli"
@@ -146,7 +146,7 @@ func provideEffectiveFactoryCatalogDiscovery(
 	files factorydefinitions.AuthoredLayoutReaderFileSystem,
 	packaged []factorydefinitions.PackagedDefinition,
 ) (factorydefinitions.EffectiveFactoryCatalogDiscovery, error) {
-	return factorydefinitionsservice.NewEffectiveCatalogDiscovery(
+	return factorydefinitionswire.NewEffectiveCatalogDiscovery(
 		catalog.ListNamedFactories,
 		files.ReadFile,
 		packaged,
@@ -174,13 +174,13 @@ func provideEffectiveFactoryCatalogOperation(
 	discovery factorydefinitions.EffectiveFactoryCatalogDiscovery,
 	normalize factorydefinitions.EffectiveFactoryDefinitionNormalizer,
 ) (factorydefinitions.EffectiveFactoryCatalogOperation, error) {
-	return factorydefinitionsservice.NewEffectiveCatalog(discovery, normalize)
+	return factorydefinitionswire.NewEffectiveCatalog(discovery, normalize)
 }
 
 func provideEffectiveFactoryDefinitionsService(
 	catalog factorydefinitions.EffectiveFactoryCatalogOperation,
-) (*factorydefinitionsservice.EffectiveCatalogService, error) {
-	return factorydefinitionsservice.NewEffectiveCatalogService(catalog)
+) (*factorydefinitionswire.EffectiveCatalogService, error) {
+	return factorydefinitionswire.NewEffectiveCatalogService(catalog)
 }
 
 func provideCurrentFactoryPointerReader(
@@ -190,20 +190,20 @@ func provideCurrentFactoryPointerReader(
 }
 
 func provideListFactoriesOperation(
-	definitions *factorydefinitionsservice.EffectiveCatalogService,
+	definitions *factorydefinitionswire.EffectiveCatalogService,
 	readCurrent factorydefinitions.CurrentFactoryPointerReader,
 ) cli.ListFactoriesOperation {
 	return factorycli.NewList(definitions.ListEffectiveFactories, readCurrent)
 }
 
 func provideFactoryNameCompletionOperation(
-	definitions *factorydefinitionsservice.EffectiveCatalogService,
+	definitions *factorydefinitionswire.EffectiveCatalogService,
 ) cobracompletion.FactoryNamesOperation {
 	return cobracompletion.NewFactoryNames(definitions.ListEffectiveFactories)
 }
 
 func provideSelectedFactorySignatureCompletionOperation(
-	definitions *factorydefinitionsservice.EffectiveCatalogService,
+	definitions *factorydefinitionswire.EffectiveCatalogService,
 ) (cobracompletion.SelectedFactorySignatureOperation, error) {
 	manifest, err := generated.RunSubmitFamilyManifest()
 	if err != nil {

--- a/pkg/wire/factory_definition_service_provider.go
+++ b/pkg/wire/factory_definition_service_provider.go
@@ -1,11 +1,9 @@
 package wire
 
 import (
-	"context"
-
+	"github.com/portpowered/infinite-you/pkg/platform/portablefiles"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factorydefinitionswire "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire"
-	factorydefinitionsservice "github.com/portpowered/infinite-you/pkg/services/factory_definitions/service"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	factorysessionwire "github.com/portpowered/infinite-you/pkg/services/factory_sessions/wire"
 )
@@ -24,59 +22,37 @@ func provideFactoryDefinitionsFactory(
 	packagedInstaller factorydefinitions.PackagedFactoryInstallationOperations,
 	requiredToolChecker factorydefinitions.RequiredToolChecker,
 	orchestratorValidator factorydefinitions.OrchestratorDefinitionValidator,
+	portableFileSystem portablefiles.FileSystem,
+	directoryReplacementStore factorydefinitions.DirectoryReplacementStore,
 ) factorysessionwire.FactoryDefinitionsFactory {
 	return func(
 		sessionHost factorysessions.DefinitionHost,
 		activationGateway factorydefinitions.DefinitionActivationGateway,
 		validator factorydefinitions.Validator,
 	) factorydefinitions.Service {
-		definitions := factorydefinitionsservice.New(
+		definitions, err := factorydefinitionswire.NewService(
 			sessionHost,
 			activationGateway,
-			clock,
-			versionFileSystem,
 			validator,
-			loader.LoadSourceFromCanonicalJSON,
-			func(
-				factoryDir string,
-				workstationLoader factorydefinitions.WorkstationLoader,
-			) (factorydefinitions.MutableLoadedFactorySource, error) {
-				return loader.LoadRuntimeSource(factoryDir, workstationLoader)
-			},
-			namedPaths.ReadCurrentPointer,
-			func(
-				ctx context.Context,
-				segment string,
-				payload []byte,
-				_ factorydefinitions.Validator,
-			) (*factorydefinitions.PreparedFactoryLayoutPayload, error) {
-				return persistence.PrepareFactoryLayout(ctx, segment, payload)
-			},
-			persistence.CreateNamedFactory,
-			namedPaths.WriteCurrentPointer,
-			factorydefinitionswire.PortableFactoryConfigPreparer(
-				applySupportedFiles,
-				applyStarterWork,
-			),
-			factorydefinitionswire.FactorySnapshotCapturer(),
-			persistence.ReplaceFactoryLayout,
+			persistence,
+			loader,
+			applySupportedFiles,
+			applyStarterWork,
 			namedPaths,
 			namedFactoryCatalogFileSystem,
+			clock,
+			versionFileSystem,
+			listEffective,
 			packagedCatalog,
 			packagedInstaller,
 			requiredToolChecker,
 			orchestratorValidator,
-		)
-		if definitions == nil {
-			return nil
-		}
-		attached, err := factorydefinitionsservice.AttachEffectiveCatalog(
-			definitions,
-			listEffective,
+			portableFileSystem,
+			directoryReplacementStore,
 		)
 		if err != nil {
 			return nil
 		}
-		return attached
+		return definitions
 	}
 }

--- a/pkg/wire/profiles.go
+++ b/pkg/wire/profiles.go
@@ -32,7 +32,6 @@ import (
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factorydefinitionswire "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire"
-	factorydefinitionsservice "github.com/portpowered/infinite-you/pkg/services/factory_definitions/service"
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	sessionexecutioncli "github.com/portpowered/infinite-you/pkg/services/factory_sessions/transports/cli/sessionexecution"
@@ -345,7 +344,7 @@ func provideSystemInitializationService(
 			Ensure: ensureOperatorBackendScope,
 		},
 		packagedCatalog,
-		factorydefinitionsservice.NewPackagedFactoryInstaller(persistence, packagedInstallationFileSystem),
+		factorydefinitionswire.NewPackagedFactoryInstaller(persistence, packagedInstallationFileSystem),
 		inspectPath,
 		migrationFiles,
 	)
@@ -371,14 +370,14 @@ func providePackagedFactoryDefinitions() ([]factorydefinitions.PackagedDefinitio
 func providePackagedFactoryCatalog(
 	definitions []factorydefinitions.PackagedDefinition,
 ) (factorydefinitions.PackagedFactoryCatalogOperations, error) {
-	return factorydefinitionsservice.NewPackagedFactoryCatalog(definitions)
+	return factorydefinitionswire.NewPackagedFactoryCatalog(definitions)
 }
 
 func providePackagedFactoryInstallation(
 	persistence factorydefinitions.Persistence,
 	fileSystem factorydefinitions.PackagedInstallationFileSystem,
 ) factorydefinitions.PackagedFactoryInstallationOperations {
-	installer := factorydefinitionsservice.NewPackagedFactoryInstallationService(persistence, fileSystem)
+	installer := factorydefinitionswire.NewPackagedFactoryInstallationService(persistence, fileSystem)
 	return factorydefinitions.PackagedFactoryInstallationOperations{
 		Install: installer.InstallPackagedFactory,
 	}

--- a/pkg/wire/session_runtime_providers.go
+++ b/pkg/wire/session_runtime_providers.go
@@ -21,7 +21,6 @@ import (
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factoryeditable "github.com/portpowered/infinite-you/pkg/services/factory_definitions/editable"
 	factorydefinitionswire "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire"
-	factorydefinitionsservice "github.com/portpowered/infinite-you/pkg/services/factory_definitions/service"
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factoryruntimewire "github.com/portpowered/infinite-you/pkg/services/factory_runtime/wire"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
@@ -436,7 +435,7 @@ func provideInitialFactorySnapshotFactory(
 	return func(
 		loaded factorydefinitions.LoadedFactorySource,
 	) (*factorydefinitions.FactorySnapshot, error) {
-		return factorydefinitionsservice.CaptureInitialSnapshot(
+		return factorydefinitionswire.CaptureInitialSnapshot(
 			loaded,
 			factorydefinitionswire.PortableFactoryConfigPreparer(
 				applySupportedFiles,

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -167,19 +167,19 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	}
 	idGenerator := provideFactoryRuntimeIDGenerator(edges2)
 	orchestrationJavaScriptExecution := provideOrchestrationJavaScriptExecution(idGenerator, javaScriptWorkflows)
-	v22, err := providePortableRecordingWriter(edges2)
+	portableRecordingWriter, err := providePortableRecordingWriter(edges2)
 	if err != nil {
 		return nil, err
 	}
-	v23 := provideFactorySessionRuntimePersistenceFileSystem(edges2)
-	v24 := provideFactorySessionRuntimePersistenceStoreFactory(v23)
-	v25 := provideFactorySessionSyncWaitScheduler()
-	v26 := provideWorkerInvocationWithProgressFactory(edges2)
+	v22 := provideFactorySessionRuntimePersistenceFileSystem(edges2)
+	v23 := provideFactorySessionRuntimePersistenceStoreFactory(v22)
+	v24 := provideFactorySessionSyncWaitScheduler()
+	v25 := provideWorkerInvocationWithProgressFactory(edges2)
 	ptyAllocator, err := provideAgyPTYAllocator(edges2)
 	if err != nil {
 		return nil, err
 	}
-	v27 := provideWorkerCommandRunnerAdapter()
+	v26 := provideWorkerCommandRunnerAdapter()
 	providersService, err := provideProvidersService(edges2)
 	if err != nil {
 		return nil, err
@@ -188,65 +188,65 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	v28, err := provideProviderRegistryRebinder(edges2)
+	v27, err := provideProviderRegistryRebinder(edges2)
 	if err != nil {
 		return nil, err
 	}
 	workersMockCommandRunnerFactory := provideWorkersMockCommandRunnerFactory()
-	v29 := provideConductorInvocationWithProgressFactory(edges2)
-	v30 := provideFactorySessionExecutionFactory(javaScriptWorkflows, orchestrationJavaScriptExecution, v22, v24, v25, v18, responseEventIDGenerator, v26, ptyAllocator, v27, registry, v28, workersMockCommandRunnerFactory, v29, edges2)
-	v31 := provideRecordingsProjectionFactory()
+	v28 := provideConductorInvocationWithProgressFactory(edges2)
+	v29 := provideFactorySessionExecutionFactory(javaScriptWorkflows, orchestrationJavaScriptExecution, portableRecordingWriter, v23, v24, v18, responseEventIDGenerator, v25, ptyAllocator, v26, registry, v27, workersMockCommandRunnerFactory, v28, edges2)
+	v30 := provideRecordingsProjectionFactory()
 	storage := provideReplayArtifactStorage()
-	v32 := provideRecordingsFactory(liveRecordingTargetPlanner, storage)
-	v33 := provideRuntimeLedgerFactory()
-	v34 := provideLoadedFactorySnapshotCapturer()
-	runtimeRecorderFactory := provideRuntimeRecorderFactory(v34)
-	v35 := provideReplayClockFactory()
+	v31 := provideRecordingsFactory(liveRecordingTargetPlanner, storage)
+	v32 := provideRuntimeLedgerFactory()
+	v33 := provideLoadedFactorySnapshotCapturer()
+	runtimeRecorderFactory := provideRuntimeRecorderFactory(v33)
+	v34 := provideReplayClockFactory()
 	replayExecutionFactory := provideReplayExecutionFactory()
 	decisionEnvelopeService := provideDecisionEnvelopeService(invocationPolicyPorts)
-	v36 := provideWorkerProcessEnvironment()
-	v37 := provideWorkerCurrentWorkingDirectory()
+	v35 := provideWorkerProcessEnvironment()
+	v36 := provideWorkerCurrentWorkingDirectory()
 	source := provideWorkersRetryRandomSource(edges2)
 	readFileInspector := provideWorkersWorkstationFileSystem(edges2)
 	temporaryFileSystem := provideWorkersProviderTemporaryFileSystem(edges2)
-	v38, err := provideWorkersRuntimeFactory(invocationInterpolationService, decisionEnvelopeService, workstationExecutionPolicyService, v36, v37, source, readFileInspector, temporaryFileSystem, ptyAllocator, edges2, registry, v28)
+	v37, err := provideWorkersRuntimeFactory(invocationInterpolationService, decisionEnvelopeService, workstationExecutionPolicyService, v35, v36, source, readFileInspector, temporaryFileSystem, ptyAllocator, edges2, registry, v27)
 	if err != nil {
 		return nil, err
 	}
 	workersRuntimeExecutorsFactory := provideWorkersRuntimeExecutorsFactory()
-	v39, err := provideAutomationHostedSourcesFactory(edges2)
+	v38, err := provideAutomationHostedSourcesFactory(edges2)
 	if err != nil {
 		return nil, err
 	}
-	v40 := provideWorkersLocalRuntimeHooksFactory()
-	v41, err := providePortableBundledDocsPruner(portablefilesFileSystem)
+	v39 := provideWorkersLocalRuntimeHooksFactory()
+	v40, err := providePortableBundledDocsPruner(portablefilesFileSystem)
 	if err != nil {
 		return nil, err
 	}
-	v42 := providePortableBundledFileWritesValidator(portablefilesFileSystem)
-	v43 := providePortableBundledFilesCopier(portablefilesFileSystem)
+	v41 := providePortableBundledFileWritesValidator(portablefilesFileSystem)
+	v42 := providePortableBundledFilesCopier(portablefilesFileSystem)
 	authoredLayoutWriterFileSystem := provideFactoryDefinitionAuthoredWriterFileSystem(edges2)
 	inputInboxSentinelEnsurer := provideFactoryDefinitionInputInboxSentinelEnsurer(authoredLayoutWriterFileSystem)
 	persistenceFileSystem := provideFactoryDefinitionPersistenceFileSystem(edges2)
 	directoryReplacementStore := provideFactoryDefinitionDirectoryReplacementStore(edges2)
-	v44, err := provideFactoryDefinitionPersistence(v13, v11, v41, v8, v42, v43, authoredLayoutWriterFileSystem, inputInboxSentinelEnsurer, persistenceFileSystem, namedPathResolver, directoryReplacementStore)
+	v43, err := provideFactoryDefinitionPersistence(v13, v11, v40, v8, v41, v42, authoredLayoutWriterFileSystem, inputInboxSentinelEnsurer, persistenceFileSystem, namedPathResolver, directoryReplacementStore)
 	if err != nil {
 		return nil, err
 	}
 	clock := provideFactoryDefinitionClock(edges2)
 	versionFileSystem := provideFactoryDefinitionVersionFileSystem(edges2)
 	packagedInstallationFileSystem := provideFactoryDefinitionPackagedInstallationFileSystem(edges2)
-	packagedFactoryInstallationOperations := providePackagedFactoryInstallation(v44, packagedInstallationFileSystem)
-	v45 := provideFactoryDefinitionsFactory(v44, v11, v6, v7, namedPathResolver, namedFactoryCatalogFileSystem, clock, versionFileSystem, effectiveFactoryCatalogOperation, packagedFactoryCatalogOperations, packagedFactoryInstallationOperations, v10, v12)
+	packagedFactoryInstallationOperations := providePackagedFactoryInstallation(v43, packagedInstallationFileSystem)
+	v44 := provideFactoryDefinitionsFactory(v43, v11, v6, v7, namedPathResolver, namedFactoryCatalogFileSystem, clock, versionFileSystem, effectiveFactoryCatalogOperation, packagedFactoryCatalogOperations, packagedFactoryInstallationOperations, v10, v12, portablefilesFileSystem, directoryReplacementStore)
 	scaffoldFileSystem := provideFactoryDefinitionScaffoldFileSystem(edges2)
 	scaffoldOutput := provideFactoryDefinitionScaffoldOutput(edges2)
-	v46, err := provideFactoryScaffoldCommandInitializer(scaffoldFileSystem, scaffoldOutput)
+	v45, err := provideFactoryScaffoldCommandInitializer(scaffoldFileSystem, scaffoldOutput)
 	if err != nil {
 		return nil, err
 	}
-	factoryScaffoldInitializer := provideFactoryScaffoldInitializer(v46)
-	v47 := provideDefinitionValidationOperation(validationOperations)
-	editableFactoryValidator := provideEditableFactoryValidator(v47, v11)
+	factoryScaffoldInitializer := provideFactoryScaffoldInitializer(v45)
+	v46 := provideDefinitionValidationOperation(validationOperations)
+	editableFactoryValidator := provideEditableFactoryValidator(v46, v11)
 	initialFactorySnapshotFactory := provideInitialFactorySnapshotFactory(v6, v7)
 	quorumPolicyService := provideQuorumPolicyService(invocationPolicyPorts)
 	invocationOutputShapingService := provideInvocationOutputShapingService(invocationPolicyPorts)
@@ -271,24 +271,24 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	inputFileSystem := provideFactoryRuntimeInputs(edges2)
 	inputDirectoryWalker := provideFactoryRuntimeInputDirectoryWalker(edges2)
 	orchestrationCompilation := provideOrchestrationCompilation(idGenerator, javaScriptWorkflows)
-	v48 := wire.NewRuntimeFactory(quorumPolicyService, invocationOutputShapingService, workPropagationPolicyService, decisionEnvelopeService, runtimeLoggerFactory, runtimeLogSinkFactory, runtimeMetricsSinkFactory, idGenerator, requestIDGenerator, runtimeDirectoryFileSystem, inputFileSystem, inputDirectoryWalker, orchestrationCompilation)
-	v49, err := wire.NewAssembly(v48)
+	v47 := wire.NewRuntimeFactory(quorumPolicyService, invocationOutputShapingService, workPropagationPolicyService, decisionEnvelopeService, runtimeLoggerFactory, runtimeLogSinkFactory, runtimeMetricsSinkFactory, idGenerator, requestIDGenerator, runtimeDirectoryFileSystem, inputFileSystem, inputDirectoryWalker, orchestrationCompilation)
+	v48, err := wire.NewAssembly(v47)
 	if err != nil {
 		return nil, err
 	}
-	v50 := provideLoadedFactoryLoader(v11)
-	v51 := provideLoadedFactorySourceFactory()
+	v49 := provideLoadedFactoryLoader(v11)
+	v50 := provideLoadedFactorySourceFactory()
 	replayRuntimeConfigDecoder := provideReplayRuntimeConfigDecoder()
 	replayArtifactLoader := provideReplayArtifactLoader(storage)
 	clockResolver := provideFactoryRuntimeClockResolver()
 	sessionLoggerFactory := provideFactoryRuntimeSessionLoggerFactory()
-	v52 := provideProviderFromCommandRunnerFactory(edges2, ptyAllocator)
+	v51 := provideProviderFromCommandRunnerFactory(edges2, ptyAllocator)
 	starter, err := provideAPIServerStarter(edges2)
 	if err != nil {
 		return nil, err
 	}
-	v53 := provideRuntimeHostOperation(starter)
-	v54, err := provideProcessRuntimeFactory(v53)
+	v52 := provideRuntimeHostOperation(starter)
+	v53, err := provideProcessRuntimeFactory(v52)
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +297,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	configEncoder := provideOperatorConfigEncoder()
 	backendScopeEnsurer := provideOperatorBackendScopeEnsurer(fileSystem, createTemporaryFile, operatorsettingsIDGenerator, configDecoder, configEncoder)
 	runtimeInstanceIDGenerator := provideFactorySessionRuntimeInstanceIDGenerator(edges2)
-	v55 := provideFactorySessionReplayRecordingReader(edges2)
+	v54 := provideFactorySessionReplayRecordingReader(edges2)
 	providerIdentityResolver := provideFactorySessionProviderIdentityResolver(registry)
 	runtimeOpeningDependencies := wire2.RuntimeOpeningDependencies{
 		ProviderSessions:                 service,
@@ -311,59 +311,59 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		WorkFactory:                      v16,
 		AutomationFactory:                v17,
 		FactorySessionsService:           factorysessionsService,
-		FactorySessionExecutionFactory:   v30,
-		RecordingsProjectionFactory:      v31,
-		RecordingsFactory:                v32,
-		RuntimeLedgerFactory:             v33,
+		FactorySessionExecutionFactory:   v29,
+		RecordingsProjectionFactory:      v30,
+		RecordingsFactory:                v31,
+		RuntimeLedgerFactory:             v32,
 		RuntimeRecorderFactory:           runtimeRecorderFactory,
-		ReplayClockFactory:               v35,
+		ReplayClockFactory:               v34,
 		ReplayExecutionFactory:           replayExecutionFactory,
-		WorkersRuntimeFactory:            v38,
+		WorkersRuntimeFactory:            v37,
 		WorkersRuntimeExecutorsFactory:   workersRuntimeExecutorsFactory,
 		WorkersMockCommandRunnerFactory:  workersMockCommandRunnerFactory,
-		AutomationHostedSourcesFactory:   v39,
-		WorkersLocalRuntimeHooksFactory:  v40,
-		FactoryDefinitionsFactory:        v45,
+		AutomationHostedSourcesFactory:   v38,
+		WorkersLocalRuntimeHooksFactory:  v39,
+		FactoryDefinitionsFactory:        v44,
 		FactoryScaffoldInitializer:       factoryScaffoldInitializer,
 		EditableFactoryValidator:         editableFactoryValidator,
 		InitialFactorySnapshotFactory:    initialFactorySnapshotFactory,
-		FactoryRuntimeAssembler:          v49,
+		FactoryRuntimeAssembler:          v48,
 		ContentMaterializer:              contentMaterializer,
-		LoadFactory:                      v50,
-		NewLoadedFactory:                 v51,
+		LoadFactory:                      v49,
+		NewLoadedFactory:                 v50,
 		DecodeReplayConfig:               replayRuntimeConfigDecoder,
 		LoadReplay:                       replayArtifactLoader,
-		CaptureLoadedFactorySnapshot:     v34,
+		CaptureLoadedFactorySnapshot:     v33,
 		ResolveClock:                     clockResolver,
 		NewSessionLogger:                 sessionLoggerFactory,
-		AdaptWorkerCommandRunner:         v27,
-		ProviderFromCommandRunnerFactory: v52,
-		ProcessRuntimeFactory:            v54,
+		AdaptWorkerCommandRunner:         v26,
+		ProviderFromCommandRunnerFactory: v51,
+		ProcessRuntimeFactory:            v53,
 		EnsureOperatorBackendScope:       backendScopeEnsurer,
 		GenerateRuntimeInstanceID:        runtimeInstanceIDGenerator,
 		ResolveHome:                      homeDirectoryResolver,
-		ReplayFiles:                      v55,
+		ReplayFiles:                      v54,
 		ProviderIdentities:               providerIdentityResolver,
 	}
-	v56, err := wire2.NewRuntimeOpeningFactory(runtimeOpeningDependencies)
+	v55, err := wire2.NewRuntimeOpeningFactory(runtimeOpeningDependencies)
 	if err != nil {
 		return nil, err
 	}
-	v57 := provideFactorySessionContractFixtureReader(edges2)
-	v58 := provideStandaloneSessionExecutionFactory(javaScriptWorkflows, orchestrationJavaScriptExecution, v22, v24, v25, v18, v57)
-	v59 := provideWorkerInvocationFactory(edges2)
+	v56 := provideFactorySessionContractFixtureReader(edges2)
+	v57 := provideStandaloneSessionExecutionFactory(javaScriptWorkflows, orchestrationJavaScriptExecution, portableRecordingWriter, v23, v24, v18, v56)
+	v58 := provideWorkerInvocationFactory(edges2)
 	runtimeArtifactRootResolver := provideRuntimeArtifactRootResolver()
-	v60 := provideFactorySessionExecutionOpeningFileSystem(edges2)
+	v59 := provideFactorySessionExecutionOpeningFileSystem(edges2)
 	logger, err := logging.NewDefaultLogger()
 	if err != nil {
 		return nil, err
 	}
-	v61, err := provideSessionExecutionOpeningFactory(v56, edges2, v58, v59, clockResolver, runtimeArtifactRootResolver, v27, v60, ptyAllocator, logger)
+	v60, err := provideSessionExecutionOpeningFactory(v55, edges2, v57, v58, clockResolver, runtimeArtifactRootResolver, v26, v59, ptyAllocator, logger)
 	if err != nil {
 		return nil, err
 	}
-	v62 := wire2.NewExecutionServiceBuilder(v61)
-	executionServiceBuilder := provideCLIExecutionServiceBuilder(v62)
+	v61 := wire2.NewExecutionServiceBuilder(v60)
+	executionServiceBuilder := provideCLIExecutionServiceBuilder(v61)
 	wireStandardCLIHTTPProtocol, err := provideStandardCLIHTTPProtocol()
 	if err != nil {
 		return nil, err
@@ -374,14 +374,14 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		return nil, err
 	}
 	modelInvocationTimeout := provideModelInvocationTimeout()
-	v63, err := provideInvocationOperation(v56, edges2, workingDirectory, v4, invocationArtifactExporter, modelInvocationTimeout, runtimeArtifactRootResolver, v18)
+	v62, err := provideInvocationOperation(v55, edges2, workingDirectory, v4, invocationArtifactExporter, modelInvocationTimeout, runtimeArtifactRootResolver, v18)
 	if err != nil {
 		return nil, err
 	}
-	invocationOperation := provideModelsCLIInvocationOperation(v63)
+	invocationOperation := provideModelsCLIInvocationOperation(v62)
 	cliService := provideModelsCLIService(wireStandardCLIHTTPProtocol, invocationOperation)
-	v64 := wire2.NewRequestPreparation()
-	sessionService := provideSessionsCLIService(wireStandardCLIHTTPProtocol, v64)
+	v63 := wire2.NewRequestPreparation()
+	sessionService := provideSessionsCLIService(wireStandardCLIHTTPProtocol, v63)
 	payloadFileReader := provideSubmitPayloadReader()
 	wireExtendedCLIHTTPProtocol, err := provideExtendedCLIHTTPProtocol()
 	if err != nil {
@@ -390,29 +390,29 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	submitWorkOperation := provideSubmitWorkOperation(payloadFileReader, wireExtendedCLIHTTPProtocol)
 	factoryRequestBatchPreparation := work.NewFactoryRequestBatchPreparation()
 	submitBatchOperation := provideSubmitBatchOperation(wireExtendedCLIHTTPProtocol, factoryRequestBatchPreparation)
-	flattenFactoryConfigOperation := provideFlattenFactoryConfigOperation(v44)
-	expandFactoryConfigOperation := provideExpandFactoryConfigOperation(v44)
+	flattenFactoryConfigOperation := provideFlattenFactoryConfigOperation(v43)
+	expandFactoryConfigOperation := provideExpandFactoryConfigOperation(v43)
 	providerCatalog := provideOperatorSettingsProviderCatalog(registry)
 	configDocumentService := provideOperatorConfigDocumentService(fileSystem, createTemporaryFile, providerCatalog, configDecoder, configEncoder)
 	configureInitOperation := provideConfigureInitOperation(configDocumentService)
 	installPackagedFactoryOperation := provideInstallPackagedFactoryOperation(packagedFactoryCatalogOperations, packagedFactoryInstallationOperations)
 	cliInstallPackagedFactoryOperation := provideInstallPackagedFactoryCLI(installPackagedFactoryOperation)
 	queryFactoryOperation := provideQueryFactoryOperation(wireStandardCLIHTTPProtocol)
-	v65 := provideCurrentFactoryPointerReader(namedPathResolver)
-	listFactoriesOperation := provideListFactoriesOperation(v3, v65)
-	v66 := provideSubmittedDefinitionValidationOperation(validationOperations)
-	validateFactoryOperation := provideValidateFactoryOperation(v66, authoredFactorySourceLoader)
-	v67 := provideNamedFactoryPersistenceOperation(v44)
-	createFactoryFromFileOperation := provideCreateFactoryFromFileOperation(v67, authoredFactorySourceLoader)
+	v64 := provideCurrentFactoryPointerReader(namedPathResolver)
+	listFactoriesOperation := provideListFactoriesOperation(v3, v64)
+	v65 := provideSubmittedDefinitionValidationOperation(validationOperations)
+	validateFactoryOperation := provideValidateFactoryOperation(v65, authoredFactorySourceLoader)
+	v66 := provideNamedFactoryPersistenceOperation(v43)
+	createFactoryFromFileOperation := provideCreateFactoryFromFileOperation(v66, authoredFactorySourceLoader)
 	replaceFactoryCurrentOperation := provideReplaceFactoryCurrentOperation(wireStandardCLIHTTPProtocol)
-	updateFactoryFromFileOperation := provideUpdateFactoryFromFileOperation(v67, authoredFactorySourceLoader)
+	updateFactoryFromFileOperation := provideUpdateFactoryFromFileOperation(v66, authoredFactorySourceLoader)
 	deleteFactoryOperation := provideDeleteFactoryOperation(v)
 	listRequestPreparation := work.NewListRequestPreparation()
 	listWorkOperation := provideListWorkOperation(wireStandardCLIHTTPProtocol, listRequestPreparation)
 	showWorkOperation := provideShowWorkOperation(wireStandardCLIHTTPProtocol)
 	moveWorkOperation := provideMoveWorkOperation(wireExtendedCLIHTTPProtocol)
-	v68 := provideWorkVisualizationOperation()
-	visualizeWorkOperation := provideVisualizeWorkOperation(v68)
+	v67 := provideWorkVisualizationOperation()
+	visualizeWorkOperation := provideVisualizeWorkOperation(v67)
 	singleWorkTargetPreparation := work.NewSingleWorkTargetPreparation()
 	mockWorkersConfigFileSystem := provideWorkersMockWorkersConfigFileSystem(edges2)
 	mockWorkersConfigLoader, err := workers.NewMockWorkersConfigLoader(mockWorkersConfigFileSystem)
@@ -426,8 +426,8 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	v69 := provideRuntimeInputResolver(edges2, clockResolver)
-	v70 := provideRuntimeOpener(v56)
+	v68 := provideRuntimeInputResolver(edges2, clockResolver)
+	v69 := provideRuntimeOpener(v55)
 	runtimeFactory := provideFactoryVisualizationFactory()
 	factoryStatusProjector := factory.NewFactoryStatusProjector()
 	contentPreparation := work.NewContentPreparation()
@@ -439,36 +439,36 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	requestPreparation := provideFactorySessionHTTPRequestPreparation(v64)
-	handler, err := application2.NewHandler(httpBinder, contentPreparation, v66, invocationWorkTypeService, contentStagingService, requestPreparationService, requestPreparation)
+	requestPreparation := provideFactorySessionHTTPRequestPreparation(v63)
+	handler, err := application2.NewHandler(httpBinder, contentPreparation, v65, invocationWorkTypeService, contentStagingService, requestPreparationService, requestPreparation)
 	if err != nil {
 		return nil, err
 	}
 	runnerFactory := provideLifecycleRunnerFactory()
-	v71, err := provideApplicationRuntimeAdapter(runtimeFactory, handler, runnerFactory)
+	v70, err := provideApplicationRuntimeAdapter(runtimeFactory, handler, runnerFactory)
 	if err != nil {
 		return nil, err
 	}
-	v72 := wire2.NewLifecyclePlanOperation()
-	v73, err := wire2.NewApplicationService(v69, v70, v71, v72)
+	v71 := wire2.NewLifecyclePlanOperation()
+	v72, err := wire2.NewApplicationService(v68, v69, v70, v71)
 	if err != nil {
 		return nil, err
 	}
-	runRuntimeRunnerBuilder, err := provideRunRuntimeRunnerBuilder(runtimeRunnerBuilder, v73)
+	runRuntimeRunnerBuilder, err := provideRunRuntimeRunnerBuilder(runtimeRunnerBuilder, v72)
 	if err != nil {
 		return nil, err
 	}
 	responsePresentation := provideResponsePresentation()
-	v74 := provideDirectJavaScriptSyncRunner()
+	v73 := provideDirectJavaScriptSyncRunner()
 	directJavaScriptHostAdapter, err := provideDirectJavaScriptHostAdapter(handler, starter, runnerFactory)
 	if err != nil {
 		return nil, err
 	}
-	v75, err := wire2.NewDirectJavaScriptRunOperation(v62, v74, v18, directJavaScriptHostAdapter)
+	v74, err := wire2.NewDirectJavaScriptRunOperation(v61, v73, v18, directJavaScriptHostAdapter)
 	if err != nil {
 		return nil, err
 	}
-	selectionFactory, err := provideRunSelectionFactory(runOpener, runRuntimeRunnerBuilder, v63, responsePresentation, v75, runtimeRunnerBuilder)
+	selectionFactory, err := provideRunSelectionFactory(runOpener, runRuntimeRunnerBuilder, v62, responsePresentation, v74, runtimeRunnerBuilder)
 	if err != nil {
 		return nil, err
 	}
@@ -499,7 +499,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		SubmitBatch:                       submitBatchOperation,
 		FlattenFactoryConfig:              flattenFactoryConfigOperation,
 		ExpandFactoryConfig:               expandFactoryConfigOperation,
-		InitFactory:                       v46,
+		InitFactory:                       v45,
 		ConfigureInit:                     configureInitOperation,
 		InstallPackagedFactory:            cliInstallPackagedFactoryOperation,
 		QueryFactory:                      queryFactoryOperation,
@@ -521,23 +521,23 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		return nil, err
 	}
 	stdioOpener := stdio.NewOpener()
-	v76 := provideFixtureStdioApplicationBuilder(stdioRunnerBuilder, runnerFactory, stdioOpener, v64, workflowPreviewOperation)
+	v75 := provideFixtureStdioApplicationBuilder(stdioRunnerBuilder, runnerFactory, stdioOpener, v63, workflowPreviewOperation)
 	openedStdioRunnerBuilder, err := application.NewOpenedStdioRunnerBuilder(managedRunnerFactory)
 	if err != nil {
 		return nil, err
 	}
-	v77 := provideRuntimeStdioApplicationBuilder(openedStdioRunnerBuilder, runnerFactory, stdioOpener, v64)
-	v78, err := wire2.NewStdioOpeningService(v61, v76, v77)
+	v76 := provideRuntimeStdioApplicationBuilder(openedStdioRunnerBuilder, runnerFactory, stdioOpener, v63)
+	v77, err := wire2.NewStdioOpeningService(v60, v75, v76)
 	if err != nil {
 		return nil, err
 	}
-	processStdioApplicationOpener, err := provideStdioApplicationOpener(v78)
+	processStdioApplicationOpener, err := provideStdioApplicationOpener(v77)
 	if err != nil {
 		return nil, err
 	}
 	inspectPath := provideSystemInitializationInspectPath(edges2)
 	legacyFactoryMigrationFileSystem := provideSystemInitializationLegacyFactoryMigrationFileSystem(edges2)
-	systeminitializationService, err := provideSystemInitializationService(v44, packagedInstallationFileSystem, packagedFactoryCatalogOperations, configLoader, backendScopeEnsurer, inspectPath, legacyFactoryMigrationFileSystem)
+	systeminitializationService, err := provideSystemInitializationService(v43, packagedInstallationFileSystem, packagedFactoryCatalogOperations, configLoader, backendScopeEnsurer, inspectPath, legacyFactoryMigrationFileSystem)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
{
  "project": "RET-DEF-ROOT-WIRE — Retarget root pkg/wire Definitions construction from service/ to wire/",
  "branchName": "pss-ret-def-root-wire",
  "description": "After Automations DEL cleared the Automations-leased root-wire hold and Definitions INV/IMP/CLN/CUT/BOOT/DEL-DEF work is Factory-terminal, retarget root pkg/wire Factory Definitions construction so process composition imports factory_definitions/wire only—not the transitional factory_definitions/service compile shim—preferring wire.NewService for inert root construction returning factorydefinitions.Service, flipping root_wire_hold_test.go to forbid the service import, leaving service/ deletion and residual DEF fold debt to DEL-DEF-RESIDUAL, and delivering through green CI until the PR is merged.",
  "context": {
    "customerAsk": "After Automations DEL cleared the Automations-leased root-wire hold, and after INV-DEF-TOPLEVEL through DEL-DEF Factory completion, retarget root pkg/wire Factory Definitions construction so process composition imports factory_definitions/wire only—not the transitional factory_definitions/service compile shim—while leaving residual DEF fold/delete work to the live DEL-DEF-RESIDUAL lane.",
    "problem": "DEL-AUTO is Factory-terminal and the Automations-leased root-wire hold is cleared. Definitions repair, fold, and DEL-DEF work are Factory-terminal, and factory_definitions/wire.NewService already exists as the packaged construction boundary. Live tip still imports factory_definitions/service from root pkg/wire in factory_definition_service_provider.go, cli_commands.go, profiles.go, and session_runtime_providers.go. root_wire_hold_test.go still encodes that residual import as an expected hold (PostAutoDELDefinitionsWireRetargetFollowUp). Leaving root Wire on the transitional shim blocks the post-AUTO retarget and keeps Definitions construction on a package DEL-DEF-RESIDUAL must later delete.",
    "solution": "Retarget the named root pkg/wire Factory Definitions construction call sites to factory_definitions/wire (prefer wire.NewService for inert root construction; publish only thin wire constructors/adapters when required for remaining packaged-catalog, effective-catalog, and snapshot helpers). Keep factory_definitions/service as an owner-local transitional shim until DEL-DEF-RESIDUAL deletes it. Flip root_wire_hold_test.go so pkg/wire is forbidden from importing factory_definitions/service. Deliver through review and CI until the PR is merged."
  },
  "acceptanceCriteria": [
    "AC-1: pkg/wire (named construction files and unavoidable Definitions construction binding fallout) no longer imports github.com/portpowered/infinite-you/pkg/services/factory_definitions/service (behavioral)",
    "AC-2: Root process composition constructs Factory Definitions through factory_definitions/wire.NewService (or equivalent published wire constructor) and still returns the singular factorydefinitions.Service peer surface (behavioral)",
    "AC-3: root_wire_hold_test.go (or successor) fails if pkg/wire reintroduces the transitional factory_definitions/service import",
    "AC-4: factory_definitions/service is not deleted by this packet; residual DEF fold/delete work remains with DEL-DEF-RESIDUAL",
    "AC-5: Quality checks pass (typecheck, lint, and tests)",
    "AC-6: Delivery loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts are resolved, and the PR is actually merged"
  ],
  "userStories": [
    {
      "id": "pss-ret-def-root-wire-001",
      "title": "Publish thin wire constructors needed for root composition",
      "description": "As a process integrator, I want any Factory Definitions construction helpers still required by root pkg/wire (packaged catalog/installer, effective catalog discovery/operation/service, initial snapshot capture, and related published types) available through factory_definitions/wire so root composition does not need the transitional service shim.",
      "acceptanceCriteria": [
        "Every construction helper that named root pkg/wire call sites currently reach through factory_definitions/service is either already available on factory_definitions/wire or is published there as a thin constructor/adapter over owner-local internals (no new pkg/root or pkg/wire Factory Definitions helper API invented for this)",
        "Thin wire publications, if any, return the same peer-facing types/ports root composition already consumes (for example packaged-catalog operations, effective-catalog operation/service, snapshot capture results) without exposing owner internals to peers",
        "factory_definitions/service remains present as an owner-local transitional shim; this story does not delete residual DEF top-level packages",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-ret-def-root-wire-002",
      "title": "Construct Factory Definitions root through wire.NewService",
      "description": "As a process integrator, I want root process composition to construct the Factory Definitions root through factory_definitions/wire.NewService (or the equivalent published wire constructor) so inert construction no longer routes through factory_definitions/service.New / AttachEffectiveCatalog.",
      "acceptanceCriteria": [
        "provideFactoryDefinitionsFactory (in factory_definition_service_provider.go or successor) constructs Definitions through factory_definitions/wire.NewService (or equivalent published wire constructor) rather than factory_definitions/service.New / AttachEffectiveCatalog",
        "Successful construction returns a non-nil value assignable to the singular factorydefinitions.Service peer surface",
        "Existing root composition / Factory Definitions construction tests continue to prove process composition can construct and use the Definitions peer surface; add only missing proofs that construction goes through factory_definitions/wire",
        "No new pkg/wire FactoryDefinitionsRootFromEdges-style helper is invented; do not invent a new peer/root test subsystem",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-ret-def-root-wire-003",
      "title": "Retarget remaining pkg/wire Definitions construction call sites off service/",
      "description": "As a maintainer, I want the remaining named root Wire Definitions construction bindings (cli_commands.go, profiles.go, session_runtime_providers.go, and unavoidable fallout under pkg/wire/**) to use factory_definitions/wire only so pkg/wire has no production import of factory_definitions/service.",
      "acceptanceCriteria": [
        "cli_commands.go constructs effective-catalog discovery/operation/service (or successors) through factory_definitions/wire published constructors, not factory_definitions/service",
        "profiles.go constructs packaged Factory catalog/installer/installation ports through factory_definitions/wire published constructors, not factory_definitions/service",
        "session_runtime_providers.go captures initial Factory snapshots through factory_definitions/wire published constructors, not factory_definitions/service",
        "After this story, go list imports for github.com/portpowered/infinite-you/pkg/wire do not include github.com/portpowered/infinite-you/pkg/services/factory_definitions/service",
        "Unavoidable Definitions construction binding fallout stays inside pkg/wire/**; no FUN-definitions, PSS-I0*, or live DEL-SET / DEL-REC / WRK-CONTRACT / FUN-work / DEL-DEF-RESIDUAL deletion leases are absorbed",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-ret-def-root-wire-004",
      "title": "Flip root_wire_hold_test to forbid service import from pkg/wire",
      "description": "As a reviewer, I want root_wire_hold_test.go to assert that pkg/wire must not import factory_definitions/service, so the Automations-leased residual hold is retired and regressions reintroducing the transitional import fail closed.",
      "acceptanceCriteria": [
        "TestRootPkgWire_StillImportsTransitionalServiceResidual (or successor) is replaced/inverted so the test fails when pkg/wire imports factory_definitions/service, and passes when that import is absent",
        "The PostAutoDELDefinitionsWireRetargetFollowUp hold naming is retired or rewritten to a post-retarget forbid assertion rather than an expected residual import",
        "Sibling boundary tests that still encode the Automations-leased residual service import from pkg/wire are updated consistently with the forbid",
        "Import-scanner proof alone is not substituted for a green construction build; reuse existing wire/root composition and Factory Definitions construction tests",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-ret-def-root-wire-005",
      "title": "Close delivery through green CI, addressed review, and merged PR",
      "description": "As the Factory delivery owner, I want the implementation/review loop to continue until the PR is actually merged with required CI terminal green, so RET-DEF-ROOT-WIRE is Factory-complete rather than merely opened or approved.",
      "acceptanceCriteria": [
        "Required CI is terminal and passing on the implementation PR",
        "Every blocking PR conversation comment is explicitly addressed",
        "Merge conflicts / shared-file reconciliation on leased paths are resolved, including rebase against live DEL-DEF-RESIDUAL or other shared baseline/Wire churn when needed",
        "The PR is actually merged; opened, green, approved, or ready-to-merge alone is not sufficient",
        "This packet did not delete factory_definitions/service or other residual DEF top-level packages",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": false,
      "notes": ""
    }
  ]
}


Made with [Cursor](https://cursor.com)