### PR TITLE
Move Models effects behind process-edge contracts

### DIFF
--- a/pkg/root/root_test.go
+++ b/pkg/root/root_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/portpowered/infinite-you/internal/testutil"
 	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
-	modelswire "github.com/portpowered/infinite-you/pkg/services/models/wire"
 	inference "github.com/portpowered/infinite-you/pkg/services/providers/wire"
 )
 
@@ -91,8 +90,12 @@ type rootRecordingModelHostLauncher struct {
 
 func (launcher *rootRecordingModelHostLauncher) Start(
 	context.Context,
-	modelswire.HostProcessStartSpec,
-) (modelswire.HostManagedProcess, error) {
+	serviceedges.HostProcessStartSpec,
+) (interface {
+	HealthEndpoint() string
+	Wait() error
+	Stop(context.Context) error
+}, error) {
 	launcher.starts++
 	panic("model host process launcher called during inert construction")
 }

--- a/pkg/services/edges/contract_ownership_test.go
+++ b/pkg/services/edges/contract_ownership_test.go
@@ -2,11 +2,14 @@ package edges
 
 import (
 	"bytes"
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/printer"
 	"go/token"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -41,9 +44,87 @@ func TestPackageDocumentsProcessEdgeArchitectureException(t *testing.T) {
 	}
 }
 
+func TestEdgesDoNotImportModelsWire(t *testing.T) {
+	t.Parallel()
+
+	err := filepath.WalkDir(".", func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") {
+			return nil
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if err != nil {
+			return fmt.Errorf("parse %s: %w", path, err)
+		}
+		for _, importSpec := range file.Imports {
+			importPath, err := strconv.Unquote(importSpec.Path.Value)
+			if err != nil {
+				return fmt.Errorf("unquote %s import path: %w", path, err)
+			}
+			if importPath == "github.com/portpowered/infinite-you/pkg/services/models/"+"wire" {
+				return fmt.Errorf("%s imports Models construction package %q", path, importPath)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestModelsRootDeclaresOnlyServiceInterface(t *testing.T) {
+	t.Parallel()
+
+	entries, err := os.ReadDir("../models")
+	if err != nil {
+		t.Fatalf("read Models root: %v", err)
+	}
+	fileSet := token.NewFileSet()
+	var interfaces []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fileSet, "../models/"+entry.Name(), nil, 0)
+		if err != nil {
+			t.Fatalf("parse Models root file %s: %v", entry.Name(), err)
+		}
+		for _, declaration := range file.Decls {
+			generic, ok := declaration.(*ast.GenDecl)
+			if !ok || generic.Tok != token.TYPE {
+				continue
+			}
+			for _, specification := range generic.Specs {
+				typed, ok := specification.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				if _, ok := typed.Type.(*ast.InterfaceType); ok {
+					interfaces = append(interfaces, entry.Name()+":"+typed.Name.Name)
+				}
+			}
+		}
+	}
+	if len(interfaces) != 1 || interfaces[0] != "service_contract.go:Service" {
+		t.Fatalf("Models root interfaces = %v, want [service_contract.go:Service]", interfaces)
+	}
+}
+
 func TestPackageOwnsOnlyTheEdgeAggregator(t *testing.T) {
 	t.Parallel()
 
+	localModelEffectTypes := map[string]struct{}{
+		"PullMetric": {},
+		"AssetMakeDirectories": {}, "AssetInspectPath": {},
+		"AssetResolveHomeDirectory": {}, "AssetWriteFile": {}, "AssetRenamePath": {},
+		"AssetRemovePath": {}, "AssetReadFile": {}, "AssetReadDirectory": {},
+		"AssetCreateFile": {}, "AssetOpenFile": {},
+		"HostProcessStartSpec": {},
+		"RuntimeInspectFile": {},
+		"RuntimeTempDirectory": {}, "RuntimeCreateTempFile": {},
+	}
 	entries, err := os.ReadDir(".")
 	if err != nil {
 		t.Fatalf("read edges package: %v", err)
@@ -67,8 +148,13 @@ func TestPackageOwnsOnlyTheEdgeAggregator(t *testing.T) {
 				if !ok || typed.Name.Name == "Edges" {
 					continue
 				}
+				if entry.Name() == "models_effects.go" {
+					if _, allowed := localModelEffectTypes[typed.Name.Name]; allowed {
+						continue
+					}
+				}
 				t.Errorf(
-					"%s declares %s; external-effect contracts belong to their effect adapter and edges only aggregates them",
+					"%s declares %s; edges may only declare the Edges aggregate and its exact Models process-edge contracts",
 					entry.Name(),
 					typed.Name.Name,
 				)
@@ -100,28 +186,28 @@ func TestEdgesAggregateExactOwnerTypes(t *testing.T) {
 		"HostedSecretResolver":                            {typeName: "automations.HostedLinearSecretResolver", effect: "resolve the Linear credential at the hosted adapter"},
 		"HostedLinearCheckpointStore":                     {typeName: "automations.HostedLinearCheckpointStore", effect: "persist hosted Linear resume checkpoints atomically"},
 		"HostedClock":                                     {typeName: "automations.HostedLinearClock", effect: "schedule hosted-poller waits"},
-		"ModelAssetHTTPClient":                            {typeName: "modelswire.AssetHTTPDoer", effect: "download external model assets"},
+		"ModelAssetHTTPClient":                            {typeName: "interface {\n\tDo(*http.Request) (*http.Response, error)\n}", effect: "download external model assets"},
 		"ModelAssetEndpoints":                             {typeName: "models.RuntimeAssetEndpoints", effect: "select external model-catalog and asset endpoints"},
 		"ModelAssetHostPlatform":                          {typeName: "models.AssetHostPlatform", effect: "select managed-model assets compatible with the process host"},
-		"ModelAssetMakeDirectories":                       {typeName: "modelswire.AssetMakeDirectories", effect: "create model asset directories"},
-		"ModelAssetInspectPath":                           {typeName: "modelswire.AssetInspectPath", effect: "inspect model asset paths"},
-		"ModelAssetResolveHomeDirectory":                  {typeName: "modelswire.AssetResolveHomeDirectory", effect: "resolve the model asset home directory"},
-		"ModelAssetWriteFile":                             {typeName: "modelswire.AssetWriteFile", effect: "write model asset files"},
-		"ModelAssetRenamePath":                            {typeName: "modelswire.AssetRenamePath", effect: "rename model asset paths"},
-		"ModelAssetRemovePath":                            {typeName: "modelswire.AssetRemovePath", effect: "remove model asset paths"},
-		"ModelAssetReadFile":                              {typeName: "modelswire.AssetReadFile", effect: "read model asset files"},
-		"ModelAssetReadDirectory":                         {typeName: "modelswire.AssetReadDirectory", effect: "read model asset directories"},
-		"ModelAssetCreateFile":                            {typeName: "modelswire.AssetCreateFile", effect: "create model asset files"},
-		"ModelAssetOpenFile":                              {typeName: "modelswire.AssetOpenFile", effect: "open model asset files"},
-		"ModelHostProcessLauncher":                        {typeName: "modelswire.HostProcessLauncher", effect: "launch the managed model host process"},
-		"ModelHostHTTPClient":                             {typeName: "modelswire.HostHTTPDoer", effect: "probe and invoke the managed model host"},
-		"ModelHostClock":                                  {typeName: "modelswire.HostClock", effect: "schedule model-host readiness probes"},
+		"ModelAssetMakeDirectories":                       {typeName: "AssetMakeDirectories", effect: "create model asset directories"},
+		"ModelAssetInspectPath":                           {typeName: "AssetInspectPath", effect: "inspect model asset paths"},
+		"ModelAssetResolveHomeDirectory":                  {typeName: "AssetResolveHomeDirectory", effect: "resolve the model asset home directory"},
+		"ModelAssetWriteFile":                             {typeName: "AssetWriteFile", effect: "write model asset files"},
+		"ModelAssetRenamePath":                            {typeName: "AssetRenamePath", effect: "rename model asset paths"},
+		"ModelAssetRemovePath":                            {typeName: "AssetRemovePath", effect: "remove model asset paths"},
+		"ModelAssetReadFile":                              {typeName: "AssetReadFile", effect: "read model asset files"},
+		"ModelAssetReadDirectory":                         {typeName: "AssetReadDirectory", effect: "read model asset directories"},
+		"ModelAssetCreateFile":                            {typeName: "AssetCreateFile", effect: "create model asset files"},
+		"ModelAssetOpenFile":                              {typeName: "AssetOpenFile", effect: "open model asset files"},
+		"ModelHostProcessLauncher":                        {typeName: "interface {\n\tStart(context.Context, HostProcessStartSpec) (interface {\n\t\tHealthEndpoint() string\n\t\tWait() error\n\t\tStop(context.Context) error\n\t}, error)\n}", effect: "launch the managed model host process"},
+		"ModelHostHTTPClient":                             {typeName: "interface {\n\tDo(*http.Request) (*http.Response, error)\n}", effect: "probe and invoke the managed model host"},
+		"ModelHostClock":                                  {typeName: "interface {\n\tNow() time.Time\n\tNewTimer(time.Duration) interface {\n\t\tC() <-chan time.Time\n\t\tStop() bool\n\t}\n}", effect: "schedule model-host readiness probes"},
 		"ModelRuntimeCommandRunner":                       {typeName: "platformprocess.CommandRunner", effect: "launch local model-runtime commands"},
-		"ModelRuntimeHTTPClient":                          {typeName: "modelswire.RuntimeHTTPDoer", effect: "invoke the local model runtime over HTTP"},
-		"ModelRuntimeInspectFile":                         {typeName: "modelswire.RuntimeInspectFile", effect: "inspect local model-runtime files"},
-		"ModelRuntimeTempDirectory":                       {typeName: "modelswire.RuntimeTempDirectory", effect: "resolve the process temporary directory"},
-		"ModelRuntimeCreateTempFile":                      {typeName: "modelswire.RuntimeCreateTempFile", effect: "create local model-runtime temporary files"},
-		"ModelInvocationArtifactFileSystem":               {typeName: "modelswire.InvocationArtifactFileSystem", effect: "export streamed model-invocation artifacts"},
+		"ModelRuntimeHTTPClient":                          {typeName: "interface {\n\tDo(*http.Request) (*http.Response, error)\n}", effect: "invoke the local model runtime over HTTP"},
+		"ModelRuntimeInspectFile":                         {typeName: "RuntimeInspectFile", effect: "inspect local model-runtime files"},
+		"ModelRuntimeTempDirectory":                       {typeName: "RuntimeTempDirectory", effect: "resolve the process temporary directory"},
+		"ModelRuntimeCreateTempFile":                      {typeName: "RuntimeCreateTempFile", effect: "create local model-runtime temporary files"},
+		"ModelInvocationArtifactFileSystem":               {typeName: "interface {\n\tOpen(string) (io.ReadCloser, error)\n\tCreate(string) (io.WriteCloser, error)\n}", effect: "export streamed model-invocation artifacts"},
 		"FactorySessionsWorkingDirectory":                 {typeName: "platformfilesystem.WorkingDirectory", effect: "resolve omitted Factory Session invocation targets"},
 		"FactorySessionExecutionOpeningFileSystem":        {typeName: "factorysessions.ExecutionOpeningFileSystem", effect: "resolve omitted durable-execution project and fixture-catalog paths"},
 		"FactorySessionDirectoryInspection":               {typeName: "factorysessions.DirectoryInspection", effect: "inspect Factory Session target directories"},
@@ -201,7 +287,7 @@ func TestEdgesAggregateExactOwnerTypes(t *testing.T) {
 		"RuntimeHostObserver":              {typeName: "factorysessions.RuntimeHostObserver", effect: "observe Factory Session runtime-host lifecycle"},
 		"FactoryVisualizationSink":         {typeName: "factoryvisualization.Sink", effect: "present projected Factory visualization views at the process boundary"},
 		"FactoryVisualizationRootObserver": {typeName: "factoryvisualization.RootObserver", effect: "observe the published Factory Visualization root composed for one runtime opening"},
-		"ModelPullMetricsRecorder":         {typeName: "modelswire.PullMetricsRecorder", effect: "publish managed-model pull metrics"},
+		"ModelPullMetricsRecorder":         {typeName: "interface{ RecordModelPullMetric(PullMetric) }", effect: "publish managed-model pull metrics"},
 		"ProviderOverride":                 {typeName: "providercontract.Provider", effect: "perform external provider inference"},
 		"WorkersExecutablePathInspector":   {typeName: "platformfilesystem.PathInspector", effect: "inspect the selected Worker executable path"},
 		"ScriptCommandRunner":              {typeName: "platformprocess.CommandRunner", effect: "launch external script processes"},

--- a/pkg/services/edges/definition.go
+++ b/pkg/services/edges/definition.go
@@ -10,9 +10,12 @@
 package edges
 
 import (
+	"context"
 	"database/sql"
 	"io"
 	"io/fs"
+	"net/http"
+	"time"
 
 	platformbrowser "github.com/portpowered/infinite-you/pkg/platform/browser"
 	platformclock "github.com/portpowered/infinite-you/pkg/platform/clock"
@@ -28,7 +31,6 @@ import (
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
 	"github.com/portpowered/infinite-you/pkg/services/models"
-	modelswire "github.com/portpowered/infinite-you/pkg/services/models/wire"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	providercontract "github.com/portpowered/infinite-you/pkg/services/providers/wire"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
@@ -41,40 +43,61 @@ import (
 // pkg/root, pkg/wire, and BuildProcess override tests) consumes this bag;
 // constructed services take exact ports instead. It is not a service locator.
 type Edges struct {
-	CLIObserver                                     platformprocess.CLIObserver
-	PlatformProcessClock                            platformprocess.Clock
-	PlatformProcessCommandFactory                   platformprocess.CommandFactory
-	ProvidersExecutableLocator                      platformprocess.ExecutableLocator
-	ProviderCommandRunner                           platformprocess.CommandRunner
-	AgyPTYHost                                      platformpty.Host
-	AgyPTYClock                                     platformclock.Source
-	HostedHTTPClient                                automations.HostedLinearHTTPDoer
-	HostedLinearEndpoint                            string
-	HostedSecretResolver                            automations.HostedLinearSecretResolver
-	HostedLinearCheckpointStore                     automations.HostedLinearCheckpointStore
-	HostedClock                                     automations.HostedLinearClock
-	ModelAssetHTTPClient                            modelswire.AssetHTTPDoer
-	ModelAssetEndpoints                             models.RuntimeAssetEndpoints
-	ModelAssetHostPlatform                          models.AssetHostPlatform
-	ModelAssetMakeDirectories                       modelswire.AssetMakeDirectories
-	ModelAssetInspectPath                           modelswire.AssetInspectPath
-	ModelAssetResolveHomeDirectory                  modelswire.AssetResolveHomeDirectory
-	ModelAssetWriteFile                             modelswire.AssetWriteFile
-	ModelAssetRenamePath                            modelswire.AssetRenamePath
-	ModelAssetRemovePath                            modelswire.AssetRemovePath
-	ModelAssetReadFile                              modelswire.AssetReadFile
-	ModelAssetReadDirectory                         modelswire.AssetReadDirectory
-	ModelAssetCreateFile                            modelswire.AssetCreateFile
-	ModelAssetOpenFile                              modelswire.AssetOpenFile
-	ModelHostProcessLauncher                        modelswire.HostProcessLauncher
-	ModelHostHTTPClient                             modelswire.HostHTTPDoer
-	ModelHostClock                                  modelswire.HostClock
-	ModelRuntimeCommandRunner                       platformprocess.CommandRunner
-	ModelRuntimeHTTPClient                          modelswire.RuntimeHTTPDoer
-	ModelRuntimeInspectFile                         modelswire.RuntimeInspectFile
-	ModelRuntimeTempDirectory                       modelswire.RuntimeTempDirectory
-	ModelRuntimeCreateTempFile                      modelswire.RuntimeCreateTempFile
-	ModelInvocationArtifactFileSystem               modelswire.InvocationArtifactFileSystem
+	CLIObserver                   platformprocess.CLIObserver
+	PlatformProcessClock          platformprocess.Clock
+	PlatformProcessCommandFactory platformprocess.CommandFactory
+	ProvidersExecutableLocator    platformprocess.ExecutableLocator
+	ProviderCommandRunner         platformprocess.CommandRunner
+	AgyPTYHost                    platformpty.Host
+	AgyPTYClock                   platformclock.Source
+	HostedHTTPClient              automations.HostedLinearHTTPDoer
+	HostedLinearEndpoint          string
+	HostedSecretResolver          automations.HostedLinearSecretResolver
+	HostedLinearCheckpointStore   automations.HostedLinearCheckpointStore
+	HostedClock                   automations.HostedLinearClock
+	ModelAssetHTTPClient          interface {
+		Do(*http.Request) (*http.Response, error)
+	}
+	ModelAssetEndpoints            models.RuntimeAssetEndpoints
+	ModelAssetHostPlatform         models.AssetHostPlatform
+	ModelAssetMakeDirectories      AssetMakeDirectories
+	ModelAssetInspectPath          AssetInspectPath
+	ModelAssetResolveHomeDirectory AssetResolveHomeDirectory
+	ModelAssetWriteFile            AssetWriteFile
+	ModelAssetRenamePath           AssetRenamePath
+	ModelAssetRemovePath           AssetRemovePath
+	ModelAssetReadFile             AssetReadFile
+	ModelAssetReadDirectory        AssetReadDirectory
+	ModelAssetCreateFile           AssetCreateFile
+	ModelAssetOpenFile             AssetOpenFile
+	ModelHostProcessLauncher       interface {
+		Start(context.Context, HostProcessStartSpec) (interface {
+			HealthEndpoint() string
+			Wait() error
+			Stop(context.Context) error
+		}, error)
+	}
+	ModelHostHTTPClient interface {
+		Do(*http.Request) (*http.Response, error)
+	}
+	ModelHostClock interface {
+		Now() time.Time
+		NewTimer(time.Duration) interface {
+			C() <-chan time.Time
+			Stop() bool
+		}
+	}
+	ModelRuntimeCommandRunner platformprocess.CommandRunner
+	ModelRuntimeHTTPClient    interface {
+		Do(*http.Request) (*http.Response, error)
+	}
+	ModelRuntimeInspectFile           RuntimeInspectFile
+	ModelRuntimeTempDirectory         RuntimeTempDirectory
+	ModelRuntimeCreateTempFile        RuntimeCreateTempFile
+	ModelInvocationArtifactFileSystem interface {
+		Open(string) (io.ReadCloser, error)
+		Create(string) (io.WriteCloser, error)
+	}
 	FactorySessionsWorkingDirectory                 platformfilesystem.WorkingDirectory
 	FactorySessionExecutionOpeningFileSystem        factorysessions.ExecutionOpeningFileSystem
 	FactorySessionDirectoryInspection               factorysessions.DirectoryInspection
@@ -151,7 +174,7 @@ type Edges struct {
 	RuntimeHostObserver              factorysessions.RuntimeHostObserver
 	FactoryVisualizationSink         factoryvisualization.Sink
 	FactoryVisualizationRootObserver factoryvisualization.RootObserver
-	ModelPullMetricsRecorder         modelswire.PullMetricsRecorder
+	ModelPullMetricsRecorder         interface{ RecordModelPullMetric(PullMetric) }
 	ProviderOverride                 providercontract.Provider
 	providercontract.ProviderRegistrations
 	WorkersFactoryDocsFileSystem       platformfilesystem.ReadFileTree

--- a/pkg/services/edges/models_effects.go
+++ b/pkg/services/edges/models_effects.go
@@ -1,0 +1,37 @@
+package edges
+
+import (
+	"io"
+	"os"
+)
+
+// PullMetric is the process-edge representation of one managed-model pull
+// metric. Models converts this edge-owned value at its wire boundary.
+type PullMetric struct {
+	Name   string
+	Labels map[string]string
+}
+
+type AssetMakeDirectories func(string, os.FileMode) error
+type AssetInspectPath func(string) (os.FileInfo, error)
+type AssetResolveHomeDirectory func() (string, error)
+type AssetWriteFile func(string, []byte, os.FileMode) error
+type AssetRenamePath func(string, string) error
+type AssetRemovePath func(string) error
+type AssetReadFile func(string) ([]byte, error)
+type AssetReadDirectory func(string) ([]os.DirEntry, error)
+type AssetCreateFile func(string) (io.WriteCloser, error)
+type AssetOpenFile func(string) (io.ReadCloser, error)
+
+type HostProcessStartSpec struct {
+	Command                 string
+	Args, Env               []string
+	WorkDir, HealthEndpoint string
+}
+
+type RuntimeInspectFile func(string) (os.FileInfo, error)
+type RuntimeTempDirectory func() string
+type RuntimeCreateTempFile func(string, string) (interface {
+	Close() error
+	Name() string
+}, error)

--- a/pkg/wire/model_invocation_edges_test.go
+++ b/pkg/wire/model_invocation_edges_test.go
@@ -6,12 +6,26 @@ import (
 	"io"
 	"io/fs"
 	"runtime"
+	"strings"
 	"testing"
+	"time"
 
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	models "github.com/portpowered/infinite-you/pkg/services/models"
+	modelswire "github.com/portpowered/infinite-you/pkg/services/models/wire"
+)
+
+var (
+	_ modelswire.AssetHTTPDoer                = serviceedges.Edges{}.ModelAssetHTTPClient
+	_ modelswire.HostHTTPDoer                 = serviceedges.Edges{}.ModelHostHTTPClient
+	_ modelswire.RuntimeHTTPDoer              = serviceedges.Edges{}.ModelRuntimeHTTPClient
+	_ modelswire.InvocationArtifactFileSystem = serviceedges.Edges{}.ModelInvocationArtifactFileSystem
+	_ modelswire.HostProcessLauncher          = modelHostProcessLauncherAdapter{}
+	_ modelswire.HostClock                    = modelHostClockAdapter{}
+	_ modelswire.RuntimeCreateTempFile        = adaptModelRuntimeTempFile(nil)
+	_ modelswire.PullMetricsRecorder          = modelsPullMetricsAdapter{}
 )
 
 func TestModelsServiceIsConstructedOnceAndOpensRuntimeScopeOnSameRoot(t *testing.T) {
@@ -156,4 +170,168 @@ func TestModelAssetHostPlatformPreservesOverrideAndSelectsProcessDefault(t *test
 	if got := provideModelAssetHostPlatform(serviceedges.Edges{ModelAssetHostPlatform: override}); got != override {
 		t.Fatalf("model asset host platform override = %#v, want %#v", got, override)
 	}
+}
+
+func TestModelsCompositionAdaptsEdgePortsAtTheWireBoundary(t *testing.T) {
+	t.Parallel()
+
+	process := &modelEdgeManagedProcess{healthEndpoint: "http://model-host/health"}
+	var gotSpec serviceedges.HostProcessStartSpec
+	launcher := adaptModelHostProcessLauncher(&modelEdgeProcessLauncher{
+		process: process,
+		gotSpec: &gotSpec,
+	})
+	gotProcess, err := launcher.Start(context.Background(), modelswire.HostProcessStartSpec{
+		Command: "model-host", Args: []string{"serve"}, Env: []string{"MODEL=seal"},
+		WorkDir: "runtime", HealthEndpoint: process.healthEndpoint,
+	})
+	if err != nil {
+		t.Fatalf("adapted process launcher: %v", err)
+	}
+	if gotSpec.Command != "model-host" || len(gotSpec.Args) != 1 || gotSpec.Args[0] != "serve" ||
+		len(gotSpec.Env) != 1 || gotSpec.Env[0] != "MODEL=seal" || gotSpec.WorkDir != "runtime" ||
+		gotSpec.HealthEndpoint != process.healthEndpoint {
+		t.Fatalf("adapted process spec = %#v, want exact edge projection", gotSpec)
+	}
+	if gotProcess.HealthEndpoint() != process.healthEndpoint {
+		t.Fatalf("adapted process health endpoint = %q, want %q", gotProcess.HealthEndpoint(), process.healthEndpoint)
+	}
+	if err := gotProcess.Stop(context.Background()); err != nil {
+		t.Fatalf("adapted managed process Stop: %v", err)
+	}
+	if !process.stopped {
+		t.Fatal("adapted managed process did not preserve the edge process")
+	}
+
+	timer := &modelEdgeTimer{}
+	clock := adaptModelHostClock(modelEdgeClock{timer: timer})
+	if got := clock.Now(); !got.Equal(modelEdgeClockTime) {
+		t.Fatalf("adapted host clock Now = %v, want %v", got, modelEdgeClockTime)
+	}
+	if got := clock.NewTimer(time.Second); got != timer {
+		t.Fatal("adapted host clock did not preserve the edge timer")
+	}
+
+	tempFile := &modelEdgeTempFile{name: "runtime.tmp"}
+	createTempFile := adaptModelRuntimeTempFile(func(string, string) (interface {
+		Close() error
+		Name() string
+	}, error) {
+		return tempFile, nil
+	})
+	gotTempFile, err := createTempFile("runtime", "model-*")
+	if err != nil {
+		t.Fatalf("adapted runtime temp file: %v", err)
+	}
+	if gotTempFile.Name() != tempFile.name {
+		t.Fatalf("adapted temp file name = %q, want %q", gotTempFile.Name(), tempFile.name)
+	}
+
+	labels := map[string]string{"model": "seal"}
+	recorder := &modelEdgePullMetricsRecorder{}
+	adaptedRecorder := adaptModelsPullMetricsRecorder(recorder)
+	adaptedRecorder.RecordModelPullMetric(modelswire.PullMetric{Name: "model.pull", Labels: labels})
+	labels["model"] = "mutated-after-record"
+	if recorder.metric.Name != "model.pull" || recorder.metric.Labels["model"] != "seal" {
+		t.Fatalf("adapted pull metric = %#v, want copied edge metric", recorder.metric)
+	}
+}
+
+func TestModelsCompositionRejectsTypedNilHostEdges(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		edges serviceedges.Edges
+		want  string
+	}{
+		{
+			name: "process launcher",
+			edges: serviceedges.Edges{
+				ModelHostProcessLauncher: (*modelEdgeProcessLauncher)(nil),
+			},
+			want: "model host process launcher is required",
+		},
+		{
+			name: "clock",
+			edges: serviceedges.Edges{
+				ModelHostClock: (*modelEdgeClock)(nil),
+			},
+			want: "model host clock is required",
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := provideModelsService(testCase.edges)
+			if err == nil || !strings.Contains(err.Error(), testCase.want) {
+				t.Fatalf("provideModelsService() error = %v, want %q", err, testCase.want)
+			}
+		})
+	}
+}
+
+var modelEdgeClockTime = time.Unix(1_725_000_000, 0)
+
+type modelEdgeManagedProcess struct {
+	healthEndpoint string
+	stopped        bool
+}
+
+func (process *modelEdgeManagedProcess) HealthEndpoint() string { return process.healthEndpoint }
+func (*modelEdgeManagedProcess) Wait() error                    { return nil }
+func (process *modelEdgeManagedProcess) Stop(context.Context) error {
+	process.stopped = true
+	return nil
+}
+
+type modelEdgeProcessLauncher struct {
+	process *modelEdgeManagedProcess
+	gotSpec *serviceedges.HostProcessStartSpec
+}
+
+func (launcher *modelEdgeProcessLauncher) Start(
+	_ context.Context,
+	spec serviceedges.HostProcessStartSpec,
+) (interface {
+	HealthEndpoint() string
+	Wait() error
+	Stop(context.Context) error
+}, error) {
+	*launcher.gotSpec = spec
+	return launcher.process, nil
+}
+
+type modelEdgeTimer struct{}
+
+func (*modelEdgeTimer) C() <-chan time.Time { return nil }
+func (*modelEdgeTimer) Stop() bool          { return true }
+
+type modelEdgeClock struct {
+	timer interface {
+		C() <-chan time.Time
+		Stop() bool
+	}
+}
+
+func (modelEdgeClock) Now() time.Time { return modelEdgeClockTime }
+func (clock modelEdgeClock) NewTimer(time.Duration) interface {
+	C() <-chan time.Time
+	Stop() bool
+} {
+	return clock.timer
+}
+
+type modelEdgeTempFile struct {
+	name string
+}
+
+func (file *modelEdgeTempFile) Close() error { return nil }
+func (file *modelEdgeTempFile) Name() string { return file.name }
+
+type modelEdgePullMetricsRecorder struct {
+	metric serviceedges.PullMetric
+}
+
+func (recorder *modelEdgePullMetricsRecorder) RecordModelPullMetric(metric serviceedges.PullMetric) {
+	recorder.metric = metric
 }

--- a/pkg/wire/models_runtime.go
+++ b/pkg/wire/models_runtime.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -117,14 +118,17 @@ func provideModelsService(edges serviceedges.Edges) (models.Service, error) {
 	}
 	runtimeTempFile := edges.ModelRuntimeCreateTempFile
 	if runtimeTempFile == nil {
-		runtimeTempFile = func(dir, pattern string) (modelswire.RuntimeTempFile, error) {
+		runtimeTempFile = func(dir, pattern string) (interface {
+			Close() error
+			Name() string
+		}, error) {
 			return os.CreateTemp(dir, pattern)
 		}
 	}
 
 	return modelswire.NewService(
 		assetPlatform,
-		modelswire.AssetHTTPDoer(assetHTTP),
+		assetHTTP,
 		assetEndpoints,
 		modelswire.AssetMakeDirectories(assetMkdirAll),
 		modelswire.AssetInspectPath(assetStat),
@@ -136,18 +140,18 @@ func provideModelsService(edges serviceedges.Edges) (models.Service, error) {
 		modelswire.AssetReadDirectory(assetReadDir),
 		modelswire.AssetCreateFile(assetCreate),
 		modelswire.AssetOpenFile(assetOpen),
-		launcher,
+		adaptModelHostProcessLauncher(launcher),
 		hostHTTP,
-		hostClock,
+		adaptModelHostClock(hostClock),
 		runtimeRunner,
-		modelswire.RuntimeHTTPDoer(runtimeHTTP),
+		runtimeHTTP,
 		modelswire.RuntimeInspectFile(runtimeInspect),
 		modelswire.RuntimeTempDirectory(runtimeTempDir),
-		runtimeTempFile,
+		adaptModelRuntimeTempFile(runtimeTempFile),
 		zap.NewNop(),
 		time.Now,
 		platformrandom.CryptoSource{},
-		edges.ModelPullMetricsRecorder,
+		adaptModelsPullMetricsRecorder(edges.ModelPullMetricsRecorder),
 		modelswire.HostDiagnosticLogger(factorysessionwire.ModelHostDiagnosticLogger(zap.NewNop())),
 		modelswire.HostMetricsRecorder(factorysessionwire.ModelHostDiagnosticMetrics(edges.InvocationMetricsRecorder)),
 		modelLocalRuntimeHooks(workerswire.LocalRuntimeHooks()),
@@ -185,7 +189,10 @@ type modelsClock struct{}
 
 func (modelsClock) Now() time.Time { return time.Now() }
 
-func (modelsClock) NewTimer(duration time.Duration) modelswire.HostTimer {
+func (modelsClock) NewTimer(duration time.Duration) interface {
+	C() <-chan time.Time
+	Stop() bool
+} {
 	return modelsTimer{Timer: time.NewTimer(duration)}
 }
 
@@ -195,7 +202,11 @@ func (timer modelsTimer) C() <-chan time.Time { return timer.Timer.C }
 
 type modelsProcessLauncher struct{}
 
-func (modelsProcessLauncher) Start(ctx context.Context, spec modelswire.HostProcessStartSpec) (modelswire.HostManagedProcess, error) {
+func (modelsProcessLauncher) Start(ctx context.Context, spec serviceedges.HostProcessStartSpec) (interface {
+	HealthEndpoint() string
+	Wait() error
+	Stop(context.Context) error
+}, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -220,6 +231,128 @@ func (modelsProcessLauncher) Start(ctx context.Context, spec modelswire.HostProc
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
 	return &modelsManagedProcess{cmd: cmd, healthEndpoint: endpoint, done: done}, nil
+}
+
+type modelHostProcessLauncherAdapter struct {
+	next interface {
+		Start(context.Context, serviceedges.HostProcessStartSpec) (interface {
+			HealthEndpoint() string
+			Wait() error
+			Stop(context.Context) error
+		}, error)
+	}
+}
+
+func adaptModelHostProcessLauncher(next interface {
+	Start(context.Context, serviceedges.HostProcessStartSpec) (interface {
+		HealthEndpoint() string
+		Wait() error
+		Stop(context.Context) error
+	}, error)
+}) modelswire.HostProcessLauncher {
+	if isNilModelEdgeDependency(next) {
+		return nil
+	}
+	return modelHostProcessLauncherAdapter{next: next}
+}
+
+func (adapter modelHostProcessLauncherAdapter) Start(
+	ctx context.Context,
+	spec modelswire.HostProcessStartSpec,
+) (modelswire.HostManagedProcess, error) {
+	process, err := adapter.next.Start(ctx, serviceedges.HostProcessStartSpec{
+		Command:        spec.Command,
+		Args:           spec.Args,
+		Env:            spec.Env,
+		WorkDir:        spec.WorkDir,
+		HealthEndpoint: spec.HealthEndpoint,
+	})
+	if err != nil || process == nil {
+		return modelswire.HostManagedProcess(process), err
+	}
+	return modelswire.HostManagedProcess(process), nil
+}
+
+type modelHostClockAdapter struct {
+	next interface {
+		Now() time.Time
+		NewTimer(time.Duration) interface {
+			C() <-chan time.Time
+			Stop() bool
+		}
+	}
+}
+
+func adaptModelHostClock(next interface {
+	Now() time.Time
+	NewTimer(time.Duration) interface {
+		C() <-chan time.Time
+		Stop() bool
+	}
+}) modelswire.HostClock {
+	if isNilModelEdgeDependency(next) {
+		return nil
+	}
+	return modelHostClockAdapter{next: next}
+}
+
+func (adapter modelHostClockAdapter) Now() time.Time { return adapter.next.Now() }
+
+func (adapter modelHostClockAdapter) NewTimer(duration time.Duration) modelswire.HostTimer {
+	return modelswire.HostTimer(adapter.next.NewTimer(duration))
+}
+
+func adaptModelRuntimeTempFile(next serviceedges.RuntimeCreateTempFile) modelswire.RuntimeCreateTempFile {
+	if next == nil {
+		return nil
+	}
+	return func(dir, pattern string) (modelswire.RuntimeTempFile, error) {
+		file, err := next(dir, pattern)
+		return modelswire.RuntimeTempFile(file), err
+	}
+}
+
+type modelsPullMetricsAdapter struct {
+	next interface {
+		RecordModelPullMetric(serviceedges.PullMetric)
+	}
+}
+
+func adaptModelsPullMetricsRecorder(next interface {
+	RecordModelPullMetric(serviceedges.PullMetric)
+}) modelswire.PullMetricsRecorder {
+	if next == nil {
+		return nil
+	}
+	return modelsPullMetricsAdapter{next: next}
+}
+
+// isNilModelEdgeDependency preserves Models Wire's typed-nil validation when
+// an edge-owned interface is wrapped by a canonical adapter. Without this
+// check, a nil pointer would become a non-nil adapter value and fail later at
+// invocation rather than during inert construction.
+func isNilModelEdgeDependency(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
+func (adapter modelsPullMetricsAdapter) RecordModelPullMetric(metric modelswire.PullMetric) {
+	labels := make(map[string]string, len(metric.Labels))
+	for key, value := range metric.Labels {
+		labels[key] = value
+	}
+	adapter.next.RecordModelPullMetric(serviceedges.PullMetric{
+		Name:   metric.Name,
+		Labels: labels,
+	})
 }
 
 func modelLocalRuntimeHooks(hooks workers.LocalRuntimeHooks) modelswire.LocalRuntimeHooks {

--- a/pkg/wire/runtime_inputs.go
+++ b/pkg/wire/runtime_inputs.go
@@ -267,7 +267,9 @@ func projectRuntimeOpeningExternalEffects(edges serviceedges.Edges) factorysessi
 }
 
 type factorySessionModelPullMetricsAdapter struct {
-	next modelswire.PullMetricsRecorder
+	next interface {
+		RecordModelPullMetric(serviceedges.PullMetric)
+	}
 }
 
 func (adapter factorySessionModelPullMetricsAdapter) RecordModelPullMetric(
@@ -280,14 +282,16 @@ func (adapter factorySessionModelPullMetricsAdapter) RecordModelPullMetric(
 	for key, value := range metric.Labels {
 		labels[key] = value
 	}
-	adapter.next.RecordModelPullMetric(modelswire.PullMetric{
+	adapter.next.RecordModelPullMetric(serviceedges.PullMetric{
 		Name:   metric.Name,
 		Labels: labels,
 	})
 }
 
 func adaptModelPullMetricsRecorder(
-	recorder modelswire.PullMetricsRecorder,
+	recorder interface {
+		RecordModelPullMetric(serviceedges.PullMetric)
+	},
 ) factorysessionwire.ModelPullMetricsRecorder {
 	if recorder == nil {
 		return nil

--- a/tests/functional/models/model_invoke/cli_test.go
+++ b/tests/functional/models/model_invoke/cli_test.go
@@ -17,7 +17,6 @@ import (
 	root "github.com/portpowered/infinite-you/pkg/root"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
-	modelswire "github.com/portpowered/infinite-you/pkg/services/models/wire"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 )
 
@@ -185,8 +184,12 @@ type processModelLauncher struct {
 
 func (launcher *processModelLauncher) Start(
 	context.Context,
-	modelswire.HostProcessStartSpec,
-) (modelswire.HostManagedProcess, error) {
+	serviceedges.HostProcessStartSpec,
+) (interface {
+	HealthEndpoint() string
+	Wait() error
+	Stop(context.Context) error
+}, error) {
 	launcher.mu.Lock()
 	defer launcher.mu.Unlock()
 	return &processModelProcess{endpoint: launcher.endpoint, stopped: make(chan struct{})}, nil

--- a/tests/functional/models/root_composition/build_process_inert_test.go
+++ b/tests/functional/models/root_composition/build_process_inert_test.go
@@ -13,7 +13,6 @@ import (
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	models "github.com/portpowered/infinite-you/pkg/services/models"
-	modelswire "github.com/portpowered/infinite-you/pkg/services/models/wire"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
@@ -198,7 +197,11 @@ func (recorder *modelEffectRecorder) recordAssetOpen(string) (io.ReadCloser, err
 	return nil, errRecordingModelEffect
 }
 
-func (recorder *modelEffectRecorder) Start(context.Context, modelswire.HostProcessStartSpec) (modelswire.HostManagedProcess, error) {
+func (recorder *modelEffectRecorder) Start(context.Context, serviceedges.HostProcessStartSpec) (interface {
+	HealthEndpoint() string
+	Wait() error
+	Stop(context.Context) error
+}, error) {
 	recorder.hostLauncher.Add(1)
 	return nil, errRecordingModelEffect
 }
@@ -208,7 +211,10 @@ func (recorder *modelEffectRecorder) Now() time.Time {
 	return time.Unix(0, 0).UTC()
 }
 
-func (recorder *modelEffectRecorder) NewTimer(time.Duration) modelswire.HostTimer {
+func (recorder *modelEffectRecorder) NewTimer(time.Duration) interface {
+	C() <-chan time.Time
+	Stop() bool
+} {
 	recorder.hostClockTimer.Add(1)
 	return recordingModelHostTimer{}
 }
@@ -233,7 +239,10 @@ func (recorder *modelEffectRecorder) recordRuntimeTempDir() string {
 	return ""
 }
 
-func (recorder *modelEffectRecorder) recordRuntimeTempFile(string, string) (modelswire.RuntimeTempFile, error) {
+func (recorder *modelEffectRecorder) recordRuntimeTempFile(string, string) (interface {
+	Close() error
+	Name() string
+}, error) {
 	recorder.runtimeTempFile.Add(1)
 	return nil, errRecordingModelEffect
 }
@@ -248,6 +257,6 @@ func (recorder *modelEffectRecorder) Create(string) (io.WriteCloser, error) {
 	return nil, errRecordingModelEffect
 }
 
-func (recorder *modelEffectRecorder) RecordModelPullMetric(modelswire.PullMetric) {
+func (recorder *modelEffectRecorder) RecordModelPullMetric(serviceedges.PullMetric) {
 	recorder.pullMetrics.Add(1)
 }

--- a/tests/functional/models/root_composition/readiness_assets_host_test.go
+++ b/tests/functional/models/root_composition/readiness_assets_host_test.go
@@ -16,7 +16,6 @@ import (
 
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
-	modelswire "github.com/portpowered/infinite-you/pkg/services/models/wire"
 	runcli "github.com/portpowered/infinite-you/pkg/transports/cli/run"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
@@ -305,8 +304,12 @@ type recordingModelHostLauncher struct {
 
 func (launcher *recordingModelHostLauncher) Start(
 	context.Context,
-	modelswire.HostProcessStartSpec,
-) (modelswire.HostManagedProcess, error) {
+	serviceedges.HostProcessStartSpec,
+) (interface {
+	HealthEndpoint() string
+	Wait() error
+	Stop(context.Context) error
+}, error) {
 	launcher.mu.Lock()
 	launcher.calls++
 	endpoint := launcher.endpoint


### PR DESCRIPTION
## Summary`n`n- move Models asset, host, runtime, invocation-artifact, and pull-metric effect ports into `pkg/services/edges``n- adapt those exact edge contracts at the canonical `pkg/wire` Models construction boundary`n- keep the Models root unary and add focused ownership, compile-time, behavior, composition, and root-construction proofs`n`n## Root cause`n`n`pkg/services/edges/definition.go` depended on the peer construction package `pkg/services/models/wire`, which violates the documented process-edge exception and fails `make pkg-boundary`. This atom removes that dependency without adding Models-root interfaces or aliases.`n`n## Verification`n`nFocused package and composition tests pass:`n`n`go test ./pkg/services/edges ./pkg/services/models/wire ./pkg/wire ./pkg/root ./tests/functional/models/root_composition ./tests/functional/models/model_invoke -count=1`n`nThe broader repository gates are being run against this exact draft head. Existing repository-wide boundary noise is being reported separately; no baseline, exception, floor, or suppression changes are included.