### PR TITLE
Type Models presentation operator defaults

### DIFF
--- a/pkg/services/factory_sessions/internal/runtimeopening/invocation/models_cli_collaboration.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/invocation/models_cli_collaboration.go
@@ -76,13 +76,10 @@ func (o *operation) OpenModelsPresentationScope(
 	target := roles.InvocationTarget{
 		FactoryDir:       factoryDir,
 		HomeDir:          request.HomeDir,
-		OperatorDefaults: operatorconfig.ResolvedDefaults{},
+		OperatorDefaults: resolvedOperatorDefaultsFromPresentation(request.OperatorDefaults),
 		Logger:           request.Logger,
 		Verbose:          request.Verbose,
 		ModelCacheDir:    request.ModelCacheDir,
-	}
-	if defaults, ok := request.OperatorDefaults.(operatorconfig.ResolvedDefaults); ok {
-		target.OperatorDefaults = defaults
 	}
 	opened, lifecycle, err := o.open(ctx, target)
 	if err != nil {
@@ -101,6 +98,15 @@ func (o *operation) OpenModelsPresentationScope(
 			return lifecycle.close(closeCtx, opened)
 		},
 	}, nil
+}
+
+func resolvedOperatorDefaultsFromPresentation(
+	defaults models.PresentationOperatorDefaults,
+) operatorconfig.ResolvedDefaults {
+	return operatorconfig.ResolvedDefaults{
+		WorkerModelProvider: defaults.WorkerModelProvider,
+		WorkerModel:         defaults.WorkerModel,
+	}
 }
 
 var _ interface {

--- a/pkg/services/factory_sessions/internal/runtimeopening/invocation/models_cli_collaboration_test.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/invocation/models_cli_collaboration_test.go
@@ -14,6 +14,21 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/models"
 )
 
+func TestResolvedOperatorDefaultsFromPresentationPreservesModelDefaults(t *testing.T) {
+	t.Parallel()
+
+	defaults := resolvedOperatorDefaultsFromPresentation(models.PresentationOperatorDefaults{
+		WorkerModelProvider: "codex",
+		WorkerModel:         "gpt-5.6",
+	})
+	if defaults.WorkerModelProvider != "codex" {
+		t.Fatalf("provider = %q, want codex", defaults.WorkerModelProvider)
+	}
+	if defaults.WorkerModel != "gpt-5.6" {
+		t.Fatalf("model = %q, want gpt-5.6", defaults.WorkerModel)
+	}
+}
+
 func TestOpenModelsCatalogScope_RequiresOperation(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/models/presentation_port.go
+++ b/pkg/services/models/presentation_port.go
@@ -6,12 +6,20 @@ import (
 	"go.uber.org/zap"
 )
 
+// PresentationOperatorDefaults carries the operator model-selection values
+// consumed while opening a Models presentation scope. Resolution metadata and
+// unrelated operator settings stay owned by Operator Settings.
+type PresentationOperatorDefaults struct {
+	WorkerModelProvider string
+	WorkerModel         string
+}
+
 // PresentationScopeRequest is the consumer-owned request for a model
 // presentation scope. Models CLI adapters may alias this value contract.
 type PresentationScopeRequest struct {
 	FactoryDir       string
 	HomeDir          string
-	OperatorDefaults any
+	OperatorDefaults PresentationOperatorDefaults
 	Logger           *zap.Logger
 	Verbose          bool
 	ModelCacheDir    string

--- a/pkg/services/models/transports/cli/bootstrap_builder_test.go
+++ b/pkg/services/models/transports/cli/bootstrap_builder_test.go
@@ -32,6 +32,24 @@ type InvocationRunner interface {
 }
 
 type testModelRunner = InvocationRunner
+
+func TestPresentationScopeRequestFromInvokePreservesModelDefaults(t *testing.T) {
+	t.Parallel()
+
+	request := presentationScopeRequestFromInvoke(InvokeConfig{
+		OperatorDefaults: operatorconfig.ResolvedDefaults{
+			WorkerModelProvider: "codex",
+			WorkerModel:         "gpt-5.6",
+		},
+	})
+	if request.OperatorDefaults.WorkerModelProvider != "codex" {
+		t.Fatalf("provider = %q, want codex", request.OperatorDefaults.WorkerModelProvider)
+	}
+	if request.OperatorDefaults.WorkerModel != "gpt-5.6" {
+		t.Fatalf("model = %q, want gpt-5.6", request.OperatorDefaults.WorkerModel)
+	}
+}
+
 type testModelRuntimeSelections struct {
 	Dir                  string
 	SystemConfigHomeDir  string

--- a/pkg/services/models/transports/cli/composition_bridge.go
+++ b/pkg/services/models/transports/cli/composition_bridge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	modelinference "github.com/portpowered/infinite-you/pkg/services/models"
+	operatorconfig "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 )
 
 type compositionCollaboratorInvocation struct {
@@ -61,8 +62,17 @@ func presentationScopeRequestFromInvoke(cfg InvokeConfig) PresentationScopeReque
 	return PresentationScopeRequest{
 		FactoryDir:       cfg.FactoryDir,
 		HomeDir:          cfg.HomeDir,
-		OperatorDefaults: cfg.OperatorDefaults,
+		OperatorDefaults: presentationOperatorDefaultsFromResolved(cfg.OperatorDefaults),
 		Logger:           cfg.Logger,
 		Verbose:          cfg.Verbose,
+	}
+}
+
+func presentationOperatorDefaultsFromResolved(
+	defaults operatorconfig.ResolvedDefaults,
+) modelinference.PresentationOperatorDefaults {
+	return modelinference.PresentationOperatorDefaults{
+		WorkerModelProvider: defaults.WorkerModelProvider,
+		WorkerModel:         defaults.WorkerModel,
 	}
 }

--- a/pkg/services/models/transports/cli/presentation_port.go
+++ b/pkg/services/models/transports/cli/presentation_port.go
@@ -17,3 +17,4 @@ type PresentationCollaborator interface {
 
 type PresentationScopeRequest = modelservice.PresentationScopeRequest
 type PresentationScope = modelservice.PresentationScope
+type PresentationOperatorDefaults = modelservice.PresentationOperatorDefaults


### PR DESCRIPTION
## Summary

- replace the Models presentation boundary's `any` operator-default payload with a Models-owned two-field value
- map provider/model defaults explicitly at the Models CLI and Factory Sessions runtime-opening seams
- add focused mapping tests for both values

## Root cause

PR #1692 sealed Factory Sessions to its unary root service but left `PresentationScopeRequest.OperatorDefaults` as `any`. Factory Sessions then used a runtime type assertion, so an unexpected dynamic value silently discarded operator defaults.

## Validation

- focused Models, Models CLI, Factory Sessions runtime-opening, Models wire, Factory Sessions wire, `pkg/wire`, and `pkg/root` Go tests
- `make pkg-structure` and `make ownership-inventory-check`
- direct focused coverage
- `make verify-fast` (passing rerun)
- full `make lint` and repository unit-coverage gates were attempted; the former is blocked by existing backend-size violations and the latter by the Windows toolchain command-length failure. No baselines, floors, exceptions, or suppressions were changed.