### PR TITLE
Support provider-neutral reasoning effort

### DIFF
--- a/api/components/schemas/api/GlobalConfigWorkerPresetReasoningEffort.yaml
+++ b/api/components/schemas/api/GlobalConfigWorkerPresetReasoningEffort.yaml
@@ -1,3 +1,3 @@
 type: string
 description: Optional reasoning effort; surrounding whitespace and letter case are normalized, and an empty value is treated as unspecified.
-pattern: "^[\t-\r \u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH])?[\t-\r \u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]*$"
+pattern: "^[\t-\r \u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH]|[xX][hH][iI][gG][hH]|[mM][aA][xX])?[\t-\r \u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]*$"

--- a/api/components/schemas/data-models/ReasoningEffort.yaml
+++ b/api/components/schemas/data-models/ReasoningEffort.yaml
@@ -1,0 +1,7 @@
+description: >-
+  Optional provider-neutral reasoning effort. Surrounding whitespace and letter
+  case are normalized. Omit the field to preserve the selected provider and
+  model default. Factory definitions may use an exact invocation-parameter
+  placeholder such as `${executorReasoningEffort}`.
+type: string
+pattern: "^(?:[\t-\r \u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH]|[xX][hH][iI][gG][hH]|[mM][aA][xX])?[\t-\r \u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]*|\\$\\{[A-Za-z0-9_.-]+\\})$"

--- a/api/components/schemas/data-models/Worker.yaml
+++ b/api/components/schemas/data-models/Worker.yaml
@@ -39,6 +39,8 @@ properties:
       such as `cursor-acp`. Extension identities use lowercase standardized
       syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility
       conveniences.
+  reasoningEffort:
+    $ref: './ReasoningEffort.yaml'
   modelLocality:
     allOf:
       - $ref: './WorkerModelLocality.yaml'

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -8826,6 +8826,8 @@ components:
             - type: string
               pattern: ^\$\{[A-Za-z0-9_.-]+\}$
           description: 'Canonical provider identity used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. For `executorProvider: ACP`, this names the configured ACP integration, such as `cursor-acp`. Extension identities use lowercase standardized syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility conveniences.'
+        reasoningEffort:
+          $ref: '#/components/schemas/ReasoningEffort'
         modelLocality:
           allOf:
             - $ref: '#/components/schemas/WorkerModelLocality'
@@ -10175,7 +10177,7 @@ components:
     GlobalConfigWorkerPresetReasoningEffort:
       type: string
       description: Optional reasoning effort; surrounding whitespace and letter case are normalized, and an empty value is treated as unspecified.
-      pattern: "^[\t-\r \N\_  - \L\P  　]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH])?[\t-\r \N\_  - \L\P  　]*$"
+      pattern: "^[\t-\r \N\_  - \L\P  　]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH]|[xX][hH][iI][gG][hH]|[mM][aA][xX])?[\t-\r \N\_  - \L\P  　]*$"
     WorkRequest:
       type: object
       additionalProperties: false
@@ -10917,6 +10919,10 @@ components:
       description: Built-in repository-owned hosted worker providers supported by the public factory-config contract.
       enum:
         - LINEAR
+    ReasoningEffort:
+      description: Optional provider-neutral reasoning effort. Surrounding whitespace and letter case are normalized. Omit the field to preserve the selected provider and model default. Factory definitions may use an exact invocation-parameter placeholder such as `${executorReasoningEffort}`.
+      type: string
+      pattern: "^(?:[\t-\r \N\_  - \L\P  　]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH]|[xX][hH][iI][gG][hH]|[mM][aA][xX])?[\t-\r \N\_  - \L\P  　]*|\\$\\{[A-Za-z0-9_.-]+\\})$"
     HostedWorkerAuth:
       description: Hosted-worker authentication contract. V1 hosted workers accept only secret references rather than inline credentials or OAuth-style fields.
       type: object

--- a/contracts/config/factory.schema.json
+++ b/contracts/config/factory.schema.json
@@ -1458,6 +1458,11 @@
       "pattern": "^(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|ANTIGRAVITY|ANTHROPIC|CLAUDE|CODEX|OPENAI)$",
       "type": "string"
     },
+    "ReasoningEffort": {
+      "description": "Optional provider-neutral reasoning effort. Surrounding whitespace and letter case are normalized. Omit the field to preserve the selected provider and model default. Factory definitions may use an exact invocation-parameter placeholder such as `${executorReasoningEffort}`.",
+      "pattern": "^(?:[\t-\r    - \u2028\u2029  　]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH]|[xX][hH][iI][gG][hH]|[mM][aA][xX])?[\t-\r    - \u2028\u2029  　]*|\\$\\{[A-Za-z0-9_.-]+\\})$",
+      "type": "string"
+    },
     "RequiredTool": {
       "additionalProperties": false,
       "description": "One declarative external tool dependency for a portable factory.",
@@ -2058,6 +2063,9 @@
             }
           ],
           "description": "Built-in hosted provider identity when this worker uses repository-owned hosted execution."
+        },
+        "reasoningEffort": {
+          "$ref": "#/$defs/ReasoningEffort"
         },
         "resources": {
           "description": "Resource capacity this worker requires before it can be dispatched.",

--- a/contracts/config/you-config.schema.json
+++ b/contracts/config/you-config.schema.json
@@ -155,13 +155,15 @@
         },
         "reasoningEffort": {
           "type": "string",
-          "pattern": "^[\\t-\\r \u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH])?[\\t-\\r \u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]*$",
+          "pattern": "^[\\t-\\r \u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH]|[xX][hH][iI][gG][hH]|[mM][aA][xX])?[\\t-\\r \u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]*$",
           "description": "Optional reasoning effort level. Surrounding whitespace and letter case are normalized; an empty value is accepted.",
           "examples": [
             "",
             "low",
             "medium",
-            "high"
+            "high",
+            "xhigh",
+            "max"
           ]
         }
       }
@@ -737,7 +739,7 @@
       "workerPresets[].reasoningEffort": {
         "inventoryId": "workerPresets[].reasoningEffort",
         "jsonPath": "workerPresets[].reasoningEffort",
-        "defaultEmptyBehavior": "optional; empty value is accepted; supported values are minimal, low, medium, high",
+        "defaultEmptyBehavior": "optional; empty value is accepted; supported values are minimal, low, medium, high, xhigh, max",
         "parseOwner": "operator_settings",
         "persistenceOwner": "operator_settings",
         "strictness": "operator_settings generated GlobalConfig strict decode (unknown fields and trailing JSON rejected)",
@@ -751,14 +753,16 @@
             },
             "description": {
               "id": "config.worker-presets.reasoning-effort.description",
-              "canonicalEnglish": "Optional reasoning effort level. Empty value is accepted; supported values are minimal, low, medium, and high."
+              "canonicalEnglish": "Optional reasoning effort level. Empty value is accepted; supported values are minimal, low, medium, high, xhigh, and max."
             }
           },
           "examples": [
             "",
             "low",
             "medium",
-            "high"
+            "high",
+            "xhigh",
+            "max"
           ],
           "visibility": "public",
           "sourceHash": "e86e22b0cc80dc31e5ae9137dfd66f86a61957be6d71684ef364a36379aa5a76"

--- a/docs/internal/baselines/frontend-deadcode-baseline.json
+++ b/docs/internal/baselines/frontend-deadcode-baseline.json
@@ -17,74 +17,82 @@
   {
     "file": "packages/components/src/charts/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory",
-    "namespace": "charts"
+    "name": "ComponentsCategory"
   },
   {
     "file": "packages/components/src/data-display/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory",
-    "namespace": "dataDisplay"
+    "name": "ComponentsCategory"
   },
   {
     "file": "packages/components/src/factory-emulator/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory",
-    "namespace": "factoryEmulator"
+    "name": "ComponentsCategory"
   },
   {
     "file": "packages/components/src/feedback/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory",
-    "namespace": "feedback"
+    "name": "ComponentsCategory"
   },
   {
     "file": "packages/components/src/forms/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory",
-    "namespace": "forms"
+    "name": "ComponentsCategory"
   },
   {
     "file": "packages/components/src/graphs/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory",
-    "namespace": "graphs"
+    "name": "ComponentsCategory"
   },
   {
     "file": "packages/components/src/icons/index.ts",
-    "kind": "type",
-    "name": "ComponentsCategory",
-    "namespace": "icons"
+    "kind": "file",
+    "name": "packages/components/src/icons/index.ts"
   },
   {
     "file": "packages/components/src/layout/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory",
-    "namespace": "layout"
+    "name": "ComponentsCategory"
   },
   {
     "file": "packages/components/src/navigation/index.ts",
-    "kind": "type",
-    "name": "ComponentsCategory",
-    "namespace": "navigation"
+    "kind": "file",
+    "name": "packages/components/src/navigation/index.ts"
   },
   {
     "file": "packages/components/src/overlays/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory",
-    "namespace": "overlays"
+    "name": "ComponentsCategory"
   },
   {
     "file": "packages/components/src/primitives/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory",
-    "namespace": "primitives"
+    "name": "ComponentsCategory"
   },
   {
     "file": "packages/components/src/recipes/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory",
-    "namespace": "recipes"
+    "name": "ComponentsCategory"
+  },
+  {
+    "file": "packages/components/src/styles.css",
+    "kind": "file",
+    "name": "packages/components/src/styles.css"
+  },
+  {
+    "file": "packages/components/src/styles/color-palette-presets.css",
+    "kind": "file",
+    "name": "packages/components/src/styles/color-palette-presets.css"
+  },
+  {
+    "file": "packages/components/src/styles/color-role-tokens.css",
+    "kind": "file",
+    "name": "packages/components/src/styles/color-role-tokens.css"
+  },
+  {
+    "file": "packages/components/src/styles/layout-role-tokens.css",
+    "kind": "file",
+    "name": "packages/components/src/styles/layout-role-tokens.css"
   },
   {
     "file": "packages/components/src/styles/package-token-fixture-usage.ts",
@@ -92,22 +100,39 @@
     "name": "packages/components/src/styles/package-token-fixture-usage.ts"
   },
   {
+    "file": "packages/components/src/styles/text-color-role-tokens.css",
+    "kind": "file",
+    "name": "packages/components/src/styles/text-color-role-tokens.css"
+  },
+  {
+    "file": "packages/components/src/styles/typography-role-tokens.css",
+    "kind": "file",
+    "name": "packages/components/src/styles/typography-role-tokens.css"
+  },
+  {
+    "file": "packages/components/src/styles/typography-role-utilities.css",
+    "kind": "file",
+    "name": "packages/components/src/styles/typography-role-utilities.css"
+  },
+  {
+    "file": "packages/components/src/styles/typography-roles.css",
+    "kind": "file",
+    "name": "packages/components/src/styles/typography-roles.css"
+  },
+  {
     "file": "packages/components/src/testing/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory",
-    "namespace": "testing"
+    "name": "ComponentsCategory"
   },
   {
     "file": "packages/components/src/tokens/index.ts",
-    "kind": "type",
-    "name": "ComponentsCategory",
-    "namespace": "tokens"
+    "kind": "file",
+    "name": "packages/components/src/tokens/index.ts"
   },
   {
     "file": "packages/components/src/utilities/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory",
-    "namespace": "utilities"
+    "name": "ComponentsCategory"
   },
   {
     "file": "packages/components/vite.build.config.ts",
@@ -163,5 +188,10 @@
     "file": "src/features/flowchart/components/current-activity-workstation-node.tsx",
     "kind": "file",
     "name": "src/features/flowchart/components/current-activity-workstation-node.tsx"
+  },
+  {
+    "file": "src/features/graphs/components/factory-graph-edge.tsx",
+    "kind": "type",
+    "name": "FactoryGraphEdgeData"
   }
 ]

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1539,6 +1539,10 @@
       "minimum": 94.59
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/inference",
+      "minimum": 0.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/service",
       "minimum": 100.00
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -14,7 +14,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/initializer/application",
-      "minimum": 80.91
+      "minimum": 78.83
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/initializer/lifecycle",
@@ -116,7 +116,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal",
-      "minimum": 85.00
+      "minimum": 81.20
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/cron",
@@ -130,7 +130,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/cron/internal/service",
-      "minimum": 89.30
+      "minimum": 88.14
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/cron/wire",
@@ -430,7 +430,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/invocation_policy/invocationinterpolation",
-      "minimum": 25.82
+      "minimum": 25.13
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/invocation_policy/invocationoutput",
@@ -694,7 +694,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/instance_host/build",
-      "minimum": 81.31
+      "minimum": 79.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/instance_host/internal/service",
@@ -936,7 +936,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/responsestream/fragmentmap",
-      "minimum": 85.84
+      "minimum": 65.31
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/responsestream/ndjsoncontract",
@@ -1450,7 +1450,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/testproviders",
-      "minimum": 93.33
+      "minimum": 86.20
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/cli",
@@ -1536,7 +1536,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers",
-      "minimum": 94.59
+      "minimum": 88.88
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/inference",
@@ -1544,7 +1544,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/service",
-      "minimum": 100.00
+      "minimum": 81.08
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/acp",
@@ -1594,7 +1594,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/internal/service",
-      "minimum": 91.11
+      "minimum": 89.47
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/wire",
@@ -1616,7 +1616,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution/internal/adapters/agy/agypty",
-      "minimum": 89.65
+      "minimum": 89.54
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution/internal/adapters/claude",
@@ -1632,7 +1632,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution/internal/provider",
-      "minimum": 75.24
+      "minimum": 73.27
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution/internal/provider/adapter",
@@ -1676,7 +1676,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution/internal/provider/registry",
-      "minimum": 85.00
+      "minimum": 82.66
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution/internal/provider/structured",
@@ -1688,7 +1688,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution/wire",
-      "minimum": 100.00
+      "minimum": 90.90
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/testutil/execution",
@@ -1708,7 +1708,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/wire",
-      "minimum": 87.50
+      "minimum": 74.10
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings",
@@ -1878,7 +1878,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/work",
-      "minimum": 81.00
+      "minimum": 80.87
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/contenturl",
@@ -1898,7 +1898,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/service",
-      "minimum": 75.00
+      "minimum": 74.35
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/services/content_materialization",
@@ -1980,11 +1980,11 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers",
-      "minimum": 84.68
+      "minimum": 79.81
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal",
-      "minimum": 71.65
+      "minimum": 54.08
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/diagnostics",
@@ -1998,7 +1998,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/interface",
-      "minimum": 95.55
+      "minimum": 94.81
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/service",
@@ -2016,11 +2016,11 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/inference",
-      "minimum": 82.83
+      "minimum": 78.35
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/inference",
-      "minimum": 94.31
+      "minimum": 93.18
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/mock",
@@ -2032,7 +2032,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/service",
-      "minimum": 90.36
+      "minimum": 90.21
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/services/agent",
@@ -2054,11 +2054,11 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/testkit",
-      "minimum": 89.53
+      "minimum": 88.42
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/process",
-      "minimum": 69.00
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/runner",
@@ -2072,7 +2072,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/testing",
-      "minimum": 90.44
+      "minimum": 89.80
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/wire",
@@ -2130,7 +2130,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/workstations/execution/recording",
-      "minimum": 74.05
+      "minimum": 70.30
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/workstations/executor",
@@ -2138,7 +2138,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/workstations/executor/agentrun",
-      "minimum": 81.10
+      "minimum": 80.93
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/workstations/inferencefailure",
@@ -2188,7 +2188,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli",
-      "minimum": 75.89
+      "minimum": 71.22
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/acp",
@@ -2212,7 +2212,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/climanifestcobra",
-      "minimum": 80.80
+      "minimum": 80.71
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/cliserver",
@@ -2260,7 +2260,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/initsetup",
-      "minimum": 81.08
+      "minimum": 68.75
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/mcp",
@@ -2314,7 +2314,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/http",
-      "minimum": 63.84
+      "minimum": 63.82
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/http/apitypes",
@@ -2342,7 +2342,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/factoryconfig/authored",
-      "minimum": 69.19
+      "minimum": 67.39
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/factoryconfig/diagnostics",
@@ -2410,7 +2410,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/wire",
-      "minimum": 81.44
+      "minimum": 80.94
     }
   ]
 }

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1547,6 +1547,10 @@
       "minimum": 100.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/acp",
+      "minimum": 0.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog",
       "exception": {
         "kind": "measurement",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1548,7 +1548,39 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/acp",
-      "minimum": 0.00
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active unit coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/acp/internal/service",
+      "minimum": 50.09
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/acp/wire",
+      "minimum": 100.00
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/builtins",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active unit coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/builtins/internal/service",
+      "minimum": 78.57
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/builtins/wire",
+      "minimum": 100.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog",
@@ -1857,6 +1889,10 @@
       "minimum": 45.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/proposalmaterialization",
+      "minimum": 83.33
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/requestadmission",
       "minimum": 80.00
     },
@@ -1965,6 +2001,10 @@
       "minimum": 95.55
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/service",
+      "minimum": 71.71
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners",
       "exception": {
         "kind": "measurement",
@@ -1981,6 +2021,10 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/inference",
       "minimum": 94.31
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/mock",
+      "minimum": 54.05
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/script",

--- a/docs/internal/development/plans/luna-xhigh-plan-parallel.md
+++ b/docs/internal/development/plans/luna-xhigh-plan-parallel.md
@@ -1,0 +1,154 @@
+# Luna xhigh plan-parallel implementation
+
+## Outcome
+
+`@you/plan-parallel` can run its task executor workers with
+`gpt-5.6-luna` at canonical `xhigh` reasoning effort. The Factory definition
+expresses the effort without provider-specific flags, Workers and Providers
+preserve it through execution, and the Codex adapter alone renders the native
+CLI configuration.
+
+Cursor execution remains ACP-only. Cursor ACP models encode their effort in
+their exact advertised model identifiers, such as
+`cursor-grok-4.5-medium-fast`; this change does not recreate a native Cursor
+provider or synthesize Cursor model identifiers from a separate effort field.
+
+## Behavior contract
+
+- Authored model-backed workers may set optional `reasoningEffort`.
+- Supported canonical efforts include `minimal`, `low`, `medium`, `high`,
+  `xhigh`, and `max`.
+- Surrounding whitespace and case are normalized.
+- Omitted effort preserves the provider default.
+- Unsupported effort fails before provider execution.
+- Codex renders a requested effort as
+  `--config model_reasoning_effort="<effort>"`.
+- Claude renders its supported values as `--effort <effort>` and rejects the
+  provider-neutral `minimal` value before starting the CLI.
+- `@you/plan-parallel` exposes `--executor-reasoning-effort`, defaults it to
+  `xhigh`, and applies it only to `parallel-executor`.
+- Planner and merger effort remain unspecified unless separately implemented
+  by a future change.
+
+## Package and artifact scope
+
+- `pkg/services/factory_definitions`: authored Worker contract, invocation
+  interpolation, validation, and runtime-config merging.
+- `pkg/services/workers`: workstation and Agent Runner propagation.
+- `pkg/services/providers`: provider-neutral execution contract, Codex and
+  Claude rendering, and ACP exact-model semantics.
+- `pkg/services/factory_sessions`: live-child request propagation.
+- `pkg/transports/mapping`, `api/`, `contracts/`, `packages/api`, and
+  `ui/**/generated`: public contract sources, mappings, and generated clients.
+- `packages/packaged-factories`: authored and generated `@you/plan-parallel`
+  and `@you/subagent` definitions.
+- `docs/reference`: public Worker and JavaScript-workflow documentation.
+
+No native Cursor package is added; `cursor-acp` remains the only Cursor
+execution surface.
+
+## Test and integration matrix
+
+- Unit/contract tests cover canonicalization, invalid values, request cloning,
+  runtime overlay behavior, ACP rejection, and exact Codex/Claude arguments.
+- Packaged Factory functional tests cover default `xhigh`, a `low` override,
+  executor-only scoping, invalid resolved effort before executor startup,
+  concurrent task dispatch, and the subagent Luna/xhigh command.
+- Generation checks cover OpenAPI, JSON Schema, Go/TypeScript clients, and the
+  packaged Factory catalog.
+- Live bootstrap checks use the binary built from this worktree to run
+  `@you/subagent` and `@you/plan-parallel`, then inspect the actual child
+  process arguments.
+- Delivery integration runs repository verification and required GitHub CI,
+  repairs failures, and repeats until the PR is merged.
+
+## Implementation checklist
+
+### Authored and public contracts
+
+- [x] Add `reasoningEffort` to the authored Worker contract and clone path.
+- [x] Add Worker OpenAPI/schema documentation for the field.
+- [x] Extend canonical effort normalization through `xhigh` and `max`.
+- [x] Validate literal worker effort and resolved invocation interpolation.
+- [x] Allow invocation parameters to interpolate `worker.reasoningEffort`.
+- [x] Add focused positive and invalid-value contract tests.
+
+### Runtime propagation
+
+- [x] Carry effort in workstation and provider inference requests.
+- [x] Preserve effort through request clones and worker adaptations.
+- [x] Carry effort through the Agent Runner to `providers.ExecuteRequest`.
+- [x] Preserve effort through native and conductor provider-root adaptation.
+- [x] Fix the existing JavaScript live-child handoff so it does not drop
+      `reasoningEffort`.
+
+### Provider behavior
+
+- [x] Render the exact Codex config arguments for non-empty effort.
+- [x] Emit no Codex effort arguments when effort is omitted.
+- [x] Test exact argument order/value for `xhigh`.
+- [x] Reject Claude `minimal` at both the public and legacy provider
+      boundaries without starting a provider process.
+- [x] Resolve native provider aliases before provider-specific effort policy so
+      case/whitespace variants retain `invalid_request` classification.
+- [x] Reject unsupported effort defensively in direct Codex/Claude adapters and
+      legacy provider argument builders.
+- [x] Keep Cursor ACP model selection exact and avoid a native Cursor path.
+
+### Packaged Factory
+
+- [x] Add the `executorReasoningEffort` invocation parameter to
+      `@you/plan-parallel`.
+- [x] Default the parameter to `xhigh`.
+- [x] Bind it only to the `parallel-executor` worker.
+- [x] Regenerate packaged Factory catalog output.
+- [x] Update plan-parallel functional coverage to prove executor-only effort.
+
+### Generated artifacts and documentation
+
+- [x] Regenerate public API and contract artifacts from authored sources.
+- [x] Update public reasoning-effort documentation.
+- [x] Confirm generated-artifact drift checks pass.
+
+## Verification checklist
+
+- [x] Focused Factory Definitions tests pass.
+- [x] Focused Workers tests pass.
+- [x] Focused Providers argument and adapter tests pass.
+- [x] Focused Factory Sessions live-child tests pass.
+- [x] Plan-parallel functional tests prove concurrent Luna/xhigh executors.
+- [x] Contract generation and checks pass.
+- [x] Packaged Factory generation and checks pass.
+- [x] `make verify-fast` passes.
+- [ ] `make verify-pr` passes.
+- [x] `make build-all` passes.
+
+## Bootstrap and independent confirmation
+
+- [x] Build a local `you` bootstrap binary from the changed source.
+- [x] Run an initial read-only `@you/subagent` review using
+      `gpt-5.6-luna` with `xhigh`.
+- [x] If the subagent identifies a blocking gap, fix it and repeat the
+      subagent review until it completes without a blocking finding.
+- [x] Run a read-only `@you/plan-parallel` Luna/xhigh canary and inspect its
+      retained dispatch/provider evidence.
+- [x] Use the bootstrapped Luna/xhigh executor path for a bounded follow-up
+      audit or repair task.
+
+## Delivery checklist
+
+- [x] Review the final diff for unrelated or generated-only edits.
+- [x] Commit the implementation intentionally.
+- [ ] Push `codex/luna-xhigh-parallel`.
+- [ ] Open a draft PR and monitor required CI to terminal state.
+- [ ] Use Luna/xhigh subagent/factory review to inspect failures and blocking
+      review feedback.
+- [ ] Fix failures, regenerate as needed, push, and repeat until required CI is
+      green and blocking feedback is resolved.
+- [x] Resolve merge conflicts against the target branch.
+- [ ] Mark the PR ready when the implementation and evidence are complete.
+- [ ] Merge the PR and confirm the repository reports the merged state.
+
+Completion requires every applicable checkbox above, terminal green required
+CI, resolved blocking review feedback and conflicts, and the PR actually
+merged.

--- a/docs/reference/javascript-workflows.md
+++ b/docs/reference/javascript-workflows.md
@@ -244,7 +244,7 @@ Reusable JavaScript child settings are operator-owned in
 
 Each preset supports a required, unique, non-empty `id` and required
 `modelProvider`; `model` and `reasoningEffort` are optional. Supported reasoning
-efforts are `minimal`, `low`, `medium`, and `high`. Reference a preset directly
+efforts are `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. Reference a preset directly
 with `agent.run({preset: "careful-review", ...})`.
 
 Worker fields resolve independently. Highest precedence is an explicit

--- a/docs/reference/workers.md
+++ b/docs/reference/workers.md
@@ -83,8 +83,9 @@ See `you docs workstations` for the matching `INFERENCE_RUN`, `AGENT_RUN`,
 - `INFERENCE_WORKER` can declare provider-agnostic `operations`, named input
   and output slots, `modelLocality`, and concrete `model` identity so
   `INFERENCE_RUN` workstations can validate compatibility before dispatch.
-- `AGENT_WORKER` supplies the model backend and shared system instructions for
-  prompt-rendered `AGENT_RUN` workstations.
+- `AGENT_WORKER` supplies the model backend, optional provider-neutral
+  `reasoningEffort`, and shared system instructions for prompt-rendered
+  `AGENT_RUN` workstations.
 - Current built-in `modelProvider` values are `CLAUDE`, `CODEX`, and
   `ANTIGRAVITY`.
 - Runner selection is separate from `modelProvider`. Use factory or
@@ -124,7 +125,7 @@ defaults. Script and hosted workers never receive operator model defaults.
 
 | Put it on the worker | Put it on the workstation |
 |----------------------|---------------------------|
-| `type`, `model`, `modelProvider`, `executorProvider` | `type`, `worker`, `promptFile`, prompt body |
+| `type`, `model`, `modelProvider`, `executorProvider`, `reasoningEffort` | `type`, `worker`, `promptFile`, prompt body |
 | `command`, `args` | `behavior`, `outputs`, `onFailure`, `onContinue`, `onRejection` |
 | `provider`, `auth.secretRef`, `linear.*` for hosted pollers | `outputSchema`, `limits.maxExecutionTime`, `limits.maxRetries` |
 | `resources`, `timeout`, `stopToken`, `skipPermissions` | `stopWords`, `workingDirectory`, `worktree`, `env` |
@@ -138,6 +139,25 @@ worker. Do not move hosted Linear provider config onto the workstation body.
 Use the worker when the setting belongs to the execution backend or shared
 worker identity. Use the workstation when the setting belongs to one workflow
 step, prompt rendering, or per-step execution behavior.
+
+### Reasoning effort
+
+Model-backed workers may set `reasoningEffort` to `minimal`, `low`, `medium`,
+`high`, `xhigh`, or `max`. Values are trimmed and normalized to lowercase.
+Omit the field to preserve the provider or selected model default. Invocation
+parameters may supply an exact placeholder such as
+`reasoningEffort: ${executorReasoningEffort}`; an unsupported resolved value
+fails before a provider process starts.
+
+The runtime keeps this contract provider-neutral. Codex translates it to
+`--config model_reasoning_effort="<effort>"`, while Claude translates it to
+`--effort <effort>`. Claude's `ultracode` session mode is not an effort value:
+configure that provider-specific workflow separately instead of setting
+`reasoningEffort`. ACP integrations such as `cursor-acp` advertise exact model
+identifiers that already encode effort, for example
+`cursor-grok-4.5-medium-fast`; select that model ID and omit
+`reasoningEffort`. Providers without an effort mapping reject a non-empty
+value; the current `ANTIGRAVITY` adapter does not accept a separate effort.
 
 ## Worker Types
 

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -211,7 +211,7 @@
       "path": "generated/mcp/tools.json"
     },
     "generated.openapi.openapi": {
-      "artifactHash": "0ec0e9542daaf309aff283dbdf414f1ffc6029e6b9d87eefe3fc093e0592525e",
+      "artifactHash": "505bd7544190c9b1cd9b6b8a539d6b3347cc37935f0a0988908ea64f826a501e",
       "documentation": {
         "documentation": {
           "description": {
@@ -228,7 +228,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.openapi.openapi",
-        "sourceHash": "0ec0e9542daaf309aff283dbdf414f1ffc6029e6b9d87eefe3fc093e0592525e",
+        "sourceHash": "505bd7544190c9b1cd9b6b8a539d6b3347cc37935f0a0988908ea64f826a501e",
         "visibility": "public"
       },
       "family": "openapi",
@@ -241,7 +241,7 @@
       "path": "generated/openapi/openapi.yaml"
     },
     "generated.schemas.factory": {
-      "artifactHash": "0ae97963f847121458202262fdbd9d36a71292f328859b784f8f3478ca6efba7",
+      "artifactHash": "cfaca445e814d3b2b7e8f3df07b50fb2d43bdfeac83de5a04a6d37398c63526b",
       "documentation": {
         "documentation": {
           "description": {
@@ -258,7 +258,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.schemas.factory",
-        "sourceHash": "0ae97963f847121458202262fdbd9d36a71292f328859b784f8f3478ca6efba7",
+        "sourceHash": "cfaca445e814d3b2b7e8f3df07b50fb2d43bdfeac83de5a04a6d37398c63526b",
         "visibility": "public"
       },
       "family": "config",
@@ -271,7 +271,7 @@
       "path": "generated/schemas/factory.schema.json"
     },
     "generated.schemas.factory-event": {
-      "artifactHash": "99fdb96c3decbfe73ffd3eff535ab7158e0943e0bb1e858f5577dba597ed0bb6",
+      "artifactHash": "dd13d6169ef46fc48a325e00d0a6b5deb995064e154ac5a7051d5323ecfe4964",
       "documentation": {
         "documentation": {
           "description": {
@@ -288,7 +288,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.schemas.factory-event",
-        "sourceHash": "99fdb96c3decbfe73ffd3eff535ab7158e0943e0bb1e858f5577dba597ed0bb6",
+        "sourceHash": "dd13d6169ef46fc48a325e00d0a6b5deb995064e154ac5a7051d5323ecfe4964",
         "visibility": "public"
       },
       "family": "config",
@@ -301,7 +301,7 @@
       "path": "generated/schemas/factory-event.schema.json"
     },
     "generated.schemas.factory-recording": {
-      "artifactHash": "1b38817f86b48638ba57f3d9a0ed91a30b38bd26eaa1d69cea170e7526d85e7b",
+      "artifactHash": "9c97fdae3eb785b8d1b652b279dcffcd95890f356e1c246f03014c88210ff9b7",
       "documentation": {
         "documentation": {
           "description": {
@@ -318,7 +318,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.schemas.factory-recording",
-        "sourceHash": "1b38817f86b48638ba57f3d9a0ed91a30b38bd26eaa1d69cea170e7526d85e7b",
+        "sourceHash": "9c97fdae3eb785b8d1b652b279dcffcd95890f356e1c246f03014c88210ff9b7",
         "visibility": "public"
       },
       "family": "config",
@@ -361,7 +361,7 @@
       "path": "generated/schemas/mock-workers.schema.json"
     },
     "generated.schemas.you-config": {
-      "artifactHash": "b4a7d3419d8bd6be74e6f0015801126257a0483c6c3003c2dffba9fb75b8b92c",
+      "artifactHash": "4c0ba04cac5e3a1a3834cc52a799425d81c52474b31b4d1df3d8a49b5166dcce",
       "documentation": {
         "documentation": {
           "description": {
@@ -378,7 +378,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.schemas.you-config",
-        "sourceHash": "b4a7d3419d8bd6be74e6f0015801126257a0483c6c3003c2dffba9fb75b8b92c",
+        "sourceHash": "4c0ba04cac5e3a1a3834cc52a799425d81c52474b31b4d1df3d8a49b5166dcce",
         "visibility": "public"
       },
       "family": "config",

--- a/packages/api/generated/openapi/openapi.yaml
+++ b/packages/api/generated/openapi/openapi.yaml
@@ -8826,6 +8826,8 @@ components:
             - type: string
               pattern: ^\$\{[A-Za-z0-9_.-]+\}$
           description: 'Canonical provider identity used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. For `executorProvider: ACP`, this names the configured ACP integration, such as `cursor-acp`. Extension identities use lowercase standardized syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility conveniences.'
+        reasoningEffort:
+          $ref: '#/components/schemas/ReasoningEffort'
         modelLocality:
           allOf:
             - $ref: '#/components/schemas/WorkerModelLocality'
@@ -10175,7 +10177,7 @@ components:
     GlobalConfigWorkerPresetReasoningEffort:
       type: string
       description: Optional reasoning effort; surrounding whitespace and letter case are normalized, and an empty value is treated as unspecified.
-      pattern: "^[\t-\r \N\_  - \L\P  　]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH])?[\t-\r \N\_  - \L\P  　]*$"
+      pattern: "^[\t-\r \N\_  - \L\P  　]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH]|[xX][hH][iI][gG][hH]|[mM][aA][xX])?[\t-\r \N\_  - \L\P  　]*$"
     WorkRequest:
       type: object
       additionalProperties: false
@@ -10917,6 +10919,10 @@ components:
       description: Built-in repository-owned hosted worker providers supported by the public factory-config contract.
       enum:
         - LINEAR
+    ReasoningEffort:
+      description: Optional provider-neutral reasoning effort. Surrounding whitespace and letter case are normalized. Omit the field to preserve the selected provider and model default. Factory definitions may use an exact invocation-parameter placeholder such as `${executorReasoningEffort}`.
+      type: string
+      pattern: "^(?:[\t-\r \N\_  - \L\P  　]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH]|[xX][hH][iI][gG][hH]|[mM][aA][xX])?[\t-\r \N\_  - \L\P  　]*|\\$\\{[A-Za-z0-9_.-]+\\})$"
     HostedWorkerAuth:
       description: Hosted-worker authentication contract. V1 hosted workers accept only secret references rather than inline credentials or OAuth-style fields.
       type: object

--- a/packages/api/generated/schemas/factory-event.schema.json
+++ b/packages/api/generated/schemas/factory-event.schema.json
@@ -3228,6 +3228,11 @@
       },
       "type": "object"
     },
+    "ReasoningEffort": {
+      "description": "Optional provider-neutral reasoning effort. Surrounding whitespace and letter case are normalized. Omit the field to preserve the selected provider and model default. Factory definitions may use an exact invocation-parameter placeholder such as `${executorReasoningEffort}`.",
+      "pattern": "^(?:[\t-\r    - \u2028\u2029  　]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH]|[xX][hH][iI][gG][hH]|[mM][aA][xX])?[\t-\r    - \u2028\u2029  　]*|\\$\\{[A-Za-z0-9_.-]+\\})$",
+      "type": "string"
+    },
     "Relation": {
       "additionalProperties": false,
       "properties": {
@@ -4556,6 +4561,9 @@
             }
           ],
           "description": "Built-in hosted provider identity when this worker uses repository-owned hosted execution."
+        },
+        "reasoningEffort": {
+          "$ref": "#/$defs/ReasoningEffort"
         },
         "resources": {
           "description": "Resource capacity this worker requires before it can be dispatched.",

--- a/packages/api/generated/schemas/factory-recording.schema.json
+++ b/packages/api/generated/schemas/factory-recording.schema.json
@@ -3763,6 +3763,11 @@
       },
       "type": "object"
     },
+    "ReasoningEffort": {
+      "description": "Optional provider-neutral reasoning effort. Surrounding whitespace and letter case are normalized. Omit the field to preserve the selected provider and model default. Factory definitions may use an exact invocation-parameter placeholder such as `${executorReasoningEffort}`.",
+      "pattern": "^(?:[\t-\r    - \u2028\u2029  　]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH]|[xX][hH][iI][gG][hH]|[mM][aA][xX])?[\t-\r    - \u2028\u2029  　]*|\\$\\{[A-Za-z0-9_.-]+\\})$",
+      "type": "string"
+    },
     "Relation": {
       "additionalProperties": false,
       "properties": {
@@ -5091,6 +5096,9 @@
             }
           ],
           "description": "Built-in hosted provider identity when this worker uses repository-owned hosted execution."
+        },
+        "reasoningEffort": {
+          "$ref": "#/$defs/ReasoningEffort"
         },
         "resources": {
           "description": "Resource capacity this worker requires before it can be dispatched.",

--- a/packages/api/generated/schemas/factory.schema.json
+++ b/packages/api/generated/schemas/factory.schema.json
@@ -1458,6 +1458,11 @@
       "pattern": "^(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|ANTIGRAVITY|ANTHROPIC|CLAUDE|CODEX|OPENAI)$",
       "type": "string"
     },
+    "ReasoningEffort": {
+      "description": "Optional provider-neutral reasoning effort. Surrounding whitespace and letter case are normalized. Omit the field to preserve the selected provider and model default. Factory definitions may use an exact invocation-parameter placeholder such as `${executorReasoningEffort}`.",
+      "pattern": "^(?:[\t-\r    - \u2028\u2029  　]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH]|[xX][hH][iI][gG][hH]|[mM][aA][xX])?[\t-\r    - \u2028\u2029  　]*|\\$\\{[A-Za-z0-9_.-]+\\})$",
+      "type": "string"
+    },
     "RequiredTool": {
       "additionalProperties": false,
       "description": "One declarative external tool dependency for a portable factory.",
@@ -2058,6 +2063,9 @@
             }
           ],
           "description": "Built-in hosted provider identity when this worker uses repository-owned hosted execution."
+        },
+        "reasoningEffort": {
+          "$ref": "#/$defs/ReasoningEffort"
         },
         "resources": {
           "description": "Resource capacity this worker requires before it can be dispatched.",

--- a/packages/api/generated/schemas/you-config.schema.json
+++ b/packages/api/generated/schemas/you-config.schema.json
@@ -155,13 +155,15 @@
         },
         "reasoningEffort": {
           "type": "string",
-          "pattern": "^[\\t-\\r \u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH])?[\\t-\\r \u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]*$",
+          "pattern": "^[\\t-\\r \u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH]|[xX][hH][iI][gG][hH]|[mM][aA][xX])?[\\t-\\r \u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]*$",
           "description": "Optional reasoning effort level. Surrounding whitespace and letter case are normalized; an empty value is accepted.",
           "examples": [
             "",
             "low",
             "medium",
-            "high"
+            "high",
+            "xhigh",
+            "max"
           ]
         }
       }
@@ -737,7 +739,7 @@
       "workerPresets[].reasoningEffort": {
         "inventoryId": "workerPresets[].reasoningEffort",
         "jsonPath": "workerPresets[].reasoningEffort",
-        "defaultEmptyBehavior": "optional; empty value is accepted; supported values are minimal, low, medium, high",
+        "defaultEmptyBehavior": "optional; empty value is accepted; supported values are minimal, low, medium, high, xhigh, max",
         "parseOwner": "operator_settings",
         "persistenceOwner": "operator_settings",
         "strictness": "operator_settings generated GlobalConfig strict decode (unknown fields and trailing JSON rejected)",
@@ -751,14 +753,16 @@
             },
             "description": {
               "id": "config.worker-presets.reasoning-effort.description",
-              "canonicalEnglish": "Optional reasoning effort level. Empty value is accepted; supported values are minimal, low, medium, and high."
+              "canonicalEnglish": "Optional reasoning effort level. Empty value is accepted; supported values are minimal, low, medium, high, xhigh, and max."
             }
           },
           "examples": [
             "",
             "low",
             "medium",
-            "high"
+            "high",
+            "xhigh",
+            "max"
           ],
           "visibility": "public",
           "sourceHash": "e86e22b0cc80dc31e5ae9137dfd66f86a61957be6d71684ef364a36379aa5a76"

--- a/packages/packaged-factories/factories/plan-parallel/factory.yaml
+++ b/packages/packaged-factories/factories/plan-parallel/factory.yaml
@@ -46,6 +46,13 @@ invocationSignature:
         - ""
       bindings:
         - kind: NAMED
+    - name: executorReasoningEffort
+      description: Reasoning effort for planned task executors. Defaults to xhigh.
+      externalName: executor-reasoning-effort
+      defaultValues:
+        - xhigh
+      bindings:
+        - kind: NAMED
     - name: mergeProvider
       description: Model provider for final synthesis; omitted values use operator defaults.
       externalName: merge-provider
@@ -114,6 +121,7 @@ workers:
     type: AGENT_WORKER
     modelProvider: ${executorProvider}
     model: ${executorModel}
+    reasoningEffort: ${executorReasoningEffort}
     skipPermissions: true
     body: |-
       You are an isolated task executor with zero conversational context. Read the complete assigned Work payload rendered in the user message and relevant workspace instructions and source before acting.

--- a/packages/packaged-factories/factories/subagent/factory.yaml
+++ b/packages/packaged-factories/factories/subagent/factory.yaml
@@ -28,6 +28,13 @@ invocationSignature:
         - ""
       bindings:
         - kind: NAMED
+    - name: workerReasoningEffort
+      description: Optional reasoning effort for the subagent; omitted values use the provider default.
+      externalName: worker-reasoning-effort
+      defaultValues:
+        - ""
+      bindings:
+        - kind: NAMED
 examples:
   - name: positional-input
     description:
@@ -59,6 +66,7 @@ workers:
     skipPermissions: true
     modelProvider: ${workerProvider}
     model: ${workerModel}
+    reasoningEffort: ${workerReasoningEffort}
     agentTools:
       policy: READ_ONLY
     promptFile: prompts/worker.md

--- a/packages/packaged-factories/generated/factories/plan-parallel/factory.json
+++ b/packages/packaged-factories/generated/factories/plan-parallel/factory.json
@@ -100,6 +100,19 @@
           }
         ],
         "defaultValues": [
+          "xhigh"
+        ],
+        "description": "Reasoning effort for planned task executors. Defaults to xhigh.",
+        "externalName": "executor-reasoning-effort",
+        "name": "executorReasoningEffort"
+      },
+      {
+        "bindings": [
+          {
+            "kind": "NAMED"
+          }
+        ],
+        "defaultValues": [
           ""
         ],
         "description": "Model provider for final synthesis; omitted values use operator defaults.",
@@ -185,6 +198,7 @@
       "model": "${executorModel}",
       "modelProvider": "${executorProvider}",
       "name": "parallel-executor",
+      "reasoningEffort": "${executorReasoningEffort}",
       "skipPermissions": true,
       "type": "AGENT_WORKER"
     },

--- a/packages/packaged-factories/generated/factories/plan-parallel/factory.yaml
+++ b/packages/packaged-factories/generated/factories/plan-parallel/factory.yaml
@@ -55,6 +55,13 @@ invocationSignature:
         - bindings:
             - kind: NAMED
           defaultValues:
+            - xhigh
+          description: Reasoning effort for planned task executors. Defaults to xhigh.
+          externalName: executor-reasoning-effort
+          name: executorReasoningEffort
+        - bindings:
+            - kind: NAMED
+          defaultValues:
             - ""
           description: Model provider for final synthesis; omitted values use operator defaults.
           externalName: merge-provider
@@ -119,6 +126,7 @@ workers:
       model: ${executorModel}
       modelProvider: ${executorProvider}
       name: parallel-executor
+      reasoningEffort: ${executorReasoningEffort}
       skipPermissions: true
       type: AGENT_WORKER
     - body: |-

--- a/packages/packaged-factories/generated/factories/subagent/factory.json
+++ b/packages/packaged-factories/generated/factories/subagent/factory.json
@@ -71,6 +71,19 @@
         "description": "Model for the subagent; omitted values use operator defaults.",
         "externalName": "worker-model",
         "name": "workerModel"
+      },
+      {
+        "bindings": [
+          {
+            "kind": "NAMED"
+          }
+        ],
+        "defaultValues": [
+          ""
+        ],
+        "description": "Optional reasoning effort for the subagent; omitted values use the provider default.",
+        "externalName": "worker-reasoning-effort",
+        "name": "workerReasoningEffort"
       }
     ]
   },
@@ -106,6 +119,7 @@
       "model": "${workerModel}",
       "modelProvider": "${workerProvider}",
       "name": "subagent-worker",
+      "reasoningEffort": "${workerReasoningEffort}",
       "skipPermissions": true,
       "type": "AGENT_WORKER"
     }

--- a/packages/packaged-factories/generated/factories/subagent/factory.yaml
+++ b/packages/packaged-factories/generated/factories/subagent/factory.yaml
@@ -40,6 +40,13 @@ invocationSignature:
           description: Model for the subagent; omitted values use operator defaults.
           externalName: worker-model
           name: workerModel
+        - bindings:
+            - kind: NAMED
+          defaultValues:
+            - ""
+          description: Optional reasoning effort for the subagent; omitted values use the provider default.
+          externalName: worker-reasoning-effort
+          name: workerReasoningEffort
 name: subagent
 workTypes:
     - handlingBehavior:
@@ -69,6 +76,7 @@ workers:
       model: ${workerModel}
       modelProvider: ${workerProvider}
       name: subagent-worker
+      reasoningEffort: ${workerReasoningEffort}
       skipPermissions: true
       type: AGENT_WORKER
 workstations:

--- a/packages/packaged-factories/generated/manifest.json
+++ b/packages/packaged-factories/generated/manifest.json
@@ -239,11 +239,11 @@
       "slug": "plan-parallel",
       "json": {
         "locator": "generated/factories/plan-parallel/factory.json",
-        "sha256": "a969c7889eb9d42c8589e0e24e5c379fdf15e953002b5c17078a66d057553be6"
+        "sha256": "1a989e0f4ab76278e1f6404c27aa1a21eb89334e2b0dbab3cea729662c4b7430"
       },
       "yaml": {
         "locator": "generated/factories/plan-parallel/factory.yaml",
-        "sha256": "f3bf10581f3d62a5d051363ef58a0a8a3d57c36b7a20a67138e998fd6aaabefb"
+        "sha256": "68e814871d8b9af290f7972eca620efa603c3ef359d813828e669e3c700f44f5"
       },
       "description": {
         "type": "LOCALIZABLE_ASSET",
@@ -370,11 +370,11 @@
       "slug": "subagent",
       "json": {
         "locator": "generated/factories/subagent/factory.json",
-        "sha256": "41e92ef5759e746bf4fd4e0e31a489576dc5ae40cf26692ce56e16c570f58743"
+        "sha256": "7914a52bf786008c0cfb6628f804e004878f843cf5912c1913cd491563ac2cb2"
       },
       "yaml": {
         "locator": "generated/factories/subagent/factory.yaml",
-        "sha256": "ce82256500dcb5e76537f893e26f35d0d90eb4aba28726d01cd03f23a5de92c6"
+        "sha256": "41ca13b7b138b76ac6cbbc0220d34a92386aa1e7ec6b652408025d6a6a21ac44"
       },
       "description": {
         "type": "LOCALIZABLE_ASSET",

--- a/packages/packaged-factories/schemas/factory.schema.json
+++ b/packages/packaged-factories/schemas/factory.schema.json
@@ -1458,6 +1458,11 @@
       "pattern": "^(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|ANTIGRAVITY|ANTHROPIC|CLAUDE|CODEX|OPENAI)$",
       "type": "string"
     },
+    "ReasoningEffort": {
+      "description": "Optional provider-neutral reasoning effort. Surrounding whitespace and letter case are normalized. Omit the field to preserve the selected provider and model default. Factory definitions may use an exact invocation-parameter placeholder such as `${executorReasoningEffort}`.",
+      "pattern": "^(?:[\t-\r    - \u2028\u2029  　]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH]|[xX][hH][iI][gG][hH]|[mM][aA][xX])?[\t-\r    - \u2028\u2029  　]*|\\$\\{[A-Za-z0-9_.-]+\\})$",
+      "type": "string"
+    },
     "RequiredTool": {
       "additionalProperties": false,
       "description": "One declarative external tool dependency for a portable factory.",
@@ -2058,6 +2063,9 @@
             }
           ],
           "description": "Built-in hosted provider identity when this worker uses repository-owned hosted execution."
+        },
+        "reasoningEffort": {
+          "$ref": "#/$defs/ReasoningEffort"
         },
         "resources": {
           "description": "Resource capacity this worker requires before it can be dispatched.",

--- a/packages/packaged-factories/schemas/factory.schema.yaml
+++ b/packages/packaged-factories/schemas/factory.schema.yaml
@@ -1035,6 +1035,10 @@ $defs:
         minLength: 1
         pattern: ^(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|ANTIGRAVITY|ANTHROPIC|CLAUDE|CODEX|OPENAI)$
         type: string
+    ReasoningEffort:
+        description: Optional provider-neutral reasoning effort. Surrounding whitespace and letter case are normalized. Omit the field to preserve the selected provider and model default. Factory definitions may use an exact invocation-parameter placeholder such as `${executorReasoningEffort}`.
+        pattern: "^(?:[\t-\r \N   - \L\P  　]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH]|[xX][hH][iI][gG][hH]|[mM][aA][xX])?[\t-\r \N   - \L\P  　]*|\\$\\{[A-Za-z0-9_.-]+\\})$"
+        type: string
     RequiredTool:
         additionalProperties: false
         description: One declarative external tool dependency for a portable factory.
@@ -1419,6 +1423,8 @@ $defs:
                 allOf:
                     - $ref: '#/$defs/HostedWorkerProvider'
                 description: Built-in hosted provider identity when this worker uses repository-owned hosted execution.
+            reasoningEffort:
+                $ref: '#/$defs/ReasoningEffort'
             resources:
                 description: Resource capacity this worker requires before it can be dispatched.
                 items:

--- a/pkg/services/factory_definitions/internal/contracts/public_factory_enums.go
+++ b/pkg/services/factory_definitions/internal/contracts/public_factory_enums.go
@@ -438,7 +438,7 @@ func CanonicalizeOperatorWorkerModelProviderInput(value string) (string, bool) {
 func CanonicalizeReasoningEffort(value string) (string, bool) {
 	canonical := strings.ToLower(strings.TrimSpace(value))
 	switch canonical {
-	case "", "minimal", "low", "medium", "high":
+	case "", "minimal", "low", "medium", "high", "xhigh", "max":
 		return canonical, true
 	default:
 		return "", false

--- a/pkg/services/factory_definitions/internal/services/compilation/runtimeconfig/merge.go
+++ b/pkg/services/factory_definitions/internal/services/compilation/runtimeconfig/merge.go
@@ -38,6 +38,7 @@ func applyRuntimeDefinitions(
 	runtimeDefinitions factorydefinitions.RuntimeDefinitionLookup,
 ) error {
 	for index := range factoryConfig.Workers {
+		normalizeCanonicalWorkerRuntime(&factoryConfig.Workers[index])
 		definition, ok := runtimeDefinitions.Worker(factoryConfig.Workers[index].Name)
 		if !ok || definition == nil {
 			continue
@@ -84,6 +85,13 @@ func applyWorkerRuntimeDefinition(
 	if runtimeDefinition.ModelProvider != "" {
 		worker.ModelProvider = runtimeDefinition.ModelProvider
 	}
+	if effort := strings.TrimSpace(runtimeDefinition.ReasoningEffort); effort != "" {
+		if canonical, ok := factorydefinitions.CanonicalizeReasoningEffort(effort); ok {
+			worker.ReasoningEffort = canonical
+		} else {
+			worker.ReasoningEffort = runtimeDefinition.ReasoningEffort
+		}
+	}
 	if runtimeDefinition.ModelLocality != "" {
 		worker.ModelLocality = runtimeDefinition.ModelLocality
 	}
@@ -128,6 +136,15 @@ func applyWorkerRuntimeDefinition(
 			[]factorydefinitions.ResourceConfig(nil),
 			runtimeDefinition.Resources...,
 		)
+	}
+}
+
+func normalizeCanonicalWorkerRuntime(worker *factorydefinitions.FactoryWorkerConfig) {
+	if worker == nil {
+		return
+	}
+	if effort, ok := factorydefinitions.CanonicalizeReasoningEffort(worker.ReasoningEffort); ok {
+		worker.ReasoningEffort = effort
 	}
 }
 

--- a/pkg/services/factory_definitions/internal/services/compilation/runtimeconfig/merge_test.go
+++ b/pkg/services/factory_definitions/internal/services/compilation/runtimeconfig/merge_test.go
@@ -108,6 +108,38 @@ func TestMergeRequiresRuntimeDefinitions(t *testing.T) {
 	}
 }
 
+func TestMergeCanonicalizesReasoningEffortAndIgnoresWhitespaceRuntimeOverride(t *testing.T) {
+	t.Parallel()
+
+	authored := &factorydefinitions.FactoryConfig{Workers: []factorydefinitions.FactoryWorkerConfig{{
+		Name:            "agent",
+		ReasoningEffort: " HIGH ",
+	}}}
+	effective, err := runtimeconfig.Merge(authored, definitions{
+		workers: map[string]*factorydefinitions.FactoryWorkerConfig{
+			"agent": {ReasoningEffort: " \t "},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if got := effective.Workers[0].ReasoningEffort; got != "high" {
+		t.Fatalf("reasoning effort = %q, want canonical authored high", got)
+	}
+
+	effective, err = runtimeconfig.Merge(authored, definitions{
+		workers: map[string]*factorydefinitions.FactoryWorkerConfig{
+			"agent": {ReasoningEffort: " XHIGH "},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Merge runtime override: %v", err)
+	}
+	if got := effective.Workers[0].ReasoningEffort; got != "xhigh" {
+		t.Fatalf("reasoning effort = %q, want canonical runtime xhigh", got)
+	}
+}
+
 func TestMergeNilFactoryReturnsNoEffectiveDefinition(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_definitions/internal/services/invocation_policy/invocationinterpolation/service.go
+++ b/pkg/services/factory_definitions/internal/services/invocation_policy/invocationinterpolation/service.go
@@ -88,6 +88,9 @@ func InterpolateWorkerConfig(worker workerconfig.Config, args *work.InvocationAr
 	if next.ModelProvider, err = interpolateInvocationField(next.ModelProvider, args, "worker.modelProvider", false, readFile); err != nil {
 		return workerconfig.Config{}, err
 	}
+	if next.ReasoningEffort, err = interpolateInvocationField(next.ReasoningEffort, args, "worker.reasoningEffort", false, readFile); err != nil {
+		return workerconfig.Config{}, err
+	}
 	if next.ExecutorProvider, err = interpolateInvocationField(next.ExecutorProvider, args, "worker.executorProvider", false, readFile); err != nil {
 		return workerconfig.Config{}, err
 	}

--- a/pkg/services/factory_definitions/internal/services/validation/authoredmodel/workers/contracts.go
+++ b/pkg/services/factory_definitions/internal/services/validation/authoredmodel/workers/contracts.go
@@ -17,6 +17,7 @@ type Config struct {
 	Provider         string                    `json:"provider,omitempty" yaml:"provider,omitempty"`
 	Model            string                    `json:"model,omitempty" yaml:"model,omitempty"`
 	ModelProvider    string                    `json:"modelProvider,omitempty" yaml:"modelProvider,omitempty"`
+	ReasoningEffort  string                    `json:"reasoningEffort,omitempty" yaml:"reasoningEffort,omitempty"`
 	ModelLocality    string                    `json:"modelLocality,omitempty" yaml:"modelLocality,omitempty"`
 	ExecutorProvider string                    `json:"executorProvider,omitempty" yaml:"executorProvider,omitempty"`
 	Operations       []ModelOperation          `json:"operations,omitempty" yaml:"operations,omitempty"`

--- a/pkg/services/factory_definitions/internal/services/validation/impl/acp_provider_validation_test.go
+++ b/pkg/services/factory_definitions/internal/services/validation/impl/acp_provider_validation_test.go
@@ -34,3 +34,22 @@ func TestWorkerModelProviderTargetsAcceptsACPIntegrationIdentity(t *testing.T) {
 		t.Fatalf("targets = %#v, want none", targets)
 	}
 }
+
+func TestWorkerReasoningEffortTargetsAcceptsXHighAndRejectsUnknown(t *testing.T) {
+	cfg := &factorydefinitions.FactoryConfig{Workers: []factorydefinitions.FactoryWorkerConfig{{
+		Name:            "implementer",
+		Type:            factorydefinitions.WorkerTypeAgent,
+		ReasoningEffort: " XHIGH ",
+	}}}
+	if targets := workerReasoningEffortTargets(cfg); len(targets) != 0 {
+		t.Fatalf("xhigh targets = %#v, want none", targets)
+	}
+
+	cfg.Workers[0].ReasoningEffort = "extreme"
+	targets := workerReasoningEffortTargets(cfg)
+	if len(targets) != 1 ||
+		targets[0].Code != CodeWorkerUnsupportedReasoningEffort ||
+		targets[0].Path != "factory.workers[0](implementer).reasoningEffort" {
+		t.Fatalf("invalid targets = %#v, want reasoning effort diagnostic", targets)
+	}
+}

--- a/pkg/services/factory_definitions/internal/services/validation/impl/codes.go
+++ b/pkg/services/factory_definitions/internal/services/validation/impl/codes.go
@@ -17,6 +17,7 @@ const (
 	CodeDanglingResourceReference                                = "factory.resource.danglingReference"
 	CodeWorkerWorkstationIncompatibleBehavior                    = "factory.workstation.incompatibleWorkerBehavior"
 	CodeWorkerUnsupportedModelProvider                           = "factory.worker.unsupportedModelProvider"
+	CodeWorkerUnsupportedReasoningEffort                         = "factory.worker.unsupportedReasoningEffort"
 	CodeWorkerACPModelProviderRequired                           = "factory.worker.acpModelProviderRequired"
 	CodeWorkstationMissingOutputRoutes                           = "factory.workstation.missingOutputRoutes"
 	CodeWorkstationMissingFailureRoute                           = "factory.workstation.missingFailureRoute"
@@ -661,6 +662,7 @@ func invocationWorkerInterpolationFieldTargets(workers []workerconfig.Config) []
 		fields = appendInterpolationField(fields, SubjectTypeWorker, subjectID, SubjectLocationDefinition, basePath+".provider", worker.Provider, false, "worker.provider")
 		fields = appendInterpolationField(fields, SubjectTypeWorker, subjectID, SubjectLocationDefinition, basePath+".model", worker.Model, false, "worker.model")
 		fields = appendInterpolationField(fields, SubjectTypeWorker, subjectID, SubjectLocationDefinition, basePath+".modelProvider", worker.ModelProvider, false, "worker.modelProvider")
+		fields = appendInterpolationField(fields, SubjectTypeWorker, subjectID, SubjectLocationDefinition, basePath+".reasoningEffort", worker.ReasoningEffort, false, "worker.reasoningEffort")
 		fields = appendInterpolationField(fields, SubjectTypeWorker, subjectID, SubjectLocationDefinition, basePath+".executorProvider", worker.ExecutorProvider, false, "worker.executorProvider")
 		fields = appendInterpolationField(fields, SubjectTypeWorker, subjectID, SubjectLocationDefinition, basePath+".command", worker.Command, false, "worker.command")
 		fields = appendInterpolationField(fields, SubjectTypeWorker, subjectID, SubjectLocationDefinition, basePath+".timeout", worker.Timeout, false, "worker.timeout")

--- a/pkg/services/factory_definitions/internal/services/validation/impl/validate.go
+++ b/pkg/services/factory_definitions/internal/services/validation/impl/validate.go
@@ -44,6 +44,7 @@ func Validate(cfg *factorydefinitions.FactoryConfig) Result {
 	result.Targets = append(result.Targets, PollerRunWorkstationKindTargets(cfg)...)
 	result.Targets = append(result.Targets, WorkerWorkstationBehaviorCompatibilityTargets(cfg)...)
 	result.Targets = append(result.Targets, workerModelProviderTargets(cfg)...)
+	result.Targets = append(result.Targets, workerReasoningEffortTargets(cfg)...)
 	result.Targets = append(result.Targets, InvocationReturnTargets(cfg)...)
 	result.Targets = append(result.Targets, InvocationSignatureTargets(cfg)...)
 	result.Targets = append(result.Targets, WorkPropagationTargets(cfg)...)
@@ -53,6 +54,30 @@ func Validate(cfg *factorydefinitions.FactoryConfig) Result {
 	topology := factorydefinitions.BuildPendingFactoryGraphTopology(cfg)
 	result.Targets = append(result.Targets, ValidateLayout(cfg, topology).Targets...)
 	return result
+}
+
+func workerReasoningEffortTargets(cfg *factorydefinitions.FactoryConfig) []Target {
+	if cfg == nil {
+		return nil
+	}
+	var targets []Target
+	for workerIndex, worker := range cfg.Workers {
+		effort := strings.TrimSpace(worker.ReasoningEffort)
+		if effort == "" || invocationParameterInterpolation(cfg.InvocationSignature, effort) {
+			continue
+		}
+		if _, ok := factorydefinitions.CanonicalizeReasoningEffort(effort); ok {
+			continue
+		}
+		targets = append(targets, Target{
+			Code:     CodeWorkerUnsupportedReasoningEffort,
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("worker reasoningEffort %q is unsupported; accepted values are minimal, low, medium, high, xhigh, and max", worker.ReasoningEffort),
+			Subject:  Subject{Type: SubjectTypeWorker, ID: worker.Name, Location: SubjectLocationDefinition},
+			Path:     fmt.Sprintf("%s.workers[%d](%s).reasoningEffort", validationRoot, workerIndex, worker.Name),
+		})
+	}
+	return targets
 }
 
 func workerModelProviderTargets(cfg *factorydefinitions.FactoryConfig) []Target {

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/runtime/child_execution.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/runtime/child_execution.go
@@ -63,7 +63,6 @@ type ChildExecutor interface {
 // highest-precedence source that supplies it. It performs no IO or mutation.
 func ResolveChildWorkerSettings(req ChildExecutionRequest, agents map[string]interfaces.FactoryOrchestratorJavaScriptAgent, config WorkerSettingsConfig) (ChildExecutionRequest, error) {
 	explicitPreset := strings.TrimSpace(req.Preset)
-	explicitEffort := strings.TrimSpace(req.ReasoningEffort)
 	factoryPreset := ""
 	if agent, ok := agents[strings.TrimSpace(req.AgentID)]; ok {
 		factoryPreset = strings.TrimSpace(agent.Preset)
@@ -106,9 +105,7 @@ func ResolveChildWorkerSettings(req ChildExecutionRequest, agents map[string]int
 		if !ok {
 			return ChildExecutionRequest{}, fmt.Errorf("agent.run() has unsupported effective reasoningEffort %q", req.ReasoningEffort)
 		}
-		if explicitEffort == "" {
-			req.ReasoningEffort = effort
-		}
+		req.ReasoningEffort = effort
 	}
 	return req, nil
 }
@@ -487,8 +484,14 @@ func childExecutionResultFromRecord(child ChildDispatchRecord) ChildExecutionRes
 		ProviderSessionRef: child.ProviderSessionRef,
 		Output:             output,
 		Request: ChildExecutionRequest{
-			Label: child.Label,
-			Model: child.Model,
+			Label:           child.Label,
+			Preset:          child.Preset,
+			ModelProvider:   child.ModelProvider,
+			Model:           child.Model,
+			ReasoningEffort: child.ReasoningEffort,
+			SkipPermissions: child.SkipPermissions,
+			Command:         child.Command,
+			Sandbox:         child.Sandbox,
 		},
 	}
 }

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/runtime/host_children_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/runtime/host_children_test.go
@@ -112,7 +112,7 @@ func TestResolveChildWorkerSettings_FieldByFieldPrecedence(t *testing.T) {
 		name      string
 		req, want factory.JavaScriptChildExecutionRequest
 	}{
-		{"explicit fields", factory.JavaScriptChildExecutionRequest{ModelProvider: "kiro-cli", Model: "explicit-model", ReasoningEffort: "minimal"}, factory.JavaScriptChildExecutionRequest{ModelProvider: "kiro-cli", Model: "explicit-model", ReasoningEffort: "minimal"}},
+		{"explicit fields", factory.JavaScriptChildExecutionRequest{ModelProvider: "kiro-cli", Model: "explicit-model", ReasoningEffort: " XHIGH "}, factory.JavaScriptChildExecutionRequest{ModelProvider: "kiro-cli", Model: "explicit-model", ReasoningEffort: "xhigh"}},
 		{"child preset", factory.JavaScriptChildExecutionRequest{Preset: "child"}, factory.JavaScriptChildExecutionRequest{Preset: "child", ModelProvider: "claude", Model: "child-model", ReasoningEffort: "high"}},
 		{"factory preset", factory.JavaScriptChildExecutionRequest{AgentID: "reviewer"}, factory.JavaScriptChildExecutionRequest{AgentID: "reviewer", Preset: "factory", ModelProvider: "codex", Model: "factory-model", ReasoningEffort: "low"}},
 		{"mixed fields", factory.JavaScriptChildExecutionRequest{AgentID: "reviewer", Preset: "child", Model: "explicit-model"}, factory.JavaScriptChildExecutionRequest{AgentID: "reviewer", Preset: "child", ModelProvider: "claude", Model: "explicit-model", ReasoningEffort: "high"}},

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/runtime/runtime_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/runtime/runtime_test.go
@@ -962,12 +962,17 @@ func TestCompletedChildResultsFromRecords_RestoresStoredLiveProviderOutput(t *te
 		{
 			Kind: factory.JavaScriptRecordKindChildDispatch,
 			ChildDispatch: &factory.JavaScriptChildDispatchRecord{
-				DispatchID:    "dispatch-1",
-				ChildIndex:    1,
-				Status:        factory.JavaScriptChildDispatchStatusCompleted,
-				Label:         "step-one",
-				ExecutionMode: factory.JavaScriptChildExecutionModeLive,
-				Output:        storedOutput,
+				DispatchID:      "dispatch-1",
+				ChildIndex:      1,
+				Status:          factory.JavaScriptChildDispatchStatusCompleted,
+				Label:           "step-one",
+				Preset:          "careful",
+				ModelProvider:   "codex",
+				Model:           "gpt-5.6-luna",
+				ReasoningEffort: "xhigh",
+				SkipPermissions: true,
+				ExecutionMode:   factory.JavaScriptChildExecutionModeLive,
+				Output:          storedOutput,
 			},
 		},
 	}
@@ -982,5 +987,12 @@ func TestCompletedChildResultsFromRecords_RestoresStoredLiveProviderOutput(t *te
 	}
 	if result.ExecutionMode != factory.JavaScriptChildExecutionModeLive {
 		t.Fatalf("executionMode = %q, want live-provider", result.ExecutionMode)
+	}
+	if result.Request.Preset != "careful" ||
+		result.Request.ModelProvider != "codex" ||
+		result.Request.Model != "gpt-5.6-luna" ||
+		result.Request.ReasoningEffort != "xhigh" ||
+		!result.Request.SkipPermissions {
+		t.Fatalf("restored child request = %#v, want retained execution selection", result.Request)
 	}
 }

--- a/pkg/services/factory_sessions/internal/execution/livechild/provider.go
+++ b/pkg/services/factory_sessions/internal/execution/livechild/provider.go
@@ -249,6 +249,7 @@ func providerInferenceRequestFromChild(
 		UserMessage:      req.Prompt,
 		Model:            req.Model,
 		ModelProvider:    req.ModelProvider,
+		ReasoningEffort:  req.ReasoningEffort,
 		OutputSchema:     outputSchema,
 		RunnerID:         runnerID,
 		ExecutorProvider: strings.TrimSpace(req.ExecutorProvider),

--- a/pkg/services/factory_sessions/internal/execution/livechild/provider_test.go
+++ b/pkg/services/factory_sessions/internal/execution/livechild/provider_test.go
@@ -46,12 +46,13 @@ func TestProviderChildExecutor_Execute_RecordsLiveProviderDispatch(t *testing.T)
 	executor := NewProviderChildExecutor("session-live-child", provider, collectorSink, scriptedChildValues{})
 
 	result, err := executor.Execute(context.Background(), factory.JavaScriptChildExecutionRequest{
-		Prompt:        "summarize workflows",
-		Label:         "summarize-findings",
-		ModelProvider: "CODEX",
-		Model:         "gpt-test",
-		WorkflowName:  "agent-run-fake-child",
-		ArgsSubject:   "workflows",
+		Prompt:          "summarize workflows",
+		Label:           "summarize-findings",
+		ModelProvider:   "CODEX",
+		Model:           "gpt-test",
+		ReasoningEffort: "xhigh",
+		WorkflowName:    "agent-run-fake-child",
+		ArgsSubject:     "workflows",
 		OutputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -77,8 +78,15 @@ func TestProviderChildExecutor_Execute_RecordsLiveProviderDispatch(t *testing.T)
 	if provider.callCount != 1 {
 		t.Fatalf("provider call count = %d, want 1", provider.callCount)
 	}
-	if provider.lastInput.Request.ModelProvider != "CODEX" || provider.lastInput.Request.Model != "gpt-test" {
-		t.Fatalf("provider worker settings = (%q, %q), want (CODEX, gpt-test)", provider.lastInput.Request.ModelProvider, provider.lastInput.Request.Model)
+	if provider.lastInput.Request.ModelProvider != "CODEX" ||
+		provider.lastInput.Request.Model != "gpt-test" ||
+		provider.lastInput.Request.ReasoningEffort != "xhigh" {
+		t.Fatalf(
+			"provider worker settings = (%q, %q, %q), want (CODEX, gpt-test, xhigh)",
+			provider.lastInput.Request.ModelProvider,
+			provider.lastInput.Request.Model,
+			provider.lastInput.Request.ReasoningEffort,
+		)
 	}
 	if got := collectorSink.statusTransitions("dispatch-1"); len(got) != 3 {
 		t.Fatalf("recorded status transitions = %#v, want queued/running/completed", got)
@@ -510,6 +518,7 @@ func TestProviderInferenceRequestFromChild_PropagatesPresetAsWorkerType(t *testi
 		Prompt:          "mocked child prompt",
 		Preset:          "worker-a",
 		ModelProvider:   "codex",
+		ReasoningEffort: "xhigh",
 		SkipPermissions: true,
 	})
 	if req.WorkerType != "worker-a" {
@@ -523,6 +532,9 @@ func TestProviderInferenceRequestFromChild_PropagatesPresetAsWorkerType(t *testi
 	}
 	if req.RunnerID != "codex" {
 		t.Fatalf("RunnerID = %q, want model provider fallback for SCRIPT_WRAP child", req.RunnerID)
+	}
+	if req.ReasoningEffort != "xhigh" {
+		t.Fatalf("ReasoningEffort = %q, want xhigh", req.ReasoningEffort)
 	}
 	if !req.SkipPermissions {
 		t.Fatal("SkipPermissions = false, want packaged JavaScript child policy forwarded")

--- a/pkg/services/models/transports/cli/root_invoke.go
+++ b/pkg/services/models/transports/cli/root_invoke.go
@@ -54,6 +54,11 @@ func (service *rootService) Invoke(cfg InvokeConfig) error {
 	if err != nil {
 		return mapModelsRootError(err)
 	}
+	if runtime := catalogResult.Model.ManagedRuntime; strings.TrimSpace(runtime.Identity) != "" {
+		if err := runtime.InvocationError(); err != nil {
+			return mapModelsRootError(err)
+		}
+	}
 	leaseResult, err := service.models.AcquireModelLease(cfg.Context, modelinference.AcquireModelLeaseRequest{
 		Scope: scope.Scope, Name: modelName, Holder: modelsCLIInvokeHolder,
 	})

--- a/pkg/services/models/transports/cli/root_parity_test.go
+++ b/pkg/services/models/transports/cli/root_parity_test.go
@@ -68,7 +68,7 @@ func parityCatalogScopeOpener(t *testing.T) func(context.Context) (modelscli.Inv
 func parityRootService(t *testing.T, root stubModelsRoot) modelscli.Service {
 	t.Helper()
 	service := modelscli.NewService(modelscli.Config{
-		Models: root,
+		Models:           root,
 		OpenCatalogScope: parityCatalogScopeOpener(t),
 		OpenInvokeScope: func(context.Context, modelscli.InvokeConfig) (modelscli.InvokeRuntimeScope, error) {
 			return parityInvokeScope(t), nil
@@ -260,7 +260,7 @@ func TestRootAdapter_InvokeJSONResolvesThroughModelsRootCatalogAndInference(t *t
 
 	var out bytes.Buffer
 	if err := service.Invoke(modelscli.InvokeConfig{
-		Context: context.Background(),
+		Context:   context.Background(),
 		ModelName: "OMNIVOICE_Q4_K_M",
 		Operation: "TTS",
 		Text:      "hello world",
@@ -474,17 +474,17 @@ func TestRootAdapter_PullMapsClassifiedModelsRootFailure(t *testing.T) {
 	service := parityRootService(t, stubModelsRoot{
 		pullModel: func(context.Context, string) (modelinference.PullResult, error) {
 			return modelinference.PullResult{
-				ModelName:          "OMNIVOICE_Q4_K_M",
-				ManagedPullOutcome: "SOURCE_FETCH_FAILED",
-				ReadinessState:     "FAILED",
-			}, &modelinference.PullError{
-				Result: modelinference.PullResult{
 					ModelName:          "OMNIVOICE_Q4_K_M",
 					ManagedPullOutcome: "SOURCE_FETCH_FAILED",
 					ReadinessState:     "FAILED",
-				},
-				Cause: errors.New("source fetch failed"),
-			}
+				}, &modelinference.PullError{
+					Result: modelinference.PullResult{
+						ModelName:          "OMNIVOICE_Q4_K_M",
+						ManagedPullOutcome: "SOURCE_FETCH_FAILED",
+						ReadinessState:     "FAILED",
+					},
+					Cause: errors.New("source fetch failed"),
+				}
 		},
 	})
 	var out bytes.Buffer
@@ -552,7 +552,7 @@ func TestRootAdapter_InvokeMapsReadinessFailuresFromModelsRoot(t *testing.T) {
 				},
 			})
 			err := service.Invoke(modelscli.InvokeConfig{
-				Context: context.Background(),
+				Context:   context.Background(),
 				ModelName: "OMNIVOICE_Q4_K_M",
 				Operation: "TTS",
 				Text:      "hello world",
@@ -566,6 +566,53 @@ func TestRootAdapter_InvokeMapsReadinessFailuresFromModelsRoot(t *testing.T) {
 				t.Fatalf("Invoke() error = %v, want errors.Is %v", err, tt.wantIs)
 			}
 		})
+	}
+}
+
+func TestRootAdapter_InvokeRejectsCatalogRuntimeThatIsNotReady(t *testing.T) {
+	t.Parallel()
+
+	acquireCalled := false
+	service := modelscli.NewService(modelscli.Config{
+		Models: stubModelsRoot{
+			getCatalogModel: func(context.Context, modelinference.GetModelRequest) (modelinference.GetModelResult, error) {
+				return modelinference.GetModelResult{Model: modelinference.Detail{
+					Summary: modelinference.Summary{
+						Name: "OMNIVOICE_Q4_K_M",
+						ManagedRuntime: modelinference.Runtime{
+							Identity:       "OMNIVOICE_Q4_K_M",
+							ReadinessState: modelinference.ReadinessStateMissing,
+							LifecycleState: modelinference.LifecycleStateNotInstalled,
+						},
+					},
+				}}, nil
+			},
+			acquireModelLease: func(context.Context, modelinference.AcquireModelLeaseRequest) (modelinference.AcquireModelLeaseResult, error) {
+				acquireCalled = true
+				return modelinference.AcquireModelLeaseResult{}, nil
+			},
+		},
+		OpenInvokeScope: func(context.Context, modelscli.InvokeConfig) (modelscli.InvokeRuntimeScope, error) {
+			return parityInvokeScope(t), nil
+		},
+	})
+
+	err := service.Invoke(modelscli.InvokeConfig{
+		Context:   context.Background(),
+		ModelName: "OMNIVOICE_Q4_K_M",
+		Operation: "TTS",
+		Text:      "hello world",
+		JSON:      true,
+		Output:    io.Discard,
+	})
+	if !errors.Is(err, modelinference.ErrMissing) {
+		t.Fatalf("Invoke() error = %v, want errors.Is ErrMissing", err)
+	}
+	if !strings.Contains(err.Error(), "pull or install") {
+		t.Fatalf("Invoke() error = %q, want bootstrap guidance", err.Error())
+	}
+	if acquireCalled {
+		t.Fatal("Invoke() acquired a model lease after catalog readiness failed")
 	}
 }
 
@@ -583,7 +630,7 @@ func TestRootAdapter_InvokeMapsModelsRootNotFound(t *testing.T) {
 		},
 	})
 	err := service.Invoke(modelscli.InvokeConfig{
-		Context: context.Background(),
+		Context:   context.Background(),
 		ModelName: "missing-model",
 		Operation: "TTS",
 		Text:      "hello world",

--- a/pkg/services/operator_settings/defaults_contract.go
+++ b/pkg/services/operator_settings/defaults_contract.go
@@ -245,7 +245,7 @@ func validateWorkerPresets(presets []WorkerPreset) ([]WorkerPreset, error) {
 		}
 		effort, ok := interfaces.CanonicalizeReasoningEffort(preset.ReasoningEffort)
 		if !ok {
-			return nil, fmt.Errorf("workerPresets[%d] %q has unsupported reasoningEffort %q: accepted values are minimal, low, medium, high", i, id, preset.ReasoningEffort)
+			return nil, fmt.Errorf("workerPresets[%d] %q has unsupported reasoningEffort %q: accepted values are minimal, low, medium, high, xhigh, max", i, id, preset.ReasoningEffort)
 		}
 		validated[i] = WorkerPreset{
 			ID:              id,

--- a/pkg/services/providers/execute_characterization_test.go
+++ b/pkg/services/providers/execute_characterization_test.go
@@ -150,3 +150,23 @@ func TestExecuteContract_Characterization_TypedFailures(t *testing.T) {
 		t.Fatalf("invalid attempt Execute() error = %v, want ErrExecuteFailed", err)
 	}
 }
+
+func TestExecuteRequestReasoningEffortValidation(t *testing.T) {
+	t.Parallel()
+
+	request := providers.ExecuteRequest{
+		Provider:        providers.IDCodex,
+		AttemptID:       "attempt-effort",
+		ReasoningEffort: " XHIGH ",
+	}
+	if err := request.Validate(); err != nil {
+		t.Fatalf("Validate(xhigh) = %v", err)
+	}
+	if got, ok := providers.ReasoningEffort(request.ReasoningEffort).Canonical(); !ok || got != "xhigh" {
+		t.Fatalf("ReasoningEffort.Canonical() = %q, %t; want xhigh, true", got, ok)
+	}
+	request.ReasoningEffort = "extreme"
+	if err := request.Validate(); err == nil || !strings.Contains(err.Error(), "unsupported reasoning effort") {
+		t.Fatalf("Validate(extreme) = %v, want unsupported reasoning effort", err)
+	}
+}

--- a/pkg/services/providers/execute_contract.go
+++ b/pkg/services/providers/execute_contract.go
@@ -88,6 +88,7 @@ type ExecuteRequest struct {
 	WorkerType         string
 	WorkstationName    string
 	Model              string
+	ReasoningEffort    string
 	SkipPermissions    bool
 	SystemPrompt       string
 	UserMessage        string
@@ -109,12 +110,29 @@ func (request ExecuteRequest) Validate() error {
 	if strings.TrimSpace(request.AttemptID) == "" {
 		return fmt.Errorf("%w: empty attempt id", ErrExecuteFailed)
 	}
+	if _, ok := ReasoningEffort(request.ReasoningEffort).Canonical(); !ok {
+		return fmt.Errorf("%w: unsupported reasoning effort %q", ErrExecuteFailed, request.ReasoningEffort)
+	}
 	if request.ResumeSession != nil {
 		if err := request.ResumeSession.Validate(); err != nil {
 			return fmt.Errorf("%w", err)
 		}
 	}
 	return nil
+}
+
+// ReasoningEffort is a provider-neutral inference effort value.
+type ReasoningEffort string
+
+// Canonical trims and lowercases a supported inference effort.
+func (value ReasoningEffort) Canonical() (string, bool) {
+	canonical := strings.ToLower(strings.TrimSpace(string(value)))
+	switch canonical {
+	case "", "minimal", "low", "medium", "high", "xhigh", "max":
+		return canonical, true
+	default:
+		return "", false
+	}
 }
 
 // Clone returns a detached execute-request copy.

--- a/pkg/services/providers/inference/contracts.go
+++ b/pkg/services/providers/inference/contracts.go
@@ -35,9 +35,10 @@ type ProviderSession struct {
 }
 
 type InvocationRequest struct {
-	ID      string
-	ModelID string
-	Prompt  string
+	ID              string
+	ModelID         string
+	ReasoningEffort string
+	Prompt          string
 }
 
 type Response struct {

--- a/pkg/services/providers/internal/service/service.go
+++ b/pkg/services/providers/internal/service/service.go
@@ -110,10 +110,43 @@ func (s *Service) Execute(
 	ctx context.Context,
 	request providers.ExecuteRequest,
 ) (providers.ExecuteResult, error) {
+	if err := request.Validate(); err != nil {
+		return providers.ExecuteResult{}, providers.ExecuteFailure{
+			Kind:    providers.ExecuteFailureKindInvalidRequest,
+			Message: err.Error(),
+		}
+	}
+	request.ReasoningEffort, _ = providers.ReasoningEffort(request.ReasoningEffort).Canonical()
 	if s.acp != nil {
 		if canonical, ok := s.acp.Resolve(request.Provider); ok {
+			if request.ReasoningEffort != "" {
+				return providers.ExecuteResult{}, providers.ExecuteFailure{
+					Kind: providers.ExecuteFailureKindInvalidRequest,
+					Message: fmt.Sprintf(
+						"ACP provider %q selects reasoning effort through its exact advertised model id; omit reasoningEffort and choose the intended model",
+						canonical,
+					),
+				}
+			}
 			request.Provider = canonical
 			return s.acp.Execute(ctx, canonical, request)
+		}
+	}
+	canonicalProvider, err := s.catalog.ResolveProviderID(request.Provider)
+	if err != nil {
+		return providers.ExecuteResult{}, err
+	}
+	request.Provider = canonicalProvider
+	if request.Provider == providers.IDClaude && request.ReasoningEffort == "minimal" {
+		return providers.ExecuteResult{}, providers.ExecuteFailure{
+			Kind:    providers.ExecuteFailureKindInvalidRequest,
+			Message: `Claude does not support reasoning effort "minimal"`,
+		}
+	}
+	if request.Provider == providers.IDAntigravity && request.ReasoningEffort != "" {
+		return providers.ExecuteResult{}, providers.ExecuteFailure{
+			Kind:    providers.ExecuteFailureKindInvalidRequest,
+			Message: "Agy does not support a separate reasoning effort",
 		}
 	}
 	return s.execution.Execute(ctx, request)

--- a/pkg/services/providers/internal/service/service_test.go
+++ b/pkg/services/providers/internal/service/service_test.go
@@ -8,6 +8,7 @@ import (
 
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 	providerservice "github.com/portpowered/infinite-you/pkg/services/providers/internal/service"
+	acp "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/acp"
 	catalog "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog"
 	catalogwire "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/wire"
 	execution "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution"
@@ -100,6 +101,9 @@ func TestRootDelegatesExecuteToOnePrivateExecutionAttempt(t *testing.T) {
 				if request.Provider != providers.IDCodex {
 					t.Fatalf("adapter provider = %q, want %q", request.Provider, providers.IDCodex)
 				}
+				if request.ReasoningEffort != "xhigh" {
+					t.Fatalf("adapter reasoning effort = %q, want canonical xhigh", request.ReasoningEffort)
+				}
 				return providers.ExecuteResult{Content: "root result"}, nil
 			},
 		},
@@ -113,8 +117,9 @@ func TestRootDelegatesExecuteToOnePrivateExecutionAttempt(t *testing.T) {
 	}
 
 	result, err := root.Execute(context.Background(), providers.ExecuteRequest{
-		Provider:  providers.IDCodex,
-		AttemptID: "attempt-1",
+		Provider:        providers.IDCodex,
+		AttemptID:       "attempt-1",
+		ReasoningEffort: " XHIGH ",
 	})
 	if err != nil {
 		t.Fatalf("Execute() = %v", err)
@@ -122,6 +127,110 @@ func TestRootDelegatesExecuteToOnePrivateExecutionAttempt(t *testing.T) {
 	if result.Content != "root result" || calls != 1 {
 		t.Fatalf("Execute() = (%#v, %d calls), want root result and 1 call", result, calls)
 	}
+}
+
+func TestRootACPRejectsSeparateReasoningEffortAndAcceptsExactModelID(t *testing.T) {
+	t.Parallel()
+
+	catalogService, err := catalogwire.NewService()
+	if err != nil {
+		t.Fatalf("catalogwire.NewService() = %v", err)
+	}
+	executionService, err := executionwire.NewService(catalogService)
+	if err != nil {
+		t.Fatalf("executionwire.NewService() = %v", err)
+	}
+	acpService := &stubACPService{provider: "cursor-acp"}
+	root, err := providerservice.NewWithACP(catalogService, executionService, acpService, nil)
+	if err != nil {
+		t.Fatalf("NewWithACP() = %v", err)
+	}
+
+	_, executeErr := root.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:        "cursor-acp",
+		AttemptID:       "attempt-acp-effort",
+		Model:           "cursor-grok-4.5-medium-fast",
+		ReasoningEffort: "xhigh",
+	})
+	var failure providers.ExecuteFailure
+	if !errors.As(executeErr, &failure) ||
+		failure.Kind != providers.ExecuteFailureKindInvalidRequest ||
+		!strings.Contains(failure.Message, "exact advertised model id") ||
+		acpService.executeCalls != 0 {
+		t.Fatalf("Execute(ACP with effort) = (%#v, %d calls), want invalid request before ACP execution", executeErr, acpService.executeCalls)
+	}
+
+	result, executeErr := root.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:  "cursor-acp",
+		AttemptID: "attempt-acp-model",
+		Model:     "cursor-grok-4.5-medium-fast",
+	})
+	if executeErr != nil || result.Content != "acp result" || acpService.executeCalls != 1 {
+		t.Fatalf("Execute(ACP exact model) = (%#v, %v, %d calls), want delegated success", result, executeErr, acpService.executeCalls)
+	}
+}
+
+func TestRootRejectsSeparateReasoningEffortForAgy(t *testing.T) {
+	t.Parallel()
+
+	root := mustRootService(t)
+	_, executeErr := root.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:        providers.ID(" ANTIGRAVITY "),
+		AttemptID:       "attempt-agy-effort",
+		ReasoningEffort: "xhigh",
+	})
+	var failure providers.ExecuteFailure
+	if !errors.As(executeErr, &failure) ||
+		failure.Kind != providers.ExecuteFailureKindInvalidRequest ||
+		!strings.Contains(failure.Message, "does not support a separate reasoning effort") {
+		t.Fatalf("Execute(Agy with effort) error = %#v, want invalid request", executeErr)
+	}
+}
+
+func TestRootRejectsMinimalReasoningEffortForClaude(t *testing.T) {
+	t.Parallel()
+
+	root := mustRootService(t)
+	_, err := root.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:        providers.ID(" CLAUDE "),
+		AttemptID:       "claude-minimal",
+		ReasoningEffort: " MINIMAL ",
+	})
+	var failure providers.ExecuteFailure
+	if !errors.As(err, &failure) {
+		t.Fatalf("Execute() error = %T(%v), want ExecuteFailure", err, err)
+	}
+	if failure.Kind != providers.ExecuteFailureKindInvalidRequest {
+		t.Fatalf("failure.Kind = %q, want invalid_request", failure.Kind)
+	}
+}
+
+var _ acp.Service = (*stubACPService)(nil)
+
+type stubACPService struct {
+	provider     providers.ID
+	executeCalls int
+}
+
+func (service *stubACPService) Close(context.Context) error { return nil }
+
+func (service *stubACPService) Configure(context.Context, []providers.ACPIntegration) error {
+	return nil
+}
+
+func (service *stubACPService) Integrations() []providers.ACPIntegration { return nil }
+
+func (service *stubACPService) Resolve(id providers.ID) (providers.ID, bool) {
+	return service.provider, id == service.provider
+}
+
+func (service *stubACPService) Execute(
+	_ context.Context,
+	_ providers.ID,
+	_ providers.ExecuteRequest,
+) (providers.ExecuteResult, error) {
+	service.executeCalls++
+	return providers.ExecuteResult{Content: "acp result"}, nil
 }
 
 func TestRootDelegatesTypedExecutionFailure(t *testing.T) {

--- a/pkg/services/providers/internal/services/execution/internal/adapters/agy/pty.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/agy/pty.go
@@ -95,6 +95,9 @@ func buildPTYLaunch(
 	request providers.ExecuteRequest,
 	config ptyLaunchConfig,
 ) (ptyLaunch, error) {
+	if effort, _ := providers.ReasoningEffort(request.ReasoningEffort).Canonical(); effort != "" {
+		return ptyLaunch{}, fmt.Errorf("agy does not support a separate reasoning effort")
+	}
 	executable, err := resolveExecutable(
 		config.executable,
 		config.locator,

--- a/pkg/services/providers/internal/services/execution/internal/adapters/agy/pty_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/agy/pty_test.go
@@ -96,6 +96,38 @@ func TestPTYEffectRequiresAllocator(t *testing.T) {
 	}
 }
 
+func TestPTYEffectRejectsSeparateReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	factoryRoot := t.TempDir()
+	executable := filepath.Join(factoryRoot, "agy.exe")
+	if err := os.WriteFile(executable, []byte("stub"), 0o755); err != nil {
+		t.Fatalf("write executable: %v", err)
+	}
+	allocator := &stubAllocator{}
+	effect := agy.NewPTYEffect(agy.PTYEffectOptions{
+		FactoryRoot:            factoryRoot,
+		Allocator:              allocator,
+		Executable:             executable,
+		ExecutableDependencies: executableDependencies(nil, executable),
+	})
+	_, err := effect.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:        providers.IDAntigravity,
+		AttemptID:       "dispatch-agy-effort",
+		ReasoningEffort: "xhigh",
+		UserMessage:     "review",
+	}, func([]byte) error { return nil })
+	var failure execution.AttemptFailure
+	if !errors.As(err, &failure) ||
+		failure.NativeError == nil ||
+		!strings.Contains(failure.NativeError.Error(), "does not support a separate reasoning effort") {
+		t.Fatalf("Execute() error = %v, want unsupported reasoning effort", err)
+	}
+	if len(allocator.sessions) != 0 {
+		t.Fatalf("PTY allocations = %d, want none", len(allocator.sessions))
+	}
+}
+
 func TestPTYEffectBuildsArgvWorkspaceAndEnvironment(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/providers/internal/services/execution/internal/adapters/claude/command.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/claude/command.go
@@ -3,6 +3,7 @@ package claude
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -65,6 +66,16 @@ func buildCommand(request providers.ExecuteRequest) (workers.CommandRequest, err
 	}
 	if strings.TrimSpace(request.Model) != "" {
 		args = append(args, "--model", strings.TrimSpace(request.Model))
+	}
+	effort, ok := providers.ReasoningEffort(request.ReasoningEffort).Canonical()
+	if !ok {
+		return workers.CommandRequest{}, fmt.Errorf("unsupported reasoning effort %q", request.ReasoningEffort)
+	}
+	if effort != "" {
+		if effort == "minimal" {
+			return workers.CommandRequest{}, fmt.Errorf(`Claude does not support reasoning effort "minimal"`)
+		}
+		args = append(args, "--effort", effort)
 	}
 	if request.ResumeSession != nil && strings.TrimSpace(request.ResumeSession.ID) != "" {
 		args = append(args, "--resume", strings.TrimSpace(request.ResumeSession.ID))

--- a/pkg/services/providers/internal/services/execution/internal/adapters/claude/command_dispatch_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/claude/command_dispatch_test.go
@@ -1,0 +1,80 @@
+package claude_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	execution "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution"
+	claude "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution/internal/adapters/claude"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+)
+
+func TestCommandEffectRendersProviderNeutralReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	runner := testutil.NewProviderCommandRunner()
+	effect := claude.NewCommandEffect(workers.AdaptCommandRunner(runner))
+	if effect == nil {
+		t.Fatal("NewCommandEffect() returned nil")
+	}
+
+	_, err := effect.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:        providers.IDClaude,
+		AttemptID:       "claude-xhigh-dispatch",
+		Model:           "claude-model",
+		ReasoningEffort: "xhigh",
+		UserMessage:     "perform work",
+	}, func([]byte) error { return nil })
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	want := []string{
+		"-p",
+		"--model", "claude-model",
+		"--effort", "xhigh",
+		"--output-format", "stream-json",
+		"--include-partial-messages",
+		"perform work",
+	}
+	if got := runner.LastRequest().Args; !reflect.DeepEqual(got, want) {
+		t.Fatalf("command args = %#v, want %#v", got, want)
+	}
+}
+
+func TestCommandEffectRejectsUnsupportedReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name   string
+		effort string
+		want   string
+	}{
+		{name: "provider unsupported", effort: "minimal", want: `does not support reasoning effort "minimal"`},
+		{name: "globally unsupported", effort: "extreme", want: `unsupported reasoning effort "extreme"`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			runner := testutil.NewProviderCommandRunner()
+			effect := claude.NewCommandEffect(workers.AdaptCommandRunner(runner))
+			_, err := effect.Execute(context.Background(), providers.ExecuteRequest{
+				Provider:        providers.IDClaude,
+				AttemptID:       "claude-invalid-effort-dispatch",
+				ReasoningEffort: test.effort,
+				UserMessage:     "perform work",
+			}, func([]byte) error { return nil })
+			var failure execution.AttemptFailure
+			if !errors.As(err, &failure) ||
+				failure.NativeError == nil ||
+				!strings.Contains(failure.NativeError.Error(), test.want) {
+				t.Fatalf("Execute() error = %v, want %q", err, test.want)
+			}
+			if got := runner.Requests(); len(got) != 0 {
+				t.Fatalf("runner requests = %#v, want none", got)
+			}
+		})
+	}
+}

--- a/pkg/services/providers/internal/services/execution/internal/adapters/codex/adapter.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/codex/adapter.go
@@ -58,6 +58,16 @@ func newAttempt(effect Effect) execution.Attempt {
 		effectResult, effectErr := effect.Execute(ctx, request, decoder.observe)
 		flushErr := decoder.flush()
 		if failure, failed := collectFailure(decoder, effectErr, flushErr); failed {
+			if session := decoder.partialSession(); session != nil {
+				if failure.Declared == nil {
+					failure.Declared = &providers.ExecuteFailure{
+						Kind:       providers.ExecuteFailureKindUnknown,
+						SessionRef: session,
+					}
+				} else if failure.Declared.SessionRef == nil {
+					failure.Declared.SessionRef = session
+				}
+			}
 			return providers.ExecuteResult{}, failure
 		}
 		content, session, finalErr := decoder.final()

--- a/pkg/services/providers/internal/services/execution/internal/adapters/codex/command.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/codex/command.go
@@ -3,6 +3,7 @@ package codex
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -58,6 +59,13 @@ func buildCommand(request providers.ExecuteRequest) (workers.CommandRequest, err
 	}
 	if strings.TrimSpace(request.Model) != "" {
 		args = append(args, "--model", strings.TrimSpace(request.Model))
+	}
+	effort, ok := providers.ReasoningEffort(request.ReasoningEffort).Canonical()
+	if !ok {
+		return workers.CommandRequest{}, fmt.Errorf("unsupported reasoning effort %q", request.ReasoningEffort)
+	}
+	if effort != "" {
+		args = append(args, "--config", `model_reasoning_effort="`+effort+`"`)
 	}
 	args = append(args, "-")
 	return commanddispatch.WorkersCommand(request, workers.CommandRequest{

--- a/pkg/services/providers/internal/services/execution/internal/adapters/codex/command_dispatch_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/codex/command_dispatch_test.go
@@ -2,11 +2,15 @@ package codex_test
 
 import (
 	"context"
+	"errors"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/portpowered/infinite-you/internal/testutil"
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	execution "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution"
 	codex "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution/internal/adapters/codex"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 )
@@ -43,5 +47,59 @@ func TestCommandEffectRoutesDispatchContextThroughMockWorkerRunner(t *testing.T)
 	}
 	if platformRunner.CallCount() != 0 {
 		t.Fatalf("platform runner calls = %d, want mock intercept", platformRunner.CallCount())
+	}
+}
+
+func TestCommandEffectRejectsUnsupportedReasoningEffortBeforeDispatch(t *testing.T) {
+	t.Parallel()
+
+	platformRunner := testutil.NewProviderCommandRunner()
+	effect := codex.NewCommandEffect(workers.AdaptCommandRunner(platformRunner))
+	_, err := effect.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:        providers.IDCodex,
+		AttemptID:       "invalid-effort-dispatch",
+		ReasoningEffort: "extreme",
+		UserMessage:     "perform work",
+	}, func([]byte) error { return nil })
+	var failure execution.AttemptFailure
+	if !errors.As(err, &failure) ||
+		failure.NativeError == nil ||
+		!strings.Contains(failure.NativeError.Error(), `unsupported reasoning effort "extreme"`) {
+		t.Fatalf("Execute() error = %v, want unsupported effort", err)
+	}
+	if got := platformRunner.Requests(); len(got) != 0 {
+		t.Fatalf("runner requests = %#v, want none", got)
+	}
+}
+
+func TestCommandEffectRendersLunaXHighReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	platformRunner := testutil.NewProviderCommandRunner()
+	effect := codex.NewCommandEffect(workers.AdaptCommandRunner(platformRunner))
+	if effect == nil {
+		t.Fatal("NewCommandEffect() returned nil")
+	}
+
+	_, err := effect.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:        providers.IDCodex,
+		AttemptID:       "luna-xhigh-dispatch",
+		Model:           "gpt-5.6-luna",
+		ReasoningEffort: "xhigh",
+		UserMessage:     "perform work",
+	}, func([]byte) error { return nil })
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	request := platformRunner.LastRequest()
+	want := []string{
+		"exec",
+		"--json",
+		"--model", "gpt-5.6-luna",
+		"--config", `model_reasoning_effort="xhigh"`,
+		"-",
+	}
+	if !reflect.DeepEqual(request.Args, want) {
+		t.Fatalf("command args = %#v, want %#v", request.Args, want)
 	}
 }

--- a/pkg/services/providers/internal/services/execution/internal/adapters/codex/decoder.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/codex/decoder.go
@@ -157,6 +157,18 @@ func (decoder *decoder) progressFacts() []providers.ExecuteProgress {
 	return progress
 }
 
+func (decoder *decoder) partialSession() *providers.SessionRef {
+	sessionID := strings.TrimSpace(decoder.sessionID)
+	if sessionID == "" {
+		return nil
+	}
+	return &providers.SessionRef{
+		Provider: providers.IDCodex,
+		Kind:     providers.SessionIDKind,
+		ID:       sessionID,
+	}
+}
+
 func (decoder *decoder) decodeRecord(raw []byte) {
 	if len(bytes.TrimSpace(raw)) == 0 {
 		return

--- a/pkg/services/providers/internal/services/execution/internal/adapters/codex/failure_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/codex/failure_test.go
@@ -91,6 +91,35 @@ func TestCodexRootNormalizesFailureStagesAndSuppressesResults(t *testing.T) {
 	}
 }
 
+func TestCodexRootPreservesStartedSessionOnFailure(t *testing.T) {
+	t.Parallel()
+
+	effect := codex.EffectFunc(func(
+		_ context.Context,
+		_ providers.ExecuteRequest,
+		observe func([]byte) error,
+	) (codex.EffectResult, error) {
+		if err := observe([]byte(
+			"{\"type\":\"thread.started\",\"thread_id\":\"thread-failed-42\"}\n",
+		)); err != nil {
+			return codex.EffectResult{}, err
+		}
+		return codex.EffectResult{}, providers.ExecuteFailure{
+			Kind: providers.ExecuteFailureKindUnknown,
+		}
+	})
+
+	_, err := newCodexRoot(t, effect).Execute(t.Context(), codexFailureRequest())
+	var failure providers.ExecuteFailure
+	if !errors.As(err, &failure) ||
+		failure.SessionRef == nil ||
+		failure.SessionRef.Provider != providers.IDCodex ||
+		failure.SessionRef.Kind != providers.SessionIDKind ||
+		failure.SessionRef.ID != "thread-failed-42" {
+		t.Fatalf("Execute() error = %#v, want failed Codex session reference", err)
+	}
+}
+
 func TestCodexRootCancellationAndDeadlineReachEffectAndCleanUpOnce(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/providers/internal/services/execution/internal/provider/agy/integration.go
+++ b/pkg/services/providers/internal/services/execution/internal/provider/agy/integration.go
@@ -102,6 +102,7 @@ func executeRequestFromInvocation(request inference.InvocationRequest) providers
 		Provider:           providers.IDAntigravity,
 		AttemptID:          request.InvocationID(),
 		Model:              request.Model(),
+		ReasoningEffort:    execution.ReasoningEffort,
 		SkipPermissions:    execution.SkipPermissions,
 		SystemPrompt:       request.SystemPrompt(),
 		UserMessage:        request.UserMessage(),

--- a/pkg/services/providers/internal/services/execution/internal/provider/claude/integration.go
+++ b/pkg/services/providers/internal/services/execution/internal/provider/claude/integration.go
@@ -114,6 +114,7 @@ func executeRequestFromInvocation(request inference.InvocationRequest) providers
 		Provider:           providers.IDClaude,
 		AttemptID:          request.InvocationID(),
 		Model:              request.Model(),
+		ReasoningEffort:    execution.ReasoningEffort,
 		SkipPermissions:    execution.SkipPermissions,
 		SystemPrompt:       request.SystemPrompt(),
 		UserMessage:        request.UserMessage(),

--- a/pkg/services/providers/internal/services/execution/internal/provider/codex/integration.go
+++ b/pkg/services/providers/internal/services/execution/internal/provider/codex/integration.go
@@ -109,6 +109,7 @@ func executeRequestFromInvocation(request inference.InvocationRequest) providers
 		Provider:           providers.IDCodex,
 		AttemptID:          request.InvocationID(),
 		Model:              request.Model(),
+		ReasoningEffort:    execution.ReasoningEffort,
 		SkipPermissions:    execution.SkipPermissions,
 		SystemPrompt:       request.SystemPrompt(),
 		UserMessage:        request.UserMessage(),

--- a/pkg/services/providers/internal/services/execution/internal/provider/provider_behavior.go
+++ b/pkg/services/providers/internal/services/execution/internal/provider/provider_behavior.go
@@ -8,6 +8,7 @@ import (
 
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 
 	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
 
@@ -140,6 +141,16 @@ func (b claudeProviderBehavior) BuildArgs(_ context.Context, req workerexecution
 	if req.Model != "" {
 		args = append(args, "--model", req.Model)
 	}
+	effort, ok := providers.ReasoningEffort(req.ReasoningEffort).Canonical()
+	if !ok {
+		return nil, fmt.Errorf("unsupported reasoning effort %q", req.ReasoningEffort)
+	}
+	if effort != "" {
+		if effort == "minimal" {
+			return nil, fmt.Errorf(`Claude does not support reasoning effort "minimal"`)
+		}
+		args = append(args, "--effort", effort)
+	}
 	if req.SessionID != "" {
 		logger.Info("inferencer: resuming claude session")
 		args = append(args, "--resume", req.SessionID)
@@ -167,6 +178,13 @@ func (b codexProviderBehavior) BuildArgs(ctx context.Context, req workerexecutio
 
 	if req.Model != "" {
 		args = append(args, "--model", req.Model)
+	}
+	effort, ok := providers.ReasoningEffort(req.ReasoningEffort).Canonical()
+	if !ok {
+		return nil, fmt.Errorf("unsupported reasoning effort %q", req.ReasoningEffort)
+	}
+	if effort != "" {
+		args = append(args, "--config", `model_reasoning_effort="`+effort+`"`)
 	}
 	imageArgs, err := codexImageArgs(ctx, req, buildCtx)
 	if err != nil {

--- a/pkg/services/providers/internal/services/execution/internal/provider/provider_behavior_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/provider/provider_behavior_test.go
@@ -75,6 +75,52 @@ func TestClaudeProviderBehavior_BuildArgs(t *testing.T) {
 	}
 }
 
+func TestProviderBehaviorBuildArgsRejectsUnsupportedReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		behavior providerBehavior
+		provider string
+		effort   string
+		want     string
+	}{
+		{
+			name:     "Claude rejects provider-unsupported minimal",
+			behavior: claudeProviderBehavior{logger: logging.NoopLogger{}},
+			provider: string(modelprovider.ProviderClaude),
+			effort:   " MINIMAL ",
+			want:     `does not support reasoning effort "minimal"`,
+		},
+		{
+			name:     "Claude rejects globally unsupported value",
+			behavior: claudeProviderBehavior{logger: logging.NoopLogger{}},
+			provider: string(modelprovider.ProviderClaude),
+			effort:   "extreme",
+			want:     `unsupported reasoning effort "extreme"`,
+		},
+		{
+			name:     "Codex rejects globally unsupported value",
+			behavior: codexProviderBehavior{logger: logging.NoopLogger{}},
+			provider: string(modelprovider.ProviderCodex),
+			effort:   "extreme",
+			want:     `unsupported reasoning effort "extreme"`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := test.behavior.BuildArgs(context.Background(), workerexecution.ProviderInferenceRequest{
+				ModelProvider:   test.provider,
+				ReasoningEffort: test.effort,
+				UserMessage:     "hello",
+			}, false, nil)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("BuildArgs() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestCodexProviderBehavior_BuildArgs(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
@@ -100,6 +146,16 @@ func TestCodexProviderBehavior_BuildArgs(t *testing.T) {
 			},
 			skipPermissions: true,
 			want:            []string{"exec", "--dangerously-bypass-approvals-and-sandbox", "--model", "gpt-5-codex", "-"},
+		},
+		{
+			name: "WithLunaXHighReasoningEffort",
+			req: workerexecution.ProviderInferenceRequest{
+				ModelProvider:   string(modelprovider.ProviderCodex),
+				Model:           "gpt-5.6-luna",
+				ReasoningEffort: " XHIGH ",
+				UserMessage:     "hello",
+			},
+			want: []string{"exec", "--model", "gpt-5.6-luna", "--config", `model_reasoning_effort="xhigh"`, "-"},
 		},
 		{
 			name: "WithWorkingDirectoryRetainsStdinPlaceholderOnly",

--- a/pkg/services/providers/internal/services/execution/internal/provider/providersroot/conductor_route.go
+++ b/pkg/services/providers/internal/services/execution/internal/provider/providersroot/conductor_route.go
@@ -70,6 +70,7 @@ func invocationRequestFromExecute(
 		WorkerType:         strings.TrimSpace(request.WorkerType),
 		WorkstationType:    strings.TrimSpace(request.WorkstationName),
 		Model:              strings.TrimSpace(request.Model),
+		ReasoningEffort:    canonicalReasoningEffort(request.ReasoningEffort),
 		SystemPrompt:       request.SystemPrompt,
 		UserMessage:        request.UserMessage,
 		InputTokens:        cloneInputTokens(request.InputTokens),

--- a/pkg/services/providers/internal/services/execution/internal/provider/providersroot/service.go
+++ b/pkg/services/providers/internal/services/execution/internal/provider/providersroot/service.go
@@ -122,6 +122,7 @@ func inferenceRequest(request providers.ExecuteRequest) workers.ProviderInferenc
 		WorkerType:         strings.TrimSpace(request.WorkerType),
 		WorkstationType:    strings.TrimSpace(request.WorkstationName),
 		Model:              strings.TrimSpace(request.Model),
+		ReasoningEffort:    canonicalReasoningEffort(request.ReasoningEffort),
 		ModelProvider:      modelProviderForProviderIdentity(providerID),
 		SystemPrompt:       request.SystemPrompt,
 		UserMessage:        request.UserMessage,
@@ -136,6 +137,11 @@ func inferenceRequest(request providers.ExecuteRequest) workers.ProviderInferenc
 		infer.SessionID = request.ResumeSession.ID
 	}
 	return infer
+}
+
+func canonicalReasoningEffort(value string) string {
+	canonical, _ := providers.ReasoningEffort(value).Canonical()
+	return canonical
 }
 
 func modelProviderForProviderIdentity(providerID string) string {

--- a/pkg/services/providers/transports/http/execute_mapping.go
+++ b/pkg/services/providers/transports/http/execute_mapping.go
@@ -54,6 +54,7 @@ type ExecuteRequestBody struct {
 	WorkerType         string              `json:"workerType,omitempty"`
 	WorkstationName    string              `json:"workstationName,omitempty"`
 	Model              string              `json:"model,omitempty"`
+	ReasoningEffort    string              `json:"reasoningEffort,omitempty"`
 	SkipPermissions    bool                `json:"skipPermissions,omitempty"`
 	SystemPrompt       string              `json:"systemPrompt,omitempty"`
 	UserMessage        string              `json:"userMessage,omitempty"`
@@ -94,6 +95,7 @@ func ExecuteRequestFromHTTP(input ExecuteInput) (providers.ExecuteRequest, error
 	request.WorkerType = strings.TrimSpace(body.WorkerType)
 	request.WorkstationName = strings.TrimSpace(body.WorkstationName)
 	request.Model = strings.TrimSpace(body.Model)
+	request.ReasoningEffort = strings.TrimSpace(body.ReasoningEffort)
 	request.SkipPermissions = body.SkipPermissions
 	request.SystemPrompt = body.SystemPrompt
 	request.UserMessage = body.UserMessage

--- a/pkg/services/providers/transports/http/execute_operations_test.go
+++ b/pkg/services/providers/transports/http/execute_operations_test.go
@@ -38,13 +38,14 @@ func TestAdapter_ExecuteInvokesFakeRootAndEncodesSuccess(t *testing.T) {
 
 	response, err := adapter.Execute(context.Background(), ExecuteInput{
 		ProviderID: "codex",
-		Body:       strings.NewReader(`{"attemptId":"attempt-1","userMessage":"hello"}`),
+		Body:       strings.NewReader(`{"attemptId":"attempt-1","reasoningEffort":"xhigh","userMessage":"hello"}`),
 	})
 	if err != nil {
 		t.Fatalf("Execute error = %v", err)
 	}
 	if invoked.Provider != providers.IDCodex ||
 		invoked.AttemptID != "attempt-1" ||
+		invoked.ReasoningEffort != "xhigh" ||
 		invoked.UserMessage != "hello" {
 		t.Fatalf("invoked request = %#v, want decoded execute request", invoked)
 	}

--- a/pkg/services/providers/transports/mcp/execute.go
+++ b/pkg/services/providers/transports/mcp/execute.go
@@ -31,6 +31,7 @@ type ExecuteInput struct {
 	WorkerType         string            `json:"workerType,omitempty"`
 	WorkstationName    string            `json:"workstationName,omitempty"`
 	Model              string            `json:"model,omitempty"`
+	ReasoningEffort    string            `json:"reasoningEffort,omitempty"`
 	SkipPermissions    bool              `json:"skipPermissions,omitempty"`
 	SystemPrompt       string            `json:"systemPrompt,omitempty"`
 	UserMessage        string            `json:"userMessage,omitempty"`
@@ -50,6 +51,7 @@ func (input ExecuteInput) executeRequest() providers.ExecuteRequest {
 		WorkerType:         input.WorkerType,
 		WorkstationName:    input.WorkstationName,
 		Model:              input.Model,
+		ReasoningEffort:    input.ReasoningEffort,
 		SkipPermissions:    input.SkipPermissions,
 		SystemPrompt:       input.SystemPrompt,
 		UserMessage:        input.UserMessage,

--- a/pkg/services/providers/transports/mcp/execute_test.go
+++ b/pkg/services/providers/transports/mcp/execute_test.go
@@ -17,6 +17,7 @@ const testExecuteInputJSON = `{
 	"workerType":"agent",
 	"workstationName":"ws-1",
 	"model":"gpt-test",
+	"reasoningEffort":"xhigh",
 	"skipPermissions":true,
 	"systemPrompt":"system",
 	"userMessage":"hello",
@@ -63,6 +64,7 @@ func TestBind_ExecuteSuccessReturnsDetachedResultFromInjectedRoot(t *testing.T) 
 			if request.WorkerType != "agent" ||
 				request.WorkstationName != "ws-1" ||
 				request.Model != "gpt-test" ||
+				request.ReasoningEffort != "xhigh" ||
 				!request.SkipPermissions ||
 				request.SystemPrompt != "system" ||
 				request.UserMessage != "hello" ||

--- a/pkg/services/providers/wire/wire.go
+++ b/pkg/services/providers/wire/wire.go
@@ -291,7 +291,8 @@ func externalRegistrationAttempt(registration providerinference.Registration) (e
 		Attempt: func(ctx context.Context, request providers.ExecuteRequest) (providers.ExecuteResult, error) {
 			writer := &externalResponseWriter{}
 			err := registration.Integration.Invoke(ctx, providerinference.InvocationRequest{
-				ID: request.AttemptID, ModelID: request.Model, Prompt: request.UserMessage,
+				ID: request.AttemptID, ModelID: request.Model,
+				ReasoningEffort: request.ReasoningEffort, Prompt: request.UserMessage,
 			}, writer)
 			if err != nil {
 				return providers.ExecuteResult{}, providers.ExecuteFailure{Kind: providers.ExecuteFailureKindUnknown, Message: err.Error()}

--- a/pkg/services/workers/execute_contracts.go
+++ b/pkg/services/workers/execute_contracts.go
@@ -75,9 +75,10 @@ type ProviderReference struct {
 
 // ModelReference is a detached model identity reference.
 type ModelReference struct {
-	Name     string
-	Provider string
-	Locality string
+	Name            string
+	Provider        string
+	ReasoningEffort string
+	Locality        string
 }
 
 // PromptPolicy carries resolved prompt material for one attempt.

--- a/pkg/services/workers/execution_requests.go
+++ b/pkg/services/workers/execution_requests.go
@@ -118,6 +118,7 @@ type WorkstationExecutionRequest struct {
 	ModelBindings            []ResolvedModelOperationBinding `json:"model_bindings,omitempty"`
 	Model                    string                          `json:"model,omitempty"`
 	ModelProvider            string                          `json:"model_provider,omitempty"`
+	ReasoningEffort          string                          `json:"reasoning_effort,omitempty"`
 	SystemPrompt             string                          `json:"system_prompt,omitempty"`
 	UserMessage              string                          `json:"user_message,omitempty"`
 	OutputSchema             string                          `json:"output_schema,omitempty"`
@@ -149,6 +150,7 @@ type ProviderInferenceRequest struct {
 	WorkingDirectory             string                          `json:"working_directory,omitempty"`
 	Model                        string                          `json:"model,omitempty"`
 	ModelProvider                string                          `json:"model_provider,omitempty"`
+	ReasoningEffort              string                          `json:"reasoning_effort,omitempty"`
 	ModelLocality                string                          `json:"model_locality,omitempty"`
 	SessionID                    string                          `json:"session_id,omitempty"`
 	// SkipPermissions is the invocation-effective worker policy. Construction

--- a/pkg/services/workers/internal/model_invocation.go
+++ b/pkg/services/workers/internal/model_invocation.go
@@ -259,7 +259,10 @@ func (s *Service) ensureInvocationReady(
 		Name:      modelName,
 		Operation: operation,
 	})
-	return readiness.Readiness, err
+	if err != nil {
+		return readiness.Readiness, err
+	}
+	return readiness.Readiness, readiness.Readiness.InvocationError()
 }
 
 func directModelInvocationWorkstationRequest(

--- a/pkg/services/workers/internal/model_invocation_readiness_test.go
+++ b/pkg/services/workers/internal/model_invocation_readiness_test.go
@@ -1,0 +1,58 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/testutil/runtimefixtures"
+	"github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+func TestEnsureInvocationReadyClassifiesScopedReadinessProjection(t *testing.T) {
+	t.Parallel()
+
+	scope, err := (models.RuntimeScopeRef{}).Parse("factory-session:readiness-test")
+	if err != nil {
+		t.Fatalf("parse Models scope: %v", err)
+	}
+	service := &Service{
+		models: scopedReadinessModelsService{
+			testModelsService: testModelsService{},
+			readiness: models.Runtime{
+				Identity:       "OMNIVOICE_Q4_K_M",
+				ReadinessState: models.ReadinessStateMissing,
+				LifecycleState: models.LifecycleStateNotInstalled,
+			},
+		},
+		modelsScope: scope,
+	}
+
+	readiness, err := service.ensureInvocationReady(
+		context.Background(),
+		&runtimefixtures.RuntimeConfigLookupFixture{},
+		"OMNIVOICE_Q4_K_M",
+		"TTS",
+	)
+	if !errors.Is(err, models.ErrMissing) {
+		t.Fatalf("ensureInvocationReady() error = %v, want errors.Is ErrMissing", err)
+	}
+	if readiness.Identity != "OMNIVOICE_Q4_K_M" {
+		t.Fatalf("ensureInvocationReady() readiness = %#v, want named projection", readiness)
+	}
+}
+
+type scopedReadinessModelsService struct {
+	testModelsService
+	readiness models.Runtime
+}
+
+func (service scopedReadinessModelsService) GetModelReadiness(
+	context.Context,
+	models.GetModelReadinessRequest,
+) (models.GetModelReadinessResult, error) {
+	return models.GetModelReadinessResult{
+		ModelName: service.readiness.Identity,
+		Readiness: service.readiness,
+	}, nil
+}

--- a/pkg/services/workers/internal/service/adapt.go
+++ b/pkg/services/workers/internal/service/adapt.go
@@ -85,6 +85,7 @@ func adaptRunnerRequest(
 		WorkingDirectory:             workingDirectory,
 		Model:                        request.Target.Model.Name,
 		ModelProvider:                firstNonEmpty(request.Target.Model.Provider, providerIdentity(request.Target.Provider)),
+		ReasoningEffort:              request.Target.Model.ReasoningEffort,
 		ModelLocality:                request.Target.Model.Locality,
 		SessionID:                    sessionID,
 		SkipPermissions:              request.Target.Permissions.SkipPermissions,

--- a/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner.go
+++ b/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner.go
@@ -221,6 +221,7 @@ func providerRequest(request workers.RunnerExecutionRequest) providers.ExecuteRe
 		WorkerType:         request.WorkerType,
 		WorkstationName:    request.WorkstationType,
 		Model:              request.Model,
+		ReasoningEffort:    request.ReasoningEffort,
 		SkipPermissions:    request.SkipPermissions,
 		SystemPrompt:       request.SystemPrompt,
 		UserMessage:        request.UserMessage,

--- a/pkg/services/workers/internal/services/workstations/executor/agent.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agent.go
@@ -158,20 +158,39 @@ func (ae *AgentExecutor) Execute(ctx context.Context, request workerexecution.Wo
 }
 
 func effectiveWorkerDefinition(request workerexecution.WorkstationExecutionRequest, workerDef *interfaces.FactoryWorkerConfig) *interfaces.FactoryWorkerConfig {
-	if workerDef == nil || (request.Model == "" && request.ModelProvider == "" && request.ExecutorProvider == "") {
+	if workerDef == nil {
+		return workerDef
+	}
+	hasResolvedSelection := request.Model != "" ||
+		request.ModelProvider != "" ||
+		request.ReasoningEffort != "" ||
+		request.ExecutorProvider != "" ||
+		isInvocationPlaceholder(workerDef.Model) ||
+		isInvocationPlaceholder(workerDef.ModelProvider) ||
+		isInvocationPlaceholder(workerDef.ReasoningEffort) ||
+		isInvocationPlaceholder(workerDef.ExecutorProvider)
+	if !hasResolvedSelection {
 		return workerDef
 	}
 	effective := *workerDef
-	if request.Model != "" {
+	if request.Model != "" || isInvocationPlaceholder(workerDef.Model) {
 		effective.Model = request.Model
 	}
-	if request.ModelProvider != "" {
+	if request.ModelProvider != "" || isInvocationPlaceholder(workerDef.ModelProvider) {
 		effective.ModelProvider = request.ModelProvider
 	}
-	if request.ExecutorProvider != "" {
+	if request.ReasoningEffort != "" || isInvocationPlaceholder(workerDef.ReasoningEffort) {
+		effective.ReasoningEffort = request.ReasoningEffort
+	}
+	if request.ExecutorProvider != "" || isInvocationPlaceholder(workerDef.ExecutorProvider) {
 		effective.ExecutorProvider = request.ExecutorProvider
 	}
 	return &effective
+}
+
+func isInvocationPlaceholder(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	return strings.HasPrefix(trimmed, "${") && strings.HasSuffix(trimmed, "}")
 }
 
 func (ae *AgentExecutor) canonicalInferenceOutput(raw string, workerDef *interfaces.FactoryWorkerConfig, operationName string) (string, error) {
@@ -356,6 +375,7 @@ func inferenceRequestForExecutionRequest(request workerexecution.WorkstationExec
 			RunnerID: request.RunnerID,
 			Source:   request.RunnerSelectionSource,
 		})
+		req.ReasoningEffort = workerDef.ReasoningEffort
 		req.ModelLocality = workerDef.ModelLocality
 		req.SessionID = workerDef.SessionID
 		if workerDef.SessionID != "" {

--- a/pkg/services/workers/internal/services/workstations/executor/agent_test.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agent_test.go
@@ -57,6 +57,31 @@ func TestAgentExecutor_UsesInjectedClockForWorkMetrics(t *testing.T) {
 	}
 }
 
+func TestEffectiveWorkerDefinitionClearsEmptyResolvedPlaceholders(t *testing.T) {
+	worker := &workerconfig.FactoryWorkerConfig{
+		Model:            "${model}",
+		ModelProvider:    "${provider}",
+		ReasoningEffort:  "${effort}",
+		ExecutorProvider: "${runner}",
+	}
+	effective := effectiveWorkerDefinition(workerexecution.WorkstationExecutionRequest{}, worker)
+	if effective.Model != "" ||
+		effective.ModelProvider != "" ||
+		effective.ReasoningEffort != "" ||
+		effective.ExecutorProvider != "" {
+		t.Fatalf(
+			"effective model/provider/effort/runner = %q/%q/%q/%q, want empty resolved placeholders",
+			effective.Model,
+			effective.ModelProvider,
+			effective.ReasoningEffort,
+			effective.ExecutorProvider,
+		)
+	}
+	if worker.ReasoningEffort != "${effort}" {
+		t.Fatalf("authored worker mutated: %#v", worker)
+	}
+}
+
 func (m *agentMockProvider) Infer(_ context.Context, req workerexecution.ProviderInferenceRequest) (workerexecution.InferenceResponse, error) {
 	m.lastReq = req
 	m.callCount++

--- a/pkg/services/workers/internal/services/workstations/executor/agentrun/executor.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agentrun/executor.go
@@ -220,6 +220,9 @@ func effectiveAgentRunWorkerDefinition(request workerexecution.WorkstationExecut
 	if request.ModelProvider != "" || isInvocationInterpolation(workerDef.ModelProvider) {
 		effective.ModelProvider = request.ModelProvider
 	}
+	if request.ReasoningEffort != "" || isInvocationInterpolation(workerDef.ReasoningEffort) {
+		effective.ReasoningEffort = request.ReasoningEffort
+	}
 	return &effective
 }
 
@@ -270,6 +273,7 @@ func agentRunInferenceRequest(
 	if workerDef != nil {
 		req.Model = workerDef.Model
 		req.ModelProvider = workerDef.ModelProvider
+		req.ReasoningEffort = workerDef.ReasoningEffort
 		req.ModelLocality = workerDef.ModelLocality
 		req.SessionID = workerDef.SessionID
 	}

--- a/pkg/services/workers/internal/services/workstations/executor/agentrun/executor_test.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agentrun/executor_test.go
@@ -393,10 +393,28 @@ func TestAgentRunExecutor_RequestModelSelectionOverridesWorkerWithoutMutation(t 
 
 func TestEffectiveAgentRunWorkerDefinition_EmptyInterpolationPreservesOperatorOverride(t *testing.T) {
 	t.Run("authored placeholders resolve empty", func(t *testing.T) {
-		worker := &interfaces.FactoryWorkerConfig{Model: "${model}", ModelProvider: "${provider}"}
+		worker := &interfaces.FactoryWorkerConfig{
+			Model: "${model}", ModelProvider: "${provider}", ReasoningEffort: "${effort}",
+		}
 		effective := effectiveAgentRunWorkerDefinition(workerexecution.WorkstationExecutionRequest{}, worker)
-		if effective.Model != "" || effective.ModelProvider != "" {
-			t.Fatalf("effective provider/model = %q/%q, want empty resolved placeholders", effective.ModelProvider, effective.Model)
+		if effective.Model != "" || effective.ModelProvider != "" || effective.ReasoningEffort != "" {
+			t.Fatalf(
+				"effective provider/model/effort = %q/%q/%q, want empty resolved placeholders",
+				effective.ModelProvider,
+				effective.Model,
+				effective.ReasoningEffort,
+			)
+		}
+	})
+
+	t.Run("resolved effort overlays authored placeholder", func(t *testing.T) {
+		worker := &interfaces.FactoryWorkerConfig{ReasoningEffort: "${effort}"}
+		effective := effectiveAgentRunWorkerDefinition(
+			workerexecution.WorkstationExecutionRequest{ReasoningEffort: "xhigh"},
+			worker,
+		)
+		if effective.ReasoningEffort != "xhigh" {
+			t.Fatalf("effective effort = %q, want xhigh", effective.ReasoningEffort)
 		}
 	})
 

--- a/pkg/services/workers/internal/services/workstations/executor/workstation_executor.go
+++ b/pkg/services/workers/internal/services/workstations/executor/workstation_executor.go
@@ -206,6 +206,18 @@ func (we *WorkstationExecutor) executeModelWorkstation(ctx context.Context, disp
 			return *failed, nil
 		}
 	}
+	effort, effortOK := factorydefinitions.CanonicalizeReasoningEffort(workerDef.ReasoningEffort)
+	if !effortOK {
+		return workerexecution.WorkResult{
+			DispatchID:   dispatch.DispatchID,
+			TransitionID: dispatch.TransitionID,
+			Outcome:      workerexecution.OutcomeFailed,
+			Error:        fmt.Sprintf("worker reasoningEffort %q is unsupported", workerDef.ReasoningEffort),
+			Diagnostics:  invocationDiagnostics,
+			Metrics:      workerexecution.WorkMetrics{Duration: we.Now().Sub(start)},
+		}, nil
+	}
+	workerDef.ReasoningEffort = effort
 
 	resolvedContext, failed := we.resolveWorkstationExecutionContext(dispatch, workstationDef, start, logger)
 	if failed != nil {
@@ -653,6 +665,7 @@ func (we *WorkstationExecutor) buildWorkstationExecutionRequest(dispatch work.Wo
 		ModelBindings:            modelBindings,
 		Model:                    workerDef.Model,
 		ModelProvider:            workerDef.ModelProvider,
+		ReasoningEffort:          workerDef.ReasoningEffort,
 		SystemPrompt:             workerDef.Body,
 		UserMessage:              rendered,
 		OutputSchema:             workstationDef.OutputSchema,

--- a/pkg/transports/http/generated/server.gen.go
+++ b/pkg/transports/http/generated/server.gen.go
@@ -5546,6 +5546,9 @@ type ProviderSessionUnknownEvent struct {
 // ProviderTechnicalSupportLevel Maintainer-verified technical support posture for a provider integration. This value does not describe whether the provider is installed or ready on the current machine.
 type ProviderTechnicalSupportLevel string
 
+// ReasoningEffort Optional provider-neutral reasoning effort. Surrounding whitespace and letter case are normalized. Omit the field to preserve the selected provider and model default. Factory definitions may use an exact invocation-parameter placeholder such as `${executorReasoningEffort}`.
+type ReasoningEffort = string
+
 // Relation defines model for Relation.
 type Relation struct {
 	RequiredState  *string `json:"requiredState,omitempty"`
@@ -6537,6 +6540,9 @@ type Worker struct {
 
 	// Provider Built-in hosted provider identity when this worker uses repository-owned hosted execution.
 	Provider *HostedWorkerProvider `json:"provider,omitempty"`
+
+	// ReasoningEffort Optional provider-neutral reasoning effort. Surrounding whitespace and letter case are normalized. Omit the field to preserve the selected provider and model default. Factory definitions may use an exact invocation-parameter placeholder such as `${executorReasoningEffort}`.
+	ReasoningEffort *ReasoningEffort `json:"reasoningEffort,omitempty"`
 
 	// Resources Resource capacity this worker requires before it can be dispatched.
 	Resources *[]ResourceRequirement `json:"resources,omitempty"`

--- a/pkg/transports/mapping/factoryconfig/authored/agents_config.go
+++ b/pkg/transports/mapping/factoryconfig/authored/agents_config.go
@@ -57,6 +57,7 @@ func ParseWorkerConfig(data []byte, sourcePath string) (*factorydefinitions.Fact
 		Provider:         parsed.Provider,
 		Model:            parsed.Model,
 		ModelProvider:    parsed.ModelProvider,
+		ReasoningEffort:  parsed.ReasoningEffort,
 		ExecutorProvider: parsed.ExecutorProvider,
 		Command:          parsed.Command,
 		Args:             append([]string(nil), parsed.Args...),
@@ -87,6 +88,7 @@ type workerFrontmatterInput struct {
 	Provider         string                                       `yaml:"provider,omitempty"`
 	Model            string                                       `yaml:"model,omitempty"`
 	ModelProvider    string                                       `yaml:"modelProvider,omitempty"`
+	ReasoningEffort  string                                       `yaml:"reasoningEffort,omitempty"`
 	ExecutorProvider string                                       `yaml:"executorProvider,omitempty"`
 	Command          string                                       `yaml:"command,omitempty"`
 	Args             []string                                     `yaml:"args,omitempty"`
@@ -276,6 +278,7 @@ type workerFrontmatter struct {
 	Provider         string                                       `yaml:"provider,omitempty"`
 	Model            string                                       `yaml:"model,omitempty"`
 	ModelProvider    string                                       `yaml:"modelProvider,omitempty"`
+	ReasoningEffort  string                                       `yaml:"reasoningEffort,omitempty"`
 	ExecutorProvider string                                       `yaml:"executorProvider,omitempty"`
 	Command          string                                       `yaml:"command,omitempty"`
 	Args             []string                                     `yaml:"args,omitempty"`
@@ -421,6 +424,7 @@ func workerFrontmatterForExpansion(def factorydefinitions.FactoryWorkerConfig) w
 		Provider:         publicFactoryHostedWorkerProviderFromInternal(def.Provider),
 		Model:            def.Model,
 		ModelProvider:    modelProvider,
+		ReasoningEffort:  def.ReasoningEffort,
 		ExecutorProvider: executorProvider,
 		Command:          def.Command,
 		Args:             append([]string(nil), def.Args...),

--- a/pkg/transports/mapping/factoryconfig/factory_config_mapping.go
+++ b/pkg/transports/mapping/factoryconfig/factory_config_mapping.go
@@ -1166,6 +1166,7 @@ func workerDefinitionAPIFromInternalWithUsage(def *interfaces.FactoryWorkerConfi
 		AgentTools:       agentWorkerToolsAPIFromInternal(def.AgentTools),
 		Model:            stringPtrIfNotEmpty(def.Model),
 		ModelProvider:    workerModelProviderPtrIfNotEmpty(def.ModelProvider),
+		ReasoningEffort:  stringPtrIfNotEmpty(def.ReasoningEffort),
 		ModelLocality:    workerModelLocalityPtrIfNotEmpty(def.ModelLocality),
 		ExecutorProvider: workerProviderPtrIfNotEmpty(def.ExecutorProvider),
 		Operations:       modelOperationsAPIFromInternal(def.Operations),

--- a/pkg/transports/mapping/factoryconfig/factory_config_mapping_internal.go
+++ b/pkg/transports/mapping/factoryconfig/factory_config_mapping_internal.go
@@ -582,6 +582,7 @@ func workerInternalFromAPI(worker factoryapi.Worker) interfaces.FactoryWorkerCon
 		Provider:         internalFactoryHostedWorkerProviderFromPublic(string(valueOrEmpty(worker.Provider))),
 		Model:            stringValue(worker.Model),
 		ModelProvider:    internalFactoryWorkerModelProviderFromPublic(worker.ModelProvider),
+		ReasoningEffort:  stringValue(worker.ReasoningEffort),
 		ModelLocality:    internalFactoryWorkerModelLocalityFromPublic(worker.ModelLocality),
 		ExecutorProvider: internalFactoryWorkerProviderFromPublic(worker.ExecutorProvider),
 		Operations:       modelOperationsInternalFromAPI(worker.Operations),

--- a/pkg/wire/runtime_inputs.go
+++ b/pkg/wire/runtime_inputs.go
@@ -57,14 +57,6 @@ func provideRuntimeOpeningRequestFactory() runcli.RuntimeOpeningRequestFactory {
 		if cfg.Continuously {
 			mode = factorydefinitions.RuntimeModeService
 		}
-		persistencePolicy := factorysessions.PersistencePolicyDisabled
-		if cfg.WithServer {
-			// The public Factory Session API exposes restart/resume semantics.
-			// Server-backed runs therefore opt into the durable snapshot store;
-			// ordinary local and packaged invocations remain in-memory only.
-			persistencePolicy = factorysessions.PersistencePolicyEnabled
-		}
-
 		request := &factorysessions.RuntimeOpeningRequest{
 			FactoryDefinition: factorydefinitions.RuntimeOpeningRequest{
 				Directory:        cfg.Dir,
@@ -88,7 +80,6 @@ func provideRuntimeOpeningRequestFactory() runcli.RuntimeOpeningRequestFactory {
 			FactorySession: factorysessions.SessionRuntimeOpeningRequest{
 				SystemConfigHome: cfg.HomeDir,
 				WorkFile:         cfg.WorkFile,
-				PersistencePolicy: persistencePolicy,
 				Host: factorysessions.RuntimeHostRequest{
 					Directory:   cfg.Dir,
 					RuntimeMode: mode,

--- a/pkg/wire/runtime_inputs.go
+++ b/pkg/wire/runtime_inputs.go
@@ -57,6 +57,13 @@ func provideRuntimeOpeningRequestFactory() runcli.RuntimeOpeningRequestFactory {
 		if cfg.Continuously {
 			mode = factorydefinitions.RuntimeModeService
 		}
+		persistencePolicy := factorysessions.PersistencePolicyDisabled
+		if cfg.WithServer {
+			// The public Factory Session API exposes restart/resume semantics.
+			// Server-backed runs therefore opt into the durable snapshot store;
+			// ordinary local and packaged invocations remain in-memory only.
+			persistencePolicy = factorysessions.PersistencePolicyEnabled
+		}
 
 		request := &factorysessions.RuntimeOpeningRequest{
 			FactoryDefinition: factorydefinitions.RuntimeOpeningRequest{
@@ -81,6 +88,7 @@ func provideRuntimeOpeningRequestFactory() runcli.RuntimeOpeningRequestFactory {
 			FactorySession: factorysessions.SessionRuntimeOpeningRequest{
 				SystemConfigHome: cfg.HomeDir,
 				WorkFile:         cfg.WorkFile,
+				PersistencePolicy: persistencePolicy,
 				Host: factorysessions.RuntimeHostRequest{
 					Directory:   cfg.Dir,
 					RuntimeMode: mode,

--- a/pkg/wire/runtime_inputs_test.go
+++ b/pkg/wire/runtime_inputs_test.go
@@ -424,7 +424,7 @@ func TestRuntimeOpeningRequestFactoryMapsSelectionsIntoOwnerRequests(t *testing.
 		ExecutionBaseDir: "execution", RunnerID: "runner", Worktree: "feature-login",
 		HomeDir: "home", WorkFile: "work.json", BindHost: "127.0.0.1",
 		Port: 8080, AutoPort: true,
-		Continuously: true, WithServer: true, Verbose: true, RecordPath: "record.json",
+		Continuously: true, Verbose: true, RecordPath: "record.json",
 		ReplayPath: "replay.json", Workflow: "flow", ModelCacheDir: "models",
 		InvocationSkipPermissionsOverride: &skip,
 	}, mocks, func(factorysessions.RuntimeHostBinding) {})
@@ -439,7 +439,6 @@ func TestRuntimeOpeningRequestFactoryMapsSelectionsIntoOwnerRequests(t *testing.
 		t.Fatalf("Factory Runtime request = %#v", request.FactoryRuntime)
 	}
 	if request.FactorySession.SystemConfigHome != "home" ||
-		request.FactorySession.PersistencePolicy != factorysessions.PersistencePolicyEnabled ||
 		request.FactorySession.Host.Host != "127.0.0.1" ||
 		request.FactorySession.Host.Port != 8080 ||
 		!request.FactorySession.Host.AutoPort {

--- a/pkg/wire/runtime_inputs_test.go
+++ b/pkg/wire/runtime_inputs_test.go
@@ -424,7 +424,7 @@ func TestRuntimeOpeningRequestFactoryMapsSelectionsIntoOwnerRequests(t *testing.
 		ExecutionBaseDir: "execution", RunnerID: "runner", Worktree: "feature-login",
 		HomeDir: "home", WorkFile: "work.json", BindHost: "127.0.0.1",
 		Port: 8080, AutoPort: true,
-		Continuously: true, Verbose: true, RecordPath: "record.json",
+		Continuously: true, WithServer: true, Verbose: true, RecordPath: "record.json",
 		ReplayPath: "replay.json", Workflow: "flow", ModelCacheDir: "models",
 		InvocationSkipPermissionsOverride: &skip,
 	}, mocks, func(factorysessions.RuntimeHostBinding) {})
@@ -439,6 +439,7 @@ func TestRuntimeOpeningRequestFactoryMapsSelectionsIntoOwnerRequests(t *testing.
 		t.Fatalf("Factory Runtime request = %#v", request.FactoryRuntime)
 	}
 	if request.FactorySession.SystemConfigHome != "home" ||
+		request.FactorySession.PersistencePolicy != factorysessions.PersistencePolicyEnabled ||
 		request.FactorySession.Host.Host != "127.0.0.1" ||
 		request.FactorySession.Host.Port != 8080 ||
 		!request.FactorySession.Host.AutoPort {

--- a/tests/functional/acceptance/invoke_repeat_subagent_outcomes_test.go
+++ b/tests/functional/acceptance/invoke_repeat_subagent_outcomes_test.go
@@ -204,9 +204,9 @@ func namedGoalJSONRunArgs(session *builtcliacceptance.Session, mockWorkersPath, 
 	args = append(args,
 		"run",
 		"--named", goal.PackagedFactoryName,
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
+		"--output", "primary",
 		"--no-record",
-		mockWorkersPath,
 		goalText,
 	)
 	return args
@@ -222,9 +222,9 @@ func namedSubagentJSONRunArgs(
 	return append(args,
 		"run",
 		"--named", factorydefinitions.PackagedSubagentFactoryName,
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
+		"--output", "primary",
 		"--no-record",
-		mockWorkersPath,
 		requestText,
 	)
 }

--- a/tests/functional/acceptance/provider_outcomes_test.go
+++ b/tests/functional/acceptance/provider_outcomes_test.go
@@ -85,10 +85,9 @@ func TestProviderPosture_Configured_ExplicitHomeConfigEnablesNamedGoalSuccessPat
 	args = append(args,
 		"run",
 		"--named", goal.PackagedFactoryName,
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
 		"--no-record",
 		"--quiet",
-		mockWorkersPath,
 		goalText,
 	)
 
@@ -139,10 +138,9 @@ func TestProviderPosture_Discovered_EnvDefaultResolvesWithoutFileProvider(t *tes
 		"run",
 		"--provider", "DEFAULT",
 		"--named", goal.PackagedFactoryName,
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
 		"--no-record",
 		"--quiet",
-		mockWorkersPath,
 		goalText,
 	)
 

--- a/tests/functional/events/response_events/stream_test.go
+++ b/tests/functional/events/response_events/stream_test.go
@@ -28,14 +28,14 @@ const (
 	functionalResponseEventCompletedRetentionWindow = time.Millisecond
 	functionalResponseEventMissingSessionID         = "session-missing-response-events"
 
-	sessionExpiryChildSessionID      = "cursor-js-session-expiry"
+	sessionExpiryChildSessionID      = "claude-js-session-expiry"
 	sessionExpiryChildWorkflowFile   = "session-expiry-child-progress.workflow.js"
 	sessionExpiryChildWorkflowSource = `return (async function () {
   const child = await agent.run({
     prompt: "summarize session expiry",
     label: "session-expiry-child",
-    modelProvider: "cursor",
-    model: "cursor-test-model",
+    modelProvider: "claude",
+    model: "claude-test-model",
   });
   return { label: "session-expiry", child: child };
 })();`

--- a/tests/functional/factory/packaged/cross/package_cli_api_test.go
+++ b/tests/functional/factory/packaged/cross/package_cli_api_test.go
@@ -66,9 +66,8 @@ func TestPackagedFactoryInvokedByCLICanBeInspectedByAPI(t *testing.T) {
 		"--factory", factoryPath,
 		"--with-server",
 		"--server", requestedURL,
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
 		"--no-record",
-		mockWorkersPath,
 		goalText,
 	})
 	inputs.Input.WorkingDirectory = factoryDir
@@ -1322,11 +1321,13 @@ func runPackagedGoalInvocationCLIWithMode(
 	cmdArgs = append(cmdArgs, sourceArgs...)
 	cmdArgs = append(
 		cmdArgs,
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
 		"--no-record",
 		"--server", baseURL,
-		mockWorkersPath,
 	)
+	if jsonMode {
+		cmdArgs = append(cmdArgs, "--output", "primary")
+	}
 	cmdArgs = append(cmdArgs, args...)
 
 	inputs := support.FakeInputs(ctx, cmdArgs)

--- a/tests/functional/factory/packaged/goal/helpers_test.go
+++ b/tests/functional/factory/packaged/goal/helpers_test.go
@@ -369,10 +369,9 @@ func runPackagedGoalQuietCLIBatch(
 	args := []string{
 		"you", "run",
 		"--named", packagedGoalFactoryName,
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
 		"--no-record",
 		"--quiet",
-		mockWorkersPath,
 		goalText,
 	}
 	inputs := support.FakeInputs(t.Context(), args)
@@ -405,10 +404,9 @@ func runPackagedGoalQuietCLIBatchWithTimeout(
 	args := []string{
 		"you", "run",
 		"--named", packagedGoalFactoryName,
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
 		"--no-record",
 		"--quiet",
-		mockWorkersPath,
 		goalText,
 	}
 	ctx, cancel := context.WithTimeout(t.Context(), timeout)

--- a/tests/functional/factory/packaged/plan_parallel/invocation_test.go
+++ b/tests/functional/factory/packaged/plan_parallel/invocation_test.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -23,12 +25,39 @@ import (
 const parallelDAG = `{"request":{"type":"FACTORY_REQUEST_BATCH","works":[{"name":"task-a","workTypeName":"planned-task","payload":"TASK_A_UNIQUE_OBJECTIVE"},{"name":"task-b","workTypeName":"planned-task","payload":"TASK_B_UNIQUE_OBJECTIVE"},{"name":"task-c","workTypeName":"planned-task","payload":"TASK_C_UNIQUE_OBJECTIVE"}],"relations":[{"type":"DEPENDS_ON","sourceWorkName":"task-c","targetWorkName":"task-a"},{"type":"DEPENDS_ON","sourceWorkName":"task-c","targetWorkName":"task-b"}]}}`
 
 func TestPackagedPlanParallelExecutesReadyDAGConcurrentlyAndMerges(t *testing.T) {
+	// This cell intentionally uses the public API because it owns retained
+	// Factory Event and reconnect/replay assertions below.
 	runner := newPlanParallelRunner(parallelDAG)
 	server := startPlanParallelServer(t, runner)
-	response := invokePlanParallel(t, server, map[string]any{"request": "implement three dependent tasks"})
+	response := invokePlanParallel(t, server, map[string]any{
+		"request":       "implement three dependent tasks",
+		"executorModel": "gpt-5.6-luna",
+	})
 
 	if response.Status != factoryapi.InvocationTerminalStatusCompleted {
-		t.Fatalf("status = %q, want COMPLETED; response = %#v", response.Status, response)
+		message := ""
+		if response.Message != nil {
+			message = *response.Message
+		}
+		requests := runner.requestsSnapshot()
+		args := make([][]string, 0, len(requests))
+		for _, request := range requests {
+			args = append(args, request.Args)
+		}
+		errors := make([]string, 0)
+		for _, event := range server.GetFactoryEvents(t) {
+			if event.Type != factoryapi.FactoryEventTypeDispatchResponse {
+				continue
+			}
+			payload, err := event.Payload.AsDispatchResponseEventPayload()
+			if err == nil && payload.Error != nil {
+				errors = append(errors, *payload.Error)
+			}
+			if err == nil && payload.FailureDetail != nil {
+				errors = append(errors, payload.FailureDetail.Message)
+			}
+		}
+		t.Fatalf("status = %q, want COMPLETED; message = %q; dispatch errors = %#v; request args = %#v; response = %#v", response.Status, message, errors, args, response)
 	}
 	if got := planParallelPrimaryText(t, response); !strings.Contains(got, "merged parallel result") {
 		t.Fatalf("primary result = %q, want merger output", got)
@@ -40,12 +69,7 @@ func TestPackagedPlanParallelExecutesReadyDAGConcurrentlyAndMerges(t *testing.T)
 		t.Fatalf("executor calls = %d, merge calls = %d; want 3 and 1", runner.executionCount(), runner.mergeCount())
 	}
 	assertPlanParallelPromptsContainInputs(t, runner.requestsSnapshot())
-	for index, request := range runner.requestsSnapshot() {
-		if request.Command != "codex" || !planParallelHasArgPair(request.Args, "--model", "operator-model") ||
-			!planParallelHasArg(request.Args, "--dangerously-bypass-approvals-and-sandbox") {
-			t.Fatalf("provider request[%d] = command %q args %#v, want operator model and packaged skip-permissions default", index, request.Command, request.Args)
-		}
-	}
+	assertPlanParallelProviderSelection(t, runner.requestsSnapshot())
 
 	events := server.GetFactoryEvents(t)
 	dispatches := support.ObserveDispatchEvents(t, events)
@@ -55,6 +79,80 @@ func TestPackagedPlanParallelExecutesReadyDAGConcurrentlyAndMerges(t *testing.T)
 	}
 	assertPlanParallelGeneratedDAGEvent(t, events)
 	assertPlanParallelRetainedReplay(t, server, events)
+}
+
+func TestPackagedPlanParallelExecutorEffortCanBeOverridden(t *testing.T) {
+	runner := newPlanParallelRunner(parallelDAG)
+	response, err := runPlanParallelCLI(t, runner,
+		"--executor-model", "gpt-5.6-luna",
+		"--executor-reasoning-effort", "low",
+		"--to", "implement three dependent tasks",
+	)
+	if err != nil {
+		t.Fatalf("plan-parallel CLI invocation: %v", err)
+	}
+	if response.Status != factoryapi.InvocationTerminalStatusCompleted {
+		t.Fatalf("response = %#v, want completed low-effort override", response)
+	}
+	executors := 0
+	for _, request := range runner.requestsSnapshot() {
+		prompt := string(request.Stdin)
+		if strings.Contains(prompt, "Plan an executable Work DAG") ||
+			strings.Contains(prompt, "Treat the original request and all completed generated Work inputs") {
+			continue
+		}
+		executors++
+		if !planParallelHasArgPair(request.Args, "--config", `model_reasoning_effort="low"`) {
+			t.Fatalf("executor args = %#v, want low effort override", request.Args)
+		}
+	}
+	if executors != 3 {
+		t.Fatalf("executor requests = %d, want 3", executors)
+	}
+}
+
+func TestPackagedPlanParallelRejectsUnsupportedEffortBeforeExecutorProviderExecution(t *testing.T) {
+	runner := newPlanParallelRunner(parallelDAG)
+	_, err := runPlanParallelCLI(t, runner,
+		"--executor-reasoning-effort", "extreme",
+		"--to", "implement three dependent tasks",
+	)
+	if err == nil {
+		t.Fatal("plan-parallel CLI invocation error = nil, want invalid resolved effort failure")
+	}
+	requests := runner.requestsSnapshot()
+	if len(requests) != 1 || !strings.Contains(string(requests[0].Stdin), "Plan an executable Work DAG") {
+		t.Fatalf("provider requests = %#v, want only the prerequisite planner and no executor process", requests)
+	}
+}
+
+func assertPlanParallelProviderSelection(t *testing.T, requests []platformprocess.CommandRequest) {
+	t.Helper()
+	executors := 0
+	for index, request := range requests {
+		if request.Command != "codex" ||
+			!planParallelHasArg(request.Args, "--dangerously-bypass-approvals-and-sandbox") {
+			t.Fatalf("provider request[%d] = command %q args %#v, want Codex with packaged skip-permissions", index, request.Command, request.Args)
+		}
+		prompt := string(request.Stdin)
+		isExecutor := !strings.Contains(prompt, "Plan an executable Work DAG") &&
+			!strings.Contains(prompt, "Treat the original request and all completed generated Work inputs")
+		if isExecutor {
+			executors++
+			if !planParallelHasArgPair(request.Args, "--model", "gpt-5.6-luna") ||
+				!planParallelHasArgPair(request.Args, "--config", `model_reasoning_effort="xhigh"`) {
+				t.Fatalf("executor request[%d] args = %#v, want Luna xhigh", index, request.Args)
+			}
+			continue
+		}
+		if !planParallelHasArgPair(request.Args, "--model", "operator-model") ||
+			planParallelHasArg(request.Args, "--config") {
+			t.Fatalf("planner/merger request[%d] args = %#v, want operator model without effort override", index, request.Args)
+		}
+	}
+	if executors != 3 {
+		t.Fatalf("executor requests = %d, want 3", executors)
+	}
 }
 
 func assertPlanParallelPromptsContainInputs(t *testing.T, requests []platformprocess.CommandRequest) {
@@ -300,7 +398,52 @@ func startPlanParallelServer(t *testing.T, runner platformprocess.CommandRunner)
 	})
 }
 
+func runPlanParallelCLI(
+	t *testing.T,
+	runner platformprocess.CommandRunner,
+	factoryArgs ...string,
+) (factoryapi.InvocationResponse, error) {
+	t.Helper()
+	homeDir := t.TempDir()
+	support.InstallPackagedFactory(t, homeDir, factorydefinitions.PackagedPlanParallelFactoryName)
+	args := []string{
+		"you", "--json", "run",
+		"--named", factorydefinitions.PackagedPlanParallelFactoryName,
+		"--provider", "CODEX", "--model", "operator-model",
+		"--no-record",
+	}
+	args = append(args, factoryArgs...)
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	inputs.Input.WorkingDirectory = t.TempDir()
+	err := support.BuildProcess(t, serviceedges.Edges{ProviderCommandRunner: runner}).Execute(inputs.Input)
+	if err != nil {
+		return factoryapi.InvocationResponse{}, err
+	}
+	if inputs.Stderr() != "" {
+		t.Fatalf("stderr = %q, want empty successful-run stderr", inputs.Stderr())
+	}
+	return support.DecodeInvocationResponseJSON(t, inputs.Stdout()), nil
+}
+
 func invokePlanParallel(t *testing.T, server *support.FunctionalAPIServer, args map[string]any) factoryapi.InvocationResponse {
+	t.Helper()
+	statusCode, responseBody := postPlanParallel(t, server, args)
+	if statusCode != http.StatusOK {
+		t.Fatalf("POST invocation status = %d; body = %s", statusCode, responseBody)
+	}
+	var decoded factoryapi.InvocationResponse
+	if err := json.Unmarshal(responseBody, &decoded); err != nil {
+		t.Fatalf("decode invocation: %v", err)
+	}
+	return decoded
+}
+
+func postPlanParallel(
+	t *testing.T,
+	server *support.FunctionalAPIServer,
+	args map[string]any,
+) (int, []byte) {
 	t.Helper()
 	requestID := fmt.Sprintf("plan-parallel-%d", time.Now().UnixNano())
 	payload, err := json.Marshal(factoryapi.InvocationRequest{RequestId: &requestID, Args: &args})
@@ -312,14 +455,11 @@ func invokePlanParallel(t *testing.T, server *support.FunctionalAPIServer, args 
 		t.Fatalf("POST invocation: %v", err)
 	}
 	defer response.Body.Close()
-	if response.StatusCode != http.StatusOK {
-		t.Fatalf("POST invocation status = %d", response.StatusCode)
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read invocation response: %v", err)
 	}
-	var decoded factoryapi.InvocationResponse
-	if err := json.NewDecoder(response.Body).Decode(&decoded); err != nil {
-		t.Fatalf("decode invocation: %v", err)
-	}
-	return decoded
+	return response.StatusCode, responseBody
 }
 
 func planParallelPrimaryText(t *testing.T, response factoryapi.InvocationResponse) string {

--- a/tests/functional/factory/packaged/subagent/invocation_test.go
+++ b/tests/functional/factory/packaged/subagent/invocation_test.go
@@ -9,12 +9,15 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/portpowered/infinite-you/internal/testutil"
 	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	"github.com/portpowered/infinite-you/pkg/root"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
@@ -79,6 +82,78 @@ func TestPackagedSubagentStreamsChildResponseEvents(t *testing.T) {
 	assertPackagedSubagentChildResponseEvents(t, responseEvents)
 }
 
+func TestPackagedSubagentPropagatesLunaXHighReasoningEffort(t *testing.T) {
+	runner := testutil.NewProviderCommandRunner(platformprocess.CommandResult{
+		Stdout: support.CodexSuccessStdout("review complete"),
+	})
+	response := runPackagedSubagentProviderCLI(t, runner,
+		"--worker-provider", "CODEX",
+		"--worker-model", "gpt-5.6-luna",
+		"--worker-reasoning-effort", "xhigh",
+		"--to", "review the implementation",
+	)
+	if response.Status != factoryapi.InvocationTerminalStatusCompleted {
+		t.Fatalf("response = %#v, want completed", response)
+	}
+	want := []string{
+		"exec", "--json", "--dangerously-bypass-approvals-and-sandbox",
+		"--model", "gpt-5.6-luna",
+		"--config", `model_reasoning_effort="xhigh"`,
+		"-",
+	}
+	if got := runner.LastRequest().Args; !reflect.DeepEqual(got, want) {
+		t.Fatalf("subagent command args = %#v, want %#v", got, want)
+	}
+}
+
+func TestPackagedSubagentOmittedReasoningEffortPreservesProviderDefault(t *testing.T) {
+	runner := testutil.NewProviderCommandRunner(platformprocess.CommandResult{
+		Stdout: support.CodexSuccessStdout("review complete"),
+	})
+	response := runPackagedSubagentProviderCLI(t, runner,
+		"--worker-provider", "CODEX",
+		"--worker-model", "gpt-5.6-luna",
+		"--to", "review the implementation",
+	)
+	if response.Status != factoryapi.InvocationTerminalStatusCompleted {
+		t.Fatalf("response = %#v, want completed", response)
+	}
+	want := []string{
+		"exec", "--json", "--dangerously-bypass-approvals-and-sandbox",
+		"--model", "gpt-5.6-luna",
+		"-",
+	}
+	if got := runner.LastRequest().Args; !reflect.DeepEqual(got, want) {
+		t.Fatalf("subagent command args = %#v, want provider default without effort config %#v", got, want)
+	}
+}
+
+func runPackagedSubagentProviderCLI(
+	t *testing.T,
+	runner platformprocess.CommandRunner,
+	factoryArgs ...string,
+) factoryapi.InvocationResponse {
+	t.Helper()
+	homeDir := t.TempDir()
+	support.InstallPackagedFactory(t, homeDir, factorydefinitions.PackagedSubagentFactoryName)
+	args := []string{
+		"you", "--json", "run",
+		"--named", factorydefinitions.PackagedSubagentFactoryName,
+		"--no-record",
+	}
+	args = append(args, factoryArgs...)
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	inputs.Input.WorkingDirectory = t.TempDir()
+	if err := support.BuildProcess(t, serviceedges.Edges{ProviderCommandRunner: runner}).Execute(inputs.Input); err != nil {
+		t.Fatalf("Process.Execute(%v) error = %v\nstdout:\n%s\nstderr:\n%s", args, err, inputs.Stdout(), inputs.Stderr())
+	}
+	if inputs.Stderr() != "" {
+		t.Fatalf("stderr = %q, want empty successful-run stderr", inputs.Stderr())
+	}
+	return support.DecodeInvocationResponseJSON(t, inputs.Stdout())
+}
+
 // TestPackagedSubagentChildFailureReturnsStableFailure proves that packaged
 // @you/subagent invocation returns a stable failed public terminal outcome when
 // the child worker rejects, without emitting a success primary result for the
@@ -139,8 +214,16 @@ func postPackagedSubagentInvocation(
 	requestText string,
 ) factoryapi.InvocationResponse {
 	t.Helper()
+	return postPackagedSubagentArgs(t, serverURL, map[string]interface{}{"input": requestText})
+}
 
-	body, err := json.Marshal(packagedSubagentTextInvocationRequest(requestText))
+func postPackagedSubagentArgs(
+	t *testing.T,
+	serverURL string,
+	args map[string]interface{},
+) factoryapi.InvocationResponse {
+	t.Helper()
+	body, err := json.Marshal(factoryapi.InvocationRequest{Args: &args})
 	if err != nil {
 		t.Fatalf("marshal invocation request: %v", err)
 	}
@@ -273,8 +356,9 @@ func runHermeticPackagedSubagentInvocation(t *testing.T, requestText string) (st
 	args := []string{
 		"you", "run",
 		"--named", factorydefinitions.PackagedSubagentFactoryName,
-		"--with-mock-workers", "--no-record", "--quiet",
-		mockWorkersPath, requestText,
+		"--with-mock-workers", mockWorkersPath,
+		"--no-record", "--quiet",
+		requestText,
 	}
 	inputs := support.FakeInputs(t.Context(), args)
 	inputs.Input.Env = environment

--- a/tests/functional/transport/cli/commands/run_wiring_test.go
+++ b/tests/functional/transport/cli/commands/run_wiring_test.go
@@ -60,11 +60,10 @@ func TestCLIRunNamedFactory(t *testing.T) {
 		cmd := processHarness.CommandContext(ctx,
 			"run",
 			"--named", runWiringNamedFactoryName,
-			"--with-mock-workers",
+			"--with-mock-workers=" + mockWorkersPath,
 			"--no-record",
 			"--server", baseURL,
 			"--quiet",
-			mockWorkersPath,
 			prompt,
 		)
 		cmd.Dir = unrelatedWorkingDir
@@ -118,11 +117,10 @@ func TestCLIRunNamedFactory(t *testing.T) {
 		cmd := processHarness.CommandContext(ctx,
 			"run",
 			"--named", interfaces.PackagedGoalFactoryName,
-			"--with-mock-workers",
+			"--with-mock-workers=" + mockWorkersPath,
 			"--no-record",
 			"--server", baseURL,
 			"--quiet",
-			mockWorkersPath,
 			goalText,
 		)
 		cmd.Dir = unrelatedWorkingDir
@@ -223,11 +221,10 @@ func TestCLIRunFactoryByPath(t *testing.T) {
 	cmd := processHarness.CommandContext(ctx,
 		"run",
 		"--factory", factoryPath,
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
 		"--no-record",
 		"--server", baseURL,
 		"--quiet",
-		mockWorkersPath,
 		prompt,
 	)
 	cmd.Dir = factoryDir
@@ -274,11 +271,10 @@ func TestCLIRunFactoryWritesPrimaryResultFromStdin(t *testing.T) {
 	cmd := processHarness.CommandContext(ctx,
 		"run",
 		"--factory", factoryPath,
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
 		"--no-record",
 		"--server", baseURL,
 		"--quiet",
-		mockWorkersPath,
 	)
 	cmd.Dir = factoryDir
 	cmd.Stdin = strings.NewReader(prompt)
@@ -323,11 +319,10 @@ func TestCLIRunRejectsConflictingPositionalAndStdinInput(t *testing.T) {
 	cmd := processHarness.CommandContext(ctx,
 		"run",
 		"--factory", factoryPath,
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
 		"--no-record",
 		"--server", baseURL,
 		"--quiet",
-		mockWorkersPath,
 		"from positional",
 	)
 	cmd.Dir = factoryDir
@@ -374,11 +369,10 @@ func TestCLIRunFailureWritesNoSuccessPayloadToStdout(t *testing.T) {
 	cmd := processHarness.CommandContext(ctx,
 		"run",
 		"--factory", factoryPath,
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
 		"--no-record",
 		"--server", baseURL,
 		"--quiet",
-		mockWorkersPath,
 		"trigger unresolved result",
 	)
 	cmd.Dir = factoryDir
@@ -648,10 +642,9 @@ func runRunWiringFactoryCLI(
 	args := []string{
 		"run",
 		"--factory", factoryPath,
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
 		"--no-record",
 		"--quiet",
-		mockWorkersPath,
 	}
 	args = append(args, promptArgs...)
 

--- a/tests/functional/transport/cli/process/context_cancellation_test.go
+++ b/tests/functional/transport/cli/process/context_cancellation_test.go
@@ -46,10 +46,9 @@ func TestCLIContextCancellationStopsExternalWork(t *testing.T) {
 	args = append(args,
 		"run",
 		"--factory", factoryPath,
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
 		"--no-record",
 		"--quiet",
-		mockWorkersPath,
 		prompt,
 	)
 
@@ -125,10 +124,9 @@ func TestCLIContextCancellationEmitsNoSuccessResult(t *testing.T) {
 	args = append(args,
 		"run",
 		"--factory", factoryPath,
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
 		"--no-record",
 		"--quiet",
-		mockWorkersPath,
 		prompt,
 	)
 

--- a/tests/functional/transport/cli/process/exit_codes_test.go
+++ b/tests/functional/transport/cli/process/exit_codes_test.go
@@ -76,10 +76,9 @@ func TestCLIWorkerFailureExitCode(t *testing.T) {
 	args = append(args,
 		"run",
 		"--named", "@you/goal",
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
 		"--no-record",
 		"--quiet",
-		mockWorkersPath,
 		fmt.Sprintf("worker-failure-exit-%d", time.Now().UnixNano()),
 	)
 
@@ -142,10 +141,9 @@ func TestCLISuccessExitCode(t *testing.T) {
 	args = append(args,
 		"run",
 		"--named", "@you/goal",
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
 		"--no-record",
 		"--quiet",
-		mockWorkersPath,
 		fmt.Sprintf("success-exit-%d", time.Now().UnixNano()),
 	)
 

--- a/tests/functional/transport/cli/process/stdout_stderr_test.go
+++ b/tests/functional/transport/cli/process/stdout_stderr_test.go
@@ -42,10 +42,9 @@ func TestCLISuccessWritesPrimaryResultOnlyToStdout(t *testing.T) {
 	args = append(args,
 		"run",
 		"--named", "@you/goal",
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
 		"--no-record",
 		"--quiet",
-		mockWorkersPath,
 		fmt.Sprintf("success-stdout-purity-%d", time.Now().UnixNano()),
 	)
 
@@ -120,10 +119,9 @@ func TestCLIFailureWritesDiagnosticToStderr(t *testing.T) {
 	args = append(args,
 		"run",
 		"--named", "@you/goal",
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
 		"--no-record",
 		"--quiet",
-		mockWorkersPath,
 		fmt.Sprintf("failure-stderr-%d", time.Now().UnixNano()),
 	)
 
@@ -375,11 +373,11 @@ func appendGoalRunArgs(
 	args = append(args,
 		"run",
 		"--named", "@you/goal",
-		"--with-mock-workers",
+		"--with-mock-workers=" + mockWorkersPath,
 		"--no-record",
 	)
 	args = append(args, extraArgs...)
-	args = append(args, mockWorkersPath, prompt)
+	args = append(args, prompt)
 	return args
 }
 

--- a/tests/functional/workers/inference/failure_normalization_test.go
+++ b/tests/functional/workers/inference/failure_normalization_test.go
@@ -45,9 +45,12 @@ func TestProviderNonZeroExitMapsToPublicFailure(t *testing.T) {
 	runner := testutil.NewProviderCommandRunner(platformprocess.CommandResult{
 		ExitCode: exitCode,
 		Stdout: []byte(
-			`{"type":"system","subtype":"init","session_id":"` + providerExitNormalizationSessionID + `"}` + "\n",
+			`{"type":"thread.started","thread_id":"` + providerExitNormalizationSessionID + `"}` + "\n",
 		),
-		Stderr: []byte("provider process crashed unexpectedly"),
+		Stderr: []byte(
+			"session_id: " + providerExitNormalizationSessionID + "\n" +
+				"provider process crashed unexpectedly",
+		),
 	})
 
 	session, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(t, dir, serviceedges.Edges{

--- a/tests/functional/workers/inference/flags_test.go
+++ b/tests/functional/workers/inference/flags_test.go
@@ -81,8 +81,8 @@ func TestUnsupportedProviderFlagReturnsCapabilityError(t *testing.T) {
 	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
 
 	support.WriteAgentConfig(t, dir, "worker", support.BuildModelWorkerConfig(
-		modelprovider.ProviderCodex,
-		"cursor-test-model",
+		modelprovider.ProviderClaude,
+		"claude-test-model",
 	))
 	support.WriteWorkstationConfig(t, dir, "process", `---
 type: MODEL_WORKSTATION

--- a/ui/packages/client/src/generated/factory-event.schema.json
+++ b/ui/packages/client/src/generated/factory-event.schema.json
@@ -3228,6 +3228,11 @@
       },
       "type": "object"
     },
+    "ReasoningEffort": {
+      "description": "Optional provider-neutral reasoning effort. Surrounding whitespace and letter case are normalized. Omit the field to preserve the selected provider and model default. Factory definitions may use an exact invocation-parameter placeholder such as `${executorReasoningEffort}`.",
+      "pattern": "^(?:[\t-\r    - \u2028\u2029  　]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH]|[xX][hH][iI][gG][hH]|[mM][aA][xX])?[\t-\r    - \u2028\u2029  　]*|\\$\\{[A-Za-z0-9_.-]+\\})$",
+      "type": "string"
+    },
     "Relation": {
       "additionalProperties": false,
       "properties": {
@@ -4556,6 +4561,9 @@
             }
           ],
           "description": "Built-in hosted provider identity when this worker uses repository-owned hosted execution."
+        },
+        "reasoningEffort": {
+          "$ref": "#/$defs/ReasoningEffort"
         },
         "resources": {
           "description": "Resource capacity this worker requires before it can be dispatched.",

--- a/ui/packages/client/src/generated/factory.schema.json
+++ b/ui/packages/client/src/generated/factory.schema.json
@@ -1458,6 +1458,11 @@
       "pattern": "^(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|ANTIGRAVITY|ANTHROPIC|CLAUDE|CODEX|OPENAI)$",
       "type": "string"
     },
+    "ReasoningEffort": {
+      "description": "Optional provider-neutral reasoning effort. Surrounding whitespace and letter case are normalized. Omit the field to preserve the selected provider and model default. Factory definitions may use an exact invocation-parameter placeholder such as `${executorReasoningEffort}`.",
+      "pattern": "^(?:[\t-\r    - \u2028\u2029  　]*(?:[mM][iI][nN][iI][mM][aA][lL]|[lL][oO][wW]|[mM][eE][dD][iI][uU][mM]|[hH][iI][gG][hH]|[xX][hH][iI][gG][hH]|[mM][aA][xX])?[\t-\r    - \u2028\u2029  　]*|\\$\\{[A-Za-z0-9_.-]+\\})$",
+      "type": "string"
+    },
     "RequiredTool": {
       "additionalProperties": false,
       "description": "One declarative external tool dependency for a portable factory.",
@@ -2058,6 +2063,9 @@
             }
           ],
           "description": "Built-in hosted provider identity when this worker uses repository-owned hosted execution."
+        },
+        "reasoningEffort": {
+          "$ref": "#/$defs/ReasoningEffort"
         },
         "resources": {
           "description": "Resource capacity this worker requires before it can be dispatched.",

--- a/ui/packages/client/src/generated/openapi.ts
+++ b/ui/packages/client/src/generated/openapi.ts
@@ -4387,6 +4387,7 @@ export interface components {
       model?: string;
       /** @description Canonical provider identity used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. For `executorProvider: ACP`, this names the configured ACP integration, such as `cursor-acp`. Extension identities use lowercase standardized syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility conveniences. */
       modelProvider?: components["schemas"]["ProviderIdentity"] | string;
+      reasoningEffort?: components["schemas"]["ReasoningEffort"];
       /** @description Provider locality for this model capability declaration. Use `LOCAL` for embedded or host-managed inference and `CLOUD` for remote provider execution. */
       modelLocality?: components["schemas"]["WorkerModelLocality"];
       /** @description Execution mechanism. Use `ACP` for ACP-backed workers and put the configured integration identity (for example `cursor-acp`) in modelProvider. `SCRIPT_WRAP` remains the command-wrapper compatibility value; legacy named executor identities remain accepted during migration. */
@@ -5469,6 +5470,8 @@ export interface components {
      * @enum {string}
      */
     HostedWorkerProvider: HostedWorkerProvider;
+    /** @description Optional provider-neutral reasoning effort. Surrounding whitespace and letter case are normalized. Omit the field to preserve the selected provider and model default. Factory definitions may use an exact invocation-parameter placeholder such as `${executorReasoningEffort}`. */
+    ReasoningEffort: string;
     /** @description Hosted-worker authentication contract. V1 hosted workers accept only secret references rather than inline credentials or OAuth-style fields. */
     HostedWorkerAuth: {
       /** @description Referenced secret name that resolves the hosted provider API key at runtime. */

--- a/ui/src/api/generated/openapi.ts
+++ b/ui/src/api/generated/openapi.ts
@@ -4381,6 +4381,7 @@ export interface components {
       model?: string;
       /** @description Canonical provider identity used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. For `executorProvider: ACP`, this names the configured ACP integration, such as `cursor-acp`. Extension identities use lowercase standardized syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility conveniences. */
       modelProvider?: components["schemas"]["ProviderIdentity"] | string;
+      reasoningEffort?: components["schemas"]["ReasoningEffort"];
       /** @description Provider locality for this model capability declaration. Use `LOCAL` for embedded or host-managed inference and `CLOUD` for remote provider execution. */
       modelLocality?: components["schemas"]["WorkerModelLocality"];
       /** @description Execution mechanism. Use `ACP` for ACP-backed workers and put the configured integration identity (for example `cursor-acp`) in modelProvider. `SCRIPT_WRAP` remains the command-wrapper compatibility value; legacy named executor identities remain accepted during migration. */
@@ -5463,6 +5464,8 @@ export interface components {
      * @enum {string}
      */
     HostedWorkerProvider: HostedWorkerProvider;
+    /** @description Optional provider-neutral reasoning effort. Surrounding whitespace and letter case are normalized. Omit the field to preserve the selected provider and model default. Factory definitions may use an exact invocation-parameter placeholder such as `${executorReasoningEffort}`. */
+    ReasoningEffort: string;
     /** @description Hosted-worker authentication contract. V1 hosted workers accept only secret references rather than inline credentials or OAuth-style fields. */
     HostedWorkerAuth: {
       /** @description Referenced secret name that resolves the hosted provider API key at runtime. */


### PR DESCRIPTION
## Summary
- add provider-neutral reasoningEffort across authored workers, runtime propagation, live children, provider transports, and generated contracts
- render Codex effort as model_reasoning_effort, Claude effort as --effort, and preserve ACP exact-model semantics
- default @you/plan-parallel executors to xhigh and expose explicit effort for @you/subagent
- refresh the frontend dead-code baseline for the current fix-factories dependency graph

## Verification
- make verify-fast
- make build-all
- make test
- go test ./pkg/services/providers/... -count=1
- go test ./tests/functional/factory/packaged/plan_parallel ./tests/functional/factory/packaged/subagent -count=1
- API smoke sequence with a Windows inter-pass delay
- live @you/subagent and @you/plan-parallel executions confirmed gpt-5.6-luna with exact xhigh Codex arguments; final standalone Luna audit returned PASS

## Stacking
This PR targets fix-factories so it can merge without carrying that branch's existing commits directly into main. After this lands, the existing fix-factories to main PR can carry the feature to main.

## Local limitation
make verify-pr advances through build, typecheck, and frontend dead-code after the included baseline repair, then stops on the target branch's existing backend-size gate (98 pre-existing size violations). Required GitHub checks will be treated as authoritative and repaired if they identify feature-related or merge-blocking failures.