### PR TITLE
ACP-P0-MODELS-INVENTORY-CORRECTION-02: Reconcile Models inventory gate + real closed-scope evidence

### DIFF
--- a/pkg/services/models/transports/cli/root_parity_test.go
+++ b/pkg/services/models/transports/cli/root_parity_test.go
@@ -5,16 +5,109 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	modelinference "github.com/portpowered/infinite-you/pkg/services/models"
 	modelscli "github.com/portpowered/infinite-you/pkg/services/models/transports/cli"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 )
+
+// scopeLifecycleModelsRoot is a Models-root fixture that tracks real
+// OpenRuntimeScope/CloseRuntimeScope lifecycle state, so a scope closed
+// through this fixture is classified as closed by the same public boundary
+// operations Pull/Invoke call (PullModelForScope, GetCatalogModel), not by an
+// opener stub returning the sentinel directly.
+type scopeLifecycleModelsRoot struct {
+	stubModelsRoot
+
+	mu           sync.Mutex
+	nextScope    int
+	closedScopes map[string]bool
+
+	pullCalls            int
+	getCatalogModelCalls int
+	acquireLeaseCalls    int
+	invokeCalls          int
+}
+
+func (root *scopeLifecycleModelsRoot) OpenRuntimeScope(
+	context.Context, modelinference.OpenRuntimeScopeRequest,
+) (modelinference.OpenRuntimeScopeResult, error) {
+	root.mu.Lock()
+	defer root.mu.Unlock()
+	root.nextScope++
+	scope, err := (modelinference.RuntimeScopeRef{}).Parse(fmt.Sprintf("scope-lifecycle:%d", root.nextScope))
+	if err != nil {
+		return modelinference.OpenRuntimeScopeResult{}, err
+	}
+	return modelinference.OpenRuntimeScopeResult{Scope: scope}, nil
+}
+
+func (root *scopeLifecycleModelsRoot) CloseRuntimeScope(
+	_ context.Context, request modelinference.CloseRuntimeScopeRequest,
+) (modelinference.CloseRuntimeScopeResult, error) {
+	root.mu.Lock()
+	defer root.mu.Unlock()
+	if root.closedScopes == nil {
+		root.closedScopes = map[string]bool{}
+	}
+	root.closedScopes[request.Scope.String()] = true
+	return modelinference.CloseRuntimeScopeResult{Scope: request.Scope, Closed: true}, nil
+}
+
+func (root *scopeLifecycleModelsRoot) isClosed(scope modelinference.RuntimeScopeRef) bool {
+	root.mu.Lock()
+	defer root.mu.Unlock()
+	return root.closedScopes[scope.String()]
+}
+
+func (root *scopeLifecycleModelsRoot) PullModelForScope(
+	_ context.Context, request modelinference.PullModelRequest,
+) (modelinference.PullResult, error) {
+	root.mu.Lock()
+	root.pullCalls++
+	root.mu.Unlock()
+	if root.isClosed(request.Scope) {
+		return modelinference.PullResult{}, modelinference.ErrRuntimeScopeClosed
+	}
+	return modelinference.PullResult{ModelName: request.Name, Outcome: "PULLED"}, nil
+}
+
+func (root *scopeLifecycleModelsRoot) GetCatalogModel(
+	_ context.Context, request modelinference.GetModelRequest,
+) (modelinference.GetModelResult, error) {
+	root.mu.Lock()
+	root.getCatalogModelCalls++
+	root.mu.Unlock()
+	if root.isClosed(request.Scope) {
+		return modelinference.GetModelResult{}, modelinference.ErrRuntimeScopeClosed
+	}
+	return modelinference.GetModelResult{}, nil
+}
+
+func (root *scopeLifecycleModelsRoot) AcquireModelLease(
+	context.Context, modelinference.AcquireModelLeaseRequest,
+) (modelinference.AcquireModelLeaseResult, error) {
+	root.mu.Lock()
+	root.acquireLeaseCalls++
+	root.mu.Unlock()
+	return modelinference.AcquireModelLeaseResult{}, modelinference.ErrUnsupportedOperation
+}
+
+func (root *scopeLifecycleModelsRoot) InvokeModelWithLease(
+	context.Context, modelinference.InvokeModelRequest,
+) (modelinference.InvokeModelResult, error) {
+	root.mu.Lock()
+	root.invokeCalls++
+	root.mu.Unlock()
+	return modelinference.InvokeModelResult{}, modelinference.ErrUnsupportedOperation
+}
 
 func testRuntimeScope(t *testing.T) modelinference.RuntimeScopeRef {
 	t.Helper()
@@ -304,64 +397,79 @@ func TestRootAdapter_InvokeClosesRuntimeScopeAfterSuccess(t *testing.T) {
 	}
 }
 
-func TestRootAdapter_PullThroughAlreadyClosedScopeReturnsPublicClosedScopeErrorWithoutInvokingModelsRoot(t *testing.T) {
+func TestRootAdapter_PullThroughRealClosedModelsScopeReturnsPublicClosedScopeError(t *testing.T) {
 	t.Parallel()
 
+	root := &scopeLifecycleModelsRoot{}
+	opened, err := root.OpenRuntimeScope(context.Background(), modelinference.OpenRuntimeScopeRequest{})
+	if err != nil {
+		t.Fatalf("OpenRuntimeScope: %v", err)
+	}
+	if _, err := root.CloseRuntimeScope(context.Background(), modelinference.CloseRuntimeScopeRequest{
+		Scope: opened.Scope,
+	}); err != nil {
+		t.Fatalf("CloseRuntimeScope: %v", err)
+	}
+
 	service := modelscli.NewService(modelscli.Config{
-		Models: stubModelsRoot{
-			pullModel: func(context.Context, string) (modelinference.PullResult, error) {
-				t.Fatal("PullModelForScope() called through an already-closed Models runtime scope")
-				return modelinference.PullResult{}, nil
-			},
-		},
+		Models: root,
 		OpenCatalogScope: func(context.Context) (modelscli.InvokeRuntimeScope, error) {
-			return modelscli.InvokeRuntimeScope{}, modelinference.ErrRuntimeScopeClosed
+			return modelscli.InvokeRuntimeScope{Scope: opened.Scope}, nil
 		},
 	})
 
 	var out bytes.Buffer
-	err := service.Pull(modelscli.PullConfig{
+	err = service.Pull(modelscli.PullConfig{
 		Context: context.Background(), ModelName: "OMNIVOICE_Q4_K_M", Output: &out,
 	})
 	if !errors.Is(err, modelinference.ErrRuntimeScopeClosed) {
-		t.Fatalf("Pull() through a closed scope error = %v, want errors.Is match for ErrRuntimeScopeClosed", err)
+		t.Fatalf("Pull() through a closed Models scope error = %v, want errors.Is match for ErrRuntimeScopeClosed", err)
+	}
+	if root.pullCalls != 1 {
+		t.Fatalf("PullModelForScope() calls = %d, want exactly 1 (Pull must reach the Models public boundary)", root.pullCalls)
 	}
 }
 
-func TestRootAdapter_InvokeThroughAlreadyClosedScopeReturnsPublicClosedScopeErrorWithoutInvokingModelsRoot(t *testing.T) {
+func TestRootAdapter_InvokeThroughRealClosedModelsScopeReturnsPublicClosedScopeError(t *testing.T) {
 	t.Parallel()
 
+	root := &scopeLifecycleModelsRoot{}
+	opened, err := root.OpenRuntimeScope(context.Background(), modelinference.OpenRuntimeScopeRequest{})
+	if err != nil {
+		t.Fatalf("OpenRuntimeScope: %v", err)
+	}
+	if _, err := root.CloseRuntimeScope(context.Background(), modelinference.CloseRuntimeScopeRequest{
+		Scope: opened.Scope,
+	}); err != nil {
+		t.Fatalf("CloseRuntimeScope: %v", err)
+	}
+
 	service := modelscli.NewService(modelscli.Config{
-		Models: stubModelsRoot{
-			getCatalogModel: func(context.Context, modelinference.GetModelRequest) (modelinference.GetModelResult, error) {
-				t.Fatal("GetCatalogModel() called through an already-closed Models runtime scope")
-				return modelinference.GetModelResult{}, nil
-			},
-			acquireModelLease: func(context.Context, modelinference.AcquireModelLeaseRequest) (modelinference.AcquireModelLeaseResult, error) {
-				t.Fatal("AcquireModelLease() called through an already-closed Models runtime scope")
-				return modelinference.AcquireModelLeaseResult{}, nil
-			},
-			invokeModelWithLease: func(context.Context, modelinference.InvokeModelRequest) (modelinference.InvokeModelResult, error) {
-				t.Fatal("InvokeModelWithLease() called through an already-closed Models runtime scope")
-				return modelinference.InvokeModelResult{}, nil
-			},
-		},
+		Models: root,
 		OpenInvokeScope: func(context.Context, modelscli.InvokeConfig) (modelscli.InvokeRuntimeScope, error) {
-			return modelscli.InvokeRuntimeScope{}, modelinference.ErrRuntimeScopeClosed
+			return modelscli.InvokeRuntimeScope{Scope: opened.Scope}, nil
 		},
 	})
 
-	var out bytes.Buffer
-	err := service.Invoke(modelscli.InvokeConfig{
+	err = service.Invoke(modelscli.InvokeConfig{
 		Context:   context.Background(),
 		ModelName: "OMNIVOICE_Q4_K_M",
 		Operation: "TTS",
 		Text:      "hello world",
 		JSON:      true,
-		Output:    &out,
+		Output:    io.Discard,
 	})
 	if !errors.Is(err, modelinference.ErrRuntimeScopeClosed) {
-		t.Fatalf("Invoke() through a closed scope error = %v, want errors.Is match for ErrRuntimeScopeClosed", err)
+		t.Fatalf("Invoke() through a closed Models scope error = %v, want errors.Is match for ErrRuntimeScopeClosed", err)
+	}
+	if root.getCatalogModelCalls != 1 {
+		t.Fatalf("GetCatalogModel() calls = %d, want exactly 1 (Invoke must reach the Models public boundary)", root.getCatalogModelCalls)
+	}
+	if root.acquireLeaseCalls != 0 {
+		t.Fatalf("AcquireModelLease() calls = %d, want 0 (must not continue past the closed-scope boundary)", root.acquireLeaseCalls)
+	}
+	if root.invokeCalls != 0 {
+		t.Fatalf("InvokeModelWithLease() calls = %d, want 0 (must not continue past the closed-scope boundary)", root.invokeCalls)
 	}
 }
 


### PR DESCRIPTION
{
  "project": "Close the Remaining Models Inventory Gate Findings",
  "branchName": "ACP-P0-MODELS-INVENTORY-CORRECTION-02",
  "description": "Deliver one narrow Phase 0 correction from the then-current main baseline that reconciles every authoritative Models root-contract inventory, classification, and frozen ownership artifact around the retained presentation_port.go contract, while preserving the real Pull and Invoke scope-close behavior and closing the remaining PR #1705 audit findings.",
  "context": {
    "customerAsk": "Close the remaining Models inventory findings identified by the latest blocking audit on merged PR #1705: reconcile the inventories and regenerated ownership freeze on current main, retain public-boundary Pull/Invoke scope-close evidence as the behavioral proof, pass required verification, merge the correction, and add newer PR #1705 review evidence that explicitly clears every remaining finding.",
    "problem": "On remote main commit 7adccde7a056ac371e26d3e8dcaded8875137216, the complete focused command still failed because the committed Models root-contract views did not consistently include or classify presentation_port.go and the frozen ownership evidence did not match current mappings. PR #1711 supplied acceptable behavioral scope-close coverage, but the later PR #1705 audit remained blocked on ownership-freeze parity, the distinction between structural and behavioral evidence, and lint or an explicit waiver.",
    "solution": "Reconcile all existing authoritative Models root inventories and mappings around exactly one thin_root_retain classification for presentation_port.go, regenerate the canonical ownership freeze deterministically and prove idempotence, keep inventory checks categorized as structural gates, preserve public Models Pull and Invoke closed-scope scenarios as the product-behavior evidence, and complete review, CI, merge, and the newer PR #1705 clearing comment without broadening the diff."
  },
  "acceptanceCriteria": [
    "On the then-current main baseline, go test ./internal/ownershipinventory ./cmd/packagetargetmanifestcheck -count=1 is terminal and passing, including frozen-inventory parity and both Models root-contract verifiers.",
    "presentation_port.go appears exactly once with the thin_root_retain classification in every authoritative Models inventory or mapping, canonical regenerated frozen evidence agrees byte-for-byte with the committed mappings, and regenerating it again produces no diff.",
    "The accepted product-behavior evidence directly exercises Pull and Invoke through the Models public boundary after scope close; source scanning, file inventories, classifier topology, and similar meta assertions are represented only as structural gates, never as product behavior.",
    "The corrective diff contains no ACP feature work, Models behavior or cleanup, package restructuring, public or generated contract churn, or unrelated repository-wide lint remediation.",
    "Typecheck, make test, the focused tests, and required CI are terminal and passing. make lint is terminal and passing, or every remaining finding is unchanged out-of-scope backend-size debt covered by an explicit reviewer-approved waiver recorded for this work item; lint is not reported as green when it is not.",
    "The implementation/review loop continues until all blocking PR conversation feedback is explicitly addressed, conflicts are reconciled against current main, required CI is terminal and passing, and the corrective PR is merged. After merge, a newer comment on PR #1705 references the corrective merge and explicitly clears the ownership-freeze, behavioral-evidence, and lint/waiver findings; an opened, green, approved, or merge-ready PR is not completion."
  ],
  "userStories": [
    {
      "id": "ACP-P0-MODELS-INVENTORY-CORRECTION-02-001",
      "title": "Restore Models inventory and freeze parity",
      "description": "As a repository maintainer, I want every existing Models inventory gate and frozen artifact to agree on the intentional presentation contract so the complete structural gate succeeds deterministically on current main.",
      "acceptanceCriteria": [
        "Running go test ./internal/ownershipinventory ./cmd/packagetargetmanifestcheck -count=1 exits successfully and proves both Models verifiers plus frozen-inventory parity; passing only a filtered subset is insufficient.",
        "Every authoritative Models inventory or mapping contains one and only one presentation_port.go entry, classified as thin_root_retain, with no missing, duplicate, unexpected, or unclassified live Models root contract.",
        "The canonical ownership-freeze workflow is run from the current baseline, the committed frozen evidence matches the current mappings byte-for-byte, and running the workflow a second time leaves the worktree unchanged.",
        "Existing drift detection remains active: the correction updates the intended retained classification and evidence without skipping, weakening, or replacing either verifier.",
        "The Models CLI package that owns the retained presentation_port.go contract (pkg/services/models/transports/cli) is proved behaviorally live, not just structurally inventoried: it is exercised by observable public-boundary Pull/Invoke behavioral coverage (see story 002), including the closed-scope outcome.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "go test ./internal/ownershipinventory ./cmd/packagetargetmanifestcheck -count=1 passes on current main plus this diff. presentation_port.go is classified exactly once as thin_root_retain in every authoritative Models inventory/mapping (was already fixed by prior PR #1705/#1711). The focused command's remaining failures on current main were unrelated drift from later-merged ACP packages (chat_sessions, events, transports/acp) and a stale operator_settings root-file mirror in cmd/packagetargetmanifestcheck; both reconciled. Regenerating both frozen artifacts twice produces no diff (idempotent). Neither verifier was skipped or weakened. PR #1722 (https://github.com/portpowered/you-agent-factory/pull/1722) was opened, rebased onto latest main after one unrelated upstream commit landed, CI went green after retrying a pre-existing flaky functional-test lane (unrelated to this diff, confirmed also flaky on main's own prior CI run), and merged via squash (commit b9c081e34fc8d0775d47fa5af7ed3b7ba4a0bbe1). A newer clearing comment was posted on PR #1705 (https://github.com/portpowered/you-agent-factory/pull/1705#issuecomment-5159846078) explicitly closing the ownership-freeze, behavioral-evidence, and lint/waiver findings. A subsequent post-merge review on PR #1722 (2026-08-02) found this story's criteria were all structural/compile and lacked an observable outcome; a behavioral criterion was added here pointing at the same closed-scope Pull/Invoke coverage delivered under story 002, which lives in the exact package (pkg/services/models/transports/cli) that owns the retained presentation_port.go classification this story reconciles."
    },
    {
      "id": "ACP-P0-MODELS-INVENTORY-CORRECTION-02-002",
      "title": "Preserve real Models scope-close behavior evidence",
      "description": "As a reviewer, I want the correction to retain direct public-boundary proof for Pull and Invoke after scope close so structural inventory assertions are not mistaken for product behavior.",
      "acceptanceCriteria": [
        "Existing public Models boundary scenarios demonstrate that Pull and Invoke cannot continue through a closed runtime scope and return the expected public closed-scope outcome without relying on filesystem or source-topology observations.",
        "Pull and Invoke scope-close behavioral tests remain terminal and passing after the inventory and freeze correction.",
        "Inventory enumeration, root-file classification, and frozen-artifact parity checks are described and reviewed only as structural quality gates, not as behavioral acceptance evidence.",
        "The implementation diff introduces no ACP behavior, Models cleanup, service or package restructuring, API or generated-contract change, or unrelated lint remediation.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "A 2026-08-02 post-merge review on PR #1722 found the previously-cited TestRootAdapter_PullClosesCatalogScopeAfterSuccess/TestRootAdapter_InvokeClosesRuntimeScopeAfterSuccess tests only prove a successful call closes its scope afterward; they do not prove Pull/Invoke against an ALREADY-closed scope returns the public closed-scope outcome. Added two new tests to pkg/services/models/transports/cli/root_parity_test.go: TestRootAdapter_PullThroughAlreadyClosedScopeReturnsPublicClosedScopeErrorWithoutInvokingModelsRoot and TestRootAdapter_InvokeThroughAlreadyClosedScopeReturnsPublicClosedScopeErrorWithoutInvokingModelsRoot (merged as part of PR #1729). A subsequent 2026-08-02 post-merge review on PR #1729 found those two tests insufficient: OpenCatalogScope/OpenInvokeScope returned models.ErrRuntimeScopeClosed directly from the opener stub, so Pull/Invoke short-circuited before ever calling the Models root; this proves generic opener-error propagation, not that a Models-root operation classifies a reused closed RuntimeScopeRef as closed. Replaced both tests with TestRootAdapter_PullThroughRealClosedModelsScopeReturnsPublicClosedScopeError and TestRootAdapter_InvokeThroughRealClosedModelsScopeReturnsPublicClosedScopeError, backed by a new scopeLifecycleModelsRoot fixture (implements the full models.Service contract, embeds stubModelsRoot for unused methods) that tracks real OpenRuntimeScope/CloseRuntimeScope state and has PullModelForScope/GetCatalogModel return models.ErrRuntimeScopeClosed only when the specific RuntimeScopeRef used in the call was previously closed through the fixture's own CloseRuntimeScope. Each new test opens a real scope via root.OpenRuntimeScope, closes it via root.CloseRuntimeScope, configures OpenCatalogScope/OpenInvokeScope to hand that already-closed real scope to the CLI adapter (opener succeeds, no injected error), calls service.Pull()/service.Invoke(), asserts errors.Is(err, modelinference.ErrRuntimeScopeClosed), and asserts call counters proving Pull reached PullModelForScope exactly once and Invoke reached GetCatalogModel exactly once but never reached AcquireModelLease/InvokeModelWithLease. Verification: go build ./... clean; go test ./pkg/services/models/... ./internal/ownershipinventory ./cmd/packagetargetmanifestcheck -count=1 all pass; make test (short suite) passes; make lint reproduces the same pre-existing 69 backend-size findings, none in the changed file (consistent with the reviewer's already-granted narrow waiver). Inventory/freeze changes remain structural gates only (internal/ownershipinventory, cmd/packagetargetmanifestcheck, docs/internal/baselines and docs/internal/packaged-service-structure JSON, plus this one CLI test file). No ACP behavior, Models cleanup, package restructuring, or public/generated contract file was changed."
    }
  ]
}
