### PR TITLE
ACP-L1-E01: publish Events stream L1 V0 contracts (review follow-up)

### DIFF
--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -234,7 +234,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/events",
-      "minimum": 94.55
+      "minimum": 95.97
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions",

--- a/pkg/services/events/append.go
+++ b/pkg/services/events/append.go
@@ -27,6 +27,24 @@ type AppendIdentity struct {
 	SourceEventID  SourceEventID
 }
 
+// Validate reports whether id names a well-formed idempotency identity: all
+// four tuple members are individually well-formed.
+func (id AppendIdentity) Validate() error {
+	if err := id.SourceType.Validate(); err != nil {
+		return err
+	}
+	if err := id.SourceID.Validate(); err != nil {
+		return err
+	}
+	if err := id.SourceSequence.Validate(); err != nil {
+		return err
+	}
+	if err := id.SourceEventID.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
 // AppendRequest asks Events to append one source-native record to Topic.
 // Payload stays source-native JSON; Events does not convert it into an
 // Events-owned kind union.
@@ -57,16 +75,7 @@ func (r AppendRequest) Validate() error {
 	if err := r.Topic.Validate(); err != nil {
 		return err
 	}
-	if err := r.SourceType.Validate(); err != nil {
-		return err
-	}
-	if err := r.SourceID.Validate(); err != nil {
-		return err
-	}
-	if err := r.SourceSequence.Validate(); err != nil {
-		return err
-	}
-	if err := r.SourceEventID.Validate(); err != nil {
+	if err := r.Identity().Validate(); err != nil {
 		return err
 	}
 	if err := r.SchemaID.Validate(); err != nil {
@@ -111,16 +120,7 @@ func (rec Record) Validate() error {
 	if err := rec.ID.Validate(); err != nil {
 		return err
 	}
-	if err := rec.SourceType.Validate(); err != nil {
-		return err
-	}
-	if err := rec.SourceID.Validate(); err != nil {
-		return err
-	}
-	if err := rec.SourceSequence.Validate(); err != nil {
-		return err
-	}
-	if err := rec.SourceEventID.Validate(); err != nil {
+	if err := rec.Identity().Validate(); err != nil {
 		return err
 	}
 	if err := rec.SchemaID.Validate(); err != nil {

--- a/pkg/services/events/append_test.go
+++ b/pkg/services/events/append_test.go
@@ -116,6 +116,45 @@ func TestRecordDetachedPayload(t *testing.T) {
 	}
 }
 
+func TestAppendIdentityValidate(t *testing.T) {
+	valid := AppendIdentity{
+		SourceType:     "worker.tool",
+		SourceID:       "worker-1",
+		SourceSequence: 1,
+		SourceEventID:  "evt-1",
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(AppendIdentity) AppendIdentity
+		wantErr error
+	}{
+		{"valid", func(id AppendIdentity) AppendIdentity { return id }, nil},
+		{"missing source type", func(id AppendIdentity) AppendIdentity { id.SourceType = ""; return id }, ErrEmptySourceType},
+		{"missing source id", func(id AppendIdentity) AppendIdentity { id.SourceID = ""; return id }, ErrEmptySourceID},
+		{"missing source sequence", func(id AppendIdentity) AppendIdentity { id.SourceSequence = 0; return id }, ErrInvalidSourceSequence},
+		{"missing source event id", func(id AppendIdentity) AppendIdentity { id.SourceEventID = ""; return id }, ErrEmptySourceEventID},
+		{"malformed source id", func(id AppendIdentity) AppendIdentity { id.SourceID = " worker-1"; return id }, ErrMalformedSourceID},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := tt.mutate(valid)
+			if err := id.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAppendRequestValidateDelegatesToIdentity(t *testing.T) {
+	req := validAppendRequest()
+	req.SourceSequence = 0
+
+	if err := req.Validate(); !errors.Is(err, ErrInvalidSourceSequence) {
+		t.Fatalf("Validate() = %v, want %v (delegated from Identity().Validate())", err, ErrInvalidSourceSequence)
+	}
+}
+
 func TestAppendOutcomeValues(t *testing.T) {
 	rec := Record{ID: RecordID{Topic: "chat-session/abc/events", Position: 1}}
 

--- a/pkg/services/events/errors.go
+++ b/pkg/services/events/errors.go
@@ -1,6 +1,9 @@
 package events
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // Identity, sequence, cursor, and retained-position validation failures.
 // Callers classify a failure with errors.Is against these sentinels rather
@@ -30,4 +33,28 @@ var (
 	ErrCursorTopicMismatch     = errors.New("events: cursor does not belong to the requested topic")
 	ErrInvalidReadLimit        = errors.New("events: read/subscribe limit must be positive")
 	ErrInconsistentReadOutcome = errors.New("events: read result outcome is inconsistent with its records/gap")
+	ErrInvalidGapFacts         = errors.New("events: gap facts are internally inconsistent")
+	ErrInconsistentDelivery    = errors.New("events: delivery is inconsistent with its kind")
+)
+
+// ErrOperationFailed classifies a Read or Subscribe call that failed for a
+// reason other than request validation or an expected at-head/gap outcome. A
+// caller distinguishes any such operation failure from a validation error or
+// a successful ReadResult/Delivery with errors.Is(err, ErrOperationFailed).
+//
+// ErrUnknownTopic and ErrUnresolvableCursor wrap ErrOperationFailed: a caller
+// can classify the specific cause with errors.Is against the narrower
+// sentinel, or classify any operation failure with the general one.
+var (
+	ErrOperationFailed = errors.New("events: operation failed")
+
+	// ErrUnknownTopic reports that a well-formed Topic names no stream
+	// Events knows about.
+	ErrUnknownTopic = fmt.Errorf("events: topic is not known: %w", ErrOperationFailed)
+	// ErrUnresolvableCursor reports that a well-formed, topic-matched Cursor
+	// names a position Events cannot resolve against the topic's aggregate
+	// ordering (distinct from ReadOutcomeInvalidCursor/DeliveryGap, which
+	// report the same condition as an expected result rather than an
+	// operation failure).
+	ErrUnresolvableCursor = fmt.Errorf("events: cursor cannot be resolved: %w", ErrOperationFailed)
 )

--- a/pkg/services/events/read_subscribe.go
+++ b/pkg/services/events/read_subscribe.go
@@ -59,6 +59,27 @@ type GapFacts struct {
 	Head             AggregateSequence
 }
 
+// Validate reports whether g names an internally consistent retention gap: a
+// well-formed Topic, a nonzero Head (a gap cannot exist on a topic that has
+// never retained a record), an EarliestRetained between 1 and Head
+// inclusive, and a Requested position strictly before EarliestRetained (the
+// position must actually have been evicted to be a gap).
+func (g GapFacts) Validate() error {
+	if err := g.Topic.Validate(); err != nil {
+		return err
+	}
+	if g.Head == 0 {
+		return ErrInvalidGapFacts
+	}
+	if g.EarliestRetained == 0 || g.EarliestRetained > g.Head {
+		return ErrInvalidGapFacts
+	}
+	if g.Requested >= g.EarliestRetained {
+		return ErrInvalidGapFacts
+	}
+	return nil
+}
+
 // ReadResult is the detached outcome of one Read call.
 type ReadResult struct {
 	Records  []Record
@@ -84,6 +105,9 @@ func (res ReadResult) Validate() error {
 	case ReadOutcomeGap:
 		if len(res.Records) != 0 || res.Gap == nil {
 			return ErrInconsistentReadOutcome
+		}
+		if err := res.Gap.Validate(); err != nil {
+			return err
 		}
 	default:
 		return ErrInconsistentReadOutcome
@@ -145,6 +169,45 @@ type Delivery struct {
 	Record Record
 	Cursor Cursor
 	Gap    *GapFacts
+}
+
+// Validate reports whether d is internally consistent with its Kind: a
+// caller can never observe an impossible combination such as DeliveryGap
+// with a nil or malformed Gap, DeliveryRecord with an unset Record/Cursor or
+// a Cursor naming a different topic than the delivered Record, or a
+// terminal/gap Delivery carrying a leftover Record or Cursor.
+func (d Delivery) Validate() error {
+	recordSet := d.Record.ID != (RecordID{})
+	cursorSet := d.Cursor != (Cursor{})
+	switch d.Kind {
+	case DeliveryRecord:
+		if !recordSet || !cursorSet || d.Gap != nil {
+			return ErrInconsistentDelivery
+		}
+		if err := d.Record.Validate(); err != nil {
+			return err
+		}
+		if err := d.Cursor.Validate(); err != nil {
+			return err
+		}
+		if !d.Cursor.BelongsTo(d.Record.ID.Topic) {
+			return ErrCursorTopicMismatch
+		}
+	case DeliveryGap:
+		if recordSet || cursorSet || d.Gap == nil {
+			return ErrInconsistentDelivery
+		}
+		if err := d.Gap.Validate(); err != nil {
+			return err
+		}
+	case DeliveryClosed, DeliveryCanceled, DeliveryBackpressure:
+		if recordSet || cursorSet || d.Gap != nil {
+			return ErrInconsistentDelivery
+		}
+	default:
+		return ErrInconsistentDelivery
+	}
+	return nil
 }
 
 // Subscription observes the next Delivery for one Subscribe call. Next may

--- a/pkg/services/events/read_subscribe_test.go
+++ b/pkg/services/events/read_subscribe_test.go
@@ -112,6 +112,99 @@ func TestGapFactsIdentifyResumablePosition(t *testing.T) {
 	}
 }
 
+func TestGapFactsValidate(t *testing.T) {
+	valid := GapFacts{Topic: testTopic, Requested: 3, EarliestRetained: 10, Head: 40}
+
+	tests := []struct {
+		name    string
+		mutate  func(GapFacts) GapFacts
+		wantErr error
+	}{
+		{"valid", func(g GapFacts) GapFacts { return g }, nil},
+		{"missing topic", func(g GapFacts) GapFacts { g.Topic = ""; return g }, ErrEmptyTopic},
+		{"zero head describes no history", func(g GapFacts) GapFacts { g.Head = 0; return g }, ErrInvalidGapFacts},
+		{"zero earliest retained with nonzero head", func(g GapFacts) GapFacts { g.EarliestRetained = 0; return g }, ErrInvalidGapFacts},
+		{"earliest retained beyond head", func(g GapFacts) GapFacts { g.EarliestRetained = 41; return g }, ErrInvalidGapFacts},
+		{"requested at or past earliest retained", func(g GapFacts) GapFacts { g.Requested = 10; return g }, ErrInvalidGapFacts},
+		{"requested past earliest retained", func(g GapFacts) GapFacts { g.Requested = 12; return g }, ErrInvalidGapFacts},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gap := tt.mutate(valid)
+			if err := gap.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDeliveryValidate(t *testing.T) {
+	rec := Record{
+		ID:             RecordID{Topic: testTopic, Position: 1},
+		SourceType:     "worker.tool",
+		SourceID:       "worker-1",
+		SourceSequence: 1,
+		SourceEventID:  "evt-1",
+		SchemaID:       "worker.output.v1",
+		Payload:        []byte(`{"tool":"grep"}`),
+	}
+	cur := Cursor{Topic: testTopic, Position: 1}
+	gap := &GapFacts{Topic: testTopic, Requested: 1, EarliestRetained: 5, Head: 9}
+
+	tests := []struct {
+		name     string
+		delivery Delivery
+		wantErr  error
+	}{
+		{"record delivery", Delivery{Kind: DeliveryRecord, Record: rec, Cursor: cur}, nil},
+		{"record delivery missing record", Delivery{Kind: DeliveryRecord, Cursor: cur}, ErrInconsistentDelivery},
+		{"record delivery missing cursor", Delivery{Kind: DeliveryRecord, Record: rec}, ErrInconsistentDelivery},
+		{"record delivery with a leftover gap", Delivery{Kind: DeliveryRecord, Record: rec, Cursor: cur, Gap: gap}, ErrInconsistentDelivery},
+		{
+			name:     "record delivery with a cursor from another topic",
+			delivery: Delivery{Kind: DeliveryRecord, Record: rec, Cursor: Cursor{Topic: "factory-session/abc/response-events", Position: 1}},
+			wantErr:  ErrCursorTopicMismatch,
+		},
+		{"gap delivery", Delivery{Kind: DeliveryGap, Gap: gap}, nil},
+		{"gap delivery with nil gap facts", Delivery{Kind: DeliveryGap}, ErrInconsistentDelivery},
+		{"gap delivery with malformed gap facts", Delivery{Kind: DeliveryGap, Gap: &GapFacts{Topic: testTopic}}, ErrInvalidGapFacts},
+		{"gap delivery with a leftover record", Delivery{Kind: DeliveryGap, Gap: gap, Record: rec}, ErrInconsistentDelivery},
+		{"gap delivery with a leftover cursor", Delivery{Kind: DeliveryGap, Gap: gap, Cursor: cur}, ErrInconsistentDelivery},
+		{"closed delivery", Delivery{Kind: DeliveryClosed}, nil},
+		{"closed delivery with a leftover record", Delivery{Kind: DeliveryClosed, Record: rec}, ErrInconsistentDelivery},
+		{"canceled delivery", Delivery{Kind: DeliveryCanceled}, nil},
+		{"canceled delivery with a leftover cursor", Delivery{Kind: DeliveryCanceled, Cursor: cur}, ErrInconsistentDelivery},
+		{"backpressure delivery", Delivery{Kind: DeliveryBackpressure}, nil},
+		{"backpressure delivery with a leftover gap", Delivery{Kind: DeliveryBackpressure, Gap: gap}, ErrInconsistentDelivery},
+		{"unspecified delivery", Delivery{}, ErrInconsistentDelivery},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.delivery.Validate(); !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestOperationFailureErrorsClassify(t *testing.T) {
+	if !errors.Is(ErrUnknownTopic, ErrOperationFailed) {
+		t.Fatalf("ErrUnknownTopic must classify as ErrOperationFailed")
+	}
+	if !errors.Is(ErrUnresolvableCursor, ErrOperationFailed) {
+		t.Fatalf("ErrUnresolvableCursor must classify as ErrOperationFailed")
+	}
+	if errors.Is(ErrUnknownTopic, ErrUnresolvableCursor) {
+		t.Fatalf("ErrUnknownTopic must not classify as the unrelated ErrUnresolvableCursor")
+	}
+	if errors.Is(ErrOperationFailed, ErrUnknownTopic) {
+		t.Fatalf("the general ErrOperationFailed must not classify as the narrower ErrUnknownTopic")
+	}
+	if errors.Is(ErrInconsistentReadOutcome, ErrOperationFailed) {
+		t.Fatalf("a validation/consistency error must not classify as an operation failure")
+	}
+}
+
 func TestSubscriptionNext(t *testing.T) {
 	rec := Record{ID: RecordID{Topic: testTopic, Position: 1}}
 	delivered := Delivery{Kind: DeliveryRecord, Record: rec, Cursor: Cursor{Topic: testTopic, Position: 1}}

--- a/pkg/services/events/service.go
+++ b/pkg/services/events/service.go
@@ -6,6 +6,15 @@ import "context"
 // read, and subscribe over one process-local, in-memory event stream (D1,
 // D2 in docs/internal/projects/acp-program/README.md). Peers depend on
 // Service rather than a store, journal, or transport type.
+//
+// Read and Subscribe return a non-nil error for a malformed request (see
+// ReadRequest.Validate/SubscribeRequest.Validate) and for an operation
+// failure distinct from an expected ReadResult/Delivery outcome: an unknown
+// topic (errors.Is(err, ErrUnknownTopic)), a well-formed but unresolvable
+// cursor (errors.Is(err, ErrUnresolvableCursor)), or any other operation
+// failure (errors.Is(err, ErrOperationFailed)). A nil error with
+// ReadOutcomeAtHead/InvalidCursor/Gap or DeliveryGap/Closed/Canceled/
+// Backpressure is an expected, successful observation, not a failure.
 type Service interface {
 	Append(context.Context, AppendRequest) (AppendResult, error)
 	AttachSource(context.Context, AttachSourceRequest) (AttachSourceResult, error)


### PR DESCRIPTION
{
  "project": "Publish the In-Memory Events Stream Contract",
  "branchName": "ACP-L1-E01-events-contracts",
  "description": "Publish the L1 V0 contract-only public root for a process-local Events stream. The concrete change adds detached topic, source, record, cursor, retention, gap, append, source-attachment, read, subscribe, and delivery contracts around source-native JSON. The intent is to give ACP Core and later Worker Events one stable session-scoped boundary while Recordings remains the canonical durable ledger and Events introduces neither persistence nor a second event taxonomy.",
  "context": {
    "customerAsk": "Implement L1 V0 Events contracts under decisions D1 and D2 in pkg/services/events: expose one public Events Service with AppendRequest, AttachSourceRequest, ReadRequest, SubscribeRequest, detached topic/source/cursor/retention/gap/subscription values, source-native JSON payload handling, and explicit cursor and gap outcomes. Do not change OpenAPI or ACP projections, add an internal/store package or durable journal, replace Recordings, create a normalized event taxonomy, or implement the V2 runtime.",
    "problem": "ACP Core and later Worker Events need one stable session-scoped stream boundary for append, source attachment, retained reads, and subscriptions. Without it, consumers will invent incompatible topic/source identities, couple to Factory Session internals, silently mistake expired history for empty success, or create competing event taxonomies and persistence ownership.",
    "solution": "Add a small public Go package root with detached value contracts, deterministic validation, typed/classifiable errors and expected outcomes, and one Service interface containing Append, AttachSource, Read, and Subscribe. Preserve source-native JSON inside delivery envelopes, bind cursors to stream identity, and make retention gaps and delivery termination explicit. Prove the contract with focused table-driven and external-consumer tests while deferring all mutable state, persistence, sequencing, retention, subscription implementation, construction, and transport work."
  },
  "acceptanceCriteria": [
    "AC-1: pkg/services/events exposes one public Service with detached append, attach-source, read, and subscribe request/result values usable without importing an implementation, transport, or another service's private packages.",
    "AC-2: Topic, source, record, sequence, cursor, retention, and idempotency identities have deterministic validation and documented zero-value semantics, and source-native JSON crosses the contract without conversion to an Events-owned taxonomy.",
    "AC-3: Reads and subscriptions explicitly distinguish successful progress, at-head, invalid or mismatched cursors, retention gaps, and terminal delivery outcomes so callers never infer missing history from empty success or parse error strings.",
    "AC-4: The slice preserves D1/D2 ownership: Recordings remains the canonical durable ledger, Events is process-local and in-memory only, and no implementation, store package, durable journal, recordings migration, OpenAPI/ACP projection, or unrelated cleanup is added.",
    "AC-5: Focused table-driven tests cover validation, detached payload behavior, error classification, and cursor/gap outcomes, and an external-package consumer test provides package-boundary evidence without meta-tests.",
    "AC-6: Quality gates pass: Typecheck, lint, focused Go tests, make pkg-file-count, and make pkg-boundary.",
    "AC-7: The implementation/review loop continues until required CI is terminal and passing, every blocking PR conversation is explicitly addressed, merge conflicts and shared-file changes are reconciled, and the PR is actually merged; an opened, green, approved, or ready-to-merge PR is not complete."
  ],
  "userStories": [
    {
      "id": "ACP-L1-E01-events-contracts-001",
      "title": "Identify topics, sources, and stream positions",
      "description": "As an Events producer or consumer, I need stable detached identities and positions so that I can name a session-scoped stream and its source without depending on storage or transport details.",
      "acceptanceCriteria": [
        "Public values represent topic identity, source type and ID, source sequence and event ID, schema identity, aggregate sequence, cursor, and retained range/head positions needed by append, attachment, read, and subscribe operations.",
        "Topic and source identities can represent factory-session/<id>/response-events and chat-session/<id>/events without hard-coding those topic families as the only valid future topics.",
        "Validation deterministically rejects empty, malformed, zero, or internally inconsistent identities and positions where they cannot name a valid operation; valid values remain detached from transport and persistence types.",
        "Cursor values carry enough topic/stream identity to reject use against a different stream rather than accidentally reading from the wrong topic.",
        "Table-driven tests prove valid and invalid identity, sequence, cursor, and retained-position cases through public behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented in pkg/services/events/identity.go and cursor.go: Topic, SourceType, SourceID, SourceSequence, SourceEventID, SchemaID, AggregateSequence, RecordID, Cursor, RetainedRange with Validate()/ValidateAssigned()/BelongsTo(). Covered by identity_test.go and cursor_test.go."
    },
    {
      "id": "ACP-L1-E01-events-contracts-002",
      "title": "Append source-native records idempotently",
      "description": "As an event producer, I need an append envelope that preserves my native JSON and source identity so that retries can be recognized without redefining my event vocabulary.",
      "acceptanceCriteria": [
        "AppendRequest identifies the destination topic, source type and ID, source sequence, source event ID, schema ID, and source-native JSON payload; (sourceType, sourceID, sourceSequence, sourceEventID) is the explicit idempotency identity.",
        "The public record and append result preserve source metadata and distinguish a newly accepted append from a duplicate/idempotent append while reporting the stable aggregate record identity assigned in either case.",
        "Validation rejects missing identity fields, invalid sequences, empty or invalid JSON payloads, and inconsistent envelopes with typed/classifiable invalid-request outcomes rather than error-string matching.",
        "Requests and returned records defensively detach payload bytes so caller mutation cannot alter the value observed across the public contract; tests use representative source-native Worker payload JSON without interpreting it as an Events-owned kind union.",
        "Table-driven tests prove valid envelopes, every required-field failure, invalid JSON handling, append outcome values, error classification, and payload detachment.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented in pkg/services/events/append.go: AppendRequest/Record/AppendResult/AppendOutcome/AppendIdentity with Validate(), Identity(), and Detached() (defensive payload copy). Covered by append_test.go."
    },
    {
      "id": "ACP-L1-E01-events-contracts-003",
      "title": "Attach a source without embedding dependencies",
      "description": "As an aggregate-stream owner, I need to describe a source attachment so that a later in-memory sequencer can follow a source from an explicit position without receiving a service, callback, or store handle.",
      "acceptanceCriteria": [
        "AttachSourceRequest uses detached identities to name the destination topic, source topic/source identity, and explicit starting or correlation cursor required for later sequencing.",
        "Attachment results distinguish a newly accepted attachment from an already-attached/idempotent outcome and return stable attachment/source correlation values suitable for callers to retain.",
        "Validation rejects self-attachment, missing or incompatible source/destination identities, invalid starting positions, and unsupported attachment modes with typed/classifiable outcomes.",
        "The attachment contract contains no embedded service, resolver, callback, channel, store, transport, or dependency bag and makes no claim that historical source data is durable.",
        "Table-driven tests prove valid attachment shapes, idempotent outcome values, failure classification, and incompatible/self-attachment cases.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented in pkg/services/events/attach.go: AttachSourceRequest/AttachSourceResult/AttachmentID/AttachMode/AttachOutcome with Validate() rejecting self-attachment, incompatible cursor topic, and unsupported modes. Covered by attach_test.go."
    },
    {
      "id": "ACP-L1-E01-events-contracts-004",
      "title": "Read and subscribe with explicit cursor and gap outcomes",
      "description": "As an event-stream consumer, I need reads and subscriptions to state whether I advanced, reached the live head, used an invalid cursor, or lost data to retention so that I never fabricate continuity.",
      "acceptanceCriteria": [
        "One public Service exposes Append, AttachSource, Read, and Subscribe with context.Context and detached typed request/result contracts; no second operational service or package-level operational API is introduced.",
        "ReadRequest and ReadResult represent a topic-bound starting cursor, bounded reads, returned records, next cursor, retained range/live head, and explicit progress, at-head, invalid-cursor, and retention-gap outcomes.",
        "SubscribeRequest represents the same cursor and bounded-delivery semantics needed for retained-then-live consumption, and the returned subscription/delivery contract reports records, cursor advancement, gaps, normal close, context cancellation, and slow-consumer/backpressure termination without silent loss.",
        "Gap values identify the requested position and the earliest retained/resumable position, and stream head where known, enabling a caller to surface or recover from loss without fabricated records or string parsing.",
        "Read/subscribe validation and typed errors distinguish malformed requests, unknown or mismatched topics/cursors, unsupported modes, and operation failures from expected at-head/gap/terminal outcomes.",
        "External-package compile-time consumer tests prove a fake can implement the root Service and consume the subscription contract using only exported detached values; table-driven tests prove read, cursor, gap, and terminal-delivery outcome semantics without scanning source topology.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Implemented in pkg/services/events/read_subscribe.go and service.go: ReadRequest/ReadResult/ReadOutcome/GapFacts, SubscribeRequest/Delivery/DeliveryKind/Subscription (function-type, mirrors recordings.EventSubscription), and the single Service interface. Covered by read_subscribe_test.go and the external-package events_external_test.go (package events_test)."
    }
  ]
}
