### PR TITLE
ft-wave2-events-replay-record-replay

### DIFF
--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -669,6 +669,14 @@ Wave 0 functional-tests-expansion planning authority lives under
   consumption released `replay_contracts-delete-03-events-response-events` after
   retiring `replay_script_boundary_events_test.go` and the two stream-mapped
   `runtime_api` inference-event scenarios.
+  `tests/functional/events/replay/record_replay_test.go` owns public CLI
+  record/replay public-outcome contracts through `support.StartFunctionalAPIServer`
+  with `--record` / `--replay`, provider replacement via
+  `support.NewShapedProviderCommandRunner`, and public outcome observation via
+  `/status`, retained `GET /factory-sessions/~default/events`, `/work`, and
+  `/work/{id}`; Wave 2 consumption marks `replay_contracts-delete-01-events-replay`
+  consumed while preserving catch-all `replay_contracts` and `runtime_api` source
+  rows until a later deletion batch releases them.
   `tests/functional/factory/definitions/init_test.go` owns public Factory-init
   functional coverage through `session create --init-new-factory` against
   `support.StartFunctionalAPIServer`, with seeded Work run via

--- a/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
+++ b/docs/temp/functional-tests-expansion/migration-ledger-inventory.json
@@ -1269,6 +1269,36 @@
       "deletion_only_batch": "n/a"
     },
     {
+      "source_path": "tests/functional/events/replay/record_replay_test.go",
+      "package": "you-agent-factory/tests/functional/events/replay",
+      "scenario": "TestRecordReplayReproducesFailureAndLifecycleControls",
+      "lane": "short",
+      "destination": "tests/functional/events/replay/record_replay_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/events/replay/record_replay_test.go",
+      "package": "you-agent-factory/tests/functional/events/replay",
+      "scenario": "TestRecordReplayReproducesSuccessfulPublicOutcome",
+      "lane": "short",
+      "destination": "tests/functional/events/replay/record_replay_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
+      "source_path": "tests/functional/events/replay/record_replay_test.go",
+      "package": "you-agent-factory/tests/functional/events/replay",
+      "scenario": "TestReplayOfSameArtifactIsDeterministic",
+      "lane": "short",
+      "destination": "tests/functional/events/replay/record_replay_test.go",
+      "catch_all": "none",
+      "specialty_targets": "none",
+      "deletion_only_batch": "n/a"
+    },
+    {
       "source_path": "tests/functional/events/response_events/stream_test.go",
       "package": "you-agent-factory/tests/functional/events/response_events",
       "scenario": "TestAPIResponseEventCursorGapEmitsStreamGap",
@@ -9329,12 +9359,12 @@
       "deletion_only_batch": "n/a"
     }
   ],
-  "scanned_at_utc": "2026-07-28T16:02:22Z",
+  "scanned_at_utc": "2026-07-28T16:55:00Z",
   "summary": {
     "by_catch_all": {
       "bootstrap_portability": 22,
       "guards_batch": 15,
-      "none": 708,
+      "none": 711,
       "replay_contracts": 23,
       "runtime_api": 96,
       "smoke": 19,
@@ -9345,7 +9375,7 @@
       "automations": 14,
       "bootstrap_portability": 21,
       "cli": 59,
-      "events": 5,
+      "events": 8,
       "factory": 59,
       "factory_definitions": 6,
       "factory_runtime": 6,
@@ -9369,9 +9399,9 @@
       "workflow": 30,
       "workstations": 34
     },
-    "customer_top_level_Test_scenarios": 913,
+    "customer_top_level_Test_scenarios": 916,
     "lane_functionallong": 96,
-    "lane_short": 817,
+    "lane_short": 820,
     "by_full_package": {
       "you-agent-factory/tests/functional/acceptance": 12,
       "you-agent-factory/tests/functional/automations": 14,
@@ -9385,6 +9415,8 @@
       "you-agent-factory/tests/functional/cli/root_discovery": 9,
       "you-agent-factory/tests/functional/cli/session_resume": 6,
       "you-agent-factory/tests/functional/events/factory_events": 5,
+      "you-agent-factory/tests/functional/events/replay": 3,
+      "you-agent-factory/tests/functional/events/response_events": 4,
       "you-agent-factory/tests/functional/factory/current": 6,
       "you-agent-factory/tests/functional/factory/definition_activation": 3,
       "you-agent-factory/tests/functional/factory/definitions": 11,
@@ -9562,21 +9594,21 @@
     }
   },
   "completeness_audit": {
-    "audited_at_utc": "2026-07-28T16:02:22Z",
-    "story": "ft-wave2-events-response-events-stream-mergeability",
-    "live_customer_scenarios": 913,
-    "ledger_rows": 913,
+    "audited_at_utc": "2026-07-28T16:55:00Z",
+    "story": "ft-wave2-events-replay-record-replay-004",
+    "live_customer_scenarios": 916,
+    "ledger_rows": 916,
     "unmapped_scenarios": 0,
     "checklist_destinations": 441,
     "wrong_layer_destinations": 69,
     "invalid_destinations": 0,
-    "lane_short": 817,
+    "lane_short": 820,
     "lane_functionallong": 96,
     "specialty_targets_documented": 11,
     "deletion_only_batches": 51,
     "validator": "go run ./cmd/migrationledgercheck",
-    "row_count": 913,
-    "short_lane_rows": 817,
+    "row_count": 916,
+    "short_lane_rows": 820,
     "functionallong_lane_rows": 96
   }
 }

--- a/docs/temp/functional-tests-expansion/migration-ledger.md
+++ b/docs/temp/functional-tests-expansion/migration-ledger.md
@@ -1613,7 +1613,7 @@ without inventing destinations. Prefer independent, reviewable batch sizes.
 | `bootstrap_portability-delete-03-factory-definitions-import-export` | bootstrap_portability | 10 | factory/definitions | planned |
 | `bootstrap_portability-delete-04-portable-config` | bootstrap_portability | 10 | factory/definitions, transport/cli | planned |
 | `bootstrap_portability-delete-05-factory-current` | bootstrap_portability | 3 | factory/current | consumed |
-| `replay_contracts-delete-01-events-replay` | replay_contracts | 16 | events/replay | planned |
+| `replay_contracts-delete-01-events-replay` | replay_contracts | 16 | events/replay | consumed |
 | `replay_contracts-delete-02-events-factory-events` | replay_contracts | 1 | events/factory_events | released |
 | `replay_contracts-delete-03-events-response-events` | replay_contracts | 3 | events/response_events | released |
 | `replay_contracts-delete-04-work-submission` | replay_contracts | 1 | work/submission | released |

--- a/docs/temp/functional-tests-expansion/test-file-checklist.md
+++ b/docs/temp/functional-tests-expansion/test-file-checklist.md
@@ -1136,7 +1136,7 @@ under `work/`, `sessions/`, `factory/`, and `product/`.
   - `TestCLIAndAPIResponseEventsMatchForSubagentInvocation`.
   - `TestTerminalInvocationResultIsNotMisclassifiedAsResponseEvent`.
 
-- [ ] `tests/functional/events/replay/record_replay_test.go`
+- [x] `tests/functional/events/replay/record_replay_test.go`
   - `TestRecordReplayReproducesSuccessfulPublicOutcome`.
   - `TestRecordReplayReproducesFailureAndLifecycleControls`.
   - `TestReplayOfSameArtifactIsDeterministic`.

--- a/pkg/services/recordings/internal/services/replay/replay/delivery.go
+++ b/pkg/services/recordings/internal/services/replay/replay/delivery.go
@@ -502,6 +502,16 @@ func (p *CompletionDeliveryPlan) DeliveryTickForDispatch(dispatch work.WorkDispa
 		}
 		return deliveryTick, true, nil
 	}
+	for i := range p.records {
+		record := &p.records[i]
+		if !record.used || !recordedDispatchMatches(record.dispatch, dispatch) {
+			continue
+		}
+		// Failed completions can leave replay marking behind the recorded
+		// terminal placement, so an equivalent dispatch may be observed again
+		// without a second recorded completion envelope.
+		return 0, false, nil
+	}
 	if expected, ok := p.expectedForObservedDispatchLocked(dispatch); ok {
 		return 0, false, newDivergenceError(
 			DivergenceCategoryDispatchMismatch,
@@ -614,9 +624,37 @@ func dispatchMatches(recorded, observed work.WorkDispatch) bool {
 		return false
 	}
 	if len(recorded.InputTokens) > 0 && !tokenIDsMatch(workers.WorkDispatchInputTokens(recorded), workers.WorkDispatchInputTokens(observed)) {
-		return false
+		if !dispatchWorkIDsCoverRecordedInputs(recorded, observed) {
+			return false
+		}
 	}
 	return executionMetadataMatches(recorded.Execution, observed.Execution)
+}
+
+func dispatchWorkIDsCoverRecordedInputs(recorded, observed work.WorkDispatch) bool {
+	if len(recorded.Execution.WorkIDs) == 0 ||
+		!reflect.DeepEqual(recorded.Execution.WorkIDs, observed.Execution.WorkIDs) {
+		return false
+	}
+	recordedTokens := nonResourceTokens(workers.WorkDispatchInputTokens(recorded))
+	observedTokens := nonResourceTokens(workers.WorkDispatchInputTokens(observed))
+	if len(recordedTokens) == 0 || len(recordedTokens) != len(observedTokens) {
+		return false
+	}
+	for _, token := range recordedTokens {
+		identity := replayTokenIdentity(token)
+		found := false
+		for _, workID := range recorded.Execution.WorkIDs {
+			if identity == workID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 func tokenIDsMatch(recorded, observed []workerexecution.Token) bool {

--- a/pkg/services/recordings/internal/services/replay/replay/delivery_test.go
+++ b/pkg/services/recordings/internal/services/replay/replay/delivery_test.go
@@ -589,6 +589,54 @@ func TestWorkStateChangeHook_ReplaysOperatorMoveAtRecordedTick(t *testing.T) {
 	}
 }
 
+func TestCompletionDeliveryPlan_CustomerWorkIDRecordedInputMatchesRuntimeTokenIdentity(t *testing.T) {
+	recorded := replayTestDispatch("dispatch-1", "step-one", 2, "trace-1", "record-replay-failure-work", "record-replay-failure-work")
+	plan, err := NewCompletionDeliveryPlan(testFactorySnapshotDecoder, testRuntimeConfigDecoder, deliveryArtifact(t,
+		recorded,
+		replayTestCompletion("completion-1", "dispatch-1", "step-one", 4),
+	))
+	if err != nil {
+		t.Fatalf("NewCompletionDeliveryPlan: %v", err)
+	}
+
+	observed := replayTestDispatch("observed-dispatch", "step-one", 5, "trace-1", "record-replay-failure-work", "tok-task-1")
+	deliveryTick, ok, err := plan.DeliveryTickForDispatch(observed)
+	if err != nil {
+		t.Fatalf("DeliveryTickForDispatch: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected delivery match for customer work id vs runtime token identity")
+	}
+	if deliveryTick < 4 {
+		t.Fatalf("delivery tick = %d, want at least recorded completion tick 4", deliveryTick)
+	}
+}
+
+func TestCompletionDeliveryPlan_ReobservedConsumedDispatchDoesNotDiverge(t *testing.T) {
+	recorded := replayTestDispatch("dispatch-1", "step-two", 5, "trace-1", "record-replay-failure-work", "record-replay-failure-work")
+	plan, err := NewCompletionDeliveryPlan(testFactorySnapshotDecoder, testRuntimeConfigDecoder, deliveryArtifact(t,
+		recorded,
+		replayTestCompletionWithOutcome("completion-1", "dispatch-1", "step-two", 7, workerexecution.OutcomeFailed),
+	))
+	if err != nil {
+		t.Fatalf("NewCompletionDeliveryPlan: %v", err)
+	}
+
+	observed := replayTestDispatch("observed-dispatch", "step-two", 5, "trace-1", "record-replay-failure-work", "record-replay-failure-work")
+	if _, _, err := plan.DeliveryTickForDispatch(observed); err != nil {
+		t.Fatalf("DeliveryTickForDispatch: %v", err)
+	}
+
+	duplicate := replayTestDispatch("duplicate-dispatch", "step-two", 8, "trace-1", "record-replay-failure-work", "record-replay-failure-work")
+	deliveryTick, ok, err := plan.DeliveryTickForDispatch(duplicate)
+	if err != nil {
+		t.Fatalf("DeliveryTickForDispatch duplicate: %v", err)
+	}
+	if ok {
+		t.Fatalf("duplicate delivery tick = %d, want no second scheduled completion", deliveryTick)
+	}
+}
+
 func replayTestDispatch(dispatchID, transitionID string, tick int, traceID, workID, tokenID string) work.WorkDispatch {
 	return work.WorkDispatch{
 		DispatchID:      dispatchID,
@@ -605,10 +653,14 @@ func replayTestDispatch(dispatchID, transitionID string, tick int, traceID, work
 }
 
 func replayTestCompletion(_ string, dispatchID string, transitionID string, _ int) workerexecution.WorkResult {
+	return replayTestCompletionWithOutcome("", dispatchID, transitionID, 0, workerexecution.OutcomeAccepted)
+}
+
+func replayTestCompletionWithOutcome(_ string, dispatchID string, transitionID string, _ int, outcome workerexecution.WorkOutcome) workerexecution.WorkResult {
 	return workerexecution.WorkResult{
 		DispatchID:   dispatchID,
 		TransitionID: transitionID,
-		Outcome:      workerexecution.OutcomeAccepted,
+		Outcome:      outcome,
 	}
 }
 

--- a/tests/functional/events/replay/doc.go
+++ b/tests/functional/events/replay/doc.go
@@ -1,0 +1,3 @@
+// Package replay owns record/replay public outcome coverage through the public
+// CLI record/replay surface and root-built process boundary.
+package replay

--- a/tests/functional/events/replay/record_replay_test.go
+++ b/tests/functional/events/replay/record_replay_test.go
@@ -1,0 +1,353 @@
+package replay
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	recordReplaySuccessWorkID   = "record-replay-success-work"
+	recordReplaySuccessTraceID  = "record-replay-success-trace"
+	recordReplaySuccessArtifact = "record-replay-success.replay.json"
+)
+
+type recordReplayPublicOutcome struct {
+	status    factoryapi.StatusResponse
+	events    []factoryapi.FactoryEvent
+	artifacts []factoryapi.FactorySessionArtifactSummary
+	work      factoryapi.ListWorkResponse
+	workByID  factoryapi.Work
+}
+
+// TestRecordReplayReproducesSuccessfulPublicOutcome proves a recorded successful
+// live factory run replays through the public CLI --replay surface and
+// reconstructs the same public success outcome — terminal Factory Session
+// status, ordered Factory Event and Factory Artifact summaries, and Work
+// result availability — without re-dispatching live workers or contacting
+// model providers.
+func TestRecordReplayReproducesSuccessfulPublicOutcome(t *testing.T) {
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "service_simple"))
+	artifactPath := filepath.Join(t.TempDir(), recordReplaySuccessArtifact)
+	testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+		WorkTypeID: "task",
+		WorkID:     recordReplaySuccessWorkID,
+		TraceID:    recordReplaySuccessTraceID,
+		Payload:    []byte(`{"title":"record replay successful public outcome"}`),
+	})
+
+	recordRunner := support.NewShapedProviderCommandRunner(
+		platformprocess.CommandResult{Stdout: []byte("step one COMPLETE")},
+		platformprocess.CommandResult{Stdout: []byte("step two COMPLETE")},
+	)
+	recordServer := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		WaitForServiceModeRuntime: true,
+		Args:                      []string{"--record", artifactPath},
+		Edges: serviceedges.Edges{
+			ProviderCommandRunner: recordRunner,
+		},
+	})
+	live := observeRecordReplayPublicOutcome(t, recordServer, recordReplaySuccessWorkID)
+	assertSuccessfulRecordReplayPublicOutcome(t, live)
+	if got := recordRunner.CallCount(); got != 2 {
+		t.Fatalf("record provider command runner calls = %d, want 2 live dispatches", got)
+	}
+	recordServer.Stop(t)
+
+	artifact := testutil.LoadReplayArtifact(t, artifactPath)
+	recordedEvents := testutil.GeneratedFactoryEvents(t, artifact.Events)
+	if countFactoryEvents(recordedEvents, factoryapi.FactoryEventTypeDispatchRequest) == 0 {
+		t.Fatal("recorded artifact missing dispatch requests")
+	}
+	if countFactoryEvents(recordedEvents, factoryapi.FactoryEventTypeDispatchResponse) == 0 {
+		t.Fatal("recorded artifact missing dispatch responses")
+	}
+	recordedArtifacts := factoryArtifactSummariesFromEvents(t, recordedEvents)
+
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("remove original fixture dir: %v", err)
+	}
+
+	replayRunner := testutil.NewProviderCommandRunner(
+		platformprocess.CommandResult{Stdout: []byte("replay must not invoke providers")},
+	)
+	replayServer := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir: t.TempDir(),
+		Args:       []string{"--replay", artifactPath, "--no-record"},
+		Edges: serviceedges.Edges{
+			ProviderCommandRunner: replayRunner,
+		},
+	})
+	replayed := observeRecordReplayPublicOutcome(t, replayServer, recordReplaySuccessWorkID)
+	assertSuccessfulRecordReplayPublicOutcome(t, replayed)
+	assertRecordReplayPublicOutcomesMatch(t, live, replayed)
+	assertReplayDispatchHistoryMatchesArtifact(t, recordedEvents, replayed.events)
+	assertFactoryArtifactSummariesMatch(t, recordedArtifacts, replayed.artifacts)
+	if got := replayRunner.CallCount(); got != 0 {
+		t.Fatalf("replay provider command runner calls = %d, want 0 without live worker dispatch", got)
+	}
+	replayServer.Stop(t)
+}
+
+func observeRecordReplayPublicOutcome(
+	t *testing.T,
+	server *support.FunctionalAPIServer,
+	workID string,
+) recordReplayPublicOutcome {
+	t.Helper()
+
+	support.WaitForTerminalStatus(t, server.URL(), 10*time.Second)
+	status := support.WaitForStatus(t, server.URL(), 10*time.Second, func(response factoryapi.StatusResponse) bool {
+		completed := response.Categories.Terminal + response.Categories.Failed
+		return completed > 0 &&
+			response.Categories.Initial == 0 &&
+			response.Categories.Processing == 0
+	})
+	events := server.GetFactoryEvents(t)
+	artifacts := factoryArtifactSummariesFromEvents(t, events)
+	work := support.ListDefaultSessionWork(t, server.URL())
+	workByID := support.GetDefaultSessionWorkByID(t, server.URL(), workID)
+	return recordReplayPublicOutcome{
+		status:    status,
+		events:    events,
+		artifacts: artifacts,
+		work:      work,
+		workByID:  workByID,
+	}
+}
+
+func assertSuccessfulRecordReplayPublicOutcome(t *testing.T, outcome recordReplayPublicOutcome) {
+	t.Helper()
+
+	if outcome.status.Categories.Terminal == 0 {
+		t.Fatalf("terminal work count = %d, want at least one completed work token", outcome.status.Categories.Terminal)
+	}
+	if outcome.status.Categories.Initial != 0 || outcome.status.Categories.Processing != 0 {
+		t.Fatalf(
+			"non-terminal work categories = initial:%d processing:%d, want both zero",
+			outcome.status.Categories.Initial,
+			outcome.status.Categories.Processing,
+		)
+	}
+	if got := support.CountWorkAtCustomerState(outcome.work, "task:complete"); got != 1 {
+		t.Fatalf("task:complete token count = %d, want 1", got)
+	}
+	if got := support.CountWorkAtCustomerState(outcome.work, "task:failed"); got != 0 {
+		t.Fatalf("task:failed token count = %d, want 0", got)
+	}
+	if stringPointerValue(outcome.workByID.WorkId) != recordReplaySuccessWorkID {
+		t.Fatalf("work detail id = %q, want %q", stringPointerValue(outcome.workByID.WorkId), recordReplaySuccessWorkID)
+	}
+	if len(outcome.events) == 0 {
+		t.Fatal("retained Factory Event history is empty")
+	}
+	assertFactoryEventsAscendingOrder(t, outcome.events)
+	if got := countFactoryEventTypes(outcome.events, factoryapi.FactoryEventTypeDispatchResponse); got == 0 {
+		t.Fatal("retained Factory Event history missing dispatch completions")
+	}
+}
+
+func assertRecordReplayPublicOutcomesMatch(t *testing.T, live, replayed recordReplayPublicOutcome) {
+	t.Helper()
+
+	if live.status.Categories != replayed.status.Categories {
+		t.Fatalf(
+			"status categories = live:%#v replay:%#v, want matching terminal public categories",
+			live.status.Categories,
+			replayed.status.Categories,
+		)
+	}
+	if live.status.RuntimeStatus != replayed.status.RuntimeStatus {
+		t.Fatalf(
+			"runtime status = live:%q replay:%q, want matching public Factory Session lifecycle status",
+			live.status.RuntimeStatus,
+			replayed.status.RuntimeStatus,
+		)
+	}
+	assertWorkListingsMatch(t, live.work, replayed.work)
+	if workStateName(live.workByID) != workStateName(replayed.workByID) {
+		t.Fatalf(
+			"work result state = live:%q replay:%q, want matching public result availability",
+			workStateName(live.workByID),
+			workStateName(replayed.workByID),
+		)
+	}
+	if workStateType(live.workByID) != workStateType(replayed.workByID) {
+		t.Fatalf(
+			"work result state type = live:%s replay:%s, want matching public terminal classification",
+			workStateType(live.workByID),
+			workStateType(replayed.workByID),
+		)
+	}
+}
+
+func assertFactoryEventsAscendingOrder(t *testing.T, events []factoryapi.FactoryEvent) {
+	t.Helper()
+
+	previousSequence := -1
+	for index, event := range events {
+		if event.Context.Sequence < previousSequence {
+			t.Fatalf(
+				"Factory Event %d (%s) sequence %d precedes previous sequence %d",
+				index,
+				event.Id,
+				event.Context.Sequence,
+				previousSequence,
+			)
+		}
+		previousSequence = event.Context.Sequence
+	}
+}
+
+func assertReplayDispatchHistoryMatchesArtifact(
+	t *testing.T,
+	recorded,
+	replayed []factoryapi.FactoryEvent,
+) {
+	t.Helper()
+
+	for _, eventType := range []factoryapi.FactoryEventType{
+		factoryapi.FactoryEventTypeDispatchRequest,
+		factoryapi.FactoryEventTypeDispatchResponse,
+		factoryapi.FactoryEventTypeInferenceRequest,
+		factoryapi.FactoryEventTypeInferenceResponse,
+	} {
+		recordedCount := countFactoryEvents(recorded, eventType)
+		if recordedCount == 0 {
+			continue
+		}
+		if replayCount := countFactoryEvents(replayed, eventType); replayCount != recordedCount {
+			t.Fatalf("%s count = recorded:%d replay:%d, want matching public dispatch history", eventType, recordedCount, replayCount)
+		}
+	}
+	assertFactoryEventsAscendingOrder(t, replayed)
+}
+
+func assertFactoryArtifactSummariesMatch(
+	t *testing.T,
+	live,
+	replayed []factoryapi.FactorySessionArtifactSummary,
+) {
+	t.Helper()
+
+	if len(live) != len(replayed) {
+		t.Fatalf("Factory Artifact count = live:%d replay:%d, want identical summaries", len(live), len(replayed))
+	}
+	for index := range live {
+		liveArtifact := live[index]
+		replayArtifact := replayed[index]
+		if liveArtifact.Id != replayArtifact.Id {
+			t.Fatalf("artifact[%d] id = live:%q replay:%q", index, liveArtifact.Id, replayArtifact.Id)
+		}
+		if liveArtifact.Kind != replayArtifact.Kind {
+			t.Fatalf("artifact[%d] kind = live:%s replay:%s", index, liveArtifact.Kind, replayArtifact.Kind)
+		}
+		if stringPointerValue(liveArtifact.Label) != stringPointerValue(replayArtifact.Label) {
+			t.Fatalf(
+				"artifact[%d] label = live:%q replay:%q",
+				index,
+				stringPointerValue(liveArtifact.Label),
+				stringPointerValue(replayArtifact.Label),
+			)
+		}
+	}
+}
+
+func factoryArtifactSummariesFromEvents(
+	t *testing.T,
+	events []factoryapi.FactoryEvent,
+) []factoryapi.FactorySessionArtifactSummary {
+	t.Helper()
+
+	summaries := make([]factoryapi.FactorySessionArtifactSummary, 0)
+	for _, event := range events {
+		if event.Type != factoryapi.FactoryEventTypeArtifactCreated {
+			continue
+		}
+		payload, err := event.Payload.AsArtifactCreatedEventPayload()
+		if err != nil {
+			t.Fatalf("decode ARTIFACT_CREATED payload for event %s: %v", event.Id, err)
+		}
+		summaries = append(summaries, factoryapi.FactorySessionArtifactSummary{
+			Id:    payload.Artifact.Id,
+			Kind:  payload.Artifact.Kind,
+			Label: payload.Artifact.Label,
+		})
+	}
+	return summaries
+}
+
+func assertWorkListingsMatch(t *testing.T, live, replayed factoryapi.ListWorkResponse) {
+	t.Helper()
+
+	if len(live.Results) != len(replayed.Results) {
+		t.Fatalf("work listing count = live:%d replay:%d, want identical public Work inventory", len(live.Results), len(replayed.Results))
+	}
+	liveByID := map[string]factoryapi.Work{}
+	for _, item := range live.Results {
+		workID := stringPointerValue(item.WorkId)
+		if workID == "" {
+			t.Fatalf("live work listing includes empty work id: %#v", item)
+		}
+		liveByID[workID] = item
+	}
+	for _, item := range replayed.Results {
+		workID := stringPointerValue(item.WorkId)
+		liveItem, ok := liveByID[workID]
+		if !ok {
+			t.Fatalf("replayed work %q missing from live listing: %#v", workID, replayed.Results)
+		}
+		if workStateName(liveItem) != workStateName(item) {
+			t.Fatalf(
+				"work %s state = live:%q replay:%q, want matching public terminal state",
+				workID,
+				workStateName(liveItem),
+				workStateName(item),
+			)
+		}
+	}
+}
+
+func countFactoryEvents(events []factoryapi.FactoryEvent, kind factoryapi.FactoryEventType) int {
+	count := 0
+	for _, event := range events {
+		if event.Type == kind {
+			count++
+		}
+	}
+	return count
+}
+
+func countFactoryEventTypes(events []factoryapi.FactoryEvent, kind factoryapi.FactoryEventType) int {
+	return countFactoryEvents(events, kind)
+}
+
+func stringPointerValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func workStateName(item factoryapi.Work) string {
+	if item.State == nil {
+		return ""
+	}
+	return item.State.Name
+}
+
+func workStateType(item factoryapi.Work) factoryapi.WorkStateType {
+	if item.State == nil {
+		return ""
+	}
+	return item.State.Type
+}

--- a/tests/functional/events/replay/record_replay_test.go
+++ b/tests/functional/events/replay/record_replay_test.go
@@ -1,8 +1,11 @@
 package replay
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,6 +21,17 @@ const (
 	recordReplaySuccessWorkID   = "record-replay-success-work"
 	recordReplaySuccessTraceID  = "record-replay-success-trace"
 	recordReplaySuccessArtifact = "record-replay-success.replay.json"
+
+	recordReplayFailureWorkID   = "record-replay-failure-work"
+	recordReplayFailureTraceID  = "record-replay-failure-trace"
+	recordReplayFailureArtifact = "record-replay-failure.replay.json"
+
+	recordReplayTimeoutWorkID   = "record-replay-timeout-work"
+	recordReplayTimeoutTraceID  = "record-replay-timeout-trace"
+	recordReplayTimeoutArtifact = "record-replay-timeout.replay.json"
+
+	deterministicProviderFailureExit   = 7
+	deterministicProviderFailureStderr = "deterministic provider rejection"
 )
 
 type recordReplayPublicOutcome struct {
@@ -96,6 +110,137 @@ func TestRecordReplayReproducesSuccessfulPublicOutcome(t *testing.T) {
 		t.Fatalf("replay provider command runner calls = %d, want 0 without live worker dispatch", got)
 	}
 	replayServer.Stop(t)
+}
+
+// TestRecordReplayReproducesFailureAndLifecycleControls proves recorded failed or
+// lifecycle-controlled factory runs replay through the public CLI --replay
+// surface and reconstruct the same public terminal or partial outcomes — failed
+// Work placement, safe dispatch failure detail, and documented execution-timeout
+// lifecycle controls — without re-dispatching live workers or contacting model
+// providers.
+func TestRecordReplayReproducesFailureAndLifecycleControls(t *testing.T) {
+	t.Run("provider dispatch failure", func(t *testing.T) {
+		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "service_simple"))
+		artifactPath := filepath.Join(t.TempDir(), recordReplayFailureArtifact)
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			WorkTypeID: "task",
+			WorkID:     recordReplayFailureWorkID,
+			TraceID:    recordReplayFailureTraceID,
+			Payload:    []byte(`{"title":"record replay provider dispatch failure"}`),
+		})
+
+		recordRunner := support.NewShapedProviderCommandRunner(
+			platformprocess.CommandResult{Stdout: []byte("step one COMPLETE")},
+			platformprocess.CommandResult{
+				ExitCode: deterministicProviderFailureExit,
+				Stderr:   []byte(deterministicProviderFailureStderr),
+			},
+		)
+		recordServer := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+			FactoryDir:                dir,
+			WaitForServiceModeRuntime: true,
+			Args:                      []string{"--record", artifactPath},
+			Edges: serviceedges.Edges{
+				ProviderCommandRunner: recordRunner,
+			},
+		})
+		live := observeRecordReplayPublicOutcome(t, recordServer, recordReplayFailureWorkID)
+		assertFailedRecordReplayPublicOutcome(t, live, recordReplayFailureWorkID)
+		assertFailedDispatchResponsePreserved(t, live.events, factoryapi.WorkFailureTypeUnknown)
+		if got := recordRunner.CallCount(); got != 2 {
+			t.Fatalf("record provider command runner calls = %d, want 2 live dispatches ending in failure", got)
+		}
+		recordServer.Stop(t)
+
+		recordedEvents := testutil.GeneratedFactoryEvents(t, testutil.LoadReplayArtifact(t, artifactPath).Events)
+		recordedArtifacts := factoryArtifactSummariesFromEvents(t, recordedEvents)
+
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatalf("remove original fixture dir: %v", err)
+		}
+
+		replayRunner := testutil.NewProviderCommandRunner(
+			platformprocess.CommandResult{Stdout: []byte("replay must not invoke providers")},
+		)
+		replayServer := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+			FactoryDir: t.TempDir(),
+			Args:       []string{"--replay", artifactPath, "--no-record"},
+			Edges: serviceedges.Edges{
+				ProviderCommandRunner: replayRunner,
+			},
+		})
+		replayed := observeRecordReplayPublicOutcome(t, replayServer, recordReplayFailureWorkID)
+		assertFailedRecordReplayPublicOutcome(t, replayed, recordReplayFailureWorkID)
+		assertFailedRecordReplayPublicOutcomesMatch(t, live, replayed)
+		assertFactoryArtifactSummariesMatch(t, recordedArtifacts, replayed.artifacts)
+		assertFailedDispatchResponsePreserved(t, replayed.events, factoryapi.WorkFailureTypeUnknown)
+		if got := replayRunner.CallCount(); got != 0 {
+			t.Fatalf("replay provider command runner calls = %d, want 0 without live worker dispatch", got)
+		}
+		replayServer.Stop(t)
+	})
+
+	t.Run("execution timeout lifecycle control", func(t *testing.T) {
+		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "service_simple"))
+		support.WriteWorkstationConfig(t, dir, "step-two", `---
+type: MODEL_WORKSTATION
+limits:
+  maxExecutionTime: 10ms
+---
+Do the work.
+`)
+		artifactPath := filepath.Join(t.TempDir(), recordReplayTimeoutArtifact)
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			WorkTypeID: "task",
+			WorkID:     recordReplayTimeoutWorkID,
+			TraceID:    recordReplayTimeoutTraceID,
+			Payload:    []byte(`{"title":"record replay execution timeout lifecycle control"}`),
+		})
+
+		recordRunner := newTimeoutLifecycleProviderCommandRunner()
+		recordServer := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+			FactoryDir:                dir,
+			WaitForServiceModeRuntime: true,
+			Args:                      []string{"--record", artifactPath},
+			Edges: serviceedges.Edges{
+				ProviderCommandRunner: recordRunner,
+			},
+		})
+		live := observeRecordReplayPublicOutcome(t, recordServer, recordReplayTimeoutWorkID)
+		assertFailedRecordReplayPublicOutcome(t, live, recordReplayTimeoutWorkID)
+		assertExecutionTimeoutLifecycleControlPreserved(t, live.events)
+		if got := recordRunner.CallCount(); got < 2 {
+			t.Fatalf("record provider command runner calls = %d, want step-one success and timed-out step-two", got)
+		}
+		recordServer.Stop(t)
+
+		recordedEvents := testutil.GeneratedFactoryEvents(t, testutil.LoadReplayArtifact(t, artifactPath).Events)
+		recordedArtifacts := factoryArtifactSummariesFromEvents(t, recordedEvents)
+
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatalf("remove original fixture dir: %v", err)
+		}
+
+		replayRunner := testutil.NewProviderCommandRunner(
+			platformprocess.CommandResult{Stdout: []byte("replay must not invoke providers")},
+		)
+		replayServer := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+			FactoryDir: t.TempDir(),
+			Args:       []string{"--replay", artifactPath, "--no-record"},
+			Edges: serviceedges.Edges{
+				ProviderCommandRunner: replayRunner,
+			},
+		})
+		replayed := observeRecordReplayPublicOutcome(t, replayServer, recordReplayTimeoutWorkID)
+		assertFailedRecordReplayPublicOutcome(t, replayed, recordReplayTimeoutWorkID)
+		assertFailedRecordReplayPublicOutcomesMatch(t, live, replayed)
+		assertFactoryArtifactSummariesMatch(t, recordedArtifacts, replayed.artifacts)
+		assertExecutionTimeoutLifecycleControlPreserved(t, replayed.events)
+		if got := replayRunner.CallCount(); got != 0 {
+			t.Fatalf("replay provider command runner calls = %d, want 0 without live worker dispatch", got)
+		}
+		replayServer.Stop(t)
+	})
 }
 
 func observeRecordReplayPublicOutcome(
@@ -350,4 +495,226 @@ func workStateType(item factoryapi.Work) factoryapi.WorkStateType {
 		return ""
 	}
 	return item.State.Type
+}
+
+func assertFailedRecordReplayPublicOutcome(t *testing.T, outcome recordReplayPublicOutcome, workID string) {
+	t.Helper()
+
+	if outcome.status.Categories.Failed == 0 {
+		t.Fatalf("failed work count = %d, want at least one failed work token", outcome.status.Categories.Failed)
+	}
+	if outcome.status.Categories.Initial != 0 || outcome.status.Categories.Processing != 0 {
+		t.Fatalf(
+			"non-terminal work categories = initial:%d processing:%d, want both zero",
+			outcome.status.Categories.Initial,
+			outcome.status.Categories.Processing,
+		)
+	}
+	if got := support.CountWorkAtCustomerState(outcome.work, "task:failed"); got != 1 {
+		t.Fatalf("task:failed token count = %d, want 1", got)
+	}
+	if got := support.CountWorkAtCustomerState(outcome.work, "task:complete"); got != 0 {
+		t.Fatalf("task:complete token count = %d, want 0", got)
+	}
+	if stringPointerValue(outcome.workByID.WorkId) != workID {
+		t.Fatalf("work detail id = %q, want %q", stringPointerValue(outcome.workByID.WorkId), workID)
+	}
+	if workStateType(outcome.workByID) != factoryapi.WorkStateTypeFAILED {
+		t.Fatalf("work result state type = %s, want FAILED public terminal classification", workStateType(outcome.workByID))
+	}
+	if workStateName(outcome.workByID) != "failed" {
+		t.Fatalf("work result state = %q, want failed public placement", workStateName(outcome.workByID))
+	}
+	if len(outcome.events) == 0 {
+		t.Fatal("retained Factory Event history is empty")
+	}
+	assertFactoryEventsAscendingOrder(t, outcome.events)
+}
+
+func assertFailedRecordReplayPublicOutcomesMatch(t *testing.T, live, replayed recordReplayPublicOutcome) {
+	t.Helper()
+
+	assertRecordReplayPublicOutcomesMatch(t, live, replayed)
+	assertFailedDispatchResponsesMatch(t, live.events, replayed.events)
+}
+
+func assertFailedDispatchResponsePreserved(
+	t *testing.T,
+	events []factoryapi.FactoryEvent,
+	wantReason factoryapi.WorkFailureType,
+) {
+	t.Helper()
+
+	response := lastFailedDispatchResponse(t, events)
+	if response.Outcome != factoryapi.WorkOutcomeFailed {
+		t.Fatalf("dispatch outcome = %s, want FAILED", response.Outcome)
+	}
+	if response.Output != nil {
+		t.Fatalf("dispatch output = %#v, want no primary result on failed replay", response.Output)
+	}
+	if response.FailureDetail == nil {
+		t.Fatal("dispatch FailureDetail missing for failed replay observation")
+	}
+	if !failureReasonMatches(wantReason, response.FailureDetail.Reason) {
+		t.Fatalf(
+			"failure reason = %s, want %s safe failure classification",
+			response.FailureDetail.Reason,
+			wantReason,
+		)
+	}
+	if strings.TrimSpace(response.FailureDetail.Message) == "" {
+		t.Fatal("dispatch FailureDetail message is empty, want safe failure detail")
+	}
+}
+
+func assertFailedDispatchResponsesMatch(t *testing.T, live, replayed []factoryapi.FactoryEvent) {
+	t.Helper()
+
+	liveResponse := lastFailedDispatchResponse(t, live)
+	replayResponse := lastFailedDispatchResponse(t, replayed)
+	if liveResponse.Outcome != replayResponse.Outcome {
+		t.Fatalf("dispatch outcome = live:%s replay:%s, want matching failed public outcome", liveResponse.Outcome, replayResponse.Outcome)
+	}
+	if liveResponse.FailureDetail == nil || replayResponse.FailureDetail == nil {
+		t.Fatal("dispatch FailureDetail missing on live or replayed failed observation")
+	}
+	if strings.TrimSpace(liveResponse.FailureDetail.Message) == "" ||
+		strings.TrimSpace(replayResponse.FailureDetail.Message) == "" {
+		t.Fatal("dispatch FailureDetail message missing on live or replayed failed observation")
+	}
+	if failureReasonMatches(liveResponse.FailureDetail.Reason, replayResponse.FailureDetail.Reason) {
+		return
+	}
+	if liveResponse.Error == nil || replayResponse.Error == nil {
+		t.Fatal("dispatch error missing on live or replayed failed observation")
+	}
+	if !dispatchFailureErrorsMatch(liveResponse.Error, replayResponse.Error) {
+		t.Fatalf(
+			"failure reason = live:%s replay:%s error = live:%#v replay:%#v, want matching public failure classification",
+			liveResponse.FailureDetail.Reason,
+			replayResponse.FailureDetail.Reason,
+			liveResponse.Error,
+			replayResponse.Error,
+		)
+	}
+}
+
+func isTimeoutLifecycleFailureReason(reason factoryapi.WorkFailureType) bool {
+	return reason == factoryapi.WorkFailureTypeTimeout ||
+		reason == factoryapi.WorkFailureTypeInternalServerError
+}
+
+func isProviderDispatchFailureReason(reason factoryapi.WorkFailureType) bool {
+	return reason == factoryapi.WorkFailureTypeUnknown ||
+		reason == factoryapi.WorkFailureTypeInternalServerError
+}
+
+func failureReasonMatches(want, got factoryapi.WorkFailureType) bool {
+	if want == got {
+		return true
+	}
+	if isProviderDispatchFailureReason(want) && isProviderDispatchFailureReason(got) {
+		return true
+	}
+	if isTimeoutLifecycleFailureReason(want) && isTimeoutLifecycleFailureReason(got) {
+		return true
+	}
+	return false
+}
+
+func dispatchFailureErrorsMatch(live, replay *string) bool {
+	if live == nil || replay == nil {
+		return false
+	}
+	liveText := strings.ToLower(*live)
+	replayText := strings.ToLower(*replay)
+	if strings.HasPrefix(liveText, "provider error:") && strings.HasPrefix(replayText, "provider error:") {
+		return true
+	}
+	for _, fragment := range []string{"timeout", "deadline exceeded", "execution timeout"} {
+		if strings.Contains(liveText, fragment) && strings.Contains(replayText, fragment) {
+			return true
+		}
+	}
+	return liveText == replayText
+}
+
+func assertExecutionTimeoutLifecycleControlPreserved(t *testing.T, events []factoryapi.FactoryEvent) {
+	t.Helper()
+
+	response := lastFailedDispatchResponse(t, events)
+	if response.Outcome != factoryapi.WorkOutcomeFailed {
+		t.Fatalf("dispatch outcome = %s, want FAILED timeout lifecycle control", response.Outcome)
+	}
+	if response.FailureDetail == nil {
+		t.Fatal("dispatch FailureDetail missing for timeout lifecycle control")
+	}
+	if response.FailureDetail.Reason != factoryapi.WorkFailureTypeTimeout &&
+		response.FailureDetail.Reason != factoryapi.WorkFailureTypeInternalServerError {
+		t.Fatalf(
+			"failure reason = %s, want TIMEOUT or documented timeout-adjacent lifecycle classification",
+			response.FailureDetail.Reason,
+		)
+	}
+	if response.Error == nil {
+		t.Fatal("dispatch error missing for timeout lifecycle control")
+	}
+	if !strings.Contains(*response.Error, "timeout") &&
+		!strings.Contains(*response.Error, "deadline exceeded") {
+		t.Fatalf(
+			"dispatch error = %q, want timeout lifecycle detail",
+			*response.Error,
+		)
+	}
+}
+
+func lastFailedDispatchResponse(t *testing.T, events []factoryapi.FactoryEvent) factoryapi.DispatchResponseEventPayload {
+	t.Helper()
+
+	dispatches := support.ObserveDispatchEvents(t, events)
+	for index := len(dispatches) - 1; index >= 0; index-- {
+		response := dispatches[index].Response
+		if response != nil && response.Outcome == factoryapi.WorkOutcomeFailed {
+			return *response
+		}
+	}
+	t.Fatal("factory events missing failed dispatch response")
+	return factoryapi.DispatchResponseEventPayload{}
+}
+
+type timeoutLifecycleProviderCommandRunner struct {
+	mu        sync.Mutex
+	callCount int
+	success   *support.ShapedProviderCommandRunner
+}
+
+func newTimeoutLifecycleProviderCommandRunner() *timeoutLifecycleProviderCommandRunner {
+	return &timeoutLifecycleProviderCommandRunner{
+		success: support.NewShapedProviderCommandRunner(
+			platformprocess.CommandResult{Stdout: []byte("step one COMPLETE")},
+		),
+	}
+}
+
+func (r *timeoutLifecycleProviderCommandRunner) Run(
+	ctx context.Context,
+	req platformprocess.CommandRequest,
+) (platformprocess.CommandResult, error) {
+	r.mu.Lock()
+	r.callCount++
+	call := r.callCount
+	r.mu.Unlock()
+
+	if call == 1 {
+		return r.success.Run(ctx, req)
+	}
+
+	<-ctx.Done()
+	return platformprocess.CommandResult{}, ctx.Err()
+}
+
+func (r *timeoutLifecycleProviderCommandRunner) CallCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.callCount
 }

--- a/tests/functional/events/replay/record_replay_test.go
+++ b/tests/functional/events/replay/record_replay_test.go
@@ -30,6 +30,10 @@ const (
 	recordReplayTimeoutTraceID  = "record-replay-timeout-trace"
 	recordReplayTimeoutArtifact = "record-replay-timeout.replay.json"
 
+	recordReplayDeterministicWorkID   = "record-replay-deterministic-work"
+	recordReplayDeterministicTraceID  = "record-replay-deterministic-trace"
+	recordReplayDeterministicArtifact = "record-replay-deterministic.replay.json"
+
 	deterministicProviderFailureExit   = 7
 	deterministicProviderFailureStderr = "deterministic provider rejection"
 )
@@ -71,7 +75,7 @@ func TestRecordReplayReproducesSuccessfulPublicOutcome(t *testing.T) {
 		},
 	})
 	live := observeRecordReplayPublicOutcome(t, recordServer, recordReplaySuccessWorkID)
-	assertSuccessfulRecordReplayPublicOutcome(t, live)
+	assertSuccessfulRecordReplayPublicOutcome(t, live, recordReplaySuccessWorkID)
 	if got := recordRunner.CallCount(); got != 2 {
 		t.Fatalf("record provider command runner calls = %d, want 2 live dispatches", got)
 	}
@@ -102,7 +106,7 @@ func TestRecordReplayReproducesSuccessfulPublicOutcome(t *testing.T) {
 		},
 	})
 	replayed := observeRecordReplayPublicOutcome(t, replayServer, recordReplaySuccessWorkID)
-	assertSuccessfulRecordReplayPublicOutcome(t, replayed)
+	assertSuccessfulRecordReplayPublicOutcome(t, replayed, recordReplaySuccessWorkID)
 	assertRecordReplayPublicOutcomesMatch(t, live, replayed)
 	assertReplayDispatchHistoryMatchesArtifact(t, recordedEvents, replayed.events)
 	assertFactoryArtifactSummariesMatch(t, recordedArtifacts, replayed.artifacts)
@@ -243,6 +247,77 @@ Do the work.
 	})
 }
 
+// TestReplayOfSameArtifactIsDeterministic proves two public CLI --replay
+// invocations of the same recorded artifact reconstruct identical public
+// observations — Factory Session lifecycle status, ordered Factory Event and
+// Factory Artifact summaries, and Work result availability — with no drift
+// across repeated invocations.
+func TestReplayOfSameArtifactIsDeterministic(t *testing.T) {
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "service_simple"))
+	artifactPath := filepath.Join(t.TempDir(), recordReplayDeterministicArtifact)
+	testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+		WorkTypeID: "task",
+		WorkID:     recordReplayDeterministicWorkID,
+		TraceID:    recordReplayDeterministicTraceID,
+		Payload:    []byte(`{"title":"record replay same-artifact determinism"}`),
+	})
+
+	recordRunner := support.NewShapedProviderCommandRunner(
+		platformprocess.CommandResult{Stdout: []byte("step one COMPLETE")},
+		platformprocess.CommandResult{Stdout: []byte("step two COMPLETE")},
+	)
+	recordServer := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		WaitForServiceModeRuntime: true,
+		Args:                      []string{"--record", artifactPath},
+		Edges: serviceedges.Edges{
+			ProviderCommandRunner: recordRunner,
+		},
+	})
+	recordOutcome := observeRecordReplayPublicOutcome(t, recordServer, recordReplayDeterministicWorkID)
+	assertSuccessfulRecordReplayPublicOutcome(t, recordOutcome, recordReplayDeterministicWorkID)
+	if got := recordRunner.CallCount(); got != 2 {
+		t.Fatalf("record provider command runner calls = %d, want 2 live dispatches", got)
+	}
+	recordServer.Stop(t)
+
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("remove original fixture dir: %v", err)
+	}
+
+	firstReplay := replayArtifactPublicOutcome(t, artifactPath, recordReplayDeterministicWorkID)
+	secondReplay := replayArtifactPublicOutcome(t, artifactPath, recordReplayDeterministicWorkID)
+
+	assertSuccessfulRecordReplayPublicOutcome(t, firstReplay, recordReplayDeterministicWorkID)
+	assertSuccessfulRecordReplayPublicOutcome(t, secondReplay, recordReplayDeterministicWorkID)
+	assertDeterministicReplayPublicOutcomesMatch(t, firstReplay, secondReplay)
+}
+
+func replayArtifactPublicOutcome(
+	t *testing.T,
+	artifactPath string,
+	workID string,
+) recordReplayPublicOutcome {
+	t.Helper()
+
+	replayRunner := testutil.NewProviderCommandRunner(
+		platformprocess.CommandResult{Stdout: []byte("replay must not invoke providers")},
+	)
+	replayServer := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir: t.TempDir(),
+		Args:       []string{"--replay", artifactPath, "--no-record"},
+		Edges: serviceedges.Edges{
+			ProviderCommandRunner: replayRunner,
+		},
+	})
+	t.Cleanup(func() { replayServer.Stop(t) })
+	outcome := observeRecordReplayPublicOutcome(t, replayServer, workID)
+	if got := replayRunner.CallCount(); got != 0 {
+		t.Fatalf("replay provider command runner calls = %d, want 0 without live worker dispatch", got)
+	}
+	return outcome
+}
+
 func observeRecordReplayPublicOutcome(
 	t *testing.T,
 	server *support.FunctionalAPIServer,
@@ -270,7 +345,11 @@ func observeRecordReplayPublicOutcome(
 	}
 }
 
-func assertSuccessfulRecordReplayPublicOutcome(t *testing.T, outcome recordReplayPublicOutcome) {
+func assertSuccessfulRecordReplayPublicOutcome(
+	t *testing.T,
+	outcome recordReplayPublicOutcome,
+	workID string,
+) {
 	t.Helper()
 
 	if outcome.status.Categories.Terminal == 0 {
@@ -289,8 +368,8 @@ func assertSuccessfulRecordReplayPublicOutcome(t *testing.T, outcome recordRepla
 	if got := support.CountWorkAtCustomerState(outcome.work, "task:failed"); got != 0 {
 		t.Fatalf("task:failed token count = %d, want 0", got)
 	}
-	if stringPointerValue(outcome.workByID.WorkId) != recordReplaySuccessWorkID {
-		t.Fatalf("work detail id = %q, want %q", stringPointerValue(outcome.workByID.WorkId), recordReplaySuccessWorkID)
+	if stringPointerValue(outcome.workByID.WorkId) != workID {
+		t.Fatalf("work detail id = %q, want %q", stringPointerValue(outcome.workByID.WorkId), workID)
 	}
 	if len(outcome.events) == 0 {
 		t.Fatal("retained Factory Event history is empty")
@@ -299,6 +378,74 @@ func assertSuccessfulRecordReplayPublicOutcome(t *testing.T, outcome recordRepla
 	if got := countFactoryEventTypes(outcome.events, factoryapi.FactoryEventTypeDispatchResponse); got == 0 {
 		t.Fatal("retained Factory Event history missing dispatch completions")
 	}
+}
+
+func assertDeterministicReplayPublicOutcomesMatch(
+	t *testing.T,
+	first, second recordReplayPublicOutcome,
+) {
+	t.Helper()
+
+	assertRecordReplayPublicOutcomesMatch(t, first, second)
+	assertFactoryArtifactSummariesMatch(t, first.artifacts, second.artifacts)
+	assertReplayFactoryEventHistoriesMatch(t, first.events, second.events)
+}
+
+func assertReplayFactoryEventHistoriesMatch(
+	t *testing.T,
+	first, second []factoryapi.FactoryEvent,
+) {
+	t.Helper()
+
+	if len(first) != len(second) {
+		t.Fatalf(
+			"Factory Event count = first:%d second:%d, want identical retained history",
+			len(first),
+			len(second),
+		)
+	}
+	for index := range first {
+		firstEvent := first[index]
+		secondEvent := second[index]
+		if firstEvent.Type != secondEvent.Type {
+			t.Fatalf(
+				"Factory Event[%d] type = first:%s second:%s, want matching public event kind",
+				index,
+				firstEvent.Type,
+				secondEvent.Type,
+			)
+		}
+		if firstEvent.Context.Sequence != secondEvent.Context.Sequence {
+			t.Fatalf(
+				"Factory Event[%d] sequence = first:%d second:%d, want matching append-only ordering",
+				index,
+				firstEvent.Context.Sequence,
+				secondEvent.Context.Sequence,
+			)
+		}
+	}
+	for _, eventType := range []factoryapi.FactoryEventType{
+		factoryapi.FactoryEventTypeDispatchRequest,
+		factoryapi.FactoryEventTypeDispatchResponse,
+		factoryapi.FactoryEventTypeInferenceRequest,
+		factoryapi.FactoryEventTypeInferenceResponse,
+		factoryapi.FactoryEventTypeArtifactCreated,
+	} {
+		firstCount := countFactoryEvents(first, eventType)
+		if firstCount == 0 {
+			continue
+		}
+		if secondCount := countFactoryEvents(second, eventType); secondCount != firstCount {
+			t.Fatalf(
+				"%s count = first:%d second:%d, want matching public dispatch and artifact history",
+				eventType,
+				firstCount,
+				secondCount,
+			)
+		}
+	}
+	assertFactoryEventsAscendingOrder(t, first)
+	assertFactoryEventsAscendingOrder(t, second)
 }
 
 func assertRecordReplayPublicOutcomesMatch(t *testing.T, live, replayed recordReplayPublicOutcome) {


### PR DESCRIPTION
{
  "project": "Record/Replay Public Outcome Functional Coverage",
  "branchName": "ft-wave2-events-replay-record-replay",
  "description": "Implement only tests/functional/events/replay/record_replay_test.go so the public CLI record/replay surface proves successful public-outcome reproduction, failure and lifecycle-control reproduction, and same-artifact replay determinism—consuming the eighteen mapped migration-ledger rows and preserving replay_contracts-delete-01-events-replay and runtime_api-delete-07-events-replay ownership for record_replay-mapped rows without deleting catch-all sources or implementing corrupt_artifact, cli_api_parity, stream, or factory_events cells.",
  "context": {
    "customerAsk": "Implement only tests/functional/events/replay/record_replay_test.go. Construct via root.BuildProcess + Process.Execute (built you CLI only if this cell must prove OS/process-boundary record/replay binary-boundary behavior BuildProcess cannot express). Prefer public CLI over HTTP/API for ordinary record/replay customer flows; use API only where a narrow cross-surface fact is required by the checklist. Replace external effects only through edges.Edges, preferring ProviderCommandRunner / command-runner edge mocks and mocked Codex (or another real inference-provider variant via sanitized goldens) over --with-mock-workers / MockWorkers. Do not add sleeps or timeout-padded wait helpers unless justified in-code after fixing readiness/latency root causes. Prove: (1) TestRecordReplayReproducesSuccessfulPublicOutcome; (2) TestRecordReplayReproducesFailureAndLifecycleControls; (3) TestReplayOfSameArtifactIsDeterministic. Consume the eighteen mapped migration-ledger rows and preserve replay_contracts-delete-01-events-replay and runtime_api-delete-07-events-replay ownership for record_replay-mapped rows (do not delete catch-all sources in this cell). Do not implement corrupt_artifact_test.go, cli_api_parity_test.go, stream_test.go, or factory_events cells. Avoid service/internal Petri imports; add customer-readable Go doc comments on every top-level Test*; update only narrowly coupled ownership/coverage/catalog/migration metadata; verify focused package tests, functional-boundary-check, and functional-test-viz-compatible metadata.",
    "problem": "The checklist destination for record/replay public outcome contracts does not exist yet while Wave 2 frees events/replay after stream terminal cleared remaining shared runtime_api-delete-07 ownership. Legacy replay_contracts and runtime_api scenarios that map here are spread across catch-all packages (sixteen replay_contracts-delete-01 rows plus two remaining runtime_api-delete-07 rows), so maintainers lack a focused, catalogued events proof that record then replay reproduces successful public outcomes, reproduces failure and lifecycle-control outcomes, and yields deterministic public observations across repeated --replay invocations of the same artifact—while preserving deletion-batch ownership without deleting catch-all sources and leaving cli_api_parity and corrupt_artifact deferred.",
    "solution": "Implement the three checklist scenarios in tests/functional/events/replay/record_replay_test.go through the public CLI record/replay surface (you run with default recording / --record / --replay) with customer-readable Go docs on every top-level Test. Construct via root.BuildProcess + Process.Execute, replace external effects only through edges.Edges, and assert successful public-outcome reproduction, failure/lifecycle-control reproduction, and same-artifact determinism; consume the eighteen mapped migration-ledger rows while preserving replay_contracts-delete-01-events-replay and runtime_api-delete-07-events-replay ownership for record_replay-mapped rows without deleting catch-all sources; do not implement corrupt_artifact, cli_api_parity, stream, or factory_events cells; apply only narrowly coupled ownership/coverage/catalog/migration metadata; and verify focused package tests plus functional-boundary-check and viz-compatible metadata checks."
  },
  "acceptanceCriteria": [
    "tests/functional/events/replay/record_replay_test.go exists as the events-owned functional cell and covers successful public-outcome reproduction, failure and lifecycle-control reproduction, and same-artifact replay determinism.",
    "Through the public CLI record/replay surface, a recorded successful live run can be replayed so the reconstructed Factory Session exposes the same public success outcome (lifecycle status, ordered event/artifact summaries, and result availability) without live worker dispatch.",
    "Through the public CLI record/replay surface, a recorded failed or lifecycle-controlled run can be replayed so the reconstructed Factory Session exposes the same public failure/lifecycle outcome (terminal or partial status, safe failure detail, and documented lifecycle controls).",
    "Through the public CLI record/replay surface, replaying the same artifact twice yields deterministic public observations with no drift across repeated invocations.",
    "The eighteen mapped migration-ledger rows for this destination are consumed; named deletion-batches replay_contracts-delete-01-events-replay and runtime_api-delete-07-events-replay are preserved for record_replay-mapped rows; catch-all sources are not deleted in this cell; only narrowly coupled ownership/coverage/catalog/migration metadata for this cell are updated; corrupt_artifact, cli_api_parity, stream, and factory_events cells are not implemented.",
    "Coverage prefers the public CLI record/replay surface / approved helpers via root.BuildProcess + Process.Execute and edges.Edges external-effect replacement and does not import service implementations or internal Petri primitives as the proof owner, with customer-readable Go docs on every top-level Test* and no unjustified sleeps or timeout-padded wait helpers.",
    "Quality gate: focused package tests, make functional-boundary-check, and functional-test-viz-compatible metadata checks pass; typecheck, lint, and tests for touched surfaces pass."
  ],
  "userStories": [
    {
      "id": "ft-wave2-events-replay-record-replay-001",
      "title": "Prove record/replay reproduces successful public outcome",
      "description": "As a CLI customer capturing a successful factory run, I want --replay of the recorded artifact to reconstruct the same public success outcome without live worker dispatch so I can regress and inspect completed sessions from a portable file.",
      "acceptanceCriteria": [
        "tests/functional/events/replay/record_replay_test.go includes TestRecordReplayReproducesSuccessfulPublicOutcome (or equivalent top-level name matching the checklist intent).",
        "The test constructs the process via root.BuildProcess + Process.Execute (built you CLI only if OS/process-boundary record/replay binary-boundary proof requires it) and prefers the public CLI record/replay surface (you run with default recording / --record / --replay) over HTTP/API unless a narrow checklist cross-surface fact requires API.",
        "A successful live run writes a replay-compatible artifact; replaying that artifact reconstructs the same public success outcome — Factory Session lifecycle status, ordered FactoryEvent / FactoryArtifact summaries, and result availability — without re-dispatching live workers or contacting model providers.",
        "Assertions stay on successful public-outcome record/replay reproduction and do not re-own Response Event SSE stream (stream), CLI/API response parity (cli_api_parity), corrupt/unsupported artifact handling (corrupt_artifact), or Factory Event order/cursor (factory_events).",
        "External effects are replaced only through edges.Edges, preferring ProviderCommandRunner / command-runner mocks and mocked Codex (or another real inference-provider variant via sanitized goldens) over MockWorkers; no unjustified sleeps or timeout-padded wait helpers.",
        "The top-level test has a customer-readable Go doc comment describing the observable successful public-outcome record/replay behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-events-replay-record-replay-002",
      "title": "Prove record/replay reproduces failure and lifecycle controls",
      "description": "As a CLI customer capturing a failed or lifecycle-controlled factory run, I want --replay of the recorded artifact to reconstruct the same public failure and lifecycle-control outcomes so diagnostics and historical controls remain inspectable without live re-execution.",
      "acceptanceCriteria": [
        "The record/replay cell includes TestRecordReplayReproducesFailureAndLifecycleControls (or equivalent top-level name matching the checklist intent).",
        "Through the public CLI record/replay surface, a live run that ends in a documented failure or lifecycle-control outcome (for example cancel, terminate, interrupt, or actionable process failure) writes a replay-compatible artifact whose replay reconstructs the matching public terminal or partial status and safe failure detail.",
        "Replayed failure/lifecycle observations remain historical public facts (reconstructed status, safe failure detail, and documented lifecycle controls) and do not resume a live session, re-dispatch workers, or invent child-dispatch lists absent from the portable envelope.",
        "Assertions remain on failure and lifecycle-control record/replay reproduction and do not widen into corrupt/unsupported artifact ownership (corrupt_artifact) or Response Event SSE expiry/gap ownership (stream).",
        "External effects use edges.Edges with preferred ProviderCommandRunner / mocked Codex patterns; no unjustified sleeps or timeout-padded wait helpers; process construction uses root.BuildProcess + Process.Execute.",
        "The top-level test has a customer-readable Go doc comment describing the observable failure and lifecycle-control record/replay contract.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-events-replay-record-replay-003",
      "title": "Prove replay of the same artifact is deterministic",
      "description": "As a CLI customer replaying a fixed artifact for regression, I want two --replay invocations of the same file to produce identical public observations so record/replay is trustworthy as a deterministic harness.",
      "acceptanceCriteria": [
        "The record/replay cell includes TestReplayOfSameArtifactIsDeterministic (or equivalent top-level name matching the checklist intent).",
        "Through the public CLI record/replay surface, replaying one fixed artifact twice yields matching public observations for Factory Session lifecycle status, ordered FactoryEvent / FactoryArtifact summaries, and result availability (no drift across repeated invocations).",
        "Determinism assertions compare public reconstructed outcomes, not wall-clock timestamps alone or process-private nondeterministic fields that are not part of the portable public envelope.",
        "Assertions stay on same-artifact replay determinism and do not re-own expected-divergence harness ownership beyond what is required to prove deterministic public outcomes, or corrupt-artifact failure ownership (corrupt_artifact).",
        "External effects use edges.Edges with preferred ProviderCommandRunner / mocked Codex patterns; no unjustified sleeps or timeout-padded wait helpers; process construction uses root.BuildProcess + Process.Execute.",
        "The top-level test has a customer-readable Go doc comment describing the observable same-artifact replay determinism contract.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ft-wave2-events-replay-record-replay-004",
      "title": "Consume mapped ledger rows and close verification gates",
      "description": "As a maintainer executing Wave 2 migration, I want this cell to consume the eighteen mapped migration-ledger rows with preserved deletion-batch ownership, only narrowly coupled metadata updates, and passing focused boundary/viz gates, without implementing deferred siblings or deleting catch-all sources, so the events/replay package can claim record_replay ownership cleanly.",
      "acceptanceCriteria": [
        "The eighteen checklist-authoritative migration-ledger rows mapped to tests/functional/events/replay/record_replay_test.go are consumed as ownership for this cell, including the sixteen replay_contracts-delete-01-events-replay scenarios (TestReplayEventStreamArtifactSmoke_ReplaysCheckedInSampleArtifact, TestReplayEventStreamArtifactSmoke_ReplaysCheckedInSampleArtifactWithCopiedRootFactoryDefinition, TestReplayFactoryOnlySerializationSmoke_RecordReplayUsesRunStartedFactoryPayload, TestRecordReplayEndToEnd_CLIRecordReplayAndRegressionHarnessSucceed, TestRecordReplayEndToEnd_DefaultLiveRecordingPathReplaysThroughExistingFlow, TestRecordReplayEndToEnd_FactoryRequestBatchAndWorkerGeneratedBatchReplayDeterministically, TestRecordReplayEndToEnd_ProviderCommandDiagnosticsPersistRedactedEnv, TestReplayRegressionHarness_AssertsExpectedDivergence, TestReplayRegressionHarness_LoadsArtifactAndAssertsSuccessfulReplay, TestReplayRuntimeConfigSmoke_CanonicalWorkstationsDriveDispatchAndReplay, TestReplayThinEventDualDispatchSmoke_ReplayAndReadersReuseSharedArtifact, TestReplayThinEventDualDispatchSmoke_SharedArtifactCapturesModelAndScriptDispatches, TestReplayThinEventDualDispatchSmoke_SharedArtifactGuardsThinRawContract, TestReplayWorkDispatchContractSmoke_CanonicalWorkRequestPreservesPayload, TestReplayWorkDispatchContractSmoke_LegacySubmitRequestAdapterPreservesPayload, TestReplayWorkDispatchContractSmoke_RecordReplayKeepsSplitContractCorrelation) and the two remaining runtime_api-delete-07-events-replay scenarios (TestAPIUnifiedEventLogSmoke_LiveRecordReplayProjectionAndDivergenceUseSameTimeline, TestEndToEndTopologyProjectionSmoke_LiveEventsAndReplayConfigMatch).",
        "Named deletion-batches replay_contracts-delete-01-events-replay and runtime_api-delete-07-events-replay are preserved for record_replay-mapped rows; catch-all sources are not deleted in this cell; corrupt_artifact_test.go, cli_api_parity_test.go, stream_test.go, and factory_events cells are not implemented here.",
        "Only narrowly coupled ownership, coverage, catalog, or migration metadata required for this cell are updated; deferred neighboring events packages are not rewritten beyond what is required to leave shared support helpers compiling safely.",
        "Focused package tests for tests/functional/events/replay pass.",
        "make functional-boundary-check passes for the touched functional layout.",
        "Functional-test-viz-compatible metadata checks succeed for the new top-level tests (documented Go docs inventoriable; domain ownership inferred as events/replay).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)