### PR TITLE
Restore Models root-contract inventory gate for presentation_port.go

### DIFF
--- a/cmd/packagetargetmanifestcheck/models_root_contract.go
+++ b/cmd/packagetargetmanifestcheck/models_root_contract.go
@@ -20,6 +20,7 @@ var modelsThinRootContractFiles = []string{
 	"host_scope_characterization_test.go",
 	"local_execution_contract.go",
 	"managed_runtime_contract.go",
+	"presentation_port.go",
 	"root_authority_seal_characterization_test.go",
 	"root_slice_characterization_test.go",
 	"runtime_config_contract.go",

--- a/docs/internal/packaged-service-structure/models-root-contract-surface-inventory.md
+++ b/docs/internal/packaged-service-structure/models-root-contract-surface-inventory.md
@@ -25,6 +25,7 @@ host_contract.go
 host_scope_characterization_test.go
 local_execution_contract.go
 managed_runtime_contract.go
+presentation_port.go
 root_authority_seal_characterization_test.go
 root_slice_characterization_test.go
 runtime_config_contract.go
@@ -32,7 +33,7 @@ runtime_construction_contract.go
 service_contract.go
 ```
 
-**Totals:** 13 root-level `.go` files — 13 thin committed root contract
+**Totals:** 14 root-level `.go` files — 14 thin committed root contract
 files, 0 excess fold clusters in this packet.
 
 The inventory is mirrored by:

--- a/internal/ownershipinventory/models_root_contract.go
+++ b/internal/ownershipinventory/models_root_contract.go
@@ -23,6 +23,7 @@ var ModelsThinRootContractFiles = []string{
 	"host_scope_characterization_test.go",
 	"local_execution_contract.go",
 	"managed_runtime_contract.go",
+	"presentation_port.go",
 	"root_authority_seal_characterization_test.go",
 	"root_slice_characterization_test.go",
 	"runtime_config_contract.go",

--- a/internal/ownershipinventory/models_root_contract_test.go
+++ b/internal/ownershipinventory/models_root_contract_test.go
@@ -31,6 +31,7 @@ func TestModelsThinRootContractFiles(t *testing.T) {
 		"host_scope_characterization_test.go",
 		"local_execution_contract.go",
 		"managed_runtime_contract.go",
+		"presentation_port.go",
 		"root_authority_seal_characterization_test.go",
 		"root_slice_characterization_test.go",
 		"runtime_config_contract.go",


### PR DESCRIPTION
{
  "project": "Restore the Models Root-Contract Inventory Gate",
  "branchName": "CI-MODELS-INVENTORY-01",
  "description": "Restore the pre-existing Models root-contract inventory gate by classifying the already-live presentation_port.go public presentation contract consistently in both committed inventories, without changing Models behavior, package topology, APIs, generated artifacts, or ACP features.",
  "context": {
    "customerAsk": "Restore the pre-existing Models inventory gate without bundling it with Models cleanup or any ACP feature work.",
    "problem": "Every ACP lane currently inherits a deterministic failing repository gate because presentation_port.go is live in the Models root but absent from the two committed root-contract inventories, causing ownershipinventory and packagetargetmanifestcheck to report false root-surface drift.",
    "solution": "Classify presentation_port.go as a retained Models root contract in both the ownership and package-target inventories, keep their mirrored expectations consistent, and prove both focused Models inventory suites pass while preserving Models behavior, construction, dependencies, public APIs, generated artifacts, and package topology."
  },
  "acceptanceCriteria": [
    "Both committed Models root-contract inventories include presentation_port.go as an intentional thin-root retained public contract.",
    "The ownership inventory and package-target inventory agree on the same complete Models root .go file set and classification.",
    "go test ./internal/ownershipinventory -run '^TestModels' -count=1 passes.",
    "go test ./cmd/packagetargetmanifestcheck -run '^TestModels' -count=1 passes.",
    "The change introduces no Models behavior, construction, dependency, package-topology, API, generated-artifact, cleanup, or ACP feature change.",
    "Typecheck, lint, all targeted tests, and all required repository CI checks are terminal and passing.",
    "The implementation/review cycle continues until all blocking PR conversation feedback is explicitly addressed, shared-file changes and merge conflicts are reconciled, required CI is terminal and passing, and the PR is actually merged; opening, approving, or making the PR merge-ready is not completion."
  ],
  "userStories": [
    {
      "id": "CI-MODELS-INVENTORY-01-001",
      "title": "Recognize the intentional Models presentation contract",
      "description": "As a maintainer, I want both Models inventory gates to recognize the existing presentation contract so unrelated work is not blocked by false root-surface drift.",
      "acceptanceCriteria": [
        "Given the current Models root, both inventory checks accept presentation_port.go as a thin_root_retain contract and report no missing, unexpected, or unclassified root .go file.",
        "The ownership inventory's committed list and its direct expected-list coverage include presentation_port.go in stable sorted order.",
        "The package-target manifest check's mirrored committed list includes presentation_port.go in stable sorted order.",
        "The focused Models tests in both internal/ownershipinventory and cmd/packagetargetmanifestcheck pass with cache disabled.",
        "No production Models contract, implementation, service, construction, dependency, package layout, API, generated artifact, or ACP path changes.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added presentation_port.go to ModelsThinRootContractFiles (internal/ownershipinventory/models_root_contract.go), its test want-slice (models_root_contract_test.go), and modelsThinRootContractFiles (cmd/packagetargetmanifestcheck/models_root_contract.go), in sorted order. Also updated the mirrored doc docs/internal/packaged-service-structure/models-root-contract-surface-inventory.md. Both required scoped test commands pass. No Models production code touched. PR not yet opened."
    }
  ]
}