### PR TITLE
BUN-UNIT-features-trace-drilldown-02

### DIFF
--- a/docs/internal/development/plans/ui-test-latency/bun-unit-features-trace-drilldown-02-timing.md
+++ b/docs/internal/development/plans/ui-test-latency/bun-unit-features-trace-drilldown-02-timing.md
@@ -1,0 +1,89 @@
+# Bun Unit Cohort Timing: features-trace-drilldown-02
+
+This record captures the Vitest `dashboard-unit` baseline for the leased
+trace-drilldown relation factory-graph cohort and reserves the matched Bun
+after measurement for the same named cases. The measurements are local
+diagnostic evidence for the migration contract; they must not be converted into
+a repository-wide speedup claim.
+
+## Workload
+
+- Cohort work item: `BUN-UNIT-features-trace-drilldown-02`
+- Leased Vitest files (before migration):
+  - `ui/src/features/trace-drilldown/lib/trace-relation-factory-graph.test.ts`
+  - `ui/src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.test.ts`
+- File count: `2`
+- Passing tests: `14`
+- Named cases:
+
+### `trace-relation-factory-graph.test.ts` (7)
+
+1. `projectTraceRelationsToFactoryGraph endpoint nodes > maps relation endpoints to work-state nodes when state and work type are known`
+2. `projectTraceRelationsToFactoryGraph endpoint nodes > derives work-state nodes from display-name work types when required state is present`
+3. `projectTraceRelationsToFactoryGraph endpoint nodes > uses work_type_id from optional work items when projecting work-state nodes`
+4. `projectTraceRelationsToFactoryGraph endpoint nodes > uses work-type nodes when relations have no required state`
+5. `projectTraceRelationsToFactoryGraph edges and overlays > emits work-type-state edges with localized aria labels`
+6. `projectTraceRelationsToFactoryGraph edges and overlays > aggregates relation metadata onto one node per endpoint`
+7. `projectTraceRelationsToFactoryGraph edges and overlays > keeps canonical factory labels separate from trace overlay display labels`
+
+### `trace-relation-factory-graph-flow.test.ts` (7)
+
+1. `buildTraceRelationFactoryGraphFlow > projects batch relations into shared work nodes and clean edges`
+2. `buildTraceRelationFactoryGraphFlow > registers only shared work graph React Flow node types`
+3. `buildTraceRelationFactoryGraphFlow relation styling > renders relations with a shared clean edge style`
+4. `buildTraceRelationFactoryGraphFlow relation styling > keeps required-state relations on the same clean edge style`
+5. `buildTraceRelationFactoryGraphFlow repeated DEPENDS_ON > renders distinct dependency edges and nodes for each relation instance`
+6. `buildTraceRelationFactoryGraphFlow selection > marks relation nodes selectable when onSelectWorkID is provided`
+7. `buildTraceRelationFactoryGraphFlow selection > marks the selected work node as active and non-selectable`
+
+## Runtime and host
+
+- Recorded: 2026-08-01 UTC.
+- Repository revision for the Vitest baseline: `7c573b37e`.
+- Bun: `1.3.12`.
+- Vitest: `4.1.3`.
+- Host: Microsoft Windows 11, version `10.0.26200`; worktree at
+  `C:\Users\andre\work\portos\infinite-you\.claude\worktrees\BUN-UNIT-features-trace-drilldown-02`.
+
+## Matched commands and raw results
+
+### Vitest baseline
+
+Command:
+
+```text
+bunx --no-install vitest run --config vitest.lanes.config.ts --project=dashboard-unit --maxWorkers=4 --retry=0 src/features/trace-drilldown/lib/trace-relation-factory-graph.test.ts src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.test.ts
+```
+
+Raw result:
+
+```text
+RUN  v4.1.3 C:/Users/andre/work/portos/infinite-you/.claude/worktrees/BUN-UNIT-features-trace-drilldown-02/ui
+Test Files  2 passed (2)
+Tests  14 passed (14)
+Start at 12:22:44
+Duration  927ms (transform 666ms, setup 0ms, import 935ms, tests 32ms, environment 0ms)
+[timing] elapsed_ms=1870
+[timing] exit_code=0
+```
+
+### Bun after (pending migration)
+
+Command (after both files adopt `.bun.unit.test.ts` + `bun:test`):
+
+```text
+bun run test:unit:bun -- src/features/trace-drilldown/lib/trace-relation-factory-graph.bun.unit.test.ts src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.bun.unit.test.ts
+```
+
+Raw result: reserved for story
+`BUN-UNIT-features-trace-drilldown-02-004` after migration completes.
+
+## Comparison fields retained for later
+
+| Field | Vitest baseline | Bun after |
+| --- | --- | --- |
+| Migrated files | 0 | pending |
+| Retained Vitest files | 2 | pending |
+| Passing tests | 14 | pending |
+| Wall-clock `elapsed_ms` | 1870 | pending |
+| Vitest duration summary | 927ms | n/a |

--- a/docs/internal/development/plans/ui-test-latency/bun-unit-features-trace-drilldown-02-timing.md
+++ b/docs/internal/development/plans/ui-test-latency/bun-unit-features-trace-drilldown-02-timing.md
@@ -1,10 +1,10 @@
 # Bun Unit Cohort Timing: features-trace-drilldown-02
 
 This record captures the Vitest `dashboard-unit` baseline for the leased
-trace-drilldown relation factory-graph cohort and reserves the matched Bun
-after measurement for the same named cases. The measurements are local
-diagnostic evidence for the migration contract; they must not be converted into
-a repository-wide speedup claim.
+trace-drilldown relation factory-graph cohort, the lane exclusivity audit after
+partial migration, and the matched focused before/after wall-clock comparison.
+The measurements are local diagnostic evidence for the migration contract; they
+must not be converted into a repository-wide speedup claim.
 
 ## Workload
 
@@ -40,6 +40,7 @@ a repository-wide speedup claim.
 
 - Recorded: 2026-08-01 UTC.
 - Repository revision for the Vitest baseline: `7c573b37e`.
+- Repository revision for lane audit + focused after: `a167aee35`.
 - Bun: `1.3.12`.
 - Vitest: `4.1.3`.
 - Host: Microsoft Windows 11, version `10.0.26200`; worktree at
@@ -67,7 +68,7 @@ Duration  927ms (transform 666ms, setup 0ms, import 935ms, tests 32ms, environme
 [timing] exit_code=0
 ```
 
-### Bun after (partial migration + retained Vitest exception)
+### Bun after (migrated file)
 
 Migrated file command:
 
@@ -75,7 +76,7 @@ Migrated file command:
 bun test src/features/trace-drilldown/lib/trace-relation-factory-graph.bun.unit.test.ts
 ```
 
-Migrated file raw result (story `002`, revision `c2af26995`):
+Migrated file raw result (story `004` audit, revision `a167aee35`):
 
 ```text
 bun test v1.3.12 (700fc117)
@@ -85,11 +86,13 @@ src\features\trace-drilldown\lib\trace-relation-factory-graph.bun.unit.test.ts:
 0 fail
 16 expect() calls
 Ran 7 tests across 1 file. [63.00ms]
+[timing] elapsed_ms=101
+[timing] exit_code=0
 ```
 
 ### Retained Vitest exception: `trace-relation-factory-graph-flow.test.ts`
 
-Decision (story `003`, recorded 2026-08-01 UTC): keep this leased file on
+Decision (story `003`, confirmed in story `004`): keep this leased file on
 Vitest. A filename/`bun:test` migration attempt fails before any case runs
 because Bun resolves `@you-agent-factory/factory-graph` →
 `@you-agent-factory/components/graphs` through package `exports` into
@@ -103,38 +106,89 @@ Bun incompatibility probe (temporary `.bun.unit.test.ts` + `bun:test` /
 bun test v1.3.12 (700fc117)
 src\features\trace-drilldown\lib\_tmp-flow.bun.unit.test.ts:
 # Unhandled error between tests
-error: Cannot find module './graph-edge' from '.../ui/packages/components/dist/graphs/index.d.ts'
+error: Cannot find module './graph-edge' from '.../components/dist/graphs/index.d.ts'
 0 pass
 1 fail
 1 error
 Ran 1 test across 1 file. [106.00ms]
 ```
 
-Retained Vitest execution evidence (same host/revision family; 7 named cases
-unchanged):
+Direct Bun probe of the retained Vitest path (story `004`, same failure class):
+
+```text
+bun test src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.test.ts
+error: Cannot find module './graph-edge' from '.../components/dist/graphs/index.d.ts'
+0 pass
+1 fail
+1 error
+Ran 1 test across 1 file. [114.00ms]
+```
+
+Retained Vitest execution evidence (story `004` focused after, revision
+`a167aee35`; 7 named cases unchanged):
 
 ```text
 bunx --no-install vitest run --config vitest.lanes.config.ts --project=dashboard-unit --maxWorkers=4 --retry=0 src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.test.ts
 Test Files  1 passed (1)
 Tests  7 passed (7)
-Duration  874ms (transform 433ms, setup 0ms, import 623ms, tests 19ms, environment 0ms)
-[timing] elapsed_ms=1515
+Duration  818ms (transform 448ms, setup 0ms, import 656ms, tests 17ms, environment 0ms)
+[timing] elapsed_ms=1425
 [timing] exit_code=0
 ```
 
 No broad Bun shim, assertion weakening, or production-source change was
 introduced. Fixing this requires Bun unit-lane package/source resolution owned
-by the foundation lane, not this leased cohort.
+by the foundation lane, not this leased cohort. Follow-up idea:
+`tasks/ideas-to-review/ui/bun-unit-lane-workspace-package-source-resolution.md`.
 
-Cohort-level before/after wall-clock comparison remains reserved for story
-`BUN-UNIT-features-trace-drilldown-02-004`.
+## Lane exclusivity audit (story 004)
 
-## Comparison fields retained for later
+| Leased file | Lane ownership | Bun execution | Vitest `dashboard-unit` |
+| --- | --- | --- | --- |
+| `trace-relation-factory-graph.bun.unit.test.ts` | Bun unit | 7/7 pass once (`elapsed_ms=101`) | No test files found (excluded via `src/**/*.bun.unit.test.ts`) |
+| `trace-relation-factory-graph-flow.test.ts` | Vitest retention | Fails before cases (`./graph-edge` from `dist/graphs/index.d.ts`) — not claimed as Bun ownership | 7/7 pass once (`elapsed_ms=1425`) |
+| `trace-relation-factory-graph.test.ts` (pre-migration path) | Removed / renamed | n/a | No test files found (file absent) |
 
-| Field | Vitest baseline | After story 003 |
+Audit conclusions:
+
+- Migrated projection file executes exactly once under Bun and is not selected by
+  Vitest `dashboard-unit`.
+- Retained flow file executes exactly once under Vitest with the evidence-backed
+  Bun package-resolution incompatibility above.
+- No double-lane ownership for either leased case set.
+
+## Focused before/after wall-clock comparison
+
+Comparable host and runner versions. Before = single Vitest command over both
+leased files. After = sequential Bun migrated file + Vitest retained exception
+(same 14 named cases).
+
+| Field | Vitest baseline | Focused after (story 004) |
 | --- | --- | --- |
 | Migrated files | 0 | 1 (`trace-relation-factory-graph`) |
 | Retained Vitest files | 2 | 1 (`trace-relation-factory-graph-flow`) |
 | Passing tests | 14 | 14 (7 Bun + 7 Vitest) |
-| Wall-clock `elapsed_ms` | 1870 | pending story 004 focused compare |
-| Vitest duration summary | 927ms | retained file alone 874ms / 1515ms wall |
+| Wall-clock `elapsed_ms` | 1870 | 1512 (Bun then Vitest sequential) |
+| Vitest duration summary | 927ms (2 files) | retained file alone 818ms / 1425ms wall |
+| Bun duration summary | n/a | migrated file 63ms / 101ms wall |
+| Patch size vs `7c573b37e` | n/a | 3 files, +186 / −1 lines (under ~1,000) |
+
+Focused after command sequence:
+
+```text
+bun test src/features/trace-drilldown/lib/trace-relation-factory-graph.bun.unit.test.ts
+bunx --no-install vitest run --config vitest.lanes.config.ts --project=dashboard-unit --maxWorkers=4 --retry=0 src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.test.ts
+```
+
+Focused after raw wall-clock:
+
+```text
+[timing] cohort_after_elapsed_ms=1512
+[timing] bun_exit_code=0
+[timing] vitest_exit_code=0
+```
+
+Observation for this cohort only: focused wall-clock improved from `1870ms` to
+`1512ms` under comparable local conditions while preserving all 14 named cases
+and assertion strength. The retained Vitest file still dominates after latency
+because of the foundation package-resolution gap.

--- a/docs/internal/development/plans/ui-test-latency/bun-unit-features-trace-drilldown-02-timing.md
+++ b/docs/internal/development/plans/ui-test-latency/bun-unit-features-trace-drilldown-02-timing.md
@@ -67,23 +67,74 @@ Duration  927ms (transform 666ms, setup 0ms, import 935ms, tests 32ms, environme
 [timing] exit_code=0
 ```
 
-### Bun after (pending migration)
+### Bun after (partial migration + retained Vitest exception)
 
-Command (after both files adopt `.bun.unit.test.ts` + `bun:test`):
+Migrated file command:
 
 ```text
-bun run test:unit:bun -- src/features/trace-drilldown/lib/trace-relation-factory-graph.bun.unit.test.ts src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.bun.unit.test.ts
+bun test src/features/trace-drilldown/lib/trace-relation-factory-graph.bun.unit.test.ts
 ```
 
-Raw result: reserved for story
-`BUN-UNIT-features-trace-drilldown-02-004` after migration completes.
+Migrated file raw result (story `002`, revision `c2af26995`):
+
+```text
+bun test v1.3.12 (700fc117)
+src\features\trace-drilldown\lib\trace-relation-factory-graph.bun.unit.test.ts:
+(pass) ... 7 named cases ...
+7 pass
+0 fail
+16 expect() calls
+Ran 7 tests across 1 file. [63.00ms]
+```
+
+### Retained Vitest exception: `trace-relation-factory-graph-flow.test.ts`
+
+Decision (story `003`, recorded 2026-08-01 UTC): keep this leased file on
+Vitest. A filename/`bun:test` migration attempt fails before any case runs
+because Bun resolves `@you-agent-factory/factory-graph` →
+`@you-agent-factory/components/graphs` through package `exports` into
+`dist/graphs/index.d.ts`, then cannot load `./graph-edge` from that types entry.
+Vitest continues to resolve the same imports through dashboard source aliases.
+
+Bun incompatibility probe (temporary `.bun.unit.test.ts` + `bun:test` /
+`mock(() => {})` adaptation of the leased file; not retained in tree):
+
+```text
+bun test v1.3.12 (700fc117)
+src\features\trace-drilldown\lib\_tmp-flow.bun.unit.test.ts:
+# Unhandled error between tests
+error: Cannot find module './graph-edge' from '.../ui/packages/components/dist/graphs/index.d.ts'
+0 pass
+1 fail
+1 error
+Ran 1 test across 1 file. [106.00ms]
+```
+
+Retained Vitest execution evidence (same host/revision family; 7 named cases
+unchanged):
+
+```text
+bunx --no-install vitest run --config vitest.lanes.config.ts --project=dashboard-unit --maxWorkers=4 --retry=0 src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.test.ts
+Test Files  1 passed (1)
+Tests  7 passed (7)
+Duration  874ms (transform 433ms, setup 0ms, import 623ms, tests 19ms, environment 0ms)
+[timing] elapsed_ms=1515
+[timing] exit_code=0
+```
+
+No broad Bun shim, assertion weakening, or production-source change was
+introduced. Fixing this requires Bun unit-lane package/source resolution owned
+by the foundation lane, not this leased cohort.
+
+Cohort-level before/after wall-clock comparison remains reserved for story
+`BUN-UNIT-features-trace-drilldown-02-004`.
 
 ## Comparison fields retained for later
 
-| Field | Vitest baseline | Bun after |
+| Field | Vitest baseline | After story 003 |
 | --- | --- | --- |
-| Migrated files | 0 | pending |
-| Retained Vitest files | 2 | pending |
-| Passing tests | 14 | pending |
-| Wall-clock `elapsed_ms` | 1870 | pending |
-| Vitest duration summary | 927ms | n/a |
+| Migrated files | 0 | 1 (`trace-relation-factory-graph`) |
+| Retained Vitest files | 2 | 1 (`trace-relation-factory-graph-flow`) |
+| Passing tests | 14 | 14 (7 Bun + 7 Vitest) |
+| Wall-clock `elapsed_ms` | 1870 | pending story 004 focused compare |
+| Vitest duration summary | 927ms | retained file alone 874ms / 1515ms wall |

--- a/tasks/ideas-to-review/ui/bun-unit-lane-workspace-package-source-resolution.md
+++ b/tasks/ideas-to-review/ui/bun-unit-lane-workspace-package-source-resolution.md
@@ -1,0 +1,45 @@
+# Bun unit lane: workspace package source resolution
+
+## Problem
+
+Bun-native unit migrations that transitively import
+`@you-agent-factory/factory-graph` or `@you-agent-factory/components/*` fail
+under `bun test` even when the same modules load under Vitest
+`dashboard-unit`.
+
+Observed failure while migrating
+`trace-relation-factory-graph-flow.test.ts`:
+
+```text
+error: Cannot find module './graph-edge' from
+'.../ui/packages/components/dist/graphs/index.d.ts'
+```
+
+Vitest resolves these packages through dashboard/tsconfig source aliases.
+Bun follows package `exports` into `dist`, and for `components/graphs` it can
+land on the types entry (`index.d.ts`) whose relative imports do not resolve
+as runtime modules. Building `packages/components` does not clear the failure.
+
+This will repeatedly block Bun unit cohort migrations that touch factory-graph
+projection/React Flow helpers, not just this leased file.
+
+## Proposed direction
+
+Owned by the Bun unit foundation / UI test lane, not by individual cohort
+PRs:
+
+1. Give the Bun unit runner the same source-package resolution strategy Vitest
+   already uses for `@you-agent-factory/*` (preload, bunfig paths, or an
+   explicit resolver), or
+2. Document a durable Vitest-retention rule for unit files whose import graph
+   requires those packages until that resolver exists.
+
+Do not ask cohort migrations to add broad `mock.module` shims that weaken
+coverage or invent per-file package fakes.
+
+## Evidence
+
+- Cohort: `BUN-UNIT-features-trace-drilldown-02`
+- Retained file: `ui/src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.test.ts`
+- Timing/evidence note:
+  `docs/internal/development/plans/ui-test-latency/bun-unit-features-trace-drilldown-02-timing.md`

--- a/ui/src/features/trace-drilldown/lib/trace-relation-factory-graph.bun.unit.test.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-relation-factory-graph.bun.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import type {
   DashboardWorkItemRef,
   DashboardWorkRelation,


### PR DESCRIPTION
{
  "project": "Migrate Bun unit cohort features-trace-drilldown-02",
  "branchName": "BUN-UNIT-features-trace-drilldown-02",
  "description": "Move the leased 2-file, ~461-line Node-oriented frontend unit-test cohort for trace-drilldown relation factory-graph projection helpers from Vitest to the Bun-native unit lane established by BUN-UNIT-00-lane-foundation, preserving the same named cases and behavioral assertions, improving focused execution latency, and delivering through an actually merged PR without recreating the foundation or editing shared runner ownership.",
  "context": {
    "customerAsk": "Migrate this exact 2-file Vitest unit cohort (trace-relation-factory-graph.test.ts and trace-relation-factory-graph-flow.test.ts) onto the current Bun unit lane, preserve observable coverage, record focused before/after wall-clock evidence, and deliver through an actually merged PR. Reuse the existing branch/worktree and continue from current commits and uncommitted edits; do not discard completed stories or recreate BUN-UNIT-00 foundation.",
    "problem": "These relation-projection unit files still run under the slower Node/Vitest dashboard-unit path even though the Bun-native unit lane already exists, keeping focused latency higher and blocking the incremental Bun migration program for this leased cohort.",
    "solution": "Adopt the foundation Bun filename/import/mock conventions for each compatible leased file (.bun.unit.test.ts + bun:test), remove Vitest-only imports for migrated files, prove each migrated file executes under Bun and is no longer selected by Vitest, retain any genuinely unsupported file on Vitest only with execution evidence, publish focused before/after timing with file/test counts, and finish through terminal green CI, resolved blocking feedback/conflicts, and actual PR merge."
  },
  "acceptanceCriteria": [
    "Every compatible listed file is Bun-native and passes with the same named cases/assertions as its Vitest baseline",
    "Lane audit confirms migrated files execute exactly once under Bun and not under Vitest; retained exceptions remain exactly once under Vitest with a specific evidence-backed reason",
    "Focused before/after wall-clock results are recorded under comparable conditions, including migrated/retained file and test counts",
    "No skipped/deleted tests, reduced assertions, snapshot laundering, timeout inflation, retries, or production-code changes solely to satisfy the runner",
    "Scope stays on the leased test files and narrowly necessary same-directory helpers; shared runner/config/classifier files owned by the foundation are not edited",
    "Focused Bun tests, affected Vitest selection checks, frontend typecheck, and lint/checks pass",
    "Delivery continues through terminal green required CI, resolved blocking review feedback and conflicts, and actual PR merge"
  ],
  "userStories": [
    {
      "id": "BUN-UNIT-features-trace-drilldown-02-001",
      "title": "Capture Vitest baseline for the leased cohort",
      "description": "As a maintainer, I need a recorded Vitest baseline for the two leased files so migration can prove preserved case names, assertion strength, test counts, and comparable wall-clock latency.",
      "acceptanceCriteria": [
        "Both leased files are executed under the existing Vitest dashboard-unit selection under comparable local conditions",
        "Baseline records file count, passing test count, named cases, and wall-clock elapsed time for the cohort",
        "Baseline evidence is retained for later before/after comparison in this work item",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Baseline recorded in docs/internal/development/plans/ui-test-latency/bun-unit-features-trace-drilldown-02-timing.md: 2 files, 14 tests, elapsed_ms=1870 on 7c573b37e."
    },
    {
      "id": "BUN-UNIT-features-trace-drilldown-02-002",
      "title": "Migrate relation factory-graph projection unit tests to Bun",
      "description": "As a maintainer, I want trace-relation-factory-graph unit coverage to run on the Bun-native unit lane so focused projection checks stay fast without losing behavioral assertions.",
      "acceptanceCriteria": [
        "The leased trace-relation-factory-graph unit file adopts the foundation Bun filename and bun:test import/mock conventions and no longer uses Vitest-only imports",
        "Bun execution passes with the same named cases and equivalent behavioral assertions/expected test count as the Vitest baseline",
        "Vitest dashboard-unit selection no longer includes the migrated file",
        "No production source changes are introduced solely to satisfy the runner",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Migrated to trace-relation-factory-graph.bun.unit.test.ts; Bun 7/7 pass; Vitest dashboard-unit no longer selects the file."
    },
    {
      "id": "BUN-UNIT-features-trace-drilldown-02-003",
      "title": "Migrate relation factory-graph flow unit tests to Bun",
      "description": "As a maintainer, I want trace-relation-factory-graph-flow unit coverage to run on the Bun-native unit lane so React Flow projection helpers keep the same observable guarantees with faster focused runs.",
      "acceptanceCriteria": [
        "The leased trace-relation-factory-graph-flow unit file adopts the foundation Bun filename and bun:test import/mock conventions and no longer uses Vitest-only imports",
        "Bun execution passes with the same named cases and equivalent behavioral assertions/expected test count as the Vitest baseline",
        "Any Bun mock/API adaptation preserves observable assertion strength; if a concrete Bun incompatibility blocks migration, the file remains on Vitest with execution evidence and no broad shim or weakened assertions",
        "Vitest dashboard-unit selection no longer includes a successfully migrated file",
        "No production source changes are introduced solely to satisfy the runner",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Retained on Vitest with execution evidence: Bun fails resolving @you-agent-factory/components/graphs via dist/graphs/index.d.ts (./graph-edge). Vitest still runs 7/7. Documented in bun-unit-features-trace-drilldown-02-timing.md; idea filed under tasks/ideas-to-review/ui/bun-unit-lane-workspace-package-source-resolution.md."
    },
    {
      "id": "BUN-UNIT-features-trace-drilldown-02-004",
      "title": "Prove lane exclusivity and publish focused latency evidence",
      "description": "As a reviewer, I need a cohort lane audit and focused before/after timing report so I can verify each file runs in exactly one lane and latency improved under comparable conditions.",
      "acceptanceCriteria": [
        "Lane audit shows each migrated file executes exactly once under Bun and not under Vitest",
        "Any retained Vitest exception is listed with a specific evidence-backed incompatibility reason and still executes exactly once under Vitest",
        "Focused before/after wall-clock results are recorded under comparable conditions and report migrated/retained file and test counts",
        "Patch remains roughly at or under ~1,000 changed lines unless unsafe coupling forces a documented split",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Lane audit: migrated Bun file 7/7 once, Vitest excludes it; retained Vitest flow 7/7 once with Bun ./graph-edge evidence. Focused wall-clock 1870ms → 1512ms (14 tests: 7 Bun + 7 Vitest). Patch +186/-1 under ~1k lines. Evidence in bun-unit-features-trace-drilldown-02-timing.md."
    },
    {
      "id": "BUN-UNIT-features-trace-drilldown-02-005",
      "title": "Finish quality gates and merge the delivery PR",
      "description": "As a delivery owner, I need the implementation/review loop to continue until required checks are terminal green and the PR is actually merged so the Factory Session can complete.",
      "acceptanceCriteria": [
        "Focused Bun cohort tests, affected Vitest selection checks, frontend typecheck, and lint/checks pass",
        "Required CI is terminal and passing",
        "All blocking PR conversation feedback is explicitly addressed",
        "Merge conflicts and shared-file drift against current main are resolved",
        "The PR for BUN-UNIT-features-trace-drilldown-02 is actually merged",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": false,
      "notes": ""
    }
  ]
}
