### PR TITLE
ACP-L1-E01: publish Events stream L1 V0 contracts

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -231,6 +231,10 @@
       "minimum": 66.14
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/events",
+      "minimum": 0.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
       "minimum": 44.60
     },

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -232,7 +232,13 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/events",
-      "minimum": 0.00
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -219,6 +219,10 @@
       "minimum": 71.65
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/events",
+      "minimum": 94.55
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",
       "minimum": 80.57
     },

--- a/pkg/services/events/append.go
+++ b/pkg/services/events/append.go
@@ -1,0 +1,164 @@
+package events
+
+import "encoding/json"
+
+// AppendOutcome distinguishes a newly accepted append from a duplicate,
+// idempotent append. Both outcomes report the same stable Record.ID: a
+// caller cannot distinguish the two by identity, only by Outcome.
+type AppendOutcome int
+
+const (
+	AppendOutcomeUnspecified AppendOutcome = iota
+	// AppendOutcomeAccepted reports that the append was newly accepted and
+	// assigned a new aggregate position.
+	AppendOutcomeAccepted
+	// AppendOutcomeDuplicate reports that an equivalent append was already
+	// accepted; the returned Record is the original, not a new one.
+	AppendOutcomeDuplicate
+)
+
+// AppendIdentity is the explicit idempotency identity for one append. A
+// duplicate append presenting the same tuple against the same topic
+// resolves to the same accepted Record rather than creating a second one.
+type AppendIdentity struct {
+	SourceType     SourceType
+	SourceID       SourceID
+	SourceSequence SourceSequence
+	SourceEventID  SourceEventID
+}
+
+// AppendRequest asks Events to append one source-native record to Topic.
+// Payload stays source-native JSON; Events does not convert it into an
+// Events-owned kind union.
+type AppendRequest struct {
+	Topic          Topic
+	SourceType     SourceType
+	SourceID       SourceID
+	SourceSequence SourceSequence
+	SourceEventID  SourceEventID
+	SchemaID       SchemaID
+	Payload        json.RawMessage
+}
+
+// Identity returns the explicit (sourceType, sourceID, sourceSequence,
+// sourceEventID) idempotency identity for r.
+func (r AppendRequest) Identity() AppendIdentity {
+	return AppendIdentity{
+		SourceType:     r.SourceType,
+		SourceID:       r.SourceID,
+		SourceSequence: r.SourceSequence,
+		SourceEventID:  r.SourceEventID,
+	}
+}
+
+// Validate reports whether r names a well-formed append envelope: every
+// identity field is well-formed and Payload is non-empty, well-formed JSON.
+func (r AppendRequest) Validate() error {
+	if err := r.Topic.Validate(); err != nil {
+		return err
+	}
+	if err := r.SourceType.Validate(); err != nil {
+		return err
+	}
+	if err := r.SourceID.Validate(); err != nil {
+		return err
+	}
+	if err := r.SourceSequence.Validate(); err != nil {
+		return err
+	}
+	if err := r.SourceEventID.Validate(); err != nil {
+		return err
+	}
+	if err := r.SchemaID.Validate(); err != nil {
+		return err
+	}
+	return validatePayload(r.Payload)
+}
+
+// Detached returns a copy of r whose Payload is backed by its own array, so
+// caller mutation of the original Payload slice after calling Detached
+// cannot alter the value observed across the public contract.
+func (r AppendRequest) Detached() AppendRequest {
+	detached := r
+	detached.Payload = clonePayload(r.Payload)
+	return detached
+}
+
+// Record is one record Events accepted into a topic's aggregate ordering.
+// Payload stays source-native JSON.
+type Record struct {
+	ID             RecordID
+	SourceType     SourceType
+	SourceID       SourceID
+	SourceSequence SourceSequence
+	SourceEventID  SourceEventID
+	SchemaID       SchemaID
+	Payload        json.RawMessage
+}
+
+// Identity returns the explicit idempotency identity recorded for rec.
+func (rec Record) Identity() AppendIdentity {
+	return AppendIdentity{
+		SourceType:     rec.SourceType,
+		SourceID:       rec.SourceID,
+		SourceSequence: rec.SourceSequence,
+		SourceEventID:  rec.SourceEventID,
+	}
+}
+
+// Validate reports whether rec names a well-formed accepted record.
+func (rec Record) Validate() error {
+	if err := rec.ID.Validate(); err != nil {
+		return err
+	}
+	if err := rec.SourceType.Validate(); err != nil {
+		return err
+	}
+	if err := rec.SourceID.Validate(); err != nil {
+		return err
+	}
+	if err := rec.SourceSequence.Validate(); err != nil {
+		return err
+	}
+	if err := rec.SourceEventID.Validate(); err != nil {
+		return err
+	}
+	if err := rec.SchemaID.Validate(); err != nil {
+		return err
+	}
+	return validatePayload(rec.Payload)
+}
+
+// Detached returns a copy of rec whose Payload is backed by its own array,
+// so caller mutation of the original Payload slice after calling Detached
+// cannot alter the value observed across the public contract.
+func (rec Record) Detached() Record {
+	detached := rec
+	detached.Payload = clonePayload(rec.Payload)
+	return detached
+}
+
+// AppendResult is the detached success outcome of one Append call.
+type AppendResult struct {
+	Record  Record
+	Outcome AppendOutcome
+}
+
+func validatePayload(payload json.RawMessage) error {
+	if len(payload) == 0 {
+		return ErrEmptyPayload
+	}
+	if !json.Valid(payload) {
+		return ErrMalformedPayloadJSON
+	}
+	return nil
+}
+
+func clonePayload(payload json.RawMessage) json.RawMessage {
+	if payload == nil {
+		return nil
+	}
+	clone := make(json.RawMessage, len(payload))
+	copy(clone, payload)
+	return clone
+}

--- a/pkg/services/events/append_test.go
+++ b/pkg/services/events/append_test.go
@@ -1,0 +1,131 @@
+package events
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func validAppendRequest() AppendRequest {
+	return AppendRequest{
+		Topic:          "chat-session/abc/events",
+		SourceType:     "worker.tool",
+		SourceID:       "worker-1",
+		SourceSequence: 1,
+		SourceEventID:  "evt-1",
+		SchemaID:       "worker.output.v1",
+		Payload:        json.RawMessage(`{"tool":"grep","status":"ok"}`),
+	}
+}
+
+func TestAppendRequestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(AppendRequest) AppendRequest
+		wantErr error
+	}{
+		{"valid", func(r AppendRequest) AppendRequest { return r }, nil},
+		{"missing topic", func(r AppendRequest) AppendRequest { r.Topic = ""; return r }, ErrEmptyTopic},
+		{"missing source type", func(r AppendRequest) AppendRequest { r.SourceType = ""; return r }, ErrEmptySourceType},
+		{"missing source id", func(r AppendRequest) AppendRequest { r.SourceID = ""; return r }, ErrEmptySourceID},
+		{"missing source sequence", func(r AppendRequest) AppendRequest { r.SourceSequence = 0; return r }, ErrInvalidSourceSequence},
+		{"missing source event id", func(r AppendRequest) AppendRequest { r.SourceEventID = ""; return r }, ErrEmptySourceEventID},
+		{"missing schema id", func(r AppendRequest) AppendRequest { r.SchemaID = ""; return r }, ErrEmptySchemaID},
+		{"empty payload", func(r AppendRequest) AppendRequest { r.Payload = nil; return r }, ErrEmptyPayload},
+		{"invalid json payload", func(r AppendRequest) AppendRequest { r.Payload = json.RawMessage(`{not json`); return r }, ErrMalformedPayloadJSON},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := tt.mutate(validAppendRequest())
+			if err := req.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAppendRequestIdentity(t *testing.T) {
+	req := validAppendRequest()
+	want := AppendIdentity{
+		SourceType:     req.SourceType,
+		SourceID:       req.SourceID,
+		SourceSequence: req.SourceSequence,
+		SourceEventID:  req.SourceEventID,
+	}
+	if got := req.Identity(); got != want {
+		t.Fatalf("Identity() = %+v, want %+v", got, want)
+	}
+}
+
+func TestAppendRequestDetachedPayload(t *testing.T) {
+	original := json.RawMessage(`{"tool":"grep"}`)
+	req := validAppendRequest()
+	req.Payload = original
+
+	detached := req.Detached()
+	original[2] = 'X' // mutate the byte backing the caller's original slice
+
+	if string(detached.Payload) != `{"tool":"grep"}` {
+		t.Fatalf("Detached().Payload = %s, want unaffected by caller mutation", detached.Payload)
+	}
+}
+
+func TestRecordValidate(t *testing.T) {
+	valid := Record{
+		ID:             RecordID{Topic: "chat-session/abc/events", Position: 1},
+		SourceType:     "worker.tool",
+		SourceID:       "worker-1",
+		SourceSequence: 1,
+		SourceEventID:  "evt-1",
+		SchemaID:       "worker.output.v1",
+		Payload:        json.RawMessage(`{"tool":"grep"}`),
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(Record) Record
+		wantErr error
+	}{
+		{"valid", func(r Record) Record { return r }, nil},
+		{"unassigned position", func(r Record) Record { r.ID.Position = 0; return r }, ErrInvalidAggregateSequence},
+		{"empty payload", func(r Record) Record { r.Payload = nil; return r }, ErrEmptyPayload},
+		{"invalid json payload", func(r Record) Record { r.Payload = json.RawMessage(`{`); return r }, ErrMalformedPayloadJSON},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := tt.mutate(valid)
+			if err := rec.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRecordDetachedPayload(t *testing.T) {
+	original := json.RawMessage(`{"tool":"grep"}`)
+	rec := Record{
+		ID:      RecordID{Topic: "chat-session/abc/events", Position: 1},
+		Payload: original,
+	}
+
+	detached := rec.Detached()
+	original[2] = 'X'
+
+	if string(detached.Payload) != `{"tool":"grep"}` {
+		t.Fatalf("Detached().Payload = %s, want unaffected by caller mutation", detached.Payload)
+	}
+}
+
+func TestAppendOutcomeValues(t *testing.T) {
+	rec := Record{ID: RecordID{Topic: "chat-session/abc/events", Position: 1}}
+
+	accepted := AppendResult{Record: rec, Outcome: AppendOutcomeAccepted}
+	duplicate := AppendResult{Record: rec, Outcome: AppendOutcomeDuplicate}
+
+	if accepted.Outcome == duplicate.Outcome {
+		t.Fatalf("accepted and duplicate outcomes must be distinct")
+	}
+	if accepted.Record.ID != duplicate.Record.ID {
+		t.Fatalf("accepted and duplicate outcomes must report the same stable Record.ID")
+	}
+}

--- a/pkg/services/events/attach.go
+++ b/pkg/services/events/attach.go
@@ -1,0 +1,99 @@
+package events
+
+// AttachMode selects how a source attachment consumes the source topic's
+// history relative to Events' live head.
+type AttachMode int
+
+const (
+	AttachModeUnspecified AttachMode = iota
+	// AttachModeRetainedThenLive replays currently retained source records
+	// starting at StartAt before delivering live records.
+	AttachModeRetainedThenLive
+	// AttachModeLiveOnly begins delivery at the source's live head and
+	// never replays retained history.
+	AttachModeLiveOnly
+)
+
+// Validate reports whether m is a supported attachment mode.
+func (m AttachMode) Validate() error {
+	switch m {
+	case AttachModeRetainedThenLive, AttachModeLiveOnly:
+		return nil
+	default:
+		return ErrUnsupportedAttachMode
+	}
+}
+
+// AttachOutcome distinguishes a newly accepted attachment from an
+// already-attached, idempotent outcome.
+type AttachOutcome int
+
+const (
+	AttachOutcomeUnspecified AttachOutcome = iota
+	// AttachOutcomeAccepted reports that the attachment was newly accepted.
+	AttachOutcomeAccepted
+	// AttachOutcomeAlreadyAttached reports that an equivalent attachment
+	// already exists; the returned ID is the original, not a new one.
+	AttachOutcomeAlreadyAttached
+)
+
+// AttachmentID stably correlates one Destination/Source attachment. Callers
+// retain it to recognize a later idempotent AttachSource call for the same
+// pair.
+type AttachmentID struct {
+	Destination Topic
+	Source      Topic
+}
+
+// Validate reports whether id names a well-formed, non-self attachment.
+func (id AttachmentID) Validate() error {
+	if err := id.Destination.Validate(); err != nil {
+		return err
+	}
+	if err := id.Source.Validate(); err != nil {
+		return err
+	}
+	if id.Destination == id.Source {
+		return ErrSelfAttachment
+	}
+	return nil
+}
+
+// AttachSourceRequest asks an aggregate-stream owner's later in-memory
+// sequencer to follow Source from StartAt. AttachSourceRequest contains no
+// embedded service, resolver, callback, channel, store, transport, or
+// dependency bag, and makes no claim that Source's historical data is
+// durable: Events retains no persistence responsibility (D1 in
+// docs/internal/projects/acp-program/README.md).
+type AttachSourceRequest struct {
+	Destination Topic
+	Source      Topic
+	StartAt     Cursor
+	Mode        AttachMode
+}
+
+// Validate reports whether r names a well-formed, compatible, non-self
+// attachment with a starting position drawn from Source.
+func (r AttachSourceRequest) Validate() error {
+	if err := (AttachmentID{Destination: r.Destination, Source: r.Source}).Validate(); err != nil {
+		return err
+	}
+	if err := r.Mode.Validate(); err != nil {
+		return err
+	}
+	if err := r.StartAt.Validate(); err != nil {
+		return err
+	}
+	if !r.StartAt.BelongsTo(r.Source) {
+		return ErrIncompatibleAttachmentCursor
+	}
+	return nil
+}
+
+// AttachSourceResult is the detached success outcome of one AttachSource
+// call.
+type AttachSourceResult struct {
+	ID      AttachmentID
+	Outcome AttachOutcome
+	StartAt Cursor
+}

--- a/pkg/services/events/attach_test.go
+++ b/pkg/services/events/attach_test.go
@@ -1,0 +1,121 @@
+package events
+
+import (
+	"errors"
+	"testing"
+)
+
+func validAttachSourceRequest() AttachSourceRequest {
+	source := Topic("factory-session/abc/response-events")
+	return AttachSourceRequest{
+		Destination: "chat-session/abc/events",
+		Source:      source,
+		StartAt:     Cursor{Topic: source, Position: 3},
+		Mode:        AttachModeRetainedThenLive,
+	}
+}
+
+func TestAttachSourceRequestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(AttachSourceRequest) AttachSourceRequest
+		wantErr error
+	}{
+		{"valid retained-then-live", func(r AttachSourceRequest) AttachSourceRequest { return r }, nil},
+		{"valid live-only", func(r AttachSourceRequest) AttachSourceRequest { r.Mode = AttachModeLiveOnly; return r }, nil},
+		{"missing destination", func(r AttachSourceRequest) AttachSourceRequest { r.Destination = ""; return r }, ErrEmptyTopic},
+		{"missing source", func(r AttachSourceRequest) AttachSourceRequest { r.Source = ""; return r }, ErrEmptyTopic},
+		{
+			name: "self attachment",
+			mutate: func(r AttachSourceRequest) AttachSourceRequest {
+				r.Source = r.Destination
+				r.StartAt = Cursor{Topic: r.Destination, Position: 3}
+				return r
+			},
+			wantErr: ErrSelfAttachment,
+		},
+		{"unsupported mode", func(r AttachSourceRequest) AttachSourceRequest { r.Mode = AttachMode(99); return r }, ErrUnsupportedAttachMode},
+		{"invalid starting position", func(r AttachSourceRequest) AttachSourceRequest { r.StartAt = Cursor{}; return r }, ErrEmptyTopic},
+		{
+			name: "starting cursor belongs to a different topic",
+			mutate: func(r AttachSourceRequest) AttachSourceRequest {
+				r.StartAt = Cursor{Topic: r.Destination, Position: 3}
+				return r
+			},
+			wantErr: ErrIncompatibleAttachmentCursor,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := tt.mutate(validAttachSourceRequest())
+			if err := req.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAttachmentIDValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      AttachmentID
+		wantErr error
+	}{
+		{
+			name:    "valid",
+			id:      AttachmentID{Destination: "chat-session/abc/events", Source: "factory-session/abc/response-events"},
+			wantErr: nil,
+		},
+		{
+			name:    "self attachment",
+			id:      AttachmentID{Destination: "chat-session/abc/events", Source: "chat-session/abc/events"},
+			wantErr: ErrSelfAttachment,
+		},
+		{
+			name:    "malformed destination",
+			id:      AttachmentID{Destination: " chat-session/abc/events", Source: "factory-session/abc/response-events"},
+			wantErr: ErrMalformedTopic,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.id.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAttachModeValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    AttachMode
+		wantErr error
+	}{
+		{"retained then live", AttachModeRetainedThenLive, nil},
+		{"live only", AttachModeLiveOnly, nil},
+		{"unspecified", AttachModeUnspecified, ErrUnsupportedAttachMode},
+		{"unknown", AttachMode(42), ErrUnsupportedAttachMode},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.mode.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAttachOutcomeValues(t *testing.T) {
+	id := AttachmentID{Destination: "chat-session/abc/events", Source: "factory-session/abc/response-events"}
+
+	accepted := AttachSourceResult{ID: id, Outcome: AttachOutcomeAccepted}
+	alreadyAttached := AttachSourceResult{ID: id, Outcome: AttachOutcomeAlreadyAttached}
+
+	if accepted.Outcome == alreadyAttached.Outcome {
+		t.Fatalf("accepted and already-attached outcomes must be distinct")
+	}
+	if accepted.ID != alreadyAttached.ID {
+		t.Fatalf("accepted and already-attached outcomes must report the same stable AttachmentID")
+	}
+}

--- a/pkg/services/events/cursor.go
+++ b/pkg/services/events/cursor.go
@@ -1,0 +1,63 @@
+package events
+
+// Cursor names a position within one Topic's aggregate ordering. A Cursor is
+// only meaningful relative to the Topic it names: callers must not present a
+// Cursor obtained for one topic to a Read or Subscribe operation on another.
+// BelongsTo lets a caller reject that mismatch explicitly instead of
+// accidentally reading from the wrong stream.
+//
+// The zero value is invalid: a valid Cursor always names its Topic, even
+// when it names the start-of-stream position, Cursor{Topic: topic} at the
+// zero Position.
+type Cursor struct {
+	Topic    Topic
+	Position AggregateSequence
+}
+
+// Validate reports whether c names a well-formed cursor. A cursor at
+// Position 0 (the start-of-topic position) is valid; Validate only requires
+// a well-formed Topic, since Position 0 is a meaningful starting position
+// rather than an assigned record position.
+func (c Cursor) Validate() error {
+	return c.Topic.Validate()
+}
+
+// BelongsTo reports whether c was issued against topic. Read and Subscribe
+// operations use this to reject a cursor's use against a different stream
+// rather than silently reading from the wrong topic.
+func (c Cursor) BelongsTo(topic Topic) bool {
+	return c.Topic == topic
+}
+
+// RetainedRange describes the span of AggregateSequence positions Events
+// currently retains for a topic, plus the topic's live head position.
+//
+// Earliest is the oldest retained record position; Head is the position of
+// the most recently accepted record. Both are 0 when the topic has never
+// accepted a record. When Head is nonzero, Earliest must be at least 1 and
+// no greater than Head: an Earliest of 0 alongside a nonzero Head describes
+// a retained record at the reserved "before the first record" position,
+// which Validate rejects as internally inconsistent.
+type RetainedRange struct {
+	Topic    Topic
+	Earliest AggregateSequence
+	Head     AggregateSequence
+}
+
+// Validate reports whether r describes an internally consistent retained
+// range for a well-formed topic.
+func (r RetainedRange) Validate() error {
+	if err := r.Topic.Validate(); err != nil {
+		return err
+	}
+	if r.Head == 0 {
+		if r.Earliest != 0 {
+			return ErrInvalidRetainedRange
+		}
+		return nil
+	}
+	if r.Earliest == 0 || r.Earliest > r.Head {
+		return ErrInvalidRetainedRange
+	}
+	return nil
+}

--- a/pkg/services/events/cursor_test.go
+++ b/pkg/services/events/cursor_test.go
@@ -1,0 +1,96 @@
+package events
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCursorValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cursor  Cursor
+		wantErr error
+	}{
+		{"start of topic is valid", Cursor{Topic: "chat-session/abc/events"}, nil},
+		{"advanced position is valid", Cursor{Topic: "chat-session/abc/events", Position: 7}, nil},
+		{"zero value is invalid", Cursor{}, ErrEmptyTopic},
+		{"malformed topic", Cursor{Topic: " chat-session/abc/events"}, ErrMalformedTopic},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.cursor.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCursorBelongsTo(t *testing.T) {
+	cursor := Cursor{Topic: "chat-session/abc/events", Position: 3}
+
+	if !cursor.BelongsTo("chat-session/abc/events") {
+		t.Fatalf("BelongsTo() = false, want true for the issuing topic")
+	}
+	if cursor.BelongsTo("chat-session/other/events") {
+		t.Fatalf("BelongsTo() = true, want false for a different topic")
+	}
+	if cursor.BelongsTo("factory-session/abc/response-events") {
+		t.Fatalf("BelongsTo() = true, want false for a different topic family")
+	}
+}
+
+func TestRetainedRangeValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		rng     RetainedRange
+		wantErr error
+	}{
+		{
+			name:    "empty topic with no records",
+			rng:     RetainedRange{Topic: "chat-session/abc/events"},
+			wantErr: nil,
+		},
+		{
+			name:    "single retained record",
+			rng:     RetainedRange{Topic: "chat-session/abc/events", Earliest: 1, Head: 1},
+			wantErr: nil,
+		},
+		{
+			name:    "multiple retained records",
+			rng:     RetainedRange{Topic: "chat-session/abc/events", Earliest: 5, Head: 20},
+			wantErr: nil,
+		},
+		{
+			name:    "zero value is invalid",
+			rng:     RetainedRange{},
+			wantErr: ErrEmptyTopic,
+		},
+		{
+			name:    "malformed topic",
+			rng:     RetainedRange{Topic: " chat-session/abc/events"},
+			wantErr: ErrMalformedTopic,
+		},
+		{
+			name:    "earliest reserved position with a nonzero head",
+			rng:     RetainedRange{Topic: "chat-session/abc/events", Earliest: 0, Head: 5},
+			wantErr: ErrInvalidRetainedRange,
+		},
+		{
+			name:    "earliest after head",
+			rng:     RetainedRange{Topic: "chat-session/abc/events", Earliest: 10, Head: 5},
+			wantErr: ErrInvalidRetainedRange,
+		},
+		{
+			name:    "nonzero earliest with a zero head",
+			rng:     RetainedRange{Topic: "chat-session/abc/events", Earliest: 1, Head: 0},
+			wantErr: ErrInvalidRetainedRange,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.rng.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/services/events/doc.go
+++ b/pkg/services/events/doc.go
@@ -1,0 +1,16 @@
+// Package events is the public Events service boundary: a process-local,
+// in-memory event stream root that gives ACP Core and later Worker Events one
+// stable session-scoped boundary for append, source attachment, retained
+// reads, and subscriptions. Persistence and event stream are separate
+// concerns (D2 in docs/internal/projects/acp-program/README.md): Recordings
+// (pkg/services/recordings) remains the canonical durable Factory Event
+// ledger, and Events introduces no durable journal (D1), no internal/store
+// package, and no second event taxonomy. Source payloads cross the contract
+// as source-native JSON — Events does not convert them into an Events-owned
+// kind union.
+//
+// This package currently publishes the L1 V0 slice described in
+// docs/internal/projects/acp-client/final-proposal.md §5: detached identity,
+// position, envelope, and outcome contracts only. It has no implementation
+// and no wire construction; those belong to a later slice.
+package events

--- a/pkg/services/events/errors.go
+++ b/pkg/services/events/errors.go
@@ -1,0 +1,33 @@
+package events
+
+import "errors"
+
+// Identity, sequence, cursor, and retained-position validation failures.
+// Callers classify a failure with errors.Is against these sentinels rather
+// than matching error strings.
+var (
+	ErrEmptyTopic               = errors.New("events: topic is empty")
+	ErrMalformedTopic           = errors.New("events: topic is malformed")
+	ErrEmptySourceType          = errors.New("events: source type is empty")
+	ErrMalformedSourceType      = errors.New("events: source type is malformed")
+	ErrEmptySourceID            = errors.New("events: source id is empty")
+	ErrMalformedSourceID        = errors.New("events: source id is malformed")
+	ErrInvalidSourceSequence    = errors.New("events: source sequence is invalid")
+	ErrEmptySourceEventID       = errors.New("events: source event id is empty")
+	ErrMalformedSourceEventID   = errors.New("events: source event id is malformed")
+	ErrEmptySchemaID            = errors.New("events: schema id is empty")
+	ErrMalformedSchemaID        = errors.New("events: schema id is malformed")
+	ErrInvalidAggregateSequence = errors.New("events: aggregate sequence is invalid")
+	ErrInvalidRetainedRange     = errors.New("events: retained range is internally inconsistent")
+
+	ErrEmptyPayload         = errors.New("events: payload is empty")
+	ErrMalformedPayloadJSON = errors.New("events: payload is not well-formed JSON")
+
+	ErrSelfAttachment               = errors.New("events: source cannot attach to itself")
+	ErrUnsupportedAttachMode        = errors.New("events: attach mode is unsupported")
+	ErrIncompatibleAttachmentCursor = errors.New("events: starting cursor does not belong to the attachment source")
+
+	ErrCursorTopicMismatch     = errors.New("events: cursor does not belong to the requested topic")
+	ErrInvalidReadLimit        = errors.New("events: read/subscribe limit must be positive")
+	ErrInconsistentReadOutcome = errors.New("events: read result outcome is inconsistent with its records/gap")
+)

--- a/pkg/services/events/events_external_test.go
+++ b/pkg/services/events/events_external_test.go
@@ -1,0 +1,138 @@
+package events_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/events"
+)
+
+// fakeService proves that events.Service can be implemented entirely from
+// outside the package, using only exported detached values. It holds no
+// private events state and imports no internal package.
+type fakeService struct {
+	records []events.Record
+}
+
+func (f *fakeService) Append(_ context.Context, req events.AppendRequest) (events.AppendResult, error) {
+	if err := req.Validate(); err != nil {
+		return events.AppendResult{}, err
+	}
+	rec := events.Record{
+		ID:             events.RecordID{Topic: req.Topic, Position: events.AggregateSequence(len(f.records) + 1)},
+		SourceType:     req.SourceType,
+		SourceID:       req.SourceID,
+		SourceSequence: req.SourceSequence,
+		SourceEventID:  req.SourceEventID,
+		SchemaID:       req.SchemaID,
+		Payload:        req.Detached().Payload,
+	}
+	f.records = append(f.records, rec)
+	return events.AppendResult{Record: rec, Outcome: events.AppendOutcomeAccepted}, nil
+}
+
+func (f *fakeService) AttachSource(_ context.Context, req events.AttachSourceRequest) (events.AttachSourceResult, error) {
+	if err := req.Validate(); err != nil {
+		return events.AttachSourceResult{}, err
+	}
+	id := events.AttachmentID{Destination: req.Destination, Source: req.Source}
+	return events.AttachSourceResult{ID: id, Outcome: events.AttachOutcomeAccepted, StartAt: req.StartAt}, nil
+}
+
+func (f *fakeService) Read(_ context.Context, req events.ReadRequest) (events.ReadResult, error) {
+	if err := req.Validate(); err != nil {
+		return events.ReadResult{}, err
+	}
+	if len(f.records) == 0 {
+		return events.ReadResult{Outcome: events.ReadOutcomeAtHead, Next: req.From}, nil
+	}
+	return events.ReadResult{
+		Records: f.records,
+		Next:    events.Cursor{Topic: req.Topic, Position: f.records[len(f.records)-1].ID.Position},
+		Outcome: events.ReadOutcomeProgress,
+	}, nil
+}
+
+func (f *fakeService) Subscribe(_ context.Context, req events.SubscribeRequest) (events.Subscription, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	index := 0
+	return events.Subscription(func(ctx context.Context) events.Delivery {
+		if ctx.Err() != nil {
+			return events.Delivery{Kind: events.DeliveryCanceled}
+		}
+		if index >= len(f.records) {
+			return events.Delivery{Kind: events.DeliveryClosed}
+		}
+		rec := f.records[index]
+		index++
+		return events.Delivery{Kind: events.DeliveryRecord, Record: rec, Cursor: events.Cursor{Topic: req.Topic, Position: rec.ID.Position}}
+	}), nil
+}
+
+var _ events.Service = (*fakeService)(nil)
+
+func TestExternalConsumerImplementsService(t *testing.T) {
+	svc := &fakeService{}
+	ctx := context.Background()
+	topic := events.Topic("chat-session/external/events")
+
+	appendResult, err := svc.Append(ctx, events.AppendRequest{
+		Topic:          topic,
+		SourceType:     "worker.tool",
+		SourceID:       "worker-1",
+		SourceSequence: 1,
+		SourceEventID:  "evt-1",
+		SchemaID:       "worker.output.v1",
+		Payload:        json.RawMessage(`{"status":"ok"}`),
+	})
+	if err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+	if appendResult.Outcome != events.AppendOutcomeAccepted {
+		t.Fatalf("Append().Outcome = %v, want AppendOutcomeAccepted", appendResult.Outcome)
+	}
+
+	readResult, err := svc.Read(ctx, events.ReadRequest{Topic: topic, From: events.Cursor{Topic: topic}, Limit: 10})
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if readResult.Outcome != events.ReadOutcomeProgress {
+		t.Fatalf("Read().Outcome = %v, want ReadOutcomeProgress", readResult.Outcome)
+	}
+	if len(readResult.Records) != 1 {
+		t.Fatalf("Read() returned %d records, want 1", len(readResult.Records))
+	}
+
+	subscription, err := svc.Subscribe(ctx, events.SubscribeRequest{Topic: topic, From: events.Cursor{Topic: topic}, Limit: 10})
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	first := subscription.Next(ctx)
+	if first.Kind != events.DeliveryRecord {
+		t.Fatalf("Next().Kind = %v, want DeliveryRecord", first.Kind)
+	}
+	second := subscription.Next(ctx)
+	if second.Kind != events.DeliveryClosed {
+		t.Fatalf("Next().Kind = %v, want DeliveryClosed once records are exhausted", second.Kind)
+	}
+}
+
+func TestExternalConsumerRejectsSelfAttachment(t *testing.T) {
+	svc := &fakeService{}
+	topic := events.Topic("chat-session/external/events")
+
+	_, err := svc.AttachSource(context.Background(), events.AttachSourceRequest{
+		Destination: topic,
+		Source:      topic,
+		StartAt:     events.Cursor{Topic: topic},
+		Mode:        events.AttachModeRetainedThenLive,
+	})
+	if !errors.Is(err, events.ErrSelfAttachment) {
+		t.Fatalf("AttachSource() error = %v, want ErrSelfAttachment", err)
+	}
+}

--- a/pkg/services/events/identity.go
+++ b/pkg/services/events/identity.go
@@ -1,0 +1,206 @@
+package events
+
+import "strings"
+
+// Conservative length ceilings for detached identity tokens. These bound
+// pathological inputs; they are not a claim about any storage limit since
+// Events has no storage responsibility.
+const (
+	maxTopicLength         = 256
+	maxSourceTypeLength    = 128
+	maxSourceIDLength      = 256
+	maxSourceEventIDLength = 256
+	maxSchemaIDLength      = 128
+)
+
+// Topic identifies one session-scoped Events stream, such as
+// "factory-session/<id>/response-events" or "chat-session/<id>/events".
+// Events does not hard-code these as the only valid topic families: any
+// caller-defined identity that satisfies Validate names a valid stream.
+//
+// The zero value ("") never validates.
+type Topic string
+
+// Validate reports whether t is a well-formed topic identity. It rejects the
+// empty value and any value containing leading/trailing whitespace, control
+// characters, or characters outside the conservative path-segment charset
+// (letters, digits, '-', '_', '.', '/', ':').
+func (t Topic) Validate() error {
+	switch validateIdentityToken(string(t), maxTopicLength) {
+	case identityTokenEmpty:
+		return ErrEmptyTopic
+	case identityTokenMalformed:
+		return ErrMalformedTopic
+	default:
+		return nil
+	}
+}
+
+// SourceType names the source-native producer family for an appended
+// record, such as a worker kind or a chat control source. Events treats
+// SourceType as an opaque identity; it does not own or restrict the set of
+// valid source types.
+//
+// The zero value ("") never validates.
+type SourceType string
+
+// Validate reports whether s is a well-formed source type identity.
+func (s SourceType) Validate() error {
+	switch validateIdentityToken(string(s), maxSourceTypeLength) {
+	case identityTokenEmpty:
+		return ErrEmptySourceType
+	case identityTokenMalformed:
+		return ErrMalformedSourceType
+	default:
+		return nil
+	}
+}
+
+// SourceID names one source instance within a SourceType, such as one
+// worker's stable identity.
+//
+// The zero value ("") never validates.
+type SourceID string
+
+// Validate reports whether s is a well-formed source id identity.
+func (s SourceID) Validate() error {
+	switch validateIdentityToken(string(s), maxSourceIDLength) {
+	case identityTokenEmpty:
+		return ErrEmptySourceID
+	case identityTokenMalformed:
+		return ErrMalformedSourceID
+	default:
+		return nil
+	}
+}
+
+// SourceSequence is a source-native monotonic sequence number scoped to one
+// (Topic, SourceType, SourceID). Together with SourceEventID it forms the
+// idempotency identity for an appended record.
+//
+// The zero value means "unset" and never validates; source sequences begin
+// at 1.
+type SourceSequence uint64
+
+// Validate reports whether s is a well-formed source sequence.
+func (s SourceSequence) Validate() error {
+	if s == 0 {
+		return ErrInvalidSourceSequence
+	}
+	return nil
+}
+
+// SourceEventID is the source-native unique identifier for one produced
+// event, used together with SourceSequence as part of the append idempotency
+// identity.
+//
+// The zero value ("") never validates.
+type SourceEventID string
+
+// Validate reports whether s is a well-formed source event id identity.
+func (s SourceEventID) Validate() error {
+	switch validateIdentityToken(string(s), maxSourceEventIDLength) {
+	case identityTokenEmpty:
+		return ErrEmptySourceEventID
+	case identityTokenMalformed:
+		return ErrMalformedSourceEventID
+	default:
+		return nil
+	}
+}
+
+// SchemaID identifies the shape of a record's source-native JSON payload,
+// such as "worker.output.v1". Events does not interpret the payload against
+// this identity; SchemaID is caller-defined metadata that crosses the
+// contract unchanged.
+//
+// The zero value ("") never validates.
+type SchemaID string
+
+// Validate reports whether s is a well-formed schema id identity.
+func (s SchemaID) Validate() error {
+	switch validateIdentityToken(string(s), maxSchemaIDLength) {
+	case identityTokenEmpty:
+		return ErrEmptySchemaID
+	case identityTokenMalformed:
+		return ErrMalformedSchemaID
+	default:
+		return nil
+	}
+}
+
+// AggregateSequence is the position Events assigns to an accepted record
+// within one topic's aggregate ordering, in commit order. The zero value
+// means "before the first record": it is valid only as a starting or
+// retained-boundary position, never as an already-assigned record's own
+// position.
+type AggregateSequence uint64
+
+// ValidateAssigned reports whether the sequence is a valid position for an
+// already-accepted record. Assigned positions begin at 1; the zero value is
+// reserved for "before the first record" and is rejected here.
+func (s AggregateSequence) ValidateAssigned() error {
+	if s == 0 {
+		return ErrInvalidAggregateSequence
+	}
+	return nil
+}
+
+// RecordID names one accepted record within a topic's aggregate ordering. A
+// RecordID is only meaningful together with the AggregateSequence Events
+// assigned to it at commit time.
+//
+// The zero value is invalid.
+type RecordID struct {
+	Topic    Topic
+	Position AggregateSequence
+}
+
+// Validate reports whether id names a specific, already-accepted record.
+func (id RecordID) Validate() error {
+	if err := id.Topic.Validate(); err != nil {
+		return err
+	}
+	return id.Position.ValidateAssigned()
+}
+
+type identityTokenShape int
+
+const (
+	identityTokenValid identityTokenShape = iota
+	identityTokenEmpty
+	identityTokenMalformed
+)
+
+// validateIdentityToken applies the shared conservative shape rules used by
+// every detached identity string in this package: non-empty, no
+// leading/trailing whitespace, within maxLen, and restricted to a
+// path-segment-safe charset.
+func validateIdentityToken(s string, maxLen int) identityTokenShape {
+	if s == "" {
+		return identityTokenEmpty
+	}
+	if len(s) > maxLen {
+		return identityTokenMalformed
+	}
+	if strings.TrimSpace(s) != s {
+		return identityTokenMalformed
+	}
+	for _, r := range s {
+		if !isIdentityTokenRune(r) {
+			return identityTokenMalformed
+		}
+	}
+	return identityTokenValid
+}
+
+func isIdentityTokenRune(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		return true
+	case r == '-' || r == '_' || r == '.' || r == '/' || r == ':':
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/services/events/identity_test.go
+++ b/pkg/services/events/identity_test.go
@@ -1,0 +1,189 @@
+package events
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestTopicValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		topic   Topic
+		wantErr error
+	}{
+		{"valid factory session topic", Topic("factory-session/abc-123/response-events"), nil},
+		{"valid chat session topic", Topic("chat-session/xyz/events"), nil},
+		{"valid arbitrary future topic family", Topic("worker-session/w-1/events"), nil},
+		{"empty", Topic(""), ErrEmptyTopic},
+		{"internal whitespace", Topic("factory-session/ abc /events"), ErrMalformedTopic},
+		{"leading whitespace", Topic(" factory-session/abc/events"), ErrMalformedTopic},
+		{"trailing whitespace", Topic("factory-session/abc/events "), ErrMalformedTopic},
+		{"control character", Topic("factory-session/abc\n/events"), ErrMalformedTopic},
+		{"disallowed character", Topic("factory-session/abc#1/events"), ErrMalformedTopic},
+		{"too long", Topic(strings.Repeat("a", maxTopicLength+1)), ErrMalformedTopic},
+		{"exactly max length", Topic(strings.Repeat("a", maxTopicLength)), nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.topic.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSourceTypeValidate(t *testing.T) {
+	tests := []struct {
+		name       string
+		sourceType SourceType
+		wantErr    error
+	}{
+		{"valid", SourceType("worker.tool"), nil},
+		{"empty", SourceType(""), ErrEmptySourceType},
+		{"whitespace only", SourceType("   "), ErrMalformedSourceType},
+		{"disallowed character", SourceType("worker tool"), ErrMalformedSourceType},
+		{"too long", SourceType(strings.Repeat("a", maxSourceTypeLength+1)), ErrMalformedSourceType},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.sourceType.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSourceIDValidate(t *testing.T) {
+	tests := []struct {
+		name     string
+		sourceID SourceID
+		wantErr  error
+	}{
+		{"valid", SourceID("worker-42"), nil},
+		{"empty", SourceID(""), ErrEmptySourceID},
+		{"disallowed character", SourceID("worker@42"), ErrMalformedSourceID},
+		{"too long", SourceID(strings.Repeat("a", maxSourceIDLength+1)), ErrMalformedSourceID},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.sourceID.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSourceSequenceValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		seq     SourceSequence
+		wantErr error
+	}{
+		{"zero is unset and invalid", SourceSequence(0), ErrInvalidSourceSequence},
+		{"one is the first valid sequence", SourceSequence(1), nil},
+		{"large sequence is valid", SourceSequence(1 << 40), nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.seq.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSourceEventIDValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      SourceEventID
+		wantErr error
+	}{
+		{"valid", SourceEventID("evt-1"), nil},
+		{"empty", SourceEventID(""), ErrEmptySourceEventID},
+		{"disallowed character", SourceEventID("evt 1"), ErrMalformedSourceEventID},
+		{"too long", SourceEventID(strings.Repeat("a", maxSourceEventIDLength+1)), ErrMalformedSourceEventID},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.id.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSchemaIDValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      SchemaID
+		wantErr error
+	}{
+		{"valid", SchemaID("worker.output.v1"), nil},
+		{"empty", SchemaID(""), ErrEmptySchemaID},
+		{"disallowed character", SchemaID("worker output v1"), ErrMalformedSchemaID},
+		{"too long", SchemaID(strings.Repeat("a", maxSchemaIDLength+1)), ErrMalformedSchemaID},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.id.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAggregateSequenceValidateAssigned(t *testing.T) {
+	tests := []struct {
+		name    string
+		seq     AggregateSequence
+		wantErr error
+	}{
+		{"zero means before the first record and is not an assigned position", AggregateSequence(0), ErrInvalidAggregateSequence},
+		{"one is the first assigned position", AggregateSequence(1), nil},
+		{"large position is valid", AggregateSequence(1 << 40), nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.seq.ValidateAssigned(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("ValidateAssigned() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRecordIDValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      RecordID
+		wantErr error
+	}{
+		{
+			name:    "valid",
+			id:      RecordID{Topic: "chat-session/abc/events", Position: 1},
+			wantErr: nil,
+		},
+		{
+			name:    "zero value is invalid",
+			id:      RecordID{},
+			wantErr: ErrEmptyTopic,
+		},
+		{
+			name:    "malformed topic",
+			id:      RecordID{Topic: " chat-session/abc/events", Position: 1},
+			wantErr: ErrMalformedTopic,
+		},
+		{
+			name:    "unassigned position with a valid topic",
+			id:      RecordID{Topic: "chat-session/abc/events", Position: 0},
+			wantErr: ErrInvalidAggregateSequence,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.id.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/services/events/read_subscribe.go
+++ b/pkg/services/events/read_subscribe.go
@@ -1,0 +1,162 @@
+package events
+
+import "context"
+
+// ReadRequest asks Events for a bounded slice of a topic's aggregate
+// ordering, starting after From.
+type ReadRequest struct {
+	Topic Topic
+	From  Cursor
+	Limit int
+}
+
+// Validate reports whether r names a well-formed, topic-bound read.
+func (r ReadRequest) Validate() error {
+	if err := r.Topic.Validate(); err != nil {
+		return err
+	}
+	if err := r.From.Validate(); err != nil {
+		return err
+	}
+	if !r.From.BelongsTo(r.Topic) {
+		return ErrCursorTopicMismatch
+	}
+	if r.Limit <= 0 {
+		return ErrInvalidReadLimit
+	}
+	return nil
+}
+
+// ReadOutcome is one explicit Read observation. A caller never infers
+// missing history from an empty Records slice: Outcome states whether the
+// read progressed, was already at the live head, used an invalid or
+// mismatched cursor, or lost history to retention.
+type ReadOutcome int
+
+const (
+	ReadOutcomeUnspecified ReadOutcome = iota
+	// ReadOutcomeProgress reports one or more records read past From.
+	ReadOutcomeProgress
+	// ReadOutcomeAtHead reports that From already names the live head; no
+	// records were available to read.
+	ReadOutcomeAtHead
+	// ReadOutcomeInvalidCursor reports that From does not name a position
+	// Events can resolve.
+	ReadOutcomeInvalidCursor
+	// ReadOutcomeGap reports that From names a position no longer
+	// retained; Gap describes the resumable position.
+	ReadOutcomeGap
+)
+
+// GapFacts identifies a retention gap: the position a caller requested, the
+// earliest position Events still retains, and the topic's live head where
+// known. A caller uses GapFacts to surface or recover from loss without
+// fabricating records or parsing an error string.
+type GapFacts struct {
+	Topic            Topic
+	Requested        AggregateSequence
+	EarliestRetained AggregateSequence
+	Head             AggregateSequence
+}
+
+// ReadResult is the detached outcome of one Read call.
+type ReadResult struct {
+	Records  []Record
+	Next     Cursor
+	Retained RetainedRange
+	Outcome  ReadOutcome
+	Gap      *GapFacts
+}
+
+// Validate reports whether res is internally consistent: Records, Gap, and
+// Outcome agree with each other so a caller cannot infer missing history
+// from an empty success.
+func (res ReadResult) Validate() error {
+	switch res.Outcome {
+	case ReadOutcomeProgress:
+		if len(res.Records) == 0 || res.Gap != nil {
+			return ErrInconsistentReadOutcome
+		}
+	case ReadOutcomeAtHead, ReadOutcomeInvalidCursor:
+		if len(res.Records) != 0 || res.Gap != nil {
+			return ErrInconsistentReadOutcome
+		}
+	case ReadOutcomeGap:
+		if len(res.Records) != 0 || res.Gap == nil {
+			return ErrInconsistentReadOutcome
+		}
+	default:
+		return ErrInconsistentReadOutcome
+	}
+	return nil
+}
+
+// SubscribeRequest asks Events for ongoing delivery of a topic's aggregate
+// ordering starting after From, bounded per delivery by Limit.
+type SubscribeRequest struct {
+	Topic Topic
+	From  Cursor
+	Limit int
+}
+
+// Validate reports whether r names a well-formed, topic-bound subscription.
+func (r SubscribeRequest) Validate() error {
+	if err := r.Topic.Validate(); err != nil {
+		return err
+	}
+	if err := r.From.Validate(); err != nil {
+		return err
+	}
+	if !r.From.BelongsTo(r.Topic) {
+		return ErrCursorTopicMismatch
+	}
+	if r.Limit <= 0 {
+		return ErrInvalidReadLimit
+	}
+	return nil
+}
+
+// DeliveryKind is one explicit subscription observation.
+type DeliveryKind int
+
+const (
+	DeliveryUnspecified DeliveryKind = iota
+	// DeliveryRecord reports one delivered Record and the Cursor the
+	// subscription advanced to.
+	DeliveryRecord
+	// DeliveryGap reports a retention gap; Gap describes the resumable
+	// position and no record is fabricated in its place.
+	DeliveryGap
+	// DeliveryClosed reports a normal, expected end of delivery.
+	DeliveryClosed
+	// DeliveryCanceled reports that delivery ended because its context was
+	// canceled.
+	DeliveryCanceled
+	// DeliveryBackpressure reports that delivery ended because the
+	// consumer could not keep up; it is an explicit terminal outcome, never
+	// silent loss.
+	DeliveryBackpressure
+)
+
+// Delivery is one observation from a Subscription. Record and Cursor are
+// set only for DeliveryRecord; Gap is set only for DeliveryGap.
+type Delivery struct {
+	Kind   DeliveryKind
+	Record Record
+	Cursor Cursor
+	Gap    *GapFacts
+}
+
+// Subscription observes the next Delivery for one Subscribe call. Next may
+// block until a record, gap, close, or context cancellation is available; it
+// does not prescribe channels, buffers, goroutines, or transport framing.
+type Subscription func(context.Context) Delivery
+
+// Next observes the next Delivery. A nil Subscription reports
+// DeliveryClosed.
+func (s Subscription) Next(ctx context.Context) Delivery {
+	if s == nil {
+		return Delivery{Kind: DeliveryClosed}
+	}
+	return s(ctx)
+}

--- a/pkg/services/events/read_subscribe_test.go
+++ b/pkg/services/events/read_subscribe_test.go
@@ -1,0 +1,164 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+const testTopic Topic = "chat-session/abc/events"
+
+func TestReadRequestValidate(t *testing.T) {
+	valid := ReadRequest{Topic: testTopic, From: Cursor{Topic: testTopic, Position: 2}, Limit: 10}
+
+	tests := []struct {
+		name    string
+		mutate  func(ReadRequest) ReadRequest
+		wantErr error
+	}{
+		{"valid", func(r ReadRequest) ReadRequest { return r }, nil},
+		{"missing topic", func(r ReadRequest) ReadRequest { r.Topic = ""; return r }, ErrEmptyTopic},
+		{"invalid cursor", func(r ReadRequest) ReadRequest { r.From = Cursor{}; return r }, ErrEmptyTopic},
+		{
+			name: "cursor from a different topic",
+			mutate: func(r ReadRequest) ReadRequest {
+				r.From = Cursor{Topic: "factory-session/abc/response-events"}
+				return r
+			},
+			wantErr: ErrCursorTopicMismatch,
+		},
+		{"zero limit", func(r ReadRequest) ReadRequest { r.Limit = 0; return r }, ErrInvalidReadLimit},
+		{"negative limit", func(r ReadRequest) ReadRequest { r.Limit = -1; return r }, ErrInvalidReadLimit},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := tt.mutate(valid)
+			if err := req.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSubscribeRequestValidate(t *testing.T) {
+	valid := SubscribeRequest{Topic: testTopic, From: Cursor{Topic: testTopic}, Limit: 1}
+
+	tests := []struct {
+		name    string
+		mutate  func(SubscribeRequest) SubscribeRequest
+		wantErr error
+	}{
+		{"valid", func(r SubscribeRequest) SubscribeRequest { return r }, nil},
+		{"missing topic", func(r SubscribeRequest) SubscribeRequest { r.Topic = ""; return r }, ErrEmptyTopic},
+		{
+			name: "cursor from a different topic",
+			mutate: func(r SubscribeRequest) SubscribeRequest {
+				r.From = Cursor{Topic: "factory-session/abc/response-events"}
+				return r
+			},
+			wantErr: ErrCursorTopicMismatch,
+		},
+		{"zero limit", func(r SubscribeRequest) SubscribeRequest { r.Limit = 0; return r }, ErrInvalidReadLimit},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := tt.mutate(valid)
+			if err := req.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestReadResultValidate(t *testing.T) {
+	rec := Record{ID: RecordID{Topic: testTopic, Position: 1}}
+	gap := &GapFacts{Topic: testTopic, Requested: 1, EarliestRetained: 5, Head: 9}
+
+	tests := []struct {
+		name    string
+		result  ReadResult
+		wantErr error
+	}{
+		{"progress with records", ReadResult{Outcome: ReadOutcomeProgress, Records: []Record{rec}}, nil},
+		{"progress with no records is inconsistent", ReadResult{Outcome: ReadOutcomeProgress}, ErrInconsistentReadOutcome},
+		{"at head with no records", ReadResult{Outcome: ReadOutcomeAtHead}, nil},
+		{"at head with records is inconsistent", ReadResult{Outcome: ReadOutcomeAtHead, Records: []Record{rec}}, ErrInconsistentReadOutcome},
+		{"invalid cursor with no records", ReadResult{Outcome: ReadOutcomeInvalidCursor}, nil},
+		{"gap with gap facts", ReadResult{Outcome: ReadOutcomeGap, Gap: gap}, nil},
+		{"gap without gap facts is inconsistent", ReadResult{Outcome: ReadOutcomeGap}, ErrInconsistentReadOutcome},
+		{"gap with fabricated records is inconsistent", ReadResult{Outcome: ReadOutcomeGap, Gap: gap, Records: []Record{rec}}, ErrInconsistentReadOutcome},
+		{"unspecified outcome is inconsistent", ReadResult{}, ErrInconsistentReadOutcome},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.result.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGapFactsIdentifyResumablePosition(t *testing.T) {
+	gap := GapFacts{Topic: testTopic, Requested: 3, EarliestRetained: 10, Head: 40}
+
+	if gap.Topic != testTopic {
+		t.Fatalf("Topic = %v, want %v", gap.Topic, testTopic)
+	}
+	if gap.EarliestRetained <= gap.Requested {
+		t.Fatalf("EarliestRetained = %d, want greater than Requested %d to describe real loss", gap.EarliestRetained, gap.Requested)
+	}
+	if gap.Head < gap.EarliestRetained {
+		t.Fatalf("Head = %d, want >= EarliestRetained %d", gap.Head, gap.EarliestRetained)
+	}
+}
+
+func TestSubscriptionNext(t *testing.T) {
+	rec := Record{ID: RecordID{Topic: testTopic, Position: 1}}
+	delivered := Delivery{Kind: DeliveryRecord, Record: rec, Cursor: Cursor{Topic: testTopic, Position: 1}}
+
+	var sub Subscription = func(ctx context.Context) Delivery {
+		return delivered
+	}
+
+	got := sub.Next(context.Background())
+	if got.Kind != delivered.Kind || got.Record.ID != delivered.Record.ID || got.Cursor != delivered.Cursor {
+		t.Fatalf("Next() = %+v, want %+v", got, delivered)
+	}
+}
+
+func TestNilSubscriptionReportsClosed(t *testing.T) {
+	var sub Subscription
+
+	got := sub.Next(context.Background())
+	if got.Kind != DeliveryClosed {
+		t.Fatalf("Next().Kind = %v, want DeliveryClosed for a nil Subscription", got.Kind)
+	}
+}
+
+func TestSubscriptionReportsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var sub Subscription = func(ctx context.Context) Delivery {
+		if ctx.Err() != nil {
+			return Delivery{Kind: DeliveryCanceled}
+		}
+		return Delivery{Kind: DeliveryRecord}
+	}
+
+	got := sub.Next(ctx)
+	if got.Kind != DeliveryCanceled {
+		t.Fatalf("Next().Kind = %v, want DeliveryCanceled once the context is canceled", got.Kind)
+	}
+}
+
+func TestSubscriptionReportsBackpressureTermination(t *testing.T) {
+	var sub Subscription = func(ctx context.Context) Delivery {
+		return Delivery{Kind: DeliveryBackpressure}
+	}
+
+	got := sub.Next(context.Background())
+	if got.Kind != DeliveryBackpressure {
+		t.Fatalf("Next().Kind = %v, want DeliveryBackpressure as an explicit terminal outcome, never silent loss", got.Kind)
+	}
+}

--- a/pkg/services/events/service.go
+++ b/pkg/services/events/service.go
@@ -1,0 +1,14 @@
+package events
+
+import "context"
+
+// Service is the singular Events root contract: append, attach a source,
+// read, and subscribe over one process-local, in-memory event stream (D1,
+// D2 in docs/internal/projects/acp-program/README.md). Peers depend on
+// Service rather than a store, journal, or transport type.
+type Service interface {
+	Append(context.Context, AppendRequest) (AppendResult, error)
+	AttachSource(context.Context, AttachSourceRequest) (AttachSourceResult, error)
+	Read(context.Context, ReadRequest) (ReadResult, error)
+	Subscribe(context.Context, SubscribeRequest) (Subscription, error)
+}


### PR DESCRIPTION
## PRD

```json
{
  "project": "Publish the In-Memory Events Stream Contract",
  "branchName": "ACP-L1-E01-events-contracts",
  "description": "Publish the L1 V0 contract-only public root for a process-local Events stream. The concrete change adds detached topic, source, record, cursor, retention, gap, append, source-attachment, read, subscribe, and delivery contracts around source-native JSON. The intent is to give ACP Core and later Worker Events one stable session-scoped boundary while Recordings remains the canonical durable ledger and Events introduces neither persistence nor a second event taxonomy.",
  "context": {
    "customerAsk": "Implement L1 V0 Events contracts under decisions D1 and D2 in pkg/services/events: expose one public Events Service with AppendRequest, AttachSourceRequest, ReadRequest, SubscribeRequest, detached topic/source/cursor/retention/gap/subscription values, source-native JSON payload handling, and explicit cursor and gap outcomes. Do not change OpenAPI or ACP projections, add an internal/store package or durable journal, replace Recordings, create a normalized event taxonomy, or implement the V2 runtime.",
    "problem": "ACP Core and later Worker Events need one stable session-scoped stream boundary for append, source attachment, retained reads, and subscriptions. Without it, consumers will invent incompatible topic/source identities, couple to Factory Session internals, silently mistake expired history for empty success, or create competing event taxonomies and persistence ownership.",
    "solution": "Add a small public Go package root with detached value contracts, deterministic validation, typed/classifiable errors and expected outcomes, and one Service interface containing Append, AttachSource, Read, and Subscribe. Preserve source-native JSON inside delivery envelopes, bind cursors to stream identity, and make retention gaps and delivery termination explicit. Prove the contract with focused table-driven and external-consumer tests while deferring all mutable state, persistence, sequencing, retention, subscription implementation, construction, and transport work."
  },
  "acceptanceCriteria": [
    "AC-1: pkg/services/events exposes one public Service with detached append, attach-source, read, and subscribe request/result values usable without importing an implementation, transport, or another service's private packages.",
    "AC-2: Topic, source, record, sequence, cursor, retention, and idempotency identities have deterministic validation and documented zero-value semantics, and source-native JSON crosses the contract without conversion to an Events-owned taxonomy.",
    "AC-3: Reads and subscriptions explicitly distinguish successful progress, at-head, invalid or mismatched cursors, retention gaps, and terminal delivery outcomes so callers never infer missing history from empty success or parse error strings.",
    "AC-4: The slice preserves D1/D2 ownership: Recordings remains the canonical durable ledger, Events is process-local and in-memory only, and no implementation, store package, durable journal, recordings migration, OpenAPI/ACP projection, or unrelated cleanup is added.",
    "AC-5: Focused table-driven tests cover validation, detached payload behavior, error classification, and cursor/gap outcomes, and an external-package consumer test provides package-boundary evidence without meta-tests.",
    "AC-6: Quality gates pass: Typecheck, lint, focused Go tests, make pkg-file-count, and make pkg-boundary.",
    "AC-7: The implementation/review loop continues until required CI is terminal and passing, every blocking PR conversation is explicitly addressed, merge conflicts and shared-file changes are reconciled, and the PR is actually merged; an opened, green, approved, or ready-to-merge PR is not complete."
  ],
  "userStories": [
    {
      "id": "ACP-L1-E01-events-contracts-001",
      "title": "Identify topics, sources, and stream positions",
      "description": "As an Events producer or consumer, I need stable detached identities and positions so that I can name a session-scoped stream and its source without depending on storage or transport details.",
      "acceptanceCriteria": [
        "Public values represent topic identity, source type and ID, source sequence and event ID, schema identity, aggregate sequence, cursor, and retained range/head positions needed by append, attachment, read, and subscribe operations.",
        "Topic and source identities can represent factory-session/<id>/response-events and chat-session/<id>/events without hard-coding those topic families as the only valid future topics.",
        "Validation deterministically rejects empty, malformed, zero, or internally inconsistent identities and positions where they cannot name a valid operation; valid values remain detached from transport and persistence types.",
        "Cursor values carry enough topic/stream identity to reject use against a different stream rather than accidentally reading from the wrong topic.",
        "Table-driven tests prove valid and invalid identity, sequence, cursor, and retained-position cases through public behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented in pkg/services/events/identity.go and cursor.go: Topic, SourceType, SourceID, SourceSequence, SourceEventID, SchemaID, AggregateSequence, RecordID, Cursor, RetainedRange with Validate()/ValidateAssigned()/BelongsTo(). Covered by identity_test.go and cursor_test.go."
    },
    {
      "id": "ACP-L1-E01-events-contracts-002",
      "title": "Append source-native records idempotently",
      "description": "As an event producer, I need an append envelope that preserves my native JSON and source identity so that retries can be recognized without redefining my event vocabulary.",
      "acceptanceCriteria": [
        "AppendRequest identifies the destination topic, source type and ID, source sequence, source event ID, schema ID, and source-native JSON payload; (sourceType, sourceID, sourceSequence, sourceEventID) is the explicit idempotency identity.",
        "The public record and append result preserve source metadata and distinguish a newly accepted append from a duplicate/idempotent append while reporting the stable aggregate record identity assigned in either case.",
        "Validation rejects missing identity fields, invalid sequences, empty or invalid JSON payloads, and inconsistent envelopes with typed/classifiable invalid-request outcomes rather than error-string matching.",
        "Requests and returned records defensively detach payload bytes so caller mutation cannot alter the value observed across the public contract; tests use representative source-native Worker payload JSON without interpreting it as an Events-owned kind union.",
        "Table-driven tests prove valid envelopes, every required-field failure, invalid JSON handling, append outcome values, error classification, and payload detachment.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented in pkg/services/events/append.go: AppendRequest/Record/AppendResult/AppendOutcome/AppendIdentity with Validate(), Identity(), and Detached() (defensive payload copy). Covered by append_test.go."
    },
    {
      "id": "ACP-L1-E01-events-contracts-003",
      "title": "Attach a source without embedding dependencies",
      "description": "As an aggregate-stream owner, I need to describe a source attachment so that a later in-memory sequencer can follow a source from an explicit position without receiving a service, callback, or store handle.",
      "acceptanceCriteria": [
        "AttachSourceRequest uses detached identities to name the destination topic, source topic/source identity, and explicit starting or correlation cursor required for later sequencing.",
        "Attachment results distinguish a newly accepted attachment from an already-attached/idempotent outcome and return stable attachment/source correlation values suitable for callers to retain.",
        "Validation rejects self-attachment, missing or incompatible source/destination identities, invalid starting positions, and unsupported attachment modes with typed/classifiable outcomes.",
        "The attachment contract contains no embedded service, resolver, callback, channel, store, transport, or dependency bag and makes no claim that historical source data is durable.",
        "Table-driven tests prove valid attachment shapes, idempotent outcome values, failure classification, and incompatible/self-attachment cases.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented in pkg/services/events/attach.go: AttachSourceRequest/AttachSourceResult/AttachmentID/AttachMode/AttachOutcome with Validate() rejecting self-attachment, incompatible cursor topic, and unsupported modes. Covered by attach_test.go."
    },
    {
      "id": "ACP-L1-E01-events-contracts-004",
      "title": "Read and subscribe with explicit cursor and gap outcomes",
      "description": "As an event-stream consumer, I need reads and subscriptions to state whether I advanced, reached the live head, used an invalid cursor, or lost data to retention so that I never fabricate continuity.",
      "acceptanceCriteria": [
        "One public Service exposes Append, AttachSource, Read, and Subscribe with context.Context and detached typed request/result contracts; no second operational service or package-level operational API is introduced.",
        "ReadRequest and ReadResult represent a topic-bound starting cursor, bounded reads, returned records, next cursor, retained range/live head, and explicit progress, at-head, invalid-cursor, and retention-gap outcomes.",
        "SubscribeRequest represents the same cursor and bounded-delivery semantics needed for retained-then-live consumption, and the returned subscription/delivery contract reports records, cursor advancement, gaps, normal close, context cancellation, and slow-consumer/backpressure termination without silent loss.",
        "Gap values identify the requested position and the earliest retained/resumable position, and stream head where known, enabling a caller to surface or recover from loss without fabricated records or string parsing.",
        "Read/subscribe validation and typed errors distinguish malformed requests, unknown or mismatched topics/cursors, unsupported modes, and operation failures from expected at-head/gap/terminal outcomes.",
        "External-package compile-time consumer tests prove a fake can implement the root Service and consume the subscription contract using only exported detached values; table-driven tests prove read, cursor, gap, and terminal-delivery outcome semantics without scanning source topology.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Implemented in pkg/services/events/read_subscribe.go and service.go: ReadRequest/ReadResult/ReadOutcome/GapFacts, SubscribeRequest/Delivery/DeliveryKind/Subscription (function-type, mirrors recordings.EventSubscription), and the single Service interface. Covered by read_subscribe_test.go and the external-package events_external_test.go (package events_test)."
    }
  ]
}

```
