### PR TITLE
ACP-L1-E01: publish Events stream L1 V0 contracts (review follow-up 2)

### DIFF
--- a/pkg/services/events/append.go
+++ b/pkg/services/events/append.go
@@ -138,6 +138,19 @@ func (rec Record) Detached() Record {
 	return detached
 }
 
+// IsZero reports whether rec carries no data in any field, including
+// Payload. A Record with some fields set and others left at their zero
+// value (a partial Record) is never zero.
+func (rec Record) IsZero() bool {
+	return rec.ID == (RecordID{}) &&
+		rec.SourceType == "" &&
+		rec.SourceID == "" &&
+		rec.SourceSequence == 0 &&
+		rec.SourceEventID == "" &&
+		rec.SchemaID == "" &&
+		len(rec.Payload) == 0
+}
+
 // AppendResult is the detached success outcome of one Append call.
 type AppendResult struct {
 	Record  Record

--- a/pkg/services/events/append_test.go
+++ b/pkg/services/events/append_test.go
@@ -101,6 +101,41 @@ func TestRecordValidate(t *testing.T) {
 	}
 }
 
+func TestRecordIsZero(t *testing.T) {
+	full := Record{
+		ID:             RecordID{Topic: "chat-session/abc/events", Position: 1},
+		SourceType:     "worker.tool",
+		SourceID:       "worker-1",
+		SourceSequence: 1,
+		SourceEventID:  "evt-1",
+		SchemaID:       "worker.output.v1",
+		Payload:        json.RawMessage(`{"tool":"grep"}`),
+	}
+
+	tests := []struct {
+		name   string
+		record Record
+		want   bool
+	}{
+		{"zero value", Record{}, true},
+		{"fully set", full, false},
+		{"only id set", Record{ID: full.ID}, false},
+		{"only payload set", Record{Payload: full.Payload}, false},
+		{"only source type set", Record{SourceType: full.SourceType}, false},
+		{"only source id set", Record{SourceID: full.SourceID}, false},
+		{"only source sequence set", Record{SourceSequence: full.SourceSequence}, false},
+		{"only source event id set", Record{SourceEventID: full.SourceEventID}, false},
+		{"only schema id set", Record{SchemaID: full.SchemaID}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.record.IsZero(); got != tt.want {
+				t.Fatalf("IsZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRecordDetachedPayload(t *testing.T) {
 	original := json.RawMessage(`{"tool":"grep"}`)
 	rec := Record{

--- a/pkg/services/events/read_subscribe.go
+++ b/pkg/services/events/read_subscribe.go
@@ -175,13 +175,16 @@ type Delivery struct {
 // caller can never observe an impossible combination such as DeliveryGap
 // with a nil or malformed Gap, DeliveryRecord with an unset Record/Cursor or
 // a Cursor naming a different topic than the delivered Record, or a
-// terminal/gap Delivery carrying a leftover Record or Cursor.
+// terminal/gap Delivery carrying a leftover Record or Cursor. A Record with
+// only some fields set (for example a stray Payload on a gap or terminal
+// delivery) is rejected the same as a fully-set one: Record.IsZero checks
+// every field, not just ID.
 func (d Delivery) Validate() error {
-	recordSet := d.Record.ID != (RecordID{})
+	recordZero := d.Record.IsZero()
 	cursorSet := d.Cursor != (Cursor{})
 	switch d.Kind {
 	case DeliveryRecord:
-		if !recordSet || !cursorSet || d.Gap != nil {
+		if recordZero || !cursorSet || d.Gap != nil {
 			return ErrInconsistentDelivery
 		}
 		if err := d.Record.Validate(); err != nil {
@@ -194,14 +197,14 @@ func (d Delivery) Validate() error {
 			return ErrCursorTopicMismatch
 		}
 	case DeliveryGap:
-		if recordSet || cursorSet || d.Gap == nil {
+		if !recordZero || cursorSet || d.Gap == nil {
 			return ErrInconsistentDelivery
 		}
 		if err := d.Gap.Validate(); err != nil {
 			return err
 		}
 	case DeliveryClosed, DeliveryCanceled, DeliveryBackpressure:
-		if recordSet || cursorSet || d.Gap != nil {
+		if !recordZero || cursorSet || d.Gap != nil {
 			return ErrInconsistentDelivery
 		}
 	default:

--- a/pkg/services/events/read_subscribe_test.go
+++ b/pkg/services/events/read_subscribe_test.go
@@ -170,12 +170,37 @@ func TestDeliveryValidate(t *testing.T) {
 		{"gap delivery with malformed gap facts", Delivery{Kind: DeliveryGap, Gap: &GapFacts{Topic: testTopic}}, ErrInvalidGapFacts},
 		{"gap delivery with a leftover record", Delivery{Kind: DeliveryGap, Gap: gap, Record: rec}, ErrInconsistentDelivery},
 		{"gap delivery with a leftover cursor", Delivery{Kind: DeliveryGap, Gap: gap, Cursor: cur}, ErrInconsistentDelivery},
+		{
+			name:     "gap delivery with a partial record carrying only a payload",
+			delivery: Delivery{Kind: DeliveryGap, Gap: gap, Record: Record{Payload: []byte(`"secret"`)}},
+			wantErr:  ErrInconsistentDelivery,
+		},
+		{
+			name:     "gap delivery with a partial record carrying only source metadata",
+			delivery: Delivery{Kind: DeliveryGap, Gap: gap, Record: Record{SourceType: "worker.tool"}},
+			wantErr:  ErrInconsistentDelivery,
+		},
 		{"closed delivery", Delivery{Kind: DeliveryClosed}, nil},
 		{"closed delivery with a leftover record", Delivery{Kind: DeliveryClosed, Record: rec}, ErrInconsistentDelivery},
+		{
+			name:     "closed delivery with a partial record carrying only a payload",
+			delivery: Delivery{Kind: DeliveryClosed, Record: Record{Payload: []byte(`"secret"`)}},
+			wantErr:  ErrInconsistentDelivery,
+		},
 		{"canceled delivery", Delivery{Kind: DeliveryCanceled}, nil},
 		{"canceled delivery with a leftover cursor", Delivery{Kind: DeliveryCanceled, Cursor: cur}, ErrInconsistentDelivery},
+		{
+			name:     "canceled delivery with a partial record carrying only a schema id",
+			delivery: Delivery{Kind: DeliveryCanceled, Record: Record{SchemaID: "worker.output.v1"}},
+			wantErr:  ErrInconsistentDelivery,
+		},
 		{"backpressure delivery", Delivery{Kind: DeliveryBackpressure}, nil},
 		{"backpressure delivery with a leftover gap", Delivery{Kind: DeliveryBackpressure, Gap: gap}, ErrInconsistentDelivery},
+		{
+			name:     "backpressure delivery with a partial record carrying only a source sequence",
+			delivery: Delivery{Kind: DeliveryBackpressure, Record: Record{SourceSequence: 1}},
+			wantErr:  ErrInconsistentDelivery,
+		},
 		{"unspecified delivery", Delivery{}, ErrInconsistentDelivery},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
{
  "project": "Publish the In-Memory Events Stream Contract",
  "branchName": "ACP-L1-E01-events-contracts",
  "description": "Publish the L1 V0 contract-only public root for a process-local Events stream. The concrete change adds detached topic, source, record, cursor, retention, gap, append, source-attachment, read, subscribe, and delivery contracts around source-native JSON. The intent is to give ACP Core and later Worker Events one stable session-scoped boundary while Recordings remains the canonical durable ledger and Events introduces neither persistence nor a second event taxonomy.",
  "context": {
    "customerAsk": "Implement L1 V0 Events contracts under decisions D1 and D2 in pkg/services/events: expose one public Events Service with AppendRequest, AttachSourceRequest, ReadRequest, SubscribeRequest, detached topic/source/cursor/retention/gap/subscription values, source-native JSON payload handling, and explicit cursor and gap outcomes. Do not change OpenAPI or ACP projections, add an internal/store package or durable journal, replace Recordings, create a normalized event taxonomy, or implement the V2 runtime.",
    "problem": "ACP Core and later Worker Events need one stable session-scoped stream boundary for append, source attachment, retained reads, and subscriptions. Without it, consumers will invent incompatible topic/source identities, couple to Factory Session internals, silently mistake expired history for empty success, or create competing event taxonomies and persistence ownership.",
    "solution": "Add a small public Go package root with detached value contracts, deterministic validation, typed/classifiable errors and expected outcomes, and one Service interface containing Append, AttachSource, Read, and Subscribe. Preserve source-native JSON inside delivery envelopes, bind cursors to stream identity, and make retention gaps and delivery termination explicit. Prove the contract with focused table-driven and external-consumer tests while deferring all mutable state, persistence, sequencing, retention, subscription implementation, construction, and transport work."
  },
  "acceptanceCriteria": [
    "AC-1: pkg/services/events exposes one public Service with detached append, attach-source, read, and subscribe request/result values usable without importing an implementation, transport, or another service's private packages.",
    "AC-2: Topic, source, record, sequence, cursor, retention, and idempotency identities have deterministic validation and documented zero-value semantics, and source-native JSON crosses the contract without conversion to an Events-owned taxonomy.",
    "AC-3: Reads and subscriptions explicitly distinguish successful progress, at-head, invalid or mismatched cursors, retention gaps, and terminal delivery outcomes so callers never infer missing history from empty success or parse error strings.",
    "AC-4: The slice preserves D1/D2 ownership: Recordings remains the canonical durable ledger, Events is process-local and in-memory only, and no implementation, store package, durable journal, recordings migration, OpenAPI/ACP projection, or unrelated cleanup is added.",
    "AC-5: Focused table-driven tests cover validation, detached payload behavior, error classification, and cursor/gap outcomes, and an external-package consumer test provides package-boundary evidence without meta-tests.",
    "AC-6: Quality gates pass: Typecheck, lint, focused Go tests, make pkg-file-count, and make pkg-boundary.",
    "AC-7: The implementation/review loop continues until required CI is terminal and passing, every blocking PR conversation is explicitly addressed, merge conflicts and shared-file changes are reconciled, and the PR is actually merged; an opened, green, approved, or ready-to-merge PR is not complete."
  ],
  "userStories": [
    {
      "id": "ACP-L1-E01-events-contracts-001",
      "title": "Identify topics, sources, and stream positions",
      "description": "As an Events producer or consumer, I need stable detached identities and positions so that I can name a session-scoped stream and its source without depending on storage or transport details.",
      "acceptanceCriteria": [
        "Public values represent topic identity, source type and ID, source sequence and event ID, schema identity, aggregate sequence, cursor, and retained range/head positions needed by append, attachment, read, and subscribe operations.",
        "Topic and source identities can represent factory-session/<id>/response-events and chat-session/<id>/events without hard-coding those topic families as the only valid future topics.",
        "Validation deterministically rejects empty, malformed, zero, or internally inconsistent identities and positions where they cannot name a valid operation; valid values remain detached from transport and persistence types.",
        "Cursor values carry enough topic/stream identity to reject use against a different stream rather than accidentally reading from the wrong topic.",
        "Table-driven tests prove valid and invalid identity, sequence, cursor, and retained-position cases through public behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented in pkg/services/events/identity.go and cursor.go: Topic, SourceType, SourceID, SourceSequence, SourceEventID, SchemaID, AggregateSequence, RecordID, Cursor, RetainedRange with Validate()/ValidateAssigned()/BelongsTo(). Covered by identity_test.go and cursor_test.go."
    },
    {
      "id": "ACP-L1-E01-events-contracts-002",
      "title": "Append source-native records idempotently",
      "description": "As an event producer, I need an append envelope that preserves my native JSON and source identity so that retries can be recognized without redefining my event vocabulary.",
      "acceptanceCriteria": [
        "AppendRequest identifies the destination topic, source type and ID, source sequence, source event ID, schema ID, and source-native JSON payload; (sourceType, sourceID, sourceSequence, sourceEventID) is the explicit idempotency identity.",
        "The public record and append result preserve source metadata and distinguish a newly accepted append from a duplicate/idempotent append while reporting the stable aggregate record identity assigned in either case.",
        "Validation rejects missing identity fields, invalid sequences, empty or invalid JSON payloads, and inconsistent envelopes with typed/classifiable invalid-request outcomes rather than error-string matching.",
        "Requests and returned records defensively detach payload bytes so caller mutation cannot alter the value observed across the public contract; tests use representative source-native Worker payload JSON without interpreting it as an Events-owned kind union.",
        "Table-driven tests prove valid envelopes, every required-field failure, invalid JSON handling, append outcome values, error classification, and payload detachment.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented in pkg/services/events/append.go: AppendRequest/Record/AppendResult/AppendOutcome/AppendIdentity with Validate(), Identity(), and Detached() (defensive payload copy). Covered by append_test.go."
    },
    {
      "id": "ACP-L1-E01-events-contracts-003",
      "title": "Attach a source without embedding dependencies",
      "description": "As an aggregate-stream owner, I need to describe a source attachment so that a later in-memory sequencer can follow a source from an explicit position without receiving a service, callback, or store handle.",
      "acceptanceCriteria": [
        "AttachSourceRequest uses detached identities to name the destination topic, source topic/source identity, and explicit starting or correlation cursor required for later sequencing.",
        "Attachment results distinguish a newly accepted attachment from an already-attached/idempotent outcome and return stable attachment/source correlation values suitable for callers to retain.",
        "Validation rejects self-attachment, missing or incompatible source/destination identities, invalid starting positions, and unsupported attachment modes with typed/classifiable outcomes.",
        "The attachment contract contains no embedded service, resolver, callback, channel, store, transport, or dependency bag and makes no claim that historical source data is durable.",
        "Table-driven tests prove valid attachment shapes, idempotent outcome values, failure classification, and incompatible/self-attachment cases.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented in pkg/services/events/attach.go: AttachSourceRequest/AttachSourceResult/AttachmentID/AttachMode/AttachOutcome with Validate() rejecting self-attachment, incompatible cursor topic, and unsupported modes. Covered by attach_test.go."
    },
    {
      "id": "ACP-L1-E01-events-contracts-004",
      "title": "Read and subscribe with explicit cursor and gap outcomes",
      "description": "As an event-stream consumer, I need reads and subscriptions to state whether I advanced, reached the live head, used an invalid cursor, or lost data to retention so that I never fabricate continuity.",
      "acceptanceCriteria": [
        "One public Service exposes Append, AttachSource, Read, and Subscribe with context.Context and detached typed request/result contracts; no second operational service or package-level operational API is introduced.",
        "ReadRequest and ReadResult represent a topic-bound starting cursor, bounded reads, returned records, next cursor, retained range/live head, and explicit progress, at-head, invalid-cursor, and retention-gap outcomes.",
        "SubscribeRequest represents the same cursor and bounded-delivery semantics needed for retained-then-live consumption, and the returned subscription/delivery contract reports records, cursor advancement, gaps, normal close, context cancellation, and slow-consumer/backpressure termination without silent loss.",
        "Gap values identify the requested position and the earliest retained/resumable position, and stream head where known, enabling a caller to surface or recover from loss without fabricated records or string parsing.",
        "Read/subscribe validation and typed errors distinguish malformed requests, unknown or mismatched topics/cursors, unsupported modes, and operation failures from expected at-head/gap/terminal outcomes.",
        "External-package compile-time consumer tests prove a fake can implement the root Service and consume the subscription contract using only exported detached values; table-driven tests prove read, cursor, gap, and terminal-delivery outcome semantics without scanning source topology.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Implemented in pkg/services/events/read_subscribe.go and service.go: ReadRequest/ReadResult/ReadOutcome/GapFacts, SubscribeRequest/Delivery/DeliveryKind/Subscription (function-type, mirrors recordings.EventSubscription), and the single Service interface. Covered by read_subscribe_test.go and the external-package events_external_test.go (package events_test)."
    }
  ]
}
