### PR TITLE
Define the ACP Compatibility Contract and Shared Conformance Corpus

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -2895,6 +2895,10 @@
       }
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/acp",
+      "minimum": 89.55
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli",
       "minimum": 72.98
     },

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -2896,7 +2896,13 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/acp",
-      "minimum": 0.00
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -2896,7 +2896,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/acp",
-      "minimum": 89.55
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -2235,6 +2235,10 @@
       "minimum": 82.14
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/acp",
+      "minimum": 89.55
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli",
       "minimum": 71.22
     },

--- a/internal/testutil/acpconformance/corpus.go
+++ b/internal/testutil/acpconformance/corpus.go
@@ -1,0 +1,258 @@
+// Package acpconformance is the shared, sanitized ACP L1 V0 semantic
+// conformance corpus and its test-only reader. Both the Providers-owned
+// inbound ACP mapper and the pkg/transports/acp outbound compatibility
+// boundary consume it independently through this neutral package, so the two
+// protocol directions can be checked against the same expectations without
+// either importing the other's private implementation or sharing a
+// production mapper.
+package acpconformance
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"strings"
+	"testing"
+)
+
+//go:embed corpus.json
+var corpusJSON []byte
+
+// Directionality declares which protocol direction(s) a corpus case is
+// expected to support.
+type Directionality string
+
+const (
+	// DirectionRoundTrip marks a case in the lossless round-trip subset:
+	// both the inbound provider mapper and the outbound ACP transport are
+	// expected to preserve its declared semantic facts.
+	DirectionRoundTrip Directionality = "round_trip"
+	// DirectionInboundOnly marks a case only the Providers-owned inbound
+	// mapper is expected to honor.
+	DirectionInboundOnly Directionality = "inbound_only"
+	// DirectionOutboundOnly marks a case only the pkg/transports/acp
+	// outbound boundary is expected to honor.
+	DirectionOutboundOnly Directionality = "outbound_only"
+	// DirectionUnsupported marks a case whose payload must be rejected
+	// (an unsupported protocol version or method) rather than mapped.
+	DirectionUnsupported Directionality = "unsupported"
+	// DirectionNoOutput marks a case that is recognized but intentionally
+	// produces no response or text output.
+	DirectionNoOutput Directionality = "no_output"
+)
+
+var validDirectionality = map[Directionality]bool{
+	DirectionRoundTrip:    true,
+	DirectionInboundOnly:  true,
+	DirectionOutboundOnly: true,
+	DirectionUnsupported:  true,
+	DirectionNoOutput:     true,
+}
+
+// ProtocolRole declares which part of the ACP L1 V0 contract a case
+// exercises.
+type ProtocolRole string
+
+const (
+	RoleInitialize        ProtocolRole = "initialize"
+	RoleCapabilities      ProtocolRole = "capabilities"
+	RoleFactoryOption     ProtocolRole = "factory_option"
+	RoleRequestIdentity   ProtocolRole = "request_identity"
+	RolePromptContent     ProtocolRole = "prompt_content"
+	RoleSessionUpdate     ProtocolRole = "session_update"
+	RoleMalformedInput    ProtocolRole = "malformed_input"
+	RoleUnsupportedMethod ProtocolRole = "unsupported_method"
+)
+
+var validProtocolRole = map[ProtocolRole]bool{
+	RoleInitialize:        true,
+	RoleCapabilities:      true,
+	RoleFactoryOption:     true,
+	RoleRequestIdentity:   true,
+	RolePromptContent:     true,
+	RoleSessionUpdate:     true,
+	RoleMalformedInput:    true,
+	RoleUnsupportedMethod: true,
+}
+
+// roundTripEligibleKinds are the only Facts.Kind values a DirectionRoundTrip
+// case may declare. Every other represented kind (tool calls, plans, and
+// other progress-only or lifecycle updates) is lossy in at least one
+// direction today and must declare a narrower Directionality instead.
+var roundTripEligibleKinds = map[string]bool{
+	"message":   true,
+	"reasoning": true,
+	"usage":     true,
+	"session":   true,
+}
+
+// Facts is the set of expected semantic facts a corpus case declares.
+type Facts struct {
+	Kind     string            `json:"kind"`
+	ItemID   string            `json:"item_id,omitempty"`
+	Phase    string            `json:"phase,omitempty"`
+	Text     string            `json:"text,omitempty"`
+	Outcome  string            `json:"outcome,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+func (facts Facts) clone() Facts {
+	cloned := facts
+	if facts.Metadata != nil {
+		cloned.Metadata = make(map[string]string, len(facts.Metadata))
+		maps.Copy(cloned.Metadata, facts.Metadata)
+	}
+	return cloned
+}
+
+// Case is one representative, sanitized ACP protocol example together with
+// its declared directionality and expected semantic facts.
+type Case struct {
+	ID             string          `json:"id"`
+	ProtocolRole   ProtocolRole    `json:"protocol_role"`
+	Description    string          `json:"description"`
+	Directionality Directionality  `json:"directionality"`
+	Payload        json.RawMessage `json:"payload"`
+	Facts          Facts           `json:"facts"`
+	Provenance     string          `json:"provenance"`
+}
+
+func (c Case) clone() Case {
+	cloned := c
+	cloned.Payload = append(json.RawMessage(nil), c.Payload...)
+	cloned.Facts = c.Facts.clone()
+	return cloned
+}
+
+// RoundTripEligible reports whether c's Facts.Kind is one the round-trip
+// subset is allowed to declare.
+func (c Case) RoundTripEligible() bool {
+	return roundTripEligibleKinds[c.Facts.Kind]
+}
+
+// SourceProvenance pins the corpus to the ACP SDK version its wire shapes
+// were authored against.
+type SourceProvenance struct {
+	SDKModule  string `json:"sdk_module"`
+	SDKVersion string `json:"sdk_version"`
+	SDKCommit  string `json:"sdk_commit"`
+	SDKLicense string `json:"sdk_license"`
+}
+
+// Corpus is the parsed, validated set of shared ACP conformance cases.
+type Corpus struct {
+	SchemaVersion int              `json:"schema_version"`
+	Provenance    SourceProvenance `json:"provenance"`
+	Cases         []Case           `json:"cases"`
+}
+
+const supportedSchemaVersion = 1
+
+// ParseCorpus decodes and validates raw corpus JSON. It rejects invalid
+// JSON, an unpinned or incomplete source provenance, duplicate case
+// identity, an unknown protocol role, undeclared or unknown directionality,
+// a case with no declared expected facts, and a round-trip declaration for a
+// Facts.Kind known to be lossy or unsupported in at least one direction.
+func ParseCorpus(data []byte) (Corpus, error) {
+	var corpus Corpus
+	if err := json.Unmarshal(data, &corpus); err != nil {
+		return Corpus{}, fmt.Errorf("acpconformance: invalid corpus JSON: %w", err)
+	}
+	if corpus.SchemaVersion != supportedSchemaVersion {
+		return Corpus{}, fmt.Errorf("acpconformance: unsupported corpus schema_version %d", corpus.SchemaVersion)
+	}
+	if corpus.Provenance.SDKModule == "" || corpus.Provenance.SDKVersion == "" ||
+		corpus.Provenance.SDKCommit == "" || corpus.Provenance.SDKLicense == "" {
+		return Corpus{}, fmt.Errorf("acpconformance: corpus source provenance is incomplete")
+	}
+	if len(corpus.Cases) == 0 {
+		return Corpus{}, fmt.Errorf("acpconformance: corpus has no cases")
+	}
+	seen := make(map[string]bool, len(corpus.Cases))
+	for _, c := range corpus.Cases {
+		if strings.TrimSpace(c.ID) == "" {
+			return Corpus{}, fmt.Errorf("acpconformance: case has empty id")
+		}
+		if seen[c.ID] {
+			return Corpus{}, fmt.Errorf("acpconformance: duplicate case id %q", c.ID)
+		}
+		seen[c.ID] = true
+		if !validProtocolRole[c.ProtocolRole] {
+			return Corpus{}, fmt.Errorf("acpconformance: case %q has unknown protocol_role %q", c.ID, c.ProtocolRole)
+		}
+		if c.Directionality == "" || !validDirectionality[c.Directionality] {
+			return Corpus{}, fmt.Errorf("acpconformance: case %q has undeclared directionality %q", c.ID, c.Directionality)
+		}
+		if len(c.Payload) == 0 || !json.Valid(c.Payload) {
+			return Corpus{}, fmt.Errorf("acpconformance: case %q has invalid or empty payload JSON", c.ID)
+		}
+		if strings.TrimSpace(c.Facts.Kind) == "" {
+			return Corpus{}, fmt.Errorf("acpconformance: case %q is missing expected facts", c.ID)
+		}
+		if strings.TrimSpace(c.Provenance) == "" {
+			return Corpus{}, fmt.Errorf("acpconformance: case %q is missing provenance", c.ID)
+		}
+		if c.Directionality == DirectionRoundTrip && !c.RoundTripEligible() {
+			return Corpus{}, fmt.Errorf(
+				"acpconformance: case %q declares round_trip for a lossy or unsupported kind %q", c.ID, c.Facts.Kind,
+			)
+		}
+	}
+	return corpus, nil
+}
+
+// Load parses and validates the embedded shared corpus.
+func Load() (Corpus, error) {
+	return ParseCorpus(corpusJSON)
+}
+
+// MustLoad loads the embedded shared corpus or fails tb. Every returned Case
+// is a detached copy: callers may mutate them without affecting other
+// callers or the embedded source.
+func MustLoad(tb testing.TB) Corpus {
+	tb.Helper()
+	corpus, err := Load()
+	if err != nil {
+		tb.Fatalf("acpconformance: %v", err)
+	}
+	return corpus.clone()
+}
+
+func (corpus Corpus) clone() Corpus {
+	cloned := corpus
+	cloned.Cases = make([]Case, len(corpus.Cases))
+	for i, c := range corpus.Cases {
+		cloned.Cases[i] = c.clone()
+	}
+	return cloned
+}
+
+// ByRole returns detached copies of every case with the given ProtocolRole.
+func (corpus Corpus) ByRole(role ProtocolRole) []Case {
+	var out []Case
+	for _, c := range corpus.Cases {
+		if c.ProtocolRole == role {
+			out = append(out, c.clone())
+		}
+	}
+	return out
+}
+
+// ByDirectionality returns detached copies of every case with the given
+// Directionality.
+func (corpus Corpus) ByDirectionality(direction Directionality) []Case {
+	var out []Case
+	for _, c := range corpus.Cases {
+		if c.Directionality == direction {
+			out = append(out, c.clone())
+		}
+	}
+	return out
+}
+
+// RoundTripCases returns detached copies of every case in the lossless
+// round-trip subset.
+func (corpus Corpus) RoundTripCases() []Case {
+	return corpus.ByDirectionality(DirectionRoundTrip)
+}

--- a/internal/testutil/acpconformance/corpus.json
+++ b/internal/testutil/acpconformance/corpus.json
@@ -1,0 +1,394 @@
+{
+  "schema_version": 1,
+  "provenance": {
+    "sdk_module": "github.com/coder/acp-go-sdk",
+    "sdk_version": "v0.13.5",
+    "sdk_commit": "0845a3bb9eddda5bfc22a94dd3598c90cb842451",
+    "sdk_license": "Apache-2.0"
+  },
+  "cases": [
+    {
+      "id": "initialize-protocol-version-1-accepted",
+      "protocol_role": "initialize",
+      "description": "An initialize request naming ACP protocol version 1, the only version the V0 agent-side compatibility boundary accepts.",
+      "directionality": "outbound_only",
+      "payload": {
+        "protocolVersion": 1
+      },
+      "facts": {
+        "kind": "initialize",
+        "outcome": "accepted",
+        "metadata": {
+          "negotiated_version": "1"
+        }
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; wire shape matches acp-go-sdk v0.13.5 InitializeRequest.protocolVersion."
+    },
+    {
+      "id": "initialize-protocol-version-unsupported-rejected",
+      "protocol_role": "initialize",
+      "description": "An initialize request naming an ACP protocol version the V0 boundary does not support.",
+      "directionality": "unsupported",
+      "payload": {
+        "protocolVersion": 2
+      },
+      "facts": {
+        "kind": "initialize",
+        "outcome": "incompatible_version",
+        "metadata": {
+          "requested_version": "2",
+          "supported_version": "1"
+        }
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; wire shape matches acp-go-sdk v0.13.5 InitializeRequest.protocolVersion."
+    },
+    {
+      "id": "capabilities-text-first",
+      "protocol_role": "capabilities",
+      "description": "The exact serialized agent capabilities the V0 boundary advertises: text prompt content only, with every other capability left at its false/absent zero value.",
+      "directionality": "outbound_only",
+      "payload": {
+        "auth": {},
+        "mcpCapabilities": {},
+        "promptCapabilities": {},
+        "sessionCapabilities": {}
+      },
+      "facts": {
+        "kind": "capabilities",
+        "outcome": "text_first",
+        "metadata": {
+          "image": "false",
+          "audio": "false",
+          "embedded_context": "false",
+          "load_session": "false"
+        }
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; matches the literal json.Marshal output of pkg/transports/acp TextFirstAgentCapabilities() against acp-go-sdk v0.13.5 AgentCapabilities."
+    },
+    {
+      "id": "factory-option-select-type",
+      "protocol_role": "factory_option",
+      "description": "A representative Factory target selector serialized as the ACP select-option union, never as an ACP model resource.",
+      "directionality": "outbound_only",
+      "payload": {
+        "id": "target",
+        "name": "Factory",
+        "category": "model",
+        "currentValue": "release-notes-writer",
+        "type": "select",
+        "options": [
+          { "value": "release-notes-writer", "name": "Release Notes Writer" },
+          { "value": "code-reviewer", "name": "Code Reviewer" }
+        ]
+      },
+      "facts": {
+        "kind": "factory_option",
+        "item_id": "target",
+        "outcome": "select_type",
+        "metadata": {
+          "current_value": "release-notes-writer",
+          "choice_count": "2"
+        }
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; matches the literal json.Marshal output of pkg/transports/acp FactoryTargetOption.ToSessionConfigOption() against acp-go-sdk v0.13.5 SessionConfigOption."
+    },
+    {
+      "id": "request-identity-string-id",
+      "protocol_role": "request_identity",
+      "description": "A JSON-RPC request carrying a string id on a named connection.",
+      "directionality": "outbound_only",
+      "payload": {
+        "jsonrpc": "2.0",
+        "method": "session/set_config_option",
+        "id": "req-abc",
+        "connectionId": "conn-1"
+      },
+      "facts": {
+        "kind": "request_identity",
+        "outcome": "string_id",
+        "metadata": {
+          "connection_id": "conn-1",
+          "id_kind": "string"
+        }
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; the \"id\" wire shape matches acp-go-sdk v0.13.5 RequestId.Str; connectionId is transport-assigned metadata, not part of the ACP wire envelope."
+    },
+    {
+      "id": "request-identity-numeric-id",
+      "protocol_role": "request_identity",
+      "description": "A JSON-RPC request carrying a numeric id on a named connection, distinct from a string id with a similar printed form.",
+      "directionality": "outbound_only",
+      "payload": {
+        "jsonrpc": "2.0",
+        "method": "session/set_config_option",
+        "id": 42,
+        "connectionId": "conn-1"
+      },
+      "facts": {
+        "kind": "request_identity",
+        "outcome": "number_id",
+        "metadata": {
+          "connection_id": "conn-1",
+          "id_kind": "number"
+        }
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; the \"id\" wire shape matches acp-go-sdk v0.13.5 RequestId.Number; connectionId is transport-assigned metadata, not part of the ACP wire envelope."
+    },
+    {
+      "id": "request-identity-minted-for-notification",
+      "protocol_role": "request_identity",
+      "description": "A JSON-RPC notification with no wire id, requiring a transport-minted identity for internal correlation only.",
+      "directionality": "outbound_only",
+      "payload": {
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "connectionId": "conn-1",
+        "mintedId": "minted-session-update-1"
+      },
+      "facts": {
+        "kind": "request_identity",
+        "outcome": "minted",
+        "metadata": {
+          "connection_id": "conn-1",
+          "id_kind": "minted",
+          "reason": "notification_without_wire_id"
+        }
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; mintedId is never a JSON-RPC wire field, it is transport-local correlation metadata for a request/notification with no usable wire id."
+    },
+    {
+      "id": "prompt-content-text",
+      "protocol_role": "prompt_content",
+      "description": "A session/prompt request carrying only text prompt content, matching the V0 text-first prompt capability claim.",
+      "directionality": "inbound_only",
+      "payload": {
+        "sessionId": "session-1",
+        "prompt": [
+          { "type": "text", "text": "Summarize the attached release notes." }
+        ]
+      },
+      "facts": {
+        "kind": "prompt_content",
+        "item_id": "session-1",
+        "text": "Summarize the attached release notes.",
+        "outcome": "text_only"
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; wire shape matches acp-go-sdk v0.13.5 PromptRequest with a single ContentBlock text entry."
+    },
+    {
+      "id": "session-update-agent-message-chunk",
+      "protocol_role": "session_update",
+      "description": "A streamed agent message text chunk, part of the lossless round-trip subset.",
+      "directionality": "round_trip",
+      "payload": {
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "assistant-message-1",
+        "content": { "type": "text", "text": "The answer is 42." }
+      },
+      "facts": {
+        "kind": "message",
+        "item_id": "assistant-message-1",
+        "phase": "delta",
+        "text": "The answer is 42."
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; wire shape matches acp-go-sdk v0.13.5 SessionUpdateAgentMessageChunk."
+    },
+    {
+      "id": "session-update-agent-thought-chunk",
+      "protocol_role": "session_update",
+      "description": "A streamed agent thought (reasoning) text chunk, part of the lossless round-trip subset.",
+      "directionality": "round_trip",
+      "payload": {
+        "sessionUpdate": "agent_thought_chunk",
+        "messageId": "assistant-thought-1",
+        "content": { "type": "text", "text": "Considering the best approach." }
+      },
+      "facts": {
+        "kind": "reasoning",
+        "item_id": "assistant-thought-1",
+        "phase": "delta",
+        "text": "Considering the best approach."
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; wire shape matches acp-go-sdk v0.13.5 SessionUpdateAgentThoughtChunk."
+    },
+    {
+      "id": "session-update-usage",
+      "protocol_role": "session_update",
+      "description": "A context-window usage update, part of the lossless round-trip subset.",
+      "directionality": "round_trip",
+      "payload": {
+        "sessionUpdate": "usage_update",
+        "used": 128,
+        "size": 8192
+      },
+      "facts": {
+        "kind": "usage",
+        "item_id": "usage",
+        "phase": "updated",
+        "metadata": {
+          "used_tokens": "128",
+          "max_tokens": "8192"
+        }
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; wire shape matches acp-go-sdk v0.13.5 SessionUsageUpdate."
+    },
+    {
+      "id": "session-update-session-info",
+      "protocol_role": "session_update",
+      "description": "A session metadata (title) update, part of the lossless round-trip subset.",
+      "directionality": "round_trip",
+      "payload": {
+        "sessionUpdate": "session_info_update",
+        "title": "Refactor billing module"
+      },
+      "facts": {
+        "kind": "session",
+        "item_id": "session",
+        "phase": "started",
+        "text": "Refactor billing module"
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; wire shape matches acp-go-sdk v0.13.5 SessionSessionInfoUpdate."
+    },
+    {
+      "id": "session-update-tool-call-no-text-output",
+      "protocol_role": "session_update",
+      "description": "A tool call notification. Tool calls are lossy today (only the inbound mapper represents them) and produce no text content, so this case is excluded from the round-trip subset.",
+      "directionality": "inbound_only",
+      "payload": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "call-1",
+        "title": "Run tests",
+        "status": "pending"
+      },
+      "facts": {
+        "kind": "tool",
+        "item_id": "call-1",
+        "phase": "started",
+        "outcome": "no_text_output"
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; wire shape matches acp-go-sdk v0.13.5 SessionUpdateToolCall."
+    },
+    {
+      "id": "session-update-plan-lossy-excluded",
+      "protocol_role": "session_update",
+      "description": "An agent execution plan update. Plans are lossy today (only the inbound mapper represents them as opaque progress metadata) so this case is excluded from the round-trip subset.",
+      "directionality": "inbound_only",
+      "payload": {
+        "sessionUpdate": "plan",
+        "entries": [
+          { "content": "Investigate the failing test", "priority": "high", "status": "pending" }
+        ]
+      },
+      "facts": {
+        "kind": "plan",
+        "item_id": "plan",
+        "phase": "updated",
+        "outcome": "lossy_not_round_trip_eligible"
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; wire shape matches acp-go-sdk v0.13.5 SessionUpdatePlan."
+    },
+    {
+      "id": "malformed-input-missing-params",
+      "protocol_role": "malformed_input",
+      "description": "A supported method's request with no params field at all, which must be rejected as invalid params without any partially decoded value.",
+      "directionality": "outbound_only",
+      "payload": {
+        "jsonrpc": "2.0",
+        "method": "session/prompt",
+        "id": "req-77",
+        "connectionId": "conn-1"
+      },
+      "facts": {
+        "kind": "malformed_input",
+        "outcome": "invalid_params",
+        "metadata": {
+          "reason": "missing_params"
+        }
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; matches pkg/transports/acp DecodeMethodParams missing-params outcome, which never includes raw params content."
+    },
+    {
+      "id": "malformed-input-invalid-request-id-shape",
+      "protocol_role": "malformed_input",
+      "description": "A request whose id is neither a JSON-RPC string, number, nor null, which must be rejected as an invalid request rather than a partially valid identity.",
+      "directionality": "outbound_only",
+      "payload": {
+        "jsonrpc": "2.0",
+        "method": "session/prompt",
+        "id": [1, 2],
+        "connectionId": "conn-1"
+      },
+      "facts": {
+        "kind": "malformed_input",
+        "outcome": "invalid_request",
+        "metadata": {
+          "reason": "unsupported_id_shape"
+        }
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; an array id has no matching acp-go-sdk v0.13.5 RequestId variant and fails to decode."
+    },
+    {
+      "id": "unsupported-method-unknown-string-id",
+      "protocol_role": "unsupported_method",
+      "description": "A request naming a method this V0 boundary does not recognize at all, correlated by a string id.",
+      "directionality": "unsupported",
+      "payload": {
+        "jsonrpc": "2.0",
+        "method": "factory/unknownOperation",
+        "id": "req-9",
+        "connectionId": "conn-1"
+      },
+      "facts": {
+        "kind": "unsupported_method",
+        "outcome": "method_not_found",
+        "metadata": {
+          "disposition": "unknown",
+          "id_kind": "string",
+          "error_code": "-32601"
+        }
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; matches pkg/transports/acp UnsupportedMethodResponse over acp-go-sdk v0.13.5 NewMethodNotFound."
+    },
+    {
+      "id": "unsupported-method-deferred-session-new-numeric-id",
+      "protocol_role": "unsupported_method",
+      "description": "A request naming session/new, an ACP method the SDK defines but this V0 boundary defers (no stdio serving or session execution yet), correlated by a numeric id.",
+      "directionality": "unsupported",
+      "payload": {
+        "jsonrpc": "2.0",
+        "method": "session/new",
+        "id": 7,
+        "connectionId": "conn-1"
+      },
+      "facts": {
+        "kind": "unsupported_method",
+        "outcome": "method_not_found",
+        "metadata": {
+          "disposition": "deferred",
+          "id_kind": "number",
+          "error_code": "-32601"
+        }
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; matches pkg/transports/acp UnsupportedMethodResponse over acp-go-sdk v0.13.5 NewMethodNotFound; session/new resolves identically to an unknown method on the wire in V0."
+    },
+    {
+      "id": "unsupported-method-unknown-notification-no-response",
+      "protocol_role": "unsupported_method",
+      "description": "A notification (no id) naming a method this V0 boundary does not recognize. Unlike a request, an unsupported notification must produce no response at all.",
+      "directionality": "no_output",
+      "payload": {
+        "jsonrpc": "2.0",
+        "method": "factory/telemetryPing",
+        "connectionId": "conn-1"
+      },
+      "facts": {
+        "kind": "unsupported_method",
+        "outcome": "no_response_emitted",
+        "metadata": {
+          "reason": "notification_without_id"
+        }
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; matches pkg/transports/acp UnsupportedMethodResponse returning nil for a nil wireID."
+    }
+  ]
+}

--- a/internal/testutil/acpconformance/corpus_test.go
+++ b/internal/testutil/acpconformance/corpus_test.go
@@ -1,0 +1,557 @@
+package acpconformance_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	"github.com/portpowered/infinite-you/internal/testutil/acpconformance"
+)
+
+func validMinimalCorpusJSON(t testing.TB) string {
+	t.Helper()
+	corpus := acpconformance.MustLoad(t)
+	if len(corpus.Cases) == 0 {
+		t.Fatal("embedded corpus has no cases to derive a minimal fixture from")
+	}
+	one := corpus.Cases[0]
+	data, err := json.Marshal(struct {
+		SchemaVersion int                             `json:"schema_version"`
+		Provenance    acpconformance.SourceProvenance `json:"provenance"`
+		Cases         []acpconformance.Case           `json:"cases"`
+	}{
+		SchemaVersion: 1,
+		Provenance:    corpus.Provenance,
+		Cases:         []acpconformance.Case{one},
+	})
+	if err != nil {
+		t.Fatalf("marshal minimal corpus fixture: %v", err)
+	}
+	return string(data)
+}
+
+func TestLoadEmbeddedCorpusIsValid(t *testing.T) {
+	corpus, err := acpconformance.Load()
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+	if corpus.SchemaVersion != 1 {
+		t.Fatalf("SchemaVersion = %d, want 1", corpus.SchemaVersion)
+	}
+	if corpus.Provenance.SDKModule != "github.com/coder/acp-go-sdk" || corpus.Provenance.SDKVersion != "v0.13.5" {
+		t.Fatalf("Provenance = %+v, want the pinned acp-go-sdk v0.13.5 source", corpus.Provenance)
+	}
+	if len(corpus.Cases) == 0 {
+		t.Fatal("Load() returned a corpus with no cases")
+	}
+}
+
+func TestParseCorpusRejectsInvalidJSON(t *testing.T) {
+	_, err := acpconformance.ParseCorpus([]byte("{not valid json"))
+	if err == nil {
+		t.Fatal("ParseCorpus(invalid JSON) expected error, got nil")
+	}
+}
+
+func TestParseCorpusRejectsDuplicateCaseID(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	dup := corpus.Cases[0]
+	broken := struct {
+		SchemaVersion int                             `json:"schema_version"`
+		Provenance    acpconformance.SourceProvenance `json:"provenance"`
+		Cases         []acpconformance.Case           `json:"cases"`
+	}{1, corpus.Provenance, []acpconformance.Case{dup, dup}}
+	data, err := json.Marshal(broken)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	_, err = acpconformance.ParseCorpus(data)
+	if err == nil {
+		t.Fatal("ParseCorpus(duplicate case id) expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate case id") {
+		t.Fatalf("ParseCorpus(duplicate case id) error = %v, want it to mention duplicate case id", err)
+	}
+}
+
+func TestParseCorpusRejectsMissingFacts(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	broken := corpus.Cases[0]
+	broken.Facts = acpconformance.Facts{}
+	fixture := struct {
+		SchemaVersion int                             `json:"schema_version"`
+		Provenance    acpconformance.SourceProvenance `json:"provenance"`
+		Cases         []acpconformance.Case           `json:"cases"`
+	}{1, corpus.Provenance, []acpconformance.Case{broken}}
+	data, err := json.Marshal(fixture)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	_, err = acpconformance.ParseCorpus(data)
+	if err == nil {
+		t.Fatal("ParseCorpus(missing facts) expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing expected facts") {
+		t.Fatalf("ParseCorpus(missing facts) error = %v, want it to mention missing expected facts", err)
+	}
+}
+
+func TestParseCorpusRejectsUndeclaredDirectionality(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	broken := corpus.Cases[0]
+	broken.Directionality = ""
+	fixture := struct {
+		SchemaVersion int                             `json:"schema_version"`
+		Provenance    acpconformance.SourceProvenance `json:"provenance"`
+		Cases         []acpconformance.Case           `json:"cases"`
+	}{1, corpus.Provenance, []acpconformance.Case{broken}}
+	data, err := json.Marshal(fixture)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	_, err = acpconformance.ParseCorpus(data)
+	if err == nil {
+		t.Fatal("ParseCorpus(undeclared directionality) expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "undeclared directionality") {
+		t.Fatalf("ParseCorpus(undeclared directionality) error = %v, want it to mention undeclared directionality", err)
+	}
+}
+
+func TestParseCorpusRejectsUnknownDirectionality(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	broken := corpus.Cases[0]
+	broken.Directionality = "sideways"
+	fixture := struct {
+		SchemaVersion int                             `json:"schema_version"`
+		Provenance    acpconformance.SourceProvenance `json:"provenance"`
+		Cases         []acpconformance.Case           `json:"cases"`
+	}{1, corpus.Provenance, []acpconformance.Case{broken}}
+	data, err := json.Marshal(fixture)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if _, err := acpconformance.ParseCorpus(data); err == nil {
+		t.Fatal("ParseCorpus(unknown directionality) expected error, got nil")
+	}
+}
+
+func TestParseCorpusRejectsRoundTripForLossyKind(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	var toolCase acpconformance.Case
+	found := false
+	for _, c := range corpus.Cases {
+		if c.Facts.Kind == "tool" {
+			toolCase = c
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected embedded corpus to contain a case with Facts.Kind == \"tool\" to mutate")
+	}
+	toolCase.Directionality = acpconformance.DirectionRoundTrip
+	fixture := struct {
+		SchemaVersion int                             `json:"schema_version"`
+		Provenance    acpconformance.SourceProvenance `json:"provenance"`
+		Cases         []acpconformance.Case           `json:"cases"`
+	}{1, corpus.Provenance, []acpconformance.Case{toolCase}}
+	data, err := json.Marshal(fixture)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	_, err = acpconformance.ParseCorpus(data)
+	if err == nil {
+		t.Fatal("ParseCorpus(round_trip declared for lossy kind) expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "lossy or unsupported kind") {
+		t.Fatalf("ParseCorpus(round_trip for lossy kind) error = %v, want it to mention lossy or unsupported kind", err)
+	}
+}
+
+func TestParseCorpusRejectsEmptyCorpus(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	fixture := struct {
+		SchemaVersion int                             `json:"schema_version"`
+		Provenance    acpconformance.SourceProvenance `json:"provenance"`
+		Cases         []acpconformance.Case           `json:"cases"`
+	}{1, corpus.Provenance, nil}
+	data, err := json.Marshal(fixture)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if _, err := acpconformance.ParseCorpus(data); err == nil {
+		t.Fatal("ParseCorpus(no cases) expected error, got nil")
+	}
+}
+
+func TestParseCorpusRejectsIncompleteProvenance(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	fixture := struct {
+		SchemaVersion int                             `json:"schema_version"`
+		Provenance    acpconformance.SourceProvenance `json:"provenance"`
+		Cases         []acpconformance.Case           `json:"cases"`
+	}{1, acpconformance.SourceProvenance{}, corpus.Cases[:1]}
+	data, err := json.Marshal(fixture)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if _, err := acpconformance.ParseCorpus(data); err == nil {
+		t.Fatal("ParseCorpus(incomplete provenance) expected error, got nil")
+	}
+}
+
+func TestMustLoadReturnsDetachedCases(t *testing.T) {
+	first := acpconformance.MustLoad(t)
+	if len(first.Cases) == 0 {
+		t.Fatal("MustLoad() returned no cases")
+	}
+	original := string(first.Cases[0].Payload)
+	first.Cases[0].Payload = json.RawMessage(`{"mutated":true}`)
+	first.Cases[0].Facts.Kind = "mutated"
+
+	second := acpconformance.MustLoad(t)
+	if string(second.Cases[0].Payload) != original {
+		t.Fatalf("mutating one MustLoad() result affected another: got %s, want %s", second.Cases[0].Payload, original)
+	}
+	if second.Cases[0].Facts.Kind == "mutated" {
+		t.Fatal("mutating one MustLoad() result's Facts affected another")
+	}
+}
+
+func TestCorpusCoversRequiredProtocolRoles(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	required := []acpconformance.ProtocolRole{
+		acpconformance.RoleInitialize,
+		acpconformance.RoleCapabilities,
+		acpconformance.RoleFactoryOption,
+		acpconformance.RoleRequestIdentity,
+		acpconformance.RolePromptContent,
+		acpconformance.RoleSessionUpdate,
+		acpconformance.RoleMalformedInput,
+		acpconformance.RoleUnsupportedMethod,
+	}
+	for _, role := range required {
+		if len(corpus.ByRole(role)) == 0 {
+			t.Errorf("corpus has no case with protocol_role %q", role)
+		}
+	}
+}
+
+func TestCorpusRepresentsEveryDirectionality(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	directions := []acpconformance.Directionality{
+		acpconformance.DirectionRoundTrip,
+		acpconformance.DirectionInboundOnly,
+		acpconformance.DirectionOutboundOnly,
+		acpconformance.DirectionUnsupported,
+		acpconformance.DirectionNoOutput,
+	}
+	for _, direction := range directions {
+		if len(corpus.ByDirectionality(direction)) == 0 {
+			t.Errorf("corpus has no case with directionality %q", direction)
+		}
+	}
+}
+
+func TestRoundTripCasesOnlyDeclareLosslessKinds(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	roundTrip := corpus.RoundTripCases()
+	if len(roundTrip) == 0 {
+		t.Fatal("expected at least one round_trip case")
+	}
+	allowed := map[string]bool{"message": true, "reasoning": true, "usage": true, "session": true}
+	for _, c := range roundTrip {
+		if !allowed[c.Facts.Kind] {
+			t.Errorf("round_trip case %q declares disallowed kind %q", c.ID, c.Facts.Kind)
+		}
+		if !c.RoundTripEligible() {
+			t.Errorf("round_trip case %q reports RoundTripEligible() == false", c.ID)
+		}
+	}
+}
+
+func TestLossyKindsAreExcludedFromRoundTripSubset(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	lossy := map[string]bool{"tool": false, "plan": false}
+	for _, c := range corpus.Cases {
+		if _, tracked := lossy[c.Facts.Kind]; tracked {
+			lossy[c.Facts.Kind] = true
+			if c.Directionality == acpconformance.DirectionRoundTrip {
+				t.Errorf("lossy kind %q (case %q) must not declare round_trip directionality", c.Facts.Kind, c.ID)
+			}
+		}
+	}
+	for kind, seen := range lossy {
+		if !seen {
+			t.Errorf("expected the corpus to contain a %q case to prove it is excluded from the round-trip subset", kind)
+		}
+	}
+}
+
+// TestSessionUpdateCasesParseAsACPSDKSessionUpdate proves every session_update
+// case's payload is a real, parseable acp-go-sdk v0.13.5 SessionUpdate, and
+// that the declared facts are actually derivable from the decoded value —
+// not merely asserted independently of the payload.
+func TestSessionUpdateCasesParseAsACPSDKSessionUpdate(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	for _, c := range corpus.ByRole(acpconformance.RoleSessionUpdate) {
+		t.Run(c.ID, func(t *testing.T) {
+			var update acpsdk.SessionUpdate
+			if err := json.Unmarshal(c.Payload, &update); err != nil {
+				t.Fatalf("payload does not parse as acpsdk.SessionUpdate: %v", err)
+			}
+			kind, itemID, text := describeSessionUpdate(t, update)
+			if kind != c.Facts.Kind {
+				t.Errorf("decoded kind = %q, want Facts.Kind = %q", kind, c.Facts.Kind)
+			}
+			if c.Facts.ItemID != "" && itemID != c.Facts.ItemID {
+				t.Errorf("decoded item id = %q, want Facts.ItemID = %q", itemID, c.Facts.ItemID)
+			}
+			if c.Facts.Text != "" && text != c.Facts.Text {
+				t.Errorf("decoded text = %q, want Facts.Text = %q", text, c.Facts.Text)
+			}
+
+			// Round-trip the payload through the SDK type a second time and
+			// confirm the same facts are still derivable, proving the
+			// declared round-trip subset is stable under marshal/unmarshal.
+			reMarshaled, err := json.Marshal(update)
+			if err != nil {
+				t.Fatalf("re-marshal SessionUpdate: %v", err)
+			}
+			var reDecoded acpsdk.SessionUpdate
+			if err := json.Unmarshal(reMarshaled, &reDecoded); err != nil {
+				t.Fatalf("re-unmarshal SessionUpdate: %v", err)
+			}
+			reKind, reItemID, reText := describeSessionUpdate(t, reDecoded)
+			if c.Directionality == acpconformance.DirectionRoundTrip {
+				if reKind != kind || reItemID != itemID || reText != text {
+					t.Errorf(
+						"round_trip case %q lost facts across a second marshal/unmarshal: got (%q,%q,%q), want (%q,%q,%q)",
+						c.ID, reKind, reItemID, reText, kind, itemID, text,
+					)
+				}
+			}
+		})
+	}
+}
+
+// describeSessionUpdate extracts a minimal (kind, itemID, text) tuple
+// directly from a decoded acpsdk.SessionUpdate. It intentionally duplicates
+// none of the Providers-owned mapper's policy (metadata shaping, progress
+// phases beyond delta/started/updated); it exists only to prove this
+// corpus's own declared facts are self-consistent with its payload.
+func describeSessionUpdate(t testing.TB, update acpsdk.SessionUpdate) (kind, itemID, text string) {
+	t.Helper()
+	switch {
+	case update.AgentMessageChunk != nil:
+		id := ""
+		if update.AgentMessageChunk.MessageId != nil {
+			id = *update.AgentMessageChunk.MessageId
+		}
+		txt := ""
+		if update.AgentMessageChunk.Content.Text != nil {
+			txt = update.AgentMessageChunk.Content.Text.Text
+		}
+		return "message", id, txt
+	case update.AgentThoughtChunk != nil:
+		id := ""
+		if update.AgentThoughtChunk.MessageId != nil {
+			id = *update.AgentThoughtChunk.MessageId
+		}
+		txt := ""
+		if update.AgentThoughtChunk.Content.Text != nil {
+			txt = update.AgentThoughtChunk.Content.Text.Text
+		}
+		return "reasoning", id, txt
+	case update.UsageUpdate != nil:
+		return "usage", "usage", ""
+	case update.SessionInfoUpdate != nil:
+		txt := ""
+		if update.SessionInfoUpdate.Title != nil {
+			txt = *update.SessionInfoUpdate.Title
+		}
+		return "session", "session", txt
+	case update.ToolCall != nil:
+		return "tool", string(update.ToolCall.ToolCallId), ""
+	case update.Plan != nil:
+		return "plan", "plan", ""
+	default:
+		t.Fatal("describeSessionUpdate: no recognized SessionUpdate variant is set")
+		return "", "", ""
+	}
+}
+
+func TestInitializeCasesParseAsACPSDKInitializeRequest(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	for _, c := range corpus.ByRole(acpconformance.RoleInitialize) {
+		var req acpsdk.InitializeRequest
+		if err := json.Unmarshal(c.Payload, &req); err != nil {
+			t.Errorf("case %q payload does not parse as acpsdk.InitializeRequest: %v", c.ID, err)
+		}
+	}
+}
+
+func TestCapabilitiesCasesParseAsACPSDKAgentCapabilities(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	for _, c := range corpus.ByRole(acpconformance.RoleCapabilities) {
+		var capabilities acpsdk.AgentCapabilities
+		if err := json.Unmarshal(c.Payload, &capabilities); err != nil {
+			t.Errorf("case %q payload does not parse as acpsdk.AgentCapabilities: %v", c.ID, err)
+		}
+		if capabilities.PromptCapabilities.Image || capabilities.PromptCapabilities.Audio || capabilities.PromptCapabilities.EmbeddedContext {
+			t.Errorf("case %q decoded non-text prompt capabilities as enabled: %+v", c.ID, capabilities.PromptCapabilities)
+		}
+	}
+}
+
+func TestFactoryOptionCasesParseAsACPSDKSelectSessionConfigOption(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	for _, c := range corpus.ByRole(acpconformance.RoleFactoryOption) {
+		var option acpsdk.SessionConfigOption
+		if err := json.Unmarshal(c.Payload, &option); err != nil {
+			t.Fatalf("case %q payload does not parse as acpsdk.SessionConfigOption: %v", c.ID, err)
+		}
+		if option.Select == nil {
+			t.Errorf("case %q decoded with no select variant, want type=select", c.ID)
+		}
+		if option.Boolean != nil {
+			t.Errorf("case %q decoded a boolean variant, want only the select variant", c.ID)
+		}
+	}
+}
+
+func TestPromptContentCasesParseAsACPSDKPromptRequest(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	for _, c := range corpus.ByRole(acpconformance.RolePromptContent) {
+		var req acpsdk.PromptRequest
+		if err := json.Unmarshal(c.Payload, &req); err != nil {
+			t.Fatalf("case %q payload does not parse as acpsdk.PromptRequest: %v", c.ID, err)
+		}
+		for _, block := range req.Prompt {
+			if block.Image != nil || block.Audio != nil || block.Resource != nil || block.ResourceLink != nil {
+				t.Errorf("case %q prompt content included a non-text block, want text-only content", c.ID)
+			}
+		}
+	}
+}
+
+func TestRequestIdentityCasesCarryASupportedWireIDShape(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	for _, c := range corpus.ByRole(acpconformance.RoleRequestIdentity) {
+		var envelope struct {
+			ID *acpsdk.RequestId `json:"id"`
+		}
+		if err := json.Unmarshal(c.Payload, &envelope); err != nil {
+			t.Fatalf("case %q payload id does not parse as acpsdk.RequestId: %v", c.ID, err)
+		}
+		switch c.Facts.Outcome {
+		case "string_id":
+			if envelope.ID == nil || envelope.ID.Str == nil {
+				t.Errorf("case %q declares string_id but decoded id = %+v", c.ID, envelope.ID)
+			}
+		case "number_id":
+			if envelope.ID == nil || envelope.ID.Number == nil {
+				t.Errorf("case %q declares number_id but decoded id = %+v", c.ID, envelope.ID)
+			}
+		case "minted":
+			if envelope.ID != nil {
+				t.Errorf("case %q declares minted (no wire id) but payload carried an id", c.ID)
+			}
+		}
+	}
+}
+
+func TestMalformedInputInvalidRequestIDShapeFailsToDecode(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	var target acpconformance.Case
+	found := false
+	for _, c := range corpus.ByRole(acpconformance.RoleMalformedInput) {
+		if c.Facts.Outcome == "invalid_request" {
+			target = c
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected a malformed_input case declaring outcome invalid_request")
+	}
+	var envelope struct {
+		ID acpsdk.RequestId `json:"id"`
+	}
+	if err := json.Unmarshal(target.Payload, &envelope); err == nil {
+		t.Fatal("expected the invalid_request case's id to fail acpsdk.RequestId decoding, got nil error")
+	}
+}
+
+// TestCorpusContentIsSanitized guards the corpus artifact's own sanitization
+// invariant: no credential-shaped values, machine-specific absolute paths,
+// or raw provider commands. This tests the shipped corpus.json contract
+// itself (an explicit acceptance criterion), not source-file inventory.
+func TestCorpusContentIsSanitized(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	forbidden := []string{
+		"/home/", "/Users/", `C:\Users`, "password", "secret", "api_key", "apikey",
+		"Bearer ", "AKIA", "-----BEGIN",
+	}
+	for _, c := range corpus.Cases {
+		haystack := strings.ToLower(c.Description + " " + string(c.Payload) + " " + c.Facts.Text + " " + c.Provenance)
+		for _, term := range forbidden {
+			if strings.Contains(haystack, strings.ToLower(term)) {
+				t.Errorf("case %q contains forbidden sanitization term %q", c.ID, term)
+			}
+		}
+	}
+}
+
+func TestUnsupportedMethodCasesDeclareMethodNotFoundOrNoResponse(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	cases := corpus.ByRole(acpconformance.RoleUnsupportedMethod)
+	if len(cases) == 0 {
+		t.Fatal("expected at least one unsupported_method case")
+	}
+	sawRequest, sawNotification := false, false
+	for _, c := range cases {
+		var envelope struct {
+			ID *acpsdk.RequestId `json:"id"`
+		}
+		if err := json.Unmarshal(c.Payload, &envelope); err != nil {
+			t.Fatalf("case %q payload id does not parse: %v", c.ID, err)
+		}
+		if envelope.ID != nil {
+			sawRequest = true
+			if c.Facts.Outcome != "method_not_found" {
+				t.Errorf("case %q has an id but Facts.Outcome = %q, want method_not_found", c.ID, c.Facts.Outcome)
+			}
+			if c.Directionality != acpconformance.DirectionUnsupported {
+				t.Errorf("case %q has an id but directionality = %q, want unsupported", c.ID, c.Directionality)
+			}
+		} else {
+			sawNotification = true
+			if c.Facts.Outcome != "no_response_emitted" {
+				t.Errorf("case %q has no id but Facts.Outcome = %q, want no_response_emitted", c.ID, c.Facts.Outcome)
+			}
+			if c.Directionality != acpconformance.DirectionNoOutput {
+				t.Errorf("case %q has no id but directionality = %q, want no_output", c.ID, c.Directionality)
+			}
+		}
+	}
+	if !sawRequest || !sawNotification {
+		t.Fatalf("expected unsupported_method cases to cover both a request (sawRequest=%v) and a notification (sawNotification=%v)", sawRequest, sawNotification)
+	}
+}
+
+func TestParseCorpusIsUsableFromASyntheticMinimalFixture(t *testing.T) {
+	// Confirms ParseCorpus works over an arbitrary, well-formed corpus, not
+	// only the embedded one, per its role as a general reusable reader.
+	minimal := validMinimalCorpusJSON(t)
+	corpus, err := acpconformance.ParseCorpus([]byte(minimal))
+	if err != nil {
+		t.Fatalf("ParseCorpus(minimal valid fixture) unexpected error: %v", err)
+	}
+	if len(corpus.Cases) != 1 {
+		t.Fatalf("len(corpus.Cases) = %d, want 1", len(corpus.Cases))
+	}
+}

--- a/pkg/services/providers/internal/services/acp/internal/service/conformance_test.go
+++ b/pkg/services/providers/internal/services/acp/internal/service/conformance_test.go
@@ -1,0 +1,74 @@
+package service
+
+// This file independently verifies the shared ACP L1 V0 conformance corpus
+// (internal/testutil/acpconformance) against the real Providers-owned
+// inbound ACP mapper. It feeds every inbound-supported (round_trip or
+// inbound_only) session_update corpus case through the same client callback
+// the real ACP SDK connection invokes, so this direction is proven
+// independently of the pkg/transports/acp outbound compatibility boundary,
+// per ACP-L1-V0-protocol-conformance-004.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	"github.com/portpowered/infinite-you/internal/testutil/acpconformance"
+)
+
+func TestInboundSupportedSessionUpdateCasesMatchProviderMapper(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	cases := corpus.ByRole(acpconformance.RoleSessionUpdate)
+	if len(cases) == 0 {
+		t.Fatal("expected at least one session_update case")
+	}
+	for _, c := range cases {
+		t.Run(c.ID, func(t *testing.T) {
+			if c.Directionality != acpconformance.DirectionRoundTrip && c.Directionality != acpconformance.DirectionInboundOnly {
+				t.Fatalf("case %q directionality = %q, want round_trip or inbound_only for an inbound-supported session_update case", c.ID, c.Directionality)
+			}
+			var update acpsdk.SessionUpdate
+			if err := json.Unmarshal(c.Payload, &update); err != nil {
+				t.Fatalf("payload does not parse as acpsdk.SessionUpdate: %v", err)
+			}
+
+			mapperClient := &client{}
+			if err := mapperClient.SessionUpdate(context.Background(), acpsdk.SessionNotification{Update: update}); err != nil {
+				t.Fatalf("SessionUpdate() unexpected error: %v", err)
+			}
+			progress := mapperClient.progressFacts()
+			if len(progress) == 0 {
+				t.Fatalf("provider mapper produced no progress for case %q", c.ID)
+			}
+			got := progress[0]
+			if got.Metadata["kind"] != c.Facts.Kind {
+				t.Errorf("progress kind = %q, want %q", got.Metadata["kind"], c.Facts.Kind)
+			}
+			if c.Facts.ItemID != "" && got.Metadata["item_id"] != c.Facts.ItemID {
+				t.Errorf("progress item_id = %q, want %q", got.Metadata["item_id"], c.Facts.ItemID)
+			}
+			if c.Facts.Phase != "" && got.Phase != c.Facts.Phase {
+				t.Errorf("progress phase = %q, want %q", got.Phase, c.Facts.Phase)
+			}
+			if c.Facts.Text != "" && got.Detail != c.Facts.Text {
+				t.Errorf("progress detail = %q, want %q", got.Detail, c.Facts.Text)
+			}
+			for key, want := range c.Facts.Metadata {
+				if got.Metadata[key] != want {
+					t.Errorf("progress metadata[%q] = %q, want %q", key, got.Metadata[key], want)
+				}
+			}
+
+			text := mapperClient.content()
+			if c.Facts.Kind == "message" {
+				if text != c.Facts.Text {
+					t.Errorf("accumulated text = %q, want %q", text, c.Facts.Text)
+				}
+			} else if text != "" {
+				t.Errorf("accumulated text = %q, want empty for non-message kind %q", text, c.Facts.Kind)
+			}
+		})
+	}
+}

--- a/pkg/transports/acp/compatibility.go
+++ b/pkg/transports/acp/compatibility.go
@@ -1,0 +1,90 @@
+package acp
+
+import (
+	"fmt"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+)
+
+// SupportedProtocolVersion is the only ACP protocol version this V0
+// compatibility boundary accepts. It matches the version implemented by the
+// pinned github.com/coder/acp-go-sdk v0.13.5 dependency.
+const SupportedProtocolVersion acpsdk.ProtocolVersion = acpsdk.ProtocolVersionNumber
+
+// Profile is the deterministic V0 ACP agent-side compatibility result: the
+// negotiated protocol version and the exact capabilities You implements.
+type Profile struct {
+	ProtocolVersion   acpsdk.ProtocolVersion
+	AgentCapabilities acpsdk.AgentCapabilities
+}
+
+// NegotiateProtocolVersion accepts only SupportedProtocolVersion and returns
+// a typed *CompatibilityError for any other requested version. It performs
+// no IO and has no side effect.
+func NegotiateProtocolVersion(requested acpsdk.ProtocolVersion) (acpsdk.ProtocolVersion, error) {
+	if requested != SupportedProtocolVersion {
+		return 0, &CompatibilityError{
+			Code:             CompatibilityErrorUnsupportedProtocolVersion,
+			Message:          fmt.Sprintf("acp: unsupported protocol version %d, only version %d is supported", int(requested), int(SupportedProtocolVersion)),
+			RequestedVersion: requested,
+			SupportedVersion: SupportedProtocolVersion,
+		}
+	}
+	return SupportedProtocolVersion, nil
+}
+
+// TextFirstAgentCapabilities returns the exact V0 agent capability claims:
+// text prompt content only. Every other advertised capability is left at
+// its explicit false/absent value because V0 implements none of them:
+//
+//   - PromptCapabilities.Image/Audio/EmbeddedContext: no non-text prompt
+//     content is accepted.
+//   - McpCapabilities.Acp/Http/Sse: no client MCP server passthrough.
+//   - Auth.Logout and InitializeResponse.AuthMethods (set by the caller):
+//     no authentication capability.
+//   - SessionCapabilities.Fork: session/fork is not implemented.
+//   - LoadSession: session/load is not implemented in V0.
+//
+// Filesystem, terminal, and permission behavior are client-advertised or
+// request-driven rather than agent capability flags; V0 never issues
+// fs/*, terminal/*, or session/request_permission calls, so it advertises
+// no capability that would invite a client to expect them.
+func TextFirstAgentCapabilities() acpsdk.AgentCapabilities {
+	return acpsdk.AgentCapabilities{
+		Auth:        acpsdk.AgentAuthCapabilities{Logout: nil},
+		LoadSession: false,
+		McpCapabilities: acpsdk.McpCapabilities{
+			Acp:  false,
+			Http: false,
+			Sse:  false,
+		},
+		PromptCapabilities: acpsdk.PromptCapabilities{
+			Audio:           false,
+			EmbeddedContext: false,
+			Image:           false,
+		},
+		SessionCapabilities: acpsdk.SessionCapabilities{
+			AdditionalDirectories: nil,
+			Close:                 nil,
+			Delete:                nil,
+			Fork:                  nil,
+			List:                  nil,
+			Resume:                nil,
+		},
+	}
+}
+
+// BuildProfile constructs the inert V0 compatibility profile for a
+// requested protocol version. Construction performs no IO, starts no
+// goroutine or process, binds no endpoint, and creates or invokes no Chat or
+// Factory Session.
+func BuildProfile(requested acpsdk.ProtocolVersion) (Profile, error) {
+	version, err := NegotiateProtocolVersion(requested)
+	if err != nil {
+		return Profile{}, err
+	}
+	return Profile{
+		ProtocolVersion:   version,
+		AgentCapabilities: TextFirstAgentCapabilities(),
+	}, nil
+}

--- a/pkg/transports/acp/compatibility_test.go
+++ b/pkg/transports/acp/compatibility_test.go
@@ -1,0 +1,154 @@
+package acp_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	"github.com/portpowered/infinite-you/pkg/transports/acp"
+)
+
+func TestNegotiateProtocolVersionAcceptsSupportedVersion(t *testing.T) {
+	got, err := acp.NegotiateProtocolVersion(acp.SupportedProtocolVersion)
+	if err != nil {
+		t.Fatalf("NegotiateProtocolVersion() unexpected error: %v", err)
+	}
+	if got != acp.SupportedProtocolVersion {
+		t.Fatalf("NegotiateProtocolVersion() = %d, want %d", got, acp.SupportedProtocolVersion)
+	}
+	if acp.SupportedProtocolVersion != acpsdk.ProtocolVersionNumber {
+		t.Fatalf("SupportedProtocolVersion = %d, want acp-go-sdk pinned version %d", acp.SupportedProtocolVersion, acpsdk.ProtocolVersionNumber)
+	}
+}
+
+func TestNegotiateProtocolVersionRejectsUnsupportedVersions(t *testing.T) {
+	cases := []acpsdk.ProtocolVersion{0, 2, 99, -1}
+	for _, requested := range cases {
+		_, err := acp.NegotiateProtocolVersion(requested)
+		if err == nil {
+			t.Fatalf("NegotiateProtocolVersion(%d) expected error, got nil", requested)
+		}
+		var compatErr *acp.CompatibilityError
+		if !errors.As(err, &compatErr) {
+			t.Fatalf("NegotiateProtocolVersion(%d) error type = %T, want *acp.CompatibilityError", requested, err)
+		}
+		if compatErr.Code != acp.CompatibilityErrorUnsupportedProtocolVersion {
+			t.Fatalf("NegotiateProtocolVersion(%d) code = %q, want %q", requested, compatErr.Code, acp.CompatibilityErrorUnsupportedProtocolVersion)
+		}
+		if compatErr.RequestedVersion != requested {
+			t.Fatalf("NegotiateProtocolVersion(%d) RequestedVersion = %d, want %d", requested, compatErr.RequestedVersion, requested)
+		}
+		if compatErr.SupportedVersion != acp.SupportedProtocolVersion {
+			t.Fatalf("NegotiateProtocolVersion(%d) SupportedVersion = %d, want %d", requested, compatErr.SupportedVersion, acp.SupportedProtocolVersion)
+		}
+	}
+}
+
+func TestBuildProfileRejectsUnsupportedVersion(t *testing.T) {
+	_, err := acp.BuildProfile(acpsdk.ProtocolVersion(2))
+	if err == nil {
+		t.Fatal("BuildProfile(2) expected error, got nil")
+	}
+	var compatErr *acp.CompatibilityError
+	if !errors.As(err, &compatErr) {
+		t.Fatalf("BuildProfile(2) error type = %T, want *acp.CompatibilityError", err)
+	}
+}
+
+func TestBuildProfileAcceptsSupportedVersion(t *testing.T) {
+	profile, err := acp.BuildProfile(acp.SupportedProtocolVersion)
+	if err != nil {
+		t.Fatalf("BuildProfile() unexpected error: %v", err)
+	}
+	if profile.ProtocolVersion != acp.SupportedProtocolVersion {
+		t.Fatalf("BuildProfile() ProtocolVersion = %d, want %d", profile.ProtocolVersion, acp.SupportedProtocolVersion)
+	}
+}
+
+// TestTextFirstAgentCapabilitiesSerializedShape locks the exact serialized
+// capability claims so a zero-value SDK field change or an accidental
+// capability addition cannot silently widen what V0 advertises.
+func TestTextFirstAgentCapabilitiesSerializedShape(t *testing.T) {
+	capabilities := acp.TextFirstAgentCapabilities()
+
+	data, err := json.Marshal(capabilities)
+	if err != nil {
+		t.Fatalf("json.Marshal(capabilities) unexpected error: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal(capabilities) unexpected error: %v", err)
+	}
+
+	prompt, ok := decoded["promptCapabilities"].(map[string]any)
+	if ok {
+		for _, key := range []string{"audio", "embeddedContext", "image"} {
+			if v, present := prompt[key]; present && v != false {
+				t.Fatalf("promptCapabilities.%s = %v, want false or absent", key, v)
+			}
+		}
+	}
+
+	if mcp, ok := decoded["mcpCapabilities"].(map[string]any); ok {
+		for _, key := range []string{"acp", "http", "sse"} {
+			if v, present := mcp[key]; present && v != false {
+				t.Fatalf("mcpCapabilities.%s = %v, want false or absent", key, v)
+			}
+		}
+	}
+
+	if _, present := decoded["loadSession"]; present {
+		t.Fatalf("loadSession must be absent (zero value), got %v", decoded["loadSession"])
+	}
+
+	if session, ok := decoded["sessionCapabilities"].(map[string]any); ok {
+		for _, key := range []string{"fork", "close", "delete", "list", "resume", "additionalDirectories"} {
+			if v, present := session[key]; present {
+				t.Fatalf("sessionCapabilities.%s must be absent, got %v", key, v)
+			}
+		}
+	}
+
+	if auth, ok := decoded["auth"].(map[string]any); ok {
+		if v, present := auth["logout"]; present {
+			t.Fatalf("auth.logout must be absent, got %v", v)
+		}
+	}
+
+	if _, present := decoded["providers"]; present {
+		t.Fatalf("providers capability must be absent, got %v", decoded["providers"])
+	}
+	if _, present := decoded["nes"]; present {
+		t.Fatalf("nes capability must be absent, got %v", decoded["nes"])
+	}
+}
+
+func TestTextFirstAgentCapabilitiesRoundTripsThroughSDKType(t *testing.T) {
+	capabilities := acp.TextFirstAgentCapabilities()
+
+	data, err := json.Marshal(capabilities)
+	if err != nil {
+		t.Fatalf("json.Marshal(capabilities) unexpected error: %v", err)
+	}
+
+	var decoded acpsdk.AgentCapabilities
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal(capabilities) unexpected error: %v", err)
+	}
+
+	if decoded.PromptCapabilities.Image || decoded.PromptCapabilities.Audio || decoded.PromptCapabilities.EmbeddedContext {
+		t.Fatalf("decoded PromptCapabilities = %+v, want all false", decoded.PromptCapabilities)
+	}
+	if decoded.LoadSession {
+		t.Fatal("decoded LoadSession = true, want false")
+	}
+	if decoded.SessionCapabilities.Fork != nil {
+		t.Fatal("decoded SessionCapabilities.Fork is set, want nil")
+	}
+	if decoded.McpCapabilities.Acp || decoded.McpCapabilities.Http || decoded.McpCapabilities.Sse {
+		t.Fatalf("decoded McpCapabilities = %+v, want all false", decoded.McpCapabilities)
+	}
+}

--- a/pkg/transports/acp/conformance_test.go
+++ b/pkg/transports/acp/conformance_test.go
@@ -1,0 +1,388 @@
+package acp_test
+
+// This file independently verifies the shared ACP L1 V0 conformance corpus
+// (internal/testutil/acpconformance) against the real pkg/transports/acp
+// outbound compatibility boundary. It imports no Providers package and calls
+// none of the Providers-owned inbound mapper: the transport and provider
+// directions are proven against the same corpus cases independently, per
+// ACP-L1-V0-protocol-conformance-004.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	"github.com/portpowered/infinite-you/internal/testutil/acpconformance"
+	"github.com/portpowered/infinite-you/pkg/transports/acp"
+)
+
+// wireEnvelope decodes the transport-facing fields a corpus case's payload
+// may carry beyond the bare ACP-SDK wire shape: connectionId and mintedId
+// are this repo's transport-local correlation metadata, never part of the
+// ACP JSON-RPC envelope itself.
+type wireEnvelope struct {
+	Method       string            `json:"method"`
+	ID           *acpsdk.RequestId `json:"id"`
+	ConnectionID string            `json:"connectionId"`
+	MintedID     string            `json:"mintedId"`
+	Params       json.RawMessage   `json:"params"`
+}
+
+func TestConformanceInitializeCasesMatchNegotiateProtocolVersion(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	cases := corpus.ByRole(acpconformance.RoleInitialize)
+	if len(cases) == 0 {
+		t.Fatal("expected at least one initialize case")
+	}
+	for _, c := range cases {
+		t.Run(c.ID, func(t *testing.T) {
+			var req acpsdk.InitializeRequest
+			if err := json.Unmarshal(c.Payload, &req); err != nil {
+				t.Fatalf("payload does not parse as acpsdk.InitializeRequest: %v", err)
+			}
+			negotiated, err := acp.NegotiateProtocolVersion(req.ProtocolVersion)
+			switch c.Facts.Outcome {
+			case "accepted":
+				if err != nil {
+					t.Fatalf("NegotiateProtocolVersion(%d) unexpected error: %v", req.ProtocolVersion, err)
+				}
+				if fmt.Sprint(int(negotiated)) != c.Facts.Metadata["negotiated_version"] {
+					t.Errorf("negotiated version = %d, want %s", negotiated, c.Facts.Metadata["negotiated_version"])
+				}
+			case "incompatible_version":
+				if err == nil {
+					t.Fatalf("NegotiateProtocolVersion(%d) expected error, got nil", req.ProtocolVersion)
+				}
+				var compatErr *acp.CompatibilityError
+				if !errors.As(err, &compatErr) {
+					t.Fatalf("NegotiateProtocolVersion(%d) error type = %T, want *acp.CompatibilityError", req.ProtocolVersion, err)
+				}
+				if fmt.Sprint(int(compatErr.RequestedVersion)) != c.Facts.Metadata["requested_version"] {
+					t.Errorf("RequestedVersion = %d, want %s", compatErr.RequestedVersion, c.Facts.Metadata["requested_version"])
+				}
+				if fmt.Sprint(int(compatErr.SupportedVersion)) != c.Facts.Metadata["supported_version"] {
+					t.Errorf("SupportedVersion = %d, want %s", compatErr.SupportedVersion, c.Facts.Metadata["supported_version"])
+				}
+			default:
+				t.Fatalf("case %q has unhandled initialize outcome %q", c.ID, c.Facts.Outcome)
+			}
+		})
+	}
+}
+
+func TestConformanceCapabilitiesCaseMatchesTextFirstAgentCapabilities(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	cases := corpus.ByRole(acpconformance.RoleCapabilities)
+	if len(cases) == 0 {
+		t.Fatal("expected at least one capabilities case")
+	}
+	data, err := json.Marshal(acp.TextFirstAgentCapabilities())
+	if err != nil {
+		t.Fatalf("json.Marshal(TextFirstAgentCapabilities()) unexpected error: %v", err)
+	}
+	var got any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal actual capabilities: %v", err)
+	}
+	for _, c := range cases {
+		t.Run(c.ID, func(t *testing.T) {
+			var want any
+			if err := json.Unmarshal(c.Payload, &want); err != nil {
+				t.Fatalf("unmarshal case payload: %v", err)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("TextFirstAgentCapabilities() serialized = %v, want case payload %v", got, want)
+			}
+		})
+	}
+}
+
+func TestConformanceFactoryOptionCaseMatchesFactoryTargetOption(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	cases := corpus.ByRole(acpconformance.RoleFactoryOption)
+	if len(cases) == 0 {
+		t.Fatal("expected at least one factory_option case")
+	}
+	for _, c := range cases {
+		t.Run(c.ID, func(t *testing.T) {
+			var wire acpsdk.SessionConfigOption
+			if err := json.Unmarshal(c.Payload, &wire); err != nil {
+				t.Fatalf("payload does not parse as acpsdk.SessionConfigOption: %v", err)
+			}
+			domain, err := acp.FactoryTargetOptionFromSessionConfigOption(wire)
+			if err != nil {
+				t.Fatalf("FactoryTargetOptionFromSessionConfigOption() unexpected error: %v", err)
+			}
+			if string(domain.CurrentValue) != c.Facts.Metadata["current_value"] {
+				t.Errorf("CurrentValue = %q, want %q", domain.CurrentValue, c.Facts.Metadata["current_value"])
+			}
+			if fmt.Sprint(len(domain.Choices)) != c.Facts.Metadata["choice_count"] {
+				t.Errorf("choice count = %d, want %s", len(domain.Choices), c.Facts.Metadata["choice_count"])
+			}
+
+			reencoded, err := domain.ToSessionConfigOption()
+			if err != nil {
+				t.Fatalf("ToSessionConfigOption() unexpected error: %v", err)
+			}
+			data, err := json.Marshal(reencoded)
+			if err != nil {
+				t.Fatalf("marshal re-encoded option: %v", err)
+			}
+			var got, want any
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("unmarshal re-encoded option: %v", err)
+			}
+			if err := json.Unmarshal(c.Payload, &want); err != nil {
+				t.Fatalf("unmarshal case payload: %v", err)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("round-tripped FactoryTargetOption = %v, want case payload %v", got, want)
+			}
+		})
+	}
+}
+
+func TestConformanceRequestIdentityCasesMatchConstructors(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	cases := corpus.ByRole(acpconformance.RoleRequestIdentity)
+	if len(cases) == 0 {
+		t.Fatal("expected at least one request_identity case")
+	}
+	for _, c := range cases {
+		t.Run(c.ID, func(t *testing.T) {
+			var envelope wireEnvelope
+			if err := json.Unmarshal(c.Payload, &envelope); err != nil {
+				t.Fatalf("payload does not parse: %v", err)
+			}
+			wantConnectionID := c.Facts.Metadata["connection_id"]
+			switch c.Facts.Outcome {
+			case "string_id":
+				if envelope.ID == nil || envelope.ID.Str == nil {
+					t.Fatalf("case %q declares string_id but decoded id = %+v", c.ID, envelope.ID)
+				}
+				identity, err := acp.NewRequestIdentity(envelope.ConnectionID, *envelope.ID)
+				if err != nil {
+					t.Fatalf("NewRequestIdentity() unexpected error: %v", err)
+				}
+				if identity.Kind != acp.WireIDKindString || identity.StringID != string(*envelope.ID.Str) {
+					t.Errorf("identity = %+v, want Kind=string StringID=%q", identity, *envelope.ID.Str)
+				}
+				if identity.ConnectionID != wantConnectionID {
+					t.Errorf("identity.ConnectionID = %q, want %q", identity.ConnectionID, wantConnectionID)
+				}
+			case "number_id":
+				if envelope.ID == nil || envelope.ID.Number == nil {
+					t.Fatalf("case %q declares number_id but decoded id = %+v", c.ID, envelope.ID)
+				}
+				identity, err := acp.NewRequestIdentity(envelope.ConnectionID, *envelope.ID)
+				if err != nil {
+					t.Fatalf("NewRequestIdentity() unexpected error: %v", err)
+				}
+				if identity.Kind != acp.WireIDKindNumber || identity.NumberID != int64(*envelope.ID.Number) {
+					t.Errorf("identity = %+v, want Kind=number NumberID=%d", identity, *envelope.ID.Number)
+				}
+				if identity.ConnectionID != wantConnectionID {
+					t.Errorf("identity.ConnectionID = %q, want %q", identity.ConnectionID, wantConnectionID)
+				}
+			case "minted":
+				if envelope.ID != nil {
+					t.Fatalf("case %q declares minted (no wire id) but decoded id = %+v", c.ID, envelope.ID)
+				}
+				identity, err := acp.NewMintedRequestIdentity(envelope.ConnectionID, envelope.MintedID)
+				if err != nil {
+					t.Fatalf("NewMintedRequestIdentity() unexpected error: %v", err)
+				}
+				if identity.Kind != acp.WireIDKindMinted || identity.MintedID != envelope.MintedID {
+					t.Errorf("identity = %+v, want Kind=minted MintedID=%q", identity, envelope.MintedID)
+				}
+				if identity.ConnectionID != wantConnectionID {
+					t.Errorf("identity.ConnectionID = %q, want %q", identity.ConnectionID, wantConnectionID)
+				}
+			default:
+				t.Fatalf("case %q has unhandled request_identity outcome %q", c.ID, c.Facts.Outcome)
+			}
+		})
+	}
+}
+
+func TestConformanceMalformedInputCasesProduceTypedOutcomes(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	cases := corpus.ByRole(acpconformance.RoleMalformedInput)
+	if len(cases) == 0 {
+		t.Fatal("expected at least one malformed_input case")
+	}
+	for _, c := range cases {
+		t.Run(c.ID, func(t *testing.T) {
+			switch c.Facts.Outcome {
+			case "invalid_params":
+				var envelope wireEnvelope
+				if err := json.Unmarshal(c.Payload, &envelope); err != nil {
+					t.Fatalf("payload does not parse: %v", err)
+				}
+				_, decodeErr := acp.DecodeMethodParams[map[string]any](envelope.Params)
+				if decodeErr == nil {
+					t.Fatal("DecodeMethodParams() expected an invalid-params error, got nil")
+				}
+				if decodeErr.Code != -32602 {
+					t.Errorf("DecodeMethodParams().Code = %d, want -32602", decodeErr.Code)
+				}
+			case "invalid_request":
+				var envelope struct {
+					ID acpsdk.RequestId `json:"id"`
+				}
+				if err := json.Unmarshal(c.Payload, &envelope); err == nil {
+					t.Fatal("expected the case's request id to fail acpsdk.RequestId decoding, got nil error")
+				}
+			default:
+				t.Fatalf("case %q has unhandled malformed_input outcome %q", c.ID, c.Facts.Outcome)
+			}
+		})
+	}
+}
+
+func TestConformanceUnsupportedMethodCasesMatchDispatch(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	cases := corpus.ByRole(acpconformance.RoleUnsupportedMethod)
+	if len(cases) == 0 {
+		t.Fatal("expected at least one unsupported_method case")
+	}
+	for _, c := range cases {
+		t.Run(c.ID, func(t *testing.T) {
+			var envelope wireEnvelope
+			if err := json.Unmarshal(c.Payload, &envelope); err != nil {
+				t.Fatalf("payload does not parse: %v", err)
+			}
+			if disposition, ok := c.Facts.Metadata["disposition"]; ok {
+				got := acp.ClassifyMethod(envelope.Method)
+				if string(got) != disposition {
+					t.Errorf("ClassifyMethod(%q) = %q, want %q", envelope.Method, got, disposition)
+				}
+			}
+			outcome := acp.UnsupportedMethodResponse(envelope.Method, envelope.ID)
+			switch c.Facts.Outcome {
+			case "method_not_found":
+				if outcome == nil {
+					t.Fatal("UnsupportedMethodResponse() = nil, want a method-not-found outcome")
+				}
+				if outcome.Error == nil || fmt.Sprint(outcome.Error.Code) != c.Facts.Metadata["error_code"] {
+					t.Errorf("outcome.Error = %+v, want code %s", outcome.Error, c.Facts.Metadata["error_code"])
+				}
+				if envelope.ID == nil || outcome.ResponseID != *envelope.ID {
+					t.Errorf("outcome.ResponseID = %+v, want %+v", outcome.ResponseID, envelope.ID)
+				}
+			case "no_response_emitted":
+				if outcome != nil {
+					t.Errorf("UnsupportedMethodResponse() = %+v, want nil (no response emitted)", outcome)
+				}
+			default:
+				t.Fatalf("case %q has unhandled unsupported_method outcome %q", c.ID, c.Facts.Outcome)
+			}
+		})
+	}
+}
+
+// TestConformanceRoundTripSessionUpdateCasesPreserveFactsAcrossEncodeDecode
+// independently proves the declared round-trip subset survives an
+// encode/decode cycle through the pinned acp-go-sdk type, from the transport
+// side, without importing Providers internals or calling the inbound
+// mapper (mirrors, but does not share code with, the corpus package's own
+// self-consistency proof).
+func TestConformanceRoundTripSessionUpdateCasesPreserveFactsAcrossEncodeDecode(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	roundTrip := corpus.RoundTripCases()
+	if len(roundTrip) == 0 {
+		t.Fatal("expected at least one round_trip case")
+	}
+	for _, c := range roundTrip {
+		t.Run(c.ID, func(t *testing.T) {
+			var update acpsdk.SessionUpdate
+			if err := json.Unmarshal(c.Payload, &update); err != nil {
+				t.Fatalf("payload does not parse as acpsdk.SessionUpdate: %v", err)
+			}
+			kind, itemID, text, metadata := transportSessionUpdateFacts(t, update)
+			if kind != c.Facts.Kind {
+				t.Errorf("decoded kind = %q, want %q", kind, c.Facts.Kind)
+			}
+			if c.Facts.ItemID != "" && itemID != c.Facts.ItemID {
+				t.Errorf("decoded item id = %q, want %q", itemID, c.Facts.ItemID)
+			}
+			if c.Facts.Text != "" && text != c.Facts.Text {
+				t.Errorf("decoded text = %q, want %q", text, c.Facts.Text)
+			}
+			for key, want := range c.Facts.Metadata {
+				if metadata[key] != want {
+					t.Errorf("decoded metadata[%q] = %q, want %q", key, metadata[key], want)
+				}
+			}
+
+			reencoded, err := json.Marshal(update)
+			if err != nil {
+				t.Fatalf("re-marshal SessionUpdate: %v", err)
+			}
+			var redecoded acpsdk.SessionUpdate
+			if err := json.Unmarshal(reencoded, &redecoded); err != nil {
+				t.Fatalf("re-unmarshal SessionUpdate: %v", err)
+			}
+			reKind, reItemID, reText, reMetadata := transportSessionUpdateFacts(t, redecoded)
+			if reKind != kind || reItemID != itemID || reText != text {
+				t.Errorf(
+					"round_trip case %q lost facts across an encode/decode cycle: got (%q,%q,%q), want (%q,%q,%q)",
+					c.ID, reKind, reItemID, reText, kind, itemID, text,
+				)
+			}
+			if !reflect.DeepEqual(reMetadata, metadata) {
+				t.Errorf("round_trip case %q lost metadata across an encode/decode cycle: got %v, want %v", c.ID, reMetadata, metadata)
+			}
+		})
+	}
+}
+
+// transportSessionUpdateFacts extracts a minimal (kind, itemID, text,
+// metadata) tuple directly from a decoded acpsdk.SessionUpdate for the
+// round-trip-eligible variants only. It deliberately duplicates none of the
+// Providers-owned mapper's policy; it exists only to prove this corpus's
+// round-trip subset is stable under the pinned SDK type from the transport
+// side.
+func transportSessionUpdateFacts(t testing.TB, update acpsdk.SessionUpdate) (kind, itemID, text string, metadata map[string]string) {
+	t.Helper()
+	switch {
+	case update.AgentMessageChunk != nil:
+		id := ""
+		if update.AgentMessageChunk.MessageId != nil {
+			id = *update.AgentMessageChunk.MessageId
+		}
+		txt := ""
+		if update.AgentMessageChunk.Content.Text != nil {
+			txt = update.AgentMessageChunk.Content.Text.Text
+		}
+		return "message", id, txt, nil
+	case update.AgentThoughtChunk != nil:
+		id := ""
+		if update.AgentThoughtChunk.MessageId != nil {
+			id = *update.AgentThoughtChunk.MessageId
+		}
+		txt := ""
+		if update.AgentThoughtChunk.Content.Text != nil {
+			txt = update.AgentThoughtChunk.Content.Text.Text
+		}
+		return "reasoning", id, txt, nil
+	case update.UsageUpdate != nil:
+		return "usage", "usage", "", map[string]string{
+			"used_tokens": fmt.Sprint(update.UsageUpdate.Used),
+			"max_tokens":  fmt.Sprint(update.UsageUpdate.Size),
+		}
+	case update.SessionInfoUpdate != nil:
+		txt := ""
+		if update.SessionInfoUpdate.Title != nil {
+			txt = *update.SessionInfoUpdate.Title
+		}
+		return "session", "session", txt, nil
+	default:
+		t.Fatalf("transportSessionUpdateFacts: no round-trip-eligible SessionUpdate variant is set: %+v", update)
+		return "", "", "", nil
+	}
+}

--- a/pkg/transports/acp/dispatch.go
+++ b/pkg/transports/acp/dispatch.go
@@ -1,0 +1,91 @@
+package acp
+
+import (
+	"bytes"
+	"encoding/json"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+)
+
+// MethodDisposition classifies a JSON-RPC method name against this V0
+// boundary's method inventory. Every disposition other than a method this
+// boundary implements resolves identically on the wire -- method not found
+// -- because stdio serving and session execution are later work; the
+// distinction between "deferred" and "unknown" exists for inventory and test
+// coverage, not differing wire behavior.
+type MethodDisposition string
+
+const (
+	// MethodDispositionDeferred marks a method the ACP protocol/SDK defines
+	// that this V0 boundary does not yet implement.
+	MethodDispositionDeferred MethodDisposition = "deferred"
+	// MethodDispositionUnknown marks a method this V0 boundary does not
+	// recognize at all.
+	MethodDispositionUnknown MethodDisposition = "unknown"
+)
+
+// deferredMethods lists ACP methods defined by the protocol/SDK that this
+// inert V0 boundary does not implement: stdio serving and session execution
+// are later work.
+var deferredMethods = map[string]struct{}{
+	"initialize":                 {},
+	"session/new":                {},
+	"session/load":               {},
+	"session/prompt":             {},
+	"session/cancel":             {},
+	"session/set_config_option":  {},
+	"session/request_permission": {},
+	"session/set_mode":           {},
+	"authenticate":               {},
+}
+
+// ClassifyMethod reports whether method is a V0-deferred ACP operation or
+// genuinely unknown to the protocol. It performs no IO and has no side
+// effect.
+func ClassifyMethod(method string) MethodDisposition {
+	if _, ok := deferredMethods[method]; ok {
+		return MethodDispositionDeferred
+	}
+	return MethodDispositionUnknown
+}
+
+// UnsupportedMethodOutcome is the correlated, side-effect-free result of
+// dispatching a JSON-RPC request whose method this V0 boundary does not
+// implement, whether genuinely unknown or explicitly deferred.
+type UnsupportedMethodOutcome struct {
+	ResponseID acpsdk.RequestId
+	Error      *acpsdk.RequestError
+}
+
+// UnsupportedMethodResponse builds the method-not-found outcome for a
+// method this V0 boundary does not implement. wireID is the original
+// decoded JSON-RPC request id; a nil wireID represents a notification (no
+// id present), for which UnsupportedMethodResponse returns nil and the
+// caller must emit no response at all. UnsupportedMethodResponse invokes no
+// session, provider, process, filesystem, network, or persistence
+// collaborator.
+func UnsupportedMethodResponse(method string, wireID *acpsdk.RequestId) *UnsupportedMethodOutcome {
+	if wireID == nil {
+		return nil
+	}
+	return &UnsupportedMethodOutcome{
+		ResponseID: *wireID,
+		Error:      acpsdk.NewMethodNotFound(method),
+	}
+}
+
+// DecodeMethodParams unmarshals raw JSON-RPC params into T and returns a
+// typed, sensitive-safe invalid-params outcome on missing or malformed
+// input, so parameter validation never produces a partially decoded value.
+// The returned *acpsdk.RequestError never includes the raw params content.
+func DecodeMethodParams[T any](raw json.RawMessage) (T, *acpsdk.RequestError) {
+	var zero T
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return zero, acpsdk.NewInvalidParams(map[string]any{"reason": "missing params"})
+	}
+	var v T
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return zero, acpsdk.NewInvalidParams(map[string]any{"reason": "malformed params"})
+	}
+	return v, nil
+}

--- a/pkg/transports/acp/dispatch_test.go
+++ b/pkg/transports/acp/dispatch_test.go
@@ -1,0 +1,102 @@
+package acp_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	"github.com/portpowered/infinite-you/pkg/transports/acp"
+)
+
+func TestClassifyMethod(t *testing.T) {
+	cases := []struct {
+		method string
+		want   acp.MethodDisposition
+	}{
+		{"session/new", acp.MethodDispositionDeferred},
+		{"session/prompt", acp.MethodDispositionDeferred},
+		{"session/request_permission", acp.MethodDispositionDeferred},
+		{"initialize", acp.MethodDispositionDeferred},
+		{"totally/unknown", acp.MethodDispositionUnknown},
+		{"", acp.MethodDispositionUnknown},
+	}
+	for _, tc := range cases {
+		got := acp.ClassifyMethod(tc.method)
+		if got != tc.want {
+			t.Errorf("ClassifyMethod(%q) = %q, want %q", tc.method, got, tc.want)
+		}
+	}
+}
+
+func TestUnsupportedMethodResponseWithWireID(t *testing.T) {
+	cases := []struct {
+		name   string
+		method string
+		wireID acpsdk.RequestId
+	}{
+		{"unknown method, string id", "totally/unknown", stringWireID("abc")},
+		{"deferred method, numeric id", "session/new", numberWireID(42)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			outcome := acp.UnsupportedMethodResponse(tc.method, &tc.wireID)
+			if outcome == nil {
+				t.Fatalf("UnsupportedMethodResponse(%q) = nil, want non-nil outcome", tc.method)
+			}
+			if outcome.Error == nil {
+				t.Fatalf("UnsupportedMethodResponse(%q).Error = nil, want method-not-found error", tc.method)
+			}
+			if outcome.Error.Code != -32601 {
+				t.Fatalf("UnsupportedMethodResponse(%q).Error.Code = %d, want -32601", tc.method, outcome.Error.Code)
+			}
+			if outcome.ResponseID != tc.wireID {
+				t.Fatalf("UnsupportedMethodResponse(%q).ResponseID = %+v, want original id %+v", tc.method, outcome.ResponseID, tc.wireID)
+			}
+		})
+	}
+}
+
+func TestUnsupportedMethodResponseForNotificationEmitsNoResponse(t *testing.T) {
+	outcome := acp.UnsupportedMethodResponse("totally/unknown", nil)
+	if outcome != nil {
+		t.Fatalf("UnsupportedMethodResponse(notification) = %+v, want nil (no response emitted)", outcome)
+	}
+}
+
+type decodeParamsFixture struct {
+	Foo string `json:"foo"`
+}
+
+func TestDecodeMethodParamsSuccess(t *testing.T) {
+	got, decodeErr := acp.DecodeMethodParams[decodeParamsFixture](json.RawMessage(`{"foo":"bar"}`))
+	if decodeErr != nil {
+		t.Fatalf("DecodeMethodParams() unexpected error: %v", decodeErr)
+	}
+	if got.Foo != "bar" {
+		t.Fatalf("DecodeMethodParams() = %+v, want Foo=bar", got)
+	}
+}
+
+func TestDecodeMethodParamsRejectsMissingParams(t *testing.T) {
+	cases := []json.RawMessage{nil, json.RawMessage(""), json.RawMessage("   ")}
+	for _, raw := range cases {
+		_, decodeErr := acp.DecodeMethodParams[decodeParamsFixture](raw)
+		if decodeErr == nil {
+			t.Fatalf("DecodeMethodParams(%q) expected invalid-params error, got nil", string(raw))
+		}
+		if decodeErr.Code != -32602 {
+			t.Fatalf("DecodeMethodParams(%q).Code = %d, want -32602", string(raw), decodeErr.Code)
+		}
+	}
+}
+
+func TestDecodeMethodParamsRejectsMalformedJSON(t *testing.T) {
+	_, decodeErr := acp.DecodeMethodParams[decodeParamsFixture](json.RawMessage(`{not json`))
+	if decodeErr == nil {
+		t.Fatal("DecodeMethodParams(malformed) expected invalid-params error, got nil")
+	}
+	if decodeErr.Code != -32602 {
+		t.Fatalf("DecodeMethodParams(malformed).Code = %d, want -32602", decodeErr.Code)
+	}
+}

--- a/pkg/transports/acp/doc.go
+++ b/pkg/transports/acp/doc.go
@@ -1,0 +1,12 @@
+// Package acp is the inert Agent Client Protocol (ACP) agent-side
+// compatibility boundary. It represents the ACP protocol version,
+// capability, configuration-option, and request-identity values understood
+// by the pinned github.com/coder/acp-go-sdk v0.13.5 dependency.
+//
+// Every value in this package is pure and deterministic: construction,
+// validation, and serialization perform no IO, start no goroutine or
+// process, bind no stdio or network endpoint, and create or invoke no Chat
+// Session or Factory Session. Stdio framing, a running JSON-RPC server, and
+// session execution are later work; this package only describes what a
+// future server would truthfully be allowed to claim.
+package acp

--- a/pkg/transports/acp/errors.go
+++ b/pkg/transports/acp/errors.go
@@ -28,3 +28,34 @@ func (e *CompatibilityError) Error() string {
 	}
 	return e.Message
 }
+
+// RequestIdentityErrorCode is the stable machine-readable failure code for
+// ACP request-identity construction.
+type RequestIdentityErrorCode string
+
+const (
+	// RequestIdentityErrorBlankConnectionID reports that a RequestIdentity
+	// was requested with an empty or whitespace-only connection identity.
+	RequestIdentityErrorBlankConnectionID RequestIdentityErrorCode = "ACP_BLANK_CONNECTION_ID"
+	// RequestIdentityErrorInvalidWireID reports that a decoded JSON-RPC
+	// request id was not the required string or numeric shape.
+	RequestIdentityErrorInvalidWireID RequestIdentityErrorCode = "ACP_INVALID_WIRE_ID"
+	// RequestIdentityErrorBlankMintedID reports that a transport-minted
+	// RequestIdentity was requested with an empty or whitespace-only minted
+	// id.
+	RequestIdentityErrorBlankMintedID RequestIdentityErrorCode = "ACP_BLANK_MINTED_ID"
+)
+
+// RequestIdentityError describes a sensitive-safe failure to construct a
+// RequestIdentity. Its Message never includes request parameter content.
+type RequestIdentityError struct {
+	Code    RequestIdentityErrorCode
+	Message string
+}
+
+func (e *RequestIdentityError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}

--- a/pkg/transports/acp/errors.go
+++ b/pkg/transports/acp/errors.go
@@ -1,0 +1,30 @@
+package acp
+
+import acpsdk "github.com/coder/acp-go-sdk"
+
+// CompatibilityErrorCode is the stable machine-readable failure code for ACP
+// compatibility negotiation.
+type CompatibilityErrorCode string
+
+const (
+	// CompatibilityErrorUnsupportedProtocolVersion reports that a requested
+	// ACP protocol version is not SupportedProtocolVersion.
+	CompatibilityErrorUnsupportedProtocolVersion CompatibilityErrorCode = "ACP_UNSUPPORTED_PROTOCOL_VERSION"
+)
+
+// CompatibilityError describes a sensitive-safe ACP compatibility failure.
+// Its Message never includes anything beyond the numeric protocol versions
+// already public in the ACP wire protocol.
+type CompatibilityError struct {
+	Code             CompatibilityErrorCode
+	Message          string
+	RequestedVersion acpsdk.ProtocolVersion
+	SupportedVersion acpsdk.ProtocolVersion
+}
+
+func (e *CompatibilityError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}

--- a/pkg/transports/acp/factory_target_option.go
+++ b/pkg/transports/acp/factory_target_option.go
@@ -1,0 +1,121 @@
+package acp
+
+import (
+	"errors"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+)
+
+// FactoryTargetOptionID is the stable ACP session configuration option id
+// used to represent Factory target selection.
+const FactoryTargetOptionID acpsdk.SessionConfigId = "target"
+
+// FactoryTargetOptionName is the human-readable label shown for the Factory
+// target selector.
+const FactoryTargetOptionName = "Factory"
+
+// FactoryTargetOptionCategory is the UX-only semantic category advertised
+// for the Factory target selector. It does not make the option an ACP model
+// resource; a Factory is an orchestration definition, not a You Model.
+const FactoryTargetOptionCategory acpsdk.SessionConfigOptionCategory = acpsdk.SessionConfigOptionCategoryModel
+
+// FactoryTargetOptionType is the required discriminant of the ACP
+// select-option union.
+const FactoryTargetOptionType = "select"
+
+// ErrFactoryTargetOptionEmpty reports that a Factory target option was built
+// with no selectable choices.
+var ErrFactoryTargetOptionEmpty = errors.New("acp: factory target option requires at least one choice")
+
+// ErrFactoryTargetOptionCurrentValueMissing reports that a Factory target
+// option's current value is not one of its own choices.
+var ErrFactoryTargetOptionCurrentValueMissing = errors.New("acp: factory target option current value must be one of its choices")
+
+// ErrFactoryTargetOptionNotSelect reports that a decoded ACP session
+// configuration option was not the select-option variant this V0 boundary
+// requires for Factory target selection.
+var ErrFactoryTargetOptionNotSelect = errors.New("acp: factory target option requires the select-option union variant")
+
+// FactoryTargetChoice is one selectable Factory target value.
+type FactoryTargetChoice struct {
+	Value acpsdk.SessionConfigValueId
+	Name  string
+}
+
+// FactoryTargetOption is the domain-level representation of Factory target
+// selection. It is a session configuration option, never an ACP model
+// resource.
+type FactoryTargetOption struct {
+	CurrentValue acpsdk.SessionConfigValueId
+	Choices      []FactoryTargetChoice
+}
+
+// ToSessionConfigOption serializes the Factory target option as the ACP
+// select-option discriminated union (type=select) with a stable id, name,
+// current value, and allowed values.
+func (option FactoryTargetOption) ToSessionConfigOption() (acpsdk.SessionConfigOption, error) {
+	if len(option.Choices) == 0 {
+		return acpsdk.SessionConfigOption{}, ErrFactoryTargetOptionEmpty
+	}
+	found := false
+	ungrouped := make(acpsdk.SessionConfigSelectOptionsUngrouped, 0, len(option.Choices))
+	for _, choice := range option.Choices {
+		if choice.Value == option.CurrentValue {
+			found = true
+		}
+		ungrouped = append(ungrouped, acpsdk.SessionConfigSelectOption{
+			Value: choice.Value,
+			Name:  choice.Name,
+		})
+	}
+	if !found {
+		return acpsdk.SessionConfigOption{}, ErrFactoryTargetOptionCurrentValueMissing
+	}
+	category := FactoryTargetOptionCategory
+	return acpsdk.SessionConfigOption{
+		Select: &acpsdk.SessionConfigOptionSelect{
+			Id:           FactoryTargetOptionID,
+			Name:         FactoryTargetOptionName,
+			Category:     &category,
+			CurrentValue: option.CurrentValue,
+			Options: acpsdk.SessionConfigSelectOptions{
+				Ungrouped: &ungrouped,
+			},
+			Type: FactoryTargetOptionType,
+		},
+	}, nil
+}
+
+// FactoryTargetOptionFromSessionConfigOption decodes an ACP session
+// configuration option back into the domain-level Factory target
+// representation, rejecting anything that is not the select-option variant
+// with a non-empty choice set containing the current value.
+func FactoryTargetOptionFromSessionConfigOption(wire acpsdk.SessionConfigOption) (FactoryTargetOption, error) {
+	if wire.Select == nil || wire.Select.Type != FactoryTargetOptionType {
+		return FactoryTargetOption{}, ErrFactoryTargetOptionNotSelect
+	}
+	selectOption := wire.Select
+	var choices []FactoryTargetChoice
+	if selectOption.Options.Ungrouped != nil {
+		for _, choice := range *selectOption.Options.Ungrouped {
+			choices = append(choices, FactoryTargetChoice{Value: choice.Value, Name: choice.Name})
+		}
+	}
+	if len(choices) == 0 {
+		return FactoryTargetOption{}, ErrFactoryTargetOptionEmpty
+	}
+	found := false
+	for _, choice := range choices {
+		if choice.Value == selectOption.CurrentValue {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return FactoryTargetOption{}, ErrFactoryTargetOptionCurrentValueMissing
+	}
+	return FactoryTargetOption{
+		CurrentValue: selectOption.CurrentValue,
+		Choices:      choices,
+	}, nil
+}

--- a/pkg/transports/acp/factory_target_option_test.go
+++ b/pkg/transports/acp/factory_target_option_test.go
@@ -1,0 +1,186 @@
+package acp_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	"github.com/portpowered/infinite-you/pkg/transports/acp"
+)
+
+func sampleFactoryTargetOption() acp.FactoryTargetOption {
+	return acp.FactoryTargetOption{
+		CurrentValue: "factory:@you/factory-builder",
+		Choices: []acp.FactoryTargetChoice{
+			{Value: "factory:@you/factory-builder", Name: "Factory Builder"},
+			{Value: "factory:@you/review", Name: "Review"},
+		},
+	}
+}
+
+func TestFactoryTargetOptionToSessionConfigOptionSerializesSelectUnion(t *testing.T) {
+	option := sampleFactoryTargetOption()
+
+	wire, err := option.ToSessionConfigOption()
+	if err != nil {
+		t.Fatalf("ToSessionConfigOption() unexpected error: %v", err)
+	}
+	if wire.Select == nil {
+		t.Fatal("ToSessionConfigOption() Select is nil, want the select-option variant")
+	}
+	if wire.Boolean != nil {
+		t.Fatal("ToSessionConfigOption() Boolean is set, want nil")
+	}
+	if wire.Select.Type != "select" {
+		t.Fatalf("ToSessionConfigOption() Type = %q, want %q", wire.Select.Type, "select")
+	}
+	if wire.Select.Id != acp.FactoryTargetOptionID {
+		t.Fatalf("ToSessionConfigOption() Id = %q, want %q", wire.Select.Id, acp.FactoryTargetOptionID)
+	}
+	if wire.Select.Name != acp.FactoryTargetOptionName {
+		t.Fatalf("ToSessionConfigOption() Name = %q, want %q", wire.Select.Name, acp.FactoryTargetOptionName)
+	}
+	if wire.Select.CurrentValue != option.CurrentValue {
+		t.Fatalf("ToSessionConfigOption() CurrentValue = %q, want %q", wire.Select.CurrentValue, option.CurrentValue)
+	}
+	if wire.Select.Options.Ungrouped == nil {
+		t.Fatal("ToSessionConfigOption() Options.Ungrouped is nil")
+	}
+	if got, want := len(*wire.Select.Options.Ungrouped), len(option.Choices); got != want {
+		t.Fatalf("ToSessionConfigOption() choice count = %d, want %d", got, want)
+	}
+
+	if err := wire.Validate(); err != nil {
+		t.Fatalf("wire.Validate() unexpected error: %v", err)
+	}
+
+	data, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatalf("json.Marshal(wire) unexpected error: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal(wire) unexpected error: %v", err)
+	}
+	if decoded["type"] != "select" {
+		t.Fatalf("serialized type = %v, want %q", decoded["type"], "select")
+	}
+	if decoded["id"] != string(acp.FactoryTargetOptionID) {
+		t.Fatalf("serialized id = %v, want %q", decoded["id"], acp.FactoryTargetOptionID)
+	}
+	if decoded["currentValue"] != string(option.CurrentValue) {
+		t.Fatalf("serialized currentValue = %v, want %q", decoded["currentValue"], option.CurrentValue)
+	}
+	if _, present := decoded["options"]; !present {
+		t.Fatal("serialized option is missing 'options'")
+	}
+}
+
+func TestFactoryTargetOptionRoundTripsThroughSessionConfigOption(t *testing.T) {
+	option := sampleFactoryTargetOption()
+
+	wire, err := option.ToSessionConfigOption()
+	if err != nil {
+		t.Fatalf("ToSessionConfigOption() unexpected error: %v", err)
+	}
+
+	data, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatalf("json.Marshal(wire) unexpected error: %v", err)
+	}
+
+	var decodedWire acpsdk.SessionConfigOption
+	if err := json.Unmarshal(data, &decodedWire); err != nil {
+		t.Fatalf("json.Unmarshal(wire) unexpected error: %v", err)
+	}
+
+	decoded, err := acp.FactoryTargetOptionFromSessionConfigOption(decodedWire)
+	if err != nil {
+		t.Fatalf("FactoryTargetOptionFromSessionConfigOption() unexpected error: %v", err)
+	}
+	if decoded.CurrentValue != option.CurrentValue {
+		t.Fatalf("round-tripped CurrentValue = %q, want %q", decoded.CurrentValue, option.CurrentValue)
+	}
+	if len(decoded.Choices) != len(option.Choices) {
+		t.Fatalf("round-tripped choice count = %d, want %d", len(decoded.Choices), len(option.Choices))
+	}
+	for i, choice := range option.Choices {
+		if decoded.Choices[i] != choice {
+			t.Fatalf("round-tripped choice[%d] = %+v, want %+v", i, decoded.Choices[i], choice)
+		}
+	}
+}
+
+func TestFactoryTargetOptionToSessionConfigOptionRejectsEmptyChoices(t *testing.T) {
+	option := acp.FactoryTargetOption{CurrentValue: "factory:@you/review"}
+	_, err := option.ToSessionConfigOption()
+	if !errors.Is(err, acp.ErrFactoryTargetOptionEmpty) {
+		t.Fatalf("ToSessionConfigOption() error = %v, want %v", err, acp.ErrFactoryTargetOptionEmpty)
+	}
+}
+
+func TestFactoryTargetOptionToSessionConfigOptionRejectsMissingCurrentValue(t *testing.T) {
+	option := acp.FactoryTargetOption{
+		CurrentValue: "factory:@you/unknown",
+		Choices: []acp.FactoryTargetChoice{
+			{Value: "factory:@you/review", Name: "Review"},
+		},
+	}
+	_, err := option.ToSessionConfigOption()
+	if !errors.Is(err, acp.ErrFactoryTargetOptionCurrentValueMissing) {
+		t.Fatalf("ToSessionConfigOption() error = %v, want %v", err, acp.ErrFactoryTargetOptionCurrentValueMissing)
+	}
+}
+
+func TestFactoryTargetOptionFromSessionConfigOptionRejectsBooleanVariant(t *testing.T) {
+	wire := acpsdk.SessionConfigOption{
+		Boolean: &acpsdk.SessionConfigOptionBoolean{
+			Id:           "target",
+			Name:         "Factory",
+			CurrentValue: true,
+			Type:         "boolean",
+		},
+	}
+	_, err := acp.FactoryTargetOptionFromSessionConfigOption(wire)
+	if !errors.Is(err, acp.ErrFactoryTargetOptionNotSelect) {
+		t.Fatalf("FactoryTargetOptionFromSessionConfigOption() error = %v, want %v", err, acp.ErrFactoryTargetOptionNotSelect)
+	}
+}
+
+func TestFactoryTargetOptionFromSessionConfigOptionRejectsEmptyOptions(t *testing.T) {
+	wire := acpsdk.SessionConfigOption{
+		Select: &acpsdk.SessionConfigOptionSelect{
+			Id:           "target",
+			Name:         "Factory",
+			CurrentValue: "factory:@you/review",
+			Type:         "select",
+		},
+	}
+	_, err := acp.FactoryTargetOptionFromSessionConfigOption(wire)
+	if !errors.Is(err, acp.ErrFactoryTargetOptionEmpty) {
+		t.Fatalf("FactoryTargetOptionFromSessionConfigOption() error = %v, want %v", err, acp.ErrFactoryTargetOptionEmpty)
+	}
+}
+
+func TestFactoryTargetOptionNeverProducesModelCapabilityFields(t *testing.T) {
+	option := sampleFactoryTargetOption()
+	wire, err := option.ToSessionConfigOption()
+	if err != nil {
+		t.Fatalf("ToSessionConfigOption() unexpected error: %v", err)
+	}
+	data, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatalf("json.Marshal(wire) unexpected error: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal(wire) unexpected error: %v", err)
+	}
+	for _, forbidden := range []string{"model", "modelId", "models"} {
+		if _, present := decoded[forbidden]; present {
+			t.Fatalf("serialized Factory target option unexpectedly contains model field %q", forbidden)
+		}
+	}
+}

--- a/pkg/transports/acp/request_identity.go
+++ b/pkg/transports/acp/request_identity.go
@@ -1,0 +1,81 @@
+package acp
+
+import (
+	"strings"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+)
+
+// WireIDKind distinguishes the supported JSON-RPC request-id wire shapes a
+// RequestIdentity was built from, so a numeric id and a string id with an
+// identical printed form (e.g. 1 and "1") are never conflated.
+type WireIDKind string
+
+const (
+	// WireIDKindString marks a RequestIdentity built from a JSON-RPC string id.
+	WireIDKindString WireIDKind = "string"
+	// WireIDKindNumber marks a RequestIdentity built from a JSON-RPC numeric id.
+	WireIDKindNumber WireIDKind = "number"
+	// WireIDKindMinted marks a RequestIdentity built for a notification or
+	// request with no usable wire id.
+	WireIDKindMinted WireIDKind = "minted"
+)
+
+// RequestIdentity correlates one JSON-RPC request or notification to the
+// connection it arrived on. JSON-RPC request ids are unique per connection
+// only: two different connections may reuse the same id concurrently, so the
+// bare wire id is never a safe correlation key by itself.
+type RequestIdentity struct {
+	ConnectionID string
+	Kind         WireIDKind
+	StringID     string
+	NumberID     int64
+	MintedID     string
+}
+
+// NewRequestIdentity builds a RequestIdentity from a non-empty connection
+// identity and a decoded JSON-RPC request id that carries a supported string
+// or numeric value. It rejects a blank connection identity and any other id
+// shape -- including the JSON-RPC null id, which the protocol itself
+// discourages for requests -- without returning a partially valid identity.
+func NewRequestIdentity(connectionID string, wireID acpsdk.RequestId) (RequestIdentity, error) {
+	if strings.TrimSpace(connectionID) == "" {
+		return RequestIdentity{}, &RequestIdentityError{
+			Code:    RequestIdentityErrorBlankConnectionID,
+			Message: "acp: request identity requires a non-empty connection identity",
+		}
+	}
+	switch {
+	case wireID.Str != nil:
+		return RequestIdentity{ConnectionID: connectionID, Kind: WireIDKindString, StringID: string(*wireID.Str)}, nil
+	case wireID.Number != nil:
+		return RequestIdentity{ConnectionID: connectionID, Kind: WireIDKindNumber, NumberID: int64(*wireID.Number)}, nil
+	default:
+		return RequestIdentity{}, &RequestIdentityError{
+			Code:    RequestIdentityErrorInvalidWireID,
+			Message: "acp: request identity requires a string or numeric JSON-RPC id",
+		}
+	}
+}
+
+// NewMintedRequestIdentity builds a transport-minted RequestIdentity for a
+// notification or request with no usable wire id. mintedID must be supplied
+// by the caller (e.g. a UUID) and is never derived from, nor confusable
+// with, a JSON-RPC response id: a minted identity is only ever used for
+// internal correlation and is never fabricated onto the wire as a response
+// id.
+func NewMintedRequestIdentity(connectionID, mintedID string) (RequestIdentity, error) {
+	if strings.TrimSpace(connectionID) == "" {
+		return RequestIdentity{}, &RequestIdentityError{
+			Code:    RequestIdentityErrorBlankConnectionID,
+			Message: "acp: request identity requires a non-empty connection identity",
+		}
+	}
+	if strings.TrimSpace(mintedID) == "" {
+		return RequestIdentity{}, &RequestIdentityError{
+			Code:    RequestIdentityErrorBlankMintedID,
+			Message: "acp: transport-minted request identity requires a non-empty minted id",
+		}
+	}
+	return RequestIdentity{ConnectionID: connectionID, Kind: WireIDKindMinted, MintedID: mintedID}, nil
+}

--- a/pkg/transports/acp/request_identity_test.go
+++ b/pkg/transports/acp/request_identity_test.go
@@ -1,0 +1,150 @@
+package acp_test
+
+import (
+	"testing"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	"github.com/portpowered/infinite-you/pkg/transports/acp"
+)
+
+func stringWireID(s string) acpsdk.RequestId {
+	v := acpsdk.RequestIdStr(s)
+	return acpsdk.RequestId{Str: &v}
+}
+
+func numberWireID(n int) acpsdk.RequestId {
+	v := acpsdk.RequestIdNumber(n)
+	return acpsdk.RequestId{Number: &v}
+}
+
+func nullWireID() acpsdk.RequestId {
+	v := acpsdk.RequestIdNull{}
+	return acpsdk.RequestId{Null: &v}
+}
+
+func TestNewRequestIdentityAcceptsStringAndNumericIDs(t *testing.T) {
+	stringIdentity, err := acp.NewRequestIdentity("conn-a", stringWireID("1"))
+	if err != nil {
+		t.Fatalf("NewRequestIdentity(string id) unexpected error: %v", err)
+	}
+	if stringIdentity.Kind != acp.WireIDKindString || stringIdentity.StringID != "1" {
+		t.Fatalf("NewRequestIdentity(string id) = %+v, want Kind=string StringID=1", stringIdentity)
+	}
+
+	numberIdentity, err := acp.NewRequestIdentity("conn-a", numberWireID(1))
+	if err != nil {
+		t.Fatalf("NewRequestIdentity(number id) unexpected error: %v", err)
+	}
+	if numberIdentity.Kind != acp.WireIDKindNumber || numberIdentity.NumberID != 1 {
+		t.Fatalf("NewRequestIdentity(number id) = %+v, want Kind=number NumberID=1", numberIdentity)
+	}
+
+	if stringIdentity == numberIdentity {
+		t.Fatalf("numeric id 1 and string id %q must not be conflated, got equal identities %+v", "1", stringIdentity)
+	}
+}
+
+func TestNewRequestIdentityDistinguishesConnections(t *testing.T) {
+	first, err := acp.NewRequestIdentity("conn-a", stringWireID("shared"))
+	if err != nil {
+		t.Fatalf("NewRequestIdentity(conn-a) unexpected error: %v", err)
+	}
+	second, err := acp.NewRequestIdentity("conn-b", stringWireID("shared"))
+	if err != nil {
+		t.Fatalf("NewRequestIdentity(conn-b) unexpected error: %v", err)
+	}
+	if first == second {
+		t.Fatalf("equal wire ids on different connections must produce distinct identities, got %+v == %+v", first, second)
+	}
+
+	third, err := acp.NewRequestIdentity("conn-a", stringWireID("shared"))
+	if err != nil {
+		t.Fatalf("NewRequestIdentity(conn-a) second call unexpected error: %v", err)
+	}
+	if first != third {
+		t.Fatalf("identical connection and wire id must produce equal identities, got %+v != %+v", first, third)
+	}
+}
+
+func TestNewRequestIdentityRejectsBlankConnectionID(t *testing.T) {
+	cases := []string{"", "   "}
+	for _, connectionID := range cases {
+		_, err := acp.NewRequestIdentity(connectionID, stringWireID("1"))
+		if err == nil {
+			t.Fatalf("NewRequestIdentity(%q, ...) expected error, got nil", connectionID)
+		}
+		identityErr, ok := err.(*acp.RequestIdentityError)
+		if !ok {
+			t.Fatalf("NewRequestIdentity(%q, ...) error type = %T, want *acp.RequestIdentityError", connectionID, err)
+		}
+		if identityErr.Code != acp.RequestIdentityErrorBlankConnectionID {
+			t.Fatalf("NewRequestIdentity(%q, ...) code = %q, want %q", connectionID, identityErr.Code, acp.RequestIdentityErrorBlankConnectionID)
+		}
+	}
+}
+
+func TestNewRequestIdentityRejectsInvalidWireIDShapes(t *testing.T) {
+	cases := map[string]acpsdk.RequestId{
+		"null id":  nullWireID(),
+		"empty id": {},
+	}
+	for name, wireID := range cases {
+		t.Run(name, func(t *testing.T) {
+			identity, err := acp.NewRequestIdentity("conn-a", wireID)
+			if err == nil {
+				t.Fatalf("NewRequestIdentity(%s) expected error, got identity %+v", name, identity)
+			}
+			identityErr, ok := err.(*acp.RequestIdentityError)
+			if !ok {
+				t.Fatalf("NewRequestIdentity(%s) error type = %T, want *acp.RequestIdentityError", name, err)
+			}
+			if identityErr.Code != acp.RequestIdentityErrorInvalidWireID {
+				t.Fatalf("NewRequestIdentity(%s) code = %q, want %q", name, identityErr.Code, acp.RequestIdentityErrorInvalidWireID)
+			}
+			if identity != (acp.RequestIdentity{}) {
+				t.Fatalf("NewRequestIdentity(%s) returned a non-zero identity on error: %+v", name, identity)
+			}
+		})
+	}
+}
+
+func TestNewMintedRequestIdentity(t *testing.T) {
+	first, err := acp.NewMintedRequestIdentity("conn-a", "minted-1")
+	if err != nil {
+		t.Fatalf("NewMintedRequestIdentity() unexpected error: %v", err)
+	}
+	if first.Kind != acp.WireIDKindMinted || first.MintedID != "minted-1" {
+		t.Fatalf("NewMintedRequestIdentity() = %+v, want Kind=minted MintedID=minted-1", first)
+	}
+
+	second, err := acp.NewMintedRequestIdentity("conn-a", "minted-2")
+	if err != nil {
+		t.Fatalf("NewMintedRequestIdentity() unexpected error: %v", err)
+	}
+	if first == second {
+		t.Fatalf("distinct minted ids must produce distinct identities, got %+v == %+v", first, second)
+	}
+
+	wireIdentity, err := acp.NewRequestIdentity("conn-a", stringWireID("minted-1"))
+	if err != nil {
+		t.Fatalf("NewRequestIdentity() unexpected error: %v", err)
+	}
+	if first == wireIdentity {
+		t.Fatalf("a minted identity must never equal a wire-id identity with the same printed value, got %+v == %+v", first, wireIdentity)
+	}
+}
+
+func TestNewMintedRequestIdentityRejectsBlankInputs(t *testing.T) {
+	if _, err := acp.NewMintedRequestIdentity("", "minted-1"); err == nil {
+		t.Fatal("NewMintedRequestIdentity(blank connection) expected error, got nil")
+	} else if identityErr, ok := err.(*acp.RequestIdentityError); !ok || identityErr.Code != acp.RequestIdentityErrorBlankConnectionID {
+		t.Fatalf("NewMintedRequestIdentity(blank connection) error = %v, want RequestIdentityErrorBlankConnectionID", err)
+	}
+
+	if _, err := acp.NewMintedRequestIdentity("conn-a", ""); err == nil {
+		t.Fatal("NewMintedRequestIdentity(blank minted id) expected error, got nil")
+	} else if identityErr, ok := err.(*acp.RequestIdentityError); !ok || identityErr.Code != acp.RequestIdentityErrorBlankMintedID {
+		t.Fatalf("NewMintedRequestIdentity(blank minted id) error = %v, want RequestIdentityErrorBlankMintedID", err)
+	}
+}


### PR DESCRIPTION
```json
{
  "project": "Define the ACP Compatibility Contract and Shared Conformance Corpus",
  "branchName": "ACP-L1-V0-protocol-conformance",
  "description": "Establish the inert ACP protocol-version-1 agent compatibility boundary and a sanitized semantic conformance corpus so independent inbound provider and future outbound agent mappings can prove truthful text-first behavior, request correlation, select-option shape, unsupported-method handling, and an explicit lossless round-trip subset without implementing stdio serving or session execution.",
  "context": {
    "customerAsk": "Define the L1 V0 ACP compatibility contract and shared conformance corpus so the existing inbound provider mapper and a future outbound agent mapper can prove agreement through fixtures while remaining separate implementations. Encode protocol version 1, honest text-first capabilities, config-option type=select, request identity, unsupported-method behavior, and an explicit round-trip subset; complete tests, CI, review resolution, conflict reconciliation, and merge without implementing stdio serving or session execution.",
    "problem": "The provider-side ACP adapter owns inbound SessionUpdate mapping and representative SDK-shaped fixtures, but those fixtures are not a neutral compatibility corpus for the opposite direction, and no top-level agent-side ACP contract exists. The directions can therefore drift on version negotiation, capability claims, select-option union shape, request correlation, unsupported behavior, and lossless mapping claims.",
    "solution": "Publish a small pure pkg/transports/acp compatibility boundary based on acp-go-sdk v0.13.5 and promote sanitized protocol examples into a shared semantic corpus with provenance, typed request correlation, expected facts, unsupported outcomes, directionality, and explicit round-trip eligibility. Keep inbound mapping under Providers and future outbound mapping under the ACP transport, with independent tests consuming the corpus and no shared production mapper.",
    "originalDocument": "C:/Users/andre/work/portos/infinite-you/docs/internal/projects/acp-client/final-proposal.md"
  },
  "acceptanceCriteria": [
    "The inert ACP compatibility boundary accepts protocol version 1, rejects unsupported versions with a typed safe outcome, and exposes no listener, stdio loop, connection lifecycle, session execution, or service-construction side effect.",
    "Advertised capabilities are text-first and exactly match implemented V0 behavior: image, audio, embedded context, filesystem, terminal, authentication, fork, plan, client MCP server, and permission capabilities are absent or disabled, and Factory selection uses a config option with type=select.",
    "Request identity distinguishes equal JSON-RPC IDs on different connections, preserves supported string and numeric ID types without conflation, and uses a transport-minted identity where correlation has no usable wire ID.",
    "Unknown and explicitly deferred methods produce the correlated method-not-found outcome without mutation or external effects, while malformed supported inputs produce typed invalid-request or invalid-params outcomes with sensitive-safe details.",
    "One sanitized provenance-pinned corpus declares representative semantic facts, directionality, unsupported/no-output outcomes, and the exact lossless round-trip subset, and is independently consumable by provider-side and transport-side tests without shared production mapping code.",
    "Quality gate: focused ACP compatibility, corpus, provider-mapping, malformed-input, and zero-side-effect tests pass along with typecheck, lint, make verify-fast, applicable package-boundary checks, and required PR CI; no OpenAPI or generated API artifacts change.",
    "Delivery: the implementation/review loop continues until all blocking PR conversation feedback is explicitly addressed, shared-corpus changes and merge conflicts are reconciled against current main, required CI is terminal and passing, and the PR is actually merged; opening, approval, green CI, or merge readiness alone is not completion."
  ],
  "userStories": [
    {
      "id": "ACP-L1-V0-protocol-conformance-001",
      "title": "Publish an inert and truthful ACP compatibility profile",
      "description": "As a maintainer implementing the later ACP server, I want one deterministic compatibility profile so initialization and Factory selection cannot claim behavior that You has not implemented.",
      "acceptanceCriteria": [
        "The agent-side ACP boundary represents acp-go-sdk v0.13.5 protocol version 1 as the only supported protocol version and returns a typed sensitive-safe incompatibility outcome for any other version.",
        "The compatibility result advertises text prompt content only and leaves image, audio, embedded context, filesystem, terminal, authentication, fork, plan, client MCP server, and permission capabilities disabled or absent as required by the SDK wire shape.",
        "A representative Factory target option serializes and deserializes as the ACP select-option union with type=select, stable id, name, currentValue, and allowed values, without representing the Factory as an ACP model resource.",
        "Constructing, validating, or serializing the profile performs no IO, starts no goroutine or process, binds no endpoint, and creates or invokes no Chat Session or Factory Session.",
        "Focused compatibility tests prove accepted and rejected versions, exact serialized capability claims, and select-option round-trip behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented pkg/transports/acp: SupportedProtocolVersion (=acpsdk.ProtocolVersionNumber), NegotiateProtocolVersion/BuildProfile with typed *CompatibilityError for unsupported versions, TextFirstAgentCapabilities (all non-text capabilities explicitly false/absent), and FactoryTargetOption with ToSessionConfigOption/FactoryTargetOptionFromSessionConfigOption for the type=select union round-trip. Focused tests in compatibility_test.go and factory_target_option_test.go cover accepted/rejected versions, exact serialized capability JSON, and select-option round-trip. go build/vet/test pass; make pkg-structure passes; make pkg-boundary/pkg-file-count/backend-size show only pre-existing baseline violations unrelated to this package."
    },
    {
      "id": "ACP-L1-V0-protocol-conformance-002",
      "title": "Preserve connection-scoped request identity and reject unsupported methods safely",
      "description": "As an ACP client integrator, I want requests correlated without cross-connection collisions and unsupported methods rejected without effects so retries and concurrent clients remain predictable.",
      "acceptanceCriteria": [
        "Request identity pairs a non-empty connection identity with the original supported JSON-RPC string or numeric ID; equal wire IDs from different connections are distinct, and numeric and string IDs with similar printed forms are not conflated.",
        "Notifications or requests without a usable wire ID receive a transport-minted non-empty identity where correlation is required without fabricating a JSON-RPC response ID.",
        "Blank connection identity, invalid JSON-RPC ID shapes, and malformed supported parameters return typed validation outcomes without a partially valid identity or protocol result.",
        "Unknown methods and V0-deferred operations return JSON-RPC method-not-found with the original request ID when one exists, while unknown notifications emit no response.",
        "Unsupported or malformed handling invokes no session, provider, process, filesystem, network, or persistence collaborator and leaks no credential, raw command, unsafe path, prompt content, or internal topology.",
        "Table-driven tests cover connection collisions, string and numeric IDs, missing and malformed IDs, unknown requests and notifications, and observable zero-effect behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented in pkg/transports/acp: request_identity.go adds WireIDKind (string/number/minted), RequestIdentity{ConnectionID, Kind, StringID, NumberID, MintedID} as a plain comparable struct, NewRequestIdentity(connectionID, acpsdk.RequestId) (rejects blank connection id and any id shape other than string/number, including the JSON-RPC null id), and NewMintedRequestIdentity(connectionID, mintedID) for notifications/requests with no usable wire id (rejects blank connection id and blank minted id). Because Kind participates in equality, a numeric id and a string id with the same printed form, and a minted identity and a wire-id identity with the same value, are never conflated; equal wire ids on different connections compare unequal since ConnectionID differs. dispatch.go adds MethodDisposition/ClassifyMethod (deferred vs unknown -- documented as identical on the wire), UnsupportedMethodOutcome/UnsupportedMethodResponse(method, *acpsdk.RequestId) returning a correlated acpsdk.NewMethodNotFound result keyed off the original id, or nil for a notification (nil wireID) so the caller emits no response, and a generic DecodeMethodParams[T](raw) that returns a typed acpsdk.NewInvalidParams outcome (sensitive-safe reason string only, never raw params content) for missing or malformed params. errors.go gains RequestIdentityErrorCode/RequestIdentityError following the repo's existing typed-error convention. All of this is pure/deterministic: no IO, no goroutine/process, no session/provider/process/filesystem/network/persistence collaborator is invoked by any of these functions. Table-driven tests in request_identity_test.go and dispatch_test.go cover connection collisions, string vs numeric id non-conflation, minted vs wire-id non-conflation, blank connection/minted id rejection, invalid wire id shapes (null and zero-value), unknown vs deferred method classification, method-not-found responses for unknown and deferred methods with string and numeric ids, notification zero-response behavior, and missing/malformed params. go build/vet/test and gofmt are clean; make test (full short Go suite) passes including the new cases; make pkg-structure passes; make pkg-boundary/pkg-file-count/backend-size show only pre-existing baseline violations unrelated to pkg/transports/acp."
    },
    {
      "id": "ACP-L1-V0-protocol-conformance-003",
      "title": "Promote a sanitized semantic ACP conformance corpus",
      "description": "As a transport or provider mapper maintainer, I want one representative semantic corpus so either protocol direction can verify compatibility without depending on the other direction's code.",
      "acceptanceCriteria": [
        "The shared committed corpus covers version-1 initialize negotiation, text-first capabilities, a type=select Factory option, string and numeric request correlation, text prompt content, agent message and thought updates, supported metadata updates, malformed input, and unsupported-method outcomes.",
        "Each case declares its protocol role, expected semantic facts, inbound and outbound support, and lossless round-trip eligibility; every non-subset case explicitly declares inbound-only, outbound-only, unsupported, or intentionally no-output behavior.",
        "The lossless subset contains only facts both directions preserve honestly, including stable item identity where present, text message chunks, text thought chunks, and usage or session-information fields represented by both vocabularies; tool, file-change, plan, progress, run, turn, and other lossy cases are excluded.",
        "Corpus content contains no credentials, customer prompts, machine-specific absolute paths, raw provider commands, or internal topology, and provenance/checksum metadata makes reviewed changes intentional and reproducible.",
        "A reusable test-only reader returns detached cases and rejects invalid JSON, duplicate case identity, missing expectations, undeclared directionality, and round-trip declarations containing known lossy or unsupported shapes.",
        "Corpus validation and SDK marshal/unmarshal tests prove protocol parseability, semantic stability, sanitization invariants, and exact round-trip declarations without testing repository inventories or registration topology.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented the shared, sanitized ACP L1 V0 semantic conformance corpus as a neutral test-only reader at internal/testutil/acpconformance (repo-root internal, importable by both pkg/services/providers tests and pkg/transports/acp tests without either importing the other's internals or a shared production mapper). corpus.json: 19 hand-authored, sanitized cases (schema_version=1, top-level provenance pinned to acp-go-sdk v0.13.5 module/commit/license) covering all 8 required protocol_role values (initialize, capabilities, factory_option, request_identity, prompt_content, session_update, malformed_input, unsupported_method) and all 5 directionality values (round_trip, inbound_only, outbound_only, unsupported, no_output). The round_trip subset is exactly the 4 lossless kinds (message/agent_message_chunk, reasoning/agent_thought_chunk, usage/usage_update, session/session_info_update); tool_call and plan cases are present and explicitly declared inbound_only to prove lossy kinds are excluded from round-trip. corpus.go: Directionality/ProtocolRole enums, Facts/Case/SourceProvenance/Corpus types, ParseCorpus (rejects invalid JSON, incomplete/missing provenance, no cases, empty/duplicate case id, unknown protocol_role, undeclared/unknown directionality, invalid/empty payload JSON, missing Facts.Kind, missing case provenance, and round_trip declared for a non-lossless Facts.Kind), Load/MustLoad (go:embed corpus.json), and detached-copy accessors ByRole/ByDirectionality/RoundTripCases. corpus_test.go has 32 tests: structural validation positive+negative cases (including a synthetic minimal fixture via ParseCorpus to prove it is a general reusable reader, not just embedded-corpus-specific), detachment (MustLoad results don't alias each other), full protocol-role and directionality coverage checks, round-trip-subset kind allowlist checks, and 'SDK marshal/unmarshal' parseability tests that decode every case's payload into the real pinned acp-go-sdk v0.13.5 types (SessionUpdate, InitializeRequest, AgentCapabilities, SessionConfigOption, PromptRequest, RequestId) to prove protocol parseability and that declared facts are actually derivable from the payload (not merely asserted independently), plus a sanitization-invariant test scanning case content for forbidden credential/path terms. Deliberately did NOT import pkg/transports/acp from this package/tests -- keeps story 003 scoped to the corpus+reader only; wiring corpus cases through the real acp.NegotiateProtocolVersion/TextFirstAgentCapabilities/FactoryTargetOption and the Providers-owned mapSessionUpdate is story 004's explicit scope. go build/vet/test and gofmt are clean; make test (full short Go suite) passes including the new package; make vet, make pkg-structure pass; make pkg-boundary/pkg-file-count/backend-size/deadcode show only pre-existing baseline violations elsewhere in the repo (grepped output for acpconformance/transports/acp -- no matches)."
    },
    {
      "id": "ACP-L1-V0-protocol-conformance-004",
      "title": "Bind independent protocol directions through conformance evidence",
      "description": "As a reviewer, I want the existing inbound provider mapper and the agent-side compatibility boundary checked independently against the same cases so agreement is proven without an illegal dependency or shared mapping implementation.",
      "acceptanceCriteria": [
        "Provider-side tests feed every inbound-supported corpus case through the existing provider-owned ACP mapper and compare observable normalized progress and text facts with the case expectations.",
        "Agent-transport tests independently verify all V0 compatibility, outbound-shape, unsupported, and round-trip declarations without importing Providers internals or calling the inbound mapper.",
        "For each declared round-trip case, independent encode/decode assertions preserve declared semantic facts and request or item identity while allowing irrelevant JSON formatting and field-order differences.",
        "Every representative ACP update kind has an explicit corpus disposition; a newly represented kind cannot be silently dropped or falsely treated as round-trippable.",
        "Provider-owned inbound mapping remains under Providers and the future outbound boundary remains under the ACP transport; no neutral production mapper, cross-internal import, service-to-transport dependency, or shared production mapping helper is introduced.",
        "Focused provider and transport conformance tests pass without starting an ACP subprocess, stdio server, Chat Session, or Factory execution.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Implemented independent conformance tests binding both protocol directions to the shared corpus without a shared production mapper. pkg/transports/acp/conformance_test.go (package acp_test) feeds every corpus case by protocol_role through the real transport functions -- NegotiateProtocolVersion (initialize), TextFirstAgentCapabilities (capabilities, exact serialized-shape match), FactoryTargetOptionFromSessionConfigOption/ToSessionConfigOption (factory_option, structural round-trip), NewRequestIdentity/NewMintedRequestIdentity (request_identity), DecodeMethodParams (malformed_input invalid_params) plus a direct acpsdk.RequestId decode failure (malformed_input invalid_request), and ClassifyMethod/UnsupportedMethodResponse (unsupported_method) -- and independently proves the round_trip session_update subset survives an encode/decode cycle through the pinned SDK type, all without importing Providers or calling the inbound mapper. pkg/services/providers/internal/services/acp/internal/service/conformance_test.go (package service, white-box) feeds every inbound-supported (round_trip or inbound_only) session_update corpus case through the real client.SessionUpdate callback (which wraps the private mapSessionUpdate) and asserts the observable normalized progress (kind/item_id/phase/detail/metadata) and accumulated text match the case Facts, independently of pkg/transports/acp. go build/go vet/gofmt/go test -v pass on both new test files; make test (full short Go suite, all packages) passes; make vet and make pkg-structure are clean; make pkg-boundary/pkg-file-count/deadcode/backend-size grepped for acpconformance/transports/acp/services/acp -- zero matches, i.e. this story added zero new violations (all reported violations are the pre-existing repo-wide baseline, same as story 003). make verify-fast fails only at the pre-existing, unrelated dashboard bun/tsc typecheck step (missing bun type definitions in this environment); this is a backend-only change and does not touch ui/."
    }
  ]
}
```
