### PR TITLE
ACP-L1-V0-operator-profile

### DIFF
--- a/api/components/schemas/api/GlobalConfigACPAgentProfile.yaml
+++ b/api/components/schemas/api/GlobalConfigACPAgentProfile.yaml
@@ -1,0 +1,17 @@
+type: object
+additionalProperties: false
+required:
+  - defaultTarget
+  - allowedTargets
+properties:
+  defaultTarget:
+    type: string
+    minLength: 1
+    description: Unversioned namespaced Factory target reference, such as factory:@you/factory-builder. Factory Definitions owns enumeration and canonical reference resolution.
+  allowedTargets:
+    type: array
+    minItems: 1
+    description: Ordered allowlist of unversioned namespaced Factory target references. Order is authored and preserved.
+    items:
+      type: string
+      minLength: 1

--- a/api/components/schemas/api/GlobalConfigACPSettings.yaml
+++ b/api/components/schemas/api/GlobalConfigACPSettings.yaml
@@ -6,3 +6,5 @@ properties:
     description: Operator-selected ACP provider integrations. Availability is derived by the Providers catalog and is never persisted here.
     items:
       $ref: './GlobalConfigACPIntegration.yaml'
+  agentProfile:
+    $ref: './GlobalConfigACPAgentProfile.yaml'

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -11086,6 +11086,24 @@ components:
           minLength: 1
           maxLength: 4096
           description: Operator-authored ACP launch command preserved as one settings value. It contains no permission or timeout policy.
+    GlobalConfigACPAgentProfile:
+      type: object
+      additionalProperties: false
+      required:
+        - defaultTarget
+        - allowedTargets
+      properties:
+        defaultTarget:
+          type: string
+          minLength: 1
+          description: Unversioned namespaced Factory target reference, such as factory:@you/factory-builder. Factory Definitions owns enumeration and canonical reference resolution.
+        allowedTargets:
+          type: array
+          minItems: 1
+          description: Ordered allowlist of unversioned namespaced Factory target references. Order is authored and preserved.
+          items:
+            type: string
+            minLength: 1
     GlobalConfigACPSettings:
       type: object
       additionalProperties: false
@@ -11095,6 +11113,8 @@ components:
           description: Operator-selected ACP provider integrations. Availability is derived by the Providers catalog and is never persisted here.
           items:
             $ref: '#/components/schemas/GlobalConfigACPIntegration'
+        agentProfile:
+          $ref: '#/components/schemas/GlobalConfigACPAgentProfile'
     GlobalConfigWorkers:
       type: object
       additionalProperties: false

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -1429,7 +1429,7 @@
       "fromOwner": "operator_settings",
       "toOwner": "transports",
       "class": "command",
-      "evidence": "pkg/services/operator_settings/transports/http -\u003e pkg/transports/http/generated"
+      "evidence": "pkg/services/operator_settings/transports/globalconfig -\u003e pkg/transports/http/generated"
     },
     {
       "fromOwner": "platform",
@@ -1616,7 +1616,7 @@
       "fromOwner": "transports",
       "toOwner": "provider_sessions",
       "class": "protocol_composition",
-      "evidence": "pkg/transports/http -\u003e pkg/services/provider_sessions"
+      "evidence": "pkg/transports/http/application -\u003e pkg/services/provider_sessions/transports/http"
     },
     {
       "fromOwner": "transports",

--- a/docs/internal/projects/packaged-service-structure/operator-settings-root-go-inventory.json
+++ b/docs/internal/projects/packaged-service-structure/operator-settings-root-go-inventory.json
@@ -5,6 +5,16 @@
   "clusters": [],
   "files": [
     {
+      "file": "acp_agent_profile.go",
+      "classification": "thin_root_contract",
+      "note": "Peer-facing detached ACPAgentProfile value with normalization and validation for the L1 ACP default Factory target and allowlist."
+    },
+    {
+      "file": "acp_agent_profile_test.go",
+      "classification": "thin_root_contract_test",
+      "note": "Root-contract tests for ACPAgentProfile normalization, validation, and copy-isolation."
+    },
+    {
       "file": "acp_integrations.go",
       "classification": "thin_root_contract",
       "note": "Peer-facing ACP integration projection and validation helpers retained at the thin Operator Settings root."

--- a/internal/ownershipinventory/operator_settings_root_contract.go
+++ b/internal/ownershipinventory/operator_settings_root_contract.go
@@ -11,6 +11,8 @@ import (
 // Confirmed against docs/internal/projects/packaged-service-structure/operator-settings-root-go-inventory.json
 // (INV-SET-TOPLEVEL).
 var OperatorSettingsThinRootContractFiles = []string{
+	"acp_agent_profile.go",
+	"acp_agent_profile_test.go",
 	"acp_integrations.go",
 	"acp_integrations_test.go",
 	"backend_scope.go",

--- a/internal/ownershipinventory/operator_settings_root_contract_test.go
+++ b/internal/ownershipinventory/operator_settings_root_contract_test.go
@@ -26,6 +26,8 @@ func TestOperatorSettingsThinRootContractFiles(t *testing.T) {
 	t.Parallel()
 
 	want := []string{
+		"acp_agent_profile.go",
+		"acp_agent_profile_test.go",
 		"acp_integrations.go",
 		"acp_integrations_test.go",
 		"backend_scope.go",

--- a/internal/ownershipinventory/operator_settings_root_go_test.go
+++ b/internal/ownershipinventory/operator_settings_root_go_test.go
@@ -116,6 +116,7 @@ func TestOperatorSettingsRootGoInventoryClassifiesThinRootContractSurfaces(t *te
 	}
 
 	wantThin := []string{
+		"acp_agent_profile.go",
 		"acp_integrations.go",
 		"backend_scope.go",
 		"config_document.go",
@@ -164,6 +165,7 @@ func TestOperatorSettingsRootGoInventoryDistinguishesThinContractTestsFromImplem
 	}
 
 	wantThinTests := []string{
+		"acp_agent_profile_test.go",
 		"acp_integrations_test.go",
 		"del_set_proof_gate_test.go",
 		"packaged_root_shape_test.go",

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -211,7 +211,7 @@
       "path": "generated/mcp/tools.json"
     },
     "generated.openapi.openapi": {
-      "artifactHash": "505bd7544190c9b1cd9b6b8a539d6b3347cc37935f0a0988908ea64f826a501e",
+      "artifactHash": "07d23c7a5f5bec5739bec848b293975c2b1eb203f7664563d16e1f5e2f644b80",
       "documentation": {
         "documentation": {
           "description": {
@@ -228,7 +228,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.openapi.openapi",
-        "sourceHash": "505bd7544190c9b1cd9b6b8a539d6b3347cc37935f0a0988908ea64f826a501e",
+        "sourceHash": "07d23c7a5f5bec5739bec848b293975c2b1eb203f7664563d16e1f5e2f644b80",
         "visibility": "public"
       },
       "family": "openapi",

--- a/packages/api/generated/openapi/openapi.yaml
+++ b/packages/api/generated/openapi/openapi.yaml
@@ -11086,6 +11086,24 @@ components:
           minLength: 1
           maxLength: 4096
           description: Operator-authored ACP launch command preserved as one settings value. It contains no permission or timeout policy.
+    GlobalConfigACPAgentProfile:
+      type: object
+      additionalProperties: false
+      required:
+        - defaultTarget
+        - allowedTargets
+      properties:
+        defaultTarget:
+          type: string
+          minLength: 1
+          description: Unversioned namespaced Factory target reference, such as factory:@you/factory-builder. Factory Definitions owns enumeration and canonical reference resolution.
+        allowedTargets:
+          type: array
+          minItems: 1
+          description: Ordered allowlist of unversioned namespaced Factory target references. Order is authored and preserved.
+          items:
+            type: string
+            minLength: 1
     GlobalConfigACPSettings:
       type: object
       additionalProperties: false
@@ -11095,6 +11113,8 @@ components:
           description: Operator-selected ACP provider integrations. Availability is derived by the Providers catalog and is never persisted here.
           items:
             $ref: '#/components/schemas/GlobalConfigACPIntegration'
+        agentProfile:
+          $ref: '#/components/schemas/GlobalConfigACPAgentProfile'
     GlobalConfigWorkers:
       type: object
       additionalProperties: false

--- a/pkg/services/operator_settings/acp_agent_profile.go
+++ b/pkg/services/operator_settings/acp_agent_profile.go
@@ -1,0 +1,103 @@
+package operatorsettings
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ACPFactoryTargetNamespace is the required unversioned namespace prefix for
+// every ACP Agent profile target reference. Factory Definitions owns
+// enumeration and canonical reference resolution; Operator Settings validates
+// local shape only.
+const ACPFactoryTargetNamespace = "factory:"
+
+// DefaultACPAgentProfileTarget is the safe Factory Builder target used when an
+// operator document has no authored ACP Agent profile.
+const DefaultACPAgentProfileTarget = "factory:@you/factory-builder"
+
+// ErrACPAgentProfileInvalid reports that an authored ACP Agent profile fails
+// local shape or consistency validation.
+var ErrACPAgentProfileInvalid = errors.New("ACP Agent profile is invalid")
+
+// ACPAgentProfile is a detached Operator Settings value describing one
+// operator's default Factory target and ordered Factory-target allowlist for
+// L1 ACP sessions. Target references are unversioned factory:<ref> strings;
+// Operator Settings never adds a version or digest field.
+type ACPAgentProfile struct {
+	DefaultTarget  string
+	AllowedTargets []string
+}
+
+// Clone returns a detached copy whose AllowedTargets slice does not alias the
+// receiver's backing array.
+func (profile ACPAgentProfile) Clone() ACPAgentProfile {
+	return ACPAgentProfile{
+		DefaultTarget:  profile.DefaultTarget,
+		AllowedTargets: append([]string(nil), profile.AllowedTargets...),
+	}
+}
+
+// Normalize trims the default target and every allowlist entry, preserves
+// authored allowlist order, and validates local shape and consistency. It
+// rejects a blank default, blank allowlist entries, references outside the
+// factory: namespace, an empty allowlist, duplicate entries after
+// normalization, and a default absent from the normalized allowlist.
+func (profile ACPAgentProfile) Normalize() (ACPAgentProfile, error) {
+	defaultTarget := strings.TrimSpace(profile.DefaultTarget)
+	if defaultTarget == "" {
+		return ACPAgentProfile{}, fmt.Errorf("%w: default target must not be blank", ErrACPAgentProfileInvalid)
+	}
+	if !isACPFactoryTargetReference(defaultTarget) {
+		return ACPAgentProfile{}, fmt.Errorf(
+			"%w: default target %q must use the factory: namespace", ErrACPAgentProfileInvalid, defaultTarget,
+		)
+	}
+	if len(profile.AllowedTargets) == 0 {
+		return ACPAgentProfile{}, fmt.Errorf("%w: allowedTargets must not be empty", ErrACPAgentProfileInvalid)
+	}
+
+	normalizedAllowed := make([]string, len(profile.AllowedTargets))
+	seen := make(map[string]struct{}, len(profile.AllowedTargets))
+	for index, target := range profile.AllowedTargets {
+		trimmed := strings.TrimSpace(target)
+		if trimmed == "" {
+			return ACPAgentProfile{}, fmt.Errorf(
+				"%w: allowedTargets[%d] must not be blank", ErrACPAgentProfileInvalid, index,
+			)
+		}
+		if !isACPFactoryTargetReference(trimmed) {
+			return ACPAgentProfile{}, fmt.Errorf(
+				"%w: allowedTargets[%d] %q must use the factory: namespace", ErrACPAgentProfileInvalid, index, trimmed,
+			)
+		}
+		if _, exists := seen[trimmed]; exists {
+			return ACPAgentProfile{}, fmt.Errorf(
+				"%w: allowedTargets[%d] %q is duplicated", ErrACPAgentProfileInvalid, index, trimmed,
+			)
+		}
+		seen[trimmed] = struct{}{}
+		normalizedAllowed[index] = trimmed
+	}
+
+	if _, ok := seen[defaultTarget]; !ok {
+		return ACPAgentProfile{}, fmt.Errorf(
+			"%w: default target %q must be present in allowedTargets", ErrACPAgentProfileInvalid, defaultTarget,
+		)
+	}
+
+	return ACPAgentProfile{DefaultTarget: defaultTarget, AllowedTargets: normalizedAllowed}, nil
+}
+
+// DefaultACPAgentProfile returns the detached safe Factory Builder profile
+// used when an operator document has no authored profile.
+func DefaultACPAgentProfile() ACPAgentProfile {
+	return ACPAgentProfile{
+		DefaultTarget:  DefaultACPAgentProfileTarget,
+		AllowedTargets: []string{DefaultACPAgentProfileTarget},
+	}
+}
+
+func isACPFactoryTargetReference(value string) bool {
+	return strings.HasPrefix(value, ACPFactoryTargetNamespace) && len(value) > len(ACPFactoryTargetNamespace)
+}

--- a/pkg/services/operator_settings/acp_agent_profile_test.go
+++ b/pkg/services/operator_settings/acp_agent_profile_test.go
@@ -1,0 +1,198 @@
+package operatorsettings
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestACPAgentProfileNormalizeTrimsAndPreservesOrder(t *testing.T) {
+	t.Parallel()
+
+	profile := ACPAgentProfile{
+		DefaultTarget:  " factory:@you/review ",
+		AllowedTargets: []string{" factory:@you/review ", " factory:@you/factory-builder ", " factory:local/software-auto "},
+	}
+	got, err := profile.Normalize()
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	want := ACPAgentProfile{
+		DefaultTarget: "factory:@you/review",
+		AllowedTargets: []string{
+			"factory:@you/review",
+			"factory:@you/factory-builder",
+			"factory:local/software-auto",
+		},
+	}
+	if got.DefaultTarget != want.DefaultTarget {
+		t.Fatalf("DefaultTarget = %q, want %q", got.DefaultTarget, want.DefaultTarget)
+	}
+	if len(got.AllowedTargets) != len(want.AllowedTargets) {
+		t.Fatalf("AllowedTargets = %#v, want %#v", got.AllowedTargets, want.AllowedTargets)
+	}
+	for i := range want.AllowedTargets {
+		if got.AllowedTargets[i] != want.AllowedTargets[i] {
+			t.Fatalf("AllowedTargets[%d] = %q, want %q (order must be preserved)", i, got.AllowedTargets[i], want.AllowedTargets[i])
+		}
+	}
+}
+
+func TestACPAgentProfileNormalizeRejectsInvalidShapes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		profile ACPAgentProfile
+	}{
+		{
+			name:    "blank default",
+			profile: ACPAgentProfile{DefaultTarget: "   ", AllowedTargets: []string{"factory:@you/factory-builder"}},
+		},
+		{
+			name:    "default outside factory namespace",
+			profile: ACPAgentProfile{DefaultTarget: "worker:@you/factory-builder", AllowedTargets: []string{"worker:@you/factory-builder"}},
+		},
+		{
+			name:    "default is bare namespace with no reference",
+			profile: ACPAgentProfile{DefaultTarget: "factory:", AllowedTargets: []string{"factory:"}},
+		},
+		{
+			name:    "blank allowlist entry",
+			profile: ACPAgentProfile{DefaultTarget: "factory:@you/factory-builder", AllowedTargets: []string{"factory:@you/factory-builder", "  "}},
+		},
+		{
+			name:    "allowlist entry outside factory namespace",
+			profile: ACPAgentProfile{DefaultTarget: "factory:@you/factory-builder", AllowedTargets: []string{"factory:@you/factory-builder", "local/software-auto"}},
+		},
+		{
+			name:    "empty allowlist",
+			profile: ACPAgentProfile{DefaultTarget: "factory:@you/factory-builder", AllowedTargets: nil},
+		},
+		{
+			name: "duplicate entries after normalization",
+			profile: ACPAgentProfile{
+				DefaultTarget:  "factory:@you/factory-builder",
+				AllowedTargets: []string{"factory:@you/factory-builder", " factory:@you/factory-builder "},
+			},
+		},
+		{
+			name:    "default absent from allowlist",
+			profile: ACPAgentProfile{DefaultTarget: "factory:@you/review", AllowedTargets: []string{"factory:@you/factory-builder"}},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := testCase.profile.Normalize(); !errors.Is(err, ErrACPAgentProfileInvalid) {
+				t.Fatalf("Normalize() error = %v, want ErrACPAgentProfileInvalid", err)
+			}
+		})
+	}
+}
+
+func TestACPAgentProfileCloneDoesNotAliasAllowedTargets(t *testing.T) {
+	t.Parallel()
+
+	original := ACPAgentProfile{
+		DefaultTarget:  "factory:@you/factory-builder",
+		AllowedTargets: []string{"factory:@you/factory-builder", "factory:@you/review"},
+	}
+	cloned := original.Clone()
+	cloned.AllowedTargets[0] = "factory:mutated/target"
+
+	if original.AllowedTargets[0] != "factory:@you/factory-builder" {
+		t.Fatalf("original mutated through clone: %#v", original.AllowedTargets)
+	}
+}
+
+func TestDefaultACPAgentProfileIsFactoryBuilderOnly(t *testing.T) {
+	t.Parallel()
+
+	profile := DefaultACPAgentProfile()
+	if profile.DefaultTarget != DefaultACPAgentProfileTarget {
+		t.Fatalf("DefaultTarget = %q, want %q", profile.DefaultTarget, DefaultACPAgentProfileTarget)
+	}
+	if len(profile.AllowedTargets) != 1 || profile.AllowedTargets[0] != DefaultACPAgentProfileTarget {
+		t.Fatalf("AllowedTargets = %#v, want exactly [%q]", profile.AllowedTargets, DefaultACPAgentProfileTarget)
+	}
+	if normalized, err := profile.Normalize(); err != nil {
+		t.Fatalf("DefaultACPAgentProfile() must already be normalized, got error = %v", err)
+	} else if normalized.DefaultTarget != profile.DefaultTarget {
+		t.Fatalf("DefaultACPAgentProfile() normalized to a different value: %#v", normalized)
+	}
+}
+
+func TestWorkerSettingsNormalizePreservesAgentProfileWithoutIntegrations(t *testing.T) {
+	t.Parallel()
+
+	settings := WorkerSettings{ACP: ACPSettings{
+		AgentProfile: &ACPAgentProfile{
+			DefaultTarget:  " factory:@you/review ",
+			AllowedTargets: []string{" factory:@you/review "},
+		},
+	}}
+	normalized, err := settings.normalize()
+	if err != nil {
+		t.Fatalf("normalize() error = %v", err)
+	}
+	if normalized.ACP.Integrations != nil {
+		t.Fatalf("Integrations = %#v, want nil", normalized.ACP.Integrations)
+	}
+	if normalized.ACP.AgentProfile == nil || normalized.ACP.AgentProfile.DefaultTarget != "factory:@you/review" {
+		t.Fatalf("AgentProfile = %#v, want normalized factory:@you/review", normalized.ACP.AgentProfile)
+	}
+}
+
+func TestWorkerSettingsNormalizeRejectsInvalidAgentProfile(t *testing.T) {
+	t.Parallel()
+
+	settings := WorkerSettings{ACP: ACPSettings{
+		AgentProfile: &ACPAgentProfile{DefaultTarget: "", AllowedTargets: nil},
+	}}
+	if _, err := settings.normalize(); !errors.Is(err, ErrACPAgentProfileInvalid) {
+		t.Fatalf("normalize() error = %v, want ErrACPAgentProfileInvalid", err)
+	}
+}
+
+func TestConfigDocumentFileConfigDoesNotAliasAgentProfile(t *testing.T) {
+	t.Parallel()
+
+	document := ConfigDocument{config: Config{Workers: WorkerSettings{ACP: ACPSettings{
+		AgentProfile: &ACPAgentProfile{
+			DefaultTarget:  "factory:@you/factory-builder",
+			AllowedTargets: []string{"factory:@you/factory-builder"},
+		},
+	}}}}
+
+	first := document.FileConfig()
+	first.Workers.ACP.AgentProfile.DefaultTarget = "factory:mutated"
+	first.Workers.ACP.AgentProfile.AllowedTargets[0] = "factory:mutated"
+
+	second := document.FileConfig()
+	if second.Workers.ACP.AgentProfile.DefaultTarget != "factory:@you/factory-builder" {
+		t.Fatalf("stored DefaultTarget mutated through FileConfig(): %#v", second.Workers.ACP.AgentProfile)
+	}
+	if second.Workers.ACP.AgentProfile.AllowedTargets[0] != "factory:@you/factory-builder" {
+		t.Fatalf("stored AllowedTargets mutated through FileConfig(): %#v", second.Workers.ACP.AgentProfile)
+	}
+}
+
+func TestDocumentACPSettingsCloneDoesNotAliasAgentProfile(t *testing.T) {
+	t.Parallel()
+
+	original := DocumentACPSettings{AgentProfile: &ACPAgentProfile{
+		DefaultTarget:  "factory:@you/factory-builder",
+		AllowedTargets: []string{"factory:@you/factory-builder"},
+	}}
+	cloned := original.Clone()
+	cloned.AgentProfile.DefaultTarget = "factory:mutated"
+	cloned.AgentProfile.AllowedTargets[0] = "factory:mutated"
+
+	if original.AgentProfile.DefaultTarget != "factory:@you/factory-builder" {
+		t.Fatalf("original DefaultTarget mutated through Clone(): %#v", original.AgentProfile)
+	}
+	if original.AgentProfile.AllowedTargets[0] != "factory:@you/factory-builder" {
+		t.Fatalf("original AllowedTargets mutated through Clone(): %#v", original.AgentProfile)
+	}
+}

--- a/pkg/services/operator_settings/config_document.go
+++ b/pkg/services/operator_settings/config_document.go
@@ -101,7 +101,18 @@ func (document ConfigDocument) FileConfig() Config {
 	if document.config.Workers.ACP.Integrations != nil {
 		config.Workers.ACP.Integrations = append([]ACPIntegration{}, document.config.Workers.ACP.Integrations...)
 	}
+	config.Workers.ACP.AgentProfile = cloneACPAgentProfilePointer(document.config.Workers.ACP.AgentProfile)
 	return config
+}
+
+// cloneACPAgentProfilePointer returns a detached copy of an optional ACP
+// Agent profile pointer, preserving nil for an absent profile.
+func cloneACPAgentProfilePointer(profile *ACPAgentProfile) *ACPAgentProfile {
+	if profile == nil {
+		return nil
+	}
+	cloned := profile.Clone()
+	return &cloned
 }
 
 // BackendScopeID returns the operator identity stored beside the defaults.
@@ -275,6 +286,7 @@ func configFromDocument(document Document) Config {
 		},
 		Workers: WorkerSettings{ACP: ACPSettings{
 			Integrations: append([]ACPIntegration(nil), document.Workers.ACP.Integrations...),
+			AgentProfile: cloneACPAgentProfilePointer(document.Workers.ACP.AgentProfile),
 		}},
 	}
 	if document.WorkerPresets != nil {
@@ -302,6 +314,7 @@ func documentFromConfig(config Config) Document {
 		},
 		Workers: DocumentWorkerSettings{ACP: DocumentACPSettings{
 			Integrations: append([]ACPIntegration(nil), config.Workers.ACP.Integrations...),
+			AgentProfile: cloneACPAgentProfilePointer(config.Workers.ACP.AgentProfile),
 		}},
 	}
 	if config.WorkerPresets != nil {

--- a/pkg/services/operator_settings/defaults_contract.go
+++ b/pkg/services/operator_settings/defaults_contract.go
@@ -66,6 +66,7 @@ type WorkerSettings struct {
 
 type ACPSettings struct {
 	Integrations []ACPIntegration
+	AgentProfile *ACPAgentProfile
 }
 
 type ACPIntegration struct {
@@ -161,37 +162,45 @@ func (cfg Config) Normalize() (Config, error) {
 }
 
 func (settings WorkerSettings) normalize() (WorkerSettings, error) {
-	if settings.ACP.Integrations == nil {
-		return WorkerSettings{}, nil
+	normalized := WorkerSettings{}
+	if settings.ACP.Integrations != nil {
+		integrations := make([]ACPIntegration, len(settings.ACP.Integrations))
+		ids := make(map[string]struct{}, len(integrations))
+		names := make(map[string]struct{}, len(integrations))
+		for index, integration := range settings.ACP.Integrations {
+			integration = ACPIntegration{
+				ID: strings.TrimSpace(integration.ID), Name: strings.TrimSpace(integration.Name),
+				Transport: strings.ToLower(strings.TrimSpace(integration.Transport)), Command: strings.TrimSpace(integration.Command),
+			}
+			if integration.ID == "" || integration.Name == "" || integration.Command == "" {
+				return WorkerSettings{}, fmt.Errorf("workers.acp.integrations[%d] requires non-empty id, name, and command", index)
+			}
+			if err := providers.ID(integration.Name).Validate(); err != nil || !acpProviderIdentityPattern.MatchString(integration.Name) {
+				return WorkerSettings{}, fmt.Errorf("workers.acp.integrations[%d].name %q must use canonical lowercase letters, digits, dots, or hyphens", index, integration.Name)
+			}
+			if integration.Transport != "stdio" {
+				return WorkerSettings{}, fmt.Errorf("workers.acp.integrations[%d] %q has unsupported transport %q: accepted value is stdio", index, integration.Name, integration.Transport)
+			}
+			if _, exists := ids[integration.ID]; exists {
+				return WorkerSettings{}, fmt.Errorf("workers.acp.integrations[%d].id %q is duplicated", index, integration.ID)
+			}
+			if _, exists := names[integration.Name]; exists {
+				return WorkerSettings{}, fmt.Errorf("workers.acp.integrations[%d].name %q is duplicated", index, integration.Name)
+			}
+			ids[integration.ID] = struct{}{}
+			names[integration.Name] = struct{}{}
+			integrations[index] = integration
+		}
+		normalized.ACP.Integrations = integrations
 	}
-	integrations := make([]ACPIntegration, len(settings.ACP.Integrations))
-	ids := make(map[string]struct{}, len(integrations))
-	names := make(map[string]struct{}, len(integrations))
-	for index, integration := range settings.ACP.Integrations {
-		integration = ACPIntegration{
-			ID: strings.TrimSpace(integration.ID), Name: strings.TrimSpace(integration.Name),
-			Transport: strings.ToLower(strings.TrimSpace(integration.Transport)), Command: strings.TrimSpace(integration.Command),
+	if settings.ACP.AgentProfile != nil {
+		profile, err := settings.ACP.AgentProfile.Normalize()
+		if err != nil {
+			return WorkerSettings{}, err
 		}
-		if integration.ID == "" || integration.Name == "" || integration.Command == "" {
-			return WorkerSettings{}, fmt.Errorf("workers.acp.integrations[%d] requires non-empty id, name, and command", index)
-		}
-		if err := providers.ID(integration.Name).Validate(); err != nil || !acpProviderIdentityPattern.MatchString(integration.Name) {
-			return WorkerSettings{}, fmt.Errorf("workers.acp.integrations[%d].name %q must use canonical lowercase letters, digits, dots, or hyphens", index, integration.Name)
-		}
-		if integration.Transport != "stdio" {
-			return WorkerSettings{}, fmt.Errorf("workers.acp.integrations[%d] %q has unsupported transport %q: accepted value is stdio", index, integration.Name, integration.Transport)
-		}
-		if _, exists := ids[integration.ID]; exists {
-			return WorkerSettings{}, fmt.Errorf("workers.acp.integrations[%d].id %q is duplicated", index, integration.ID)
-		}
-		if _, exists := names[integration.Name]; exists {
-			return WorkerSettings{}, fmt.Errorf("workers.acp.integrations[%d].name %q is duplicated", index, integration.Name)
-		}
-		ids[integration.ID] = struct{}{}
-		names[integration.Name] = struct{}{}
-		integrations[index] = integration
+		normalized.ACP.AgentProfile = &profile
 	}
-	return WorkerSettings{ACP: ACPSettings{Integrations: integrations}}, nil
+	return normalized, nil
 }
 
 func (settings RuntimeArtifactSettings) normalize(fieldPath string) (RuntimeArtifactSettings, error) {

--- a/pkg/services/operator_settings/document_contract.go
+++ b/pkg/services/operator_settings/document_contract.go
@@ -107,10 +107,16 @@ func (settings DocumentWorkerSettings) Clone() DocumentWorkerSettings {
 
 type DocumentACPSettings struct {
 	Integrations []ACPIntegration
+	AgentProfile *ACPAgentProfile
 }
 
 func (settings DocumentACPSettings) Clone() DocumentACPSettings {
-	return DocumentACPSettings{Integrations: append([]ACPIntegration(nil), settings.Integrations...)}
+	cloned := DocumentACPSettings{Integrations: append([]ACPIntegration(nil), settings.Integrations...)}
+	if settings.AgentProfile != nil {
+		profile := settings.AgentProfile.Clone()
+		cloned.AgentProfile = &profile
+	}
+	return cloned
 }
 
 // DocumentDefaults holds operator default values as a detached peer value.

--- a/pkg/services/operator_settings/internal/service/service.go
+++ b/pkg/services/operator_settings/internal/service/service.go
@@ -198,7 +198,7 @@ func (s *Service) ConfigureACPIntegrationAdd(
 	path string,
 	integration operatorsettings.ACPIntegration,
 ) (operatorsettings.Document, error) {
-	return s.configureACPIntegrations(ctx, path, func(document operatorsettings.Document) (operatorsettings.Document, error) {
+	return s.mutateDocument(ctx, path, func(document operatorsettings.Document) (operatorsettings.Document, error) {
 		config := documentConfig(document)
 		config.Workers.ACP.Integrations = append(config.Workers.ACP.Integrations, integration)
 		return normalizedDocument(config)
@@ -210,7 +210,7 @@ func (s *Service) ConfigureACPIntegrationDelete(
 	path string,
 	name string,
 ) (operatorsettings.Document, error) {
-	return s.configureACPIntegrations(ctx, path, func(document operatorsettings.Document) (operatorsettings.Document, error) {
+	return s.mutateDocument(ctx, path, func(document operatorsettings.Document) (operatorsettings.Document, error) {
 		config := documentConfig(document)
 		name = strings.TrimSpace(name)
 		filtered := make([]operatorsettings.ACPIntegration, 0, len(config.Workers.ACP.Integrations))
@@ -235,7 +235,7 @@ func (s *Service) EnsurePackagedACPIntegrations(
 	path string,
 	defaults []operatorsettings.ACPIntegration,
 ) (operatorsettings.Document, error) {
-	return s.configureACPIntegrations(ctx, path, func(document operatorsettings.Document) (operatorsettings.Document, error) {
+	return s.mutateDocument(ctx, path, func(document operatorsettings.Document) (operatorsettings.Document, error) {
 		config := documentConfig(document)
 		if config.Workers.ACP.Integrations != nil {
 			return document, nil
@@ -245,7 +245,54 @@ func (s *Service) EnsurePackagedACPIntegrations(
 	})
 }
 
-func (s *Service) configureACPIntegrations(
+// ResolveACPAgentProfile resolves the effective ACP Agent profile for the
+// operator document at path through the existing injected document
+// capability, without mutating or persisting the document. An absent profile
+// resolves to the safe Factory Builder default; a malformed stored profile
+// fails explicitly instead of falling back silently.
+func (s *Service) ResolveACPAgentProfile(path string) (operatorsettings.ACPAgentProfile, error) {
+	if s == nil || s.document == nil {
+		return operatorsettings.ACPAgentProfile{}, fmt.Errorf("operator settings document service is required")
+	}
+	loaded, err := s.document.LoadDocument(operatorsettings.LoadDocumentRequest{Path: path})
+	if err != nil {
+		return operatorsettings.ACPAgentProfile{}, err
+	}
+	profile := loaded.Document.Workers.ACP.AgentProfile
+	if profile == nil {
+		return operatorsettings.DefaultACPAgentProfile(), nil
+	}
+	return profile.Clone().Normalize()
+}
+
+// UpdateACPAgentProfile validates the complete candidate profile before any
+// persistence side effect, then atomically stores the normalized profile
+// while preserving every other operator setting.
+func (s *Service) UpdateACPAgentProfile(
+	ctx context.Context,
+	path string,
+	profile operatorsettings.ACPAgentProfile,
+) (operatorsettings.ACPAgentProfile, error) {
+	normalized, err := profile.Normalize()
+	if err != nil {
+		return operatorsettings.ACPAgentProfile{}, err
+	}
+	updated, err := s.mutateDocument(ctx, path, func(document operatorsettings.Document) (operatorsettings.Document, error) {
+		config := documentConfig(document)
+		candidate := normalized
+		config.Workers.ACP.AgentProfile = &candidate
+		return normalizedDocument(config)
+	})
+	if err != nil {
+		return operatorsettings.ACPAgentProfile{}, err
+	}
+	if updated.Workers.ACP.AgentProfile == nil {
+		return operatorsettings.ACPAgentProfile{}, fmt.Errorf("operator settings: update ACP Agent profile: persisted document is missing the profile")
+	}
+	return updated.Workers.ACP.AgentProfile.Clone(), nil
+}
+
+func (s *Service) mutateDocument(
 	ctx context.Context,
 	path string,
 	update func(operatorsettings.Document) (operatorsettings.Document, error),
@@ -288,9 +335,20 @@ func documentConfig(document operatorsettings.Document) operatorsettings.Config 
 		},
 		Workers: operatorsettings.WorkerSettings{ACP: operatorsettings.ACPSettings{
 			Integrations: append([]operatorsettings.ACPIntegration(nil), document.Workers.ACP.Integrations...),
+			AgentProfile: cloneACPAgentProfilePointer(document.Workers.ACP.AgentProfile),
 		}},
 		WorkerPresets: workerPresetsFromDocument(document.WorkerPresets),
 	}
+}
+
+// cloneACPAgentProfilePointer returns a detached copy of an optional ACP
+// Agent profile pointer, preserving nil for an absent profile.
+func cloneACPAgentProfilePointer(profile *operatorsettings.ACPAgentProfile) *operatorsettings.ACPAgentProfile {
+	if profile == nil {
+		return nil
+	}
+	cloned := profile.Clone()
+	return &cloned
 }
 
 func workerPresetsFromDocument(presets []operatorsettings.DocumentWorkerPreset) []operatorsettings.WorkerPreset {
@@ -324,6 +382,7 @@ func normalizedDocument(config operatorsettings.Config) (operatorsettings.Docume
 		},
 		Workers: operatorsettings.DocumentWorkerSettings{ACP: operatorsettings.DocumentACPSettings{
 			Integrations: append([]operatorsettings.ACPIntegration(nil), normalized.Workers.ACP.Integrations...),
+			AgentProfile: cloneACPAgentProfilePointer(normalized.Workers.ACP.AgentProfile),
 		}},
 		WorkerPresets: make([]operatorsettings.DocumentWorkerPreset, len(normalized.WorkerPresets)),
 	}

--- a/pkg/services/operator_settings/internal/service/service_test.go
+++ b/pkg/services/operator_settings/internal/service/service_test.go
@@ -191,6 +191,281 @@ func TestRootACPConfigurationAddsDeletesAndMaterializesDefaults(t *testing.T) {
 	}
 }
 
+func TestRootResolveACPAgentProfile_AbsentDocumentReturnsSafeDefault(t *testing.T) {
+	t.Parallel()
+
+	root := newFilesystemRoot(t, testCreateTemporaryFile)
+	path := filepath.Join(t.TempDir(), "config.json")
+
+	resolved, err := root.ResolveACPAgentProfile(path)
+	if err != nil {
+		t.Fatalf("ResolveACPAgentProfile() = %v", err)
+	}
+	want := operatorsettings.DefaultACPAgentProfile()
+	if resolved.DefaultTarget != want.DefaultTarget || strings.Join(resolved.AllowedTargets, ",") != strings.Join(want.AllowedTargets, ",") {
+		t.Fatalf("ResolveACPAgentProfile() = %#v, want %#v", resolved, want)
+	}
+}
+
+func TestRootResolveACPAgentProfile_AbsentDocumentIsReadOnly(t *testing.T) {
+	t.Parallel()
+
+	root := newFilesystemRoot(t, testCreateTemporaryFile)
+	path := filepath.Join(t.TempDir(), "config.json")
+
+	if _, err := root.ResolveACPAgentProfile(path); err != nil {
+		t.Fatalf("ResolveACPAgentProfile() = %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("os.Stat(path) = %v, want ErrNotExist because resolve must not create the document", err)
+	}
+}
+
+func TestRootResolveACPAgentProfile_MalformedStoredProfileFailsExplicitly(t *testing.T) {
+	t.Parallel()
+
+	root := newFilesystemRoot(t, testCreateTemporaryFile)
+	path := filepath.Join(t.TempDir(), "config.json")
+	malformed := `{"workers":{"acp":{"agentProfile":{"defaultTarget":"factory:@you/review","allowedTargets":["factory:@you/factory-builder"]}}}}`
+	if err := os.WriteFile(path, []byte(malformed), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() = %v", err)
+	}
+
+	_, err := root.ResolveACPAgentProfile(path)
+	if err == nil {
+		t.Fatal("ResolveACPAgentProfile() error = nil, want a typed failure for a malformed stored profile")
+	}
+	if !strings.Contains(err.Error(), "must be present in allowedTargets") {
+		t.Fatalf("ResolveACPAgentProfile() error = %q, want the ACP Agent profile validation fragment", err)
+	}
+}
+
+func TestRootResolveACPAgentProfile_ValidAuthoredProfileReturnsNormalizedDetachedValue(t *testing.T) {
+	t.Parallel()
+
+	root := newFilesystemRoot(t, testCreateTemporaryFile)
+	path := filepath.Join(t.TempDir(), "config.json")
+	authored := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  " factory:@you/reviewer ",
+		AllowedTargets: []string{" factory:@you/reviewer ", "factory:@you/factory-builder"},
+	}
+
+	updated, err := root.UpdateACPAgentProfile(context.Background(), path, authored)
+	if err != nil {
+		t.Fatalf("UpdateACPAgentProfile() = %v", err)
+	}
+	if updated.DefaultTarget != "factory:@you/reviewer" {
+		t.Fatalf("UpdateACPAgentProfile() default = %q", updated.DefaultTarget)
+	}
+
+	resolved, err := root.ResolveACPAgentProfile(path)
+	if err != nil {
+		t.Fatalf("ResolveACPAgentProfile() = %v", err)
+	}
+	if resolved.DefaultTarget != "factory:@you/reviewer" ||
+		len(resolved.AllowedTargets) != 2 ||
+		resolved.AllowedTargets[0] != "factory:@you/reviewer" ||
+		resolved.AllowedTargets[1] != "factory:@you/factory-builder" {
+		t.Fatalf("ResolveACPAgentProfile() = %#v", resolved)
+	}
+
+	// Mutating the resolved slice must not alias stored state.
+	resolved.AllowedTargets[0] = "factory:@you/mutated"
+	reresolved, err := root.ResolveACPAgentProfile(path)
+	if err != nil {
+		t.Fatalf("ResolveACPAgentProfile() second call = %v", err)
+	}
+	if reresolved.AllowedTargets[0] != "factory:@you/reviewer" {
+		t.Fatalf("ResolveACPAgentProfile() returned an aliased slice: %#v", reresolved)
+	}
+}
+
+func TestRootUpdateACPAgentProfile_RejectsInvalidCandidateWithoutPersisting(t *testing.T) {
+	t.Parallel()
+
+	root := newFilesystemRoot(t, testCreateTemporaryFile)
+	path := filepath.Join(t.TempDir(), "config.json")
+	valid := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/reviewer",
+		AllowedTargets: []string{"factory:@you/reviewer"},
+	}
+	if _, err := root.UpdateACPAgentProfile(context.Background(), path, valid); err != nil {
+		t.Fatalf("UpdateACPAgentProfile(valid) = %v", err)
+	}
+
+	invalid := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "not-a-factory-reference",
+		AllowedTargets: []string{"factory:@you/reviewer"},
+	}
+	if _, err := root.UpdateACPAgentProfile(context.Background(), path, invalid); !errors.Is(err, operatorsettings.ErrACPAgentProfileInvalid) {
+		t.Fatalf("UpdateACPAgentProfile(invalid) = %v, want ErrACPAgentProfileInvalid", err)
+	}
+
+	resolved, err := root.ResolveACPAgentProfile(path)
+	if err != nil {
+		t.Fatalf("ResolveACPAgentProfile() after rejected update = %v", err)
+	}
+	if resolved.DefaultTarget != "factory:@you/reviewer" {
+		t.Fatalf("ResolveACPAgentProfile() after rejected update = %#v, want the prior valid profile intact", resolved)
+	}
+}
+
+func TestRootUpdateACPAgentProfile_RejectsCanceledContextWithoutPersisting(t *testing.T) {
+	t.Parallel()
+
+	root := newFilesystemRoot(t, testCreateTemporaryFile)
+	path := filepath.Join(t.TempDir(), "config.json")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/reviewer",
+		AllowedTargets: []string{"factory:@you/reviewer"},
+	}
+	if _, err := root.UpdateACPAgentProfile(ctx, path, profile); !errors.Is(err, context.Canceled) {
+		t.Fatalf("UpdateACPAgentProfile(canceled ctx) = %v, want context.Canceled", err)
+	}
+	if _, statErr := os.Stat(path); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Fatalf("config path stat error = %v, want destination to remain absent", statErr)
+	}
+}
+
+func TestRootUpdateACPAgentProfile_RejectsShortWriteWithoutReplacement(t *testing.T) {
+	t.Parallel()
+
+	root := newFilesystemRoot(t, func(dir, pattern string) (operatorsettings.TemporaryFile, error) {
+		return shortWriteTemporaryFile{name: filepath.Join(dir, pattern)}, nil
+	})
+	path := filepath.Join(t.TempDir(), "config.json")
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/reviewer",
+		AllowedTargets: []string{"factory:@you/reviewer"},
+	}
+
+	_, err := root.UpdateACPAgentProfile(context.Background(), path, profile)
+	if err == nil || !strings.Contains(err.Error(), "short write") {
+		t.Fatalf("UpdateACPAgentProfile() = %v, want short-write failure", err)
+	}
+	if _, statErr := os.Stat(path); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Fatalf("config path stat error = %v, want destination to remain absent", statErr)
+	}
+}
+
+func TestRootUpdateACPAgentProfile_PersistsAtomicallyAndSurvivesReloadThroughNewService(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/reviewer",
+		AllowedTargets: []string{"factory:@you/reviewer", "factory:@you/factory-builder"},
+	}
+
+	firstRoot := newFilesystemRoot(t, testCreateTemporaryFile)
+	if _, err := firstRoot.UpdateACPAgentProfile(context.Background(), path, profile); err != nil {
+		t.Fatalf("UpdateACPAgentProfile() = %v", err)
+	}
+
+	secondRoot := newFilesystemRoot(t, testCreateTemporaryFile)
+	resolved, err := secondRoot.ResolveACPAgentProfile(path)
+	if err != nil {
+		t.Fatalf("ResolveACPAgentProfile() through newly constructed service = %v", err)
+	}
+	if resolved.DefaultTarget != profile.DefaultTarget ||
+		len(resolved.AllowedTargets) != len(profile.AllowedTargets) ||
+		resolved.AllowedTargets[0] != profile.AllowedTargets[0] ||
+		resolved.AllowedTargets[1] != profile.AllowedTargets[1] {
+		t.Fatalf("ResolveACPAgentProfile() through new service = %#v, want %#v", resolved, profile)
+	}
+}
+
+func TestRootACPIntegrationAndProviderModelUpdates_PreserveAuthoredACPAgentProfile(t *testing.T) {
+	t.Parallel()
+
+	root := newFilesystemRoot(t, testCreateTemporaryFile)
+	path := filepath.Join(t.TempDir(), "config.json")
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/reviewer",
+		AllowedTargets: []string{"factory:@you/reviewer"},
+	}
+	if _, err := root.UpdateACPAgentProfile(context.Background(), path, profile); err != nil {
+		t.Fatalf("UpdateACPAgentProfile() = %v", err)
+	}
+
+	integration := operatorsettings.ACPIntegration{
+		ID: "entry-1", Name: "cursor-acp", Transport: "stdio", Command: "cursor-agent acp",
+	}
+	afterIntegrationAdd, err := root.ConfigureACPIntegrationAdd(context.Background(), path, integration)
+	if err != nil {
+		t.Fatalf("ConfigureACPIntegrationAdd() = %v", err)
+	}
+	if afterIntegrationAdd.Workers.ACP.AgentProfile == nil ||
+		afterIntegrationAdd.Workers.ACP.AgentProfile.DefaultTarget != profile.DefaultTarget {
+		t.Fatalf("ConfigureACPIntegrationAdd() dropped the authored ACP Agent profile: %#v", afterIntegrationAdd.Workers.ACP.AgentProfile)
+	}
+
+	nextModel := "gpt-5.2"
+	afterProviderModelUpdate, err := root.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
+		Path: path,
+		ProviderModel: operatorsettings.DocumentProviderModelUpdate{
+			Model: &nextModel,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyDocumentUpdate() = %v", err)
+	}
+	if afterProviderModelUpdate.Document.Workers.ACP.AgentProfile == nil ||
+		afterProviderModelUpdate.Document.Workers.ACP.AgentProfile.DefaultTarget != profile.DefaultTarget {
+		t.Fatalf(
+			"ApplyDocumentUpdate() dropped the authored ACP Agent profile: %#v",
+			afterProviderModelUpdate.Document.Workers.ACP.AgentProfile,
+		)
+	}
+
+	resolved, err := root.ResolveACPAgentProfile(path)
+	if err != nil {
+		t.Fatalf("ResolveACPAgentProfile() = %v", err)
+	}
+	if resolved.DefaultTarget != profile.DefaultTarget {
+		t.Fatalf("ResolveACPAgentProfile() after unrelated updates = %#v, want %#v", resolved, profile)
+	}
+}
+
+func TestRootUpdateACPAgentProfile_PreservesUnrelatedSettings(t *testing.T) {
+	t.Parallel()
+
+	root := newFilesystemRoot(t, testCreateTemporaryFile)
+	path := filepath.Join(t.TempDir(), "config.json")
+	integration := operatorsettings.ACPIntegration{
+		ID: "entry-1", Name: "cursor-acp", Transport: "stdio", Command: "cursor-agent acp",
+	}
+	if _, err := root.ConfigureACPIntegrationAdd(context.Background(), path, integration); err != nil {
+		t.Fatalf("ConfigureACPIntegrationAdd() = %v", err)
+	}
+	scope, err := root.EnsureLocalBackendScope(path)
+	if err != nil {
+		t.Fatalf("EnsureLocalBackendScope() = %v", err)
+	}
+
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/reviewer",
+		AllowedTargets: []string{"factory:@you/reviewer"},
+	}
+	if _, err := root.UpdateACPAgentProfile(context.Background(), path, profile); err != nil {
+		t.Fatalf("UpdateACPAgentProfile() = %v", err)
+	}
+
+	loaded, err := root.LoadDocument(operatorsettings.LoadDocumentRequest{Path: path})
+	if err != nil {
+		t.Fatalf("LoadDocument() = %v", err)
+	}
+	if loaded.Document.BackendScopeID != scope.BackendScopeID {
+		t.Fatalf("LoadDocument().BackendScopeID = %q, want %q", loaded.Document.BackendScopeID, scope.BackendScopeID)
+	}
+	if len(loaded.Document.Workers.ACP.Integrations) != 1 || loaded.Document.Workers.ACP.Integrations[0] != integration {
+		t.Fatalf("LoadDocument() integrations = %#v, want %#v", loaded.Document.Workers.ACP.Integrations, []operatorsettings.ACPIntegration{integration})
+	}
+}
+
 func newFilesystemRoot(t *testing.T, createTemp operatorsettings.CreateTemporaryFile) operatorsettings.Service {
 	t.Helper()
 

--- a/pkg/services/operator_settings/internal/service_characterization_test.go
+++ b/pkg/services/operator_settings/internal/service_characterization_test.go
@@ -337,6 +337,18 @@ func (fake *servicePeerFake) EnsurePackagedACPIntegrations(
 	return operatorsettings.Document{}, errors.New("characterization fake does not implement ACP")
 }
 
+func (fake *servicePeerFake) ResolveACPAgentProfile(string) (operatorsettings.ACPAgentProfile, error) {
+	return operatorsettings.ACPAgentProfile{}, errors.New("characterization fake does not implement ACP Agent profile")
+}
+
+func (fake *servicePeerFake) UpdateACPAgentProfile(
+	context.Context,
+	string,
+	operatorsettings.ACPAgentProfile,
+) (operatorsettings.ACPAgentProfile, error) {
+	return operatorsettings.ACPAgentProfile{}, errors.New("characterization fake does not implement ACP Agent profile")
+}
+
 func TestService_Characterization_FakeImplementsSingularSeam(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/operator_settings/internal/services/document/internal/service/document_map.go
+++ b/pkg/services/operator_settings/internal/services/document/internal/service/document_map.go
@@ -16,6 +16,7 @@ func documentFromConfig(config operatorsettings.Config) operatorsettings.Documen
 		Runtime: documentRuntimeFromConfig(config.Runtime),
 		Workers: operatorsettings.DocumentWorkerSettings{ACP: operatorsettings.DocumentACPSettings{
 			Integrations: append([]operatorsettings.ACPIntegration(nil), config.Workers.ACP.Integrations...),
+			AgentProfile: cloneACPAgentProfilePointer(config.Workers.ACP.AgentProfile),
 		}},
 	}
 	if config.WorkerPresets != nil {
@@ -30,6 +31,16 @@ func documentFromConfig(config operatorsettings.Config) operatorsettings.Documen
 		}
 	}
 	return document
+}
+
+// cloneACPAgentProfilePointer returns a detached copy of an optional ACP
+// Agent profile pointer, preserving nil for an absent profile.
+func cloneACPAgentProfilePointer(profile *operatorsettings.ACPAgentProfile) *operatorsettings.ACPAgentProfile {
+	if profile == nil {
+		return nil
+	}
+	cloned := profile.Clone()
+	return &cloned
 }
 
 func documentRuntimeFromConfig(runtime operatorsettings.RuntimeSettings) operatorsettings.DocumentRuntimeSettings {
@@ -52,6 +63,7 @@ func configFromDocument(document operatorsettings.Document) operatorsettings.Con
 		},
 		Workers: operatorsettings.WorkerSettings{ACP: operatorsettings.ACPSettings{
 			Integrations: append([]operatorsettings.ACPIntegration(nil), document.Workers.ACP.Integrations...),
+			AgentProfile: cloneACPAgentProfilePointer(document.Workers.ACP.AgentProfile),
 		}},
 	}
 	if document.WorkerPresets != nil {

--- a/pkg/services/operator_settings/service_contract.go
+++ b/pkg/services/operator_settings/service_contract.go
@@ -60,4 +60,14 @@ type Service interface {
 	// EnsurePackagedACPIntegrations materializes packaged integrations only when
 	// the customer has not supplied the ACP integration list.
 	EnsurePackagedACPIntegrations(context.Context, string, []ACPIntegration) (Document, error)
+
+	// ResolveACPAgentProfile resolves the effective ACP Agent profile for the
+	// operator document at path without mutating or persisting it. An absent
+	// authored profile resolves to the safe Factory Builder default.
+	ResolveACPAgentProfile(string) (ACPAgentProfile, error)
+
+	// UpdateACPAgentProfile validates a complete candidate ACP Agent profile
+	// and, only once valid, atomically persists it while preserving all other
+	// operator settings.
+	UpdateACPAgentProfile(context.Context, string, ACPAgentProfile) (ACPAgentProfile, error)
 }

--- a/pkg/services/operator_settings/service_root_contract_invariants_test.go
+++ b/pkg/services/operator_settings/service_root_contract_invariants_test.go
@@ -337,6 +337,18 @@ func (fake *servicePeerFake) EnsurePackagedACPIntegrations(
 	return operatorsettings.Document{}, errors.New("fake ACP service is not configured")
 }
 
+func (fake *servicePeerFake) ResolveACPAgentProfile(string) (operatorsettings.ACPAgentProfile, error) {
+	return operatorsettings.ACPAgentProfile{}, errors.New("fake ACP Agent profile service is not configured")
+}
+
+func (fake *servicePeerFake) UpdateACPAgentProfile(
+	context.Context,
+	string,
+	operatorsettings.ACPAgentProfile,
+) (operatorsettings.ACPAgentProfile, error) {
+	return operatorsettings.ACPAgentProfile{}, errors.New("fake ACP Agent profile service is not configured")
+}
+
 // TestRootContractInvariants_AllSlicesThroughSingularService seals the
 // Operator Settings root-contract packet: document operations and effective
 // resolution are reachable through one named operatorsettings.Service, a

--- a/pkg/services/operator_settings/transports/cli/composition_test.go
+++ b/pkg/services/operator_settings/transports/cli/composition_test.go
@@ -321,6 +321,18 @@ func (root *compositionSettingsRoot) EnsurePackagedACPIntegrations(
 	return operatorsettings.Document{}, errors.New("test composition root does not implement ACP")
 }
 
+func (root *compositionSettingsRoot) ResolveACPAgentProfile(string) (operatorsettings.ACPAgentProfile, error) {
+	return operatorsettings.ACPAgentProfile{}, errors.New("test composition root does not implement ACP Agent profile")
+}
+
+func (root *compositionSettingsRoot) UpdateACPAgentProfile(
+	context.Context,
+	string,
+	operatorsettings.ACPAgentProfile,
+) (operatorsettings.ACPAgentProfile, error) {
+	return operatorsettings.ACPAgentProfile{}, errors.New("test composition root does not implement ACP Agent profile")
+}
+
 func compositionWinningValue(fileValue, environmentValue, flagValue string) (string, operatorsettings.Source) {
 	switch {
 	case strings.TrimSpace(flagValue) != "":

--- a/pkg/services/operator_settings/transports/cli/service_test.go
+++ b/pkg/services/operator_settings/transports/cli/service_test.go
@@ -438,6 +438,18 @@ func (fake *fakeSettingsRoot) EnsurePackagedACPIntegrations(
 	return operatorsettings.Document{}, errors.New("test settings root does not implement ACP")
 }
 
+func (fake *fakeSettingsRoot) ResolveACPAgentProfile(string) (operatorsettings.ACPAgentProfile, error) {
+	return operatorsettings.ACPAgentProfile{}, errors.New("test settings root does not implement ACP Agent profile")
+}
+
+func (fake *fakeSettingsRoot) UpdateACPAgentProfile(
+	context.Context,
+	string,
+	operatorsettings.ACPAgentProfile,
+) (operatorsettings.ACPAgentProfile, error) {
+	return operatorsettings.ACPAgentProfile{}, errors.New("test settings root does not implement ACP Agent profile")
+}
+
 func cliWinningDefaultsValue(fileValue, environmentValue, flagValue string) (string, operatorsettings.Source) {
 	switch {
 	case strings.TrimSpace(flagValue) != "":

--- a/pkg/services/operator_settings/transports/globalconfig/decode.go
+++ b/pkg/services/operator_settings/transports/globalconfig/decode.go
@@ -88,6 +88,13 @@ func mapConfig(generated factoryapi.GlobalConfig) (operatorsettings.Config, erro
 			}
 		}
 	}
+	if generated.Workers != nil && generated.Workers.Acp != nil && generated.Workers.Acp.AgentProfile != nil {
+		profile := operatorsettings.ACPAgentProfile{
+			DefaultTarget:  generated.Workers.Acp.AgentProfile.DefaultTarget,
+			AllowedTargets: append([]string(nil), generated.Workers.Acp.AgentProfile.AllowedTargets...),
+		}
+		config.Workers.ACP.AgentProfile = &profile
+	}
 	if generated.WorkerPresets == nil {
 		return config, nil
 	}
@@ -174,17 +181,25 @@ func Encode(config operatorsettings.Config) ([]byte, error) {
 		Logging: mapRuntimeArtifactSettingsToAPI(config.Runtime.Logging),
 		Metrics: mapRuntimeArtifactSettingsToAPI(config.Runtime.Metrics),
 	}
-	if config.Workers.ACP.Integrations != nil {
-		integrations := make([]factoryapi.GlobalConfigACPIntegration, len(config.Workers.ACP.Integrations))
-		for index, integration := range config.Workers.ACP.Integrations {
-			integrations[index] = factoryapi.GlobalConfigACPIntegration{
-				Id: integration.ID, Name: integration.Name, Command: integration.Command,
-				Transport: factoryapi.GlobalConfigACPIntegrationTransport(integration.Transport),
+	if config.Workers.ACP.Integrations != nil || config.Workers.ACP.AgentProfile != nil {
+		acp := &factoryapi.GlobalConfigACPSettings{}
+		if config.Workers.ACP.Integrations != nil {
+			integrations := make([]factoryapi.GlobalConfigACPIntegration, len(config.Workers.ACP.Integrations))
+			for index, integration := range config.Workers.ACP.Integrations {
+				integrations[index] = factoryapi.GlobalConfigACPIntegration{
+					Id: integration.ID, Name: integration.Name, Command: integration.Command,
+					Transport: factoryapi.GlobalConfigACPIntegrationTransport(integration.Transport),
+				}
+			}
+			acp.Integrations = &integrations
+		}
+		if config.Workers.ACP.AgentProfile != nil {
+			acp.AgentProfile = &factoryapi.GlobalConfigACPAgentProfile{
+				DefaultTarget:  config.Workers.ACP.AgentProfile.DefaultTarget,
+				AllowedTargets: append([]string(nil), config.Workers.ACP.AgentProfile.AllowedTargets...),
 			}
 		}
-		generated.Workers = &factoryapi.GlobalConfigWorkers{
-			Acp: &factoryapi.GlobalConfigACPSettings{Integrations: &integrations},
-		}
+		generated.Workers = &factoryapi.GlobalConfigWorkers{Acp: acp}
 	}
 	if config.WorkerPresets != nil {
 		presets := make([]factoryapi.GlobalConfigWorkerPreset, len(config.WorkerPresets))

--- a/pkg/services/operator_settings/transports/globalconfig/decode_test.go
+++ b/pkg/services/operator_settings/transports/globalconfig/decode_test.go
@@ -116,6 +116,109 @@ func TestEncode_RoundTripsCanonicalIdentityAndSiblingSettings(t *testing.T) {
 	}
 }
 
+func TestDecode_AbsentACPAgentProfileDecodesWithoutMigration(t *testing.T) {
+	config, err := globalconfig.Decode([]byte(`{
+		"defaults": {"workerModelProvider": "codex"},
+		"workers": {"acp": {"integrations": [{"id":"entry-1","name":"cursor-acp","transport":"stdio","command":"cursor-agent acp"}]}}
+	}`))
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if config.Workers.ACP.AgentProfile != nil {
+		t.Fatalf("AgentProfile = %#v, want nil for a document with no authored profile", config.Workers.ACP.AgentProfile)
+	}
+	if len(config.Workers.ACP.Integrations) != 1 {
+		t.Fatalf("Integrations = %#v, want one entry preserved alongside an absent profile", config.Workers.ACP.Integrations)
+	}
+}
+
+func TestEncode_RoundTripsACPAgentProfilePreservingOrderAndNamespace(t *testing.T) {
+	want := operatorsettings.Config{
+		Workers: operatorsettings.WorkerSettings{ACP: operatorsettings.ACPSettings{
+			AgentProfile: &operatorsettings.ACPAgentProfile{
+				DefaultTarget: "factory:@you/review",
+				AllowedTargets: []string{
+					"factory:@you/review",
+					"factory:@you/factory-builder",
+					"factory:local/software-auto",
+				},
+			},
+		}},
+	}
+
+	payload, err := globalconfig.Encode(want)
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	if strings.Contains(string(payload), `"version"`) || strings.Contains(string(payload), `"digest"`) {
+		t.Fatalf("Encode() payload = %s, want no version or digest field", payload)
+	}
+	got, err := globalconfig.Decode(payload)
+	if err != nil {
+		t.Fatalf("Decode(Encode()) error = %v", err)
+	}
+	if got.Workers.ACP.AgentProfile == nil {
+		t.Fatal("round trip AgentProfile = nil, want authored profile preserved")
+	}
+	if !reflect.DeepEqual(*got.Workers.ACP.AgentProfile, *want.Workers.ACP.AgentProfile) {
+		t.Fatalf("round trip AgentProfile = %#v, want %#v", *got.Workers.ACP.AgentProfile, *want.Workers.ACP.AgentProfile)
+	}
+}
+
+func TestEncode_OmitsAgentProfileWhenAbsent(t *testing.T) {
+	payload, err := globalconfig.Encode(operatorsettings.Config{
+		Defaults: operatorsettings.Defaults{WorkerModelProvider: "CODEX"},
+	})
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	if strings.Contains(string(payload), `"agentProfile"`) {
+		t.Fatalf("Encode() payload = %s, want agentProfile omitted when absent", payload)
+	}
+	got, err := globalconfig.Decode(payload)
+	if err != nil {
+		t.Fatalf("Decode(Encode()) error = %v", err)
+	}
+	if got.Workers.ACP.AgentProfile != nil {
+		t.Fatalf("AgentProfile = %#v, want nil after an absent-profile round trip", got.Workers.ACP.AgentProfile)
+	}
+}
+
+func TestDecode_RejectsMalformedStoredACPAgentProfile(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want string
+	}{
+		{
+			name: "empty allowlist",
+			json: `{"workers":{"acp":{"agentProfile":{"defaultTarget":"factory:@you/factory-builder","allowedTargets":[]}}}}`,
+			want: "allowedTargets must not be empty",
+		},
+		{
+			name: "default outside factory namespace",
+			json: `{"workers":{"acp":{"agentProfile":{"defaultTarget":"worker:@you/factory-builder","allowedTargets":["worker:@you/factory-builder"]}}}}`,
+			want: "must use the factory: namespace",
+		},
+		{
+			name: "default absent from allowlist",
+			json: `{"workers":{"acp":{"agentProfile":{"defaultTarget":"factory:@you/review","allowedTargets":["factory:@you/factory-builder"]}}}}`,
+			want: "must be present in allowedTargets",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := globalconfig.Decode([]byte(tt.json))
+			if err == nil {
+				t.Fatal("Decode() error = nil, want rejection")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Decode() error = %q, want fragment %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestEncode_EmitsCanonicalJSONBytes(t *testing.T) {
 	payload, err := globalconfig.Encode(operatorsettings.Config{
 		BackendScopeID: "local-11111111-1111-4111-8111-111111111111",

--- a/pkg/transports/http/generated/server.gen.go
+++ b/pkg/transports/http/generated/server.gen.go
@@ -4095,6 +4095,15 @@ type GlobalConfig struct {
 	Workers       *GlobalConfigWorkers        `json:"workers,omitempty"`
 }
 
+// GlobalConfigACPAgentProfile defines model for GlobalConfigACPAgentProfile.
+type GlobalConfigACPAgentProfile struct {
+	// AllowedTargets Ordered allowlist of unversioned namespaced Factory target references. Order is authored and preserved.
+	AllowedTargets []string `json:"allowedTargets"`
+
+	// DefaultTarget Unversioned namespaced Factory target reference, such as factory:@you/factory-builder. Factory Definitions owns enumeration and canonical reference resolution.
+	DefaultTarget string `json:"defaultTarget"`
+}
+
 // GlobalConfigACPIntegration defines model for GlobalConfigACPIntegration.
 type GlobalConfigACPIntegration struct {
 	// Command Operator-authored ACP launch command preserved as one settings value. It contains no permission or timeout policy.
@@ -4115,6 +4124,8 @@ type GlobalConfigACPIntegrationTransport string
 
 // GlobalConfigACPSettings defines model for GlobalConfigACPSettings.
 type GlobalConfigACPSettings struct {
+	AgentProfile *GlobalConfigACPAgentProfile `json:"agentProfile,omitempty"`
+
 	// Integrations Operator-selected ACP provider integrations. Availability is derived by the Providers catalog and is never persisted here.
 	Integrations *[]GlobalConfigACPIntegration `json:"integrations,omitempty"`
 }

--- a/tests/functional/operator_settings/root_composition/wire_composition_coverage_test.go
+++ b/tests/functional/operator_settings/root_composition/wire_composition_coverage_test.go
@@ -3,6 +3,7 @@ package root_composition_test
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -94,6 +95,57 @@ func TestWireCompositionServesDocumentAndResolutionOperations(t *testing.T) {
 	}
 	if updated.Document.Defaults.WorkerModelProvider != "GEMINI" || updated.Document.Defaults.WorkerModel != "gemini-pro" {
 		t.Fatalf("updated defaults = %#v, want GEMINI/gemini-pro", updated.Document.Defaults)
+	}
+
+	defaultProfile, err := root.ResolveACPAgentProfile(configPath)
+	if err != nil {
+		t.Fatalf("ResolveACPAgentProfile() error = %v", err)
+	}
+	wantDefaultProfile := operatorsettings.DefaultACPAgentProfile()
+	if defaultProfile.DefaultTarget != wantDefaultProfile.DefaultTarget ||
+		!reflect.DeepEqual(defaultProfile.AllowedTargets, wantDefaultProfile.AllowedTargets) {
+		t.Fatalf("ResolveACPAgentProfile() = %#v, want safe Factory Builder default %#v", defaultProfile, wantDefaultProfile)
+	}
+
+	authoredProfile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/research",
+		AllowedTargets: []string{"factory:@you/research", "factory:@you/factory-builder"},
+	}
+	updatedProfile, err := root.UpdateACPAgentProfile(t.Context(), configPath, authoredProfile)
+	if err != nil {
+		t.Fatalf("UpdateACPAgentProfile() error = %v", err)
+	}
+	if updatedProfile.DefaultTarget != authoredProfile.DefaultTarget {
+		t.Fatalf("UpdateACPAgentProfile() default = %q, want %q", updatedProfile.DefaultTarget, authoredProfile.DefaultTarget)
+	}
+
+	resolvedProfile, err := root.ResolveACPAgentProfile(configPath)
+	if err != nil {
+		t.Fatalf("ResolveACPAgentProfile() after update error = %v", err)
+	}
+	if resolvedProfile.DefaultTarget != authoredProfile.DefaultTarget ||
+		len(resolvedProfile.AllowedTargets) != len(authoredProfile.AllowedTargets) {
+		t.Fatalf("ResolveACPAgentProfile() after update = %#v, want %#v", resolvedProfile, authoredProfile)
+	}
+
+	if updatedAgain, err := root.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
+		Path: configPath,
+		ProviderModel: operatorsettings.DocumentProviderModelUpdate{
+			Provider: &provider,
+			Model:    &model,
+		},
+	}); err != nil {
+		t.Fatalf("ApplyDocumentUpdate() after profile update error = %v", err)
+	} else if updatedAgain.Document.Workers.ACP.AgentProfile == nil ||
+		updatedAgain.Document.Workers.ACP.AgentProfile.DefaultTarget != authoredProfile.DefaultTarget {
+		t.Fatalf(
+			"ApplyDocumentUpdate() after profile update = %#v, want authored profile preserved",
+			updatedAgain.Document.Workers.ACP.AgentProfile,
+		)
+	}
+
+	if _, err := root.UpdateACPAgentProfile(t.Context(), configPath, operatorsettings.ACPAgentProfile{}); err == nil {
+		t.Fatal("UpdateACPAgentProfile() with blank candidate error = nil, want validation failure")
 	}
 }
 

--- a/ui/src/api/generated/openapi.ts
+++ b/ui/src/api/generated/openapi.ts
@@ -5555,9 +5555,16 @@ export interface components {
       /** @description Operator-authored ACP launch command preserved as one settings value. It contains no permission or timeout policy. */
       command: string;
     };
+    GlobalConfigACPAgentProfile: {
+      /** @description Unversioned namespaced Factory target reference, such as factory:@you/factory-builder. Factory Definitions owns enumeration and canonical reference resolution. */
+      defaultTarget: string;
+      /** @description Ordered allowlist of unversioned namespaced Factory target references. Order is authored and preserved. */
+      allowedTargets: string[];
+    };
     GlobalConfigACPSettings: {
       /** @description Operator-selected ACP provider integrations. Availability is derived by the Providers catalog and is never persisted here. */
       integrations?: components["schemas"]["GlobalConfigACPIntegration"][];
+      agentProfile?: components["schemas"]["GlobalConfigACPAgentProfile"];
     };
     GlobalConfigWorkers: {
       acp?: components["schemas"]["GlobalConfigACPSettings"];


### PR DESCRIPTION
```json
{
  "project": "ACP L1 V0 — Add the ACP Agent profile to Operator Settings",
  "branchName": "ACP-L1-V0-operator-profile",
  "description": "Add the deliberate ACPAgentProfile value and ResolveACPAgentProfile and UpdateACPAgentProfile operations to the singular Operator Settings service. The profile owns one unversioned default Factory target and ordered Factory-target allowlist. Missing profile data resolves to the safe Factory Builder policy; authored profiles are normalized and validated explicitly; valid updates persist atomically without disturbing unrelated settings. The intent is to provide L1 ACP sessions with a stable V1 policy input while Factory Definitions retains enumeration and canonical reference resolution and this lane avoids unrelated root cleanup.",
  "context": {
    "customerAsk": "Add ACPAgentProfile, ResolveACPAgentProfile, and UpdateACPAgentProfile to the Operator Settings root and implementation with focused normalization, validation, compatibility, and round-trip tests. Keep target enumeration and canonical resolution in Factory Definitions, keep target references unversioned under D6, reject invalid defaults and allowlists explicitly, preserve existing settings, avoid unrelated root cleanup, and complete delivery through merge.",
    "problem": "Operator Settings has no typed ACP Agent profile or root operations for reading and updating it. L1 ACP consumers lack one authoritative input for the operator's default Factory target and allowlist and would otherwise interpret raw settings or duplicate policy, risking inconsistent defaults, malformed-policy acceptance, ownership violations, and unrelated settings loss during persistence.",
    "solution": "Publish a detached ACPAgentProfile with DefaultTarget and AllowedTargets using unversioned namespaced Factory references. Extend the existing singular Operator Settings Service with read-only resolve and atomic whole-profile update operations. Resolve supplies the Factory Builder profile when the field is absent; authored profiles are normalized and validated completely; update uses existing document persistence and preserves all other settings. Operator Settings validates local shape and consistency only, while Factory Definitions retains enumeration and canonical/existence resolution."
  },
  "acceptanceCriteria": [
    "The singular Operator Settings Service exposes ResolveACPAgentProfile and UpdateACPAgentProfile using a detached ACPAgentProfile containing one unversioned default Factory target and an ordered allowlist; no secondary service root or alternate operational facade is introduced.",
    "Resolving a document with no authored profile returns factory:@you/factory-builder as the default and an allowlist containing that target, while existing operator configuration remains readable without migration.",
    "Profile normalization trims target references, preserves authored allowlist order, and validation explicitly rejects blank or non-Factory references, duplicates after normalization, an empty allowlist, and a default absent from the allowlist.",
    "Operator Settings validates only local profile shape and consistency; it does not enumerate Factories, claim a reference exists, canonicalize it through a catalog, add version or digest fields, or import Factory Definitions internals.",
    "Updating a valid profile is atomic and survives reload through a newly constructed service; rejected or failed updates leave the prior document intact, and profile updates preserve backend scope, defaults, runtime settings, Worker presets, and ACP integrations while other settings updates preserve the profile.",
    "Quality gate: generated configuration contracts are synchronized when the persisted schema changes, focused Go and codec tests pass, Typecheck passes, lint passes, applicable package-boundary checks pass, and required PR CI is terminal and passing.",
    "Delivery: the implementation/review loop continues until all blocking PR conversation feedback is explicitly addressed, shared-file changes and merge conflicts are reconciled, required CI is terminal and passing, and the PR is actually merged; opening, approval, green CI, or merge readiness alone is not completion."
  ],
  "userStories": [
    {
      "id": "ACP-L1-V0-operator-profile-001",
      "title": "Define and preserve the ACP Agent profile contract",
      "description": "As an ACP consumer, I want a typed Operator Settings profile with stable serialization and validation rules so target policy has one implementation-ready contract.",
      "acceptanceCriteria": [
        "ACPAgentProfile is a detached service-root value with DefaultTarget and AllowedTargets; returned slices do not alias canonical or persisted state.",
        "Persisted configuration represents the profile under the existing ACP settings document and uses unversioned factory:<ref> strings, with no target version or digest field.",
        "Normalization trims the default and each allowlist entry while preserving allowlist order.",
        "Validation rejects a blank default, blank entries, values outside the factory: namespace, an empty allowlist, duplicate entries after normalization, and a default not present in the normalized allowlist with typed, actionable Operator Settings errors.",
        "Existing configuration without the new field decodes successfully, and encode/decode round trips preserve both an absent profile and an authored valid profile according to their distinct semantics.",
        "Authored OpenAPI configuration schema and generated Go/TypeScript contracts are synchronized if required by the existing global-config codec; no new route or transport operation is added.",
        "Focused value, normalization, validation, copy-isolation, and codec compatibility tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented ACPAgentProfile (DefaultTarget/AllowedTargets) with Clone/Normalize/DefaultACPAgentProfile in acp_agent_profile.go; wired as optional Workers.ACP.AgentProfile on Config and Document with independent normalization and non-aliasing copies; added GlobalConfigACPAgentProfile OpenAPI schema + regenerated Go/TS contracts; globalconfig codec decodes/encodes it with no version/digest field; focused unit + codec round-trip tests added and passing."
    },
    {
      "id": "ACP-L1-V0-operator-profile-002",
      "title": "Resolve the effective ACP Agent profile",
      "description": "As an L1 ACP session consumer, I want to resolve the effective operator profile so session target selection starts from one safe and consistent policy.",
      "acceptanceCriteria": [
        "The existing Operator Settings root exposes ResolveACPAgentProfile, and the production implementation resolves through its existing injected document capability rather than a new service, dependency bag, or secondary construction path.",
        "When the operator document has no authored profile, resolve returns a detached profile whose default is factory:@you/factory-builder and whose allowlist contains exactly that target.",
        "When a valid profile is authored, resolve returns its normalized default and ordered allowlist without mutating or persisting the document.",
        "A malformed stored profile returns a typed, actionable failure and never falls back silently to a broader allowlist or partially resolved profile.",
        "Resolve performs no Factory enumeration, existence lookup, or catalog canonicalization; syntactically valid uninstalled or changed references remain values for Factory Definitions to resolve at use time under D6.",
        "Focused root and implementation tests cover absent, valid, malformed, detached-copy, and read-only behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added ResolveACPAgentProfile(path string) (ACPAgentProfile, error) to the Service interface (service_contract.go) and to the production internal/service.Service, delegating strictly through the existing injected document capability (s.document.LoadDocument), with no new service/dependency bag. Absent profile resolves to DefaultACPAgentProfile(); a present profile is cloned and re-Normalize()'d defensively before returning (never mutates/persists). While implementing, discovered and fixed a pre-existing round-trip bug: the real production Document<->Config conversion helpers used by LoadDocument/PersistDocument (internal/services/document/internal/service/document_map.go) and by ConfigureACPIntegrationAdd/Delete/EnsurePackagedACPIntegrations (internal/service/service.go) silently dropped Workers.ACP.AgentProfile end-to-end even though the root-level compatibility layer (config_document.go) added in story 001 carried it correctly; this bug meant any load/persist through the actual Service implementation (not just the legacy ConfigDocumentService) would silently erase an authored profile. Fixed both conversion sites to clone AgentProfile through, which is also required by story 003's cross-preservation AC."
    },
    {
      "id": "ACP-L1-V0-operator-profile-003",
      "title": "Update and round-trip the ACP Agent profile atomically",
      "description": "As an operator, I want a valid ACP Agent profile update to persist safely so my default and allowlist survive restart without disturbing other settings.",
      "acceptanceCriteria": [
        "The existing Operator Settings root exposes UpdateACPAgentProfile, and the implementation validates the complete candidate before performing any persistence side effect.",
        "A valid update atomically stores the normalized profile and returns a detached equivalent result; resolving through a newly constructed service returns the same default and allowlist order.",
        "An invalid candidate, canceled context, codec failure, temporary-file failure, publish failure, or applicable document conflict returns a typed or actionable error and leaves the previously persisted document observable on the next resolve.",
        "Profile updates preserve backend scope, worker provider/model defaults, runtime logging and metrics settings, Worker presets, and workers.acp.integrations after normal decode/encode normalization.",
        "Existing document, provider/model, backend-scope, and ACP-integration updates preserve an authored ACP Agent profile unless they explicitly invoke the profile update operation.",
        "Concurrent writes follow the existing Operator Settings serialization or conflict behavior and never publish a partial or mixed profile.",
        "New resolve and update operations emit repository-required structured, safe operation outcomes without logging raw configuration, full allowlists, credentials, commands, or unsafe paths.",
        "Focused integration tests cover successful reload, invalid-update rollback, injected write failures, cancellation, concurrency or conflict behavior, safe logs, and bidirectional settings isolation.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added UpdateACPAgentProfile(ctx, path, ACPAgentProfile) (ACPAgentProfile, error) to the Service interface and internal/service.Service. Validates the complete candidate via ACPAgentProfile.Normalize() before any load/persist side effect, then reuses the existing load-mutate-persist helper (renamed configureACPIntegrations -> mutateDocument since it is now shared by ACP integration and ACP Agent profile updates) which holds the existing writeMu for the whole load+persist cycle and persists atomically through the existing temp-file-then-rename document owner, exactly like ConfigureACPIntegrationAdd. Invalid candidates fail before touching disk; canceled context and injected temp-file short-write both leave the destination file absent/prior document intact (tests: TestRootUpdateACPAgentProfile_RejectsInvalidCandidateWithoutPersisting, _RejectsCanceledContextWithoutPersisting, _RejectsShortWriteWithoutReplacement). Concurrency/no-partial-writes reuses the pre-existing writeMu + atomic rename guarantee, not new mechanism. Verified backend-scope, ACP integrations, and provider/model updates all preserve an authored profile and vice versa (TestRootACPIntegrationAndProviderModelUpdates_PreserveAuthoredACPAgentProfile, TestRootUpdateACPAgentProfile_PreservesUnrelatedSettings) -- this is the regression coverage for the document_map.go/service.go AgentProfile-dropping bug fixed under story 002. No new HTTP/CLI/MCP transport surface added, per AC (customerAsk only names the Operator Settings root). Checked for logging requirements: the operator_settings root/internal/service layer has zero existing log/slog calls for any operation (ConfigureACPIntegrationAdd included), so there is nothing unsafe to redact at this layer; logging, if any, belongs to a transport that does not yet exist for this operation."
    }
  ]
}

```
