### PR TITLE
Address PR #1724 review: reject trailing JSON content in corpus parser

### DIFF
--- a/internal/testutil/acpconformance/corpus.go
+++ b/internal/testutil/acpconformance/corpus.go
@@ -13,7 +13,9 @@ import (
 	_ "embed"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"strings"
 	"testing"
@@ -198,6 +200,9 @@ func ParseCorpus(data []byte) (Corpus, error) {
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&corpus); err != nil {
 		return Corpus{}, fmt.Errorf("acpconformance: invalid corpus JSON: %w", err)
+	}
+	if err := dec.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
+		return Corpus{}, fmt.Errorf("acpconformance: invalid corpus JSON: trailing content after top-level value")
 	}
 	if corpus.SchemaVersion != supportedSchemaVersion {
 		return Corpus{}, fmt.Errorf("acpconformance: unsupported corpus schema_version %d", corpus.SchemaVersion)

--- a/internal/testutil/acpconformance/corpus_test.go
+++ b/internal/testutil/acpconformance/corpus_test.go
@@ -75,6 +75,19 @@ func TestParseCorpusRejectsInvalidJSON(t *testing.T) {
 	}
 }
 
+func TestParseCorpusRejectsTrailingContent(t *testing.T) {
+	corpus := acpconformance.MustLoad(t)
+	valid := marshalFixture(t, corpus.Provenance, corpus.Cases[:1])
+	trailing := append(append([]byte{}, valid...), []byte("\n{}")...)
+	_, err := acpconformance.ParseCorpus(trailing)
+	if err == nil {
+		t.Fatal("ParseCorpus(valid corpus + trailing JSON value) expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "trailing content") {
+		t.Fatalf("ParseCorpus(trailing content) error = %v, want it to mention trailing content", err)
+	}
+}
+
 func TestParseCorpusRejectsDuplicateCaseID(t *testing.T) {
 	corpus := acpconformance.MustLoad(t)
 	dup := corpus.Cases[0]


### PR DESCRIPTION
Follow-up to PR #1724 (merged as `e5873aeac`), addressing a blocking post-merge review comment on that PR.

## Fix

`internal/testutil/acpconformance/corpus.go`'s `ParseCorpus` decoded only the first top-level JSON value via a single `json.Decoder.Decode` call, so a syntactically valid corpus document followed by a second/trailing JSON value was silently accepted instead of rejected. This violated story 003's requirement that the shared corpus reader reject invalid JSON. Fixed by decoding a second value after the corpus itself and requiring `io.EOF`, plus a new regression test (`TestParseCorpusRejectsTrailingContent`) reproducing the exact case the reviewer found (valid corpus + trailing `{}`).

## Verification

- `go build ./...`, `go vet`, `gofmt -l` clean on the changed package
- `go test ./internal/testutil/acpconformance/... ./pkg/transports/acp/... ./pkg/services/providers/...` all pass
- `make test` (full short Go suite) — zero FAIL lines
- `make vet`, `make pkg-boundary`, `make pkg-file-count`, `make backend-size`, `make deadcode` — zero new violations from this change (grepped for `acpconformance`/`transports/acp`)
- `make pkg-structure` reports one pre-existing violation in `pkg/services/operator_settings/acp_agent_profile.go` unrelated to this branch (present on `origin/main` before this commit, from a separate already-merged PR)

## PRD

```json
{
  "project": "Define the ACP Compatibility Contract and Shared Conformance Corpus",
  "branchName": "ACP-L1-V0-protocol-conformance",
  "description": "Establish the inert ACP protocol-version-1 agent compatibility boundary and a sanitized semantic conformance corpus so independent inbound provider and future outbound agent mappings can prove truthful text-first behavior, request correlation, select-option shape, unsupported-method handling, and an explicit lossless round-trip subset without implementing stdio serving or session execution.",
  "context": {
    "customerAsk": "Define the L1 V0 ACP compatibility contract and shared conformance corpus so the existing inbound provider mapper and a future outbound agent mapper can prove agreement through fixtures while remaining separate implementations. Encode protocol version 1, honest text-first capabilities, config-option type=select, request identity, unsupported-method behavior, and an explicit round-trip subset; complete tests, CI, review resolution, conflict reconciliation, and merge without implementing stdio serving or session execution.",
    "problem": "The provider-side ACP adapter owns inbound SessionUpdate mapping and representative SDK-shaped fixtures, but those fixtures are not a neutral compatibility corpus for the opposite direction, and no top-level agent-side ACP contract exists. The directions can therefore drift on version negotiation, capability claims, select-option union shape, request correlation, unsupported behavior, and lossless mapping claims.",
    "solution": "Publish a small pure pkg/transports/acp compatibility boundary based on acp-go-sdk v0.13.5 and promote sanitized protocol examples into a shared semantic corpus with provenance, typed request correlation, expected facts, unsupported outcomes, directionality, and explicit round-trip eligibility. Keep inbound mapping under Providers and future outbound mapping under the ACP transport, with independent tests consuming the corpus and no shared production mapper.",
    "originalDocument": "C:/Users/andre/work/portos/infinite-you/docs/internal/projects/acp-client/final-proposal.md"
  },
  "acceptanceCriteria": [
    "The inert ACP compatibility boundary accepts protocol version 1, rejects unsupported versions with a typed safe outcome, and exposes no listener, stdio loop, connection lifecycle, session execution, or service-construction side effect.",
    "Advertised capabilities are text-first and exactly match implemented V0 behavior: image, audio, embedded context, filesystem, terminal, authentication, fork, plan, client MCP server, and permission capabilities are absent or disabled, and Factory selection uses a config option with type=select.",
    "Request identity distinguishes equal JSON-RPC IDs on different connections, preserves supported string and numeric ID types without conflation, and uses a transport-minted identity where correlation has no usable wire ID.",
    "Unknown and explicitly deferred methods produce the correlated method-not-found outcome without mutation or external effects, while malformed supported inputs produce typed invalid-request or invalid-params outcomes with sensitive-safe details.",
    "One sanitized provenance-pinned corpus declares representative semantic facts, directionality, unsupported/no-output outcomes, and the exact lossless round-trip subset, and is independently consumable by provider-side and transport-side tests without shared production mapping code.",
    "Quality gate: focused ACP compatibility, corpus, provider-mapping, malformed-input, and zero-side-effect tests pass along with typecheck, lint, make verify-fast, applicable package-boundary checks, and required PR CI; no OpenAPI or generated API artifacts change.",
    "Delivery: the implementation/review loop continues until all blocking PR conversation feedback is explicitly addressed, shared-corpus changes and merge conflicts are reconciled against current main, required CI is terminal and passing, and the PR is actually merged; opening, approval, green CI, or merge readiness alone is not completion."
  ],
  "userStories": [
    {
      "id": "ACP-L1-V0-protocol-conformance-001",
      "title": "Publish an inert and truthful ACP compatibility profile",
      "description": "As a maintainer implementing the later ACP server, I want one deterministic compatibility profile so initialization and Factory selection cannot claim behavior that You has not implemented.",
      "acceptanceCriteria": [
        "The agent-side ACP boundary represents acp-go-sdk v0.13.5 protocol version 1 as the only supported protocol version and returns a typed sensitive-safe incompatibility outcome for any other version.",
        "The compatibility result advertises text prompt content only and leaves image, audio, embedded context, filesystem, terminal, authentication, fork, plan, client MCP server, and permission capabilities disabled or absent as required by the SDK wire shape.",
        "A representative Factory target option serializes and deserializes as the ACP select-option union with type=select, stable id, name, currentValue, and allowed values, without representing the Factory as an ACP model resource.",
        "Constructing, validating, or serializing the profile performs no IO, starts no goroutine or process, binds no endpoint, and creates or invokes no Chat Session or Factory Session.",
        "Focused compatibility tests prove accepted and rejected versions, exact serialized capability claims, and select-option round-trip behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented pkg/transports/acp: SupportedProtocolVersion (=acpsdk.ProtocolVersionNumber), NegotiateProtocolVersion/BuildProfile with typed *CompatibilityError for unsupported versions, TextFirstAgentCapabilities (all non-text capabilities explicitly false/absent), and FactoryTargetOption with ToSessionConfigOption/FactoryTargetOptionFromSessionConfigOption for the type=select union round-trip. Focused tests in compatibility_test.go and factory_target_option_test.go cover accepted/rejected versions, exact serialized capability JSON, and select-option round-trip. go build/vet/test pass; make pkg-structure passes; make pkg-boundary/pkg-file-count/backend-size show only pre-existing baseline violations unrelated to this package."
    },
    {
      "id": "ACP-L1-V0-protocol-conformance-002",
      "title": "Preserve connection-scoped request identity and reject unsupported methods safely",
      "description": "As an ACP client integrator, I want requests correlated without cross-connection collisions and unsupported methods rejected without effects so retries and concurrent clients remain predictable.",
      "acceptanceCriteria": [
        "Request identity pairs a non-empty connection identity with the original supported JSON-RPC string or numeric ID; equal wire IDs from different connections are distinct, and numeric and string IDs with similar printed forms are not conflated.",
        "Notifications or requests without a usable wire ID receive a transport-minted non-empty identity where correlation is required without fabricating a JSON-RPC response ID.",
        "Blank connection identity, invalid JSON-RPC ID shapes, and malformed supported parameters return typed validation outcomes without a partially valid identity or protocol result.",
        "Unknown methods and V0-deferred operations return JSON-RPC method-not-found with the original request ID when one exists, while unknown notifications emit no response.",
        "Unsupported or malformed handling invokes no session, provider, process, filesystem, network, or persistence collaborator and leaks no credential, raw command, unsafe path, prompt content, or internal topology.",
        "Table-driven tests cover connection collisions, string and numeric IDs, missing and malformed IDs, unknown requests and notifications, and observable zero-effect behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented in pkg/transports/acp: request_identity.go adds WireIDKind (string/number/minted), RequestIdentity{ConnectionID, Kind, StringID, NumberID, MintedID} as a plain comparable struct, NewRequestIdentity(connectionID, acpsdk.RequestId) (rejects blank connection id and any id shape other than string/number, including the JSON-RPC null id), and NewMintedRequestIdentity(connectionID, mintedID) for notifications/requests with no usable wire id (rejects blank connection id and blank minted id). Because Kind participates in equality, a numeric id and a string id with the same printed form, and a minted identity and a wire-id identity with the same value, are never conflated; equal wire ids on different connections compare unequal since ConnectionID differs. dispatch.go adds MethodDisposition/ClassifyMethod (deferred vs unknown -- documented as identical on the wire), UnsupportedMethodOutcome/UnsupportedMethodResponse(method, *acpsdk.RequestId) returning a correlated acpsdk.NewMethodNotFound result keyed off the original id, or nil for a notification (nil wireID) so the caller emits no response, and a generic DecodeMethodParams[T](raw) that returns a typed acpsdk.NewInvalidParams outcome (sensitive-safe reason string only, never raw params content) for missing or malformed params. errors.go gains RequestIdentityErrorCode/RequestIdentityError following the repo's existing typed-error convention. All of this is pure/deterministic: no IO, no goroutine/process, no session/provider/process/filesystem/network/persistence collaborator is invoked by any of these functions. Table-driven tests in request_identity_test.go and dispatch_test.go cover connection collisions, string vs numeric id non-conflation, minted vs wire-id non-conflation, blank connection/minted id rejection, invalid wire id shapes (null and zero-value), unknown vs deferred method classification, method-not-found responses for unknown and deferred methods with string and numeric ids, notification zero-response behavior, and missing/malformed params. go build/vet/test and gofmt are clean; make test (full short Go suite) passes including the new cases; make pkg-structure passes; make pkg-boundary/pkg-file-count/backend-size show only pre-existing baseline violations unrelated to pkg/transports/acp. POST-MERGE FIX (PR #1712 review): DecodeMethodParams originally only checked JSON unmarshal success, so a syntactically valid but semantically incomplete supported request (e.g. session/prompt params={} or {\"sessionId\":\"session-1\"}, missing the required prompt field) and a literal JSON null params value both passed through as accepted, contradicting this story acceptance criterion that malformed supported inputs produce typed invalid-request/invalid-params outcomes. Fixed by rejecting literal JSON null (previously only empty/whitespace raw bytes were rejected) and, when the decoded type T implements the acp-go-sdk types own Validate() error method (checked via a new unexported validatable interface asserted on *T), calling it and returning the same sensitive-safe invalid-params outcome (reason: \"invalid params\", never the underlying validation error text) on failure. New tests in dispatch_test.go: TestDecodeMethodParamsRejectsNullParams, TestDecodeMethodParamsRejectsSemanticallyInvalidSupportedRequest (acpsdk.PromptRequest with missing prompt, two payload shapes), TestDecodeMethodParamsAcceptsSemanticallyValidSupportedRequest (control case proving the fix does not reject valid input). Two new corpus cases (malformed-input-null-params, malformed-input-semantically-invalid-supported-request) and a conformance_test.go update route the semantically-invalid case through the real acpsdk.PromptRequest type. go build/vet/test and gofmt clean; make test full suite passes; make vet/pkg-structure clean; make pkg-boundary/pkg-file-count/deadcode/backend-size show zero new violations for pkg/transports/acp. SECOND POST-MERGE FIX (PR #1720 review, landed after squash-merge as fb0cf7f3a): DecodeMethodParams still accepted a syntactically+Validate()-valid but wire-incomplete supported request when a *required scalar* field was omitted (e.g. session/prompt with prompt present but sessionId omitted), because acpsdk.PromptRequest.Validate() only checks Prompt != nil and a required string/number field decodes to the same Go zero value whether its key was present or absent. Fixed by adding requiredStructFieldsPresent(raw, reflect.TypeOf(v)) in pkg/transports/acp/dispatch.go: for struct T, decode raw into map[string]json.RawMessage and require every field whose json tag lacks omitempty to be present as a key; non-struct T (e.g. map[string]any) and non-object raw are unaffected. New tests: TestDecodeMethodParamsRejectsMissingRequiredScalarField, TestDecodeMethodParamsRequiredFieldPresenceIsGeneric, TestDecodeMethodParamsRequiredFieldPresenceSkipsNonRequiredTagShapes, TestDecodeMethodParamsSkipsRequiredFieldCheckForNonObjectPayload. New corpus case malformed-input-missing-required-scalar-field; conformance_test.go routes it (and semantically_invalid_params) through the real acpsdk.PromptRequest type."
    },
    {
      "id": "ACP-L1-V0-protocol-conformance-003",
      "title": "Promote a sanitized semantic ACP conformance corpus",
      "description": "As a transport or provider mapper maintainer, I want one representative semantic corpus so either protocol direction can verify compatibility without depending on the other direction's code.",
      "acceptanceCriteria": [
        "The shared committed corpus covers version-1 initialize negotiation, text-first capabilities, a type=select Factory option, string and numeric request correlation, text prompt content, agent message and thought updates, supported metadata updates, malformed input, and unsupported-method outcomes.",
        "Each case declares its protocol role, expected semantic facts, inbound and outbound support, and lossless round-trip eligibility; every non-subset case explicitly declares inbound-only, outbound-only, unsupported, or intentionally no-output behavior.",
        "The lossless subset contains only facts both directions preserve honestly, including stable item identity where present, text message chunks, text thought chunks, and usage or session-information fields represented by both vocabularies; tool, file-change, plan, progress, run, turn, and other lossy cases are excluded.",
        "Corpus content contains no credentials, customer prompts, machine-specific absolute paths, raw provider commands, or internal topology, and provenance/checksum metadata makes reviewed changes intentional and reproducible.",
        "A reusable test-only reader returns detached cases and rejects invalid JSON, duplicate case identity, missing expectations, undeclared directionality, and round-trip declarations containing known lossy or unsupported shapes.",
        "Corpus validation and SDK marshal/unmarshal tests prove protocol parseability, semantic stability, sanitization invariants, and exact round-trip declarations without testing repository inventories or registration topology.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented the shared, sanitized ACP L1 V0 semantic conformance corpus as a neutral test-only reader at internal/testutil/acpconformance (repo-root internal, importable by both pkg/services/providers tests and pkg/transports/acp tests without either importing the other's internals or a shared production mapper). corpus.json: 19 hand-authored, sanitized cases (schema_version=1, top-level provenance pinned to acp-go-sdk v0.13.5 module/commit/license) covering all 8 required protocol_role values (initialize, capabilities, factory_option, request_identity, prompt_content, session_update, malformed_input, unsupported_method) and all 5 directionality values (round_trip, inbound_only, outbound_only, unsupported, no_output). The round_trip subset is exactly the 4 lossless kinds (message/agent_message_chunk, reasoning/agent_thought_chunk, usage/usage_update, session/session_info_update); tool_call and plan cases are present and explicitly declared inbound_only to prove lossy kinds are excluded from round-trip. corpus.go: Directionality/ProtocolRole enums, Facts/Case/SourceProvenance/Corpus types, ParseCorpus (rejects invalid JSON, incomplete/missing provenance, no cases, empty/duplicate case id, unknown protocol_role, undeclared/unknown directionality, invalid/empty payload JSON, missing Facts.Kind, missing case provenance, and round_trip declared for a non-lossless Facts.Kind), Load/MustLoad (go:embed corpus.json), and detached-copy accessors ByRole/ByDirectionality/RoundTripCases. corpus_test.go has 32 tests: structural validation positive+negative cases (including a synthetic minimal fixture via ParseCorpus to prove it is a general reusable reader, not just embedded-corpus-specific), detachment (MustLoad results don't alias each other), full protocol-role and directionality coverage checks, round-trip-subset kind allowlist checks, and 'SDK marshal/unmarshal' parseability tests that decode every case's payload into the real pinned acp-go-sdk v0.13.5 types (SessionUpdate, InitializeRequest, AgentCapabilities, SessionConfigOption, PromptRequest, RequestId) to prove protocol parseability and that declared facts are actually derivable from the payload (not merely asserted independently), plus a sanitization-invariant test scanning case content for forbidden credential/path terms. Deliberately did NOT import pkg/transports/acp from this package/tests -- keeps story 003 scoped to the corpus+reader only; wiring corpus cases through the real acp.NegotiateProtocolVersion/TextFirstAgentCapabilities/FactoryTargetOption and the Providers-owned mapSessionUpdate is story 004's explicit scope. go build/vet/test and gofmt are clean; make test (full short Go suite) passes including the new package; make vet, make pkg-structure pass; make pkg-boundary/pkg-file-count/backend-size/deadcode show only pre-existing baseline violations elsewhere in the repo (grepped output for acpconformance/transports/acp -- no matches). POST-MERGE FIX (PR #1712 review): the corpus declared source provenance (SDK module/version/commit/license) but no checksum over the case content itself, so an edit to cases.json could silently drift from what was reviewed, contradicting this story acceptance criterion that provenance/checksum metadata make reviewed changes intentional and reproducible. Fixed by adding a top-level cases_checksum field (hex SHA-256 over the deterministic JSON encoding of the cases array, computed by a new exported acpconformance.ChecksumCases(cases) function that never includes itself) and having ParseCorpus recompute and reject on any missing or mismatched checksum, forcing an explicit, matching update whenever case content changes. Added TestParseCorpusRejectsMissingChecksum, TestParseCorpusRejectsMismatchedChecksum, TestChecksumCasesIsDeterministicAndContentSensitive, and TestEmbeddedCorpusChecksumIsSelfConsistent; refactored the existing negative-fixture tests in corpus_test.go onto a shared marshalFixture helper so every ParseCorpus fixture carries a correct, independently-computed checksum unless a test deliberately corrupts it. go build/vet/test and gofmt clean; make test full suite passes; make vet/pkg-structure clean; make pkg-boundary/pkg-file-count/deadcode/backend-size show zero new violations for internal/testutil/acpconformance. SECOND POST-MERGE FIX (PR #1720 review, landed after squash-merge as fb0cf7f3a): cases_checksum was computed over the *typed* []Case value after json.Unmarshal, so an unrecognized field added to a case raw JSON object was silently dropped before hashing, leaving a stale checksum valid despite changed committed content. Fixed by decoding the corpus with a json.Decoder configured with DisallowUnknownFields() in internal/testutil/acpconformance/corpus.go ParseCorpus, so any unrecognized field outside a case free-form Payload now fails the parse outright instead of being silently dropped. New test TestParseCorpusRejectsUnknownCaseField proves a case with an added unknown field is rejected even when cases_checksum is exactly what ChecksumCases would compute over the field-stripped typed value (the precise loophole the reviewer found). Recomputed and updated the embedded corpus cases_checksum for the added case in story 002."
    },
    {
      "id": "ACP-L1-V0-protocol-conformance-004",
      "title": "Bind independent protocol directions through conformance evidence",
      "description": "As a reviewer, I want the existing inbound provider mapper and the agent-side compatibility boundary checked independently against the same cases so agreement is proven without an illegal dependency or shared mapping implementation.",
      "acceptanceCriteria": [
        "Provider-side tests feed every inbound-supported corpus case through the existing provider-owned ACP mapper and compare observable normalized progress and text facts with the case expectations.",
        "Agent-transport tests independently verify all V0 compatibility, outbound-shape, unsupported, and round-trip declarations without importing Providers internals or calling the inbound mapper.",
        "For each declared round-trip case, independent encode/decode assertions preserve declared semantic facts and request or item identity while allowing irrelevant JSON formatting and field-order differences.",
        "Every representative ACP update kind has an explicit corpus disposition; a newly represented kind cannot be silently dropped or falsely treated as round-trippable.",
        "Provider-owned inbound mapping remains under Providers and the future outbound boundary remains under the ACP transport; no neutral production mapper, cross-internal import, service-to-transport dependency, or shared production mapping helper is introduced.",
        "Focused provider and transport conformance tests pass without starting an ACP subprocess, stdio server, Chat Session, or Factory execution.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Implemented independent conformance tests binding both protocol directions to the shared corpus without a shared production mapper. pkg/transports/acp/conformance_test.go (package acp_test) feeds every corpus case by protocol_role through the real transport functions -- NegotiateProtocolVersion (initialize), TextFirstAgentCapabilities (capabilities, exact serialized-shape match), FactoryTargetOptionFromSessionConfigOption/ToSessionConfigOption (factory_option, structural round-trip), NewRequestIdentity/NewMintedRequestIdentity (request_identity), DecodeMethodParams (malformed_input invalid_params) plus a direct acpsdk.RequestId decode failure (malformed_input invalid_request), and ClassifyMethod/UnsupportedMethodResponse (unsupported_method) -- and independently proves the round_trip session_update subset survives an encode/decode cycle through the pinned SDK type, all without importing Providers or calling the inbound mapper. pkg/services/providers/internal/services/acp/internal/service/conformance_test.go (package service, white-box) feeds every inbound-supported (round_trip or inbound_only) session_update corpus case through the real client.SessionUpdate callback (which wraps the private mapSessionUpdate) and asserts the observable normalized progress (kind/item_id/phase/detail/metadata) and accumulated text match the case Facts, independently of pkg/transports/acp. go build/go vet/gofmt/go test -v pass on both new test files; make test (full short Go suite, all packages) passes; make vet and make pkg-structure are clean; make pkg-boundary/pkg-file-count/deadcode/backend-size grepped for acpconformance/transports/acp/services/acp -- zero matches, i.e. this story added zero new violations (all reported violations are the pre-existing repo-wide baseline, same as story 003). make verify-fast fails only at the pre-existing, unrelated dashboard bun/tsc typecheck step (missing bun type definitions in this environment); this is a backend-only change and does not touch ui/."
    }
  ]
}
```