### PR TITLE
Reconcile Models/ACP ownership-inventory gate on current main (ACP-P0-MODELS-INVENTORY-CORRECTION-02)

### DIFF
--- a/pkg/services/models/transports/cli/root_parity_test.go
+++ b/pkg/services/models/transports/cli/root_parity_test.go
@@ -304,6 +304,67 @@ func TestRootAdapter_InvokeClosesRuntimeScopeAfterSuccess(t *testing.T) {
 	}
 }
 
+func TestRootAdapter_PullThroughAlreadyClosedScopeReturnsPublicClosedScopeErrorWithoutInvokingModelsRoot(t *testing.T) {
+	t.Parallel()
+
+	service := modelscli.NewService(modelscli.Config{
+		Models: stubModelsRoot{
+			pullModel: func(context.Context, string) (modelinference.PullResult, error) {
+				t.Fatal("PullModelForScope() called through an already-closed Models runtime scope")
+				return modelinference.PullResult{}, nil
+			},
+		},
+		OpenCatalogScope: func(context.Context) (modelscli.InvokeRuntimeScope, error) {
+			return modelscli.InvokeRuntimeScope{}, modelinference.ErrRuntimeScopeClosed
+		},
+	})
+
+	var out bytes.Buffer
+	err := service.Pull(modelscli.PullConfig{
+		Context: context.Background(), ModelName: "OMNIVOICE_Q4_K_M", Output: &out,
+	})
+	if !errors.Is(err, modelinference.ErrRuntimeScopeClosed) {
+		t.Fatalf("Pull() through a closed scope error = %v, want errors.Is match for ErrRuntimeScopeClosed", err)
+	}
+}
+
+func TestRootAdapter_InvokeThroughAlreadyClosedScopeReturnsPublicClosedScopeErrorWithoutInvokingModelsRoot(t *testing.T) {
+	t.Parallel()
+
+	service := modelscli.NewService(modelscli.Config{
+		Models: stubModelsRoot{
+			getCatalogModel: func(context.Context, modelinference.GetModelRequest) (modelinference.GetModelResult, error) {
+				t.Fatal("GetCatalogModel() called through an already-closed Models runtime scope")
+				return modelinference.GetModelResult{}, nil
+			},
+			acquireModelLease: func(context.Context, modelinference.AcquireModelLeaseRequest) (modelinference.AcquireModelLeaseResult, error) {
+				t.Fatal("AcquireModelLease() called through an already-closed Models runtime scope")
+				return modelinference.AcquireModelLeaseResult{}, nil
+			},
+			invokeModelWithLease: func(context.Context, modelinference.InvokeModelRequest) (modelinference.InvokeModelResult, error) {
+				t.Fatal("InvokeModelWithLease() called through an already-closed Models runtime scope")
+				return modelinference.InvokeModelResult{}, nil
+			},
+		},
+		OpenInvokeScope: func(context.Context, modelscli.InvokeConfig) (modelscli.InvokeRuntimeScope, error) {
+			return modelscli.InvokeRuntimeScope{}, modelinference.ErrRuntimeScopeClosed
+		},
+	})
+
+	var out bytes.Buffer
+	err := service.Invoke(modelscli.InvokeConfig{
+		Context:   context.Background(),
+		ModelName: "OMNIVOICE_Q4_K_M",
+		Operation: "TTS",
+		Text:      "hello world",
+		JSON:      true,
+		Output:    &out,
+	})
+	if !errors.Is(err, modelinference.ErrRuntimeScopeClosed) {
+		t.Fatalf("Invoke() through a closed scope error = %v, want errors.Is match for ErrRuntimeScopeClosed", err)
+	}
+}
+
 func TestRootAdapter_InvokeJSONResolvesThroughModelsRootCatalogAndInference(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
{
  "project": "Close the Remaining Models Inventory Gate Findings",
  "branchName": "ACP-P0-MODELS-INVENTORY-CORRECTION-02",
  "description": "Deliver one narrow Phase 0 correction from the then-current main baseline that reconciles every authoritative Models root-contract inventory, classification, and frozen ownership artifact around the retained presentation_port.go contract, while preserving the real Pull and Invoke scope-close behavior and closing the remaining PR #1705 audit findings.",
  "context": {
    "customerAsk": "Close the remaining Models inventory findings identified by the latest blocking audit on merged PR #1705: reconcile the inventories and regenerated ownership freeze on current main, retain public-boundary Pull/Invoke scope-close evidence as the behavioral proof, pass required verification, merge the correction, and add newer PR #1705 review evidence that explicitly clears every remaining finding.",
    "problem": "On remote main commit 7adccde7a056ac371e26d3e8dcaded8875137216, the complete focused command still failed because the committed Models root-contract views did not consistently include or classify presentation_port.go and the frozen ownership evidence did not match current mappings. PR #1711 supplied acceptable behavioral scope-close coverage, but the later PR #1705 audit remained blocked on ownership-freeze parity, the distinction between structural and behavioral evidence, and lint or an explicit waiver.",
    "solution": "Reconcile all existing authoritative Models root inventories and mappings around exactly one thin_root_retain classification for presentation_port.go, regenerate the canonical ownership freeze deterministically and prove idempotence, keep inventory checks categorized as structural gates, preserve public Models Pull and Invoke closed-scope scenarios as the product-behavior evidence, and complete review, CI, merge, and the newer PR #1705 clearing comment without broadening the diff."
  },
  "acceptanceCriteria": [
    "On the then-current main baseline, go test ./internal/ownershipinventory ./cmd/packagetargetmanifestcheck -count=1 is terminal and passing, including frozen-inventory parity and both Models root-contract verifiers.",
    "presentation_port.go appears exactly once with the thin_root_retain classification in every authoritative Models inventory or mapping, canonical regenerated frozen evidence agrees byte-for-byte with the committed mappings, and regenerating it again produces no diff.",
    "The accepted product-behavior evidence directly exercises Pull and Invoke through the Models public boundary after scope close; source scanning, file inventories, classifier topology, and similar meta assertions are represented only as structural gates, never as product behavior.",
    "The corrective diff contains no ACP feature work, Models behavior or cleanup, package restructuring, public or generated contract churn, or unrelated repository-wide lint remediation.",
    "Typecheck, make test, the focused tests, and required CI are terminal and passing. make lint is terminal and passing, or every remaining finding is unchanged out-of-scope backend-size debt covered by an explicit reviewer-approved waiver recorded for this work item; lint is not reported as green when it is not.",
    "The implementation/review loop continues until all blocking PR conversation feedback is explicitly addressed, conflicts are reconciled against current main, required CI is terminal and passing, and the corrective PR is merged. After merge, a newer comment on PR #1705 references the corrective merge and explicitly clears the ownership-freeze, behavioral-evidence, and lint/waiver findings; an opened, green, approved, or merge-ready PR is not completion."
  ],
  "userStories": [
    {
      "id": "ACP-P0-MODELS-INVENTORY-CORRECTION-02-001",
      "title": "Restore Models inventory and freeze parity",
      "description": "As a repository maintainer, I want every existing Models inventory gate and frozen artifact to agree on the intentional presentation contract so the complete structural gate succeeds deterministically on current main.",
      "acceptanceCriteria": [
        "Running go test ./internal/ownershipinventory ./cmd/packagetargetmanifestcheck -count=1 exits successfully and proves both Models verifiers plus frozen-inventory parity; passing only a filtered subset is insufficient.",
        "Every authoritative Models inventory or mapping contains one and only one presentation_port.go entry, classified as thin_root_retain, with no missing, duplicate, unexpected, or unclassified live Models root contract.",
        "The canonical ownership-freeze workflow is run from the current baseline, the committed frozen evidence matches the current mappings byte-for-byte, and running the workflow a second time leaves the worktree unchanged.",
        "Existing drift detection remains active: the correction updates the intended retained classification and evidence without skipping, weakening, or replacing either verifier.",
        "The Models CLI package that owns the retained presentation_port.go contract (pkg/services/models/transports/cli) is proved behaviorally live, not just structurally inventoried: it is exercised by observable public-boundary Pull/Invoke behavioral coverage (see story 002), including the closed-scope outcome.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "go test ./internal/ownershipinventory ./cmd/packagetargetmanifestcheck -count=1 passes on current main plus this diff. presentation_port.go is classified exactly once as thin_root_retain in every authoritative Models inventory/mapping (was already fixed by prior PR #1705/#1711). The focused command's remaining failures on current main were unrelated drift from later-merged ACP packages (chat_sessions, events, transports/acp) and a stale operator_settings root-file mirror in cmd/packagetargetmanifestcheck; both reconciled. Regenerating both frozen artifacts twice produces no diff (idempotent). Neither verifier was skipped or weakened. PR #1722 (https://github.com/portpowered/you-agent-factory/pull/1722) was opened, rebased onto latest main after one unrelated upstream commit landed, CI went green after retrying a pre-existing flaky functional-test lane (unrelated to this diff, confirmed also flaky on main's own prior CI run), and merged via squash (commit b9c081e34fc8d0775d47fa5af7ed3b7ba4a0bbe1). A newer clearing comment was posted on PR #1705 (https://github.com/portpowered/you-agent-factory/pull/1705#issuecomment-5159846078) explicitly closing the ownership-freeze, behavioral-evidence, and lint/waiver findings. A subsequent post-merge review on PR #1722 (2026-08-02) found this story's criteria were all structural/compile and lacked an observable outcome; a behavioral criterion was added here pointing at the same closed-scope Pull/Invoke coverage delivered under story 002, which lives in the exact package (pkg/services/models/transports/cli) that owns the retained presentation_port.go classification this story reconciles."
    },
    {
      "id": "ACP-P0-MODELS-INVENTORY-CORRECTION-02-002",
      "title": "Preserve real Models scope-close behavior evidence",
      "description": "As a reviewer, I want the correction to retain direct public-boundary proof for Pull and Invoke after scope close so structural inventory assertions are not mistaken for product behavior.",
      "acceptanceCriteria": [
        "Existing public Models boundary scenarios demonstrate that Pull and Invoke cannot continue through a closed runtime scope and return the expected public closed-scope outcome without relying on filesystem or source-topology observations.",
        "Pull and Invoke scope-close behavioral tests remain terminal and passing after the inventory and freeze correction.",
        "Inventory enumeration, root-file classification, and frozen-artifact parity checks are described and reviewed only as structural quality gates, not as behavioral acceptance evidence.",
        "The implementation diff introduces no ACP behavior, Models cleanup, service or package restructuring, API or generated-contract change, or unrelated lint remediation.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "A 2026-08-02 post-merge review on PR #1722 found the previously-cited TestRootAdapter_PullClosesCatalogScopeAfterSuccess/TestRootAdapter_InvokeClosesRuntimeScopeAfterSuccess tests only prove a successful call closes its scope afterward; they do not prove Pull/Invoke against an ALREADY-closed scope returns the public closed-scope outcome. Added two new tests to pkg/services/models/transports/cli/root_parity_test.go: TestRootAdapter_PullThroughAlreadyClosedScopeReturnsPublicClosedScopeErrorWithoutInvokingModelsRoot and TestRootAdapter_InvokeThroughAlreadyClosedScopeReturnsPublicClosedScopeErrorWithoutInvokingModelsRoot. Each simulates an already-closed scope by having OpenCatalogScope/OpenInvokeScope return models.ErrRuntimeScopeClosed (the real error the Models runtime factory returns for reuse of a closed scope, per pkg/services/models/runtime_config_contract.go and internal/service/runtime_factory.go), asserts service.Pull()/service.Invoke() propagate that error via errors.Is against the public modelinference.ErrRuntimeScopeClosed sentinel (mapModelsRootError's default case returns the error unwrapped, preserving errors.Is), and asserts the underlying model-root stub functions (PullModelForScope, GetCatalogModel, AcquireModelLease, InvokeModelWithLease) are never invoked (each calls t.Fatal if reached), proving no downstream work continues. Both new tests pass; the existing close-after-success tests are unchanged and still pass; go build ./... and go test ./pkg/services/models/... -count=1 are clean. Inventory/freeze changes remain structural gates only (internal/ownershipinventory, cmd/packagetargetmanifestcheck, docs/internal/baselines and docs/internal/packaged-service-structure JSON, plus this one CLI test file). No ACP behavior, Models cleanup, package restructuring, or public/generated contract file was changed."
    }
  ]
}
