### PR TITLE
ACP-L4-W1: Worker Session operation logging follow-up (PR #1742 review)

### DIFF
--- a/pkg/services/worker_sessions/internal/service/service.go
+++ b/pkg/services/worker_sessions/internal/service/service.go
@@ -34,16 +34,19 @@ func New(logger logging.Logger) workersessions.Service {
 
 func (r *registry) Reserve(_ context.Context, req workersessions.ReserveRequest) (workersessions.Session, error) {
 	if err := req.Validate(); err != nil {
+		r.logger.Info("worker session reserve rejected", "sessionID", req.ID, "outcome", "invalid")
 		return workersessions.Session{}, err
 	}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, exists := r.sessions[req.ID]; exists {
+		r.logger.Info("worker session reserve", "sessionID", req.ID, "outcome", "duplicate")
 		return workersessions.Session{}, workersessions.ErrSessionAlreadyExists
 	}
 	session := workersessions.Session{ID: req.ID, State: workersessions.StateReserved}
 	r.sessions[req.ID] = session
+	r.logger.Info("worker session reserve", "sessionID", req.ID, "outcome", "reserved")
 	return session, nil
 }
 
@@ -67,6 +70,7 @@ func (r *registry) Get(_ context.Context, req workersessions.GetRequest) (worker
 
 func (r *registry) List(_ context.Context, req workersessions.ListRequest) (workersessions.ListResult, error) {
 	if err := req.Validate(); err != nil {
+		r.logger.Info("worker session list rejected", "outcome", "invalid")
 		return workersessions.ListResult{}, err
 	}
 
@@ -80,6 +84,7 @@ func (r *registry) List(_ context.Context, req workersessions.ListRequest) (work
 	r.mu.RUnlock()
 
 	sort.Slice(matched, func(i, j int) bool { return matched[i].ID < matched[j].ID })
+	r.logger.Info("worker session list", "outcome", "success", "filter_state_count", len(req.Filter.States), "result_count", len(matched))
 	return workersessions.ListResult{Sessions: matched}, nil
 }
 

--- a/pkg/services/worker_sessions/internal/service/service_logging_test.go
+++ b/pkg/services/worker_sessions/internal/service/service_logging_test.go
@@ -1,0 +1,140 @@
+package service_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	workersessions "github.com/portpowered/infinite-you/pkg/services/worker_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/worker_sessions/internal/service"
+)
+
+type recordedLogEntry struct {
+	message string
+	fields  map[string]any
+}
+
+// recordingLogger implements logging.Logger for asserting the exact safe
+// fields the registry emits without depending on a concrete logging backend.
+type recordingLogger struct {
+	mu      sync.Mutex
+	entries []recordedLogEntry
+}
+
+func (l *recordingLogger) Debug(message string, keysAndValues ...any) {
+	l.record(message, keysAndValues)
+}
+
+func (l *recordingLogger) Info(message string, keysAndValues ...any) {
+	l.record(message, keysAndValues)
+}
+
+func (l *recordingLogger) Warn(message string, keysAndValues ...any) {
+	l.record(message, keysAndValues)
+}
+
+func (l *recordingLogger) Error(message string, keysAndValues ...any) {
+	l.record(message, keysAndValues)
+}
+
+func (l *recordingLogger) Verbose(message string, keysAndValues ...any) {
+	l.record(message, keysAndValues)
+}
+
+func (l *recordingLogger) record(message string, keysAndValues []any) {
+	fields := make(map[string]any, len(keysAndValues)/2)
+	for index := 0; index+1 < len(keysAndValues); index += 2 {
+		key, ok := keysAndValues[index].(string)
+		if !ok {
+			continue
+		}
+		fields[key] = keysAndValues[index+1]
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append(l.entries, recordedLogEntry{message: message, fields: fields})
+}
+
+func (l *recordingLogger) entriesFor(message string) []recordedLogEntry {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var matches []recordedLogEntry
+	for _, entry := range l.entries {
+		if entry.message == message {
+			matches = append(matches, entry)
+		}
+	}
+	return matches
+}
+
+func assertNoPayloadOrCredentialKeys(t *testing.T, fields map[string]any) {
+	t.Helper()
+	for key := range fields {
+		switch key {
+		case "sessionID", "outcome", "state", "filter_state_count", "result_count":
+			continue
+		default:
+			t.Fatalf("unexpected log field %q leaked into operation log: %#v", key, fields)
+		}
+	}
+}
+
+func TestRegistryLogsReserveOutcomes(t *testing.T) {
+	logger := &recordingLogger{}
+	registry := service.New(logger)
+	ctx := context.Background()
+
+	if _, err := registry.Reserve(ctx, workersessions.ReserveRequest{ID: "   "}); err == nil {
+		t.Fatalf("Reserve() with invalid ID unexpectedly succeeded")
+	}
+	rejected := logger.entriesFor("worker session reserve rejected")
+	if len(rejected) != 1 || rejected[0].fields["outcome"] != "invalid" {
+		t.Fatalf("reserve-rejected log = %#v", rejected)
+	}
+	assertNoPayloadOrCredentialKeys(t, rejected[0].fields)
+
+	if _, err := registry.Reserve(ctx, workersessions.ReserveRequest{ID: "worker-1"}); err != nil {
+		t.Fatalf("Reserve() error = %v, want nil", err)
+	}
+	accepted := logger.entriesFor("worker session reserve")
+	if len(accepted) != 1 || accepted[0].fields["sessionID"] != "worker-1" || accepted[0].fields["outcome"] != "reserved" {
+		t.Fatalf("reserve-accepted log = %#v", accepted)
+	}
+	assertNoPayloadOrCredentialKeys(t, accepted[0].fields)
+
+	if _, err := registry.Reserve(ctx, workersessions.ReserveRequest{ID: "worker-1"}); err == nil {
+		t.Fatalf("duplicate Reserve() unexpectedly succeeded")
+	}
+	accepted = logger.entriesFor("worker session reserve")
+	if len(accepted) != 2 || accepted[1].fields["sessionID"] != "worker-1" || accepted[1].fields["outcome"] != "duplicate" {
+		t.Fatalf("reserve-duplicate log = %#v", accepted)
+	}
+	assertNoPayloadOrCredentialKeys(t, accepted[1].fields)
+}
+
+func TestRegistryLogsListOutcomes(t *testing.T) {
+	logger := &recordingLogger{}
+	registry := service.New(logger)
+	ctx := context.Background()
+
+	if _, err := registry.List(ctx, workersessions.ListRequest{Filter: workersessions.Filter{States: []workersessions.State{"INTERRUPTED"}}}); err == nil {
+		t.Fatalf("List() with invalid filter unexpectedly succeeded")
+	}
+	rejected := logger.entriesFor("worker session list rejected")
+	if len(rejected) != 1 || rejected[0].fields["outcome"] != "invalid" {
+		t.Fatalf("list-rejected log = %#v", rejected)
+	}
+	assertNoPayloadOrCredentialKeys(t, rejected[0].fields)
+
+	if _, err := registry.Reserve(ctx, workersessions.ReserveRequest{ID: "worker-1"}); err != nil {
+		t.Fatalf("Reserve() error = %v, want nil", err)
+	}
+	if _, err := registry.List(ctx, workersessions.ListRequest{}); err != nil {
+		t.Fatalf("List() error = %v, want nil", err)
+	}
+	succeeded := logger.entriesFor("worker session list")
+	if len(succeeded) != 1 || succeeded[0].fields["outcome"] != "success" || succeeded[0].fields["result_count"] != 1 {
+		t.Fatalf("list-success log = %#v", succeeded)
+	}
+	assertNoPayloadOrCredentialKeys(t, succeeded[0].fields)
+}


### PR DESCRIPTION
## Summary
- Follow-up to merged PR #1742 (`ACP-L4-W1: Worker Session identity and registry foundation`), addressing the [BLOCKING post-merge review comment](https://github.com/portpowered/you-agent-factory/pull/1742#issuecomment-5163322137).
- The review found that `Reserve` and `List` in `pkg/services/worker_sessions/internal/service/service.go` emitted no structured logs at all (only `Get` did), which the backend standard requires for public service operations.
- Adds `sessionID`/`outcome`-only structured logging to `Reserve` (invalid/duplicate/reserved) and `List` (invalid/success with `filter_state_count`/`result_count`), matching `Get`'s existing safe field set, with no payload or credential data.
- Adds `service_logging_test.go` with a `recordingLogger` test double (same pattern already used in `pkg/services/workers/.../workstations/internal/service`) asserting the exact log messages/fields for every outcome, plus a safe-field allowlist check.
- Verified the review's other two flagged gates (`make pkg-boundary`: 95 violations, `make pkg-structure`: 5 violations) are pre-existing repo debt in `chat_sessions`/`operator_settings`/oversized functions unrelated to this PR — `grep -i worker_sessions` over both tools' output returns zero matches on this head.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/services/worker_sessions/...`
- [x] `go test ./pkg/services/worker_sessions/...` (includes new logging tests)
- [x] `go test ./pkg/services/worker_sessions/... -race -count=20` (via PowerShell)
- [x] `make test` (full unit lane)
- [x] Confirmed unit coverage manifest values unchanged (100.00% for both `worker_sessions` packages)
- [x] Confirmed zero `pkg-boundary`/`pkg-structure` findings reference `worker_sessions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)