### PR TITLE
fix: enable Claude verbose stream JSON output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,204 @@
+# Repository Agent Instructions
+
+This repository is `you-agent-factory`: a Go, OpenAPI, and React system for
+scheduling and orchestrating many AI workers concurrently through the `you` CLI,
+backend runtime, and dashboard.
+
+The product model is a factory: users define work types, work states,
+workstations, workers, guards, resources, and orchestration policy. The runtime
+turns submitted work and worker output into ordered events, then derives live
+and historical world state from that event stream.
+
+## Current Architecture
+
+- The backend core is an event-first factory runtime. Workers and agents do not
+  mutate canonical state directly; they emit outputs that re-enter the runtime
+  as events.
+- Product behavior is split across Factory Definitions, Factory Runtime,
+  Factory Sessions, Recordings, Work, Workers, Providers, Models, Automations,
+  Provider Sessions, Operator Settings, Factory Visualization, and System
+  Initialization services. `pkg/wire` composes these services and
+  `pkg/initializer` owns application lifecycle.
+- Public terminology is defined in
+  `docs/architecture/data-model.md`: `Factory`, `Factory Session`, `Current
+  Factory`, `Work`, `Work Request`, and `Provider Session`.
+- The customer-facing model hides the internal Petri-net implementation.
+  Internal packages can use tokens, places, transitions, markings, and guards;
+  public docs and API surfaces should prefer customer-facing vocabulary.
+- Factory events and projections are canonical for replay, dashboard state,
+  session lifecycle, dispatch lifecycle, work payload lineage, and historical
+  inspection.
+- The frontend consumes generated OpenAPI types and event streams, derives
+  client-side dashboard/editor projections, and sends user actions back through
+  API requests. The backend remains authoritative for runtime state.
+- OpenAPI is authored in component fragments under `api/components/` and bundled
+  into `api/openapi.yaml`; generated Go and TypeScript clients are derived from
+  that contract.
+
+Read these architecture notes when the work touches their area:
+
+- `docs/architecture/architecture.md` for backend loop, service/session
+  boundaries, event stream, frontend composition, and graph-editor state flow.
+- `docs/architecture/structures.md` to understand the overall interaction of components within the system.
+- `docs/architecture/data-model.md` for public resource vocabulary and the
+  customer/internal data-model split.
+- `docs/architecture/packaged-structure.md` for the current Go package families,
+  service package convention, dependency direction, and composition boundaries.
+
+## Standards
+
+Start with `docs/internal/standards/STANDARDS.md`, then read the relevant
+standard before changing code:
+
+- `docs/internal/standards/code/code-review-standards.md` for reviews and PR
+  quality gates.
+- `docs/internal/standards/code/general-backend-standards.md` for Go backend,
+  state management, architecture, linting, testing, CI, and complexity.
+- `docs/internal/standards/code/general-website-standards.md` for React,
+  accessibility, responsive design, styling, state, performance, and tests.
+- `docs/internal/standards/code/planning-standards.md` for PRDs, work stories,
+  acceptance criteria, and implementation plans.
+
+Treat files under `docs/internal/standards/` as normative. Development notes and
+process maps can provide examples and file inventories, but they do not override
+the standards.
+
+## Repository Map
+
+- `api/` contains the authored OpenAPI entrypoint, component fragments,
+  reusable parameters/responses/schemas, and generated bundled contract.
+- `cmd/` contains Go command entrypoints and maintenance tools, including the
+  main `you` binary under `cmd/factory/`.
+- `docs/` contains public docs, architecture notes, comparison docs, examples,
+  and internal maintainer standards/process docs.
+- `docs/reference/` is the canonical packaged `you docs <topic>` markdown.
+  Edit reference topics there, not in generated or embedded copies.
+- `examples/` contains example factory directories.
+- `factory/` contains this repository's checked-in factory scaffold and
+  factory-local docs.
+- `packages/` contains publishable API, model-provider, and packaged-factory
+  sources and generated distribution artifacts. Authored packaged factories
+  live under `packages/packaged-factories/factories/`; generated package output
+  lives under `packages/packaged-factories/generated/`.
+- `pkg/` has six approved top-level package families: `initializer`, `platform`,
+  `root`, `services`, `transports`, and `wire`.
+- `pkg/root/` exposes the caller-facing `BuildProcess` construction boundary.
+  `pkg/wire/` owns the canonical application dependency graph, and
+  `pkg/initializer/` activates and unwinds already-constructed lifecycle roles.
+- `pkg/transports/` owns protocol composition for CLI, HTTP, MCP, generated
+  transport contracts and clients, and representation mapping. Service-specific
+  adapters may live under the owning service's `transports/` directory.
+- `pkg/platform/` contains policy-free cross-cutting implementations such as
+  filesystem, process, logging, metrics, replay storage, clocks, PTY, and
+  runtime-artifact support.
+- `pkg/services/` contains the product-domain service families. Service roots
+  expose public contracts and operations; private implementation belongs under
+  the owning service's `internal/` tree, focused construction providers under
+  `wire/`, and service-owned protocol adapters under `transports/`.
+- `pkg/services/factory_definitions/` owns Factory definition loading,
+  persistence, validation, compilation, authored layout, packaged distribution,
+  catalog behavior, and invocation policy.
+- `pkg/services/factory_runtime/` owns event-first orchestration, scheduling,
+  dispatch, runtime projections, Petri execution, JavaScript workflows, and
+  checkpoint recovery.
+- `pkg/services/factory_sessions/` owns live and durable Factory Session state,
+  runtime opening, lifecycle gateways, response streams, invocation, controls,
+  and persisted execution behavior.
+- `pkg/services/recordings/` owns the canonical Factory Event ledger, recording
+  lifecycle, replay, artifacts, and read-model projections.
+- `pkg/services/work/` owns Work and Work Request contracts, admission, content,
+  materialization, staging, lineage, read behavior, and pure invocation return
+  policy.
+- `pkg/services/workers/` owns worker and workstation execution, runners,
+  prompt/output shaping, worktrees, mock-worker behavior, and worker capability
+  policy.
+- `pkg/services/providers/` owns provider identity, catalog, lifecycle, ACP
+  integration, and provider execution. Workers consume Providers through its
+  public contracts; provider implementations do not belong to Workers.
+- `pkg/services/models/` owns the managed local-model catalog, assets, runtime
+  readiness and lifecycle, host supervision, source resolution, cache, pull,
+  and local inference support.
+- `pkg/services/automations/` owns cron, filesystem watcher, script poller,
+  hosted-source, reconciliation, and invocation-schedule behavior.
+- `pkg/services/provider_sessions/` owns provider-session discovery and
+  transcript/session inspection.
+- `pkg/services/operator_settings/`, `pkg/services/factory_visualization/`, and
+  `pkg/services/system_initialization/` own settings resolution, runtime
+  presentation/projection, and system bootstrap/rollback respectively.
+- `pkg/services/edges/` aggregates the exact replaceable external-effect ports
+  accepted by `root.BuildProcess`; it is not a product service locator.
+- `pkg/services/factory_runtime/internal/orchestrators/petri/` contains internal
+  Petri-net primitives. External packages consume Factory Runtime root
+  contracts instead.
+- `pkg/services/factory_runtime/internal/services/orchestration/javascript/` contains
+  JavaScript workflow runtime, preview, source lookup, storage, and validation
+  implementations. Public orchestration contracts are exposed at
+  `pkg/services/factory_runtime`.
+- `tests/` contains broader functional, release, smoke, and integration tests.
+- `ui/` contains the React dashboard, generated TypeScript OpenAPI types,
+  feature modules, shared components, theme/styles, Storybook, and frontend
+  tests.
+
+## API And Code Generation
+
+- Author OpenAPI changes in `api/openapi-main.yaml` and component fragments
+  under `api/components/`.
+- Do not hand-edit generated files:
+  - `api/openapi.yaml`
+  - `pkg/transports/http/generated/server.gen.go`
+  - `pkg/transports/http/client/client.gen.go`
+  - `ui/src/api/generated/openapi.ts`
+- Run `make generate-api` for the bundled OpenAPI and direct Go/dashboard
+  clients. Use `make interfaces-all` when a change also affects generated
+  contract schemas or publishable UI package clients; the scoped
+  `interfaces-go` and `interfaces-ui` targets are available when only one
+  consumer family changed.
+- For API surface changes, update the matching `pkg/transports/http` handlers,
+  `pkg/transports/mapping` mappers/normalizers, generated clients, UI API adapters, and
+  contract tests as applicable.
+- Run `make api-smoke` for public REST contract changes when feasible.
+
+## Documentation
+
+- Public packaged CLI docs live in `docs/reference/` and are embedded for
+  `you docs <topic>`.
+- Run `make docs-reference-smoke` after changing `docs/reference/` or packaged
+  docs behavior.
+- Run `make readme-check` after changing README structure or linked README
+  assets.
+- Keep root docs as routing/index material. Avoid duplicating long customer
+  guides or feature inventories outside their canonical docs.
+
+## Verification
+
+Choose the narrowest useful verification for the change, then broaden when the
+surface area is shared or public:
+
+- `make test` runs the short Go suite.
+- `make ui-test` runs the frontend unit suite.
+- `make ui-lint` runs frontend lint and UI boundary checks.
+- `make lint` runs the repository lint suite.
+- `make verify-fast` runs dashboard typecheck, short UI/unit tests, and short
+  Go tests.
+- `make verify-pr` runs the broader PR verification tier.
+- `make build-all` regenerates public interfaces and builds the publishable UI
+  packages, dashboard, and Go CLI from canonical sources.
+- `make test-full`, `make test-functional`, `make test-ui-coverage`, and
+  specialty Make targets are available for higher-risk runtime, API, or UI
+  changes.
+
+When changing frontend behavior, run focused UI tests where possible and inspect
+the UI in a browser for layout-sensitive work. When changing event replay,
+factory sessions, dispatch lifecycle, or projections, add or update projection
+and replay tests near the affected package.
+
+## Working Rules
+
+- Preserve user work in the tree. Do not revert unrelated changes.
+- Prefer existing package boundaries and local helpers over new abstractions.
+- Keep generated files in sync with their source contracts.
+- Keep public resource names aligned with `docs/architecture/data-model.md`.
+- Keep CLI and API behavior equivalent when shared contracts say they are
+  equivalent, especially invocation behavior.
+- Use `rg`/`rg --files` for code discovery.
+- Add tests proportional to the risk and blast radius of the change.

--- a/docs/internal/projects/acp-client/final-proposal.md
+++ b/docs/internal/projects/acp-client/final-proposal.md
@@ -1,0 +1,710 @@
+# L1 — ACP Core: Chat Sessions, Events Stream, and the ACP Agent Transport
+
+Status: proposed
+Date: 2026-08-02
+Lane: L1 of `docs/internal/projects/acp-program/README.md`
+Audience: backend, transport, and test maintainers
+Supersedes: the prior single-document ACP proposal and
+`docs/internal/projects/acp-client/design.md`
+
+Governing decisions live in the lane map. This plan cites D1–D6 and does not
+restate them.
+
+## 1. Problem and outcome
+
+You is convenient once a customer has decided to invoke a Factory through the
+CLI, HTTP API, MCP, or dashboard. It is inconvenient for one-off work inside an
+editor where the customer already has a preferred interaction surface.
+
+Requiring one configured ACP process per installed Factory produces poor setup
+UX. Modeling a Factory as a You Model would corrupt the domain model — a Factory
+is an orchestration definition, not a provider model.
+
+Target outcome:
+
+> A customer runs `you acp serve` once, selects an installed You Factory from
+> the client's existing picker, chats across multiple turns, sees the Factory's
+> customer-facing output as assistant messages, and can cancel, close, load, or
+> reconnect without exposing You's internal orchestration.
+
+## 2. Scope
+
+### In scope
+
+- `pkg/services/chat_sessions` — conversation, target selection, turn admission,
+  attachment, and control-intent owner.
+- `pkg/services/events` — session-scoped event **stream** (D2): ordering,
+  cursors, subscriptions, retention, gaps, backpressure. Absorbs
+  `factory_sessions/internal/{responseeventstore,responsestream,cursors}`.
+- `pkg/transports/acp` — JSON-RPC/stdio, capability negotiation, request
+  mapping, and record→ACP projection.
+- `@you/factory-builder` packaged Factory as the default target.
+- One additive Operator Settings root operation pair for the ACP profile.
+
+### Out of scope
+
+| Deferred to | What |
+| --- | --- |
+| L4 | Worker Sessions, child Worker tool calls, worker control fan-out |
+| L2 | Root sealing, dead-API removal, opportunistic cleanup |
+| L3 | Everything else in packaged-service-structure |
+| — | Durable storage of any kind (D1) |
+| — | Filesystem callbacks, terminals, fork, agent plans, client MCP servers, auth |
+| — | Remote HTTP/WebSocket ACP |
+
+**Consequence of deferring L4:** in L1 a Factory turn produces top-level
+assistant output only. Child Worker activity is not projected. This is a real
+functional limitation and it is deliberate — it makes L1 shippable without the
+Worker Sessions control plane.
+
+### Existing code this lane consumes unchanged
+
+- `pkg/services/factory_sessions` through a thin consumer-owned shim (D4). The
+  root is 45 methods with three parallel pause/resume families; L1 does not seal
+  it and does not depend on it being sealed.
+- `pkg/services/workers/response_drafts.go` as the normalized vocabulary owner.
+  L1 introduces no taxonomy.
+- `github.com/coder/acp-go-sdk v0.13.5`, already a direct dependency. It
+  supports `session/new`, `prompt`, `cancel`, `load`, `resume`, `close`,
+  `set_config_option`, and `request_permission`. Protocol version 1.
+
+## 3. Target selection
+
+Installed Factories are presented through the ACP client's config-option
+selector. The SDK type is a union requiring `type`:
+
+```json
+{
+  "type": "select",
+  "id": "target",
+  "name": "Factory",
+  "category": "model",
+  "currentValue": "factory:@you/factory-builder",
+  "options": [
+    { "value": "factory:@you/factory-builder", "name": "Factory Builder" },
+    { "value": "factory:@you/review",          "name": "Review" },
+    { "value": "factory:local/software-auto",  "name": "Software Auto" }
+  ]
+}
+```
+
+`category` is `SessionConfigOptionCategoryModel` and is documented in the SDK as
+*"Optional semantic category for this option (UX only)."* It is a presentation
+hint. Internally every value decodes to a typed `ChatTargetRef`:
+
+```go
+type ChatTargetRef struct {
+    Kind ChatTargetKind // FACTORY | WORKER
+    Ref  string
+}
+```
+
+`WORKER` is defined in L1 but never produced; direct Worker targets are L4.
+
+Operator Settings owns the default and allowlist. Factory Definitions owns
+enumeration and canonical reference resolution. Target refs are unversioned
+(D6).
+
+**Fallback.** Config options are the newer surface. If a client does not render
+them, the customer cannot select a Factory. L1 therefore also advertises
+`availableCommands` with `/factory <target>`, delegating to the same Chat
+Session operation as `session/set_config_option`. This is a P0 fallback, not a
+P1 nicety — without it the feature is unusable on clients that lag.
+
+## 4. Chat Sessions
+
+### 4.1 Model
+
+```go
+type Session struct {
+    ID             string
+    State          SessionState
+    SelectedTarget ChatTargetRef
+    TargetEpisode  uint64
+    ActiveTurnID   string
+    Version        uint64
+    StreamHead     uint64
+    CreatedAt      time.Time
+    UpdatedAt      time.Time
+}
+
+type TargetEpisode struct {
+    Number           uint64
+    State            TargetEpisodeState
+    Target           ChatTargetRef
+    FactorySessionID string
+    StartedAt        time.Time
+    ClosedAt         *time.Time
+}
+
+type Turn struct {
+    ID               string
+    Episode          uint64
+    State            TurnState
+    RequestID        RequestIdentity
+    StartSequence    uint64
+    TerminalSequence uint64
+}
+
+type Attachment struct {
+    ID             string
+    SessionID      string
+    ConnectionID   string
+    AfterSequence  uint64
+    Interactive    bool
+}
+
+type ControlIntent struct {
+    RequestID       RequestIdentity
+    SessionID       string
+    TurnID          string
+    TargetEpisode   uint64
+    ExpectedVersion uint64
+    Action          ControlAction
+    State           ControlIntentState
+    RequestedAt     time.Time
+}
+```
+
+Three distinct positions, never conflated:
+
+- **stream head** — last event sequenced for the Chat Session;
+- **attachment cursor** — last event delivered to one attachment;
+- **active control target** — turn ID, episode, and version captured when a
+  control request commits.
+
+Chat Sessions atomically captures and persists the control target *before*
+invoking downstream controls. A newly admitted turn cannot be affected by an
+older control intent.
+
+### 4.2 Enum hardening
+
+Every enum below is exhaustively defined with a transition table, a `Validate()`
+method, and exhaustive-switch enforcement. The prior proposal referenced these
+without enumerating them.
+
+**`ChatTargetKind`** — `FACTORY`, `WORKER`.
+
+**`SessionState`**
+
+| From | To | Trigger |
+| --- | --- | --- |
+| `CREATED` | `ACTIVE` | first turn admitted |
+| `CREATED` | `CLOSED` | `session/close` |
+| `ACTIVE` | `CLOSED` | `session/close`, or process exit (D1) |
+| `CLOSED` | — | terminal |
+
+**`TargetEpisodeState`**
+
+| From | To | Trigger |
+| --- | --- | --- |
+| `OPEN` | `CLOSED` | target changed, or session closed |
+| `CLOSED` | — | terminal; accepts no new turns |
+
+**`TurnState`**
+
+| From | To | Trigger |
+| --- | --- | --- |
+| `ADMITTED` | `RUNNING` | downstream invocation accepted |
+| `ADMITTED` | `CANCELED` | control intent commits before invocation |
+| `RUNNING` | `COMPLETED` | terminal success |
+| `RUNNING` | `FAILED` | terminal failure |
+| `RUNNING` | `CANCELED` | cancel fan-out reached the target |
+| terminal | — | terminal |
+
+At most one non-terminal turn per session. Turn admission while one is active
+returns a typed busy error.
+
+**`ControlAction`** — `CANCEL`, `CLOSE`. (`PAUSE`, `RESUME`, `TERMINATE` are
+declared for L4 but rejected as unsupported in L1.)
+
+**`ControlIntentState`**
+
+| From | To | Meaning |
+| --- | --- | --- |
+| `REQUESTED` | `COMMITTED` | target captured and persisted |
+| `COMMITTED` | `COMPLETED` | fan-out reached the captured turn |
+| `COMMITTED` | `NOOP` | captured turn already terminal on arrival |
+| `COMMITTED` | `SUPERSEDED` | captured turn no longer current — never applied |
+
+`NOOP` and `SUPERSEDED` are how the cancel-versus-completion race resolves
+deterministically. An intent never migrates to a later turn.
+
+**Existing vocabulary.** `workers.Kind` (12 values) and `workers.Phase` (6
+values) are hardened, not extended: add `Validate()`, exhaustive-switch
+enforcement, and a **parity test asserting every `(Kind, Phase)` pair has a
+declared ACP mapping outcome — including explicit "no output."** This mirrors
+the existing `recordings/internal/events/kinds/parity.go` pattern and prevents
+§6.2's table from silently dropping a case.
+
+**Simplification from D1.** Because state is session-scoped and process exit
+terminalizes everything, there is no `INTERRUPTED` state, no restart
+reconciliation, and no recovery scan. Historical inspection comes from recorder
+JSONL.
+
+### 4.3 Target episodes
+
+A Chat Session contains multiple immutable episodes. Changing the target:
+
+- is rejected while a turn is active;
+- applies to the next admitted turn;
+- increments the episode;
+- never changes the identity of historical events;
+- does not retroactively change connection capabilities.
+
+L1 negotiates the text-first capability intersection across selectable targets.
+`promptCapabilities` advertises no image, audio, or embedded context.
+
+## 5. Events stream service
+
+Per D2, `pkg/services/events` is a **stream, not a store**. It has no
+`internal/store/` package and no persistence responsibility.
+
+```go
+type Service interface {
+    Append(context.Context, AppendRequest) (AppendResult, error)
+    AttachSource(context.Context, AttachSourceRequest) (AttachSourceResult, error)
+    Read(context.Context, ReadRequest) (ReadResult, error)
+    Subscribe(context.Context, SubscribeRequest) (Subscription, error)
+}
+
+type AppendRequest struct {
+    TopicID        string
+    SourceType     SourceType
+    SourceID       string
+    SourceSequence uint64
+    SourceEventID  string
+    SchemaID       string
+    Payload        json.RawMessage
+}
+```
+
+The envelope is delivery metadata; `Payload` stays source-native. The *kind*
+taxonomy is `workers.Kind` (lane map §3).
+
+### 5.1 Migration inputs
+
+This service is an **extraction**, not a greenfield build. It absorbs working,
+tested machinery out of `factory_sessions`:
+
+| Source | Provides |
+| --- | --- |
+| `internal/responseeventstore/` | sequence counter, tier retention, `droppedSequences`, subscriber map, `backpressure_stress_test.go` |
+| `internal/responsestream/` | registry, stream, publisher, subscription |
+| `internal/cursors/` | `StorageIdentity`, `Checkpoint`, `Store`, `PreflightResult` |
+| `response_event_contract.go` | `ResponseEventCursor`, `ResponseEventRetentionLimits`, gap and stale-cursor errors |
+
+Factory Sessions gains no new event logic; it loses what it has. Its root
+continues to expose `SubscribeFactoryResponseEvents` as a delegating shim until
+L2 retires it.
+
+### 5.2 Topics and ordering
+
+L1 topics:
+
+- `factory-session/<id>/response-events`
+- `chat-session/<id>/events` — ordered references plus Chat control facts
+
+The Chat topic assigns one monotonic aggregate sequence in **commit order, not
+timestamp order**. Idempotency key:
+
+```text
+(sourceType, sourceID, sourceSequence, sourceEventID)
+```
+
+**Concurrency model, stated explicitly:** L1 is single-process. Each Chat
+Session has one serialization point for sequence assignment. Multi-process
+sequencing is out of scope and no lane plans it.
+
+### 5.3 Stable item identity
+
+Chat Sessions assigns the **stable ACP item ID onto each aggregate record at
+sequencing time**, not at projection time. This is what makes item IDs survive
+`session/load` and reconnect, and it is what lets the transport stay a pure
+function (§6.1). It also pre-empts the ordering problem L4 inherits: a child
+record cannot be sequenced before its parent because the sequencer assigns both.
+
+## 6. ACP transport
+
+### 6.1 Where the inversion transformation belongs
+
+The repository's established shape is: one normalized vocabulary owned by a
+service, one outward mapper per transport, located at the transport.
+
+```
+external ACP agent ──mapSessionUpdate──► providers.ExecuteProgress
+                                              │   [providers/internal/.../acp/internal/service/service.go:819]
+                                              ▼
+                                        workers.Draft          ← vocabulary owner
+                                              │                  [workers/response_drafts.go]
+                     ┌────────────────────────┼────────────────────────┐
+                     ▼                        ▼                        ▼
+          HTTP/OpenAPI mapper        CLI NDJSON mapper          ◄NEW► ACP mapper
+   transports/mapping/factorysession  responsestream/ndjsoncontract
+```
+
+Therefore:
+
+- **Outbound (`record → acpsdk.SessionUpdate`) lives in
+  `pkg/transports/acp/internal/mapping`.** Not `pkg/transports/mapping/` — that
+  package serves the generated OpenAPI contract, and ACP's types come from the
+  vendored SDK with no generator.
+- **Inbound stays where it is.** `mapSessionUpdate` is provider-execution
+  policy: how a third-party agent's stream becomes Worker progress. Moving it
+  would invert service→transport dependency.
+- **They must not share code.** A service may not import a transport, and the
+  transport must not import `providers/internal`. There is no legal neutral
+  home. Bind them **by fixture instead**: promote the corpus in
+  `tests/functional/providers/acp/golden_fixture_test.go` into a shared
+  committed ACP conformance corpus that both directions assert against, plus a
+  round-trip property test over the subset both support.
+
+Because Chat Sessions assigns item identity (§5.3), the outbound mapper is a
+pure function of one record. That is what makes exhaustive table-driven coverage
+achievable.
+
+### 6.2 Projection
+
+| Source record | ACP output |
+| --- | --- |
+| Chat user turn admitted | `user_message_chunk` during load replay |
+| Factory response `MESSAGE` | `agent_message_chunk` |
+| Factory response `REASONING` | `agent_thought_chunk` |
+| Factory turn terminal | prompt result with stop reason |
+| `USAGE` with meaningful primary context | `usage_update` |
+| Title/time change | `session_info_update` |
+| Target option change | `session_config_option_update` |
+| `TOOL`, `FILE_CHANGE`, `PLAN`, `PROGRESS`, `SESSION`, `RUN`, `TURN` | no output in L1 — declared, not dropped |
+| `STREAM_GAP` | surfaced as an explicit gap notice, never fabricated content |
+
+`PLAN` deserves a note: `PlanPayload`/`PlanStep` already exist in the taxonomy
+and ACP has a first-class plan concept. L1 declares no output as a scope cut,
+not because plumbing is missing.
+
+### 6.3 Stop reasons
+
+Total mapping, with a defined default:
+
+| Terminal outcome | ACP stop reason |
+| --- | --- |
+| Factory turn completed | `end_turn` |
+| Cancel intent reached the captured turn | `cancelled` |
+| Provider reported token exhaustion | `max_tokens` |
+| Provider refused | `refusal` |
+| Factory failed, or any unmapped terminal | `end_turn` with an error record already streamed |
+
+### 6.4 Errors
+
+| Condition | JSON-RPC |
+| --- | --- |
+| Unknown target ref | invalid params |
+| Target not in allowlist | invalid params |
+| Chat session not found | invalid params |
+| Turn already active | internal error, typed busy payload |
+| Stale `expectedVersion` on config change | invalid params, conflict payload |
+| Cursor expired (`ErrResponseEventStoreExpired`, `ErrReconnectCursorExpired`) | internal error, reconnect hint |
+| Unsupported method | method not found, no side effects |
+
+Errors omit credentials, raw provider commands, unsafe paths, and internal
+topology.
+
+## 7. P0 operations the prior proposal omitted
+
+1. **`cwd`.** `session/new(cwd)` becomes the Factory Session working root. When
+   the selected Factory pins its own root, the mismatch is a typed rejection at
+   session or turn admission — not a silent override. A customer in an editor
+   expects the agent to act on the open project; this is the operation that
+   makes that true.
+2. **Permission passthrough.** For ACP-backed providers the plumbing exists —
+   the provider-side client already implements `RequestPermission`. For
+   subprocess CLI providers, confirm whether approval is surfaced at all. If it
+   is not, L1 **must not advertise a permission capability**; shipping an editor
+   agent that silently writes files is not an acceptable default.
+3. **Request identity.** JSON-RPC ids are unique per connection only.
+   `RequestIdentity` is `(ConnectionID, JSONRPCID)` or a transport-minted UUID.
+   Never the bare id.
+4. **Interactive leader.** First interactive attachment is leader. On leader
+   disconnect with an outstanding `session/request_permission`, the request is
+   denied after a bounded timeout and the turn continues with the denial. Never
+   hang.
+5. **`session/new` rejection surface.** Non-empty `mcpServers` is explicitly
+   rejected, not ignored.
+6. **Capability honesty.** `loadSession` and `sessionCapabilities` advertise
+   only what is implemented. Under D1, `session/load` is valid only for sessions
+   in the current process; loading an unknown session is an explicit failure,
+   never fabricated history.
+7. **Content bounding.** Retained per-session records are bounded by the
+   inherited tier-eviction limits, and eviction surfaces as `STREAM_GAP`.
+
+## 8. Package structure
+
+```text
+pkg/
+  services/
+    chat_sessions/
+      contracts.go  types.go  errors.go
+      internal/{service,store,projection}/
+      wire/wire.go
+    events/
+      contracts.go  types.go  errors.go
+      internal/{journal,sequencing,subscriptions,retention}/
+      wire/wire.go
+  transports/
+    acp/
+      contracts.go                    # minimal inert stdio-server operation
+      internal/{server,connection,capabilities,stdio}/
+      internal/mapping/{content,events,tools,usage,stopreason,errors}.go
+      wire/wire.go
+```
+
+`events/` has no `store/` package by construction (D2). `chat_sessions/store/`
+is in-memory session state, not persistence.
+
+Naming: the CLI already uses `acp` for the opposite direction (`you workers acp
+add|delete`, backed by `pkg/transports/cli/acp/`). The agent-side command is
+therefore **`you serve acp`**, not `you acp serve`, and the two directions are
+cross-referenced in `docs/reference/`.
+
+`pkg/wire`, `pkg/root`, and `pkg/initializer` receive additive composition edits
+resolved by normal rebase (D3). `cmd/factory` is unchanged.
+
+## 9. Flows
+
+### 9.1 Create and select
+
+```mermaid
+sequenceDiagram
+    participant C as ACP Client
+    participant A as ACP Transport
+    participant Chat as Chat Sessions
+    participant Set as Operator Settings
+    participant Def as Factory Definitions
+    participant Ev as Events
+
+    C->>A: initialize(version, client capabilities)
+    A-->>C: text-first capabilities
+    C->>A: session/new(cwd)
+    A->>Chat: CreateSession(requestIdentity, cwd)
+    Chat->>Set: resolve ACP profile
+    Chat->>Def: list canonical Factory targets
+    Chat->>Ev: append CHAT_SESSION_CREATED
+    Chat-->>A: sessionId, target option
+    A-->>C: sessionId, config options (type=select)
+    C->>A: session/set_config_option(target, factory:@you/review)
+    A->>Chat: SetTarget(id, expectedVersion, target)
+    Chat-->>A: full current option list
+    A-->>C: updated config options
+```
+
+### 9.2 Prompt
+
+```mermaid
+sequenceDiagram
+    participant C as ACP Client
+    participant A as ACP Transport
+    participant Chat as Chat Sessions
+    participant FS as Factory Sessions (via shim)
+    participant Ev as Events
+
+    C->>A: session/prompt(sessionId, content)
+    A->>Chat: StartTurn(requestIdentity, content)
+    Chat->>Chat: admit turn, persist episode
+    alt first turn in episode
+        Chat->>FS: Start(resolved Factory request, cwd)
+        FS-->>Chat: factorySessionId
+        Chat->>Ev: AttachSource(factory-session topic)
+    else existing episode
+        Chat->>FS: Invoke(factorySessionId, content)
+    end
+    FS-->>Ev: response events
+    Ev-->>Chat: sequenced with stable item IDs
+    Chat-->>A: ordered aggregate records
+    A-->>C: agent_message_chunk / agent_thought_chunk
+    Chat-->>A: terminal turn result
+    A-->>C: prompt result(stopReason)
+```
+
+### 9.3 Cancel without racing a new turn
+
+```mermaid
+sequenceDiagram
+    participant C as ACP Client
+    participant A as ACP Transport
+    participant Chat as Chat Sessions
+    participant FS as Factory Sessions (via shim)
+
+    C->>A: session/cancel(sessionId)
+    A->>Chat: CancelActiveTurn(requestIdentity)
+    Chat->>Chat: atomically capture turn, episode, version
+    Chat->>Chat: persist intent COMMITTED
+    Chat->>FS: Cancel(factorySessionId, captured turn)
+    FS-->>Chat: outcome
+    alt captured turn still current
+        Chat->>Chat: intent COMPLETED, turn CANCELED
+    else already terminal
+        Chat->>Chat: intent NOOP
+    end
+    Chat-->>A: captured turn outcome
+    A-->>C: prompt stopReason cancelled
+```
+
+### 9.4 Load and resume
+
+`session/load` replays retained records from the Chat topic with their assigned
+stable item IDs, then returns current target options, title, and usage.
+`session/resume` attaches at live head with no replay. Attachment delivery
+position is never used as a control target.
+
+## 10. Slices
+
+Each slice is independently demonstrable. A later slice's task may start as soon
+as its actual inputs exist.
+
+**V0 — contracts.** `chat_sessions`, `events`, and ACP compatibility contracts
+plus representative fixtures. Additive `ResolveACPAgentProfile` /
+`UpdateACPAgentProfile` on the Operator Settings root. The `factory_sessions`
+shim, registered as an L2 deletion candidate.
+
+**V1 — one Chat Session runs one Factory.** Chat store and versioning, target
+catalog, ACP stdio framing and initialize, `session/new`, picker,
+`set_config_option`, prompt delegation, `/factory` fallback command. Wire
+injection and `you serve acp`. Demo: prompt a Factory, receive a terminal text
+result in a real client.
+
+**V2 — Events extraction and durable-in-session streaming.** Move
+`responseeventstore`, `responsestream`, and `cursors` into `pkg/services/events`
+behind the new root; Factory Sessions delegates. Chat aggregate sequencer with
+stable item IDs. Attachment cursors. Message, thought, usage, and session-info
+projectors. Demo: streaming output, two attachments with independent cursors,
+disconnect and reconnect.
+
+**V3 — lifecycle controls.** Control intents with expected-version capture,
+cancel and close mapping, deterministic stop reasons, shutdown ordering. Demo:
+cancel mid-turn; cancel racing completion; close and reload.
+
+**V4 — Factory Builder and hardening.** `@you/factory-builder` authored source
+and `docs/reference/` coverage audit; enum parity tests; retention and gap
+behavior; safe logging and secret audit; documentation reconciliation
+(lane map §6); real-client evidence.
+
+```mermaid
+flowchart TD
+    K01[contracts] --> C01[chat store]
+    K01 --> E01[events root]
+    O01[settings profile] --> C02[target selection]
+    D01[factory catalog] --> C02
+    C01 --> C02
+    SH[factory_sessions shim] --> C03[prompt delegation]
+    C02 --> C03
+    T01[stdio + initialize] --> T02[new/picker/prompt mapping]
+    C03 --> T02
+    T02 --> I01[wire + serve acp]
+    I01 --> V1[V1 demo]
+
+    E01 --> E02[extraction: store/stream/cursors]
+    E02 --> E03[chat sequencer + item IDs]
+    C01 --> C04[attachments]
+    C04 --> E03
+    E03 --> T03[message projectors]
+    T03 --> V2[V2 demo]
+
+    C04 --> C05[control intents]
+    C05 --> T06[cancel/close mapping]
+    T06 --> V3[V3 demo]
+
+    V2 --> H01[retention/gaps]
+    V3 --> H02[enum parity + race]
+    F01[factory builder] --> H04[docs reconciliation]
+    H01 --> M01[merge]
+    H02 --> M01
+    H04 --> M01
+```
+
+## 11. Tests
+
+Construction rules: functional tests build through `root.BuildProcess` and call
+`Process.Execute`. External provider effects are replaced only through
+`edges.Edges`, preferring `ProviderCommandRunner` with sanitized
+real-provider-shaped fixtures. A built binary is used only for the OS-level
+stdio framing cell. No arbitrary sleeps — synchronize on committed events,
+controlled edges, or explicit lifecycle outcomes. Concurrency paths run under
+the race detector with repeat/stress modes.
+
+| ID | Path | Scenario | Evidence |
+| --- | --- | --- | --- |
+| L1-01 | `transport/acp` | Initialize over stdio | Valid framing; advertised capabilities exactly match implemented behavior |
+| L1-02 | `sessions/chat` | Create session | Default Factory Builder target; option carries `type: "select"` |
+| L1-03 | `sessions/chat` | Enumerate Factories | Stable namespaced target IDs; allowlist and default applied |
+| L1-04 | `sessions/chat` | Change target before prompt | Version increments; next episode uses the selection |
+| L1-05 | `sessions/chat` | Reject target change during active turn | Typed busy; active execution unchanged |
+| L1-06 | `sessions/chat` | `/factory` fallback | Same operation as `set_config_option`; persisted in history |
+| L1-07 | `factory/acp_projection` | Final-only Factory prompt | One top-level result and a mapped stop reason |
+| L1-08 | `factory/acp_projection` | Streaming response | Stable item IDs; ordered text and thought chunks |
+| L1-09 | `factory/acp_projection` | `cwd` honored | Factory executes against the supplied root; pinned-root mismatch rejects typed |
+| L1-10 | `events` | Aggregate ordering | Commit order independent of timestamps |
+| L1-11 | `events` | Retained-then-live handoff | No missing or duplicated aggregate sequence |
+| L1-12 | `events` | Duplicate source delivery | Idempotency tuple prevents duplicate output |
+| L1-13 | `events` | Retention eviction | Surfaces `STREAM_GAP`; never fabricates history |
+| L1-14 | `sessions/chat` | Two attachments | Independent cursors, identical records, one execution |
+| L1-15 | `sessions/chat` | Cancel active turn | Intent commits before fan-out; captured turn canceled |
+| L1-16 | `sessions/chat` | Cancel/completion race | Deterministic `COMPLETED`/`NOOP`; a later turn is never canceled |
+| L1-17 | `sessions/chat` | Close active session | Turn canceled, attachments detached, history retained in-process |
+| L1-18 | `sessions/chat` | Load | Retained history replayed with the same item IDs |
+| L1-19 | `sessions/chat` | Resume | Attaches at live head with no replay |
+| L1-20 | `transport/acp` | Unsupported methods | Plans, FS, terminal, fork, auth, client MCP rejected without side effects |
+| L1-21 | `transport/acp` | Enum parity | Every `(Kind, Phase)` pair has a declared mapping outcome |
+| L1-22 | `transport/acp` | Conformance corpus round-trip | Inbound and outbound mappers agree on the shared fixture subset |
+| L1-23 | `factory` | Factory Builder success | Creates and validates graph and JavaScript examples through public behavior |
+| L1-24 | `factory` | Factory Builder invalid Factory | Actionable validation explanation; invalid output not installed |
+
+End-to-end with `acpx` or another real client, plus human acceptance on Zed, a
+Neovim ACP client, a VS Code ACP-capable client, and one non-editor client.
+Retain sanitized transcripts, logs, and provider invocation records.
+
+## 12. Acceptance criteria
+
+### Customer
+
+- One configured `you serve acp` agent entry.
+- `session/new` returns a default `@you/factory-builder` target and all allowed
+  installed Factories in the client's picker.
+- Selecting a Factory neither exposes nor mutates You Model resources.
+- Multi-turn prompting against the selected Factory works.
+- Changing Factory between turns opens a new episode without losing history.
+- The Factory's customer-facing output appears as top-level assistant output.
+- Cancel and close visibly stop the intended active turn.
+- Load reproduces retained history; resume reconnects without replay.
+- The agent operates against the workspace the editor supplied.
+
+### Correctness
+
+- Control requests capture turn, episode, and expected version before fan-out;
+  an older intent can never affect a newly admitted turn.
+- Every enum in §4.2 is exhaustive, validated, and transition-tested.
+- Each Chat Session has one monotonic aggregate sequence in commit order.
+- Duplicate source delivery cannot duplicate output.
+- Item IDs assigned at sequencing survive load and reconnect.
+- Retention eviction surfaces as `STREAM_GAP`; history is never fabricated.
+- Slow consumers do not block Factory execution.
+- Advertised capabilities exactly match implemented behavior.
+- No durable store is introduced (D1); no second event taxonomy is introduced.
+- Factory Sessions gains no new event logic (D2).
+
+### Delivery
+
+Complete only when required CI is terminal and passing, blocking review
+conversations are explicitly addressed, conflicts with concurrent lanes are
+resolved against current `main`, generated artifacts are reconciled, and the
+implementation PR is **merged**. Opening a PR, obtaining approval, or reaching
+green CI without merge is not completion.
+
+## References
+
+- `docs/internal/projects/acp-program/README.md` — lane map and decisions
+- `docs/internal/projects/root-consolidation/proposal.md` — L2
+- `docs/internal/projects/acp-worker-events/proposal.md` — L4
+- `docs/architecture/{architecture,data-model,event-streams}.md`
+- `docs/internal/standards/code/planning-standards.md`
+- [ACP session config options](https://agentclientprotocol.com/rfds/session-config-options)
+- [ACP session resume](https://agentclientprotocol.com/rfds/session-resume)
+- [ACP session close](https://agentclientprotocol.com/rfds/session-close)

--- a/docs/internal/projects/acp-program/README.md
+++ b/docs/internal/projects/acp-program/README.md
@@ -1,0 +1,185 @@
+# ACP Program — Lane Map and Cross-Lane Contracts
+
+Status: proposed
+Date: 2026-08-02
+Audience: planners and implementers across ACP, Chat, Events, Worker Sessions,
+Runtime, Workers, Recordings, and packaged-service-structure
+
+This document is the routing index for four independently executable lanes. It
+owns lane boundaries, cross-lane contracts, and the decisions that let the lanes
+run in parallel. It does not contain implementation plans; each lane owns its
+own.
+
+## 1. Lanes
+
+| Lane | Project | Ships | Depends on |
+| --- | --- | --- | --- |
+| **L1 — ACP Core** | `docs/internal/projects/acp-client/` | Chat Sessions, ACP stdio transport, Events stream service, Factory Builder. Factory targets, streaming, cancel/close/load. | nothing |
+| **L2 — Root Consolidation** | `docs/internal/projects/root-consolidation/` | The root contracts worker events require, plus opportunistic cleanup and dead-API removal. | nothing |
+| **L3 — PSS remainder** | `docs/internal/projects/packaged-service-structure/` | Everything in packaged-service-structure not required by worker events. | L2 |
+| **L4 — ACP Worker Events** | `docs/internal/projects/acp-worker-events/` | Worker Sessions control plane, Runtime dispatch cutover, child Worker tool calls, control fan-out. | L1 contracts, L2 |
+
+L3 runs in the background and **gates nothing**. It is slow because it is
+complex; that is acceptable because no other lane waits on it.
+
+L2 is extracted *out of* L3 and inverted: packaged-service-structure consumes
+L2's sealed roots rather than owning them. L2 is deliberately small — only the
+highest-value root cleanup. Everything else defers to L3.
+
+## 2. Decisions
+
+These are settled. Lanes cite them rather than re-deriving them.
+
+### D1 — No storage engine, ever
+
+You introduces no durable event journal, no embedded database for its own state,
+and no write-ahead log. There is no SQLite, bolt, or segment-file backend for
+Chat, Worker, or Factory event history.
+
+- Session state is **session-scoped**. It lives for the duration of the process
+  and is discarded on exit. Terminating a session is a normal, acceptable
+  outcome.
+- Historical reconstruction comes from **the recorder's recorded JSONL
+  artifacts** only.
+- The existing read-only SQLite in `provider_sessions` stays read-only and stays
+  scoped to inspecting third-party agent databases. It is not a precedent.
+
+This supersedes the follow-on in `DEC-RUN-REC-DURABILITY` that anticipated
+"Recordings durable log/cursor/retention." That work is cancelled, not deferred.
+The process-local `CheckpointStore` adapter shipped under
+`factory_runtime/internal/services/checkpoint_recovery` is therefore the
+permanent answer, not an interim one.
+
+### D2 — Persistence and event stream are separate concerns
+
+packaged-service-structure currently bundles durable log, cursor, and retention
+into one Recordings sequence step. That bundling is wrong and L3 revises it.
+
+| Concern | Owner | Nature |
+| --- | --- | --- |
+| Canonical Factory history and replay | Recordings | JSONL artifacts on disk |
+| Event stream: ordering, cursors, subscriptions, retention, gaps, backpressure | Events service | in-memory, session-scoped |
+
+The Events service is a **stream**, not a store. It has no persistence
+responsibility and no `internal/store/` package. Recordings remains the
+canonical ledger and cedes nothing.
+
+### D3 — `pkg/wire` is not an exclusive lease
+
+Adding a service to the composition graph is a few lines in
+`pkg/wire/wire.go`, `wire_gen.go`, and `profiles.go`. Treating that as an
+exclusive path lease serialises every lane behind one packet for no correctness
+benefit.
+
+`pkg/wire/`, `pkg/root/`, and `pkg/initializer/` are **shared append-only
+composition surfaces**. Conflicts there are resolved by normal rebase. No lane
+holds a lease on them, no lane waits for a fan-in integration packet, and
+composition edits are not phase gates.
+
+Exclusive leases remain correct for paths where two packets would make
+*semantically incompatible* edits to the same contract. They are not correct for
+additive composition.
+
+### D4 — Thin shims over current contracts, registered for deletion
+
+L1 and L4 consume existing services through the narrowest consumer-owned port
+that satisfies them, adapted from whatever the root looks like today — including
+the 45-method `factory_sessions.Service`. Shims:
+
+- live in the consumer package, never the provider;
+- import only the provider's public root, never its `internal/` tree;
+- change no behavior;
+- are registered as deletion candidates in L2's catalog at the moment they are
+  created, so they cannot rot silently.
+
+Additive root operations are exempt: adding one deliberate operation to a root
+is preferred over a shim that reaches around it.
+
+### D5 — Opportunistic cleanup belongs to L2
+
+Architecture cleanup is wanted, but it does not travel with feature work. Dead
+API removal, duplicate-method collapse, alias-surface reduction, and
+secondary-injection retirement are L2 tasks. L1 and L4 carry none of it.
+
+### D6 — Target references are unversioned
+
+`factory:@you/review` carries no version or digest. Resolving a target that has
+changed or been uninstalled is a runtime error, not a historical-fidelity
+problem. Accepted as-is.
+
+## 3. Cross-lane contracts
+
+Published on day 0 so all four lanes code against them with fakes immediately.
+Contract definition is not a lane; it is the first task inside each owning lane,
+and no lane waits for another lane's implementation.
+
+| Contract | Owner lane | Consumed by |
+| --- | --- | --- |
+| `events.Service` — append, attach source, read, subscribe | L1 | L1, L4 |
+| `events` record envelope and topic identity | L1 | L1, L4 |
+| `chat_sessions.Service` — session, target, turn, control, attachment | L1 | L1, L4 |
+| `ChatTargetRef` and target-catalog values | L1 | L1, L4 |
+| `worker_sessions.Service` — start, turn, control, association | L4 | L4 |
+| Sealed `workers` execution root | L2 | L4 |
+| Sealed Runtime dispatch operations | L2 | L4 |
+| Providers attempt-control capability results | L2 | L4 |
+| `operator_settings.ACPAgentProfile` (additive) | L1 | L1, L4 |
+
+### Vocabulary is not re-declared
+
+`pkg/services/workers/response_drafts.go` is the canonical normalized event
+vocabulary: `Kind`, `Phase`, `Draft`, `ContentBlock`, and the typed payloads
+including `ToolPayload{ToolCallID, ToolName, Status, ArgumentsSummary,
+ResultSummary}`.
+
+No lane introduces a second taxonomy. The Events service carries source-native
+payloads behind a delivery envelope; the *kind* taxonomy is the one above.
+`factory_sessions/internal/responseevents` and
+`factory_sessions/response_event_contract.go` are existing re-alias layers over
+it and are migration inputs to L1, not new vocabulary.
+
+## 4. Shared surfaces and how conflicts resolve
+
+| Surface | Rule |
+| --- | --- |
+| `pkg/wire/**`, `pkg/root/**`, `pkg/initializer/**` | Shared, append-only, normal rebase. No lease. (D3) |
+| `pkg/services/workers/response_drafts.go` | L2 may harden; no lane may extend the taxonomy. |
+| `factory_sessions/internal/{responseeventstore,responsestream,cursors}` | L1 migrates these into `pkg/services/events`. L2/L3 do not touch them while L1 is active. |
+| `pkg/services/factory_sessions` root | L1 and L4 read through shims only. L2 owns changes. |
+| Recordings JSONL artifact format | Recordings-owned. Any lane needing a field files it as an L2 or L3 request. |
+| `docs/architecture/{architecture,data-model,event-streams}.md` | L1 owns the reconciliation pass (§6). |
+
+## 5. Non-goals across all lanes
+
+- No durable event store, in any lane, at any phase. (D1)
+- No second canonical Factory ledger. Recordings stays canonical.
+- No universal normalized event vocabulary beyond the existing one.
+- No repository freeze, baseline-recording task, or path lease on composition.
+- No ACP filesystem callbacks, terminals, fork, agent plans, client-supplied MCP
+  servers, or authentication in either ACP lane's first release.
+- No Factory represented as a Model.
+
+## 6. Documentation reconciliation owed
+
+L1 carries these; they are currently inconsistent with every lane.
+
+- `docs/architecture/architecture.md` names `pkg/services/chat`,
+  `pkg/services/event_stream`, and `pkg/services/docs`. Actual packages are
+  `chat_sessions` and `events`; there is no Docs service. Reconcile.
+- `docs/architecture/data-model.md` documents `FactoryResponseEvent` as
+  ephemeral and outside replay history. That remains true under D1 and D2 — but
+  the public vocabulary gains `Chat Session`, `Worker Session`, `Target
+  Episode`, and `Turn`. Add them.
+- `docs/architecture/event-streams.md` sketches a third hierarchical event
+  vocabulary. Either reconcile it with `workers.Kind` or mark it superseded.
+- `packaged-service-structure/README.md` and its local plan need the D1/D2/D3
+  revisions recorded.
+
+## 7. Lane plans
+
+| Lane | Plan document |
+| --- | --- |
+| L1 | `docs/internal/projects/acp-client/final-proposal.md` |
+| L2 | `docs/internal/projects/root-consolidation/proposal.md` |
+| L3 | `docs/internal/projects/packaged-service-structure/README.md` |
+| L4 | `docs/internal/projects/acp-worker-events/proposal.md` |

--- a/docs/internal/projects/acp-worker-events/proposal.md
+++ b/docs/internal/projects/acp-worker-events/proposal.md
@@ -1,0 +1,474 @@
+# L4 — ACP Worker Events
+
+Status: proposed
+Date: 2026-08-02
+Lane: L4 of `docs/internal/projects/acp-program/README.md`
+Depends on: L1 published contracts (`events.Service`, `chat_sessions.Service`),
+L2 sealed roots (`workers` execution, Runtime dispatch, Providers attempt
+control)
+
+Program decisions D1–D6 are settled in the lane map. This plan cites them and
+does not re-derive them.
+
+## 1. What this lane adds
+
+L1 ships a Chat Session that prompts a Factory and streams its customer-facing
+response. L1 has no concept of the Workers executing underneath — a Factory turn
+is opaque text.
+
+L4 makes each Worker execution a first-class, controllable, observable resource
+and projects it into ACP as a tool call:
+
+- `pkg/services/worker_sessions` — durable-for-the-session Worker execution
+  identity, supervision, control, and Provider Session association.
+- Factory Runtime dispatch cutover from the workstation-pool boundary to
+  `worker_sessions.Service.Start`.
+- Worker topics on the L1 Events stream.
+- ACP parent/child tool-call projection.
+- pause / resume / cancel / terminate fan-out from a Chat turn to every
+  descendant Worker Session.
+
+Out of scope: direct Worker chat targets (that is an L1 follow-on once Worker
+Sessions exists), provider daemon pooling (§4.9), and anything in L2 or L3.
+
+## 2. Assumed inputs
+
+| Input | Owner | Consumed as |
+| --- | --- | --- |
+| `events.Service` append/attach/read/subscribe | L1 | injected root |
+| `chat_sessions.Service` turn + control + aggregate sequencing | L1 | injected root |
+| Sealed `workers` execution root | L2 | injected root |
+| Sealed Runtime dispatch operations | L2 | injected root |
+| Providers attempt-control capability results | L2 | injected root |
+| `providers.SessionRef{Provider, Kind, ID}` + `Validate()` | existing | value type |
+| `workers.Kind` / `Phase` / `Draft` / `ToolPayload` | existing | vocabulary (lane map §3) |
+
+Where an L2 seal has not landed when a task begins, that task uses a thin
+consumer-owned shim per D4 and registers it as an L2 deletion candidate. L4
+never blocks on L2 completion.
+
+## 3. Worker Sessions contract
+
+```go
+type Service interface {
+    Start(context.Context, StartRequest) (StartResult, error)
+    StartTurn(context.Context, StartTurnRequest) (StartTurnResult, error)
+    Get(context.Context, GetRequest) (Session, error)
+    List(context.Context, ListRequest) (ListResult, error)
+    Pause(context.Context, ControlRequest) (ControlResult, error)
+    Resume(context.Context, ControlRequest) (ControlResult, error)
+    Cancel(context.Context, ControlRequest) (ControlResult, error)
+    Terminate(context.Context, ControlRequest) (ControlResult, error)
+    GetResult(context.Context, ResultRequest) (Result, error)
+    ListProviderSessions(context.Context, ProviderSessionListRequest) (ProviderSessionListResult, error)
+}
+```
+
+`Start` ordering is load-bearing and testable:
+
+1. validate an already-resolved Worker execution specification;
+2. reserve the Worker Session ID and record `RESERVED`;
+3. attach the Worker source to its Events topic;
+4. transition `STARTING` and hand the attempt to the Workers root under
+   supervision;
+5. return the Worker Session ID.
+
+Step 3 precedes step 4. The identifier and its stream exist before any Worker
+output can be produced. This is what makes §4.7 work.
+
+Worker Sessions owns lifecycle and supervision. It does not own runner policy,
+prompts, worktrees, output shaping, or provider invocation — those stay in
+Workers.
+
+## 4. Design
+
+### 4.1 Worker Session state machine
+
+Per D1, sessions are session-scoped and die with the process. There is **no
+`INTERRUPTED` state and no restart reconciliation**. Process exit is a normal
+terminal condition; history is reconstructable from Recordings JSONL.
+
+States: `RESERVED`, `STARTING`, `RUNNING`, `PAUSED`, `COMPLETED`, `FAILED`,
+`CANCELED`, `TERMINATED`.
+
+| From | Event | To | Notes |
+| --- | --- | --- | --- |
+| `RESERVED` | source attached, attempt handed off | `STARTING` | |
+| `RESERVED` | validation failure | `FAILED` | no attempt started |
+| `RESERVED` | `Cancel` / `Terminate` | `CANCELED` / `TERMINATED` | no attempt started; no external effect |
+| `STARTING` | first attempt acknowledgement | `RUNNING` | |
+| `STARTING` | start failure | `FAILED` | typed cause required |
+| `STARTING` | `Cancel` / `Terminate` | `CANCELED` / `TERMINATED` | must join the in-flight handoff |
+| `RUNNING` | terminal success | `COMPLETED` | |
+| `RUNNING` | terminal failure | `FAILED` | typed cause required (§4.4) |
+| `RUNNING` | `Pause` accepted, all operations terminal-or-resumable | `PAUSED` | |
+| `RUNNING` | `Cancel` | `CANCELED` | via §4.3 |
+| `RUNNING` | `Terminate` | `TERMINATED` | via §4.3, joins the process |
+| `PAUSED` | `Resume` with validated association | `RUNNING` | §4.10 |
+| `PAUSED` | `Cancel` / `Terminate` | `CANCELED` / `TERMINATED` | |
+| terminal | any control | unchanged | idempotent no-op result, not an error |
+
+Rules:
+
+- `Pause` reports `PAUSED` only after every active operation is terminal or
+  safely resumable. A `Pause` that cannot reach that condition returns a typed
+  refusal and leaves state `RUNNING`.
+- Terminal states are absorbing. Repeat controls return a deterministic no-op
+  `ControlResult`, never an error and never a second external effect.
+- Every transition into `FAILED` carries a non-nil typed cause.
+
+`ControlAction` = `PAUSE | RESUME | CANCEL | TERMINATE`. Control results are
+`ACCEPTED | NOOP | REFUSED`, each with a typed reason.
+
+### 4.2 Runtime dispatch cutover
+
+Today Factory Runtime dispatches through the workstation-pool boundary:
+
+```
+factory_runtime/internal/services/orchestration/runtime/factory.go
+  → workers.NewWorkstationPoolBoundary(...)
+  → workstationPoolBoundary.Publish(ctx, request, accept)
+  → workers.Service.DispatchWorkstation
+  → workerExecutorRequestAdapter.Execute
+  → WorkerExecutor.Execute(ctx, work.WorkDispatch)
+```
+
+L4 inserts Worker Sessions above that seam: Runtime calls
+`worker_sessions.Service.Start` with the resolved dispatch, receives the Worker
+Session ID, records the dispatch→Worker-Session association in canonical Factory
+Events, and Worker Sessions drives the existing boundary underneath.
+
+The boundary is **not** removed in this lane. `workers.Service.Execute` is
+currently dead in production (no `workers.ExecuteRequest` construction exists
+outside the Workers package); whether to finish that cutover or delete it is an
+L2 decision under D5, not an L4 task. L4 targets whichever surface L2 has
+sealed, through a shim if necessary.
+
+### 4.3 Cancellation routes through the boundary, not context
+
+`workstationPoolBoundary.Publish` deliberately severs caller cancellation:
+
+```go
+execute := func() {
+    result, err := b.service.DispatchWorkstation(context.WithoutCancel(ctx), request)
+    accept(context.Background(), request, result, err)
+}
+if b.async { go execute(); return nil }
+```
+
+`context.WithoutCancel(ctx)` means cancelling the caller's context does nothing
+to a running dispatch, and `context.Background()` means the result callback is
+likewise uncancellable.
+
+Therefore **Worker Session `Cancel` and `Terminate` must call
+`WorkstationPoolBoundary.Cancel` → `workers.Service.CancelWorkstationDispatch`.**
+Any implementation that cancels a context and reports `CANCELED` is wrong and
+will pass naive tests while leaving the provider process running.
+
+`Terminate` additionally joins the dispatch: it does not report `TERMINATED`
+until the accept callback has fired or the supervisor has positively reaped the
+attempt. Cancellation tests assert on observed provider-edge effects, not on
+state transitions alone.
+
+### 4.4 Terminal-outcome fidelity
+
+`workerExecutorRequestAdapter.Execute` recovers executor panics:
+
+```go
+defer func() {
+    if recovered := recover(); recovered != nil {
+        result = WorkResult{
+            DispatchID: ..., TransitionID: ...,
+            Outcome: OutcomeFailed,
+            Error:   fmt.Sprintf("executor panic: %v", recovered),
+        }
+        err = nil
+    }
+}()
+```
+
+The failure is real but arrives with `err == nil`. A supervisor that branches on
+`err` alone sees success. Worker Sessions must classify terminal outcome from
+`WorkResult.Outcome` first and `err` second, and must map
+`OutcomeFailed` + non-empty `Error` to `FAILED` with a typed
+`FailureCause{Kind: EXECUTOR_PANIC, Detail: ...}`.
+
+This is required for the state machine's "every `FAILED` carries a non-nil typed
+cause" rule to hold, and it is the specific case that makes deterministic
+terminal outcomes testable.
+
+### 4.5 Worker topics on the Events stream
+
+One topic per Worker Session: `worker-session/<id>/events`. Records carry
+source-native payloads behind the L1 delivery envelope; the kind taxonomy is
+`workers.Kind` (lane map §3). Idempotency key is
+`(sourceType, sourceID, sourceSequence, sourceEventID)`.
+
+Per D2 the topic is an in-memory stream with session-scoped retention. It is not
+a store and it does not persist.
+
+### 4.6 Tool-call identity is assigned by the sequencer
+
+The original proposal had a "registration barrier" that made early child output
+wait until a dispatch→Worker-Session association was indexed. That mechanism is
+**deleted**, because it solved a problem that the ordering model removes.
+
+Chat Sessions assigns, at sequencing time, onto every aggregate record:
+
+- `ItemID` — the stable ACP item this record belongs to;
+- `ParentItemID` — the parent tool call, empty for top-level assistant output.
+
+A Worker Session's parent tool call is created by the record that opens it, and
+every child record is sequenced after that record because the sequencer assigns
+both. A child cannot precede its parent by construction. No barrier, no waiting,
+no buffering.
+
+This makes the ACP transport a **pure function**: `record → SessionUpdate`, with
+no connection-local map from Worker Session to open tool item. That is what lets
+the mapping be exhaustively table-tested, and it is why stable IDs survive
+`session/load` and reconnect — the IDs come from the sequencer, not from
+per-connection reconstruction.
+
+Projection:
+
+| Source record | ACP output |
+| --- | --- |
+| Worker Session opened for a Factory dispatch | `tool_call` (`pending`) |
+| Worker Session `STARTING` → `RUNNING` | `tool_call_update` (`in_progress`) |
+| Child `MESSAGE` / `REASONING` / `TOOL` / `PROGRESS` | `tool_call_update` content on the parent item |
+| Worker Session terminal | terminal `tool_call_update` (`completed` / `failed`) |
+| Factory customer-facing `MESSAGE` / `REASONING` | top-level `agent_message_chunk` / `agent_thought_chunk` |
+
+`workers.ToolPayload` already carries `ToolCallID`, `ToolName`, `Status`,
+`ArgumentsSummary`, and `ResultSummary`; native child tool calls map through
+those fields rather than a new shape.
+
+### 4.7 Tool-call content bounding
+
+Appending every child record into one parent `tool_call_update` is unbounded: a
+long-running Worker emitting thousands of chunks degrades client rendering and
+inflates replay.
+
+L4 reuses the eviction semantics already specified in
+`factory_sessions/internal/responseeventstore/doc.go` rather than inventing new
+ones:
+
+- hard per-parent-item limits on retained child records and serialized bytes;
+- evict the oldest record in the lowest semantic tier first (`PROGRESS` before
+  `MESSAGE` before `TOOL` before terminal);
+- retained envelopes and their published identities are preserved verbatim;
+- evicted spans surface as one cursor-relative `STREAM_GAP` before retained
+  catch-up, out-of-band at sequence zero, never retained, never consuming a
+  published identity.
+
+The customer-visible contract: a tool call may show an explicit elision marker.
+It never silently drops content and never fabricates history.
+
+### 4.8 Provider concurrency gate — decision
+
+`providers/internal/services/acp/internal/service/service.go` keeps one retained
+subprocess per configured ACP integration, serialized by a
+`gate: make(chan struct{}, 1)` acquired around prompt and cancel. **One
+concurrent prompt per integration.** Three Factory Workers targeting the same
+ACP integration execute serially, however concurrent the Factory is.
+
+Decision for L4:
+
+1. **Do not change provider daemon lifecycle in this lane.** Subprocess pooling
+   is Providers-owned and changing it alongside a dispatch cutover compounds two
+   risky changes.
+2. **Render queued children honestly.** A Worker Session in `RESERVED` /
+   `STARTING` still emits its parent `tool_call` in `pending`. The customer sees
+   three tool calls immediately and watches them progress serially, rather than
+   seeing tool calls appear one at a time with no explanation.
+3. **Scope concurrency acceptance evidence to distinct provider integrations**
+   or non-ACP providers, so the test proves isolation of the projection rather
+   than accidentally proving the gate.
+4. **File per-session daemon pooling as an explicit Providers follow-on** in the
+   L2 catalog. It is a real limit with a real customer symptom; it is recorded,
+   not hidden.
+
+### 4.9 Provider Session association and resume
+
+Association record:
+
+```text
+WorkerProviderSessionAssociation {
+  workerSessionId
+  providerSessionRef providers.SessionRef { Provider, Kind, ID }
+  turnId, dispatchId, attemptId
+  role, status
+  firstWorkerEventSequence, lastWorkerEventSequence
+}
+```
+
+Rules:
+
+- The association is recorded **before** any event that depends on it is
+  published.
+- `Resume` validates the exact typed reference through the Providers root
+  (`SessionRef.Validate()`, then provider-side existence) and passes it as
+  `ExecuteRequest.ResumeSession`.
+- A resume whose reference is missing or invalid **fails with a typed error**.
+  It never silently reselects the current default provider or model. This is the
+  single most important correctness rule in this section: silent reselection
+  produces a plausible-looking answer from the wrong context.
+- Factory Runtime records dispatch→Worker-Session associations in canonical
+  Factory Events. Factory Sessions resolves descendant Worker Session IDs from
+  that projection for control fan-out; it does not duplicate Provider Session
+  associations.
+
+### 4.10 Control fan-out
+
+Cancel of a Chat turn, per L1, captures turn ID, target episode, and expected
+version before any downstream call. L4 supplies the descendant half:
+
+- Factory control enters through Factory Sessions → Factory Runtime.
+- Runtime stops new scheduling, resolves descendant Worker Session IDs from the
+  canonical projection, and dispatches the control to each.
+- `PAUSED` is reported only after every descendant is terminal or safely
+  resumable.
+- `TERMINATED` is reported only after every descendant is joined.
+- An old control intent can never affect a newly admitted turn; the captured
+  turn ID is the target.
+
+## 5. Vertical slices
+
+Each slice is independently demonstrable.
+
+**W1 — Worker Session identity.** Contracts, state machine, in-memory session
+registry, `Get`/`List`. Outcome: a Worker execution has an ID and an inspectable
+state before it produces output.
+
+**W2 — Supervision and terminal fidelity.** `Start` ordering, attempt handoff,
+outcome classification including §4.4. Outcome: every Worker execution reaches
+exactly one terminal state with a typed cause.
+
+**W3 — Worker events.** Topic attachment, record publication, result projection.
+Outcome: a Worker's output is readable through the Events stream by cursor.
+
+**W4 — Runtime cutover.** Factory Runtime dispatches through Worker Sessions;
+dispatch→session association recorded in Factory Events. Outcome: Factory
+children and direct executions converge on one control plane.
+
+**W5 — ACP tool calls.** Sequencer item identity, pure transport projection,
+content bounding. Outcome: concurrent Factory children appear as stable,
+isolated ACP tool calls.
+
+**W6 — Controls.** Pause/resume/cancel/terminate on Worker Sessions via §4.3,
+plus Factory fan-out. Outcome: cancelling a Chat turn provably stops every
+descendant Worker.
+
+**W7 — Provider continuation.** Association store and exact-reference resume.
+Outcome: a paused Worker resumes into the same provider session.
+
+```mermaid
+flowchart TD
+    W1["W1 identity + state machine"]
+    W2["W2 supervision + terminal fidelity"]
+    W3["W3 worker events topic"]
+    W4["W4 runtime dispatch cutover"]
+    W5["W5 ACP tool-call projection"]
+    W6["W6 controls + fan-out"]
+    W7["W7 provider continuation"]
+    L1C["L1 events + chat contracts"]
+    L2C["L2 sealed workers/runtime/providers roots"]
+
+    L1C --> W3
+    L1C --> W5
+    L2C --> W2
+    L2C --> W4
+    L2C --> W7
+    W1 --> W2
+    W1 --> W3
+    W2 --> W4
+    W3 --> W4
+    W3 --> W5
+    W4 --> W5
+    W2 --> W6
+    W4 --> W6
+    W6 --> W7
+```
+
+## 6. Functional tests
+
+Construction rules: tests build through `root.BuildProcess` and call
+`Process.Execute`. External provider effects are replaced only through
+`edges.Edges`, preferring `ProviderCommandRunner` with sanitized
+real-provider-shaped fixtures. No arbitrary sleeps — synchronization is on
+committed Events records, controlled provider edges, or explicit lifecycle
+outcomes. Concurrency paths run under `-race` with repeat/stress modes.
+
+| ID | Path | Scenario | Required evidence |
+| --- | --- | --- | --- |
+| WEV-FT-001 | `workers/sessions` | Factory-originated Worker Session | ID and topic exist before first output record |
+| WEV-FT-002 | `workers/sessions` | Every terminal state reachable | Each of COMPLETED/FAILED/CANCELED/TERMINATED observed with typed cause |
+| WEV-FT-003 | `workers/sessions` | Executor panic | `FAILED` with `EXECUTOR_PANIC` cause despite nil error from the adapter |
+| WEV-FT-004 | `workers/sessions` | Terminal control idempotence | Repeat cancel returns NOOP; no second provider effect at the edge |
+| WEV-FT-005 | `workers/sessions` | Cancel stops the process | Provider edge observes termination; context-only cancel would fail this test |
+| WEV-FT-006 | `workers/sessions` | Terminate joins | No provider effect after `TERMINATED` is reported |
+| WEV-FT-007 | `workers/sessions` | Pause gating | `PAUSED` only after all operations terminal-or-resumable; refusal is typed |
+| WEV-FT-008 | `workers/sessions` | Resume exact reference | Provider receives the exact `SessionRef`; no default reselection |
+| WEV-FT-009 | `workers/sessions` | Resume with invalid reference | Typed failure; no attempt started |
+| WEV-FT-010 | `events` | Worker topic ordering | Records delivered in commit order with no gaps or duplicates |
+| WEV-FT-011 | `events` | Duplicate source delivery | Idempotency tuple prevents duplicate output |
+| WEV-FT-012 | `factory/acp_projection` | Parent precedes children | Every child record carries a `ParentItemID` sequenced after its parent |
+| WEV-FT-013 | `factory/acp_projection` | Concurrent children | One stable tool call per Worker Session with isolated deltas; distinct integrations per §4.8 |
+| WEV-FT-014 | `factory/acp_projection` | Queued child rendering | A not-yet-started Worker still shows a `pending` tool call |
+| WEV-FT-015 | `factory/acp_projection` | Content bounding | Eviction produces an explicit gap marker; no silent drop, no fabricated history |
+| WEV-FT-016 | `factory/acp_projection` | Pure mapping | Table-driven coverage of every `(Kind, Phase)` pair, including explicit no-output cases |
+| WEV-FT-017 | `factory/acp_projection` | Replay stability | Item IDs identical across load and live delivery |
+| WEV-FT-018 | `sessions/chat` | Cancel fan-out | Every descendant Worker Session reaches a terminal state |
+| WEV-FT-019 | `sessions/chat` | Cancel vs completion race | One deterministic outcome for the captured turn; a later turn is unaffected |
+| WEV-FT-020 | `factory/acp_projection` | Factory pause/resume | Control reaches every associated descendant |
+| WEV-FT-021 | `workers/sessions` | Process exit | All sessions terminalize; no INTERRUPTED state; Recordings JSONL reconstructs history |
+| WEV-FT-022 | `workers/sessions` | Partial child failure | One failing child does not corrupt sibling tool calls or the Factory turn result |
+
+## 7. Acceptance criteria
+
+Customer-observable:
+
+- Each Worker a Factory runs appears as its own ACP tool call, with its own
+  progress, and its own terminal status.
+- Concurrent Workers appear as separate tool calls whose content does not
+  interleave.
+- Cancelling a turn visibly stops every Worker that turn started.
+- A long-running Worker's tool call stays readable; elided content is marked, not
+  dropped.
+- A resumed Worker continues the same provider conversation, or fails visibly.
+
+Behavioral correctness:
+
+- Every Worker execution obtains a Worker Session ID and an attached event topic
+  before it produces output.
+- Every Worker Session reaches exactly one terminal state, and every `FAILED`
+  carries a non-nil typed cause — including executor panics.
+- Cancel and terminate produce an observable effect at the provider edge, not
+  only a state transition.
+- Repeat controls on a terminal session are no-ops with no second external
+  effect.
+- `PAUSED` is reported only when every active operation is terminal or safely
+  resumable.
+- Resume passes the exact typed `SessionRef` and never falls back to a default.
+- No child ACP record is ever delivered before the parent tool call that owns it.
+- The ACP record→`SessionUpdate` mapping is a pure function with exhaustive
+  `(Kind, Phase)` coverage.
+- Factory-originated and direct Worker executions have the same session, result,
+  and control shape.
+- Process exit terminalizes all sessions; no reconciliation path exists and none
+  is required.
+
+Quality gates (necessary, not sufficient): focused package tests, the functional
+matrix above under `-race` with repeat, `make verify-fast`, and the required PR
+verification tier.
+
+## 8. Delivery boundary
+
+This lane is complete only when required CI is terminal and passing, blocking
+review conversations are explicitly addressed, conflicts with concurrent lanes
+are resolved against current `main`, and the implementation is **merged**.
+Opening a PR, obtaining approval, or reaching green CI without merge is not
+completion.
+
+Composition edits under `pkg/wire/**` are resolved by normal rebase per D3 and
+are not a phase gate for this lane.

--- a/docs/internal/projects/packaged-service-structure/README.md
+++ b/docs/internal/projects/packaged-service-structure/README.md
@@ -15,6 +15,8 @@ CLI manifests/generators, or provider registry/conductor surfaces.
 | `internal/ownershipinventory` | Builds/validates the PSS-F01 freeze using FND-10 mechanics |
 | `docs/temp/projects/packaged-service-structure/plan.md` | Source plan prose and Changed-Path Lease Matrix |
 | [`docs/temp/projects/packaged-service-structure/dec-run-rec-durability.md`](../../../temp/projects/packaged-service-structure/dec-run-rec-durability.md) | DEC-RUN-REC-DURABILITY — Runtime checkpoint vs Recordings history ownership |
+| [`docs/internal/projects/acp-program/README.md`](../acp-program/README.md) | ACP Program lane map — owns D1/D2/D3 and the L2 extraction this program now consumes |
+| `docs/internal/projects/root-consolidation/` | **L2** — root consolidation extracted from this program; PSS depends on it |
 
 `docs/temp/**` remains local planner working state (gitignored). The committed
 ledger under this directory is the reviewable program-metadata source for
@@ -95,6 +97,131 @@ second architecture tree, or take shared Wire/HTTP/CLI/MCP fan-in cutovers
 those integration packets; do not edit generated OpenAPI bundles, CLI
 manifests/generators, or provider registry/conductor surfaces to record lease
 or packet-state evidence.
+
+## Program lane position
+
+This program is **L3** in
+[`docs/internal/projects/acp-program/README.md`](../acp-program/README.md).
+
+- L3 runs in the **background** and gates nothing. No other lane waits on a PSS
+  packet reaching a terminal state.
+- The highest-value root cleanup required by ACP Worker Events is extracted into
+  **L2** (`docs/internal/projects/root-consolidation/`). PSS **depends on L2**
+  rather than owning that work. The dependency is inverted deliberately: L2 is
+  small and fast, PSS is large and slow, and coupling ACP delivery to PSS
+  scheduling was the constraint being removed.
+- Packets whose scope L2 now covers are superseded rather than re-planned here.
+  When L2 seals a root, the corresponding PSS packet records the L2 packet as a
+  prerequisite and narrows to whatever remains.
+
+PSS retains everything not required by worker events: Petri surface retirement,
+architecture-rule enforcement, ownership inventory, behavior baselines, and the
+remaining integration lanes.
+
+## Durability and event-stream revisions
+
+Two decisions from the ACP program lane map revise this program's Recordings
+sequence. Planners cite them by ID; they are not re-derived here.
+
+### D1 — no storage engine, ever (supersedes a DEC-RUN-REC-DURABILITY follow-on)
+
+[`DEC-RUN-REC-DURABILITY`](../../../temp/projects/packaged-service-structure/dec-run-rec-durability.md)
+remains the accepted decision for checkpoint-versus-history ownership. Its
+anticipated follow-on — "Recordings-backed durable checkpoint bytes after
+Recordings durable log/cursor/retention" — is now **cancelled, not deferred**.
+
+- You introduces no durable event journal, embedded database, or write-ahead log
+  for its own state, at any phase.
+- The opaque process-local `CheckpointStore` adapter already shipped under
+  `factory_runtime/internal/services/checkpoint_recovery` (IMP-RUN-04, PR #1580)
+  is the **permanent** answer, not an interim one.
+- Historical reconstruction comes from the recorder's recorded JSONL artifacts
+  only.
+- "Recordings durable log/cursor/retention" is removed from the Recordings
+  sequence. It is not a later step; it is not a step.
+
+The read-only SQLite in `provider_sessions` stays read-only and stays scoped to
+inspecting third-party agent databases. It is not a precedent.
+
+### D2 — persistence and event stream are separate concerns
+
+This program previously bundled durable log, cursor, and retention into one
+Recordings sequence step. That bundling is wrong: the two concerns have
+different owners, lifetimes, and failure modes.
+
+| Concern | Owner | Nature |
+| --- | --- | --- |
+| Canonical Factory history and replay | Recordings | JSONL artifacts on disk |
+| Ordering, cursors, subscriptions, retention, gaps, backpressure | Events service (L1) | in-memory, session-scoped |
+
+The Events service is a **stream**, not a store. It carries no persistence
+responsibility and has no store package. Recordings remains the canonical ledger
+and cedes nothing to it.
+
+Consequences for PSS packets:
+
+- `FND-08` (`event-contract`, `pkg/services/recordings/events/kinds/`) stays
+  Recordings-owned and is unaffected — event *kinds* are contract, not stream.
+- `PSS-I05` (`event-backbone`) must be re-scoped against D2 before dispatch. An
+  "event backbone convergence" that merges persistence with streaming
+  contradicts this split.
+- `factory_sessions/internal/{responseeventstore,responsestream,cursors}` migrate
+  into `pkg/services/events` under L1. **PSS packets must not touch those paths
+  while L1 is active.**
+
+## Composition surfaces are not leased
+
+### D3 — `pkg/wire`, `pkg/root`, and `pkg/initializer` carry no exclusive lease
+
+Registering a service in the composition graph is a few additive lines across
+`pkg/wire/wire.go`, `pkg/wire/wire_gen.go`, and `pkg/wire/profiles.go`. Holding
+an exclusive path lease over those files serialises every lane in the portfolio
+behind one packet, for no correctness benefit: two packets adding two different
+providers do not produce a semantic conflict, only a textual one.
+
+The lease mechanism exists to prevent **semantically incompatible edits to the
+same contract**. It is not a merge-conflict avoidance tool. Textual conflicts in
+additive composition are resolved by normal rebase, which is implementation
+mechanics rather than a scheduling gate.
+
+Accordingly:
+
+- `pkg/wire/**`, `pkg/root/**`, and `pkg/initializer/**` are **shared,
+  append-only composition surfaces**.
+- No packet blocks another by claiming them.
+- No lane waits for a fan-in integration packet before landing its own
+  constructor and lifecycle registration.
+
+Structural changes remain exclusive: altering `root.BuildProcess`'s signature,
+restructuring the `profiles.go` provider sets, or changing the `wire_gen`
+regeneration contract are contract edits and still warrant a lease.
+
+## Required manifest follow-up
+
+D3 requires a `path-lease-packet-manifest.json` change that has **not** been
+applied. It is recorded here rather than executed because the manifest is
+validated by `internal/psslease` and edits must be made with its validators.
+
+Target packet — identified by its current exclusive paths:
+
+| Packet | `leaseClass` | Current exclusive paths | Required change |
+| --- | --- | --- | --- |
+| `PSS-I01` | `root-wire-process` | `pkg/wire/` ; `pkg/root/` ; `pkg/initializer/` | Narrow to the structural surfaces it genuinely owns; drop the blanket directory prefixes so additive composition is unleased |
+
+Constraints the follow-up must respect:
+
+- `ValidateCatalog` requires `PSS-I01` to remain present. The packet is
+  **narrowed, not deleted**.
+- `exclusivePaths` must stay non-empty; an empty set fails validation.
+- The path-overlap rule is prefix-based, so `pkg/wire/` must be replaced with
+  specific files rather than left as a directory claim.
+
+If a future planner instead wants "additive edits shared, structural edits
+exclusive" expressed directly, that requires a change-kind dimension in
+`internal/psslease` which does not exist today. Narrowing the paths is the
+change that fits the current mechanism.
+
+`PSS-I05` re-scoping under D2 is a second follow-up and is described above.
 
 ## Planner state updates
 

--- a/docs/internal/projects/root-consolidation/proposal.md
+++ b/docs/internal/projects/root-consolidation/proposal.md
@@ -1,0 +1,308 @@
+# Root Consolidation (L2) — Primary Dependencies for Worker Events
+
+Status: proposed
+Date: 2026-08-02
+Lane: L2 in `docs/internal/projects/acp-program/README.md`
+Audience: Workers, Factory Runtime, Providers, Recordings maintainers
+
+Governing decisions live in the lane map. This plan cites `D1`–`D6` and does not
+restate them.
+
+## 1. Why this lane exists
+
+ACP Worker Events (L4) needs a small number of service roots to actually mean
+what they claim. That work is currently inside packaged-service-structure (L3),
+which is slow because it is comprehensive. L2 extracts only the roots L4
+consumes, ships them ahead of L3, and L3 then depends on L2's sealed surfaces
+rather than re-deriving them.
+
+L2 is also the only lane permitted to carry opportunistic cleanup (`D5`). Dead
+API removal and duplicate-surface collapse land here so L1 and L4 stay
+feature-shaped.
+
+## 2. Scope fence
+
+### L2 owns
+
+| Area | Reason L4 needs it |
+| --- | --- |
+| Workers execution surface | Worker Sessions must start and cancel one supervised attempt through a sealed root |
+| Workers panic/terminal semantics | Worker Session terminal states must carry a typed cause |
+| Workers runner injection | Mutable reinjection prevents a single injected Workers root |
+| Factory Runtime dispatch operations | Runtime must hand dispatch identity to Worker Sessions |
+| Providers attempt control | Worker pause/cancel/terminate must reach a running provider attempt |
+| Providers continuation | Worker resume must pass an exact typed provider session reference |
+
+### L2 explicitly defers to L3
+
+- **Factory Sessions root sealing.** All 45 methods stay as they are. L1 and L4
+  read through thin shims (`D4`). L4 never calls Factory Sessions for Worker
+  execution, so nothing in L4 blocks on it.
+- **`runtimeOpener` / `RuntimeOpeningFactory` retirement.**
+  `runtimeopening.NewFactory` takes **44 parameters**
+  (`pkg/services/factory_sessions/internal/runtimeopening/factory.go:78-123`)
+  and `RuntimeOpeningDependencies` has **44 exported fields**
+  (`pkg/services/factory_sessions/wire/application_graph.go:145-188`). This is
+  real debt, but no L4 behavior depends on it.
+- **Recordings alias-surface reduction.** `pkg/services/recordings/contracts.go`
+  is 402 lines, 383 of them pure `X = recordingcontracts.X` aliases, and
+  `Service` embeds `recordingcontracts.Service`
+  (`pkg/services/recordings/contracts.go:399-402`) over a 1388-line internal
+  interface. L4 consumes Recordings only for dispatch/Worker-Session
+  associations, which the current surface already supports. Defer.
+- **Factory Definitions catalog sealing.** L1 needs additive catalog reads only.
+- **Petri surface retirement, HTTP/MCP/CLI ownership splits, package-structure
+  checkers.** Untouched.
+
+### Correction to prior analysis
+
+`models.Service` does **not** expose `ForRuntime`
+(`pkg/services/models/service_contract.go:11`). It exposes
+`OpenRuntimeScope`/`CloseRuntimeScope` returning opaque references, with the
+explicit contract *"Implementations must not construct or return another
+Service, host, runtime, puller, limiter, process, or storage handle while
+opening the scope."* Models is **already sealed and is the exemplar pattern**
+for this lane. `ForRuntime` survives only on the private implementation
+(`pkg/services/models/internal/service/runtime_factory.go:123,554`) and in
+legacy input projections (`runtime_config_contract.go:96,230`) — a `DEL-`
+candidate, not a contract problem.
+
+## 3. Evidence base
+
+Verified against the working tree on 2026-08-02.
+
+### E1 — `workers.Service.Execute` is dead in production
+
+`Execute(context.Context, ExecuteRequest) (ExecuteResult, error)` is declared at
+`pkg/services/workers/workstation_contracts.go:266` and documented as *"the
+canonical request-scoped operation"* with pool lifecycle described as
+*"temporary compatibility surfaces for later cutover."*
+
+`workers.ExecuteRequest` has **zero non-test references outside
+`pkg/services/workers`**. Every non-test occurrence is an implementation or
+signature site: `internal/root.go:17,84`, `internal/service/provider.go:18`,
+`internal/service/normalize.go:15`, `internal/service/execute.go:20,121`,
+`internal/service/adapt.go:27`, `internal/runtime_service.go:273`.
+
+The live path is the opposite of the documentation:
+
+```
+factory_runtime/internal/services/orchestration/runtime/factory.go:412
+  → workers.NewWorkstationPoolBoundary(...)
+  → WorkstationPoolBoundary.Publish            (workstation_pool_boundary_impl.go:116)
+  → workers.Service.DispatchWorkstation        (internal/runtime_service.go:331)
+  → workerExecutorRequestAdapter.Execute       (workstation_pool_boundary_impl.go:43)
+  → WorkerExecutor.Execute(ctx, work.WorkDispatch)
+```
+
+### E2 — Cancellation is severed at the boundary
+
+`pkg/services/workers/workstation_pool_boundary_impl.go:116-134`:
+
+```go
+execute := func() {
+	result, err := b.service.DispatchWorkstation(context.WithoutCancel(ctx), request)
+	accept(context.Background(), request, result, err)
+}
+if b.async { go execute(); return nil }
+```
+
+The caller's cancellation and deadline are deliberately dropped. Worker control
+must route through `WorkstationExecutionService.CancelWorkstationDispatch`
+(`workstation_pool_boundary_contracts.go:13`), never through context.
+
+### E3 — Panics produce a nil error
+
+`pkg/services/workers/workstation_pool_boundary_impl.go:43-55` recovers a panic
+into `WorkResult{Outcome: OutcomeFailed, Error: fmt.Sprintf("executor panic: %v",
+recovered)}` and sets `err = nil`. The failure string survives; the Go error does
+not. A caller branching on `err != nil` sees success.
+
+### E4 — Workers runner injection is mutable
+
+`pkg/services/workers/runtime_service.go:34-46` declares `RuntimeService` with
+`WithCommandRunners(CommandRunner, CommandRunner) (RuntimeService, error)` and
+`WithProgressPublisher(...) (RuntimeService, error)` — copy-on-configure builders
+on a service interface. Single production caller:
+`pkg/services/factory_runtime/internal/runtime_build.go:329-357`
+(`workerServiceWithProgress`). Implementations at
+`pkg/services/workers/internal/runtime_construction.go:57,145`.
+
+### E5 — Five Factory Runtime root methods are unimplemented
+
+`pkg/services/factory_runtime/interfaces.go` declares `PlanDispatch` (:88),
+`AcceptDispatchResult` (:96), `CaptureCheckpoint` (:103), `LoadCheckpoint`
+(:110), and `RestoreCheckpoint` (:117), each returning
+`ErrCapabilityUnavailable` (`composition_contracts.go:64`) *"until nested IMP-RUN
+packets"* land. `ErrCapabilityUnavailable` is documented as not a successful
+no-op.
+
+Under `D1` the three checkpoint methods have no durable backing and no planned
+one. The two dispatch methods are what L4 needs.
+
+### E6 — Providers has no attempt control
+
+`pkg/services/providers/service_contract.go:11-28` is three methods:
+`ListProviders`, `GetProvider`, `Execute`. Continuation is half-built —
+`ExecuteRequest.ResumeSession *SessionRef` exists
+(`execute_contract.go:99`) and results *"may carry an optional detached
+SessionRef"*. There is no pause, cancel, or terminate; cancellation is only
+observable after the fact as `ErrExecuteCancelled`.
+
+## 4. Decisions this lane makes
+
+### DEC-L2-EXEC — Delete `Execute`, seal `WorkstationExecutionService`
+
+**Decision:** remove `workers.Service.Execute`, `ExecuteRequest`, and
+`ExecuteResult` from the root; promote the existing narrow port
+`WorkstationExecutionService`
+(`pkg/services/workers/workstation_pool_boundary_contracts.go:9-14`) to the
+sealed Workers execution surface.
+
+Rationale:
+
+1. Deleting `Execute` removes code that has never run in production, not
+   working behavior. Its supporting `internal/service/*.go` normalize/adapt/
+   provider path goes with it.
+2. `Execute` is synchronous and returns no handle. L4 needs start-then-cancel
+   supervision. `WorkstationExecutionService` already provides
+   `DispatchWorkstation` + `CancelWorkstationDispatch` and is the proven path.
+3. A method documented as "canonical" that nothing calls is a trap; the next
+   implementer builds on it and discovers E1 the hard way.
+
+Rejected alternative — finishing the `Execute` cutover — means migrating the
+live boundary onto an untested surface to satisfy a comment.
+
+### DEC-L2-CKPT — Checkpoint methods are removed, not implemented
+
+Under `D1` there is no durable store and none is planned, so `CaptureCheckpoint`,
+`LoadCheckpoint`, and `RestoreCheckpoint` cannot be honestly implemented. They
+are deleted from the root. The process-local `CheckpointStore` under
+`factory_runtime/internal/services/checkpoint_recovery` remains private and
+permanent. Requires an amendment note in
+`packaged-service-structure` recording that the `IMP-RUN-04` follow-on is closed.
+
+## 5. Task catalog
+
+Packets follow the packaged-service-structure vocabulary. Each is independently
+dispatchable unless a dependency is named.
+
+### Workers
+
+| Packet | Scope | Depends on |
+| --- | --- | --- |
+| `CTR-WRK-EXEC` | Publish `WorkstationExecutionService` as the sealed Workers execution contract with documented start/dispatch/cancel semantics, including that cancellation is boundary-routed not context-routed (E2). | — |
+| `DEL-WRK-EXECUTE` | Delete `Service.Execute`, `ExecuteRequest`, `ExecuteResult`, and their `internal/service` normalize/adapt/provider path (E1). | `CTR-WRK-EXEC` |
+| `IMP-WRK-PANIC` | Panic recovery returns a typed non-nil error alongside `OutcomeFailed` (E3). Existing `WorkResult.Error` string retained. | — |
+| `CLN-WRK-RUNNERS` | Inject command runners and progress publisher once at construction; delete `WithCommandRunners`/`WithProgressPublisher` from `RuntimeService` (E4). | — |
+| `CUT-RUN-WRK-RUNNERS` | Migrate `runtime_build.go:329-357` onto constructor injection. | `CLN-WRK-RUNNERS` |
+
+### Factory Runtime
+
+| Packet | Scope | Depends on |
+| --- | --- | --- |
+| `IMP-RUN-DISPATCH` | Implement `PlanDispatch` and `AcceptDispatchResult` against the sealed Workers execution contract, returning dispatch identity L4 associates with a Worker Session (E5). | `CTR-WRK-EXEC` |
+| `DEL-RUN-CKPT` | Delete `CaptureCheckpoint`, `LoadCheckpoint`, `RestoreCheckpoint` from the root per `DEC-L2-CKPT`. | — |
+| `CLN-RUN-CAPUNAVAIL` | Remove `ErrCapabilityUnavailable` returns that no longer exist; keep the sentinel only if a declared-unimplemented method remains. | `IMP-RUN-DISPATCH`, `DEL-RUN-CKPT` |
+
+### Providers
+
+| Packet | Scope | Depends on |
+| --- | --- | --- |
+| `CTR-PRV-CONTROL` | Add typed attempt pause/cancel/terminate to the root, each returning an explicit capability result including a typed *unsupported* outcome so callers branch rather than guess (E6). | — |
+| `IMP-PRV-CONTROL` | Implement control for providers that support it; return unsupported for the rest. | `CTR-PRV-CONTROL` |
+| `CTR-PRV-CONT` | Promote continuation from an optional `ExecuteRequest` field to an explicit typed root input with defined failure when the reference is stale or foreign. | — |
+
+### Opportunistic cleanup (`D5`)
+
+| Packet | Scope |
+| --- | --- |
+| `DEL-MOD-FORRUNTIME` | Remove the private `ForRuntime` leftovers and legacy input projections in Models (`internal/service/runtime_factory.go:123,554`, `runtime_config_contract.go:96,230`). Root is already sealed; this is dead-path removal. |
+| `CLN-L2-SHIMS` | Maintain the shim deletion register (§6). One packet, updated as L1/L4 create shims. |
+
+## 6. Outputs and shim register
+
+### L4 consumes from L2
+
+| L4 need | L2 output |
+| --- | --- |
+| Start one supervised Worker attempt | `CTR-WRK-EXEC` |
+| Cancel/terminate a running attempt | `CTR-WRK-EXEC` + `CTR-PRV-CONTROL` |
+| Typed terminal cause on panic | `IMP-WRK-PANIC` |
+| Dispatch identity for Worker Session association | `IMP-RUN-DISPATCH` |
+| Exact provider session continuation on resume | `CTR-PRV-CONT` |
+| Single injected Workers root | `CLN-WRK-RUNNERS` + `CUT-RUN-WRK-RUNNERS` |
+
+### Shims registered for deletion
+
+Created by L1/L4 under `D4`, owned for removal by `CLN-L2-SHIMS`. Each entry
+records the consumer package, the provider root it adapts, and the L2 or L3
+packet whose completion retires it.
+
+| Shim | Adapts | Retired by |
+| --- | --- | --- |
+| `chat_sessions/internal/factorysessionsshim` | `factory_sessions.Service` (45 methods) | L3 Factory Sessions sealing |
+| `worker_sessions/internal/workersshim` | Workers execution | `CTR-WRK-EXEC` (may retire at creation) |
+| `worker_sessions/internal/providersshim` | `providers.Service` | `CTR-PRV-CONTROL` + `CTR-PRV-CONT` |
+
+A shim added without a register entry is a review defect.
+
+## 7. Acceptance criteria
+
+Behavioral outcomes a reviewer can verify. Architecture properties are design
+constraints, not acceptance evidence.
+
+1. A Worker attempt cancelled through the sealed execution contract stops the
+   underlying provider process, and the attempt reports a terminal cancelled
+   outcome. Cancelling an already-terminal attempt is a typed no-op, not an
+   error.
+2. A Worker executor that panics produces a terminal failed outcome **and** a
+   non-nil typed error carrying the panic cause. A caller branching only on
+   `err != nil` observes the failure.
+3. A Factory dispatch returns a dispatch identity before any worker output is
+   published, and that identity resolves to the same dispatch on later lookup.
+4. Requesting pause on a provider that cannot pause returns an explicit
+   unsupported outcome; the attempt continues running and is still cancellable.
+5. Resuming a Worker attempt passes the exact provider/kind/id continuation
+   reference. A stale or foreign reference fails with a typed error and does not
+   silently start a fresh provider session.
+6. Building the application no longer constructs a second Workers service view;
+   command runners and the progress publisher are supplied once and observable
+   in a single constructed instance.
+7. `workers.Service.Execute` and the three Factory Runtime checkpoint methods are
+   absent from the public surface, and no consumer references them.
+8. Existing Factory execution behavior is unchanged: a Factory run that
+   succeeded before this lane succeeds after it, with the same terminal result
+   and event sequence.
+
+## 8. Verification
+
+Narrowest useful tier first, broadened where the surface is shared.
+
+- Focused package tests for each changed service (`go test ./pkg/services/workers/...`,
+  `./pkg/services/factory_runtime/...`, `./pkg/services/providers/...`).
+- `make test` for the short Go suite.
+- `make lint`.
+- `make pkg-boundary` and `make pkg-structure` — these already gate ownership;
+  extend their fixtures to the changed roots rather than adding bespoke
+  import-graph tests.
+- `make verify-fast` before review; `make verify-pr` before merge.
+- Cancellation, panic, and dispatch-identity paths run under the race detector
+  with repeat/stress mode, per `planning-standards.md` regulation 7.
+- `make test-functional` for the dispatch cutover packets, since Factory
+  execution is shared surface.
+
+Deleted surfaces additionally require: `rg` evidence of zero remaining
+references, and a green build with the declaration removed rather than
+deprecated.
+
+## 9. Delivery boundary
+
+Per `planning-standards.md` regulation 9, a packet is complete only when required
+CI is terminal and passing, blocking review conversations are explicitly
+addressed, conflicts with concurrent L1/L3/L4 work are resolved against current
+`main`, and the pull request is **merged**. Opening a PR, obtaining approval, or
+reaching green CI without merge is not completion.
+
+Composition edits under `pkg/wire/`, `pkg/root/`, and `pkg/initializer/` are
+resolved by normal rebase and are not phase gates (`D3`).

--- a/docs/temp/meta.md
+++ b/docs/temp/meta.md
@@ -1,281 +1,33 @@
 # Current world state
 
-## System architecture and priorities
+## System architecture
 
-1. Schema-Driven CLI and Clean CLI UX are accepted complete; CLI continues only
-   as package-structure migration (family adapters Factory-terminal; CLI-MOD
-   terminal).
-2. Backend refactoring is active at live `executor-slot` capacity 16 and
-   `concurrent-planners` 1.
-3. #1352 batch-ingress starvation is fixed and verified (PR #1424 / `5b832986e`).
-4. Keep one semantic owner for Wire/root, OpenAPI/generation, and broad
-   functional-test topology. Shared coverage/ownership/package-target manifest
-   churn may overlap and is reconciled during each PR's merge loop — **do not
-   treat `pkg/wire` as a planner hold gate**.
-5. Concrete IMP-PROV adapter groups are closed: IMP-PROV-05 (#1587 /
-   `693c366b2`) and IMP-PROV-06 Agy/PTY (#1609 / `c5c9fa190`) Factory-terminal.
-   LWR-PROV Factory-terminal (#1625 / `274bc4a92`). Providers HTTP/CLI/MCP
-   adapters are all Factory-terminal (#1639 / #1640 / #1638). Providers root on
-   tip is `wire/`, `internal/`, `transports/`.
-6. Work/Settings HTTP/CLI/MCP adapters are Factory-terminal. CUT-SES-* /
-   CUT-VIS-* consumer cuts that were gated on Petri are Factory-terminal.
-   CLN-RUN-FOLD-SERVICE and CLN-RUN-FOLD-ENGINE-PIPELINE (#1602 / `a9d50a34b`)
-   are Factory-terminal. FUN-automations (#1578), IMP-RUN-04 (#1580),
-   FUN-sessions (#1593), FUN-models (#1581), FUN-visualization (#1583),
-   FUN-provider-sessions (#1632 / `806ef3022`), CLN-DEF-FOLD (#1579),
-   CLN-SET-FOLD (#1592), CLN-WORK-LEGACY (#1597), INV-DEF-INVOCATION-POLICY
-   (#1605), PSES vertical INV→CLN→DEL (#1598 / #1616), DEL-RUN-SERVICE
-   (`655e4167e`), DEL-RUN-ENGINE-PIPELINE (#1637 / `6e48c875f`),
-   CLN-DEF-FOLD-COMPILATION (#1607 / `d1956e624`), WRK-LEGACY (#1599 /
-   `bbcb4fef5`), Work vertical INV→CLN→DEL (#1641 / `fdeb6696f`),
-   CUT-RUN-REC (#1644 / `87370d39c`), CLI-PROV (#1640 / `83ea40dc6`),
-   FUN-runtime (#1645 / `d6e3a57b4`), Providers adapters, collateral DEF
-   residual folds (#1606/#1613/#1611/#1610/#1608), DEL-DEF (#1603 /
-   `1d4e73fbf`), Settings vertical INV→CLN→DEL (#1646 / `869e22efb`),
-   FUN-work (#1650 / `f646bec54`), Recordings vertical INV→CLN→DEL
-   (#1647 / `4f64dc9a8`), RET-DEF-ROOT-WIRE (#1651 / `2f4ce21ae`),
-   FUN-settings (#1652 / `ec021038c`), FUN-recordings (#1655 / `1d225ba7e`),
-   DEL-DEF-RESIDUAL (#1657 / `e8d81d5c6`), WRK-CONTRACT (#1656 /
-   `7183487f4`), and DEL-WRK (#1659 / `9562acafa`) are accepted/terminal as
-   noted. Origin tip also includes ACP executor providers (#1648 /
-   `0d61b69fc`) — outside PSS pause admissions.
-
-## Customer pause (authoritative)
-
-`docs/temp/customer-ask.md` Current state: **pause new admissions; finish only
-whatever remains.** Do not submit new idea batches. Leave already-queued and
-in-flight remaining work to drain naturally. After the queue drains, keep
-holding until the customer re-opens work.
-
-## Scheduling preference — vertical deletion over horizontal construction
-
-Maximize throughput, but when an owner has finished IMP + LWR + its owner-local
-adapters and still has transitional root shape debt, **prefer a vertical
-completion chunk** for that owner over admitting more horizontal construction
-elsewhere. **Superseded while customer pause is active** — no new vertical
-admissions.
-
-### Mandatory shape of every vertical completion chunk
-
-1. **`INV-<OWNER>-TOPLEVEL`**
-2. **`CUT-*` consumer edges**
-3. **`CLN-*-FOLD-*` / `CLN-*-LEGACY-*` / `CLN-*-CONTRACT-ROOTS`**
-4. **`DEL-*`** — prefer subpackage DEL slices (Runtime SERVICE then ENGINE)
-5. **`FUN-*` public-process proof**
-
-Do not invent horizontal adapters for owners that are already adapter-complete.
-
-## Ideafy / meta-planner payload rigor (mandatory)
-
-Every submitted idea payload MUST follow `factory/docs/idea-payload-template.md`
-(`ask`, `systemShapeRequirements`, `testCoverageRequirements`,
-`acceptanceCriteria`, `outOfScope`, `antiPatterns`, `currentProgress`,
-long-form `requestedOutcome`, `changedPathLease`). Include the full delivery
-contract (CI green, blocking comments addressed, conflicts reconciled, PR
-merged, then Factory complete).
-
-## Living service-root shape inventory
-
-Canonical product-service root directories are only `wire/`, `internal/`, and
-`transports/` plus a thin contract file set at the service root.
-
-### Factory Definitions (post DEL-DEF + RET-DEF + DEL-DEF-RESIDUAL)
-
-DEL-DEF Factory-terminal (#1603 / `1d4e73fbf`). RET-DEF-ROOT-WIRE
-Factory-terminal (#1651 / `2f4ce21ae`): tip `pkg/wire` constructs Definitions
-through `factory_definitions/wire` only. DEL-DEF-RESIDUAL Factory-terminal
-(#1657 / `e8d81d5c6`): residual emptied top-level packages deleted. Public root
-on tip still has unexpected transitional siblings
-`clonetests/`, `definition/`, `service/`, `systeminitializationtests/` plus
-`wire/`/`internal/`/`transports/` — **not** wire/internal/transports-clean.
-Functional proofs exist under `tests/functional/factory_definitions/transports`
-(CLI named_lifecycle / validate_persist / yaml_parity) but not yet a
-root_composition FUN packet. FUN-definitions gated on clean root **and**
-customer pause — do not admit.
-
-### Provider Sessions (post FUN)
-
-On tip after FUN-provider-sessions (#1632 / `806ef3022`), public
-`provider_sessions` children are `wire/`, `internal/`, `transports/`. Functional
-proofs live under `tests/functional/provider_sessions`. No further PSES vertical
-packet required.
-
-### Factory Runtime residual debt (post FUN + CUT-RUN-REC)
-
-On tip after FUN-runtime (#1645 / `d6e3a57b4`) and CUT-RUN-REC (#1644 /
-`87370d39c`) Factory-complete, public `factory_runtime` directories are `wire/`,
-`internal/`, `transports/`, plus residual unexpected `testdata/`. Functional
-suite under `tests/functional/factory_runtime`. No further Runtime FUN/CUT
-packet required at current tip shape.
-
-### Work residual (post DEL-WORK + FUN-work)
-
-On tip after DEL-WORK (#1641 / `fdeb6696f`) and FUN-work (#1650 /
-`f646bec54`), public `pkg/services/work` children are `wire/`, `internal/`,
-`transports/`, plus residual unexpected `testdata/`. Functional suite under
-`tests/functional/work`. No further Work FUN packet required.
-
-### Workers residual (post INV→CLN→DEL-WRK Factory-terminal)
-
-WRK-LEGACY Factory-terminal (#1599 / `bbcb4fef5`); WRK-CONTRACT Factory-terminal
-(#1656 / `7183487f4`); DEL-WRK Factory-terminal (#1659 / `9562acafa`):
-idea/plan/task/review all `complete`. Tip deletes emptied transitional shims
-(construction/diagnostics/draftvalidation/execution/executor/inferencefailure/
-interface/services agents+inference/skippermissions/workstationpool). Public
-Workers directories on tip still include unexpected transitional siblings
-`agypty/`, `cliprovider/`, `envdiagnostics/`, `executor/`, `invocation/`,
-`process/`, `prompting/`, `provider/`, `provider_test/`, `runner/`, `service/`,
-`services/`, `worktree/` plus `wire/`/`internal/`; **no `transports/` yet**.
-Do **not** treat build-beside `internal/` as migration complete. FUN-workers
-dual-gated on clean canonical root **and** customer re-open — do not admit
-under pause. Existing functional proofs under `tests/functional/workers`
-(agent/inference/mock/script/transports CLI) are not a FUN-workers substitute.
-
-### Providers residual (post LWR + HTTP/CLI/MCP adapters)
-
-On tip after HTTP-PROV (#1639), CLI-PROV (#1640), MCP-PROV (#1638), Providers
-public children are `wire/`, `internal/`, `transports/`. Adapter-complete; do
-not invent further horizontal adapters. Tip also carries ACP executor provider
-integration (#1648) under that shape.
-
-### Settings (post DEL-SET + FUN-settings)
-
-DEL-SET Factory-terminal (#1646 / `869e22efb`). FUN-settings Factory-terminal
-(#1652 / `ec021038c`). Public `operator_settings` directories are `wire/`,
-`internal/`, `transports/`, plus residual unexpected `testdata/` and thin root
-contracts. Functional proofs under `tests/functional/operator_settings`. No
-further Settings FUN packet required.
-
-### Recordings (post DEL-REC + FUN-recordings)
-
-DEL-REC Factory-terminal (#1647 / `4f64dc9a8`). FUN-recordings
-Factory-terminal (#1655 / `1d225ba7e`): idea/plan/task/review all
-`complete`. Public `recordings` directories are exactly `wire/`, `internal/`,
-`transports/` plus thin root contracts. Public-process proofs under
-`tests/functional/recordings` (root_composition + peer boundary). No further
-Recordings FUN packet required.
-
-### Automations / Factory Sessions
-
-Both public roots are `wire/`, `internal/`, `transports/` on tip. DEL-AUTO and
-FUN-automations Factory-terminal; Automations-leased root-wire hold cleared.
-
-### Active vertical chunks
-
-| Request | Contents | Notes |
-|---|---|---|
-| `planner-wave-fun-recordings-20260728` | FUN-recordings **Factory-terminal** (#1655 / `1d225ba7e`) | tip inventory confirmed |
-| `planner-wave-fun-settings-20260728` | FUN-settings **Factory-terminal** (#1652 / `ec021038c`) | inventory confirmed |
-| `planner-wave-fun-work-20260728` | FUN-work **Factory-terminal** (#1650) | |
-| `planner-wave-def-migration-repair-20260728` | INV→IMP-R→CUT→BOOT→CLN→DEL-DEF **Factory-terminal** | |
-| `planner-wave-def-residual-folds-20260728` | INV + residual folds + DEL-DEF-RESIDUAL **Factory-terminal** (#1657 / `e8d81d5c6`) | tip DEF still multi-sibling |
-| `planner-wave-ret-def-root-wire-20260728` | RET-DEF-ROOT-WIRE **Factory-terminal** (#1651 / `2f4ce21ae`) | wire forbid verified |
-| `planner-wave-set-toplevel-cleanup-20260728` | INV-SET→CLN-SET→DEL-SET **Factory-terminal** (#1646) | |
-| `planner-wave-wrk-toplevel-cleanup-20260728` | INV→CLN-FOLD→CLN-LEGACY→WRK-CONTRACT→DEL-WRK **Factory-terminal** (#1659 / `9562acafa`) | Workers still multi-sibling; no transports/; hold FUN under pause |
-| `planner-wave-fun-run-cut-run-rec-20260728` | FUN-runtime + CUT-RUN-REC **Factory-terminal** | |
-| `planner-wave-pses-toplevel-cleanup-20260728` | INV→CLN→DEL-PSES **terminal** (#1616) | |
-| `planner-wave-fun-pses-20260728` | FUN-provider-sessions **terminal** (#1632) | |
-| `planner-wave-prov-adapters-20260728` | HTTP/CLI/MCP-PROV **terminal** | |
+- Customer ask: implement `docs/internal/projects/acp-client/final-proposal.md`
+  completely, with P0 ACP Chat/Factory behavior and the Worker Sessions control
+  plane delivered through singular, statically injected service roots.
+- Current code has none of the proposed `chat_sessions`, `worker_sessions`,
+  `events`, or top-level ACP transport packages. `RuntimeOpeningFactory` and
+  `runtimeOpener` remain live migration targets.
+- Live default PETRI session: `5146e0a4-a4d3-4d93-a51c-560a5243a474`.
 
 ## Operational notes
 
-- Session `~default` ACTIVE. Local `main` at origin tip `9562acafa`
-  (#1659 DEL-WRK). Planner-owned `docs/temp/**` dirty; expected.
-- This pass (`work-thoughts-546` cron:though-retrigger): honor customer pause;
-  state-type filters show only this cron PROCESSING + superseded failed cron
-  `work-thoughts-151`; tip inventories reconfirmed; submit **no** new idea
-  batch.
-- Remaining live ~0/16 executor tasks. Free ~16 unused under pause.
-- Hold IMP-WRK-07 / PSS-I0* and all new FUN/CLN/DEL admissions under customer
-  pause. Do not admit FUN-workers|definitions — pause forbids new admissions;
-  Definitions root still not wire/internal/transports-clean; Workers still
-  transitional (unexpected top-level packages remain; no `transports/`).
-- Recordings / PSES already wire/internal/transports + FUN-terminal; no further
-  fold→DEL packet.
-- Next residual owner debt after pause re-open: Workers residual CLN/transports
-  path (or FUN only after clean root), then Definitions residual clean-root /
-  FUN-definitions. Do not invent short packets.
-- Failed priority Work otherwise: superseded cron `work-thoughts-151` only.
-- Open non-PSS PRs (#1658/#1654/#1653/#1202) are outside pause admissions.
-- Do not revive monolithic `pss-del-run` or deleted Work/Settings/Recordings
-  transitional packages.
-- Do not invent WRK protocol adapters, DEF horizontal adapters, or reopen
-  accepted CLI UX.
-- No deliberate `you work move` this pass.
+- The prior lint/Bun queue was replaced. Current queue began this pass with two
+  failed legacy tasks whose only last output was successful workspace setup.
+- Both failures were retried once to `task:init` after capacity recovered and
+  failed again immediately with unchanged setup-only output. Do not retry again
+  without new process-dispatch/provider evidence or a narrow correction.
+- Root has unrelated Claude provider/test changes. ACP workers must preserve
+  them and resolve normal shared-file conflicts through the delivery loop.
+- `docs/temp/**` is gitignored planner state.
 
 # Progressive change notes
 
-- Cron ideafy (2026-07-28T21:00-07:00): honor customer pause; tip unchanged
-  `9562acafa`; queue drained (only this cron + failed cron-151 non-complete);
-  Workers still multi-sibling (no transports/); DEF still unclean; submit
-  **no** new batch.
-- Cron ideafy (2026-07-28T20:00-07:00): honor customer pause; tip unchanged
-  `9562acafa`; queue drained (only this cron + failed cron-151 non-complete);
-  Workers still multi-sibling (no transports/); DEF still unclean; submit
-  **no** new batch.
-- Cron ideafy (2026-07-28T19:00-07:00): honor customer pause; tip unchanged
-  `9562acafa`; queue drained (only this cron + failed cron-151 non-complete);
-  Workers still multi-sibling (no transports/); DEF still unclean; submit
-  **no** new batch.
-- Cron ideafy (2026-07-28T18:00-07:00): honor customer pause; tip unchanged
-  `9562acafa`; queue drained (only this cron + failed cron-151 non-complete);
-  Workers still multi-sibling (no transports/); DEF still unclean; submit
-  **no** new batch.
-- Cron ideafy (2026-07-28T17:01-07:00): honor customer pause; tip unchanged
-  `9562acafa`; full queue drained (720 complete except this cron + failed
-  cron-151); Workers still multi-sibling (no transports/); DEF still unclean;
-  submit **no** new batch.
-- Cron ideafy (2026-07-28T16:01-07:00): honor customer pause; tip unchanged
-  `9562acafa`; full queue drained (719 complete except this cron + failed
-  cron-151); Workers still multi-sibling (no transports/); DEF still unclean;
-  submit **no** new batch.
-- Cron ideafy (2026-07-28T15:00-07:00): honor customer pause; tip unchanged
-  `9562acafa`; full queue drained (718 complete except this cron + failed
-  cron-151); Workers still multi-sibling (no transports/); DEF still unclean;
-  submit **no** new batch.
-- Cron ideafy (2026-07-28T14:01-07:00): honor customer pause; tip unchanged
-  `9562acafa`; queue drained ~0/16; Workers still multi-sibling (no
-  transports/); DEF still unclean; submit **no** new batch.
-- WRK toplevel loopback (2026-07-28T13:25-07:00): accept DEL-WRK Factory-
-  terminal (#1659 / `9562acafa`); tip Workers still multi-sibling transitional
-  (no transports/); Recordings/PSES already clean+FUN-terminal; customer pause
-  → submit **no** new batch; hold FUN-workers|definitions.
-- Cron ideafy (2026-07-28T13:01-07:00): honor customer pause; tip still
-  `7183487f4`; DEL-WRK remaining with active `pss-del-wrk` worktree commits
-  (no open PR yet); no recoverable stranded Work; submit **no** new batch.
-- Cron ideafy (2026-07-28T12:01-07:00): accept WRK-CONTRACT Factory-terminal
-  (#1656 / `7183487f4`); tip Workers still multi-sibling transitional (no
-  transports/); remaining DEL-WRK `work-task-535` `task:init`; customer pause
-  → submit **no** new batch; leave DEL-WRK drain.
-- DEF residual loopback (2026-07-28T11:15-07:00): accept DEL-DEF-RESIDUAL
-  Factory-terminal (#1657 / `e8d81d5c6`); tip DEF still has
-  clonetests/definition/service/systeminitializationtests + wire/internal/
-  transports — not clean; customer pause overrides FUN-definitions preference;
-  leave WRK-CONTRACT #1656 / queued DEL-WRK; submit **no** new batch.
-- Cron ideafy (2026-07-28T11:01-07:00): honor customer pause; FF main
-  `1d225ba7e`→`0d61b69fc` (#1648 ACP landed on tip); no recoverable stranded
-  Work; leave WRK-CONTRACT #1656 / DEL-DEF-RESIDUAL #1657 / queued DEL-WRK;
-  submit **no** new batch.
-- FUN-recordings loopback (2026-07-28T10:05-07:00): accept FUN-recordings
-  Factory-terminal (#1655 / `1d225ba7e`); tip recordings =
-  wire/internal/transports + `tests/functional/recordings`; honor customer
-  pause over loopback refill preference; hold all new admissions; leave
-  WRK-CONTRACT #1656 / DEL-DEF-RESIDUAL #1657 / queued DEL-WRK to drain.
-- Cron ideafy / customer pause (2026-07-28T10:03-07:00): honor
-  `customer-ask.md` pause; accept FUN-recordings GitHub-merged (#1655 /
-  `1d225ba7e`); tip recordings = wire/internal/transports +
-  `tests/functional/recordings`; hold all new admissions; leave
-  WRK-CONTRACT #1656 / DEL-DEF-RESIDUAL #1657 / FUN Factory consume / queued
-  DEL-WRK to drain.
-- FUN-settings loopback (2026-07-28T10:00-07:00): accept FUN-settings
-  Factory-terminal (#1652 / `ec021038c`); hold refill.
-- RET-DEF loopback (2026-07-28T09:06-07:00): accept RET-DEF-ROOT-WIRE
-  Factory-terminal (#1651 / `2f4ce21ae`); hold refill.
-- Cron ideafy (2026-07-28T09:02-07:00): preferred ready set empty → hold.
-- REC toplevel loopback (2026-07-28T08:53-07:00): accept DEL-REC; admit
-  FUN-recordings.
-- FUN-work loopback (2026-07-28T08:38-07:00): accept FUN-work; hold refill.
-- SET toplevel loopback (2026-07-28T08:17-07:00): accept DEL-SET; admit
-  FUN-settings.
-- Policy: no planner-level `pkg/wire` hold; universal merge-before-complete
-  delivery contract; customer pause overrides refill preference.
+## High-level track state
+
+- ACP Phase 0 is active under request `planner-acp-v0-contracts-20260802`: nine
+  ideas are processing and the loopback is guarded on all nine completions.
+- Subsequent work follows the semantic DAG in final-proposal section 9.3;
+  numbered phases are review checkpoints, not repository freezes.
+- Every loopback must reconcile queue health and verify actual merged evidence
+  before admitting the next dependency-ready vertical slice.

--- a/docs/temp/projects/packaged-service-structure/plan.md
+++ b/docs/temp/projects/packaged-service-structure/plan.md
@@ -18,7 +18,7 @@ top-level Checkpoint service.
 | 4 | IMP-RUN-03 — Dispatch Planning private subservice | Planned | Workers command/result contract lock |
 | 5 | Orchestration fold / engine-pipeline CLN | **Factory-terminal** | `CLN-RUN-FOLD-SERVICE` + `CLN-RUN-FOLD-ENGINE-PIPELINE` (#1602 / `a9d50a34b`); DEL-RUN-SERVICE (`655e4167e`) + DEL-RUN-ENGINE (#1637 / `6e48c875f`) terminal |
 | 6 | CUT-VIS-RUN / CUT-RUN-WRK / consumer-edge CUTs | Mixed | CUT-VIS-RUN + CUT-RUN-WRK terminal; CUT-RUN-REC admitted with FUN-runtime (`planner-wave-fun-run-cut-run-rec-20260728`) |
-| 7 | **Checkpoint/Recovery** (`IMP-RUN-04`, `checkpoint_recovery`) | **Factory-terminal** (PR #1580) | Durability ownership decided in [`dec-run-rec-durability.md`](dec-run-rec-durability.md). Opaque CheckpointStore + process-local adapter shipped under `factory_runtime/internal/services/checkpoint_recovery`. Recordings-backed durable checkpoint bytes remain follow-on after Recordings durable log/cursor/retention. |
+| 7 | **Checkpoint/Recovery** (`IMP-RUN-04`, `checkpoint_recovery`) | **Factory-terminal** (PR #1580) | Durability ownership decided in [`dec-run-rec-durability.md`](dec-run-rec-durability.md). Opaque CheckpointStore + process-local adapter shipped under `factory_runtime/internal/services/checkpoint_recovery`. **Permanent** under D1 — the Recordings-backed durable checkpoint follow-on is cancelled, not deferred. |
 
 ### Step 7 — Checkpoint/Recovery (IMP-RUN-04)
 
@@ -33,8 +33,10 @@ instead of treating durability as an indefinite verbal hold.
 - IMP-RUN-04 (`factory_runtime/checkpoint_recovery`) is **dependency-ready** for
   a future implementation packet.
 - Recordings durable-log completion is **not** a gate for starting IMP-RUN-04.
-- A Recordings-backed durable CheckpointStore adapter remains explicit follow-on
-  work after Recordings durable log/cursor/retention exists.
+- ~~A Recordings-backed durable CheckpointStore adapter remains explicit
+  follow-on work after Recordings durable log/cursor/retention exists.~~
+  **Cancelled under D1.** There is no durable log to wait for. The shipped
+  process-local adapter is the permanent implementation.
 
 **Explicit non-goals for the decision packet:**
 
@@ -44,10 +46,76 @@ instead of treating durability as an indefinite verbal hold.
 
 ## Recordings implementation sequence (checkpoint bytes context)
 
-Recordings durable log/cursor/retention is a **later Recordings sequence step**.
-It is **not** a prerequisite for admitting IMP-RUN-04 with a process-local/default
-CheckpointStore adapter. Future Recordings-backed durable checkpoint byte storage
-follows DEC-RUN-REC-DURABILITY phase table (see decision note).
+**Revised under D1 and D2** — see
+[`docs/internal/projects/acp-program/README.md`](../../../internal/projects/acp-program/README.md).
+
+Recordings durable log/cursor/retention was previously planned as a later
+Recordings sequence step. It is now **removed from the sequence entirely**. It is
+not a later step; it is not a step.
+
+### D1 — no storage engine, ever
+
+You introduces no durable event journal, embedded database, or write-ahead log
+for its own state, at any phase. This supersedes the DEC-RUN-REC-DURABILITY
+follow-on that anticipated durable checkpoint bytes.
+
+- Historical reconstruction comes from the recorder's recorded JSONL artifacts
+  only.
+- Session state is session-scoped: it lives for the process lifetime and is
+  discarded on exit. Terminating a session is a normal outcome.
+- The process-local `CheckpointStore` adapter is permanent.
+
+### D2 — persistence and event stream are separate concerns
+
+Bundling durable log, cursor, and retention into one Recordings step conflated
+two concerns with different owners and lifetimes. They split as follows:
+
+| Concern | Owner | Nature |
+| --- | --- | --- |
+| Canonical Factory history and replay | Recordings | JSONL artifacts on disk |
+| Ordering, cursors, subscriptions, retention, gaps, backpressure | Events service (L1) | in-memory, session-scoped |
+
+The Events service is a **stream**, not a store. Recordings remains the canonical
+ledger and cedes nothing.
+
+Packet consequences:
+
+- `FND-08` (`pkg/services/recordings/events/kinds/`) is unaffected — event
+  *kinds* are contract, not stream.
+- `PSS-I05` (`event-backbone`) must be re-scoped before dispatch; a convergence
+  that merges persistence with streaming contradicts D2.
+- `factory_sessions/internal/{responseeventstore,responsestream,cursors}` migrate
+  to `pkg/services/events` under L1. PSS packets must not touch those paths while
+  L1 is active.
+
+## Composition surfaces are not leased (D3)
+
+`pkg/wire/**`, `pkg/root/**`, and `pkg/initializer/**` are shared, append-only
+composition surfaces. Registering a service is a few additive lines; two packets
+adding two different providers produce a textual conflict, not a semantic one,
+and textual conflicts are resolved by rebase rather than by scheduling.
+
+`PSS-I01` (`root-wire-process`) must be narrowed accordingly — it keeps
+structural surfaces such as the `root.BuildProcess` signature and the
+`profiles.go` provider-set shape, and drops the blanket directory claims. The
+required manifest change is recorded under **Required manifest follow-up** in
+`docs/internal/projects/packaged-service-structure/README.md`; it is not applied
+here because the manifest is validated by `internal/psslease`.
+
+## Program lane position
+
+This program is **L3** in the ACP program lane map. It runs in the background and
+gates nothing.
+
+The highest-value root cleanup required by ACP Worker Events is extracted into
+**L2** (`docs/internal/projects/root-consolidation/`). PSS **depends on L2**
+rather than owning that work — the inversion is deliberate, because L2 is small
+and fast while PSS is large and slow, and coupling ACP delivery to PSS
+scheduling was the constraint being removed.
+
+Packets whose scope L2 covers are superseded rather than re-planned here. When L2
+seals a root, the corresponding PSS packet records the L2 packet as a
+prerequisite and narrows to whatever remains.
 
 ## Changed-Path Lease Matrix (DEC-RUN-REC-DURABILITY)
 
@@ -72,3 +140,5 @@ proof**.
 | [`README.md`](README.md) | Local planner index |
 | `docs/temp/meta.md` | Planner hold/admission text for IMP-RUN-04 |
 | `docs/internal/projects/packaged-service-structure/README.md` | Committed program-metadata index |
+| `docs/internal/projects/acp-program/README.md` | ACP Program lane map — owns D1/D2/D3 and the L2 extraction |
+| `docs/internal/projects/root-consolidation/` | **L2** — root consolidation this program now depends on |

--- a/pkg/services/providers/internal/services/execution/internal/adapters/claude/command.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/claude/command.go
@@ -82,6 +82,7 @@ func buildCommand(request providers.ExecuteRequest) (workers.CommandRequest, err
 	}
 	args = append(
 		args,
+		"--verbose",
 		"--output-format",
 		outputFormatStreamJSON,
 		"--include-partial-messages",

--- a/pkg/services/providers/internal/services/execution/internal/adapters/claude/command_dispatch_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/claude/command_dispatch_test.go
@@ -37,6 +37,7 @@ func TestCommandEffectRendersProviderNeutralReasoningEffort(t *testing.T) {
 		"-p",
 		"--model", "claude-model",
 		"--effort", "xhigh",
+		"--verbose",
 		"--output-format", "stream-json",
 		"--include-partial-messages",
 		"perform work",

--- a/tests/functional/providers/claude/haiku_golden_test.go
+++ b/tests/functional/providers/claude/haiku_golden_test.go
@@ -1,0 +1,185 @@
+package claude
+
+import (
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	haikuGoldenRoot   = "testdata/haiku_stream_json"
+	haikuGoldenResult = "HAIKU GOLDEN COMPLETE"
+)
+
+//go:embed testdata/haiku_stream_json/manifest.json testdata/haiku_stream_json/*.jsonl
+var haikuGoldenFiles embed.FS
+
+type haikuGoldenManifest struct {
+	SchemaVersion int               `json:"schemaVersion"`
+	Source        haikuGoldenSource `json:"source"`
+	Cases         []haikuGoldenCase `json:"cases"`
+}
+
+type haikuGoldenSource struct {
+	Command         string `json:"command"`
+	ProviderVersion string `json:"providerVersion"`
+	Prompt          string `json:"prompt"`
+}
+
+type haikuGoldenCase struct {
+	Name          string `json:"name"`
+	Selector      string `json:"selector"`
+	ReportedModel string `json:"reportedModel"`
+	SessionID     string `json:"sessionId"`
+	StdoutFile    string `json:"stdoutFile"`
+	SHA256        string `json:"sha256"`
+}
+
+// TestClaudeHaikuStreamJSONGoldens replays sanitized streams captured from
+// three live Claude Haiku selectors through the customer process boundary.
+func TestClaudeHaikuStreamJSONGoldens(t *testing.T) {
+	manifest := loadHaikuGoldenManifest(t)
+	for _, golden := range manifest.Cases {
+		golden := golden
+		t.Run(golden.Name, func(t *testing.T) {
+			stdout := loadHaikuGoldenStdout(t, golden)
+			assertHaikuGoldenNativeShape(t, stdout, golden)
+			replayHaikuGolden(t, golden, stdout)
+		})
+	}
+}
+
+func loadHaikuGoldenManifest(t *testing.T) haikuGoldenManifest {
+	t.Helper()
+	raw, err := haikuGoldenFiles.ReadFile(haikuGoldenRoot + "/manifest.json")
+	if err != nil {
+		t.Fatalf("read Haiku golden manifest: %v", err)
+	}
+	var manifest haikuGoldenManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("decode Haiku golden manifest: %v", err)
+	}
+	if manifest.SchemaVersion != 1 || len(manifest.Cases) != 3 {
+		t.Fatalf("Haiku golden manifest = %#v, want schema 1 with three cases", manifest)
+	}
+	for _, required := range []string{"-p", "--verbose", "--output-format stream-json", "--include-partial-messages"} {
+		if !strings.Contains(manifest.Source.Command, required) {
+			t.Fatalf("capture command %q missing %q", manifest.Source.Command, required)
+		}
+	}
+	if manifest.Source.ProviderVersion == "" || manifest.Source.Prompt == "" {
+		t.Fatalf("Haiku golden source metadata is incomplete: %#v", manifest.Source)
+	}
+	return manifest
+}
+
+func loadHaikuGoldenStdout(t *testing.T, golden haikuGoldenCase) []byte {
+	t.Helper()
+	if golden.Name == "" || golden.Selector == "" || golden.ReportedModel == "" ||
+		golden.SessionID == "" || golden.StdoutFile == "" || golden.SHA256 == "" {
+		t.Fatalf("Haiku golden case metadata is incomplete: %#v", golden)
+	}
+	raw, err := haikuGoldenFiles.ReadFile(haikuGoldenRoot + "/" + golden.StdoutFile)
+	if err != nil {
+		t.Fatalf("read Haiku golden %q: %v", golden.StdoutFile, err)
+	}
+	if err := support.ValidateProviderSessionFixtureContent(
+		"claude-haiku-"+golden.Name,
+		golden.StdoutFile,
+		raw,
+	); err != nil {
+		t.Fatalf("validate Haiku golden %q sanitization: %v", golden.StdoutFile, err)
+	}
+	digest := sha256.Sum256(raw)
+	if got := hex.EncodeToString(digest[:]); got != golden.SHA256 {
+		t.Fatalf("Haiku golden %q sha256 = %s, want %s", golden.StdoutFile, got, golden.SHA256)
+	}
+	return raw
+}
+
+func assertHaikuGoldenNativeShape(t *testing.T, stdout []byte, golden haikuGoldenCase) {
+	t.Helper()
+	var sawModel, sawDelta, sawResult bool
+	for index, line := range strings.Split(strings.TrimSpace(string(stdout)), "\n") {
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("Haiku golden %q line %d: %v", golden.Name, index+1, err)
+		}
+		encoded := string(line)
+		sawModel = sawModel || strings.Contains(encoded, `"model":"`+golden.ReportedModel+`"`)
+		sawDelta = sawDelta || strings.Contains(encoded, `"type":"text_delta"`) &&
+			strings.Contains(encoded, haikuGoldenResult)
+		sawResult = sawResult || record["type"] == "result" && record["result"] == haikuGoldenResult
+	}
+	if !sawModel || !sawDelta || !sawResult {
+		t.Fatalf("Haiku golden %q shape model=%t delta=%t result=%t", golden.Name, sawModel, sawDelta, sawResult)
+	}
+}
+
+func replayHaikuGolden(t *testing.T, golden haikuGoldenCase, stdout []byte) {
+	t.Helper()
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
+	support.WriteAgentConfig(t, dir, "worker", support.BuildModelWorkerConfig(
+		modelprovider.ProviderClaude,
+		golden.Selector,
+	))
+	testutil.WriteSeedFile(t, dir, "task", []byte(`{"title":"claude Haiku golden replay"}`))
+	runner := testutil.NewProviderCommandRunner(platformprocess.CommandResult{Stdout: stdout})
+
+	_, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
+		t,
+		dir,
+		serviceedges.Edges{ProviderCommandRunner: runner},
+		20*time.Second,
+	)
+	if got := support.CountWorkAtCustomerState(listed, "task:done"); got != 1 {
+		t.Fatalf("completed work = %d, want 1; listed=%#v", got, listed)
+	}
+	if got := support.CountWorkAtCustomerState(listed, "task:failed"); got != 0 {
+		t.Fatalf("failed work = %d, want 0", got)
+	}
+	if runner.CallCount() != 1 {
+		t.Fatalf("Claude command calls = %d, want 1", runner.CallCount())
+	}
+	support.AssertArgsContainSequence(t, runner.LastRequest().Args, []string{
+		"--model", golden.Selector,
+		"--verbose",
+		"--output-format", "stream-json",
+		"--include-partial-messages",
+	})
+	assertHaikuGoldenInferenceResult(t, events, golden.SessionID)
+}
+
+func assertHaikuGoldenInferenceResult(t *testing.T, events []factoryapi.FactoryEvent, wantSessionID string) {
+	t.Helper()
+	for _, event := range events {
+		if event.Type != factoryapi.FactoryEventTypeModelResponse {
+			continue
+		}
+		payload, err := support.AsInferenceResponseObservation(event)
+		if err != nil {
+			t.Fatalf("decode Haiku inference response: %v", err)
+		}
+		if payload.Outcome != factoryapi.InferenceOutcomeSucceeded || payload.Response == nil ||
+			strings.TrimSpace(*payload.Response) != haikuGoldenResult {
+			continue
+		}
+		if payload.ProviderSession == nil || payload.ProviderSession.Id == nil ||
+			*payload.ProviderSession.Id != wantSessionID {
+			t.Fatalf("provider session = %#v, want id %q", payload.ProviderSession, wantSessionID)
+		}
+		return
+	}
+	t.Fatalf("Factory events omitted successful Haiku result %q", haikuGoldenResult)
+}

--- a/tests/functional/providers/claude/process_harness_test.go
+++ b/tests/functional/providers/claude/process_harness_test.go
@@ -1,0 +1,54 @@
+package claude
+
+import (
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const claudeFunctionalModel = "claude-sonnet-5"
+
+// TestClaudeStreamJSONCommandThroughRootBuildProcess proves the customer
+// process dispatches the complete Claude streaming CLI contract and consumes
+// its native terminal result successfully.
+func TestClaudeStreamJSONCommandThroughRootBuildProcess(t *testing.T) {
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
+	support.WriteAgentConfig(t, dir, "worker", support.BuildModelWorkerConfig(
+		modelprovider.ProviderClaude,
+		claudeFunctionalModel,
+	))
+	testutil.WriteSeedFile(t, dir, "task", []byte(`{"title":"claude stream-json command"}`))
+
+	runner := support.NewRecordingCommandRunner("Done. COMPLETE")
+	_, listed := support.RunFactoryToCompletionWithEdgesAndWork(
+		t,
+		dir,
+		serviceedges.Edges{ProviderCommandRunner: runner},
+		20*time.Second,
+	)
+
+	if got := support.CountWorkAtCustomerState(listed, "task:done"); got != 1 {
+		t.Fatalf("completed work = %d, want 1; listed=%#v", got, listed)
+	}
+	if got := support.CountWorkAtCustomerState(listed, "task:failed"); got != 0 {
+		t.Fatalf("failed work = %d, want 0", got)
+	}
+	if runner.CallCount() != 1 {
+		t.Fatalf("Claude command calls = %d, want 1", runner.CallCount())
+	}
+
+	request := runner.LastRequest()
+	if request.Command != string(modelprovider.ProviderClaude) {
+		t.Fatalf("command = %q, want %q", request.Command, modelprovider.ProviderClaude)
+	}
+	support.AssertArgsContainSequence(t, request.Args, []string{
+		"--model", claudeFunctionalModel,
+		"--verbose",
+		"--output-format", "stream-json",
+		"--include-partial-messages",
+	})
+}

--- a/tests/functional/providers/claude/testdata/haiku_stream_json/claude-haiku-4-5-20251001.jsonl
+++ b/tests/functional/providers/claude/testdata/haiku_stream_json/claude-haiku-4-5-20251001.jsonl
@@ -1,0 +1,11 @@
+{"type":"system","subtype":"init","session_id":"claude-haiku-pinned-session","model":"claude-haiku-4-5-20251001","claude_code_version":"2.1.220"}
+{"type":"system","subtype":"status","status":"requesting","session_id":"claude-haiku-pinned-session"}
+{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","rateLimitType":"five_hour"},"session_id":"claude-haiku-pinned-session"}
+{"type":"stream_event","event":{"type":"message_start","message":{"model":"claude-haiku-4-5-20251001","id":"claude-haiku-pinned-message","type":"message","role":"assistant","content":[]}},"session_id":"claude-haiku-pinned-session","parent_tool_use_id":null}
+{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}},"session_id":"claude-haiku-pinned-session","parent_tool_use_id":null}
+{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"HAIKU GOLDEN COMPLETE"}},"session_id":"claude-haiku-pinned-session","parent_tool_use_id":null}
+{"type":"assistant","message":{"model":"claude-haiku-4-5-20251001","id":"claude-haiku-pinned-message","type":"message","role":"assistant","content":[{"type":"text","text":"HAIKU GOLDEN COMPLETE"}]},"parent_tool_use_id":null,"session_id":"claude-haiku-pinned-session"}
+{"type":"stream_event","event":{"type":"content_block_stop","index":1},"session_id":"claude-haiku-pinned-session","parent_tool_use_id":null}
+{"type":"stream_event","event":{"type":"message_delta","delta":{"stop_reason":"end_turn"}},"session_id":"claude-haiku-pinned-session","parent_tool_use_id":null}
+{"type":"stream_event","event":{"type":"message_stop"},"session_id":"claude-haiku-pinned-session","parent_tool_use_id":null}
+{"type":"result","subtype":"success","is_error":false,"session_id":"claude-haiku-pinned-session","result":"HAIKU GOLDEN COMPLETE","terminal_reason":"completed"}

--- a/tests/functional/providers/claude/testdata/haiku_stream_json/claude-haiku-4-5.jsonl
+++ b/tests/functional/providers/claude/testdata/haiku_stream_json/claude-haiku-4-5.jsonl
@@ -1,0 +1,11 @@
+{"type":"system","subtype":"init","session_id":"claude-haiku-family-session","model":"claude-haiku-4-5","claude_code_version":"2.1.220"}
+{"type":"system","subtype":"status","status":"requesting","session_id":"claude-haiku-family-session"}
+{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","rateLimitType":"five_hour"},"session_id":"claude-haiku-family-session"}
+{"type":"stream_event","event":{"type":"message_start","message":{"model":"claude-haiku-4-5-20251001","id":"claude-haiku-family-message","type":"message","role":"assistant","content":[]}},"session_id":"claude-haiku-family-session","parent_tool_use_id":null}
+{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}},"session_id":"claude-haiku-family-session","parent_tool_use_id":null}
+{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"HAIKU GOLDEN COMPLETE"}},"session_id":"claude-haiku-family-session","parent_tool_use_id":null}
+{"type":"assistant","message":{"model":"claude-haiku-4-5-20251001","id":"claude-haiku-family-message","type":"message","role":"assistant","content":[{"type":"text","text":"HAIKU GOLDEN COMPLETE"}]},"parent_tool_use_id":null,"session_id":"claude-haiku-family-session"}
+{"type":"stream_event","event":{"type":"content_block_stop","index":1},"session_id":"claude-haiku-family-session","parent_tool_use_id":null}
+{"type":"stream_event","event":{"type":"message_delta","delta":{"stop_reason":"end_turn"}},"session_id":"claude-haiku-family-session","parent_tool_use_id":null}
+{"type":"stream_event","event":{"type":"message_stop"},"session_id":"claude-haiku-family-session","parent_tool_use_id":null}
+{"type":"result","subtype":"success","is_error":false,"session_id":"claude-haiku-family-session","result":"HAIKU GOLDEN COMPLETE","terminal_reason":"completed"}

--- a/tests/functional/providers/claude/testdata/haiku_stream_json/haiku.jsonl
+++ b/tests/functional/providers/claude/testdata/haiku_stream_json/haiku.jsonl
@@ -1,0 +1,11 @@
+{"type":"system","subtype":"init","session_id":"claude-haiku-alias-session","model":"claude-haiku-4-5-20251001","claude_code_version":"2.1.220"}
+{"type":"system","subtype":"status","status":"requesting","session_id":"claude-haiku-alias-session"}
+{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","rateLimitType":"five_hour"},"session_id":"claude-haiku-alias-session"}
+{"type":"stream_event","event":{"type":"message_start","message":{"model":"claude-haiku-4-5-20251001","id":"claude-haiku-alias-message","type":"message","role":"assistant","content":[]}},"session_id":"claude-haiku-alias-session","parent_tool_use_id":null}
+{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}},"session_id":"claude-haiku-alias-session","parent_tool_use_id":null}
+{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"HAIKU GOLDEN COMPLETE"}},"session_id":"claude-haiku-alias-session","parent_tool_use_id":null}
+{"type":"assistant","message":{"model":"claude-haiku-4-5-20251001","id":"claude-haiku-alias-message","type":"message","role":"assistant","content":[{"type":"text","text":"HAIKU GOLDEN COMPLETE"}]},"parent_tool_use_id":null,"session_id":"claude-haiku-alias-session"}
+{"type":"stream_event","event":{"type":"content_block_stop","index":1},"session_id":"claude-haiku-alias-session","parent_tool_use_id":null}
+{"type":"stream_event","event":{"type":"message_delta","delta":{"stop_reason":"end_turn"}},"session_id":"claude-haiku-alias-session","parent_tool_use_id":null}
+{"type":"stream_event","event":{"type":"message_stop"},"session_id":"claude-haiku-alias-session","parent_tool_use_id":null}
+{"type":"result","subtype":"success","is_error":false,"session_id":"claude-haiku-alias-session","result":"HAIKU GOLDEN COMPLETE","terminal_reason":"completed"}

--- a/tests/functional/providers/claude/testdata/haiku_stream_json/manifest.json
+++ b/tests/functional/providers/claude/testdata/haiku_stream_json/manifest.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": 1,
+  "source": {
+    "command": "claude -p --verbose --model <selector> --setting-sources '' --tools '' --disable-slash-commands --output-format stream-json --include-partial-messages <prompt>",
+    "providerVersion": "2.1.220",
+    "capturedAt": "2026-08-02",
+    "prompt": "Reply with exactly: HAIKU GOLDEN COMPLETE",
+    "sanitization": "Removed host paths, credentials, thinking text/signatures, usage/cost, timestamps, durations, and random identifiers; retained native record shapes and reported model identities."
+  },
+  "cases": [
+    {
+      "name": "alias",
+      "selector": "haiku",
+      "reportedModel": "claude-haiku-4-5-20251001",
+      "sessionId": "claude-haiku-alias-session",
+      "stdoutFile": "haiku.jsonl",
+      "sha256": "1740003b0bb4fe298091f6c7d91b0cd152ce123deaec44bef263646e6c7e9686"
+    },
+    {
+      "name": "family",
+      "selector": "claude-haiku-4-5",
+      "reportedModel": "claude-haiku-4-5-20251001",
+      "sessionId": "claude-haiku-family-session",
+      "stdoutFile": "claude-haiku-4-5.jsonl",
+      "sha256": "9f5456715706c1c7461a190110cde9cc4fab6fda90c06b1c4a1eb4e3ae6faea2"
+    },
+    {
+      "name": "pinned",
+      "selector": "claude-haiku-4-5-20251001",
+      "reportedModel": "claude-haiku-4-5-20251001",
+      "sessionId": "claude-haiku-pinned-session",
+      "stdoutFile": "claude-haiku-4-5-20251001.jsonl",
+      "sha256": "54e5c03c8dcac5352857ad83dee0d9c4a3ecf2de33a4bb96363a8c3ef791e5fa"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- enable Claude CLI verbose output for `stream-json` executions
- add deterministic root-process coverage using sanitized Haiku stream fixtures
- capture ACP proposals, program notes, and package-structure planning updates

## Why

Claude streaming consumers require the verbose stream format; the added fixture replays protect the provider-session and final-response behavior across supported Haiku selectors.

## Validation

- `go test ./pkg/services/providers/internal/services/execution/internal/adapters/claude ./tests/functional/providers/claude`
