### PR TITLE
ACP-L2-CTR-WRK-EXEC

### DIFF
--- a/pkg/services/workers/internal/progress_composition_test.go
+++ b/pkg/services/workers/internal/progress_composition_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	workeragentrun "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/workstations/executor/agentrun"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 var testRetryRandom = platformrandom.SourceFunc(func(int64) (int64, error) {
@@ -144,6 +146,16 @@ func TestNewInvocationRequiresCompositionSelectedWorkerEffects(t *testing.T) {
 
 func testWorkerService(t *testing.T, providerRunner workers.CommandRunner) *Service {
 	t.Helper()
+	return testWorkerServiceWithRunnerAndLogger(t, providerRunner, zap.NewNop())
+}
+
+func testWorkerServiceWithLogger(t *testing.T, logger *zap.Logger) *Service {
+	t.Helper()
+	return testWorkerServiceWithRunnerAndLogger(t, nil, logger)
+}
+
+func testWorkerServiceWithRunnerAndLogger(t *testing.T, providerRunner workers.CommandRunner, logger *zap.Logger) *Service {
+	t.Helper()
 	if providerRunner == nil {
 		providerRunner = injectedProviderRunner{}
 	}
@@ -154,7 +166,7 @@ func testWorkerService(t *testing.T, providerRunner workers.CommandRunner) *Serv
 		providerRunner,
 		injectedProviderRunner{},
 		&workers.MockPTYAllocator{},
-		zap.NewNop(),
+		logger,
 		false,
 		"",
 		"",
@@ -183,6 +195,39 @@ func testWorkerService(t *testing.T, providerRunner workers.CommandRunner) *Serv
 		t.Fatalf("construct Worker service: %v", err)
 	}
 	return service
+}
+
+// TestWithCommandRunnersPreservesInjectedLoggerForWorkstationPool proves the
+// logger a runtime opening injects at construction keeps reaching the cloned
+// workstation pool through WithCommandRunners, the path every normal Factory
+// Runtime opening takes (factory_runtime/internal/runtime_build.go).
+func TestWithCommandRunnersPreservesInjectedLoggerForWorkstationPool(t *testing.T) {
+	t.Parallel()
+
+	core, logs := observer.New(zapcore.InfoLevel)
+	service := testWorkerServiceWithLogger(t, zap.New(core))
+
+	runtime, err := service.WithCommandRunners(injectedProviderRunner{}, injectedProviderRunner{})
+	if err != nil {
+		t.Fatalf("WithCommandRunners() error = %v", err)
+	}
+
+	if _, err := runtime.StartWorkstationPool(
+		context.Background(),
+		workers.WorkstationPoolStartRequest{Bindings: []workers.AssembledRuntimeBinding{
+			{RoleName: "review", RoleKind: workers.RuntimeBuildRoleKindWorkstation},
+		}},
+	); err != nil {
+		t.Fatalf("StartWorkstationPool() error = %v", err)
+	}
+
+	entries := logs.FilterMessage("workers workstation pool start").All()
+	if len(entries) != 1 {
+		t.Fatalf(
+			"observed logs = %#v, want exactly one workstation pool start record surviving WithCommandRunners",
+			logs.All(),
+		)
+	}
 }
 
 type inertCurrentRuntimeResolver struct{}

--- a/pkg/services/workers/internal/runtime_composition.go
+++ b/pkg/services/workers/internal/runtime_composition.go
@@ -102,7 +102,10 @@ func NewRuntime(
 	if err != nil {
 		return nil, err
 	}
-	runtimeService.Root = RootFrom(assembly, workstationswire.NewService())
+	runtimeService.Root = RootFrom(
+		assembly,
+		workstationswire.NewService(logging.NewZapLogger(logger, verbose)),
+	)
 	return runtimeService, nil
 }
 

--- a/pkg/services/workers/internal/runtime_construction.go
+++ b/pkg/services/workers/internal/runtime_construction.go
@@ -83,7 +83,7 @@ func (s *Service) WithCommandRunners(providerRunner, scriptRunner workers.Comman
 	// Each opened Factory Runtime owns an independent workstation lifecycle.
 	// Sharing the process-level pool would couple route admission, cancellation,
 	// and terminal stop state across otherwise separate Factory Sessions.
-	clone.Root = clone.Root.ReplaceWorkstations(workstationswire.NewService())
+	clone.Root = clone.Root.ReplaceWorkstations(workstationswire.NewService(logging.NewZapLogger(s.logger, s.verbose)))
 	clone.executorBuilder = rebuildExecutorBuilder(
 		s.executorBuilder,
 		clone.providers,

--- a/pkg/services/workers/internal/services/workstations/internal/service/service.go
+++ b/pkg/services/workers/internal/services/workstations/internal/service/service.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	workstations "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/workstations"
 )
@@ -29,6 +30,7 @@ type Pool struct {
 	dispatches map[string]*dispatchRecord
 	active     sync.WaitGroup
 	stopped    chan struct{}
+	logger     logging.Logger
 }
 
 type routePool struct {
@@ -54,16 +56,24 @@ type dispatchRecord struct {
 	canceled        bool
 	result          workers.WorkstationDispatchResult
 	err             error
+	logger          logging.Logger
 }
 
 var _ workstations.Service = (*Pool)(nil)
 
-// New constructs an inert pool without starting background activity.
-func New() *Pool {
+// New constructs an inert pool without starting background activity. Logger
+// is optional and constructed directly here; omitting it selects a no-op
+// logger rather than a service locator or mutable reinjection path.
+func New(logger ...logging.Logger) *Pool {
+	var provided logging.Logger
+	if len(logger) > 0 {
+		provided = logger[0]
+	}
 	return &Pool{
 		state:      stateConstructed,
 		dispatches: make(map[string]*dispatchRecord),
 		stopped:    make(chan struct{}),
+		logger:     logging.EnsureLogger(provided),
 	}
 }
 
@@ -101,14 +111,27 @@ func (p *Pool) start(
 	case stateConstructed:
 		p.routes = snapshot
 		p.state = stateRunning
+		p.logStart(workers.WorkstationPoolLifecycleOutcomeStarted, len(snapshot))
 		return workers.WorkstationPoolLifecycleOutcomeStarted, nil
 	case stateRunning:
+		p.logStart(workers.WorkstationPoolLifecycleOutcomeAlreadyRunning, len(p.routes))
 		return workers.WorkstationPoolLifecycleOutcomeAlreadyRunning, nil
 	case stateStopping, stateStopped:
 		return "", workers.ErrWorkstationPoolStopped
 	default:
 		return "", workers.ErrWorkstationPoolUnavailable
 	}
+}
+
+func (p *Pool) logStart(outcome workers.WorkstationPoolLifecycleOutcome, routeCount int) {
+	if p == nil || p.logger == nil {
+		return
+	}
+	p.logger.Info(
+		"workers workstation pool start",
+		"outcome", string(outcome),
+		"workstation_count", routeCount,
+	)
 }
 
 // Stop closes admission and returns the Workers-root lifecycle result.
@@ -211,12 +234,13 @@ func (p *Pool) Dispatch(
 	}
 
 	executionCtx, cancelExecution := context.WithCancel(ctx)
-	record := newDispatchRecord(request, name, cancelExecution)
+	record := newDispatchRecord(request, name, cancelExecution, p.logger)
 	route, entry, err := p.accept(record)
 	if err != nil {
 		cancelExecution()
 		return workers.WorkstationDispatchResult{}, err
 	}
+	p.logAccepted(name, record.dispatchID)
 	defer p.active.Done()
 	defer cancelExecution()
 
@@ -241,6 +265,17 @@ func (p *Pool) Dispatch(
 		return record.commitCancellation(executionCtx.Err())
 	}
 	return record.commit(dispatchResult, executeErr)
+}
+
+func (p *Pool) logAccepted(workstationName, dispatchID string) {
+	if p == nil || p.logger == nil {
+		return
+	}
+	p.logger.Info(
+		"workers workstation dispatch accepted",
+		"workstation_name", workstationName,
+		"dispatch_id", dispatchID,
+	)
 }
 
 // execute contains untrusted executor behavior so an implementation panic
@@ -396,12 +431,14 @@ func newDispatchRecord(
 	request workers.WorkstationDispatchRequest,
 	workstationName string,
 	cancel context.CancelFunc,
+	logger logging.Logger,
 ) *dispatchRecord {
 	return &dispatchRecord{
 		dispatchID:      request.Execution.Dispatch.DispatchID,
 		workstationName: workstationName,
 		transitionID:    request.Execution.Dispatch.TransitionID,
 		cancel:          cancel,
+		logger:          logger,
 	}
 }
 
@@ -417,7 +454,23 @@ func (record *dispatchRecord) commit(
 	record.terminal = true
 	record.result = cloneDispatchResult(result)
 	record.err = err
+	record.logTerminal()
 	return cloneDispatchResult(record.result), err
+}
+
+// logTerminal emits exactly one structured record for this dispatch's
+// terminal completion, regardless of whether it committed through the
+// executor path, cancellation, or pool shutdown. Callers hold record.mu.
+func (record *dispatchRecord) logTerminal() {
+	if record == nil || record.logger == nil {
+		return
+	}
+	record.logger.Info(
+		"workers workstation dispatch terminal",
+		"workstation_name", record.workstationName,
+		"dispatch_id", record.dispatchID,
+		"terminal_outcome", string(record.result.TerminalOutcome),
+	)
 }
 
 func (record *dispatchRecord) commitCancellation(
@@ -445,6 +498,7 @@ func (record *dispatchRecord) commitCancellationLocked(
 	record.result.Result.Outcome = workers.OutcomeFailed
 	record.result.Result.Error = workers.ErrWorkstationDispatchCanceled.Error()
 	record.err = canceledDispatchError(cause)
+	record.logTerminal()
 	return record.result, record.err, record.cancel
 }
 
@@ -461,6 +515,7 @@ func (record *dispatchRecord) cancelOutcome() (
 			err = nil
 		}
 		record.mu.Unlock()
+		record.logCancelOutcome(outcome)
 		return workers.WorkstationDispatchCancelResult{
 			DispatchID: record.dispatchID,
 			Outcome:    outcome,
@@ -469,10 +524,26 @@ func (record *dispatchRecord) cancelOutcome() (
 	_, _, cancel := record.commitCancellationLocked(context.Canceled)
 	record.mu.Unlock()
 	cancel()
+	record.logCancelOutcome(workers.WorkstationDispatchCancelOutcomeCanceled)
 	return workers.WorkstationDispatchCancelResult{
 		DispatchID: record.dispatchID,
 		Outcome:    workers.WorkstationDispatchCancelOutcomeCanceled,
 	}, nil
+}
+
+// logCancelOutcome emits one structured record per explicit Cancel call,
+// including idempotent no-op outcomes. dispatchID and workstationName are
+// immutable after construction so this is safe without holding record.mu.
+func (record *dispatchRecord) logCancelOutcome(outcome workers.WorkstationDispatchCancelOutcome) {
+	if record == nil || record.logger == nil {
+		return
+	}
+	record.logger.Info(
+		"workers workstation dispatch cancellation",
+		"workstation_name", record.workstationName,
+		"dispatch_id", record.dispatchID,
+		"outcome", string(outcome),
+	)
 }
 
 func (record *dispatchRecord) baseResult() workers.WorkstationDispatchResult {

--- a/pkg/services/workers/internal/services/workstations/internal/service/service_logging_test.go
+++ b/pkg/services/workers/internal/services/workstations/internal/service/service_logging_test.go
@@ -128,6 +128,39 @@ func TestPoolLogsStartAcceptedAndTerminalDispatchOutcomes(t *testing.T) {
 	}
 }
 
+func TestPoolLogsFailedTerminalDispatchOutcome(t *testing.T) {
+	t.Parallel()
+
+	logger := &recordingLogger{}
+	executeErr := errors.New("executor failed")
+	executor := &recordingExecutor{err: executeErr}
+	pool := New(logger)
+	if _, err := pool.start(context.Background(), []workstations.Route{
+		{WorkstationName: "review", Executor: executor},
+	}); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	result, err := pool.Dispatch(
+		context.Background(),
+		dispatchRequest("dispatch-failed", "transition-failed", "review"),
+	)
+	if !errors.Is(err, executeErr) {
+		t.Fatalf("Dispatch() error = %v, want executor failure", err)
+	}
+	if result.TerminalOutcome != workers.WorkstationDispatchTerminalOutcomeFailed {
+		t.Fatalf("Dispatch() terminal outcome = %q", result.TerminalOutcome)
+	}
+
+	terminal := logger.entriesFor("workers workstation dispatch terminal")
+	if len(terminal) != 1 || len(terminal[0].fields) != 3 ||
+		terminal[0].fields["workstation_name"] != "review" ||
+		terminal[0].fields["dispatch_id"] != "dispatch-failed" ||
+		terminal[0].fields["terminal_outcome"] != string(workers.WorkstationDispatchTerminalOutcomeFailed) {
+		t.Fatalf("terminal log = %#v", terminal)
+	}
+}
+
 func TestPoolLogsCancellationOutcomesIncludingNoOps(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/workers/internal/services/workstations/internal/service/service_logging_test.go
+++ b/pkg/services/workers/internal/services/workstations/internal/service/service_logging_test.go
@@ -1,0 +1,216 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	workstations "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/workstations"
+)
+
+type recordedLogEntry struct {
+	message string
+	fields  map[string]any
+}
+
+// recordingLogger implements logging.Logger for asserting the exact safe
+// fields the workstation pool emits without depending on a concrete logging
+// backend.
+type recordingLogger struct {
+	mu      sync.Mutex
+	entries []recordedLogEntry
+}
+
+func (l *recordingLogger) Debug(message string, keysAndValues ...any) {
+	l.record(message, keysAndValues)
+}
+
+func (l *recordingLogger) Info(message string, keysAndValues ...any) {
+	l.record(message, keysAndValues)
+}
+
+func (l *recordingLogger) Warn(message string, keysAndValues ...any) {
+	l.record(message, keysAndValues)
+}
+
+func (l *recordingLogger) Error(message string, keysAndValues ...any) {
+	l.record(message, keysAndValues)
+}
+
+func (l *recordingLogger) Verbose(message string, keysAndValues ...any) {
+	l.record(message, keysAndValues)
+}
+
+func (l *recordingLogger) record(message string, keysAndValues []any) {
+	fields := make(map[string]any, len(keysAndValues)/2)
+	for index := 0; index+1 < len(keysAndValues); index += 2 {
+		key, ok := keysAndValues[index].(string)
+		if !ok {
+			continue
+		}
+		fields[key] = keysAndValues[index+1]
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append(l.entries, recordedLogEntry{message: message, fields: fields})
+}
+
+func (l *recordingLogger) entriesFor(message string) []recordedLogEntry {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var matches []recordedLogEntry
+	for _, entry := range l.entries {
+		if entry.message == message {
+			matches = append(matches, entry)
+		}
+	}
+	return matches
+}
+
+func TestPoolLogsStartAcceptedAndTerminalDispatchOutcomes(t *testing.T) {
+	t.Parallel()
+
+	logger := &recordingLogger{}
+	pool := New(logger)
+	executor := &recordingExecutor{
+		result: workers.WorkResult{Outcome: workers.OutcomeAccepted, Output: "done"},
+	}
+	if _, err := pool.start(context.Background(), []workstations.Route{
+		{WorkstationName: "review", Executor: executor},
+	}); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	starts := logger.entriesFor("workers workstation pool start")
+	if len(starts) != 1 ||
+		starts[0].fields["outcome"] != string(workers.WorkstationPoolLifecycleOutcomeStarted) {
+		t.Fatalf("start log = %#v", starts)
+	}
+
+	if _, err := pool.start(
+		context.Background(),
+		[]workstations.Route{{WorkstationName: "other"}},
+	); err != nil {
+		t.Fatalf("repeated Start() error = %v", err)
+	}
+	starts = logger.entriesFor("workers workstation pool start")
+	if len(starts) != 2 ||
+		starts[1].fields["outcome"] != string(workers.WorkstationPoolLifecycleOutcomeAlreadyRunning) {
+		t.Fatalf("repeated start log = %#v", starts)
+	}
+
+	result, err := pool.Dispatch(
+		context.Background(),
+		dispatchRequest("dispatch-review", "transition-review", "review"),
+	)
+	if err != nil {
+		t.Fatalf("Dispatch() error = %v", err)
+	}
+	if result.TerminalOutcome != workers.WorkstationDispatchTerminalOutcomeCompleted {
+		t.Fatalf("Dispatch() terminal outcome = %q", result.TerminalOutcome)
+	}
+
+	accepted := logger.entriesFor("workers workstation dispatch accepted")
+	if len(accepted) != 1 || len(accepted[0].fields) != 2 ||
+		accepted[0].fields["workstation_name"] != "review" ||
+		accepted[0].fields["dispatch_id"] != "dispatch-review" {
+		t.Fatalf("accepted log = %#v", accepted)
+	}
+
+	terminal := logger.entriesFor("workers workstation dispatch terminal")
+	if len(terminal) != 1 || len(terminal[0].fields) != 3 ||
+		terminal[0].fields["workstation_name"] != "review" ||
+		terminal[0].fields["dispatch_id"] != "dispatch-review" ||
+		terminal[0].fields["terminal_outcome"] != string(workers.WorkstationDispatchTerminalOutcomeCompleted) {
+		t.Fatalf("terminal log = %#v", terminal)
+	}
+}
+
+func TestPoolLogsCancellationOutcomesIncludingNoOps(t *testing.T) {
+	t.Parallel()
+
+	logger := &recordingLogger{}
+	pool := New(logger)
+	cancelExecutor := newControlledExecutor("dispatch-cancel")
+	completeExecutor := newControlledExecutor("dispatch-complete")
+	if _, err := pool.start(context.Background(), []workstations.Route{
+		{
+			WorkstationName: "review",
+			Executor:        cancelExecutor,
+			Capacity:        1,
+			QueueCapacity:   1,
+		},
+		{
+			WorkstationName: "implement",
+			Executor:        completeExecutor,
+			Capacity:        1,
+			QueueCapacity:   1,
+		},
+	}); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	canceledCompletion := dispatchResultAsync(pool, context.Background(), "dispatch-cancel", "review")
+	assertStarted(t, cancelExecutor, "dispatch-cancel")
+
+	canceled, err := pool.Cancel(
+		context.Background(),
+		workers.WorkstationDispatchCancelRequest{DispatchID: "dispatch-cancel"},
+	)
+	if err != nil || canceled.Outcome != workers.WorkstationDispatchCancelOutcomeCanceled {
+		t.Fatalf("Cancel() = %#v, %v", canceled, err)
+	}
+	<-canceledCompletion
+
+	cancelEntries := logger.entriesFor("workers workstation dispatch cancellation")
+	if len(cancelEntries) != 1 ||
+		cancelEntries[0].fields["dispatch_id"] != "dispatch-cancel" ||
+		cancelEntries[0].fields["outcome"] != string(workers.WorkstationDispatchCancelOutcomeCanceled) {
+		t.Fatalf("cancellation log = %#v", cancelEntries)
+	}
+	terminalEntries := logger.entriesFor("workers workstation dispatch terminal")
+	if len(terminalEntries) != 1 ||
+		terminalEntries[0].fields["terminal_outcome"] != string(workers.WorkstationDispatchTerminalOutcomeCanceled) {
+		t.Fatalf("terminal log after cancel = %#v", terminalEntries)
+	}
+
+	repeatCanceled, err := pool.Cancel(
+		context.Background(),
+		workers.WorkstationDispatchCancelRequest{DispatchID: "dispatch-cancel"},
+	)
+	if err != nil || repeatCanceled.Outcome != workers.WorkstationDispatchCancelOutcomeAlreadyCanceled {
+		t.Fatalf("repeated Cancel() = %#v, %v", repeatCanceled, err)
+	}
+	cancelEntries = logger.entriesFor("workers workstation dispatch cancellation")
+	if len(cancelEntries) != 2 ||
+		cancelEntries[1].fields["outcome"] != string(workers.WorkstationDispatchCancelOutcomeAlreadyCanceled) {
+		t.Fatalf("repeated cancellation log = %#v", cancelEntries)
+	}
+	// A repeated no-op cancellation must not replace or duplicate the
+	// canonical terminal-completion record.
+	if terminalEntries := logger.entriesFor("workers workstation dispatch terminal"); len(terminalEntries) != 1 {
+		t.Fatalf("terminal log after repeat cancel = %#v", terminalEntries)
+	}
+
+	completeSignal := dispatchResultAsync(pool, context.Background(), "dispatch-complete", "implement")
+	assertStarted(t, completeExecutor, "dispatch-complete")
+	completeExecutor.release("dispatch-complete")
+	<-completeSignal
+
+	lateCancel, err := pool.Cancel(
+		context.Background(),
+		workers.WorkstationDispatchCancelRequest{DispatchID: "dispatch-complete"},
+	)
+	if lateCancel.Outcome != workers.WorkstationDispatchCancelOutcomeAlreadyTerminal ||
+		!errors.Is(err, workers.ErrWorkstationDispatchAlreadyTerminal) {
+		t.Fatalf("late Cancel() = %#v, %v", lateCancel, err)
+	}
+	cancelEntries = logger.entriesFor("workers workstation dispatch cancellation")
+	if len(cancelEntries) != 3 ||
+		cancelEntries[2].fields["dispatch_id"] != "dispatch-complete" ||
+		cancelEntries[2].fields["outcome"] != string(workers.WorkstationDispatchCancelOutcomeAlreadyTerminal) {
+		t.Fatalf("late cancellation log = %#v", cancelEntries)
+	}
+}

--- a/pkg/services/workers/internal/services/workstations/wire/wire.go
+++ b/pkg/services/workers/internal/services/workstations/wire/wire.go
@@ -2,14 +2,16 @@
 package wire
 
 import (
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	workstations "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/workstations"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/workstations/internal/service"
 	"github.com/portpowered/infinite-you/pkg/services/workers/internal/services/workstations/prompting"
 )
 
-// NewService constructs an inert workstation capability.
-func NewService() workstations.Service {
-	return internalservice.New()
+// NewService constructs an inert workstation capability. Logger is optional
+// and passed directly at construction; omitting it selects a no-op logger.
+func NewService(logger ...logging.Logger) workstations.Service {
+	return internalservice.New(logger...)
 }
 
 var NewFactoryDocsLoader = prompting.NewFactoryDocsLoader

--- a/pkg/services/workers/wire/wire.go
+++ b/pkg/services/workers/wire/wire.go
@@ -100,7 +100,11 @@ func NewService(
 	if err != nil {
 		return nil, fmt.Errorf("construct Workers: %w", err)
 	}
-	return workersinternal.NewRoot(runtimeAssembly, workstationswire.NewService(), executeService)
+	return workersinternal.NewRoot(
+		runtimeAssembly,
+		workstationswire.NewService(executeOptions.Logger),
+		executeService,
+	)
 }
 
 func validateConstructionPorts(


### PR DESCRIPTION
{
  "project": "Publish the Sealed Workers Workstation-Execution Contract",
  "branchName": "ACP-L2-CTR-WRK-EXEC",
  "description": "Publish WorkstationExecutionService on the singular Workers root with detached start and dispatch identity, one attributed terminal result, boundary-routed cancellation, and typed idempotent no-op outcomes while preserving Service.Execute, legacy Workers behavior, and runtime dispatch.",
  "context": {
    "customerAsk": "Use spare capacity for the first independently executable L2 packet only. Implement CTR-WRK-EXEC without blocking ACP Core and without deleting legacy Workers paths in this packet.",
    "problem": "Later Worker Sessions work needs one injectable Workers execution boundary with explicit start, dispatch, terminal-result, and boundary-routed cancellation semantics, but the current Workers root does not publish that narrow contract as its sealed execution surface.",
    "solution": "Publish WorkstationExecutionService on the singular Workers root using detached Workers-owned values; preserve route and caller-supplied dispatch identity through one terminal result; route cancellation through WorkstationPoolBoundary.Cancel and CancelWorkstationDispatch with typed idempotent outcomes; and add structured safe operation logs using direct construction dependencies without changing legacy execution or transports."
  },
  "acceptanceCriteria": [
    "The singular workers.Service publishes WorkstationExecutionService, and consumers can use the narrow interface without importing Workers internals or constructing another Workers service.",
    "Detached start preserves workstation route identity, and each accepted dispatch returns its caller-supplied dispatch identity and workstation identity with exactly one COMPLETED, FAILED, or CANCELED terminal outcome.",
    "Accepted work is canceled through WorkstationPoolBoundary.Cancel or CancelWorkstationDispatch; repeated and late cancellation return typed no-op outcomes without replacing the committed terminal result or returning an operation failure.",
    "Existing successful Workers and Factory Runtime execution remains behaviorally unchanged, Service.Execute and legacy Workers paths remain available, and no runtime dispatch or public transport contract changes are introduced.",
    "The Workers-owned implementation uses direct construction dependencies, explicit pool and dispatch state, and structured safe logs without introducing Worker Sessions, peer-internal imports, or sensitive payload logging.",
    "Typecheck, focused and required tests, cancellation race/repeat coverage where applicable, package-boundary checks, lint, and required CI pass.",
    "The implementation and review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, shared-file and merge conflicts are resolved against current main, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "ACP-L2-CTR-WRK-EXEC-001",
      "title": "Publish the narrow execution boundary on the Workers root",
      "description": "As a Workers consumer, I want the singular Workers root to expose the narrow workstation-execution contract so that I can start, dispatch, and cancel work without depending on the broad root shape or implementation packages.",
      "acceptanceCriteria": [
        "workers.Service publishes WorkstationExecutionService as the canonical narrow contract for workstation-pool start, stop, dispatch, and cancellation while remaining satisfied by the single production Workers implementation.",
        "A consumer holding only WorkstationExecutionService can perform every declared operation using public detached Workers values and without importing a Workers internal package.",
        "The public contract documents start and stop idempotence, dispatch terminal-result behavior, and explicit cancellation semantics.",
        "Service.Execute, ExecuteRequest, ExecuteResult, and existing legacy Workers operations remain present and behaviorally available.",
        "Public contract compilation and focused service tests prove use through both the narrow interface and the aggregate root.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Already satisfied by the existing codebase before this iteration: workers.Service publishes StartWorkstationPool/StopWorkstationPool/DispatchWorkstation/CancelWorkstationDispatch (pkg/services/workers/workstation_contracts.go), WorkstationExecutionServiceFromRoot adapts the root to the narrow interface (pkg/services/workers/workstation_pool_boundary_contracts.go), and pkg/services/workers/wire/wire_test.go drives the narrow interface from an external test package via wire.NewService()+WorkstationExecutionServiceFromRoot without importing Workers internals."
    },
    {
      "id": "ACP-L2-CTR-WRK-EXEC-002",
      "title": "Preserve identity and one terminal result from detached execution",
      "description": "As an execution supervisor, I want detached start and dispatch requests to preserve route and dispatch identity through completion so that I can correlate every accepted attempt without inspecting runtime internals.",
      "acceptanceCriteria": [
        "Starting from detached runtime bindings creates an immutable route snapshot whose workstation names remain the identities used for subsequent dispatch admission.",
        "A valid dispatch preserves the caller-supplied dispatch ID and workstation name in its result and returns exactly one typed terminal outcome: COMPLETED, FAILED, or CANCELED.",
        "Invalid start or dispatch input, an unknown route, and unavailable or saturated admission fail before executor side effects begin using established typed Workers errors.",
        "A representative dispatch that succeeded before this change still invokes its configured executor once and returns the same successful WorkResult with terminal outcome COMPLETED.",
        "Focused start, dispatch, rejection, terminal-result, and unchanged-success-path tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Already satisfied by the existing codebase before this iteration: pkg/services/workers/internal/services/workstations/internal/service/service.go's Pool commits exactly one typed terminal outcome (COMPLETED/FAILED/CANCELED) per dispatch, preserves caller dispatch ID/workstation name, and rejects invalid input/unknown routes/saturation before invoking the executor. Covered by service_test.go (TestPoolDispatchesToImmutableRouteBindingWithDetachedAttribution, TestPoolDispatchReturnsTypedRoutingFailuresWithoutExecutorEntry, TestPoolEnforcesCapacityBoundedQueueAndFIFO, etc.)."
    },
    {
      "id": "ACP-L2-CTR-WRK-EXEC-003",
      "title": "Route cancellation explicitly with typed no-op outcomes",
      "description": "As an execution supervisor, I want to cancel accepted work by dispatch identity through the workstation boundary so that cancellation remains controllable after asynchronous publication detaches from its caller context.",
      "acceptanceCriteria": [
        "WorkstationPoolBoundary.Publish may detach accepted execution from the publishing context, and its public contract directs callers to WorkstationPoolBoundary.Cancel rather than context cancellation to control that accepted dispatch.",
        "Canceling queued or running work by dispatch ID stops that work and commits a terminal CANCELED result attributed to the same dispatch.",
        "Repeated cancellation returns ALREADY_CANCELED and cancellation after a completed or failed result returns ALREADY_TERMINAL; both are successful typed no-op outcomes and do not replace the canonical terminal result.",
        "Missing or unknown dispatch identities remain distinguishable typed request errors and do not affect other dispatches.",
        "Deterministic focused tests and race/repeat coverage prove cancellation timing cases commit only one terminal result without data races.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Already satisfied by the existing codebase before this iteration: WorkstationPoolBoundary.Publish detaches accepted execution and its contract directs callers to Cancel/CancelWorkstationDispatch; Pool.Cancel commits a terminal CANCELED result by dispatch ID and returns typed ALREADY_CANCELED/ALREADY_TERMINAL no-op outcomes without replacing the committed result; unknown dispatch IDs return ErrUnknownWorkstationDispatch. Covered by cancellation_race_test.go (race/repeat coverage) and service_test.go cancellation cases."
    },
    {
      "id": "ACP-L2-CTR-WRK-EXEC-004",
      "title": "Make execution-boundary operations safely diagnosable",
      "description": "As an operator and maintainer, I want structured execution-boundary logs and direct dependency ownership so that start, dispatch, cancellation, and terminal outcomes can be diagnosed without leaking work content or hiding collaborators.",
      "acceptanceCriteria": [
        "The singular Workers implementation receives any logger and execution collaborators directly at construction and adds no dependency bag, service locator, runtime factory, mutable reinjection path, or second Workers root.",
        "Start, accepted dispatch, cancellation outcome, and terminal completion produce structured operation records containing relevant safe route or dispatch identity and typed outcome at an appropriate level.",
        "Operation records exclude work payloads, prompt bodies, credentials, environment values, and raw provider or command content.",
        "Focused tests prove successful, failed, canceled, and no-op operations emit actionable safe fields without changing the returned execution result.",
        "Package-boundary evidence confirms the public Workers root owns the contract and no peer or transport internal package is introduced.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Implemented this iteration: Pool now receives a logging.Logger directly at construction (New(logger ...logging.Logger), threaded through workstations wire.NewService and both of its production callers with no dependency bag, service locator, or second Workers root). Structured Info-level logs now emit for pool start (outcome, workstation_count), accepted dispatch (workstation_name, dispatch_id), cancellation outcome (workstation_name, dispatch_id, outcome, including no-op ALREADY_CANCELED/ALREADY_TERMINAL), and terminal completion (workstation_name, dispatch_id, terminal_outcome) exactly once per dispatch regardless of which path committed it. No work payloads, prompts, or raw error/output content are logged. Added pkg/services/workers/internal/services/workstations/internal/service/service_logging_test.go with a recording logging.Logger fake verifying exact safe field sets."
    }
  ]
}
