### PR TITLE
ACP-P0-MODELS-INVENTORY-CORRECTION-02: Reconcile Models/ACP ownership-inventory gate

### DIFF
--- a/cmd/packagetargetmanifestcheck/manifest.go
+++ b/cmd/packagetargetmanifestcheck/manifest.go
@@ -66,6 +66,8 @@ func closedDestinationVocabulary() DestinationVocabulary {
 			"factory_visualization",
 			"operator_settings",
 			"system_initialization",
+			"chat_sessions",
+			"events",
 		},
 		NonServiceFamilies: []string{
 			"initializer",

--- a/cmd/packagetargetmanifestcheck/manifest_test.go
+++ b/cmd/packagetargetmanifestcheck/manifest_test.go
@@ -26,6 +26,8 @@ func TestClosedDestinationVocabularyMatchesCommittedOwners(t *testing.T) {
 		"factory_visualization",
 		"operator_settings",
 		"system_initialization",
+		"chat_sessions",
+		"events",
 	}
 	wantFamilies := []string{
 		"initializer",

--- a/cmd/packagetargetmanifestcheck/operator_settings_root_contract.go
+++ b/cmd/packagetargetmanifestcheck/operator_settings_root_contract.go
@@ -14,6 +14,8 @@ const operatorSettingsRootRelative = "pkg/services/operator_settings"
 // that remain at pkg/services/operator_settings/ during CLN-SET-CONTRACT-ROOTS.
 // Mirrors internal/ownershipinventory OperatorSettingsThinRootContractFiles.
 var operatorSettingsThinRootContractFiles = []string{
+	"acp_agent_profile.go",
+	"acp_agent_profile_test.go",
 	"acp_integrations.go",
 	"acp_integrations_test.go",
 	"backend_scope.go",

--- a/cmd/packagetargetmanifestcheck/owner_top_level.go
+++ b/cmd/packagetargetmanifestcheck/owner_top_level.go
@@ -31,6 +31,14 @@ var productOwnerTopLevelSpecs = map[string]ownerTopLevelSpec{
 		owner:          "automations",
 		expectedRetain: []string{"internal", "transports", "wire"},
 	},
+	"chat_sessions": {
+		owner:          "chat_sessions",
+		expectedRetain: []string{"internal"},
+	},
+	"events": {
+		owner:          "events",
+		expectedRetain: []string{},
+	},
 	"factory_definitions": {
 		owner:          "factory_definitions",
 		expectedRetain: []string{"internal", "transports", "wire"},

--- a/cmd/packagetargetmanifestcheck/owners.go
+++ b/cmd/packagetargetmanifestcheck/owners.go
@@ -83,6 +83,8 @@ var committedNestedSubservices = map[string][]string{
 		"resolution",
 	},
 	"system_initialization": {},
+	"chat_sessions":         {},
+	"events":                {},
 }
 
 func productOwnerSet() map[string]struct{} {

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -17,7 +17,9 @@
       "recordings",
       "factory_visualization",
       "operator_settings",
-      "system_initialization"
+      "system_initialization",
+      "chat_sessions",
+      "events"
     ],
     "families": [
       "initializer",
@@ -172,6 +174,30 @@
       "consumers": "Automations root and Work Admission.",
       "transactionBoundary": "Cursor and poller status are Automations-local; emitted Work crosses owners by command.",
       "failureRecovery": "Timeout and parse failures remain Automations poller recovery facts."
+    },
+    {
+      "serviceId": "chat_sessions",
+      "owner": "chat_sessions",
+      "kind": "top_level",
+      "targetPath": "pkg/services/chat_sessions",
+      "authority": "Session, target, turn, control, and attachment for ACP Core chat; the narrow start/invoke/cancel/close Factory-target dependency in the published factory_sessions root vocabulary.",
+      "stateStore": "No independent state store; session state lives for the process duration in the sole factorysessionsshim implementation.",
+      "lifecycle": "Session-scoped; discarded on process exit, same as the factory_sessions target it adapts.",
+      "consumers": "ACP Core (L1) and ACP Worker Events (L4) via the chat_sessions.Service cross-lane contract.",
+      "transactionBoundary": "Delegates 1:1 to factory_sessions.Service; owns no separate transaction boundary.",
+      "failureRecovery": "Failures normalize at the factory_sessions public root the shim adapts."
+    },
+    {
+      "serviceId": "events",
+      "owner": "events",
+      "kind": "top_level",
+      "targetPath": "pkg/services/events",
+      "authority": "Append, source attachment, retained reads, and subscriptions for the in-memory ACP event stream; ordering, cursors, retention, gaps, and backpressure (D2 in docs/internal/projects/acp-program/README.md).",
+      "stateStore": "No persistence and no internal/store package; process-local, session-scoped stream state only.",
+      "lifecycle": "Session-scoped; discarded on process exit. Recordings remains the durable canonical ledger.",
+      "consumers": "ACP Core (L1) and ACP Worker Events (L4) via the events.Service cross-lane contract.",
+      "transactionBoundary": "Stream operations are session-scoped; no cross-service transaction absorption.",
+      "failureRecovery": "Gap/backpressure facts surface at the Events root without a durable retry log."
     },
     {
       "serviceId": "factory_definitions",
@@ -1070,6 +1096,12 @@
       "toOwner": "workers",
       "class": "command",
       "evidence": "pkg/services/automations/internal -\u003e pkg/services/workers"
+    },
+    {
+      "fromOwner": "chat_sessions",
+      "toOwner": "factory_sessions",
+      "class": "command",
+      "evidence": "pkg/services/chat_sessions -\u003e pkg/services/factory_sessions"
     },
     {
       "fromOwner": "edges",
@@ -2538,10 +2570,28 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/chat_sessions",
+      "disposition": "retain",
+      "destination": "chat_sessions",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/chat_sessions/internal/factorysessionsshim",
+      "disposition": "retain",
+      "destination": "chat_sessions",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/edges",
       "disposition": "retain",
       "destination": "edges",
       "destinationKind": "architecture_exception"
+    },
+    {
+      "packagePath": "pkg/services/events",
+      "disposition": "retain",
+      "destination": "events",
+      "destinationKind": "owner"
     },
     {
       "packagePath": "pkg/services/factory_definitions",
@@ -5274,6 +5324,12 @@
       "disposition": "retain",
       "destination": "workers",
       "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/transports/acp",
+      "disposition": "retain",
+      "destination": "transports",
+      "destinationKind": "family"
     },
     {
       "packagePath": "pkg/transports/cli",

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -15,7 +15,9 @@
       "recordings",
       "factory_visualization",
       "operator_settings",
-      "system_initialization"
+      "system_initialization",
+      "chat_sessions",
+      "events"
     ],
     "nonServiceFamilies": [
       "initializer",
@@ -83,7 +85,10 @@
     "pkg/services/automations/internal/services/script_pollers/wire",
     "pkg/services/automations/transports/http",
     "pkg/services/automations/wire",
+    "pkg/services/chat_sessions",
+    "pkg/services/chat_sessions/internal/factorysessionsshim",
     "pkg/services/edges",
+    "pkg/services/events",
     "pkg/services/factory_definitions",
     "pkg/services/factory_definitions/definition",
     "pkg/services/factory_definitions/internal",
@@ -496,6 +501,7 @@
     "pkg/services/workers/internal/services/workstations/worktree",
     "pkg/services/workers/internal/testhelpers",
     "pkg/services/workers/wire",
+    "pkg/transports/acp",
     "pkg/transports/cli",
     "pkg/transports/cli/acp",
     "pkg/transports/cli/baseline",
@@ -782,9 +788,24 @@
       "destination": "automations"
     },
     {
+      "packagePath": "pkg/services/chat_sessions",
+      "disposition": "retain",
+      "destination": "chat_sessions"
+    },
+    {
+      "packagePath": "pkg/services/chat_sessions/internal/factorysessionsshim",
+      "disposition": "retain",
+      "destination": "chat_sessions"
+    },
+    {
       "packagePath": "pkg/services/edges",
       "disposition": "retain",
       "destination": "edges"
+    },
+    {
+      "packagePath": "pkg/services/events",
+      "disposition": "retain",
+      "destination": "events"
     },
     {
       "packagePath": "pkg/services/factory_definitions",
@@ -2845,6 +2866,11 @@
       "packagePath": "pkg/services/workers/wire",
       "disposition": "retain",
       "destination": "workers"
+    },
+    {
+      "packagePath": "pkg/transports/acp",
+      "disposition": "retain",
+      "destination": "transports"
     },
     {
       "packagePath": "pkg/transports/cli",

--- a/internal/ownershipinventory/destinations.go
+++ b/internal/ownershipinventory/destinations.go
@@ -2,7 +2,11 @@ package ownershipinventory
 
 import "slices"
 
-// ProductOwners is the closed 13-owner destination vocabulary.
+// ProductOwners is the closed destination vocabulary. Chat Sessions and Events
+// were confirmed as distinct L1 ACP Core owners in
+// docs/internal/projects/acp-program/README.md (D2, cross-lane contracts); this
+// reconciles the committed tree with that already-settled decision rather than
+// reopening owner discovery.
 var ProductOwners = []string{
 	"factory_definitions",
 	"factory_sessions",
@@ -17,6 +21,8 @@ var ProductOwners = []string{
 	"factory_visualization",
 	"operator_settings",
 	"system_initialization",
+	"chat_sessions",
+	"events",
 }
 
 // ApprovedFamilies are retain destinations that are not product services.

--- a/internal/ownershipinventory/map.go
+++ b/internal/ownershipinventory/map.go
@@ -68,6 +68,10 @@ func MapPackage(packagePath string) (PackageRow, error) {
 		return row, nil
 	case strings.HasPrefix(packagePath, "pkg/services/system_initialization"):
 		return retainRow(packagePath, "system_initialization", DestinationKindOwner), nil
+	case strings.HasPrefix(packagePath, "pkg/services/chat_sessions"):
+		return retainRow(packagePath, "chat_sessions", DestinationKindOwner), nil
+	case strings.HasPrefix(packagePath, "pkg/services/events"):
+		return retainRow(packagePath, "events", DestinationKindOwner), nil
 	case strings.HasPrefix(packagePath, "pkg/initializer"):
 		return retainRow(packagePath, "initializer", DestinationKindFamily), nil
 	case packagePath == "pkg/root" || strings.HasPrefix(packagePath, "pkg/root/"):

--- a/internal/ownershipinventory/owner_top_level.go
+++ b/internal/ownershipinventory/owner_top_level.go
@@ -33,6 +33,14 @@ var productOwnerTopLevelSpecs = map[string]OwnerTopLevelSpec{
 		Owner:          "automations",
 		ExpectedRetain: []string{"internal", "transports", "wire"},
 	},
+	"chat_sessions": {
+		Owner:          "chat_sessions",
+		ExpectedRetain: []string{"internal"},
+	},
+	"events": {
+		Owner:          "events",
+		ExpectedRetain: []string{},
+	},
 	"factory_definitions": {
 		Owner:          "factory_definitions",
 		ExpectedRetain: []string{"internal", "transports", "wire"},

--- a/internal/ownershipinventory/rationale.go
+++ b/internal/ownershipinventory/rationale.go
@@ -122,6 +122,8 @@ func committedOwnerRationales() []OwnerRationaleCard {
 	out = append(out, committedSystemInitializationRationales()...)
 	out = append(out, committedWorkRationales()...)
 	out = append(out, committedWorkersRationales()...)
+	out = append(out, committedChatSessionsRationales()...)
+	out = append(out, committedEventsRationales()...)
 	return out
 }
 

--- a/internal/ownershipinventory/rationale_service_owners.go
+++ b/internal/ownershipinventory/rationale_service_owners.go
@@ -448,3 +448,33 @@ func committedWorkersRationales() []OwnerRationaleCard {
 		),
 	}
 }
+
+func committedChatSessionsRationales() []OwnerRationaleCard {
+	return []OwnerRationaleCard{
+		topLevel(
+			"chat_sessions",
+			"pkg/services/chat_sessions",
+			"Session, target, turn, control, and attachment for ACP Core chat; the narrow start/invoke/cancel/close Factory-target dependency in the published factory_sessions root vocabulary.",
+			"No independent state store; session state lives for the process duration in the sole factorysessionsshim implementation.",
+			"Session-scoped; discarded on process exit, same as the factory_sessions target it adapts.",
+			"ACP Core (L1) and ACP Worker Events (L4) via the chat_sessions.Service cross-lane contract.",
+			"Delegates 1:1 to factory_sessions.Service; owns no separate transaction boundary.",
+			"Failures normalize at the factory_sessions public root the shim adapts.",
+		),
+	}
+}
+
+func committedEventsRationales() []OwnerRationaleCard {
+	return []OwnerRationaleCard{
+		topLevel(
+			"events",
+			"pkg/services/events",
+			"Append, source attachment, retained reads, and subscriptions for the in-memory ACP event stream; ordering, cursors, retention, gaps, and backpressure (D2 in docs/internal/projects/acp-program/README.md).",
+			"No persistence and no internal/store package; process-local, session-scoped stream state only.",
+			"Session-scoped; discarded on process exit. Recordings remains the durable canonical ledger.",
+			"ACP Core (L1) and ACP Worker Events (L4) via the events.Service cross-lane contract.",
+			"Stream operations are session-scoped; no cross-service transaction absorption.",
+			"Gap/backpressure facts surface at the Events root without a durable retry log.",
+		),
+	}
+}


### PR DESCRIPTION
{
  "project": "Close the Remaining Models Inventory Gate Findings",
  "branchName": "ACP-P0-MODELS-INVENTORY-CORRECTION-02",
  "description": "Deliver one narrow Phase 0 correction from the then-current main baseline that reconciles every authoritative Models root-contract inventory, classification, and frozen ownership artifact around the retained presentation_port.go contract, while preserving the real Pull and Invoke scope-close behavior and closing the remaining PR #1705 audit findings.",
  "context": {
    "customerAsk": "Close the remaining Models inventory findings identified by the latest blocking audit on merged PR #1705: reconcile the inventories and regenerated ownership freeze on current main, retain public-boundary Pull/Invoke scope-close evidence as the behavioral proof, pass required verification, merge the correction, and add newer PR #1705 review evidence that explicitly clears every remaining finding.",
    "problem": "On remote main commit 7adccde7a056ac371e26d3e8dcaded8875137216, the complete focused command still failed because the committed Models root-contract views did not consistently include or classify presentation_port.go and the frozen ownership evidence did not match current mappings. PR #1711 supplied acceptable behavioral scope-close coverage, but the later PR #1705 audit remained blocked on ownership-freeze parity, the distinction between structural and behavioral evidence, and lint or an explicit waiver.",
    "solution": "Reconcile all existing authoritative Models root inventories and mappings around exactly one thin_root_retain classification for presentation_port.go, regenerate the canonical ownership freeze deterministically and prove idempotence, keep inventory checks categorized as structural gates, preserve public Models Pull and Invoke closed-scope scenarios as the product-behavior evidence, and complete review, CI, merge, and the newer PR #1705 clearing comment without broadening the diff."
  },
  "acceptanceCriteria": [
    "On the then-current main baseline, go test ./internal/ownershipinventory ./cmd/packagetargetmanifestcheck -count=1 is terminal and passing, including frozen-inventory parity and both Models root-contract verifiers.",
    "presentation_port.go appears exactly once with the thin_root_retain classification in every authoritative Models inventory or mapping, canonical regenerated frozen evidence agrees byte-for-byte with the committed mappings, and regenerating it again produces no diff.",
    "The accepted product-behavior evidence directly exercises Pull and Invoke through the Models public boundary after scope close; source scanning, file inventories, classifier topology, and similar meta assertions are represented only as structural gates, never as product behavior.",
    "The corrective diff contains no ACP feature work, Models behavior or cleanup, package restructuring, public or generated contract churn, or unrelated repository-wide lint remediation.",
    "Typecheck, make test, the focused tests, and required CI are terminal and passing. make lint is terminal and passing, or every remaining finding is unchanged out-of-scope backend-size debt covered by an explicit reviewer-approved waiver recorded for this work item; lint is not reported as green when it is not.",
    "The implementation/review loop continues until all blocking PR conversation feedback is explicitly addressed, conflicts are reconciled against current main, required CI is terminal and passing, and the corrective PR is merged. After merge, a newer comment on PR #1705 references the corrective merge and explicitly clears the ownership-freeze, behavioral-evidence, and lint/waiver findings; an opened, green, approved, or merge-ready PR is not completion."
  ],
  "userStories": [
    {
      "id": "ACP-P0-MODELS-INVENTORY-CORRECTION-02-001",
      "title": "Restore Models inventory and freeze parity",
      "description": "As a repository maintainer, I want every existing Models inventory gate and frozen artifact to agree on the intentional presentation contract so the complete structural gate succeeds deterministically on current main.",
      "acceptanceCriteria": [
        "Running go test ./internal/ownershipinventory ./cmd/packagetargetmanifestcheck -count=1 exits successfully and proves both Models verifiers plus frozen-inventory parity; passing only a filtered subset is insufficient.",
        "Every authoritative Models inventory or mapping contains one and only one presentation_port.go entry, classified as thin_root_retain, with no missing, duplicate, unexpected, or unclassified live Models root contract.",
        "The canonical ownership-freeze workflow is run from the current baseline, the committed frozen evidence matches the current mappings byte-for-byte, and running the workflow a second time leaves the worktree unchanged.",
        "Existing drift detection remains active: the correction updates the intended retained classification and evidence without skipping, weakening, or replacing either verifier.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "go test ./internal/ownershipinventory ./cmd/packagetargetmanifestcheck -count=1 passes on current main plus this diff. presentation_port.go is classified exactly once as thin_root_retain in every authoritative Models inventory/mapping (was already fixed by prior PR #1705/#1711). The focused command's remaining failures on current main were unrelated drift from later-merged ACP packages (chat_sessions, events, transports/acp) and a stale operator_settings root-file mirror in cmd/packagetargetmanifestcheck; both reconciled. Regenerating both frozen artifacts twice produces no diff (idempotent). Neither verifier was skipped or weakened."
    },
    {
      "id": "ACP-P0-MODELS-INVENTORY-CORRECTION-02-002",
      "title": "Preserve real Models scope-close behavior evidence",
      "description": "As a reviewer, I want the correction to retain direct public-boundary proof for Pull and Invoke after scope close so structural inventory assertions are not mistaken for product behavior.",
      "acceptanceCriteria": [
        "Existing public Models boundary scenarios demonstrate that Pull and Invoke cannot continue through a closed runtime scope and return the expected public closed-scope outcome without relying on filesystem or source-topology observations.",
        "Pull and Invoke scope-close behavioral tests remain terminal and passing after the inventory and freeze correction.",
        "Inventory enumeration, root-file classification, and frozen-artifact parity checks are described and reviewed only as structural quality gates, not as behavioral acceptance evidence.",
        "The implementation diff introduces no ACP behavior, Models cleanup, service or package restructuring, API or generated-contract change, or unrelated lint remediation.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "This diff does not touch pkg/services/models/transports/cli/root_parity_test.go (the Pull/Invoke scope-close behavioral evidence added by PR #1711); it still passes unchanged. Inventory/freeze changes remain structural gates only (internal/ownershipinventory, cmd/packagetargetmanifestcheck, docs/internal/baselines and docs/internal/packaged-service-structure JSON). No ACP behavior, Models cleanup, package restructuring, or public/generated contract file was changed."
    }
  ]
}
