### PR TITLE
Define the ACP Compatibility Contract and Shared Conformance Corpus

### DIFF
--- a/internal/testutil/acpconformance/corpus.go
+++ b/internal/testutil/acpconformance/corpus.go
@@ -8,6 +8,7 @@
 package acpconformance
 
 import (
+	"bytes"
 	"crypto/sha256"
 	_ "embed"
 	"encoding/hex"
@@ -174,14 +175,28 @@ func ChecksumCases(cases []Case) (string, error) {
 }
 
 // ParseCorpus decodes and validates raw corpus JSON. It rejects invalid
-// JSON, an unpinned or incomplete source provenance, a missing or mismatched
+// JSON, an unrecognized field anywhere outside a case's free-form Payload,
+// an unpinned or incomplete source provenance, a missing or mismatched
 // cases_checksum, duplicate case identity, an unknown protocol role,
 // undeclared or unknown directionality, a case with no declared expected
 // facts, and a round-trip declaration for a Facts.Kind known to be lossy or
 // unsupported in at least one direction.
+//
+// Unrecognized fields are rejected (rather than silently dropped) because
+// cases_checksum is computed over the *typed* Cases value after decoding: a
+// plain json.Unmarshal would discard any field not present on Case/Facts/
+// SourceProvenance before ChecksumCases ever saw it, so a change that only
+// added an unknown field to a case would leave the previous cases_checksum
+// valid even though the committed case content changed. Rejecting unknown
+// fields up front means the only way to add a field to a case is to add it
+// to the Case/Facts struct too, which then changes the typed checksum along
+// with it. Case.Payload is a json.RawMessage, so this does not constrain the
+// arbitrary ACP wire JSON a case's payload may contain.
 func ParseCorpus(data []byte) (Corpus, error) {
 	var corpus Corpus
-	if err := json.Unmarshal(data, &corpus); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&corpus); err != nil {
 		return Corpus{}, fmt.Errorf("acpconformance: invalid corpus JSON: %w", err)
 	}
 	if corpus.SchemaVersion != supportedSchemaVersion {

--- a/internal/testutil/acpconformance/corpus.json
+++ b/internal/testutil/acpconformance/corpus.json
@@ -6,7 +6,7 @@
     "sdk_commit": "0845a3bb9eddda5bfc22a94dd3598c90cb842451",
     "sdk_license": "Apache-2.0"
   },
-  "cases_checksum": "39941d81a0ac65999b3689d9d9ade356d42631887cdf507989d111f0b177db39",
+  "cases_checksum": "b0640aab4b648114e147d769386fd603dd798a90c253fca98bf30e6fbb583ab7",
   "cases": [
     {
       "id": "initialize-protocol-version-1-accepted",
@@ -369,6 +369,27 @@
         }
       },
       "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; matches pkg/transports/acp DecodeMethodParams' acpsdk.PromptRequest.Validate() enforcement of the required prompt field, proving structurally valid but semantically incomplete supported input is rejected."
+    },
+    {
+      "id": "malformed-input-missing-required-scalar-field",
+      "protocol_role": "malformed_input",
+      "description": "A session/prompt request whose params decode successfully as JSON and pass acpsdk.PromptRequest.Validate() (prompt is present) but omit the required sessionId scalar field, which Validate() alone does not check and which must still be rejected as invalid params rather than accepted with an empty sessionId.",
+      "directionality": "outbound_only",
+      "payload": {
+        "jsonrpc": "2.0",
+        "method": "session/prompt",
+        "id": "req-80",
+        "connectionId": "conn-1",
+        "params": { "prompt": [{ "type": "text", "text": "hi" }] }
+      },
+      "facts": {
+        "kind": "malformed_input",
+        "outcome": "invalid_params",
+        "metadata": {
+          "reason": "missing_required_scalar_field"
+        }
+      },
+      "provenance": "Hand-authored for ACP-L1-V0-protocol-conformance; matches pkg/transports/acp DecodeMethodParams' required-field-presence check, proving an omitted required scalar field (sessionId) is rejected even though acpsdk.PromptRequest.Validate() does not itself check for it."
     },
     {
       "id": "unsupported-method-unknown-string-id",

--- a/internal/testutil/acpconformance/corpus_test.go
+++ b/internal/testutil/acpconformance/corpus_test.go
@@ -2,6 +2,7 @@ package acpconformance_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -212,6 +213,53 @@ func TestParseCorpusRejectsMismatchedChecksum(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "cases_checksum mismatch") {
 		t.Fatalf("ParseCorpus(mismatched cases_checksum) error = %v, want it to mention cases_checksum mismatch", err)
+	}
+}
+
+// TestParseCorpusRejectsUnknownCaseField proves ParseCorpus cannot be
+// fooled by the exact loophole a prior review found: cases_checksum is
+// computed over the *typed* []Case value, so if unknown fields were merely
+// dropped by json.Unmarshal (rather than rejected), adding an unrecognized
+// field to a case's raw JSON would leave the previously-computed checksum
+// still valid, silently defeating the "checksum makes every case-content
+// change explicit" guarantee. The checksum below is deliberately computed
+// from the clean (no extra field) case -- exactly what would happen if
+// ParseCorpus only checksummed the post-decode typed value -- to prove that
+// is not enough: the unknown field itself must cause ParseCorpus to fail.
+func TestParseCorpusRejectsUnknownCaseField(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	one := corpus.Cases[0]
+	checksum, err := acpconformance.ChecksumCases([]acpconformance.Case{one})
+	if err != nil {
+		t.Fatalf("ChecksumCases: %v", err)
+	}
+	caseJSON, err := json.Marshal(one)
+	if err != nil {
+		t.Fatalf("marshal case: %v", err)
+	}
+	var caseFields map[string]json.RawMessage
+	if err := json.Unmarshal(caseJSON, &caseFields); err != nil {
+		t.Fatalf("unmarshal case: %v", err)
+	}
+	caseFields["unexpected_extra_field"] = json.RawMessage(`"snuck in"`)
+	mutatedCase, err := json.Marshal(caseFields)
+	if err != nil {
+		t.Fatalf("marshal mutated case: %v", err)
+	}
+	provenanceJSON, err := json.Marshal(corpus.Provenance)
+	if err != nil {
+		t.Fatalf("marshal provenance: %v", err)
+	}
+	data := fmt.Appendf(nil,
+		`{"schema_version":1,"provenance":%s,"cases_checksum":%q,"cases":[%s]}`,
+		provenanceJSON, checksum, mutatedCase,
+	)
+	_, err = acpconformance.ParseCorpus(data)
+	if err == nil {
+		t.Fatal("ParseCorpus(case with unknown field, checksum computed as if the field were absent) expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("ParseCorpus(unknown case field) error = %v, want it to mention an unknown field", err)
 	}
 }
 

--- a/pkg/transports/acp/conformance_test.go
+++ b/pkg/transports/acp/conformance_test.go
@@ -224,16 +224,19 @@ func TestConformanceMalformedInputCasesProduceTypedOutcomes(t *testing.T) {
 					t.Fatalf("payload does not parse: %v", err)
 				}
 				var decodeErr *acpsdk.RequestError
-				if c.Facts.Metadata["reason"] == "semantically_invalid_params" {
+				switch c.Facts.Metadata["reason"] {
+				case "semantically_invalid_params", "missing_required_scalar_field":
 					// A syntactically valid params object that fails the real
 					// acp-go-sdk request type's own Validate() (e.g. a
 					// session/prompt request missing the required prompt
-					// field) must decode through the actual supported
+					// field), or that omits a required scalar field
+					// Validate() alone cannot detect (e.g. a missing
+					// sessionId), must decode through the actual supported
 					// request type, not a generic map, to prove
-					// DecodeMethodParams enforces semantic validity and not
-					// only JSON structure.
+					// DecodeMethodParams enforces semantic validity and
+					// required-field presence, not only JSON structure.
 					_, decodeErr = acp.DecodeMethodParams[acpsdk.PromptRequest](envelope.Params)
-				} else {
+				default:
 					_, decodeErr = acp.DecodeMethodParams[map[string]any](envelope.Params)
 				}
 				if decodeErr == nil {

--- a/pkg/transports/acp/dispatch.go
+++ b/pkg/transports/acp/dispatch.go
@@ -3,6 +3,8 @@ package acp
 import (
 	"bytes"
 	"encoding/json"
+	"reflect"
+	"strings"
 
 	acpsdk "github.com/coder/acp-go-sdk"
 )
@@ -86,10 +88,17 @@ type validatable interface {
 // DecodeMethodParams unmarshals raw JSON-RPC params into T and returns a
 // typed, sensitive-safe invalid-params outcome on missing, null, malformed,
 // or semantically invalid input, so parameter validation never produces a
-// partially decoded value. When T implements validatable (as the acp-go-sdk
-// request types do), the decoded value's own Validate() is also enforced.
-// The returned *acpsdk.RequestError never includes the raw params content or
-// the underlying validation error text.
+// partially decoded value. Required-field presence is enforced generically
+// for every struct T from the raw JSON object's keys (see
+// requiredStructFieldsPresent), because acp-go-sdk v0.13.5's generated
+// Validate() methods do not consistently check that every required scalar
+// field (e.g. PromptRequest.SessionId) was actually present on the wire --
+// a required string/number field silently decodes to its Go zero value
+// whether the key was omitted or the key was present with a zero value, and
+// Validate() alone cannot tell those apart. When T (or *T) additionally
+// implements validatable, the decoded value's own Validate() is also
+// enforced. The returned *acpsdk.RequestError never includes the raw params
+// content or the underlying validation error text.
 func DecodeMethodParams[T any](raw json.RawMessage) (T, *acpsdk.RequestError) {
 	var zero T
 	trimmed := bytes.TrimSpace(raw)
@@ -100,10 +109,55 @@ func DecodeMethodParams[T any](raw json.RawMessage) (T, *acpsdk.RequestError) {
 	if err := json.Unmarshal(raw, &v); err != nil {
 		return zero, acpsdk.NewInvalidParams(map[string]any{"reason": "malformed params"})
 	}
+	if !requiredStructFieldsPresent(trimmed, reflect.TypeOf(v)) {
+		return zero, acpsdk.NewInvalidParams(map[string]any{"reason": "invalid params"})
+	}
 	if validator, ok := any(&v).(validatable); ok {
 		if err := validator.Validate(); err != nil {
 			return zero, acpsdk.NewInvalidParams(map[string]any{"reason": "invalid params"})
 		}
 	}
 	return v, nil
+}
+
+// requiredStructFieldsPresent reports whether every field of struct type t
+// whose json tag lacks "omitempty" (i.e. every field the wire shape declares
+// required) is present as a key in raw's top-level JSON object. It returns
+// true for any non-struct t (e.g. map[string]any params) and for any raw
+// that is not itself a JSON object, since presence checking only applies to
+// struct-shaped, field-required params. This closes the gap a bare
+// json.Unmarshal + Validate() leaves open: a required scalar field (string,
+// number, bool) decodes to the same Go zero value whether its key was
+// omitted or present-but-empty, so Validate() implementations that only
+// check "is this the zero value" cannot detect an omitted required scalar
+// field the way they can detect an omitted required pointer/slice/map field.
+func requiredStructFieldsPresent(raw []byte, t reflect.Type) bool {
+	if t.Kind() != reflect.Struct {
+		return true
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return true
+	}
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.PkgPath != "" {
+			continue
+		}
+		tag, ok := field.Tag.Lookup("json")
+		if !ok || tag == "-" {
+			continue
+		}
+		name, opts, _ := strings.Cut(tag, ",")
+		if name == "" {
+			name = field.Name
+		}
+		if strings.Contains(opts, "omitempty") {
+			continue
+		}
+		if _, present := obj[name]; !present {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/transports/acp/dispatch_test.go
+++ b/pkg/transports/acp/dispatch_test.go
@@ -142,6 +142,128 @@ func TestDecodeMethodParamsRejectsSemanticallyInvalidSupportedRequest(t *testing
 	}
 }
 
+// TestDecodeMethodParamsRejectsMissingRequiredScalarField proves the
+// regression a prior review found: acpsdk.PromptRequest.Validate() only
+// checks that Prompt is non-nil, so a request that omits the required
+// sessionId scalar field (rather than the required prompt slice field)
+// previously decoded successfully with SessionId left at its Go zero value
+// ("") indistinguishable from an explicit empty sessionId. Required-field
+// presence must be checked against the raw JSON object's keys, not just the
+// SDK's own Validate().
+func TestDecodeMethodParamsRejectsMissingRequiredScalarField(t *testing.T) {
+	raw := json.RawMessage(`{"prompt":[{"type":"text","text":"hi"}]}`)
+	got, decodeErr := acp.DecodeMethodParams[acpsdk.PromptRequest](raw)
+	if decodeErr == nil {
+		t.Fatalf("DecodeMethodParams(%s) expected invalid-params error for omitted sessionId, got value %+v", raw, got)
+	}
+	if decodeErr.Code != -32602 {
+		t.Fatalf("DecodeMethodParams(%s).Code = %d, want -32602", raw, decodeErr.Code)
+	}
+	if !reflect.DeepEqual(got, acpsdk.PromptRequest{}) {
+		t.Fatalf("DecodeMethodParams(%s) returned a non-zero value %+v on error, want the zero value", raw, got)
+	}
+}
+
+type requiredAndOptionalFieldsFixture struct {
+	Required string  `json:"required"`
+	Optional *string `json:"optional,omitempty"`
+}
+
+// TestDecodeMethodParamsRequiredFieldPresenceIsGeneric proves the
+// required-field-presence check is driven by the json tag's omitempty
+// option, not by a per-type allowlist: a struct with a required field
+// omitted is rejected regardless of the field's zero value, an explicit
+// zero value for a required field is accepted (presence, not truthiness,
+// is what is checked), and an omitted optional field is accepted.
+func TestDecodeMethodParamsRequiredFieldPresenceIsGeneric(t *testing.T) {
+	t.Run("omitted required field is rejected", func(t *testing.T) {
+		_, decodeErr := acp.DecodeMethodParams[requiredAndOptionalFieldsFixture](json.RawMessage(`{"optional":"x"}`))
+		if decodeErr == nil {
+			t.Fatal("DecodeMethodParams(omitted required field) expected invalid-params error, got nil")
+		}
+	})
+	t.Run("explicit zero value for required field is accepted", func(t *testing.T) {
+		got, decodeErr := acp.DecodeMethodParams[requiredAndOptionalFieldsFixture](json.RawMessage(`{"required":""}`))
+		if decodeErr != nil {
+			t.Fatalf("DecodeMethodParams(explicit empty required field) unexpected error: %v", decodeErr)
+		}
+		if got.Required != "" {
+			t.Fatalf("DecodeMethodParams() = %+v, want Required=\"\"", got)
+		}
+	})
+	t.Run("omitted optional field is accepted", func(t *testing.T) {
+		got, decodeErr := acp.DecodeMethodParams[requiredAndOptionalFieldsFixture](json.RawMessage(`{"required":"present"}`))
+		if decodeErr != nil {
+			t.Fatalf("DecodeMethodParams(omitted optional field) unexpected error: %v", decodeErr)
+		}
+		if got.Optional != nil {
+			t.Fatalf("DecodeMethodParams() = %+v, want Optional=nil", got)
+		}
+	})
+	t.Run("non-struct T is unaffected", func(t *testing.T) {
+		got, decodeErr := acp.DecodeMethodParams[map[string]any](json.RawMessage(`{}`))
+		if decodeErr != nil {
+			t.Fatalf("DecodeMethodParams(map[string]any) unexpected error: %v", decodeErr)
+		}
+		if len(got) != 0 {
+			t.Fatalf("DecodeMethodParams() = %+v, want empty map", got)
+		}
+	})
+}
+
+type requiredFieldPresenceEdgeCasesFixture struct {
+	unexported string //nolint:unused // exercises the unexported-field skip branch
+	NoJSONTag  string
+	Dash       string `json:"-"`
+	NoName     string `json:",omitempty"`
+	Required   string `json:"required"`
+}
+
+// TestDecodeMethodParamsRequiredFieldPresenceSkipsNonRequiredTagShapes
+// proves the required-field-presence check only constrains fields with an
+// explicit json tag naming a required key: an unexported field, a field
+// with no json tag at all, a field tagged "-", and an omitempty field with
+// no explicit name are all ignored, so a params object providing only the
+// one genuinely required field decodes successfully.
+func TestDecodeMethodParamsRequiredFieldPresenceSkipsNonRequiredTagShapes(t *testing.T) {
+	got, decodeErr := acp.DecodeMethodParams[requiredFieldPresenceEdgeCasesFixture](json.RawMessage(`{"required":"x"}`))
+	if decodeErr != nil {
+		t.Fatalf("DecodeMethodParams() unexpected error: %v", decodeErr)
+	}
+	if got.Required != "x" {
+		t.Fatalf("DecodeMethodParams() = %+v, want Required=x", got)
+	}
+}
+
+type stringCustomUnmarshalFixture struct {
+	Value string
+}
+
+func (f *stringCustomUnmarshalFixture) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	f.Value = s
+	return nil
+}
+
+// TestDecodeMethodParamsSkipsRequiredFieldCheckForNonObjectPayload proves
+// required-field-presence checking is a no-op when the raw JSON-RPC params
+// is not itself a JSON object, even though T is a struct type: a struct
+// with a custom UnmarshalJSON may legitimately decode from a bare JSON
+// string, and presence checking only applies when there is a top-level
+// object to check keys against.
+func TestDecodeMethodParamsSkipsRequiredFieldCheckForNonObjectPayload(t *testing.T) {
+	got, decodeErr := acp.DecodeMethodParams[stringCustomUnmarshalFixture](json.RawMessage(`"hello"`))
+	if decodeErr != nil {
+		t.Fatalf("DecodeMethodParams() unexpected error: %v", decodeErr)
+	}
+	if got.Value != "hello" {
+		t.Fatalf("DecodeMethodParams() = %+v, want Value=hello", got)
+	}
+}
+
 func TestDecodeMethodParamsAcceptsSemanticallyValidSupportedRequest(t *testing.T) {
 	raw := json.RawMessage(`{"sessionId":"session-1","prompt":[{"type":"text","text":"hi"}]}`)
 	got, decodeErr := acp.DecodeMethodParams[acpsdk.PromptRequest](raw)

--- a/pkg/transports/acp/errors_test.go
+++ b/pkg/transports/acp/errors_test.go
@@ -1,0 +1,35 @@
+package acp_test
+
+import (
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/transports/acp"
+)
+
+func TestCompatibilityErrorImplementsError(t *testing.T) {
+	err := &acp.CompatibilityError{
+		Code:    acp.CompatibilityErrorUnsupportedProtocolVersion,
+		Message: "unsupported protocol version",
+	}
+	if err.Error() != "unsupported protocol version" {
+		t.Fatalf("Error() = %q, want %q", err.Error(), "unsupported protocol version")
+	}
+	var nilErr *acp.CompatibilityError
+	if nilErr.Error() != "" {
+		t.Fatalf("nil *CompatibilityError.Error() = %q, want empty string", nilErr.Error())
+	}
+}
+
+func TestRequestIdentityErrorImplementsError(t *testing.T) {
+	err := &acp.RequestIdentityError{
+		Code:    acp.RequestIdentityErrorBlankConnectionID,
+		Message: "blank connection id",
+	}
+	if err.Error() != "blank connection id" {
+		t.Fatalf("Error() = %q, want %q", err.Error(), "blank connection id")
+	}
+	var nilErr *acp.RequestIdentityError
+	if nilErr.Error() != "" {
+		t.Fatalf("nil *RequestIdentityError.Error() = %q, want empty string", nilErr.Error())
+	}
+}


### PR DESCRIPTION
```json
{
  "project": "Define the ACP Compatibility Contract and Shared Conformance Corpus",
  "branchName": "ACP-L1-V0-protocol-conformance",
  "description": "Establish the inert ACP protocol-version-1 agent compatibility boundary and a sanitized semantic conformance corpus so independent inbound provider and future outbound agent mappings can prove truthful text-first behavior, request correlation, select-option shape, unsupported-method handling, and an explicit lossless round-trip subset without implementing stdio serving or session execution.",
  "context": {
    "customerAsk": "Define the L1 V0 ACP compatibility contract and shared conformance corpus so the existing inbound provider mapper and a future outbound agent mapper can prove agreement through fixtures while remaining separate implementations. Encode protocol version 1, honest text-first capabilities, config-option type=select, request identity, unsupported-method behavior, and an explicit round-trip subset; complete tests, CI, review resolution, conflict reconciliation, and merge without implementing stdio serving or session execution.",
    "problem": "The provider-side ACP adapter owns inbound SessionUpdate mapping and representative SDK-shaped fixtures, but those fixtures are not a neutral compatibility corpus for the opposite direction, and no top-level agent-side ACP contract exists. The directions can therefore drift on version negotiation, capability claims, select-option union shape, request correlation, unsupported behavior, and lossless mapping claims.",
    "solution": "Publish a small pure pkg/transports/acp compatibility boundary based on acp-go-sdk v0.13.5 and promote sanitized protocol examples into a shared semantic corpus with provenance, typed request correlation, expected facts, unsupported outcomes, directionality, and explicit round-trip eligibility. Keep inbound mapping under Providers and future outbound mapping under the ACP transport, with independent tests consuming the corpus and no shared production mapper.",
    "originalDocument": "C:/Users/andre/work/portos/infinite-you/docs/internal/projects/acp-client/final-proposal.md"
  },
  "acceptanceCriteria": [
    "The inert ACP compatibility boundary accepts protocol version 1, rejects unsupported versions with a typed safe outcome, and exposes no listener, stdio loop, connection lifecycle, session execution, or service-construction side effect.",
    "Advertised capabilities are text-first and exactly match implemented V0 behavior: image, audio, embedded context, filesystem, terminal, authentication, fork, plan, client MCP server, and permission capabilities are absent or disabled, and Factory selection uses a config option with type=select.",
    "Request identity distinguishes equal JSON-RPC IDs on different connections, preserves supported string and numeric ID types without conflation, and uses a transport-minted identity where correlation has no usable wire ID.",
    "Unknown and explicitly deferred methods produce the correlated method-not-found outcome without mutation or external effects, while malformed supported inputs produce typed invalid-request or invalid-params outcomes with sensitive-safe details.",
    "One sanitized provenance-pinned corpus declares representative semantic facts, directionality, unsupported/no-output outcomes, and the exact lossless round-trip subset, and is independently consumable by provider-side and transport-side tests without shared production mapping code.",
    "Quality gate: focused ACP compatibility, corpus, provider-mapping, malformed-input, and zero-side-effect tests pass along with typecheck, lint, make verify-fast, applicable package-boundary checks, and required PR CI; no OpenAPI or generated API artifacts change.",
    "Delivery: the implementation/review loop continues until all blocking PR conversation feedback is explicitly addressed, shared-corpus changes and merge conflicts are reconciled against current main, required CI is terminal and passing, and the PR is actually merged; opening, approval, green CI, or merge readiness alone is not completion."
  ],
  "userStories": [
    {
      "id": "ACP-L1-V0-protocol-conformance-001",
      "title": "Publish an inert and truthful ACP compatibility profile",
      "description": "As a maintainer implementing the later ACP server, I want one deterministic compatibility profile so initialization and Factory selection cannot claim behavior that You has not implemented.",
      "acceptanceCriteria": [
        "The agent-side ACP boundary represents acp-go-sdk v0.13.5 protocol version 1 as the only supported protocol version and returns a typed sensitive-safe incompatibility outcome for any other version.",
        "The compatibility result advertises text prompt content only and leaves image, audio, embedded context, filesystem, terminal, authentication, fork, plan, client MCP server, and permission capabilities disabled or absent as required by the SDK wire shape.",
        "A representative Factory target option serializes and deserializes as the ACP select-option union with type=select, stable id, name, currentValue, and allowed values, without representing the Factory as an ACP model resource.",
        "Constructing, validating, or serializing the profile performs no IO, starts no goroutine or process, binds no endpoint, and creates or invokes no Chat Session or Factory Session.",
        "Focused compatibility tests prove accepted and rejected versions, exact serialized capability claims, and select-option round-trip behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented pkg/transports/acp: SupportedProtocolVersion (=acpsdk.ProtocolVersionNumber), NegotiateProtocolVersion/BuildProfile with typed *CompatibilityError for unsupported versions, TextFirstAgentCapabilities (all non-text capabilities explicitly false/absent), and FactoryTargetOption with ToSessionConfigOption/FactoryTargetOptionFromSessionConfigOption for the type=select union round-trip. Focused tests in compatibility_test.go and factory_target_option_test.go cover accepted/rejected versions, exact serialized capability JSON, and select-option round-trip. go build/vet/test pass; make pkg-structure passes; make pkg-boundary/pkg-file-count/backend-size show only pre-existing baseline violations unrelated to this package."
    },
    {
      "id": "ACP-L1-V0-protocol-conformance-002",
      "title": "Preserve connection-scoped request identity and reject unsupported methods safely",
      "description": "As an ACP client integrator, I want requests correlated without cross-connection collisions and unsupported methods rejected without effects so retries and concurrent clients remain predictable.",
      "acceptanceCriteria": [
        "Request identity pairs a non-empty connection identity with the original supported JSON-RPC string or numeric ID; equal wire IDs from different connections are distinct, and numeric and string IDs with similar printed forms are not conflated.",
        "Notifications or requests without a usable wire ID receive a transport-minted non-empty identity where correlation is required without fabricating a JSON-RPC response ID.",
        "Blank connection identity, invalid JSON-RPC ID shapes, and malformed supported parameters return typed validation outcomes without a partially valid identity or protocol result.",
        "Unknown methods and V0-deferred operations return JSON-RPC method-not-found with the original request ID when one exists, while unknown notifications emit no response.",
        "Unsupported or malformed handling invokes no session, provider, process, filesystem, network, or persistence collaborator and leaks no credential, raw command, unsafe path, prompt content, or internal topology.",
        "Table-driven tests cover connection collisions, string and numeric IDs, missing and malformed IDs, unknown requests and notifications, and observable zero-effect behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented in pkg/transports/acp: request_identity.go adds WireIDKind (string/number/minted), RequestIdentity{ConnectionID, Kind, StringID, NumberID, MintedID} as a plain comparable struct, NewRequestIdentity(connectionID, acpsdk.RequestId) (rejects blank connection id and any id shape other than string/number, including the JSON-RPC null id), and NewMintedRequestIdentity(connectionID, mintedID) for notifications/requests with no usable wire id (rejects blank connection id and blank minted id). Because Kind participates in equality, a numeric id and a string id with the same printed form, and a minted identity and a wire-id identity with the same value, are never conflated; equal wire ids on different connections compare unequal since ConnectionID differs. dispatch.go adds MethodDisposition/ClassifyMethod (deferred vs unknown -- documented as identical on the wire), UnsupportedMethodOutcome/UnsupportedMethodResponse(method, *acpsdk.RequestId) returning a correlated acpsdk.NewMethodNotFound result keyed off the original id, or nil for a notification (nil wireID) so the caller emits no response, and a generic DecodeMethodParams[T](raw) that returns a typed acpsdk.NewInvalidParams outcome (sensitive-safe reason string only, never raw params content) for missing or malformed params. errors.go gains RequestIdentityErrorCode/RequestIdentityError following the repo's existing typed-error convention. All of this is pure/deterministic: no IO, no goroutine/process, no session/provider/process/filesystem/network/persistence collaborator is invoked by any of these functions. Table-driven tests in request_identity_test.go and dispatch_test.go cover connection collisions, string vs numeric id non-conflation, minted vs wire-id non-conflation, blank connection/minted id rejection, invalid wire id shapes (null and zero-value), unknown vs deferred method classification, method-not-found responses for unknown and deferred methods with string and numeric ids, notification zero-response behavior, and missing/malformed params. go build/vet/test and gofmt are clean; make test (full short Go suite) passes including the new cases; make pkg-structure passes; make pkg-boundary/pkg-file-count/backend-size show only pre-existing baseline violations unrelated to pkg/transports/acp. POST-MERGE FIX (PR #1712 review): DecodeMethodParams originally only checked JSON unmarshal success, so a syntactically valid but semantically incomplete supported request (e.g. session/prompt params={} or {\"sessionId\":\"session-1\"}, missing the required prompt field) and a literal JSON null params value both passed through as accepted, contradicting this story acceptance criterion that malformed supported inputs produce typed invalid-request/invalid-params outcomes. Fixed by rejecting literal JSON null (previously only empty/whitespace raw bytes were rejected) and, when the decoded type T implements the acp-go-sdk types own Validate() error method (checked via a new unexported validatable interface asserted on *T), calling it and returning the same sensitive-safe invalid-params outcome (reason: \"invalid params\", never the underlying validation error text) on failure. New tests in dispatch_test.go: TestDecodeMethodParamsRejectsNullParams, TestDecodeMethodParamsRejectsSemanticallyInvalidSupportedRequest (acpsdk.PromptRequest with missing prompt, two payload shapes), TestDecodeMethodParamsAcceptsSemanticallyValidSupportedRequest (control case proving the fix does not reject valid input). Two new corpus cases (malformed-input-null-params, malformed-input-semantically-invalid-supported-request) and a conformance_test.go update route the semantically-invalid case through the real acpsdk.PromptRequest type. go build/vet/test and gofmt clean; make test full suite passes; make vet/pkg-structure clean; make pkg-boundary/pkg-file-count/deadcode/backend-size show zero new violations for pkg/transports/acp."
    },
    {
      "id": "ACP-L1-V0-protocol-conformance-003",
      "title": "Promote a sanitized semantic ACP conformance corpus",
      "description": "As a transport or provider mapper maintainer, I want one representative semantic corpus so either protocol direction can verify compatibility without depending on the other direction's code.",
      "acceptanceCriteria": [
        "The shared committed corpus covers version-1 initialize negotiation, text-first capabilities, a type=select Factory option, string and numeric request correlation, text prompt content, agent message and thought updates, supported metadata updates, malformed input, and unsupported-method outcomes.",
        "Each case declares its protocol role, expected semantic facts, inbound and outbound support, and lossless round-trip eligibility; every non-subset case explicitly declares inbound-only, outbound-only, unsupported, or intentionally no-output behavior.",
        "The lossless subset contains only facts both directions preserve honestly, including stable item identity where present, text message chunks, text thought chunks, and usage or session-information fields represented by both vocabularies; tool, file-change, plan, progress, run, turn, and other lossy cases are excluded.",
        "Corpus content contains no credentials, customer prompts, machine-specific absolute paths, raw provider commands, or internal topology, and provenance/checksum metadata makes reviewed changes intentional and reproducible.",
        "A reusable test-only reader returns detached cases and rejects invalid JSON, duplicate case identity, missing expectations, undeclared directionality, and round-trip declarations containing known lossy or unsupported shapes.",
        "Corpus validation and SDK marshal/unmarshal tests prove protocol parseability, semantic stability, sanitization invariants, and exact round-trip declarations without testing repository inventories or registration topology.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented the shared, sanitized ACP L1 V0 semantic conformance corpus as a neutral test-only reader at internal/testutil/acpconformance (repo-root internal, importable by both pkg/services/providers tests and pkg/transports/acp tests without either importing the other's internals or a shared production mapper). corpus.json: 19 hand-authored, sanitized cases (schema_version=1, top-level provenance pinned to acp-go-sdk v0.13.5 module/commit/license) covering all 8 required protocol_role values (initialize, capabilities, factory_option, request_identity, prompt_content, session_update, malformed_input, unsupported_method) and all 5 directionality values (round_trip, inbound_only, outbound_only, unsupported, no_output). The round_trip subset is exactly the 4 lossless kinds (message/agent_message_chunk, reasoning/agent_thought_chunk, usage/usage_update, session/session_info_update); tool_call and plan cases are present and explicitly declared inbound_only to prove lossy kinds are excluded from round-trip. corpus.go: Directionality/ProtocolRole enums, Facts/Case/SourceProvenance/Corpus types, ParseCorpus (rejects invalid JSON, incomplete/missing provenance, no cases, empty/duplicate case id, unknown protocol_role, undeclared/unknown directionality, invalid/empty payload JSON, missing Facts.Kind, missing case provenance, and round_trip declared for a non-lossless Facts.Kind), Load/MustLoad (go:embed corpus.json), and detached-copy accessors ByRole/ByDirectionality/RoundTripCases. corpus_test.go has 32 tests: structural validation positive+negative cases (including a synthetic minimal fixture via ParseCorpus to prove it is a general reusable reader, not just embedded-corpus-specific), detachment (MustLoad results don't alias each other), full protocol-role and directionality coverage checks, round-trip-subset kind allowlist checks, and 'SDK marshal/unmarshal' parseability tests that decode every case's payload into the real pinned acp-go-sdk v0.13.5 types (SessionUpdate, InitializeRequest, AgentCapabilities, SessionConfigOption, PromptRequest, RequestId) to prove protocol parseability and that declared facts are actually derivable from the payload (not merely asserted independently), plus a sanitization-invariant test scanning case content for forbidden credential/path terms. Deliberately did NOT import pkg/transports/acp from this package/tests -- keeps story 003 scoped to the corpus+reader only; wiring corpus cases through the real acp.NegotiateProtocolVersion/TextFirstAgentCapabilities/FactoryTargetOption and the Providers-owned mapSessionUpdate is story 004's explicit scope. go build/vet/test and gofmt are clean; make test (full short Go suite) passes including the new package; make vet, make pkg-structure pass; make pkg-boundary/pkg-file-count/backend-size/deadcode show only pre-existing baseline violations elsewhere in the repo (grepped output for acpconformance/transports/acp -- no matches). POST-MERGE FIX (PR #1712 review): the corpus declared source provenance (SDK module/version/commit/license) but no checksum over the case content itself, so an edit to cases.json could silently drift from what was reviewed, contradicting this story acceptance criterion that provenance/checksum metadata make reviewed changes intentional and reproducible. Fixed by adding a top-level cases_checksum field (hex SHA-256 over the deterministic JSON encoding of the cases array, computed by a new exported acpconformance.ChecksumCases(cases) function that never includes itself) and having ParseCorpus recompute and reject on any missing or mismatched checksum, forcing an explicit, matching update whenever case content changes. Added TestParseCorpusRejectsMissingChecksum, TestParseCorpusRejectsMismatchedChecksum, TestChecksumCasesIsDeterministicAndContentSensitive, and TestEmbeddedCorpusChecksumIsSelfConsistent; refactored the existing negative-fixture tests in corpus_test.go onto a shared marshalFixture helper so every ParseCorpus fixture carries a correct, independently-computed checksum unless a test deliberately corrupts it. go build/vet/test and gofmt clean; make test full suite passes; make vet/pkg-structure clean; make pkg-boundary/pkg-file-count/deadcode/backend-size show zero new violations for internal/testutil/acpconformance."
    },
    {
      "id": "ACP-L1-V0-protocol-conformance-004",
      "title": "Bind independent protocol directions through conformance evidence",
      "description": "As a reviewer, I want the existing inbound provider mapper and the agent-side compatibility boundary checked independently against the same cases so agreement is proven without an illegal dependency or shared mapping implementation.",
      "acceptanceCriteria": [
        "Provider-side tests feed every inbound-supported corpus case through the existing provider-owned ACP mapper and compare observable normalized progress and text facts with the case expectations.",
        "Agent-transport tests independently verify all V0 compatibility, outbound-shape, unsupported, and round-trip declarations without importing Providers internals or calling the inbound mapper.",
        "For each declared round-trip case, independent encode/decode assertions preserve declared semantic facts and request or item identity while allowing irrelevant JSON formatting and field-order differences.",
        "Every representative ACP update kind has an explicit corpus disposition; a newly represented kind cannot be silently dropped or falsely treated as round-trippable.",
        "Provider-owned inbound mapping remains under Providers and the future outbound boundary remains under the ACP transport; no neutral production mapper, cross-internal import, service-to-transport dependency, or shared production mapping helper is introduced.",
        "Focused provider and transport conformance tests pass without starting an ACP subprocess, stdio server, Chat Session, or Factory execution.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Implemented independent conformance tests binding both protocol directions to the shared corpus without a shared production mapper. pkg/transports/acp/conformance_test.go (package acp_test) feeds every corpus case by protocol_role through the real transport functions -- NegotiateProtocolVersion (initialize), TextFirstAgentCapabilities (capabilities, exact serialized-shape match), FactoryTargetOptionFromSessionConfigOption/ToSessionConfigOption (factory_option, structural round-trip), NewRequestIdentity/NewMintedRequestIdentity (request_identity), DecodeMethodParams (malformed_input invalid_params) plus a direct acpsdk.RequestId decode failure (malformed_input invalid_request), and ClassifyMethod/UnsupportedMethodResponse (unsupported_method) -- and independently proves the round_trip session_update subset survives an encode/decode cycle through the pinned SDK type, all without importing Providers or calling the inbound mapper. pkg/services/providers/internal/services/acp/internal/service/conformance_test.go (package service, white-box) feeds every inbound-supported (round_trip or inbound_only) session_update corpus case through the real client.SessionUpdate callback (which wraps the private mapSessionUpdate) and asserts the observable normalized progress (kind/item_id/phase/detail/metadata) and accumulated text match the case Facts, independently of pkg/transports/acp. go build/go vet/gofmt/go test -v pass on both new test files; make test (full short Go suite, all packages) passes; make vet and make pkg-structure are clean; make pkg-boundary/pkg-file-count/deadcode/backend-size grepped for acpconformance/transports/acp/services/acp -- zero matches, i.e. this story added zero new violations (all reported violations are the pre-existing repo-wide baseline, same as story 003). make verify-fast fails only at the pre-existing, unrelated dashboard bun/tsc typecheck step (missing bun type definitions in this environment); this is a backend-only change and does not touch ui/."
    }
  ]
}

```
