### PR TITLE
Add Chat Sessions Factory Sessions shim

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -227,6 +227,20 @@
       }
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/factorysessionsshim",
+      "minimum": 0.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/edges",
       "minimum": 66.14
     },

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -238,7 +238,13 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/factorysessionsshim",
-      "minimum": 0.00
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/edges",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -216,7 +216,13 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions",
-      "minimum": 0.00
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active unit coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
+      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/factorysessionsshim",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -215,6 +215,14 @@
       "minimum": 84.61
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions",
+      "minimum": 0.00
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/factorysessionsshim",
+      "minimum": 100.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/edges",
       "minimum": 71.65
     },

--- a/pkg/services/chat_sessions/contracts.go
+++ b/pkg/services/chat_sessions/contracts.go
@@ -1,0 +1,29 @@
+package chatsessions
+
+import (
+	"context"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+)
+
+// Service is the singular Chat Sessions root contract. It currently exposes
+// only the Factory-target execution capabilities the L1 Chat Sessions flows
+// need: start one Factory Session, invoke it, cancel the captured turn, and
+// close the session. Requests, results, and errors are the published
+// factory_sessions root vocabulary, unmodified; peers do not import
+// factory_sessions directly for these operations, and Service does not
+// reinterpret results or reach into Factory Sessions internals.
+type Service interface {
+	StartFactoryTarget(context.Context, factorysessions.StartRequest) (factorysessions.AsyncStartResult, error)
+	InvokeFactoryTarget(
+		context.Context,
+		string,
+		factorysessions.InvocationRequest,
+	) (factorysessions.InvocationResult, error)
+	CancelFactoryTarget(
+		context.Context,
+		string,
+		factorysessions.ControlRequest,
+	) (factorysessions.LifecycleControlResult, error)
+	CloseFactoryTarget(context.Context, string) error
+}

--- a/pkg/services/chat_sessions/doc.go
+++ b/pkg/services/chat_sessions/doc.go
@@ -1,0 +1,15 @@
+// Package chatsessions is the public Chat Sessions service boundary.
+//
+// Peer-facing root contract (source of truth for published slices):
+//   - Service — singular cross-service seam
+//
+// Chat Sessions currently owns only the narrow Factory-target execution
+// dependency described on Service: start, invoke, cancel, and close one
+// Factory Session, in the published factory_sessions root vocabulary.
+// internal/factorysessionsshim is the sole implementation, adapting the
+// public factory_sessions.Service root without importing its internals or
+// becoming a second session authority. It is registered under "Shims
+// registered for deletion" in
+// docs/internal/projects/root-consolidation/proposal.md, retired at L3
+// Factory Sessions sealing.
+package chatsessions

--- a/pkg/services/chat_sessions/internal/factorysessionsshim/doc.go
+++ b/pkg/services/chat_sessions/internal/factorysessionsshim/doc.go
@@ -1,0 +1,9 @@
+// Package factorysessionsshim is the Chat Sessions-owned adapter over the
+// public factory_sessions.Service root. It exposes only the Factory-target
+// start, invoke, cancel, and close capabilities Chat Sessions needs and
+// delegates each call exactly once, unmodified, to the injected root. It is
+// registered under "Shims registered for deletion" in
+// docs/internal/projects/root-consolidation/proposal.md, retired at L3
+// Factory Sessions sealing; it must not grow into a second session
+// authority.
+package factorysessionsshim

--- a/pkg/services/chat_sessions/internal/factorysessionsshim/shim.go
+++ b/pkg/services/chat_sessions/internal/factorysessionsshim/shim.go
@@ -1,0 +1,58 @@
+package factorysessionsshim
+
+import (
+	"context"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+)
+
+// Shim adapts the public factory_sessions.Service root to the Chat Sessions
+// chatsessions.Service contract. It is stateless: it holds only the injected
+// Service and forwards each call exactly once, with the original context,
+// identifiers, request, result, and error intact.
+type Shim struct {
+	service factorysessions.Service
+}
+
+var _ chatsessions.Service = (*Shim)(nil)
+
+// New constructs the Factory Sessions shim over the given public Service.
+func New(service factorysessions.Service) *Shim {
+	return &Shim{service: service}
+}
+
+// StartFactoryTarget delegates exactly once to the existing asynchronous
+// Factory Sessions start operation.
+func (shim *Shim) StartFactoryTarget(
+	ctx context.Context,
+	request factorysessions.StartRequest,
+) (factorysessions.AsyncStartResult, error) {
+	return shim.service.StartAsync(ctx, request)
+}
+
+// InvokeFactoryTarget delegates exactly once to the existing Factory Session
+// invocation operation.
+func (shim *Shim) InvokeFactoryTarget(
+	ctx context.Context,
+	sessionID string,
+	request factorysessions.InvocationRequest,
+) (factorysessions.InvocationResult, error) {
+	return shim.service.InvokeFactorySession(ctx, sessionID, request)
+}
+
+// CancelFactoryTarget delegates exactly once to the existing public Factory
+// Sessions cancel operation.
+func (shim *Shim) CancelFactoryTarget(
+	ctx context.Context,
+	sessionID string,
+	request factorysessions.ControlRequest,
+) (factorysessions.LifecycleControlResult, error) {
+	return shim.service.Cancel(ctx, sessionID, request)
+}
+
+// CloseFactoryTarget delegates exactly once to the existing public Factory
+// Session close operation.
+func (shim *Shim) CloseFactoryTarget(ctx context.Context, sessionID string) error {
+	return shim.service.CloseFactorySession(ctx, sessionID)
+}

--- a/pkg/services/chat_sessions/internal/factorysessionsshim/shim_test.go
+++ b/pkg/services/chat_sessions/internal/factorysessionsshim/shim_test.go
@@ -1,0 +1,237 @@
+package factorysessionsshim
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+)
+
+// recordingFactorySessionsService is a recording fake over
+// factorysessions.Service. It embeds the interface unimplemented so any call
+// to a capability beyond Start/Invoke/Cancel/Close panics on a nil method
+// value, proving the shim never reaches beyond its four delegated operations.
+type recordingFactorySessionsService struct {
+	factorysessions.Service
+
+	startCalls  []factorysessions.StartRequest
+	startResult factorysessions.AsyncStartResult
+	startErr    error
+
+	invokeCalls  []invokeCall
+	invokeResult factorysessions.InvocationResult
+	invokeErr    error
+
+	cancelCalls  []cancelCall
+	cancelResult factorysessions.LifecycleControlResult
+	cancelErr    error
+
+	closeCalls []string
+	closeErr   error
+}
+
+type invokeCall struct {
+	sessionID string
+	request   factorysessions.InvocationRequest
+}
+
+type cancelCall struct {
+	sessionID string
+	request   factorysessions.ControlRequest
+}
+
+func (fake *recordingFactorySessionsService) StartAsync(
+	_ context.Context,
+	request factorysessions.StartRequest,
+) (factorysessions.AsyncStartResult, error) {
+	fake.startCalls = append(fake.startCalls, request)
+	return fake.startResult, fake.startErr
+}
+
+func (fake *recordingFactorySessionsService) InvokeFactorySession(
+	_ context.Context,
+	sessionID string,
+	request factorysessions.InvocationRequest,
+) (factorysessions.InvocationResult, error) {
+	fake.invokeCalls = append(fake.invokeCalls, invokeCall{sessionID: sessionID, request: request})
+	return fake.invokeResult, fake.invokeErr
+}
+
+func (fake *recordingFactorySessionsService) Cancel(
+	_ context.Context,
+	sessionID string,
+	request factorysessions.ControlRequest,
+) (factorysessions.LifecycleControlResult, error) {
+	fake.cancelCalls = append(fake.cancelCalls, cancelCall{sessionID: sessionID, request: request})
+	return fake.cancelResult, fake.cancelErr
+}
+
+func (fake *recordingFactorySessionsService) CloseFactorySession(_ context.Context, sessionID string) error {
+	fake.closeCalls = append(fake.closeCalls, sessionID)
+	return fake.closeErr
+}
+
+func TestShimStart(t *testing.T) {
+	tests := []struct {
+		name   string
+		result factorysessions.AsyncStartResult
+		err    error
+	}{
+		{
+			name:   "success",
+			result: factorysessions.AsyncStartResult{SessionID: "session-1", Status: "RUNNING"},
+		},
+		{
+			name: "provider error",
+			err:  errors.New("start failed"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &recordingFactorySessionsService{startResult: tt.result, startErr: tt.err}
+			shim := New(fake)
+			request := factorysessions.StartRequest{RequestID: "req-1", Args: map[string]any{"k": "v"}}
+
+			got, err := shim.StartFactoryTarget(context.Background(), request)
+
+			if len(fake.startCalls) != 1 {
+				t.Fatalf("StartAsync call count = %d, want 1", len(fake.startCalls))
+			}
+			if !reflect.DeepEqual(fake.startCalls[0], request) {
+				t.Fatalf("StartAsync request = %#v, want %#v", fake.startCalls[0], request)
+			}
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("StartFactoryTarget() error = %v, want %v", err, tt.err)
+			}
+			if !reflect.DeepEqual(got, tt.result) {
+				t.Fatalf("StartFactoryTarget() result = %#v, want %#v", got, tt.result)
+			}
+		})
+	}
+}
+
+func TestShimInvoke(t *testing.T) {
+	tests := []struct {
+		name   string
+		result factorysessions.InvocationResult
+		err    error
+	}{
+		{
+			name:   "success",
+			result: factorysessions.InvocationResult{RequestID: "req-1", SessionID: "session-1", Status: factorysessions.InvocationTerminalStatusCompleted},
+		},
+		{
+			name: "provider error",
+			err:  errors.New("invoke failed"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &recordingFactorySessionsService{invokeResult: tt.result, invokeErr: tt.err}
+			shim := New(fake)
+			request := factorysessions.InvocationRequest{RequestID: strPtr("req-1")}
+
+			got, err := shim.InvokeFactoryTarget(context.Background(), "session-1", request)
+
+			if len(fake.invokeCalls) != 1 {
+				t.Fatalf("InvokeFactorySession call count = %d, want 1", len(fake.invokeCalls))
+			}
+			if fake.invokeCalls[0].sessionID != "session-1" || !reflect.DeepEqual(fake.invokeCalls[0].request, request) {
+				t.Fatalf("InvokeFactorySession call = %#v, want session-1 / %#v", fake.invokeCalls[0], request)
+			}
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("InvokeFactoryTarget() error = %v, want %v", err, tt.err)
+			}
+			if !reflect.DeepEqual(got, tt.result) {
+				t.Fatalf("InvokeFactoryTarget() result = %#v, want %#v", got, tt.result)
+			}
+			if len(fake.startCalls) != 0 {
+				t.Fatalf("StartAsync call count = %d, want 0", len(fake.startCalls))
+			}
+		})
+	}
+}
+
+func TestShimCancel(t *testing.T) {
+	tests := []struct {
+		name   string
+		result factorysessions.LifecycleControlResult
+		err    error
+	}{
+		{
+			name:   "success",
+			result: factorysessions.LifecycleControlResult{SessionID: "session-1", Outcome: "CANCELED"},
+		},
+		{
+			name: "provider error",
+			err:  errors.New("cancel failed"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &recordingFactorySessionsService{cancelResult: tt.result, cancelErr: tt.err}
+			shim := New(fake)
+			request := factorysessions.ControlRequest{RequestID: "req-1", Reason: "user requested"}
+
+			got, err := shim.CancelFactoryTarget(context.Background(), "session-1", request)
+
+			if len(fake.cancelCalls) != 1 {
+				t.Fatalf("Cancel call count = %d, want 1", len(fake.cancelCalls))
+			}
+			if fake.cancelCalls[0].sessionID != "session-1" || !reflect.DeepEqual(fake.cancelCalls[0].request, request) {
+				t.Fatalf("Cancel call = %#v, want session-1 / %#v", fake.cancelCalls[0], request)
+			}
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("CancelFactoryTarget() error = %v, want %v", err, tt.err)
+			}
+			if !reflect.DeepEqual(got, tt.result) {
+				t.Fatalf("CancelFactoryTarget() result = %#v, want %#v", got, tt.result)
+			}
+			if len(fake.startCalls) != 0 || len(fake.invokeCalls) != 0 || len(fake.closeCalls) != 0 {
+				t.Fatalf(
+					"unexpected delegation: start=%d invoke=%d close=%d, want all 0",
+					len(fake.startCalls), len(fake.invokeCalls), len(fake.closeCalls),
+				)
+			}
+		})
+	}
+}
+
+func TestShimClose(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "success"},
+		{name: "provider error", err: errors.New("close failed")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &recordingFactorySessionsService{closeErr: tt.err}
+			shim := New(fake)
+
+			err := shim.CloseFactoryTarget(context.Background(), "session-1")
+
+			if len(fake.closeCalls) != 1 || fake.closeCalls[0] != "session-1" {
+				t.Fatalf("CloseFactorySession calls = %#v, want [session-1]", fake.closeCalls)
+			}
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("CloseFactoryTarget() error = %v, want %v", err, tt.err)
+			}
+			if len(fake.startCalls) != 0 || len(fake.invokeCalls) != 0 || len(fake.cancelCalls) != 0 {
+				t.Fatalf(
+					"unexpected delegation: start=%d invoke=%d cancel=%d, want all 0",
+					len(fake.startCalls), len(fake.invokeCalls), len(fake.cancelCalls),
+				)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }


### PR DESCRIPTION
## PRD

```json
{
  "project": "Create the Chat-Owned Factory Sessions Shim",
  "branchName": "ACP-L1-V0-factory-sessions-shim",
  "description": "Create the narrow consumer-owned Factory Sessions adapter required by Chat Sessions for future Factory-target start, invoke, cancel, and close behavior, preserving the existing provider root's behavior while explicitly tracking the shim for L3 retirement.",
  "context": {
    "customerAsk": "Add pkg/services/chat_sessions/internal/factorysessionsshim as the narrow consumer-owned adapter needed for future Factory target start, invoke, cancel, and close behavior. It must consume only the public factory_sessions root, expose the smallest testable Chat-owned port, include compile-time and delegation evidence, change no Factory Sessions behavior, preserve the root-consolidation shim register and its L3 retirement condition, and complete delivery through CI, review, and merge.",
    "problem": "The current Factory Sessions root exposes 45 methods and multiple overlapping lifecycle families. Depending on that broad root directly would couple Chat Sessions to capabilities it does not own or need, while waiting for L2/L3 root sealing would unnecessarily block ACP Core. A narrow boundary is required now, but it must not become a new authority, reinterpret results, reach into provider internals, or silently outlive the root consolidation that makes it unnecessary.",
    "solution": "Introduce a stateless adapter inside the Chat Sessions ownership boundary. It accepts the existing public factory_sessions.Service, exposes only asynchronous start, invoke, cancel, and close, and delegates each call with the original context, identifiers, requests, results, and errors intact. Focused compile-time and recording-fake tests prove the narrow contract and exact delegation, while the existing root-consolidation register continues to assign retirement to L3 Factory Sessions sealing."
  },
  "acceptanceCriteria": [
    "Chat-owned code can depend on one narrow port containing only the Factory-target start, invoke, cancel, and close capabilities required by the L1 flows.",
    "The adapter imports only the public pkg/services/factory_sessions root and does not import Factory Sessions internals, create another session authority, or introduce runtime service discovery or secondary injection.",
    "Each adapter operation delegates exactly once to the corresponding existing public Factory Sessions operation and preserves context, request values, session identity, typed result, and error behavior.",
    "No Factory Sessions implementation, provider behavior, public API/OpenAPI contract, generated artifact, frontend behavior, or unrelated package is changed by this packet.",
    "The root-consolidation shim register accurately names chat_sessions/internal/factorysessionsshim, the broad factory_sessions.Service it adapts, and L3 Factory Sessions sealing as its retirement condition; no meta-test scans the register or repository topology.",
    "Typecheck, formatting, lint, focused delegation tests, and the required repository test/CI tier pass.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file reconciliation are complete, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "ACP-L1-V0-factory-sessions-shim-001",
      "title": "Delegate Factory target start and invoke",
      "description": "As a Chat Sessions implementer, I want one narrow Factory execution dependency so that a first Factory-target turn can start a session and later turns can invoke it without coupling Chat to the full Factory Sessions root.",
      "priority": 1,
      "passes": true
    },
    {
      "id": "ACP-L1-V0-factory-sessions-shim-002",
      "title": "Delegate Factory target cancel and close with explicit retirement",
      "description": "As a Chat Sessions implementer, I want the same narrow dependency to cancel the captured Factory turn and close its Factory Session so that future Chat lifecycle behavior uses the provider's existing outcomes without owning Factory Sessions policy.",
      "priority": 2,
      "passes": true
    }
  ]
}
```

## Summary

- Added `pkg/services/chat_sessions` as a new, minimal service root exposing exactly one narrow `Service` interface (`StartFactoryTarget`, `InvokeFactoryTarget`, `CancelFactoryTarget`, `CloseFactoryTarget`) using the published `factory_sessions` request/result/error vocabulary directly.
- Added `pkg/services/chat_sessions/internal/factorysessionsshim`, a stateless `Shim` that holds an injected `factorysessions.Service` and delegates each of the four operations exactly once (`StartAsync`, `InvokeFactorySession`, `Cancel`, `CloseFactorySession`), with no translation, retry, or reclassification.
- Compile-time proof: `var _ chatsessions.Service = (*Shim)(nil)`.
- Table-driven delegation tests use a recording fake that embeds `factorysessions.Service` unimplemented, so any accidental call outside the four wired methods panics — this is also the proof that `Cancel`/`Close` never call `Start`/`Invoke` or any other capability.
- `docs/internal/projects/root-consolidation/proposal.md` already lists `chat_sessions/internal/factorysessionsshim | factory_sessions.Service (45 methods) | L3 Factory Sessions sealing` in its shim register; left unchanged since it was already accurate.

## Known gap (flagged for reviewer)

`pkg/services/chat_sessions` is the first package under a brand-new top-level service directory. `go run ./cmd/ownershipinventorycheck` (wired into `make lint`, but **not** invoked anywhere in `.github/workflows/ci.yml`) enforces a closed 13-owner vocabulary in `internal/ownershipinventory/destinations.go`. Registering Chat Sessions as an officially governed 14th owner (owner rationale card, responsibility clusters, named-owner confirmation) is a separate, larger architecture decision explicitly deferred by `docs/internal/projects/root-consolidation/proposal.md` §2 ("package-structure checkers ... untouched") and was left out of this packet's scope. `go run ./cmd/pkgstructurecheck -root .` (the "exactly one root interface" rule) is satisfied.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l pkg/services/chat_sessions/` (clean)
- [x] `go test ./pkg/services/chat_sessions/...` (all pass)
- [x] `go run ./cmd/pkgstructurecheck -root .` (no chat_sessions violation)
- [x] `go run ./cmd/pkgboundarycheck -root .` (no chat_sessions violation; 94 pre-existing unrelated violations confirmed present on `main` too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
