### PR TITLE
Move Recordings artifact publication behind process edges

### DIFF
--- a/cmd/pkgboundarycheck/production_defaults.go
+++ b/cmd/pkgboundarycheck/production_defaults.go
@@ -153,12 +153,6 @@ var productionDefaultAllowances = []productionDefaultAllowance{
 	{filePath: "pkg/platform/replay/storage.go", operation: "Local.WriteFile", symbol: "os.Rename", wireSymbol: repositoryImportPrefix + "pkg/platform/replay.NewLocal"},
 	{filePath: "pkg/platform/replay/storage.go", operation: "Local.ReadFile", symbol: "os.ReadFile", wireSymbol: repositoryImportPrefix + "pkg/platform/replay.NewLocal"},
 
-	{filePath: "pkg/services/recordings/internal/services/artifacts_export/wire/publication.go", operation: "NewOSPublication", symbol: "os.MkdirAll", wireSymbol: repositoryImportPrefix + "pkg/services/recordings/internal.NewPortableArtifactPublication"},
-	{filePath: "pkg/services/recordings/internal/services/artifacts_export/wire/publication.go", operation: "NewOSPublication", symbol: "os.CreateTemp", wireSymbol: repositoryImportPrefix + "pkg/services/recordings/internal.NewPortableArtifactPublication"},
-	{filePath: "pkg/services/recordings/internal/services/artifacts_export/wire/publication.go", operation: "NewOSPublication", symbol: "os.Remove", wireSymbol: repositoryImportPrefix + "pkg/services/recordings/internal.NewPortableArtifactPublication"},
-	{filePath: "pkg/services/recordings/internal/services/artifacts_export/wire/publication.go", operation: "NewOSPublication", symbol: "os.Rename", wireSymbol: repositoryImportPrefix + "pkg/services/recordings/internal.NewPortableArtifactPublication"},
-	{filePath: "pkg/services/recordings/internal/services/artifacts_export/wire/publication.go", operation: "NewOSPublication", symbol: "os.ReadFile", wireSymbol: repositoryImportPrefix + "pkg/services/recordings/internal.NewPortableArtifactPublication"},
-
 	// These become allowed only after Wire explicitly selects the adapter. Until
 	// then their ambient effects remain ordinary deletion-only findings.
 	{filePath: "pkg/platform/process/command.go", operation: "ExecCommandRunner.Run", symbol: "os/exec.Command", wireSymbol: repositoryImportPrefix + "pkg/platform/process.ExecCommandRunner"},

--- a/pkg/root/recordings_artifacts_export_composition_test.go
+++ b/pkg/root/recordings_artifacts_export_composition_test.go
@@ -18,3 +18,20 @@ func TestBuildProcessWiresRecordingsArtifactExportGraph(t *testing.T) {
 		t.Fatalf("BuildProcess() error = %v", err)
 	}
 }
+
+func TestBuildProcessAcceptsRecordingArtifactReadEdgeWithoutConstructionIO(t *testing.T) {
+	t.Parallel()
+
+	readCalls := 0
+	if _, err := root.BuildProcess(context.Background(), serviceedges.Edges{
+		RecordingReadFile: func(string) ([]byte, error) {
+			readCalls++
+			return nil, nil
+		},
+	}); err != nil {
+		t.Fatalf("BuildProcess() with RecordingReadFile edge error = %v", err)
+	}
+	if readCalls != 0 {
+		t.Fatalf("RecordingReadFile calls during inert BuildProcess() = %d, want zero", readCalls)
+	}
+}

--- a/pkg/services/edges/contract_ownership_test.go
+++ b/pkg/services/edges/contract_ownership_test.go
@@ -281,6 +281,7 @@ func TestEdgesAggregateExactOwnerTypes(t *testing.T) {
 		"RecordingCreateTempFile":          {typeName: "recordings.RecordingCreateTemporaryFile", effect: "create portable recording temporary files"},
 		"RecordingRemovePath":              {typeName: "recordings.RecordingRemovePath", effect: "remove portable recording temporary files"},
 		"RecordingRenamePath":              {typeName: "recordings.RecordingRenamePath", effect: "publish portable recording files atomically"},
+		"RecordingReadFile":                {typeName: "recordings.RecordingReadFile", effect: "read published portable recording artifacts"},
 		"APIServerStarter":                 {typeName: "platformhttpserver.Starter", effect: "bind and serve the external HTTP listener"},
 		"BrowserOpener":                    {typeName: "platformbrowser.Opener", effect: "open a customer-facing URL in the host browser"},
 		"InvocationMetricsRecorder":        {typeName: "factorysessions.InvocationMetricsRecorder", effect: "publish Factory Session invocation metrics"},

--- a/pkg/services/edges/definition.go
+++ b/pkg/services/edges/definition.go
@@ -168,6 +168,7 @@ type Edges struct {
 	RecordingCreateTempFile          recordings.RecordingCreateTemporaryFile
 	RecordingRemovePath              recordings.RecordingRemovePath
 	RecordingRenamePath              recordings.RecordingRenamePath
+	RecordingReadFile                recordings.RecordingReadFile
 	APIServerStarter                 platformhttpserver.Starter
 	BrowserOpener                    platformbrowser.Opener
 	InvocationMetricsRecorder        factorysessions.InvocationMetricsRecorder
@@ -503,6 +504,9 @@ func Merge(defaults Edges, replacements Edges) Edges {
 	}
 	if replacements.RecordingRenamePath != nil {
 		defaults.RecordingRenamePath = replacements.RecordingRenamePath
+	}
+	if replacements.RecordingReadFile != nil {
+		defaults.RecordingReadFile = replacements.RecordingReadFile
 	}
 	if replacements.APIServerStarter != nil {
 		defaults.APIServerStarter = replacements.APIServerStarter

--- a/pkg/services/edges/definition_test.go
+++ b/pkg/services/edges/definition_test.go
@@ -21,8 +21,17 @@ import (
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 	inference "github.com/portpowered/infinite-you/pkg/services/providers/wire"
+	recordings "github.com/portpowered/infinite-you/pkg/services/recordings"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
+)
+
+var (
+	_ recordings.RecordingMakeDirectories     = Edges{}.RecordingMakeDirectories
+	_ recordings.RecordingCreateTemporaryFile = Edges{}.RecordingCreateTempFile
+	_ recordings.RecordingRemovePath          = Edges{}.RecordingRemovePath
+	_ recordings.RecordingRenamePath          = Edges{}.RecordingRenamePath
+	_ recordings.RecordingReadFile            = Edges{}.RecordingReadFile
 )
 
 // backendsizecheck:ignore-function service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption.
@@ -417,6 +426,30 @@ func TestMergeWithEmptyReplacementsPreservesProductionDefaults(t *testing.T) {
 
 	if merged.APIServerStarter == nil {
 		t.Fatal("APIServerStarter = nil")
+	}
+}
+
+func TestMergeReplacesAndPreservesRecordingArtifactReadEffect(t *testing.T) {
+	t.Parallel()
+
+	defaultRead := recordings.RecordingReadFile(func(string) ([]byte, error) {
+		return []byte("default"), nil
+	})
+	replacementRead := recordings.RecordingReadFile(func(string) ([]byte, error) {
+		return []byte("replacement"), nil
+	})
+
+	merged := Merge(
+		Edges{RecordingReadFile: defaultRead},
+		Edges{RecordingReadFile: replacementRead},
+	)
+	if got, err := merged.RecordingReadFile("artifact"); err != nil || string(got) != "replacement" {
+		t.Fatalf("merged RecordingReadFile = (%q, %v), want replacement", got, err)
+	}
+
+	preserved := Merge(Edges{RecordingReadFile: defaultRead}, Edges{})
+	if got, err := preserved.RecordingReadFile("artifact"); err != nil || string(got) != "default" {
+		t.Fatalf("preserved RecordingReadFile = (%q, %v), want default", got, err)
 	}
 }
 

--- a/pkg/services/recordings/contracts.go
+++ b/pkg/services/recordings/contracts.go
@@ -171,6 +171,7 @@ type (
 	RecordingLifecycleState                                    = recordingcontracts.RecordingLifecycleState
 	RecordingMakeDirectories                                   = recordingcontracts.RecordingMakeDirectories
 	RecordingPathJoiner                                        = recordingcontracts.RecordingPathJoiner
+	RecordingReadFile                                          = recordingcontracts.RecordingReadFile
 	RecordingRemovePath                                        = recordingcontracts.RecordingRemovePath
 	RecordingRenamePath                                        = recordingcontracts.RecordingRenamePath
 	RecordingSnapshot                                          = recordingcontracts.RecordingSnapshot

--- a/pkg/services/recordings/internal/combined_service_plain_contract_test.go
+++ b/pkg/services/recordings/internal/combined_service_plain_contract_test.go
@@ -62,7 +62,15 @@ func TestNewServiceRejectsNilDependencies(t *testing.T) {
 func TestNewServiceWithLifecycleEffectsUsesProvidedPublicationAndPlanner(t *testing.T) {
 	t.Parallel()
 
-	publication, err := NewPortableArtifactPublication()
+	publication, err := NewPortableArtifactPublication(
+		os.MkdirAll,
+		func(dir, pattern string) (recordings.RecordingTemporaryFile, error) {
+			return os.CreateTemp(dir, pattern)
+		},
+		os.Remove,
+		os.Rename,
+		os.ReadFile,
+	)
 	if err != nil {
 		t.Fatalf("NewPortableArtifactPublication: %v", err)
 	}
@@ -933,7 +941,26 @@ func TestCombinedServicePortableExportAndReadDelegates(t *testing.T) {
 		t.Fatalf("Mkdir: %v", err)
 	}
 	ledger := &stubLedger{}
-	svc := NewService(ledger, NewProjectionService())
+	publication, err := NewPortableArtifactPublication(
+		os.MkdirAll,
+		func(dir, pattern string) (recordings.RecordingTemporaryFile, error) {
+			return os.CreateTemp(dir, pattern)
+		},
+		os.Remove,
+		os.Rename,
+		os.ReadFile,
+	)
+	if err != nil {
+		t.Fatalf("NewPortableArtifactPublication: %v", err)
+	}
+	svc := NewServiceWithLifecycleEffects(
+		ledger,
+		NewProjectionService(),
+		nil,
+		nil,
+		nil,
+		publication,
+	)
 	scope := recordings.CanonicalEventScope{FactorySessionID: "session-export-delegate"}
 	bound, err := svc.BindRecording(recordings.BindRecordingRequest{
 		RecordingID: "recording-export-delegate",

--- a/pkg/services/recordings/internal/contracts/portable_recording.go
+++ b/pkg/services/recordings/internal/contracts/portable_recording.go
@@ -208,6 +208,9 @@ type RecordingRemovePath func(string) error
 // RecordingRenamePath renames a path during portable recording writes.
 type RecordingRenamePath func(string, string) error
 
+// RecordingReadFile reads a published portable recording or artifact.
+type RecordingReadFile func(string) ([]byte, error)
+
 // PortableRecordingWriter validates and atomically persists one portable
 // recording.
 type PortableRecordingWriter interface {

--- a/pkg/services/recordings/internal/core.go
+++ b/pkg/services/recordings/internal/core.go
@@ -239,13 +239,6 @@ func NewServiceWithLifecycleEffects(
 		tickers,
 		clocks...,
 	)
-	if publication == nil {
-		var err error
-		publication, err = NewPortableArtifactPublication()
-		if err != nil {
-			return nil
-		}
-	}
 	return &combinedService{
 		Ledger:            ledger,
 		ProjectionService: projection,

--- a/pkg/services/recordings/internal/portable_artifact_publication.go
+++ b/pkg/services/recordings/internal/portable_artifact_publication.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 
+	recordings "github.com/portpowered/infinite-you/pkg/services/recordings"
 	artifactsexportwire "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/artifacts_export/wire"
 )
 
@@ -11,8 +12,20 @@ type portableArtifactPublication interface {
 	Read(context.Context, string) ([]byte, error)
 }
 
-// NewPortableArtifactPublication constructs the Wire-selected host publication
-// effect for portable artifact export and read.
-func NewPortableArtifactPublication() (portableArtifactPublication, error) {
-	return artifactsexportwire.NewOSPublication()
+// NewPortableArtifactPublication constructs the private publication effect
+// from exact filesystem operations selected by the application graph.
+func NewPortableArtifactPublication(
+	makeDirectories recordings.RecordingMakeDirectories,
+	createTemporaryFile recordings.RecordingCreateTemporaryFile,
+	removePath recordings.RecordingRemovePath,
+	renamePath recordings.RecordingRenamePath,
+	readFile recordings.RecordingReadFile,
+) (portableArtifactPublication, error) {
+	return artifactsexportwire.NewPublication(
+		makeDirectories,
+		createTemporaryFile,
+		removePath,
+		renamePath,
+		readFile,
+	)
 }

--- a/pkg/services/recordings/internal/services/artifacts_export/internal/service/service_test.go
+++ b/pkg/services/recordings/internal/services/artifacts_export/internal/service/service_test.go
@@ -22,6 +22,18 @@ type snapshotSourceFake struct {
 	err      error
 }
 
+func newOSPublication() (artifactsexportservice.PortableArtifactPublication, error) {
+	return artifactsexportwire.NewPublication(
+		os.MkdirAll,
+		func(dir, pattern string) (recordings.RecordingTemporaryFile, error) {
+			return os.CreateTemp(dir, pattern)
+		},
+		os.Remove,
+		os.Rename,
+		os.ReadFile,
+	)
+}
+
 func (fake snapshotSourceFake) Snapshot(recordings.RecordingID) (recordinglifecycle.Snapshot, error) {
 	if fake.err != nil {
 		return recordinglifecycle.Snapshot{}, fake.err
@@ -237,9 +249,9 @@ func TestExportPortableArtifactPublishesCompleteReadableArtifact(t *testing.T) {
 		Payload:    "{}",
 	}
 	destination := filepath.Join(t.TempDir(), "public-export.json")
-	publication, err := artifactsexportwire.NewOSPublication()
+	publication, err := newOSPublication()
 	if err != nil {
-		t.Fatalf("NewOSPublication: %v", err)
+		t.Fatalf("newOSPublication: %v", err)
 	}
 	service := artifactsexportservice.New(snapshotSourceFake{
 		snapshot: recordinglifecycle.Snapshot{
@@ -288,9 +300,9 @@ func TestReadPortableArtifactRejectsMissingRecordingAndHandle(t *testing.T) {
 			FinalizedAt: &finalizedAt,
 		},
 	}
-	publication, err := artifactsexportwire.NewOSPublication()
+	publication, err := newOSPublication()
 	if err != nil {
-		t.Fatalf("NewOSPublication: %v", err)
+		t.Fatalf("newOSPublication: %v", err)
 	}
 	service := artifactsexportservice.New(snapshotSourceFake{snapshot: snapshot}, publication)
 
@@ -328,9 +340,9 @@ func TestReadPortableArtifactRejectsForeignHandle(t *testing.T) {
 		Payload:    `{"public":true}`,
 	}
 	destination := filepath.Join(t.TempDir(), "foreign-read.json")
-	publication, err := artifactsexportwire.NewOSPublication()
+	publication, err := newOSPublication()
 	if err != nil {
-		t.Fatalf("NewOSPublication: %v", err)
+		t.Fatalf("newOSPublication: %v", err)
 	}
 	ownerSnapshot := recordinglifecycle.Snapshot{
 		Status: recordings.RecordingStatusFacts{
@@ -395,9 +407,9 @@ func TestReadPortableArtifactErrorsOmitPrivatePaths(t *testing.T) {
 			FinalizedAt: &finalizedAt,
 		},
 	}
-	publication, err := artifactsexportwire.NewOSPublication()
+	publication, err := newOSPublication()
 	if err != nil {
-		t.Fatalf("NewOSPublication: %v", err)
+		t.Fatalf("newOSPublication: %v", err)
 	}
 	service := artifactsexportservice.New(snapshotSourceFake{snapshot: snapshot}, publication)
 
@@ -430,9 +442,9 @@ func TestExportPortableArtifactRejectsPreCancelledContext(t *testing.T) {
 
 	finalizedAt := time.Unix(1_700_000_000, 0).UTC()
 	scope := recordings.CanonicalEventScope{FactorySessionID: "session-cancel-export"}
-	publication, err := artifactsexportwire.NewOSPublication()
+	publication, err := newOSPublication()
 	if err != nil {
-		t.Fatalf("NewOSPublication: %v", err)
+		t.Fatalf("newOSPublication: %v", err)
 	}
 	service := artifactsexportservice.New(snapshotSourceFake{
 		snapshot: recordinglifecycle.Snapshot{
@@ -539,9 +551,9 @@ func TestReadPortableArtifactRejectsPreCancelledContext(t *testing.T) {
 
 	finalizedAt := time.Unix(1_700_000_000, 0).UTC()
 	scope := recordings.CanonicalEventScope{FactorySessionID: "session-cancel-read"}
-	publication, err := artifactsexportwire.NewOSPublication()
+	publication, err := newOSPublication()
 	if err != nil {
-		t.Fatalf("NewOSPublication: %v", err)
+		t.Fatalf("newOSPublication: %v", err)
 	}
 	service := artifactsexportservice.New(snapshotSourceFake{
 		snapshot: recordinglifecycle.Snapshot{
@@ -586,9 +598,9 @@ func TestReadPortableArtifactCancellationDuringReadDoesNotReturnPartialArtifact(
 		Payload:    "{}",
 	}
 	destination := filepath.Join(t.TempDir(), "public-read.json")
-	publication, err := artifactsexportwire.NewOSPublication()
+	publication, err := newOSPublication()
 	if err != nil {
-		t.Fatalf("NewOSPublication: %v", err)
+		t.Fatalf("newOSPublication: %v", err)
 	}
 	service := artifactsexportservice.New(snapshotSourceFake{
 		snapshot: recordinglifecycle.Snapshot{

--- a/pkg/services/recordings/internal/services/artifacts_export/root_integration_test.go
+++ b/pkg/services/recordings/internal/services/artifacts_export/root_integration_test.go
@@ -12,20 +12,41 @@ import (
 	"time"
 
 	recordings "github.com/portpowered/infinite-you/pkg/services/recordings"
-	recordingsinternal "github.com/portpowered/infinite-you/pkg/services/recordings/internal"
+	recordingswire "github.com/portpowered/infinite-you/pkg/services/recordings/wire"
 )
 
 type unusedLedger struct {
 	recordings.Ledger
 }
 
+func newRecordingsRoot(
+	t *testing.T,
+	planner recordings.LiveRecordingTargetPlanner,
+) recordings.Service {
+	t.Helper()
+	root, err := recordingswire.NewServiceWithProjectionAndEffects(
+		&unusedLedger{},
+		recordingswire.NewProjectionService(),
+		planner,
+		nil,
+		os.MkdirAll,
+		func(dir, pattern string) (recordings.RecordingTemporaryFile, error) {
+			return os.CreateTemp(dir, pattern)
+		},
+		os.Remove,
+		os.Rename,
+		os.ReadFile,
+	)
+	if err != nil {
+		t.Fatalf("construct Recordings root: %v", err)
+	}
+	return root
+}
+
 func TestAcceptedRecordingsRootUsesPrivateArtifactsExport(t *testing.T) {
 	t.Parallel()
 
-	root := recordingsinternal.NewService(
-		&unusedLedger{},
-		recordingsinternal.NewProjectionService(),
-	)
+	root := newRecordingsRoot(t, nil)
 	scope := recordings.CanonicalEventScope{FactorySessionID: "session-export-root"}
 	bound, err := root.BindRecording(recordings.BindRecordingRequest{
 		RecordingID: "recording-export-root",
@@ -100,11 +121,7 @@ func TestRecordingsRootPortableExportRoundTripOmitsPrivateStorage(t *testing.T) 
 			}, nil
 		},
 	)
-	root := recordingsinternal.NewService(
-		&unusedLedger{},
-		recordingsinternal.NewProjectionService(),
-		planner,
-	)
+	root := newRecordingsRoot(t, planner)
 	scope := recordings.CanonicalEventScope{FactorySessionID: "session-round-trip"}
 	started, err := root.StartRecording(recordings.StartRecordingRequest{
 		Enabled:     true,
@@ -199,10 +216,7 @@ func TestRecordingsRootFailedExportLeavesNoReadablePublicArtifact(t *testing.T) 
 	if err := os.Mkdir(destination, 0o700); err != nil {
 		t.Fatalf("Mkdir: %v", err)
 	}
-	root := recordingsinternal.NewService(
-		&unusedLedger{},
-		recordingsinternal.NewProjectionService(),
-	)
+	root := newRecordingsRoot(t, nil)
 	scope := recordings.CanonicalEventScope{FactorySessionID: "session-failed-root-export"}
 	bound, err := root.BindRecording(recordings.BindRecordingRequest{
 		RecordingID: "recording-failed-root-export",
@@ -253,10 +267,7 @@ func TestRecordingsRootFailedExportLeavesNoReadablePublicArtifact(t *testing.T) 
 func TestRecordingsRootReadPortableArtifactRejectsMissingAndForeignHandles(t *testing.T) {
 	t.Parallel()
 
-	root := recordingsinternal.NewService(
-		&unusedLedger{},
-		recordingsinternal.NewProjectionService(),
-	)
+	root := newRecordingsRoot(t, nil)
 	scope := recordings.CanonicalEventScope{FactorySessionID: "session-root-read-guards"}
 	owner, err := root.BindRecording(recordings.BindRecordingRequest{
 		RecordingID: "recording-root-owner",
@@ -310,10 +321,7 @@ func TestRecordingsRootReadPortableArtifactRejectsMissingAndForeignHandles(t *te
 func TestRecordingsRootExportCancellationLeavesNoReadableArtifact(t *testing.T) {
 	t.Parallel()
 
-	root := recordingsinternal.NewService(
-		&unusedLedger{},
-		recordingsinternal.NewProjectionService(),
-	)
+	root := newRecordingsRoot(t, nil)
 	scope := recordings.CanonicalEventScope{FactorySessionID: "session-root-cancel-export"}
 	bound, err := root.BindRecording(recordings.BindRecordingRequest{
 		RecordingID: "recording-root-cancel-export",
@@ -352,10 +360,7 @@ func TestRecordingsRootExportCancellationLeavesNoReadableArtifact(t *testing.T) 
 func TestRecordingsRootReadPortableArtifactRejectsCancelledContext(t *testing.T) {
 	t.Parallel()
 
-	root := recordingsinternal.NewService(
-		&unusedLedger{},
-		recordingsinternal.NewProjectionService(),
-	)
+	root := newRecordingsRoot(t, nil)
 	scope := recordings.CanonicalEventScope{FactorySessionID: "session-root-cancel-read"}
 	bound, err := root.BindRecording(recordings.BindRecordingRequest{
 		RecordingID: "recording-root-cancel-read",

--- a/pkg/services/recordings/internal/services/artifacts_export/wire/publication.go
+++ b/pkg/services/recordings/internal/services/artifacts_export/wire/publication.go
@@ -1,21 +1,35 @@
 package wire
 
 import (
-	"os"
-
+	recordings "github.com/portpowered/infinite-you/pkg/services/recordings"
 	artifactsexportservice "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/artifacts_export/internal/service"
 )
 
-// NewOSPublication constructs the default host publication effect for portable
-// artifact export and read.
-func NewOSPublication() (artifactsexportservice.PortableArtifactPublication, error) {
-	return artifactsexportservice.NewPublication(
-		os.MkdirAll,
-		func(dir, pattern string) (artifactsexportservice.PublicationTemporaryFile, error) {
-			return os.CreateTemp(dir, pattern)
-		},
-		os.Remove,
-		os.Rename,
-		os.ReadFile,
+// NewPublication constructs the private publication capability from exact
+// filesystem effects selected by the application graph.
+func NewPublication(
+	makeDirectories recordings.RecordingMakeDirectories,
+	createTemporaryFile recordings.RecordingCreateTemporaryFile,
+	removePath recordings.RecordingRemovePath,
+	renamePath recordings.RecordingRenamePath,
+	readFile recordings.RecordingReadFile,
+) (artifactsexportservice.PortableArtifactPublication, error) {
+	var createFile func(string, string) (artifactsexportservice.PublicationTemporaryFile, error)
+	if createTemporaryFile != nil {
+		createFile = func(dir, pattern string) (artifactsexportservice.PublicationTemporaryFile, error) {
+			file, err := createTemporaryFile(dir, pattern)
+			return file, err
+		}
+	}
+	publication, err := artifactsexportservice.NewPublication(
+		makeDirectories,
+		createFile,
+		removePath,
+		renamePath,
+		readFile,
 	)
+	if err != nil {
+		return nil, err
+	}
+	return publication, nil
 }

--- a/pkg/services/recordings/internal/services/artifacts_export/wire/wire_test.go
+++ b/pkg/services/recordings/internal/services/artifacts_export/wire/wire_test.go
@@ -1,14 +1,69 @@
 package wire_test
 
 import (
+	"context"
+	"errors"
+	"io/fs"
+	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	recordings "github.com/portpowered/infinite-you/pkg/services/recordings"
-	recordinglifecycle "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/recording_lifecycle"
+	artifactsexportservice "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/artifacts_export/internal/service"
 	artifactsexportwire "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/artifacts_export/wire"
+	recordinglifecycle "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/recording_lifecycle"
 )
 
 type snapshotSourceStub struct{}
+
+type publicationFileStub struct {
+	name     string
+	calls    *[]string
+	payload  []byte
+	chmodErr error
+	syncErr  error
+	closeErr error
+	writeErr error
+}
+
+func (file *publicationFileStub) Write(payload []byte) (int, error) {
+	*file.calls = append(*file.calls, "write")
+	if file.writeErr != nil {
+		return 0, file.writeErr
+	}
+	file.payload = append(file.payload[:0], payload...)
+	return len(payload), nil
+}
+
+func (file *publicationFileStub) Name() string { return file.name }
+
+func (file *publicationFileStub) Chmod(mode fs.FileMode) error {
+	*file.calls = append(*file.calls, "chmod")
+	if file.chmodErr != nil {
+		return file.chmodErr
+	}
+	if mode.Perm() != 0o600 {
+		return errors.New("unexpected temporary-file mode")
+	}
+	return nil
+}
+
+func (file *publicationFileStub) Sync() error {
+	*file.calls = append(*file.calls, "sync")
+	if file.syncErr != nil {
+		return file.syncErr
+	}
+	return nil
+}
+
+func (file *publicationFileStub) Close() error {
+	*file.calls = append(*file.calls, "close")
+	if file.closeErr != nil {
+		return file.closeErr
+	}
+	return nil
+}
 
 func (snapshotSourceStub) Snapshot(recordings.RecordingID) (recordinglifecycle.Snapshot, error) {
 	return recordinglifecycle.Snapshot{}, recordings.ErrMissingRecordingTarget
@@ -19,5 +74,260 @@ func TestNewServiceConstructsArtifactsExportCapability(t *testing.T) {
 
 	if service := artifactsexportwire.NewService(snapshotSourceStub{}, nil); service == nil {
 		t.Fatal("NewService() = nil")
+	}
+}
+
+func TestNewPublicationUsesInjectedEffectsInAtomicOrder(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	var mkdirPath string
+	var mkdirMode fs.FileMode
+	var temporaryDir, temporaryPattern string
+	var renameSource, renameDestination, removedPath, readPath string
+	temporary := &publicationFileStub{name: filepath.Join("publish", "artifact.json.tmp"), calls: &calls}
+
+	publication, err := artifactsexportwire.NewPublication(
+		func(path string, mode fs.FileMode) error {
+			calls = append(calls, "mkdir")
+			mkdirPath, mkdirMode = path, mode
+			return nil
+		},
+		func(dir, pattern string) (recordings.RecordingTemporaryFile, error) {
+			calls = append(calls, "temp")
+			temporaryDir, temporaryPattern = dir, pattern
+			return temporary, nil
+		},
+		func(path string) error {
+			calls = append(calls, "remove")
+			removedPath = path
+			return nil
+		},
+		func(source, destination string) error {
+			calls = append(calls, "rename")
+			renameSource, renameDestination = source, destination
+			return nil
+		},
+		func(path string) ([]byte, error) {
+			calls = append(calls, "read")
+			readPath = path
+			return []byte("published"), nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewPublication() error = %v", err)
+	}
+
+	destination := filepath.Join("publish", "artifact.json")
+	if err := publication.Publish(context.Background(), destination, []byte("payload")); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	read, err := publication.Read(context.Background(), destination)
+	if err != nil || string(read) != "published" {
+		t.Fatalf("Read() = (%q, %v), want published", read, err)
+	}
+
+	if want := []string{"mkdir", "temp", "chmod", "write", "sync", "close", "rename", "remove", "read"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("injected effect order = %#v, want %#v", calls, want)
+	}
+	if mkdirPath != filepath.Dir(destination) || mkdirMode.Perm() != 0o700 {
+		t.Fatalf("mkdir effect = (%q, %v), want destination directory and 0700", mkdirPath, mkdirMode.Perm())
+	}
+	if temporaryDir != filepath.Dir(destination) || temporaryPattern != "artifact.json.*.tmp" {
+		t.Fatalf("temporary effect = (%q, %q), want destination directory and artifact pattern", temporaryDir, temporaryPattern)
+	}
+	if string(temporary.payload) != "payload" {
+		t.Fatalf("temporary payload = %q, want payload", temporary.payload)
+	}
+	if renameSource != temporary.Name() || renameDestination != destination || removedPath != temporary.Name() {
+		t.Fatalf("publish paths = rename(%q, %q), remove(%q); want temp=%q destination=%q", renameSource, renameDestination, removedPath, temporary.Name(), destination)
+	}
+	if readPath != destination {
+		t.Fatalf("read path = %q, want %q", readPath, destination)
+	}
+}
+
+func TestNewPublicationCleansTemporaryFileWhenInjectedWriteFails(t *testing.T) {
+	t.Parallel()
+
+	writeErr := errors.New("write blocked")
+	var calls []string
+	temporary := &publicationFileStub{
+		name:     "artifact.tmp",
+		calls:    &calls,
+		writeErr: writeErr,
+	}
+	publication, err := artifactsexportwire.NewPublication(
+		func(string, fs.FileMode) error { calls = append(calls, "mkdir"); return nil },
+		func(string, string) (recordings.RecordingTemporaryFile, error) {
+			calls = append(calls, "temp")
+			return temporary, nil
+		},
+		func(string) error { calls = append(calls, "remove"); return nil },
+		func(string, string) error { calls = append(calls, "rename"); return nil },
+		func(string) ([]byte, error) { calls = append(calls, "read"); return nil, nil },
+	)
+	if err != nil {
+		t.Fatalf("NewPublication() error = %v", err)
+	}
+	if err := publication.Publish(context.Background(), "artifact.json", []byte("payload")); !errors.Is(err, writeErr) {
+		t.Fatalf("Publish() error = %v, want write error", err)
+	}
+	if want := []string{"mkdir", "temp", "chmod", "write", "close", "remove"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("write-failure effects = %#v, want %#v", calls, want)
+	}
+}
+
+func TestNewPublicationPropagatesInjectedOperationErrors(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name       string
+		operation  string
+		makeErr    error
+		createErr  error
+		writeErr   error
+		renameErr  error
+		removeErr  error
+		readErr    error
+		wantCalls  []string
+		wantResult error
+	}
+	cases := []testCase{
+		{
+			name:       "mkdir",
+			operation:  "publish",
+			makeErr:    errors.New("mkdir blocked"),
+			wantCalls:  []string{"mkdir"},
+			wantResult: errors.New("mkdir blocked"),
+		},
+		{
+			name:       "create",
+			operation:  "publish",
+			createErr:  errors.New("create blocked"),
+			wantCalls:  []string{"mkdir", "temp"},
+			wantResult: errors.New("create blocked"),
+		},
+		{
+			name:       "write",
+			operation:  "publish",
+			writeErr:   errors.New("write blocked"),
+			wantCalls:  []string{"mkdir", "temp", "chmod", "write", "close", "remove"},
+			wantResult: errors.New("write blocked"),
+		},
+		{
+			name:       "rename",
+			operation:  "publish",
+			renameErr:  errors.New("rename blocked"),
+			wantCalls:  []string{"mkdir", "temp", "chmod", "write", "sync", "close", "rename", "remove"},
+			wantResult: errors.New("rename blocked"),
+		},
+		{
+			name:      "remove cleanup is best effort",
+			operation: "publish",
+			removeErr: errors.New("remove blocked"),
+			wantCalls: []string{"mkdir", "temp", "chmod", "write", "sync", "close", "rename", "remove"},
+		},
+		{
+			name:       "read",
+			operation:  "read",
+			readErr:    errors.New("read blocked"),
+			wantCalls:  []string{"read"},
+			wantResult: errors.New("read blocked"),
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var calls []string
+			file := &publicationFileStub{
+				name:     "artifact.tmp",
+				calls:    &calls,
+				writeErr: testCase.writeErr,
+			}
+			publication, err := artifactsexportwire.NewPublication(
+				func(string, fs.FileMode) error {
+					calls = append(calls, "mkdir")
+					return testCase.makeErr
+				},
+				func(string, string) (recordings.RecordingTemporaryFile, error) {
+					calls = append(calls, "temp")
+					if testCase.createErr != nil {
+						return nil, testCase.createErr
+					}
+					return file, nil
+				},
+				func(string) error {
+					calls = append(calls, "remove")
+					return testCase.removeErr
+				},
+				func(string, string) error {
+					calls = append(calls, "rename")
+					return testCase.renameErr
+				},
+				func(string) ([]byte, error) {
+					calls = append(calls, "read")
+					return nil, testCase.readErr
+				},
+			)
+			if err != nil {
+				t.Fatalf("NewPublication() error = %v", err)
+			}
+
+			var operationErr error
+			if testCase.operation == "publish" {
+				operationErr = publication.Publish(context.Background(), "artifact.json", []byte("payload"))
+			} else {
+				_, operationErr = publication.Read(context.Background(), "artifact.json")
+			}
+			if testCase.wantResult == nil {
+				if operationErr != nil {
+					t.Fatalf("operation error = %v, want nil", operationErr)
+				}
+			} else if operationErr == nil || operationErr.Error() == "" || !strings.Contains(operationErr.Error(), testCase.wantResult.Error()) {
+				t.Fatalf("operation error = %v, want %q", operationErr, testCase.wantResult)
+			}
+			if !reflect.DeepEqual(calls, testCase.wantCalls) {
+				t.Fatalf("injected effects = %#v, want %#v", calls, testCase.wantCalls)
+			}
+		})
+	}
+}
+
+func TestNewPublicationRejectsMissingEffect(t *testing.T) {
+	t.Parallel()
+
+	validMakeDirectories := func(string, fs.FileMode) error { return nil }
+	validCreateTemporaryFile := func(string, string) (recordings.RecordingTemporaryFile, error) {
+		return nil, nil
+	}
+	validRemove := func(string) error { return nil }
+	validRename := func(string, string) error { return nil }
+	validRead := func(string) ([]byte, error) { return nil, nil }
+	cases := []struct {
+		name string
+		make func() (artifactsexportservice.PortableArtifactPublication, error)
+	}{
+		{name: "mkdir", make: func() (artifactsexportservice.PortableArtifactPublication, error) {
+			return artifactsexportwire.NewPublication(nil, validCreateTemporaryFile, validRemove, validRename, validRead)
+		}},
+		{name: "temp", make: func() (artifactsexportservice.PortableArtifactPublication, error) {
+			return artifactsexportwire.NewPublication(validMakeDirectories, nil, validRemove, validRename, validRead)
+		}},
+		{name: "remove", make: func() (artifactsexportservice.PortableArtifactPublication, error) {
+			return artifactsexportwire.NewPublication(validMakeDirectories, validCreateTemporaryFile, nil, validRename, validRead)
+		}},
+		{name: "rename", make: func() (artifactsexportservice.PortableArtifactPublication, error) {
+			return artifactsexportwire.NewPublication(validMakeDirectories, validCreateTemporaryFile, validRemove, nil, validRead)
+		}},
+		{name: "read", make: func() (artifactsexportservice.PortableArtifactPublication, error) {
+			return artifactsexportwire.NewPublication(validMakeDirectories, validCreateTemporaryFile, validRemove, validRename, nil)
+		}},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if publication, err := testCase.make(); err == nil || publication != nil {
+				t.Fatalf("NewPublication() = (%#v, %v), want missing %s effect error", publication, err, testCase.name)
+			}
+		})
 	}
 }

--- a/pkg/services/recordings/wire/fold_behavior_preservation_test.go
+++ b/pkg/services/recordings/wire/fold_behavior_preservation_test.go
@@ -54,12 +54,20 @@ func (ledger *behavioralLedger) AppendRecordedEvent(event factorydefinitions.Fac
 
 func newWireFoldService(t *testing.T, ledger recordings.Ledger) recordings.Service {
 	t.Helper()
-	service, err := recordingswire.NewService(
+	service, err := recordingswire.NewServiceWithProjectionAndEffects(
 		ledger,
+		recordingswire.NewProjectionService(),
 		nil,
 		func(path string, data []byte) error {
 			return os.WriteFile(path, data, 0o644)
 		},
+		os.MkdirAll,
+		func(dir, pattern string) (recordings.RecordingTemporaryFile, error) {
+			return os.CreateTemp(dir, pattern)
+		},
+		os.Remove,
+		os.Rename,
+		os.ReadFile,
 	)
 	if err != nil {
 		t.Fatalf("NewService() = %v", err)

--- a/pkg/services/recordings/wire/providers.go
+++ b/pkg/services/recordings/wire/providers.go
@@ -1,6 +1,7 @@
 package wire
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -104,6 +105,11 @@ func NewServiceWithProjection(
 	projection recordings.ProjectionService,
 	targets recordings.LiveRecordingTargetPlanner,
 	writeFile func(string, []byte) error,
+	makeDirectories recordings.RecordingMakeDirectories,
+	createTemporaryFile recordings.RecordingCreateTemporaryFile,
+	removePath recordings.RecordingRemovePath,
+	renamePath recordings.RecordingRenamePath,
+	readFile recordings.RecordingReadFile,
 	clocks ...recordings.RecordingClock,
 ) (recordings.Service, error) {
 	if ledger == nil {
@@ -115,11 +121,91 @@ func NewServiceWithProjection(
 	if writeFile == nil {
 		return nil, fmt.Errorf("construct Recordings: snapshot write function is required")
 	}
-	writer := recordingsinternal.NewReplayRecordingSnapshotWriter(writeFile)
-	tickers := recordingsinternal.NewRecordingFlushTickerFactory()
-	publication, err := recordingsinternal.NewPortableArtifactPublication()
+	return NewServiceWithProjectionAndEffects(
+		ledger,
+		projection,
+		targets,
+		writeFile,
+		makeDirectories,
+		createTemporaryFile,
+		removePath,
+		renamePath,
+		readFile,
+		clocks...,
+	)
+}
+
+// NewServiceWithProjectionAndEffects constructs the Recordings root with the
+// exact portable-artifact filesystem effects selected by the application
+// graph. This owner wire adapts those effects into the private artifact
+// publication capability and selects no host defaults.
+func NewServiceWithProjectionAndEffects(
+	ledger recordings.Ledger,
+	projection recordings.ProjectionService,
+	targets recordings.LiveRecordingTargetPlanner,
+	writeFile func(string, []byte) error,
+	makeDirectories recordings.RecordingMakeDirectories,
+	createTemporaryFile recordings.RecordingCreateTemporaryFile,
+	removePath recordings.RecordingRemovePath,
+	renamePath recordings.RecordingRenamePath,
+	readFile recordings.RecordingReadFile,
+	clocks ...recordings.RecordingClock,
+) (recordings.Service, error) {
+	if ledger == nil {
+		return nil, fmt.Errorf("construct Recordings: ledger is required")
+	}
+	if projection == nil {
+		return nil, fmt.Errorf("construct Recordings: projection is required")
+	}
+	publication, err := recordingsinternal.NewPortableArtifactPublication(
+		makeDirectories,
+		createTemporaryFile,
+		removePath,
+		renamePath,
+		readFile,
+	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("construct Recordings publication: %w", err)
+	}
+	return newServiceWithProjection(
+		ledger,
+		projection,
+		targets,
+		writeFile,
+		publication,
+		false,
+		clocks...,
+	)
+}
+
+type portableArtifactPublication interface {
+	Publish(context.Context, string, []byte) error
+	Read(context.Context, string) ([]byte, error)
+}
+
+func newServiceWithProjection(
+	ledger recordings.Ledger,
+	projection recordings.ProjectionService,
+	targets recordings.LiveRecordingTargetPlanner,
+	writeFile func(string, []byte) error,
+	publication portableArtifactPublication,
+	requireWriter bool,
+	clocks ...recordings.RecordingClock,
+) (recordings.Service, error) {
+	if ledger == nil {
+		return nil, fmt.Errorf("construct Recordings: ledger is required")
+	}
+	if projection == nil {
+		return nil, fmt.Errorf("construct Recordings: projection is required")
+	}
+	if requireWriter && writeFile == nil {
+		return nil, fmt.Errorf("construct Recordings: snapshot write function is required")
+	}
+	var writer recordings.RecordingSnapshotWriter
+	var tickers recordings.RecordingFlushTickerFactory
+	if writeFile != nil {
+		writer = recordingsinternal.NewReplayRecordingSnapshotWriter(writeFile)
+		tickers = recordingsinternal.NewRecordingFlushTickerFactory()
 	}
 	service := recordingsinternal.NewServiceWithLifecycleEffects(
 		ledger,

--- a/pkg/services/recordings/wire/providers_test.go
+++ b/pkg/services/recordings/wire/providers_test.go
@@ -2,6 +2,9 @@ package wire_test
 
 import (
 	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -57,6 +60,13 @@ func TestNewServiceWithProjectionRejectsMissingProjection(t *testing.T) {
 		nil,
 		nil,
 		func(string, []byte) error { return nil },
+		os.MkdirAll,
+		func(dir, pattern string) (recordings.RecordingTemporaryFile, error) {
+			return os.CreateTemp(dir, pattern)
+		},
+		os.Remove,
+		os.Rename,
+		os.ReadFile,
 	)
 	if err == nil {
 		t.Fatal("NewServiceWithProjection() error = nil, want missing projection dependency")
@@ -66,5 +76,30 @@ func TestNewServiceWithProjectionRejectsMissingProjection(t *testing.T) {
 	}
 	if service != nil {
 		t.Fatalf("NewServiceWithProjection() = %#v, want nil service", service)
+	}
+}
+
+func TestRecordingsOwnerConstructionDoesNotSelectHostOSPublication(t *testing.T) {
+	t.Parallel()
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller() did not identify the test file")
+	}
+	ownerRoot := filepath.Dir(currentFile)
+	productionFiles := []string{
+		filepath.Join(ownerRoot, "providers.go"),
+		filepath.Join(ownerRoot, "..", "internal", "portable_artifact_publication.go"),
+		filepath.Join(ownerRoot, "..", "internal", "services", "artifacts_export", "wire", "publication.go"),
+	}
+	for _, path := range productionFiles {
+		source, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		text := string(source)
+		if strings.Contains(text, `"os"`) || strings.Contains(text, "os.") || strings.Contains(text, "NewOSPublication") {
+			t.Fatalf("Recordings owner construction file %s selects host OS publication effects", path)
+		}
 	}
 }

--- a/pkg/services/recordings/wire/wire.go
+++ b/pkg/services/recordings/wire/wire.go
@@ -22,6 +22,11 @@ func NewService(
 	ledger recordings.Ledger,
 	targets recordings.LiveRecordingTargetPlanner,
 	writeFile func(string, []byte) error,
+	makeDirectories recordings.RecordingMakeDirectories,
+	createTemporaryFile recordings.RecordingCreateTemporaryFile,
+	removePath recordings.RecordingRemovePath,
+	renamePath recordings.RecordingRenamePath,
+	readFile recordings.RecordingReadFile,
 	clocks ...recordings.RecordingClock,
 ) (recordings.Service, error) {
 	if ledger == nil {
@@ -35,6 +40,11 @@ func NewService(
 		recordingsinternal.NewProjectionService(),
 		targets,
 		writeFile,
+		makeDirectories,
+		createTemporaryFile,
+		removePath,
+		renamePath,
+		readFile,
 		clocks...,
 	)
 }

--- a/pkg/services/recordings/wire/wire_test.go
+++ b/pkg/services/recordings/wire/wire_test.go
@@ -3,6 +3,7 @@ package wire_test
 import (
 	"context"
 	"errors"
+	"os"
 	"runtime"
 	"testing"
 	"time"
@@ -77,7 +78,17 @@ func TestNewServiceConstructsInertRoot(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 	baseline := runtime.NumGoroutine()
 
-	service, err := recordingswire.NewService(ledger, nil, writeFile)
+	makeDirectories, createTemporaryFile, removePath, renamePath, readFile := testPublicationEffects()
+	service, err := recordingswire.NewService(
+		ledger,
+		nil,
+		writeFile,
+		makeDirectories,
+		createTemporaryFile,
+		removePath,
+		renamePath,
+		readFile,
+	)
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
 	}
@@ -134,7 +145,17 @@ func TestNewServiceRejectsMissingRequiredDependencies(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			service, err := recordingswire.NewService(test.ledger, nil, test.writeFile)
+			makeDirectories, createTemporaryFile, removePath, renamePath, readFile := testPublicationEffects()
+			service, err := recordingswire.NewService(
+				test.ledger,
+				nil,
+				test.writeFile,
+				makeDirectories,
+				createTemporaryFile,
+				removePath,
+				renamePath,
+				readFile,
+			)
 			if err == nil {
 				t.Fatalf("NewService() error = nil, want missing %s dependency", test.name)
 			}
@@ -155,6 +176,13 @@ func TestNewServiceConstructsPublishedRoot(t *testing.T) {
 		stubLedger{},
 		nil,
 		func(string, []byte) error { return nil },
+		func(string, os.FileMode) error { return nil },
+		func(dir, pattern string) (recordings.RecordingTemporaryFile, error) {
+			return os.CreateTemp(dir, pattern)
+		},
+		os.Remove,
+		os.Rename,
+		os.ReadFile,
 	)
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
@@ -168,4 +196,44 @@ func TestNewServiceConstructsPublishedRoot(t *testing.T) {
 	}); !errors.Is(err, recordings.ErrReplayRecordingNotFound) {
 		t.Fatalf("LoadReplayRecording() = %v, want ErrReplayRecordingNotFound", err)
 	}
+}
+
+func TestNewServiceRejectsMissingArtifactPublicationEffects(t *testing.T) {
+	t.Parallel()
+
+	service, err := recordingswire.NewService(
+		stubLedger{},
+		nil,
+		func(string, []byte) error { return nil },
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("NewService() error = nil, want missing artifact publication effects")
+	}
+	if err.Error() != "construct Recordings publication: portable artifact publication operations are required" {
+		t.Fatalf("NewService() error = %q, want missing publication effects", err.Error())
+	}
+	if service != nil {
+		t.Fatalf("NewService() = %#v, want nil service", service)
+	}
+}
+
+func testPublicationEffects() (
+	recordings.RecordingMakeDirectories,
+	recordings.RecordingCreateTemporaryFile,
+	recordings.RecordingRemovePath,
+	recordings.RecordingRenamePath,
+	recordings.RecordingReadFile,
+) {
+	return os.MkdirAll,
+		func(dir, pattern string) (recordings.RecordingTemporaryFile, error) {
+			return os.CreateTemp(dir, pattern)
+		},
+		os.Remove,
+		os.Rename,
+		os.ReadFile
 }

--- a/pkg/wire/recordings_artifacts_export_composition_test.go
+++ b/pkg/wire/recordings_artifacts_export_composition_test.go
@@ -1,7 +1,9 @@
 package wire
 
 import (
+	"context"
 	"errors"
+	"io/fs"
 	"path/filepath"
 	"testing"
 	"time"
@@ -22,11 +24,13 @@ type inertRecordingsLedger struct {
 func TestInjectBundleComposesRecordingsArtifactExportThroughWireFactory(t *testing.T) {
 	t.Parallel()
 
-	if _, err := InjectBundle(t.Context(), serviceedges.Edges{}); err != nil {
+	edges := injectedRecordingArtifactEdges()
+	if _, err := InjectBundle(t.Context(), edges); err != nil {
 		t.Fatalf("InjectBundle() error = %v", err)
 	}
 
 	factory := provideRecordingsFactory(
+		edges,
 		provideLiveRecordingTargetPlanner(),
 		platformreplay.Local{},
 	)
@@ -115,9 +119,95 @@ func TestInjectBundleComposesRecordingsArtifactExportThroughWireFactory(t *testi
 	if err != nil || summarized.Summary.RecordingID != bound.Status.RecordingID {
 		t.Fatalf("SummarizePortableArtifact = (%#v, %v)", summarized, err)
 	}
+	exported, err := rootService.ExportPortableArtifact(context.Background(), recordings.ExportPortableArtifactRequest{
+		RecordingID: bound.Status.RecordingID,
+	})
+	if err != nil || exported.Reference != recordings.RecordingArtifactReference(artifactPath) {
+		t.Fatalf("ExportPortableArtifact = (%#v, %v)", exported, err)
+	}
+	read, err := rootService.ReadPortableArtifact(context.Background(), recordings.ReadPortableArtifactRequest{
+		RecordingID: bound.Status.RecordingID,
+		Reference:   exported.Reference,
+	})
+	if err != nil || read.Artifact.Integrity != exported.Artifact.Integrity {
+		t.Fatalf("ReadPortableArtifact = (%#v, %v), want exported artifact", read, err)
+	}
 	if _, err := rootService.DecodePortableArtifact(recordings.DecodePortableArtifactRequest{
 		Payload: []byte(`{`),
 	}); !errors.Is(err, recordings.ErrInvalidPortableArtifact) {
 		t.Fatalf("DecodePortableArtifact malformed = %v, want ErrInvalidPortableArtifact", err)
+	}
+}
+
+type injectedPublicationFile struct {
+	name    string
+	calls   *[]string
+	payload []byte
+}
+
+func (file *injectedPublicationFile) Write(payload []byte) (int, error) {
+	*file.calls = append(*file.calls, "write")
+	file.payload = append(file.payload[:0], payload...)
+	return len(payload), nil
+}
+
+func (file *injectedPublicationFile) Name() string { return file.name }
+
+func (file *injectedPublicationFile) Chmod(fs.FileMode) error {
+	*file.calls = append(*file.calls, "chmod")
+	return nil
+}
+
+func (file *injectedPublicationFile) Sync() error {
+	*file.calls = append(*file.calls, "sync")
+	return nil
+}
+
+func (file *injectedPublicationFile) Close() error {
+	*file.calls = append(*file.calls, "close")
+	return nil
+}
+
+func injectedRecordingArtifactEdges() serviceedges.Edges {
+	var calls []string
+	temporaryFiles := make(map[string]*injectedPublicationFile)
+	published := make(map[string][]byte)
+	return serviceedges.Edges{
+		RecordingMakeDirectories: func(string, fs.FileMode) error {
+			calls = append(calls, "mkdir")
+			return nil
+		},
+		RecordingCreateTempFile: func(dir, pattern string) (recordings.RecordingTemporaryFile, error) {
+			calls = append(calls, "temp")
+			file := &injectedPublicationFile{
+				name:  filepath.Join(dir, pattern),
+				calls: &calls,
+			}
+			temporaryFiles[file.name] = file
+			return file, nil
+		},
+		RecordingRemovePath: func(path string) error {
+			calls = append(calls, "remove")
+			delete(temporaryFiles, path)
+			return nil
+		},
+		RecordingRenamePath: func(source, destination string) error {
+			calls = append(calls, "rename")
+			file := temporaryFiles[source]
+			if file == nil {
+				return errors.New("injected temporary file missing")
+			}
+			published[destination] = append([]byte(nil), file.payload...)
+			delete(temporaryFiles, source)
+			return nil
+		},
+		RecordingReadFile: func(path string) ([]byte, error) {
+			calls = append(calls, "read")
+			payload, ok := published[path]
+			if !ok {
+				return nil, errors.New("injected artifact missing")
+			}
+			return append([]byte(nil), payload...), nil
+		},
 	}
 }

--- a/pkg/wire/recordings_factory_test.go
+++ b/pkg/wire/recordings_factory_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	platformreplay "github.com/portpowered/infinite-you/pkg/platform/replay"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	recordings "github.com/portpowered/infinite-you/pkg/services/recordings"
 	recordingswire "github.com/portpowered/infinite-you/pkg/services/recordings/wire"
 )
@@ -16,6 +17,7 @@ func TestProvideRecordingsFactoryConstructsThroughRecordingsWire(t *testing.T) {
 	t.Parallel()
 
 	factory := provideRecordingsFactory(
+		serviceedges.Edges{},
 		recordings.LiveRecordingTargetPlannerFunc(
 			func(recordings.LiveRecordingTargetRequest) (recordings.LiveRecordingTarget, error) {
 				return recordings.LiveRecordingTarget{}, nil

--- a/pkg/wire/recordings_neutral_replay_composition_test.go
+++ b/pkg/wire/recordings_neutral_replay_composition_test.go
@@ -28,6 +28,7 @@ func TestInjectBundleComposesRecordingsNeutralReplayThroughWireFactory(t *testin
 	}
 
 	factory := provideRecordingsFactory(
+		serviceedges.Edges{},
 		provideLiveRecordingTargetPlanner(),
 		platformreplay.Local{},
 	)

--- a/pkg/wire/recordings_providers.go
+++ b/pkg/wire/recordings_providers.go
@@ -3,6 +3,7 @@ package wire
 import (
 	platformclock "github.com/portpowered/infinite-you/pkg/platform/clock"
 	platformreplay "github.com/portpowered/infinite-you/pkg/platform/replay"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorysessionwire "github.com/portpowered/infinite-you/pkg/services/factory_sessions/wire"
 	recordings "github.com/portpowered/infinite-you/pkg/services/recordings"
 	recordingscli "github.com/portpowered/infinite-you/pkg/services/recordings/transports/cli"
@@ -14,6 +15,7 @@ func provideRecordingsCLIAdapter() recordingscli.Adapter {
 }
 
 func provideRecordingsFactory(
+	edges serviceedges.Edges,
 	targets recordings.LiveRecordingTargetPlanner,
 	storage platformreplay.Storage,
 ) factorysessionwire.RecordingsFactory {
@@ -21,11 +23,17 @@ func provideRecordingsFactory(
 		ledger recordings.Ledger,
 		projection recordings.ProjectionService,
 	) recordings.Service {
-		service, err := recordingswire.NewServiceWithProjection(
+		makeDirectories, createTemporaryFile, removePath, renamePath, readFile := provideRecordingFilesystemEffects(edges)
+		service, err := recordingswire.NewServiceWithProjectionAndEffects(
 			ledger,
 			projection,
 			targets,
 			storage.WriteFile,
+			makeDirectories,
+			createTemporaryFile,
+			removePath,
+			renamePath,
+			readFile,
 			platformclock.Real{},
 		)
 		if err != nil {

--- a/pkg/wire/session_runtime_providers.go
+++ b/pkg/wire/session_runtime_providers.go
@@ -644,6 +644,19 @@ func provideRuntimeLedgerFactory() factorysessionwire.RuntimeLedgerFactory {
 }
 
 func providePortableRecordingWriter(edges serviceedges.Edges) (recordings.PortableRecordingWriter, error) {
+	makeDirectories, createTemporaryFile, removePath, renamePath, _ := provideRecordingFilesystemEffects(edges)
+	return recordingswire.NewPortableRecordingWriter(makeDirectories, createTemporaryFile, removePath, renamePath)
+}
+
+func provideRecordingFilesystemEffects(
+	edges serviceedges.Edges,
+) (
+	recordings.RecordingMakeDirectories,
+	recordings.RecordingCreateTemporaryFile,
+	recordings.RecordingRemovePath,
+	recordings.RecordingRenamePath,
+	recordings.RecordingReadFile,
+) {
 	makeDirectories := edges.RecordingMakeDirectories
 	if makeDirectories == nil {
 		makeDirectories = os.MkdirAll
@@ -662,7 +675,11 @@ func providePortableRecordingWriter(edges serviceedges.Edges) (recordings.Portab
 	if renamePath == nil {
 		renamePath = os.Rename
 	}
-	return recordingswire.NewPortableRecordingWriter(makeDirectories, createTemporaryFile, removePath, renamePath)
+	readFile := edges.RecordingReadFile
+	if readFile == nil {
+		readFile = os.ReadFile
+	}
+	return makeDirectories, createTemporaryFile, removePath, renamePath, readFile
 }
 
 func provideLoadedFactorySnapshotCapturer() factorydefinitions.LoadedFactorySnapshotCapturer {

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -206,7 +206,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	v31 := provideFactorySessionExecutionFactory(javaScriptWorkflows, orchestrationJavaScriptExecution, v23, v25, v26, v19, responseEventIDGenerator, responseEventRetentionLimits, v27, ptyAllocator, v28, providerRegistry, v29, workersMockCommandRunnerFactory, v30, edges2)
 	v32 := provideRecordingsProjectionFactory()
 	storage := provideReplayArtifactStorage()
-	v33 := provideRecordingsFactory(v5, storage)
+	v33 := provideRecordingsFactory(edges2, v5, storage)
 	v34 := provideRuntimeLedgerFactory()
 	v35 := provideLoadedFactorySnapshotCapturer()
 	v36 := provideRuntimeRecorderFactory(v35)

--- a/tests/functional/recordings/root_composition/portable_transport_activation_test.go
+++ b/tests/functional/recordings/root_composition/portable_transport_activation_test.go
@@ -36,7 +36,15 @@ func TestRecordingsPortableBuildValidateAndTransportsActivateThroughRootBuildPro
 	testutil.WriteSeedFile(t, dir, "task", []byte(`{"title":"FUN Recordings transport activation"}`))
 
 	recordArtifactPath := filepath.Join(t.TempDir(), "fun-recordings-transport-activation.replay.json")
-	edges := serviceedges.Edges{}
+	edges := serviceedges.Edges{
+		RecordingMakeDirectories: os.MkdirAll,
+		RecordingCreateTempFile: func(dir, pattern string) (recordings.RecordingTemporaryFile, error) {
+			return os.CreateTemp(dir, pattern)
+		},
+		RecordingRemovePath: os.Remove,
+		RecordingRenamePath: os.Rename,
+		RecordingReadFile:   os.ReadFile,
+	}
 	recordServer := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:                dir,
 		Args:                      []string{"--record", recordArtifactPath},
@@ -161,6 +169,11 @@ func recordingsTransportActivationService(
 		func(path string, payload []byte) error {
 			return os.WriteFile(path, payload, 0o600)
 		},
+		edges.RecordingMakeDirectories,
+		edges.RecordingCreateTempFile,
+		edges.RecordingRemovePath,
+		edges.RecordingRenamePath,
+		edges.RecordingReadFile,
 	)
 	if err != nil {
 		t.Fatalf("compose Recordings service for transport activation: %v", err)


### PR DESCRIPTION
## Summary

- make the complete portable artifact-publication filesystem capability explicit in pkg/services/edges
- select host defaults only in canonical pkg/wire and pass all five effects through the Recordings owner wire
- remove Recordings construction fallbacks and preserve atomic export/read behavior, cleanup, cancellation, and replay semantics

## Verification

- focused Recordings, Edges, pkg/wire, and pkg/root Go suites
- functional portable transport activation test
- targeted race suite and full short Go suite
- structure, target-manifest, ownership-inventory, durable-runtime, logging-boundary, and vet checks

The branch started from 9b5638df2ac199d956ee3f0f580153cf22247d2e. Main advanced independently during local verification; this draft will be updated onto the new main head before merge, with exact-SHA review and CI evidence repeated.