### PR TITLE
ACP-L1-C03: Harden Workers Kind/Phase validation and ACP L1 parity

### DIFF
--- a/pkg/services/workers/internal/services/workstations/draftvalidation/acp_l1_outcome_parity_test.go
+++ b/pkg/services/workers/internal/services/workstations/draftvalidation/acp_l1_outcome_parity_test.go
@@ -1,0 +1,306 @@
+package draftvalidation
+
+import "testing"
+
+// This file proves, entirely from test code, that every legal Kind/Phase
+// pair declared by allowedPhasesByKind (the one existing legal-pair policy
+// owner) has exactly one declared ACP L1 outcome, and that no illegal or
+// unknown pair has one. It adds no production surface: acpOutcome,
+// declaredACPL1Outcomes, and compareACPOutcomeParity all live in this _test.go
+// file and are unreachable from non-test code.
+
+// acpOutcome names the ACP L1 treatment applied to a legal Kind/Phase pair.
+type acpOutcome string
+
+const (
+	acpOutcomeMessageChunk   acpOutcome = "MESSAGE_CHUNK"
+	acpOutcomeThoughtChunk   acpOutcome = "THOUGHT_CHUNK"
+	acpOutcomeUsageUpdate    acpOutcome = "USAGE_UPDATE"
+	acpOutcomeGapNotice      acpOutcome = "GAP_NOTICE"
+	acpOutcomeErrorOutOfBand acpOutcome = "ERROR_OUT_OF_BAND"
+	acpOutcomeNoOutput       acpOutcome = "NO_OUTPUT"
+)
+
+// kindPhase is a comparable (Kind, Phase) pair used as a set element.
+type kindPhase struct {
+	Kind  Kind
+	Phase Phase
+}
+
+// acpOutcomeDeclaration is one test-owned outcome assignment. Declarations
+// are held as a slice, not a map, so a mutated fixture can represent a
+// duplicate declaration for the same pair.
+type acpOutcomeDeclaration struct {
+	Kind    Kind
+	Phase   Phase
+	Outcome acpOutcome
+}
+
+// declaredACPL1Outcomes assigns exactly one ACP L1 outcome to every legal
+// Kind/Phase pair, matching the pairs declared by allowedPhasesByKind.
+var declaredACPL1Outcomes = []acpOutcomeDeclaration{
+	{KindSession, PhaseStarted, acpOutcomeNoOutput},
+	{KindSession, PhaseCompleted, acpOutcomeNoOutput},
+	{KindSession, PhaseFailed, acpOutcomeNoOutput},
+	{KindSession, PhaseCanceled, acpOutcomeNoOutput},
+
+	{KindRun, PhaseStarted, acpOutcomeNoOutput},
+	{KindRun, PhaseCompleted, acpOutcomeNoOutput},
+	{KindRun, PhaseFailed, acpOutcomeNoOutput},
+	{KindRun, PhaseCanceled, acpOutcomeNoOutput},
+
+	{KindTurn, PhaseStarted, acpOutcomeNoOutput},
+	{KindTurn, PhaseCompleted, acpOutcomeNoOutput},
+	{KindTurn, PhaseFailed, acpOutcomeNoOutput},
+	{KindTurn, PhaseCanceled, acpOutcomeNoOutput},
+
+	{KindMessage, PhaseStarted, acpOutcomeMessageChunk},
+	{KindMessage, PhaseDelta, acpOutcomeMessageChunk},
+	{KindMessage, PhaseCompleted, acpOutcomeMessageChunk},
+
+	{KindReasoning, PhaseStarted, acpOutcomeThoughtChunk},
+	{KindReasoning, PhaseDelta, acpOutcomeThoughtChunk},
+	{KindReasoning, PhaseCompleted, acpOutcomeThoughtChunk},
+
+	{KindTool, PhaseStarted, acpOutcomeNoOutput},
+	{KindTool, PhaseDelta, acpOutcomeNoOutput},
+	{KindTool, PhaseCompleted, acpOutcomeNoOutput},
+	{KindTool, PhaseFailed, acpOutcomeNoOutput},
+	{KindTool, PhaseCanceled, acpOutcomeNoOutput},
+
+	{KindFileChange, PhaseUpdated, acpOutcomeNoOutput},
+	{KindPlan, PhaseUpdated, acpOutcomeNoOutput},
+	{KindProgress, PhaseUpdated, acpOutcomeNoOutput},
+
+	{KindUsage, PhaseUpdated, acpOutcomeUsageUpdate},
+
+	{KindError, PhaseUpdated, acpOutcomeErrorOutOfBand},
+	{KindError, PhaseFailed, acpOutcomeErrorOutOfBand},
+
+	{KindStreamGap, PhaseUpdated, acpOutcomeGapNotice},
+}
+
+// acpParityReport is the drift report produced by compareACPOutcomeParity.
+type acpParityReport struct {
+	// Missing lists legal pairs that have no declared outcome.
+	Missing []kindPhase
+	// Duplicate lists pairs declared more than once.
+	Duplicate []kindPhase
+	// Extra lists declared pairs that are not legal (illegal or unknown).
+	Extra []kindPhase
+}
+
+func (r acpParityReport) isClean() bool {
+	return len(r.Missing) == 0 && len(r.Duplicate) == 0 && len(r.Extra) == 0
+}
+
+// legalKindPhasePairs reads the one existing legal-pair policy owner and
+// returns its pairs as a set, without mutating it.
+func legalKindPhasePairs() map[kindPhase]struct{} {
+	pairs := make(map[kindPhase]struct{})
+	for kind, phases := range allowedPhasesByKind {
+		for _, phase := range phases {
+			pairs[kindPhase{Kind: kind, Phase: phase}] = struct{}{}
+		}
+	}
+	return pairs
+}
+
+// compareACPOutcomeParity reports every legal pair missing a declaration,
+// every pair declared more than once, and every declared pair that is not
+// legal. It performs no I/O and mutates neither input.
+func compareACPOutcomeParity(declarations []acpOutcomeDeclaration, legal map[kindPhase]struct{}) acpParityReport {
+	seen := make(map[kindPhase]int, len(declarations))
+	var report acpParityReport
+
+	for _, decl := range declarations {
+		pair := kindPhase{Kind: decl.Kind, Phase: decl.Phase}
+		seen[pair]++
+		if seen[pair] == 2 {
+			report.Duplicate = append(report.Duplicate, pair)
+		}
+		if _, ok := legal[pair]; !ok {
+			report.Extra = append(report.Extra, pair)
+		}
+	}
+	for pair := range legal {
+		if seen[pair] == 0 {
+			report.Missing = append(report.Missing, pair)
+		}
+	}
+
+	sortKindPhasePairs(report.Missing)
+	sortKindPhasePairs(report.Duplicate)
+	sortKindPhasePairs(report.Extra)
+	return report
+}
+
+func sortKindPhasePairs(pairs []kindPhase) {
+	for i := 1; i < len(pairs); i++ {
+		for j := i; j > 0 && kindPhaseLess(pairs[j], pairs[j-1]); j-- {
+			pairs[j], pairs[j-1] = pairs[j-1], pairs[j]
+		}
+	}
+}
+
+func kindPhaseLess(a, b kindPhase) bool {
+	if a.Kind != b.Kind {
+		return a.Kind < b.Kind
+	}
+	return a.Phase < b.Phase
+}
+
+// TestACPL1OutcomeParity_MatchesLegalPairsExactly proves the production
+// legal-pair set and the test-owned outcome table are in exact 1:1
+// correspondence: nothing missing, nothing duplicated, nothing extra.
+func TestACPL1OutcomeParity_MatchesLegalPairsExactly(t *testing.T) {
+	t.Parallel()
+
+	report := compareACPOutcomeParity(declaredACPL1Outcomes, legalKindPhasePairs())
+	if !report.isClean() {
+		t.Fatalf("ACP L1 outcome parity drift detected: missing=%v duplicate=%v extra=%v", report.Missing, report.Duplicate, report.Extra)
+	}
+}
+
+// TestACPL1OutcomeParity_DeclaresExpectedOutcomeFamilies proves the outcome
+// assigned to each Kind matches the required ACP L1 treatment across every
+// phase that Kind allows.
+func TestACPL1OutcomeParity_DeclaresExpectedOutcomeFamilies(t *testing.T) {
+	t.Parallel()
+
+	wantOutcomeByKind := map[Kind]acpOutcome{
+		KindSession:    acpOutcomeNoOutput,
+		KindRun:        acpOutcomeNoOutput,
+		KindTurn:       acpOutcomeNoOutput,
+		KindMessage:    acpOutcomeMessageChunk,
+		KindReasoning:  acpOutcomeThoughtChunk,
+		KindTool:       acpOutcomeNoOutput,
+		KindFileChange: acpOutcomeNoOutput,
+		KindPlan:       acpOutcomeNoOutput,
+		KindProgress:   acpOutcomeNoOutput,
+		KindUsage:      acpOutcomeUsageUpdate,
+		KindError:      acpOutcomeErrorOutOfBand,
+		KindStreamGap:  acpOutcomeGapNotice,
+	}
+
+	if len(declaredACPL1Outcomes) == 0 {
+		t.Fatalf("declaredACPL1Outcomes must not be empty")
+	}
+	for _, decl := range declaredACPL1Outcomes {
+		want, ok := wantOutcomeByKind[decl.Kind]
+		if !ok {
+			t.Fatalf("declaration for unexpected kind %q", decl.Kind)
+		}
+		if decl.Outcome != want {
+			t.Fatalf("kind %q phase %q outcome = %q, want %q", decl.Kind, decl.Phase, decl.Outcome, want)
+		}
+	}
+}
+
+// TestACPL1OutcomeParity_DetectsMissingLegalPair proves the comparator flags
+// a legal pair that has no declaration, without mutating the production
+// declaration table.
+func TestACPL1OutcomeParity_DetectsMissingLegalPair(t *testing.T) {
+	t.Parallel()
+
+	missingVariant := make([]acpOutcomeDeclaration, 0, len(declaredACPL1Outcomes)-1)
+	var removed kindPhase
+	for i, decl := range declaredACPL1Outcomes {
+		if i == 0 {
+			removed = kindPhase{Kind: decl.Kind, Phase: decl.Phase}
+			continue
+		}
+		missingVariant = append(missingVariant, decl)
+	}
+
+	report := compareACPOutcomeParity(missingVariant, legalKindPhasePairs())
+	if len(report.Missing) != 1 || report.Missing[0] != removed {
+		t.Fatalf("expected exactly one missing pair %v, got %v", removed, report.Missing)
+	}
+	if len(report.Duplicate) != 0 || len(report.Extra) != 0 {
+		t.Fatalf("expected no duplicate/extra defects for a missing-only fixture, got duplicate=%v extra=%v", report.Duplicate, report.Extra)
+	}
+
+	// The production table itself remains unaffected by building the variant.
+	if len(declaredACPL1Outcomes) == len(missingVariant) {
+		t.Fatalf("test fixture did not actually remove an entry")
+	}
+}
+
+// TestACPL1OutcomeParity_DetectsDuplicateDeclaration proves the comparator
+// flags a pair declared more than once.
+func TestACPL1OutcomeParity_DetectsDuplicateDeclaration(t *testing.T) {
+	t.Parallel()
+
+	duplicateVariant := make([]acpOutcomeDeclaration, len(declaredACPL1Outcomes), len(declaredACPL1Outcomes)+1)
+	copy(duplicateVariant, declaredACPL1Outcomes)
+	duplicated := duplicateVariant[0]
+	duplicateVariant = append(duplicateVariant, duplicated)
+
+	report := compareACPOutcomeParity(duplicateVariant, legalKindPhasePairs())
+	wantPair := kindPhase{Kind: duplicated.Kind, Phase: duplicated.Phase}
+	if len(report.Duplicate) != 1 || report.Duplicate[0] != wantPair {
+		t.Fatalf("expected exactly one duplicate pair %v, got %v", wantPair, report.Duplicate)
+	}
+	if len(report.Missing) != 0 || len(report.Extra) != 0 {
+		t.Fatalf("expected no missing/extra defects for a duplicate-only fixture, got missing=%v extra=%v", report.Missing, report.Extra)
+	}
+}
+
+// TestACPL1OutcomeParity_DetectsExtraIllegalPair proves the comparator flags
+// a declared pair that the legal-pair policy does not allow.
+func TestACPL1OutcomeParity_DetectsExtraIllegalPair(t *testing.T) {
+	t.Parallel()
+
+	// SESSION never allows DELTA per allowedPhasesByKind.
+	extraDecl := acpOutcomeDeclaration{Kind: KindSession, Phase: PhaseDelta, Outcome: acpOutcomeNoOutput}
+	extraVariant := make([]acpOutcomeDeclaration, len(declaredACPL1Outcomes), len(declaredACPL1Outcomes)+1)
+	copy(extraVariant, declaredACPL1Outcomes)
+	extraVariant = append(extraVariant, extraDecl)
+
+	report := compareACPOutcomeParity(extraVariant, legalKindPhasePairs())
+	wantPair := kindPhase{Kind: extraDecl.Kind, Phase: extraDecl.Phase}
+	if len(report.Extra) != 1 || report.Extra[0] != wantPair {
+		t.Fatalf("expected exactly one extra pair %v, got %v", wantPair, report.Extra)
+	}
+	if len(report.Missing) != 0 || len(report.Duplicate) != 0 {
+		t.Fatalf("expected no missing/duplicate defects for an extra-only fixture, got missing=%v duplicate=%v", report.Missing, report.Duplicate)
+	}
+}
+
+// TestACPL1OutcomeParity_DetectsUnknownPairAndCombinedDefects proves the
+// comparator flags a declared pair for an unknown Kind/Phase combination that
+// is not even a member of the declared vocabulary, and that missing,
+// duplicate, and extra defects are all reported together in one fixture.
+func TestACPL1OutcomeParity_DetectsUnknownPairAndCombinedDefects(t *testing.T) {
+	t.Parallel()
+
+	combined := make([]acpOutcomeDeclaration, 0, len(declaredACPL1Outcomes)+1)
+	var removed kindPhase
+	for i, decl := range declaredACPL1Outcomes {
+		if i == 0 {
+			removed = kindPhase{Kind: decl.Kind, Phase: decl.Phase}
+			continue
+		}
+		combined = append(combined, decl)
+	}
+	duplicated := combined[0]
+	combined = append(combined, duplicated)
+	unknownDecl := acpOutcomeDeclaration{Kind: "NOT_A_KIND", Phase: "NOT_A_PHASE", Outcome: acpOutcomeNoOutput}
+	combined = append(combined, unknownDecl)
+
+	report := compareACPOutcomeParity(combined, legalKindPhasePairs())
+
+	wantDuplicate := kindPhase{Kind: duplicated.Kind, Phase: duplicated.Phase}
+	wantExtra := kindPhase{Kind: unknownDecl.Kind, Phase: unknownDecl.Phase}
+
+	if len(report.Missing) != 1 || report.Missing[0] != removed {
+		t.Fatalf("expected exactly one missing pair %v, got %v", removed, report.Missing)
+	}
+	if len(report.Duplicate) != 1 || report.Duplicate[0] != wantDuplicate {
+		t.Fatalf("expected exactly one duplicate pair %v, got %v", wantDuplicate, report.Duplicate)
+	}
+	if len(report.Extra) != 1 || report.Extra[0] != wantExtra {
+		t.Fatalf("expected exactly one extra pair %v, got %v", wantExtra, report.Extra)
+	}
+}

--- a/pkg/services/workers/kind_phase_validation.go
+++ b/pkg/services/workers/kind_phase_validation.go
@@ -1,0 +1,50 @@
+package workers
+
+import "fmt"
+
+// InvalidKindError reports that a value is not one of the twelve declared
+// Kind constants. Zero, unknown, case-variant, whitespace-variant, and
+// near-miss values all resolve to this error rather than being normalized.
+type InvalidKindError struct {
+	Value Kind
+}
+
+func (e *InvalidKindError) Error() string {
+	return fmt.Sprintf("workers: kind %q is not a declared Kind value", string(e.Value))
+}
+
+// InvalidPhaseError reports that a value is not one of the six declared
+// Phase constants. Zero, unknown, case-variant, whitespace-variant, and
+// near-miss values all resolve to this error rather than being normalized.
+type InvalidPhaseError struct {
+	Value Phase
+}
+
+func (e *InvalidPhaseError) Error() string {
+	return fmt.Sprintf("workers: phase %q is not a declared Phase value", string(e.Value))
+}
+
+// Validate reports whether k is exactly one of the twelve canonical Kind
+// values. Validate is pure, side-effect free, and independent of any
+// Kind/Phase pair policy.
+func (k Kind) Validate() error {
+	switch k {
+	case KindSession, KindRun, KindTurn, KindMessage, KindReasoning, KindTool,
+		KindFileChange, KindPlan, KindProgress, KindUsage, KindError, KindStreamGap:
+		return nil
+	default:
+		return &InvalidKindError{Value: k}
+	}
+}
+
+// Validate reports whether p is exactly one of the six canonical Phase
+// values. Validate is pure, side-effect free, and independent of any
+// Kind/Phase pair policy.
+func (p Phase) Validate() error {
+	switch p {
+	case PhaseStarted, PhaseDelta, PhaseUpdated, PhaseCompleted, PhaseFailed, PhaseCanceled:
+		return nil
+	default:
+		return &InvalidPhaseError{Value: p}
+	}
+}

--- a/pkg/services/workers/kind_phase_validation_test.go
+++ b/pkg/services/workers/kind_phase_validation_test.go
@@ -1,0 +1,112 @@
+package workers
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestKindValidate_AcceptsExactlyTheDeclaredValues(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range []Kind{
+		KindSession, KindRun, KindTurn, KindMessage, KindReasoning, KindTool,
+		KindFileChange, KindPlan, KindProgress, KindUsage, KindError, KindStreamGap,
+	} {
+		t.Run(string(kind), func(t *testing.T) {
+			t.Parallel()
+			if err := kind.Validate(); err != nil {
+				t.Fatalf("Kind(%q).Validate() error = %v, want nil", kind, err)
+			}
+		})
+	}
+}
+
+func TestKindValidate_RejectsUndeclaredValues(t *testing.T) {
+	t.Parallel()
+
+	cases := []Kind{
+		"",            // zero value
+		"UNKNOWN",     // unknown
+		"session",     // lowercase
+		"Session",     // case variant
+		" SESSION",    // leading whitespace
+		"SESSION ",    // trailing whitespace
+		"SESSIONX",    // near miss (extra suffix)
+		"MESSAG",      // near miss (truncated)
+		"STREAM_GAP ", // near miss (whitespace variant of a real value)
+		"STREAM GAP",  // near miss (space instead of underscore)
+	}
+	for _, kind := range cases {
+		t.Run(string(kind), func(t *testing.T) {
+			t.Parallel()
+			err := kind.Validate()
+			var invalidKind *InvalidKindError
+			if !errors.As(err, &invalidKind) {
+				t.Fatalf("Kind(%q).Validate() error = %T(%v), want *InvalidKindError", kind, err, err)
+			}
+			if invalidKind.Value != kind {
+				t.Fatalf("InvalidKindError.Value = %q, want %q", invalidKind.Value, kind)
+			}
+		})
+	}
+}
+
+func TestPhaseValidate_AcceptsExactlyTheDeclaredValues(t *testing.T) {
+	t.Parallel()
+
+	for _, phase := range []Phase{
+		PhaseStarted, PhaseDelta, PhaseUpdated, PhaseCompleted, PhaseFailed, PhaseCanceled,
+	} {
+		t.Run(string(phase), func(t *testing.T) {
+			t.Parallel()
+			if err := phase.Validate(); err != nil {
+				t.Fatalf("Phase(%q).Validate() error = %v, want nil", phase, err)
+			}
+		})
+	}
+}
+
+func TestPhaseValidate_RejectsUndeclaredValues(t *testing.T) {
+	t.Parallel()
+
+	cases := []Phase{
+		"",          // zero value
+		"UNKNOWN",   // unknown
+		"started",   // lowercase
+		"Started",   // case variant
+		" STARTED",  // leading whitespace
+		"STARTED ",  // trailing whitespace
+		"STARTEDX",  // near miss (extra suffix)
+		"COMPLETE",  // near miss (truncated form of COMPLETED)
+		"CANCELLED", // near miss (double-L variant of CANCELED)
+	}
+	for _, phase := range cases {
+		t.Run(string(phase), func(t *testing.T) {
+			t.Parallel()
+			err := phase.Validate()
+			var invalidPhase *InvalidPhaseError
+			if !errors.As(err, &invalidPhase) {
+				t.Fatalf("Phase(%q).Validate() error = %T(%v), want *InvalidPhaseError", phase, err, err)
+			}
+			if invalidPhase.Value != phase {
+				t.Fatalf("InvalidPhaseError.Value = %q, want %q", invalidPhase.Value, phase)
+			}
+		})
+	}
+}
+
+func TestKindPhaseValidate_ErrorsAreDistinctTypes(t *testing.T) {
+	t.Parallel()
+
+	kindErr := Kind("NOT_A_KIND").Validate()
+	phaseErr := Phase("NOT_A_PHASE").Validate()
+
+	var invalidKind *InvalidKindError
+	if errors.As(phaseErr, &invalidKind) {
+		t.Fatalf("Phase validation error unexpectedly matched *InvalidKindError")
+	}
+	var invalidPhase *InvalidPhaseError
+	if errors.As(kindErr, &invalidPhase) {
+		t.Fatalf("Kind validation error unexpectedly matched *InvalidPhaseError")
+	}
+}

--- a/pkg/services/workers/validate_draft.go
+++ b/pkg/services/workers/validate_draft.go
@@ -5,8 +5,18 @@ import workstationdraftvalidation "github.com/portpowered/infinite-you/pkg/servi
 // ValidationError identifies the response-event field that failed draft validation.
 type ValidationError = workstationdraftvalidation.ValidationError
 
-// ValidateDraft checks a provider draft before it crosses the publication boundary.
+// ValidateDraft checks a provider draft before it crosses the publication
+// boundary. Canonical Kind and Phase vocabulary validation runs first so an
+// unknown Kind or unknown Phase is reported distinctly from a known Kind
+// paired with a known but disallowed Phase, which the existing internal
+// legal-pair policy owner reports as a phase-policy failure.
 func ValidateDraft(draft Draft) error {
+	if err := draft.Kind.Validate(); err != nil {
+		return err
+	}
+	if err := draft.Phase.Validate(); err != nil {
+		return err
+	}
 	return workstationdraftvalidation.ValidateDraft(workstationdraftvalidation.Draft{
 		Kind:    workstationdraftvalidation.Kind(draft.Kind),
 		Phase:   workstationdraftvalidation.Phase(draft.Phase),

--- a/pkg/services/workers/validate_draft_test.go
+++ b/pkg/services/workers/validate_draft_test.go
@@ -1,0 +1,215 @@
+package workers
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// legalKindPhasePairs mirrors the pairs declared by the existing internal
+// draft-validation policy owner (allowedPhasesByKind in
+// pkg/services/workers/internal/services/workstations/draftvalidation). It is
+// duplicated here only as fixture data for exercising the public boundary;
+// the policy itself has exactly one owner.
+func legalKindPhasePairs() []struct {
+	Kind  Kind
+	Phase Phase
+} {
+	return []struct {
+		Kind  Kind
+		Phase Phase
+	}{
+		{KindSession, PhaseStarted}, {KindSession, PhaseCompleted}, {KindSession, PhaseFailed}, {KindSession, PhaseCanceled},
+		{KindRun, PhaseStarted}, {KindRun, PhaseCompleted}, {KindRun, PhaseFailed}, {KindRun, PhaseCanceled},
+		{KindTurn, PhaseStarted}, {KindTurn, PhaseCompleted}, {KindTurn, PhaseFailed}, {KindTurn, PhaseCanceled},
+		{KindMessage, PhaseStarted}, {KindMessage, PhaseDelta}, {KindMessage, PhaseCompleted},
+		{KindReasoning, PhaseStarted}, {KindReasoning, PhaseDelta}, {KindReasoning, PhaseCompleted},
+		{KindTool, PhaseStarted}, {KindTool, PhaseDelta}, {KindTool, PhaseCompleted}, {KindTool, PhaseFailed}, {KindTool, PhaseCanceled},
+		{KindFileChange, PhaseUpdated},
+		{KindPlan, PhaseUpdated},
+		{KindProgress, PhaseUpdated},
+		{KindUsage, PhaseUpdated},
+		{KindError, PhaseUpdated}, {KindError, PhaseFailed},
+		{KindStreamGap, PhaseUpdated},
+	}
+}
+
+func sampleDraftPayload(t *testing.T, kind Kind, phase Phase) json.RawMessage {
+	t.Helper()
+
+	if kind == KindMessage && phase == PhaseDelta {
+		return json.RawMessage(`{"contentBlockIndex":0,"contentBlockKind":"TEXT","textDelta":"hello"}`)
+	}
+	if kind == KindMessage {
+		return json.RawMessage(`{"role":"assistant","contentBlocks":[{"kind":"TEXT","text":"hello"}]}`)
+	}
+	if kind == KindTool && phase == PhaseDelta {
+		return json.RawMessage(`{"toolCallId":"call-1","outputDelta":"partial"}`)
+	}
+	if kind == KindTool {
+		return json.RawMessage(`{"toolCallId":"call-1","toolName":"read_file","status":"started"}`)
+	}
+
+	switch kind {
+	case KindSession:
+		return json.RawMessage(`{"status":"active"}`)
+	case KindRun:
+		return json.RawMessage(`{"status":"running"}`)
+	case KindTurn:
+		return json.RawMessage(`{"turnIndex":1,"status":"active"}`)
+	case KindReasoning:
+		return json.RawMessage(`{"summaryDelta":"thinking"}`)
+	case KindFileChange:
+		return json.RawMessage(`{"path":"README.md","operation":"MODIFY"}`)
+	case KindPlan:
+		return json.RawMessage(`{"summary":"step plan","steps":[{"id":"1","description":"inspect"}]}`)
+	case KindProgress:
+		return json.RawMessage(`{"label":"compile","message":"building"}`)
+	case KindUsage:
+		return json.RawMessage(`{"inputTokens":10,"outputTokens":5,"totalTokens":15,"model":"example-model"}`)
+	case KindError:
+		return json.RawMessage(`{"code":"temporary","message":"retry later","retryable":true}`)
+	case KindStreamGap:
+		return json.RawMessage(`{"fromSequence":10,"toSequence":20,"firstAvailableSequence":21,"reason":"retention"}`)
+	default:
+		t.Fatalf("unsupported sample kind %q", kind)
+		return nil
+	}
+}
+
+func TestValidateDraft_AcceptsEveryLegalKindPhasePair(t *testing.T) {
+	t.Parallel()
+
+	for _, pair := range legalKindPhasePairs() {
+		t.Run(string(pair.Kind)+"/"+string(pair.Phase), func(t *testing.T) {
+			t.Parallel()
+			draft := Draft{Kind: pair.Kind, Phase: pair.Phase, Payload: sampleDraftPayload(t, pair.Kind, pair.Phase)}
+			if err := ValidateDraft(draft); err != nil {
+				t.Fatalf("ValidateDraft(%s/%s) error = %v", pair.Kind, pair.Phase, err)
+			}
+		})
+	}
+}
+
+func TestValidateDraft_RejectsUnknownKindDistinctlyFromPhasePolicy(t *testing.T) {
+	t.Parallel()
+
+	cases := []Kind{"", "NOT_A_KIND", "session"}
+	for _, kind := range cases {
+		t.Run(string(kind), func(t *testing.T) {
+			t.Parallel()
+			draft := Draft{Kind: kind, Phase: PhaseStarted, Payload: json.RawMessage(`{}`)}
+			err := ValidateDraft(draft)
+
+			var invalidKind *InvalidKindError
+			if !errors.As(err, &invalidKind) {
+				t.Fatalf("ValidateDraft() error = %T(%v), want *InvalidKindError", err, err)
+			}
+
+			var validationErr *ValidationError
+			if errors.As(err, &validationErr) {
+				t.Fatalf("ValidateDraft() unexpectedly returned a phase-policy *ValidationError for kind %q: %v", kind, err)
+			}
+		})
+	}
+}
+
+func TestValidateDraft_RejectsUnknownPhaseDistinctlyFromPhasePolicy(t *testing.T) {
+	t.Parallel()
+
+	cases := []Phase{"", "NOT_A_PHASE", "started"}
+	for _, phase := range cases {
+		t.Run(string(phase), func(t *testing.T) {
+			t.Parallel()
+			draft := Draft{Kind: KindSession, Phase: phase, Payload: json.RawMessage(`{}`)}
+			err := ValidateDraft(draft)
+
+			var invalidPhase *InvalidPhaseError
+			if !errors.As(err, &invalidPhase) {
+				t.Fatalf("ValidateDraft() error = %T(%v), want *InvalidPhaseError", err, err)
+			}
+
+			var validationErr *ValidationError
+			if errors.As(err, &validationErr) {
+				t.Fatalf("ValidateDraft() unexpectedly returned a phase-policy *ValidationError for phase %q: %v", phase, err)
+			}
+		})
+	}
+}
+
+func TestValidateDraft_RejectsKnownButDisallowedPhaseAsPhasePolicyFailure(t *testing.T) {
+	t.Parallel()
+
+	// SESSION is a declared Kind and DELTA is a declared Phase, but SESSION
+	// never allows DELTA per the existing legal-pair policy.
+	draft := Draft{Kind: KindSession, Phase: PhaseDelta, Payload: json.RawMessage(`{}`)}
+	err := ValidateDraft(draft)
+
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("ValidateDraft() error = %T(%v), want *ValidationError (phase-policy failure)", err, err)
+	}
+	if validationErr.Field != "phase" {
+		t.Fatalf("ValidationError.Field = %q, want %q", validationErr.Field, "phase")
+	}
+
+	var invalidKind *InvalidKindError
+	if errors.As(err, &invalidKind) {
+		t.Fatalf("phase-policy failure unexpectedly matched *InvalidKindError")
+	}
+	var invalidPhase *InvalidPhaseError
+	if errors.As(err, &invalidPhase) {
+		t.Fatalf("phase-policy failure unexpectedly matched *InvalidPhaseError")
+	}
+}
+
+func TestValidateDraft_RejectsRepresentativeDisallowedPairsPerKind(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		kind  Kind
+		phase Phase
+	}{
+		{"session rejects delta", KindSession, PhaseDelta},
+		{"run rejects updated", KindRun, PhaseUpdated},
+		{"turn rejects delta", KindTurn, PhaseDelta},
+		{"message rejects updated", KindMessage, PhaseUpdated},
+		{"reasoning rejects failed", KindReasoning, PhaseFailed},
+		{"tool rejects updated", KindTool, PhaseUpdated},
+		{"file change rejects started", KindFileChange, PhaseStarted},
+		{"plan rejects completed", KindPlan, PhaseCompleted},
+		{"progress rejects canceled", KindProgress, PhaseCanceled},
+		{"usage rejects failed", KindUsage, PhaseFailed},
+		{"error rejects started", KindError, PhaseStarted},
+		{"stream gap rejects delta", KindStreamGap, PhaseDelta},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			draft := Draft{Kind: tc.kind, Phase: tc.phase, Payload: json.RawMessage(`{}`)}
+			err := ValidateDraft(draft)
+			var validationErr *ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("ValidateDraft(%s/%s) error = %T(%v), want *ValidationError", tc.kind, tc.phase, err, err)
+			}
+			if validationErr.Field != "phase" {
+				t.Fatalf("ValidationError.Field = %q, want %q", validationErr.Field, "phase")
+			}
+		})
+	}
+}
+
+func TestValidateDraft_DoesNotMutateInputOnFailure(t *testing.T) {
+	t.Parallel()
+
+	payload := json.RawMessage(`{"status":"active"}`)
+	draft := Draft{Kind: KindSession, Phase: PhaseDelta, Payload: payload}
+	original := CloneDraft(draft)
+
+	_ = ValidateDraft(draft)
+
+	if string(draft.Payload) != string(original.Payload) || draft.Kind != original.Kind || draft.Phase != original.Phase {
+		t.Fatalf("ValidateDraft() mutated its input draft: got %+v, want %+v", draft, original)
+	}
+}


### PR DESCRIPTION
This PR is described by the following `prd.json` used to drive its implementation.

```json
{
  "project": "ACP-L1-C03 — Harden Workers Kind and Phase validation and ACP L1 parity",
  "branchName": "ACP-L1-C03-worker-vocabulary-parity",
  "description": "Harden the existing Workers response-draft vocabulary on current main without changing its taxonomy: add deterministic exhaustive validation for the canonical 12 Kind and six Phase values, preserve and enforce the existing legal-pair policy, and add test-owned proof that every legal Kind/Phase pair has exactly one declared ACP L1 outcome including explicit no-output cases. Make vocabulary and policy drift observable without exported production test helpers, runtime projection, a second vocabulary, unrelated cleanup, or weaker coverage.",
  "context": {
    "customerAsk": "On current origin/main, land the independent Workers correction that did not merge with PR #1710: add exhaustive validation for the existing workers.Kind and workers.Phase values, prove every legal Kind/Phase pair has exactly one declared ACP L1 outcome including explicit no-output cases, and make vocabulary or allowed-pair drift fail visibly. Keep enumeration and parity support test-owned or inside the existing internal validation owner; add no test-only root APIs, runtime projection, copied taxonomy, coverage reduction, or incompatible Chat Sessions work; complete review, CI, merge, and PR #1710 convergence evidence.",
    "problem": "The canonical Workers vocabulary declares 12 Kind values and six Phase values, and an internal validation owner defines legal combinations, but current main has no Kind.Validate or Phase.Validate contract and no total ACP outcome parity evidence. Vocabulary or allowed-pair changes can therefore leave later ACP mapping incomplete or silently omit cases. The prior implementation was coupled to an incompatible Chat Sessions PR and exposed production enumeration support used only by tests, which reviewers rejected as dead surface that harmed coverage.",
    "solution": "Add pure exhaustive Validate methods to the canonical Workers enum types, preserve the existing internal legal-pair owner, and verify validation through owning-package tables. Add a test-owned ACP outcome declaration and comparator that exactly matches the legal-pair set, detects missing, duplicate, and extra cases, and treats no output as an explicit outcome. Run focused and required Go gates, address review and conflicts through merge, then link the merged correction from PR #1710 as superseding its independent Workers portion."
  },
  "acceptanceCriteria": [
    "workers.Kind.Validate accepts exactly SESSION, RUN, TURN, MESSAGE, REASONING, TOOL, FILE_CHANGE, PLAN, PROGRESS, USAGE, ERROR, and STREAM_GAP, and workers.Phase.Validate accepts exactly STARTED, DELTA, UPDATED, COMPLETED, FAILED, and CANCELED; zero, unknown, case-variant, whitespace-variant, and near-miss values fail deterministically with inspectable errors.",
    "Response-draft validation accepts exactly the existing legal Kind/Phase combinations and rejects unknown kinds, unknown phases, and valid-but-disallowed combinations with actionable distinct outcomes, without mutating input or adding side effects.",
    "Exhaustive parity evidence proves the declared ACP L1 outcome table is an exact one-to-one match for the legal Kind/Phase pair set: no legal pair is missing or duplicated and no illegal or unknown pair is declared.",
    "ACP outcomes explicitly cover message chunks for MESSAGE, thought chunks for REASONING, usage updates for USAGE, gap notices for STREAM_GAP, out-of-band error treatment for ERROR, and explicit no output for SESSION, RUN, TURN, TOOL, FILE_CHANGE, PLAN, and PROGRESS across each kind's allowed phases.",
    "The implementation adds no Kind or Phase, second normalized vocabulary, ACP runtime projection, Worker Session behavior, exported production enumeration/parity API used only by tests, coverage-floor reduction, or unrelated cleanup.",
    "Quality gate: formatting, Go typecheck and compilation, focused pkg/services/workers/... tests, lint, make verify-fast, the required PR verification tier, and all required CI checks are terminal and passing without weakening tests or coverage thresholds.",
    "Delivery continues through implementation and correctness-first review until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file churn are reconciled against current main, and the correction PR is actually merged; after merge, PR #1710 receives explicit convergence evidence linking the merged correction and stating that its independent Workers portion is superseded."
  ],
  "userStories": [
    {
      "id": "ACP-L1-C03-worker-vocabulary-parity-001",
      "title": "Validate the canonical Kind and Phase vocabulary",
      "description": "As a Workers contract consumer, I want canonical Kind and Phase values to validate themselves so malformed or drifted response-draft vocabulary is rejected consistently before later ACP mapping.",
      "acceptanceCriteria": [
        "Kind.Validate accepts exactly the 12 currently declared Kind constants and Phase.Validate accepts exactly the six currently declared Phase constants; the change adds, removes, renames, aliases, or normalizes none of them.",
        "Zero values, unknown strings, lowercase and case variants, whitespace variants, and representative near-miss values return deterministic inspectable errors rather than being normalized or accepted.",
        "Validation is pure and side-effect free, uses exhaustive switch enforcement, and does not require exported lists, maps, enumeration helpers, or parity APIs.",
        "Table-driven owning-package tests exercise every valid value and representative invalid values and prove stable error classification without matching only error text.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added Kind.Validate()/Phase.Validate() exhaustive switch methods plus *InvalidKindError/*InvalidPhaseError in pkg/services/workers/kind_phase_validation.go, with table-driven owning-package tests in kind_phase_validation_test.go covering all 12/6 declared values and representative zero, unknown, case-variant, whitespace-variant, and near-miss inputs. go build/go vet/go test pass for pkg/services/workers/...."
    },
    {
      "id": "ACP-L1-C03-worker-vocabulary-parity-002",
      "title": "Enforce the existing legal Kind and Phase pair policy",
      "description": "As a response-draft producer, I want every Kind/Phase combination checked against one existing owner so invalid lifecycle combinations cannot pass merely because each enum member is valid independently.",
      "acceptanceCriteria": [
        "Response-draft validation invokes canonical Kind and Phase validation and then accepts exactly the legal combinations already declared by the internal draft-validation policy.",
        "A known Kind with a known but disallowed Phase is rejected as a phase-policy failure, while unknown Kind and unknown Phase inputs remain distinguishable and actionable.",
        "The legal-pair policy has one owner in the existing internal validation boundary; the change does not add a parallel allow-list or copy the Kind/Phase taxonomy into a new package.",
        "Validation results are deterministic, input drafts remain unchanged on success or failure, and no filesystem, network, runtime, projection, or other side effect is introduced.",
        "Table-driven tests cover every allowed pair plus representative disallowed pairs for each Kind, including zero and unknown enum inputs.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "pkg/services/workers/validate_draft.go now calls draft.Kind.Validate() and draft.Phase.Validate() before delegating to the existing internal draftvalidation.ValidateDraft legal-pair owner (unchanged), so unknown Kind/Phase surface as *InvalidKindError/*InvalidPhaseError while a known-but-disallowed pair still surfaces as the existing *ValidationError{Field:\"phase\"}. validate_draft_test.go covers all 30 legal pairs, one representative disallowed pair per Kind, and zero/unknown/known-invalid Kind and Phase inputs, plus a no-mutation check. Legal-pair policy has exactly one owner (draftvalidation.allowedPhasesByKind); no parallel allow-list added."
    },
    {
      "id": "ACP-L1-C03-worker-vocabulary-parity-003",
      "title": "Prove total ACP L1 outcome parity and drift detection",
      "description": "As an ACP maintainer, I want every legal Workers Kind/Phase pair assigned exactly one declared L1 outcome so vocabulary and allow-policy changes cannot silently drop output or invent behavior.",
      "acceptanceCriteria": [
        "Test-owned parity data assigns exactly one named outcome to every legal Kind/Phase pair and no outcome to an illegal or unknown pair.",
        "Declared outcomes are message chunk for MESSAGE, thought chunk for REASONING, usage update for USAGE, gap notice for STREAM_GAP, out-of-band error treatment for ERROR, and explicit no output for SESSION, RUN, TURN, TOOL, FILE_CHANGE, PLAN, and PROGRESS across each kind's allowed phases.",
        "The parity comparison reports missing legal pairs, duplicate declarations, and extra or illegal declarations with the affected Kind and Phase, making both vocabulary drift and allowed-pair-policy drift actionable.",
        "A focused negative test perturbs test-owned parity input or exercises the comparison with incomplete, duplicate, and extra fixtures to prove drift detection without mutating package-global production state.",
        "Enumeration and comparison helpers remain in test code or the existing internal validation owner; no exported root enumeration or parity API, production ACP outcome table, dead test-support surface, or coverage exception is introduced.",
        "The proof validates mapping-policy completeness only; it adds no ACP SessionUpdate, runtime projection, event emission, Worker Session, transport, API, CLI, or UI behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added pkg/services/workers/internal/services/workstations/draftvalidation/acp_l1_outcome_parity_test.go, a white-box _test.go (package draftvalidation) that reads the production allowedPhasesByKind map directly, declares a test-owned []acpOutcomeDeclaration slice assigning exactly one of MESSAGE_CHUNK/THOUGHT_CHUNK/USAGE_UPDATE/GAP_NOTICE/ERROR_OUT_OF_BAND/NO_OUTPUT to every legal pair, and a compareACPOutcomeParity comparator that reports missing/duplicate/extra pairs. Positive test proves exact 1:1 parity; four negative tests build local slice copies (never mutating the production table or allowedPhasesByKind) to prove missing, duplicate, extra, and combined-with-unknown-pair drift are all detected. No exported/production API added; all types and helpers are test-only."
    }
  ]
}

```
