### PR TITLE
ACP-L1-E01-events-contracts

### DIFF
--- a/pkg/services/events/read_subscribe.go
+++ b/pkg/services/events/read_subscribe.go
@@ -100,7 +100,12 @@ type ReadResult struct {
 // no aggregate position is silently skipped), to stay within Retained, and
 // Next to name exactly the last delivered Record's position; AtHead
 // requires Next to name exactly the Retained head, since being at head
-// means there is nothing to advance past.
+// means there is nothing to advance past. ReadOutcomeInvalidCursor and
+// ReadOutcomeGap carry no resume/retention state of their own: Next and
+// Retained must be their zero values, since an invalid cursor names no
+// resolvable position and a gap's resumable position is already carried by
+// Gap; a leftover Next or Retained on either outcome would let a caller
+// observe two contradictory resume states for the same read.
 func (res ReadResult) Validate() error {
 	switch res.Outcome {
 	case ReadOutcomeProgress:
@@ -145,12 +150,18 @@ func (res ReadResult) Validate() error {
 		if len(res.Records) != 0 || res.Gap != nil {
 			return ErrInconsistentReadOutcome
 		}
+		if res.Next != (Cursor{}) || res.Retained != (RetainedRange{}) {
+			return ErrInconsistentReadOutcome
+		}
 	case ReadOutcomeGap:
 		if len(res.Records) != 0 || res.Gap == nil {
 			return ErrInconsistentReadOutcome
 		}
 		if err := res.Gap.Validate(); err != nil {
 			return err
+		}
+		if res.Next != (Cursor{}) || res.Retained != (RetainedRange{}) {
+			return ErrInconsistentReadOutcome
 		}
 	default:
 		return ErrInconsistentReadOutcome

--- a/pkg/services/events/read_subscribe_test.go
+++ b/pkg/services/events/read_subscribe_test.go
@@ -215,6 +215,16 @@ func TestReadResultValidate(t *testing.T) {
 			ReadResult{Outcome: ReadOutcomeInvalidCursor, Records: []Record{rec1}},
 			ErrInconsistentReadOutcome,
 		},
+		{
+			"invalid cursor with a leftover Next cursor is inconsistent",
+			ReadResult{Outcome: ReadOutcomeInvalidCursor, Next: next, Retained: retained},
+			ErrInconsistentReadOutcome,
+		},
+		{
+			"invalid cursor with a leftover Retained range is inconsistent",
+			ReadResult{Outcome: ReadOutcomeInvalidCursor, Retained: retained},
+			ErrInconsistentReadOutcome,
+		},
 		{"gap with gap facts", ReadResult{Outcome: ReadOutcomeGap, Gap: gap}, nil},
 		{"gap without gap facts is inconsistent", ReadResult{Outcome: ReadOutcomeGap}, ErrInconsistentReadOutcome},
 		{"gap with fabricated records is inconsistent", ReadResult{Outcome: ReadOutcomeGap, Gap: gap, Records: []Record{rec1}}, ErrInconsistentReadOutcome},
@@ -222,6 +232,16 @@ func TestReadResultValidate(t *testing.T) {
 			"gap with malformed gap facts is inconsistent",
 			ReadResult{Outcome: ReadOutcomeGap, Gap: &GapFacts{Topic: testTopic}},
 			ErrInvalidGapFacts,
+		},
+		{
+			"gap with an unrelated leftover Next cursor is inconsistent",
+			ReadResult{Outcome: ReadOutcomeGap, Gap: gap, Next: Cursor{Topic: testTopic, Position: 1}, Retained: retained},
+			ErrInconsistentReadOutcome,
+		},
+		{
+			"gap with an unrelated leftover Retained range is inconsistent",
+			ReadResult{Outcome: ReadOutcomeGap, Gap: gap, Retained: retained},
+			ErrInconsistentReadOutcome,
 		},
 		{"unspecified outcome is inconsistent", ReadResult{}, ErrInconsistentReadOutcome},
 	}


### PR DESCRIPTION
{
  "project": "Publish the In-Memory Events Stream Contract",
  "branchName": "ACP-L1-E01-events-contracts",
  "description": "Publish the L1 V0 contract-only public root for a process-local Events stream. The concrete change adds detached topic, source, record, cursor, retention, gap, append, source-attachment, read, subscribe, and delivery contracts around source-native JSON. The intent is to give ACP Core and later Worker Events one stable session-scoped boundary while Recordings remains the canonical durable ledger and Events introduces neither persistence nor a second event taxonomy.",
  "context": {
    "customerAsk": "Implement L1 V0 Events contracts under decisions D1 and D2 in pkg/services/events: expose one public Events Service with AppendRequest, AttachSourceRequest, ReadRequest, SubscribeRequest, detached topic/source/cursor/retention/gap/subscription values, source-native JSON payload handling, and explicit cursor and gap outcomes. Do not change OpenAPI or ACP projections, add an internal/store package or durable journal, replace Recordings, create a normalized event taxonomy, or implement the V2 runtime.",
    "problem": "ACP Core and later Worker Events need one stable session-scoped stream boundary for append, source attachment, retained reads, and subscriptions. Without it, consumers will invent incompatible topic/source identities, couple to Factory Session internals, silently mistake expired history for empty success, or create competing event taxonomies and persistence ownership.",
    "solution": "Add a small public Go package root with detached value contracts, deterministic validation, typed/classifiable errors and expected outcomes, and one Service interface containing Append, AttachSource, Read, and Subscribe. Preserve source-native JSON inside delivery envelopes, bind cursors to stream identity, and make retention gaps and delivery termination explicit. Prove the contract with focused table-driven and external-consumer tests while deferring all mutable state, persistence, sequencing, retention, subscription implementation, construction, and transport work."
  },
  "acceptanceCriteria": [
    "AC-1: pkg/services/events exposes one public Service with detached append, attach-source, read, and subscribe request/result values usable without importing an implementation, transport, or another service's private packages.",
    "AC-2: Topic, source, record, sequence, cursor, retention, and idempotency identities have deterministic validation and documented zero-value semantics, and source-native JSON crosses the contract without conversion to an Events-owned taxonomy.",
    "AC-3: Reads and subscriptions explicitly distinguish successful progress, at-head, invalid or mismatched cursors, retention gaps, and terminal delivery outcomes so callers never infer missing history from empty success or parse error strings.",
    "AC-4: The slice preserves D1/D2 ownership: Recordings remains the canonical durable ledger, Events is process-local and in-memory only, and no implementation, store package, durable journal, recordings migration, OpenAPI/ACP projection, or unrelated cleanup is added.",
    "AC-5: Focused table-driven tests cover validation, detached payload behavior, error classification, and cursor/gap outcomes, and an external-package consumer test provides package-boundary evidence without meta-tests.",
    "AC-6: Quality gates pass: Typecheck, lint, focused Go tests, make pkg-file-count, and make pkg-boundary.",
    "AC-7: The implementation/review loop continues until required CI is terminal and passing, every blocking PR conversation is explicitly addressed, merge conflicts and shared-file changes are reconciled, and the PR is actually merged; an opened, green, approved, or ready-to-merge PR is not complete."
  ],
  "userStories": [
    {
      "id": "ACP-L1-E01-events-contracts-001",
      "title": "Identify topics, sources, and stream positions",
      "description": "As an Events producer or consumer, I need stable detached identities and positions so that I can name a session-scoped stream and its source without depending on storage or transport details.",
      "acceptanceCriteria": [
        "Public values represent topic identity, source type and ID, source sequence and event ID, schema identity, aggregate sequence, cursor, and retained range/head positions needed by append, attachment, read, and subscribe operations.",
        "Topic and source identities can represent factory-session/<id>/response-events and chat-session/<id>/events without hard-coding those topic families as the only valid future topics.",
        "Validation deterministically rejects empty, malformed, zero, or internally inconsistent identities and positions where they cannot name a valid operation; valid values remain detached from transport and persistence types.",
        "Cursor values carry enough topic/stream identity to reject use against a different stream rather than accidentally reading from the wrong topic.",
        "Table-driven tests prove valid and invalid identity, sequence, cursor, and retained-position cases through public behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented in pkg/services/events/identity.go and cursor.go: Topic, SourceType, SourceID, SourceSequence, SourceEventID, SchemaID, AggregateSequence, RecordID, Cursor, RetainedRange with Validate()/ValidateAssigned()/BelongsTo(). Covered by identity_test.go and cursor_test.go."
    },
    {
      "id": "ACP-L1-E01-events-contracts-002",
      "title": "Append source-native records idempotently",
      "description": "As an event producer, I need an append envelope that preserves my native JSON and source identity so that retries can be recognized without redefining my event vocabulary.",
      "acceptanceCriteria": [
        "AppendRequest identifies the destination topic, source type and ID, source sequence, source event ID, schema ID, and source-native JSON payload; (sourceType, sourceID, sourceSequence, sourceEventID) is the explicit idempotency identity.",
        "The public record and append result preserve source metadata and distinguish a newly accepted append from a duplicate/idempotent append while reporting the stable aggregate record identity assigned in either case.",
        "Validation rejects missing identity fields, invalid sequences, empty or invalid JSON payloads, and inconsistent envelopes with typed/classifiable invalid-request outcomes rather than error-string matching.",
        "Requests and returned records defensively detach payload bytes so caller mutation cannot alter the value observed across the public contract; tests use representative source-native Worker payload JSON without interpreting it as an Events-owned kind union.",
        "Table-driven tests prove valid envelopes, every required-field failure, invalid JSON handling, append outcome values, error classification, and payload detachment.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented in pkg/services/events/append.go: AppendRequest/Record/AppendResult/AppendOutcome/AppendIdentity with Validate(), Identity(), and Detached() (defensive payload copy). Covered by append_test.go."
    },
    {
      "id": "ACP-L1-E01-events-contracts-003",
      "title": "Attach a source without embedding dependencies",
      "description": "As an aggregate-stream owner, I need to describe a source attachment so that a later in-memory sequencer can follow a source from an explicit position without receiving a service, callback, or store handle.",
      "acceptanceCriteria": [
        "AttachSourceRequest uses detached identities to name the destination topic, source topic/source identity, and explicit starting or correlation cursor required for later sequencing.",
        "Attachment results distinguish a newly accepted attachment from an already-attached/idempotent outcome and return stable attachment/source correlation values suitable for callers to retain.",
        "Validation rejects self-attachment, missing or incompatible source/destination identities, invalid starting positions, and unsupported attachment modes with typed/classifiable outcomes.",
        "The attachment contract contains no embedded service, resolver, callback, channel, store, transport, or dependency bag and makes no claim that historical source data is durable.",
        "Table-driven tests prove valid attachment shapes, idempotent outcome values, failure classification, and incompatible/self-attachment cases.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented in pkg/services/events/attach.go: AttachSourceRequest/AttachSourceResult/AttachmentID/AttachMode/AttachOutcome with Validate() rejecting self-attachment, incompatible cursor topic, and unsupported modes. Covered by attach_test.go."
    },
    {
      "id": "ACP-L1-E01-events-contracts-004",
      "title": "Read and subscribe with explicit cursor and gap outcomes",
      "description": "As an event-stream consumer, I need reads and subscriptions to state whether I advanced, reached the live head, used an invalid cursor, or lost data to retention so that I never fabricate continuity.",
      "acceptanceCriteria": [
        "One public Service exposes Append, AttachSource, Read, and Subscribe with context.Context and detached typed request/result contracts; no second operational service or package-level operational API is introduced.",
        "ReadRequest and ReadResult represent a topic-bound starting cursor, bounded reads, returned records, next cursor, retained range/live head, and explicit progress, at-head, invalid-cursor, and retention-gap outcomes.",
        "SubscribeRequest represents the same cursor and bounded-delivery semantics needed for retained-then-live consumption, and the returned subscription/delivery contract reports records, cursor advancement, gaps, normal close, context cancellation, and slow-consumer/backpressure termination without silent loss.",
        "Gap values identify the requested position and the earliest retained/resumable position, and stream head where known, enabling a caller to surface or recover from loss without fabricated records or string parsing.",
        "Read/subscribe validation and typed errors distinguish malformed requests, unknown or mismatched topics/cursors, unsupported modes, and operation failures from expected at-head/gap/terminal outcomes.",
        "External-package compile-time consumer tests prove a fake can implement the root Service and consume the subscription contract using only exported detached values; table-driven tests prove read, cursor, gap, and terminal-delivery outcome semantics without scanning source topology.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Implemented in pkg/services/events/read_subscribe.go and service.go: ReadRequest/ReadResult/ReadOutcome/GapFacts, SubscribeRequest/Delivery/DeliveryKind/Subscription (function-type, mirrors recordings.EventSubscription), and the single Service interface. Covered by read_subscribe_test.go and the external-package events_external_test.go (package events_test)."
    }
  ]
}
