### PR TITLE
Serve ACP Initialize over Framed Stdio

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -2955,6 +2955,26 @@
       }
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/acp/internal/stdio",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/acp/wire",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli",
       "minimum": 72.98
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -2259,6 +2259,14 @@
       "minimum": 88.43
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/acp/internal/stdio",
+      "minimum": 94.25
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/acp/wire",
+      "minimum": 100.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli",
       "minimum": 71.22
     },

--- a/pkg/transports/acp/internal/envelope/envelope.go
+++ b/pkg/transports/acp/internal/envelope/envelope.go
@@ -29,6 +29,49 @@ import (
 // method-specific validation failure.
 var ErrMalformedEnvelope = errors.New("acp: malformed json-rpc envelope")
 
+// ErrInvalidJSON marks a Decode failure caused by input that never parsed
+// as JSON at all. It wraps ErrMalformedEnvelope, so a caller checking only
+// for ErrMalformedEnvelope still matches, while a caller that needs the
+// JSON-RPC 2.0 parse-error-vs-invalid-request distinction can check for
+// this sentinel specifically.
+var ErrInvalidJSON = fmt.Errorf("%w: invalid JSON", ErrMalformedEnvelope)
+
+// ErrInvalidRequestShape marks a Decode failure caused by input that parsed
+// as JSON but violates the JSON-RPC 2.0 request shape this transport
+// requires: a wrong or missing "jsonrpc" version, a missing or blank
+// method, an unsupported id shape, an id-bearing notification, or a
+// request-shaped method with no id. It wraps ErrMalformedEnvelope for the
+// same reason ErrInvalidJSON does.
+var ErrInvalidRequestShape = fmt.Errorf("%w: invalid JSON-RPC request shape", ErrMalformedEnvelope)
+
+// DecodeError classifies a Decode failure and, when possible, carries the
+// JSON-RPC id token a caller may still correlate a rejection response to.
+// Per JSON-RPC 2.0, a request that is otherwise malformed should still
+// receive a response correlated to its id when that id token was itself
+// syntactically valid; ID reports false when the inbound message had no id,
+// or its id was itself malformed, or the failure was ErrInvalidJSON (input
+// unparseable enough that no id could ever be recovered from it).
+type DecodeError struct {
+	cause error
+	id    identity.JSONRPCID
+	hasID bool
+}
+
+// Error returns the underlying cause's message.
+func (e *DecodeError) Error() string { return e.cause.Error() }
+
+// Unwrap exposes the underlying cause so errors.Is/errors.As can match
+// ErrMalformedEnvelope, ErrInvalidJSON, or ErrInvalidRequestShape.
+func (e *DecodeError) Unwrap() error { return e.cause }
+
+// ID returns the JSON-RPC id to correlate a rejection response to, and true
+// only when the inbound message's id token was itself syntactically valid.
+func (e *DecodeError) ID() (identity.JSONRPCID, bool) { return e.id, e.hasID }
+
+func newDecodeError(cause error, id identity.JSONRPCID, hasID bool) *DecodeError {
+	return &DecodeError{cause: cause, id: id, hasID: hasID}
+}
+
 // jsonrpcVersion is the only JSON-RPC protocol version this boundary
 // accepts on the wire.
 const jsonrpcVersion = "2.0"
@@ -84,35 +127,54 @@ type Envelope struct {
 // JSON, a wrong or missing "jsonrpc" version, a missing method, a blank
 // connection id, any id shape identity.NewJSONRPCID does not accept, an
 // id-bearing NotificationMethods message, and a non-notification method
-// with no id, before ever producing an Envelope value. A notification
-// carries no JSON-RPC id to correlate by, so its identity is instead minted
-// from the connection, the method, and notificationSeq -- a value the
-// connection/framing layer must supply as unique per notification received
-// on this connection (for example a connection-local monotonic counter),
-// since Decode itself has no state across calls and cannot otherwise tell
-// two same-method notifications on one connection apart. Decode performs no
-// IO and invokes no downstream validator or effect: a rejection here can
-// never have a side effect to undo.
+// with no id, before ever producing an Envelope value. Every rejection is
+// returned as a *DecodeError: unparseable JSON wraps ErrInvalidJSON and
+// never carries a recoverable id, while every other rejection wraps
+// ErrInvalidRequestShape and carries the message's id when that id token
+// was itself syntactically valid, even though some other part of the
+// message was rejected. A notification carries no JSON-RPC id to correlate
+// by, so its identity is instead minted from the connection, the method,
+// and notificationSeq -- a value the connection/framing layer must supply
+// as unique per notification received on this connection (for example a
+// connection-local monotonic counter), since Decode itself has no state
+// across calls and cannot otherwise tell two same-method notifications on
+// one connection apart. Decode performs no IO and invokes no downstream
+// validator or effect: a rejection here can never have a side effect to
+// undo.
 func Decode(connectionID identity.ConnectionID, notificationSeq uint64, raw json.RawMessage) (Envelope, error) {
 	var w wireRequest
 	if err := json.Unmarshal(raw, &w); err != nil {
-		return Envelope{}, fmt.Errorf("%w: invalid JSON: %v", ErrMalformedEnvelope, err)
+		return Envelope{}, newDecodeError(fmt.Errorf("%w: %v", ErrInvalidJSON, err), identity.JSONRPCID{}, false)
 	}
+
+	// candidateID is a best-effort recovery of the message's id, used to
+	// correlate a rejection response for every failure below that isn't
+	// ErrInvalidJSON. It is populated only when the id token itself is a
+	// syntactically valid JSON-RPC id, regardless of what else about the
+	// message is rejected.
+	var candidateID identity.JSONRPCID
+	candidateOK := false
+	if w.ID != nil {
+		if parsed, err := identity.NewJSONRPCID(w.ID); err == nil {
+			candidateID, candidateOK = parsed, true
+		}
+	}
+
 	if w.JSONRPC != jsonrpcVersion {
-		return Envelope{}, fmt.Errorf("%w: jsonrpc must be %q", ErrMalformedEnvelope, jsonrpcVersion)
+		return Envelope{}, newDecodeError(fmt.Errorf("%w: jsonrpc must be %q", ErrInvalidRequestShape, jsonrpcVersion), candidateID, candidateOK)
 	}
 	if strings.TrimSpace(w.Method) == "" {
-		return Envelope{}, fmt.Errorf("%w: method is required", ErrMalformedEnvelope)
+		return Envelope{}, newDecodeError(fmt.Errorf("%w: method is required", ErrInvalidRequestShape), candidateID, candidateOK)
 	}
 	if strings.TrimSpace(string(connectionID)) == "" {
-		return Envelope{}, fmt.Errorf("%w: connection id must not be empty", ErrMalformedEnvelope)
+		return Envelope{}, newDecodeError(fmt.Errorf("%w: connection id must not be empty", ErrInvalidRequestShape), candidateID, candidateOK)
 	}
 
 	idPresent := w.ID != nil
 
 	if NotificationMethods[w.Method] {
 		if idPresent {
-			return Envelope{}, fmt.Errorf("%w: %s is a notification and must not carry an id", ErrMalformedEnvelope, w.Method)
+			return Envelope{}, newDecodeError(fmt.Errorf("%w: %s is a notification and must not carry an id", ErrInvalidRequestShape, w.Method), candidateID, candidateOK)
 		}
 		// connectionID and w.Method are already validated non-blank above,
 		// so this formatted string can never be empty and NewMinted can
@@ -122,11 +184,11 @@ func Decode(connectionID identity.ConnectionID, notificationSeq uint64, raw json
 	}
 
 	if !idPresent {
-		return Envelope{}, fmt.Errorf("%w: id is required for a request method", ErrMalformedEnvelope)
+		return Envelope{}, newDecodeError(fmt.Errorf("%w: id is required for a request method", ErrInvalidRequestShape), identity.JSONRPCID{}, false)
 	}
 	id, err := identity.NewJSONRPCID(w.ID)
 	if err != nil {
-		return Envelope{}, fmt.Errorf("%w: %v", ErrMalformedEnvelope, err)
+		return Envelope{}, newDecodeError(fmt.Errorf("%w: %v", ErrInvalidRequestShape, err), identity.JSONRPCID{}, false)
 	}
 	// connectionID is already validated non-blank above, and id is already
 	// validated non-zero by NewJSONRPCID, so NewCorrelated can never fail

--- a/pkg/transports/acp/internal/envelope/envelope_test.go
+++ b/pkg/transports/acp/internal/envelope/envelope_test.go
@@ -3,6 +3,7 @@ package envelope
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/identity"
@@ -111,6 +112,21 @@ func TestDecode_RejectsMalformedInput(t *testing.T) {
 				t.Fatalf("Decode(%s) recovered id = %s, want %s", tt.raw, gotID, tt.wantID)
 			}
 		})
+	}
+}
+
+func TestDecodeError_ErrorReturnsCauseMessage(t *testing.T) {
+	_, err := Decode("conn-1", 1, json.RawMessage(`{not json`))
+
+	var decodeErr *DecodeError
+	if !errors.As(err, &decodeErr) {
+		t.Fatalf("Decode error = %v (%T), want *DecodeError", err, err)
+	}
+	if got, want := decodeErr.Error(), decodeErr.Unwrap().Error(); got != want {
+		t.Fatalf("DecodeError.Error() = %q, want it to equal Unwrap().Error() = %q", got, want)
+	}
+	if !strings.HasPrefix(decodeErr.Error(), ErrInvalidJSON.Error()) {
+		t.Fatalf("DecodeError.Error() = %q, want it to start with %q", decodeErr.Error(), ErrInvalidJSON.Error())
 	}
 }
 

--- a/pkg/transports/acp/internal/envelope/envelope_test.go
+++ b/pkg/transports/acp/internal/envelope/envelope_test.go
@@ -48,20 +48,27 @@ func TestDecode_RejectsMalformedInput(t *testing.T) {
 	tests := []struct {
 		name string
 		raw  string
+		// wantInvalidJSON selects ErrInvalidJSON; when false the case wants
+		// ErrInvalidRequestShape instead.
+		wantInvalidJSON bool
+		// wantID is the raw JSON-RPC id token DecodeError.ID() should
+		// recover, or "" when no id should be recoverable.
+		wantID string
 	}{
-		{"invalid JSON", `{not json`},
-		{"wrong jsonrpc version", `{"jsonrpc":"1.0","id":1,"method":"session/prompt"}`},
-		{"missing jsonrpc version", `{"id":1,"method":"session/prompt"}`},
-		{"missing method", `{"jsonrpc":"2.0","id":1}`},
-		{"blank method", `{"jsonrpc":"2.0","id":1,"method":"   "}`},
-		{"missing id on a request method", `{"jsonrpc":"2.0","method":"session/prompt"}`},
-		{"null id on a request method", `{"jsonrpc":"2.0","id":null,"method":"session/prompt"}`},
-		{"object id", `{"jsonrpc":"2.0","id":{},"method":"session/prompt"}`},
-		{"array id", `{"jsonrpc":"2.0","id":[],"method":"session/prompt"}`},
-		{"boolean id", `{"jsonrpc":"2.0","id":true,"method":"session/prompt"}`},
-		{"id-bearing session/cancel notification", `{"jsonrpc":"2.0","id":1,"method":"session/cancel","params":{"sessionId":"s"}}`},
-		{"id-bearing session/update notification", `{"jsonrpc":"2.0","id":1,"method":"session/update","params":{"sessionId":"s","update":{}}}`},
-		{"null id-bearing session/cancel notification", `{"jsonrpc":"2.0","id":null,"method":"session/cancel","params":{"sessionId":"s"}}`},
+		{name: "invalid JSON", raw: `{not json`, wantInvalidJSON: true},
+		{name: "wrong jsonrpc version", raw: `{"jsonrpc":"1.0","id":1,"method":"session/prompt"}`, wantID: "1"},
+		{name: "missing jsonrpc version", raw: `{"id":1,"method":"session/prompt"}`, wantID: "1"},
+		{name: "missing method", raw: `{"jsonrpc":"2.0","id":1}`, wantID: "1"},
+		{name: "blank method", raw: `{"jsonrpc":"2.0","id":1,"method":"   "}`, wantID: "1"},
+		{name: "missing id on a request method", raw: `{"jsonrpc":"2.0","method":"session/prompt"}`},
+		{name: "null id on a request method", raw: `{"jsonrpc":"2.0","id":null,"method":"session/prompt"}`},
+		{name: "object id", raw: `{"jsonrpc":"2.0","id":{},"method":"session/prompt"}`},
+		{name: "array id", raw: `{"jsonrpc":"2.0","id":[],"method":"session/prompt"}`},
+		{name: "boolean id", raw: `{"jsonrpc":"2.0","id":true,"method":"session/prompt"}`},
+		{name: "id-bearing session/cancel notification", raw: `{"jsonrpc":"2.0","id":1,"method":"session/cancel","params":{"sessionId":"s"}}`, wantID: "1"},
+		{name: "id-bearing session/update notification", raw: `{"jsonrpc":"2.0","id":2,"method":"session/update","params":{"sessionId":"s","update":{}}}`, wantID: "2"},
+		{name: "id-bearing session/cancel notification with a string id", raw: `{"jsonrpc":"2.0","id":"req-9","method":"session/cancel","params":{"sessionId":"s"}}`, wantID: `"req-9"`},
+		{name: "null id-bearing session/cancel notification", raw: `{"jsonrpc":"2.0","id":null,"method":"session/cancel","params":{"sessionId":"s"}}`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -71,6 +78,37 @@ func TestDecode_RejectsMalformedInput(t *testing.T) {
 			}
 			if !errors.Is(err, ErrMalformedEnvelope) {
 				t.Fatalf("Decode(%s) error = %v, want it to wrap ErrMalformedEnvelope", tt.raw, err)
+			}
+
+			gotInvalidJSON := errors.Is(err, ErrInvalidJSON)
+			gotInvalidShape := errors.Is(err, ErrInvalidRequestShape)
+			if gotInvalidJSON == gotInvalidShape {
+				t.Fatalf("Decode(%s) error = %v, want exactly one of ErrInvalidJSON/ErrInvalidRequestShape", tt.raw, err)
+			}
+			if gotInvalidJSON != tt.wantInvalidJSON {
+				t.Fatalf("Decode(%s) classified as ErrInvalidJSON = %v, want %v", tt.raw, gotInvalidJSON, tt.wantInvalidJSON)
+			}
+
+			var decodeErr *DecodeError
+			if !errors.As(err, &decodeErr) {
+				t.Fatalf("Decode(%s) error = %v (%T), want *DecodeError", tt.raw, err, err)
+			}
+			id, hasID := decodeErr.ID()
+			if tt.wantID == "" {
+				if hasID {
+					t.Fatalf("Decode(%s) recovered id %+v, want no recoverable id", tt.raw, id)
+				}
+				return
+			}
+			if !hasID {
+				t.Fatalf("Decode(%s) recovered no id, want %s", tt.raw, tt.wantID)
+			}
+			gotID, err := id.MarshalJSON()
+			if err != nil {
+				t.Fatalf("Decode(%s) recovered id failed to marshal: %v", tt.raw, err)
+			}
+			if string(gotID) != tt.wantID {
+				t.Fatalf("Decode(%s) recovered id = %s, want %s", tt.raw, gotID, tt.wantID)
 			}
 		})
 	}

--- a/pkg/transports/acp/internal/identity/identity.go
+++ b/pkg/transports/acp/internal/identity/identity.go
@@ -188,6 +188,16 @@ func (r RequestIdentity) IsMinted() bool {
 	return r.kind == requestIdentityKindMinted
 }
 
+// WireID returns the original JSON-RPC id this identity was correlated to,
+// and true only for a connection-correlated identity. A minted identity
+// never arrived as a JSON-RPC request and so has no wire id to return.
+func (r RequestIdentity) WireID() (JSONRPCID, bool) {
+	if r.kind != requestIdentityKindCorrelated {
+		return JSONRPCID{}, false
+	}
+	return r.jsonrpcID, true
+}
+
 type requestIdentityWire struct {
 	Kind         string          `json:"kind"`
 	ConnectionID string          `json:"connectionId,omitempty"`

--- a/pkg/transports/acp/internal/identity/identity.go
+++ b/pkg/transports/acp/internal/identity/identity.go
@@ -14,12 +14,25 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 )
 
 // ConnectionID identifies one JSON-RPC connection. The transport mints a
 // distinct ConnectionID per connection; it is never reused within a
 // process lifetime.
 type ConnectionID string
+
+// connectionSequence backs NewConnectionID with a process-lifetime-unique,
+// monotonically increasing counter, so minting never has to perform I/O or
+// depend on wall-clock or process entropy sources to stay collision-free.
+var connectionSequence atomic.Uint64
+
+// NewConnectionID mints a ConnectionID that is stable for the caller's
+// invocation and distinct from every other ConnectionID minted by this
+// process, including concurrent callers. It performs no I/O.
+func NewConnectionID() ConnectionID {
+	return ConnectionID(fmt.Sprintf("acp-conn-%d", connectionSequence.Add(1)))
+}
 
 // JSONRPCID is a JSON-RPC 2.0 request id: a JSON string or JSON number
 // token. ACP requests always carry a non-null id, so the null variant JSON-

--- a/pkg/transports/acp/internal/identity/identity_test.go
+++ b/pkg/transports/acp/internal/identity/identity_test.go
@@ -117,6 +117,35 @@ func TestRequestIdentityValidation(t *testing.T) {
 	}
 }
 
+func TestNewConnectionIDIsDistinctPerCall(t *testing.T) {
+	first := NewConnectionID()
+	second := NewConnectionID()
+
+	if first == "" || second == "" {
+		t.Fatalf("expected minted connection ids to be non-empty, got %q and %q", first, second)
+	}
+	if first == second {
+		t.Fatalf("expected distinct connection ids, got the same value %q twice", first)
+	}
+}
+
+func TestNewConnectionIDIsDistinctUnderConcurrentCalls(t *testing.T) {
+	const count = 100
+	ids := make(chan ConnectionID, count)
+	for range count {
+		go func() { ids <- NewConnectionID() }()
+	}
+
+	seen := make(map[ConnectionID]bool, count)
+	for range count {
+		id := <-ids
+		if seen[id] {
+			t.Fatalf("connection id %q minted more than once under concurrent calls", id)
+		}
+		seen[id] = true
+	}
+}
+
 func TestJSONRPCIDRejectsUnsupportedShapes(t *testing.T) {
 	cases := []struct {
 		name string

--- a/pkg/transports/acp/internal/identity/identity_test.go
+++ b/pkg/transports/acp/internal/identity/identity_test.go
@@ -201,3 +201,26 @@ func TestConnectionIDReflectsOnlyCorrelatedIdentities(t *testing.T) {
 		t.Fatalf("expected a minted identity to report itself as minted")
 	}
 }
+
+func TestWireIDReflectsOnlyCorrelatedIdentities(t *testing.T) {
+	wantID := NewStringJSONRPCID("req-7")
+	correlated, err := NewCorrelated(ConnectionID("conn-a"), wantID)
+	if err != nil {
+		t.Fatalf("NewCorrelated: %v", err)
+	}
+	gotID, ok := correlated.WireID()
+	if !ok {
+		t.Fatalf("expected a correlated identity to expose its wire id")
+	}
+	if !gotID.equal(wantID) {
+		t.Fatalf("WireID() = %+v, want %+v", gotID, wantID)
+	}
+
+	minted, err := NewMinted("permission-1")
+	if err != nil {
+		t.Fatalf("NewMinted: %v", err)
+	}
+	if _, ok := minted.WireID(); ok {
+		t.Fatalf("expected a minted identity to have no wire id")
+	}
+}

--- a/pkg/transports/acp/internal/protocol/errors.go
+++ b/pkg/transports/acp/internal/protocol/errors.go
@@ -5,6 +5,8 @@ import (
 
 	acpsdk "github.com/coder/acp-go-sdk"
 
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/envelope"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/identity"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/session"
 )
 
@@ -77,4 +79,47 @@ func MethodNotFound(method string) *acpsdk.RequestError {
 // way.
 func SafeReject(cause error) *acpsdk.RequestError {
 	return acpsdk.NewInvalidParams(map[string]any{"reason": string(Classify(cause))})
+}
+
+// ParseError returns the bounded JSON-RPC parse-error response for input
+// that never parsed as JSON at all. It carries only a fixed, static reason
+// label -- never the underlying parse cause's message -- so it can never
+// disclose fragments of unparseable client input.
+func ParseError() *acpsdk.RequestError {
+	return acpsdk.NewParseError(map[string]any{"reason": "invalid_json"})
+}
+
+// InvalidRequest returns the bounded JSON-RPC invalid-request response for
+// input that parsed as JSON but violates the JSON-RPC 2.0 request shape
+// this transport requires (for example a missing method, a wrong protocol
+// version token, or an id-bearing message for a notification-only method).
+// It carries only a fixed, static reason label, for the same reason
+// ParseError does.
+func InvalidRequest() *acpsdk.RequestError {
+	return acpsdk.NewInvalidRequest(map[string]any{"reason": "invalid_request_shape"})
+}
+
+// RejectEnvelope classifies an envelope.Decode failure into the bounded
+// JSON-RPC error to serialize, and the JSON-RPC id, if any, to correlate
+// the response to. Completely unparseable JSON classifies as ParseError and
+// is never correlated, matching JSON-RPC 2.0's requirement that a parse
+// error response always carries a null id. Every other envelope.Decode
+// failure classifies as InvalidRequest and is correlated to the message's
+// id only when envelope.DecodeError reports that id as syntactically valid
+// -- an id that is itself malformed, or altogether absent, has nothing to
+// correlate to. A cause that is not an *envelope.DecodeError (for example a
+// method-specific params decode failure a caller passes through this same
+// path) falls back to the general SafeReject classification and is never
+// correlated by this function; a caller with its own recoverable id for
+// that case correlates it separately.
+func RejectEnvelope(cause error) (*acpsdk.RequestError, identity.JSONRPCID, bool) {
+	var decodeErr *envelope.DecodeError
+	if errors.As(cause, &decodeErr) {
+		if errors.Is(decodeErr, envelope.ErrInvalidJSON) {
+			return ParseError(), identity.JSONRPCID{}, false
+		}
+		id, ok := decodeErr.ID()
+		return InvalidRequest(), id, ok
+	}
+	return SafeReject(cause), identity.JSONRPCID{}, false
 }

--- a/pkg/transports/acp/internal/protocol/errors_test.go
+++ b/pkg/transports/acp/internal/protocol/errors_test.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/envelope"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/session"
 )
 
@@ -122,6 +125,96 @@ func TestSafeReject_RedactsSensitiveInternalCauses(t *testing.T) {
 		}
 		if strings.Contains(string(encoded), cause.Error()) {
 			t.Errorf("SafeReject() leaked the raw internal cause into serialized error %s", encoded)
+		}
+	}
+}
+
+func TestRejectEnvelope_ClassifiesInvalidJSONAsUncorrelatedParseError(t *testing.T) {
+	_, err := envelope.Decode("conn-1", 1, json.RawMessage(`{not json`))
+	if err == nil {
+		t.Fatal("envelope.Decode() error = nil, want a decode failure")
+	}
+
+	reqErr, id, hasID := RejectEnvelope(err)
+	if reqErr.Code != -32700 {
+		t.Errorf("RejectEnvelope() code = %d, want -32700 (parse error)", reqErr.Code)
+	}
+	if hasID {
+		t.Errorf("RejectEnvelope() recovered id %+v for unparseable JSON, want no recoverable id", id)
+	}
+}
+
+func TestRejectEnvelope_ClassifiesInvalidShapeAsCorrelatedInvalidRequest(t *testing.T) {
+	_, err := envelope.Decode("conn-1", 1, json.RawMessage(`{"jsonrpc":"1.0","id":7,"method":"session/prompt"}`))
+	if err == nil {
+		t.Fatal("envelope.Decode() error = nil, want a decode failure")
+	}
+
+	reqErr, id, hasID := RejectEnvelope(err)
+	if reqErr.Code != -32600 {
+		t.Errorf("RejectEnvelope() code = %d, want -32600 (invalid request)", reqErr.Code)
+	}
+	if !hasID {
+		t.Fatal("RejectEnvelope() recovered no id, want the request's valid numeric id")
+	}
+	gotID, err := id.MarshalJSON()
+	if err != nil {
+		t.Fatalf("id.MarshalJSON() error = %v", err)
+	}
+	if string(gotID) != "7" {
+		t.Errorf("RejectEnvelope() recovered id = %s, want 7", gotID)
+	}
+}
+
+func TestRejectEnvelope_InvalidShapeWithUnrecoverableIDIsUncorrelated(t *testing.T) {
+	_, err := envelope.Decode("conn-1", 1, json.RawMessage(`{"jsonrpc":"2.0","id":{},"method":"session/prompt"}`))
+	if err == nil {
+		t.Fatal("envelope.Decode() error = nil, want a decode failure")
+	}
+
+	reqErr, _, hasID := RejectEnvelope(err)
+	if reqErr.Code != -32600 {
+		t.Errorf("RejectEnvelope() code = %d, want -32600 (invalid request)", reqErr.Code)
+	}
+	if hasID {
+		t.Error("RejectEnvelope() recovered an id from a malformed id token, want no recoverable id")
+	}
+}
+
+func TestRejectEnvelope_FallsBackToSafeRejectForNonDecodeErrors(t *testing.T) {
+	cause := errors.New("acp: cwd is required")
+	reqErr, _, hasID := RejectEnvelope(cause)
+	if reqErr.Code != -32602 {
+		t.Errorf("RejectEnvelope() code = %d, want -32602 (invalid params, matching SafeReject)", reqErr.Code)
+	}
+	if hasID {
+		t.Error("RejectEnvelope() recovered an id for a non-DecodeError cause, want no recoverable id")
+	}
+}
+
+// TestParseErrorAndInvalidRequest_NeverCarrySensitiveData proves both
+// bounded constructors serialize only their fixed static reason label,
+// mirroring the redaction proofs already required of MethodNotFound and
+// SafeReject.
+func TestParseErrorAndInvalidRequest_NeverCarrySensitiveData(t *testing.T) {
+	for _, reqErr := range []*acpsdk.RequestError{ParseError(), InvalidRequest()} {
+		encoded, err := json.Marshal(reqErr)
+		if err != nil {
+			t.Fatalf("json.Marshal() error = %v", err)
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal(encoded, &decoded); err != nil {
+			t.Fatalf("json.Unmarshal() error = %v", err)
+		}
+		data, ok := decoded["data"].(map[string]any)
+		if !ok {
+			t.Fatalf("encoded error %s has no object data field", encoded)
+		}
+		if len(data) != 1 {
+			t.Fatalf("encoded error data = %v, want exactly one static reason field", data)
+		}
+		if _, ok := data["reason"]; !ok {
+			t.Fatalf("encoded error data = %v, want a reason field", data)
 		}
 	}
 }

--- a/pkg/transports/acp/internal/stdio/server.go
+++ b/pkg/transports/acp/internal/stdio/server.go
@@ -1,0 +1,91 @@
+// Package stdio implements the ACP agent-side JSON-RPC stdio server:
+// caller-owned stream serving, one-connection lifecycle, and
+// connection-scoped identity assignment. Framing, request dispatch, and
+// shutdown semantics beyond clean EOF are added by later stories in this
+// slice. It is internal to pkg/transports/acp; callers use the package
+// root's exported operations instead of this package directly.
+package stdio
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/identity"
+)
+
+// ErrStreamsRequired marks a Serve call that is missing a required input or
+// output stream.
+var ErrStreamsRequired = errors.New("acp: stdio serve requires input and output streams")
+
+// Server serves one ACP JSON-RPC agent-side connection at a time over
+// caller-owned stdio streams. Construction performs no I/O and starts no
+// goroutine, process, listener, session, or persistence; each Serve call
+// begins one connection-scoped invocation over the streams the caller
+// supplies for that call.
+type Server struct {
+	logger logging.Logger
+}
+
+// New constructs an inert stdio Server. Construction alone performs no
+// reads, writes, goroutine starts, process starts, endpoint binding,
+// session creation, or persistence.
+func New(logger logging.Logger) *Server {
+	return &Server{logger: logging.EnsureLogger(logger)}
+}
+
+// Serve begins one connection-scoped serving invocation over caller-owned
+// input and output streams and returns once the connection terminates.
+// Starting the invocation creates one connection-scoped identity, minted
+// via identity.NewConnectionID, that is stable for the duration of this
+// call and distinct from every other invocation. Start and terminal
+// outcomes are logged as structured, payload-free diagnostics carrying only
+// the connection id and a bounded outcome label.
+func (s *Server) Serve(ctx context.Context, in io.Reader, out io.Writer) error {
+	if s == nil {
+		return errors.New("acp: stdio server is required")
+	}
+	if in == nil || out == nil {
+		return ErrStreamsRequired
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	connectionID := identity.NewConnectionID()
+	logger := logging.EnsureLogger(s.logger)
+	logger.Info("acp stdio connection started", "connectionId", string(connectionID))
+
+	err := drainFrames(in)
+
+	logger.Info("acp stdio connection terminated",
+		"connectionId", string(connectionID),
+		"outcome", terminalOutcomeLabel(err),
+	)
+	return err
+}
+
+// terminalOutcomeLabel classifies a Serve result into a bounded, safe label
+// for diagnostics. It never includes the error's message text, so a cause
+// that happens to mention sensitive request content can never reach a log
+// record through this label.
+func terminalOutcomeLabel(err error) string {
+	if err == nil {
+		return "eof"
+	}
+	return "error"
+}
+
+// drainFrames reads line-delimited input to a clean EOF. It establishes the
+// one-connection read lifecycle this story owns; decoding lines into
+// JSON-RPC envelopes and dispatching them is added by a later story in this
+// slice.
+func drainFrames(in io.Reader) error {
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	for scanner.Scan() {
+	}
+	return scanner.Err()
+}

--- a/pkg/transports/acp/internal/stdio/server.go
+++ b/pkg/transports/acp/internal/stdio/server.go
@@ -1,19 +1,31 @@
 // Package stdio implements the ACP agent-side JSON-RPC stdio server:
-// caller-owned stream serving, one-connection lifecycle, and
-// connection-scoped identity assignment. Framing, request dispatch, and
-// shutdown semantics beyond clean EOF are added by later stories in this
-// slice. It is internal to pkg/transports/acp; callers use the package
-// root's exported operations instead of this package directly.
+// caller-owned stream serving, one-connection lifecycle, connection-scoped
+// identity assignment, and newline-delimited JSON-RPC framing and dispatch
+// for the "initialize" method. Every other method -- including deferred ACP
+// session and prompt methods -- is not yet implemented by this transport and
+// receives method-not-found rather than being dispatched. Finer-grained
+// protocol-error classification (parse error vs. invalid request vs.
+// invalid params) and shutdown semantics beyond clean EOF are added by
+// later stories in this slice. It is internal to pkg/transports/acp;
+// callers use the package root's exported operations instead of this
+// package directly.
 package stdio
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 
+	acpsdk "github.com/coder/acp-go-sdk"
+
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/envelope"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/identity"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/negotiation"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/protocol"
 )
 
 // ErrStreamsRequired marks a Serve call that is missing a required input or
@@ -58,7 +70,7 @@ func (s *Server) Serve(ctx context.Context, in io.Reader, out io.Writer) error {
 	logger := logging.EnsureLogger(s.logger)
 	logger.Info("acp stdio connection started", "connectionId", string(connectionID))
 
-	err := drainFrames(in)
+	err := serveConnection(connectionID, in, out)
 
 	logger.Info("acp stdio connection terminated",
 		"connectionId", string(connectionID),
@@ -78,14 +90,118 @@ func terminalOutcomeLabel(err error) string {
 	return "error"
 }
 
-// drainFrames reads line-delimited input to a clean EOF. It establishes the
-// one-connection read lifecycle this story owns; decoding lines into
-// JSON-RPC envelopes and dispatching them is added by a later story in this
-// slice.
-func drainFrames(in io.Reader) error {
+// serveConnection reads line-delimited input to a clean EOF, treating every
+// complete non-empty line as one JSON-RPC 2.0 message. Each notification is
+// dispatched with no response ever written for it, and every other message
+// receives exactly one complete newline-terminated JSON-RPC response before
+// the next line is read, so no two responses can interleave.
+func serveConnection(connectionID identity.ConnectionID, in io.Reader, out io.Writer) error {
 	scanner := bufio.NewScanner(in)
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+
+	var notificationSeq uint64
 	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		raw := append(json.RawMessage(nil), line...)
+
+		env, result, rpcErr := dispatchRequest(connectionID, notificationSeq, raw)
+		if env.IsNotification {
+			notificationSeq++
+			continue
+		}
+		if err := writeResponse(out, env.Identity, result, rpcErr); err != nil {
+			return err
+		}
 	}
 	return scanner.Err()
+}
+
+// dispatchRequest decodes and executes one JSON-RPC message received on
+// connectionID. It returns the decoded envelope -- the zero Envelope for a
+// message that never successfully decoded -- alongside the outcome: a
+// non-nil result for a successful initialize exchange, or a bounded,
+// protocol-safe *acpsdk.RequestError for every rejection. The only method
+// this transport dispatches to an effect in this slice is "initialize";
+// protocol-version policy is delegated entirely to the existing V0
+// negotiation behavior rather than re-implemented here.
+func dispatchRequest(connectionID identity.ConnectionID, notificationSeq uint64, raw json.RawMessage) (envelope.Envelope, json.RawMessage, *acpsdk.RequestError) {
+	env, err := envelope.Decode(connectionID, notificationSeq, raw)
+	if err != nil {
+		return envelope.Envelope{}, nil, protocol.SafeReject(err)
+	}
+	if env.IsNotification {
+		return env, nil, nil
+	}
+
+	if env.Method != acpsdk.AgentMethodInitialize {
+		return env, nil, protocol.MethodNotFound(env.Method)
+	}
+
+	var req acpsdk.InitializeRequest
+	if err := json.Unmarshal(env.Params, &req); err != nil {
+		return env, nil, protocol.SafeReject(err)
+	}
+
+	resp, negotiateErr := negotiation.Negotiate(req)
+	if negotiateErr != nil {
+		reqErr, ok := negotiateErr.(*acpsdk.RequestError)
+		if !ok {
+			reqErr = protocol.SafeReject(negotiateErr)
+		}
+		return env, nil, reqErr
+	}
+
+	result, err := json.Marshal(resp)
+	if err != nil {
+		return env, nil, protocol.SafeReject(err)
+	}
+	return env, result, nil
+}
+
+// rpcMessage is the wire shape of one JSON-RPC 2.0 response: exactly one of
+// Result or Error is ever populated.
+type rpcMessage struct {
+	JSONRPC string               `json:"jsonrpc"`
+	ID      json.RawMessage      `json:"id"`
+	Result  json.RawMessage      `json:"result,omitempty"`
+	Error   *acpsdk.RequestError `json:"error,omitempty"`
+}
+
+// nullID is the JSON-RPC id for a response that cannot be correlated to a
+// request id -- for example a message that never decoded far enough to
+// recover one.
+var nullID = json.RawMessage("null")
+
+// writeResponse serializes and writes exactly one complete
+// newline-terminated JSON-RPC response for a request identity, correlating
+// it to the identity's original wire id when one is available. A short
+// write is reported as io.ErrShortWrite rather than treated as success, so
+// a truncated response can never be mistaken for a complete one.
+func writeResponse(out io.Writer, reqIdentity identity.RequestIdentity, result json.RawMessage, rpcErr *acpsdk.RequestError) error {
+	msg := rpcMessage{JSONRPC: "2.0", ID: nullID, Result: result, Error: rpcErr}
+	if wireID, ok := reqIdentity.WireID(); ok {
+		idBytes, err := wireID.MarshalJSON()
+		if err != nil {
+			return err
+		}
+		msg.ID = idBytes
+	}
+
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	body = append(body, '\n')
+
+	n, err := out.Write(body)
+	if err != nil {
+		return err
+	}
+	if n != len(body) {
+		return io.ErrShortWrite
+	}
+	return nil
 }

--- a/pkg/transports/acp/internal/stdio/server.go
+++ b/pkg/transports/acp/internal/stdio/server.go
@@ -1,15 +1,14 @@
 // Package stdio implements the ACP agent-side JSON-RPC stdio server:
 // caller-owned stream serving, one-connection lifecycle, connection-scoped
 // identity assignment, newline-delimited JSON-RPC framing and dispatch for
-// the "initialize" method, and protocol-safe rejection of malformed input,
-// unsupported methods, and unsupported protocol versions. Every method
-// other than "initialize" -- including deferred ACP session and prompt
-// methods -- is not yet implemented by this transport and receives
-// method-not-found rather than being dispatched. Shutdown semantics beyond
-// clean EOF (mid-read cancellation, writer-failure termination guarantees,
-// and concurrent-lifecycle coverage) are added by a later story in this
-// slice. It is internal to pkg/transports/acp; callers use the package
-// root's exported operations instead of this package directly.
+// the "initialize" method, protocol-safe rejection of malformed input,
+// unsupported methods, and unsupported protocol versions, and deterministic
+// termination on clean EOF, context cancellation, a partial trailing frame,
+// or a writer failure. Every method other than "initialize" -- including
+// deferred ACP session and prompt methods -- is not yet implemented by this
+// transport and receives method-not-found rather than being dispatched. It
+// is internal to pkg/transports/acp; callers use the package root's
+// exported operations instead of this package directly.
 package stdio
 
 import (
@@ -71,7 +70,7 @@ func (s *Server) Serve(ctx context.Context, in io.Reader, out io.Writer) error {
 	logger := logging.EnsureLogger(s.logger)
 	logger.Info("acp stdio connection started", "connectionId", string(connectionID))
 
-	err := serveConnection(connectionID, in, out)
+	err := serveConnection(ctx, connectionID, in, out)
 
 	logger.Info("acp stdio connection terminated",
 		"connectionId", string(connectionID),
@@ -85,23 +84,72 @@ func (s *Server) Serve(ctx context.Context, in io.Reader, out io.Writer) error {
 // that happens to mention sensitive request content can never reach a log
 // record through this label.
 func terminalOutcomeLabel(err error) string {
-	if err == nil {
+	switch {
+	case err == nil:
 		return "eof"
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return "cancelled"
+	default:
+		return "error"
 	}
-	return "error"
+}
+
+// errPartialTrailingFrame marks input that reaches EOF with a non-empty
+// remainder that was never terminated by a newline. Treating that remainder
+// as a final request -- the way bufio.ScanLines does by default -- would
+// execute less than the full message the client meant to send, so it is
+// instead a deterministic protocol failure that ends the connection.
+var errPartialTrailingFrame = errors.New("acp: stdio input ended with a partial trailing frame")
+
+// scanCompleteLines is a bufio.SplitFunc that only ever yields complete,
+// newline-terminated lines, unlike bufio.ScanLines' default behavior of
+// also yielding a final non-newline-terminated remainder at EOF.
+func scanCompleteLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		return i + 1, data[:i], nil
+	}
+	if atEOF {
+		if len(bytes.TrimSpace(data)) > 0 {
+			return 0, nil, errPartialTrailingFrame
+		}
+		return len(data), nil, nil
+	}
+	return 0, nil, nil
 }
 
 // serveConnection reads line-delimited input to a clean EOF, treating every
 // complete non-empty line as one JSON-RPC 2.0 message. Each notification is
 // dispatched with no response ever written for it, and every other message
 // receives exactly one complete newline-terminated JSON-RPC response before
-// the next line is read, so no two responses can interleave.
-func serveConnection(connectionID identity.ConnectionID, in io.Reader, out io.Writer) error {
+// the next line is read, so no two responses can interleave. Context
+// cancellation is checked before every read: it stops accepting new work
+// immediately, and once a read fails or ends because the caller-owned
+// stream itself was closed or cancelled on the context's behalf, the
+// context's error is reported instead of the stream's raw error, so a
+// deliberate shutdown is never mistaken for a fault. A partial trailing
+// frame at EOF and a response write failure both end the connection with
+// their own error instead of being treated as success.
+func serveConnection(ctx context.Context, connectionID identity.ConnectionID, in io.Reader, out io.Writer) error {
 	scanner := bufio.NewScanner(in)
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	scanner.Split(scanCompleteLines)
 
 	var notificationSeq uint64
-	for scanner.Scan() {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
+				return err
+			}
+			return nil
+		}
+
 		line := scanner.Bytes()
 		if len(bytes.TrimSpace(line)) == 0 {
 			continue
@@ -117,7 +165,6 @@ func serveConnection(connectionID identity.ConnectionID, in io.Reader, out io.Wr
 			return err
 		}
 	}
-	return scanner.Err()
 }
 
 // dispatchRequest decodes and executes one JSON-RPC message received on

--- a/pkg/transports/acp/internal/stdio/server.go
+++ b/pkg/transports/acp/internal/stdio/server.go
@@ -1,14 +1,15 @@
 // Package stdio implements the ACP agent-side JSON-RPC stdio server:
 // caller-owned stream serving, one-connection lifecycle, connection-scoped
-// identity assignment, and newline-delimited JSON-RPC framing and dispatch
-// for the "initialize" method. Every other method -- including deferred ACP
-// session and prompt methods -- is not yet implemented by this transport and
-// receives method-not-found rather than being dispatched. Finer-grained
-// protocol-error classification (parse error vs. invalid request vs.
-// invalid params) and shutdown semantics beyond clean EOF are added by
-// later stories in this slice. It is internal to pkg/transports/acp;
-// callers use the package root's exported operations instead of this
-// package directly.
+// identity assignment, newline-delimited JSON-RPC framing and dispatch for
+// the "initialize" method, and protocol-safe rejection of malformed input,
+// unsupported methods, and unsupported protocol versions. Every method
+// other than "initialize" -- including deferred ACP session and prompt
+// methods -- is not yet implemented by this transport and receives
+// method-not-found rather than being dispatched. Shutdown semantics beyond
+// clean EOF (mid-read cancellation, writer-failure termination guarantees,
+// and concurrent-lifecycle coverage) are added by a later story in this
+// slice. It is internal to pkg/transports/acp; callers use the package
+// root's exported operations instead of this package directly.
 package stdio
 
 import (
@@ -120,17 +121,33 @@ func serveConnection(connectionID identity.ConnectionID, in io.Reader, out io.Wr
 }
 
 // dispatchRequest decodes and executes one JSON-RPC message received on
-// connectionID. It returns the decoded envelope -- the zero Envelope for a
-// message that never successfully decoded -- alongside the outcome: a
-// non-nil result for a successful initialize exchange, or a bounded,
-// protocol-safe *acpsdk.RequestError for every rejection. The only method
-// this transport dispatches to an effect in this slice is "initialize";
-// protocol-version policy is delegated entirely to the existing V0
-// negotiation behavior rather than re-implemented here.
+// connectionID. It returns the decoded envelope -- the zero Envelope, or an
+// Envelope carrying only a correlated Identity, for a message that never
+// successfully decoded -- alongside the outcome: a non-nil result for a
+// successful initialize exchange, or a bounded, protocol-safe
+// *acpsdk.RequestError for every rejection. An envelope.Decode failure is
+// classified by protocol.RejectEnvelope into a parse error (uncorrelated,
+// for unparseable JSON) or an invalid-request error (correlated to the
+// message's id when that id was itself syntactically valid); a decoded
+// envelope with valid params that Negotiate rejects becomes the richer
+// unsupported-protocol-version error unwrapped, and every other rejection
+// -- an unimplemented method, or params that fail to decode into the pinned
+// initialize request shape -- becomes method-not-found or invalid-params.
+// The only method this transport dispatches to an effect in this slice is
+// "initialize"; protocol-version policy is delegated entirely to the
+// existing V0 negotiation behavior rather than re-implemented here.
 func dispatchRequest(connectionID identity.ConnectionID, notificationSeq uint64, raw json.RawMessage) (envelope.Envelope, json.RawMessage, *acpsdk.RequestError) {
 	env, err := envelope.Decode(connectionID, notificationSeq, raw)
 	if err != nil {
-		return envelope.Envelope{}, nil, protocol.SafeReject(err)
+		rpcErr, wireID, hasID := protocol.RejectEnvelope(err)
+		rejected := envelope.Envelope{}
+		if hasID {
+			// connectionID is always non-blank for a real connection, and
+			// wireID is already validated by envelope.Decode, so
+			// NewCorrelated can never fail here.
+			rejected.Identity, _ = identity.NewCorrelated(connectionID, wireID)
+		}
+		return rejected, nil, rpcErr
 	}
 	if env.IsNotification {
 		return env, nil, nil

--- a/pkg/transports/acp/internal/stdio/server_smoke_test.go
+++ b/pkg/transports/acp/internal/stdio/server_smoke_test.go
@@ -1,0 +1,86 @@
+package stdio
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestServe_PipeSmoke_RealStdioInitializeExchangeAndCleanEOF is this slice's
+// single OS/process-boundary functional cell (see PRD acceptance criteria
+// for story 002): it proves a real pipe-based initialize exchange and clean
+// stdin EOF over genuine os.Pipe stdio, which the table-driven
+// strings.Reader/bytes.Buffer cells elsewhere in this file cannot express --
+// only a real OS pipe exercises genuine blocking-read and EOF-on-close
+// semantics. There is nothing else in this repository that can exercise
+// pkg/transports/acp/internal/stdio through root.BuildProcess: this
+// transport is not yet wired into pkg/wire or any CLI command (that lands
+// with the later CLI-command story in this PRD), so a tests/functional/
+// scenario built on root.BuildProcess cannot reach it either.
+//
+// Synchronization is entirely blocking-IO/channel based: the client's
+// bufio.Reader.ReadString('\n') call blocks until the server actually
+// writes the response, and Serve's outcome is read from a buffered channel.
+// The only timer is a single terminal time.After deadline guarding against
+// a genuine hang, matching this repository's established stdio smoke-test
+// pattern (see pkg/transports/cli/mcp/serve_smoke_test.go); it is not a
+// retry or polling loop.
+func TestServe_PipeSmoke_RealStdioInitializeExchangeAndCleanEOF(t *testing.T) {
+	stdinRead, stdinWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	stdoutRead, stdoutWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = stdinRead.Close()
+		_ = stdinWrite.Close()
+		_ = stdoutRead.Close()
+		_ = stdoutWrite.Close()
+	})
+
+	server := New(nil)
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- server.Serve(context.Background(), stdinRead, stdoutWrite)
+	}()
+
+	if _, err := stdinWrite.Write([]byte(initializeLine("1"))); err != nil {
+		t.Fatalf("write initialize request: %v", err)
+	}
+
+	line, err := bufio.NewReader(stdoutRead).ReadString('\n')
+	if err != nil {
+		t.Fatalf("read initialize response: %v", err)
+	}
+
+	var resp rpcMessage
+	if err := json.Unmarshal([]byte(line), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if string(resp.ID) != "1" {
+		t.Fatalf("response id = %s, want 1", resp.ID)
+	}
+	if resp.Error != nil {
+		t.Fatalf("response error = %+v, want a successful result", resp.Error)
+	}
+	assertJSONEqualStrings(t, initializeSuccessResult, string(resp.Result))
+
+	if err := stdinWrite.Close(); err != nil {
+		t.Fatalf("close stdin: %v", err)
+	}
+
+	select {
+	case err := <-serveErr:
+		if err != nil {
+			t.Fatalf("Serve() error = %v, want nil on clean stdin EOF", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve did not return after stdin closed")
+	}
+}

--- a/pkg/transports/acp/internal/stdio/server_test.go
+++ b/pkg/transports/acp/internal/stdio/server_test.go
@@ -340,8 +340,206 @@ func TestServeIsolatesConnectionsReusingTheSameWireID(t *testing.T) {
 	}
 }
 
-func TestServeRespondsMethodNotFoundForAnUnimplementedMethod(t *testing.T) {
-	input := `{"jsonrpc":"2.0","id":9,"method":"session/new","params":{}}` + "\n"
+// TestServeRespondsMethodNotFoundForEveryUnimplementedMethod covers every
+// deferred ACP session/prompt method already listed in
+// protocol.SupportedMethods (a forward-looking closed set for the whole
+// future method surface, not what this transport slice actually
+// implements -- see the Codebase Patterns entry on protocol.SupportedMethods)
+// plus a method this transport never expects at all, proving all of them
+// get method-not-found rather than being dispatched or hanging.
+func TestServeRespondsMethodNotFoundForEveryUnimplementedMethod(t *testing.T) {
+	methods := []string{
+		"session/new",
+		"session/load",
+		"session/resume",
+		"session/set_config_option",
+		"session/prompt",
+		"session/request_permission",
+		"totally/unrecognized_method",
+	}
+
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			input := fmt.Sprintf(`{"jsonrpc":"2.0","id":9,"method":%q,"params":{}}`, method) + "\n"
+
+			out := &bytes.Buffer{}
+			server := New(nil)
+			if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
+				t.Fatalf("Serve() error = %v", err)
+			}
+
+			resp := assertSingleResponseLine(t, out)
+			if string(resp.ID) != "9" {
+				t.Fatalf("id = %s, want 9", resp.ID)
+			}
+			if resp.Error == nil || resp.Error.Code != -32601 {
+				t.Fatalf("error = %+v, want method-not-found (-32601)", resp.Error)
+			}
+		})
+	}
+}
+
+// TestServeRespondsWithParseErrorForMalformedJSON proves input that never
+// parses as JSON at all gets a JSON-RPC parse error with a null id, since no
+// id could ever be recovered from input this broken.
+func TestServeRespondsWithParseErrorForMalformedJSON(t *testing.T) {
+	out := &bytes.Buffer{}
+	server := New(nil)
+	if err := server.Serve(context.Background(), strings.NewReader("{not json\n"), out); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	resp := assertSingleResponseLine(t, out)
+	if resp.Error == nil || resp.Error.Code != -32700 {
+		t.Fatalf("error = %+v, want parse error (-32700)", resp.Error)
+	}
+	if string(resp.ID) != "null" {
+		t.Fatalf("id = %s, want null for unparseable input", resp.ID)
+	}
+}
+
+// TestServeRespondsWithInvalidRequestForStructurallyInvalidShapes proves
+// input that parses as JSON but violates the JSON-RPC 2.0 request shape
+// this transport requires gets an invalid-request response, correlated to
+// the message's id only when that id token was itself syntactically valid.
+func TestServeRespondsWithInvalidRequestForStructurallyInvalidShapes(t *testing.T) {
+	cases := []struct {
+		name   string
+		line   string
+		wantID string
+	}{
+		{
+			name:   "wrong jsonrpc version with a valid id",
+			line:   `{"jsonrpc":"1.0","id":5,"method":"initialize","params":{"protocolVersion":1}}` + "\n",
+			wantID: "5",
+		},
+		{
+			name:   "missing method with a valid id",
+			line:   `{"jsonrpc":"2.0","id":6}` + "\n",
+			wantID: "6",
+		},
+		{
+			name:   "id-bearing session/cancel notification",
+			line:   `{"jsonrpc":"2.0","id":7,"method":"session/cancel","params":{"sessionId":"s"}}` + "\n",
+			wantID: "7",
+		},
+		{
+			name:   "malformed id shape has no recoverable id",
+			line:   `{"jsonrpc":"2.0","id":{},"method":"initialize","params":{"protocolVersion":1}}` + "\n",
+			wantID: "null",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			server := New(nil)
+			if err := server.Serve(context.Background(), strings.NewReader(tc.line), out); err != nil {
+				t.Fatalf("Serve() error = %v", err)
+			}
+
+			resp := assertSingleResponseLine(t, out)
+			if resp.Error == nil || resp.Error.Code != -32600 {
+				t.Fatalf("error = %+v, want invalid-request (-32600)", resp.Error)
+			}
+			if string(resp.ID) != tc.wantID {
+				t.Fatalf("id = %s, want %s", resp.ID, tc.wantID)
+			}
+		})
+	}
+}
+
+// TestServeRespondsWithInvalidParamsForBadInitializeParams proves missing
+// and malformed initialize params both produce an invalid-params response
+// correlated to the original valid request id.
+func TestServeRespondsWithInvalidParamsForBadInitializeParams(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+	}{
+		{name: "missing params", line: `{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n"},
+		{name: "malformed params type", line: `{"jsonrpc":"2.0","id":1,"method":"initialize","params":"not-an-object"}` + "\n"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			server := New(nil)
+			if err := server.Serve(context.Background(), strings.NewReader(tc.line), out); err != nil {
+				t.Fatalf("Serve() error = %v", err)
+			}
+
+			resp := assertSingleResponseLine(t, out)
+			if resp.Error == nil || resp.Error.Code != -32602 {
+				t.Fatalf("error = %+v, want invalid-params (-32602)", resp.Error)
+			}
+			if string(resp.ID) != "1" {
+				t.Fatalf("id = %s, want 1", resp.ID)
+			}
+		})
+	}
+}
+
+// TestServeMapsUnsupportedProtocolVersionToCorrelatedFactsWithNoCapabilities
+// proves an unsupported protocol version request receives the existing
+// typed negotiation rejection unwrapped: an invalid-params response
+// correlated to the request id, carrying only the requested/supported
+// public version facts, and no result/capabilities alongside it.
+func TestServeMapsUnsupportedProtocolVersionToCorrelatedFactsWithNoCapabilities(t *testing.T) {
+	line := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":99}}` + "\n"
+
+	out := &bytes.Buffer{}
+	server := New(nil)
+	if err := server.Serve(context.Background(), strings.NewReader(line), out); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	resp := assertSingleResponseLine(t, out)
+	if string(resp.ID) != "1" {
+		t.Fatalf("id = %s, want 1", resp.ID)
+	}
+	if resp.Result != nil {
+		t.Fatalf("result = %s, want no result/capabilities alongside a rejection", resp.Result)
+	}
+	if resp.Error == nil || resp.Error.Code != -32602 {
+		t.Fatalf("error = %+v, want invalid-params (-32602)", resp.Error)
+	}
+	data, ok := resp.Error.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("error data = %#v, want an object carrying version facts", resp.Error.Data)
+	}
+	if data["reason"] != "unsupported_protocol_version" {
+		t.Fatalf("error data reason = %v, want unsupported_protocol_version", data["reason"])
+	}
+	if data["requestedVersion"] != float64(99) {
+		t.Fatalf("error data requestedVersion = %v, want 99", data["requestedVersion"])
+	}
+	if data["supportedVersion"] != float64(1) {
+		t.Fatalf("error data supportedVersion = %v, want 1", data["supportedVersion"])
+	}
+}
+
+// TestServeEmitsNoResponseForAValidNotification proves a well-formed
+// notification (no id, a method in envelope.NotificationMethods) never
+// receives any response -- success or error -- per JSON-RPC 2.0.
+func TestServeEmitsNoResponseForAValidNotification(t *testing.T) {
+	line := `{"jsonrpc":"2.0","method":"session/cancel","params":{"sessionId":"s"}}` + "\n"
+
+	out := &bytes.Buffer{}
+	server := New(nil)
+	if err := server.Serve(context.Background(), strings.NewReader(line), out); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("output = %q, want no response for a valid notification", out.Bytes())
+	}
+}
+
+// TestServeContinuesProcessingAfterARecoverableRequestError proves a
+// request-level rejection does not end the connection: the next valid
+// framed request on the same connection still gets processed and answered.
+func TestServeContinuesProcessingAfterARecoverableRequestError(t *testing.T) {
+	input := "{not json\n" + initializeLine("1")
 
 	out := &bytes.Buffer{}
 	server := New(nil)
@@ -349,12 +547,75 @@ func TestServeRespondsMethodNotFoundForAnUnimplementedMethod(t *testing.T) {
 		t.Fatalf("Serve() error = %v", err)
 	}
 
-	resp := assertSingleResponseLine(t, out)
-	if string(resp.ID) != "9" {
-		t.Fatalf("id = %s, want 9", resp.ID)
+	lines := nonEmptyResponseLines(t, out)
+	if len(lines) != 2 {
+		t.Fatalf("got %d response lines, want 2 (one rejection, one recovered success): %q", len(lines), out.Bytes())
 	}
-	if resp.Error == nil || resp.Error.Code != -32601 {
-		t.Fatalf("error = %+v, want method-not-found (-32601)", resp.Error)
+
+	var first rpcMessage
+	if err := json.Unmarshal(lines[0], &first); err != nil {
+		t.Fatalf("unmarshal first response: %v", err)
+	}
+	if first.Error == nil || first.Error.Code != -32700 {
+		t.Fatalf("first response error = %+v, want parse error (-32700)", first.Error)
+	}
+
+	var second rpcMessage
+	if err := json.Unmarshal(lines[1], &second); err != nil {
+		t.Fatalf("unmarshal second response: %v", err)
+	}
+	if second.Error != nil {
+		t.Fatalf("second response error = %+v, want a successful result after recovering from the first rejection", second.Error)
+	}
+	if string(second.ID) != "1" {
+		t.Fatalf("second response id = %s, want 1", second.ID)
+	}
+	assertJSONEqualStrings(t, initializeSuccessResult, string(second.Result))
+}
+
+// TestServeErrorResponsesAndDiagnosticsNeverLeakSeededSensitiveSentinels
+// seeds a credential, an absolute filesystem path, a raw provider command,
+// and an internal topology sentinel into every request-level error class
+// this transport can produce -- malformed JSON, an unsupported method name,
+// and malformed initialize params -- then proves none of those sentinels
+// ever survive into the written response bytes or into the structured
+// start/terminal diagnostics, mirroring the redaction proofs already
+// required of protocol.MethodNotFound/SafeReject at the classification
+// layer, but now proven at the actual wire and logging boundary.
+func TestServeErrorResponsesAndDiagnosticsNeverLeakSeededSensitiveSentinels(t *testing.T) {
+	sentinels := []string{
+		"sk-live-credential-ABC123XYZ",
+		"/home/operator/.ssh/id_rsa",
+		"/usr/local/bin/agent --token=sk-live-credential-ABC123XYZ",
+		"internal-dispatch-node-7.factory.internal",
+	}
+
+	for _, sentinel := range sentinels {
+		lines := map[string]string{
+			"malformed JSON":              fmt.Sprintf(`{not json %s`, sentinel) + "\n",
+			"unsupported method name":     fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":%q,"params":{}}`, sentinel) + "\n",
+			"malformed initialize params": fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":%q}`, sentinel) + "\n",
+		}
+		for name, line := range lines {
+			t.Run(sentinel+"/"+name, func(t *testing.T) {
+				out := &bytes.Buffer{}
+				logger := &recordingLogger{}
+				server := New(logger)
+				if err := server.Serve(context.Background(), strings.NewReader(line), out); err != nil {
+					t.Fatalf("Serve() error = %v", err)
+				}
+				if strings.Contains(out.String(), sentinel) {
+					t.Fatalf("response leaked sentinel %q: %s", sentinel, out.Bytes())
+				}
+				for _, entry := range logger.entries {
+					for key, value := range entry.fields {
+						if text, ok := value.(string); ok && strings.Contains(text, sentinel) {
+							t.Fatalf("log field %q leaked sentinel %q: %v", key, sentinel, value)
+						}
+					}
+				}
+			})
+		}
 	}
 }
 

--- a/pkg/transports/acp/internal/stdio/server_test.go
+++ b/pkg/transports/acp/internal/stdio/server_test.go
@@ -1,0 +1,189 @@
+package stdio
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+)
+
+type recordingLogger struct {
+	entries []logEntry
+}
+
+type logEntry struct {
+	level   string
+	message string
+	fields  map[string]any
+}
+
+func (l *recordingLogger) Debug(msg string, keysAndValues ...any) {
+	l.record("debug", msg, keysAndValues...)
+}
+func (l *recordingLogger) Info(msg string, keysAndValues ...any) {
+	l.record("info", msg, keysAndValues...)
+}
+func (l *recordingLogger) Warn(msg string, keysAndValues ...any) {
+	l.record("warn", msg, keysAndValues...)
+}
+func (l *recordingLogger) Error(msg string, keysAndValues ...any) {
+	l.record("error", msg, keysAndValues...)
+}
+func (l *recordingLogger) Verbose(msg string, keysAndValues ...any) {
+	l.record("verbose", msg, keysAndValues...)
+}
+
+func (l *recordingLogger) record(level, msg string, keysAndValues ...any) {
+	fields := map[string]any{}
+	for index := 0; index+1 < len(keysAndValues); index += 2 {
+		key, ok := keysAndValues[index].(string)
+		if !ok {
+			continue
+		}
+		fields[key] = keysAndValues[index+1]
+	}
+	l.entries = append(l.entries, logEntry{level: level, message: msg, fields: fields})
+}
+
+var _ logging.Logger = (*recordingLogger)(nil)
+
+func TestNewPerformsNoIO(t *testing.T) {
+	logger := &recordingLogger{}
+	server := New(logger)
+	if server == nil {
+		t.Fatal("New() returned nil")
+	}
+	if len(logger.entries) != 0 {
+		t.Fatalf("New() logged %d entries, want 0: construction must perform no I/O", len(logger.entries))
+	}
+}
+
+func TestServeRejectsMissingStreams(t *testing.T) {
+	server := New(nil)
+	buf := &bytes.Buffer{}
+
+	cases := []struct {
+		name string
+		in   io.Reader
+		out  io.Writer
+	}{
+		{name: "missing input", in: nil, out: buf},
+		{name: "missing output", in: strings.NewReader(""), out: nil},
+		{name: "missing both", in: nil, out: nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := server.Serve(context.Background(), tc.in, tc.out)
+			if err == nil {
+				t.Fatal("Serve() error = nil, want an actionable error for missing streams")
+			}
+			if !errors.Is(err, ErrStreamsRequired) {
+				t.Fatalf("Serve() error = %v, want ErrStreamsRequired", err)
+			}
+		})
+	}
+}
+
+func TestServeRejectsNilServer(t *testing.T) {
+	var server *Server
+	err := server.Serve(context.Background(), strings.NewReader(""), &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("Serve() error = nil, want an error for a nil server")
+	}
+}
+
+func TestServeReturnsOnCleanEOF(t *testing.T) {
+	server := New(nil)
+	err := server.Serve(context.Background(), strings.NewReader("first line\nsecond line\n"), &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("Serve() error = %v, want nil on clean EOF", err)
+	}
+}
+
+func TestServeRejectsAlreadyCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	server := New(nil)
+	err := server.Serve(ctx, strings.NewReader(""), &bytes.Buffer{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Serve() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestServeMintsDistinctConnectionIDsPerInvocation(t *testing.T) {
+	logger := &recordingLogger{}
+	server := New(logger)
+
+	if err := server.Serve(context.Background(), strings.NewReader(""), &bytes.Buffer{}); err != nil {
+		t.Fatalf("Serve() first call error = %v", err)
+	}
+	if err := server.Serve(context.Background(), strings.NewReader(""), &bytes.Buffer{}); err != nil {
+		t.Fatalf("Serve() second call error = %v", err)
+	}
+
+	first := connectionIDAt(t, logger, 0)
+	second := connectionIDAt(t, logger, 2)
+
+	if first == "" || second == "" {
+		t.Fatalf("expected non-empty connection ids, got %q and %q", first, second)
+	}
+	if first == second {
+		t.Fatalf("expected distinct connection ids across invocations, got %q both times", first)
+	}
+}
+
+func TestServeLogsStartAndTerminalOutcomeWithoutPayload(t *testing.T) {
+	logger := &recordingLogger{}
+	server := New(logger)
+
+	payload := "super-secret-prompt-content"
+	if err := server.Serve(context.Background(), strings.NewReader(payload+"\n"), &bytes.Buffer{}); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	if len(logger.entries) != 2 {
+		t.Fatalf("got %d log entries, want 2 (start and terminal)", len(logger.entries))
+	}
+
+	start := logger.entries[0]
+	if start.message != "acp stdio connection started" {
+		t.Fatalf("start message = %q, want the connection-started message", start.message)
+	}
+	if _, ok := start.fields["connectionId"]; !ok {
+		t.Fatal("start log entry is missing connectionId")
+	}
+
+	terminal := logger.entries[1]
+	if terminal.message != "acp stdio connection terminated" {
+		t.Fatalf("terminal message = %q, want the connection-terminated message", terminal.message)
+	}
+	if terminal.fields["outcome"] != "eof" {
+		t.Fatalf("terminal outcome = %v, want %q", terminal.fields["outcome"], "eof")
+	}
+
+	for _, entry := range logger.entries {
+		for key, value := range entry.fields {
+			if text, ok := value.(string); ok && strings.Contains(text, payload) {
+				t.Fatalf("log field %q leaked request payload: %v", key, value)
+			}
+		}
+	}
+}
+
+func connectionIDAt(t *testing.T, logger *recordingLogger, index int) string {
+	t.Helper()
+	if index >= len(logger.entries) {
+		t.Fatalf("no log entry at index %d (have %d)", index, len(logger.entries))
+	}
+	value, ok := logger.entries[index].fields["connectionId"].(string)
+	if !ok {
+		t.Fatalf("log entry at index %d has no string connectionId field", index)
+	}
+	return value
+}

--- a/pkg/transports/acp/internal/stdio/server_test.go
+++ b/pkg/transports/acp/internal/stdio/server_test.go
@@ -9,7 +9,9 @@ import (
 	"io"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 )
@@ -633,5 +635,350 @@ func assertJSONEqualStrings(t *testing.T, want, got string) {
 	}
 	if !reflect.DeepEqual(wantAny, gotAny) {
 		t.Fatalf("got %s, want %s", got, want)
+	}
+}
+
+// readerFunc adapts a function to io.Reader.
+type readerFunc func(p []byte) (int, error)
+
+func (f readerFunc) Read(p []byte) (int, error) { return f(p) }
+
+// TestServeReturnsContextErrorOnMidReadCancellation proves cancellation
+// unblocks Serve while the connection's read is genuinely parked waiting
+// for input that will never arrive, for a stream that itself supports
+// cancellation/closure: an io.Pipe's Read blocks until data is written or
+// the pipe is closed, and this test closes the read side once ctx is done
+// -- the same shape a real caller uses to make its context cancellable
+// (pairing WithCancel with a stream close), which is exactly the "stream
+// supports cancellation/closure" case this connection is required to
+// honor. Serve then reports ctx's own error rather than the raw
+// closed-pipe error it observes. Synchronization is entirely channel-based:
+// the wrapped reader closes readStarted the first time it is called, which
+// -- by Go's happens-before rule for goroutine creation -- can only happen
+// after Serve has actually begun reading, so cancel() is never raced
+// against Serve's own pre-check of an already-cancelled context. The single
+// terminal time.After is a hang-safety net, not a poll loop.
+func TestServeReturnsContextErrorOnMidReadCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	pr, pw := io.Pipe()
+	t.Cleanup(func() {
+		_ = pr.Close()
+		_ = pw.Close()
+	})
+	go func() {
+		<-ctx.Done()
+		_ = pr.Close()
+	}()
+
+	readStarted := make(chan struct{})
+	var signalOnce sync.Once
+	in := readerFunc(func(p []byte) (int, error) {
+		signalOnce.Do(func() { close(readStarted) })
+		return pr.Read(p)
+	})
+
+	server := New(nil)
+	done := make(chan error, 1)
+	go func() {
+		done <- server.Serve(ctx, in, &bytes.Buffer{})
+	}()
+
+	select {
+	case <-readStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve never started reading")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Serve() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve did not return after context cancellation")
+	}
+}
+
+// TestServeLogsCancelledOutcomeDistinctFromError proves a mid-connection
+// context cancellation is reported through its own "cancelled" outcome
+// label rather than the generic "error" label a real failure gets, so an
+// operator watching diagnostics can distinguish a deliberate shutdown from
+// a fault. As in TestServeReturnsContextErrorOnMidReadCancellation, it
+// closes the read stream once ctx is done to model a caller-owned stream
+// that supports cancellation/closure, and cancels only after Serve's read
+// has actually started, proving the connection was genuinely mid-flight
+// rather than pre-empted by the already-cancelled-context check
+// (TestServeRejectsAlreadyCancelledContext covers that separate path,
+// which never logs at all).
+func TestServeLogsCancelledOutcomeDistinctFromError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	pr, pw := io.Pipe()
+	t.Cleanup(func() {
+		_ = pr.Close()
+		_ = pw.Close()
+	})
+	go func() {
+		<-ctx.Done()
+		_ = pr.Close()
+	}()
+
+	readStarted := make(chan struct{})
+	var signalOnce sync.Once
+	in := readerFunc(func(p []byte) (int, error) {
+		signalOnce.Do(func() { close(readStarted) })
+		return pr.Read(p)
+	})
+
+	logger := &recordingLogger{}
+	server := New(logger)
+	done := make(chan error, 1)
+	go func() {
+		done <- server.Serve(ctx, in, &bytes.Buffer{})
+	}()
+
+	select {
+	case <-readStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve never started reading")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Serve() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve did not return after context cancellation")
+	}
+
+	if len(logger.entries) != 2 {
+		t.Fatalf("got %d log entries, want 2 (start and terminal)", len(logger.entries))
+	}
+	terminal := logger.entries[1]
+	if terminal.message != "acp stdio connection terminated" {
+		t.Fatalf("message = %q, want the connection-terminated message", terminal.message)
+	}
+	if outcome := terminal.fields["outcome"]; outcome != "cancelled" {
+		t.Fatalf("outcome = %v, want %q", outcome, "cancelled")
+	}
+}
+
+// TestServeRejectsPartialTrailingFrameAsProtocolFailure proves a
+// non-newline-terminated remainder at EOF is treated as a deterministic
+// protocol failure -- ending the connection with an error and writing no
+// response -- rather than being executed as a request the way
+// bufio.ScanLines' default final-token behavior would allow.
+func TestServeRejectsPartialTrailingFrameAsProtocolFailure(t *testing.T) {
+	partial := strings.TrimSuffix(initializeLine("1"), "\n")
+
+	out := &bytes.Buffer{}
+	server := New(nil)
+	err := server.Serve(context.Background(), strings.NewReader(partial), out)
+	if err == nil {
+		t.Fatal("Serve() error = nil, want a protocol failure for a partial trailing frame")
+	}
+	if !errors.Is(err, errPartialTrailingFrame) {
+		t.Fatalf("Serve() error = %v, want errPartialTrailingFrame", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("output = %q, want no response written for an unexecuted partial frame", out.Bytes())
+	}
+}
+
+// TestServeRejectsPartialTrailingFrameAfterACompleteLine proves a partial
+// trailing frame still ends the connection with a protocol failure even
+// after a preceding complete line was already answered -- the earlier
+// response is not undone, but the trailing partial content is never
+// dispatched.
+func TestServeRejectsPartialTrailingFrameAfterACompleteLine(t *testing.T) {
+	input := initializeLine("1") + `{"jsonrpc":"2.0","id":2,"method":"initialize"`
+
+	out := &bytes.Buffer{}
+	server := New(nil)
+	err := server.Serve(context.Background(), strings.NewReader(input), out)
+	if !errors.Is(err, errPartialTrailingFrame) {
+		t.Fatalf("Serve() error = %v, want errPartialTrailingFrame", err)
+	}
+
+	lines := nonEmptyResponseLines(t, out)
+	if len(lines) != 1 {
+		t.Fatalf("got %d response lines, want 1 (only the earlier complete line): %q", len(lines), out.Bytes())
+	}
+	var resp rpcMessage
+	if err := json.Unmarshal(lines[0], &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if string(resp.ID) != "1" {
+		t.Fatalf("id = %s, want 1", resp.ID)
+	}
+}
+
+// countingErrorWriter fails every Write with a fixed error and counts how
+// many times Write was called, so a test can prove the connection stops
+// writing after the first failure instead of retrying or continuing.
+type countingErrorWriter struct {
+	err   error
+	calls int
+}
+
+func (w *countingErrorWriter) Write(p []byte) (int, error) {
+	w.calls++
+	return 0, w.err
+}
+
+// TestServeSurfacesWriterFailureAndStopsFurtherWrites proves a write
+// failure is returned to the caller and ends the connection immediately --
+// a second framed request in the same input never gets an attempted
+// response write.
+func TestServeSurfacesWriterFailureAndStopsFurtherWrites(t *testing.T) {
+	wantErr := errors.New("acp test: simulated write failure")
+	writer := &countingErrorWriter{err: wantErr}
+
+	server := New(nil)
+	input := initializeLine("1") + initializeLine("2")
+	err := server.Serve(context.Background(), strings.NewReader(input), writer)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Serve() error = %v, want %v", err, wantErr)
+	}
+	if writer.calls != 1 {
+		t.Fatalf("writer was called %d times, want exactly 1 (no writes after the first failure)", writer.calls)
+	}
+}
+
+// shortWriter always writes one byte fewer than it was given, without
+// itself returning an error, mirroring a real short write.
+type shortWriter struct{}
+
+func (shortWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return len(p) - 1, nil
+}
+
+// TestServeTreatsShortWriteAsFailureNotSuccess proves a short write is
+// reported as io.ErrShortWrite and ends the connection, so a truncated
+// response can never be mistaken for a successful initialize exchange.
+func TestServeTreatsShortWriteAsFailureNotSuccess(t *testing.T) {
+	server := New(nil)
+	err := server.Serve(context.Background(), strings.NewReader(initializeLine("1")), shortWriter{})
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("Serve() error = %v, want io.ErrShortWrite", err)
+	}
+}
+
+// syncRecordingLogger is recordingLogger's concurrency-safe twin: multiple
+// connections served concurrently on the same *Server share one logger, so
+// TestServeHandlesConcurrentConnectionsWithoutRaces needs a logger safe for
+// concurrent Info calls (recordingLogger itself is intentionally not
+// synchronized, since every other test in this file drives it from a
+// single goroutine).
+type syncRecordingLogger struct {
+	mu      sync.Mutex
+	entries []logEntry
+}
+
+func (l *syncRecordingLogger) Debug(msg string, keysAndValues ...any) {
+	l.record("debug", msg, keysAndValues...)
+}
+func (l *syncRecordingLogger) Info(msg string, keysAndValues ...any) {
+	l.record("info", msg, keysAndValues...)
+}
+func (l *syncRecordingLogger) Warn(msg string, keysAndValues ...any) {
+	l.record("warn", msg, keysAndValues...)
+}
+func (l *syncRecordingLogger) Error(msg string, keysAndValues ...any) {
+	l.record("error", msg, keysAndValues...)
+}
+func (l *syncRecordingLogger) Verbose(msg string, keysAndValues ...any) {
+	l.record("verbose", msg, keysAndValues...)
+}
+
+func (l *syncRecordingLogger) record(level, msg string, keysAndValues ...any) {
+	fields := map[string]any{}
+	for index := 0; index+1 < len(keysAndValues); index += 2 {
+		key, ok := keysAndValues[index].(string)
+		if !ok {
+			continue
+		}
+		fields[key] = keysAndValues[index+1]
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append(l.entries, logEntry{level: level, message: msg, fields: fields})
+}
+
+func (l *syncRecordingLogger) startedConnectionIDs() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var ids []string
+	for _, entry := range l.entries {
+		if entry.message != "acp stdio connection started" {
+			continue
+		}
+		if id, ok := entry.fields["connectionId"].(string); ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+var _ logging.Logger = (*syncRecordingLogger)(nil)
+
+// TestServeHandlesConcurrentConnectionsWithoutRaces runs many Serve
+// invocations concurrently on one shared *Server (exercising the shared
+// connection-id counter and logger under real concurrency; run with
+// `go test -race` to prove there is no data race) and asserts every
+// connection still gets its own distinct connection id and its own
+// correct, whole-frame initialize response -- concurrent connections never
+// observe each other's identity or output.
+func TestServeHandlesConcurrentConnectionsWithoutRaces(t *testing.T) {
+	const concurrency = 20
+
+	logger := &syncRecordingLogger{}
+	server := New(logger)
+
+	outs := make([]*bytes.Buffer, concurrency)
+	errs := make([]error, concurrency)
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for i := range concurrency {
+		outs[i] = &bytes.Buffer{}
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = server.Serve(context.Background(), strings.NewReader(initializeLine("1")), outs[i])
+		}(i)
+	}
+	wg.Wait()
+
+	for i := range concurrency {
+		if errs[i] != nil {
+			t.Fatalf("connection %d: Serve() error = %v", i, errs[i])
+		}
+		resp := assertSingleResponseLine(t, outs[i])
+		if string(resp.ID) != "1" {
+			t.Fatalf("connection %d: id = %s, want 1", i, resp.ID)
+		}
+		if resp.Error != nil {
+			t.Fatalf("connection %d: error = %+v, want a successful result", i, resp.Error)
+		}
+		assertJSONEqualStrings(t, initializeSuccessResult, string(resp.Result))
+	}
+
+	ids := logger.startedConnectionIDs()
+	if len(ids) != concurrency {
+		t.Fatalf("got %d started-connection log entries, want %d", len(ids), concurrency)
+	}
+	seen := make(map[string]bool, concurrency)
+	for _, id := range ids {
+		if id == "" {
+			t.Fatal("got an empty connection id")
+		}
+		if seen[id] {
+			t.Fatalf("connection id %q was reused across concurrent connections", id)
+		}
+		seen[id] = true
 	}
 }

--- a/pkg/transports/acp/internal/stdio/server_test.go
+++ b/pkg/transports/acp/internal/stdio/server_test.go
@@ -3,8 +3,11 @@ package stdio
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -186,4 +189,188 @@ func connectionIDAt(t *testing.T, logger *recordingLogger, index int) string {
 		t.Fatalf("log entry at index %d has no string connectionId field", index)
 	}
 	return value
+}
+
+// initializeSuccessResult is the exact expected result payload for a
+// supported-version initialize request against the pinned honest P0
+// text-first agent capability profile (mirrors
+// internal/testutil/acpfixtures/testdata/initialization.json's accepted
+// case): the pinned protocol version, an empty authentication-method list,
+// and exactly the capabilities negotiation.Negotiate advertises -- no
+// deferred capability.
+const initializeSuccessResult = `{"protocolVersion":1,"authMethods":[],"agentCapabilities":{"auth":{},"loadSession":true,"mcpCapabilities":{},"promptCapabilities":{},"sessionCapabilities":{"resume":{}}}}`
+
+// initializeLine builds one complete newline-terminated JSON-RPC initialize
+// request line carrying rawID as its id token (e.g. "1" or `"req-abc"`).
+func initializeLine(rawID string) string {
+	return fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":%s,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{"fs":{"readTextFile":true,"writeTextFile":true},"terminal":true}}}`+"\n",
+		rawID,
+	)
+}
+
+// assertSingleResponseLine asserts out holds exactly one complete
+// newline-terminated JSON object -- no interleaving, no partial frame -- and
+// returns it decoded.
+func assertSingleResponseLine(t *testing.T, out *bytes.Buffer) rpcMessage {
+	t.Helper()
+	lines := nonEmptyResponseLines(t, out)
+	if len(lines) != 1 {
+		t.Fatalf("got %d response lines, want 1: %q", len(lines), out.Bytes())
+	}
+	var resp rpcMessage
+	if err := json.Unmarshal(lines[0], &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	return resp
+}
+
+// nonEmptyResponseLines splits out's contents into its newline-delimited
+// frames, asserting the buffer's contents end in a trailing newline (so no
+// partial trailing frame was ever written).
+func nonEmptyResponseLines(t *testing.T, out *bytes.Buffer) [][]byte {
+	t.Helper()
+	data := out.Bytes()
+	if len(data) == 0 {
+		return nil
+	}
+	if data[len(data)-1] != '\n' {
+		t.Fatalf("response output = %q, want every response newline-terminated", data)
+	}
+	trimmed := bytes.TrimSuffix(data, []byte("\n"))
+	return bytes.Split(trimmed, []byte("\n"))
+}
+
+func TestServeRespondsToValidInitializeRequests(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+	}{
+		{name: "numeric id", id: "1"},
+		{name: "string id", id: `"req-abc"`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			server := New(nil)
+			if err := server.Serve(context.Background(), strings.NewReader(initializeLine(tc.id)), out); err != nil {
+				t.Fatalf("Serve() error = %v", err)
+			}
+
+			resp := assertSingleResponseLine(t, out)
+			if resp.JSONRPC != "2.0" {
+				t.Fatalf("jsonrpc = %q, want 2.0", resp.JSONRPC)
+			}
+			if string(resp.ID) != tc.id {
+				t.Fatalf("id = %s, want %s", resp.ID, tc.id)
+			}
+			if resp.Error != nil {
+				t.Fatalf("error = %+v, want a successful result", resp.Error)
+			}
+			assertJSONEqualStrings(t, initializeSuccessResult, string(resp.Result))
+		})
+	}
+}
+
+func TestServeFramesOneResponsePerCompleteInputLine(t *testing.T) {
+	input := initializeLine("1") + initializeLine("2")
+
+	out := &bytes.Buffer{}
+	server := New(nil)
+	if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	lines := nonEmptyResponseLines(t, out)
+	if len(lines) != 2 {
+		t.Fatalf("got %d response lines, want 2: %q", len(lines), out.Bytes())
+	}
+	for index, wantID := range []string{"1", "2"} {
+		var resp rpcMessage
+		if err := json.Unmarshal(lines[index], &resp); err != nil {
+			t.Fatalf("unmarshal response %d: %v", index, err)
+		}
+		if string(resp.ID) != wantID {
+			t.Fatalf("response %d id = %s, want %s", index, resp.ID, wantID)
+		}
+	}
+}
+
+func TestServeSkipsEmptyLines(t *testing.T) {
+	input := "\n" + initializeLine("1") + "\n"
+
+	out := &bytes.Buffer{}
+	server := New(nil)
+	if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	assertSingleResponseLine(t, out)
+}
+
+func TestServeIsolatesConnectionsReusingTheSameWireID(t *testing.T) {
+	logger := &recordingLogger{}
+	server := New(logger)
+
+	firstOut := &bytes.Buffer{}
+	if err := server.Serve(context.Background(), strings.NewReader(initializeLine("1")), firstOut); err != nil {
+		t.Fatalf("first Serve() error = %v", err)
+	}
+	secondOut := &bytes.Buffer{}
+	if err := server.Serve(context.Background(), strings.NewReader(initializeLine("1")), secondOut); err != nil {
+		t.Fatalf("second Serve() error = %v", err)
+	}
+
+	firstConnID := connectionIDAt(t, logger, 0)
+	secondConnID := connectionIDAt(t, logger, 2)
+	if firstConnID == secondConnID {
+		t.Fatalf("expected distinct connection ids across invocations reusing wire id 1, got %q both times", firstConnID)
+	}
+
+	for _, out := range []*bytes.Buffer{firstOut, secondOut} {
+		resp := assertSingleResponseLine(t, out)
+		if string(resp.ID) != "1" {
+			t.Fatalf("response id = %s, want 1", resp.ID)
+		}
+		if resp.Error != nil {
+			t.Fatalf("response error = %+v, want a successful result", resp.Error)
+		}
+		assertJSONEqualStrings(t, initializeSuccessResult, string(resp.Result))
+	}
+}
+
+func TestServeRespondsMethodNotFoundForAnUnimplementedMethod(t *testing.T) {
+	input := `{"jsonrpc":"2.0","id":9,"method":"session/new","params":{}}` + "\n"
+
+	out := &bytes.Buffer{}
+	server := New(nil)
+	if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	resp := assertSingleResponseLine(t, out)
+	if string(resp.ID) != "9" {
+		t.Fatalf("id = %s, want 9", resp.ID)
+	}
+	if resp.Error == nil || resp.Error.Code != -32601 {
+		t.Fatalf("error = %+v, want method-not-found (-32601)", resp.Error)
+	}
+}
+
+// assertJSONEqualStrings compares two JSON documents structurally rather
+// than byte-for-byte, so object key ordering never causes a spurious
+// mismatch.
+func assertJSONEqualStrings(t *testing.T, want, got string) {
+	t.Helper()
+	var wantAny, gotAny any
+	if err := json.Unmarshal([]byte(want), &wantAny); err != nil {
+		t.Fatalf("decode want: %v", err)
+	}
+	if err := json.Unmarshal([]byte(got), &gotAny); err != nil {
+		t.Fatalf("decode got: %v", err)
+	}
+	if !reflect.DeepEqual(wantAny, gotAny) {
+		t.Fatalf("got %s, want %s", got, want)
+	}
 }

--- a/pkg/transports/acp/server.go
+++ b/pkg/transports/acp/server.go
@@ -1,0 +1,23 @@
+package acp
+
+import (
+	"context"
+	"io"
+)
+
+// Server serves one ACP JSON-RPC agent-side connection at a time over
+// caller-owned stdio streams. Construction alone performs no reads, writes,
+// goroutine starts, process starts, endpoint binding, session creation, or
+// persistence; a Server begins connection I/O only when Serve is called.
+//
+// Production construction is owned by pkg/transports/acp/wire, which
+// injects only explicit collaborators; this package never resolves a
+// Server through a dependency bag, service locator, secondary injector, or
+// process-global stdio lookup.
+type Server interface {
+	// Serve begins one connection-scoped invocation over caller-owned input
+	// and output streams and returns once the connection terminates. Each
+	// call is assigned its own connection-scoped identity, stable for that
+	// call and distinct from every other invocation.
+	Serve(ctx context.Context, in io.Reader, out io.Writer) error
+}

--- a/pkg/transports/acp/wire/wire.go
+++ b/pkg/transports/acp/wire/wire.go
@@ -1,0 +1,22 @@
+// Package wire is the ACP stdio transport composition boundary.
+//
+// Wire performs construction only: it injects the explicit collaborators an
+// ACP acp.Server needs and starts no goroutine, process, listener, session,
+// or persistence. Callers inject their own streams into the returned
+// Server's Serve method; wire never reads process-global stdio itself, so
+// this package introduces no dependency bag, service locator, or secondary
+// injector.
+package wire
+
+import (
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	acp "github.com/portpowered/infinite-you/pkg/transports/acp"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/stdio"
+)
+
+// NewServer constructs the production ACP stdio Server. Construction alone
+// performs no reads, writes, goroutine starts, process starts, endpoint
+// binding, session creation, or persistence.
+func NewServer(logger logging.Logger) acp.Server {
+	return stdio.New(logger)
+}

--- a/pkg/transports/acp/wire/wire_test.go
+++ b/pkg/transports/acp/wire/wire_test.go
@@ -1,0 +1,34 @@
+package wire_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/transports/acp/wire"
+)
+
+func TestNewServerConstructsWithoutIO(t *testing.T) {
+	server := wire.NewServer(nil)
+	if server == nil {
+		t.Fatal("NewServer() returned nil")
+	}
+}
+
+func TestNewServerServesOneConnection(t *testing.T) {
+	server := wire.NewServer(nil)
+	out := &bytes.Buffer{}
+
+	if err := server.Serve(context.Background(), strings.NewReader(""), out); err != nil {
+		t.Fatalf("Serve() error = %v, want nil on clean EOF", err)
+	}
+}
+
+func TestNewServerRejectsMissingStreams(t *testing.T) {
+	server := wire.NewServer(nil)
+
+	if err := server.Serve(context.Background(), nil, nil); err == nil {
+		t.Fatal("Serve() error = nil, want an actionable error for missing streams")
+	}
+}


### PR DESCRIPTION
```json
{
    "project": "Serve ACP Initialize over Framed Stdio",
    "branchName": "ACP-L1-V1-T10-stdio-initialize",
    "description": "Add an inert, injectable ACP agent-side stdio server that owns line-delimited JSON-RPC framing and one-connection lifecycle, assigns connection-scoped request identity, serves the pinned ACP v1 initialize operation through the existing V0 negotiation contract, and advertises exactly the implemented text-first capabilities. The intent is to establish a safe and deterministic transport foundation before sessions, prompt dispatch, event streaming, persistence, remote transports, root composition, or the final CLI command are added.",
    "context": {
        "customerAsk": "Implement injectable ACP stdio framing and connection lifecycle so a real ACP v1 initialize request is decoded, receives connection-scoped identity, is negotiated through the V0 compatibility boundary, and receives an honest text-first capability response. Malformed input, unsupported methods, version mismatch, write failure, EOF, and shutdown must behave deterministically and must not expose prompts, credentials, filesystem paths, raw provider commands, or topology.",
        "problem": "pkg/transports/acp currently provides pure compatibility negotiation, request identity, parameter decoding, and protocol-safe error helpers, but it has no serving operation. A client therefore cannot exchange a framed initialize request over stdio, connection lifecycle has no owner, and error and shutdown behavior is unproven at the actual IO boundary.",
        "solution": "Expose one minimal transport operation over caller-owned input and output streams, construct it inertly through pkg/transports/acp/wire, create connection state only when serving starts, keep newline-delimited JSON-RPC framing and lifecycle in the transport, and delegate version/capability policy to the existing V0 operations. Prove behavior with table-driven transport tests and exactly one deterministic OS/process-boundary stdio cell for pipe and EOF mechanics that root.BuildProcess cannot express."
    },
    "acceptanceCriteria": [
        "A caller can construct the ACP server without starting IO, goroutines, processes, sessions, listeners, or persistence, then explicitly serve one connection over caller-owned input and output streams.",
        "A line-delimited ACP v1 initialize request with a string or numeric JSON-RPC ID receives one correlated JSON-RPC success response containing the negotiated pinned version and exactly the existing text-first agent capabilities.",
        "Every accepted request is associated with an identity scoped by a unique connection ID and its wire ID; reuse of the same wire ID by separate connections cannot collide.",
        "Malformed JSON/JSON-RPC, invalid initialize parameters, unsupported methods, and incompatible versions yield correlated protocol-safe outcomes when a response is permitted, while unsupported notifications emit no response.",
        "Clean EOF and context shutdown terminate deterministically; output write or short-write failure is returned to the server caller and ends the connection without hanging, silently reporting success, or leaking prompts, credentials, filesystem paths, raw provider commands, raw request data, or topology.",
        "Focused typecheck/build, formatting, diff-scoped lint, table-driven transport tests, and the single justified OS/process-boundary stdio functional cell pass with no arbitrary sleeps.",
        "The implementation/review loop continues until required CI is terminal and passing, every blocking PR conversation is explicitly addressed, shared-file changes and merge conflicts are reconciled against current main, and the PR is actually merged; opening, approving, or making the PR merge-ready is not completion."
    ],
    "userStories": [
        {
            "id": "ACP-L1-V1-T10-stdio-initialize-001",
            "title": "Construct an inert injectable stdio server",
            "description": "As an application integrator, I want a minimal ACP server operation constructed through the transport's wire provider so I can inject streams and control when connection IO begins without activating unrelated product services.",
            "acceptanceCriteria": [
                "Construction alone performs no reads, writes, goroutine starts, process starts, endpoint binding, session creation, or persistence.",
                "The public operation accepts a context and caller-owned input/output streams for one serving invocation and rejects missing required streams with an actionable, sensitive-safe error.",
                "Production construction is owned by pkg/transports/acp/wire and injects only explicit collaborators; no dependency bag, service locator, secondary injector, or process-global stdio lookup is introduced.",
                "Starting the operation creates one connection-scoped identity that is stable for that invocation and distinct from other invocations.",
                "Start and terminal outcomes are observable through structured, payload-free diagnostics using safe connection/outcome facts only.",
                "Tests pass",
                "Typecheck passes"
            ],
            "priority": 1,
            "passes": true,
            "notes": "Implemented: internal/identity.NewConnectionID mints a process-unique ConnectionID (atomic counter, no I/O). pkg/transports/acp/internal/stdio.Server is the inert implementation (New() performs no I/O; Serve validates streams, mints a connection id, logs structured start/terminal diagnostics, and drains input to clean EOF -- framing/dispatch land in story 002). pkg/transports/acp.Server is the exported interface. pkg/transports/acp/wire.NewServer(logger) is the sole production constructor, injecting only an explicit logging.Logger collaborator. Table-driven tests cover no-IO construction, missing-stream rejection, nil-server rejection, already-cancelled-context rejection, clean-EOF return, distinct connection ids across invocations, and payload-free start/terminal diagnostics. make test (full unit lane) and go vet/build are green; pkg-boundary/pkg-structure/pkg-maint/pkg-file-count/backend-size/deadcode/logging-boundary-check show no new violations versus main."
        },
        {
            "id": "ACP-L1-V1-T10-stdio-initialize-002",
            "title": "Initialize over framed stdio with honest capabilities",
            "description": "As an ACP client, I want to initialize over standard line-delimited JSON-RPC so I can confirm protocol compatibility without being promised capabilities the agent does not yet implement.",
            "acceptanceCriteria": [
                "One complete non-empty input line is treated as one JSON-RPC 2.0 message, and every response is emitted as one complete newline-terminated JSON object without interleaving.",
                "Valid initialize requests with both string and numeric IDs are decoded into the pinned ACP SDK request shape and assigned a RequestIdentity containing the active connection ID and original ID kind/value.",
                "The operation delegates protocol-version policy to the existing V0 negotiation/profile behavior rather than defining a second compatibility policy.",
                "A supported-version request receives exactly one response with the same JSON-RPC ID, the pinned protocol version, an empty authentication-method list, and the serialized existing text-first agent capabilities; no deferred capability is advertised.",
                "Table-driven transport tests prove framing, ID correlation, connection isolation when wire IDs are reused, and the exact serialized initialize response.",
                "Exactly one OS/process-boundary functional cell proves a real pipe-based initialize exchange and clean stdin EOF; it is limited to stdio behavior root.BuildProcess cannot express and uses no arbitrary sleeps or timeout-padded polling.",
                "Tests pass",
                "Typecheck passes"
            ],
            "priority": 2,
            "passes": true,
            "notes": "Implemented: pkg/transports/acp/internal/stdio/server.go's serveConnection now reads line-delimited input via bufio.Scanner, treating every complete non-empty line as one JSON-RPC message (blank lines are skipped, not errored) and writing exactly one complete newline-terminated JSON-RPC response per non-notification message via the new writeResponse helper (single json.Marshal + single out.Write call, so no interleaving is possible and a short write returns io.ErrShortWrite). dispatchRequest decodes each line through envelope.Decode (existing, unchanged) and, for the 'initialize' method only, unmarshals params into acpsdk.InitializeRequest and delegates all protocol-version/capability policy to negotiation.Negotiate (existing V0 negotiation, unchanged) -- no second compatibility policy was added. Any other method (including session/* methods already listed in protocol.SupportedMethods for future stories) receives protocol.MethodNotFound directly rather than being routed through protocol.Guard/GuardEnvelope, because protocol.SupportedMethods is a forward-looking closed set for the whole future ACP method surface, not what this transport slice actually implements; only 'initialize' has a real effect in this slice. A response's JSON-RPC id is recovered via a new identity.RequestIdentity.WireID() accessor (added alongside the existing ConnectionID()/IsMinted() accessors) that returns the original JSONRPCID for a correlated identity so it can be re-marshaled onto the wire via JSONRPCID's existing MarshalJSON; a decode failure (no identity yet) responds with a null id. Tests added/extended in pkg/transports/acp/internal/stdio/server_test.go: valid initialize requests with both string and numeric ids decode and respond with the exact pinned-version/empty-authMethods/honest-P0-capabilities result (byte-identical to internal/testutil/acpfixtures/testdata/initialization.json's accepted case); one-line-per-message framing across multiple lines; blank lines are skipped; two separate Serve invocations reusing the same wire id ('1') both get correct independent responses and are logged under distinct connection ids (connection isolation); and a lightweight sanity check that an unimplemented method (session/new) gets method-not-found rather than hanging or crashing (full error-class coverage is story 003's scope). Added the single required OS/process-boundary functional cell in the new pkg/transports/acp/internal/stdio/server_smoke_test.go: a real os.Pipe()-based initialize exchange plus real stdin-close EOF, following this repo's existing pkg/transports/cli/mcp/serve_smoke_test.go pattern (untagged, runs in the normal unit lane; synchronization is blocking IO/channel-based, with a single terminal time.After(5s) only as a hang-safety net, not a poll loop). All existing story-001 lifecycle tests (missing streams, nil server, clean EOF, cancelled context, distinct connection ids, payload-free logging) needed no changes and still pass unmodified against the new dispatch loop. Verification: go build ./..., go vet ./..., gofmt -l (clean), make test (full unit lane, all green), and the Go-only repo lint checks (pkgboundarycheck/pkgstructurecheck/pkgmaintcheck/pkgfilecountcheck/backendsizecheck/deadcodecheck/loggingboundarycheck) diffed against a git-stash-u baseline confirm zero new violations (only a line-number shift on a pre-existing unrelated pkgboundarycheck finding)."
        },
        {
            "id": "ACP-L1-V1-T10-stdio-initialize-003",
            "title": "Return protocol-safe request failures",
            "description": "As an ACP client, I want invalid or unsupported input to produce standard, correlated JSON-RPC outcomes so I can recover without receiving internal or sensitive implementation details.",
            "acceptanceCriteria": [
                "Malformed JSON produces a JSON-RPC parse-error response with a null ID, and a structurally invalid JSON-RPC request produces an invalid-request response using the request ID only when it is valid and correlation is permitted.",
                "Missing, null, malformed, or semantically invalid initialize params produce an invalid-params response correlated to the original valid request ID.",
                "Requests for methods not implemented in this slice, including deferred ACP session and prompt methods, receive method-not-found; notifications without an ID receive no response.",
                "An unsupported protocol version is mapped from the existing typed compatibility failure to a stable, correlated JSON-RPC error that exposes only requested/supported public version facts and advertises no capabilities.",
                "After a recoverable request-level error, the same connection can process the next valid framed request; framing or output failures that make continuation unsafe terminate instead.",
                "Table-driven tests cover each error class and assert that responses, returned errors, and captured diagnostics do not contain seeded prompt, credential, filesystem-path, provider-command, raw-params, or topology sentinels.",
                "Tests pass",
                "Typecheck passes"
            ],
            "priority": 3,
            "passes": true,
            "notes": "Implemented: pkg/transports/acp/internal/envelope/envelope.go's Decode now classifies every rejection through a new *DecodeError (Error()/Unwrap()/ID()) that wraps one of two new sentinels -- ErrInvalidJSON (input that never parsed as JSON, chained under the existing ErrMalformedEnvelope so old errors.Is(ErrMalformedEnvelope) callers are unaffected) or ErrInvalidRequestShape (valid JSON that violates the JSON-RPC 2.0 request shape: wrong/missing jsonrpc version, missing/blank method, an unsupported id shape, an id-bearing notification, or a request method with no id) -- and, for every ErrInvalidRequestShape case, carries the message's JSON-RPC id when that id token was itself syntactically valid (recovered via a best-effort identity.NewJSONRPCID parse performed once, right after the JSON itself parses, before any shape check runs), so a structurally invalid request can still be correlated back to its own id per JSON-RPC 2.0, while completely unparseable input never has an id to give back. Added pkg/transports/acp/internal/protocol/errors.go's ParseError() (-32700, fixed reason, never correlated), InvalidRequest() (-32600, fixed reason), and RejectEnvelope(cause) -- which classifies an envelope.Decode failure into the right bounded *acpsdk.RequestError plus the JSON-RPC id (if any) to correlate to, falling back to the existing SafeReject/invalid-params classification for any cause that isn't a *envelope.DecodeError. pkg/transports/acp/internal/stdio/server.go's dispatchRequest now calls protocol.RejectEnvelope on every envelope.Decode failure and builds a correlated identity.RequestIdentity via identity.NewCorrelated when a recoverable id exists, so writeResponse serializes the right JSON-RPC id (or null) automatically through its existing WireID() path -- no changes needed to writeResponse itself. protocol.Guard/GuardEnvelope (used only by the separate acpfixtures-based conformance test harness, not by the stdio dispatch path per the story-002 learnings) were deliberately left unchanged: this story's classification work is scoped to the stdio transport's own dispatch, which already bypasses Guard/GuardEnvelope. Missing/malformed initialize params and the unsupported-protocol-version case needed no new production code: json.Unmarshal failure on env.Params already produced a correlated SafeReject invalid-params response (verified: env.Params is nil for an absent params key, and json.Unmarshal(nil, ...) always errors before ever reaching acpsdk.InitializeRequest's custom UnmarshalJSON), and negotiation.Negotiate's existing unsupported_protocol_version rejection already flows through unwrapped and correlated via env.Identity (confirmed acpsdk.InitializeRequest.UnmarshalJSON accepts a literal JSON null params value without error, defaulting ProtocolVersion to 0, which negotiation.Negotiate then rejects as unsupported_protocol_version -- so null params is already covered by the existing version-mismatch path, not a separate code path). Tests added: pkg/transports/acp/internal/envelope/envelope_test.go's TestDecode_RejectsMalformedInput was rewritten into a table asserting, per malformed-input case, the exact ErrInvalidJSON vs ErrInvalidRequestShape classification and the exact recoverable id (or its absence) via the new DecodeError.ID() accessor. pkg/transports/acp/internal/protocol/errors_test.go gained TestRejectEnvelope_ClassifiesInvalidJSONAsUncorrelatedParseError, TestRejectEnvelope_ClassifiesInvalidShapeAsCorrelatedInvalidRequest, TestRejectEnvelope_InvalidShapeWithUnrecoverableIDIsUncorrelated, TestRejectEnvelope_FallsBackToSafeRejectForNonDecodeErrors, and TestParseErrorAndInvalidRequest_NeverCarrySensitiveData (mirrors the existing MethodNotFound/SafeReject redaction-proof style: asserts each constructor's serialized data is exactly one fixed reason field). pkg/transports/acp/internal/stdio/server_test.go gained: TestServeRespondsMethodNotFoundForEveryUnimplementedMethod (table-driven, replacing the old single-method test, covering every deferred session/* method plus a wholly unrecognized method); TestServeRespondsWithParseErrorForMalformedJSON; TestServeRespondsWithInvalidRequestForStructurallyInvalidShapes (table covering a wrong-version request with a valid id, a missing-method request with a valid id, an id-bearing session/cancel notification, and a malformed id shape with no recoverable id); TestServeRespondsWithInvalidParamsForBadInitializeParams (missing and malformed-type params); TestServeMapsUnsupportedProtocolVersionToCorrelatedFactsWithNoCapabilities (asserts the exact reason/requestedVersion/supportedVersion facts and that no result/capabilities ever accompanies a rejection); TestServeEmitsNoResponseForAValidNotification; TestServeContinuesProcessingAfterARecoverableRequestError (proves a rejected line does not end the connection: the next valid line on the same connection still gets a correct response); and TestServeErrorResponsesAndDiagnosticsNeverLeakSeededSensitiveSentinels (seeds a credential, an absolute path, a raw provider command, and a topology sentinel into malformed JSON, an unsupported method name, and malformed initialize params, then asserts none of those sentinels appear in the written response bytes or in any structured log field via recordingLogger -- extending the existing payload-leak proof pattern from story 001 to every request-level error class this transport can produce). Verification: go build ./..., go vet ./..., gofmt -l (clean), make test (full unit lane, all green), and the Go-only repo lint checks (pkgboundarycheck/pkgstructurecheck/pkgmaintcheck/pkgfilecountcheck/backendsizecheck/deadcodecheck/loggingboundarycheck) diffed against a git-stash-u baseline on this branch confirm zero new violations (only the same pre-existing line-number shift on the unrelated pkgboundarycheck EnsureLogger finding already noted in story 002's notes)."
        },
        {
            "id": "ACP-L1-V1-T10-stdio-initialize-004",
            "title": "Terminate connections deterministically",
            "description": "As the process owner, I want EOF, cancellation, and output failure to complete the serving operation deterministically so shutdown cannot hang or hide data-loss failures.",
            "acceptanceCriteria": [
                "Clean EOF after all complete frames are handled is a successful terminal outcome and causes the serve operation to return without requiring an extra message or timer.",
                "Context cancellation stops accepting new work, unblocks the connection lifecycle when the provided stream supports cancellation/closure, and returns the context outcome without leaving transport-owned work running.",
                "A partial trailing frame at EOF is handled as a deterministic protocol failure rather than being executed as a request.",
                "Writer errors and short writes are surfaced to the serve caller, stop further response writes, and cannot be mistaken for a successful initialize exchange.",
                "Concurrent lifecycle edges preserve whole-frame writes and a single terminal outcome; focused repeat/race coverage is added where concurrency is present.",
                "Tests synchronize with EOF, closed pipes/channels, injected writer outcomes, or context completion and contain no arbitrary sleeps.",
                "Tests pass",
                "Typecheck passes"
            ],
            "priority": 4,
            "passes": true,
            "notes": "Implemented: pkg/transports/acp/internal/stdio/server.go's serveConnection now checks ctx.Err() before every scanner.Scan() call (stopping new work immediately on cancellation) and, when Scan() fails, prefers ctx.Err() over the raw stream error whenever ctx is also done -- so a caller-owned stream that supports cancellation/closure (e.g. one the caller closes when its own context is cancelled) reports the context outcome rather than a generic read-failure. This deliberately does not spawn a background reader goroutine: an earlier goroutine+channel design was rejected because pkg/transports files are prohibited from using go/make(chan) directly (cmd/pkgboundarycheck's transport 'concurrency' rule -- confirmed by diffing pkgboundarycheck output against a git-stash-u baseline, which showed two new findings for exactly that shape), and the established in-repo precedent for a context-cancellable stdio reader (pkg/platform/stdio.ContextLineReader, used via an injected factory from the outer pkg/wire, e.g. pkg/transports/cli/initsetup) requires root composition this PRD explicitly defers to a later story. The synchronous per-Scan()-call check is therefore the in-scope, architecture-compliant way to satisfy 'stops accepting new work' and 'unblocks... when the provided stream supports cancellation/closure' without owning concurrency in the transport layer. Also added scanCompleteLines, a bufio.SplitFunc used via scanner.Split that -- unlike bufio.ScanLines' default behavior -- never yields a final non-newline-terminated remainder at EOF as a token; instead it returns the new errPartialTrailingFrame sentinel, which serveConnection returns as-is (ending the connection, writing no response for that unexecuted partial content) rather than executing less than the full line the client meant to send. Writer failures and short writes needed no production changes: writeResponse already returned io.ErrShortWrite for a short write and any writer error verbatim (since story 002), and serveConnection already returned immediately on a non-nil writeResponse error without attempting further writes -- both behaviors were previously unverified at the wire/test boundary and are now covered directly. Tests added to pkg/transports/acp/internal/stdio/server_test.go: TestServeReturnsContextErrorOnMidReadCancellation and TestServeLogsCancelledOutcomeDistinctFromError both use a real io.Pipe with a background goroutine (test-file-only; the pkgboundarycheck concurrency rule exempts _test.go files) that closes the pipe's read side once ctx.Done() fires -- modeling a stream that itself supports cancellation/closure -- and synchronize deterministically via a wrapped reader that closes a readStarted channel on its first call (Go's happens-before rule for goroutine creation guarantees this can only happen after Serve has already logged its start entry), so cancel() is never raced against Serve's own already-cancelled-context pre-check; the terminal outcome label gains a new 'cancelled' case (terminalOutcomeLabel: eof/cancelled/error) distinct from a generic fault, asserted directly. TestServeRejectsPartialTrailingFrameAsProtocolFailure and TestServeRejectsPartialTrailingFrameAfterACompleteLine prove a non-newline-terminated remainder at EOF ends the connection with errPartialTrailingFrame and writes no response for it, including after an earlier complete line was already correctly answered. TestServeSurfacesWriterFailureAndStopsFurtherWrites (a countingErrorWriter proving exactly one Write call occurs despite two framed requests in the input) and TestServeTreatsShortWriteAsFailureNotSuccess (a shortWriter always writing one byte short) cover the writer-failure and short-write paths directly. TestServeHandlesConcurrentConnectionsWithoutRaces runs 20 concurrent Serve invocations on one shared *Server against a new mutex-protected syncRecordingLogger (recordingLogger itself is intentionally unsynchronized, since every other test in the file drives it from a single goroutine), asserting every connection gets its own distinct connection id and correct whole-frame response with no data race on the shared identity.NewConnectionID atomic counter or logger. Verification: go build ./..., go vet ./..., gofmt -l (clean), make test-unit-fresh (full unit lane, all green across repeated runs; one run showed an unrelated transient FAIL with no failing test name printed, not reproducible on immediate rerun or across pkg/transports/acp-only reruns at -count=20), and pkgmaintcheck/pkgboundarycheck/pkgstructurecheck/pkgfilecountcheck/deadcodecheck/loggingboundarycheck diffed against a git-stash-u baseline confirm zero new violations except the same pre-existing line-number shift on the unrelated pkgboundarycheck EnsureLogger finding noted since story 002 (go test -race could not be evaluated in this sandboxed Windows environment -- ThreadSanitizer failed to allocate memory across every package, a pre-existing environment limitation unrelated to this change)."
        }
    ]
}
```
