### PR TITLE
ACP-L2-IMP-WRK-PANIC: Split executor-panic functional coverage out of oversized test

### DIFF
--- a/tests/functional/orchestration/petri/dispatch/executor_panic_test.go
+++ b/tests/functional/orchestration/petri/dispatch/executor_panic_test.go
@@ -1,0 +1,122 @@
+package dispatch
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+// TestPetriExecutorPanicRoutesToFailedTerminal proves a panicking
+// WorkerExecutor still reaches the documented failed terminal with the
+// established "executor panic: <cause>" compatibility text, split into its
+// own focused top-level test (out of
+// TestPetriWorkerErrorReturnsFailedTerminalOutcome in simple_run_test.go) so
+// this scenario does not deepen that file's/function's existing backend-size
+// debt.
+func TestPetriExecutorPanicRoutesToFailedTerminal(t *testing.T) {
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
+	traceID := "trace-executor-panic"
+	testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+		WorkTypeID: "task",
+		TraceID:    traceID,
+		Payload:    []byte(`{"title":"will panic at executor"}`),
+	})
+
+	// ProviderOverride (not ProviderCommandRunner) is required here; see the
+	// documented in-scope exception on panicInferenceProvider below.
+	provider := panicInferenceProvider{message: "simulated executor catastrophic panic"}
+	session, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
+		t,
+		dir,
+		serviceedges.Edges{ProviderOverride: provider},
+		10*time.Second,
+	)
+
+	failedTerminal := support.WorkCustomerLocation("task", "failed")
+	successTerminal := support.WorkCustomerLocation("task", "done")
+	assertWorkAtCustomerStates(t, listed, map[string]int{
+		failedTerminal:  1,
+		successTerminal: 0,
+		support.WorkCustomerLocation("task", "init"): 0,
+	})
+	assertTerminalWorkCorrelatesToTraceIDs(t, listed, failedTerminal, []string{traceID})
+	assertTraceAbsentAtCustomerState(t, listed, successTerminal, traceID)
+	assertQuiescentSession(t, session, 0, 1)
+
+	failedWorkID, ok := workIDAtCustomerState(t, listed, failedTerminal, traceID)
+	if !ok {
+		t.Fatalf("missing failed Work for trace %q at %s", traceID, failedTerminal)
+	}
+	dispatches := support.ObserveDispatchEvents(t, events)
+	assertFailedDispatchForWork(t, dispatches, failedWorkID)
+	assertFailedDispatchResponseErrorForWork(t, dispatches, failedWorkID)
+	assertDispatchResponseErrorContains(
+		t,
+		dispatches,
+		failedWorkID,
+		"executor panic: simulated executor catastrophic panic",
+	)
+}
+
+// panicInferenceProvider panics from Infer to exercise the Workers execution
+// boundary's WorkerExecutor panic recovery through the customer process
+// boundary rather than any internal Petri or Workers seam.
+//
+// backend-review construction-path exception: general-backend-standards.md §7
+// rule 3 / code-review-standards.md §9 prefer ProviderCommandRunner and other
+// command-runner edge mocks over custom in-process provider fakes. This cell
+// uses ProviderOverride instead because there is no CommandResult/exit-code
+// shape that can reach the WorkerExecutor recover() boundary this test
+// proves: ScriptWrapProvider.Execute converts CommandRunner.Run's
+// (CommandResult, error) return into an ordinary *ProviderError branch on
+// err != nil or ExitCode != 0
+// (pkg/services/providers/internal/services/execution/internal/provider/inference_provider.go:179-217),
+// and everything downstream of that (invocation.Executor.Execute at
+// pkg/services/workers/internal/services/workstations/invocation/executor.go:51)
+// only calls deterministic, non-panicking string/format helpers on the
+// result. A subprocess boundary cannot unwind the calling goroutine's stack,
+// so ProviderCommandRunner can only ever produce the ordinary failed-executor
+// path already covered by the "provider_command_exit_routes_to_failed_terminal"
+// subtest in simple_run_test.go, never a Go-level panic. An in-process
+// Provider.Infer fake is therefore the only way to exercise the recover() in
+// workerExecutorRequestAdapter.Execute
+// (pkg/services/workers/workstation_pool_boundary_impl.go).
+type panicInferenceProvider struct {
+	message string
+}
+
+func (p panicInferenceProvider) Infer(
+	_ context.Context,
+	_ workerexecution.ProviderInferenceRequest,
+) (workerexecution.InferenceResponse, error) {
+	panic(p.message)
+}
+
+func assertDispatchResponseErrorContains(
+	t *testing.T,
+	dispatches []support.DispatchEventObservation,
+	workID string,
+	want string,
+) {
+	t.Helper()
+
+	for _, dispatch := range dispatches {
+		if !support.DispatchObservationIncludesWork(dispatch, workID) {
+			continue
+		}
+		if dispatch.Response == nil || dispatch.Response.Error == nil {
+			continue
+		}
+		if strings.Contains(*dispatch.Response.Error, want) {
+			return
+		}
+	}
+	t.Fatalf("no dispatch response error for work %q containing %q", workID, want)
+}

--- a/tests/functional/orchestration/petri/dispatch/simple_run_test.go
+++ b/tests/functional/orchestration/petri/dispatch/simple_run_test.go
@@ -550,52 +550,6 @@ func TestPetriWorkerErrorReturnsFailedTerminalOutcome(t *testing.T) {
 		}
 	})
 
-	t.Run("executor_panic_routes_to_failed_terminal", func(t *testing.T) {
-		t.Parallel()
-		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_success"))
-		traceID := "trace-executor-panic"
-		testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
-			WorkTypeID: "task",
-			TraceID:    traceID,
-			Payload:    []byte(`{"title":"will panic at executor"}`),
-		})
-
-		// ProviderOverride (not ProviderCommandRunner) is required here; see the
-		// documented in-scope exception on panicInferenceProvider below.
-		provider := panicInferenceProvider{message: "simulated executor catastrophic panic"}
-		session, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
-			t,
-			dir,
-			serviceedges.Edges{ProviderOverride: provider},
-			10*time.Second,
-		)
-
-		failedTerminal := support.WorkCustomerLocation("task", "failed")
-		successTerminal := support.WorkCustomerLocation("task", "done")
-		assertWorkAtCustomerStates(t, listed, map[string]int{
-			failedTerminal:  1,
-			successTerminal: 0,
-			support.WorkCustomerLocation("task", "init"): 0,
-		})
-		assertTerminalWorkCorrelatesToTraceIDs(t, listed, failedTerminal, []string{traceID})
-		assertTraceAbsentAtCustomerState(t, listed, successTerminal, traceID)
-		assertQuiescentSession(t, session, 0, 1)
-
-		failedWorkID, ok := workIDAtCustomerState(t, listed, failedTerminal, traceID)
-		if !ok {
-			t.Fatalf("missing failed Work for trace %q at %s", traceID, failedTerminal)
-		}
-		dispatches := support.ObserveDispatchEvents(t, events)
-		assertFailedDispatchForWork(t, dispatches, failedWorkID)
-		assertFailedDispatchResponseErrorForWork(t, dispatches, failedWorkID)
-		assertDispatchResponseErrorContains(
-			t,
-			dispatches,
-			failedWorkID,
-			"executor panic: simulated executor catastrophic panic",
-		)
-	})
-
 	t.Run("provider_command_exit_routes_to_failed_terminal", func(t *testing.T) {
 		t.Parallel()
 		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "executor_failure_no_arcs"))
@@ -1454,60 +1408,4 @@ func (r nonZeroExitScriptCommandRunner) Run(
 		Stderr:   []byte(r.stderr),
 		ExitCode: r.exitCode,
 	}, nil
-}
-
-// panicInferenceProvider panics from Infer to exercise the Workers execution
-// boundary's WorkerExecutor panic recovery through the customer process
-// boundary rather than any internal Petri or Workers seam.
-//
-// backend-review construction-path exception: general-backend-standards.md §7
-// rule 3 / code-review-standards.md §9 prefer ProviderCommandRunner and other
-// command-runner edge mocks over custom in-process provider fakes. This cell
-// uses ProviderOverride instead because there is no CommandResult/exit-code
-// shape that can reach the WorkerExecutor recover() boundary this test
-// proves: ScriptWrapProvider.Execute converts CommandRunner.Run's
-// (CommandResult, error) return into an ordinary *ProviderError branch on
-// err != nil or ExitCode != 0
-// (pkg/services/providers/internal/services/execution/internal/provider/inference_provider.go:179-217),
-// and everything downstream of that (invocation.Executor.Execute at
-// pkg/services/workers/internal/services/workstations/invocation/executor.go:51)
-// only calls deterministic, non-panicking string/format helpers on the
-// result. A subprocess boundary cannot unwind the calling goroutine's stack,
-// so ProviderCommandRunner can only ever produce the ordinary failed-executor
-// path already covered by the "provider_command_exit_routes_to_failed_terminal"
-// subtest below, never a Go-level panic. An in-process Provider.Infer fake is
-// therefore the only way to exercise the recover() in
-// workerExecutorRequestAdapter.Execute
-// (pkg/services/workers/workstation_pool_boundary_impl.go).
-type panicInferenceProvider struct {
-	message string
-}
-
-func (p panicInferenceProvider) Infer(
-	_ context.Context,
-	_ workerexecution.ProviderInferenceRequest,
-) (workerexecution.InferenceResponse, error) {
-	panic(p.message)
-}
-
-func assertDispatchResponseErrorContains(
-	t *testing.T,
-	dispatches []support.DispatchEventObservation,
-	workID string,
-	want string,
-) {
-	t.Helper()
-
-	for _, dispatch := range dispatches {
-		if !support.DispatchObservationIncludesWork(dispatch, workID) {
-			continue
-		}
-		if dispatch.Response == nil || dispatch.Response.Error == nil {
-			continue
-		}
-		if strings.Contains(*dispatch.Response.Error, want) {
-			return
-		}
-	}
-	t.Fatalf("no dispatch response error for work %q containing %q", workID, want)
 }


### PR DESCRIPTION
## Summary

Addresses the newer BLOCKING post-merge review comment posted on #1741 after #1743 merged (finding 1: oversized file/function).

- Moves the `executor_panic_routes_to_failed_terminal` functional scenario out of `tests/functional/orchestration/petri/dispatch/simple_run_test.go`'s `TestPetriWorkerErrorReturnsFailedTerminalOutcome` (which the #1741/#1743 panic-typing work had grown to 365 lines) into a new focused, top-level `TestPetriExecutorPanicRoutesToFailedTerminal` test in a new file, `executor_panic_test.go`, in the same `dispatch` package.
- The `panicInferenceProvider` fake and its documented construction-path exception comment (added in #1743), plus the `assertDispatchResponseErrorContains` helper (only used by this scenario), move with it.
- `simple_run_test.go` returns to its pre-#1741 baseline: 1412 lines (was 1492), and `TestPetriWorkerErrorReturnsFailedTerminalOutcome` returns to 321 lines (was 365) — this PR's diff does not deepen either pre-existing `make backend-size` violation.
- No production code changes; `pkg/services/workers` is untouched by this PR.

## Why not also fix `make lint`/`make pkg-boundary` fully green

The blocking comment also flagged that `make lint` (at `backend-size`) and `make pkg-boundary` are not fully green on the reviewed head. Verified locally on this head:
- `go run ./cmd/backendsizecheck -root .` still reports **72 pre-existing** violations across dozens of unrelated files/functions (`pkg/wire/session_runtime_providers.go`, `pkg/transports/cli/root.go`, `tests/functional/events/factory_events/order_and_cursor_test.go`, etc.) — none touched by this PRD.
- `make pkg-boundary` still reports the same **95 pre-existing** violations reported in the review (cross-owner-service-policy test boundary calls in `operator_settings`/`factory_definitions`/`cli`, a pre-existing `pkg/services/workers/provider_port.go` durable-provider-effect finding last touched by an unrelated commit, and a 154-entry Petri public-surface migration baseline) — none introduced or touched by #1741/#1743/this PR.

Bringing those two repository-wide gates fully green is out of scope for the ACP-L2-IMP-WRK-PANIC PRD, which explicitly scopes the change to `pkg/services/workers` and forbids "unrelated executor deletion or runner-injection cleanup." This PR fixes the one violation this PRD's own diff actually caused (the size deepening in finding 1) and leaves the pre-existing, unrelated repo-wide debt for its own tracked cleanup.

## Test plan
- [x] `go test ./tests/functional/orchestration/petri/dispatch/... -run 'TestPetriExecutorPanicRoutesToFailedTerminal|TestPetriWorkerErrorReturnsFailedTerminalOutcome' -v` — all pass
- [x] `go test ./pkg/services/workers/... -run 'Panic' -v` — all pass
- [x] `make test`
- [x] `make verify-fast`
- [x] `go run ./cmd/backendsizecheck -root .` — confirms `simple_run_test.go`/`TestPetriWorkerErrorReturnsFailedTerminalOutcome` back at pre-#1741 baseline, no new violations from `executor_panic_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
