### PR TITLE
Address PR #1713 review: logging, failure coverage, construction path

### DIFF
--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -1421,6 +1421,12 @@
     },
     {
       "fromOwner": "operator_settings",
+      "toOwner": "platform",
+      "class": "external_effect",
+      "evidence": "pkg/services/operator_settings/internal/service -\u003e pkg/platform/logging"
+    },
+    {
+      "fromOwner": "operator_settings",
       "toOwner": "providers",
       "class": "command",
       "evidence": "pkg/services/operator_settings -\u003e pkg/services/providers"

--- a/pkg/services/operator_settings/internal/construct/composition.go
+++ b/pkg/services/operator_settings/internal/construct/composition.go
@@ -39,5 +39,6 @@ func newServiceRoot(
 		decoder,
 		encoder,
 		idGenerator,
+		nil,
 	)
 }

--- a/pkg/services/operator_settings/internal/service/acp_agent_profile_test.go
+++ b/pkg/services/operator_settings/internal/service/acp_agent_profile_test.go
@@ -1,0 +1,719 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
+)
+
+func TestRootResolveACPAgentProfile_AbsentDocumentReturnsSafeDefault(t *testing.T) {
+	t.Parallel()
+
+	root := newFilesystemRoot(t, testCreateTemporaryFile)
+	path := filepath.Join(t.TempDir(), "config.json")
+
+	resolved, err := root.ResolveACPAgentProfile(path)
+	if err != nil {
+		t.Fatalf("ResolveACPAgentProfile() = %v", err)
+	}
+	want := operatorsettings.DefaultACPAgentProfile()
+	if resolved.DefaultTarget != want.DefaultTarget || strings.Join(resolved.AllowedTargets, ",") != strings.Join(want.AllowedTargets, ",") {
+		t.Fatalf("ResolveACPAgentProfile() = %#v, want %#v", resolved, want)
+	}
+}
+
+func TestRootResolveACPAgentProfile_AbsentDocumentIsReadOnly(t *testing.T) {
+	t.Parallel()
+
+	root := newFilesystemRoot(t, testCreateTemporaryFile)
+	path := filepath.Join(t.TempDir(), "config.json")
+
+	if _, err := root.ResolveACPAgentProfile(path); err != nil {
+		t.Fatalf("ResolveACPAgentProfile() = %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("os.Stat(path) = %v, want ErrNotExist because resolve must not create the document", err)
+	}
+}
+
+func TestRootResolveACPAgentProfile_MalformedStoredProfileFailsExplicitly(t *testing.T) {
+	t.Parallel()
+
+	root := newFilesystemRoot(t, testCreateTemporaryFile)
+	path := filepath.Join(t.TempDir(), "config.json")
+	malformed := `{"workers":{"acp":{"agentProfile":{"defaultTarget":"factory:@you/review","allowedTargets":["factory:@you/factory-builder"]}}}}`
+	if err := os.WriteFile(path, []byte(malformed), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() = %v", err)
+	}
+
+	_, err := root.ResolveACPAgentProfile(path)
+	if err == nil {
+		t.Fatal("ResolveACPAgentProfile() error = nil, want a typed failure for a malformed stored profile")
+	}
+	if !strings.Contains(err.Error(), "must be present in allowedTargets") {
+		t.Fatalf("ResolveACPAgentProfile() error = %q, want the ACP Agent profile validation fragment", err)
+	}
+}
+
+func TestRootResolveACPAgentProfile_ValidAuthoredProfileReturnsNormalizedDetachedValue(t *testing.T) {
+	t.Parallel()
+
+	root := newFilesystemRoot(t, testCreateTemporaryFile)
+	path := filepath.Join(t.TempDir(), "config.json")
+	authored := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  " factory:@you/reviewer ",
+		AllowedTargets: []string{" factory:@you/reviewer ", "factory:@you/factory-builder"},
+	}
+
+	updated, err := root.UpdateACPAgentProfile(context.Background(), path, authored)
+	if err != nil {
+		t.Fatalf("UpdateACPAgentProfile() = %v", err)
+	}
+	if updated.DefaultTarget != "factory:@you/reviewer" {
+		t.Fatalf("UpdateACPAgentProfile() default = %q", updated.DefaultTarget)
+	}
+
+	resolved, err := root.ResolveACPAgentProfile(path)
+	if err != nil {
+		t.Fatalf("ResolveACPAgentProfile() = %v", err)
+	}
+	if resolved.DefaultTarget != "factory:@you/reviewer" ||
+		len(resolved.AllowedTargets) != 2 ||
+		resolved.AllowedTargets[0] != "factory:@you/reviewer" ||
+		resolved.AllowedTargets[1] != "factory:@you/factory-builder" {
+		t.Fatalf("ResolveACPAgentProfile() = %#v", resolved)
+	}
+
+	// Mutating the resolved slice must not alias stored state.
+	resolved.AllowedTargets[0] = "factory:@you/mutated"
+	reresolved, err := root.ResolveACPAgentProfile(path)
+	if err != nil {
+		t.Fatalf("ResolveACPAgentProfile() second call = %v", err)
+	}
+	if reresolved.AllowedTargets[0] != "factory:@you/reviewer" {
+		t.Fatalf("ResolveACPAgentProfile() returned an aliased slice: %#v", reresolved)
+	}
+}
+
+func TestRootResolveACPAgentProfile_LogsStartAndFinishedOutcomeSafely(t *testing.T) {
+	t.Parallel()
+
+	spy := &spyLogger{}
+	root := newFilesystemRootWithOptions(t, filesystemRootOptions{
+		files:      platformfilesystem.Local{},
+		createTemp: testCreateTemporaryFile,
+		decode:     globalconfigmapping.Decode,
+		encode:     globalconfigmapping.Encode,
+		logger:     spy,
+	})
+	path := filepath.Join(t.TempDir(), "config.json")
+
+	if _, err := root.ResolveACPAgentProfile(path); err != nil {
+		t.Fatalf("ResolveACPAgentProfile() = %v", err)
+	}
+
+	messages := spy.messages()
+	if !containsString(messages, "operator_settings.resolve_acp_agent_profile.started") {
+		t.Fatalf("log messages = %v, want a start log", messages)
+	}
+	if !containsString(messages, "operator_settings.resolve_acp_agent_profile.finished") {
+		t.Fatalf("log messages = %v, want a finished log", messages)
+	}
+	assertNoSensitiveValuesLogged(t, spy, path)
+}
+
+func TestRootResolveACPAgentProfile_LogsFailureReasonWithoutLeakingValues(t *testing.T) {
+	t.Parallel()
+
+	spy := &spyLogger{}
+	root := newFilesystemRootWithOptions(t, filesystemRootOptions{
+		files:      platformfilesystem.Local{},
+		createTemp: testCreateTemporaryFile,
+		decode:     globalconfigmapping.Decode,
+		encode:     globalconfigmapping.Encode,
+		logger:     spy,
+	})
+	path := filepath.Join(t.TempDir(), "config.json")
+	malformed := `{"workers":{"acp":{"agentProfile":{"defaultTarget":"factory:@you/review","allowedTargets":["factory:@you/factory-builder"]}}}}`
+	if err := os.WriteFile(path, []byte(malformed), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() = %v", err)
+	}
+
+	if _, err := root.ResolveACPAgentProfile(path); err == nil {
+		t.Fatal("ResolveACPAgentProfile() error = nil, want a malformed-profile failure")
+	}
+
+	messages := spy.messages()
+	if !containsString(messages, "operator_settings.resolve_acp_agent_profile.failed") {
+		t.Fatalf("log messages = %v, want a failed log", messages)
+	}
+	// The stored document fails Config.Normalize() during decode, so the
+	// document-load boundary reports it as a malformed document rather than
+	// reaching ResolveACPAgentProfile's own defensive Normalize() call.
+	if !containsKeyValue(spy, "reason", "document_malformed") {
+		t.Fatalf("log entries = %#v, want reason=document_malformed", spy.entries)
+	}
+	assertNoSensitiveValuesLogged(t, spy, path, "factory:@you/review", "factory:@you/factory-builder")
+}
+
+func TestRootUpdateACPAgentProfile_LogsStartAndFinishedOutcomeSafely(t *testing.T) {
+	t.Parallel()
+
+	spy := &spyLogger{}
+	root := newFilesystemRootWithOptions(t, filesystemRootOptions{
+		files:      platformfilesystem.Local{},
+		createTemp: testCreateTemporaryFile,
+		decode:     globalconfigmapping.Decode,
+		encode:     globalconfigmapping.Encode,
+		logger:     spy,
+	})
+	path := filepath.Join(t.TempDir(), "config.json")
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/reviewer",
+		AllowedTargets: []string{"factory:@you/reviewer"},
+	}
+
+	if _, err := root.UpdateACPAgentProfile(context.Background(), path, profile); err != nil {
+		t.Fatalf("UpdateACPAgentProfile() = %v", err)
+	}
+
+	messages := spy.messages()
+	if !containsString(messages, "operator_settings.update_acp_agent_profile.started") {
+		t.Fatalf("log messages = %v, want a start log", messages)
+	}
+	if !containsString(messages, "operator_settings.update_acp_agent_profile.finished") {
+		t.Fatalf("log messages = %v, want a finished log", messages)
+	}
+	assertNoSensitiveValuesLogged(t, spy, path, profile.DefaultTarget)
+}
+
+func TestRootUpdateACPAgentProfile_LogsFailureReasonForInvalidCandidateWithoutLeakingValues(t *testing.T) {
+	t.Parallel()
+
+	spy := &spyLogger{}
+	root := newFilesystemRootWithOptions(t, filesystemRootOptions{
+		files:      platformfilesystem.Local{},
+		createTemp: testCreateTemporaryFile,
+		decode:     globalconfigmapping.Decode,
+		encode:     globalconfigmapping.Encode,
+		logger:     spy,
+	})
+	path := filepath.Join(t.TempDir(), "config.json")
+	invalid := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "not-a-factory-reference",
+		AllowedTargets: []string{"factory:@you/reviewer"},
+	}
+
+	if _, err := root.UpdateACPAgentProfile(context.Background(), path, invalid); !errors.Is(err, operatorsettings.ErrACPAgentProfileInvalid) {
+		t.Fatalf("UpdateACPAgentProfile(invalid) = %v, want ErrACPAgentProfileInvalid", err)
+	}
+
+	messages := spy.messages()
+	if !containsString(messages, "operator_settings.update_acp_agent_profile.failed") {
+		t.Fatalf("log messages = %v, want a failed log", messages)
+	}
+	if !containsKeyValue(spy, "reason", "profile_invalid") {
+		t.Fatalf("log entries = %#v, want reason=profile_invalid", spy.entries)
+	}
+	assertNoSensitiveValuesLogged(t, spy, path, invalid.DefaultTarget, "factory:@you/reviewer")
+}
+
+func TestRootUpdateACPAgentProfile_RejectsInvalidCandidateWithoutPersisting(t *testing.T) {
+	t.Parallel()
+
+	root := newFilesystemRoot(t, testCreateTemporaryFile)
+	path := filepath.Join(t.TempDir(), "config.json")
+	valid := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/reviewer",
+		AllowedTargets: []string{"factory:@you/reviewer"},
+	}
+	if _, err := root.UpdateACPAgentProfile(context.Background(), path, valid); err != nil {
+		t.Fatalf("UpdateACPAgentProfile(valid) = %v", err)
+	}
+
+	invalid := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "not-a-factory-reference",
+		AllowedTargets: []string{"factory:@you/reviewer"},
+	}
+	if _, err := root.UpdateACPAgentProfile(context.Background(), path, invalid); !errors.Is(err, operatorsettings.ErrACPAgentProfileInvalid) {
+		t.Fatalf("UpdateACPAgentProfile(invalid) = %v, want ErrACPAgentProfileInvalid", err)
+	}
+
+	resolved, err := root.ResolveACPAgentProfile(path)
+	if err != nil {
+		t.Fatalf("ResolveACPAgentProfile() after rejected update = %v", err)
+	}
+	if resolved.DefaultTarget != "factory:@you/reviewer" {
+		t.Fatalf("ResolveACPAgentProfile() after rejected update = %#v, want the prior valid profile intact", resolved)
+	}
+}
+
+func TestRootUpdateACPAgentProfile_RejectsCanceledContextWithoutPersisting(t *testing.T) {
+	t.Parallel()
+
+	root := newFilesystemRoot(t, testCreateTemporaryFile)
+	path := filepath.Join(t.TempDir(), "config.json")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/reviewer",
+		AllowedTargets: []string{"factory:@you/reviewer"},
+	}
+	if _, err := root.UpdateACPAgentProfile(ctx, path, profile); !errors.Is(err, context.Canceled) {
+		t.Fatalf("UpdateACPAgentProfile(canceled ctx) = %v, want context.Canceled", err)
+	}
+	if _, statErr := os.Stat(path); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Fatalf("config path stat error = %v, want destination to remain absent", statErr)
+	}
+}
+
+func TestRootUpdateACPAgentProfile_RejectsShortWriteWithoutReplacement(t *testing.T) {
+	t.Parallel()
+
+	root := newFilesystemRoot(t, func(dir, pattern string) (operatorsettings.TemporaryFile, error) {
+		return shortWriteTemporaryFile{name: filepath.Join(dir, pattern)}, nil
+	})
+	path := filepath.Join(t.TempDir(), "config.json")
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/reviewer",
+		AllowedTargets: []string{"factory:@you/reviewer"},
+	}
+
+	_, err := root.UpdateACPAgentProfile(context.Background(), path, profile)
+	if err == nil || !strings.Contains(err.Error(), "short write") {
+		t.Fatalf("UpdateACPAgentProfile() = %v, want short-write failure", err)
+	}
+	if _, statErr := os.Stat(path); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Fatalf("config path stat error = %v, want destination to remain absent", statErr)
+	}
+}
+
+func TestRootUpdateACPAgentProfile_RejectsCodecEncodeFailureWithoutReplacement(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	original := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/reviewer",
+		AllowedTargets: []string{"factory:@you/reviewer"},
+	}
+	seedRoot := newFilesystemRoot(t, testCreateTemporaryFile)
+	if _, err := seedRoot.UpdateACPAgentProfile(context.Background(), path, original); err != nil {
+		t.Fatalf("seed UpdateACPAgentProfile() = %v", err)
+	}
+	originalBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile(seed) = %v", err)
+	}
+
+	failingRoot := newFilesystemRootWithOptions(t, filesystemRootOptions{
+		files:      platformfilesystem.Local{},
+		createTemp: testCreateTemporaryFile,
+		decode:     globalconfigmapping.Decode,
+		encode: func(operatorsettings.Config) ([]byte, error) {
+			return nil, errors.New("injected encode failure")
+		},
+	})
+	candidate := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/rejected",
+		AllowedTargets: []string{"factory:@you/rejected"},
+	}
+	if _, err := failingRoot.UpdateACPAgentProfile(context.Background(), path, candidate); err == nil ||
+		!strings.Contains(err.Error(), "injected encode failure") {
+		t.Fatalf("UpdateACPAgentProfile() with failing encoder = %v, want injected encode failure", err)
+	}
+
+	assertDocumentBytesUnchanged(t, path, originalBytes)
+	verifyRoot := newFilesystemRoot(t, testCreateTemporaryFile)
+	resolved, err := verifyRoot.ResolveACPAgentProfile(path)
+	if err != nil {
+		t.Fatalf("ResolveACPAgentProfile() after rejected encode = %v", err)
+	}
+	if resolved.DefaultTarget != original.DefaultTarget {
+		t.Fatalf("ResolveACPAgentProfile() after rejected encode = %#v, want the prior profile intact", resolved)
+	}
+}
+
+func TestRootUpdateACPAgentProfile_RejectsTempFileCreationFailureWithExistingDocumentIntact(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	original := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/reviewer",
+		AllowedTargets: []string{"factory:@you/reviewer"},
+	}
+	seedRoot := newFilesystemRoot(t, testCreateTemporaryFile)
+	if _, err := seedRoot.UpdateACPAgentProfile(context.Background(), path, original); err != nil {
+		t.Fatalf("seed UpdateACPAgentProfile() = %v", err)
+	}
+	originalBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile(seed) = %v", err)
+	}
+
+	failingRoot := newFilesystemRoot(t, func(string, string) (operatorsettings.TemporaryFile, error) {
+		return nil, errors.New("injected create failure")
+	})
+	candidate := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/rejected",
+		AllowedTargets: []string{"factory:@you/rejected"},
+	}
+	if _, err := failingRoot.UpdateACPAgentProfile(context.Background(), path, candidate); err == nil ||
+		!strings.Contains(err.Error(), "injected create failure") {
+		t.Fatalf("UpdateACPAgentProfile() with failing temp-file creation = %v, want injected create failure", err)
+	}
+
+	assertDocumentBytesUnchanged(t, path, originalBytes)
+	verifyRoot := newFilesystemRoot(t, testCreateTemporaryFile)
+	resolved, err := verifyRoot.ResolveACPAgentProfile(path)
+	if err != nil {
+		t.Fatalf("ResolveACPAgentProfile() after rejected create = %v", err)
+	}
+	if resolved.DefaultTarget != original.DefaultTarget {
+		t.Fatalf("ResolveACPAgentProfile() after rejected create = %#v, want the prior profile intact", resolved)
+	}
+}
+
+func TestRootUpdateACPAgentProfile_RejectsPublishFailureWithExistingDocumentIntact(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	original := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/reviewer",
+		AllowedTargets: []string{"factory:@you/reviewer"},
+	}
+	seedRoot := newFilesystemRoot(t, testCreateTemporaryFile)
+	if _, err := seedRoot.UpdateACPAgentProfile(context.Background(), path, original); err != nil {
+		t.Fatalf("seed UpdateACPAgentProfile() = %v", err)
+	}
+	originalBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile(seed) = %v", err)
+	}
+
+	failingRoot := newFilesystemRootWithOptions(t, filesystemRootOptions{
+		files:      &renameFailingFileSystem{FileSystem: platformfilesystem.Local{}},
+		createTemp: testCreateTemporaryFile,
+		decode:     globalconfigmapping.Decode,
+		encode:     globalconfigmapping.Encode,
+	})
+	candidate := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/rejected",
+		AllowedTargets: []string{"factory:@you/rejected"},
+	}
+	if _, err := failingRoot.UpdateACPAgentProfile(context.Background(), path, candidate); err == nil ||
+		!strings.Contains(err.Error(), "injected rename failure") {
+		t.Fatalf("UpdateACPAgentProfile() with failing rename = %v, want injected rename failure", err)
+	}
+
+	assertDocumentBytesUnchanged(t, path, originalBytes)
+	verifyRoot := newFilesystemRoot(t, testCreateTemporaryFile)
+	resolved, err := verifyRoot.ResolveACPAgentProfile(path)
+	if err != nil {
+		t.Fatalf("ResolveACPAgentProfile() after rejected publish = %v", err)
+	}
+	if resolved.DefaultTarget != original.DefaultTarget {
+		t.Fatalf("ResolveACPAgentProfile() after rejected publish = %#v, want the prior profile intact", resolved)
+	}
+}
+
+func TestRootUpdateACPAgentProfile_ConcurrentUpdatesNeverPersistMixedProfile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	root := newFilesystemRoot(t, testCreateTemporaryFile)
+
+	const attempts = 8
+	candidates := make([]operatorsettings.ACPAgentProfile, attempts)
+	for index := range candidates {
+		target := fmt.Sprintf("factory:@you/candidate-%d", index)
+		candidates[index] = operatorsettings.ACPAgentProfile{
+			DefaultTarget:  target,
+			AllowedTargets: []string{target, "factory:@you/factory-builder"},
+		}
+	}
+
+	var start, done sync.WaitGroup
+	start.Add(1)
+	errs := make([]error, attempts)
+	for index := range candidates {
+		done.Add(1)
+		go func(index int) {
+			defer done.Done()
+			start.Wait()
+			_, errs[index] = root.UpdateACPAgentProfile(context.Background(), path, candidates[index])
+		}(index)
+	}
+	start.Done()
+	done.Wait()
+
+	for index, err := range errs {
+		if err != nil {
+			t.Fatalf("UpdateACPAgentProfile() attempt %d = %v", index, err)
+		}
+	}
+
+	resolved, err := root.ResolveACPAgentProfile(path)
+	if err != nil {
+		t.Fatalf("ResolveACPAgentProfile() after concurrent updates = %v", err)
+	}
+	matchedIndex := -1
+	for index, candidate := range candidates {
+		if resolved.DefaultTarget == candidate.DefaultTarget {
+			matchedIndex = index
+			break
+		}
+	}
+	if matchedIndex == -1 {
+		t.Fatalf("ResolveACPAgentProfile() = %#v, want an exact match to one attempted candidate", resolved)
+	}
+	want := candidates[matchedIndex]
+	if len(resolved.AllowedTargets) != len(want.AllowedTargets) ||
+		resolved.AllowedTargets[0] != want.AllowedTargets[0] ||
+		resolved.AllowedTargets[1] != want.AllowedTargets[1] {
+		t.Fatalf(
+			"ResolveACPAgentProfile() = %#v, mixed with another attempt instead of matching candidate %#v",
+			resolved, want,
+		)
+	}
+}
+
+func TestRootUpdateACPAgentProfile_PersistsAtomicallyAndSurvivesReloadThroughNewService(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/reviewer",
+		AllowedTargets: []string{"factory:@you/reviewer", "factory:@you/factory-builder"},
+	}
+
+	firstRoot := newFilesystemRoot(t, testCreateTemporaryFile)
+	if _, err := firstRoot.UpdateACPAgentProfile(context.Background(), path, profile); err != nil {
+		t.Fatalf("UpdateACPAgentProfile() = %v", err)
+	}
+
+	secondRoot := newFilesystemRoot(t, testCreateTemporaryFile)
+	resolved, err := secondRoot.ResolveACPAgentProfile(path)
+	if err != nil {
+		t.Fatalf("ResolveACPAgentProfile() through newly constructed service = %v", err)
+	}
+	if resolved.DefaultTarget != profile.DefaultTarget ||
+		len(resolved.AllowedTargets) != len(profile.AllowedTargets) ||
+		resolved.AllowedTargets[0] != profile.AllowedTargets[0] ||
+		resolved.AllowedTargets[1] != profile.AllowedTargets[1] {
+		t.Fatalf("ResolveACPAgentProfile() through new service = %#v, want %#v", resolved, profile)
+	}
+}
+
+func TestRootACPIntegrationAndProviderModelUpdates_PreserveAuthoredACPAgentProfile(t *testing.T) {
+	t.Parallel()
+
+	root := newFilesystemRoot(t, testCreateTemporaryFile)
+	path := filepath.Join(t.TempDir(), "config.json")
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/reviewer",
+		AllowedTargets: []string{"factory:@you/reviewer"},
+	}
+	if _, err := root.UpdateACPAgentProfile(context.Background(), path, profile); err != nil {
+		t.Fatalf("UpdateACPAgentProfile() = %v", err)
+	}
+
+	integration := operatorsettings.ACPIntegration{
+		ID: "entry-1", Name: "cursor-acp", Transport: "stdio", Command: "cursor-agent acp",
+	}
+	afterIntegrationAdd, err := root.ConfigureACPIntegrationAdd(context.Background(), path, integration)
+	if err != nil {
+		t.Fatalf("ConfigureACPIntegrationAdd() = %v", err)
+	}
+	if afterIntegrationAdd.Workers.ACP.AgentProfile == nil ||
+		afterIntegrationAdd.Workers.ACP.AgentProfile.DefaultTarget != profile.DefaultTarget {
+		t.Fatalf("ConfigureACPIntegrationAdd() dropped the authored ACP Agent profile: %#v", afterIntegrationAdd.Workers.ACP.AgentProfile)
+	}
+
+	nextModel := "gpt-5.2"
+	afterProviderModelUpdate, err := root.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
+		Path: path,
+		ProviderModel: operatorsettings.DocumentProviderModelUpdate{
+			Model: &nextModel,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyDocumentUpdate() = %v", err)
+	}
+	if afterProviderModelUpdate.Document.Workers.ACP.AgentProfile == nil ||
+		afterProviderModelUpdate.Document.Workers.ACP.AgentProfile.DefaultTarget != profile.DefaultTarget {
+		t.Fatalf(
+			"ApplyDocumentUpdate() dropped the authored ACP Agent profile: %#v",
+			afterProviderModelUpdate.Document.Workers.ACP.AgentProfile,
+		)
+	}
+
+	resolved, err := root.ResolveACPAgentProfile(path)
+	if err != nil {
+		t.Fatalf("ResolveACPAgentProfile() = %v", err)
+	}
+	if resolved.DefaultTarget != profile.DefaultTarget {
+		t.Fatalf("ResolveACPAgentProfile() after unrelated updates = %#v, want %#v", resolved, profile)
+	}
+}
+
+func TestRootUpdateACPAgentProfile_PreservesUnrelatedSettings(t *testing.T) {
+	t.Parallel()
+
+	root := newFilesystemRoot(t, testCreateTemporaryFile)
+	path := filepath.Join(t.TempDir(), "config.json")
+	integration := operatorsettings.ACPIntegration{
+		ID: "entry-1", Name: "cursor-acp", Transport: "stdio", Command: "cursor-agent acp",
+	}
+	if _, err := root.ConfigureACPIntegrationAdd(context.Background(), path, integration); err != nil {
+		t.Fatalf("ConfigureACPIntegrationAdd() = %v", err)
+	}
+	scope, err := root.EnsureLocalBackendScope(path)
+	if err != nil {
+		t.Fatalf("EnsureLocalBackendScope() = %v", err)
+	}
+
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/reviewer",
+		AllowedTargets: []string{"factory:@you/reviewer"},
+	}
+	if _, err := root.UpdateACPAgentProfile(context.Background(), path, profile); err != nil {
+		t.Fatalf("UpdateACPAgentProfile() = %v", err)
+	}
+
+	loaded, err := root.LoadDocument(operatorsettings.LoadDocumentRequest{Path: path})
+	if err != nil {
+		t.Fatalf("LoadDocument() = %v", err)
+	}
+	if loaded.Document.BackendScopeID != scope.BackendScopeID {
+		t.Fatalf("LoadDocument().BackendScopeID = %q, want %q", loaded.Document.BackendScopeID, scope.BackendScopeID)
+	}
+	if len(loaded.Document.Workers.ACP.Integrations) != 1 || loaded.Document.Workers.ACP.Integrations[0] != integration {
+		t.Fatalf("LoadDocument() integrations = %#v, want %#v", loaded.Document.Workers.ACP.Integrations, []operatorsettings.ACPIntegration{integration})
+	}
+}
+
+// renameFailingFileSystem wraps a real FileSystem and injects a failure only
+// on the final atomic-publish Rename step, so PersistDocument's earlier
+// steps (mkdir, temp-file write) still exercise the real filesystem while
+// proving the destination survives a rename/publish failure untouched.
+type renameFailingFileSystem struct {
+	operatorsettings.FileSystem
+}
+
+func (files *renameFailingFileSystem) Rename(string, string) error {
+	return errors.New("injected rename failure")
+}
+
+// assertDocumentBytesUnchanged fails the test unless the file at path still
+// holds exactly want, proving a rejected mutation never replaced the
+// previously persisted document.
+func assertDocumentBytesUnchanged(t *testing.T, path string, want []byte) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q) = %v", path, err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("document at %q changed after a rejected update: got %q, want %q", path, got, want)
+	}
+}
+
+// spyLoggedEntry captures one structured log call for assertion.
+type spyLoggedEntry struct {
+	level string
+	msg   string
+	kv    []any
+}
+
+// spyLogger is a logging.Logger fake that records every call so tests can
+// assert on operation-log shape (message names, safe fields) without a real
+// logging backend.
+type spyLogger struct {
+	mu      sync.Mutex
+	entries []spyLoggedEntry
+}
+
+func (s *spyLogger) Debug(msg string, kv ...any)   { s.record("debug", msg, kv) }
+func (s *spyLogger) Info(msg string, kv ...any)    { s.record("info", msg, kv) }
+func (s *spyLogger) Warn(msg string, kv ...any)    { s.record("warn", msg, kv) }
+func (s *spyLogger) Error(msg string, kv ...any)   { s.record("error", msg, kv) }
+func (s *spyLogger) Verbose(msg string, kv ...any) { s.record("verbose", msg, kv) }
+
+func (s *spyLogger) record(level, msg string, kv []any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries = append(s.entries, spyLoggedEntry{level: level, msg: msg, kv: append([]any(nil), kv...)})
+}
+
+func (s *spyLogger) messages() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.entries))
+	for index, entry := range s.entries {
+		out[index] = entry.msg
+	}
+	return out
+}
+
+func containsString(values []string, want string) bool {
+	return slices.Contains(values, want)
+}
+
+// containsKeyValue reports whether any recorded entry has key immediately
+// followed by want in its key/value pairs.
+func containsKeyValue(spy *spyLogger, key string, want any) bool {
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	for _, entry := range spy.entries {
+		for index := 0; index+1 < len(entry.kv); index += 2 {
+			if entry.kv[index] == key && entry.kv[index+1] == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// assertNoSensitiveValuesLogged fails the test if any recorded log message or
+// key/value field contains the config path or any other forbidden value
+// (profile target references, raw configuration contents).
+func assertNoSensitiveValuesLogged(t *testing.T, spy *spyLogger, forbidden ...string) {
+	t.Helper()
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	for _, entry := range spy.entries {
+		if containsForbiddenSubstring(entry.msg, forbidden) {
+			t.Fatalf("log message %q leaked a forbidden value from %v", entry.msg, forbidden)
+		}
+		for _, value := range entry.kv {
+			text, ok := value.(string)
+			if !ok {
+				continue
+			}
+			if containsForbiddenSubstring(text, forbidden) {
+				t.Fatalf("log field %q leaked a forbidden value from %v", text, forbidden)
+			}
+		}
+	}
+}
+
+func containsForbiddenSubstring(value string, forbidden []string) bool {
+	for _, needle := range forbidden {
+		if needle != "" && strings.Contains(value, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/services/operator_settings/internal/service/service.go
+++ b/pkg/services/operator_settings/internal/service/service.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	identityinventory "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/identityinputinventory"
 	settingsdocument "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document"
@@ -26,13 +27,16 @@ type Service struct {
 	decoder     operatorsettings.ConfigDecoder
 	encoder     operatorsettings.ConfigEncoder
 	idGenerator operatorsettings.IDGenerator
+	logger      logging.Logger
 	writeMu     sync.Mutex
 }
 
 var _ operatorsettings.Service = (*Service)(nil)
 
 // New constructs an inert Operator Settings root facade over the private
-// document and resolution capabilities.
+// document and resolution capabilities. logger is the repository-injected
+// operation-logging abstraction; a nil logger resolves to a safe no-op so
+// construction never fails or discovers its own logger.
 func New(
 	documentService settingsdocument.Service,
 	resolutionService resolution.Service,
@@ -41,6 +45,7 @@ func New(
 	decoder operatorsettings.ConfigDecoder,
 	encoder operatorsettings.ConfigEncoder,
 	idGenerator operatorsettings.IDGenerator,
+	logger logging.Logger,
 ) (operatorsettings.Service, error) {
 	if documentService == nil {
 		return nil, fmt.Errorf("construct Operator Settings: document is required")
@@ -56,6 +61,7 @@ func New(
 		decoder:     decoder,
 		encoder:     encoder,
 		idGenerator: idGenerator,
+		logger:      logging.EnsureLogger(logger),
 	}, nil
 }
 
@@ -254,6 +260,23 @@ func (s *Service) ResolveACPAgentProfile(path string) (operatorsettings.ACPAgent
 	if s == nil || s.document == nil {
 		return operatorsettings.ACPAgentProfile{}, fmt.Errorf("operator settings document service is required")
 	}
+	s.logger.Info("operator_settings.resolve_acp_agent_profile.started")
+	profile, err := s.resolveACPAgentProfile(path)
+	if err != nil {
+		s.logger.Warn(
+			"operator_settings.resolve_acp_agent_profile.failed",
+			"reason", classifyACPAgentProfileFailure(err),
+		)
+		return operatorsettings.ACPAgentProfile{}, err
+	}
+	s.logger.Info(
+		"operator_settings.resolve_acp_agent_profile.finished",
+		"allowed_target_count", len(profile.AllowedTargets),
+	)
+	return profile, nil
+}
+
+func (s *Service) resolveACPAgentProfile(path string) (operatorsettings.ACPAgentProfile, error) {
 	loaded, err := s.document.LoadDocument(operatorsettings.LoadDocumentRequest{Path: path})
 	if err != nil {
 		return operatorsettings.ACPAgentProfile{}, err
@@ -269,6 +292,27 @@ func (s *Service) ResolveACPAgentProfile(path string) (operatorsettings.ACPAgent
 // persistence side effect, then atomically stores the normalized profile
 // while preserving every other operator setting.
 func (s *Service) UpdateACPAgentProfile(
+	ctx context.Context,
+	path string,
+	profile operatorsettings.ACPAgentProfile,
+) (operatorsettings.ACPAgentProfile, error) {
+	s.logger.Info("operator_settings.update_acp_agent_profile.started")
+	updated, err := s.updateACPAgentProfile(ctx, path, profile)
+	if err != nil {
+		s.logger.Warn(
+			"operator_settings.update_acp_agent_profile.failed",
+			"reason", classifyACPAgentProfileFailure(err),
+		)
+		return operatorsettings.ACPAgentProfile{}, err
+	}
+	s.logger.Info(
+		"operator_settings.update_acp_agent_profile.finished",
+		"allowed_target_count", len(updated.AllowedTargets),
+	)
+	return updated, nil
+}
+
+func (s *Service) updateACPAgentProfile(
 	ctx context.Context,
 	path string,
 	profile operatorsettings.ACPAgentProfile,
@@ -290,6 +334,25 @@ func (s *Service) UpdateACPAgentProfile(
 		return operatorsettings.ACPAgentProfile{}, fmt.Errorf("operator settings: update ACP Agent profile: persisted document is missing the profile")
 	}
 	return updated.Workers.ACP.AgentProfile.Clone(), nil
+}
+
+// classifyACPAgentProfileFailure reports a safe, actionable failure category
+// for operation logs without leaking the config path, profile contents, or
+// allowlist values that may appear inside the underlying error message.
+func classifyACPAgentProfileFailure(err error) string {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "context_canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "context_deadline_exceeded"
+	case errors.Is(err, operatorsettings.ErrACPAgentProfileInvalid):
+		return "profile_invalid"
+	}
+	var documentFailure operatorsettings.DocumentFailure
+	if errors.As(err, &documentFailure) {
+		return "document_" + string(documentFailure.Kind)
+	}
+	return "operation_failed"
 }
 
 func (s *Service) mutateDocument(

--- a/pkg/services/operator_settings/internal/service/service_test.go
+++ b/pkg/services/operator_settings/internal/service/service_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	operatorservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/service"
 	documentwire "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/wire"
@@ -41,6 +42,7 @@ func TestRootDelegatesResolveEffectiveToPrivateOwner(t *testing.T) {
 		rootTestConfigDecoder,
 		rootTestConfigEncoder,
 		func() string { return "00000000-0000-4000-8000-000000000001" },
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("New() = %v", err)
@@ -78,7 +80,7 @@ func TestNew_RejectsNilDocument(t *testing.T) {
 		t.Fatalf("resolutionwire.NewService() = %v", err)
 	}
 
-	service, err := operatorservice.New(nil, resolutionService, nil, nil, nil, nil, nil)
+	service, err := operatorservice.New(nil, resolutionService, nil, nil, nil, nil, nil, nil)
 	if err == nil || service != nil {
 		t.Fatalf("New(nil, resolution) = (%v, %v), want error", service, err)
 	}
@@ -95,7 +97,7 @@ func TestNew_RejectsNilResolution(t *testing.T) {
 		rootTestProviderCatalog,
 	)
 
-	service, err := operatorservice.New(documentService, nil, nil, nil, nil, nil, nil)
+	service, err := operatorservice.New(documentService, nil, nil, nil, nil, nil, nil, nil)
 	if err == nil || service != nil {
 		t.Fatalf("New(document, nil) = (%v, %v), want error", service, err)
 	}
@@ -191,290 +193,41 @@ func TestRootACPConfigurationAddsDeletesAndMaterializesDefaults(t *testing.T) {
 	}
 }
 
-func TestRootResolveACPAgentProfile_AbsentDocumentReturnsSafeDefault(t *testing.T) {
-	t.Parallel()
-
-	root := newFilesystemRoot(t, testCreateTemporaryFile)
-	path := filepath.Join(t.TempDir(), "config.json")
-
-	resolved, err := root.ResolveACPAgentProfile(path)
-	if err != nil {
-		t.Fatalf("ResolveACPAgentProfile() = %v", err)
-	}
-	want := operatorsettings.DefaultACPAgentProfile()
-	if resolved.DefaultTarget != want.DefaultTarget || strings.Join(resolved.AllowedTargets, ",") != strings.Join(want.AllowedTargets, ",") {
-		t.Fatalf("ResolveACPAgentProfile() = %#v, want %#v", resolved, want)
-	}
-}
-
-func TestRootResolveACPAgentProfile_AbsentDocumentIsReadOnly(t *testing.T) {
-	t.Parallel()
-
-	root := newFilesystemRoot(t, testCreateTemporaryFile)
-	path := filepath.Join(t.TempDir(), "config.json")
-
-	if _, err := root.ResolveACPAgentProfile(path); err != nil {
-		t.Fatalf("ResolveACPAgentProfile() = %v", err)
-	}
-	if _, err := os.Stat(path); !errors.Is(err, fs.ErrNotExist) {
-		t.Fatalf("os.Stat(path) = %v, want ErrNotExist because resolve must not create the document", err)
-	}
-}
-
-func TestRootResolveACPAgentProfile_MalformedStoredProfileFailsExplicitly(t *testing.T) {
-	t.Parallel()
-
-	root := newFilesystemRoot(t, testCreateTemporaryFile)
-	path := filepath.Join(t.TempDir(), "config.json")
-	malformed := `{"workers":{"acp":{"agentProfile":{"defaultTarget":"factory:@you/review","allowedTargets":["factory:@you/factory-builder"]}}}}`
-	if err := os.WriteFile(path, []byte(malformed), 0o600); err != nil {
-		t.Fatalf("os.WriteFile() = %v", err)
-	}
-
-	_, err := root.ResolveACPAgentProfile(path)
-	if err == nil {
-		t.Fatal("ResolveACPAgentProfile() error = nil, want a typed failure for a malformed stored profile")
-	}
-	if !strings.Contains(err.Error(), "must be present in allowedTargets") {
-		t.Fatalf("ResolveACPAgentProfile() error = %q, want the ACP Agent profile validation fragment", err)
-	}
-}
-
-func TestRootResolveACPAgentProfile_ValidAuthoredProfileReturnsNormalizedDetachedValue(t *testing.T) {
-	t.Parallel()
-
-	root := newFilesystemRoot(t, testCreateTemporaryFile)
-	path := filepath.Join(t.TempDir(), "config.json")
-	authored := operatorsettings.ACPAgentProfile{
-		DefaultTarget:  " factory:@you/reviewer ",
-		AllowedTargets: []string{" factory:@you/reviewer ", "factory:@you/factory-builder"},
-	}
-
-	updated, err := root.UpdateACPAgentProfile(context.Background(), path, authored)
-	if err != nil {
-		t.Fatalf("UpdateACPAgentProfile() = %v", err)
-	}
-	if updated.DefaultTarget != "factory:@you/reviewer" {
-		t.Fatalf("UpdateACPAgentProfile() default = %q", updated.DefaultTarget)
-	}
-
-	resolved, err := root.ResolveACPAgentProfile(path)
-	if err != nil {
-		t.Fatalf("ResolveACPAgentProfile() = %v", err)
-	}
-	if resolved.DefaultTarget != "factory:@you/reviewer" ||
-		len(resolved.AllowedTargets) != 2 ||
-		resolved.AllowedTargets[0] != "factory:@you/reviewer" ||
-		resolved.AllowedTargets[1] != "factory:@you/factory-builder" {
-		t.Fatalf("ResolveACPAgentProfile() = %#v", resolved)
-	}
-
-	// Mutating the resolved slice must not alias stored state.
-	resolved.AllowedTargets[0] = "factory:@you/mutated"
-	reresolved, err := root.ResolveACPAgentProfile(path)
-	if err != nil {
-		t.Fatalf("ResolveACPAgentProfile() second call = %v", err)
-	}
-	if reresolved.AllowedTargets[0] != "factory:@you/reviewer" {
-		t.Fatalf("ResolveACPAgentProfile() returned an aliased slice: %#v", reresolved)
-	}
-}
-
-func TestRootUpdateACPAgentProfile_RejectsInvalidCandidateWithoutPersisting(t *testing.T) {
-	t.Parallel()
-
-	root := newFilesystemRoot(t, testCreateTemporaryFile)
-	path := filepath.Join(t.TempDir(), "config.json")
-	valid := operatorsettings.ACPAgentProfile{
-		DefaultTarget:  "factory:@you/reviewer",
-		AllowedTargets: []string{"factory:@you/reviewer"},
-	}
-	if _, err := root.UpdateACPAgentProfile(context.Background(), path, valid); err != nil {
-		t.Fatalf("UpdateACPAgentProfile(valid) = %v", err)
-	}
-
-	invalid := operatorsettings.ACPAgentProfile{
-		DefaultTarget:  "not-a-factory-reference",
-		AllowedTargets: []string{"factory:@you/reviewer"},
-	}
-	if _, err := root.UpdateACPAgentProfile(context.Background(), path, invalid); !errors.Is(err, operatorsettings.ErrACPAgentProfileInvalid) {
-		t.Fatalf("UpdateACPAgentProfile(invalid) = %v, want ErrACPAgentProfileInvalid", err)
-	}
-
-	resolved, err := root.ResolveACPAgentProfile(path)
-	if err != nil {
-		t.Fatalf("ResolveACPAgentProfile() after rejected update = %v", err)
-	}
-	if resolved.DefaultTarget != "factory:@you/reviewer" {
-		t.Fatalf("ResolveACPAgentProfile() after rejected update = %#v, want the prior valid profile intact", resolved)
-	}
-}
-
-func TestRootUpdateACPAgentProfile_RejectsCanceledContextWithoutPersisting(t *testing.T) {
-	t.Parallel()
-
-	root := newFilesystemRoot(t, testCreateTemporaryFile)
-	path := filepath.Join(t.TempDir(), "config.json")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	profile := operatorsettings.ACPAgentProfile{
-		DefaultTarget:  "factory:@you/reviewer",
-		AllowedTargets: []string{"factory:@you/reviewer"},
-	}
-	if _, err := root.UpdateACPAgentProfile(ctx, path, profile); !errors.Is(err, context.Canceled) {
-		t.Fatalf("UpdateACPAgentProfile(canceled ctx) = %v, want context.Canceled", err)
-	}
-	if _, statErr := os.Stat(path); !errors.Is(statErr, fs.ErrNotExist) {
-		t.Fatalf("config path stat error = %v, want destination to remain absent", statErr)
-	}
-}
-
-func TestRootUpdateACPAgentProfile_RejectsShortWriteWithoutReplacement(t *testing.T) {
-	t.Parallel()
-
-	root := newFilesystemRoot(t, func(dir, pattern string) (operatorsettings.TemporaryFile, error) {
-		return shortWriteTemporaryFile{name: filepath.Join(dir, pattern)}, nil
-	})
-	path := filepath.Join(t.TempDir(), "config.json")
-	profile := operatorsettings.ACPAgentProfile{
-		DefaultTarget:  "factory:@you/reviewer",
-		AllowedTargets: []string{"factory:@you/reviewer"},
-	}
-
-	_, err := root.UpdateACPAgentProfile(context.Background(), path, profile)
-	if err == nil || !strings.Contains(err.Error(), "short write") {
-		t.Fatalf("UpdateACPAgentProfile() = %v, want short-write failure", err)
-	}
-	if _, statErr := os.Stat(path); !errors.Is(statErr, fs.ErrNotExist) {
-		t.Fatalf("config path stat error = %v, want destination to remain absent", statErr)
-	}
-}
-
-func TestRootUpdateACPAgentProfile_PersistsAtomicallyAndSurvivesReloadThroughNewService(t *testing.T) {
-	t.Parallel()
-
-	path := filepath.Join(t.TempDir(), "config.json")
-	profile := operatorsettings.ACPAgentProfile{
-		DefaultTarget:  "factory:@you/reviewer",
-		AllowedTargets: []string{"factory:@you/reviewer", "factory:@you/factory-builder"},
-	}
-
-	firstRoot := newFilesystemRoot(t, testCreateTemporaryFile)
-	if _, err := firstRoot.UpdateACPAgentProfile(context.Background(), path, profile); err != nil {
-		t.Fatalf("UpdateACPAgentProfile() = %v", err)
-	}
-
-	secondRoot := newFilesystemRoot(t, testCreateTemporaryFile)
-	resolved, err := secondRoot.ResolveACPAgentProfile(path)
-	if err != nil {
-		t.Fatalf("ResolveACPAgentProfile() through newly constructed service = %v", err)
-	}
-	if resolved.DefaultTarget != profile.DefaultTarget ||
-		len(resolved.AllowedTargets) != len(profile.AllowedTargets) ||
-		resolved.AllowedTargets[0] != profile.AllowedTargets[0] ||
-		resolved.AllowedTargets[1] != profile.AllowedTargets[1] {
-		t.Fatalf("ResolveACPAgentProfile() through new service = %#v, want %#v", resolved, profile)
-	}
-}
-
-func TestRootACPIntegrationAndProviderModelUpdates_PreserveAuthoredACPAgentProfile(t *testing.T) {
-	t.Parallel()
-
-	root := newFilesystemRoot(t, testCreateTemporaryFile)
-	path := filepath.Join(t.TempDir(), "config.json")
-	profile := operatorsettings.ACPAgentProfile{
-		DefaultTarget:  "factory:@you/reviewer",
-		AllowedTargets: []string{"factory:@you/reviewer"},
-	}
-	if _, err := root.UpdateACPAgentProfile(context.Background(), path, profile); err != nil {
-		t.Fatalf("UpdateACPAgentProfile() = %v", err)
-	}
-
-	integration := operatorsettings.ACPIntegration{
-		ID: "entry-1", Name: "cursor-acp", Transport: "stdio", Command: "cursor-agent acp",
-	}
-	afterIntegrationAdd, err := root.ConfigureACPIntegrationAdd(context.Background(), path, integration)
-	if err != nil {
-		t.Fatalf("ConfigureACPIntegrationAdd() = %v", err)
-	}
-	if afterIntegrationAdd.Workers.ACP.AgentProfile == nil ||
-		afterIntegrationAdd.Workers.ACP.AgentProfile.DefaultTarget != profile.DefaultTarget {
-		t.Fatalf("ConfigureACPIntegrationAdd() dropped the authored ACP Agent profile: %#v", afterIntegrationAdd.Workers.ACP.AgentProfile)
-	}
-
-	nextModel := "gpt-5.2"
-	afterProviderModelUpdate, err := root.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
-		Path: path,
-		ProviderModel: operatorsettings.DocumentProviderModelUpdate{
-			Model: &nextModel,
-		},
-	})
-	if err != nil {
-		t.Fatalf("ApplyDocumentUpdate() = %v", err)
-	}
-	if afterProviderModelUpdate.Document.Workers.ACP.AgentProfile == nil ||
-		afterProviderModelUpdate.Document.Workers.ACP.AgentProfile.DefaultTarget != profile.DefaultTarget {
-		t.Fatalf(
-			"ApplyDocumentUpdate() dropped the authored ACP Agent profile: %#v",
-			afterProviderModelUpdate.Document.Workers.ACP.AgentProfile,
-		)
-	}
-
-	resolved, err := root.ResolveACPAgentProfile(path)
-	if err != nil {
-		t.Fatalf("ResolveACPAgentProfile() = %v", err)
-	}
-	if resolved.DefaultTarget != profile.DefaultTarget {
-		t.Fatalf("ResolveACPAgentProfile() after unrelated updates = %#v, want %#v", resolved, profile)
-	}
-}
-
-func TestRootUpdateACPAgentProfile_PreservesUnrelatedSettings(t *testing.T) {
-	t.Parallel()
-
-	root := newFilesystemRoot(t, testCreateTemporaryFile)
-	path := filepath.Join(t.TempDir(), "config.json")
-	integration := operatorsettings.ACPIntegration{
-		ID: "entry-1", Name: "cursor-acp", Transport: "stdio", Command: "cursor-agent acp",
-	}
-	if _, err := root.ConfigureACPIntegrationAdd(context.Background(), path, integration); err != nil {
-		t.Fatalf("ConfigureACPIntegrationAdd() = %v", err)
-	}
-	scope, err := root.EnsureLocalBackendScope(path)
-	if err != nil {
-		t.Fatalf("EnsureLocalBackendScope() = %v", err)
-	}
-
-	profile := operatorsettings.ACPAgentProfile{
-		DefaultTarget:  "factory:@you/reviewer",
-		AllowedTargets: []string{"factory:@you/reviewer"},
-	}
-	if _, err := root.UpdateACPAgentProfile(context.Background(), path, profile); err != nil {
-		t.Fatalf("UpdateACPAgentProfile() = %v", err)
-	}
-
-	loaded, err := root.LoadDocument(operatorsettings.LoadDocumentRequest{Path: path})
-	if err != nil {
-		t.Fatalf("LoadDocument() = %v", err)
-	}
-	if loaded.Document.BackendScopeID != scope.BackendScopeID {
-		t.Fatalf("LoadDocument().BackendScopeID = %q, want %q", loaded.Document.BackendScopeID, scope.BackendScopeID)
-	}
-	if len(loaded.Document.Workers.ACP.Integrations) != 1 || loaded.Document.Workers.ACP.Integrations[0] != integration {
-		t.Fatalf("LoadDocument() integrations = %#v, want %#v", loaded.Document.Workers.ACP.Integrations, []operatorsettings.ACPIntegration{integration})
-	}
-}
-
+// newFilesystemRoot constructs a real-filesystem Operator Settings root Service
+// with the default codec, so tests can exercise persistence without
+// duplicating construction. See newFilesystemRootWithOptions for injecting
+// fault-injecting or observing fakes (filesystem, codec, logger).
 func newFilesystemRoot(t *testing.T, createTemp operatorsettings.CreateTemporaryFile) operatorsettings.Service {
 	t.Helper()
 
-	files := platformfilesystem.Local{}
+	return newFilesystemRootWithOptions(t, filesystemRootOptions{
+		files:      platformfilesystem.Local{},
+		createTemp: createTemp,
+		decode:     globalconfigmapping.Decode,
+		encode:     globalconfigmapping.Encode,
+	})
+}
+
+// filesystemRootOptions overrides the ports newFilesystemRootWithOptions
+// wires into a root Service, so tests can inject fault-injecting or
+// observing fakes (filesystem, codec, logger) without duplicating the whole
+// construction sequence.
+type filesystemRootOptions struct {
+	files      operatorsettings.FileSystem
+	createTemp operatorsettings.CreateTemporaryFile
+	decode     operatorsettings.ConfigDecoder
+	encode     operatorsettings.ConfigEncoder
+	logger     logging.Logger
+}
+
+func newFilesystemRootWithOptions(t *testing.T, opts filesystemRootOptions) operatorsettings.Service {
+	t.Helper()
+
 	documentService := documentwire.NewService(
-		files,
-		createTemp,
-		globalconfigmapping.Decode,
-		globalconfigmapping.Encode,
+		opts.files,
+		opts.createTemp,
+		opts.decode,
+		opts.encode,
 		rootTestProviderCatalog,
 	)
 	resolutionService, err := resolutionwire.NewService(internaltestproviders.StandardCatalog())
@@ -484,11 +237,12 @@ func newFilesystemRoot(t *testing.T, createTemp operatorsettings.CreateTemporary
 	root, err := operatorservice.New(
 		documentService,
 		resolutionService,
-		files,
-		createTemp,
-		globalconfigmapping.Decode,
-		globalconfigmapping.Encode,
+		opts.files,
+		opts.createTemp,
+		opts.decode,
+		opts.encode,
 		func() string { return "00000000-0000-4000-8000-000000000001" },
+		opts.logger,
 	)
 	if err != nil {
 		t.Fatalf("operatorservice.New() = %v", err)

--- a/pkg/services/operator_settings/wire/service_from_config_document.go
+++ b/pkg/services/operator_settings/wire/service_from_config_document.go
@@ -3,6 +3,7 @@ package wire
 import (
 	"fmt"
 
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	operatorservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/service"
 	settingsdocument "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document"
@@ -12,10 +13,14 @@ import (
 
 // NewServiceFromConfigDocument constructs the accepted Settings root from the
 // ConfigDocumentService ports Wire already injects for configure composition.
+// logger is an optional trailing operation-logging abstraction; omitting it
+// (or passing nil) resolves to a safe no-op, so existing callers are
+// unaffected.
 func NewServiceFromConfigDocument(
 	service operatorsettings.ConfigDocumentService,
 	providersRoot providers.Service,
 	idGenerator operatorsettings.IDGenerator,
+	logger ...logging.Logger,
 ) (operatorsettings.Service, error) {
 	if providersRoot == nil {
 		return nil, fmt.Errorf("operator settings providers root is required")
@@ -47,5 +52,6 @@ func NewServiceFromConfigDocument(
 		service.Decoder,
 		service.Encoder,
 		idGenerator,
+		firstLogger(logger),
 	)
 }

--- a/pkg/services/operator_settings/wire/service_from_home_ports.go
+++ b/pkg/services/operator_settings/wire/service_from_home_ports.go
@@ -3,6 +3,7 @@ package wire
 import (
 	"fmt"
 
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	operatorservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/service"
 	documentwire "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/wire"
@@ -12,11 +13,14 @@ import (
 
 // NewServiceFromHomePorts constructs the accepted Settings root from the
 // filesystem and decoder ports Wire already injects for defaults resolution.
+// logger is an optional trailing operation-logging abstraction; omitting it
+// (or passing nil) resolves to a safe no-op.
 func NewServiceFromHomePorts(
 	files operatorsettings.FileSystem,
 	decode operatorsettings.ConfigDecoder,
 	providersRoot providers.Service,
 	idGenerator operatorsettings.IDGenerator,
+	logger ...logging.Logger,
 ) (operatorsettings.Service, error) {
 	if files == nil {
 		return nil, fmt.Errorf("operator settings filesystem is required")
@@ -43,5 +47,6 @@ func NewServiceFromHomePorts(
 		decode,
 		nil,
 		idGenerator,
+		firstLogger(logger),
 	)
 }

--- a/pkg/services/operator_settings/wire/wire.go
+++ b/pkg/services/operator_settings/wire/wire.go
@@ -9,6 +9,7 @@ package wire
 import (
 	"fmt"
 
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	operatorservice "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/service"
 	documentwire "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/wire"
@@ -16,10 +17,22 @@ import (
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
+// firstLogger returns the first optional logger supplied to a Settings wire
+// constructor, or nil when omitted. operatorservice.New resolves a nil logger
+// to a safe no-op, so this keeps every Settings wire constructor's logger
+// parameter optional without duplicating that fallback at each call site.
+func firstLogger(logger []logging.Logger) logging.Logger {
+	if len(logger) == 0 {
+		return nil
+	}
+	return logger[0]
+}
+
 // NewService constructs an inert Operator Settings root from construction and
 // process-edge ports. It composes the accepted root through parent-private
 // document and resolution owners without publishing owner types on the returned
-// peer surface.
+// peer surface. logger is an optional trailing operation-logging abstraction;
+// omitting it (or passing nil) resolves to a safe no-op.
 func NewService(
 	files operatorsettings.FileSystem,
 	createTemp operatorsettings.CreateTemporaryFile,
@@ -28,6 +41,7 @@ func NewService(
 	providersCatalog operatorsettings.ProviderCatalog,
 	providersRoot providers.Service,
 	idGenerator operatorsettings.IDGenerator,
+	logger ...logging.Logger,
 ) (operatorsettings.Service, error) {
 	if err := validateNewServiceInputs(
 		files,
@@ -62,6 +76,7 @@ func NewService(
 		decoder,
 		encoder,
 		idGenerator,
+		firstLogger(logger),
 	)
 }
 

--- a/tests/functional/operator_settings/root_composition/wire_composition_coverage_test.go
+++ b/tests/functional/operator_settings/root_composition/wire_composition_coverage_test.go
@@ -15,12 +15,14 @@ import (
 	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 )
 
-// TestWireCompositionServesDocumentAndResolutionOperations exercises published
-// Settings wire surfaces through the functional lane so transitional composition
-// hooks (construct/testlink/testproviders) retain coverage after servicewire/
-// retargeting.
-func TestWireCompositionServesDocumentAndResolutionOperations(t *testing.T) {
-	t.Parallel()
+// newWireCompositionRoot constructs an Operator Settings root through the
+// same settingswire composition retargeting this whole test cell exists to
+// protect, seeded with a config file authored on disk. See the package-level
+// exception note above TestWireCompositionServesDocumentAndResolutionOperations
+// for why these tests construct through settingswire directly instead of
+// root.BuildProcess + Process.Execute.
+func newWireCompositionRoot(t *testing.T) (operatorsettings.Service, string) {
+	t.Helper()
 
 	homeDir := t.TempDir()
 	configPath := operatorsettings.DefaultConfigPath(homeDir)
@@ -57,6 +59,31 @@ func TestWireCompositionServesDocumentAndResolutionOperations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServiceFromConfigDocument() error = %v", err)
 	}
+	return root, configPath
+}
+
+// TestWireCompositionServesDocumentAndResolutionOperations exercises published
+// Settings wire surfaces through the functional lane so transitional composition
+// hooks (construct/testlink/testproviders) retain coverage after servicewire/
+// retargeting.
+//
+// backend-review construction-path exception: general-backend-standards.md §7
+// prefers root.BuildProcess + Process.Execute for functional application
+// tests. This cell (and its ACP Agent profile siblings below) construct
+// through settingswire directly instead, for two independent, in-scope
+// reasons: (1) this file's whole purpose, predating the ACP Agent profile
+// work, is proving the Settings wire composition/retargeting seam itself
+// (see the sibling TestWireCompositionFromHomePorts*/TestResolveFromHome*
+// tests in this same file, none of which use root.BuildProcess either); and
+// (2) ACP Agent Profile V0 deliberately adds no CLI/HTTP/MCP transport surface
+// (docs/internal/projects/acp-client/final-proposal.md V0 scope), so no
+// root.BuildProcess-observable command exists that could exercise
+// ResolveACPAgentProfile/UpdateACPAgentProfile at all. This is the only
+// functional-lane coverage available for those two operations pre-transport.
+func TestWireCompositionServesDocumentAndResolutionOperations(t *testing.T) {
+	t.Parallel()
+
+	root, configPath := newWireCompositionRoot(t)
 
 	loaded, err := root.LoadDocument(operatorsettings.LoadDocumentRequest{Path: configPath})
 	if err != nil {
@@ -96,6 +123,15 @@ func TestWireCompositionServesDocumentAndResolutionOperations(t *testing.T) {
 	if updated.Document.Defaults.WorkerModelProvider != "GEMINI" || updated.Document.Defaults.WorkerModel != "gemini-pro" {
 		t.Fatalf("updated defaults = %#v, want GEMINI/gemini-pro", updated.Document.Defaults)
 	}
+}
+
+// TestWireCompositionResolvesDefaultACPAgentProfileWhenAbsent covers
+// ResolveACPAgentProfile through the wire-composed root; see the construction-
+// path exception documented on TestWireCompositionServesDocumentAndResolutionOperations.
+func TestWireCompositionResolvesDefaultACPAgentProfileWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	root, configPath := newWireCompositionRoot(t)
 
 	defaultProfile, err := root.ResolveACPAgentProfile(configPath)
 	if err != nil {
@@ -106,6 +142,17 @@ func TestWireCompositionServesDocumentAndResolutionOperations(t *testing.T) {
 		!reflect.DeepEqual(defaultProfile.AllowedTargets, wantDefaultProfile.AllowedTargets) {
 		t.Fatalf("ResolveACPAgentProfile() = %#v, want safe Factory Builder default %#v", defaultProfile, wantDefaultProfile)
 	}
+}
+
+// TestWireCompositionUpdatesACPAgentProfileAndPreservesSiblingSettings covers
+// UpdateACPAgentProfile through the wire-composed root, including the
+// bidirectional preservation guarantee against an unrelated ApplyDocumentUpdate;
+// see the construction-path exception documented on
+// TestWireCompositionServesDocumentAndResolutionOperations.
+func TestWireCompositionUpdatesACPAgentProfileAndPreservesSiblingSettings(t *testing.T) {
+	t.Parallel()
+
+	root, configPath := newWireCompositionRoot(t)
 
 	authoredProfile := operatorsettings.ACPAgentProfile{
 		DefaultTarget:  "factory:@you/research",
@@ -128,6 +175,8 @@ func TestWireCompositionServesDocumentAndResolutionOperations(t *testing.T) {
 		t.Fatalf("ResolveACPAgentProfile() after update = %#v, want %#v", resolvedProfile, authoredProfile)
 	}
 
+	provider := "gemini"
+	model := "gemini-pro"
 	if updatedAgain, err := root.ApplyDocumentUpdate(operatorsettings.ApplyDocumentUpdateRequest{
 		Path: configPath,
 		ProviderModel: operatorsettings.DocumentProviderModelUpdate{
@@ -143,6 +192,16 @@ func TestWireCompositionServesDocumentAndResolutionOperations(t *testing.T) {
 			updatedAgain.Document.Workers.ACP.AgentProfile,
 		)
 	}
+}
+
+// TestWireCompositionUpdateACPAgentProfileRejectsBlankCandidate covers
+// UpdateACPAgentProfile's validation-before-persistence guarantee through the
+// wire-composed root; see the construction-path exception documented on
+// TestWireCompositionServesDocumentAndResolutionOperations.
+func TestWireCompositionUpdateACPAgentProfileRejectsBlankCandidate(t *testing.T) {
+	t.Parallel()
+
+	root, configPath := newWireCompositionRoot(t)
 
 	if _, err := root.UpdateACPAgentProfile(t.Context(), configPath, operatorsettings.ACPAgentProfile{}); err == nil {
 		t.Fatal("UpdateACPAgentProfile() with blank candidate error = nil, want validation failure")


### PR DESCRIPTION
## Summary

PR #1713 (`ACP-L1-V0-operator-profile`) merged to `main` as `3cce81a5913903c043ba3601b4494e7f1be147d8`. After merge, a blocking review comment was posted on #1713 (https://github.com/portpowered/you-agent-factory/pull/1713#issuecomment-5159626517) identifying four issues. This PR is built on top of latest `main` (which already contains #1713's shipped content) and addresses all four:

1. **Functional-test construction path / size.** `TestWireCompositionServesDocumentAndResolutionOperations` grew to 129 lines (over the 100-line `backend-size` gate) and bypassed `root.BuildProcess` + `Process.Execute`. Split it into four focused functions sharing a `newWireCompositionRoot` helper, each well under the limit, and added an in-code comment documenting why this test cell (pre-dating the ACP work, proving Settings wire composition/retargeting itself) and the new ACP Agent profile assertions specifically construct through `settingswire` directly: ACP Agent Profile V0 deliberately adds no CLI/HTTP/MCP transport surface (see `docs/internal/projects/acp-client/final-proposal.md` V0 scope), so no `root.BuildProcess`-observable command exists that could exercise `ResolveACPAgentProfile`/`UpdateACPAgentProfile` at all.
2. **Missing operation logging.** Added an optional `logging.Logger` dependency to the Operator Settings root `Service`, threaded through all three wire constructors (`NewService`, `NewServiceFromConfigDocument`, `NewServiceFromHomePorts`) as an optional trailing parameter so no existing call site needed updating. `ResolveACPAgentProfile`/`UpdateACPAgentProfile` now emit a start log and a terminal success/failure log, with failures classified into a safe reason string (`profile_invalid`, `document_malformed`, `context_canceled`, etc.) instead of the raw error text, which can embed path/target values. Tests assert the exact log messages and that no log field ever contains the config path or any profile target reference.
3. **Failure/concurrency coverage.** Added root-level tests for `UpdateACPAgentProfile` covering: codec encode failure, temp-file creation failure, and publish/rename failure (each proving the previously persisted document survives untouched), plus a concurrency test that fires 8 concurrent `UpdateACPAgentProfile` calls at the same path and asserts the final persisted profile exactly matches one attempted candidate (never a mixed/partial write).
4. **Ownership-inventory meta-test edits.** Verified these are pre-existing, hand-maintained repo-wide gate tests (`internal/ownershipinventory/operator_settings_root_contract_test.go`, `operator_settings_root_go_test.go`) that predate the ACP work; the diff in #1713 was the required 1-2 line registration of two new root files, not a new meta-test authored by that PR. No further change was needed here.

While implementing the logging fix, `go run ./cmd/pkgboundarycheck` caught a real regression I introduced (direct `time.Now()` calls for duration measurement, which this repo's boundary check forbids outside Wire-constructed leaf adapters) — dropped duration measurement entirely since it's an optional field per the logging standard, not required. Also registered the new `operator_settings -> platform` cross-service edge (from the `logging` import) in the frozen `docs/internal/baselines/ownership-inventory.json`, since `cmd/ownershipinventoryfreeze` can't currently regenerate it end-to-end (pre-existing, unrelated `chat_sessions` inventory drift blocks the full freeze — confirmed identical on a clean `main` checkout).

## Known overlap with PR #1723

**#1723** (`ACP-L1-O01-operator-settings-profile-gaps`, a different PRD) is also open against `main` and independently touches several of the same files (`internal/service/service.go`, `internal/construct/composition.go`, `wire/service_from_config_document.go`, `wire/service_from_home_ports.go`, `wire/wire.go`) to add its own ACP Agent profile logging (a dedicated `ACPAgentProfileLogger` port wired for real in `pkg/wire/profiles.go`/`wire_gen.go`) plus stricter Factory-reference validation. That PR does not touch the functional test file, the failure/concurrency coverage, or the ownership-inventory question this PR addresses. Whichever of #1723 / this PR merges second will need to reconcile the two logging approaches on `internal/service/service.go` — flagging this now so a reviewer/maintainer can decide which logging design to keep rather than have it discovered as a silent merge conflict.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./pkg/services/operator_settings/... ./tests/functional/operator_settings/... ./pkg/wire/...` — all pass
- [x] `make test` (short unit lane) — exit 0, no failures
- [x] `go run ./cmd/backendsizecheck` — 67 violations (down from 68 pre-fix), none in touched files; remaining are pre-existing and out of scope
- [x] `go run ./cmd/pkgboundarycheck` — 94 violations, identical set to clean `main` (confirmed via diff), no new violations
- [x] `make ownership-inventory-check` — `edges` now `true` (was the only newly-failing field after my logging change); remaining `MissingPackages` (`chat_sessions`, `events`, `transports/acp`) confirmed identical on clean `main`, pre-existing and out of scope
- [x] `make logging-boundary-check` — passes