### PR TITLE
ACP-L1-V1-C11-factory-target-catalog

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -247,6 +247,26 @@
       }
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/service",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions/wire",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/edges",
       "minimum": 66.14
     },

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -3203,6 +3203,16 @@
       "minimum": 75.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/factorytarget",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/optional",
       "minimum": 97.50
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -229,6 +229,10 @@
       "minimum": 100.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/service",
+      "minimum": 92.59
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/edges",
       "minimum": 71.65
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -2453,6 +2453,10 @@
       "minimum": 87.50
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/factorytarget",
+      "minimum": 100.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/optional",
       "minimum": 100.00
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -233,6 +233,10 @@
       "minimum": 92.59
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions/wire",
+      "minimum": 100.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/edges",
       "minimum": 71.65
     },

--- a/pkg/services/chat_sessions/doc.go
+++ b/pkg/services/chat_sessions/doc.go
@@ -12,6 +12,18 @@
 // behavior, or alternate peer-facing service contract, and they import only
 // the standard library.
 //
+// FactoryTargetCatalogService (factory_target_catalog_contract.go,
+// factory_target_catalog_errors.go) is a separate L1 V1 detached root
+// contract published by this same package: it resolves the allowed,
+// installed FACTORY target catalog for an ACP client picker by combining the
+// effective Operator Settings ACP Agent profile with Factory Definitions'
+// public installed-catalog behavior. Its public files publish only the
+// interface and its detached request/result/error values and import only the
+// standard library, matching Service's contract-only convention. Its
+// implementation lives in internal/service, composed through wire/, and is
+// the first implementation this package publishes; the L1 V0 Service root
+// above remains contract-only until its own L1 V1 implementation lands.
+//
 // internal/factorysessionsshim is a private, unexported implementation
 // detail owned by this package but outside its public contract: a
 // stopgap adapter over the published factory_sessions.Service root that some

--- a/pkg/services/chat_sessions/factory_target_catalog_contract.go
+++ b/pkg/services/chat_sessions/factory_target_catalog_contract.go
@@ -1,0 +1,69 @@
+package chatsessions
+
+import "context"
+
+// FactoryTargetCatalogService is the singular Chat Sessions detached
+// operation that resolves the allowed, installed FACTORY target catalog for
+// an ACP client picker. It combines the effective Operator Settings ACP
+// Agent profile with Factory Definitions' public installed-catalog behavior
+// so callers never assemble this cross-service policy themselves. This
+// package publishes only the interface and its detached request/result
+// values; it has no implementation, persistence, or dependency-injection
+// wiring.
+//
+// Every resolution reads current collaborator state: it never persists,
+// caches, or returns a result that can be affected by caller mutation of the
+// returned value or by anything but the next call's collaborator facts.
+type FactoryTargetCatalogService interface {
+	// ResolveFactoryTargetCatalog returns the FACTORY targets that are both
+	// allowed by the effective ACP Agent profile and currently installed,
+	// plus exactly one current/default target drawn from that same set. It
+	// reports *FactoryTargetCatalogError when the effective profile cannot
+	// be resolved, the installed catalog cannot be read, or no requested or
+	// configured current target belongs to the allowed/installed
+	// intersection.
+	ResolveFactoryTargetCatalog(ctx context.Context, req ResolveFactoryTargetCatalogRequest) (ResolveFactoryTargetCatalogResult, error)
+}
+
+// FactoryDiscoveryRoots selects the project-local and global roots used to
+// read the installed Factory catalog, mirroring Factory Definitions'
+// ListEffectiveFactoriesRequest root pair.
+type FactoryDiscoveryRoots struct {
+	ProjectRoot string
+	GlobalRoot  string
+}
+
+// ResolveFactoryTargetCatalogRequest carries the inputs required to resolve
+// one Factory target catalog.
+type ResolveFactoryTargetCatalogRequest struct {
+	// OperatorSettingsPath identifies the operator document the effective
+	// ACP Agent profile is resolved from.
+	OperatorSettingsPath string
+	// FactoryDiscovery selects the roots the installed Factory catalog is
+	// read from.
+	FactoryDiscovery FactoryDiscoveryRoots
+	// ClientWorkingRoot is the ACP client's own working root, used to
+	// validate a Factory that pins an incompatible working root.
+	ClientWorkingRoot string
+	// CurrentTarget, when non-blank, is a caller-supplied canonical
+	// unversioned factory:<ref> validated in place of the effective
+	// profile's configured default target.
+	CurrentTarget string
+}
+
+// FactoryTargetCatalogChoice is one selectable FACTORY target. Value is its
+// canonical unversioned factory:<ref> and Name is a non-empty stable display
+// name derived from Factory Definitions-owned canonical identity facts.
+type FactoryTargetCatalogChoice struct {
+	Value string
+	Name  string
+}
+
+// ResolveFactoryTargetCatalogResult carries the deterministic, deduplicated,
+// stably ordered FACTORY choice list and the one current/default target
+// selected from it. It is detached from collaborator-owned slices: mutating
+// it never affects a subsequent resolution.
+type ResolveFactoryTargetCatalogResult struct {
+	Choices       []FactoryTargetCatalogChoice
+	CurrentTarget string
+}

--- a/pkg/services/chat_sessions/factory_target_catalog_contract.go
+++ b/pkg/services/chat_sessions/factory_target_catalog_contract.go
@@ -18,10 +18,21 @@ type FactoryTargetCatalogService interface {
 	// ResolveFactoryTargetCatalog returns the FACTORY targets that are both
 	// allowed by the effective ACP Agent profile and currently installed,
 	// plus exactly one current/default target drawn from that same set. It
-	// reports *FactoryTargetCatalogError when the effective profile cannot
-	// be resolved, the installed catalog cannot be read, or no requested or
-	// configured current target belongs to the allowed/installed
-	// intersection.
+	// reports *FactoryTargetCatalogError, unwrapping to one of this
+	// package's sentinel Factory target-catalog errors, when: the effective
+	// profile cannot be resolved or is invalid/empty
+	// (ErrFactoryTargetProfileUnavailable); the installed catalog or a
+	// canonical cross-root resolution cannot be read
+	// (ErrFactoryTargetCatalogUnavailable); a requested current target is
+	// not a well-formed unversioned factory:<ref>, including a version- or
+	// digest-pinned ref (ErrFactoryTargetReferenceMalformed); the allowed and
+	// installed sets share no target at all (ErrFactoryTargetCatalogEmpty);
+	// the resolved current/default target is unknown or not installed
+	// (ErrFactoryTargetNotInstalled); it is installed but outside the
+	// allowlist (ErrFactoryTargetNotAllowed); or it pins a project-local
+	// working root incompatible with a supplied ClientWorkingRoot
+	// (ErrFactoryTargetWorkingRootIncompatible). It never returns a partial
+	// choice list alongside an error.
 	ResolveFactoryTargetCatalog(ctx context.Context, req ResolveFactoryTargetCatalogRequest) (ResolveFactoryTargetCatalogResult, error)
 }
 

--- a/pkg/services/chat_sessions/factory_target_catalog_errors.go
+++ b/pkg/services/chat_sessions/factory_target_catalog_errors.go
@@ -1,0 +1,47 @@
+package chatsessions
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel Factory target-catalog failure categories. Callers use errors.Is
+// against these sentinels (typically through a returned
+// *FactoryTargetCatalogError) instead of parsing Error() text.
+var (
+	// ErrFactoryTargetProfileUnavailable reports that the effective Operator
+	// Settings ACP Agent profile could not be resolved, including a missing,
+	// malformed, or otherwise invalid stored profile.
+	ErrFactoryTargetProfileUnavailable = errors.New("chat sessions: ACP Agent profile is unavailable")
+	// ErrFactoryTargetCatalogUnavailable reports that the installed Factory
+	// catalog could not be read from Factory Definitions.
+	ErrFactoryTargetCatalogUnavailable = errors.New("chat sessions: installed Factory catalog is unavailable")
+	// ErrFactoryTargetCurrentUnavailable reports that neither a
+	// caller-supplied current target nor the profile's configured default
+	// target belongs to the allowed, installed Factory target intersection.
+	ErrFactoryTargetCurrentUnavailable = errors.New("chat sessions: no allowed, installed current Factory target is available")
+)
+
+// FactoryTargetCatalogError reports one Factory target-catalog resolution
+// failure. Target is the offending canonical target reference, empty when
+// the failure applies before any target is considered. Err is one of the
+// package sentinel errors so callers can use errors.Is without parsing
+// Error() text. Fields carry only safe identity facts: never a credential,
+// prompt, raw provider command, filesystem path, or private topology detail.
+type FactoryTargetCatalogError struct {
+	Target string
+	Err    error
+}
+
+func (e *FactoryTargetCatalogError) Error() string {
+	if e.Target == "" {
+		return fmt.Sprintf("chat sessions: factory target catalog: %v", e.Err)
+	}
+	return fmt.Sprintf("chat sessions: factory target catalog %q: %v", e.Target, e.Err)
+}
+
+// Unwrap exposes the underlying sentinel so errors.Is/errors.As can classify
+// the failure.
+func (e *FactoryTargetCatalogError) Unwrap() error {
+	return e.Err
+}

--- a/pkg/services/chat_sessions/factory_target_catalog_errors.go
+++ b/pkg/services/chat_sessions/factory_target_catalog_errors.go
@@ -11,15 +11,35 @@ import (
 var (
 	// ErrFactoryTargetProfileUnavailable reports that the effective Operator
 	// Settings ACP Agent profile could not be resolved, including a missing,
-	// malformed, or otherwise invalid stored profile.
+	// empty, malformed, or otherwise invalid stored profile (including a
+	// configured default absent from its own effective allowlist, which
+	// Operator Settings rejects while resolving the profile).
 	ErrFactoryTargetProfileUnavailable = errors.New("chat sessions: ACP Agent profile is unavailable")
 	// ErrFactoryTargetCatalogUnavailable reports that the installed Factory
-	// catalog could not be read from Factory Definitions.
+	// catalog, or a Factory's canonical cross-root resolution, could not be
+	// read from Factory Definitions.
 	ErrFactoryTargetCatalogUnavailable = errors.New("chat sessions: installed Factory catalog is unavailable")
-	// ErrFactoryTargetCurrentUnavailable reports that neither a
-	// caller-supplied current target nor the profile's configured default
-	// target belongs to the allowed, installed Factory target intersection.
-	ErrFactoryTargetCurrentUnavailable = errors.New("chat sessions: no allowed, installed current Factory target is available")
+	// ErrFactoryTargetReferenceMalformed reports that a caller-supplied
+	// current target is not a well-formed unversioned factory:<ref>
+	// reference: it is missing the factory: namespace, is otherwise
+	// lexically invalid, or carries a version or digest pin that this
+	// unversioned picker contract never accepts.
+	ErrFactoryTargetReferenceMalformed = errors.New("chat sessions: Factory target reference is malformed")
+	// ErrFactoryTargetCatalogEmpty reports that the effective profile
+	// allowlist and the installed Factory catalog share no target in common,
+	// so no current/default target can ever be selected.
+	ErrFactoryTargetCatalogEmpty = errors.New("chat sessions: no Factory target is both allowed and installed")
+	// ErrFactoryTargetNotInstalled reports that a well-formed current/default
+	// target is unknown to, or not currently installed in, the Factory
+	// Definitions catalog.
+	ErrFactoryTargetNotInstalled = errors.New("chat sessions: Factory target is unknown or not installed")
+	// ErrFactoryTargetNotAllowed reports that a well-formed, installed
+	// current/default target is outside the effective profile's allowlist.
+	ErrFactoryTargetNotAllowed = errors.New("chat sessions: Factory target is outside the allowed target list")
+	// ErrFactoryTargetWorkingRootIncompatible reports that the resolved
+	// current/default target is pinned to a project-local root that differs
+	// from the ACP client's supplied working root.
+	ErrFactoryTargetWorkingRootIncompatible = errors.New("chat sessions: Factory target working root is incompatible with the client working root")
 )
 
 // FactoryTargetCatalogError reports one Factory target-catalog resolution

--- a/pkg/services/chat_sessions/factory_target_catalog_errors.go
+++ b/pkg/services/chat_sessions/factory_target_catalog_errors.go
@@ -44,10 +44,13 @@ var (
 
 // FactoryTargetCatalogError reports one Factory target-catalog resolution
 // failure. Target is the offending canonical target reference, empty when
-// the failure applies before any target is considered. Err is one of the
-// package sentinel errors so callers can use errors.Is without parsing
-// Error() text. Fields carry only safe identity facts: never a credential,
-// prompt, raw provider command, filesystem path, or private topology detail.
+// the failure applies before any target is considered, or when the target
+// has not yet passed lexical validation (ErrFactoryTargetReferenceMalformed
+// never populates Target, since a malformed value may itself be unsafe
+// caller-supplied input). Err is one of the package sentinel errors so
+// callers can use errors.Is without parsing Error() text. Fields carry only
+// safe identity facts: never a credential, prompt, raw provider command,
+// filesystem path, or private topology detail.
 type FactoryTargetCatalogError struct {
 	Target string
 	Err    error

--- a/pkg/services/chat_sessions/internal/service/factory_target_catalog.go
+++ b/pkg/services/chat_sessions/internal/service/factory_target_catalog.go
@@ -137,9 +137,11 @@ func (s *Service) resolveFactoryTargetCatalog(
 		current = profile.DefaultTarget
 	}
 	if !isWellFormedFactoryTargetReference(current) {
+		// current has not passed lexical validation: it may be arbitrary
+		// caller-supplied input (a path, credential-like value, or control
+		// text), so it is never copied into the public error's Target field.
 		return chatsessions.ResolveFactoryTargetCatalogResult{}, &chatsessions.FactoryTargetCatalogError{
-			Target: current,
-			Err:    chatsessions.ErrFactoryTargetReferenceMalformed,
+			Err: chatsessions.ErrFactoryTargetReferenceMalformed,
 		}
 	}
 	if len(choicesByValue) == 0 {

--- a/pkg/services/chat_sessions/internal/service/factory_target_catalog.go
+++ b/pkg/services/chat_sessions/internal/service/factory_target_catalog.go
@@ -1,0 +1,112 @@
+package service
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
+
+// ResolveFactoryTargetCatalog resolves the effective ACP Agent profile
+// through Operator Settings, reads the installed Factory catalog through
+// Factory Definitions, intersects the profile's allowlist with that catalog,
+// and returns the deduplicated, stably ordered FACTORY choices plus one
+// current/default target drawn from the intersection. Every call reads
+// current collaborator state; nothing is persisted, cached, or reused across
+// calls.
+func (s *Service) ResolveFactoryTargetCatalog(
+	ctx context.Context,
+	req chatsessions.ResolveFactoryTargetCatalogRequest,
+) (chatsessions.ResolveFactoryTargetCatalogResult, error) {
+	profile, err := s.operatorSettings.ResolveACPAgentProfile(req.OperatorSettingsPath)
+	if err != nil {
+		return chatsessions.ResolveFactoryTargetCatalogResult{}, &chatsessions.FactoryTargetCatalogError{
+			Err: chatsessions.ErrFactoryTargetProfileUnavailable,
+		}
+	}
+
+	listing, err := s.factoryDefinitions.ListEffectiveFactories(ctx, factorydefinitions.ListEffectiveFactoriesRequest{
+		ProjectRoot: req.FactoryDiscovery.ProjectRoot,
+		GlobalRoot:  req.FactoryDiscovery.GlobalRoot,
+	})
+	if err != nil {
+		return chatsessions.ResolveFactoryTargetCatalogResult{}, &chatsessions.FactoryTargetCatalogError{
+			Err: chatsessions.ErrFactoryTargetCatalogUnavailable,
+		}
+	}
+
+	installed := make(map[string]factorydefinitions.EffectiveFactoryCatalogEntry, len(listing.Entries))
+	for _, entry := range listing.Entries {
+		installed[entry.Name] = entry
+	}
+
+	choicesByValue := make(map[string]chatsessions.FactoryTargetCatalogChoice, len(profile.AllowedTargets))
+	for _, target := range profile.AllowedTargets {
+		if _, exists := choicesByValue[target]; exists {
+			continue
+		}
+		name := strings.TrimPrefix(target, operatorsettings.ACPFactoryTargetNamespace)
+		entry, ok := installed[name]
+		if !ok {
+			continue
+		}
+		choicesByValue[target] = chatsessions.FactoryTargetCatalogChoice{
+			Value: target,
+			Name:  factoryDisplayName(entry),
+		}
+	}
+
+	current := req.CurrentTarget
+	if current == "" {
+		current = profile.DefaultTarget
+	}
+	currentChoice, ok := choicesByValue[current]
+	if !ok {
+		return chatsessions.ResolveFactoryTargetCatalogResult{}, &chatsessions.FactoryTargetCatalogError{
+			Target: current,
+			Err:    chatsessions.ErrFactoryTargetCurrentUnavailable,
+		}
+	}
+
+	return chatsessions.ResolveFactoryTargetCatalogResult{
+		Choices:       orderedFactoryTargetChoices(choicesByValue, currentChoice),
+		CurrentTarget: currentChoice.Value,
+	}, nil
+}
+
+// orderedFactoryTargetChoices returns current first, followed by every other
+// choice in ascending canonical target-ref order, independent of the
+// supplied map's iteration order.
+func orderedFactoryTargetChoices(
+	choicesByValue map[string]chatsessions.FactoryTargetCatalogChoice,
+	current chatsessions.FactoryTargetCatalogChoice,
+) []chatsessions.FactoryTargetCatalogChoice {
+	remaining := make([]chatsessions.FactoryTargetCatalogChoice, 0, len(choicesByValue))
+	for value, choice := range choicesByValue {
+		if value == current.Value {
+			continue
+		}
+		remaining = append(remaining, choice)
+	}
+	sort.Slice(remaining, func(i, j int) bool { return remaining[i].Value < remaining[j].Value })
+
+	ordered := make([]chatsessions.FactoryTargetCatalogChoice, 0, len(choicesByValue))
+	ordered = append(ordered, current)
+	return append(ordered, remaining...)
+}
+
+// factoryDisplayName returns a non-empty stable display name derived from
+// Factory Definitions-owned canonical identity facts: the Factory
+// definition's authored Name when present, otherwise the catalog entry's
+// canonical name.
+func factoryDisplayName(entry factorydefinitions.EffectiveFactoryCatalogEntry) string {
+	if entry.Definition != nil {
+		if trimmed := strings.TrimSpace(entry.Definition.Name); trimmed != "" {
+			return trimmed
+		}
+	}
+	return entry.Name
+}

--- a/pkg/services/chat_sessions/internal/service/factory_target_catalog.go
+++ b/pkg/services/chat_sessions/internal/service/factory_target_catalog.go
@@ -2,6 +2,9 @@ package service
 
 import (
 	"context"
+	"path/filepath"
+	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -9,6 +12,28 @@ import (
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 )
+
+// factoryTargetReferencePattern mirrors Operator Settings' local factory:
+// target-reference grammar (pkg/services/operator_settings/acp_agent_profile.go):
+// one or more lowercase kebab-case path segments separated by '/', with an
+// optional leading '@' scope marker on the first segment. It intentionally
+// has no room for a version or digest pin, so a version- or digest-pinned
+// reference is rejected the same way as any other malformed shape. Operator
+// Settings only validates profile-sourced references (its own AllowedTargets
+// and DefaultTarget); this package validates a caller-supplied CurrentTarget
+// the same way, since that value never passes through Operator Settings'
+// normalization.
+var factoryTargetReferencePattern = regexp.MustCompile(
+	`^@?[a-z0-9]+(?:-[a-z0-9]+)*(?:/[a-z0-9]+(?:-[a-z0-9]+)*)+$`,
+)
+
+func isWellFormedFactoryTargetReference(value string) bool {
+	if !strings.HasPrefix(value, operatorsettings.ACPFactoryTargetNamespace) {
+		return false
+	}
+	suffix := strings.TrimPrefix(value, operatorsettings.ACPFactoryTargetNamespace)
+	return factoryTargetReferencePattern.MatchString(suffix)
+}
 
 // ResolveFactoryTargetCatalog resolves the effective ACP Agent profile
 // through Operator Settings, reads the installed Factory catalog through
@@ -63,14 +88,54 @@ func (s *Service) ResolveFactoryTargetCatalog(
 	if current == "" {
 		current = profile.DefaultTarget
 	}
-	currentChoice, ok := choicesByValue[current]
-	if !ok {
+	if !isWellFormedFactoryTargetReference(current) {
 		return chatsessions.ResolveFactoryTargetCatalogResult{}, &chatsessions.FactoryTargetCatalogError{
 			Target: current,
-			Err:    chatsessions.ErrFactoryTargetCurrentUnavailable,
+			Err:    chatsessions.ErrFactoryTargetReferenceMalformed,
+		}
+	}
+	if len(choicesByValue) == 0 {
+		return chatsessions.ResolveFactoryTargetCatalogResult{}, &chatsessions.FactoryTargetCatalogError{
+			Err: chatsessions.ErrFactoryTargetCatalogEmpty,
 		}
 	}
 
+	bareName := strings.TrimPrefix(current, operatorsettings.ACPFactoryTargetNamespace)
+	if _, installedOK := installed[bareName]; !installedOK {
+		return chatsessions.ResolveFactoryTargetCatalogResult{}, &chatsessions.FactoryTargetCatalogError{
+			Target: current,
+			Err:    chatsessions.ErrFactoryTargetNotInstalled,
+		}
+	}
+	if !slices.Contains(profile.AllowedTargets, current) {
+		return chatsessions.ResolveFactoryTargetCatalogResult{}, &chatsessions.FactoryTargetCatalogError{
+			Target: current,
+			Err:    chatsessions.ErrFactoryTargetNotAllowed,
+		}
+	}
+
+	if clientRoot := strings.TrimSpace(req.ClientWorkingRoot); clientRoot != "" {
+		resolved, err := s.factoryDefinitions.ResolveNamedFactory(ctx, factorydefinitions.ResolveNamedFactoryRequest{
+			ProjectRoot: req.FactoryDiscovery.ProjectRoot,
+			GlobalRoot:  req.FactoryDiscovery.GlobalRoot,
+			Name:        bareName,
+		})
+		if err != nil {
+			return chatsessions.ResolveFactoryTargetCatalogResult{}, &chatsessions.FactoryTargetCatalogError{
+				Target: current,
+				Err:    chatsessions.ErrFactoryTargetCatalogUnavailable,
+			}
+		}
+		if resolved.Resolution.Source == factorydefinitions.NamedFactoryResolutionSourceProjectLocal &&
+			filepath.Clean(clientRoot) != filepath.Clean(resolved.Resolution.ProjectRoot) {
+			return chatsessions.ResolveFactoryTargetCatalogResult{}, &chatsessions.FactoryTargetCatalogError{
+				Target: current,
+				Err:    chatsessions.ErrFactoryTargetWorkingRootIncompatible,
+			}
+		}
+	}
+
+	currentChoice := choicesByValue[current]
 	return chatsessions.ResolveFactoryTargetCatalogResult{
 		Choices:       orderedFactoryTargetChoices(choicesByValue, currentChoice),
 		CurrentTarget: currentChoice.Value,

--- a/pkg/services/chat_sessions/internal/service/factory_target_catalog.go
+++ b/pkg/services/chat_sessions/internal/service/factory_target_catalog.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -43,6 +44,53 @@ func isWellFormedFactoryTargetReference(value string) bool {
 // current collaborator state; nothing is persisted, cached, or reused across
 // calls.
 func (s *Service) ResolveFactoryTargetCatalog(
+	ctx context.Context,
+	req chatsessions.ResolveFactoryTargetCatalogRequest,
+) (chatsessions.ResolveFactoryTargetCatalogResult, error) {
+	s.logger.Info("chat_sessions.resolve_factory_target_catalog.started")
+	result, err := s.resolveFactoryTargetCatalog(ctx, req)
+	if err != nil {
+		s.logger.Warn(
+			"chat_sessions.resolve_factory_target_catalog.failed",
+			"reason", classifyFactoryTargetCatalogFailure(err),
+		)
+		return chatsessions.ResolveFactoryTargetCatalogResult{}, err
+	}
+	s.logger.Info(
+		"chat_sessions.resolve_factory_target_catalog.finished",
+		"choice_count", len(result.Choices),
+	)
+	return result, nil
+}
+
+// classifyFactoryTargetCatalogFailure returns a stable, safe reason label for
+// operation logs. It never echoes a raw target, path, or collaborator error
+// message, only the classification sentinel the failure unwraps to.
+func classifyFactoryTargetCatalogFailure(err error) string {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "context_canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "context_deadline_exceeded"
+	case errors.Is(err, chatsessions.ErrFactoryTargetProfileUnavailable):
+		return "profile_unavailable"
+	case errors.Is(err, chatsessions.ErrFactoryTargetCatalogUnavailable):
+		return "catalog_unavailable"
+	case errors.Is(err, chatsessions.ErrFactoryTargetReferenceMalformed):
+		return "reference_malformed"
+	case errors.Is(err, chatsessions.ErrFactoryTargetCatalogEmpty):
+		return "catalog_empty"
+	case errors.Is(err, chatsessions.ErrFactoryTargetNotInstalled):
+		return "target_not_installed"
+	case errors.Is(err, chatsessions.ErrFactoryTargetNotAllowed):
+		return "target_not_allowed"
+	case errors.Is(err, chatsessions.ErrFactoryTargetWorkingRootIncompatible):
+		return "working_root_incompatible"
+	}
+	return "operation_failed"
+}
+
+func (s *Service) resolveFactoryTargetCatalog(
 	ctx context.Context,
 	req chatsessions.ResolveFactoryTargetCatalogRequest,
 ) (chatsessions.ResolveFactoryTargetCatalogResult, error) {

--- a/pkg/services/chat_sessions/internal/service/factory_target_catalog_construction_test.go
+++ b/pkg/services/chat_sessions/internal/service/factory_target_catalog_construction_test.go
@@ -1,0 +1,273 @@
+package service_test
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	chatsessionsservice "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/service"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
+
+// spyLoggedEntry captures one structured log call for assertion.
+type spyLoggedEntry struct {
+	level string
+	msg   string
+	kv    []any
+}
+
+// spyLogger is a logging.Logger fake that records every call so tests can
+// assert on operation-log shape (message names, safe fields) without a real
+// logging backend. Mirrors the equivalent fake in
+// pkg/services/operator_settings/internal/service.
+type spyLogger struct {
+	mu      sync.Mutex
+	entries []spyLoggedEntry
+}
+
+func (s *spyLogger) Debug(msg string, kv ...any)   { s.record("debug", msg, kv) }
+func (s *spyLogger) Info(msg string, kv ...any)    { s.record("info", msg, kv) }
+func (s *spyLogger) Warn(msg string, kv ...any)    { s.record("warn", msg, kv) }
+func (s *spyLogger) Error(msg string, kv ...any)   { s.record("error", msg, kv) }
+func (s *spyLogger) Verbose(msg string, kv ...any) { s.record("verbose", msg, kv) }
+
+func (s *spyLogger) record(level, msg string, kv []any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries = append(s.entries, spyLoggedEntry{level: level, msg: msg, kv: append([]any(nil), kv...)})
+}
+
+func (s *spyLogger) messages() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.entries))
+	for index, entry := range s.entries {
+		out[index] = entry.msg
+	}
+	return out
+}
+
+func (s *spyLogger) containsMessage(want string) bool {
+	return slices.Contains(s.messages(), want)
+}
+
+func (s *spyLogger) containsKeyValue(key string, want any) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, entry := range s.entries {
+		for index := 0; index+1 < len(entry.kv); index += 2 {
+			if entry.kv[index] == key && entry.kv[index+1] == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// assertNoForbiddenValuesLogged fails the test if any recorded log message or
+// key/value field contains one of the forbidden substrings (raw targets,
+// paths, or other sensitive facts the operation must never log).
+func (s *spyLogger) assertNoForbiddenValuesLogged(t *testing.T, forbidden ...string) {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, entry := range s.entries {
+		if containsForbiddenSubstring(entry.msg, forbidden) {
+			t.Fatalf("log message %q leaked a forbidden value from %v", entry.msg, forbidden)
+		}
+		for _, value := range entry.kv {
+			text, ok := value.(string)
+			if !ok {
+				continue
+			}
+			if containsForbiddenSubstring(text, forbidden) {
+				t.Fatalf("log field %q leaked a forbidden value from %v", text, forbidden)
+			}
+		}
+	}
+}
+
+func containsForbiddenSubstring(value string, forbidden []string) bool {
+	for _, needle := range forbidden {
+		if needle != "" && strings.Contains(value, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestResolveFactoryTargetCatalogLogsStartedAndFinishedSafely(t *testing.T) {
+	t.Parallel()
+
+	spy := &spyLogger{}
+	settings := &operatorSettingsFake{
+		resolveACPAgentProfile: func(string) (operatorsettings.ACPAgentProfile, error) {
+			return operatorsettings.ACPAgentProfile{
+				DefaultTarget:  "factory:@you/factory-builder",
+				AllowedTargets: []string{"factory:@you/factory-builder"},
+			}, nil
+		},
+	}
+	definitions := &factoryDefinitionsFake{
+		listEffectiveFactories: func(context.Context, factorydefinitions.ListEffectiveFactoriesRequest) (factorydefinitions.ListEffectiveFactoriesResult, error) {
+			return factorydefinitions.ListEffectiveFactoriesResult{
+				Entries: []factorydefinitions.EffectiveFactoryCatalogEntry{
+					{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+				},
+			}, nil
+		},
+	}
+	service, err := chatsessionsservice.New(settings, definitions, spy)
+	if err != nil {
+		t.Fatalf("New: unexpected error: %v", err)
+	}
+
+	operatorSettingsPath := "/very/private/operator-settings.json"
+	if _, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: operatorSettingsPath,
+	}); err != nil {
+		t.Fatalf("ResolveFactoryTargetCatalog: unexpected error: %v", err)
+	}
+
+	if !spy.containsMessage("chat_sessions.resolve_factory_target_catalog.started") {
+		t.Fatalf("log messages = %v, want a start log", spy.messages())
+	}
+	if !spy.containsMessage("chat_sessions.resolve_factory_target_catalog.finished") {
+		t.Fatalf("log messages = %v, want a finished log", spy.messages())
+	}
+	if !spy.containsKeyValue("choice_count", 1) {
+		t.Fatalf("log entries = %#v, want choice_count=1", spy.entries)
+	}
+	spy.assertNoForbiddenValuesLogged(t, operatorSettingsPath, "factory:@you/factory-builder")
+}
+
+func TestResolveFactoryTargetCatalogLogsFailureReasonWithoutLeakingValues(t *testing.T) {
+	t.Parallel()
+
+	spy := &spyLogger{}
+	settings := &operatorSettingsFake{
+		resolveACPAgentProfile: func(string) (operatorsettings.ACPAgentProfile, error) {
+			return operatorsettings.ACPAgentProfile{
+				DefaultTarget:  "factory:@you/factory-builder",
+				AllowedTargets: []string{"factory:@you/factory-builder"},
+			}, nil
+		},
+	}
+	definitions := &factoryDefinitionsFake{
+		listEffectiveFactories: func(context.Context, factorydefinitions.ListEffectiveFactoriesRequest) (factorydefinitions.ListEffectiveFactoriesResult, error) {
+			// No installed Factories: the allowed/installed intersection is
+			// empty, so resolution fails with ErrFactoryTargetCatalogEmpty.
+			return factorydefinitions.ListEffectiveFactoriesResult{}, nil
+		},
+	}
+	service, err := chatsessionsservice.New(settings, definitions, spy)
+	if err != nil {
+		t.Fatalf("New: unexpected error: %v", err)
+	}
+
+	operatorSettingsPath := "/very/private/operator-settings.json"
+	_, err = service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: operatorSettingsPath,
+	})
+	if err == nil {
+		t.Fatal("ResolveFactoryTargetCatalog: error = nil, want ErrFactoryTargetCatalogEmpty")
+	}
+
+	if !spy.containsMessage("chat_sessions.resolve_factory_target_catalog.failed") {
+		t.Fatalf("log messages = %v, want a failed log", spy.messages())
+	}
+	if !spy.containsKeyValue("reason", "catalog_empty") {
+		t.Fatalf("log entries = %#v, want reason=catalog_empty", spy.entries)
+	}
+	spy.assertNoForbiddenValuesLogged(t, operatorSettingsPath, "factory:@you/factory-builder")
+}
+
+func TestResolveFactoryTargetCatalogUsesEachInjectedCollaboratorExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	var profileCalls, catalogCalls int
+	settings := &operatorSettingsFake{
+		resolveACPAgentProfile: func(string) (operatorsettings.ACPAgentProfile, error) {
+			profileCalls++
+			return operatorsettings.ACPAgentProfile{
+				DefaultTarget:  "factory:@you/factory-builder",
+				AllowedTargets: []string{"factory:@you/factory-builder"},
+			}, nil
+		},
+	}
+	definitions := &factoryDefinitionsFake{
+		listEffectiveFactories: func(context.Context, factorydefinitions.ListEffectiveFactoriesRequest) (factorydefinitions.ListEffectiveFactoriesResult, error) {
+			catalogCalls++
+			return factorydefinitions.ListEffectiveFactoriesResult{
+				Entries: []factorydefinitions.EffectiveFactoryCatalogEntry{
+					{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+				},
+			}, nil
+		},
+	}
+	service, err := chatsessionsservice.New(settings, definitions, nil)
+	if err != nil {
+		t.Fatalf("New: unexpected error: %v", err)
+	}
+
+	if _, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+	}); err != nil {
+		t.Fatalf("ResolveFactoryTargetCatalog: unexpected error: %v", err)
+	}
+
+	if profileCalls != 1 {
+		t.Fatalf("operator settings ResolveACPAgentProfile call count = %d, want exactly 1", profileCalls)
+	}
+	if catalogCalls != 1 {
+		t.Fatalf("factory definitions ListEffectiveFactories call count = %d, want exactly 1", catalogCalls)
+	}
+}
+
+// TestResolveFactoryTargetCatalogObservesLiveCollaboratorDrift proves the
+// operation never caches a prior resolution: the same long-lived Service
+// instance reflects an installation change on its very next call.
+func TestResolveFactoryTargetCatalogObservesLiveCollaboratorDrift(t *testing.T) {
+	t.Parallel()
+
+	installed := true
+	settings := &operatorSettingsFake{
+		resolveACPAgentProfile: func(string) (operatorsettings.ACPAgentProfile, error) {
+			return operatorsettings.ACPAgentProfile{
+				DefaultTarget:  "factory:@you/factory-builder",
+				AllowedTargets: []string{"factory:@you/factory-builder"},
+			}, nil
+		},
+	}
+	definitions := &factoryDefinitionsFake{
+		listEffectiveFactories: func(context.Context, factorydefinitions.ListEffectiveFactoriesRequest) (factorydefinitions.ListEffectiveFactoriesResult, error) {
+			if !installed {
+				return factorydefinitions.ListEffectiveFactoriesResult{}, nil
+			}
+			return factorydefinitions.ListEffectiveFactoriesResult{
+				Entries: []factorydefinitions.EffectiveFactoryCatalogEntry{
+					{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+				},
+			}, nil
+		},
+	}
+	service, err := chatsessionsservice.New(settings, definitions, nil)
+	if err != nil {
+		t.Fatalf("New: unexpected error: %v", err)
+	}
+	req := chatsessions.ResolveFactoryTargetCatalogRequest{OperatorSettingsPath: "/operator.json"}
+
+	if _, err := service.ResolveFactoryTargetCatalog(context.Background(), req); err != nil {
+		t.Fatalf("ResolveFactoryTargetCatalog (installed) = %v, want success", err)
+	}
+
+	installed = false
+	_, err = service.ResolveFactoryTargetCatalog(context.Background(), req)
+	if err == nil {
+		t.Fatal("ResolveFactoryTargetCatalog (uninstalled) = nil error, want the drift to be observed on the very next call")
+	}
+}

--- a/pkg/services/chat_sessions/internal/service/factory_target_catalog_fakes_test.go
+++ b/pkg/services/chat_sessions/internal/service/factory_target_catalog_fakes_test.go
@@ -24,12 +24,15 @@ func (fake *operatorSettingsFake) ResolveACPAgentProfile(path string) (operators
 }
 
 // factoryDefinitionsFake is a focused Factory Definitions root fake
-// exercising only ListEffectiveFactories, the sole collaborator method the
-// Factory target-catalog operation depends on.
+// exercising only ListEffectiveFactories and ResolveNamedFactory, the
+// collaborator methods the Factory target-catalog operation depends on.
+// resolveNamedFactory is only exercised when a test supplies a
+// ClientWorkingRoot, since the operation only calls it in that case.
 type factoryDefinitionsFake struct {
 	factorydefinitions.Service
 
 	listEffectiveFactories func(context.Context, factorydefinitions.ListEffectiveFactoriesRequest) (factorydefinitions.ListEffectiveFactoriesResult, error)
+	resolveNamedFactory    func(context.Context, factorydefinitions.ResolveNamedFactoryRequest) (factorydefinitions.ResolveNamedFactoryResult, error)
 }
 
 func (fake *factoryDefinitionsFake) ListEffectiveFactories(
@@ -40,6 +43,16 @@ func (fake *factoryDefinitionsFake) ListEffectiveFactories(
 		return fake.listEffectiveFactories(ctx, request)
 	}
 	return factorydefinitions.ListEffectiveFactoriesResult{}, errUnexpectedCall
+}
+
+func (fake *factoryDefinitionsFake) ResolveNamedFactory(
+	ctx context.Context,
+	request factorydefinitions.ResolveNamedFactoryRequest,
+) (factorydefinitions.ResolveNamedFactoryResult, error) {
+	if fake.resolveNamedFactory != nil {
+		return fake.resolveNamedFactory(ctx, request)
+	}
+	return factorydefinitions.ResolveNamedFactoryResult{}, errUnexpectedCall
 }
 
 type unexpectedCallError struct{}

--- a/pkg/services/chat_sessions/internal/service/factory_target_catalog_fakes_test.go
+++ b/pkg/services/chat_sessions/internal/service/factory_target_catalog_fakes_test.go
@@ -1,0 +1,49 @@
+package service_test
+
+import (
+	"context"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
+
+// operatorSettingsFake is a focused Operator Settings root fake exercising
+// only ResolveACPAgentProfile, the sole collaborator method the Factory
+// target-catalog operation depends on.
+type operatorSettingsFake struct {
+	operatorsettings.Service
+
+	resolveACPAgentProfile func(string) (operatorsettings.ACPAgentProfile, error)
+}
+
+func (fake *operatorSettingsFake) ResolveACPAgentProfile(path string) (operatorsettings.ACPAgentProfile, error) {
+	if fake.resolveACPAgentProfile != nil {
+		return fake.resolveACPAgentProfile(path)
+	}
+	return operatorsettings.ACPAgentProfile{}, errUnexpectedCall
+}
+
+// factoryDefinitionsFake is a focused Factory Definitions root fake
+// exercising only ListEffectiveFactories, the sole collaborator method the
+// Factory target-catalog operation depends on.
+type factoryDefinitionsFake struct {
+	factorydefinitions.Service
+
+	listEffectiveFactories func(context.Context, factorydefinitions.ListEffectiveFactoriesRequest) (factorydefinitions.ListEffectiveFactoriesResult, error)
+}
+
+func (fake *factoryDefinitionsFake) ListEffectiveFactories(
+	ctx context.Context,
+	request factorydefinitions.ListEffectiveFactoriesRequest,
+) (factorydefinitions.ListEffectiveFactoriesResult, error) {
+	if fake.listEffectiveFactories != nil {
+		return fake.listEffectiveFactories(ctx, request)
+	}
+	return factorydefinitions.ListEffectiveFactoriesResult{}, errUnexpectedCall
+}
+
+type unexpectedCallError struct{}
+
+func (unexpectedCallError) Error() string { return "unexpected fake call" }
+
+var errUnexpectedCall = unexpectedCallError{}

--- a/pkg/services/chat_sessions/internal/service/factory_target_catalog_rejection_test.go
+++ b/pkg/services/chat_sessions/internal/service/factory_target_catalog_rejection_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
@@ -94,7 +95,53 @@ func TestResolveFactoryTargetCatalogRejectsMalformedCurrentTarget(t *testing.T) 
 				OperatorSettingsPath: "/operator.json",
 				CurrentTarget:        testCase.target,
 			})
-			assertFactoryTargetCatalogError(t, err, chatsessions.ErrFactoryTargetReferenceMalformed, testCase.target)
+			// A malformed CurrentTarget never appears in the public error's
+			// Target field or rendered message: the value has not passed
+			// lexical validation and may itself be unsafe caller-supplied
+			// input (a path, credential-like value, or control text).
+			assertFactoryTargetCatalogError(t, err, chatsessions.ErrFactoryTargetReferenceMalformed, "")
+			if strings.Contains(err.Error(), testCase.target) {
+				t.Fatalf("error message %q echoes the raw malformed CurrentTarget %q", err.Error(), testCase.target)
+			}
+		})
+	}
+}
+
+func TestResolveFactoryTargetCatalogMalformedCurrentTargetNeverLeaksHostileInput(t *testing.T) {
+	t.Parallel()
+
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/factory-builder",
+		AllowedTargets: []string{"factory:@you/factory-builder"},
+	}
+	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
+		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+	}
+
+	cases := []struct {
+		name   string
+		target string
+	}{
+		{name: "filesystem path", target: "/etc/passwd"},
+		{name: "windows filesystem path", target: `C:\Users\victim\.ssh\id_rsa`},
+		{name: "credential-like value", target: "factory:token=sk-live-abcdef0123456789"},
+		{name: "control characters", target: "factory:@you/bad\x00\x1bref"},
+		{name: "shell metacharacters", target: "factory:@you/x`rm -rf /`"},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			service := newTestService(t, profile, entries)
+
+			_, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+				OperatorSettingsPath: "/operator.json",
+				CurrentTarget:        testCase.target,
+			})
+			assertFactoryTargetCatalogError(t, err, chatsessions.ErrFactoryTargetReferenceMalformed, "")
+			if strings.Contains(err.Error(), testCase.target) {
+				t.Fatalf("error message %q echoes the supplied hostile input %q", err.Error(), testCase.target)
+			}
 		})
 	}
 }

--- a/pkg/services/chat_sessions/internal/service/factory_target_catalog_rejection_test.go
+++ b/pkg/services/chat_sessions/internal/service/factory_target_catalog_rejection_test.go
@@ -1,0 +1,376 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	chatsessionsservice "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/service"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
+
+var errCollaboratorUnavailable = errors.New("collaborator unavailable")
+
+func TestResolveFactoryTargetCatalogRejectsEmptyProfile(t *testing.T) {
+	t.Parallel()
+
+	settings := &operatorSettingsFake{
+		resolveACPAgentProfile: func(string) (operatorsettings.ACPAgentProfile, error) {
+			return operatorsettings.ACPAgentProfile{}, errCollaboratorUnavailable
+		},
+	}
+	definitions := &factoryDefinitionsFake{}
+	service, err := chatsessionsservice.New(settings, definitions, logging.NoopLogger{})
+	if err != nil {
+		t.Fatalf("New: unexpected error: %v", err)
+	}
+
+	_, err = service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+	})
+	assertFactoryTargetCatalogError(t, err, chatsessions.ErrFactoryTargetProfileUnavailable, "")
+	if errors.Is(err, errCollaboratorUnavailable) {
+		t.Fatalf("error unwraps to the raw collaborator error, leaking internal detail: %v", err)
+	}
+}
+
+func TestResolveFactoryTargetCatalogRejectsInvalidProfileNormalization(t *testing.T) {
+	t.Parallel()
+
+	// A default absent from its own allowlist fails Operator Settings'
+	// Normalize while resolving the profile; this proves that failure
+	// surfaces as a typed Chat Sessions profile failure, not a raw error.
+	settings := &operatorSettingsFake{
+		resolveACPAgentProfile: func(string) (operatorsettings.ACPAgentProfile, error) {
+			profile := operatorsettings.ACPAgentProfile{
+				DefaultTarget:  "factory:@you/review",
+				AllowedTargets: []string{"factory:@you/factory-builder"},
+			}
+			return profile.Normalize()
+		},
+	}
+	definitions := &factoryDefinitionsFake{}
+	service, err := chatsessionsservice.New(settings, definitions, logging.NoopLogger{})
+	if err != nil {
+		t.Fatalf("New: unexpected error: %v", err)
+	}
+
+	_, err = service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+	})
+	assertFactoryTargetCatalogError(t, err, chatsessions.ErrFactoryTargetProfileUnavailable, "")
+}
+
+func TestResolveFactoryTargetCatalogRejectsMalformedCurrentTarget(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		target string
+	}{
+		{name: "missing namespace", target: "@you/factory-builder"},
+		{name: "internal whitespace", target: "factory:@you/bad ref"},
+		{name: "version pinned", target: "factory:@you/factory-builder@1.2.3"},
+		{name: "digest pinned", target: "factory:@you/factory-builder@sha256:abcdef0123456789"},
+	}
+
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/factory-builder",
+		AllowedTargets: []string{"factory:@you/factory-builder"},
+	}
+	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
+		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			service := newTestService(t, profile, entries)
+
+			_, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+				OperatorSettingsPath: "/operator.json",
+				CurrentTarget:        testCase.target,
+			})
+			assertFactoryTargetCatalogError(t, err, chatsessions.ErrFactoryTargetReferenceMalformed, testCase.target)
+		})
+	}
+}
+
+func TestResolveFactoryTargetCatalogRejectsEmptyEffectiveCatalog(t *testing.T) {
+	t.Parallel()
+
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/factory-builder",
+		AllowedTargets: []string{"factory:@you/factory-builder"},
+	}
+	// Nothing installed: the allowlist and installed catalog share no target.
+	service := newTestService(t, profile, nil)
+
+	_, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+	})
+	assertFactoryTargetCatalogError(t, err, chatsessions.ErrFactoryTargetCatalogEmpty, "")
+}
+
+func TestResolveFactoryTargetCatalogRejectsUnknownUninstalledTarget(t *testing.T) {
+	t.Parallel()
+
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/factory-builder",
+		AllowedTargets: []string{"factory:@you/factory-builder", "factory:@you/ghost"},
+	}
+	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
+		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+	}
+	service := newTestService(t, profile, entries)
+
+	_, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+		CurrentTarget:        "factory:@you/ghost",
+	})
+	assertFactoryTargetCatalogError(t, err, chatsessions.ErrFactoryTargetNotInstalled, "factory:@you/ghost")
+}
+
+func TestResolveFactoryTargetCatalogRejectsRequestedTargetOutsideAllowlist(t *testing.T) {
+	t.Parallel()
+
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/factory-builder",
+		AllowedTargets: []string{"factory:@you/factory-builder"},
+	}
+	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
+		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+		{Name: "@you/review", Definition: &factorydefinitions.FactoryConfig{Name: "Review"}},
+	}
+	service := newTestService(t, profile, entries)
+
+	_, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+		CurrentTarget:        "factory:@you/review",
+	})
+	assertFactoryTargetCatalogError(t, err, chatsessions.ErrFactoryTargetNotAllowed, "factory:@you/review")
+}
+
+func TestResolveFactoryTargetCatalogRejectsUninstalledTargetAfterPriorSuccess(t *testing.T) {
+	t.Parallel()
+
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/factory-builder",
+		AllowedTargets: []string{"factory:@you/factory-builder"},
+	}
+	installed := []factorydefinitions.EffectiveFactoryCatalogEntry{
+		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+	}
+
+	settings := &operatorSettingsFake{
+		resolveACPAgentProfile: func(string) (operatorsettings.ACPAgentProfile, error) { return profile, nil },
+	}
+	definitions := &factoryDefinitionsFake{
+		listEffectiveFactories: func(context.Context, factorydefinitions.ListEffectiveFactoriesRequest) (factorydefinitions.ListEffectiveFactoriesResult, error) {
+			return factorydefinitions.ListEffectiveFactoriesResult{Entries: installed}, nil
+		},
+	}
+	service, err := chatsessionsservice.New(settings, definitions, logging.NoopLogger{})
+	if err != nil {
+		t.Fatalf("New: unexpected error: %v", err)
+	}
+
+	first, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+	})
+	if err != nil {
+		t.Fatalf("first ResolveFactoryTargetCatalog: unexpected error: %v", err)
+	}
+	if first.CurrentTarget != "factory:@you/factory-builder" {
+		t.Fatalf("first CurrentTarget = %q, want %q", first.CurrentTarget, "factory:@you/factory-builder")
+	}
+
+	// The Factory is uninstalled between calls; nothing is cached from the
+	// prior successful resolution, so the next call observes the change live.
+	installed = nil
+
+	_, err = service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+	})
+	assertFactoryTargetCatalogError(t, err, chatsessions.ErrFactoryTargetCatalogEmpty, "")
+}
+
+func TestResolveFactoryTargetCatalogRejectsIncompatiblePinnedWorkingRoot(t *testing.T) {
+	t.Parallel()
+
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/factory-builder",
+		AllowedTargets: []string{"factory:@you/factory-builder"},
+	}
+	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
+		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+	}
+
+	settings := &operatorSettingsFake{
+		resolveACPAgentProfile: func(string) (operatorsettings.ACPAgentProfile, error) { return profile, nil },
+	}
+	definitions := &factoryDefinitionsFake{
+		listEffectiveFactories: func(context.Context, factorydefinitions.ListEffectiveFactoriesRequest) (factorydefinitions.ListEffectiveFactoriesResult, error) {
+			return factorydefinitions.ListEffectiveFactoriesResult{Entries: entries}, nil
+		},
+		resolveNamedFactory: func(context.Context, factorydefinitions.ResolveNamedFactoryRequest) (factorydefinitions.ResolveNamedFactoryResult, error) {
+			return factorydefinitions.ResolveNamedFactoryResult{
+				Resolution: factorydefinitions.NamedFactoryResolution{
+					Name:        "@you/factory-builder",
+					Source:      factorydefinitions.NamedFactoryResolutionSourceProjectLocal,
+					ProjectRoot: "/repos/project-a",
+				},
+			}, nil
+		},
+	}
+	service, err := chatsessionsservice.New(settings, definitions, logging.NoopLogger{})
+	if err != nil {
+		t.Fatalf("New: unexpected error: %v", err)
+	}
+
+	_, err = service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+		FactoryDiscovery:     chatsessions.FactoryDiscoveryRoots{ProjectRoot: "/repos/project-a"},
+		ClientWorkingRoot:    "/repos/project-b",
+	})
+	assertFactoryTargetCatalogError(t, err, chatsessions.ErrFactoryTargetWorkingRootIncompatible, "factory:@you/factory-builder")
+}
+
+func TestResolveFactoryTargetCatalogAllowsCompatiblePinnedWorkingRoot(t *testing.T) {
+	t.Parallel()
+
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/factory-builder",
+		AllowedTargets: []string{"factory:@you/factory-builder"},
+	}
+	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
+		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+	}
+
+	settings := &operatorSettingsFake{
+		resolveACPAgentProfile: func(string) (operatorsettings.ACPAgentProfile, error) { return profile, nil },
+	}
+	definitions := &factoryDefinitionsFake{
+		listEffectiveFactories: func(context.Context, factorydefinitions.ListEffectiveFactoriesRequest) (factorydefinitions.ListEffectiveFactoriesResult, error) {
+			return factorydefinitions.ListEffectiveFactoriesResult{Entries: entries}, nil
+		},
+		resolveNamedFactory: func(context.Context, factorydefinitions.ResolveNamedFactoryRequest) (factorydefinitions.ResolveNamedFactoryResult, error) {
+			return factorydefinitions.ResolveNamedFactoryResult{
+				Resolution: factorydefinitions.NamedFactoryResolution{
+					Name:        "@you/factory-builder",
+					Source:      factorydefinitions.NamedFactoryResolutionSourceProjectLocal,
+					ProjectRoot: "/repos/project-a",
+				},
+			}, nil
+		},
+	}
+	service, err := chatsessionsservice.New(settings, definitions, logging.NoopLogger{})
+	if err != nil {
+		t.Fatalf("New: unexpected error: %v", err)
+	}
+
+	result, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+		FactoryDiscovery:     chatsessions.FactoryDiscoveryRoots{ProjectRoot: "/repos/project-a"},
+		ClientWorkingRoot:    "/repos/project-a/",
+	})
+	if err != nil {
+		t.Fatalf("ResolveFactoryTargetCatalog: unexpected error: %v", err)
+	}
+	if result.CurrentTarget != "factory:@you/factory-builder" {
+		t.Fatalf("CurrentTarget = %q, want %q", result.CurrentTarget, "factory:@you/factory-builder")
+	}
+}
+
+func TestResolveFactoryTargetCatalogWrapsCanonicalResolutionDependencyFailure(t *testing.T) {
+	t.Parallel()
+
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/factory-builder",
+		AllowedTargets: []string{"factory:@you/factory-builder"},
+	}
+	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
+		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+	}
+
+	settings := &operatorSettingsFake{
+		resolveACPAgentProfile: func(string) (operatorsettings.ACPAgentProfile, error) { return profile, nil },
+	}
+	definitions := &factoryDefinitionsFake{
+		listEffectiveFactories: func(context.Context, factorydefinitions.ListEffectiveFactoriesRequest) (factorydefinitions.ListEffectiveFactoriesResult, error) {
+			return factorydefinitions.ListEffectiveFactoriesResult{Entries: entries}, nil
+		},
+		resolveNamedFactory: func(context.Context, factorydefinitions.ResolveNamedFactoryRequest) (factorydefinitions.ResolveNamedFactoryResult, error) {
+			return factorydefinitions.ResolveNamedFactoryResult{}, errCollaboratorUnavailable
+		},
+	}
+	service, err := chatsessionsservice.New(settings, definitions, logging.NoopLogger{})
+	if err != nil {
+		t.Fatalf("New: unexpected error: %v", err)
+	}
+
+	_, err = service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+		FactoryDiscovery:     chatsessions.FactoryDiscoveryRoots{ProjectRoot: "/repos/project-a"},
+		ClientWorkingRoot:    "/repos/project-a",
+	})
+	assertFactoryTargetCatalogError(t, err, chatsessions.ErrFactoryTargetCatalogUnavailable, "factory:@you/factory-builder")
+	if errors.Is(err, errCollaboratorUnavailable) {
+		t.Fatalf("error unwraps to the raw collaborator error, leaking internal detail: %v", err)
+	}
+}
+
+func TestResolveFactoryTargetCatalogWrapsInstalledCatalogDependencyFailure(t *testing.T) {
+	t.Parallel()
+
+	settings := &operatorSettingsFake{
+		resolveACPAgentProfile: func(string) (operatorsettings.ACPAgentProfile, error) {
+			return operatorsettings.ACPAgentProfile{
+				DefaultTarget:  "factory:@you/factory-builder",
+				AllowedTargets: []string{"factory:@you/factory-builder"},
+			}, nil
+		},
+	}
+	definitions := &factoryDefinitionsFake{
+		listEffectiveFactories: func(context.Context, factorydefinitions.ListEffectiveFactoriesRequest) (factorydefinitions.ListEffectiveFactoriesResult, error) {
+			return factorydefinitions.ListEffectiveFactoriesResult{}, errCollaboratorUnavailable
+		},
+	}
+	service, err := chatsessionsservice.New(settings, definitions, logging.NoopLogger{})
+	if err != nil {
+		t.Fatalf("New: unexpected error: %v", err)
+	}
+
+	_, err = service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+	})
+	assertFactoryTargetCatalogError(t, err, chatsessions.ErrFactoryTargetCatalogUnavailable, "")
+	if errors.Is(err, errCollaboratorUnavailable) {
+		t.Fatalf("error unwraps to the raw collaborator error, leaking internal detail: %v", err)
+	}
+}
+
+// assertFactoryTargetCatalogError fails the test unless err is a
+// *chatsessions.FactoryTargetCatalogError classifiable via errors.Is against
+// wantSentinel, carrying wantTarget. It never inspects err.Error() text,
+// since this operation's typed errors are meant to be classified by
+// errors.Is/errors.As rather than parsed.
+func assertFactoryTargetCatalogError(t *testing.T, err error, wantSentinel error, wantTarget string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("ResolveFactoryTargetCatalog: expected error wrapping %v, got nil", wantSentinel)
+	}
+	if !errors.Is(err, wantSentinel) {
+		t.Fatalf("ResolveFactoryTargetCatalog: error = %v, want errors.Is match for %v", err, wantSentinel)
+	}
+	var typed *chatsessions.FactoryTargetCatalogError
+	if !errors.As(err, &typed) {
+		t.Fatalf("ResolveFactoryTargetCatalog: error = %v, want *chatsessions.FactoryTargetCatalogError", err)
+	}
+	if typed.Target != wantTarget {
+		t.Fatalf("FactoryTargetCatalogError.Target = %q, want %q", typed.Target, wantTarget)
+	}
+}

--- a/pkg/services/chat_sessions/internal/service/factory_target_catalog_test.go
+++ b/pkg/services/chat_sessions/internal/service/factory_target_catalog_test.go
@@ -1,0 +1,179 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	chatsessionsservice "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/service"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
+
+func newTestService(t *testing.T, profile operatorsettings.ACPAgentProfile, entries []factorydefinitions.EffectiveFactoryCatalogEntry) chatsessions.FactoryTargetCatalogService {
+	t.Helper()
+
+	settings := &operatorSettingsFake{
+		resolveACPAgentProfile: func(string) (operatorsettings.ACPAgentProfile, error) {
+			return profile, nil
+		},
+	}
+	definitions := &factoryDefinitionsFake{
+		listEffectiveFactories: func(context.Context, factorydefinitions.ListEffectiveFactoriesRequest) (factorydefinitions.ListEffectiveFactoriesResult, error) {
+			return factorydefinitions.ListEffectiveFactoriesResult{Entries: entries}, nil
+		},
+	}
+
+	service, err := chatsessionsservice.New(settings, definitions, logging.NoopLogger{})
+	if err != nil {
+		t.Fatalf("New: unexpected error: %v", err)
+	}
+	return service
+}
+
+func TestResolveFactoryTargetCatalogExactAllowlistFiltering(t *testing.T) {
+	t.Parallel()
+
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/factory-builder",
+		AllowedTargets: []string{"factory:@you/factory-builder", "factory:@you/review"},
+	}
+	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
+		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+		{Name: "@you/review", Definition: &factorydefinitions.FactoryConfig{Name: "Review"}},
+		{Name: "@you/extra", Definition: &factorydefinitions.FactoryConfig{Name: "Extra"}},
+	}
+	service := newTestService(t, profile, entries)
+
+	result, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+	})
+	if err != nil {
+		t.Fatalf("ResolveFactoryTargetCatalog: unexpected error: %v", err)
+	}
+
+	if result.CurrentTarget != "factory:@you/factory-builder" {
+		t.Fatalf("CurrentTarget = %q, want %q", result.CurrentTarget, "factory:@you/factory-builder")
+	}
+	wantValues := []string{"factory:@you/factory-builder", "factory:@you/review"}
+	if len(result.Choices) != len(wantValues) {
+		t.Fatalf("Choices = %+v, want values %v", result.Choices, wantValues)
+	}
+	for index, choice := range result.Choices {
+		if choice.Value != wantValues[index] {
+			t.Fatalf("Choices[%d].Value = %q, want %q", index, choice.Value, wantValues[index])
+		}
+		if choice.Name == "" {
+			t.Fatalf("Choices[%d].Name is empty", index)
+		}
+	}
+}
+
+func TestResolveFactoryTargetCatalogMissingProfileDefaultsToFactoryBuilder(t *testing.T) {
+	t.Parallel()
+
+	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
+		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+	}
+	// A missing authored profile resolves to Operator Settings' safe default,
+	// which this fake models directly since ResolveACPAgentProfile itself
+	// already owns that defaulting behavior.
+	service := newTestService(t, operatorsettings.DefaultACPAgentProfile(), entries)
+
+	result, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+	})
+	if err != nil {
+		t.Fatalf("ResolveFactoryTargetCatalog: unexpected error: %v", err)
+	}
+
+	if result.CurrentTarget != operatorsettings.DefaultACPAgentProfileTarget {
+		t.Fatalf("CurrentTarget = %q, want %q", result.CurrentTarget, operatorsettings.DefaultACPAgentProfileTarget)
+	}
+	if len(result.Choices) != 1 || result.Choices[0].Value != operatorsettings.DefaultACPAgentProfileTarget {
+		t.Fatalf("Choices = %+v, want exactly the default Factory Builder target", result.Choices)
+	}
+}
+
+func TestResolveFactoryTargetCatalogExcludesAllowedButUninstalled(t *testing.T) {
+	t.Parallel()
+
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/factory-builder",
+		AllowedTargets: []string{"factory:@you/factory-builder", "factory:@you/missing"},
+	}
+	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
+		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+	}
+	service := newTestService(t, profile, entries)
+
+	result, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+	})
+	if err != nil {
+		t.Fatalf("ResolveFactoryTargetCatalog: unexpected error: %v", err)
+	}
+
+	if len(result.Choices) != 1 || result.Choices[0].Value != "factory:@you/factory-builder" {
+		t.Fatalf("Choices = %+v, want only the installed allowed target", result.Choices)
+	}
+}
+
+func TestResolveFactoryTargetCatalogExcludesInstalledButDisallowed(t *testing.T) {
+	t.Parallel()
+
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/factory-builder",
+		AllowedTargets: []string{"factory:@you/factory-builder"},
+	}
+	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
+		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+		{Name: "@you/extra", Definition: &factorydefinitions.FactoryConfig{Name: "Extra"}},
+	}
+	service := newTestService(t, profile, entries)
+
+	result, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+	})
+	if err != nil {
+		t.Fatalf("ResolveFactoryTargetCatalog: unexpected error: %v", err)
+	}
+
+	if len(result.Choices) != 1 || result.Choices[0].Value != "factory:@you/factory-builder" {
+		t.Fatalf("Choices = %+v, want only the allowed installed target", result.Choices)
+	}
+}
+
+func TestResolveFactoryTargetCatalogResultIsDetached(t *testing.T) {
+	t.Parallel()
+
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/factory-builder",
+		AllowedTargets: []string{"factory:@you/factory-builder", "factory:@you/review"},
+	}
+	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
+		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+		{Name: "@you/review", Definition: &factorydefinitions.FactoryConfig{Name: "Review"}},
+	}
+	service := newTestService(t, profile, entries)
+
+	first, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+	})
+	if err != nil {
+		t.Fatalf("ResolveFactoryTargetCatalog: unexpected error: %v", err)
+	}
+	first.Choices[0].Value = "mutated"
+	first.Choices[0].Name = "mutated"
+
+	second, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+	})
+	if err != nil {
+		t.Fatalf("ResolveFactoryTargetCatalog: unexpected error: %v", err)
+	}
+	if second.Choices[0].Value == "mutated" {
+		t.Fatalf("second result observed mutation of a prior result's Choices slice")
+	}
+}

--- a/pkg/services/chat_sessions/internal/service/factory_target_catalog_test.go
+++ b/pkg/services/chat_sessions/internal/service/factory_target_catalog_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
@@ -142,6 +143,86 @@ func TestResolveFactoryTargetCatalogExcludesInstalledButDisallowed(t *testing.T)
 
 	if len(result.Choices) != 1 || result.Choices[0].Value != "factory:@you/factory-builder" {
 		t.Fatalf("Choices = %+v, want only the allowed installed target", result.Choices)
+	}
+}
+
+func TestResolveFactoryTargetCatalogDeterministicOrderingAndDedup(t *testing.T) {
+	t.Parallel()
+
+	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
+		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+		{Name: "@you/review", Definition: &factorydefinitions.FactoryConfig{Name: "Review"}},
+		{Name: "@you/analysis", Definition: &factorydefinitions.FactoryConfig{Name: "Analysis"}},
+	}
+	reorderedEntries := []factorydefinitions.EffectiveFactoryCatalogEntry{entries[2], entries[0], entries[1]}
+	duplicatedEntries := append(append([]factorydefinitions.EffectiveFactoryCatalogEntry{}, entries...), entries[1], entries[0])
+
+	wantValues := []string{"factory:@you/factory-builder", "factory:@you/analysis", "factory:@you/review"}
+
+	cases := []struct {
+		name           string
+		allowedTargets []string
+		entries        []factorydefinitions.EffectiveFactoryCatalogEntry
+	}{
+		{
+			name:           "canonical enumeration order",
+			allowedTargets: []string{"factory:@you/factory-builder", "factory:@you/review", "factory:@you/analysis"},
+			entries:        entries,
+		},
+		{
+			name:           "reordered allowlist and reordered installed catalog",
+			allowedTargets: []string{"factory:@you/analysis", "factory:@you/factory-builder", "factory:@you/review"},
+			entries:        reorderedEntries,
+		},
+		{
+			name:           "duplicate allowlist entries",
+			allowedTargets: []string{"factory:@you/review", "factory:@you/factory-builder", "factory:@you/review", "factory:@you/analysis", "factory:@you/factory-builder"},
+			entries:        entries,
+		},
+		{
+			name:           "duplicate installed catalog entries",
+			allowedTargets: []string{"factory:@you/factory-builder", "factory:@you/review", "factory:@you/analysis"},
+			entries:        duplicatedEntries,
+		},
+	}
+
+	var results []chatsessions.ResolveFactoryTargetCatalogResult
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Deliberately sequential (no t.Parallel()): results are collected
+			// below for a deep-equivalence check across cases, which requires
+			// every subtest to have completed before that check runs.
+			profile := operatorsettings.ACPAgentProfile{
+				DefaultTarget:  "factory:@you/factory-builder",
+				AllowedTargets: testCase.allowedTargets,
+			}
+			service := newTestService(t, profile, testCase.entries)
+
+			result, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+				OperatorSettingsPath: "/operator.json",
+			})
+			if err != nil {
+				t.Fatalf("ResolveFactoryTargetCatalog: unexpected error: %v", err)
+			}
+			if result.CurrentTarget != "factory:@you/factory-builder" {
+				t.Fatalf("CurrentTarget = %q, want %q", result.CurrentTarget, "factory:@you/factory-builder")
+			}
+			if len(result.Choices) != len(wantValues) {
+				t.Fatalf("Choices = %+v, want %d deduplicated values", result.Choices, len(wantValues))
+			}
+			for index, value := range wantValues {
+				if result.Choices[index].Value != value {
+					t.Fatalf("Choices[%d].Value = %q, want %q (current-first, then ascending)", index, result.Choices[index].Value, value)
+				}
+			}
+			results = append(results, result)
+		})
+	}
+
+	for index := 1; index < len(results); index++ {
+		if !reflect.DeepEqual(results[0], results[index]) {
+			t.Fatalf("case %d result %+v is not deeply equivalent to case 0 result %+v despite equivalent profile/catalog facts", index, results[index], results[0])
+		}
 	}
 }
 

--- a/pkg/services/chat_sessions/internal/service/service.go
+++ b/pkg/services/chat_sessions/internal/service/service.go
@@ -1,0 +1,49 @@
+// Package service is the parent-private implementation of the Chat Sessions
+// FactoryTargetCatalogService detached root contract. It is composed only
+// through pkg/services/chat_sessions/wire and consumed by peers exclusively
+// through the chatsessions.FactoryTargetCatalogService interface.
+package service
+
+import (
+	"fmt"
+
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
+
+// Service implements chatsessions.FactoryTargetCatalogService by combining
+// the singular Operator Settings and Factory Definitions public service
+// roots, injected directly and exactly once.
+type Service struct {
+	operatorSettings   operatorsettings.Service
+	factoryDefinitions factorydefinitions.Service
+	logger             logging.Logger
+}
+
+var _ chatsessions.FactoryTargetCatalogService = (*Service)(nil)
+
+// New constructs a Service from its required collaborator roots. logger is
+// the direct, required operation-logging abstraction; callers with no
+// operation logging pass logging.NoopLogger{}.
+func New(
+	operatorSettings operatorsettings.Service,
+	factoryDefinitions factorydefinitions.Service,
+	logger logging.Logger,
+) (*Service, error) {
+	if operatorSettings == nil {
+		return nil, fmt.Errorf("construct chat sessions factory target catalog: operator settings root is required")
+	}
+	if factoryDefinitions == nil {
+		return nil, fmt.Errorf("construct chat sessions factory target catalog: factory definitions root is required")
+	}
+	if logger == nil {
+		logger = logging.NoopLogger{}
+	}
+	return &Service{
+		operatorSettings:   operatorSettings,
+		factoryDefinitions: factoryDefinitions,
+		logger:             logger,
+	}, nil
+}

--- a/pkg/services/chat_sessions/wire/wire.go
+++ b/pkg/services/chat_sessions/wire/wire.go
@@ -1,0 +1,31 @@
+// Package wire is the Chat Sessions FactoryTargetCatalogService composition
+// boundary.
+//
+// Wire performs construction only, returns the singular
+// chatsessions.FactoryTargetCatalogService root interface, and starts no
+// lifecycle components. It composes the implementation through direct single
+// injection of the singular Operator Settings and Factory Definitions
+// public service roots, with no dependency bag, service locator, or
+// alternate construction path.
+package wire
+
+import (
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	chatsessionsservice "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/service"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
+
+// NewFactoryTargetCatalogService constructs the Chat Sessions Factory
+// target-catalog root from the singular Operator Settings and Factory
+// Definitions public service roots. logger is the direct, required
+// operation-logging abstraction; callers with no operation logging pass
+// logging.NoopLogger{}.
+func NewFactoryTargetCatalogService(
+	operatorSettings operatorsettings.Service,
+	factoryDefinitions factorydefinitions.Service,
+	logger logging.Logger,
+) (chatsessions.FactoryTargetCatalogService, error) {
+	return chatsessionsservice.New(operatorSettings, factoryDefinitions, logger)
+}

--- a/pkg/transports/mapping/factorytarget/factory_target_option.go
+++ b/pkg/transports/mapping/factorytarget/factory_target_option.go
@@ -1,0 +1,30 @@
+// Package factorytarget projects a resolved Chat Sessions Factory
+// target-catalog result onto the merged ACP Factory target select-option
+// contract, so ACP transports consume one deterministic mapping instead of
+// building the select-option shape themselves.
+package factorytarget
+
+import (
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	"github.com/portpowered/infinite-you/pkg/transports/acp"
+)
+
+// FromCatalogResult maps a resolved Factory target catalog onto the
+// domain-level ACP Factory target option, preserving choice order, choice
+// names, and the current/default target exactly. It performs no I/O and
+// invokes no downstream service.
+func FromCatalogResult(result chatsessions.ResolveFactoryTargetCatalogResult) acp.FactoryTargetOption {
+	choices := make([]acp.FactoryTargetChoice, 0, len(result.Choices))
+	for _, choice := range result.Choices {
+		choices = append(choices, acp.FactoryTargetChoice{
+			Value: acpsdk.SessionConfigValueId(choice.Value),
+			Name:  choice.Name,
+		})
+	}
+	return acp.FactoryTargetOption{
+		CurrentValue: acpsdk.SessionConfigValueId(result.CurrentTarget),
+		Choices:      choices,
+	}
+}

--- a/pkg/transports/mapping/factorytarget/factory_target_option_test.go
+++ b/pkg/transports/mapping/factorytarget/factory_target_option_test.go
@@ -1,0 +1,127 @@
+package factorytarget_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	"github.com/portpowered/infinite-you/pkg/transports/acp"
+	"github.com/portpowered/infinite-you/pkg/transports/mapping/factorytarget"
+)
+
+func TestFromCatalogResultSerializesSelectOptionContract(t *testing.T) {
+	t.Parallel()
+
+	result := chatsessions.ResolveFactoryTargetCatalogResult{
+		CurrentTarget: "factory:@you/factory-builder",
+		Choices: []chatsessions.FactoryTargetCatalogChoice{
+			{Value: "factory:@you/factory-builder", Name: "Factory Builder"},
+			{Value: "factory:@you/review", Name: "Review"},
+		},
+	}
+
+	option := factorytarget.FromCatalogResult(result)
+	wire, err := option.ToSessionConfigOption()
+	if err != nil {
+		t.Fatalf("ToSessionConfigOption() unexpected error: %v", err)
+	}
+	if wire.Select == nil {
+		t.Fatal("ToSessionConfigOption() Select is nil, want the select-option variant")
+	}
+	if wire.Select.Id != acp.FactoryTargetOptionID {
+		t.Fatalf("Id = %q, want %q", wire.Select.Id, acp.FactoryTargetOptionID)
+	}
+	if wire.Select.Name != acp.FactoryTargetOptionName {
+		t.Fatalf("Name = %q, want %q", wire.Select.Name, acp.FactoryTargetOptionName)
+	}
+	if wire.Select.Type != "select" {
+		t.Fatalf("Type = %q, want %q", wire.Select.Type, "select")
+	}
+	if wire.Select.Category == nil || *wire.Select.Category != acp.FactoryTargetOptionCategory {
+		t.Fatalf("Category = %+v, want %q", wire.Select.Category, acp.FactoryTargetOptionCategory)
+	}
+	if string(wire.Select.CurrentValue) != result.CurrentTarget {
+		t.Fatalf("CurrentValue = %q, want %q", wire.Select.CurrentValue, result.CurrentTarget)
+	}
+	if wire.Select.Options.Ungrouped == nil {
+		t.Fatal("Options.Ungrouped is nil")
+	}
+	ungrouped := *wire.Select.Options.Ungrouped
+	if len(ungrouped) != len(result.Choices) {
+		t.Fatalf("choice count = %d, want %d", len(ungrouped), len(result.Choices))
+	}
+	for index, choice := range result.Choices {
+		if string(ungrouped[index].Value) != choice.Value {
+			t.Fatalf("choice[%d].Value = %q, want %q", index, ungrouped[index].Value, choice.Value)
+		}
+		if ungrouped[index].Name != choice.Name {
+			t.Fatalf("choice[%d].Name = %q, want %q", index, ungrouped[index].Name, choice.Name)
+		}
+	}
+
+	if err := wire.Validate(); err != nil {
+		t.Fatalf("wire.Validate() unexpected error: %v", err)
+	}
+	data, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatalf("json.Marshal(wire) unexpected error: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal(wire) unexpected error: %v", err)
+	}
+	if decoded["category"] != "model" {
+		t.Fatalf("serialized category = %v, want %q", decoded["category"], "model")
+	}
+	for _, forbidden := range []string{"modelId", "models"} {
+		if _, present := decoded[forbidden]; present {
+			t.Fatalf("serialized Factory target option unexpectedly contains model field %q", forbidden)
+		}
+	}
+}
+
+func TestFromCatalogResultPreservesCallerSuppliedOrder(t *testing.T) {
+	t.Parallel()
+
+	builder := chatsessions.FactoryTargetCatalogChoice{Value: "factory:@you/factory-builder", Name: "Factory Builder"}
+	analysis := chatsessions.FactoryTargetCatalogChoice{Value: "factory:@you/analysis", Name: "Analysis"}
+	review := chatsessions.FactoryTargetCatalogChoice{Value: "factory:@you/review", Name: "Review"}
+
+	cases := []struct {
+		name    string
+		choices []chatsessions.FactoryTargetCatalogChoice
+	}{
+		{name: "canonical order", choices: []chatsessions.FactoryTargetCatalogChoice{builder, analysis, review}},
+		{name: "reordered", choices: []chatsessions.FactoryTargetCatalogChoice{review, builder, analysis}},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			option := factorytarget.FromCatalogResult(chatsessions.ResolveFactoryTargetCatalogResult{
+				CurrentTarget: "factory:@you/factory-builder",
+				Choices:       testCase.choices,
+			})
+			if len(option.Choices) != len(testCase.choices) {
+				t.Fatalf("choice count = %d, want %d", len(option.Choices), len(testCase.choices))
+			}
+			for index, want := range testCase.choices {
+				if string(option.Choices[index].Value) != want.Value || option.Choices[index].Name != want.Name {
+					t.Fatalf("choice[%d] = %+v, want {Value:%s Name:%s} (projection must not reorder)", index, option.Choices[index], want.Value, want.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestFromCatalogResultRejectsEmptyChoicesThroughSerialization(t *testing.T) {
+	t.Parallel()
+
+	option := factorytarget.FromCatalogResult(chatsessions.ResolveFactoryTargetCatalogResult{
+		CurrentTarget: "factory:@you/factory-builder",
+	})
+	if _, err := option.ToSessionConfigOption(); err == nil {
+		t.Fatal("ToSessionConfigOption() unexpected nil error for an empty catalog projection")
+	}
+}

--- a/pkg/wire/chat_sessions.go
+++ b/pkg/wire/chat_sessions.go
@@ -1,0 +1,23 @@
+package wire
+
+import (
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	chatsessionswire "github.com/portpowered/infinite-you/pkg/services/chat_sessions/wire"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
+
+// provideChatSessionsFactoryTargetCatalogService constructs the Chat
+// Sessions Factory target-catalog root through the owning Chat Sessions Wire
+// package's focused constructor, from the same singular Operator Settings
+// and Factory Definitions public service roots the rest of this graph
+// composes. It performs no dependency-bag or service-locator composition:
+// every collaborator is a direct constructor parameter.
+func provideChatSessionsFactoryTargetCatalogService(
+	operatorSettings operatorsettings.Service,
+	factoryDefinitions factorydefinitions.Service,
+	logger logging.Logger,
+) (chatsessions.FactoryTargetCatalogService, error) {
+	return chatsessionswire.NewFactoryTargetCatalogService(operatorSettings, factoryDefinitions, logger)
+}

--- a/pkg/wire/chat_sessions_composition_test.go
+++ b/pkg/wire/chat_sessions_composition_test.go
@@ -1,0 +1,140 @@
+package wire
+
+import (
+	"context"
+	"path/filepath"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/testutil/testdeps"
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"go.uber.org/zap/zapcore"
+)
+
+// staticFactoryDefinitionsService is a minimal factorydefinitions.Service
+// double covering only ListEffectiveFactories, the sole collaborator method
+// the Chat Sessions Factory target-catalog operation depends on. Factory
+// Definitions' full production Service is only constructible from a live
+// Factory Session's SessionHost/DefinitionActivationGateway/Validator
+// (pkg/wire/factory_definition_service_provider.go's
+// provideFactoryDefinitionsFactory), so this composition test proves the
+// Chat Sessions side of the wiring (real canonical Operator Settings root,
+// real canonical logger, direct single injection, no dependency bag) with a
+// focused double standing in for the Factory Definitions root, matching the
+// same fake-collaborator convention used by
+// pkg/services/chat_sessions/internal/service's own unit tests.
+type staticFactoryDefinitionsService struct {
+	factorydefinitions.Service
+
+	mu      sync.Mutex
+	calls   int
+	entries []factorydefinitions.EffectiveFactoryCatalogEntry
+}
+
+func (s *staticFactoryDefinitionsService) ListEffectiveFactories(
+	context.Context,
+	factorydefinitions.ListEffectiveFactoriesRequest,
+) (factorydefinitions.ListEffectiveFactoriesResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	return factorydefinitions.ListEffectiveFactoriesResult{Entries: s.entries}, nil
+}
+
+func (s *staticFactoryDefinitionsService) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+func (s *staticFactoryDefinitionsService) setEntries(entries []factorydefinitions.EffectiveFactoryCatalogEntry) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries = entries
+}
+
+// TestProvideChatSessionsFactoryTargetCatalogServiceComposesThroughTheCanonicalWireGraph
+// proves the exact provider chain pkg/wire registers for the Chat Sessions
+// Factory target-catalog root (provideChatSessionsFactoryTargetCatalogService
+// consuming the same provideOperatorSettingsService chain and canonical
+// process logger as every other canonical consumer) performs direct single
+// injection with no dependency bag, threads a real logger into the
+// operation's started/finished logs, observes live Factory Definitions
+// drift on the very next call, and never invokes anything beyond the one
+// read-only collaborator method it depends on.
+func TestProvideChatSessionsFactoryTargetCatalogServiceComposesThroughTheCanonicalWireGraph(t *testing.T) {
+	t.Parallel()
+
+	zapLogger, observed := testdeps.CapturingZapLogger(zapcore.InfoLevel)
+	logger := provideOperatorSettingsLogger(zapLogger)
+
+	edges := serviceedges.Edges{}
+	files := provideOperatorSettingsFileSystem(edges)
+	providersRoot, err := provideProvidersService(edges)
+	if err != nil {
+		t.Fatalf("provideProvidersService() error = %v", err)
+	}
+	providerRegistry, err := provideProviderRegistry(edges, providersRoot)
+	if err != nil {
+		t.Fatalf("provideProviderRegistry() error = %v", err)
+	}
+	operatorSettings, err := provideOperatorSettingsService(
+		files,
+		provideOperatorSettingsCreateTemporaryFile(edges),
+		provideOperatorSettingsProviderCatalog(providerRegistry),
+		provideOperatorConfigDecoder(),
+		provideOperatorConfigEncoder(),
+		provideOperatorSettingsIDGenerator(edges),
+		providersRoot,
+		logger,
+	)
+	if err != nil {
+		t.Fatalf("provideOperatorSettingsService() error = %v", err)
+	}
+
+	factoryDefinitions := &staticFactoryDefinitionsService{
+		entries: []factorydefinitions.EffectiveFactoryCatalogEntry{
+			{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+		},
+	}
+
+	catalog, err := provideChatSessionsFactoryTargetCatalogService(operatorSettings, factoryDefinitions, logger)
+	if err != nil {
+		t.Fatalf("provideChatSessionsFactoryTargetCatalogService() error = %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	req := chatsessions.ResolveFactoryTargetCatalogRequest{OperatorSettingsPath: path}
+
+	if _, err := catalog.ResolveFactoryTargetCatalog(context.Background(), req); err != nil {
+		t.Fatalf("ResolveFactoryTargetCatalog() error = %v", err)
+	}
+	if factoryDefinitions.callCount() != 1 {
+		t.Fatalf("ListEffectiveFactories call count = %d, want exactly 1 for one resolution", factoryDefinitions.callCount())
+	}
+
+	var messages []string
+	for _, entry := range observed.All() {
+		messages = append(messages, entry.Message)
+	}
+	if !slices.Contains(messages, "chat_sessions.resolve_factory_target_catalog.started") {
+		t.Fatalf("observed log messages = %v, want a start log proving the canonical wire logger reached the service", messages)
+	}
+	if !slices.Contains(messages, "chat_sessions.resolve_factory_target_catalog.finished") {
+		t.Fatalf("observed log messages = %v, want a finished log proving the canonical wire logger reached the service", messages)
+	}
+
+	// Drift: Factory Builder becomes uninstalled between calls. The same
+	// long-lived catalog root must observe it on the very next call instead
+	// of replaying a cached prior resolution.
+	factoryDefinitions.setEntries(nil)
+	if _, err := catalog.ResolveFactoryTargetCatalog(context.Background(), req); err == nil {
+		t.Fatal("ResolveFactoryTargetCatalog() after uninstalling the default target = nil error, want live drift to be observed")
+	}
+	if factoryDefinitions.callCount() != 2 {
+		t.Fatalf("ListEffectiveFactories call count = %d, want exactly 2 after a second resolution", factoryDefinitions.callCount())
+	}
+}

--- a/pkg/wire/wire.go
+++ b/pkg/wire/wire.go
@@ -61,6 +61,7 @@ var servicesSet = wire.NewSet(
 	provideOperatorSettingsLogger,
 	provideOperatorSettingsService,
 	provideOperatorSettingsIDGenerator,
+	provideChatSessionsFactoryTargetCatalogService,
 	provideOperatorConfigDecoder,
 	provideOperatorConfigEncoder,
 	provideSystemInitializationInspectPath,

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -586,6 +586,7 @@ var servicesSet = wire3.NewSet(
 	provideOperatorSettingsLogger,
 	provideOperatorSettingsService,
 	provideOperatorSettingsIDGenerator,
+	provideChatSessionsFactoryTargetCatalogService,
 	provideOperatorConfigDecoder,
 	provideOperatorConfigEncoder,
 	provideSystemInitializationInspectPath,


### PR DESCRIPTION
{
  "project": "ACP L1 V1 C11 \u00e2\u20ac\u201d Resolve the allowed ACP Factory target catalog",
  "branchName": "ACP-L1-V1-C11-factory-target-catalog",
  "description": "Add one Chat Sessions-owned target-catalog operation that combines the Operator Settings ACP agent profile with Factory Definitions public installed-catalog and canonical-resolution behavior. It returns a deterministic list of allowed, installed, canonical, unversioned Factory target choices plus exactly one valid default/current target for the ACP picker, including factory:@you/factory-builder when configured and valid. It rejects malformed, unknown, uninstalled, disallowed, empty, invalid-profile, and pinned-working-root-incompatible targets with typed safe errors, produces no WORKER targets, preserves the Factory/Model domain boundary, performs no persistence or provider-root cleanup, and projects through the merged ACP select-option contract.",
  "context": {
    "customerAsk": "Resolve the Operator Settings ACP profile against Factory Definitions public contracts and return the configured default plus allowed installed Factories for the ACP client picker. Preserve canonical namespaced refs and stable ordering, reuse the merged ACP select-option contract with type=select and category=model, reject invalid or drifted targets with typed safe errors, use direct single injection and focused wire construction, emit safe structured logs, and continue delivery through actual PR merge.",
    "problem": "Operator Settings owns ACP target policy and Factory Definitions owns installed Factory identity, but Chat Sessions has no operation that combines those authorities into one trustworthy picker catalog. Caller-side joins would duplicate policy, permit stale or unavailable choices, produce unstable or duplicate output, risk unsafe errors, and blur the boundary between orchestration Factories, Models, and future Worker targets.",
    "solution": "Extend the singular Chat Sessions service with a detached runtime target-catalog operation. On every call it resolves the effective ACP profile through Operator Settings, reads and canonically resolves installed Factories through Factory Definitions, filters by the exact allowlist, validates the configured default or requested current target and client working root, deduplicates and stably orders canonical factory: refs, and returns one valid default/current choice. Publish typed sensitive-safe failures, compose the implementation through direct single injection in the focused and canonical wire graphs, emit safe structured logs, and map successful output through the existing ACP Factory select-option contract without persistence or unrelated mutation."
  },
  "acceptanceCriteria": [
    "The singular Chat Sessions service exposes one detached Factory target-catalog operation that combines the effective Operator Settings ACP profile with Factory Definitions public catalog and canonical-resolution contracts; callers do not assemble this policy themselves.",
    "A successful result contains only L1 FACTORY choices whose canonical unversioned factory: refs are both allowed and currently installed, contains no duplicate refs or WORKER choices, and identifies exactly one current/default choice present in the returned list.",
    "The configured default is honored, including factory:@you/factory-builder when configured and valid; choice ordering and display output are stable regardless of input enumeration order or duplicate discoveries.",
    "Unknown, uninstalled, disallowed, malformed, empty-effective-catalog, invalid-profile, and pinned-working-root-incompatible targets return distinguishable typed Chat Sessions errors with no partial catalog and no sensitive path, provider, command, credential, or topology details.",
    "Catalog resolution observes installation and configuration drift on each operation: a changed or uninstalled default/current target cannot remain silently selectable, and resolution performs no persistence, provider-root cleanup, Factory mutation, or Model mutation.",
    "Quality gate: typecheck, lint, focused Chat Sessions package tests, focused wire/construction tests, relevant ACP contract tests, diff-scoped repository gates, and required PR CI are terminal and passing.",
    "Delivery: the implementation/review loop continues until required CI is terminal and passing, every blocking PR conversation is explicitly addressed, shared-file changes and merge conflicts are reconciled, and the PR is actually merged; an opened, green, approved, or merge-ready PR is not complete."
  ],
  "userStories": [
    {
      "id": "ACP-L1-V1-C11-factory-target-catalog-001",
      "title": "Return the allowed installed Factory catalog",
      "description": "As an ACP client user, I want the Factory picker to contain the configured default and only the allowed Factories that are actually installed so every displayed choice can be selected legitimately.",
      "acceptanceCriteria": [
        "The singular Chat Sessions root exposes a detached target-catalog request/result operation whose inputs include the operator-settings location, Factory discovery context, the client working root, and an optional current/requested target when validation of an existing selection is required.",
        "Each successful choice is a FACTORY target with the canonical unversioned value factory:<canonical Factory ref> obtained through Factory Definitions public root behavior; the result produces no WORKER target and no Model resource.",
        "The effective Operator Settings allowlist is intersected with the currently installed Factory catalog, and the configured default is returned as the sole default/current target only when it belongs to that intersection.",
        "A missing authored ACP profile uses the Operator Settings effective default, so factory:@you/factory-builder is selected when that is the resolved default and Factory Builder is installed and compatible.",
        "The result is detached from collaborator-owned slices and definitions; caller mutation cannot affect subsequent catalog results.",
        "Focused success-path package tests cover exact allowlist filtering, missing-profile defaulting, and exclusion of installed-but-disallowed and allowed-but-uninstalled Factories.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented as a new detached FactoryTargetCatalogService root contract in pkg/services/chat_sessions (factory_target_catalog_contract.go, factory_target_catalog_errors.go), separate from the still-contract-only L1 V0 Service interface. Implementation lives in pkg/services/chat_sessions/internal/service, composed via pkg/services/chat_sessions/wire.NewFactoryTargetCatalogService with direct single injection of operatorsettings.Service and factorydefinitions.Service. Not yet wired into the canonical pkg/wire graph (deferred to story 004) and dedup/ordering only lightly exercised here (full coverage in story 002)."
    },
    {
      "id": "ACP-L1-V1-C11-factory-target-catalog-002",
      "title": "Produce deterministic picker choices",
      "description": "As an ACP client user, I want the same Factory catalog to render in the same order with stable labels so the picker does not jump or show repeated entries as discovery sources change order.",
      "acceptanceCriteria": [
        "Duplicate installed entries and repeated canonical identities collapse to one choice by canonical namespaced ref without changing the configured default.",
        "The default/current choice is first, followed by remaining choices in ascending canonical target-ref order; collaborator enumeration order, map order, and duplicate position cannot affect the output.",
        "Every choice has a non-empty stable display name derived from Factory Definitions-owned canonical identity facts, while its value preserves the exact canonical unversioned factory: ref.",
        "Repeated resolution with equivalent profile and installed-catalog facts returns deeply equivalent detached output.",
        "The ACP adapter consumes the resolved catalog through the merged Factory target-option contract and serializes id=target, name=Factory, type=select, category=model, one current value, and the same ordered choices; this UX category does not publish or mutate a You Model.",
        "Focused table-driven tests vary enumeration order and duplicates and assert exact picker output plus ACP select-option serialization.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "The core dedup-by-canonical-ref and current-first/ascending ordering logic already existed from story 001 (map-keyed choicesByValue + sort.Slice). Added table-driven coverage in factory_target_catalog_test.go (TestResolveFactoryTargetCatalogDeterministicOrderingAndDedup) proving 4 independent enumeration-order/duplicate variants (canonical order, reordered allowlist+catalog, duplicate allowlist entries, duplicate installed-catalog entries) all produce the exact same ordered/deduplicated Choices and are deeply equivalent (reflect.DeepEqual) to each other. Added a new pkg/transports/mapping/factorytarget package with FromCatalogResult(chatsessions.ResolveFactoryTargetCatalogResult) acp.FactoryTargetOption -- a pure, I/O-free projection (chosen as a mapping-package function rather than living inside pkg/transports/acp itself, since that package's doc.go explicitly forbids importing/invoking downstream services; pkg/transports/mapping is the existing convention for service-to-transport projections). Tests in factory_target_option_test.go prove exact select-option serialization (id=target, name=Factory, type=select, category=model, one current value) via acp.FactoryTargetOption.ToSessionConfigOption(), order preservation across enumeration variants, and rejection of an empty catalog projection."
    },
    {
      "id": "ACP-L1-V1-C11-factory-target-catalog-003",
      "title": "Reject invalid and drifted targets safely",
      "description": "As an ACP client user, I want target selection to fail clearly when configuration, installation, or workspace compatibility has changed so the agent never silently runs a different Factory or root.",
      "acceptanceCriteria": [
        "Malformed or non-factory: target refs, version- or digest-pinned refs, invalid or empty effective profiles, and a default absent from its effective allowlist are rejected with typed Chat Sessions validation or profile failures.",
        "An unknown or currently uninstalled default/current target, a requested target outside the allowlist, and an effective catalog with no valid default return distinct classifiable errors and no partial choices.",
        "A Factory that pins a working root incompatible with the client-supplied working root is rejected with a typed incompatibility error; the service never silently overrides either root.",
        "Catalog and canonical-resolution dependency failures are wrapped into typed actionable Chat Sessions errors while remaining classifiable by errors.Is/errors.As as appropriate.",
        "Error values and messages omit credentials, prompts, raw provider commands, unrestricted configuration payloads, unsafe filesystem paths, and private Factory/provider topology.",
        "Focused package tests cover empty and invalid profiles, malformed and pinned refs, unknown and disallowed targets, an uninstalled target after a previously successful resolution, pinned-root mismatch, and dependency failure without string-parsing assertions.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented: split coarse current-target-unavailable sentinel into 5 distinct typed sentinels (ErrFactoryTargetReferenceMalformed, ErrFactoryTargetCatalogEmpty, ErrFactoryTargetNotInstalled, ErrFactoryTargetNotAllowed, ErrFactoryTargetWorkingRootIncompatible); added lexical validation of caller-supplied CurrentTarget mirroring Operator Settings unversioned factory: grammar; added pinned-project-local-working-root incompatibility check via factorydefinitions.ResolveNamedFactory, gated on a non-blank ClientWorkingRoot; focused rejection tests cover all AC1/AC2/AC3/AC4 scenarios without string-parsing assertions."
    },
    {
      "id": "ACP-L1-V1-C11-factory-target-catalog-004",
      "title": "Compose and observe the catalog operation",
      "description": "As a maintainer, I want the target catalog to use the canonical service graph and safe operation logs so its behavior is diagnosable without creating alternate construction or ownership paths.",
      "acceptanceCriteria": [
        "The Chat Sessions implementation receives the singular Operator Settings and Factory Definitions public service roots directly and exactly once; it imports neither service internals nor provider internals.",
        "The owning Chat Sessions wire provider and canonical pkg/wire graph construct the implementation through focused direct injection with no dependency bag, service locator, secondary injector, runtime factory, or out-of-wire production construction.",
        "Every resolution reads current collaborator state rather than a persisted or long-lived copied catalog, so allowlist changes, default changes, installation, uninstallation, and canonical-resolution drift are observable on the next call.",
        "Accepted intent and terminal success/failure are emitted through the injected structured logger with stable operation/outcome and safe aggregate identifiers or counts, without logging raw profiles, unrestricted target lists, unsafe roots, credentials, prompts, provider commands, or private topology.",
        "Resolving a catalog has no write or cleanup side effects in Operator Settings, Factory Definitions, Models, Providers, provider roots, or the filesystem.",
        "Focused construction and collaboration tests prove the real injected roots are used once, live drift is observed, safe logs are emitted, and no mutation is requested from either owner.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Added the started/failed/finished structured logging triad to ResolveFactoryTargetCatalog (pkg/services/chat_sessions/internal/service/factory_target_catalog.go), with a classifyFactoryTargetCatalogFailure helper mapping every typed sentinel plus context cancellation/deadline to a stable safe reason label -- no raw target, path, or collaborator error text is ever logged. Registered pkg/wire/chat_sessions.go's provideChatSessionsFactoryTargetCatalogService (direct single injection of operatorsettings.Service, factorydefinitions.Service, and the canonical process logging.Logger, calling chatsessionswire.NewFactoryTargetCatalogService) into pkg/wire's servicesSet, mirroring provideACPCLIService's shape exactly. Verified with `go generate ./pkg/...` / `make wire-smoke` that registering this provider produces zero drift in wire_gen.go beyond the provider-set listing itself, since no current transport requests chatsessions.FactoryTargetCatalogService as an injector output yet (Factory Definitions' full Service is only constructible from a live Factory Session's SessionHost/DefinitionActivationGateway/Validator -- pkg/wire/factory_definition_service_provider.go -- so there is no standalone process-level factorydefinitions.Service singleton for any consumer to attach to today; that is Factory Definitions' existing architecture, not something this story changes). Added pkg/wire/chat_sessions_composition_test.go proving the real canonical Operator Settings chain (provideOperatorSettingsService et al., exactly as pkg/wire/operator_settings_logging_test.go already does) and the real canonical process logger flow through provideChatSessionsFactoryTargetCatalogService correctly, using a focused factorydefinitions.Service double for the one collaborator method (ListEffectiveFactories) that has no standalone canonical constructor, and proving live drift (an uninstalled default is observed on the very next call, not cached) plus exactly-once collaborator calls per resolution. Added matching focused tests directly in pkg/services/chat_sessions/internal/service (factory_target_catalog_construction_test.go) for logging shape/safety, per-call collaborator call counts, and live drift using the package's existing fakes. No persistence, provider-root cleanup, or mutation call is made anywhere in this operation (both fakes/doubles only ever implement read-only methods; any other call would nil-pointer-panic, which no test triggers)."
    }
  ]
}
