### PR TITLE
ACP-L4-W1: Worker Session identity and registry foundation

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -2665,6 +2665,26 @@
       "minimum": 8.82
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/worker_sessions",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/worker_sessions/internal/service",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers",
       "minimum": 56.00
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -2029,6 +2029,14 @@
       "minimum": 100.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/worker_sessions",
+      "minimum": 100.00
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/worker_sessions/internal/service",
+      "minimum": 100.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers",
       "minimum": 79.81
     },

--- a/pkg/services/worker_sessions/contracts.go
+++ b/pkg/services/worker_sessions/contracts.go
@@ -1,0 +1,114 @@
+package workersessions
+
+import (
+	"context"
+	"errors"
+)
+
+// Service is the W1 Worker Session identity and registry foundation: stable
+// identity reservation and immutable deterministic inspection. Supervision,
+// Start/StartTurn, Events publication, Runtime and Provider Session
+// association, Pause/Resume/Cancel/Terminate controls, persistence, and
+// transport behavior are later ACP Worker Events slices (W2-W7) and are not
+// exposed here. Later slices land as additive methods on this same named
+// interface; W1 does not publish placeholder methods for them.
+type Service interface {
+	// Reserve validates req and, when req.ID is not already registered,
+	// stores a new session in StateReserved and returns its snapshot.
+	// Reserving an identity that already exists returns
+	// ErrSessionAlreadyExists and leaves the existing session unchanged; this
+	// is the one deterministic outcome for duplicate reservation.
+	Reserve(ctx context.Context, req ReserveRequest) (Session, error)
+
+	// Get returns the current immutable snapshot for req.ID. An invalid
+	// req.ID returns ErrInvalidSessionID; a valid but unregistered req.ID
+	// returns the distinguishable ErrSessionNotFound.
+	Get(ctx context.Context, req GetRequest) (Session, error)
+
+	// List returns immutable snapshots matching req.Filter in the documented
+	// deterministic order (ascending by ID), independent of insertion order
+	// or concurrent access. An empty registry or filter match returns a
+	// successful empty ListResult, not a not-found failure. An invalid
+	// filter value returns a typed validation error and no partial result.
+	List(ctx context.Context, req ListRequest) (ListResult, error)
+}
+
+// ReserveRequest asks Service to reserve one new Worker Session identity.
+type ReserveRequest struct {
+	ID string
+}
+
+// Validate reports whether req carries a non-empty stable identity. Validate
+// is pure and does not mutate req.
+func (req ReserveRequest) Validate() error {
+	if !validSessionID(req.ID) {
+		return ErrInvalidSessionID
+	}
+	return nil
+}
+
+// GetRequest asks Service to inspect one Worker Session identity.
+type GetRequest struct {
+	ID string
+}
+
+// Validate reports whether req carries a non-empty stable identity. Validate
+// is pure and does not mutate req.
+func (req GetRequest) Validate() error {
+	if !validSessionID(req.ID) {
+		return ErrInvalidSessionID
+	}
+	return nil
+}
+
+// Filter narrows List results. The zero-value Filter matches every session.
+type Filter struct {
+	// States restricts results to sessions whose State is in States. An
+	// empty States matches every state.
+	States []State
+}
+
+// Validate reports whether every state named in f.States is one of the eight
+// accepted lifecycle states. Validate is pure and does not mutate f.
+func (f Filter) Validate() error {
+	for _, state := range f.States {
+		if !state.Valid() {
+			return ErrInvalidState
+		}
+	}
+	return nil
+}
+
+// ListRequest asks Service for the deterministic filtered set of current
+// Worker Session snapshots.
+type ListRequest struct {
+	Filter Filter
+}
+
+// Validate reports whether req.Filter is valid. Validate is pure and does not
+// mutate req.
+func (req ListRequest) Validate() error {
+	return req.Filter.Validate()
+}
+
+// ListResult is the deterministic immutable snapshot collection returned by
+// List. Mutating Sessions, or any element of it, after List returns never
+// affects registry-owned state or a later List/Get result.
+type ListResult struct {
+	Sessions []Session
+}
+
+var (
+	// ErrInvalidSessionID reports a request or session with an empty or
+	// whitespace-only identity.
+	ErrInvalidSessionID = errors.New("worker session: invalid session id")
+	// ErrInvalidState reports a request, filter, or session naming a value
+	// outside the eight accepted lifecycle states.
+	ErrInvalidState = errors.New("worker session: invalid state")
+	// ErrSessionAlreadyExists reports Reserve called with an identity that is
+	// already registered.
+	ErrSessionAlreadyExists = errors.New("worker session: already exists")
+	// ErrSessionNotFound reports Get called with a valid but unregistered
+	// identity.
+	ErrSessionNotFound = errors.New("worker session: not found")
+)

--- a/pkg/services/worker_sessions/doc.go
+++ b/pkg/services/worker_sessions/doc.go
@@ -1,0 +1,14 @@
+// Package workersessions is the ACP Worker Events W1 foundation: one stable
+// process-scoped Worker Session identity, the exact eight-state lifecycle
+// vocabulary, and immutable deterministic Get/List inspection over a
+// concurrency-safe in-memory registry.
+//
+// W1 exposes only Reserve, Get, and List. Worker launch, supervision,
+// terminal-cause classification, Events publication, Runtime and Provider
+// Session association, Pause/Resume/Cancel/Terminate controls, persistence,
+// and transport behavior belong to later ACP Worker Events slices (W2-W7)
+// and are intentionally absent from this package.
+//
+// Implementation state lives under internal/. Peers depend on Service and the
+// request/result/value types published at this root.
+package workersessions

--- a/pkg/services/worker_sessions/internal/service/service.go
+++ b/pkg/services/worker_sessions/internal/service/service.go
@@ -1,0 +1,91 @@
+// Package service implements the Worker Sessions W1 registry: reservation,
+// immutable Get, and deterministic filtered List over a synchronized
+// process-local map.
+package service
+
+import (
+	"context"
+	"slices"
+	"sort"
+	"sync"
+
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	workersessions "github.com/portpowered/infinite-you/pkg/services/worker_sessions"
+)
+
+type registry struct {
+	mu       sync.RWMutex
+	sessions map[string]workersessions.Session
+	logger   logging.Logger
+}
+
+// Compile-time proof that production registry seals the W1 root contract
+// (Reserve + Get + List) without exposing the mutable map or a broader API.
+var _ workersessions.Service = (*registry)(nil)
+
+// New constructs the process-local Worker Session registry. A nil logger
+// falls back to logging.NoopLogger.
+func New(logger logging.Logger) workersessions.Service {
+	return &registry{
+		sessions: make(map[string]workersessions.Session),
+		logger:   logging.EnsureLogger(logger),
+	}
+}
+
+func (r *registry) Reserve(_ context.Context, req workersessions.ReserveRequest) (workersessions.Session, error) {
+	if err := req.Validate(); err != nil {
+		return workersessions.Session{}, err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.sessions[req.ID]; exists {
+		return workersessions.Session{}, workersessions.ErrSessionAlreadyExists
+	}
+	session := workersessions.Session{ID: req.ID, State: workersessions.StateReserved}
+	r.sessions[req.ID] = session
+	return session, nil
+}
+
+func (r *registry) Get(_ context.Context, req workersessions.GetRequest) (workersessions.Session, error) {
+	if err := req.Validate(); err != nil {
+		r.logger.Info("worker session get rejected", "sessionID", req.ID, "outcome", "invalid")
+		return workersessions.Session{}, err
+	}
+
+	r.mu.RLock()
+	session, exists := r.sessions[req.ID]
+	r.mu.RUnlock()
+
+	if !exists {
+		r.logger.Info("worker session get", "sessionID", req.ID, "outcome", "not_found")
+		return workersessions.Session{}, workersessions.ErrSessionNotFound
+	}
+	r.logger.Info("worker session get", "sessionID", req.ID, "outcome", "found", "state", string(session.State))
+	return session, nil
+}
+
+func (r *registry) List(_ context.Context, req workersessions.ListRequest) (workersessions.ListResult, error) {
+	if err := req.Validate(); err != nil {
+		return workersessions.ListResult{}, err
+	}
+
+	r.mu.RLock()
+	matched := make([]workersessions.Session, 0, len(r.sessions))
+	for _, session := range r.sessions {
+		if matchesFilter(session, req.Filter) {
+			matched = append(matched, session)
+		}
+	}
+	r.mu.RUnlock()
+
+	sort.Slice(matched, func(i, j int) bool { return matched[i].ID < matched[j].ID })
+	return workersessions.ListResult{Sessions: matched}, nil
+}
+
+func matchesFilter(session workersessions.Session, filter workersessions.Filter) bool {
+	if len(filter.States) == 0 {
+		return true
+	}
+	return slices.Contains(filter.States, session.State)
+}

--- a/pkg/services/worker_sessions/internal/service/service_test.go
+++ b/pkg/services/worker_sessions/internal/service/service_test.go
@@ -1,0 +1,392 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	workersessions "github.com/portpowered/infinite-you/pkg/services/worker_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/worker_sessions/internal/service"
+)
+
+func newRegistry() workersessions.Service {
+	return service.New(logging.NoopLogger{})
+}
+
+func TestReserve_ValidIdentity_StoresSessionInReservedState(t *testing.T) {
+	registry := newRegistry()
+
+	session, err := registry.Reserve(context.Background(), workersessions.ReserveRequest{ID: "worker-1"})
+	if err != nil {
+		t.Fatalf("Reserve() error = %v, want nil", err)
+	}
+	if session.ID != "worker-1" || session.State != workersessions.StateReserved {
+		t.Fatalf("Reserve() = %+v, want ID=worker-1 State=RESERVED", session)
+	}
+}
+
+func TestReserve_InvalidIdentity_ReturnsTypedValidationError(t *testing.T) {
+	registry := newRegistry()
+
+	_, err := registry.Reserve(context.Background(), workersessions.ReserveRequest{ID: "   "})
+	if !errors.Is(err, workersessions.ErrInvalidSessionID) {
+		t.Fatalf("Reserve() error = %v, want ErrInvalidSessionID", err)
+	}
+}
+
+func TestReserve_DuplicateIdentity_ReturnsTypedErrorAndLeavesExistingSessionUnchanged(t *testing.T) {
+	registry := newRegistry()
+	ctx := context.Background()
+
+	first, err := registry.Reserve(ctx, workersessions.ReserveRequest{ID: "worker-1"})
+	if err != nil {
+		t.Fatalf("first Reserve() error = %v, want nil", err)
+	}
+
+	_, err = registry.Reserve(ctx, workersessions.ReserveRequest{ID: "worker-1"})
+	if !errors.Is(err, workersessions.ErrSessionAlreadyExists) {
+		t.Fatalf("duplicate Reserve() error = %v, want ErrSessionAlreadyExists", err)
+	}
+
+	got, err := registry.Get(ctx, workersessions.GetRequest{ID: "worker-1"})
+	if err != nil {
+		t.Fatalf("Get() error = %v, want nil", err)
+	}
+	if got != first {
+		t.Fatalf("Get() after duplicate Reserve() = %+v, want unchanged %+v", got, first)
+	}
+}
+
+func TestGet_UnknownIdentity_ReturnsTypedNotFoundDistinctFromValidationFailure(t *testing.T) {
+	registry := newRegistry()
+	ctx := context.Background()
+
+	_, notFoundErr := registry.Get(ctx, workersessions.GetRequest{ID: "missing"})
+	if !errors.Is(notFoundErr, workersessions.ErrSessionNotFound) {
+		t.Fatalf("Get() error = %v, want ErrSessionNotFound", notFoundErr)
+	}
+
+	_, invalidErr := registry.Get(ctx, workersessions.GetRequest{ID: ""})
+	if !errors.Is(invalidErr, workersessions.ErrInvalidSessionID) {
+		t.Fatalf("Get() error = %v, want ErrInvalidSessionID", invalidErr)
+	}
+
+	if errors.Is(notFoundErr, workersessions.ErrInvalidSessionID) || errors.Is(invalidErr, workersessions.ErrSessionNotFound) {
+		t.Fatalf("not-found and validation errors must be distinguishable")
+	}
+}
+
+func TestGet_RepeatedCalls_ReturnSameIdentityAndCurrentState(t *testing.T) {
+	registry := newRegistry()
+	ctx := context.Background()
+
+	if _, err := registry.Reserve(ctx, workersessions.ReserveRequest{ID: "worker-1"}); err != nil {
+		t.Fatalf("Reserve() error = %v, want nil", err)
+	}
+
+	first, err := registry.Get(ctx, workersessions.GetRequest{ID: "worker-1"})
+	if err != nil {
+		t.Fatalf("first Get() error = %v, want nil", err)
+	}
+	second, err := registry.Get(ctx, workersessions.GetRequest{ID: "worker-1"})
+	if err != nil {
+		t.Fatalf("second Get() error = %v, want nil", err)
+	}
+	if first != second {
+		t.Fatalf("repeated Get() = %+v then %+v, want identical snapshots", first, second)
+	}
+}
+
+func TestGet_MutatingReturnedSnapshot_DoesNotAffectLaterGet(t *testing.T) {
+	registry := newRegistry()
+	ctx := context.Background()
+
+	if _, err := registry.Reserve(ctx, workersessions.ReserveRequest{ID: "worker-1"}); err != nil {
+		t.Fatalf("Reserve() error = %v, want nil", err)
+	}
+
+	snapshot, err := registry.Get(ctx, workersessions.GetRequest{ID: "worker-1"})
+	if err != nil {
+		t.Fatalf("Get() error = %v, want nil", err)
+	}
+	snapshot.State = workersessions.StateTerminated
+	snapshot.ID = "mutated"
+	t.Logf("mutated local snapshot: %+v", snapshot)
+
+	after, err := registry.Get(ctx, workersessions.GetRequest{ID: "worker-1"})
+	if err != nil {
+		t.Fatalf("Get() error = %v, want nil", err)
+	}
+	if after.State != workersessions.StateReserved || after.ID != "worker-1" {
+		t.Fatalf("mutating a returned snapshot leaked into the registry: got %+v", after)
+	}
+}
+
+func TestList_EmptyRegistry_ReturnsSuccessfulEmptyResult(t *testing.T) {
+	registry := newRegistry()
+
+	result, err := registry.List(context.Background(), workersessions.ListRequest{})
+	if err != nil {
+		t.Fatalf("List() error = %v, want nil", err)
+	}
+	if len(result.Sessions) != 0 {
+		t.Fatalf("List() sessions = %v, want empty", result.Sessions)
+	}
+}
+
+func TestList_MultipleInsertionOrders_ReturnSameDeterministicOrdering(t *testing.T) {
+	ctx := context.Background()
+	ids := []string{"worker-c", "worker-a", "worker-b"}
+	reverseIDs := []string{"worker-b", "worker-a", "worker-c"}
+
+	forward := newRegistry()
+	for _, id := range ids {
+		if _, err := forward.Reserve(ctx, workersessions.ReserveRequest{ID: id}); err != nil {
+			t.Fatalf("Reserve(%q) error = %v, want nil", id, err)
+		}
+	}
+	reversed := newRegistry()
+	for _, id := range reverseIDs {
+		if _, err := reversed.Reserve(ctx, workersessions.ReserveRequest{ID: id}); err != nil {
+			t.Fatalf("Reserve(%q) error = %v, want nil", id, err)
+		}
+	}
+
+	forwardResult, err := forward.List(ctx, workersessions.ListRequest{})
+	if err != nil {
+		t.Fatalf("List() error = %v, want nil", err)
+	}
+	reversedResult, err := reversed.List(ctx, workersessions.ListRequest{})
+	if err != nil {
+		t.Fatalf("List() error = %v, want nil", err)
+	}
+
+	wantOrder := []string{"worker-a", "worker-b", "worker-c"}
+	if got := idsOf(forwardResult.Sessions); !equalStrings(got, wantOrder) {
+		t.Fatalf("List() order = %v, want %v", got, wantOrder)
+	}
+	if got := idsOf(reversedResult.Sessions); !equalStrings(got, wantOrder) {
+		t.Fatalf("List() order = %v, want %v", got, wantOrder)
+	}
+}
+
+func TestList_FilterByState_ReturnsExactlyMatchingSessions(t *testing.T) {
+	registry := newRegistry()
+	ctx := context.Background()
+
+	if _, err := registry.Reserve(ctx, workersessions.ReserveRequest{ID: "worker-1"}); err != nil {
+		t.Fatalf("Reserve() error = %v, want nil", err)
+	}
+	if _, err := registry.Reserve(ctx, workersessions.ReserveRequest{ID: "worker-2"}); err != nil {
+		t.Fatalf("Reserve() error = %v, want nil", err)
+	}
+
+	result, err := registry.List(ctx, workersessions.ListRequest{Filter: workersessions.Filter{States: []workersessions.State{workersessions.StateRunning}}})
+	if err != nil {
+		t.Fatalf("List() error = %v, want nil", err)
+	}
+	if len(result.Sessions) != 0 {
+		t.Fatalf("List() filtered by RUNNING = %v, want empty (all sessions are RESERVED)", result.Sessions)
+	}
+
+	result, err = registry.List(ctx, workersessions.ListRequest{Filter: workersessions.Filter{States: []workersessions.State{workersessions.StateReserved}}})
+	if err != nil {
+		t.Fatalf("List() error = %v, want nil", err)
+	}
+	if got := idsOf(result.Sessions); !equalStrings(got, []string{"worker-1", "worker-2"}) {
+		t.Fatalf("List() filtered by RESERVED = %v, want [worker-1 worker-2]", got)
+	}
+}
+
+func TestList_InvalidFilter_ReturnsTypedValidationErrorAndNoPartialResult(t *testing.T) {
+	registry := newRegistry()
+	ctx := context.Background()
+	if _, err := registry.Reserve(ctx, workersessions.ReserveRequest{ID: "worker-1"}); err != nil {
+		t.Fatalf("Reserve() error = %v, want nil", err)
+	}
+
+	result, err := registry.List(ctx, workersessions.ListRequest{Filter: workersessions.Filter{States: []workersessions.State{"INTERRUPTED"}}})
+	if !errors.Is(err, workersessions.ErrInvalidState) {
+		t.Fatalf("List() error = %v, want ErrInvalidState", err)
+	}
+	if len(result.Sessions) != 0 {
+		t.Fatalf("List() with invalid filter returned a partial result: %v", result.Sessions)
+	}
+}
+
+func TestList_MutatingReturnedResult_DoesNotAffectLaterListOrGet(t *testing.T) {
+	registry := newRegistry()
+	ctx := context.Background()
+	if _, err := registry.Reserve(ctx, workersessions.ReserveRequest{ID: "worker-1"}); err != nil {
+		t.Fatalf("Reserve() error = %v, want nil", err)
+	}
+
+	result, err := registry.List(ctx, workersessions.ListRequest{})
+	if err != nil {
+		t.Fatalf("List() error = %v, want nil", err)
+	}
+	result.Sessions[0].State = workersessions.StateTerminated
+	result.Sessions = append(result.Sessions, workersessions.Session{ID: "injected", State: workersessions.StateRunning})
+
+	after, err := registry.List(ctx, workersessions.ListRequest{})
+	if err != nil {
+		t.Fatalf("List() error = %v, want nil", err)
+	}
+	if len(after.Sessions) != 1 || after.Sessions[0].State != workersessions.StateReserved {
+		t.Fatalf("mutating a returned List() result leaked into the registry: got %+v", after.Sessions)
+	}
+
+	got, err := registry.Get(ctx, workersessions.GetRequest{ID: "worker-1"})
+	if err != nil {
+		t.Fatalf("Get() error = %v, want nil", err)
+	}
+	if got.State != workersessions.StateReserved {
+		t.Fatalf("Get() after mutating a List() result = %+v, want State=RESERVED", got)
+	}
+}
+
+func TestConcurrentReserve_DistinctIdentities_RetainsEveryUniqueSession(t *testing.T) {
+	registry := newRegistry()
+	ctx := context.Background()
+	const count = 200
+
+	var wg sync.WaitGroup
+	wg.Add(count)
+	for i := range count {
+		go func(i int) {
+			defer wg.Done()
+			id := fmt.Sprintf("worker-%d", i)
+			if _, err := registry.Reserve(ctx, workersessions.ReserveRequest{ID: id}); err != nil {
+				t.Errorf("Reserve(%q) error = %v, want nil", id, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	result, err := registry.List(ctx, workersessions.ListRequest{})
+	if err != nil {
+		t.Fatalf("List() error = %v, want nil", err)
+	}
+	if len(result.Sessions) != count {
+		t.Fatalf("List() returned %d sessions, want %d", len(result.Sessions), count)
+	}
+	for _, session := range result.Sessions {
+		if session.State != workersessions.StateReserved {
+			t.Errorf("session %q state = %q, want RESERVED", session.ID, session.State)
+		}
+	}
+}
+
+func TestConcurrentReserve_SameIdentity_ExactlyOneSucceeds(t *testing.T) {
+	registry := newRegistry()
+	ctx := context.Background()
+	const attempts = 50
+
+	var wg sync.WaitGroup
+	results := make([]error, attempts)
+	wg.Add(attempts)
+	for i := range attempts {
+		go func(i int) {
+			defer wg.Done()
+			_, err := registry.Reserve(ctx, workersessions.ReserveRequest{ID: "shared"})
+			results[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	successes, duplicates := 0, 0
+	for _, err := range results {
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, workersessions.ErrSessionAlreadyExists):
+			duplicates++
+		default:
+			t.Fatalf("Reserve() error = %v, want nil or ErrSessionAlreadyExists", err)
+		}
+	}
+	if successes != 1 || duplicates != attempts-1 {
+		t.Fatalf("got %d successes and %d duplicates, want exactly 1 success and %d duplicates", successes, duplicates, attempts-1)
+	}
+
+	got, err := registry.Get(ctx, workersessions.GetRequest{ID: "shared"})
+	if err != nil {
+		t.Fatalf("Get() error = %v, want nil", err)
+	}
+	if got.ID != "shared" || got.State != workersessions.StateReserved {
+		t.Fatalf("Get() after concurrent duplicate Reserve() = %+v, want ID=shared State=RESERVED", got)
+	}
+}
+
+func TestConcurrentGetAndList_DuringReservation_ReturnInternallyConsistentSnapshots(t *testing.T) {
+	registry := newRegistry()
+	ctx := context.Background()
+	const writers = 50
+	const readers = 50
+
+	var wg sync.WaitGroup
+	wg.Add(writers + readers)
+	for i := range writers {
+		go func(i int) {
+			defer wg.Done()
+			id := fmt.Sprintf("worker-%d", i)
+			if _, err := registry.Reserve(ctx, workersessions.ReserveRequest{ID: id}); err != nil {
+				t.Errorf("Reserve(%q) error = %v, want nil", id, err)
+			}
+		}(i)
+	}
+	for i := range readers {
+		go func(i int) {
+			defer wg.Done()
+			id := fmt.Sprintf("worker-%d", i%writers)
+			if session, err := registry.Get(ctx, workersessions.GetRequest{ID: id}); err == nil {
+				if err := session.Validate(); err != nil {
+					t.Errorf("Get(%q) returned an invalid snapshot: %v", id, err)
+				}
+			} else if !errors.Is(err, workersessions.ErrSessionNotFound) {
+				t.Errorf("Get(%q) error = %v, want nil or ErrSessionNotFound", id, err)
+			}
+			if result, err := registry.List(ctx, workersessions.ListRequest{}); err != nil {
+				t.Errorf("List() error = %v, want nil", err)
+			} else {
+				for _, session := range result.Sessions {
+					if err := session.Validate(); err != nil {
+						t.Errorf("List() returned an invalid snapshot: %v", err)
+					}
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	result, err := registry.List(ctx, workersessions.ListRequest{})
+	if err != nil {
+		t.Fatalf("List() error = %v, want nil", err)
+	}
+	if len(result.Sessions) != writers {
+		t.Fatalf("List() returned %d sessions, want %d", len(result.Sessions), writers)
+	}
+}
+
+func idsOf(sessions []workersessions.Session) []string {
+	ids := make([]string, len(sessions))
+	for i, session := range sessions {
+		ids[i] = session.ID
+	}
+	return ids
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/services/worker_sessions/session.go
+++ b/pkg/services/worker_sessions/session.go
@@ -1,0 +1,33 @@
+package workersessions
+
+import "strings"
+
+// Session is an immutable snapshot of one Worker Session's stable identity
+// and current lifecycle state. Session is a plain value; callers that mutate
+// a returned Session never affect registry-owned state.
+type Session struct {
+	ID    string
+	State State
+}
+
+// Validate reports whether s has a non-empty stable identity and exactly one
+// accepted lifecycle state. Validate is pure and does not mutate s.
+func (s Session) Validate() error {
+	if !validSessionID(s.ID) {
+		return ErrInvalidSessionID
+	}
+	if !s.State.Valid() {
+		return ErrInvalidState
+	}
+	return nil
+}
+
+// Terminal reports whether s is currently in one of the four absorbing
+// terminal states.
+func (s Session) Terminal() bool {
+	return s.State.Terminal()
+}
+
+func validSessionID(id string) bool {
+	return strings.TrimSpace(id) != ""
+}

--- a/pkg/services/worker_sessions/session_test.go
+++ b/pkg/services/worker_sessions/session_test.go
@@ -1,0 +1,95 @@
+package workersessions_test
+
+import (
+	"errors"
+	"testing"
+
+	workersessions "github.com/portpowered/infinite-you/pkg/services/worker_sessions"
+)
+
+func TestSession_Validate_AcceptsNonEmptyIDAndAcceptedState(t *testing.T) {
+	session := workersessions.Session{ID: "worker-1", State: workersessions.StateRunning}
+	if err := session.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil", err)
+	}
+}
+
+func TestSession_Validate_RejectsEmptyAndWhitespaceIdentity(t *testing.T) {
+	for _, id := range []string{"", "   ", "\t"} {
+		session := workersessions.Session{ID: id, State: workersessions.StateRunning}
+		if err := session.Validate(); !errors.Is(err, workersessions.ErrInvalidSessionID) {
+			t.Errorf("Validate() with ID %q = %v, want ErrInvalidSessionID", id, err)
+		}
+	}
+}
+
+func TestSession_Validate_RejectsUnknownAndInterruptedState(t *testing.T) {
+	for _, state := range []workersessions.State{"", "INTERRUPTED", "unknown"} {
+		session := workersessions.Session{ID: "worker-1", State: state}
+		if err := session.Validate(); !errors.Is(err, workersessions.ErrInvalidState) {
+			t.Errorf("Validate() with state %q = %v, want ErrInvalidState", state, err)
+		}
+	}
+}
+
+func TestSession_Validate_IsDeterministicAndDoesNotMutate(t *testing.T) {
+	session := workersessions.Session{ID: "worker-1", State: workersessions.StateRunning}
+	original := session
+
+	firstErr := session.Validate()
+	secondErr := session.Validate()
+
+	if firstErr != nil || secondErr != nil {
+		t.Fatalf("Validate() = (%v, %v), want (nil, nil)", firstErr, secondErr)
+	}
+	if session != original {
+		t.Fatalf("Validate() mutated the session: got %+v, want %+v", session, original)
+	}
+}
+
+func TestSession_Terminal_MatchesStateTerminal(t *testing.T) {
+	for _, state := range []workersessions.State{
+		workersessions.StateReserved, workersessions.StateStarting, workersessions.StateRunning, workersessions.StatePaused,
+		workersessions.StateCompleted, workersessions.StateFailed, workersessions.StateCanceled, workersessions.StateTerminated,
+	} {
+		session := workersessions.Session{ID: "worker-1", State: state}
+		if got, want := session.Terminal(), state.Terminal(); got != want {
+			t.Errorf("Session.Terminal() with state %q = %v, want %v", state, got, want)
+		}
+	}
+}
+
+func TestReserveRequest_Validate_RejectsEmptyIdentity(t *testing.T) {
+	if err := (workersessions.ReserveRequest{ID: ""}).Validate(); !errors.Is(err, workersessions.ErrInvalidSessionID) {
+		t.Errorf("Validate() = %v, want ErrInvalidSessionID", err)
+	}
+	if err := (workersessions.ReserveRequest{ID: "worker-1"}).Validate(); err != nil {
+		t.Errorf("Validate() = %v, want nil", err)
+	}
+}
+
+func TestGetRequest_Validate_RejectsEmptyIdentity(t *testing.T) {
+	if err := (workersessions.GetRequest{ID: ""}).Validate(); !errors.Is(err, workersessions.ErrInvalidSessionID) {
+		t.Errorf("Validate() = %v, want ErrInvalidSessionID", err)
+	}
+	if err := (workersessions.GetRequest{ID: "worker-1"}).Validate(); err != nil {
+		t.Errorf("Validate() = %v, want nil", err)
+	}
+}
+
+func TestFilter_Validate_RejectsUnknownState(t *testing.T) {
+	filter := workersessions.Filter{States: []workersessions.State{workersessions.StateRunning, "INTERRUPTED"}}
+	if err := filter.Validate(); !errors.Is(err, workersessions.ErrInvalidState) {
+		t.Errorf("Validate() = %v, want ErrInvalidState", err)
+	}
+}
+
+func TestFilter_Validate_AcceptsEmptyAndAllValidStates(t *testing.T) {
+	if err := (workersessions.Filter{}).Validate(); err != nil {
+		t.Errorf("Validate() on empty filter = %v, want nil", err)
+	}
+	filter := workersessions.Filter{States: []workersessions.State{workersessions.StateRunning, workersessions.StateCompleted}}
+	if err := filter.Validate(); err != nil {
+		t.Errorf("Validate() = %v, want nil", err)
+	}
+}

--- a/pkg/services/worker_sessions/state.go
+++ b/pkg/services/worker_sessions/state.go
@@ -1,0 +1,39 @@
+package workersessions
+
+// State is the exact eight-value Worker Session lifecycle vocabulary. No
+// other value, including INTERRUPTED, is accepted anywhere W1 validates a
+// state.
+type State string
+
+const (
+	StateReserved   State = "RESERVED"
+	StateStarting   State = "STARTING"
+	StateRunning    State = "RUNNING"
+	StatePaused     State = "PAUSED"
+	StateCompleted  State = "COMPLETED"
+	StateFailed     State = "FAILED"
+	StateCanceled   State = "CANCELED"
+	StateTerminated State = "TERMINATED"
+)
+
+// Valid reports whether s is one of the eight accepted lifecycle states.
+func (s State) Valid() bool {
+	switch s {
+	case StateReserved, StateStarting, StateRunning, StatePaused, StateCompleted, StateFailed, StateCanceled, StateTerminated:
+		return true
+	default:
+		return false
+	}
+}
+
+// Terminal reports whether s is one of the four absorbing terminal states:
+// COMPLETED, FAILED, CANCELED, or TERMINATED. Transition rules into or out of
+// a terminal state are outside W1.
+func (s State) Terminal() bool {
+	switch s {
+	case StateCompleted, StateFailed, StateCanceled, StateTerminated:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/services/worker_sessions/state_test.go
+++ b/pkg/services/worker_sessions/state_test.go
@@ -1,0 +1,63 @@
+package workersessions_test
+
+import (
+	"testing"
+
+	workersessions "github.com/portpowered/infinite-you/pkg/services/worker_sessions"
+)
+
+func TestState_Valid_AcceptsExactlyTheEightLifecycleStates(t *testing.T) {
+	accepted := []workersessions.State{
+		workersessions.StateReserved,
+		workersessions.StateStarting,
+		workersessions.StateRunning,
+		workersessions.StatePaused,
+		workersessions.StateCompleted,
+		workersessions.StateFailed,
+		workersessions.StateCanceled,
+		workersessions.StateTerminated,
+	}
+	if len(accepted) != 8 {
+		t.Fatalf("accepted state vocabulary has %d entries, want exactly 8", len(accepted))
+	}
+	for _, state := range accepted {
+		if !state.Valid() {
+			t.Errorf("State(%q).Valid() = false, want true", state)
+		}
+	}
+}
+
+func TestState_Valid_RejectsUnknownEmptyAndInterrupted(t *testing.T) {
+	rejected := []workersessions.State{"", "INTERRUPTED", "running", "unknown", "RESERVED "}
+	for _, state := range rejected {
+		if state.Valid() {
+			t.Errorf("State(%q).Valid() = true, want false", state)
+		}
+	}
+}
+
+func TestState_Terminal_IdentifiesExactlyTheFourAbsorbingStates(t *testing.T) {
+	terminal := map[workersessions.State]bool{
+		workersessions.StateReserved:   false,
+		workersessions.StateStarting:   false,
+		workersessions.StateRunning:    false,
+		workersessions.StatePaused:     false,
+		workersessions.StateCompleted:  true,
+		workersessions.StateFailed:     true,
+		workersessions.StateCanceled:   true,
+		workersessions.StateTerminated: true,
+	}
+	for state, want := range terminal {
+		if got := state.Terminal(); got != want {
+			t.Errorf("State(%q).Terminal() = %v, want %v", state, got, want)
+		}
+	}
+}
+
+func TestState_Terminal_RejectsUnknownAndInterruptedAsNonTerminal(t *testing.T) {
+	for _, state := range []workersessions.State{"", "INTERRUPTED", "unknown"} {
+		if state.Terminal() {
+			t.Errorf("State(%q).Terminal() = true, want false for an unrecognized state", state)
+		}
+	}
+}


### PR DESCRIPTION
{
  "project": "Create the Worker Session Identity and Registry Foundation",
  "branchName": "ACP-L4-W1-worker-session-identity",
  "description": "Implement ACP Worker Events W1 by introducing one stable process-scoped Worker Session identity, the exact eight-state lifecycle vocabulary, a concurrency-safe in-memory registry, and immutable deterministic Get/List inspection, without taking on Worker launch, Events, Runtime association, controls, persistence, transports, or UI behavior.",
  "context": {
    "customerAsk": "Begin the first admissible ACP Worker Events slice, W1: introduce Worker Session identity, the eight-state lifecycle vocabulary, an in-memory session registry, and stable Get/List inspection without waiting on unfinished L2 terminal-cause work or taking ownership of unfinished L1 Events implementation.",
    "problem": "Factory execution is opaque below the Factory turn: there is no session-scoped Worker execution identity, shared lifecycle vocabulary, or inspectable registry that later supervision, event publication, ACP projection, and controls can use as one authority.",
    "solution": "Add one Worker Sessions service-root foundation with validated identity and lifecycle contracts, a synchronized process-local registry, immutable Get snapshots, deterministic filtered List snapshots, and typed validation/not-found outcomes. Keep later supervision, Events, Runtime, Provider Session, control, persistence, and transport behavior out of W1.",
    "originalDocument": "C:/Users/andre/work/portos/infinite-you/docs/internal/projects/acp-worker-events/proposal.md"
  },
  "changes": {
    "packages": [
      "pkg/services/worker_sessions owns public identity, state, snapshot, request/result, validation, typed-error, and Get/List contracts.",
      "pkg/services/worker_sessions/internal owns the synchronized process-local registry implementation and mutable state.",
      "pkg/services/worker_sessions/wire, pkg/wire, pkg/root, and pkg/initializer change only for a real W1 production consumer and must preserve the single inert canonical composition graph."
    ],
    "contracts": [
      "A Worker Session has one non-empty stable session-scoped identity and exactly one state from RESERVED, STARTING, RUNNING, PAUSED, COMPLETED, FAILED, CANCELED, and TERMINATED.",
      "Get returns the current immutable session snapshot or a typed validation/not-found result.",
      "List returns immutable snapshots in a documented deterministic order, with explicit validated filtering and no mutable registry exposure.",
      "Terminal vocabulary is exactly COMPLETED, FAILED, CANCELED, and TERMINATED; transition rules and typed terminal causes remain outside W1, and INTERRUPTED is not accepted."
    ],
    "services": "Create one explicit Worker Sessions root and a narrowly scoped concurrency-safe in-memory registry. Expose only implemented W1 inspection operations on injected service methods; add no service locator, dependency bag, global registry, hidden runtime construction, placeholder later-slice methods, or secondary composition graph.",
    "api": "No OpenAPI, HTTP, CLI, MCP, ACP, generated-client, dashboard, or browser-visible operation changes are included in W1.",
    "tests": "Add focused behavioral coverage for validation, exact lifecycle and terminal vocabulary, reservation, immutable Get, typed missing-session behavior, deterministic empty/ordered/filtered List, and concurrent registry access under race/repeat where applicable. Run focused tests, typecheck, make test, make lint, make pkg-boundary, make pkg-structure, make verify-fast, required CI/review/conflict resolution, and actual merge; do not add synthetic Worker launch, Events, transport inventory, or meta tests."
  },
  "acceptanceCriteria": [
    "Every stored Worker Session has one non-empty stable identity and exactly one of RESERVED, STARTING, RUNNING, PAUSED, COMPLETED, FAILED, CANCELED, or TERMINATED; invalid identity, state, and request values return typed validation failures and INTERRUPTED is not accepted.",
    "Get returns an immutable current snapshot for a valid existing identity and a distinguishable typed not-found result for a valid missing identity without exposing or allowing mutation of registry-owned state.",
    "List applies its defined validated filters and returns immutable session snapshots in a documented deterministic order regardless of insertion order or concurrent access.",
    "Concurrent reservation, inspection, and listing preserve unique stable identity and internally consistent snapshots without races, deadlocks, cross-session mutation, or leaked mutable registry internals.",
    "W1 exposes no unimplemented operational methods and adds no Worker launch, Events publication, Runtime dispatch/association, Provider Session association, control, persistence, transport, or UI behavior; shared composition changes occur only for a demonstrated production consumer and use the existing canonical graph.",
    "Typecheck, focused Worker Sessions tests including race/repeat evidence where applicable, make test, make lint, make pkg-boundary, make pkg-structure, make verify-fast, and all required CI checks are terminal and passing.",
    "The implementation/review loop continues until all blocking PR conversation feedback is explicitly addressed, shared-file or merge conflicts are reconciled, required CI is terminal and passing, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "ACP-L4-W1-worker-session-identity-001",
      "title": "Define stable identity and lifecycle snapshots",
      "description": "As a later Worker supervision or presentation consumer, I want a validated Worker Session identity and one shared lifecycle vocabulary so that every layer can refer to the same execution and state without inventing its own terms.",
      "acceptanceCriteria": [
        "A valid Worker Session snapshot contains one non-empty stable session identity and exactly one lifecycle state.",
        "The only accepted states are RESERVED, STARTING, RUNNING, PAUSED, COMPLETED, FAILED, CANCELED, and TERMINATED; unknown, empty, and INTERRUPTED states are rejected with a typed validation result.",
        "Terminal-state classification identifies exactly COMPLETED, FAILED, CANCELED, and TERMINATED without defining transition, cause, control, or handoff behavior.",
        "Validation is deterministic and does not mutate the supplied value.",
        "Focused identity, lifecycle vocabulary, terminal classification, and validation tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented in pkg/services/worker_sessions/state.go and session.go: State type with exactly the eight constants, Valid()/Terminal() methods, Session value type with a pure Validate() method. Covered by state_test.go and session_test.go."
    },
    {
      "id": "ACP-L4-W1-worker-session-identity-002",
      "title": "Inspect one reserved session safely",
      "description": "As a Worker Session consumer, I want to retrieve a session by its stable identity so that I can inspect its current state without gaining access to mutable registry internals.",
      "acceptanceCriteria": [
        "Once a valid session identity is reserved in the owned registry, repeated Get requests for that identity return the same identity and the current valid state.",
        "An invalid Get request returns a typed validation result, while a valid unknown identity returns a distinguishable typed not-found result.",
        "Mutating any caller-owned request or returned snapshot data after Get cannot alter the stored session or a later Get result.",
        "Duplicate reservation of an existing identity has one deterministic typed outcome and cannot replace or partially mutate the existing session.",
        "The service logs accepted inspection intent and outcomes with safe structured identity context and no work payload or credential data.",
        "Focused reservation, Get, immutability, validation, duplicate, and not-found tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented Reserve and Get on the internal registry (pkg/services/worker_sessions/internal/service/service.go) behind the workersessions.Service interface. Duplicate Reserve returns ErrSessionAlreadyExists and leaves the stored session untouched; Get distinguishes ErrInvalidSessionID from ErrSessionNotFound and logs sessionID/outcome only. Snapshot isolation verified by mutating returned Session values and re-Getting. Covered by internal/service/service_test.go."
    },
    {
      "id": "ACP-L4-W1-worker-session-identity-003",
      "title": "List deterministic filtered snapshots",
      "description": "As a Worker Session consumer, I want deterministic filtered session listings so that inspection and later projections do not depend on map iteration or insertion order.",
      "acceptanceCriteria": [
        "An empty valid List request returns a successful empty result rather than a not-found failure.",
        "With multiple sessions inserted in different orders, repeated equivalent List requests return the same documented total ordering with no missing or duplicate sessions.",
        "Each supported filter returns exactly the matching snapshots, and invalid filter values return a typed validation result without a partial result.",
        "Mutating a returned result, its session collection, or caller-owned filter data cannot alter registry state or later List/Get results.",
        "Focused empty, ordering, filtering, validation, and snapshot-isolation tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented List with a validated Filter{States []State}; registry snapshots are sorted ascending by ID for deterministic ordering independent of map iteration/insertion order. Empty registry/filter match returns a successful empty ListResult. Invalid filter state returns ErrInvalidState with no partial result. Snapshot isolation verified by mutating the returned ListResult. Covered by internal/service/service_test.go."
    },
    {
      "id": "ACP-L4-W1-worker-session-identity-004",
      "title": "Preserve inspection behavior under concurrency",
      "description": "As a customer whose Factory may coordinate many Workers, I want concurrent Worker Session registration and inspection to remain isolated and deterministic so that one execution cannot corrupt another's identity or snapshot.",
      "acceptanceCriteria": [
        "Concurrent reservation of distinct sessions retains every unique identity and valid state without lost updates or cross-session mutation.",
        "Concurrent attempts to reserve the same identity produce the defined duplicate outcome while preserving one internally consistent stored snapshot.",
        "Concurrent Get and List calls return internally consistent immutable snapshots and complete without deadlock or exposure of partially written state.",
        "Focused concurrency coverage passes under the Go race detector and repeat/stress execution where supported, using deterministic synchronization rather than arbitrary sleeps.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Registry uses a sync.RWMutex around a plain map; Reserve/Get/List tested under `go test -race -count=20`. Concurrent distinct-identity Reserve retains every session; concurrent same-identity Reserve yields exactly one success; concurrent Get/List during writes validate every returned snapshot. -race requires the PowerShell tool in this environment (the Bash tool's sandbox fails ThreadSanitizer's memory allocation on Windows) -- see progress.txt Codebase Patterns."
    }
  ]
}
