### PR TITLE
Add Chat Sessions Factory Sessions shim

### DIFF
--- a/pkg/services/chat_sessions/internal/factorysessionsshim/shim_test.go
+++ b/pkg/services/chat_sessions/internal/factorysessionsshim/shim_test.go
@@ -16,7 +16,7 @@ import (
 type recordingFactorySessionsService struct {
 	factorysessions.Service
 
-	startCalls  []factorysessions.StartRequest
+	startCalls  []startCall
 	startResult factorysessions.AsyncStartResult
 	startErr    error
 
@@ -28,50 +28,88 @@ type recordingFactorySessionsService struct {
 	cancelResult factorysessions.LifecycleControlResult
 	cancelErr    error
 
-	closeCalls []string
+	closeCalls []closeCall
 	closeErr   error
 }
 
+type startCall struct {
+	ctx     context.Context
+	request factorysessions.StartRequest
+}
+
 type invokeCall struct {
+	ctx       context.Context
 	sessionID string
 	request   factorysessions.InvocationRequest
 }
 
 type cancelCall struct {
+	ctx       context.Context
 	sessionID string
 	request   factorysessions.ControlRequest
 }
 
+type closeCall struct {
+	ctx       context.Context
+	sessionID string
+}
+
 func (fake *recordingFactorySessionsService) StartAsync(
-	_ context.Context,
+	ctx context.Context,
 	request factorysessions.StartRequest,
 ) (factorysessions.AsyncStartResult, error) {
-	fake.startCalls = append(fake.startCalls, request)
+	fake.startCalls = append(fake.startCalls, startCall{ctx: ctx, request: request})
 	return fake.startResult, fake.startErr
 }
 
 func (fake *recordingFactorySessionsService) InvokeFactorySession(
-	_ context.Context,
+	ctx context.Context,
 	sessionID string,
 	request factorysessions.InvocationRequest,
 ) (factorysessions.InvocationResult, error) {
-	fake.invokeCalls = append(fake.invokeCalls, invokeCall{sessionID: sessionID, request: request})
+	fake.invokeCalls = append(fake.invokeCalls, invokeCall{ctx: ctx, sessionID: sessionID, request: request})
 	return fake.invokeResult, fake.invokeErr
 }
 
 func (fake *recordingFactorySessionsService) Cancel(
-	_ context.Context,
+	ctx context.Context,
 	sessionID string,
 	request factorysessions.ControlRequest,
 ) (factorysessions.LifecycleControlResult, error) {
-	fake.cancelCalls = append(fake.cancelCalls, cancelCall{sessionID: sessionID, request: request})
+	fake.cancelCalls = append(fake.cancelCalls, cancelCall{ctx: ctx, sessionID: sessionID, request: request})
 	return fake.cancelResult, fake.cancelErr
 }
 
-func (fake *recordingFactorySessionsService) CloseFactorySession(_ context.Context, sessionID string) error {
-	fake.closeCalls = append(fake.closeCalls, sessionID)
+func (fake *recordingFactorySessionsService) CloseFactorySession(ctx context.Context, sessionID string) error {
+	fake.closeCalls = append(fake.closeCalls, closeCall{ctx: ctx, sessionID: sessionID})
 	return fake.closeErr
 }
+
+// assertNoOtherCalls fails the test unless every recorded call slice other
+// than the named target operation is empty, proving the shim delegated to
+// exactly one Factory Sessions capability.
+func assertNoOtherCalls(t *testing.T, fake *recordingFactorySessionsService, target string) {
+	t.Helper()
+	counts := map[string]int{
+		"start":  len(fake.startCalls),
+		"invoke": len(fake.invokeCalls),
+		"cancel": len(fake.cancelCalls),
+		"close":  len(fake.closeCalls),
+	}
+	for name, count := range counts {
+		if name == target {
+			continue
+		}
+		if count != 0 {
+			t.Fatalf("unexpected delegation to %s: call count = %d, want 0", name, count)
+		}
+	}
+}
+
+// ctxProbeKey distinguishes each test's context.Context value so the
+// delegation assertions below prove the shim forwards the exact context it
+// was given, rather than substituting a fresh one.
+type ctxProbeKey struct{}
 
 func TestShimStart(t *testing.T) {
 	tests := []struct {
@@ -93,22 +131,27 @@ func TestShimStart(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fake := &recordingFactorySessionsService{startResult: tt.result, startErr: tt.err}
 			shim := New(fake)
+			ctx := context.WithValue(context.Background(), ctxProbeKey{}, "start-"+tt.name)
 			request := factorysessions.StartRequest{RequestID: "req-1", Args: map[string]any{"k": "v"}}
 
-			got, err := shim.StartFactoryTarget(context.Background(), request)
+			got, err := shim.StartFactoryTarget(ctx, request)
 
 			if len(fake.startCalls) != 1 {
 				t.Fatalf("StartAsync call count = %d, want 1", len(fake.startCalls))
 			}
-			if !reflect.DeepEqual(fake.startCalls[0], request) {
-				t.Fatalf("StartAsync request = %#v, want %#v", fake.startCalls[0], request)
+			if fake.startCalls[0].ctx != ctx {
+				t.Fatalf("StartAsync ctx = %#v, want the exact ctx passed in", fake.startCalls[0].ctx)
 			}
-			if !errors.Is(err, tt.err) {
-				t.Fatalf("StartFactoryTarget() error = %v, want %v", err, tt.err)
+			if !reflect.DeepEqual(fake.startCalls[0].request, request) {
+				t.Fatalf("StartAsync request = %#v, want %#v", fake.startCalls[0].request, request)
+			}
+			if err != tt.err {
+				t.Fatalf("StartFactoryTarget() error = %v, want the exact same error value %v", err, tt.err)
 			}
 			if !reflect.DeepEqual(got, tt.result) {
 				t.Fatalf("StartFactoryTarget() result = %#v, want %#v", got, tt.result)
 			}
+			assertNoOtherCalls(t, fake, "start")
 		})
 	}
 }
@@ -133,25 +176,27 @@ func TestShimInvoke(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fake := &recordingFactorySessionsService{invokeResult: tt.result, invokeErr: tt.err}
 			shim := New(fake)
+			ctx := context.WithValue(context.Background(), ctxProbeKey{}, "invoke-"+tt.name)
 			request := factorysessions.InvocationRequest{RequestID: strPtr("req-1")}
 
-			got, err := shim.InvokeFactoryTarget(context.Background(), "session-1", request)
+			got, err := shim.InvokeFactoryTarget(ctx, "session-1", request)
 
 			if len(fake.invokeCalls) != 1 {
 				t.Fatalf("InvokeFactorySession call count = %d, want 1", len(fake.invokeCalls))
 			}
+			if fake.invokeCalls[0].ctx != ctx {
+				t.Fatalf("InvokeFactorySession ctx = %#v, want the exact ctx passed in", fake.invokeCalls[0].ctx)
+			}
 			if fake.invokeCalls[0].sessionID != "session-1" || !reflect.DeepEqual(fake.invokeCalls[0].request, request) {
 				t.Fatalf("InvokeFactorySession call = %#v, want session-1 / %#v", fake.invokeCalls[0], request)
 			}
-			if !errors.Is(err, tt.err) {
-				t.Fatalf("InvokeFactoryTarget() error = %v, want %v", err, tt.err)
+			if err != tt.err {
+				t.Fatalf("InvokeFactoryTarget() error = %v, want the exact same error value %v", err, tt.err)
 			}
 			if !reflect.DeepEqual(got, tt.result) {
 				t.Fatalf("InvokeFactoryTarget() result = %#v, want %#v", got, tt.result)
 			}
-			if len(fake.startCalls) != 0 {
-				t.Fatalf("StartAsync call count = %d, want 0", len(fake.startCalls))
-			}
+			assertNoOtherCalls(t, fake, "invoke")
 		})
 	}
 }
@@ -176,28 +221,27 @@ func TestShimCancel(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fake := &recordingFactorySessionsService{cancelResult: tt.result, cancelErr: tt.err}
 			shim := New(fake)
+			ctx := context.WithValue(context.Background(), ctxProbeKey{}, "cancel-"+tt.name)
 			request := factorysessions.ControlRequest{RequestID: "req-1", Reason: "user requested"}
 
-			got, err := shim.CancelFactoryTarget(context.Background(), "session-1", request)
+			got, err := shim.CancelFactoryTarget(ctx, "session-1", request)
 
 			if len(fake.cancelCalls) != 1 {
 				t.Fatalf("Cancel call count = %d, want 1", len(fake.cancelCalls))
 			}
+			if fake.cancelCalls[0].ctx != ctx {
+				t.Fatalf("Cancel ctx = %#v, want the exact ctx passed in", fake.cancelCalls[0].ctx)
+			}
 			if fake.cancelCalls[0].sessionID != "session-1" || !reflect.DeepEqual(fake.cancelCalls[0].request, request) {
 				t.Fatalf("Cancel call = %#v, want session-1 / %#v", fake.cancelCalls[0], request)
 			}
-			if !errors.Is(err, tt.err) {
-				t.Fatalf("CancelFactoryTarget() error = %v, want %v", err, tt.err)
+			if err != tt.err {
+				t.Fatalf("CancelFactoryTarget() error = %v, want the exact same error value %v", err, tt.err)
 			}
 			if !reflect.DeepEqual(got, tt.result) {
 				t.Fatalf("CancelFactoryTarget() result = %#v, want %#v", got, tt.result)
 			}
-			if len(fake.startCalls) != 0 || len(fake.invokeCalls) != 0 || len(fake.closeCalls) != 0 {
-				t.Fatalf(
-					"unexpected delegation: start=%d invoke=%d close=%d, want all 0",
-					len(fake.startCalls), len(fake.invokeCalls), len(fake.closeCalls),
-				)
-			}
+			assertNoOtherCalls(t, fake, "cancel")
 		})
 	}
 }
@@ -215,21 +259,23 @@ func TestShimClose(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fake := &recordingFactorySessionsService{closeErr: tt.err}
 			shim := New(fake)
+			ctx := context.WithValue(context.Background(), ctxProbeKey{}, "close-"+tt.name)
 
-			err := shim.CloseFactoryTarget(context.Background(), "session-1")
+			err := shim.CloseFactoryTarget(ctx, "session-1")
 
-			if len(fake.closeCalls) != 1 || fake.closeCalls[0] != "session-1" {
-				t.Fatalf("CloseFactorySession calls = %#v, want [session-1]", fake.closeCalls)
+			if len(fake.closeCalls) != 1 {
+				t.Fatalf("CloseFactorySession call count = %d, want 1", len(fake.closeCalls))
 			}
-			if !errors.Is(err, tt.err) {
-				t.Fatalf("CloseFactoryTarget() error = %v, want %v", err, tt.err)
+			if fake.closeCalls[0].ctx != ctx {
+				t.Fatalf("CloseFactorySession ctx = %#v, want the exact ctx passed in", fake.closeCalls[0].ctx)
 			}
-			if len(fake.startCalls) != 0 || len(fake.invokeCalls) != 0 || len(fake.cancelCalls) != 0 {
-				t.Fatalf(
-					"unexpected delegation: start=%d invoke=%d cancel=%d, want all 0",
-					len(fake.startCalls), len(fake.invokeCalls), len(fake.cancelCalls),
-				)
+			if fake.closeCalls[0].sessionID != "session-1" {
+				t.Fatalf("CloseFactorySession sessionID = %q, want session-1", fake.closeCalls[0].sessionID)
 			}
+			if err != tt.err {
+				t.Fatalf("CloseFactoryTarget() error = %v, want the exact same error value %v", err, tt.err)
+			}
+			assertNoOtherCalls(t, fake, "close")
 		})
 	}
 }


### PR DESCRIPTION
```json
{
  "project": "Create the Chat-Owned Factory Sessions Shim",
  "branchName": "ACP-L1-V0-factory-sessions-shim",
  "description": "Create the narrow consumer-owned Factory Sessions adapter required by Chat Sessions for future Factory-target start, invoke, cancel, and close behavior, preserving the existing provider root's behavior while explicitly tracking the shim for L3 retirement.",
  "context": {
    "customerAsk": "Add pkg/services/chat_sessions/internal/factorysessionsshim as the narrow consumer-owned adapter needed for future Factory target start, invoke, cancel, and close behavior. It must consume only the public factory_sessions root, expose the smallest testable Chat-owned port, include compile-time and delegation evidence, change no Factory Sessions behavior, preserve the root-consolidation shim register and its L3 retirement condition, and complete delivery through CI, review, and merge.",
    "problem": "The current Factory Sessions root exposes 45 methods and multiple overlapping lifecycle families. Depending on that broad root directly would couple Chat Sessions to capabilities it does not own or need, while waiting for L2/L3 root sealing would unnecessarily block ACP Core. A narrow boundary is required now, but it must not become a new authority, reinterpret results, reach into provider internals, or silently outlive the root consolidation that makes it unnecessary.",
    "solution": "Introduce a stateless adapter inside the Chat Sessions ownership boundary. It accepts the existing public factory_sessions.Service, exposes only asynchronous start, invoke, cancel, and close, and delegates each call with the original context, identifiers, requests, results, and errors intact. Focused compile-time and recording-fake tests prove the narrow contract and exact delegation, while the existing root-consolidation register continues to assign retirement to L3 Factory Sessions sealing."
  },
  "acceptanceCriteria": [
    "Chat-owned code can depend on one narrow port containing only the Factory-target start, invoke, cancel, and close capabilities required by the L1 flows.",
    "The adapter imports only the public pkg/services/factory_sessions root and does not import Factory Sessions internals, create another session authority, or introduce runtime service discovery or secondary injection.",
    "Each adapter operation delegates exactly once to the corresponding existing public Factory Sessions operation and preserves context, request values, session identity, typed result, and error behavior.",
    "No Factory Sessions implementation, provider behavior, public API/OpenAPI contract, generated artifact, frontend behavior, or unrelated package is changed by this packet.",
    "The root-consolidation shim register accurately names chat_sessions/internal/factorysessionsshim, the broad factory_sessions.Service it adapts, and L3 Factory Sessions sealing as its retirement condition; no meta-test scans the register or repository topology.",
    "Typecheck, formatting, lint, focused delegation tests, and the required repository test/CI tier pass.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file reconciliation are complete, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "ACP-L1-V0-factory-sessions-shim-001",
      "title": "Delegate Factory target start and invoke",
      "description": "As a Chat Sessions implementer, I want one narrow Factory execution dependency so that a first Factory-target turn can start a session and later turns can invoke it without coupling Chat to the full Factory Sessions root.",
      "acceptanceCriteria": [
        "The Chat-owned port exposes only the four planned Factory-target capabilities, with start and invoke available through provider-root public request, result, and error vocabulary rather than private or duplicated contract types.",
        "Starting through the adapter calls the existing asynchronous Factory Sessions start operation exactly once with the same context and complete request, and returns the same result and error without translation or additional side effects.",
        "Invoking through the adapter calls the existing Factory Session invocation operation exactly once with the same context, session identity, and complete request, and returns the same result and error without translation or additional side effects.",
        "Compile-time interface satisfaction proves the adapter implements the narrow Chat-owned port while its injected dependency remains the public factory_sessions.Service.",
        "Focused table-driven delegation tests cover successful results and provider-root errors for start and invoke using an explicit recording fake.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented in pkg/services/chat_sessions/internal/factorysessionsshim/shim.go (StartFactoryTarget, InvokeFactoryTarget) delegating to factorysessions.Service.StartAsync / InvokeFactorySession. Table-driven recording-fake tests in shim_test.go cover success and error for both."
    },
    {
      "id": "ACP-L1-V0-factory-sessions-shim-002",
      "title": "Delegate Factory target cancel and close with explicit retirement",
      "description": "As a Chat Sessions implementer, I want the same narrow dependency to cancel the captured Factory turn and close its Factory Session so that future Chat lifecycle behavior uses the provider's existing outcomes without owning Factory Sessions policy.",
      "acceptanceCriteria": [
        "Canceling through the adapter calls the existing public Factory Sessions cancel operation exactly once with the same context, session identity, and complete control request, and returns the same lifecycle result and error without reclassifying the outcome.",
        "Closing through the adapter calls the existing public Factory Session close operation exactly once with the same context and session identity and returns the provider-root error unchanged.",
        "Focused table-driven delegation tests cover successful and failed cancel and close calls and prove that neither operation calls start, invoke, or any other Factory Sessions capability.",
        "The root-consolidation shim register remains accurate for the created Chat-owned shim and continues to assign its removal to L3 Factory Sessions sealing; implementation does not add a register-scanning or source-topology meta-test.",
        "No provider implementation, Factory Sessions contract, generated API artifact, or visible UI behavior changes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented CancelFactoryTarget/CloseFactoryTarget in the same shim.go, delegating to factorysessions.Service.Cancel / CloseFactorySession. TestShimCancel/TestShimClose assert zero start/invoke/cancel/close cross-calls via a recording fake that embeds factorysessions.Service unimplemented (nil) so any unexpected capability call panics. The root-consolidation shim register at docs/internal/projects/root-consolidation/proposal.md already named this exact shim path; left unchanged."
    }
  ]
}
```

## Follow-up: addressed post-merge review feedback

PR #1708 (this branch, `ACP-L1-V0-factory-sessions-shim`) was merged, then received a blocking review comment after merge pointing out that the delegation tests did not actually prove the PRD's exact-preservation contract:

- All four fake methods discarded `context.Context`, so a shim that substituted `context.Background()` internally would still have passed.
- Error assertions used `errors.Is(err, tt.err)`, so a shim that wrapped/translated the original error would still have passed.
- `TestShimStart` did not assert zero invoke/cancel/close calls, and `TestShimInvoke` only excluded start (not cancel/close).

This PR is a test-only follow-up on top of the already-merged shim, containing exactly one commit that fixes `pkg/services/chat_sessions/internal/factorysessionsshim/shim_test.go`:

- The recording fake now records the exact `context.Context` received on every call; each test asserts identity against the context it passed in.
- Error assertions now use exact value identity (`err != tt.err`) instead of `errors.Is`, proving the shim returns the original error value unchanged rather than a wrapped/translated one.
- Every test (`TestShimStart`, `TestShimInvoke`, `TestShimCancel`, `TestShimClose`) now asserts zero calls to the other three operations via a shared `assertNoOtherCalls` helper.

No production code (`shim.go`, `contracts.go`, `doc.go`), coverage manifest, root-consolidation register, or any other file changed — this is purely stronger test evidence for behavior that was already correct.
