### PR TITLE
ACP-L2-IMP-WRK-PANIC: Address post-merge review feedback on executor-panic functional test

### DIFF
--- a/tests/functional/orchestration/petri/dispatch/simple_run_test.go
+++ b/tests/functional/orchestration/petri/dispatch/simple_run_test.go
@@ -560,6 +560,8 @@ func TestPetriWorkerErrorReturnsFailedTerminalOutcome(t *testing.T) {
 			Payload:    []byte(`{"title":"will panic at executor"}`),
 		})
 
+		// ProviderOverride (not ProviderCommandRunner) is required here; see the
+		// documented in-scope exception on panicInferenceProvider below.
 		provider := panicInferenceProvider{message: "simulated executor catastrophic panic"}
 		session, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
 			t,
@@ -1457,6 +1459,26 @@ func (r nonZeroExitScriptCommandRunner) Run(
 // panicInferenceProvider panics from Infer to exercise the Workers execution
 // boundary's WorkerExecutor panic recovery through the customer process
 // boundary rather than any internal Petri or Workers seam.
+//
+// backend-review construction-path exception: general-backend-standards.md §7
+// rule 3 / code-review-standards.md §9 prefer ProviderCommandRunner and other
+// command-runner edge mocks over custom in-process provider fakes. This cell
+// uses ProviderOverride instead because there is no CommandResult/exit-code
+// shape that can reach the WorkerExecutor recover() boundary this test
+// proves: ScriptWrapProvider.Execute converts CommandRunner.Run's
+// (CommandResult, error) return into an ordinary *ProviderError branch on
+// err != nil or ExitCode != 0
+// (pkg/services/providers/internal/services/execution/internal/provider/inference_provider.go:179-217),
+// and everything downstream of that (invocation.Executor.Execute at
+// pkg/services/workers/internal/services/workstations/invocation/executor.go:51)
+// only calls deterministic, non-panicking string/format helpers on the
+// result. A subprocess boundary cannot unwind the calling goroutine's stack,
+// so ProviderCommandRunner can only ever produce the ordinary failed-executor
+// path already covered by the "provider_command_exit_routes_to_failed_terminal"
+// subtest below, never a Go-level panic. An in-process Provider.Infer fake is
+// therefore the only way to exercise the recover() in
+// workerExecutorRequestAdapter.Execute
+// (pkg/services/workers/workstation_pool_boundary_impl.go).
 type panicInferenceProvider struct {
 	message string
 }


### PR DESCRIPTION
Follow-up to #1741 (merged), addressing the BLOCKING post-merge review comment at https://github.com/portpowered/you-agent-factory/pull/1741#issuecomment-5163194038.

## What this addresses

**Finding 1 (functional-test construction preference) — fixed in this PR.**
`tests/functional/orchestration/petri/dispatch/simple_run_test.go`'s
`executor_panic_routes_to_failed_terminal` subtest uses an in-process
`ProviderOverride` fake (`panicInferenceProvider`) instead of the preferred
`ProviderCommandRunner` command-runner edge mock. This PR adds the
documented, in-scope exception required by
`general-backend-standards.md` §7 rule 3 / `code-review-standards.md` §9,
matching the existing exception-comment convention in
`tests/functional/operator_settings/root_composition/wire_composition_coverage_test.go`.
The exception is architectural, not a preference: `ProviderCommandRunner`'s
`Run` method returns `(CommandResult, error)`, and everything between that
return and the `WorkerExecutor` recover boundary
(`ScriptWrapProvider.Execute`,
`pkg/services/providers/internal/services/execution/internal/provider/inference_provider.go:179-217`,
and `invocation.Executor.Execute`,
`pkg/services/workers/internal/services/workstations/invocation/executor.go:51`)
only does deterministic, non-panicking branches on `err`/`ExitCode`. A
subprocess boundary cannot unwind the calling goroutine's stack, so there is
no `CommandResult` shape that can reach
`workerExecutorRequestAdapter.Execute`'s `recover()`
(`pkg/services/workers/workstation_pool_boundary_impl.go`). An in-process
`Provider.Infer` fake is the only way to exercise a recovered panic.

**Finding 2 (`make pkg-boundary` / `make lint`) — verified pre-existing, out of scope for this PRD.**
`make pkg-boundary` fails identically (95 violations, byte-for-byte same
output) on the merge-base commit before PR #1741 (`86576b923`) and on
#1741's merged head. None of the 95 reported violations reference any file
this PRD touched. Separately, `make backend-size` (also a `make lint`
subtarget, runs before `pkg-boundary` in `LINT_TARGETS`) fails with the same
73 violations on both commits as well — again none introduced by this PRD's
changes, though this PR's new subtest does add lines to two files/functions
that were already over their size limits before this PRD started
(`simple_run_test.go`, and its `TestPetriWorkerErrorReturnsFailedTerminalOutcome`
function). Bringing either check to green would mean touching dozens of
files across `pkg/services/operator_settings`, `pkg/services/providers`,
`pkg/services/models`, `pkg/services/recordings`, `pkg/services/work`,
`pkg/wire`, `pkg/transports/cli`, and more — all unrelated to
`ACP-L2-IMP-WRK-PANIC`'s scope (PRD acceptance criterion 5: "no unrelated
executor deletion or runner-injection cleanup"). This is repository-wide
baseline debt that predates and is unaffected by this PRD; it is not
something this narrowly-scoped change can or should absorb.

## Quality evidence for this follow-up head

- `go build ./...` — clean.
- `go vet ./tests/functional/orchestration/petri/dispatch/...` — clean.
- `gofmt -l` on the changed file — clean.
- `go test ./tests/functional/orchestration/petri/dispatch/... -run TestPetriWorkerErrorReturnsFailedTerminalOutcome -v -count=1` — all subtests pass, including `executor_panic_routes_to_failed_terminal`.
- `make pkg-boundary` and `make backend-size` — confirmed identical violation sets (95 and 73 respectively) on this head and on the pre-#1741 merge-base commit; no new entries from this PRD.

This PR is comment-only (no production or test-logic changes); it satisfies
Finding 1 and provides the evidence needed to close Finding 2 as pre-existing
and out of scope.

## Original PRD

```json
$(cat prd.json)
```

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>