### PR TITLE
ACP-L2-IMP-WRK-PANIC: Return a typed error when a worker executor panics

### DIFF
--- a/pkg/services/workers/workstation_pool_boundary_impl.go
+++ b/pkg/services/workers/workstation_pool_boundary_impl.go
@@ -2,10 +2,50 @@ package workers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
 )
+
+// WorkerExecutorPanicError is the Workers-owned typed failure returned when a
+// configured WorkerExecutor panics inside the Workers execution boundary. Its
+// Error text preserves the established `executor panic: <cause>` WorkResult
+// compatibility string, and Cause retains the original recovered panic value
+// (which may not be an error) for errors.As-based inspection without string
+// parsing.
+type WorkerExecutorPanicError struct {
+	Cause any
+}
+
+func (e *WorkerExecutorPanicError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("executor panic: %v", e.Cause)
+}
+
+// Unwrap exposes the recovered panic value's error chain when the recovered
+// cause is itself an error.
+func (e *WorkerExecutorPanicError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	if cause, ok := e.Cause.(error); ok {
+		return cause
+	}
+	return nil
+}
+
+// AsWorkerExecutorPanicError reports whether err contains a recovered
+// WorkerExecutor panic, exposing the original recovered cause.
+func AsWorkerExecutorPanicError(err error) (*WorkerExecutorPanicError, bool) {
+	var panicErr *WorkerExecutorPanicError
+	if errors.As(err, &panicErr) && panicErr != nil {
+		return panicErr, true
+	}
+	return nil, false
+}
 
 // NewWorkstationPoolBoundary constructs a Workers-owned pool boundary from
 // detached executor bindings and route names supplied by the runtime peer.
@@ -46,12 +86,13 @@ func (a workerExecutorRequestAdapter) Execute(
 ) (result WorkResult, err error) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
+			panicErr := &WorkerExecutorPanicError{Cause: recovered}
 			result = WorkResult{
 				DispatchID: request.Dispatch.DispatchID, TransitionID: request.Dispatch.TransitionID,
 				Outcome: OutcomeFailed,
-				Error:   fmt.Sprintf("executor panic: %v", recovered),
+				Error:   panicErr.Error(),
 			}
-			err = nil
+			err = panicErr
 		}
 	}()
 	workerType := request.WorkerType

--- a/pkg/services/workers/workstation_pool_boundary_impl.go
+++ b/pkg/services/workers/workstation_pool_boundary_impl.go
@@ -2,7 +2,6 @@ package workers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -31,20 +30,8 @@ func (e *WorkerExecutorPanicError) Unwrap() error {
 	if e == nil {
 		return nil
 	}
-	if cause, ok := e.Cause.(error); ok {
-		return cause
-	}
-	return nil
-}
-
-// AsWorkerExecutorPanicError reports whether err contains a recovered
-// WorkerExecutor panic, exposing the original recovered cause.
-func AsWorkerExecutorPanicError(err error) (*WorkerExecutorPanicError, bool) {
-	var panicErr *WorkerExecutorPanicError
-	if errors.As(err, &panicErr) && panicErr != nil {
-		return panicErr, true
-	}
-	return nil, false
+	cause, _ := e.Cause.(error)
+	return cause
 }
 
 // NewWorkstationPoolBoundary constructs a Workers-owned pool boundary from

--- a/pkg/services/workers/workstation_pool_boundary_impl_test.go
+++ b/pkg/services/workers/workstation_pool_boundary_impl_test.go
@@ -2,6 +2,7 @@ package workers
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/portpowered/infinite-you/pkg/services/work"
@@ -11,6 +12,143 @@ type poolBoundaryTestExecutor struct{}
 
 func (poolBoundaryTestExecutor) Execute(context.Context, work.WorkDispatch) (WorkResult, error) {
 	return WorkResult{}, nil
+}
+
+type poolBoundaryPanicExecutor struct {
+	panicValue any
+}
+
+func (e poolBoundaryPanicExecutor) Execute(context.Context, work.WorkDispatch) (WorkResult, error) {
+	panic(e.panicValue)
+}
+
+type poolBoundaryErrorExecutor struct {
+	err error
+}
+
+func (e poolBoundaryErrorExecutor) Execute(context.Context, work.WorkDispatch) (WorkResult, error) {
+	return WorkResult{Outcome: OutcomeFailed, Error: e.err.Error()}, e.err
+}
+
+func poolBoundaryDispatchRequest(dispatchID, transitionID, workerType string) WorkstationExecutionRequest {
+	return WorkstationExecutionRequest{
+		WorkerType: workerType,
+		Dispatch: work.WorkDispatch{
+			DispatchID:   dispatchID,
+			TransitionID: transitionID,
+			WorkerType:   workerType,
+		},
+	}
+}
+
+func TestWorkerExecutorRequestAdapterExecuteRecoversErrorPanic(t *testing.T) {
+	cause := errors.New("boom")
+	adapter := workerExecutorRequestAdapter{
+		executors: map[string]WorkerExecutor{"swe": poolBoundaryPanicExecutor{panicValue: cause}},
+	}
+	request := poolBoundaryDispatchRequest("dispatch-1", "transition-1", "swe")
+
+	result, err := adapter.Execute(context.Background(), request)
+
+	if err == nil {
+		t.Fatalf("Execute() err = nil, want non-nil typed panic error")
+	}
+	var panicErr *WorkerExecutorPanicError
+	if !errors.As(err, &panicErr) || panicErr == nil {
+		t.Fatalf("errors.As(err, *WorkerExecutorPanicError) = false, want true; err = %v", err)
+	}
+	if panicErr.Cause != any(cause) {
+		t.Fatalf("panicErr.Cause = %v, want %v", panicErr.Cause, cause)
+	}
+	if !errors.Is(err, cause) {
+		t.Fatalf("errors.Is(err, cause) = false, want true via Unwrap")
+	}
+	wantText := "executor panic: boom"
+	if err.Error() != wantText {
+		t.Fatalf("err.Error() = %q, want %q", err.Error(), wantText)
+	}
+	if result.Outcome != OutcomeFailed {
+		t.Fatalf("result.Outcome = %q, want %q", result.Outcome, OutcomeFailed)
+	}
+	if result.Error != wantText {
+		t.Fatalf("result.Error = %q, want %q", result.Error, wantText)
+	}
+	if result.DispatchID != "dispatch-1" || result.TransitionID != "transition-1" {
+		t.Fatalf(
+			"result identity = (%q, %q), want (%q, %q)",
+			result.DispatchID, result.TransitionID, "dispatch-1", "transition-1",
+		)
+	}
+}
+
+func TestWorkerExecutorRequestAdapterExecuteRecoversNonErrorPanic(t *testing.T) {
+	adapter := workerExecutorRequestAdapter{
+		executors: map[string]WorkerExecutor{"swe": poolBoundaryPanicExecutor{panicValue: "catastrophic failure"}},
+	}
+	request := poolBoundaryDispatchRequest("dispatch-2", "transition-2", "swe")
+
+	result, err := adapter.Execute(context.Background(), request)
+
+	panicErr, ok := AsWorkerExecutorPanicError(err)
+	if !ok || panicErr == nil {
+		t.Fatalf("AsWorkerExecutorPanicError(err) = (_, false), want true; err = %v", err)
+	}
+	if panicErr.Cause != any("catastrophic failure") {
+		t.Fatalf("panicErr.Cause = %v, want %q", panicErr.Cause, "catastrophic failure")
+	}
+	wantText := "executor panic: catastrophic failure"
+	if err.Error() != wantText {
+		t.Fatalf("err.Error() = %q, want %q", err.Error(), wantText)
+	}
+	if result.Error != wantText || result.Outcome != OutcomeFailed {
+		t.Fatalf("result = %#v, want Error=%q Outcome=%q", result, wantText, OutcomeFailed)
+	}
+}
+
+func TestWorkerExecutorRequestAdapterExecuteSuccessUnaffected(t *testing.T) {
+	want := WorkResult{Outcome: OutcomeAccepted}
+	adapter := workerExecutorRequestAdapter{
+		executors: map[string]WorkerExecutor{"swe": poolBoundaryErrorExecutorSuccess{result: want}},
+	}
+	request := poolBoundaryDispatchRequest("dispatch-3", "transition-3", "swe")
+
+	result, err := adapter.Execute(context.Background(), request)
+
+	if err != nil {
+		t.Fatalf("Execute() err = %v, want nil", err)
+	}
+	if result.Outcome != want.Outcome {
+		t.Fatalf("Execute() result = %#v, want %#v", result, want)
+	}
+}
+
+func TestWorkerExecutorRequestAdapterExecuteOrdinaryErrorUnaffected(t *testing.T) {
+	wantErr := errors.New("ordinary executor failure")
+	adapter := workerExecutorRequestAdapter{
+		executors: map[string]WorkerExecutor{"swe": poolBoundaryErrorExecutor{err: wantErr}},
+	}
+	request := poolBoundaryDispatchRequest("dispatch-4", "transition-4", "swe")
+
+	result, err := adapter.Execute(context.Background(), request)
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Execute() err = %v, want %v", err, wantErr)
+	}
+	var panicErr *WorkerExecutorPanicError
+	if errors.As(err, &panicErr) {
+		t.Fatalf("errors.As(err, *WorkerExecutorPanicError) = true, want false for an ordinary error")
+	}
+	if result.Outcome != OutcomeFailed || result.Error != wantErr.Error() {
+		t.Fatalf("result = %#v, want Outcome=%q Error=%q", result, OutcomeFailed, wantErr.Error())
+	}
+}
+
+type poolBoundaryErrorExecutorSuccess struct {
+	result WorkResult
+}
+
+func (e poolBoundaryErrorExecutorSuccess) Execute(context.Context, work.WorkDispatch) (WorkResult, error) {
+	return e.result, nil
 }
 
 func TestWorkstationPoolBoundaryBindingsPreserveLegacyConcurrency(t *testing.T) {

--- a/pkg/services/workers/workstation_pool_boundary_impl_test.go
+++ b/pkg/services/workers/workstation_pool_boundary_impl_test.go
@@ -89,9 +89,9 @@ func TestWorkerExecutorRequestAdapterExecuteRecoversNonErrorPanic(t *testing.T) 
 
 	result, err := adapter.Execute(context.Background(), request)
 
-	panicErr, ok := AsWorkerExecutorPanicError(err)
-	if !ok || panicErr == nil {
-		t.Fatalf("AsWorkerExecutorPanicError(err) = (_, false), want true; err = %v", err)
+	var panicErr *WorkerExecutorPanicError
+	if !errors.As(err, &panicErr) || panicErr == nil {
+		t.Fatalf("errors.As(err, *WorkerExecutorPanicError) = false, want true; err = %v", err)
 	}
 	if panicErr.Cause != any("catastrophic failure") {
 		t.Fatalf("panicErr.Cause = %v, want %q", panicErr.Cause, "catastrophic failure")

--- a/pkg/services/workers/workstation_pool_boundary_publish_panic_test.go
+++ b/pkg/services/workers/workstation_pool_boundary_publish_panic_test.go
@@ -1,0 +1,242 @@
+package workers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// poolBoundaryFakeService is a minimal WorkstationExecutionService that routes
+// a dispatch straight to its bound executor, mirroring the pass-through error
+// behavior of the production internal pool service closely enough to prove
+// Publish propagates a recovered executor panic's typed error unchanged.
+type poolBoundaryFakeService struct {
+	mu     sync.Mutex
+	routes map[string]WorkstationRequestExecutor
+}
+
+func (s *poolBoundaryFakeService) StartWorkstationPool(
+	_ context.Context,
+	request WorkstationPoolStartRequest,
+) (WorkstationPoolStartResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.routes = make(map[string]WorkstationRequestExecutor, len(request.Bindings))
+	for _, binding := range request.Bindings {
+		s.routes[binding.RoleName] = binding.Executor
+	}
+	return WorkstationPoolStartResult{Outcome: WorkstationPoolLifecycleOutcomeStarted}, nil
+}
+
+func (*poolBoundaryFakeService) StopWorkstationPool(context.Context) (WorkstationPoolStopResult, error) {
+	return WorkstationPoolStopResult{Outcome: WorkstationPoolLifecycleOutcomeStopped}, nil
+}
+
+func (s *poolBoundaryFakeService) DispatchWorkstation(
+	ctx context.Context,
+	request WorkstationDispatchRequest,
+) (WorkstationDispatchResult, error) {
+	s.mu.Lock()
+	executor := s.routes[request.WorkstationName]
+	s.mu.Unlock()
+	result, err := executor.Execute(ctx, request.Execution)
+	terminal := WorkstationDispatchTerminalOutcomeCompleted
+	if err != nil || result.Outcome == OutcomeFailed {
+		terminal = WorkstationDispatchTerminalOutcomeFailed
+	}
+	return WorkstationDispatchResult{
+		DispatchID:      request.Execution.Dispatch.DispatchID,
+		WorkstationName: request.WorkstationName,
+		TerminalOutcome: terminal,
+		Result:          result,
+	}, err
+}
+
+func (*poolBoundaryFakeService) CancelWorkstationDispatch(
+	_ context.Context,
+	request WorkstationDispatchCancelRequest,
+) (WorkstationDispatchCancelResult, error) {
+	return WorkstationDispatchCancelResult{
+		DispatchID: request.DispatchID,
+		Outcome:    WorkstationDispatchCancelOutcomeCanceled,
+	}, nil
+}
+
+type publishOutcome struct {
+	result WorkstationDispatchResult
+	err    error
+}
+
+func publishAndAwait(
+	t *testing.T,
+	boundary WorkstationPoolBoundary,
+	request WorkstationDispatchRequest,
+) publishOutcome {
+	t.Helper()
+	done := make(chan publishOutcome, 1)
+	var callbacks int32
+	err := boundary.Publish(context.Background(), request, func(
+		_ context.Context,
+		_ WorkstationDispatchRequest,
+		result WorkstationDispatchResult,
+		publishErr error,
+	) {
+		if atomic.AddInt32(&callbacks, 1) != 1 {
+			t.Errorf("dispatch %s received more than one terminal callback", request.Execution.Dispatch.DispatchID)
+		}
+		done <- publishOutcome{result: result, err: publishErr}
+	})
+	if err != nil {
+		t.Fatalf("Publish() err = %v, want nil", err)
+	}
+	select {
+	case outcome := <-done:
+		return outcome
+	case <-time.After(5 * time.Second):
+		t.Fatalf("dispatch %s: timed out waiting for terminal callback", request.Execution.Dispatch.DispatchID)
+		return publishOutcome{}
+	}
+}
+
+func assertPublishPanicFailure(
+	t *testing.T,
+	outcome publishOutcome,
+	dispatchID, transitionID, cause string,
+) {
+	t.Helper()
+	if outcome.err == nil {
+		t.Fatalf("dispatch %s: publish err = nil, want non-nil typed panic error", dispatchID)
+	}
+	var panicErr *WorkerExecutorPanicError
+	if !errors.As(outcome.err, &panicErr) || panicErr == nil {
+		t.Fatalf("dispatch %s: errors.As(err, *WorkerExecutorPanicError) = false; err = %v", dispatchID, outcome.err)
+	}
+	if panicErr.Cause != any(cause) {
+		t.Fatalf("dispatch %s: panicErr.Cause = %v, want %q", dispatchID, panicErr.Cause, cause)
+	}
+	wantText := fmt.Sprintf("executor panic: %s", cause)
+	if outcome.result.Result.Error != wantText {
+		t.Fatalf("dispatch %s: result.Error = %q, want %q", dispatchID, outcome.result.Result.Error, wantText)
+	}
+	if outcome.result.Result.Outcome != OutcomeFailed {
+		t.Fatalf("dispatch %s: result.Outcome = %q, want %q", dispatchID, outcome.result.Result.Outcome, OutcomeFailed)
+	}
+	if outcome.result.TerminalOutcome != WorkstationDispatchTerminalOutcomeFailed {
+		t.Fatalf(
+			"dispatch %s: TerminalOutcome = %q, want %q",
+			dispatchID, outcome.result.TerminalOutcome, WorkstationDispatchTerminalOutcomeFailed,
+		)
+	}
+	if outcome.result.Result.DispatchID != dispatchID || outcome.result.Result.TransitionID != transitionID {
+		t.Fatalf(
+			"dispatch %s: result identity = (%q, %q), want (%q, %q)",
+			dispatchID, outcome.result.Result.DispatchID, outcome.result.Result.TransitionID, dispatchID, transitionID,
+		)
+	}
+}
+
+func TestWorkstationPoolBoundaryPublishSynchronousPanicDeliversTypedFailure(t *testing.T) {
+	service := &poolBoundaryFakeService{}
+	boundary := NewWorkstationPoolBoundary(WorkstationPoolBoundaryConfig{
+		Service:    service,
+		Executors:  map[string]WorkerExecutor{"swe": poolBoundaryPanicExecutor{panicValue: "sync boom"}},
+		RouteNames: []string{"swe"},
+		Async:      false,
+	})
+
+	request := WorkstationDispatchRequest{
+		WorkstationName: "swe",
+		Execution:       poolBoundaryDispatchRequest("dispatch-sync-panic", "transition-sync-panic", "swe"),
+	}
+	outcome := publishAndAwait(t, boundary, request)
+	assertPublishPanicFailure(t, outcome, "dispatch-sync-panic", "transition-sync-panic", "sync boom")
+
+	// A later dispatch on the same boundary still executes after the
+	// recovered panic; the panic must not have escaped its goroutine or
+	// left the boundary unusable.
+	nextRequest := WorkstationDispatchRequest{
+		WorkstationName: "swe",
+		Execution:       poolBoundaryDispatchRequest("dispatch-sync-after-panic", "transition-sync-panic", "swe"),
+	}
+	next := publishAndAwait(t, boundary, nextRequest)
+	if next.err == nil {
+		t.Fatalf("second dispatch err = nil, want typed panic error (same panicking executor)")
+	}
+	var panicErr *WorkerExecutorPanicError
+	if !errors.As(next.err, &panicErr) {
+		t.Fatalf("second dispatch errors.As(err, *WorkerExecutorPanicError) = false; err = %v", next.err)
+	}
+}
+
+func TestWorkstationPoolBoundaryPublishAsynchronousPanicDeliversTypedFailure(t *testing.T) {
+	service := &poolBoundaryFakeService{}
+	boundary := NewWorkstationPoolBoundary(WorkstationPoolBoundaryConfig{
+		Service:    service,
+		Executors:  map[string]WorkerExecutor{"swe": poolBoundaryPanicExecutor{panicValue: "async boom"}},
+		RouteNames: []string{"swe"},
+		Async:      true,
+	})
+
+	request := WorkstationDispatchRequest{
+		WorkstationName: "swe",
+		Execution:       poolBoundaryDispatchRequest("dispatch-async-panic", "transition-async-panic", "swe"),
+	}
+	outcome := publishAndAwait(t, boundary, request)
+	assertPublishPanicFailure(t, outcome, "dispatch-async-panic", "transition-async-panic", "async boom")
+}
+
+func TestWorkstationPoolBoundaryPublishAsynchronousPanicLaterDispatchStillExecutes(t *testing.T) {
+	panicService := &poolBoundaryFakeService{}
+	panicBoundary := NewWorkstationPoolBoundary(WorkstationPoolBoundaryConfig{
+		Service:    panicService,
+		Executors:  map[string]WorkerExecutor{"swe": poolBoundaryPanicExecutor{panicValue: "boom"}},
+		RouteNames: []string{"swe"},
+		Async:      true,
+	})
+	panicked := publishAndAwait(t, panicBoundary, WorkstationDispatchRequest{
+		WorkstationName: "swe",
+		Execution:       poolBoundaryDispatchRequest("dispatch-async-panic-first", "transition-1", "swe"),
+	})
+	assertPublishPanicFailure(t, panicked, "dispatch-async-panic-first", "transition-1", "boom")
+
+	successService := &poolBoundaryFakeService{}
+	successBoundary := NewWorkstationPoolBoundary(WorkstationPoolBoundaryConfig{
+		Service:    successService,
+		Executors:  map[string]WorkerExecutor{"swe": poolBoundaryErrorExecutorSuccess{result: WorkResult{Outcome: OutcomeAccepted}}},
+		RouteNames: []string{"swe"},
+		Async:      true,
+	})
+	succeeded := publishAndAwait(t, successBoundary, WorkstationDispatchRequest{
+		WorkstationName: "swe",
+		Execution:       poolBoundaryDispatchRequest("dispatch-async-after-panic", "transition-2", "swe"),
+	})
+	if succeeded.err != nil {
+		t.Fatalf("later dispatch err = %v, want nil", succeeded.err)
+	}
+	if succeeded.result.Result.Outcome != OutcomeAccepted {
+		t.Fatalf("later dispatch outcome = %q, want %q", succeeded.result.Result.Outcome, OutcomeAccepted)
+	}
+}
+
+func TestWorkstationPoolBoundaryPublishAsynchronousPanicRepeatWithoutDuplicateAcceptance(t *testing.T) {
+	const iterations = 25
+	service := &poolBoundaryFakeService{}
+	boundary := NewWorkstationPoolBoundary(WorkstationPoolBoundaryConfig{
+		Service:    service,
+		Executors:  map[string]WorkerExecutor{"swe": poolBoundaryPanicExecutor{panicValue: "repeat boom"}},
+		RouteNames: []string{"swe"},
+		Async:      true,
+	})
+	for i := range iterations {
+		dispatchID := fmt.Sprintf("dispatch-async-repeat-%d", i)
+		outcome := publishAndAwait(t, boundary, WorkstationDispatchRequest{
+			WorkstationName: "swe",
+			Execution:       poolBoundaryDispatchRequest(dispatchID, "transition-repeat", "swe"),
+		})
+		assertPublishPanicFailure(t, outcome, dispatchID, "transition-repeat", "repeat boom")
+	}
+}

--- a/tests/functional/orchestration/petri/dispatch/simple_run_test.go
+++ b/tests/functional/orchestration/petri/dispatch/simple_run_test.go
@@ -550,6 +550,50 @@ func TestPetriWorkerErrorReturnsFailedTerminalOutcome(t *testing.T) {
 		}
 	})
 
+	t.Run("executor_panic_routes_to_failed_terminal", func(t *testing.T) {
+		t.Parallel()
+		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
+		traceID := "trace-executor-panic"
+		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+			WorkTypeID: "task",
+			TraceID:    traceID,
+			Payload:    []byte(`{"title":"will panic at executor"}`),
+		})
+
+		provider := panicInferenceProvider{message: "simulated executor catastrophic panic"}
+		session, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
+			t,
+			dir,
+			serviceedges.Edges{ProviderOverride: provider},
+			10*time.Second,
+		)
+
+		failedTerminal := support.WorkCustomerLocation("task", "failed")
+		successTerminal := support.WorkCustomerLocation("task", "done")
+		assertWorkAtCustomerStates(t, listed, map[string]int{
+			failedTerminal:  1,
+			successTerminal: 0,
+			support.WorkCustomerLocation("task", "init"): 0,
+		})
+		assertTerminalWorkCorrelatesToTraceIDs(t, listed, failedTerminal, []string{traceID})
+		assertTraceAbsentAtCustomerState(t, listed, successTerminal, traceID)
+		assertQuiescentSession(t, session, 0, 1)
+
+		failedWorkID, ok := workIDAtCustomerState(t, listed, failedTerminal, traceID)
+		if !ok {
+			t.Fatalf("missing failed Work for trace %q at %s", traceID, failedTerminal)
+		}
+		dispatches := support.ObserveDispatchEvents(t, events)
+		assertFailedDispatchForWork(t, dispatches, failedWorkID)
+		assertFailedDispatchResponseErrorForWork(t, dispatches, failedWorkID)
+		assertDispatchResponseErrorContains(
+			t,
+			dispatches,
+			failedWorkID,
+			"executor panic: simulated executor catastrophic panic",
+		)
+	})
+
 	t.Run("provider_command_exit_routes_to_failed_terminal", func(t *testing.T) {
 		t.Parallel()
 		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_failure_no_arcs"))
@@ -1408,4 +1452,40 @@ func (r nonZeroExitScriptCommandRunner) Run(
 		Stderr:   []byte(r.stderr),
 		ExitCode: r.exitCode,
 	}, nil
+}
+
+// panicInferenceProvider panics from Infer to exercise the Workers execution
+// boundary's WorkerExecutor panic recovery through the customer process
+// boundary rather than any internal Petri or Workers seam.
+type panicInferenceProvider struct {
+	message string
+}
+
+func (p panicInferenceProvider) Infer(
+	_ context.Context,
+	_ workerexecution.ProviderInferenceRequest,
+) (workerexecution.InferenceResponse, error) {
+	panic(p.message)
+}
+
+func assertDispatchResponseErrorContains(
+	t *testing.T,
+	dispatches []support.DispatchEventObservation,
+	workID string,
+	want string,
+) {
+	t.Helper()
+
+	for _, dispatch := range dispatches {
+		if !support.DispatchObservationIncludesWork(dispatch, workID) {
+			continue
+		}
+		if dispatch.Response == nil || dispatch.Response.Error == nil {
+			continue
+		}
+		if strings.Contains(*dispatch.Response.Error, want) {
+			return
+		}
+	}
+	t.Fatalf("no dispatch response error for work %q containing %q", workID, want)
 }


### PR DESCRIPTION
{
  "project": "Return a Typed Error When a Worker Executor Panics",
  "branchName": "ACP-L2-IMP-WRK-PANIC",
  "description": "Deliver the L2 IMP-WRK-PANIC packet by making the existing Workers executor recovery boundary return an attributed OutcomeFailed WorkResult and a Workers-owned typed, non-nil error carrying the recovered panic cause, while preserving the exact established WorkResult.Error text `executor panic: <cause>`. The intent is to make error-based callers, synchronous dispatch consumers, and detached asynchronous publish consumers agree that the Worker attempt failed without widening ownership or changing public transports.",
  "context": {
    "customerAsk": "Deliver the L2 IMP-WRK-PANIC packet: Worker executor panic recovery must return a typed, non-nil panic cause while preserving the existing WorkResult.Error compatibility string required by downstream consumers.",
    "problem": "The runtime-facing Workers adapter recovers a WorkerExecutor panic and returns OutcomeFailed with WorkResult.Error set to `executor panic: <cause>`, but clears the accompanying Go error. Callers that use err == nil as the success signal can therefore treat a failed Worker attempt as successful, including through detached publish acceptance.",
    "solution": "Keep recovery at the existing Workers-owned executor boundary and return a Workers-owned typed error whenever a panic is recovered. Retain the recovered value for errors.As-based inspection, preserve dispatch attribution, OutcomeFailed, and the exact WorkResult.Error compatibility text, and prove equivalent direct, synchronous publish, and asynchronous publish failure behavior with focused Workers tests.",
    "originalDocument": "C:/Users/andre/work/portos/infinite-you/docs/internal/projects/root-consolidation/proposal.md"
  },
  "acceptanceCriteria": [
    "When a configured WorkerExecutor panics, the Workers execution boundary returns a WorkResult with the original dispatch and transition identity, OutcomeFailed, and Error exactly equal to `executor panic: <cause>`.",
    "The same recovery returns a non-nil Workers-owned typed error; errors.As identifies that type and exposes the original recovered panic value without requiring string parsing.",
    "Synchronous dispatch and detached publish acceptance, including asynchronous publish where applicable, observe the same failed result and typed non-nil error, and the panic does not escape its goroutine or prevent later dispatches.",
    "Non-panicking executor success and ordinary executor-error behavior remain unchanged.",
    "The change remains owned by pkg/services/workers and introduces no Factory Runtime, ACP Worker Events, Provider, Worker Session, OpenAPI, HTTP, CLI, or MCP contract change and no unrelated executor deletion or runner-injection cleanup.",
    "Quality gate: focused Workers tests, supported race/repeat coverage for the panic path, make test, make lint, make pkg-boundary, make verify-fast, typecheck, and all required PR CI are terminal and passing.",
    "Delivery: the implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are reconciled, and the PR is actually merged; opening, approval, green CI, or merge readiness alone is not completion."
  ],
  "userStories": [
    {
      "id": "ACP-L2-IMP-WRK-PANIC-001",
      "title": "Report executor panics as typed terminal failures",
      "description": "As a Workers caller, I want a recovered executor panic to return both a failed result and an inspectable typed error so that error-based control flow cannot mistake the attempt for success.",
      "acceptanceCriteria": [
        "A panic from a configured WorkerExecutor is recovered inside the existing Workers execution boundary and does not escape to the caller.",
        "The returned result retains the request's dispatch and transition identity, reports OutcomeFailed, and retains the exact compatibility text `executor panic: <cause>` in WorkResult.Error.",
        "The accompanying error is non-nil, is identifiable as the Workers-owned executor-panic error through errors.As, and exposes the original recovered panic value without string parsing.",
        "A non-error panic value and an error-valued panic are both retained as their original causes by the typed error; its presentation does not alter WorkResult.Error compatibility.",
        "Successful executor results and ordinary returned executor errors preserve their existing result and error behavior.",
        "Focused Workers regression tests cover typed identity, recovered cause, failed outcome, dispatch attribution, compatibility text, and unaffected non-panic paths.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added WorkerExecutorPanicError (Cause any, Error(), Unwrap(), AsWorkerExecutorPanicError helper) in pkg/services/workers/workstation_pool_boundary_impl.go; workerExecutorRequestAdapter.Execute now returns it instead of err=nil while preserving the exact WorkResult.Error text via panicErr.Error(). Covered by workstation_pool_boundary_impl_test.go (error-cause panic, non-error-cause panic, unaffected success, unaffected ordinary error)."
    },
    {
      "id": "ACP-L2-IMP-WRK-PANIC-002",
      "title": "Preserve panic failure semantics for detached publish consumers",
      "description": "As a Factory Runtime result consumer, I want detached publish acceptance to receive the same typed panic failure as direct execution so that synchronous and asynchronous dispatch handling cannot disagree about terminal success.",
      "acceptanceCriteria": [
        "A synchronous detached publish whose executor panics invokes its acceptance callback with the attributed OutcomeFailed result, exact `executor panic: <cause>` compatibility text, and the typed non-nil panic error.",
        "An asynchronous detached publish may return after acceptance as established, but its eventual callback receives the same failed result, typed error identity, and original panic cause; the panic does not escape the detached goroutine.",
        "Each accepted dispatch produces one terminal callback, and a later dispatch can still execute after a recovered panic.",
        "Focused tests use deterministic callback observation rather than sleeps or timeout padding as the primary synchronization mechanism.",
        "Supported race and repeat runs cover the detached panic path without data races, deadlock, duplicate acceptance, or intermittent nil errors.",
        "No Factory Runtime, event, provider, transport, or generated-contract behavior is changed to prove this Workers-owned result contract.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Publish() shares one accept-callback code path for sync (Async:false) and async (Async:true) dispatch, so the story-001 fix propagates automatically. Added workstation_pool_boundary_publish_panic_test.go with a fake WorkstationExecutionService exercising both sync and async Publish panics via deterministic channel-based accept callbacks (no sleeps), a later-dispatch-still-executes case, and a 25-iteration repeat test asserting exactly one terminal callback per dispatch."
    }
  ]
}
