### PR TITLE
Require explicit Operator Settings identity generation

### DIFF
--- a/pkg/services/operator_settings/root_wire_behavioral_boundary_test.go
+++ b/pkg/services/operator_settings/root_wire_behavioral_boundary_test.go
@@ -132,6 +132,7 @@ func TestRootWireBehavioralBoundary_PublishedServicePreservesBackendScopeAndConf
 	root, err := settingswire.NewServiceFromConfigDocument(
 		rootWireConfigDocumentService(),
 		internaltestproviders.StandardCatalog(),
+		func() string { return "00000000-0000-4000-8000-000000000001" },
 	)
 	if err != nil {
 		t.Fatalf("NewServiceFromConfigDocument() = %v", err)
@@ -271,6 +272,7 @@ func newRootWireBehavioralService(t *testing.T) operatorsettings.Service {
 		globalconfigmapping.Encode,
 		rootWireProviderCatalog,
 		providersRoot,
+		func() string { return "00000000-0000-4000-8000-000000000001" },
 	)
 	if err != nil {
 		t.Fatalf("NewService() = %v", err)

--- a/pkg/services/operator_settings/transports/cli/service_parity_test.go
+++ b/pkg/services/operator_settings/transports/cli/service_parity_test.go
@@ -400,6 +400,7 @@ func paritySettingsRoot(t *testing.T) operatorsettings.Service {
 	root, err := settingswire.NewServiceFromConfigDocument(
 		parityTestConfigService(),
 		internaltestproviders.StandardCatalog(),
+		func() string { return "00000000-0000-4000-8000-000000000001" },
 	)
 	if err != nil {
 		t.Fatalf("NewServiceFromConfigDocument() error = %v", err)

--- a/pkg/services/operator_settings/wire/behavioral_preservation_test.go
+++ b/pkg/services/operator_settings/wire/behavioral_preservation_test.go
@@ -42,6 +42,7 @@ func TestWireFoldPreservesDocumentIdentityResolutionAndConfigBehavior(t *testing
 	root, err := settingswire.NewServiceFromConfigDocument(
 		testConfigDocumentService(),
 		internaltestproviders.StandardCatalog(),
+		testIDGenerator(),
 	)
 	if err != nil {
 		t.Fatalf("NewServiceFromConfigDocument() error = %v", err)
@@ -141,6 +142,7 @@ func TestWireFoldPreservesDefaultsResolutionFromHomeOwnershipPath(t *testing.T) 
 		platformfilesystem.Local{},
 		globalconfigmapping.Decode,
 		internaltestproviders.StandardCatalog(),
+		testIDGenerator(),
 	)
 	if err != nil {
 		t.Fatalf("NewServiceFromHomePorts() error = %v", err)
@@ -171,6 +173,7 @@ func TestWireFoldDefaultsResolutionFromHomeRejectsMissingFilesystemPorts(t *test
 		nil,
 		globalconfigmapping.Decode,
 		internaltestproviders.StandardCatalog(),
+		testIDGenerator(),
 	)
 	if err == nil || !strings.Contains(err.Error(), "filesystem is required") {
 		t.Fatalf("NewServiceFromHomePorts() error = %v, want home-port construction failure", err)

--- a/pkg/services/operator_settings/wire/composition_test.go
+++ b/pkg/services/operator_settings/wire/composition_test.go
@@ -21,6 +21,7 @@ func TestNewServiceFromConfigDocumentRequiresDocumentPorts(t *testing.T) {
 	_, err := settingswire.NewServiceFromConfigDocument(
 		operatorsettings.ConfigDocumentService{},
 		internaltestproviders.StandardCatalog(),
+		testIDGenerator(),
 	)
 	if err == nil || !strings.Contains(err.Error(), "operator settings document ports are required") {
 		t.Fatalf("NewServiceFromConfigDocument() error = %v, want document ports required", err)
@@ -33,6 +34,7 @@ func TestNewServiceFromConfigDocumentConstructsFromPorts(t *testing.T) {
 	root, err := settingswire.NewServiceFromConfigDocument(
 		testConfigDocumentService(),
 		internaltestproviders.StandardCatalog(),
+		testIDGenerator(),
 	)
 	if err != nil {
 		t.Fatalf("NewServiceFromConfigDocument() error = %v", err)
@@ -57,6 +59,7 @@ func TestNewServiceFromConfigDocumentUsesInjectedDocumentOwner(t *testing.T) {
 	root, err := settingswire.NewServiceFromConfigDocument(
 		service,
 		internaltestproviders.StandardCatalog(),
+		testIDGenerator(),
 	)
 	if err != nil {
 		t.Fatalf("NewServiceFromConfigDocument() error = %v", err)
@@ -104,6 +107,7 @@ func TestWireCompositionDelegatesDocumentAndResolutionOperations(t *testing.T) {
 	root, err := settingswire.NewServiceFromConfigDocument(
 		testConfigDocumentService(),
 		internaltestproviders.StandardCatalog(),
+		testIDGenerator(),
 	)
 	if err != nil {
 		t.Fatalf("NewServiceFromConfigDocument() error = %v", err)
@@ -159,6 +163,19 @@ func TestWireCompositionDelegatesDocumentAndResolutionOperations(t *testing.T) {
 	})
 	if !errors.Is(err, operatorsettings.ErrResolutionUnsupportedOverride) {
 		t.Fatalf("unsupported override error = %v, want ErrResolutionUnsupportedOverride", err)
+	}
+}
+
+func TestNewServiceFromConfigDocumentRejectsMissingIDGenerator(t *testing.T) {
+	t.Parallel()
+
+	_, err := settingswire.NewServiceFromConfigDocument(
+		testConfigDocumentService(),
+		internaltestproviders.StandardCatalog(),
+		nil,
+	)
+	if err == nil || err.Error() != "operator settings ID generator is required" {
+		t.Fatalf("NewServiceFromConfigDocument() error = %v, want missing ID generator", err)
 	}
 }
 

--- a/pkg/services/operator_settings/wire/consumer_edge_preservation_test.go
+++ b/pkg/services/operator_settings/wire/consumer_edge_preservation_test.go
@@ -115,6 +115,7 @@ func newPreservationWireService(t *testing.T) operatorsettings.Service {
 		globalconfigmapping.Encode,
 		preservationProviderCatalog,
 		providersRoot,
+		testIDGenerator(),
 	)
 	if err != nil {
 		t.Fatalf("NewService() = %v", err)

--- a/pkg/services/operator_settings/wire/legacy_packages_behavior_preservation_test.go
+++ b/pkg/services/operator_settings/wire/legacy_packages_behavior_preservation_test.go
@@ -29,6 +29,7 @@ func TestWireLegacyPackagesFoldPreservesExistingBackendScopeIdentity(t *testing.
 	root, err := settingswire.NewServiceFromConfigDocument(
 		testConfigDocumentService(),
 		internaltestproviders.StandardCatalog(),
+		testIDGenerator(),
 	)
 	if err != nil {
 		t.Fatalf("NewServiceFromConfigDocument() error = %v", err)
@@ -104,6 +105,7 @@ func TestWireLegacyPackagesFoldPreservesRootBehaviorWithRelocatedTestHelpers(t *
 		globalconfigmapping.Encode,
 		preservationProviderCatalog,
 		providersRoot,
+		testIDGenerator(),
 	)
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)

--- a/pkg/services/operator_settings/wire/service_from_config_document.go
+++ b/pkg/services/operator_settings/wire/service_from_config_document.go
@@ -3,8 +3,6 @@ package wire
 import (
 	"fmt"
 
-	"github.com/google/uuid"
-
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	operatorservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/service"
 	settingsdocument "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document"
@@ -17,7 +15,7 @@ import (
 func NewServiceFromConfigDocument(
 	service operatorsettings.ConfigDocumentService,
 	providersRoot providers.Service,
-	idGenerators ...operatorsettings.IDGenerator,
+	idGenerator operatorsettings.IDGenerator,
 ) (operatorsettings.Service, error) {
 	if providersRoot == nil {
 		return nil, fmt.Errorf("operator settings providers root is required")
@@ -34,13 +32,12 @@ func NewServiceFromConfigDocument(
 	if !ok {
 		return nil, fmt.Errorf("operator settings document owner must implement the private document service")
 	}
+	if idGenerator == nil {
+		return nil, fmt.Errorf("operator settings ID generator is required")
+	}
 	resolution, err := resolutionwire.NewService(providersRoot)
 	if err != nil {
 		return nil, err
-	}
-	idGenerator := operatorsettings.IDGenerator(uuid.NewString)
-	if len(idGenerators) > 0 && idGenerators[0] != nil {
-		idGenerator = idGenerators[0]
 	}
 	return operatorservice.New(
 		document,

--- a/pkg/services/operator_settings/wire/service_from_home_ports.go
+++ b/pkg/services/operator_settings/wire/service_from_home_ports.go
@@ -3,8 +3,6 @@ package wire
 import (
 	"fmt"
 
-	"github.com/google/uuid"
-
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	operatorservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/service"
 	documentwire "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/wire"
@@ -18,7 +16,7 @@ func NewServiceFromHomePorts(
 	files operatorsettings.FileSystem,
 	decode operatorsettings.ConfigDecoder,
 	providersRoot providers.Service,
-	idGenerators ...operatorsettings.IDGenerator,
+	idGenerator operatorsettings.IDGenerator,
 ) (operatorsettings.Service, error) {
 	if files == nil {
 		return nil, fmt.Errorf("operator settings filesystem is required")
@@ -29,9 +27,8 @@ func NewServiceFromHomePorts(
 	if providersRoot == nil {
 		return nil, fmt.Errorf("operator settings providers root is required")
 	}
-	idGenerator := operatorsettings.IDGenerator(uuid.NewString)
-	if len(idGenerators) > 0 && idGenerators[0] != nil {
-		idGenerator = idGenerators[0]
+	if idGenerator == nil {
+		return nil, fmt.Errorf("operator settings ID generator is required")
 	}
 	document := documentwire.NewService(files, nil, decode, nil, nil)
 	resolution, err := resolutionwire.NewService(providersRoot)

--- a/pkg/services/operator_settings/wire/service_from_home_ports_test.go
+++ b/pkg/services/operator_settings/wire/service_from_home_ports_test.go
@@ -16,7 +16,7 @@ import (
 func TestNewServiceFromHomePortsRequiresFilesystem(t *testing.T) {
 	t.Parallel()
 
-	_, err := settingswire.NewServiceFromHomePorts(nil, globalconfigmapping.Decode, internaltestproviders.StandardCatalog())
+	_, err := settingswire.NewServiceFromHomePorts(nil, globalconfigmapping.Decode, internaltestproviders.StandardCatalog(), testIDGenerator())
 	if err == nil || !strings.Contains(err.Error(), "filesystem is required") {
 		t.Fatalf("NewServiceFromHomePorts(nil, decode) error = %v, want filesystem required", err)
 	}
@@ -25,7 +25,7 @@ func TestNewServiceFromHomePortsRequiresFilesystem(t *testing.T) {
 func TestNewServiceFromHomePortsRequiresDecoder(t *testing.T) {
 	t.Parallel()
 
-	_, err := settingswire.NewServiceFromHomePorts(platformfilesystem.Local{}, nil, internaltestproviders.StandardCatalog())
+	_, err := settingswire.NewServiceFromHomePorts(platformfilesystem.Local{}, nil, internaltestproviders.StandardCatalog(), testIDGenerator())
 	if err == nil || !strings.Contains(err.Error(), "decoder is required") {
 		t.Fatalf("NewServiceFromHomePorts(files, nil) error = %v, want decoder required", err)
 	}
@@ -38,6 +38,7 @@ func TestNewServiceFromHomePortsConstructsAcceptedSettingsRoot(t *testing.T) {
 		platformfilesystem.Local{},
 		globalconfigmapping.Decode,
 		internaltestproviders.StandardCatalog(),
+		testIDGenerator(),
 	)
 	if err != nil {
 		t.Fatalf("NewServiceFromHomePorts() error = %v", err)
@@ -68,6 +69,7 @@ func TestResolveFromHomeViaSettingsCLIAdapterOwnershipPath(t *testing.T) {
 		platformfilesystem.Local{},
 		globalconfigmapping.Decode,
 		internaltestproviders.StandardCatalog(),
+		testIDGenerator(),
 	)
 	if err != nil {
 		t.Fatalf("NewServiceFromHomePorts() error = %v", err)
@@ -95,8 +97,23 @@ func TestResolveFromHomeViaSettingsCLIRejectsMissingFilesystemPorts(t *testing.T
 		nil,
 		globalconfigmapping.Decode,
 		internaltestproviders.StandardCatalog(),
+		testIDGenerator(),
 	)
 	if err == nil || !strings.Contains(err.Error(), "filesystem is required") {
 		t.Fatalf("NewServiceFromHomePorts() error = %v, want home-port construction failure", err)
+	}
+}
+
+func TestNewServiceFromHomePortsRejectsMissingIDGenerator(t *testing.T) {
+	t.Parallel()
+
+	_, err := settingswire.NewServiceFromHomePorts(
+		platformfilesystem.Local{},
+		globalconfigmapping.Decode,
+		internaltestproviders.StandardCatalog(),
+		nil,
+	)
+	if err == nil || err.Error() != "operator settings ID generator is required" {
+		t.Fatalf("NewServiceFromHomePorts() error = %v, want missing ID generator", err)
 	}
 }

--- a/pkg/services/operator_settings/wire/wire.go
+++ b/pkg/services/operator_settings/wire/wire.go
@@ -9,7 +9,6 @@ package wire
 import (
 	"fmt"
 
-	"github.com/google/uuid"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	operatorservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/service"
 	documentwire "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/wire"
@@ -28,7 +27,7 @@ func NewService(
 	encoder operatorsettings.ConfigEncoder,
 	providersCatalog operatorsettings.ProviderCatalog,
 	providersRoot providers.Service,
-	idGenerators ...operatorsettings.IDGenerator,
+	idGenerator operatorsettings.IDGenerator,
 ) (operatorsettings.Service, error) {
 	if err := validateNewServiceInputs(
 		files,
@@ -39,6 +38,9 @@ func NewService(
 		providersRoot,
 	); err != nil {
 		return nil, err
+	}
+	if idGenerator == nil {
+		return nil, fmt.Errorf("construct Operator Settings: ID generator is required")
 	}
 
 	documentService := documentwire.NewService(
@@ -51,10 +53,6 @@ func NewService(
 	resolutionService, err := resolutionwire.NewService(providersRoot)
 	if err != nil {
 		return nil, err
-	}
-	idGenerator := operatorsettings.IDGenerator(uuid.NewString)
-	if len(idGenerators) > 0 && idGenerators[0] != nil {
-		idGenerator = idGenerators[0]
 	}
 	return operatorservice.New(
 		documentService,

--- a/pkg/services/operator_settings/wire/wire_test.go
+++ b/pkg/services/operator_settings/wire/wire_test.go
@@ -4,15 +4,23 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
 
+	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	internaltestproviders "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/testproviders"
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
 )
+
+func testIDGenerator() operatorsettings.IDGenerator {
+	return func() string { return "00000000-0000-4000-8000-000000000001" }
+}
 
 func TestNewServiceConstructsPublishedRoot(t *testing.T) {
 	t.Parallel()
@@ -26,6 +34,7 @@ func TestNewServiceConstructsPublishedRoot(t *testing.T) {
 		stubConfigEncoder,
 		stubProviderCatalog,
 		providersRoot,
+		testIDGenerator(),
 	)
 	if err != nil {
 		t.Fatalf("NewService() = %v", err)
@@ -52,6 +61,7 @@ func TestNewServiceServesPublishedPeerBehavior(t *testing.T) {
 		stubConfigEncoder,
 		stubProviderCatalog,
 		providersRoot,
+		testIDGenerator(),
 	)
 	if err != nil {
 		t.Fatalf("NewService() = %v", err)
@@ -103,6 +113,39 @@ func TestNewServiceServesPublishedPeerBehavior(t *testing.T) {
 	}
 }
 
+func TestNewServiceUsesInjectedIDGeneratorForBackendScope(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("WriteFile(config) = %v", err)
+	}
+
+	service, err := settingswire.NewService(
+		platformfilesystem.Local{},
+		func(dir, pattern string) (operatorsettings.TemporaryFile, error) {
+			return os.CreateTemp(dir, pattern)
+		},
+		globalconfigmapping.Decode,
+		globalconfigmapping.Encode,
+		stubProviderCatalog,
+		internaltestproviders.StandardCatalog(),
+		testIDGenerator(),
+	)
+	if err != nil {
+		t.Fatalf("NewService() = %v", err)
+	}
+
+	resolved, err := service.EnsureLocalBackendScope(configPath)
+	if err != nil {
+		t.Fatalf("EnsureLocalBackendScope() = %v", err)
+	}
+	want := operatorsettings.LocalBackendScopePrefix + "00000000-0000-4000-8000-000000000001"
+	if resolved.BackendScopeID != want || resolved.Outcome != operatorsettings.BackendScopeOutcomeGenerated {
+		t.Fatalf("EnsureLocalBackendScope() = %#v, want generated scope %q", resolved, want)
+	}
+}
+
 func TestNewServiceConstructsInertRoot(t *testing.T) {
 	t.Parallel()
 
@@ -124,6 +167,7 @@ func TestNewServiceConstructsInertRoot(t *testing.T) {
 		encoder.fn,
 		providersCatalog.fn,
 		providersRoot,
+		testIDGenerator(),
 	)
 	if err != nil {
 		t.Fatalf("NewService() = %v", err)
@@ -191,6 +235,7 @@ func TestNewServiceRejectsMissingFileSystem(t *testing.T) {
 			stubConfigEncoder,
 			stubProviderCatalog,
 			internaltestproviders.StandardCatalog(),
+			testIDGenerator(),
 		)
 	}, "construct Operator Settings: filesystem is required")
 }
@@ -206,6 +251,7 @@ func TestNewServiceRejectsMissingTemporaryFileCreator(t *testing.T) {
 			stubConfigEncoder,
 			stubProviderCatalog,
 			internaltestproviders.StandardCatalog(),
+			testIDGenerator(),
 		)
 	}, "construct Operator Settings: create temporary file is required")
 }
@@ -221,6 +267,7 @@ func TestNewServiceRejectsMissingConfigDecoder(t *testing.T) {
 			stubConfigEncoder,
 			stubProviderCatalog,
 			internaltestproviders.StandardCatalog(),
+			testIDGenerator(),
 		)
 	}, "construct Operator Settings: config decoder is required")
 }
@@ -236,6 +283,7 @@ func TestNewServiceRejectsMissingConfigEncoder(t *testing.T) {
 			nil,
 			stubProviderCatalog,
 			internaltestproviders.StandardCatalog(),
+			testIDGenerator(),
 		)
 	}, "construct Operator Settings: config encoder is required")
 }
@@ -251,6 +299,7 @@ func TestNewServiceRejectsMissingProviderCatalog(t *testing.T) {
 			stubConfigEncoder,
 			nil,
 			internaltestproviders.StandardCatalog(),
+			testIDGenerator(),
 		)
 	}, "construct Operator Settings: provider catalog is required")
 }
@@ -266,8 +315,25 @@ func TestNewServiceRejectsMissingProvidersRoot(t *testing.T) {
 			stubConfigEncoder,
 			stubProviderCatalog,
 			nil,
+			testIDGenerator(),
 		)
 	}, "construct Operator Settings: providers root is required")
+}
+
+func TestNewServiceRejectsMissingIDGenerator(t *testing.T) {
+	t.Parallel()
+
+	assertNewServiceRejectsMissingPort(t, func() (operatorsettings.Service, error) {
+		return settingswire.NewService(
+			&stubFileSystem{},
+			stubCreateTemporaryFile,
+			stubConfigDecoder,
+			stubConfigEncoder,
+			stubProviderCatalog,
+			internaltestproviders.StandardCatalog(),
+			nil,
+		)
+	}, "construct Operator Settings: ID generator is required")
 }
 
 func assertNewServiceRejectsMissingPort(

--- a/pkg/transports/cli/initsetup/init_test.go
+++ b/pkg/transports/cli/initsetup/init_test.go
@@ -207,6 +207,7 @@ func testConfigService() operatorsettings.Service {
 		globalconfigmapping.Encode,
 		testProviderCatalog,
 		providersRoot,
+		func() string { return "00000000-0000-4000-8000-000000000001" },
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/wire/session_runtime_providers_test.go
+++ b/pkg/wire/session_runtime_providers_test.go
@@ -216,6 +216,7 @@ func TestOperatorSettingsHomePortCompositionUsesProcessProviderRoot(t *testing.T
 		platformfilesystem.Local{},
 		globalconfigmapping.Decode,
 		providersRoot,
+		func() string { return "00000000-0000-4000-8000-000000000001" },
 	)
 	if err != nil {
 		t.Fatalf("NewServiceFromHomePorts() error = %v", err)

--- a/tests/functional/operator_settings/root_composition/defaults_resolution_fallback_test.go
+++ b/tests/functional/operator_settings/root_composition/defaults_resolution_fallback_test.go
@@ -42,6 +42,7 @@ func TestResolveFromHomeFallbackPreservesAcceptedSemantics(t *testing.T) {
 		platformfilesystem.Local{},
 		globalconfigmapping.Decode,
 		providersRoot,
+		func() string { return "00000000-0000-4000-8000-000000000001" },
 	)
 	if err != nil {
 		t.Fatalf("NewServiceFromHomePorts() error = %v", err)

--- a/tests/functional/operator_settings/root_composition/identity_input_inventory_activation_test.go
+++ b/tests/functional/operator_settings/root_composition/identity_input_inventory_activation_test.go
@@ -92,6 +92,7 @@ func TestOperatorInputInventoryActivatesThroughRootBuildProcessAfterLifecycle(t 
 		platformfilesystem.Local{},
 		globalconfigmapping.Decode,
 		providersRoot,
+		func() string { return "00000000-0000-4000-8000-000000000001" },
 	)
 	if err != nil {
 		t.Fatalf("NewServiceFromHomePorts() error = %v", err)

--- a/tests/functional/operator_settings/root_composition/transport_activation_test.go
+++ b/tests/functional/operator_settings/root_composition/transport_activation_test.go
@@ -46,6 +46,7 @@ func TestHTTPSettingsTransportActivatesThroughRootBuildProcessAfterLifecycle(t *
 		&operatorSettingsActivationFileSystem{recorder: recorder},
 		globalconfigmapping.Decode,
 		providersRoot,
+		func() string { return "00000000-0000-4000-8000-000000000001" },
 	)
 	if err != nil {
 		t.Fatalf("NewServiceFromHomePorts() error = %v", err)
@@ -101,6 +102,7 @@ func TestMCPSettingsTransportActivatesThroughRootBuildProcessAfterLifecycle(t *t
 		&operatorSettingsActivationFileSystem{recorder: recorder},
 		globalconfigmapping.Decode,
 		providersRoot,
+		func() string { return "00000000-0000-4000-8000-000000000001" },
 	)
 	if err != nil {
 		t.Fatalf("NewServiceFromHomePorts() error = %v", err)

--- a/tests/functional/operator_settings/root_composition/wire_composition_coverage_test.go
+++ b/tests/functional/operator_settings/root_composition/wire_composition_coverage_test.go
@@ -51,6 +51,7 @@ func TestWireCompositionServesDocumentAndResolutionOperations(t *testing.T) {
 			&sync.Mutex{},
 		),
 		providersRoot,
+		func() string { return "00000000-0000-4000-8000-000000000001" },
 	)
 	if err != nil {
 		t.Fatalf("NewServiceFromConfigDocument() error = %v", err)
@@ -107,6 +108,7 @@ func TestWireCompositionFromHomePortsConstructsSettingsRoot(t *testing.T) {
 		platformfilesystem.Local{},
 		globalconfigmapping.Decode,
 		providersRoot,
+		func() string { return "00000000-0000-4000-8000-000000000001" },
 	)
 	if err != nil {
 		t.Fatalf("NewServiceFromHomePorts() error = %v", err)
@@ -123,12 +125,12 @@ func TestWireCompositionFromHomePortsRejectsMissingPorts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("providerswire.NewService() error = %v", err)
 	}
-	_, err = settingswire.NewServiceFromHomePorts(nil, globalconfigmapping.Decode, providersRoot)
+	_, err = settingswire.NewServiceFromHomePorts(nil, globalconfigmapping.Decode, providersRoot, func() string { return "00000000-0000-4000-8000-000000000001" })
 	if err == nil || !strings.Contains(err.Error(), "filesystem is required") {
 		t.Fatalf("NewServiceFromHomePorts(nil, decode) error = %v, want filesystem required", err)
 	}
 
-	_, err = settingswire.NewServiceFromHomePorts(platformfilesystem.Local{}, nil, providersRoot)
+	_, err = settingswire.NewServiceFromHomePorts(platformfilesystem.Local{}, nil, providersRoot, func() string { return "00000000-0000-4000-8000-000000000001" })
 	if err == nil || !strings.Contains(err.Error(), "decoder is required") {
 		t.Fatalf("NewServiceFromHomePorts(files, nil) error = %v, want decoder required", err)
 	}
@@ -151,6 +153,7 @@ func TestResolveFromHomeRejectsMissingFilesystemPorts(t *testing.T) {
 		nil,
 		globalconfigmapping.Decode,
 		providersRoot,
+		func() string { return "00000000-0000-4000-8000-000000000001" },
 	)
 	if err == nil || !strings.Contains(err.Error(), "operator settings filesystem is required") {
 		t.Fatalf("NewServiceFromHomePorts() error = %v, want home-port construction failure", err)
@@ -182,6 +185,7 @@ func TestResolveFromHomeUsesSettingsAdapterOwnershipPath(t *testing.T) {
 		platformfilesystem.Local{},
 		globalconfigmapping.Decode,
 		providersRoot,
+		func() string { return "00000000-0000-4000-8000-000000000001" },
 	)
 	if err != nil {
 		t.Fatalf("NewServiceFromHomePorts() error = %v", err)
@@ -214,7 +218,7 @@ func TestWireCompositionFromConfigDocumentConstructsFromDocumentPorts(t *testing
 		CreateTemp: func(dir, pattern string) (operatorsettings.TemporaryFile, error) {
 			return os.CreateTemp(dir, pattern)
 		},
-	}, providersRoot)
+	}, providersRoot, func() string { return "00000000-0000-4000-8000-000000000001" })
 	if err != nil {
 		t.Fatalf("NewServiceFromConfigDocument() error = %v", err)
 	}
@@ -230,7 +234,7 @@ func TestWireCompositionFromConfigDocumentRejectsMissingDocumentPorts(t *testing
 	if err != nil {
 		t.Fatalf("providerswire.NewService() error = %v", err)
 	}
-	_, err = settingswire.NewServiceFromConfigDocument(operatorsettings.ConfigDocumentService{}, providersRoot)
+	_, err = settingswire.NewServiceFromConfigDocument(operatorsettings.ConfigDocumentService{}, providersRoot, func() string { return "00000000-0000-4000-8000-000000000001" })
 	if err == nil || !strings.Contains(err.Error(), "operator settings document ports are required") {
 		t.Fatalf("NewServiceFromConfigDocument() error = %v, want document ports required", err)
 	}


### PR DESCRIPTION
## Summary

- Make the Operator Settings owner-wire identity generator required in all three public construction paths.
- Remove hidden UUID fallback behavior from owner construction while preserving the unary service root.
- Migrate production and test callers and add deterministic identity plus nil-constructor coverage.

## Verification

- make test
- go test ./pkg/services/operator_settings/...
- go test ./pkg/root ./pkg/wire
- go test ./tests/functional/operator_settings/...
- go test ./tests/functional/providers/acp/...
- go test ./tests/functional/product/init_setup
- make package-target-manifest-check
- make ownership-inventory-check
- make pkg-structure

The repository-wide boundary/file-count checks report existing migration-baseline violations; UI typecheck/lint are unavailable in this checkout because Bun type definitions and Biome are not installed. No baselines or dependency files are changed.