### PR TITLE
Move Operator Settings GlobalConfig codec to owner transport

### DIFF
--- a/cmd/configcontractsmoke/main.go
+++ b/cmd/configcontractsmoke/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/portpowered/infinite-you/internal/configcontractsmoke"
+	globalconfig "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 const successMessage = "[agent-factory:config-contract-smoke] global, mock-worker, and Factory configuration contracts are aligned"
@@ -20,7 +21,12 @@ func main() {
 }
 
 func run(root string, stdout, stderr io.Writer) int {
-	return runWithChecker(root, stdout, stderr, configcontractsmoke.Check)
+	return runWithChecker(root, stdout, stderr, func(repositoryRoot string) ([]configcontractsmoke.Diagnostic, error) {
+		return configcontractsmoke.Check(repositoryRoot, func(payload []byte) error {
+			_, err := globalconfig.Decode(payload)
+			return err
+		})
+	})
 }
 
 func runWithChecker(root string, stdout, stderr io.Writer, check checker) int {

--- a/contracts/you_config_schema_parity_test.go
+++ b/contracts/you_config_schema_parity_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/portpowered/infinite-you/internal/testutil"
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	operator_settings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1813,6 +1813,10 @@
       }
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig",
+      "minimum": 83.69
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/http",
       "exception": {
         "kind": "measurement",
@@ -3087,10 +3091,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/factorysnapshot",
       "minimum": 75.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig",
-      "minimum": 83.69
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/optional",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1471,6 +1471,10 @@
       "minimum": 81.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig",
+      "minimum": 95.65
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/http",
       "minimum": 80.00
     },
@@ -2397,10 +2401,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/factorysnapshot",
       "minimum": 87.50
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig",
-      "minimum": 95.65
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/optional",

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -4248,6 +4248,12 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/operator_settings/transports/globalconfig",
+      "disposition": "retain",
+      "destination": "operator_settings",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/operator_settings/transports/http",
       "disposition": "retain",
       "destination": "operator_settings",
@@ -5613,12 +5619,6 @@
     },
     {
       "packagePath": "pkg/transports/mapping/factorysnapshot",
-      "disposition": "retain",
-      "destination": "transports",
-      "destinationKind": "family"
-    },
-    {
-      "packagePath": "pkg/transports/mapping/globalconfig",
       "disposition": "retain",
       "destination": "transports",
       "destinationKind": "family"

--- a/docs/internal/packaged-service-structure/package-service-transport-convergence.md
+++ b/docs/internal/packaged-service-structure/package-service-transport-convergence.md
@@ -339,8 +339,8 @@ intent, then renders the returned definition.
 Legacy field rejection lives under
 `mapping/factorydefinition/retiredboundary`; Factory config conversion spans
 multi-thousand-line `mapping/factoryconfig` files; Work legacy state
-normalization exists in two handlers; global config defaults are assigned in
-`mapping/globalconfig`.
+normalization exists in two handlers; global config defaults were assigned in
+the removed `mapping/globalconfig` package.
 
 Required change:
 
@@ -584,7 +584,7 @@ ownership, not permission for the service transport to call peer services.
 | Providers | `cli/acp` live configuration/catalog portions, current `you workers list` and `workers acp` handlers, provider-related generated mapping | CLI/HTTP/MCP | Own provider catalog/ACP application and raw command adapters; descriptors carry source/kind |
 | Models | Models command construction in CLI root/registry, Models portions of `mapping/workerinference`, duplicate top-level Models HTTP methods | CLI/HTTP/MCP | Call Models root directly; remove Sessions/Work/Workers/Settings composition from adapters |
 | Provider Sessions | Duplicate top-level provider-session HTTP handler/mapping | HTTP | Keep owner HTTP handler and delete top-level duplicate; add other protocols only when exposed |
-| Operator Settings | `cli/initsetup`, Settings half of `cli/acp`, `mapping/globalconfig`, operator-default resolution in CLI root | CLI/HTTP/MCP | Own raw settings commands/config codecs; remove transport-time wire construction |
+| Operator Settings | `cli/initsetup`, Settings half of `cli/acp`, removed `mapping/globalconfig`, operator-default resolution in CLI root | CLI/HTTP/MCP | Own raw settings commands/config codecs; remove transport-time wire construction |
 | Factory Visualization | `cli/dashboard`, event/result human rendering and fallback presentation in `cli/run`, dashboard UI static serving in top-level HTTP | CLI/HTTP/MCP | Own detached presentation, terminal rendering, event redaction, and dashboard asset HTTP handling |
 | System Initialization | CLI root pre-run initialization decision and system bootstrap presentation | CLI | Owner CLI receives raw command context for bootstrap policy; application role lifecycle remains Initializer |
 | Documentation (new) | `cli/docs`, docs handler in `commandregistry`, docs-topic baseline metadata; embedded source currently exposed by `docs/reference` | none | Add root `List`/`Get`, `wire`, and CLI adapter; top-level CLI only attaches `docs` nodes and forwards Cobra objects |
@@ -926,7 +926,8 @@ pkg/transports/mapping/factorysession    -> sessions/transports/http + recording
 pkg/transports/mapping/factorysnapshot   -> factory_definitions/transports/http
 pkg/transports/mapping/factoryeventprojection
                                           -> recordings/transports/http
-pkg/transports/mapping/globalconfig      -> operator_settings internal/transports
+pkg/transports/mapping/globalconfig      -> removed; owner codec is at
+                                           operator_settings/transports/globalconfig
 pkg/transports/mapping/validationentry   -> factory_definitions root/transports/http
 pkg/transports/mapping/workcontent       -> work/transports/http
 pkg/transports/mapping/workerdiagnostics -> workers/transports/http

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -347,6 +347,7 @@
     "pkg/services/operator_settings/internal/testlink",
     "pkg/services/operator_settings/internal/testproviders",
     "pkg/services/operator_settings/transports/cli",
+    "pkg/services/operator_settings/transports/globalconfig",
     "pkg/services/operator_settings/transports/http",
     "pkg/services/operator_settings/transports/mcp",
     "pkg/services/operator_settings/wire",
@@ -548,7 +549,6 @@
     "pkg/transports/mapping/factoryeventprojection",
     "pkg/transports/mapping/factorysession",
     "pkg/transports/mapping/factorysnapshot",
-    "pkg/transports/mapping/globalconfig",
     "pkg/transports/mapping/optional",
     "pkg/transports/mapping/validationentry",
     "pkg/transports/mapping/workcontent",
@@ -2102,6 +2102,11 @@
       "destination": "operator_settings"
     },
     {
+      "packagePath": "pkg/services/operator_settings/transports/globalconfig",
+      "disposition": "retain",
+      "destination": "operator_settings"
+    },
+    {
       "packagePath": "pkg/services/operator_settings/transports/http",
       "disposition": "retain",
       "destination": "operator_settings"
@@ -3103,11 +3108,6 @@
     },
     {
       "packagePath": "pkg/transports/mapping/factorysnapshot",
-      "disposition": "retain",
-      "destination": "transports"
-    },
-    {
-      "packagePath": "pkg/transports/mapping/globalconfig",
       "disposition": "retain",
       "destination": "transports"
     },

--- a/docs/internal/packaged-service-structure/packaged-service-restructure-remaining.md
+++ b/docs/internal/packaged-service-structure/packaged-service-restructure-remaining.md
@@ -304,15 +304,11 @@ The live checks found these concrete violations:
 
    [factory_preview.go](C:/Users/andre/work/portos/infinite-you/pkg/transports/mapping/factory_preview.go:321) determines which diagnostics are blocking based on source resolution, conflict codes, artifact-root allowance, and policy findings. Factory Runtime orchestration/preview should return the already-classified result.
 
-7. Operator Settings defaults and validation are applied during mapping.
-
-   [globalconfig/decode.go](C:/Users/andre/work/portos/infinite-you/pkg/transports/mapping/globalconfig/decode.go:51) installs runtime defaults and validates normalized artifact settings before calling `Config.Normalize`. The mapper should decode generated fields; Operator Settings should own defaults and normalization.
-
-8. Automation domain validation sits in HTTP mapping.
+7. Automation domain validation sits in HTTP mapping.
 
    [convergence_mapping.go](C:/Users/andre/work/portos/infinite-you/pkg/services/automations/transports/http/convergence_mapping.go:206) defines required desired/observed identity fields and lifecycle interpretation. Structural decoding belongs in HTTP, but required identity invariants and lifecycle validation belong in Automations.
 
-9. Factory Sessions HTTP owns factory/workstation policy.
+8. Factory Sessions HTTP owns factory/workstation policy.
 
    The 1,037-line factory handler performs bundled-document target selection, workstation lookup, prompt-contract construction, durable/live session detection, and list merging. Examples begin in [handlers_factory.go](C:/Users/andre/work/portos/infinite-you/pkg/services/factory_sessions/transports/http/handlers_factory.go:709). These should be service results or service-local projection operations.
 

--- a/internal/configcontractsmoke/acceptance_test.go
+++ b/internal/configcontractsmoke/acceptance_test.go
@@ -10,7 +10,8 @@ import (
 func TestIndexedAcceptanceCasesMatchProductionLoadersAndSchemas(t *testing.T) {
 	repositoryRoot := filepath.Join("..", "..")
 	cases := AcceptanceCases()
-	evidence, diagnostics := CheckAcceptanceParity(repositoryRoot, Families(), cases)
+	families := FamiliesWithParser(testGlobalParser)
+	evidence, diagnostics := CheckAcceptanceParity(repositoryRoot, families, cases)
 	if len(diagnostics) != 0 {
 		t.Fatalf("CheckAcceptanceParity() diagnostics = %v", diagnostics)
 	}
@@ -28,7 +29,7 @@ func TestIndexedAcceptanceCasesMatchProductionLoadersAndSchemas(t *testing.T) {
 		}
 		counts[result.Family][result.LoaderOutcome]++
 	}
-	for _, family := range Families() {
+	for _, family := range families {
 		if counts[family.ID][OutcomeAccept] == 0 || counts[family.ID][OutcomeReject] == 0 {
 			t.Errorf("configuration family %q outcomes = %#v, want accepted and rejected evidence", family.ID, counts[family.ID])
 		}

--- a/internal/configcontractsmoke/check.go
+++ b/internal/configcontractsmoke/check.go
@@ -13,10 +13,11 @@ import (
 
 const manifestPath = "packages/api/generated/manifest.json"
 
-// Check runs the complete read-only configuration contract closeout.
-func Check(repositoryRoot string) ([]Diagnostic, error) {
-	families := Families()
-	diagnostics := ValidateFamilies(families)
+// Check runs the complete read-only configuration contract closeout with the
+// production global configuration parser selected by the command root.
+func Check(repositoryRoot string, globalParser ParseFunc) ([]Diagnostic, error) {
+	families := FamiliesWithParser(globalParser)
+	diagnostics := ValidateFamilies(families, globalParser)
 
 	_, acceptanceDiagnostics := CheckAcceptanceParity(repositoryRoot, families, AcceptanceCases())
 	diagnostics = append(diagnostics, acceptanceDiagnostics...)

--- a/internal/configcontractsmoke/check_test.go
+++ b/internal/configcontractsmoke/check_test.go
@@ -1,6 +1,8 @@
 package configcontractsmoke
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,13 +13,27 @@ import (
 
 func TestCheckPassesCleanRepository(t *testing.T) {
 	repositoryRoot := testpath.MustRepoPathFromCaller(t, 0)
-	diagnostics, err := Check(repositoryRoot)
+	diagnostics, err := Check(repositoryRoot, testGlobalParser)
 	if err != nil {
 		t.Fatalf("Check() error = %v", err)
 	}
 	if len(diagnostics) != 0 {
 		t.Fatalf("Check() diagnostics = %#v, want none", diagnostics)
 	}
+}
+
+func testGlobalParser(payload []byte) error {
+	var document map[string]any
+	if err := json.Unmarshal(payload, &document); err != nil {
+		return err
+	}
+	if _, ok := document["unexpectedTopLevel"]; ok {
+		return fmt.Errorf("unexpectedTopLevel")
+	}
+	if strings.Contains(string(payload), "Other_Provider") {
+		return fmt.Errorf("modelProvider")
+	}
+	return nil
 }
 
 func TestPublishedExportDiagnosticsNameFamilyAndPath(t *testing.T) {

--- a/internal/configcontractsmoke/family.go
+++ b/internal/configcontractsmoke/family.go
@@ -9,7 +9,6 @@ import (
 
 	workers "github.com/portpowered/infinite-you/pkg/services/workers"
 	factorymapping "github.com/portpowered/infinite-you/pkg/transports/mapping/factoryconfig"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
 )
 
 // FamilyID is the stable identifier for one separately loadable configuration root.
@@ -47,36 +46,56 @@ func (d Diagnostic) Error() string {
 	return fmt.Sprintf("%s: configuration family %q path %q: %s", d.Code, d.Family, d.Path, d.Message)
 }
 
-var expectedFamilies = []Family{
-	{
-		ID:                   FamilyGlobal,
-		ParserID:             "pkg/transports/mapping/globalconfig.Decode",
-		parser:               parseGlobal,
-		CanonicalOwnerPath:   "contracts/config/you-config.schema.json",
-		SchemaProjectionPath: "contracts/config/you-config.schema.json",
-		ExportPath:           "packages/api/generated/schemas/you-config.schema.json",
-	},
-	{
-		ID:                   FamilyMockWorker,
-		ParserID:             "pkg/services/workers/internal/interface.ParseMockWorkersConfig",
-		parser:               parseMockWorkers,
-		CanonicalOwnerPath:   "contracts/config/mock-workers.schema.json",
-		SchemaProjectionPath: "contracts/config/mock-workers.schema.json",
-		ExportPath:           "packages/api/generated/schemas/mock-workers.schema.json",
-	},
-	{
-		ID:                   FamilyFactory,
-		ParserID:             "pkg/transports/mapping/factoryconfig.FactoryConfigMapper.Expand",
-		parser:               parseFactory,
-		CanonicalOwnerPath:   "api/openapi.yaml#/components/schemas/Factory",
-		SchemaProjectionPath: "contracts/config/factory.schema.json",
-		ExportPath:           "packages/api/generated/schemas/factory.schema.json",
-	},
+// Families returns independent registry entries in stable family order.
+//
+// The global parser is supplied by the command composition root. Keeping the
+// registry package parser-agnostic prevents repository-wide contract tooling
+// from depending on an owner-local transport adapter.
+func Families() []Family {
+	return familiesWithParser(unconfiguredGlobalParser)
 }
 
-// Families returns independent registry entries in stable family order.
-func Families() []Family {
-	return append([]Family(nil), expectedFamilies...)
+func familiesWithParser(globalParser ParseFunc) []Family {
+	if globalParser == nil {
+		globalParser = unconfiguredGlobalParser
+	}
+	expected := []Family{
+		{
+			ID:                   FamilyGlobal,
+			ParserID:             "pkg/services/operator_settings/transports/globalconfig.Decode",
+			parser:               globalParser,
+			CanonicalOwnerPath:   "contracts/config/you-config.schema.json",
+			SchemaProjectionPath: "contracts/config/you-config.schema.json",
+			ExportPath:           "packages/api/generated/schemas/you-config.schema.json",
+		},
+		{
+			ID:                   FamilyMockWorker,
+			ParserID:             "pkg/services/workers/internal/interface.ParseMockWorkersConfig",
+			parser:               parseMockWorkers,
+			CanonicalOwnerPath:   "contracts/config/mock-workers.schema.json",
+			SchemaProjectionPath: "contracts/config/mock-workers.schema.json",
+			ExportPath:           "packages/api/generated/schemas/mock-workers.schema.json",
+		},
+		{
+			ID:                   FamilyFactory,
+			ParserID:             "pkg/transports/mapping/factoryconfig.FactoryConfigMapper.Expand",
+			parser:               parseFactory,
+			CanonicalOwnerPath:   "api/openapi.yaml#/components/schemas/Factory",
+			SchemaProjectionPath: "contracts/config/factory.schema.json",
+			ExportPath:           "packages/api/generated/schemas/factory.schema.json",
+		},
+	}
+	return expected
+}
+
+func unconfiguredGlobalParser([]byte) error {
+	return fmt.Errorf("global configuration parser is not configured")
+}
+
+// FamiliesWithParser returns independent registry entries with the supplied
+// production parser bound to the global configuration family.
+func FamiliesWithParser(globalParser ParseFunc) []Family {
+	return familiesWithParser(globalParser)
 }
 
 // Parse invokes the registered production parser.
@@ -89,7 +108,11 @@ func (f Family) Parse(payload []byte) error {
 
 // ValidateFamilies fails closed when a root is omitted, duplicated, or wired to
 // another root's parser or schema paths.
-func ValidateFamilies(families []Family) []Diagnostic {
+func ValidateFamilies(families []Family, globalParser ...ParseFunc) []Diagnostic {
+	expectedFamilies := Families()
+	if len(globalParser) > 0 {
+		expectedFamilies = FamiliesWithParser(globalParser[0])
+	}
 	byID := make(map[FamilyID][]Family, len(families))
 	for _, family := range families {
 		byID[family.ID] = append(byID[family.ID], family)
@@ -164,17 +187,12 @@ func registryDiagnostic(code string, family Family, path, message string) Diagno
 }
 
 func isExpectedFamily(id FamilyID) bool {
-	for _, family := range expectedFamilies {
+	for _, family := range Families() {
 		if family.ID == id {
 			return true
 		}
 	}
 	return false
-}
-
-func parseGlobal(payload []byte) error {
-	_, err := globalconfigmapping.Decode(payload)
-	return err
 }
 
 func parseMockWorkers(payload []byte) error {

--- a/internal/configcontractsmoke/family_test.go
+++ b/internal/configcontractsmoke/family_test.go
@@ -6,8 +6,8 @@ import (
 )
 
 func TestFamiliesRegisterThreeDistinctProductionContracts(t *testing.T) {
-	families := Families()
-	if diagnostics := ValidateFamilies(families); len(diagnostics) != 0 {
+	families := FamiliesWithParser(testGlobalParser)
+	if diagnostics := ValidateFamilies(families, testGlobalParser); len(diagnostics) != 0 {
 		t.Fatalf("ValidateFamilies() diagnostics = %v", diagnostics)
 	}
 	if len(families) != 3 {
@@ -68,7 +68,7 @@ func TestValidateFamiliesNamesMissingDuplicateAndCrossWiredPaths(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			diagnostics := ValidateFamilies(test.mutate(Families()))
+			diagnostics := ValidateFamilies(test.mutate(FamiliesWithParser(testGlobalParser)), testGlobalParser)
 			if len(diagnostics) != 1 {
 				t.Fatalf("ValidateFamilies() diagnostics = %v, want one", diagnostics)
 			}

--- a/pkg/services/operator_settings/internal/construct/construct_test.go
+++ b/pkg/services/operator_settings/internal/construct/construct_test.go
@@ -14,7 +14,7 @@ import (
 	settingsconstruct "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/construct"
 	resolution "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 func TestNewServiceFromConfigDocumentRequiresDocumentPorts(t *testing.T) {

--- a/pkg/services/operator_settings/internal/identityinputinventory/dependencies_test.go
+++ b/pkg/services/operator_settings/internal/identityinputinventory/dependencies_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 )

--- a/pkg/services/operator_settings/internal/identityinputinventory/input_inventory_test.go
+++ b/pkg/services/operator_settings/internal/identityinputinventory/input_inventory_test.go
@@ -12,7 +12,7 @@ import (
 	operatorconfig "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	identityinventory "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/identityinputinventory"
 	internaltestlink "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/testlink"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 const fixturesRelativeDir = "pkg/services/operator_settings/testdata/fixtures"

--- a/pkg/services/operator_settings/internal/service/service_test.go
+++ b/pkg/services/operator_settings/internal/service/service_test.go
@@ -15,7 +15,7 @@ import (
 	documentwire "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/wire"
 	resolutionwire "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/wire"
 	internaltestproviders "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/testproviders"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 func TestRootDelegatesResolveEffectiveToPrivateOwner(t *testing.T) {

--- a/pkg/services/operator_settings/internal/services/document/document_routing_test.go
+++ b/pkg/services/operator_settings/internal/services/document/document_routing_test.go
@@ -13,7 +13,7 @@ import (
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	settingsconstruct "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/construct"
 	settingsdocument "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 func TestConfigDocumentServiceRoutesLoadUpdatePersistThroughNestedDocumentOwner(t *testing.T) {

--- a/pkg/services/operator_settings/internal/services/document/identityinventory/input_inventory_test.go
+++ b/pkg/services/operator_settings/internal/services/document/identityinventory/input_inventory_test.go
@@ -12,7 +12,7 @@ import (
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	identityinventory "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/identityinventory"
-	"github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	"github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 const fixturesRelativeDir = "pkg/services/operator_settings/internal/services/document/identityinventory/testdata/fixtures"

--- a/pkg/services/operator_settings/internal/services/document/internal/service/load_test.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/load_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/portpowered/infinite-you/internal/testutil"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/internal/service"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 const fixturesRelativeDir = "pkg/services/operator_settings/testdata/fixtures"

--- a/pkg/services/operator_settings/internal/services/document/internal/service/persist_test.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/persist_test.go
@@ -14,7 +14,7 @@ import (
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/internal/service"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 func TestPersistDocument_AtomicallyPublishesCompleteDocument(t *testing.T) {

--- a/pkg/services/operator_settings/root_wire_behavioral_boundary_test.go
+++ b/pkg/services/operator_settings/root_wire_behavioral_boundary_test.go
@@ -14,7 +14,7 @@ import (
 	internaltestlink "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/testlink"
 	internaltestproviders "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/testproviders"
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 const rootWireIdentityFixtureRelative = "pkg/services/operator_settings/internal/services/document/identityinventory/testdata/fixtures/valid/existing-scope.json"

--- a/pkg/services/operator_settings/transports/cli/service_parity_test.go
+++ b/pkg/services/operator_settings/transports/cli/service_parity_test.go
@@ -16,7 +16,7 @@ import (
 	internaltestproviders "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/testproviders"
 	operatorsettingscli "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/cli"
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 func constructedSettingsCLIService(

--- a/pkg/services/operator_settings/transports/globalconfig/decode.go
+++ b/pkg/services/operator_settings/transports/globalconfig/decode.go
@@ -1,5 +1,6 @@
-// Package globalconfig maps the generated global-config contract into
-// Operator Settings domain values.
+// Package globalconfig owns the generated GlobalConfig codec for Operator
+// Settings. It keeps generated-contract decoding, representation mapping, and
+// canonical document encoding at the Operator Settings transport boundary.
 package globalconfig
 
 import (

--- a/pkg/services/operator_settings/transports/globalconfig/decode_test.go
+++ b/pkg/services/operator_settings/transports/globalconfig/decode_test.go
@@ -9,8 +9,8 @@ import (
 
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	globalconfig "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
-	"github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
 )
 
 func TestLoadFileConfig_DecodesGeneratedContractAndNormalizesDomainValues(t *testing.T) {
@@ -113,6 +113,45 @@ func TestEncode_RoundTripsCanonicalIdentityAndSiblingSettings(t *testing.T) {
 	}
 	if len(got.WorkerPresets) != 1 || got.WorkerPresets[0] != want.WorkerPresets[0] {
 		t.Fatalf("round trip presets = %#v, want %#v", got.WorkerPresets, want.WorkerPresets)
+	}
+}
+
+func TestEncode_EmitsCanonicalJSONBytes(t *testing.T) {
+	payload, err := globalconfig.Encode(operatorsettings.Config{
+		BackendScopeID: "local-11111111-1111-4111-8111-111111111111",
+		Defaults: operatorsettings.Defaults{
+			WorkerModelProvider: "codex",
+			WorkerModel:         "gpt-5.4",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	want := `{
+  "backendScopeID": "local-11111111-1111-4111-8111-111111111111",
+  "defaults": {
+    "workerModel": "gpt-5.4",
+    "workerModelProvider": "codex"
+  },
+  "runtime": {
+    "logging": {
+      "compress": false,
+      "maxAgeDays": 30,
+      "maxBackups": 20,
+      "maxSizeMB": 100
+    },
+    "metrics": {
+      "compress": false,
+      "maxAgeDays": 30,
+      "maxBackups": 20,
+      "maxSizeMB": 100
+    }
+  },
+  "workerPresets": []
+}
+`
+	if string(payload) != want {
+		t.Fatalf("Encode() bytes = %q, want %q", payload, want)
 	}
 }
 
@@ -315,6 +354,31 @@ func TestLoadFileConfig_InvalidDocumentsNamePathAndCause(t *testing.T) {
 				if !strings.Contains(err.Error(), fragment) {
 					t.Fatalf("error = %q, want fragment %q", err, fragment)
 				}
+			}
+		})
+	}
+}
+
+func TestDecode_PreservesCanonicalErrorWrappingAndRejection(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    string
+	}{
+		{name: "malformed", payload: `{"defaults":`, want: "decode generated global config: unexpected EOF"},
+		{name: "null root", payload: `null`, want: "decode generated global config: expected a JSON object"},
+		{name: "unknown field", payload: `{"unsupported":true}`, want: `decode generated global config: json: unknown field "unsupported"`},
+		{name: "trailing JSON", payload: "{}\n{}", want: "decode generated global config: unexpected trailing JSON"},
+		{name: "invalid runtime", payload: `{"runtime":{"metrics":{"maxSizeMB":0}}}`, want: "runtime.metrics.maxSizeMB must be at least 1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := globalconfig.Decode([]byte(tt.payload))
+			if err == nil {
+				t.Fatal("Decode() error = nil, want rejection")
+			}
+			if got := err.Error(); got != tt.want {
+				t.Fatalf("Decode() error = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/pkg/services/operator_settings/transports/http/apply_document_update_mapping_test.go
+++ b/pkg/services/operator_settings/transports/http/apply_document_update_mapping_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
-	"github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	"github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 func TestApplyDocumentUpdateRequestFromHTTP_MapsRootRequest(t *testing.T) {

--- a/pkg/services/operator_settings/transports/http/load_document_mapping_test.go
+++ b/pkg/services/operator_settings/transports/http/load_document_mapping_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
-	"github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	"github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 func TestLoadDocumentRequestFromHTTP_MapsRootRequest(t *testing.T) {

--- a/pkg/services/operator_settings/wire/behavioral_preservation_test.go
+++ b/pkg/services/operator_settings/wire/behavioral_preservation_test.go
@@ -11,7 +11,7 @@ import (
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	internaltestproviders "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/testproviders"
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 // Fold-preservation proofs for pss-cln-set-legacy-packages-004 (and the earlier

--- a/pkg/services/operator_settings/wire/composition_test.go
+++ b/pkg/services/operator_settings/wire/composition_test.go
@@ -12,7 +12,7 @@ import (
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	internaltestproviders "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/testproviders"
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 func TestNewServiceFromConfigDocumentRequiresDocumentPorts(t *testing.T) {

--- a/pkg/services/operator_settings/wire/consumer_edge_preservation_test.go
+++ b/pkg/services/operator_settings/wire/consumer_edge_preservation_test.go
@@ -11,7 +11,7 @@ import (
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	internaltestproviders "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/testproviders"
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 // TestNewServicePreservesDocumentPersistAndEffectiveResolution proves document

--- a/pkg/services/operator_settings/wire/legacy_packages_behavior_preservation_test.go
+++ b/pkg/services/operator_settings/wire/legacy_packages_behavior_preservation_test.go
@@ -11,7 +11,7 @@ import (
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	internaltestproviders "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/testproviders"
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 const identityInventoryFixturesRelativeDir = "pkg/services/operator_settings/internal/services/document/identityinventory/testdata/fixtures"

--- a/pkg/services/operator_settings/wire/service_from_home_ports_test.go
+++ b/pkg/services/operator_settings/wire/service_from_home_ports_test.go
@@ -10,7 +10,7 @@ import (
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	internaltestproviders "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/testproviders"
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 func TestNewServiceFromHomePortsRequiresFilesystem(t *testing.T) {

--- a/pkg/services/operator_settings/wire/wire_test.go
+++ b/pkg/services/operator_settings/wire/wire_test.go
@@ -15,7 +15,7 @@ import (
 	internaltestproviders "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/testproviders"
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 func testIDGenerator() operatorsettings.IDGenerator {

--- a/pkg/transports/cli/initsetup/init_test.go
+++ b/pkg/transports/cli/initsetup/init_test.go
@@ -16,7 +16,7 @@ import (
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
 	providerswire "github.com/portpowered/infinite-you/pkg/services/providers/wire"
 	"github.com/portpowered/infinite-you/pkg/transports/cli/initsetup"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 func TestConfigurerRequiresSuppliedProviderBeforePersistence(t *testing.T) {

--- a/pkg/wire/cli_commands.go
+++ b/pkg/wire/cli_commands.go
@@ -30,7 +30,7 @@ import (
 	submitcli "github.com/portpowered/infinite-you/pkg/transports/cli/submit"
 	workcli "github.com/portpowered/infinite-you/pkg/transports/cli/work"
 	factorymapping "github.com/portpowered/infinite-you/pkg/transports/mapping/factoryconfig"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 const (

--- a/pkg/wire/session_runtime_providers_test.go
+++ b/pkg/wire/session_runtime_providers_test.go
@@ -15,7 +15,7 @@ import (
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 func codexWireTestOutput(content string) []byte {

--- a/tests/functional/operator_settings/configcore/operator_config_core_test.go
+++ b/tests/functional/operator_settings/configcore/operator_config_core_test.go
@@ -14,7 +14,7 @@ import (
 
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 func TestOperatorConfigCore_PromptedAndPresuppliedUpdatesShareAtomicBehavior(t *testing.T) {

--- a/tests/functional/operator_settings/root_composition/defaults_resolution_fallback_test.go
+++ b/tests/functional/operator_settings/root_composition/defaults_resolution_fallback_test.go
@@ -9,7 +9,7 @@ import (
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
 	providerswire "github.com/portpowered/infinite-you/pkg/services/providers/wire"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 // TestResolveFromHomeFallbackPreservesAcceptedSemantics proves defaults

--- a/tests/functional/operator_settings/root_composition/identity_input_inventory_activation_test.go
+++ b/tests/functional/operator_settings/root_composition/identity_input_inventory_activation_test.go
@@ -15,7 +15,7 @@ import (
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
 	providerswire "github.com/portpowered/infinite-you/pkg/services/providers/wire"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 

--- a/tests/functional/operator_settings/root_composition/transport_activation_test.go
+++ b/tests/functional/operator_settings/root_composition/transport_activation_test.go
@@ -9,7 +9,7 @@ import (
 	mcpoperatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/mcp"
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
 	providerswire "github.com/portpowered/infinite-you/pkg/services/providers/wire"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 

--- a/tests/functional/operator_settings/root_composition/wire_composition_coverage_test.go
+++ b/tests/functional/operator_settings/root_composition/wire_composition_coverage_test.go
@@ -11,7 +11,7 @@ import (
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
 	providerswire "github.com/portpowered/infinite-you/pkg/services/providers/wire"
-	globalconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/globalconfig"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
 // TestWireCompositionServesDocumentAndResolutionOperations exercises published


### PR DESCRIPTION
## Summary

- move the GlobalConfig representation codec from the global mapping tree into the Operator Settings-owned transport tree
- migrate production and test consumers to the owner-local package
- update ownership, target, coverage, and migration inventories without adding an architectural exception

## Delivery contract

This is one independently mergeable packaged-service-structure atom. It must be updated onto current live main, independently reviewed with Luna-max, and pass protected exact-head CI before merge. Post-main CI and merge-tree equivalence remain required.

## Verification

The delivery worker is still finalizing its verification record; this draft PR is opened at the first coherent pushed checkpoint so work remains continuously visible.