### PR TITLE
Define the ACP Compatibility Contract and Shared Conformance Corpus

### DIFF
--- a/internal/testutil/acpconformance/corpus.go
+++ b/internal/testutil/acpconformance/corpus.go
@@ -8,7 +8,9 @@
 package acpconformance
 
 import (
+	"crypto/sha256"
 	_ "embed"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -144,16 +146,39 @@ type SourceProvenance struct {
 type Corpus struct {
 	SchemaVersion int              `json:"schema_version"`
 	Provenance    SourceProvenance `json:"provenance"`
-	Cases         []Case           `json:"cases"`
+	// CasesChecksum is a hex-encoded SHA-256 digest over the deterministic
+	// JSON encoding of Cases. It never includes itself, so it cannot
+	// self-reference. ParseCorpus recomputes it with ChecksumCases and
+	// rejects the corpus if the declared and recomputed values differ,
+	// which makes any change to case content -- reviewed or not -- require
+	// an explicit, matching checksum update.
+	CasesChecksum string `json:"cases_checksum"`
+	Cases         []Case `json:"cases"`
 }
 
 const supportedSchemaVersion = 1
 
+// ChecksumCases returns the hex-encoded SHA-256 digest of cases' canonical
+// JSON encoding. It is deterministic for a given slice of cases (field
+// order is fixed by the Case struct, and map[string]string keys sort
+// alphabetically under encoding/json), so it is reproducible by any caller
+// re-deriving it from the same case content, and is the value ParseCorpus
+// compares a corpus's declared cases_checksum against.
+func ChecksumCases(cases []Case) (string, error) {
+	encoded, err := json.Marshal(cases)
+	if err != nil {
+		return "", fmt.Errorf("acpconformance: encoding cases for checksum: %w", err)
+	}
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:]), nil
+}
+
 // ParseCorpus decodes and validates raw corpus JSON. It rejects invalid
-// JSON, an unpinned or incomplete source provenance, duplicate case
-// identity, an unknown protocol role, undeclared or unknown directionality,
-// a case with no declared expected facts, and a round-trip declaration for a
-// Facts.Kind known to be lossy or unsupported in at least one direction.
+// JSON, an unpinned or incomplete source provenance, a missing or mismatched
+// cases_checksum, duplicate case identity, an unknown protocol role,
+// undeclared or unknown directionality, a case with no declared expected
+// facts, and a round-trip declaration for a Facts.Kind known to be lossy or
+// unsupported in at least one direction.
 func ParseCorpus(data []byte) (Corpus, error) {
 	var corpus Corpus
 	if err := json.Unmarshal(data, &corpus); err != nil {
@@ -168,6 +193,19 @@ func ParseCorpus(data []byte) (Corpus, error) {
 	}
 	if len(corpus.Cases) == 0 {
 		return Corpus{}, fmt.Errorf("acpconformance: corpus has no cases")
+	}
+	if strings.TrimSpace(corpus.CasesChecksum) == "" {
+		return Corpus{}, fmt.Errorf("acpconformance: corpus is missing cases_checksum")
+	}
+	computedChecksum, err := ChecksumCases(corpus.Cases)
+	if err != nil {
+		return Corpus{}, err
+	}
+	if !strings.EqualFold(corpus.CasesChecksum, computedChecksum) {
+		return Corpus{}, fmt.Errorf(
+			"acpconformance: cases_checksum mismatch: corpus declares %q, computed %q from case content -- update cases_checksum after reviewing the case changes",
+			corpus.CasesChecksum, computedChecksum,
+		)
 	}
 	seen := make(map[string]bool, len(corpus.Cases))
 	for _, c := range corpus.Cases {

--- a/internal/testutil/acpconformance/corpus.json
+++ b/internal/testutil/acpconformance/corpus.json
@@ -6,6 +6,7 @@
     "sdk_commit": "0845a3bb9eddda5bfc22a94dd3598c90cb842451",
     "sdk_license": "Apache-2.0"
   },
+  "cases_checksum": "39941d81a0ac65999b3689d9d9ade356d42631887cdf507989d111f0b177db39",
   "cases": [
     {
       "id": "initialize-protocol-version-1-accepted",
@@ -326,6 +327,48 @@
         }
       },
       "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; an array id has no matching acp-go-sdk v0.13.5 RequestId variant and fails to decode."
+    },
+    {
+      "id": "malformed-input-null-params",
+      "protocol_role": "malformed_input",
+      "description": "A supported method's request whose params field is JSON null rather than absent, which must be rejected as invalid params without producing a zero-value decoded result.",
+      "directionality": "outbound_only",
+      "payload": {
+        "jsonrpc": "2.0",
+        "method": "session/prompt",
+        "id": "req-78",
+        "connectionId": "conn-1",
+        "params": null
+      },
+      "facts": {
+        "kind": "malformed_input",
+        "outcome": "invalid_params",
+        "metadata": {
+          "reason": "null_params"
+        }
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; matches pkg/transports/acp DecodeMethodParams' explicit JSON null rejection, distinct from an absent params field."
+    },
+    {
+      "id": "malformed-input-semantically-invalid-supported-request",
+      "protocol_role": "malformed_input",
+      "description": "A session/prompt request whose params decode successfully as JSON but omit the required prompt content, which must be rejected as invalid params rather than accepted with a missing required field.",
+      "directionality": "outbound_only",
+      "payload": {
+        "jsonrpc": "2.0",
+        "method": "session/prompt",
+        "id": "req-79",
+        "connectionId": "conn-1",
+        "params": { "sessionId": "session-1" }
+      },
+      "facts": {
+        "kind": "malformed_input",
+        "outcome": "invalid_params",
+        "metadata": {
+          "reason": "semantically_invalid_params"
+        }
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; matches pkg/transports/acp DecodeMethodParams' acpsdk.PromptRequest.Validate() enforcement of the required prompt field, proving structurally valid but semantically incomplete supported input is rejected."
     },
     {
       "id": "unsupported-method-unknown-string-id",

--- a/internal/testutil/acpconformance/corpus_test.go
+++ b/internal/testutil/acpconformance/corpus_test.go
@@ -10,6 +10,37 @@ import (
 	"github.com/portpowered/infinite-you/internal/testutil/acpconformance"
 )
 
+// corpusFixture mirrors acpconformance.Corpus's JSON shape for building test
+// fixtures with an explicit, independently-computed cases_checksum.
+type corpusFixture struct {
+	SchemaVersion int                             `json:"schema_version"`
+	Provenance    acpconformance.SourceProvenance `json:"provenance"`
+	CasesChecksum string                          `json:"cases_checksum"`
+	Cases         []acpconformance.Case           `json:"cases"`
+}
+
+// marshalFixture builds a corpus fixture with a correct cases_checksum
+// computed from cases via the same acpconformance.ChecksumCases function
+// ParseCorpus itself uses, so every fixture below stays valid on that axis
+// unless a test deliberately corrupts the checksum field afterward.
+func marshalFixture(t testing.TB, provenance acpconformance.SourceProvenance, cases []acpconformance.Case) []byte {
+	t.Helper()
+	checksum, err := acpconformance.ChecksumCases(cases)
+	if err != nil {
+		t.Fatalf("ChecksumCases: %v", err)
+	}
+	data, err := json.Marshal(corpusFixture{
+		SchemaVersion: 1,
+		Provenance:    provenance,
+		CasesChecksum: checksum,
+		Cases:         cases,
+	})
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	return data
+}
+
 func validMinimalCorpusJSON(t testing.TB) string {
 	t.Helper()
 	corpus := acpconformance.MustLoad(t)
@@ -17,19 +48,7 @@ func validMinimalCorpusJSON(t testing.TB) string {
 		t.Fatal("embedded corpus has no cases to derive a minimal fixture from")
 	}
 	one := corpus.Cases[0]
-	data, err := json.Marshal(struct {
-		SchemaVersion int                             `json:"schema_version"`
-		Provenance    acpconformance.SourceProvenance `json:"provenance"`
-		Cases         []acpconformance.Case           `json:"cases"`
-	}{
-		SchemaVersion: 1,
-		Provenance:    corpus.Provenance,
-		Cases:         []acpconformance.Case{one},
-	})
-	if err != nil {
-		t.Fatalf("marshal minimal corpus fixture: %v", err)
-	}
-	return string(data)
+	return string(marshalFixture(t, corpus.Provenance, []acpconformance.Case{one}))
 }
 
 func TestLoadEmbeddedCorpusIsValid(t *testing.T) {
@@ -58,16 +77,8 @@ func TestParseCorpusRejectsInvalidJSON(t *testing.T) {
 func TestParseCorpusRejectsDuplicateCaseID(t *testing.T) {
 	corpus := acpconformance.MustLoad(t)
 	dup := corpus.Cases[0]
-	broken := struct {
-		SchemaVersion int                             `json:"schema_version"`
-		Provenance    acpconformance.SourceProvenance `json:"provenance"`
-		Cases         []acpconformance.Case           `json:"cases"`
-	}{1, corpus.Provenance, []acpconformance.Case{dup, dup}}
-	data, err := json.Marshal(broken)
-	if err != nil {
-		t.Fatalf("marshal fixture: %v", err)
-	}
-	_, err = acpconformance.ParseCorpus(data)
+	data := marshalFixture(t, corpus.Provenance, []acpconformance.Case{dup, dup})
+	_, err := acpconformance.ParseCorpus(data)
 	if err == nil {
 		t.Fatal("ParseCorpus(duplicate case id) expected error, got nil")
 	}
@@ -80,16 +91,8 @@ func TestParseCorpusRejectsMissingFacts(t *testing.T) {
 	corpus := acpconformance.MustLoad(t)
 	broken := corpus.Cases[0]
 	broken.Facts = acpconformance.Facts{}
-	fixture := struct {
-		SchemaVersion int                             `json:"schema_version"`
-		Provenance    acpconformance.SourceProvenance `json:"provenance"`
-		Cases         []acpconformance.Case           `json:"cases"`
-	}{1, corpus.Provenance, []acpconformance.Case{broken}}
-	data, err := json.Marshal(fixture)
-	if err != nil {
-		t.Fatalf("marshal fixture: %v", err)
-	}
-	_, err = acpconformance.ParseCorpus(data)
+	data := marshalFixture(t, corpus.Provenance, []acpconformance.Case{broken})
+	_, err := acpconformance.ParseCorpus(data)
 	if err == nil {
 		t.Fatal("ParseCorpus(missing facts) expected error, got nil")
 	}
@@ -102,16 +105,8 @@ func TestParseCorpusRejectsUndeclaredDirectionality(t *testing.T) {
 	corpus := acpconformance.MustLoad(t)
 	broken := corpus.Cases[0]
 	broken.Directionality = ""
-	fixture := struct {
-		SchemaVersion int                             `json:"schema_version"`
-		Provenance    acpconformance.SourceProvenance `json:"provenance"`
-		Cases         []acpconformance.Case           `json:"cases"`
-	}{1, corpus.Provenance, []acpconformance.Case{broken}}
-	data, err := json.Marshal(fixture)
-	if err != nil {
-		t.Fatalf("marshal fixture: %v", err)
-	}
-	_, err = acpconformance.ParseCorpus(data)
+	data := marshalFixture(t, corpus.Provenance, []acpconformance.Case{broken})
+	_, err := acpconformance.ParseCorpus(data)
 	if err == nil {
 		t.Fatal("ParseCorpus(undeclared directionality) expected error, got nil")
 	}
@@ -124,15 +119,7 @@ func TestParseCorpusRejectsUnknownDirectionality(t *testing.T) {
 	corpus := acpconformance.MustLoad(t)
 	broken := corpus.Cases[0]
 	broken.Directionality = "sideways"
-	fixture := struct {
-		SchemaVersion int                             `json:"schema_version"`
-		Provenance    acpconformance.SourceProvenance `json:"provenance"`
-		Cases         []acpconformance.Case           `json:"cases"`
-	}{1, corpus.Provenance, []acpconformance.Case{broken}}
-	data, err := json.Marshal(fixture)
-	if err != nil {
-		t.Fatalf("marshal fixture: %v", err)
-	}
+	data := marshalFixture(t, corpus.Provenance, []acpconformance.Case{broken})
 	if _, err := acpconformance.ParseCorpus(data); err == nil {
 		t.Fatal("ParseCorpus(unknown directionality) expected error, got nil")
 	}
@@ -153,16 +140,8 @@ func TestParseCorpusRejectsRoundTripForLossyKind(t *testing.T) {
 		t.Fatal("expected embedded corpus to contain a case with Facts.Kind == \"tool\" to mutate")
 	}
 	toolCase.Directionality = acpconformance.DirectionRoundTrip
-	fixture := struct {
-		SchemaVersion int                             `json:"schema_version"`
-		Provenance    acpconformance.SourceProvenance `json:"provenance"`
-		Cases         []acpconformance.Case           `json:"cases"`
-	}{1, corpus.Provenance, []acpconformance.Case{toolCase}}
-	data, err := json.Marshal(fixture)
-	if err != nil {
-		t.Fatalf("marshal fixture: %v", err)
-	}
-	_, err = acpconformance.ParseCorpus(data)
+	data := marshalFixture(t, corpus.Provenance, []acpconformance.Case{toolCase})
+	_, err := acpconformance.ParseCorpus(data)
 	if err == nil {
 		t.Fatal("ParseCorpus(round_trip declared for lossy kind) expected error, got nil")
 	}
@@ -173,15 +152,7 @@ func TestParseCorpusRejectsRoundTripForLossyKind(t *testing.T) {
 
 func TestParseCorpusRejectsEmptyCorpus(t *testing.T) {
 	corpus := acpconformance.MustLoad(t)
-	fixture := struct {
-		SchemaVersion int                             `json:"schema_version"`
-		Provenance    acpconformance.SourceProvenance `json:"provenance"`
-		Cases         []acpconformance.Case           `json:"cases"`
-	}{1, corpus.Provenance, nil}
-	data, err := json.Marshal(fixture)
-	if err != nil {
-		t.Fatalf("marshal fixture: %v", err)
-	}
+	data := marshalFixture(t, corpus.Provenance, nil)
 	if _, err := acpconformance.ParseCorpus(data); err == nil {
 		t.Fatal("ParseCorpus(no cases) expected error, got nil")
 	}
@@ -189,17 +160,97 @@ func TestParseCorpusRejectsEmptyCorpus(t *testing.T) {
 
 func TestParseCorpusRejectsIncompleteProvenance(t *testing.T) {
 	corpus := acpconformance.MustLoad(t)
-	fixture := struct {
-		SchemaVersion int                             `json:"schema_version"`
-		Provenance    acpconformance.SourceProvenance `json:"provenance"`
-		Cases         []acpconformance.Case           `json:"cases"`
-	}{1, acpconformance.SourceProvenance{}, corpus.Cases[:1]}
+	data := marshalFixture(t, acpconformance.SourceProvenance{}, corpus.Cases[:1])
+	if _, err := acpconformance.ParseCorpus(data); err == nil {
+		t.Fatal("ParseCorpus(incomplete provenance) expected error, got nil")
+	}
+}
+
+func TestParseCorpusRejectsMissingChecksum(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	fixture := corpusFixture{
+		SchemaVersion: 1,
+		Provenance:    corpus.Provenance,
+		CasesChecksum: "",
+		Cases:         corpus.Cases[:1],
+	}
 	data, err := json.Marshal(fixture)
 	if err != nil {
 		t.Fatalf("marshal fixture: %v", err)
 	}
-	if _, err := acpconformance.ParseCorpus(data); err == nil {
-		t.Fatal("ParseCorpus(incomplete provenance) expected error, got nil")
+	_, err = acpconformance.ParseCorpus(data)
+	if err == nil {
+		t.Fatal("ParseCorpus(missing cases_checksum) expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing cases_checksum") {
+		t.Fatalf("ParseCorpus(missing cases_checksum) error = %v, want it to mention missing cases_checksum", err)
+	}
+}
+
+func TestParseCorpusRejectsMismatchedChecksum(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	correct, err := acpconformance.ChecksumCases(corpus.Cases[:1])
+	if err != nil {
+		t.Fatalf("ChecksumCases: %v", err)
+	}
+	fixture := corpusFixture{
+		SchemaVersion: 1,
+		Provenance:    corpus.Provenance,
+		CasesChecksum: correct[:len(correct)-1] + "0",
+		Cases:         corpus.Cases[:1],
+	}
+	if fixture.CasesChecksum == correct {
+		t.Fatal("test setup bug: corrupted checksum equals the correct checksum")
+	}
+	data, err := json.Marshal(fixture)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	_, err = acpconformance.ParseCorpus(data)
+	if err == nil {
+		t.Fatal("ParseCorpus(mismatched cases_checksum) expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cases_checksum mismatch") {
+		t.Fatalf("ParseCorpus(mismatched cases_checksum) error = %v, want it to mention cases_checksum mismatch", err)
+	}
+}
+
+func TestChecksumCasesIsDeterministicAndContentSensitive(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	first, err := acpconformance.ChecksumCases(corpus.Cases)
+	if err != nil {
+		t.Fatalf("ChecksumCases: %v", err)
+	}
+	second, err := acpconformance.ChecksumCases(corpus.Cases)
+	if err != nil {
+		t.Fatalf("ChecksumCases: %v", err)
+	}
+	if first != second {
+		t.Fatalf("ChecksumCases(same cases) = %q then %q, want identical results", first, second)
+	}
+
+	mutated := corpus.Cases
+	mutated[0].Description = mutated[0].Description + " (mutated)"
+	changed, err := acpconformance.ChecksumCases(mutated)
+	if err != nil {
+		t.Fatalf("ChecksumCases: %v", err)
+	}
+	if changed == first {
+		t.Fatal("ChecksumCases did not change after mutating a case's content")
+	}
+}
+
+func TestEmbeddedCorpusChecksumIsSelfConsistent(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	if strings.TrimSpace(corpus.CasesChecksum) == "" {
+		t.Fatal("embedded corpus has no cases_checksum")
+	}
+	recomputed, err := acpconformance.ChecksumCases(corpus.Cases)
+	if err != nil {
+		t.Fatalf("ChecksumCases: %v", err)
+	}
+	if recomputed != corpus.CasesChecksum {
+		t.Fatalf("recomputed cases checksum %q != declared cases_checksum %q", recomputed, corpus.CasesChecksum)
 	}
 }
 

--- a/pkg/transports/acp/conformance_test.go
+++ b/pkg/transports/acp/conformance_test.go
@@ -223,7 +223,19 @@ func TestConformanceMalformedInputCasesProduceTypedOutcomes(t *testing.T) {
 				if err := json.Unmarshal(c.Payload, &envelope); err != nil {
 					t.Fatalf("payload does not parse: %v", err)
 				}
-				_, decodeErr := acp.DecodeMethodParams[map[string]any](envelope.Params)
+				var decodeErr *acpsdk.RequestError
+				if c.Facts.Metadata["reason"] == "semantically_invalid_params" {
+					// A syntactically valid params object that fails the real
+					// acp-go-sdk request type's own Validate() (e.g. a
+					// session/prompt request missing the required prompt
+					// field) must decode through the actual supported
+					// request type, not a generic map, to prove
+					// DecodeMethodParams enforces semantic validity and not
+					// only JSON structure.
+					_, decodeErr = acp.DecodeMethodParams[acpsdk.PromptRequest](envelope.Params)
+				} else {
+					_, decodeErr = acp.DecodeMethodParams[map[string]any](envelope.Params)
+				}
 				if decodeErr == nil {
 					t.Fatal("DecodeMethodParams() expected an invalid-params error, got nil")
 				}

--- a/pkg/transports/acp/dispatch.go
+++ b/pkg/transports/acp/dispatch.go
@@ -74,18 +74,36 @@ func UnsupportedMethodResponse(method string, wireID *acpsdk.RequestId) *Unsuppo
 	}
 }
 
+// validatable is implemented by acp-go-sdk request types that enforce
+// required-field and other semantic constraints beyond JSON structural
+// decoding (e.g. *acpsdk.PromptRequest rejecting a missing prompt).
+// DecodeMethodParams calls it, when T implements it, so a syntactically
+// valid but semantically incomplete supported request is still rejected.
+type validatable interface {
+	Validate() error
+}
+
 // DecodeMethodParams unmarshals raw JSON-RPC params into T and returns a
-// typed, sensitive-safe invalid-params outcome on missing or malformed
-// input, so parameter validation never produces a partially decoded value.
-// The returned *acpsdk.RequestError never includes the raw params content.
+// typed, sensitive-safe invalid-params outcome on missing, null, malformed,
+// or semantically invalid input, so parameter validation never produces a
+// partially decoded value. When T implements validatable (as the acp-go-sdk
+// request types do), the decoded value's own Validate() is also enforced.
+// The returned *acpsdk.RequestError never includes the raw params content or
+// the underlying validation error text.
 func DecodeMethodParams[T any](raw json.RawMessage) (T, *acpsdk.RequestError) {
 	var zero T
-	if len(bytes.TrimSpace(raw)) == 0 {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
 		return zero, acpsdk.NewInvalidParams(map[string]any{"reason": "missing params"})
 	}
 	var v T
 	if err := json.Unmarshal(raw, &v); err != nil {
 		return zero, acpsdk.NewInvalidParams(map[string]any{"reason": "malformed params"})
+	}
+	if validator, ok := any(&v).(validatable); ok {
+		if err := validator.Validate(); err != nil {
+			return zero, acpsdk.NewInvalidParams(map[string]any{"reason": "invalid params"})
+		}
 	}
 	return v, nil
 }

--- a/pkg/transports/acp/dispatch_test.go
+++ b/pkg/transports/acp/dispatch_test.go
@@ -2,6 +2,7 @@ package acp_test
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	acpsdk "github.com/coder/acp-go-sdk"
@@ -98,5 +99,56 @@ func TestDecodeMethodParamsRejectsMalformedJSON(t *testing.T) {
 	}
 	if decodeErr.Code != -32602 {
 		t.Fatalf("DecodeMethodParams(malformed).Code = %d, want -32602", decodeErr.Code)
+	}
+}
+
+func TestDecodeMethodParamsRejectsNullParams(t *testing.T) {
+	_, decodeErr := acp.DecodeMethodParams[decodeParamsFixture](json.RawMessage(`null`))
+	if decodeErr == nil {
+		t.Fatal("DecodeMethodParams(null) expected invalid-params error, got nil")
+	}
+	if decodeErr.Code != -32602 {
+		t.Fatalf("DecodeMethodParams(null).Code = %d, want -32602", decodeErr.Code)
+	}
+}
+
+// TestDecodeMethodParamsRejectsSemanticallyInvalidSupportedRequest proves a
+// syntactically valid but semantically incomplete supported request (an
+// object that unmarshals cleanly but fails the real acp-go-sdk request
+// type's own Validate(), e.g. session/prompt with no prompt content) is
+// rejected as invalid params rather than silently accepted with a zero
+// required field.
+func TestDecodeMethodParamsRejectsSemanticallyInvalidSupportedRequest(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  json.RawMessage
+	}{
+		{"empty object missing required prompt", json.RawMessage(`{}`)},
+		{"sessionId present but prompt still missing", json.RawMessage(`{"sessionId":"session-1"}`)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, decodeErr := acp.DecodeMethodParams[acpsdk.PromptRequest](tc.raw)
+			if decodeErr == nil {
+				t.Fatalf("DecodeMethodParams(%s) expected invalid-params error, got value %+v", tc.raw, got)
+			}
+			if decodeErr.Code != -32602 {
+				t.Fatalf("DecodeMethodParams(%s).Code = %d, want -32602", tc.raw, decodeErr.Code)
+			}
+			if !reflect.DeepEqual(got, acpsdk.PromptRequest{}) {
+				t.Fatalf("DecodeMethodParams(%s) returned a non-zero value %+v on error, want the zero value", tc.raw, got)
+			}
+		})
+	}
+}
+
+func TestDecodeMethodParamsAcceptsSemanticallyValidSupportedRequest(t *testing.T) {
+	raw := json.RawMessage(`{"sessionId":"session-1","prompt":[{"type":"text","text":"hi"}]}`)
+	got, decodeErr := acp.DecodeMethodParams[acpsdk.PromptRequest](raw)
+	if decodeErr != nil {
+		t.Fatalf("DecodeMethodParams() unexpected error: %v", decodeErr)
+	}
+	if len(got.Prompt) != 1 {
+		t.Fatalf("DecodeMethodParams() = %+v, want exactly one prompt content block", got)
 	}
 }


### PR DESCRIPTION
```json
{
  "project": "Define the ACP Compatibility Contract and Shared Conformance Corpus",
  "branchName": "ACP-L1-V0-protocol-conformance",
  "description": "Establish the inert ACP protocol-version-1 agent compatibility boundary and a sanitized semantic conformance corpus so independent inbound provider and future outbound agent mappings can prove truthful text-first behavior, request correlation, select-option shape, unsupported-method handling, and an explicit lossless round-trip subset without implementing stdio serving or session execution.",
  "context": {
    "customerAsk": "Define the L1 V0 ACP compatibility contract and shared conformance corpus so the existing inbound provider mapper and a future outbound agent mapper can prove agreement through fixtures while remaining separate implementations. Encode protocol version 1, honest text-first capabilities, config-option type=select, request identity, unsupported-method behavior, and an explicit round-trip subset; complete tests, CI, review resolution, conflict reconciliation, and merge without implementing stdio serving or session execution.",
    "problem": "The provider-side ACP adapter owns inbound SessionUpdate mapping and representative SDK-shaped fixtures, but those fixtures are not a neutral compatibility corpus for the opposite direction, and no top-level agent-side ACP contract exists. The directions can therefore drift on version negotiation, capability claims, select-option union shape, request correlation, unsupported behavior, and lossless mapping claims.",
    "solution": "Publish a small pure pkg/transports/acp compatibility boundary based on acp-go-sdk v0.13.5 and promote sanitized protocol examples into a shared semantic corpus with provenance, typed request correlation, expected facts, unsupported outcomes, directionality, and explicit round-trip eligibility. Keep inbound mapping under Providers and future outbound mapping under the ACP transport, with independent tests consuming the corpus and no shared production mapper.",
    "originalDocument": "C:/Users/andre/work/portos/infinite-you/docs/internal/projects/acp-client/final-proposal.md"
  },
  "acceptanceCriteria": [
    "The inert ACP compatibility boundary accepts protocol version 1, rejects unsupported versions with a typed safe outcome, and exposes no listener, stdio loop, connection lifecycle, session execution, or service-construction side effect.",
    "Advertised capabilities are text-first and exactly match implemented V0 behavior: image, audio, embedded context, filesystem, terminal, authentication, fork, plan, client MCP server, and permission capabilities are absent or disabled, and Factory selection uses a config option with type=select.",
    "Request identity distinguishes equal JSON-RPC IDs on different connections, preserves supported string and numeric ID types without conflation, and uses a transport-minted identity where correlation has no usable wire ID.",
    "Unknown and explicitly deferred methods produce the correlated method-not-found outcome without mutation or external effects, while malformed supported inputs produce typed invalid-request or invalid-params outcomes with sensitive-safe details.",
    "One sanitized provenance-pinned corpus declares representative semantic facts, directionality, unsupported/no-output outcomes, and the exact lossless round-trip subset, and is independently consumable by provider-side and transport-side tests without shared production mapping code.",
    "Quality gate: focused ACP compatibility, corpus, provider-mapping, malformed-input, and zero-side-effect tests pass along with typecheck, lint, make verify-fast, applicable package-boundary checks, and required PR CI; no OpenAPI or generated API artifacts change.",
    "Delivery: the implementation/review loop continues until all blocking PR conversation feedback is explicitly addressed, shared-corpus changes and merge conflicts are reconciled against current main, required CI is terminal and passing, and the PR is actually merged; opening, approval, green CI, or merge readiness alone is not completion."
  ],
  "userStories": [
    {
      "id": "ACP-L1-V0-protocol-conformance-001",
      "title": "Publish an inert and truthful ACP compatibility profile",
      "description": "As a maintainer implementing the later ACP server, I want one deterministic compatibility profile so initialization and Factory selection cannot claim behavior that You has not implemented.",
      "acceptanceCriteria": [
        "The agent-side ACP boundary represents acp-go-sdk v0.13.5 protocol version 1 as the only supported protocol version and returns a typed sensitive-safe incompatibility outcome for any other version.",
        "The compatibility result advertises text prompt content only and leaves image, audio, embedded context, filesystem, terminal, authentication, fork, plan, client MCP server, and permission capabilities disabled or absent as required by the SDK wire shape.",
        "A representative Factory target option serializes and deserializes as the ACP select-option union with type=select, stable id, name, currentValue, and allowed values, without representing the Factory as an ACP model resource.",
        "Constructing, validating, or serializing the profile performs no IO, starts no goroutine or process, binds no endpoint, and creates or invokes no Chat Session or Factory Session.",
        "Focused compatibility tests prove accepted and rejected versions, exact serialized capability claims, and select-option round-trip behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented pkg/transports/acp: SupportedProtocolVersion (=acpsdk.ProtocolVersionNumber), NegotiateProtocolVersion/BuildProfile with typed *CompatibilityError for unsupported versions, TextFirstAgentCapabilities (all non-text capabilities explicitly false/absent), and FactoryTargetOption with ToSessionConfigOption/FactoryTargetOptionFromSessionConfigOption for the type=select union round-trip. Focused tests in compatibility_test.go and factory_target_option_test.go cover accepted/rejected versions, exact serialized capability JSON, and select-option round-trip. go build/vet/test pass; make pkg-structure passes; make pkg-boundary/pkg-file-count/backend-size show only pre-existing baseline violations unrelated to this package."
    },
    {
      "id": "ACP-L1-V0-protocol-conformance-002",
      "title": "Preserve connection-scoped request identity and reject unsupported methods safely",
      "description": "As an ACP client integrator, I want requests correlated without cross-connection collisions and unsupported methods rejected without effects so retries and concurrent clients remain predictable.",
      "acceptanceCriteria": [
        "Request identity pairs a non-empty connection identity with the original supported JSON-RPC string or numeric ID; equal wire IDs from different connections are distinct, and numeric and string IDs with similar printed forms are not conflated.",
        "Notifications or requests without a usable wire ID receive a transport-minted non-empty identity where correlation is required without fabricating a JSON-RPC response ID.",
        "Blank connection identity, invalid JSON-RPC ID shapes, and malformed supported parameters return typed validation outcomes without a partially valid identity or protocol result.",
        "Unknown methods and V0-deferred operations return JSON-RPC method-not-found with the original request ID when one exists, while unknown notifications emit no response.",
        "Unsupported or malformed handling invokes no session, provider, process, filesystem, network, or persistence collaborator and leaks no credential, raw command, unsafe path, prompt content, or internal topology.",
        "Table-driven tests cover connection collisions, string and numeric IDs, missing and malformed IDs, unknown requests and notifications, and observable zero-effect behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented in pkg/transports/acp: request_identity.go adds WireIDKind (string/number/minted), RequestIdentity{ConnectionID, Kind, StringID, NumberID, MintedID} as a plain comparable struct, NewRequestIdentity(connectionID, acpsdk.RequestId) (rejects blank connection id and any id shape other than string/number, including the JSON-RPC null id), and NewMintedRequestIdentity(connectionID, mintedID) for notifications/requests with no usable wire id (rejects blank connection id and blank minted id). Because Kind participates in equality, a numeric id and a string id with the same printed form, and a minted identity and a wire-id identity with the same value, are never conflated; equal wire ids on different connections compare unequal since ConnectionID differs. dispatch.go adds MethodDisposition/ClassifyMethod (deferred vs unknown -- documented as identical on the wire), UnsupportedMethodOutcome/UnsupportedMethodResponse(method, *acpsdk.RequestId) returning a correlated acpsdk.NewMethodNotFound result keyed off the original id, or nil for a notification (nil wireID) so the caller emits no response, and a generic DecodeMethodParams[T](raw) that returns a typed acpsdk.NewInvalidParams outcome (sensitive-safe reason string only, never raw params content) for missing or malformed params. errors.go gains RequestIdentityErrorCode/RequestIdentityError following the repo's existing typed-error convention. All of this is pure/deterministic: no IO, no goroutine/process, no session/provider/process/filesystem/network/persistence collaborator is invoked by any of these functions. Table-driven tests in request_identity_test.go and dispatch_test.go cover connection collisions, string vs numeric id non-conflation, minted vs wire-id non-conflation, blank connection/minted id rejection, invalid wire id shapes (null and zero-value), unknown vs deferred method classification, method-not-found responses for unknown and deferred methods with string and numeric ids, notification zero-response behavior, and missing/malformed params. go build/vet/test and gofmt are clean; make test (full short Go suite) passes including the new cases; make pkg-structure passes; make pkg-boundary/pkg-file-count/backend-size show only pre-existing baseline violations unrelated to pkg/transports/acp. POST-MERGE FIX (PR #1712 review): DecodeMethodParams originally only checked JSON unmarshal success, so a syntactically valid but semantically incomplete supported request (e.g. session/prompt params={} or {\"sessionId\":\"session-1\"}, missing the required prompt field) and a literal JSON null params value both passed through as accepted, contradicting this story acceptance criterion that malformed supported inputs produce typed invalid-request/invalid-params outcomes. Fixed by rejecting literal JSON null (previously only empty/whitespace raw bytes were rejected) and, when the decoded type T implements the acp-go-sdk types own Validate() error method (checked via a new unexported validatable interface asserted on *T), calling it and returning the same sensitive-safe invalid-params outcome (reason: \"invalid params\", never the underlying validation error text) on failure. New tests in dispatch_test.go: TestDecodeMethodParamsRejectsNullParams, TestDecodeMethodParamsRejectsSemanticallyInvalidSupportedRequest (acpsdk.PromptRequest with missing prompt, two payload shapes), TestDecodeMethodParamsAcceptsSemanticallyValidSupportedRequest (control case proving the fix does not reject valid input). Two new corpus cases (malformed-input-null-params, malformed-input-semantically-invalid-supported-request) and a conformance_test.go update route the semantically-invalid case through the real acpsdk.PromptRequest type. go build/vet/test and gofmt clean; make test full suite passes; make vet/pkg-structure clean; make pkg-boundary/pkg-file-count/deadcode/backend-size show zero new violations for pkg/transports/acp."
    },
    {
      "id": "ACP-L1-V0-protocol-conformance-003",
      "title": "Promote a sanitized semantic ACP conformance corpus",
      "description": "As a transport or provider mapper maintainer, I want one representative semantic corpus so either protocol direction can verify compatibility without depending on the other direction's code.",
      "acceptanceCriteria": [
        "The shared committed corpus covers version-1 initialize negotiation, text-first capabilities, a type=select Factory option, string and numeric request correlation, text prompt content, agent message and thought updates, supported metadata updates, malformed input, and unsupported-method outcomes.",
        "Each case declares its protocol role, expected semantic facts, inbound and outbound support, and lossless round-trip eligibility; every non-subset case explicitly declares inbound-only, outbound-only, unsupported, or intentionally no-output behavior.",
        "The lossless subset contains only facts both directions preserve honestly, including stable item identity where present, text message chunks, text thought chunks, and usage or session-information fields represented by both vocabularies; tool, file-change, plan, progress, run, turn, and other lossy cases are excluded.",
        "Corpus content contains no credentials, customer prompts, machine-specific absolute paths, raw provider commands, or internal topology, and provenance/checksum metadata makes reviewed changes intentional and reproducible.",
        "A reusable test-only reader returns detached cases and rejects invalid JSON, duplicate case identity, missing expectations, undeclared directionality, and round-trip declarations containing known lossy or unsupported shapes.",
        "Corpus validation and SDK marshal/unmarshal tests prove protocol parseability, semantic stability, sanitization invariants, and exact round-trip declarations without testing repository inventories or registration topology.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented the shared, sanitized ACP L1 V0 semantic conformance corpus as a neutral test-only reader at internal/testutil/acpconformance (repo-root internal, importable by both pkg/services/providers tests and pkg/transports/acp tests without either importing the other's internals or a shared production mapper). corpus.json: 19 hand-authored, sanitized cases (schema_version=1, top-level provenance pinned to acp-go-sdk v0.13.5 module/commit/license) covering all 8 required protocol_role values (initialize, capabilities, factory_option, request_identity, prompt_content, session_update, malformed_input, unsupported_method) and all 5 directionality values (round_trip, inbound_only, outbound_only, unsupported, no_output). The round_trip subset is exactly the 4 lossless kinds (message/agent_message_chunk, reasoning/agent_thought_chunk, usage/usage_update, session/session_info_update); tool_call and plan cases are present and explicitly declared inbound_only to prove lossy kinds are excluded from round-trip. corpus.go: Directionality/ProtocolRole enums, Facts/Case/SourceProvenance/Corpus types, ParseCorpus (rejects invalid JSON, incomplete/missing provenance, no cases, empty/duplicate case id, unknown protocol_role, undeclared/unknown directionality, invalid/empty payload JSON, missing Facts.Kind, missing case provenance, and round_trip declared for a non-lossless Facts.Kind), Load/MustLoad (go:embed corpus.json), and detached-copy accessors ByRole/ByDirectionality/RoundTripCases. corpus_test.go has 32 tests: structural validation positive+negative cases (including a synthetic minimal fixture via ParseCorpus to prove it is a general reusable reader, not just embedded-corpus-specific), detachment (MustLoad results don't alias each other), full protocol-role and directionality coverage checks, round-trip-subset kind allowlist checks, and 'SDK marshal/unmarshal' parseability tests that decode every case's payload into the real pinned acp-go-sdk v0.13.5 types (SessionUpdate, InitializeRequest, AgentCapabilities, SessionConfigOption, PromptRequest, RequestId) to prove protocol parseability and that declared facts are actually derivable from the payload (not merely asserted independently), plus a sanitization-invariant test scanning case content for forbidden credential/path terms. Deliberately did NOT import pkg/transports/acp from this package/tests -- keeps story 003 scoped to the corpus+reader only; wiring corpus cases through the real acp.NegotiateProtocolVersion/TextFirstAgentCapabilities/FactoryTargetOption and the Providers-owned mapSessionUpdate is story 004's explicit scope. go build/vet/test and gofmt are clean; make test (full short Go suite) passes including the new package; make vet, make pkg-structure pass; make pkg-boundary/pkg-file-count/backend-size/deadcode show only pre-existing baseline violations elsewhere in the repo (grepped output for acpconformance/transports/acp -- no matches). POST-MERGE FIX (PR #1712 review): the corpus declared source provenance (SDK module/version/commit/license) but no checksum over the case content itself, so an edit to cases.json could silently drift from what was reviewed, contradicting this story acceptance criterion that provenance/checksum metadata make reviewed changes intentional and reproducible. Fixed by adding a top-level cases_checksum field (hex SHA-256 over the deterministic JSON encoding of the cases array, computed by a new exported acpconformance.ChecksumCases(cases) function that never includes itself) and having ParseCorpus recompute and reject on any missing or mismatched checksum, forcing an explicit, matching update whenever case content changes. Added TestParseCorpusRejectsMissingChecksum, TestParseCorpusRejectsMismatchedChecksum, TestChecksumCasesIsDeterministicAndContentSensitive, and TestEmbeddedCorpusChecksumIsSelfConsistent; refactored the existing negative-fixture tests in corpus_test.go onto a shared marshalFixture helper so every ParseCorpus fixture carries a correct, independently-computed checksum unless a test deliberately corrupts it. go build/vet/test and gofmt clean; make test full suite passes; make vet/pkg-structure clean; make pkg-boundary/pkg-file-count/deadcode/backend-size show zero new violations for internal/testutil/acpconformance."
    },
    {
      "id": "ACP-L1-V0-protocol-conformance-004",
      "title": "Bind independent protocol directions through conformance evidence",
      "description": "As a reviewer, I want the existing inbound provider mapper and the agent-side compatibility boundary checked independently against the same cases so agreement is proven without an illegal dependency or shared mapping implementation.",
      "acceptanceCriteria": [
        "Provider-side tests feed every inbound-supported corpus case through the existing provider-owned ACP mapper and compare observable normalized progress and text facts with the case expectations.",
        "Agent-transport tests independently verify all V0 compatibility, outbound-shape, unsupported, and round-trip declarations without importing Providers internals or calling the inbound mapper.",
        "For each declared round-trip case, independent encode/decode assertions preserve declared semantic facts and request or item identity while allowing irrelevant JSON formatting and field-order differences.",
        "Every representative ACP update kind has an explicit corpus disposition; a newly represented kind cannot be silently dropped or falsely treated as round-trippable.",
        "Provider-owned inbound mapping remains under Providers and the future outbound boundary remains under the ACP transport; no neutral production mapper, cross-internal import, service-to-transport dependency, or shared production mapping helper is introduced.",
        "Focused provider and transport conformance tests pass without starting an ACP subprocess, stdio server, Chat Session, or Factory execution.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Implemented independent conformance tests binding both protocol directions to the shared corpus without a shared production mapper. pkg/transports/acp/conformance_test.go (package acp_test) feeds every corpus case by protocol_role through the real transport functions -- NegotiateProtocolVersion (initialize), TextFirstAgentCapabilities (capabilities, exact serialized-shape match), FactoryTargetOptionFromSessionConfigOption/ToSessionConfigOption (factory_option, structural round-trip), NewRequestIdentity/NewMintedRequestIdentity (request_identity), DecodeMethodParams (malformed_input invalid_params) plus a direct acpsdk.RequestId decode failure (malformed_input invalid_request), and ClassifyMethod/UnsupportedMethodResponse (unsupported_method) -- and independently proves the round_trip session_update subset survives an encode/decode cycle through the pinned SDK type, all without importing Providers or calling the inbound mapper. pkg/services/providers/internal/services/acp/internal/service/conformance_test.go (package service, white-box) feeds every inbound-supported (round_trip or inbound_only) session_update corpus case through the real client.SessionUpdate callback (which wraps the private mapSessionUpdate) and asserts the observable normalized progress (kind/item_id/phase/detail/metadata) and accumulated text match the case Facts, independently of pkg/transports/acp. go build/go vet/gofmt/go test -v pass on both new test files; make test (full short Go suite, all packages) passes; make vet and make pkg-structure are clean; make pkg-boundary/pkg-file-count/deadcode/backend-size grepped for acpconformance/transports/acp/services/acp -- zero matches, i.e. this story added zero new violations (all reported violations are the pre-existing repo-wide baseline, same as story 003). make verify-fast fails only at the pre-existing, unrelated dashboard bun/tsc typecheck step (missing bun type definitions in this environment); this is a backend-only change and does not touch ui/."
    }
  ]
}
```
