### PR TITLE
LTV-UI-LINT-01 — Restore a Clean Frontend Dead-Code Lint Baseline

### DIFF
--- a/docs/internal/baselines/frontend-deadcode-baseline.json
+++ b/docs/internal/baselines/frontend-deadcode-baseline.json
@@ -17,82 +17,74 @@
   {
     "file": "packages/components/src/charts/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory"
+    "name": "ComponentsCategory",
+    "namespace": "charts"
   },
   {
     "file": "packages/components/src/data-display/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory"
+    "name": "ComponentsCategory",
+    "namespace": "dataDisplay"
   },
   {
     "file": "packages/components/src/factory-emulator/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory"
+    "name": "ComponentsCategory",
+    "namespace": "factoryEmulator"
   },
   {
     "file": "packages/components/src/feedback/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory"
+    "name": "ComponentsCategory",
+    "namespace": "feedback"
   },
   {
     "file": "packages/components/src/forms/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory"
+    "name": "ComponentsCategory",
+    "namespace": "forms"
   },
   {
     "file": "packages/components/src/graphs/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory"
+    "name": "ComponentsCategory",
+    "namespace": "graphs"
   },
   {
     "file": "packages/components/src/icons/index.ts",
-    "kind": "file",
-    "name": "packages/components/src/icons/index.ts"
+    "kind": "type",
+    "name": "ComponentsCategory",
+    "namespace": "icons"
   },
   {
     "file": "packages/components/src/layout/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory"
+    "name": "ComponentsCategory",
+    "namespace": "layout"
   },
   {
     "file": "packages/components/src/navigation/index.ts",
-    "kind": "file",
-    "name": "packages/components/src/navigation/index.ts"
+    "kind": "type",
+    "name": "ComponentsCategory",
+    "namespace": "navigation"
   },
   {
     "file": "packages/components/src/overlays/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory"
+    "name": "ComponentsCategory",
+    "namespace": "overlays"
   },
   {
     "file": "packages/components/src/primitives/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory"
+    "name": "ComponentsCategory",
+    "namespace": "primitives"
   },
   {
     "file": "packages/components/src/recipes/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory"
-  },
-  {
-    "file": "packages/components/src/styles.css",
-    "kind": "file",
-    "name": "packages/components/src/styles.css"
-  },
-  {
-    "file": "packages/components/src/styles/color-palette-presets.css",
-    "kind": "file",
-    "name": "packages/components/src/styles/color-palette-presets.css"
-  },
-  {
-    "file": "packages/components/src/styles/color-role-tokens.css",
-    "kind": "file",
-    "name": "packages/components/src/styles/color-role-tokens.css"
-  },
-  {
-    "file": "packages/components/src/styles/layout-role-tokens.css",
-    "kind": "file",
-    "name": "packages/components/src/styles/layout-role-tokens.css"
+    "name": "ComponentsCategory",
+    "namespace": "recipes"
   },
   {
     "file": "packages/components/src/styles/package-token-fixture-usage.ts",
@@ -100,39 +92,22 @@
     "name": "packages/components/src/styles/package-token-fixture-usage.ts"
   },
   {
-    "file": "packages/components/src/styles/text-color-role-tokens.css",
-    "kind": "file",
-    "name": "packages/components/src/styles/text-color-role-tokens.css"
-  },
-  {
-    "file": "packages/components/src/styles/typography-role-tokens.css",
-    "kind": "file",
-    "name": "packages/components/src/styles/typography-role-tokens.css"
-  },
-  {
-    "file": "packages/components/src/styles/typography-role-utilities.css",
-    "kind": "file",
-    "name": "packages/components/src/styles/typography-role-utilities.css"
-  },
-  {
-    "file": "packages/components/src/styles/typography-roles.css",
-    "kind": "file",
-    "name": "packages/components/src/styles/typography-roles.css"
-  },
-  {
     "file": "packages/components/src/testing/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory"
+    "name": "ComponentsCategory",
+    "namespace": "testing"
   },
   {
     "file": "packages/components/src/tokens/index.ts",
-    "kind": "file",
-    "name": "packages/components/src/tokens/index.ts"
+    "kind": "type",
+    "name": "ComponentsCategory",
+    "namespace": "tokens"
   },
   {
     "file": "packages/components/src/utilities/index.ts",
     "kind": "type",
-    "name": "ComponentsCategory"
+    "name": "ComponentsCategory",
+    "namespace": "utilities"
   },
   {
     "file": "packages/components/vite.build.config.ts",
@@ -188,10 +163,5 @@
     "file": "src/features/flowchart/components/current-activity-workstation-node.tsx",
     "kind": "file",
     "name": "src/features/flowchart/components/current-activity-workstation-node.tsx"
-  },
-  {
-    "file": "src/features/graphs/components/factory-graph-edge.tsx",
-    "kind": "type",
-    "name": "FactoryGraphEdgeData"
   }
 ]

--- a/ui/biome.jsonc
+++ b/ui/biome.jsonc
@@ -27,7 +27,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "complexity": {
         "noExcessiveLinesPerFunction": {
           "level": "error",


### PR DESCRIPTION
{
  "project": "LTV-UI-LINT-01 — Restore a Clean Frontend Dead-Code Lint Baseline",
  "branchName": "LTV-UI-LINT-01-deadcode-baseline",
  "description": "Restore the frontend dead-code and repository lint gates with the smallest evidence-backed cleanup of the publishable components package. Distinguish intentional public exports from genuinely unused code, preserve verified consumer contracts, remove stale code and baseline entries, and allow later repository lint checks to run. Apply the installed Biome migration only if it preserves lint behavior.",
  "context": {
    "customerAsk": "Restore the frontend lint/dead-code gate with a minimal, reviewed cleanup so later validation failures become visible and unused website code does not accumulate.",
    "problem": "The repository-wide lint gate stops at ui-deadcode because Knip now qualifies component-package ComponentsCategory types by namespace while the baseline contains former unqualified identities and stale style/index entries. The drift masks later lint evidence; wholesale baseline replacement would accept unrelated debt, and deleting exports without consumer checks could break the public package.",
    "solution": "Classify each changed in-scope finding using declared package exports and real workspace or installed-consumer evidence. Preserve and precisely baseline intentional public exports, remove genuinely unused code and stale entries, retain the current package topology, optionally apply only a behavior-preserving installed Biome migration, and verify the frontend, package, repository lint, CI, review, conflict-resolution, and merge outcomes."
  },
  "acceptanceCriteria": [
    "The current qualified ComponentsCategory drift and stale in-scope style/index baseline entries are reconciled individually; the committed baseline contains only findings supported by explicit intentional-public-surface evidence and is not replaced wholesale from the current report.",
    "Intentional @you-agent-factory/components exports remain importable through their declared public package subpaths in focused installed/package consumer verification, while every in-scope item classified as genuinely unused is removed from both source and baseline.",
    "Package topology, declared component-package entrypoints, dependency direction, and runtime/UI behavior remain unchanged; generated API artifacts, ui/src/features/work-outcome/**, chart implementations, and docs/internal/processes/manual-qa.md are untouched.",
    "If the installed Biome migration emits a supported behavior-preserving replacement for the deprecated linter configuration, that replacement is applied and the same lint rules remain enforced; otherwise the advisory is left out of the implementation rather than suppressed.",
    "From a clean worktree, cd ui && bun run deadcode, make ui-lint, the focused component-package build/typecheck/consumer checks, and make lint through and beyond ui-deadcode provide terminal evidence; any later unrelated lint failure is reported without expanding this lane.",
    "Typecheck, frontend lint, dead-code validation, relevant package builds/tests, and required CI are terminal and passing.",
    "The implementation/review loop continues until required CI is terminal and passing, every blocking PR conversation item is explicitly addressed, shared-file or baseline conflicts are reconciled, merge conflicts are resolved, and the PR is actually merged; opened, green, approved, or ready-to-merge is not complete."
  ],
  "userStories": [
    {
      "id": "LTV-UI-LINT-01-deadcode-baseline-001",
      "title": "Reconcile the component package dead-code contract",
      "description": "As a maintainer of the public components package, I want every changed dead-code finding classified against real consumer behavior so intentional exports remain usable and genuine dead code is removed without accepting unrelated debt.",
      "acceptanceCriteria": [
        "Each in-scope qualified ComponentsCategory and stale style/index finding is classified as intentional public surface or genuinely unused using declared package exports plus workspace or installed-consumer evidence.",
        "Intentional category exports remain importable from their declared @you-agent-factory/components subpaths, including type-only consumption, in the focused package consumer verification.",
        "Genuinely unused in-scope symbols/files and their stale baseline entries are removed; the work does not add ignore rules or copy the complete current dead-code report into the baseline.",
        "cd ui && bun run deadcode reports an exact baseline match from a clean worktree and continues to reject a new unreviewed finding or a stale accepted entry.",
        "The component-package build, typecheck, dependency-boundary checks, and focused installed/package consumer tests pass.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Reconciled the 15 qualified ComponentsCategory exports and removed only stale style/index and FactoryGraphEdgeData baseline records. Knip, UI lint/typecheck, component package build/typecheck/unit/boundary/pack/installed-consumer checks pass."
    },
    {
      "id": "LTV-UI-LINT-01-deadcode-baseline-002",
      "title": "Restore lint-chain visibility without changing UI behavior",
      "description": "As a repository maintainer, I want frontend and repository lint execution to proceed beyond dead-code validation so later failures are visible and the gate can prevent renewed drift.",
      "acceptanceCriteria": [
        "make ui-lint completes successfully with the reconciled dead-code result and without a new broad suppression or ignore rule.",
        "make lint reaches and passes ui-deadcode, then runs subsequent configured checks; any unrelated downstream failure is captured as evidence and is not folded into this cleanup.",
        "If the installed Biome migration generates a behavior-preserving replacement for the deprecated linter setting, the migrated configuration emits no deprecation advisory and representative existing lint violations remain rejected; if it does not, no manual suppression or speculative config rewrite is added.",
        "No browser-visible UI behavior changes: existing loading, empty, error, and success states, accessible semantics, keyboard interactions, and responsive layouts remain unaffected, so direct browser verification is not required for this tooling-only story.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Applied the installed Biome 2.5.6 migration from linter.rules.recommended=true to preset=\"recommended\"; ui-lint, UI dead-code, lint rejection probe, typecheck, unit tests, and focused components-package build/typecheck/test/pack/installed-consumer checks pass. make lint reaches ui-deadcode and then reports the unrelated 95-violation backend-size failure; the full component wrapper exceeds its existing 150-second budget with 990 underlying tests passing, and bun run check reports unrelated pre-existing formatting drift outside this tooling change."
    }
  ]
}
