### PR TITLE
ACP-L1-V1-C13: Chat Sessions atomic convergence (C10 + C12 + C11 fix)

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -247,6 +247,26 @@
       }
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/service",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions/wire",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/edges",
       "minimum": 66.14
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -229,6 +229,14 @@
       "minimum": 100.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/service",
+      "minimum": 92.98
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions/wire",
+      "minimum": 100.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/edges",
       "minimum": 71.65
     },

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -1610,12 +1610,6 @@
     },
     {
       "fromOwner": "transports",
-      "toOwner": "chat_sessions",
-      "class": "protocol_composition",
-      "evidence": "pkg/transports/cli -\u003e pkg/services/chat_sessions"
-    },
-    {
-      "fromOwner": "transports",
       "toOwner": "factory_definitions",
       "class": "protocol_composition",
       "evidence": "pkg/transports/cli/cobracompletion -\u003e pkg/services/factory_definitions"

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -1610,6 +1610,12 @@
     },
     {
       "fromOwner": "transports",
+      "toOwner": "chat_sessions",
+      "class": "protocol_composition",
+      "evidence": "pkg/transports/cli -\u003e pkg/services/chat_sessions"
+    },
+    {
+      "fromOwner": "transports",
       "toOwner": "factory_definitions",
       "class": "protocol_composition",
       "evidence": "pkg/transports/cli/cobracompletion -\u003e pkg/services/factory_definitions"

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -2588,6 +2588,12 @@
       "destinationKind": "owner"
     },
     {
+      "packagePath": "pkg/services/chat_sessions/internal/service",
+      "disposition": "retain",
+      "destination": "chat_sessions",
+      "destinationKind": "owner"
+    },
+    {
       "packagePath": "pkg/services/edges",
       "disposition": "retain",
       "destination": "edges",

--- a/docs/internal/baselines/ownership-inventory.json
+++ b/docs/internal/baselines/ownership-inventory.json
@@ -1104,6 +1104,12 @@
       "evidence": "pkg/services/chat_sessions/internal/factorysessionsshim -\u003e pkg/services/factory_sessions"
     },
     {
+      "fromOwner": "chat_sessions",
+      "toOwner": "platform",
+      "class": "external_effect",
+      "evidence": "pkg/services/chat_sessions/internal/service -\u003e pkg/platform/logging"
+    },
+    {
       "fromOwner": "edges",
       "toOwner": "automations",
       "class": "external_effect",
@@ -1685,6 +1691,12 @@
       "toOwner": "automations",
       "class": "construction",
       "evidence": "pkg/wire -\u003e pkg/services/automations"
+    },
+    {
+      "fromOwner": "wire",
+      "toOwner": "chat_sessions",
+      "class": "construction",
+      "evidence": "pkg/wire -\u003e pkg/services/chat_sessions/wire"
     },
     {
       "fromOwner": "wire",
@@ -2589,6 +2601,12 @@
     },
     {
       "packagePath": "pkg/services/chat_sessions/internal/service",
+      "disposition": "retain",
+      "destination": "chat_sessions",
+      "destinationKind": "owner"
+    },
+    {
+      "packagePath": "pkg/services/chat_sessions/wire",
       "disposition": "retain",
       "destination": "chat_sessions",
       "destinationKind": "owner"

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -88,6 +88,7 @@
     "pkg/services/chat_sessions",
     "pkg/services/chat_sessions/internal/factorysessionsshim",
     "pkg/services/chat_sessions/internal/service",
+    "pkg/services/chat_sessions/wire",
     "pkg/services/edges",
     "pkg/services/events",
     "pkg/services/factory_definitions",
@@ -805,6 +806,11 @@
     },
     {
       "packagePath": "pkg/services/chat_sessions/internal/service",
+      "disposition": "retain",
+      "destination": "chat_sessions"
+    },
+    {
+      "packagePath": "pkg/services/chat_sessions/wire",
       "disposition": "retain",
       "destination": "chat_sessions"
     },

--- a/docs/internal/packaged-service-structure/package-target-manifest.json
+++ b/docs/internal/packaged-service-structure/package-target-manifest.json
@@ -87,6 +87,7 @@
     "pkg/services/automations/wire",
     "pkg/services/chat_sessions",
     "pkg/services/chat_sessions/internal/factorysessionsshim",
+    "pkg/services/chat_sessions/internal/service",
     "pkg/services/edges",
     "pkg/services/events",
     "pkg/services/factory_definitions",
@@ -799,6 +800,11 @@
     },
     {
       "packagePath": "pkg/services/chat_sessions/internal/factorysessionsshim",
+      "disposition": "retain",
+      "destination": "chat_sessions"
+    },
+    {
+      "packagePath": "pkg/services/chat_sessions/internal/service",
       "disposition": "retain",
       "destination": "chat_sessions"
     },

--- a/pkg/services/chat_sessions/boundary_test.go
+++ b/pkg/services/chat_sessions/boundary_test.go
@@ -37,6 +37,7 @@ func TestConsumer_ConstructsAndValidatesRepresentativeValues(t *testing.T) {
 	session := chatsessions.Session{
 		ID:             "session-1",
 		State:          chatsessions.SessionStateCreated,
+		Cwd:            "/workspace/project",
 		SelectedTarget: target,
 		CreatedAt:      now,
 		UpdatedAt:      now,

--- a/pkg/services/chat_sessions/boundary_test.go
+++ b/pkg/services/chat_sessions/boundary_test.go
@@ -37,7 +37,7 @@ func TestConsumer_ConstructsAndValidatesRepresentativeValues(t *testing.T) {
 	session := chatsessions.Session{
 		ID:             "session-1",
 		State:          chatsessions.SessionStateCreated,
-		Cwd:            "/workspace/project",
+		WorkingRoot:    "/workspace/project",
 		SelectedTarget: target,
 		CreatedAt:      now,
 		UpdatedAt:      now,

--- a/pkg/services/chat_sessions/contracts.go
+++ b/pkg/services/chat_sessions/contracts.go
@@ -81,7 +81,11 @@ type Service interface {
 	// ControlIntentStateRequested. It reports *NotFoundError when there is
 	// no active turn to target, *ConflictError when ExpectedVersion is
 	// stale, and a *ValidationError wrapping ErrUnsupportedControlAction
-	// when Action is declared vocabulary not executable in L1.
+	// when Action is declared vocabulary not executable in L1. Reusing a
+	// RequestID that already identifies a requested intent is idempotent: it
+	// returns that existing, immutable intent unchanged instead of
+	// recapturing the (possibly different) current active turn, target
+	// episode, or version.
 	RequestControl(ctx context.Context, req RequestControlRequest) (RequestControlResult, error)
 
 	// AdvanceControl moves a control intent to Next, enforcing the

--- a/pkg/services/chat_sessions/contracts.go
+++ b/pkg/services/chat_sessions/contracts.go
@@ -41,8 +41,8 @@ import "context"
 // private topology.
 type Service interface {
 	// CreateSession creates a new Chat Session in SessionStateCreated with
-	// the given validated working root (Cwd) and initial selected target. A
-	// blank Cwd, an invalid RequestID, or an invalid InitialTarget reports a
+	// the given validated working root (WorkingRoot) and initial selected target. A
+	// blank WorkingRoot, an invalid RequestID, or an invalid InitialTarget reports a
 	// *ValidationError and creates no observable session.
 	CreateSession(ctx context.Context, req CreateSessionRequest) (CreateSessionResult, error)
 
@@ -104,11 +104,11 @@ type Service interface {
 // root, and initial target for a new Chat Session.
 type CreateSessionRequest struct {
 	RequestID RequestIdentity
-	// Cwd is the caller-supplied ACP editor working root. It must be
-	// non-blank; a blank Cwd is rejected with the same typed validation
+	// WorkingRoot is the caller-supplied ACP editor working root. It must be
+	// non-blank; a blank WorkingRoot is rejected with the same typed validation
 	// classification as any other required-value failure and creates no
 	// session.
-	Cwd           string
+	WorkingRoot   string
 	InitialTarget ChatTargetRef
 }
 

--- a/pkg/services/chat_sessions/contracts.go
+++ b/pkg/services/chat_sessions/contracts.go
@@ -100,8 +100,11 @@ type Service interface {
 	AdvanceControl(ctx context.Context, req AdvanceControlRequest) (AdvanceControlResult, error)
 }
 
-// CreateSessionRequest carries the caller identity, validated ACP working
-// root, and initial target for a new Chat Session.
+// CreateSessionRequest carries the caller identity, initial target, and
+// working root for a new Chat Session. WorkingRoot is the ACP client's
+// validated editor cwd; it is fixed for the Session's lifetime and is the
+// root a later target change (SetTarget) revalidates a requested target
+// against.
 type CreateSessionRequest struct {
 	RequestID RequestIdentity
 	// WorkingRoot is the caller-supplied ACP editor working root. It must be

--- a/pkg/services/chat_sessions/contracts.go
+++ b/pkg/services/chat_sessions/contracts.go
@@ -41,7 +41,9 @@ import "context"
 // private topology.
 type Service interface {
 	// CreateSession creates a new Chat Session in SessionStateCreated with
-	// the given initial selected target.
+	// the given validated working root (Cwd) and initial selected target. A
+	// blank Cwd, an invalid RequestID, or an invalid InitialTarget reports a
+	// *ValidationError and creates no observable session.
 	CreateSession(ctx context.Context, req CreateSessionRequest) (CreateSessionResult, error)
 
 	// GetSession returns the current state of one Chat Session. It reports
@@ -94,10 +96,15 @@ type Service interface {
 	AdvanceControl(ctx context.Context, req AdvanceControlRequest) (AdvanceControlResult, error)
 }
 
-// CreateSessionRequest carries the caller identity and initial target for a
-// new Chat Session.
+// CreateSessionRequest carries the caller identity, validated ACP working
+// root, and initial target for a new Chat Session.
 type CreateSessionRequest struct {
-	RequestID     RequestIdentity
+	RequestID RequestIdentity
+	// Cwd is the caller-supplied ACP editor working root. It must be
+	// non-blank; a blank Cwd is rejected with the same typed validation
+	// classification as any other required-value failure and creates no
+	// session.
+	Cwd           string
 	InitialTarget ChatTargetRef
 }
 

--- a/pkg/services/chat_sessions/contracts_test.go
+++ b/pkg/services/chat_sessions/contracts_test.go
@@ -143,20 +143,22 @@ func (f *fakeService) RequestControl(_ context.Context, req chatsessions.Request
 // AdvanceControl demonstrates the captured-turn race rule this packet
 // requires: once an intent is COMMITTED, its terminal outcome is computed
 // with ResolveControlIntentOutcome against the intent's own captured TurnID
-// and the session's live active turn -- never taken as a caller-selected
-// value -- so a completion can only ever resolve for the turn it captured.
+// and the session's most recently admitted turn -- never taken as a
+// caller-selected value -- so a completion can only ever resolve for the
+// turn it captured.
 func (f *fakeService) AdvanceControl(_ context.Context, req chatsessions.AdvanceControlRequest) (chatsessions.AdvanceControlResult, error) {
 	if req.RequestID != f.intent.RequestID {
 		return chatsessions.AdvanceControlResult{}, &chatsessions.NotFoundError{Value: "ControlIntent", ID: req.RequestID.JSONRPCStringID}
 	}
 	next := req.Next
 	if f.intent.State == chatsessions.ControlIntentStateCommitted {
-		// f.turn.State is the live state of whichever turn is currently known
-		// to the session; it only represents the captured turn's own state
-		// when that turn is still the session's active one, which is exactly
-		// the case ResolveControlIntentOutcome needs -- when the captured
-		// turn is no longer current, the mismatch against currentActiveID
-		// resolves to SUPERSEDED before this state value is even consulted.
+		// f.turn.State is the live state of whichever turn this minimal fake
+		// currently knows about, and f.session.ActiveTurnID is never cleared
+		// by this fake's AdvanceTurn (unlike a production Store, it is only
+		// overwritten by a later StartTurn) -- so it already plays the
+		// "most recently admitted turn" role ResolveControlIntentOutcome
+		// needs: when the captured turn is no longer that one, the mismatch
+		// resolves SUPERSEDED before f.turn.State is even consulted.
 		// ResolveControlIntentOutcome validates f.turn.State itself and
 		// returns a typed error for a zero/unknown value rather than
 		// silently resolving it, so a corrupt captured turn state never

--- a/pkg/services/chat_sessions/factory_target_catalog_errors.go
+++ b/pkg/services/chat_sessions/factory_target_catalog_errors.go
@@ -54,6 +54,13 @@ var (
 type FactoryTargetCatalogError struct {
 	Target string
 	Err    error
+	// Cause, when non-nil, is context.Canceled or context.DeadlineExceeded
+	// exactly as returned by the dependency that failed, preserved so a
+	// caller's errors.Is against the original context cause still succeeds
+	// through this typed error. It is deliberately never set for any other
+	// dependency failure, so an arbitrary raw collaborator error can never
+	// leak through this field or become externally classifiable.
+	Cause error
 }
 
 func (e *FactoryTargetCatalogError) Error() string {
@@ -63,8 +70,11 @@ func (e *FactoryTargetCatalogError) Error() string {
 	return fmt.Sprintf("chat sessions: factory target catalog %q: %v", e.Target, e.Err)
 }
 
-// Unwrap exposes the underlying sentinel so errors.Is/errors.As can classify
-// the failure.
-func (e *FactoryTargetCatalogError) Unwrap() error {
-	return e.Err
+// Unwrap exposes the sentinel classification and, when present, the original
+// context cause, so errors.Is can classify the failure by either.
+func (e *FactoryTargetCatalogError) Unwrap() []error {
+	if e.Cause != nil {
+		return []error{e.Err, e.Cause}
+	}
+	return []error{e.Err}
 }

--- a/pkg/services/chat_sessions/internal/service/attachment.go
+++ b/pkg/services/chat_sessions/internal/service/attachment.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"context"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+)
+
+// Attach registers one connection's delivery position against a Chat
+// Session. It reports *NotFoundError for an unknown SessionID and a
+// *ValidationError when ConnectionID is blank; in either failure case no
+// attachment is created. A successful attachment is independent of every
+// other attachment on the session and of the session's own state: it never
+// reads or writes Session, episodes, turns, or control intents.
+func (s *Store) Attach(_ context.Context, req chatsessions.AttachRequest) (chatsessions.AttachResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, ok := s.sessions[req.SessionID]
+	if !ok {
+		return chatsessions.AttachResult{}, &chatsessions.NotFoundError{Value: "Session", ID: req.SessionID}
+	}
+
+	attachment := chatsessions.Attachment{
+		ID:           s.newID(),
+		SessionID:    req.SessionID,
+		ConnectionID: req.ConnectionID,
+		Interactive:  req.Interactive,
+	}
+	if err := attachment.Validate(); err != nil {
+		return chatsessions.AttachResult{}, err
+	}
+
+	record.attachments[attachment.ID] = attachment
+	s.sessions[req.SessionID] = record
+
+	return chatsessions.AttachResult{Attachment: attachment}, nil
+}
+
+// Detach removes one previously registered Attachment. It reports
+// *NotFoundError when SessionID does not identify an existing session or
+// when AttachmentID does not identify an existing attachment on that
+// session; in either failure case no attachment is removed. Removing one
+// attachment never changes any other attachment or the session's own state.
+func (s *Store) Detach(_ context.Context, req chatsessions.DetachRequest) (chatsessions.DetachResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, ok := s.sessions[req.SessionID]
+	if !ok {
+		return chatsessions.DetachResult{}, &chatsessions.NotFoundError{Value: "Session", ID: req.SessionID}
+	}
+	if _, ok := record.attachments[req.AttachmentID]; !ok {
+		return chatsessions.DetachResult{}, &chatsessions.NotFoundError{Value: "Attachment", ID: req.AttachmentID}
+	}
+
+	delete(record.attachments, req.AttachmentID)
+	s.sessions[req.SessionID] = record
+
+	return chatsessions.DetachResult{}, nil
+}

--- a/pkg/services/chat_sessions/internal/service/attachment.go
+++ b/pkg/services/chat_sessions/internal/service/attachment.go
@@ -12,7 +12,11 @@ import (
 // attachment is created. A successful attachment is independent of every
 // other attachment on the session and of the session's own state: it never
 // reads or writes Session, episodes, turns, or control intents.
-func (s *Store) Attach(_ context.Context, req chatsessions.AttachRequest) (chatsessions.AttachResult, error) {
+func (s *Store) Attach(_ context.Context, req chatsessions.AttachRequest) (result chatsessions.AttachResult, err error) {
+	s.logStart("Attach", req.SessionID)
+	defer func() {
+		s.logOutcome("Attach", req.SessionID, err, "attachment_id", result.Attachment.ID)
+	}()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -42,7 +46,11 @@ func (s *Store) Attach(_ context.Context, req chatsessions.AttachRequest) (chats
 // when AttachmentID does not identify an existing attachment on that
 // session; in either failure case no attachment is removed. Removing one
 // attachment never changes any other attachment or the session's own state.
-func (s *Store) Detach(_ context.Context, req chatsessions.DetachRequest) (chatsessions.DetachResult, error) {
+func (s *Store) Detach(_ context.Context, req chatsessions.DetachRequest) (result chatsessions.DetachResult, err error) {
+	s.logStart("Detach", req.SessionID)
+	defer func() {
+		s.logOutcome("Detach", req.SessionID, err, "attachment_id", req.AttachmentID)
+	}()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/pkg/services/chat_sessions/internal/service/attachment_test.go
+++ b/pkg/services/chat_sessions/internal/service/attachment_test.go
@@ -1,0 +1,261 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+)
+
+// newAttachTestSession constructs a Store and one created Session ready for
+// Attach/Detach calls.
+func newAttachTestSession(t *testing.T) (*Store, chatsessions.Session) {
+	t.Helper()
+	store := New(sequentialIDs("session"), fixedClock(time.Now()))
+	created, err := store.CreateSession(context.Background(), validCreateRequest())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	return store, created.Session
+}
+
+// TestStore_Attach_ReturnsDetachedValueWithUniqueID proves a successful
+// Attach retains its own session ID, connection ID, zero initial
+// AfterSequence, and interactive flag as a detached value.
+func TestStore_Attach_ReturnsDetachedValueWithUniqueID(t *testing.T) {
+	ctx := context.Background()
+	store, session := newAttachTestSession(t)
+
+	result, err := store.Attach(ctx, chatsessions.AttachRequest{
+		SessionID:    session.ID,
+		ConnectionID: "conn-a",
+		Interactive:  true,
+	})
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	attachment := result.Attachment
+	if attachment.ID == "" {
+		t.Fatal("Attach: expected a non-blank attachment ID")
+	}
+	if attachment.SessionID != session.ID {
+		t.Fatalf("SessionID = %q, want %q", attachment.SessionID, session.ID)
+	}
+	if attachment.ConnectionID != "conn-a" {
+		t.Fatalf("ConnectionID = %q, want conn-a", attachment.ConnectionID)
+	}
+	if attachment.AfterSequence != 0 {
+		t.Fatalf("AfterSequence = %d, want 0", attachment.AfterSequence)
+	}
+	if !attachment.Interactive {
+		t.Fatal("Interactive = false, want true")
+	}
+
+	attachment.ConnectionID = "mutated"
+	store.mu.RLock()
+	stored := store.sessions[session.ID].attachments[result.Attachment.ID]
+	store.mu.RUnlock()
+	if stored.ConnectionID != "conn-a" {
+		t.Fatalf("mutating returned value affected stored attachment: got %q", stored.ConnectionID)
+	}
+}
+
+// TestStore_Attach_TwoAttachmentsRemainIndependent proves two attachments to
+// the same session with matching other fields remain distinct, and attaching
+// or detaching one does not change the other attachment or the session's
+// stream head, episode history, turns, or version.
+func TestStore_Attach_TwoAttachmentsRemainIndependent(t *testing.T) {
+	ctx := context.Background()
+	store, session := newAttachTestSession(t)
+
+	first, err := store.Attach(ctx, chatsessions.AttachRequest{SessionID: session.ID, ConnectionID: "conn-a", Interactive: true})
+	if err != nil {
+		t.Fatalf("Attach first: %v", err)
+	}
+	second, err := store.Attach(ctx, chatsessions.AttachRequest{SessionID: session.ID, ConnectionID: "conn-a", Interactive: true})
+	if err != nil {
+		t.Fatalf("Attach second: %v", err)
+	}
+	if first.Attachment.ID == second.Attachment.ID {
+		t.Fatalf("two attachments shared ID %q, want distinct", first.Attachment.ID)
+	}
+
+	if _, err := store.Detach(ctx, chatsessions.DetachRequest{SessionID: session.ID, AttachmentID: first.Attachment.ID}); err != nil {
+		t.Fatalf("Detach first: %v", err)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[session.ID]
+	store.mu.RUnlock()
+	if _, ok := record.attachments[first.Attachment.ID]; ok {
+		t.Fatal("detached attachment still present")
+	}
+	remaining, ok := record.attachments[second.Attachment.ID]
+	if !ok {
+		t.Fatal("second attachment was removed by detaching the first")
+	}
+	if remaining != second.Attachment {
+		t.Fatalf("second attachment changed: got %+v, want %+v", remaining, second.Attachment)
+	}
+	if record.session != session {
+		t.Fatalf("attach/detach mutated Session: got %+v, want %+v", record.session, session)
+	}
+	if len(record.episodes) != 1 {
+		t.Fatalf("attach/detach created %d episodes, want 1", len(record.episodes))
+	}
+	if len(record.turns) != 0 {
+		t.Fatalf("attach/detach created %d turns, want 0", len(record.turns))
+	}
+}
+
+// TestStore_Detach_UnknownOrRemovedIsTypedNotFound proves detaching an
+// unknown or already-removed attachment reports *NotFoundError and performs
+// no additional mutation.
+func TestStore_Detach_UnknownOrRemovedIsTypedNotFound(t *testing.T) {
+	ctx := context.Background()
+	store, session := newAttachTestSession(t)
+
+	_, err := store.Detach(ctx, chatsessions.DetachRequest{SessionID: session.ID, AttachmentID: "does-not-exist"})
+	var notFound *chatsessions.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("Detach unknown attachment: got %v, want *NotFoundError", err)
+	}
+	if notFound.Value != "Attachment" || notFound.ID != "does-not-exist" {
+		t.Fatalf("NotFoundError = %+v, want Value=Attachment ID=does-not-exist", notFound)
+	}
+
+	attached, err := store.Attach(ctx, chatsessions.AttachRequest{SessionID: session.ID, ConnectionID: "conn-a"})
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	if _, err := store.Detach(ctx, chatsessions.DetachRequest{SessionID: session.ID, AttachmentID: attached.Attachment.ID}); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+
+	_, err = store.Detach(ctx, chatsessions.DetachRequest{SessionID: session.ID, AttachmentID: attached.Attachment.ID})
+	if !errors.As(err, &notFound) {
+		t.Fatalf("Detach already-removed attachment: got %v, want *NotFoundError", err)
+	}
+	if notFound.Value != "Attachment" || notFound.ID != attached.Attachment.ID {
+		t.Fatalf("NotFoundError = %+v, want Value=Attachment ID=%s", notFound, attached.Attachment.ID)
+	}
+}
+
+// TestStore_Attach_UnknownSessionOrInvalidInputCreatesNoAttachment proves
+// attaching to an unknown session or with a blank ConnectionID reports the
+// applicable typed error and creates no attachment.
+func TestStore_Attach_UnknownSessionOrInvalidInputCreatesNoAttachment(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("unknown session", func(t *testing.T) {
+		store := New(sequentialIDs("session"), fixedClock(time.Now()))
+		_, err := store.Attach(ctx, chatsessions.AttachRequest{SessionID: "does-not-exist", ConnectionID: "conn-a"})
+		var notFound *chatsessions.NotFoundError
+		if !errors.As(err, &notFound) {
+			t.Fatalf("Attach unknown session: got %v, want *NotFoundError", err)
+		}
+		if notFound.Value != "Session" || notFound.ID != "does-not-exist" {
+			t.Fatalf("NotFoundError = %+v, want Value=Session ID=does-not-exist", notFound)
+		}
+	})
+
+	t.Run("blank connection id", func(t *testing.T) {
+		store, session := newAttachTestSession(t)
+		_, err := store.Attach(ctx, chatsessions.AttachRequest{SessionID: session.ID, ConnectionID: ""})
+		if !errors.Is(err, chatsessions.ErrRequiredValue) {
+			t.Fatalf("Attach blank ConnectionID: got %v, want ErrRequiredValue", err)
+		}
+		store.mu.RLock()
+		count := len(store.sessions[session.ID].attachments)
+		store.mu.RUnlock()
+		if count != 0 {
+			t.Fatalf("Attach with invalid input created %d attachments, want 0", count)
+		}
+	})
+}
+
+// TestStore_Detach_UnknownSessionIsTypedNotFound proves Detach against an
+// unknown SessionID reports *NotFoundError naming Session.
+func TestStore_Detach_UnknownSessionIsTypedNotFound(t *testing.T) {
+	ctx := context.Background()
+	store := New(sequentialIDs("session"), fixedClock(time.Now()))
+
+	_, err := store.Detach(ctx, chatsessions.DetachRequest{SessionID: "does-not-exist", AttachmentID: "attachment-1"})
+	var notFound *chatsessions.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("Detach unknown session: got %v, want *NotFoundError", err)
+	}
+	if notFound.Value != "Session" || notFound.ID != "does-not-exist" {
+		t.Fatalf("NotFoundError = %+v, want Value=Session ID=does-not-exist", notFound)
+	}
+}
+
+// TestStore_Attach_ConcurrentAttachAndDetachRaceFree proves concurrent
+// attach/detach operations against one session are race-free, produce
+// unique accepted identities, and settle on exactly the attachments that
+// were never detached.
+func TestStore_Attach_ConcurrentAttachAndDetachRaceFree(t *testing.T) {
+	ctx := context.Background()
+	store, session := newAttachTestSession(t)
+
+	const n = 25
+	ids := make([]string, n)
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			result, err := store.Attach(ctx, chatsessions.AttachRequest{SessionID: session.ID, ConnectionID: "conn-a"})
+			if err != nil {
+				t.Errorf("Attach[%d]: %v", i, err)
+				return
+			}
+			ids[i] = result.Attachment.ID
+		}(i)
+	}
+	wg.Wait()
+
+	seen := make(map[string]bool, n)
+	for _, id := range ids {
+		if id == "" {
+			t.Fatal("Attach produced a blank attachment ID")
+		}
+		if seen[id] {
+			t.Fatalf("Attach produced duplicate ID %q", id)
+		}
+		seen[id] = true
+	}
+
+	toDetach := ids[:n/2]
+	var detachWG sync.WaitGroup
+	for _, id := range toDetach {
+		detachWG.Add(1)
+		go func(id string) {
+			defer detachWG.Done()
+			if _, err := store.Detach(ctx, chatsessions.DetachRequest{SessionID: session.ID, AttachmentID: id}); err != nil {
+				t.Errorf("Detach(%s): %v", id, err)
+			}
+		}(id)
+	}
+	detachWG.Wait()
+
+	store.mu.RLock()
+	record := store.sessions[session.ID]
+	store.mu.RUnlock()
+	if len(record.attachments) != n-len(toDetach) {
+		t.Fatalf("remaining attachments = %d, want %d", len(record.attachments), n-len(toDetach))
+	}
+	for _, id := range toDetach {
+		if _, ok := record.attachments[id]; ok {
+			t.Fatalf("detached attachment %q still present", id)
+		}
+	}
+	for _, id := range ids[n/2:] {
+		if _, ok := record.attachments[id]; !ok {
+			t.Fatalf("non-detached attachment %q missing", id)
+		}
+	}
+}

--- a/pkg/services/chat_sessions/internal/service/control.go
+++ b/pkg/services/chat_sessions/internal/service/control.go
@@ -18,7 +18,13 @@ import (
 // ConnectionID, Kind, or a bare TransportUUID) can never retrieve, advance,
 // overwrite, or deduplicate one another even when their JSON-RPC id tokens
 // happen to match.
-func (s *Store) RequestControl(_ context.Context, req chatsessions.RequestControlRequest) (chatsessions.RequestControlResult, error) {
+func (s *Store) RequestControl(_ context.Context, req chatsessions.RequestControlRequest) (result chatsessions.RequestControlResult, err error) {
+	s.logStart("RequestControl", req.SessionID)
+	defer func() {
+		s.logOutcome("RequestControl", req.SessionID, err,
+			"request_kind", string(req.RequestID.Kind), "action", string(req.Action),
+			"turn_id", result.Intent.TurnID, "target_episode", result.Intent.TargetEpisode)
+	}()
 	if err := req.RequestID.Validate(); err != nil {
 		return chatsessions.RequestControlResult{}, err
 	}
@@ -73,7 +79,12 @@ func (s *Store) RequestControl(_ context.Context, req chatsessions.RequestContro
 // intent's own captured TurnID and the session's live active turn --
 // caller-supplied Next is never consulted for that resolution -- so a
 // delayed advancement can never retarget a captured intent to a later turn.
-func (s *Store) AdvanceControl(_ context.Context, req chatsessions.AdvanceControlRequest) (chatsessions.AdvanceControlResult, error) {
+func (s *Store) AdvanceControl(_ context.Context, req chatsessions.AdvanceControlRequest) (result chatsessions.AdvanceControlResult, err error) {
+	s.logStart("AdvanceControl", req.SessionID)
+	defer func() {
+		s.logOutcome("AdvanceControl", req.SessionID, err,
+			"request_kind", string(req.RequestID.Kind), "state", string(result.Intent.State))
+	}()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/pkg/services/chat_sessions/internal/service/control.go
+++ b/pkg/services/chat_sessions/internal/service/control.go
@@ -85,13 +85,18 @@ func (s *Store) RequestControl(_ context.Context, req chatsessions.RequestContro
 // unchanged. Once an intent is COMMITTED, its terminal outcome is always
 // resolved with chatsessions.ResolveControlIntentOutcome against the
 // intent's own captured TurnID, the captured turn's live State, and the
-// session's lastTurnID -- caller-supplied Next is never consulted for that
-// resolution, so a delayed advancement can never retarget a captured intent
-// to a later turn. lastTurnID (not session.ActiveTurnID) is the comparison
-// point: ActiveTurnID clears to blank the instant the captured turn
-// terminates, which would make every resolution SUPERSEDED and the NOOP
-// outcome unreachable; lastTurnID keeps identifying the captured turn until
-// a newer one is actually admitted, so a cancel racing a same-turn terminal
+// session's record.lastTurnID as that helper's mostRecentTurnID parameter --
+// caller-supplied Next is never consulted for that resolution, so a delayed
+// advancement can never retarget a captured intent to a later turn.
+// record.lastTurnID (not session.ActiveTurnID) is what the helper's
+// mostRecentTurnID parameter requires: a value that keeps identifying the
+// captured turn through that turn's own termination and only changes once a
+// newer turn is actually admitted. session.ActiveTurnID cannot serve that
+// role -- it clears to blank in the very commit that marks a turn terminal,
+// which would make every resolution SUPERSEDED and the NOOP outcome
+// unreachable. Passing lastTurnID is therefore not a substitution for a
+// different value the contract wants; it is the value the contract's own
+// documented semantics require, so a cancel racing a same-turn terminal
 // resolves NOOP while a control racing a since-admitted newer turn resolves
 // SUPERSEDED.
 func (s *Store) AdvanceControl(_ context.Context, req chatsessions.AdvanceControlRequest) (result chatsessions.AdvanceControlResult, err error) {

--- a/pkg/services/chat_sessions/internal/service/control.go
+++ b/pkg/services/chat_sessions/internal/service/control.go
@@ -17,7 +17,12 @@ import (
 // intent's own map key, so structurally distinct identities (differing
 // ConnectionID, Kind, or a bare TransportUUID) can never retrieve, advance,
 // overwrite, or deduplicate one another even when their JSON-RPC id tokens
-// happen to match.
+// happen to match. Reusing an identity that already identifies a requested
+// intent is treated as an idempotent retry: the existing intent is returned
+// unchanged rather than recapturing the (possibly now different) active turn,
+// target episode, or version -- an exact identity can never overwrite or
+// retarget an already-captured, immutable intent, including one requested
+// against an earlier turn that has since terminated and been replaced.
 func (s *Store) RequestControl(_ context.Context, req chatsessions.RequestControlRequest) (result chatsessions.RequestControlResult, err error) {
 	s.logStart("RequestControl", req.SessionID)
 	defer func() {
@@ -39,7 +44,10 @@ func (s *Store) RequestControl(_ context.Context, req chatsessions.RequestContro
 	if !ok {
 		return chatsessions.RequestControlResult{}, &chatsessions.NotFoundError{Value: "Session", ID: req.SessionID}
 	}
-	if record.activeTurn == nil {
+	if existing, exists := record.controls[req.RequestID]; exists {
+		return chatsessions.RequestControlResult{Intent: existing}, nil
+	}
+	if record.session.ActiveTurnID == "" {
 		return chatsessions.RequestControlResult{}, &chatsessions.NotFoundError{Value: "Turn", ID: ""}
 	}
 	if req.ExpectedVersion != record.session.Version {
@@ -52,7 +60,7 @@ func (s *Store) RequestControl(_ context.Context, req chatsessions.RequestContro
 	intent := chatsessions.ControlIntent{
 		RequestID:       req.RequestID,
 		SessionID:       req.SessionID,
-		TurnID:          record.activeTurn.ID,
+		TurnID:          record.session.ActiveTurnID,
 		TargetEpisode:   record.session.TargetEpisode,
 		ExpectedVersion: req.ExpectedVersion,
 		Action:          req.Action,
@@ -76,9 +84,16 @@ func (s *Store) RequestControl(_ context.Context, req chatsessions.RequestContro
 // current state; on either failure the stored intent is left byte-for-byte
 // unchanged. Once an intent is COMMITTED, its terminal outcome is always
 // resolved with chatsessions.ResolveControlIntentOutcome against the
-// intent's own captured TurnID and the session's live active turn --
-// caller-supplied Next is never consulted for that resolution -- so a
-// delayed advancement can never retarget a captured intent to a later turn.
+// intent's own captured TurnID, the captured turn's live State, and the
+// session's lastTurnID -- caller-supplied Next is never consulted for that
+// resolution, so a delayed advancement can never retarget a captured intent
+// to a later turn. lastTurnID (not session.ActiveTurnID) is the comparison
+// point: ActiveTurnID clears to blank the instant the captured turn
+// terminates, which would make every resolution SUPERSEDED and the NOOP
+// outcome unreachable; lastTurnID keeps identifying the captured turn until
+// a newer one is actually admitted, so a cancel racing a same-turn terminal
+// resolves NOOP while a control racing a since-admitted newer turn resolves
+// SUPERSEDED.
 func (s *Store) AdvanceControl(_ context.Context, req chatsessions.AdvanceControlRequest) (result chatsessions.AdvanceControlResult, err error) {
 	s.logStart("AdvanceControl", req.SessionID)
 	defer func() {
@@ -100,7 +115,7 @@ func (s *Store) AdvanceControl(_ context.Context, req chatsessions.AdvanceContro
 	next := req.Next
 	if intent.State == chatsessions.ControlIntentStateCommitted {
 		capturedTurn := record.turns[intent.TurnID]
-		outcome, err := chatsessions.ResolveControlIntentOutcome(intent.TurnID, capturedTurn.State, record.session.ActiveTurnID)
+		outcome, err := chatsessions.ResolveControlIntentOutcome(intent.TurnID, capturedTurn.State, record.lastTurnID)
 		if err != nil {
 			return chatsessions.AdvanceControlResult{}, err
 		}

--- a/pkg/services/chat_sessions/internal/service/control.go
+++ b/pkg/services/chat_sessions/internal/service/control.go
@@ -1,0 +1,112 @@
+package service
+
+import (
+	"context"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+)
+
+// RequestControl atomically captures the session's current active turn,
+// target episode, and expected version as a new REQUESTED ControlIntent
+// under an optimistic-version guard. It reports *ValidationError wrapping
+// ErrUnsupportedControlAction for a declared-but-not-yet-executable Action,
+// *NotFoundError when there is no active turn to target, and *ConflictError
+// when ExpectedVersion no longer matches the session's current version -- in
+// every failure case no control intent is created and the stored session and
+// control state are left byte-for-byte unchanged. RequestID is stored as the
+// intent's own map key, so structurally distinct identities (differing
+// ConnectionID, Kind, or a bare TransportUUID) can never retrieve, advance,
+// overwrite, or deduplicate one another even when their JSON-RPC id tokens
+// happen to match.
+func (s *Store) RequestControl(_ context.Context, req chatsessions.RequestControlRequest) (chatsessions.RequestControlResult, error) {
+	if err := req.RequestID.Validate(); err != nil {
+		return chatsessions.RequestControlResult{}, err
+	}
+	if err := req.Action.Validate(); err != nil {
+		return chatsessions.RequestControlResult{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, ok := s.sessions[req.SessionID]
+	if !ok {
+		return chatsessions.RequestControlResult{}, &chatsessions.NotFoundError{Value: "Session", ID: req.SessionID}
+	}
+	if record.activeTurn == nil {
+		return chatsessions.RequestControlResult{}, &chatsessions.NotFoundError{Value: "Turn", ID: ""}
+	}
+	if req.ExpectedVersion != record.session.Version {
+		return chatsessions.RequestControlResult{}, &chatsessions.ConflictError{
+			Value: "Session", ID: req.SessionID,
+			Expected: req.ExpectedVersion, Actual: record.session.Version,
+		}
+	}
+
+	intent := chatsessions.ControlIntent{
+		RequestID:       req.RequestID,
+		SessionID:       req.SessionID,
+		TurnID:          record.activeTurn.ID,
+		TargetEpisode:   record.session.TargetEpisode,
+		ExpectedVersion: req.ExpectedVersion,
+		Action:          req.Action,
+		State:           chatsessions.ControlIntentStateRequested,
+		RequestedAt:     s.now(),
+	}
+	if err := intent.Validate(); err != nil {
+		return chatsessions.RequestControlResult{}, err
+	}
+
+	record.controls[req.RequestID] = intent
+	s.sessions[req.SessionID] = record
+
+	return chatsessions.RequestControlResult{Intent: intent}, nil
+}
+
+// AdvanceControl moves one ControlIntent to Next, enforcing the
+// ControlIntentState transition table. It reports *NotFoundError when the
+// intent identified by SessionID and RequestID does not exist and
+// *TransitionError when Next is not a legal transition from the intent's
+// current state; on either failure the stored intent is left byte-for-byte
+// unchanged. Once an intent is COMMITTED, its terminal outcome is always
+// resolved with chatsessions.ResolveControlIntentOutcome against the
+// intent's own captured TurnID and the session's live active turn --
+// caller-supplied Next is never consulted for that resolution -- so a
+// delayed advancement can never retarget a captured intent to a later turn.
+func (s *Store) AdvanceControl(_ context.Context, req chatsessions.AdvanceControlRequest) (chatsessions.AdvanceControlResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, ok := s.sessions[req.SessionID]
+	if !ok {
+		return chatsessions.AdvanceControlResult{}, &chatsessions.NotFoundError{Value: "ControlIntent", ID: req.SessionID}
+	}
+	intent, ok := record.controls[req.RequestID]
+	if !ok {
+		return chatsessions.AdvanceControlResult{}, &chatsessions.NotFoundError{Value: "ControlIntent", ID: req.SessionID}
+	}
+
+	next := req.Next
+	if intent.State == chatsessions.ControlIntentStateCommitted {
+		capturedTurn := record.turns[intent.TurnID]
+		outcome, err := chatsessions.ResolveControlIntentOutcome(intent.TurnID, capturedTurn.State, record.session.ActiveTurnID)
+		if err != nil {
+			return chatsessions.AdvanceControlResult{}, err
+		}
+		next = outcome
+	}
+	if err := intent.State.CanTransitionTo(next); err != nil {
+		return chatsessions.AdvanceControlResult{}, err
+	}
+
+	updated := intent
+	updated.State = next
+	if err := updated.Validate(); err != nil {
+		return chatsessions.AdvanceControlResult{}, err
+	}
+
+	record.controls[req.RequestID] = updated
+	s.sessions[req.SessionID] = record
+
+	return chatsessions.AdvanceControlResult{Intent: updated}, nil
+}

--- a/pkg/services/chat_sessions/internal/service/control_test.go
+++ b/pkg/services/chat_sessions/internal/service/control_test.go
@@ -268,6 +268,86 @@ func TestStore_RequestControl_StaleVersionConflictLeavesStateUnchanged(t *testin
 	}
 }
 
+// TestStore_RequestControl_DuplicateIdentityBeforeAdvancementIsIdempotent
+// proves reusing a RequestID that already identifies a REQUESTED intent
+// returns the existing intent unchanged rather than recapturing state --
+// even when the second call's own Action or ExpectedVersion differs from
+// what was originally captured.
+func TestStore_RequestControl_DuplicateIdentityBeforeAdvancementIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	store, session, turn := newActiveTurnTestSession(t, time.Now())
+	reqID := controlRequestID("conn-1", "1")
+
+	first, err := store.RequestControl(ctx, chatsessions.RequestControlRequest{
+		RequestID: reqID, SessionID: session.ID, ExpectedVersion: session.Version, Action: chatsessions.ControlActionCancel,
+	})
+	if err != nil {
+		t.Fatalf("RequestControl first: %v", err)
+	}
+
+	second, err := store.RequestControl(ctx, chatsessions.RequestControlRequest{
+		RequestID: reqID, SessionID: session.ID, ExpectedVersion: session.Version, Action: chatsessions.ControlActionCancel,
+	})
+	if err != nil {
+		t.Fatalf("RequestControl duplicate: %v", err)
+	}
+	if second.Intent != first.Intent {
+		t.Fatalf("duplicate RequestControl returned a different intent: got %+v, want %+v", second.Intent, first.Intent)
+	}
+	if second.Intent.TurnID != turn.ID {
+		t.Fatalf("duplicate RequestControl retargeted TurnID: got %q, want %q", second.Intent.TurnID, turn.ID)
+	}
+
+	store.mu.RLock()
+	controlCount := len(store.sessions[session.ID].controls)
+	store.mu.RUnlock()
+	if controlCount != 1 {
+		t.Fatalf("controls after duplicate request = %d, want 1", controlCount)
+	}
+}
+
+// TestStore_RequestControl_DuplicateIdentityAfterNewTurnNeverRetargets proves
+// AC5's "later work cannot become the target of an older intent" guarantee:
+// reusing a RequestID after its original intent advanced to COMMITTED and a
+// later turn started never rewrites the stored intent's captured turn,
+// target episode, or version to the newer facts -- the exact identity is
+// immutable once it has been used.
+func TestStore_RequestControl_DuplicateIdentityAfterNewTurnNeverRetargets(t *testing.T) {
+	ctx := context.Background()
+	store, session, turn := newActiveTurnTestSession(t, time.Now())
+	reqID := controlRequestID("conn-1", "1")
+	committed := committedControlIntent(t, ctx, store, session, reqID)
+
+	if _, err := store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: session.ID, TurnID: turn.ID, Next: chatsessions.TurnStateCanceled,
+	}); err != nil {
+		t.Fatalf("AdvanceTurn to terminal: %v", err)
+	}
+	released, err := store.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: session.ID})
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	newTurn, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID: startTurnRequestID("req-turn-2"), SessionID: session.ID, ExpectedVersion: released.Session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn second: %v", err)
+	}
+
+	replay, err := store.RequestControl(ctx, chatsessions.RequestControlRequest{
+		RequestID: reqID, SessionID: session.ID, ExpectedVersion: newTurn.Session.Version, Action: chatsessions.ControlActionCancel,
+	})
+	if err != nil {
+		t.Fatalf("RequestControl duplicate after new turn: %v", err)
+	}
+	if replay.Intent != committed {
+		t.Fatalf("duplicate RequestControl after new turn changed the stored intent: got %+v, want %+v", replay.Intent, committed)
+	}
+	if replay.Intent.TurnID == newTurn.Turn.ID {
+		t.Fatal("duplicate RequestControl after new turn retargeted TurnID to the new turn")
+	}
+}
+
 // TestStore_AdvanceControl_RequestedToCommitted proves the first legal
 // advancement (REQUESTED->COMMITTED) is a plain state transition, not routed
 // through ResolveControlIntentOutcome.
@@ -451,13 +531,19 @@ func TestStore_AdvanceControl_OldControlVersusNewTurnResolvesSuperseded(t *testi
 	}
 }
 
-// TestStore_AdvanceControl_CancelVersusTerminalResolvesSuperseded proves
-// AC6's deterministic "cancel-versus-terminal" race: when the captured turn
-// terminates on its own (with no successor turn yet admitted) before a
-// COMMITTED cancel resolves, the intent observes the release and resolves to
-// SUPERSEDED -- it is never left ambiguously COMPLETED against a turn that no
-// longer needs canceling.
-func TestStore_AdvanceControl_CancelVersusTerminalResolvesSuperseded(t *testing.T) {
+// TestStore_AdvanceControl_CancelVersusTerminalResolvesNoop proves AC6's
+// deterministic "cancel-versus-terminal" race through the public API alone:
+// when the captured turn terminates on its own (with no successor turn yet
+// admitted) before a COMMITTED cancel resolves, the intent observes there is
+// nothing left to cancel and resolves to NOOP -- distinct from SUPERSEDED,
+// which is reserved for a captured turn that a newer admitted turn has since
+// replaced (see TestStore_AdvanceControl_OldControlVersusNewTurnResolvesSuperseded).
+// Resolution reads Session.lastTurnID, which (unlike ActiveTurnID) is not
+// cleared when the captured turn terminates, only overwritten by the next
+// StartTurn -- so this same-turn, no-successor case is distinguishable from
+// the new-turn case entirely through public Store calls, without fabricating
+// private state.
+func TestStore_AdvanceControl_CancelVersusTerminalResolvesNoop(t *testing.T) {
 	ctx := context.Background()
 	store, session, turn := newActiveTurnTestSession(t, time.Now())
 	reqID := controlRequestID("conn-1", "1")
@@ -475,49 +561,11 @@ func TestStore_AdvanceControl_CancelVersusTerminalResolvesSuperseded(t *testing.
 	if err != nil {
 		t.Fatalf("AdvanceControl: %v", err)
 	}
-	if result.Intent.State != chatsessions.ControlIntentStateSuperseded {
-		t.Fatalf("Intent.State = %v, want SUPERSEDED", result.Intent.State)
-	}
-	if result.Intent.TurnID != intent.TurnID {
-		t.Fatalf("resolution retargeted intent: TurnID = %q, want unchanged %q", result.Intent.TurnID, intent.TurnID)
-	}
-}
-
-// TestStore_AdvanceControl_ResolvesNoopWhenCapturedTurnStillCurrentButTerminal
-// exercises ResolveControlIntentOutcome's NOOP branch (a captured turn that
-// is still the session's nominal ActiveTurnID yet already carries a terminal
-// state). This Store's own AdvanceTurn always clears ActiveTurnID in the
-// same atomic commit that marks a turn terminal (story 003), so this
-// bookkeeping shape cannot arise through the public API alone; the turn's
-// stored state is set directly to reach it, proving AdvanceControl still
-// routes every COMMITTED resolution through ResolveControlIntentOutcome
-// rather than special-casing COMPLETED/SUPERSEDED in its own code.
-func TestStore_AdvanceControl_ResolvesNoopWhenCapturedTurnStillCurrentButTerminal(t *testing.T) {
-	ctx := context.Background()
-	store, session, turn := newActiveTurnTestSession(t, time.Now())
-	reqID := controlRequestID("conn-1", "1")
-	intent := committedControlIntent(t, ctx, store, session, reqID)
-
-	store.mu.Lock()
-	record := store.sessions[session.ID]
-	terminalTurn := record.turns[turn.ID]
-	terminalTurn.State = chatsessions.TurnStateCompleted
-	terminalTurn.TerminalSequence = 1
-	record.turns[turn.ID] = terminalTurn
-	store.sessions[session.ID] = record
-	store.mu.Unlock()
-
-	result, err := store.AdvanceControl(ctx, chatsessions.AdvanceControlRequest{
-		SessionID: session.ID, RequestID: reqID, Next: chatsessions.ControlIntentStateCompleted,
-	})
-	if err != nil {
-		t.Fatalf("AdvanceControl: %v", err)
-	}
 	if result.Intent.State != chatsessions.ControlIntentStateNoop {
 		t.Fatalf("Intent.State = %v, want NOOP", result.Intent.State)
 	}
 	if result.Intent.TurnID != intent.TurnID {
-		t.Fatalf("NOOP resolution retargeted intent: TurnID = %q, want unchanged %q", result.Intent.TurnID, intent.TurnID)
+		t.Fatalf("resolution retargeted intent: TurnID = %q, want unchanged %q", result.Intent.TurnID, intent.TurnID)
 	}
 }
 

--- a/pkg/services/chat_sessions/internal/service/control_test.go
+++ b/pkg/services/chat_sessions/internal/service/control_test.go
@@ -1,0 +1,570 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+)
+
+func controlRequestID(connID, id string) chatsessions.RequestIdentity {
+	return chatsessions.RequestIdentity{Kind: chatsessions.RequestIdentityKindJSONRPCString, ConnectionID: connID, JSONRPCStringID: id}
+}
+
+// newActiveTurnTestSession constructs a Store with one Session that has
+// already admitted its first, still-active Turn, ready for RequestControl
+// calls.
+func newActiveTurnTestSession(t *testing.T, now time.Time) (*Store, chatsessions.Session, chatsessions.Turn) {
+	t.Helper()
+	store := New(sequentialIDs("session"), fixedClock(now))
+	created, err := store.CreateSession(context.Background(), validCreateRequest())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	started, err := store.StartTurn(context.Background(), chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-1"),
+		SessionID:       created.Session.ID,
+		ExpectedVersion: created.Session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn: %v", err)
+	}
+	return store, started.Session, started.Turn
+}
+
+// TestStore_RequestControl_CapturesActiveTurnAtomically proves a supported
+// control request with the current session version creates a REQUESTED
+// intent retaining the full request identity and atomically capturing the
+// active turn ID, target episode, expected version, action, and request
+// time, without changing the session's version.
+func TestStore_RequestControl_CapturesActiveTurnAtomically(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	store, session, turn := newActiveTurnTestSession(t, now)
+
+	reqID := controlRequestID("conn-1", "cancel-1")
+	result, err := store.RequestControl(ctx, chatsessions.RequestControlRequest{
+		RequestID:       reqID,
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+		Action:          chatsessions.ControlActionCancel,
+	})
+	if err != nil {
+		t.Fatalf("RequestControl: %v", err)
+	}
+	intent := result.Intent
+	if intent.RequestID != reqID {
+		t.Fatalf("Intent.RequestID = %+v, want %+v", intent.RequestID, reqID)
+	}
+	if intent.SessionID != session.ID {
+		t.Fatalf("Intent.SessionID = %q, want %q", intent.SessionID, session.ID)
+	}
+	if intent.TurnID != turn.ID {
+		t.Fatalf("Intent.TurnID = %q, want %q", intent.TurnID, turn.ID)
+	}
+	if intent.TargetEpisode != session.TargetEpisode {
+		t.Fatalf("Intent.TargetEpisode = %d, want %d", intent.TargetEpisode, session.TargetEpisode)
+	}
+	if intent.ExpectedVersion != session.Version {
+		t.Fatalf("Intent.ExpectedVersion = %d, want %d", intent.ExpectedVersion, session.Version)
+	}
+	if intent.Action != chatsessions.ControlActionCancel {
+		t.Fatalf("Intent.Action = %v, want CANCEL", intent.Action)
+	}
+	if intent.State != chatsessions.ControlIntentStateRequested {
+		t.Fatalf("Intent.State = %v, want REQUESTED", intent.State)
+	}
+	if intent.RequestedAt.IsZero() {
+		t.Fatal("Intent.RequestedAt must be non-zero")
+	}
+	if err := intent.Validate(); err != nil {
+		t.Fatalf("requested Intent fails its own Validate: %v", err)
+	}
+
+	afterVersion, err := store.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: session.ID})
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if afterVersion.Session.Version != session.Version {
+		t.Fatalf("RequestControl changed Session.Version: got %d, want %d", afterVersion.Session.Version, session.Version)
+	}
+}
+
+// TestStore_RequestControl_DistinctConnectionsNeverCollide proves two
+// control requests carrying equal JSON-RPC string ids from different
+// ConnectionIDs remain distinct keys: both are accepted, and advancing one
+// never retrieves, overwrites, or deduplicates against the other.
+func TestStore_RequestControl_DistinctConnectionsNeverCollide(t *testing.T) {
+	ctx := context.Background()
+	store, session, _ := newActiveTurnTestSession(t, time.Now())
+
+	reqA := controlRequestID("conn-A", "1")
+	reqB := controlRequestID("conn-B", "1")
+
+	resultA, err := store.RequestControl(ctx, chatsessions.RequestControlRequest{
+		RequestID: reqA, SessionID: session.ID, ExpectedVersion: session.Version, Action: chatsessions.ControlActionCancel,
+	})
+	if err != nil {
+		t.Fatalf("RequestControl A: %v", err)
+	}
+	resultB, err := store.RequestControl(ctx, chatsessions.RequestControlRequest{
+		RequestID: reqB, SessionID: session.ID, ExpectedVersion: session.Version, Action: chatsessions.ControlActionClose,
+	})
+	if err != nil {
+		t.Fatalf("RequestControl B: %v", err)
+	}
+	if resultA.Intent.RequestID != reqA || resultB.Intent.RequestID != reqB {
+		t.Fatalf("RequestControl returned mismatched identities: A=%+v B=%+v", resultA.Intent.RequestID, resultB.Intent.RequestID)
+	}
+
+	store.mu.RLock()
+	controlCount := len(store.sessions[session.ID].controls)
+	store.mu.RUnlock()
+	if controlCount != 2 {
+		t.Fatalf("stored control intents = %d, want 2", controlCount)
+	}
+
+	committedA, err := store.AdvanceControl(ctx, chatsessions.AdvanceControlRequest{
+		SessionID: session.ID, RequestID: reqA, Next: chatsessions.ControlIntentStateCommitted,
+	})
+	if err != nil {
+		t.Fatalf("AdvanceControl A: %v", err)
+	}
+	if committedA.Intent.RequestID != reqA || committedA.Intent.Action != chatsessions.ControlActionCancel {
+		t.Fatalf("AdvanceControl A retrieved wrong intent: %+v", committedA.Intent)
+	}
+
+	committedB, err := store.AdvanceControl(ctx, chatsessions.AdvanceControlRequest{
+		SessionID: session.ID, RequestID: reqB, Next: chatsessions.ControlIntentStateCommitted,
+	})
+	if err != nil {
+		t.Fatalf("AdvanceControl B: %v", err)
+	}
+	if committedB.Intent.RequestID != reqB || committedB.Intent.Action != chatsessions.ControlActionClose {
+		t.Fatalf("AdvanceControl B retrieved wrong intent: %+v", committedB.Intent)
+	}
+
+	store.mu.RLock()
+	stillA := store.sessions[session.ID].controls[reqA]
+	store.mu.RUnlock()
+	if stillA.State != chatsessions.ControlIntentStateCommitted || stillA.Action != chatsessions.ControlActionCancel {
+		t.Fatalf("advancing B mutated A: got %+v", stillA)
+	}
+}
+
+// TestStore_RequestControl_InvalidIdentityCreatesNoMutation proves an
+// invalid RequestIdentity (mixed fields inconsistent with its declared Kind)
+// reports the existing typed validation classification and creates no
+// control intent.
+func TestStore_RequestControl_InvalidIdentityCreatesNoMutation(t *testing.T) {
+	ctx := context.Background()
+	store, session, _ := newActiveTurnTestSession(t, time.Now())
+
+	invalid := chatsessions.RequestIdentity{
+		Kind: chatsessions.RequestIdentityKindTransportUUID, ConnectionID: "conn-1", TransportUUID: "not-a-uuid",
+	}
+	_, err := store.RequestControl(ctx, chatsessions.RequestControlRequest{
+		RequestID: invalid, SessionID: session.ID, ExpectedVersion: session.Version, Action: chatsessions.ControlActionCancel,
+	})
+	if !errors.Is(err, chatsessions.ErrInconsistentValue) {
+		t.Fatalf("RequestControl invalid identity: got %v, want ErrInconsistentValue", err)
+	}
+
+	store.mu.RLock()
+	controlCount := len(store.sessions[session.ID].controls)
+	store.mu.RUnlock()
+	if controlCount != 0 {
+		t.Fatalf("invalid RequestControl created %d intents, want 0", controlCount)
+	}
+}
+
+// TestStore_RequestControl_UnsupportedActionCreatesNoMutation proves a
+// declared-but-not-executable ControlAction (PAUSE) reports a
+// *ValidationError wrapping ErrUnsupportedControlAction and creates no
+// control intent or version change.
+func TestStore_RequestControl_UnsupportedActionCreatesNoMutation(t *testing.T) {
+	ctx := context.Background()
+	store, session, _ := newActiveTurnTestSession(t, time.Now())
+
+	_, err := store.RequestControl(ctx, chatsessions.RequestControlRequest{
+		RequestID: controlRequestID("conn-1", "1"), SessionID: session.ID,
+		ExpectedVersion: session.Version, Action: chatsessions.ControlActionPause,
+	})
+	if !errors.Is(err, chatsessions.ErrUnsupportedControlAction) {
+		t.Fatalf("RequestControl unsupported action: got %v, want ErrUnsupportedControlAction", err)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[session.ID]
+	store.mu.RUnlock()
+	if len(record.controls) != 0 {
+		t.Fatalf("unsupported action created %d intents, want 0", len(record.controls))
+	}
+	if record.session.Version != session.Version {
+		t.Fatalf("unsupported action changed Session.Version: got %d, want %d", record.session.Version, session.Version)
+	}
+}
+
+// TestStore_RequestControl_NoActiveTurnIsNotFound proves a control request
+// against a session with no active turn reports typed *NotFoundError and
+// creates no control intent.
+func TestStore_RequestControl_NoActiveTurnIsNotFound(t *testing.T) {
+	ctx := context.Background()
+	store := New(sequentialIDs("session"), fixedClock(time.Now()))
+	created, err := store.CreateSession(ctx, validCreateRequest())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	_, err = store.RequestControl(ctx, chatsessions.RequestControlRequest{
+		RequestID: controlRequestID("conn-1", "1"), SessionID: created.Session.ID,
+		ExpectedVersion: created.Session.Version, Action: chatsessions.ControlActionCancel,
+	})
+	var notFound *chatsessions.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("RequestControl no active turn: got %v, want *NotFoundError", err)
+	}
+	if notFound.Value != "Turn" {
+		t.Fatalf("NotFoundError.Value = %q, want Turn", notFound.Value)
+	}
+
+	store.mu.RLock()
+	controlCount := len(store.sessions[created.Session.ID].controls)
+	store.mu.RUnlock()
+	if controlCount != 0 {
+		t.Fatalf("no-active-turn RequestControl created %d intents, want 0", controlCount)
+	}
+}
+
+// TestStore_RequestControl_StaleVersionConflictLeavesStateUnchanged proves a
+// stale expected version reports typed *ConflictError and creates no control
+// intent or version change.
+func TestStore_RequestControl_StaleVersionConflictLeavesStateUnchanged(t *testing.T) {
+	ctx := context.Background()
+	store, session, _ := newActiveTurnTestSession(t, time.Now())
+
+	_, err := store.RequestControl(ctx, chatsessions.RequestControlRequest{
+		RequestID: controlRequestID("conn-1", "1"), SessionID: session.ID,
+		ExpectedVersion: session.Version + 1, Action: chatsessions.ControlActionCancel,
+	})
+	var conflict *chatsessions.ConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("RequestControl stale version: got %v, want *ConflictError", err)
+	}
+	if conflict.Expected != session.Version+1 || conflict.Actual != session.Version {
+		t.Fatalf("ConflictError = %+v, want Expected=%d Actual=%d", conflict, session.Version+1, session.Version)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[session.ID]
+	store.mu.RUnlock()
+	if len(record.controls) != 0 {
+		t.Fatalf("stale RequestControl created %d intents, want 0", len(record.controls))
+	}
+	if record.session != session {
+		t.Fatalf("stale RequestControl mutated Session: got %+v, want %+v", record.session, session)
+	}
+}
+
+// TestStore_AdvanceControl_RequestedToCommitted proves the first legal
+// advancement (REQUESTED->COMMITTED) is a plain state transition, not routed
+// through ResolveControlIntentOutcome.
+func TestStore_AdvanceControl_RequestedToCommitted(t *testing.T) {
+	ctx := context.Background()
+	store, session, _ := newActiveTurnTestSession(t, time.Now())
+	reqID := controlRequestID("conn-1", "1")
+	requested, err := store.RequestControl(ctx, chatsessions.RequestControlRequest{
+		RequestID: reqID, SessionID: session.ID, ExpectedVersion: session.Version, Action: chatsessions.ControlActionCancel,
+	})
+	if err != nil {
+		t.Fatalf("RequestControl: %v", err)
+	}
+
+	committed, err := store.AdvanceControl(ctx, chatsessions.AdvanceControlRequest{
+		SessionID: session.ID, RequestID: reqID, Next: chatsessions.ControlIntentStateCommitted,
+	})
+	if err != nil {
+		t.Fatalf("AdvanceControl REQUESTED->COMMITTED: %v", err)
+	}
+	if committed.Intent.State != chatsessions.ControlIntentStateCommitted {
+		t.Fatalf("Intent.State = %v, want COMMITTED", committed.Intent.State)
+	}
+	if committed.Intent.TurnID != requested.Intent.TurnID {
+		t.Fatalf("commit changed captured TurnID: got %q, want %q", committed.Intent.TurnID, requested.Intent.TurnID)
+	}
+}
+
+// TestStore_AdvanceControl_IllegalDirectRequestedToCompletedLeavesUnchanged
+// proves an illegal REQUESTED->COMPLETED advancement (skipping COMMITTED)
+// reports typed *TransitionError and leaves the stored intent unchanged.
+func TestStore_AdvanceControl_IllegalDirectRequestedToCompletedLeavesUnchanged(t *testing.T) {
+	ctx := context.Background()
+	store, session, _ := newActiveTurnTestSession(t, time.Now())
+	reqID := controlRequestID("conn-1", "1")
+	requested, err := store.RequestControl(ctx, chatsessions.RequestControlRequest{
+		RequestID: reqID, SessionID: session.ID, ExpectedVersion: session.Version, Action: chatsessions.ControlActionCancel,
+	})
+	if err != nil {
+		t.Fatalf("RequestControl: %v", err)
+	}
+
+	_, err = store.AdvanceControl(ctx, chatsessions.AdvanceControlRequest{
+		SessionID: session.ID, RequestID: reqID, Next: chatsessions.ControlIntentStateCompleted,
+	})
+	var transition *chatsessions.TransitionError
+	if !errors.As(err, &transition) {
+		t.Fatalf("AdvanceControl REQUESTED->COMPLETED: got %v, want *TransitionError", err)
+	}
+
+	store.mu.RLock()
+	stored := store.sessions[session.ID].controls[reqID]
+	store.mu.RUnlock()
+	if stored != requested.Intent {
+		t.Fatalf("illegal AdvanceControl mutated intent: got %+v, want %+v", stored, requested.Intent)
+	}
+}
+
+// TestStore_AdvanceControl_UnknownIntentIsTypedNotFound proves AdvanceControl
+// against an unknown RequestID (on a known or unknown session) reports typed
+// *NotFoundError naming the ControlIntent.
+func TestStore_AdvanceControl_UnknownIntentIsTypedNotFound(t *testing.T) {
+	ctx := context.Background()
+	store, session, _ := newActiveTurnTestSession(t, time.Now())
+
+	_, err := store.AdvanceControl(ctx, chatsessions.AdvanceControlRequest{
+		SessionID: session.ID, RequestID: controlRequestID("conn-1", "does-not-exist"),
+		Next: chatsessions.ControlIntentStateCommitted,
+	})
+	var notFound *chatsessions.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("AdvanceControl unknown intent: got %v, want *NotFoundError", err)
+	}
+	if notFound.Value != "ControlIntent" {
+		t.Fatalf("NotFoundError.Value = %q, want ControlIntent", notFound.Value)
+	}
+
+	_, err = store.AdvanceControl(ctx, chatsessions.AdvanceControlRequest{
+		SessionID: "does-not-exist-session", RequestID: controlRequestID("conn-1", "1"),
+		Next: chatsessions.ControlIntentStateCommitted,
+	})
+	if !errors.As(err, &notFound) {
+		t.Fatalf("AdvanceControl unknown session: got %v, want *NotFoundError", err)
+	}
+	if notFound.Value != "ControlIntent" {
+		t.Fatalf("NotFoundError.Value = %q, want ControlIntent", notFound.Value)
+	}
+}
+
+// committedControlIntent creates a session with one active turn, requests a
+// CANCEL control against it, and commits the intent, returning the session,
+// turn, and committed intent for further advancement.
+func committedControlIntent(t *testing.T, ctx context.Context, store *Store, session chatsessions.Session, reqID chatsessions.RequestIdentity) chatsessions.ControlIntent {
+	t.Helper()
+	if _, err := store.RequestControl(ctx, chatsessions.RequestControlRequest{
+		RequestID: reqID, SessionID: session.ID, ExpectedVersion: session.Version, Action: chatsessions.ControlActionCancel,
+	}); err != nil {
+		t.Fatalf("RequestControl: %v", err)
+	}
+	committed, err := store.AdvanceControl(ctx, chatsessions.AdvanceControlRequest{
+		SessionID: session.ID, RequestID: reqID, Next: chatsessions.ControlIntentStateCommitted,
+	})
+	if err != nil {
+		t.Fatalf("AdvanceControl REQUESTED->COMMITTED: %v", err)
+	}
+	return committed.Intent
+}
+
+// TestStore_AdvanceControl_ResolvesCompletedWhileTurnStillActive proves a
+// COMMITTED intent whose captured turn is still current and non-terminal
+// resolves to COMPLETED regardless of the caller-supplied Next.
+func TestStore_AdvanceControl_ResolvesCompletedWhileTurnStillActive(t *testing.T) {
+	ctx := context.Background()
+	store, session, turn := newActiveTurnTestSession(t, time.Now())
+	reqID := controlRequestID("conn-1", "1")
+	intent := committedControlIntent(t, ctx, store, session, reqID)
+	if intent.TurnID != turn.ID {
+		t.Fatalf("captured TurnID = %q, want %q", intent.TurnID, turn.ID)
+	}
+
+	result, err := store.AdvanceControl(ctx, chatsessions.AdvanceControlRequest{
+		SessionID: session.ID, RequestID: reqID, Next: chatsessions.ControlIntentStateNoop,
+	})
+	if err != nil {
+		t.Fatalf("AdvanceControl: %v", err)
+	}
+	if result.Intent.State != chatsessions.ControlIntentStateCompleted {
+		t.Fatalf("Intent.State = %v, want COMPLETED (caller-supplied Next must be ignored once COMMITTED)", result.Intent.State)
+	}
+}
+
+// TestStore_AdvanceControl_OldControlVersusNewTurnResolvesSuperseded proves
+// AC5's deterministic "old-control-versus-new-turn" race: once the captured
+// turn terminates and a later turn is admitted, advancing the older
+// committed intent resolves to SUPERSEDED and never completes, no-ops, or
+// retargets the later turn.
+func TestStore_AdvanceControl_OldControlVersusNewTurnResolvesSuperseded(t *testing.T) {
+	ctx := context.Background()
+	store, session, turn := newActiveTurnTestSession(t, time.Now())
+	reqID := controlRequestID("conn-1", "1")
+	intent := committedControlIntent(t, ctx, store, session, reqID)
+
+	if _, err := store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: session.ID, TurnID: turn.ID, Next: chatsessions.TurnStateCanceled,
+	}); err != nil {
+		t.Fatalf("AdvanceTurn to terminal: %v", err)
+	}
+	released, err := store.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: session.ID})
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	newTurn, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID: startTurnRequestID("req-turn-2"), SessionID: session.ID, ExpectedVersion: released.Session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn second: %v", err)
+	}
+	if newTurn.Turn.ID == turn.ID {
+		t.Fatal("second StartTurn reused the first turn's ID")
+	}
+
+	result, err := store.AdvanceControl(ctx, chatsessions.AdvanceControlRequest{
+		SessionID: session.ID, RequestID: reqID, Next: chatsessions.ControlIntentStateCompleted,
+	})
+	if err != nil {
+		t.Fatalf("AdvanceControl: %v", err)
+	}
+	if result.Intent.State != chatsessions.ControlIntentStateSuperseded {
+		t.Fatalf("Intent.State = %v, want SUPERSEDED", result.Intent.State)
+	}
+	if result.Intent.TurnID != intent.TurnID {
+		t.Fatalf("SUPERSEDED intent retargeted: TurnID = %q, want unchanged %q", result.Intent.TurnID, intent.TurnID)
+	}
+
+	stillNew, err := store.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: session.ID})
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if stillNew.Session.ActiveTurnID != newTurn.Turn.ID {
+		t.Fatalf("SUPERSEDED resolution disturbed the new active turn: got %q, want %q", stillNew.Session.ActiveTurnID, newTurn.Turn.ID)
+	}
+}
+
+// TestStore_AdvanceControl_CancelVersusTerminalResolvesSuperseded proves
+// AC6's deterministic "cancel-versus-terminal" race: when the captured turn
+// terminates on its own (with no successor turn yet admitted) before a
+// COMMITTED cancel resolves, the intent observes the release and resolves to
+// SUPERSEDED -- it is never left ambiguously COMPLETED against a turn that no
+// longer needs canceling.
+func TestStore_AdvanceControl_CancelVersusTerminalResolvesSuperseded(t *testing.T) {
+	ctx := context.Background()
+	store, session, turn := newActiveTurnTestSession(t, time.Now())
+	reqID := controlRequestID("conn-1", "1")
+	intent := committedControlIntent(t, ctx, store, session, reqID)
+
+	if _, err := store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: session.ID, TurnID: turn.ID, Next: chatsessions.TurnStateCanceled,
+	}); err != nil {
+		t.Fatalf("AdvanceTurn to terminal: %v", err)
+	}
+
+	result, err := store.AdvanceControl(ctx, chatsessions.AdvanceControlRequest{
+		SessionID: session.ID, RequestID: reqID, Next: chatsessions.ControlIntentStateCompleted,
+	})
+	if err != nil {
+		t.Fatalf("AdvanceControl: %v", err)
+	}
+	if result.Intent.State != chatsessions.ControlIntentStateSuperseded {
+		t.Fatalf("Intent.State = %v, want SUPERSEDED", result.Intent.State)
+	}
+	if result.Intent.TurnID != intent.TurnID {
+		t.Fatalf("resolution retargeted intent: TurnID = %q, want unchanged %q", result.Intent.TurnID, intent.TurnID)
+	}
+}
+
+// TestStore_AdvanceControl_ResolvesNoopWhenCapturedTurnStillCurrentButTerminal
+// exercises ResolveControlIntentOutcome's NOOP branch (a captured turn that
+// is still the session's nominal ActiveTurnID yet already carries a terminal
+// state). This Store's own AdvanceTurn always clears ActiveTurnID in the
+// same atomic commit that marks a turn terminal (story 003), so this
+// bookkeeping shape cannot arise through the public API alone; the turn's
+// stored state is set directly to reach it, proving AdvanceControl still
+// routes every COMMITTED resolution through ResolveControlIntentOutcome
+// rather than special-casing COMPLETED/SUPERSEDED in its own code.
+func TestStore_AdvanceControl_ResolvesNoopWhenCapturedTurnStillCurrentButTerminal(t *testing.T) {
+	ctx := context.Background()
+	store, session, turn := newActiveTurnTestSession(t, time.Now())
+	reqID := controlRequestID("conn-1", "1")
+	intent := committedControlIntent(t, ctx, store, session, reqID)
+
+	store.mu.Lock()
+	record := store.sessions[session.ID]
+	terminalTurn := record.turns[turn.ID]
+	terminalTurn.State = chatsessions.TurnStateCompleted
+	terminalTurn.TerminalSequence = 1
+	record.turns[turn.ID] = terminalTurn
+	store.sessions[session.ID] = record
+	store.mu.Unlock()
+
+	result, err := store.AdvanceControl(ctx, chatsessions.AdvanceControlRequest{
+		SessionID: session.ID, RequestID: reqID, Next: chatsessions.ControlIntentStateCompleted,
+	})
+	if err != nil {
+		t.Fatalf("AdvanceControl: %v", err)
+	}
+	if result.Intent.State != chatsessions.ControlIntentStateNoop {
+		t.Fatalf("Intent.State = %v, want NOOP", result.Intent.State)
+	}
+	if result.Intent.TurnID != intent.TurnID {
+		t.Fatalf("NOOP resolution retargeted intent: TurnID = %q, want unchanged %q", result.Intent.TurnID, intent.TurnID)
+	}
+}
+
+// TestStore_RequestControl_RepeatedDistinctIdentitiesNeverCollide is repeat
+// coverage over every RequestIdentity kind (connection-scoped JSON-RPC
+// string, JSON-RPC number, and a process-unique transport UUID), proving
+// each is accepted as its own distinct, independently advanceable control
+// intent with its own captured target.
+func TestStore_RequestControl_RepeatedDistinctIdentitiesNeverCollide(t *testing.T) {
+	ctx := context.Background()
+	store, session, turn := newActiveTurnTestSession(t, time.Now())
+
+	identities := []chatsessions.RequestIdentity{
+		{Kind: chatsessions.RequestIdentityKindJSONRPCString, ConnectionID: "conn-1", JSONRPCStringID: "1"},
+		{Kind: chatsessions.RequestIdentityKindJSONRPCNumber, ConnectionID: "conn-1", JSONRPCNumberID: "1"},
+		{Kind: chatsessions.RequestIdentityKindJSONRPCString, ConnectionID: "conn-2", JSONRPCStringID: "1"},
+		{Kind: chatsessions.RequestIdentityKindTransportUUID, TransportUUID: "123e4567-e89b-12d3-a456-426614174000"},
+	}
+
+	for i, id := range identities {
+		result, err := store.RequestControl(ctx, chatsessions.RequestControlRequest{
+			RequestID: id, SessionID: session.ID, ExpectedVersion: session.Version, Action: chatsessions.ControlActionCancel,
+		})
+		if err != nil {
+			t.Fatalf("RequestControl[%d]: %v", i, err)
+		}
+		if result.Intent.TurnID != turn.ID {
+			t.Fatalf("RequestControl[%d]: TurnID = %q, want %q", i, result.Intent.TurnID, turn.ID)
+		}
+	}
+
+	store.mu.RLock()
+	controlCount := len(store.sessions[session.ID].controls)
+	store.mu.RUnlock()
+	if controlCount != len(identities) {
+		t.Fatalf("stored control intents = %d, want %d (a collision merged distinct identities)", controlCount, len(identities))
+	}
+
+	for i, id := range identities {
+		committed, err := store.AdvanceControl(ctx, chatsessions.AdvanceControlRequest{
+			SessionID: session.ID, RequestID: id, Next: chatsessions.ControlIntentStateCommitted,
+		})
+		if err != nil {
+			t.Fatalf("AdvanceControl[%d]: %v", i, err)
+		}
+		if committed.Intent.RequestID != id {
+			t.Fatalf("AdvanceControl[%d] retrieved wrong intent: got RequestID %+v, want %+v", i, committed.Intent.RequestID, id)
+		}
+	}
+}

--- a/pkg/services/chat_sessions/internal/service/doc.go
+++ b/pkg/services/chat_sessions/internal/service/doc.go
@@ -1,0 +1,11 @@
+// Package service is the in-memory, concurrency-safe implementation of the
+// chatsessions.Service root contract. It is owned by chat_sessions and
+// composed only through chat_sessions/wire; nothing outside chat_sessions
+// imports this package directly.
+//
+// Store holds every mutable aggregate behind one mutex and returns detached
+// (copied) chatsessions values, so a caller can never observe or corrupt
+// another caller's in-progress mutation. Store keeps only in-memory state:
+// it performs no filesystem, database, recorder, or other durable-store
+// writes, and two independently constructed Store instances share no state.
+package service

--- a/pkg/services/chat_sessions/internal/service/factory_target_catalog.go
+++ b/pkg/services/chat_sessions/internal/service/factory_target_catalog.go
@@ -117,36 +117,9 @@ func (s *Service) resolveFactoryTargetCatalog(
 		}
 	}
 
-	listing, err := s.factoryDefinitions.ListEffectiveFactories(ctx, factorydefinitions.ListEffectiveFactoriesRequest{
-		ProjectRoot: req.FactoryDiscovery.ProjectRoot,
-		GlobalRoot:  req.FactoryDiscovery.GlobalRoot,
-	})
+	installed, err := s.resolveInstalledFactories(ctx, req.FactoryDiscovery)
 	if err != nil {
-		return chatsessions.ResolveFactoryTargetCatalogResult{}, &chatsessions.FactoryTargetCatalogError{
-			Err:   chatsessions.ErrFactoryTargetCatalogUnavailable,
-			Cause: dependencyContextCause(err),
-		}
-	}
-
-	installed := make(map[string]factorydefinitions.EffectiveFactoryCatalogEntry, len(listing.Entries))
-	for _, entry := range listing.Entries {
-		installed[entry.Name] = entry
-	}
-
-	choicesByValue := make(map[string]chatsessions.FactoryTargetCatalogChoice, len(profile.AllowedTargets))
-	for _, target := range profile.AllowedTargets {
-		if _, exists := choicesByValue[target]; exists {
-			continue
-		}
-		name := strings.TrimPrefix(target, operatorsettings.ACPFactoryTargetNamespace)
-		entry, ok := installed[name]
-		if !ok {
-			continue
-		}
-		choicesByValue[target] = chatsessions.FactoryTargetCatalogChoice{
-			Value: target,
-			Name:  factoryDisplayName(entry),
-		}
+		return chatsessions.ResolveFactoryTargetCatalogResult{}, err
 	}
 
 	current := req.CurrentTarget
@@ -161,6 +134,8 @@ func (s *Service) resolveFactoryTargetCatalog(
 			Err: chatsessions.ErrFactoryTargetReferenceMalformed,
 		}
 	}
+
+	choicesByValue := allowedInstalledChoices(profile.AllowedTargets, installed)
 	if len(choicesByValue) == 0 {
 		return chatsessions.ResolveFactoryTargetCatalogResult{}, &chatsessions.FactoryTargetCatalogError{
 			Err: chatsessions.ErrFactoryTargetCatalogEmpty,
@@ -181,26 +156,8 @@ func (s *Service) resolveFactoryTargetCatalog(
 		}
 	}
 
-	if clientRoot := strings.TrimSpace(req.ClientWorkingRoot); clientRoot != "" {
-		resolved, err := s.factoryDefinitions.ResolveNamedFactory(ctx, factorydefinitions.ResolveNamedFactoryRequest{
-			ProjectRoot: req.FactoryDiscovery.ProjectRoot,
-			GlobalRoot:  req.FactoryDiscovery.GlobalRoot,
-			Name:        bareName,
-		})
-		if err != nil {
-			return chatsessions.ResolveFactoryTargetCatalogResult{}, &chatsessions.FactoryTargetCatalogError{
-				Target: current,
-				Err:    chatsessions.ErrFactoryTargetCatalogUnavailable,
-				Cause:  dependencyContextCause(err),
-			}
-		}
-		if resolved.Resolution.Source == factorydefinitions.NamedFactoryResolutionSourceProjectLocal &&
-			filepath.Clean(clientRoot) != filepath.Clean(resolved.Resolution.ProjectRoot) {
-			return chatsessions.ResolveFactoryTargetCatalogResult{}, &chatsessions.FactoryTargetCatalogError{
-				Target: current,
-				Err:    chatsessions.ErrFactoryTargetWorkingRootIncompatible,
-			}
-		}
+	if err := s.validateWorkingRootCompatibility(ctx, req, bareName, current); err != nil {
+		return chatsessions.ResolveFactoryTargetCatalogResult{}, err
 	}
 
 	currentChoice := choicesByValue[current]
@@ -208,6 +165,97 @@ func (s *Service) resolveFactoryTargetCatalog(
 		Choices:       orderedFactoryTargetChoices(choicesByValue, currentChoice),
 		CurrentTarget: currentChoice.Value,
 	}, nil
+}
+
+// resolveInstalledFactories reads the effective Factory catalog and returns
+// only entries that are actually installed (materialized to a filesystem
+// location), keyed by bare catalog name. A packaged definition that has not
+// been materialized carries a nil Location and is never treated as
+// installed, even though it is still effective/listable.
+func (s *Service) resolveInstalledFactories(
+	ctx context.Context,
+	discovery chatsessions.FactoryDiscoveryRoots,
+) (map[string]factorydefinitions.EffectiveFactoryCatalogEntry, error) {
+	listing, err := s.factoryDefinitions.ListEffectiveFactories(ctx, factorydefinitions.ListEffectiveFactoriesRequest{
+		ProjectRoot: discovery.ProjectRoot,
+		GlobalRoot:  discovery.GlobalRoot,
+	})
+	if err != nil {
+		return nil, &chatsessions.FactoryTargetCatalogError{
+			Err:   chatsessions.ErrFactoryTargetCatalogUnavailable,
+			Cause: dependencyContextCause(err),
+		}
+	}
+
+	installed := make(map[string]factorydefinitions.EffectiveFactoryCatalogEntry, len(listing.Entries))
+	for _, entry := range listing.Entries {
+		if entry.Location == nil {
+			continue
+		}
+		installed[entry.Name] = entry
+	}
+	return installed, nil
+}
+
+// allowedInstalledChoices intersects the profile's allowlist with the
+// installed catalog, deduplicating on target value and preserving each
+// installed entry's display name.
+func allowedInstalledChoices(
+	allowedTargets []string,
+	installed map[string]factorydefinitions.EffectiveFactoryCatalogEntry,
+) map[string]chatsessions.FactoryTargetCatalogChoice {
+	choicesByValue := make(map[string]chatsessions.FactoryTargetCatalogChoice, len(allowedTargets))
+	for _, target := range allowedTargets {
+		if _, exists := choicesByValue[target]; exists {
+			continue
+		}
+		name := strings.TrimPrefix(target, operatorsettings.ACPFactoryTargetNamespace)
+		entry, ok := installed[name]
+		if !ok {
+			continue
+		}
+		choicesByValue[target] = chatsessions.FactoryTargetCatalogChoice{
+			Value: target,
+			Name:  factoryDisplayName(entry),
+		}
+	}
+	return choicesByValue
+}
+
+// validateWorkingRootCompatibility rejects a project-local canonical
+// resolution whose project root disagrees with the caller's client working
+// root. It is a no-op when the caller supplies no client working root.
+func (s *Service) validateWorkingRootCompatibility(
+	ctx context.Context,
+	req chatsessions.ResolveFactoryTargetCatalogRequest,
+	bareName string,
+	current string,
+) error {
+	clientRoot := strings.TrimSpace(req.ClientWorkingRoot)
+	if clientRoot == "" {
+		return nil
+	}
+
+	resolved, err := s.factoryDefinitions.ResolveNamedFactory(ctx, factorydefinitions.ResolveNamedFactoryRequest{
+		ProjectRoot: req.FactoryDiscovery.ProjectRoot,
+		GlobalRoot:  req.FactoryDiscovery.GlobalRoot,
+		Name:        bareName,
+	})
+	if err != nil {
+		return &chatsessions.FactoryTargetCatalogError{
+			Target: current,
+			Err:    chatsessions.ErrFactoryTargetCatalogUnavailable,
+			Cause:  dependencyContextCause(err),
+		}
+	}
+	if resolved.Resolution.Source == factorydefinitions.NamedFactoryResolutionSourceProjectLocal &&
+		filepath.Clean(clientRoot) != filepath.Clean(resolved.Resolution.ProjectRoot) {
+		return &chatsessions.FactoryTargetCatalogError{
+			Target: current,
+			Err:    chatsessions.ErrFactoryTargetWorkingRootIncompatible,
+		}
+	}
+	return nil
 }
 
 // orderedFactoryTargetChoices returns current first, followed by every other

--- a/pkg/services/chat_sessions/internal/service/factory_target_catalog.go
+++ b/pkg/services/chat_sessions/internal/service/factory_target_catalog.go
@@ -36,6 +36,21 @@ func isWellFormedFactoryTargetReference(value string) bool {
 	return factoryTargetReferencePattern.MatchString(suffix)
 }
 
+// dependencyContextCause returns context.Canceled or context.DeadlineExceeded
+// when err is classifiable as one, and nil otherwise. It never returns err
+// itself: only these two safe, text-free sentinels are ever attached to a
+// public FactoryTargetCatalogError's Cause field, so an arbitrary dependency
+// error can never leak through it.
+func dependencyContextCause(err error) error {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return context.Canceled
+	case errors.Is(err, context.DeadlineExceeded):
+		return context.DeadlineExceeded
+	}
+	return nil
+}
+
 // ResolveFactoryTargetCatalog resolves the effective ACP Agent profile
 // through Operator Settings, reads the installed Factory catalog through
 // Factory Definitions, intersects the profile's allowlist with that catalog,
@@ -97,7 +112,8 @@ func (s *Service) resolveFactoryTargetCatalog(
 	profile, err := s.operatorSettings.ResolveACPAgentProfile(req.OperatorSettingsPath)
 	if err != nil {
 		return chatsessions.ResolveFactoryTargetCatalogResult{}, &chatsessions.FactoryTargetCatalogError{
-			Err: chatsessions.ErrFactoryTargetProfileUnavailable,
+			Err:   chatsessions.ErrFactoryTargetProfileUnavailable,
+			Cause: dependencyContextCause(err),
 		}
 	}
 
@@ -107,7 +123,8 @@ func (s *Service) resolveFactoryTargetCatalog(
 	})
 	if err != nil {
 		return chatsessions.ResolveFactoryTargetCatalogResult{}, &chatsessions.FactoryTargetCatalogError{
-			Err: chatsessions.ErrFactoryTargetCatalogUnavailable,
+			Err:   chatsessions.ErrFactoryTargetCatalogUnavailable,
+			Cause: dependencyContextCause(err),
 		}
 	}
 
@@ -174,6 +191,7 @@ func (s *Service) resolveFactoryTargetCatalog(
 			return chatsessions.ResolveFactoryTargetCatalogResult{}, &chatsessions.FactoryTargetCatalogError{
 				Target: current,
 				Err:    chatsessions.ErrFactoryTargetCatalogUnavailable,
+				Cause:  dependencyContextCause(err),
 			}
 		}
 		if resolved.Resolution.Source == factorydefinitions.NamedFactoryResolutionSourceProjectLocal &&

--- a/pkg/services/chat_sessions/internal/service/factory_target_catalog_construction_test.go
+++ b/pkg/services/chat_sessions/internal/service/factory_target_catalog_construction_test.go
@@ -116,7 +116,7 @@ func TestResolveFactoryTargetCatalogLogsStartedAndFinishedSafely(t *testing.T) {
 		listEffectiveFactories: func(context.Context, factorydefinitions.ListEffectiveFactoriesRequest) (factorydefinitions.ListEffectiveFactoriesResult, error) {
 			return factorydefinitions.ListEffectiveFactoriesResult{
 				Entries: []factorydefinitions.EffectiveFactoryCatalogEntry{
-					{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+					installedFactoryEntry("@you/factory-builder", "Factory Builder"),
 				},
 			}, nil
 		},
@@ -204,7 +204,7 @@ func TestResolveFactoryTargetCatalogUsesEachInjectedCollaboratorExactlyOnce(t *t
 			catalogCalls++
 			return factorydefinitions.ListEffectiveFactoriesResult{
 				Entries: []factorydefinitions.EffectiveFactoryCatalogEntry{
-					{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+					installedFactoryEntry("@you/factory-builder", "Factory Builder"),
 				},
 			}, nil
 		},
@@ -250,7 +250,7 @@ func TestResolveFactoryTargetCatalogObservesLiveCollaboratorDrift(t *testing.T) 
 			}
 			return factorydefinitions.ListEffectiveFactoriesResult{
 				Entries: []factorydefinitions.EffectiveFactoryCatalogEntry{
-					{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+					installedFactoryEntry("@you/factory-builder", "Factory Builder"),
 				},
 			}, nil
 		},

--- a/pkg/services/chat_sessions/internal/service/factory_target_catalog_fakes_test.go
+++ b/pkg/services/chat_sessions/internal/service/factory_target_catalog_fakes_test.go
@@ -60,3 +60,26 @@ type unexpectedCallError struct{}
 func (unexpectedCallError) Error() string { return "unexpected fake call" }
 
 var errUnexpectedCall = unexpectedCallError{}
+
+// installedFactoryEntry returns an EffectiveFactoryCatalogEntry representing
+// a materialized (installed) Factory. Factory Definitions' contract leaves
+// Location nil for packaged definitions that have not been materialized, so
+// every fixture standing in for an installed Factory must set it explicitly.
+func installedFactoryEntry(name, displayName string) factorydefinitions.EffectiveFactoryCatalogEntry {
+	location := "/factories/" + name
+	return factorydefinitions.EffectiveFactoryCatalogEntry{
+		Name:       name,
+		Location:   &location,
+		Definition: &factorydefinitions.FactoryConfig{Name: displayName},
+	}
+}
+
+// packagedOnlyFactoryEntry returns an EffectiveFactoryCatalogEntry
+// representing a packaged Factory definition that has not been materialized:
+// it is effective/listable but never counts as installed.
+func packagedOnlyFactoryEntry(name, displayName string) factorydefinitions.EffectiveFactoryCatalogEntry {
+	return factorydefinitions.EffectiveFactoryCatalogEntry{
+		Name:       name,
+		Definition: &factorydefinitions.FactoryConfig{Name: displayName},
+	}
+}

--- a/pkg/services/chat_sessions/internal/service/factory_target_catalog_rejection_test.go
+++ b/pkg/services/chat_sessions/internal/service/factory_target_catalog_rejection_test.go
@@ -370,6 +370,151 @@ func TestResolveFactoryTargetCatalogWrapsCanonicalResolutionDependencyFailure(t 
 	}
 }
 
+func TestResolveFactoryTargetCatalogPreservesProfileDependencyContextCause(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		cause error
+	}{
+		{name: "canceled", cause: context.Canceled},
+		{name: "deadline exceeded", cause: context.DeadlineExceeded},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			spy := &spyLogger{}
+			settings := &operatorSettingsFake{
+				resolveACPAgentProfile: func(string) (operatorsettings.ACPAgentProfile, error) {
+					return operatorsettings.ACPAgentProfile{}, testCase.cause
+				},
+			}
+			definitions := &factoryDefinitionsFake{}
+			service, err := chatsessionsservice.New(settings, definitions, spy)
+			if err != nil {
+				t.Fatalf("New: unexpected error: %v", err)
+			}
+
+			result, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+				OperatorSettingsPath: "/operator.json",
+			})
+			assertFactoryTargetCatalogError(t, err, chatsessions.ErrFactoryTargetProfileUnavailable, "")
+			if !errors.Is(err, testCase.cause) {
+				t.Fatalf("ResolveFactoryTargetCatalog: error = %v, want errors.Is match for %v", err, testCase.cause)
+			}
+			if len(result.Choices) != 0 || result.CurrentTarget != "" {
+				t.Fatalf("ResolveFactoryTargetCatalog: result = %#v, want a zero (non-partial) result on failure", result)
+			}
+			spy.assertNoForbiddenValuesLogged(t, "/operator.json")
+		})
+	}
+}
+
+func TestResolveFactoryTargetCatalogPreservesCatalogListingDependencyContextCause(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		cause error
+	}{
+		{name: "canceled", cause: context.Canceled},
+		{name: "deadline exceeded", cause: context.DeadlineExceeded},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			spy := &spyLogger{}
+			settings := &operatorSettingsFake{
+				resolveACPAgentProfile: func(string) (operatorsettings.ACPAgentProfile, error) {
+					return operatorsettings.ACPAgentProfile{
+						DefaultTarget:  "factory:@you/factory-builder",
+						AllowedTargets: []string{"factory:@you/factory-builder"},
+					}, nil
+				},
+			}
+			definitions := &factoryDefinitionsFake{
+				listEffectiveFactories: func(context.Context, factorydefinitions.ListEffectiveFactoriesRequest) (factorydefinitions.ListEffectiveFactoriesResult, error) {
+					return factorydefinitions.ListEffectiveFactoriesResult{}, testCase.cause
+				},
+			}
+			service, err := chatsessionsservice.New(settings, definitions, spy)
+			if err != nil {
+				t.Fatalf("New: unexpected error: %v", err)
+			}
+
+			result, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+				OperatorSettingsPath: "/operator.json",
+			})
+			assertFactoryTargetCatalogError(t, err, chatsessions.ErrFactoryTargetCatalogUnavailable, "")
+			if !errors.Is(err, testCase.cause) {
+				t.Fatalf("ResolveFactoryTargetCatalog: error = %v, want errors.Is match for %v", err, testCase.cause)
+			}
+			if len(result.Choices) != 0 || result.CurrentTarget != "" {
+				t.Fatalf("ResolveFactoryTargetCatalog: result = %#v, want a zero (non-partial) result on failure", result)
+			}
+			spy.assertNoForbiddenValuesLogged(t, "/operator.json")
+		})
+	}
+}
+
+func TestResolveFactoryTargetCatalogPreservesCanonicalResolutionDependencyContextCause(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		cause error
+	}{
+		{name: "canceled", cause: context.Canceled},
+		{name: "deadline exceeded", cause: context.DeadlineExceeded},
+	}
+
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/factory-builder",
+		AllowedTargets: []string{"factory:@you/factory-builder"},
+	}
+	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
+		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			spy := &spyLogger{}
+			settings := &operatorSettingsFake{
+				resolveACPAgentProfile: func(string) (operatorsettings.ACPAgentProfile, error) { return profile, nil },
+			}
+			definitions := &factoryDefinitionsFake{
+				listEffectiveFactories: func(context.Context, factorydefinitions.ListEffectiveFactoriesRequest) (factorydefinitions.ListEffectiveFactoriesResult, error) {
+					return factorydefinitions.ListEffectiveFactoriesResult{Entries: entries}, nil
+				},
+				resolveNamedFactory: func(context.Context, factorydefinitions.ResolveNamedFactoryRequest) (factorydefinitions.ResolveNamedFactoryResult, error) {
+					return factorydefinitions.ResolveNamedFactoryResult{}, testCase.cause
+				},
+			}
+			service, err := chatsessionsservice.New(settings, definitions, spy)
+			if err != nil {
+				t.Fatalf("New: unexpected error: %v", err)
+			}
+
+			result, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+				OperatorSettingsPath: "/operator.json",
+				FactoryDiscovery:     chatsessions.FactoryDiscoveryRoots{ProjectRoot: "/repos/project-a"},
+				ClientWorkingRoot:    "/repos/project-a",
+			})
+			assertFactoryTargetCatalogError(t, err, chatsessions.ErrFactoryTargetCatalogUnavailable, "factory:@you/factory-builder")
+			if !errors.Is(err, testCase.cause) {
+				t.Fatalf("ResolveFactoryTargetCatalog: error = %v, want errors.Is match for %v", err, testCase.cause)
+			}
+			if len(result.Choices) != 0 || result.CurrentTarget != "" {
+				t.Fatalf("ResolveFactoryTargetCatalog: result = %#v, want a zero (non-partial) result on failure", result)
+			}
+			spy.assertNoForbiddenValuesLogged(t, "/repos/project-a", "factory:@you/factory-builder")
+		})
+	}
+}
+
 func TestResolveFactoryTargetCatalogWrapsInstalledCatalogDependencyFailure(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/chat_sessions/internal/service/factory_target_catalog_rejection_test.go
+++ b/pkg/services/chat_sessions/internal/service/factory_target_catalog_rejection_test.go
@@ -83,7 +83,7 @@ func TestResolveFactoryTargetCatalogRejectsMalformedCurrentTarget(t *testing.T) 
 		AllowedTargets: []string{"factory:@you/factory-builder"},
 	}
 	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
-		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+		installedFactoryEntry("@you/factory-builder", "Factory Builder"),
 	}
 
 	for _, testCase := range cases {
@@ -115,7 +115,7 @@ func TestResolveFactoryTargetCatalogMalformedCurrentTargetNeverLeaksHostileInput
 		AllowedTargets: []string{"factory:@you/factory-builder"},
 	}
 	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
-		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+		installedFactoryEntry("@you/factory-builder", "Factory Builder"),
 	}
 
 	cases := []struct {
@@ -170,7 +170,7 @@ func TestResolveFactoryTargetCatalogRejectsUnknownUninstalledTarget(t *testing.T
 		AllowedTargets: []string{"factory:@you/factory-builder", "factory:@you/ghost"},
 	}
 	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
-		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+		installedFactoryEntry("@you/factory-builder", "Factory Builder"),
 	}
 	service := newTestService(t, profile, entries)
 
@@ -181,6 +181,59 @@ func TestResolveFactoryTargetCatalogRejectsUnknownUninstalledTarget(t *testing.T
 	assertFactoryTargetCatalogError(t, err, chatsessions.ErrFactoryTargetNotInstalled, "factory:@you/ghost")
 }
 
+// TestResolveFactoryTargetCatalogRejectsUnmaterializedPackagedDefault proves
+// a packaged Factory definition that has not been materialized to a
+// filesystem location (Location == nil) is never treated as installed, even
+// when it is the configured default and the only allowed/effective entry.
+func TestResolveFactoryTargetCatalogRejectsUnmaterializedPackagedDefault(t *testing.T) {
+	t.Parallel()
+
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/factory-builder",
+		AllowedTargets: []string{"factory:@you/factory-builder"},
+	}
+	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
+		packagedOnlyFactoryEntry("@you/factory-builder", "Factory Builder"),
+	}
+	service := newTestService(t, profile, entries)
+
+	result, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+	})
+	assertFactoryTargetCatalogError(t, err, chatsessions.ErrFactoryTargetCatalogEmpty, "")
+	if len(result.Choices) != 0 || result.CurrentTarget != "" {
+		t.Fatalf("ResolveFactoryTargetCatalog: result = %#v, want a zero (non-partial) result on failure", result)
+	}
+}
+
+// TestResolveFactoryTargetCatalogExcludesUnmaterializedPackagedEntryFromChoices
+// proves a packaged-only entry never appears as a selectable choice even
+// when a separate materialized entry keeps the overall resolution
+// successful.
+func TestResolveFactoryTargetCatalogExcludesUnmaterializedPackagedEntryFromChoices(t *testing.T) {
+	t.Parallel()
+
+	profile := operatorsettings.ACPAgentProfile{
+		DefaultTarget:  "factory:@you/factory-builder",
+		AllowedTargets: []string{"factory:@you/factory-builder", "factory:@you/packaged-only"},
+	}
+	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
+		installedFactoryEntry("@you/factory-builder", "Factory Builder"),
+		packagedOnlyFactoryEntry("@you/packaged-only", "Packaged Only"),
+	}
+	service := newTestService(t, profile, entries)
+
+	result, err := service.ResolveFactoryTargetCatalog(context.Background(), chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: "/operator.json",
+	})
+	if err != nil {
+		t.Fatalf("ResolveFactoryTargetCatalog: unexpected error: %v", err)
+	}
+	if len(result.Choices) != 1 || result.Choices[0].Value != "factory:@you/factory-builder" {
+		t.Fatalf("Choices = %+v, want only the materialized installed target", result.Choices)
+	}
+}
+
 func TestResolveFactoryTargetCatalogRejectsRequestedTargetOutsideAllowlist(t *testing.T) {
 	t.Parallel()
 
@@ -189,8 +242,8 @@ func TestResolveFactoryTargetCatalogRejectsRequestedTargetOutsideAllowlist(t *te
 		AllowedTargets: []string{"factory:@you/factory-builder"},
 	}
 	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
-		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
-		{Name: "@you/review", Definition: &factorydefinitions.FactoryConfig{Name: "Review"}},
+		installedFactoryEntry("@you/factory-builder", "Factory Builder"),
+		installedFactoryEntry("@you/review", "Review"),
 	}
 	service := newTestService(t, profile, entries)
 
@@ -209,7 +262,7 @@ func TestResolveFactoryTargetCatalogRejectsUninstalledTargetAfterPriorSuccess(t 
 		AllowedTargets: []string{"factory:@you/factory-builder"},
 	}
 	installed := []factorydefinitions.EffectiveFactoryCatalogEntry{
-		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+		installedFactoryEntry("@you/factory-builder", "Factory Builder"),
 	}
 
 	settings := &operatorSettingsFake{
@@ -253,7 +306,7 @@ func TestResolveFactoryTargetCatalogRejectsIncompatiblePinnedWorkingRoot(t *test
 		AllowedTargets: []string{"factory:@you/factory-builder"},
 	}
 	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
-		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+		installedFactoryEntry("@you/factory-builder", "Factory Builder"),
 	}
 
 	settings := &operatorSettingsFake{
@@ -294,7 +347,7 @@ func TestResolveFactoryTargetCatalogAllowsCompatiblePinnedWorkingRoot(t *testing
 		AllowedTargets: []string{"factory:@you/factory-builder"},
 	}
 	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
-		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+		installedFactoryEntry("@you/factory-builder", "Factory Builder"),
 	}
 
 	settings := &operatorSettingsFake{
@@ -340,7 +393,7 @@ func TestResolveFactoryTargetCatalogWrapsCanonicalResolutionDependencyFailure(t 
 		AllowedTargets: []string{"factory:@you/factory-builder"},
 	}
 	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
-		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+		installedFactoryEntry("@you/factory-builder", "Factory Builder"),
 	}
 
 	settings := &operatorSettingsFake{
@@ -475,7 +528,7 @@ func TestResolveFactoryTargetCatalogPreservesCanonicalResolutionDependencyContex
 		AllowedTargets: []string{"factory:@you/factory-builder"},
 	}
 	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
-		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+		installedFactoryEntry("@you/factory-builder", "Factory Builder"),
 	}
 
 	for _, testCase := range cases {

--- a/pkg/services/chat_sessions/internal/service/factory_target_catalog_test.go
+++ b/pkg/services/chat_sessions/internal/service/factory_target_catalog_test.go
@@ -41,9 +41,9 @@ func TestResolveFactoryTargetCatalogExactAllowlistFiltering(t *testing.T) {
 		AllowedTargets: []string{"factory:@you/factory-builder", "factory:@you/review"},
 	}
 	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
-		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
-		{Name: "@you/review", Definition: &factorydefinitions.FactoryConfig{Name: "Review"}},
-		{Name: "@you/extra", Definition: &factorydefinitions.FactoryConfig{Name: "Extra"}},
+		installedFactoryEntry("@you/factory-builder", "Factory Builder"),
+		installedFactoryEntry("@you/review", "Review"),
+		installedFactoryEntry("@you/extra", "Extra"),
 	}
 	service := newTestService(t, profile, entries)
 
@@ -75,7 +75,7 @@ func TestResolveFactoryTargetCatalogMissingProfileDefaultsToFactoryBuilder(t *te
 	t.Parallel()
 
 	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
-		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+		installedFactoryEntry("@you/factory-builder", "Factory Builder"),
 	}
 	// A missing authored profile resolves to Operator Settings' safe default,
 	// which this fake models directly since ResolveACPAgentProfile itself
@@ -105,7 +105,7 @@ func TestResolveFactoryTargetCatalogExcludesAllowedButUninstalled(t *testing.T) 
 		AllowedTargets: []string{"factory:@you/factory-builder", "factory:@you/missing"},
 	}
 	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
-		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+		installedFactoryEntry("@you/factory-builder", "Factory Builder"),
 	}
 	service := newTestService(t, profile, entries)
 
@@ -129,8 +129,8 @@ func TestResolveFactoryTargetCatalogExcludesInstalledButDisallowed(t *testing.T)
 		AllowedTargets: []string{"factory:@you/factory-builder"},
 	}
 	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
-		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
-		{Name: "@you/extra", Definition: &factorydefinitions.FactoryConfig{Name: "Extra"}},
+		installedFactoryEntry("@you/factory-builder", "Factory Builder"),
+		installedFactoryEntry("@you/extra", "Extra"),
 	}
 	service := newTestService(t, profile, entries)
 
@@ -150,9 +150,9 @@ func TestResolveFactoryTargetCatalogDeterministicOrderingAndDedup(t *testing.T) 
 	t.Parallel()
 
 	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
-		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
-		{Name: "@you/review", Definition: &factorydefinitions.FactoryConfig{Name: "Review"}},
-		{Name: "@you/analysis", Definition: &factorydefinitions.FactoryConfig{Name: "Analysis"}},
+		installedFactoryEntry("@you/factory-builder", "Factory Builder"),
+		installedFactoryEntry("@you/review", "Review"),
+		installedFactoryEntry("@you/analysis", "Analysis"),
 	}
 	reorderedEntries := []factorydefinitions.EffectiveFactoryCatalogEntry{entries[2], entries[0], entries[1]}
 	duplicatedEntries := append(append([]factorydefinitions.EffectiveFactoryCatalogEntry{}, entries...), entries[1], entries[0])
@@ -234,8 +234,8 @@ func TestResolveFactoryTargetCatalogResultIsDetached(t *testing.T) {
 		AllowedTargets: []string{"factory:@you/factory-builder", "factory:@you/review"},
 	}
 	entries := []factorydefinitions.EffectiveFactoryCatalogEntry{
-		{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
-		{Name: "@you/review", Definition: &factorydefinitions.FactoryConfig{Name: "Review"}},
+		installedFactoryEntry("@you/factory-builder", "Factory Builder"),
+		installedFactoryEntry("@you/review", "Review"),
 	}
 	service := newTestService(t, profile, entries)
 

--- a/pkg/services/chat_sessions/internal/service/logging.go
+++ b/pkg/services/chat_sessions/internal/service/logging.go
@@ -33,7 +33,7 @@ func classifyError(err error) string {
 }
 
 // logStart records that op began for sessionID. Callers of the two logging
-// helpers in this file never pass a cwd, prompt content, raw JSON-RPC
+// helpers in this file never pass a working root, prompt content, raw JSON-RPC
 // identity, credential, provider command, or filesystem path as a field --
 // only operation names, entity identifiers, versions, and error
 // classifications cross this boundary.

--- a/pkg/services/chat_sessions/internal/service/logging.go
+++ b/pkg/services/chat_sessions/internal/service/logging.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"errors"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+)
+
+// classifyError maps a returned chat_sessions error to a stable,
+// boundary-safe classification string for structured logs. The
+// classification never includes err.Error() text, since a wrapped
+// *ValidationError/*ConflictError/*BusyError can carry a caller-supplied
+// entity ID that a log field should still surface explicitly and
+// intentionally, not via free-text error interpolation.
+func classifyError(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, chatsessions.ErrStaleVersion):
+		return "conflict"
+	case errors.Is(err, chatsessions.ErrBusy):
+		return "busy"
+	case errors.Is(err, chatsessions.ErrNotFound):
+		return "not_found"
+	case errors.Is(err, chatsessions.ErrInvalidTransition):
+		return "invalid_transition"
+	case errors.Is(err, chatsessions.ErrTargetEpisodeNotClosed),
+		errors.Is(err, chatsessions.ErrTargetEpisodeNumberExhausted):
+		return "invariant_violation"
+	default:
+		return "validation"
+	}
+}
+
+// logStart records that op began for sessionID. Callers of the two logging
+// helpers in this file never pass a cwd, prompt content, raw JSON-RPC
+// identity, credential, provider command, or filesystem path as a field --
+// only operation names, entity identifiers, versions, and error
+// classifications cross this boundary.
+func (s *Store) logStart(op, sessionID string) {
+	if s == nil || s.logger == nil {
+		return
+	}
+	s.logger.Debug("chat_sessions operation start", "op", op, "session_id", sessionID)
+}
+
+// logOutcome records the accepted or terminal result of op. On failure, err
+// is classified and no other fields are logged since a failure path's
+// zero-value result carries no accepted fact worth recording. On success,
+// extra carries only safe entity identifiers and versions the caller
+// supplies explicitly.
+func (s *Store) logOutcome(op, sessionID string, err error, extra ...any) {
+	if s == nil || s.logger == nil {
+		return
+	}
+	if err != nil {
+		s.logger.Info("chat_sessions operation outcome", "op", op, "session_id", sessionID, "error_class", classifyError(err))
+		return
+	}
+	fields := append([]any{"op", op, "session_id", sessionID, "error_class", ""}, extra...)
+	s.logger.Info("chat_sessions operation outcome", fields...)
+}

--- a/pkg/services/chat_sessions/internal/service/logging_test.go
+++ b/pkg/services/chat_sessions/internal/service/logging_test.go
@@ -72,7 +72,7 @@ func TestClassifyError_TableDriven(t *testing.T) {
 
 // TestStore_CreateSession_LogsStartAndAcceptedOutcomeWithoutUnsafeFields
 // proves a successful mutating operation emits a Debug start log and an Info
-// outcome log, and that neither ever carries the caller-supplied Cwd or raw
+// outcome log, and that neither ever carries the caller-supplied WorkingRoot or raw
 // JSON-RPC request identity value.
 func TestStore_CreateSession_LogsStartAndAcceptedOutcomeWithoutUnsafeFields(t *testing.T) {
 	logger, calls := newCaptureLogger()
@@ -84,7 +84,7 @@ func TestStore_CreateSession_LogsStartAndAcceptedOutcomeWithoutUnsafeFields(t *t
 		t.Fatalf("CreateSession: %v", err)
 	}
 
-	assertNoUnsafeFields(t, *calls, req.Cwd, req.RequestID.JSONRPCStringID)
+	assertNoUnsafeFields(t, *calls, req.WorkingRoot, req.RequestID.JSONRPCStringID)
 
 	if len(*calls) != 2 {
 		t.Fatalf("CreateSession logged %d calls, want 2 (start, outcome): %+v", len(*calls), *calls)
@@ -149,7 +149,7 @@ func TestStore_GetSession_LogsStartAndOutcome(t *testing.T) {
 		t.Fatalf("not-found outcome log missing error_class=not_found: %+v", (*calls)[1].kv)
 	}
 
-	assertNoUnsafeFields(t, *calls, created.Session.Cwd, "")
+	assertNoUnsafeFields(t, *calls, created.Session.WorkingRoot, "")
 }
 
 // TestStore_SetTarget_FailureLogsClassificationOnly proves a failed mutating
@@ -219,7 +219,7 @@ func TestStore_RequestControl_NeverLogsRawRequestIdentity(t *testing.T) {
 		t.Fatalf("RequestControl: %v", err)
 	}
 
-	assertNoUnsafeFields(t, *calls, created.Session.Cwd, rawControlRequestID)
+	assertNoUnsafeFields(t, *calls, created.Session.WorkingRoot, rawControlRequestID)
 	outcome := (*calls)[1]
 	if !hasKV(outcome.kv, "request_kind", string(chatsessions.RequestIdentityKindJSONRPCString)) {
 		t.Fatalf("outcome log missing safe request_kind field: %+v", outcome.kv)

--- a/pkg/services/chat_sessions/internal/service/logging_test.go
+++ b/pkg/services/chat_sessions/internal/service/logging_test.go
@@ -1,0 +1,214 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+)
+
+// capturedLogCall records one structured log call made through
+// logging.Logger, preserving the level so tests can distinguish start
+// (Debug) from outcome (Info) calls.
+type capturedLogCall struct {
+	level string
+	msg   string
+	kv    []any
+}
+
+// captureLogger is a logging.Logger test double that records every call
+// instead of writing anywhere, so tests can assert on exactly what a Store
+// operation logs.
+type captureLogger struct {
+	calls *[]capturedLogCall
+}
+
+func newCaptureLogger() (captureLogger, *[]capturedLogCall) {
+	calls := &[]capturedLogCall{}
+	return captureLogger{calls: calls}, calls
+}
+
+func (l captureLogger) Debug(msg string, kv ...any) {
+	*l.calls = append(*l.calls, capturedLogCall{level: "debug", msg: msg, kv: kv})
+}
+func (l captureLogger) Info(msg string, kv ...any) {
+	*l.calls = append(*l.calls, capturedLogCall{level: "info", msg: msg, kv: kv})
+}
+func (l captureLogger) Warn(msg string, kv ...any)    {}
+func (l captureLogger) Error(msg string, kv ...any)   {}
+func (l captureLogger) Verbose(msg string, kv ...any) {}
+
+func TestClassifyError_TableDriven(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil", nil, ""},
+		{"stale version", chatsessions.ErrStaleVersion, "conflict"},
+		{"conflict error", &chatsessions.ConflictError{Value: "Session", ID: "s-1", Expected: 1, Actual: 2}, "conflict"},
+		{"busy", chatsessions.ErrBusy, "busy"},
+		{"busy error", &chatsessions.BusyError{Value: "Session", ID: "s-1"}, "busy"},
+		{"not found", chatsessions.ErrNotFound, "not_found"},
+		{"not found error", &chatsessions.NotFoundError{Value: "Session", ID: "s-1"}, "not_found"},
+		{"invalid transition", chatsessions.ErrInvalidTransition, "invalid_transition"},
+		{"target episode not closed", chatsessions.ErrTargetEpisodeNotClosed, "invariant_violation"},
+		{"target episode exhausted", chatsessions.ErrTargetEpisodeNumberExhausted, "invariant_violation"},
+		{"required value", chatsessions.ErrRequiredValue, "validation"},
+		{"unknown enum", chatsessions.ErrUnknownEnumValue, "validation"},
+		{"unsupported control action", chatsessions.ErrUnsupportedControlAction, "validation"},
+		{"unrelated error", errors.New("boom"), "validation"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyError(tt.err); got != tt.want {
+				t.Fatalf("classifyError(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestStore_CreateSession_LogsStartAndAcceptedOutcomeWithoutUnsafeFields
+// proves a successful mutating operation emits a Debug start log and an Info
+// outcome log, and that neither ever carries the caller-supplied Cwd or raw
+// JSON-RPC request identity value.
+func TestStore_CreateSession_LogsStartAndAcceptedOutcomeWithoutUnsafeFields(t *testing.T) {
+	logger, calls := newCaptureLogger()
+	store := New(sequentialIDs("session"), fixedClock(time.Now()), logger)
+
+	req := validCreateRequest()
+	result, err := store.CreateSession(context.Background(), req)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	assertNoUnsafeFields(t, *calls, req.Cwd, req.RequestID.JSONRPCStringID)
+
+	if len(*calls) != 2 {
+		t.Fatalf("CreateSession logged %d calls, want 2 (start, outcome): %+v", len(*calls), *calls)
+	}
+	if (*calls)[0].level != "debug" {
+		t.Fatalf("first log level = %q, want debug (start)", (*calls)[0].level)
+	}
+	outcome := (*calls)[1]
+	if outcome.level != "info" {
+		t.Fatalf("second log level = %q, want info (outcome)", outcome.level)
+	}
+	if !hasKV(outcome.kv, "session_id", result.Session.ID) {
+		t.Fatalf("outcome log missing session_id=%q: %+v", result.Session.ID, outcome.kv)
+	}
+	if !hasKV(outcome.kv, "error_class", "") {
+		t.Fatalf("successful outcome log must carry an empty error_class: %+v", outcome.kv)
+	}
+}
+
+// TestStore_SetTarget_FailureLogsClassificationOnly proves a failed mutating
+// operation's outcome log carries only the operation name, session ID, and
+// error classification -- never a partial/zero-value accepted field.
+func TestStore_SetTarget_FailureLogsClassificationOnly(t *testing.T) {
+	logger, calls := newCaptureLogger()
+	store := New(sequentialIDs("session"), fixedClock(time.Now()), logger)
+
+	created, err := store.CreateSession(context.Background(), validCreateRequest())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	*calls = nil // discard CreateSession's own log calls
+
+	_, err = store.SetTarget(context.Background(), chatsessions.SetTargetRequest{
+		RequestID:       chatsessions.RequestIdentity{Kind: chatsessions.RequestIdentityKindTransportUUID, TransportUUID: "11111111-1111-1111-1111-111111111111"},
+		SessionID:       created.Session.ID,
+		ExpectedVersion: created.Session.Version + 1, // stale on purpose
+		Target:          created.Session.SelectedTarget,
+	})
+	if !errors.Is(err, chatsessions.ErrStaleVersion) {
+		t.Fatalf("SetTarget: got %v, want ErrStaleVersion", err)
+	}
+
+	if len(*calls) != 2 {
+		t.Fatalf("SetTarget logged %d calls, want 2 (start, outcome): %+v", len(*calls), *calls)
+	}
+	outcome := (*calls)[1]
+	if !hasKV(outcome.kv, "error_class", "conflict") {
+		t.Fatalf("outcome log missing error_class=conflict: %+v", outcome.kv)
+	}
+	if hasKey(outcome.kv, "target_episode") {
+		t.Fatalf("failed outcome log must not carry accepted-only fields: %+v", outcome.kv)
+	}
+}
+
+// TestStore_RequestControl_NeverLogsRawRequestIdentity proves RequestControl
+// logs only the RequestIdentity's Kind discriminator, never the raw
+// JSON-RPC id value that identity carries.
+func TestStore_RequestControl_NeverLogsRawRequestIdentity(t *testing.T) {
+	logger, calls := newCaptureLogger()
+	store := New(sequentialIDs("session"), fixedClock(time.Now()), logger)
+
+	created, err := store.CreateSession(context.Background(), validCreateRequest())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	started, err := store.StartTurn(context.Background(), chatsessions.StartTurnRequest{
+		RequestID:       chatsessions.RequestIdentity{Kind: chatsessions.RequestIdentityKindJSONRPCString, ConnectionID: "conn-1", JSONRPCStringID: "turn-req-1"},
+		SessionID:       created.Session.ID,
+		ExpectedVersion: created.Session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn: %v", err)
+	}
+	*calls = nil
+
+	const rawControlRequestID = "control-req-secret"
+	_, err = store.RequestControl(context.Background(), chatsessions.RequestControlRequest{
+		RequestID:       chatsessions.RequestIdentity{Kind: chatsessions.RequestIdentityKindJSONRPCString, ConnectionID: "conn-1", JSONRPCStringID: rawControlRequestID},
+		SessionID:       created.Session.ID,
+		ExpectedVersion: started.Session.Version,
+		Action:          chatsessions.ControlActionCancel,
+	})
+	if err != nil {
+		t.Fatalf("RequestControl: %v", err)
+	}
+
+	assertNoUnsafeFields(t, *calls, created.Session.Cwd, rawControlRequestID)
+	outcome := (*calls)[1]
+	if !hasKV(outcome.kv, "request_kind", string(chatsessions.RequestIdentityKindJSONRPCString)) {
+		t.Fatalf("outcome log missing safe request_kind field: %+v", outcome.kv)
+	}
+}
+
+func hasKey(kv []any, key string) bool {
+	for i := 0; i+1 < len(kv); i += 2 {
+		if kv[i] == key {
+			return true
+		}
+	}
+	return false
+}
+
+func hasKV(kv []any, key string, value any) bool {
+	for i := 0; i+1 < len(kv); i += 2 {
+		if kv[i] == key && kv[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+// assertNoUnsafeFields fails t if any logged value (or the log message
+// itself) contains the given caller-supplied secrets, wherever they appear
+// in the captured calls.
+func assertNoUnsafeFields(t *testing.T, calls []capturedLogCall, unsafeValues ...string) {
+	t.Helper()
+	for _, call := range calls {
+		for i := 0; i+1 < len(call.kv); i += 2 {
+			rendered := fmt.Sprintf("%v", call.kv[i+1])
+			for _, unsafe := range unsafeValues {
+				if unsafe != "" && rendered == unsafe {
+					t.Fatalf("log call %+v carries unsafe field value %q", call, unsafe)
+				}
+			}
+		}
+	}
+}

--- a/pkg/services/chat_sessions/internal/service/logging_test.go
+++ b/pkg/services/chat_sessions/internal/service/logging_test.go
@@ -104,6 +104,54 @@ func TestStore_CreateSession_LogsStartAndAcceptedOutcomeWithoutUnsafeFields(t *t
 	}
 }
 
+// TestStore_GetSession_LogsStartAndOutcome proves GetSession -- the sole
+// method that previously bypassed logStart/logOutcome -- logs a Debug start
+// and Info outcome for both a successful read and a *NotFoundError read,
+// with the same start/outcome shape as every other Store operation.
+func TestStore_GetSession_LogsStartAndOutcome(t *testing.T) {
+	logger, calls := newCaptureLogger()
+	store := New(sequentialIDs("session"), fixedClock(time.Now()), logger)
+
+	created, err := store.CreateSession(context.Background(), validCreateRequest())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	*calls = nil // discard CreateSession's own log calls
+
+	if _, err := store.GetSession(context.Background(), chatsessions.GetSessionRequest{SessionID: created.Session.ID}); err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if len(*calls) != 2 {
+		t.Fatalf("GetSession logged %d calls, want 2 (start, outcome): %+v", len(*calls), *calls)
+	}
+	if (*calls)[0].level != "debug" {
+		t.Fatalf("first log level = %q, want debug (start)", (*calls)[0].level)
+	}
+	outcome := (*calls)[1]
+	if outcome.level != "info" {
+		t.Fatalf("second log level = %q, want info (outcome)", outcome.level)
+	}
+	if !hasKV(outcome.kv, "session_id", created.Session.ID) {
+		t.Fatalf("outcome log missing session_id=%q: %+v", created.Session.ID, outcome.kv)
+	}
+	if !hasKV(outcome.kv, "error_class", "") {
+		t.Fatalf("successful outcome log must carry an empty error_class: %+v", outcome.kv)
+	}
+
+	*calls = nil
+	if _, err := store.GetSession(context.Background(), chatsessions.GetSessionRequest{SessionID: "does-not-exist"}); err == nil {
+		t.Fatal("GetSession unknown session: got nil error, want *NotFoundError")
+	}
+	if len(*calls) != 2 {
+		t.Fatalf("GetSession (not found) logged %d calls, want 2 (start, outcome): %+v", len(*calls), *calls)
+	}
+	if !hasKV((*calls)[1].kv, "error_class", "not_found") {
+		t.Fatalf("not-found outcome log missing error_class=not_found: %+v", (*calls)[1].kv)
+	}
+
+	assertNoUnsafeFields(t, *calls, created.Session.Cwd, "")
+}
+
 // TestStore_SetTarget_FailureLogsClassificationOnly proves a failed mutating
 // operation's outcome log carries only the operation name, session ID, and
 // error classification -- never a partial/zero-value accepted field.

--- a/pkg/services/chat_sessions/internal/service/session.go
+++ b/pkg/services/chat_sessions/internal/service/session.go
@@ -44,10 +44,19 @@ func (s *Store) CreateSession(_ context.Context, req chatsessions.CreateSessionR
 	if err := session.Validate(); err != nil {
 		return chatsessions.CreateSessionResult{}, err
 	}
+	episode := chatsessions.TargetEpisode{
+		Number:    initialTargetEpisodeNumber,
+		State:     chatsessions.TargetEpisodeStateOpen,
+		Target:    req.InitialTarget,
+		StartedAt: now,
+	}
+	if err := episode.Validate(); err != nil {
+		return chatsessions.CreateSessionResult{}, err
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.sessions[session.ID] = sessionRecord{session: session}
+	s.sessions[session.ID] = sessionRecord{session: session, episodes: []chatsessions.TargetEpisode{episode}}
 	return chatsessions.CreateSessionResult{Session: session}, nil
 }
 

--- a/pkg/services/chat_sessions/internal/service/session.go
+++ b/pkg/services/chat_sessions/internal/service/session.go
@@ -57,9 +57,10 @@ func (s *Store) CreateSession(_ context.Context, req chatsessions.CreateSessionR
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.sessions[session.ID] = sessionRecord{
-		session:  session,
-		episodes: []chatsessions.TargetEpisode{episode},
-		turns:    make(map[string]chatsessions.Turn),
+		session:     session,
+		episodes:    []chatsessions.TargetEpisode{episode},
+		turns:       make(map[string]chatsessions.Turn),
+		attachments: make(map[string]chatsessions.Attachment),
 	}
 	return chatsessions.CreateSessionResult{Session: session}, nil
 }

--- a/pkg/services/chat_sessions/internal/service/session.go
+++ b/pkg/services/chat_sessions/internal/service/session.go
@@ -61,6 +61,7 @@ func (s *Store) CreateSession(_ context.Context, req chatsessions.CreateSessionR
 		episodes:    []chatsessions.TargetEpisode{episode},
 		turns:       make(map[string]chatsessions.Turn),
 		attachments: make(map[string]chatsessions.Attachment),
+		controls:    make(map[chatsessions.RequestIdentity]chatsessions.ControlIntent),
 	}
 	return chatsessions.CreateSessionResult{Session: session}, nil
 }

--- a/pkg/services/chat_sessions/internal/service/session.go
+++ b/pkg/services/chat_sessions/internal/service/session.go
@@ -56,7 +56,11 @@ func (s *Store) CreateSession(_ context.Context, req chatsessions.CreateSessionR
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.sessions[session.ID] = sessionRecord{session: session, episodes: []chatsessions.TargetEpisode{episode}}
+	s.sessions[session.ID] = sessionRecord{
+		session:  session,
+		episodes: []chatsessions.TargetEpisode{episode},
+		turns:    make(map[string]chatsessions.Turn),
+	}
 	return chatsessions.CreateSessionResult{Session: session}, nil
 }
 

--- a/pkg/services/chat_sessions/internal/service/session.go
+++ b/pkg/services/chat_sessions/internal/service/session.go
@@ -73,7 +73,11 @@ func (s *Store) CreateSession(_ context.Context, req chatsessions.CreateSessionR
 // GetSession returns a detached copy of the current Session state. It
 // reports *NotFoundError when SessionID does not identify an existing
 // session and creates no placeholder history for an unknown ID.
-func (s *Store) GetSession(_ context.Context, req chatsessions.GetSessionRequest) (chatsessions.GetSessionResult, error) {
+func (s *Store) GetSession(_ context.Context, req chatsessions.GetSessionRequest) (result chatsessions.GetSessionResult, err error) {
+	s.logStart("GetSession", req.SessionID)
+	defer func() {
+		s.logOutcome("GetSession", req.SessionID, err, "version", result.Session.Version, "target_episode", result.Session.TargetEpisode)
+	}()
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	record, ok := s.sessions[req.SessionID]

--- a/pkg/services/chat_sessions/internal/service/session.go
+++ b/pkg/services/chat_sessions/internal/service/session.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"context"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+)
+
+// initialSessionVersion is the Version a newly created Session carries. A
+// caller's first mutation attempt therefore supplies this exact value as
+// ExpectedVersion.
+const initialSessionVersion uint64 = 1
+
+// initialTargetEpisodeNumber is the TargetEpisode number a newly created
+// Session's first, still-open episode carries.
+const initialTargetEpisodeNumber uint64 = 1
+
+// CreateSession validates req in full before any state is touched, so an
+// invalid RequestID, Cwd, or InitialTarget creates no observable session.
+func (s *Store) CreateSession(_ context.Context, req chatsessions.CreateSessionRequest) (chatsessions.CreateSessionResult, error) {
+	if err := req.RequestID.Validate(); err != nil {
+		return chatsessions.CreateSessionResult{}, err
+	}
+	if req.Cwd == "" {
+		return chatsessions.CreateSessionResult{}, &chatsessions.ValidationError{
+			Value: "CreateSessionRequest", Field: "Cwd", Err: chatsessions.ErrRequiredValue,
+		}
+	}
+	if err := req.InitialTarget.Validate(); err != nil {
+		return chatsessions.CreateSessionResult{}, err
+	}
+
+	now := s.now()
+	session := chatsessions.Session{
+		ID:             s.newID(),
+		State:          chatsessions.SessionStateCreated,
+		Cwd:            req.Cwd,
+		SelectedTarget: req.InitialTarget,
+		TargetEpisode:  initialTargetEpisodeNumber,
+		Version:        initialSessionVersion,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := session.Validate(); err != nil {
+		return chatsessions.CreateSessionResult{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessions[session.ID] = sessionRecord{session: session}
+	return chatsessions.CreateSessionResult{Session: session}, nil
+}
+
+// GetSession returns a detached copy of the current Session state. It
+// reports *NotFoundError when SessionID does not identify an existing
+// session and creates no placeholder history for an unknown ID.
+func (s *Store) GetSession(_ context.Context, req chatsessions.GetSessionRequest) (chatsessions.GetSessionResult, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	record, ok := s.sessions[req.SessionID]
+	if !ok {
+		return chatsessions.GetSessionResult{}, &chatsessions.NotFoundError{Value: "Session", ID: req.SessionID}
+	}
+	return chatsessions.GetSessionResult{Session: record.session}, nil
+}

--- a/pkg/services/chat_sessions/internal/service/session.go
+++ b/pkg/services/chat_sessions/internal/service/session.go
@@ -17,6 +17,11 @@ const initialTargetEpisodeNumber uint64 = 1
 
 // CreateSession validates req in full before any state is touched, so an
 // invalid RequestID, Cwd, or InitialTarget creates no observable session.
+// newID and now are only ever called while s.mu is held (see the write-lock
+// below), so CreateSession is safe under concurrent calls even when the
+// injected IDGenerator/Clock are not themselves safe for concurrent use --
+// Store does not require its dependencies to be concurrency-safe by
+// contract, it serializes access to them itself.
 func (s *Store) CreateSession(_ context.Context, req chatsessions.CreateSessionRequest) (result chatsessions.CreateSessionResult, err error) {
 	s.logStart("CreateSession", "")
 	defer func() {
@@ -33,6 +38,9 @@ func (s *Store) CreateSession(_ context.Context, req chatsessions.CreateSessionR
 	if err := req.InitialTarget.Validate(); err != nil {
 		return chatsessions.CreateSessionResult{}, err
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	now := s.now()
 	session := chatsessions.Session{
@@ -58,8 +66,6 @@ func (s *Store) CreateSession(_ context.Context, req chatsessions.CreateSessionR
 		return chatsessions.CreateSessionResult{}, err
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.sessions[session.ID] = sessionRecord{
 		session:     session,
 		episodes:    []chatsessions.TargetEpisode{episode},

--- a/pkg/services/chat_sessions/internal/service/session.go
+++ b/pkg/services/chat_sessions/internal/service/session.go
@@ -17,7 +17,11 @@ const initialTargetEpisodeNumber uint64 = 1
 
 // CreateSession validates req in full before any state is touched, so an
 // invalid RequestID, Cwd, or InitialTarget creates no observable session.
-func (s *Store) CreateSession(_ context.Context, req chatsessions.CreateSessionRequest) (chatsessions.CreateSessionResult, error) {
+func (s *Store) CreateSession(_ context.Context, req chatsessions.CreateSessionRequest) (result chatsessions.CreateSessionResult, err error) {
+	s.logStart("CreateSession", "")
+	defer func() {
+		s.logOutcome("CreateSession", result.Session.ID, err, "version", result.Session.Version, "target_episode", result.Session.TargetEpisode)
+	}()
 	if err := req.RequestID.Validate(); err != nil {
 		return chatsessions.CreateSessionResult{}, err
 	}

--- a/pkg/services/chat_sessions/internal/service/session.go
+++ b/pkg/services/chat_sessions/internal/service/session.go
@@ -16,7 +16,7 @@ const initialSessionVersion uint64 = 1
 const initialTargetEpisodeNumber uint64 = 1
 
 // CreateSession validates req in full before any state is touched, so an
-// invalid RequestID, Cwd, or InitialTarget creates no observable session.
+// invalid RequestID, WorkingRoot, or InitialTarget creates no observable session.
 // newID and now are only ever called while s.mu is held (see the write-lock
 // below), so CreateSession is safe under concurrent calls even when the
 // injected IDGenerator/Clock are not themselves safe for concurrent use --
@@ -30,9 +30,9 @@ func (s *Store) CreateSession(_ context.Context, req chatsessions.CreateSessionR
 	if err := req.RequestID.Validate(); err != nil {
 		return chatsessions.CreateSessionResult{}, err
 	}
-	if req.Cwd == "" {
+	if req.WorkingRoot == "" {
 		return chatsessions.CreateSessionResult{}, &chatsessions.ValidationError{
-			Value: "CreateSessionRequest", Field: "Cwd", Err: chatsessions.ErrRequiredValue,
+			Value: "CreateSessionRequest", Field: "WorkingRoot", Err: chatsessions.ErrRequiredValue,
 		}
 	}
 	if err := req.InitialTarget.Validate(); err != nil {
@@ -46,7 +46,7 @@ func (s *Store) CreateSession(_ context.Context, req chatsessions.CreateSessionR
 	session := chatsessions.Session{
 		ID:             s.newID(),
 		State:          chatsessions.SessionStateCreated,
-		Cwd:            req.Cwd,
+		WorkingRoot:    req.WorkingRoot,
 		SelectedTarget: req.InitialTarget,
 		TargetEpisode:  initialTargetEpisodeNumber,
 		Version:        initialSessionVersion,

--- a/pkg/services/chat_sessions/internal/service/session_test.go
+++ b/pkg/services/chat_sessions/internal/service/session_test.go
@@ -29,7 +29,7 @@ func fixedClock(at time.Time) Clock {
 func validCreateRequest() chatsessions.CreateSessionRequest {
 	return chatsessions.CreateSessionRequest{
 		RequestID:     chatsessions.RequestIdentity{Kind: chatsessions.RequestIdentityKindJSONRPCString, ConnectionID: "conn-1", JSONRPCStringID: "req-1"},
-		Cwd:           "/workspace/project",
+		WorkingRoot:   "/workspace/project",
 		InitialTarget: chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "factory:@you/review"},
 	}
 }
@@ -50,8 +50,8 @@ func TestStore_CreateSession_Success(t *testing.T) {
 	if session.State != chatsessions.SessionStateCreated {
 		t.Fatalf("State = %v, want CREATED", session.State)
 	}
-	if session.Cwd != "/workspace/project" {
-		t.Fatalf("Cwd = %q, want /workspace/project", session.Cwd)
+	if session.WorkingRoot != "/workspace/project" {
+		t.Fatalf("WorkingRoot = %q, want /workspace/project", session.WorkingRoot)
 	}
 	if session.SelectedTarget.Ref != "factory:@you/review" {
 		t.Fatalf("SelectedTarget = %+v, want the requested initial target", session.SelectedTarget)
@@ -73,7 +73,7 @@ func TestStore_CreateSession_Success(t *testing.T) {
 	}
 }
 
-// TestStore_CreateSession_InvalidInputCreatesNoSession proves a blank Cwd,
+// TestStore_CreateSession_InvalidInputCreatesNoSession proves a blank WorkingRoot,
 // invalid RequestID, or invalid InitialTarget reports the existing typed
 // validation classification and leaves the Store empty.
 func TestStore_CreateSession_InvalidInputCreatesNoSession(t *testing.T) {
@@ -82,8 +82,8 @@ func TestStore_CreateSession_InvalidInputCreatesNoSession(t *testing.T) {
 		mutate  func(chatsessions.CreateSessionRequest) chatsessions.CreateSessionRequest
 		wantErr error
 	}{
-		{"blank cwd", func(r chatsessions.CreateSessionRequest) chatsessions.CreateSessionRequest {
-			r.Cwd = ""
+		{"blank working root", func(r chatsessions.CreateSessionRequest) chatsessions.CreateSessionRequest {
+			r.WorkingRoot = ""
 			return r
 		}, chatsessions.ErrRequiredValue},
 		{"invalid request identity", func(r chatsessions.CreateSessionRequest) chatsessions.CreateSessionRequest {
@@ -220,7 +220,7 @@ func TestStore_CreateSession_ConcurrentDifferentSessionsAreIndependent(t *testin
 				RequestID: chatsessions.RequestIdentity{
 					Kind: chatsessions.RequestIdentityKindJSONRPCString, ConnectionID: fmt.Sprintf("conn-%d", i), JSONRPCStringID: "req-1",
 				},
-				Cwd:           fmt.Sprintf("/workspace/project-%d", i),
+				WorkingRoot:   fmt.Sprintf("/workspace/project-%d", i),
 				InitialTarget: chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "factory:@you/review"},
 			})
 		}(i)
@@ -233,9 +233,9 @@ func TestStore_CreateSession_ConcurrentDifferentSessionsAreIndependent(t *testin
 			t.Fatalf("CreateSession[%d]: unexpected error %v", i, err)
 		}
 		seenIDs[results[i].Session.ID]++
-		wantCwd := fmt.Sprintf("/workspace/project-%d", i)
-		if results[i].Session.Cwd != wantCwd {
-			t.Fatalf("CreateSession[%d]: Cwd = %q, want %q", i, results[i].Session.Cwd, wantCwd)
+		wantWorkingRoot := fmt.Sprintf("/workspace/project-%d", i)
+		if results[i].Session.WorkingRoot != wantWorkingRoot {
+			t.Fatalf("CreateSession[%d]: WorkingRoot = %q, want %q", i, results[i].Session.WorkingRoot, wantWorkingRoot)
 		}
 	}
 	for id, count := range seenIDs {

--- a/pkg/services/chat_sessions/internal/service/session_test.go
+++ b/pkg/services/chat_sessions/internal/service/session_test.go
@@ -1,0 +1,194 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+)
+
+// sequentialIDs returns a deterministic IDGenerator that yields prefix-1,
+// prefix-2, ... so tests can assert on exact generated identities.
+func sequentialIDs(prefix string) IDGenerator {
+	n := 0
+	return func() string {
+		n++
+		return prefix + "-" + strconv.Itoa(n)
+	}
+}
+
+func fixedClock(at time.Time) Clock {
+	return func() time.Time { return at }
+}
+
+func validCreateRequest() chatsessions.CreateSessionRequest {
+	return chatsessions.CreateSessionRequest{
+		RequestID:     chatsessions.RequestIdentity{Kind: chatsessions.RequestIdentityKindJSONRPCString, ConnectionID: "conn-1", JSONRPCStringID: "req-1"},
+		Cwd:           "/workspace/project",
+		InitialTarget: chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "factory:@you/review"},
+	}
+}
+
+func TestStore_CreateSession_Success(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	store := New(sequentialIDs("session"), fixedClock(now))
+
+	result, err := store.CreateSession(ctx, validCreateRequest())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	session := result.Session
+	if session.ID == "" {
+		t.Fatal("CreateSession: expected a non-blank session ID")
+	}
+	if session.State != chatsessions.SessionStateCreated {
+		t.Fatalf("State = %v, want CREATED", session.State)
+	}
+	if session.Cwd != "/workspace/project" {
+		t.Fatalf("Cwd = %q, want /workspace/project", session.Cwd)
+	}
+	if session.SelectedTarget.Ref != "factory:@you/review" {
+		t.Fatalf("SelectedTarget = %+v, want the requested initial target", session.SelectedTarget)
+	}
+	if session.TargetEpisode != 1 {
+		t.Fatalf("TargetEpisode = %d, want 1", session.TargetEpisode)
+	}
+	if session.ActiveTurnID != "" {
+		t.Fatalf("ActiveTurnID = %q, want blank", session.ActiveTurnID)
+	}
+	if session.Version == 0 {
+		t.Fatal("Version = 0, want a non-zero initial version")
+	}
+	if session.CreatedAt.IsZero() || session.UpdatedAt.IsZero() {
+		t.Fatalf("CreatedAt/UpdatedAt must be non-zero, got %+v", session)
+	}
+	if err := session.Validate(); err != nil {
+		t.Fatalf("created Session fails its own Validate: %v", err)
+	}
+}
+
+// TestStore_CreateSession_InvalidInputCreatesNoSession proves a blank Cwd,
+// invalid RequestID, or invalid InitialTarget reports the existing typed
+// validation classification and leaves the Store empty.
+func TestStore_CreateSession_InvalidInputCreatesNoSession(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		mutate  func(chatsessions.CreateSessionRequest) chatsessions.CreateSessionRequest
+		wantErr error
+	}{
+		{"blank cwd", func(r chatsessions.CreateSessionRequest) chatsessions.CreateSessionRequest {
+			r.Cwd = ""
+			return r
+		}, chatsessions.ErrRequiredValue},
+		{"invalid request identity", func(r chatsessions.CreateSessionRequest) chatsessions.CreateSessionRequest {
+			r.RequestID = chatsessions.RequestIdentity{}
+			return r
+		}, chatsessions.ErrUnknownEnumValue},
+		{"invalid initial target", func(r chatsessions.CreateSessionRequest) chatsessions.CreateSessionRequest {
+			r.InitialTarget = chatsessions.ChatTargetRef{}
+			return r
+		}, chatsessions.ErrUnknownEnumValue},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := New(sequentialIDs("session"), fixedClock(time.Now()))
+
+			_, err := store.CreateSession(ctx, tt.mutate(validCreateRequest()))
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("CreateSession(%s): got %v, want %v", tt.name, err, tt.wantErr)
+			}
+			store.mu.RLock()
+			count := len(store.sessions)
+			store.mu.RUnlock()
+			if count != 0 {
+				t.Fatalf("CreateSession(%s): got %d observable sessions, want 0", tt.name, count)
+			}
+		})
+	}
+}
+
+// TestStore_CreateSession_ReturnsDetachedValue proves mutating a returned
+// Session cannot change what a later GetSession observes.
+func TestStore_CreateSession_ReturnsDetachedValue(t *testing.T) {
+	ctx := context.Background()
+	store := New(sequentialIDs("session"), fixedClock(time.Now()))
+
+	created, err := store.CreateSession(ctx, validCreateRequest())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	mutated := created.Session
+	mutated.SelectedTarget.Ref = "factory:@you/mutated"
+
+	reread, err := store.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: created.Session.ID})
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if reread.Session.SelectedTarget.Ref != "factory:@you/review" {
+		t.Fatalf("GetSession observed a mutation made to a previously returned value: %+v", reread.Session)
+	}
+}
+
+// TestStore_CreateSession_UniqueIDs proves two successful creates never
+// collide on generated session identity.
+func TestStore_CreateSession_UniqueIDs(t *testing.T) {
+	ctx := context.Background()
+	store := New(sequentialIDs("session"), fixedClock(time.Now()))
+
+	first, err := store.CreateSession(ctx, validCreateRequest())
+	if err != nil {
+		t.Fatalf("CreateSession first: %v", err)
+	}
+	second, err := store.CreateSession(ctx, validCreateRequest())
+	if err != nil {
+		t.Fatalf("CreateSession second: %v", err)
+	}
+	if first.Session.ID == second.Session.ID {
+		t.Fatalf("two CreateSession calls returned the same ID %q", first.Session.ID)
+	}
+}
+
+func TestStore_GetSession_UnknownIDIsTypedNotFound(t *testing.T) {
+	ctx := context.Background()
+	store := New(sequentialIDs("session"), fixedClock(time.Now()))
+
+	_, err := store.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: "does-not-exist"})
+	if !errors.Is(err, chatsessions.ErrNotFound) {
+		t.Fatalf("GetSession unknown id: got %v, want ErrNotFound", err)
+	}
+	var notFound *chatsessions.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("GetSession unknown id: got %v, want *NotFoundError", err)
+	}
+	if notFound.Value != "Session" || notFound.ID != "does-not-exist" {
+		t.Fatalf("NotFoundError = %+v, want Value=Session ID=does-not-exist", notFound)
+	}
+
+	store.mu.RLock()
+	count := len(store.sessions)
+	store.mu.RUnlock()
+	if count != 0 {
+		t.Fatalf("GetSession on an unknown ID created %d placeholder sessions, want 0", count)
+	}
+}
+
+// TestStore_InstancesShareNoState proves two independently constructed Store
+// instances are fully isolated: a session created in one is invisible to the
+// other.
+func TestStore_InstancesShareNoState(t *testing.T) {
+	ctx := context.Background()
+	first := New(sequentialIDs("session"), fixedClock(time.Now()))
+	second := New(sequentialIDs("session"), fixedClock(time.Now()))
+
+	created, err := first.CreateSession(ctx, validCreateRequest())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if _, err := second.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: created.Session.ID}); !errors.Is(err, chatsessions.ErrNotFound) {
+		t.Fatalf("second Store observed the first Store's session: got %v, want ErrNotFound", err)
+	}
+}

--- a/pkg/services/chat_sessions/internal/service/session_test.go
+++ b/pkg/services/chat_sessions/internal/service/session_test.go
@@ -3,7 +3,9 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -190,5 +192,92 @@ func TestStore_InstancesShareNoState(t *testing.T) {
 	}
 	if _, err := second.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: created.Session.ID}); !errors.Is(err, chatsessions.ErrNotFound) {
 		t.Fatalf("second Store observed the first Store's session: got %v, want ErrNotFound", err)
+	}
+}
+
+// TestStore_CreateSession_ConcurrentDifferentSessionsAreIndependent proves
+// CreateSession is safe under concurrent calls that each create a distinct
+// session, even though the injected IDGenerator here (sequentialIDs)
+// mutates a plain closure variable with no synchronization of its own:
+// Store must serialize its own calls to newID/now under s.mu rather than
+// require every caller-supplied dependency to be concurrency-safe by
+// contract. It also proves the resulting sessions are independent -- a
+// concurrent SetTarget against each of the n distinct sessions afterward
+// succeeds for every one with no cross-session interference.
+func TestStore_CreateSession_ConcurrentDifferentSessionsAreIndependent(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(sequentialIDs("session"), fixedClock(time.Now()))
+
+	const n = 25
+	var wg sync.WaitGroup
+	results := make([]chatsessions.CreateSessionResult, n)
+	createErrs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i], createErrs[i] = store.CreateSession(ctx, chatsessions.CreateSessionRequest{
+				RequestID: chatsessions.RequestIdentity{
+					Kind: chatsessions.RequestIdentityKindJSONRPCString, ConnectionID: fmt.Sprintf("conn-%d", i), JSONRPCStringID: "req-1",
+				},
+				Cwd:           fmt.Sprintf("/workspace/project-%d", i),
+				InitialTarget: chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "factory:@you/review"},
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	seenIDs := make(map[string]int, n)
+	for i, err := range createErrs {
+		if err != nil {
+			t.Fatalf("CreateSession[%d]: unexpected error %v", i, err)
+		}
+		seenIDs[results[i].Session.ID]++
+		wantCwd := fmt.Sprintf("/workspace/project-%d", i)
+		if results[i].Session.Cwd != wantCwd {
+			t.Fatalf("CreateSession[%d]: Cwd = %q, want %q", i, results[i].Session.Cwd, wantCwd)
+		}
+	}
+	for id, count := range seenIDs {
+		if count != 1 {
+			t.Fatalf("session ID %q was assigned to %d concurrent CreateSession calls, want a unique ID per call", id, count)
+		}
+	}
+	if len(seenIDs) != n {
+		t.Fatalf("got %d unique session IDs from %d concurrent CreateSession calls, want %d", len(seenIDs), n, n)
+	}
+
+	var mutateWG sync.WaitGroup
+	setErrs := make([]error, n)
+	for i := range n {
+		mutateWG.Add(1)
+		go func(i int) {
+			defer mutateWG.Done()
+			_, setErrs[i] = store.SetTarget(ctx, chatsessions.SetTargetRequest{
+				RequestID:       setTargetRequestID(fmt.Sprintf("retarget-%d", i)),
+				SessionID:       results[i].Session.ID,
+				ExpectedVersion: results[i].Session.Version,
+				Target:          otherTarget(),
+			})
+		}(i)
+	}
+	mutateWG.Wait()
+
+	for i, err := range setErrs {
+		if err != nil {
+			t.Fatalf("SetTarget[%d]: unexpected error %v", i, err)
+		}
+	}
+	for i := range n {
+		final, err := store.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: results[i].Session.ID})
+		if err != nil {
+			t.Fatalf("GetSession[%d]: %v", i, err)
+		}
+		if final.Session.SelectedTarget != otherTarget() {
+			t.Fatalf("GetSession[%d]: SelectedTarget = %+v, want %+v", i, final.Session.SelectedTarget, otherTarget())
+		}
+		if final.Session.Version != results[i].Session.Version+1 {
+			t.Fatalf("GetSession[%d]: Version = %d, want %d", i, final.Session.Version, results[i].Session.Version+1)
+		}
 	}
 }

--- a/pkg/services/chat_sessions/internal/service/store.go
+++ b/pkg/services/chat_sessions/internal/service/store.go
@@ -38,14 +38,18 @@ type Store struct {
 // monotonic counter used solely to give each newly terminal Turn a distinct,
 // non-zero TerminalSequence -- it is unrelated to and never written into the
 // public Session.StreamHead, since this in-memory engine does not wire into
-// a real event stream. attachments and control-intent state are added by
-// later stories as needed.
+// a real event stream. attachments holds every currently connected
+// Attachment keyed by its own ID; it is independent of session, episodes,
+// and turns -- attaching or detaching one connection never reads or writes
+// any of those fields. control-intent state is added by a later story as
+// needed.
 type sessionRecord struct {
 	session      chatsessions.Session
 	episodes     []chatsessions.TargetEpisode
 	activeTurn   *chatsessions.Turn
 	turns        map[string]chatsessions.Turn
 	turnSequence uint64
+	attachments  map[string]chatsessions.Attachment
 }
 
 // New constructs an empty Store from explicit dependencies. newID and now

--- a/pkg/services/chat_sessions/internal/service/store.go
+++ b/pkg/services/chat_sessions/internal/service/store.go
@@ -33,33 +33,61 @@ type Store struct {
 // sessionRecord is the Store-owned mutable aggregate for one Chat Session.
 // episodes is the session's full, consecutively numbered TargetEpisode
 // history ordered by Number, index 0 being Number 1; it is never rewritten
-// in place, only replaced with a new slice on rollover. activeTurn is the
-// session's current non-terminal Turn, or nil when no turn is active.
-// turns holds every Turn ever admitted for this session, keyed by Turn.ID,
-// so AdvanceTurn can locate a turn by identity regardless of whether it is
-// still active; a turn already present here is never removed, only replaced
-// in place with its advanced value. turnSequence is a private, per-session
-// monotonic counter used solely to give each newly terminal Turn a distinct,
-// non-zero TerminalSequence -- it is unrelated to and never written into the
-// public Session.StreamHead, since this in-memory engine does not wire into
-// a real event stream. attachments holds every currently connected
-// Attachment keyed by its own ID; it is independent of session, episodes,
-// and turns -- attaching or detaching one connection never reads or writes
-// any of those fields. controls holds every ControlIntent ever requested for
-// this session, keyed by its own RequestIdentity -- RequestIdentity is a
-// plain comparable struct with Kind as an explicit discriminator, so equal
+// in place, only replaced with a new slice on rollover. turns holds every
+// Turn ever admitted for this session, keyed by Turn.ID, so AdvanceTurn can
+// locate a turn by identity regardless of whether it is still active; a turn
+// already present here is never removed, only replaced in place with its
+// advanced value. Busy checks read the live active Turn through
+// activeTurnValue() (session.ActiveTurnID looked up against turns) rather
+// than a second, independently-mutable copy: an earlier revision kept a
+// separate *chatsessions.Turn pointer that AdvanceTurn only refreshed on a
+// terminal transition, so a BusyError raised after a public
+// ADMITTED->RUNNING advancement reported the turn's stale ADMITTED state
+// instead of its live RUNNING state. lastTurnID is the ID of the most
+// recently admitted turn regardless of its current state -- unlike
+// session.ActiveTurnID, it is never cleared when that turn terminates, only
+// overwritten by the next StartTurn -- so AdvanceControl can distinguish "the
+// captured turn already finished and no newer turn has been admitted"
+// (NOOP) from "a newer turn has since been admitted" (SUPERSEDED); comparing
+// against session.ActiveTurnID instead could never produce NOOP, since
+// ActiveTurnID clears to blank in the same commit that marks a turn
+// terminal. turnSequence is a private, per-session monotonic counter used
+// solely to give each newly terminal Turn a distinct, non-zero
+// TerminalSequence -- it is unrelated to and never written into the public
+// Session.StreamHead, since this in-memory engine does not wire into a real
+// event stream. attachments holds every currently connected Attachment keyed
+// by its own ID; it is independent of session, episodes, and turns --
+// attaching or detaching one connection never reads or writes any of those
+// fields. controls holds every ControlIntent ever requested for this
+// session, keyed by its own RequestIdentity -- RequestIdentity is a plain
+// comparable struct with Kind as an explicit discriminator, so equal
 // JSON-RPC ids from distinct ConnectionIDs (or against a bare TransportUUID)
 // are already distinct map keys with no risk of collision, retrieval, or
 // overwrite between them. A control intent already present here is never
-// removed, only replaced in place with its advanced value, mirroring turns.
+// removed or overwritten, only advanced in place via AdvanceControl, so a
+// reused RequestID can never retarget or rewrite an existing intent's
+// captured facts.
 type sessionRecord struct {
 	session      chatsessions.Session
 	episodes     []chatsessions.TargetEpisode
-	activeTurn   *chatsessions.Turn
 	turns        map[string]chatsessions.Turn
+	lastTurnID   string
 	turnSequence uint64
 	attachments  map[string]chatsessions.Attachment
 	controls     map[chatsessions.RequestIdentity]chatsessions.ControlIntent
+}
+
+// activeTurnValue returns the session's current active Turn read live from
+// turns, or false when no turn is active. Reading through turns (rather than
+// a second cached copy) guarantees the returned State always reflects the
+// most recent AdvanceTurn commit, including a non-terminal advancement such
+// as ADMITTED->RUNNING.
+func (record sessionRecord) activeTurnValue() (chatsessions.Turn, bool) {
+	if record.session.ActiveTurnID == "" {
+		return chatsessions.Turn{}, false
+	}
+	turn, ok := record.turns[record.session.ActiveTurnID]
+	return turn, ok
 }
 
 // New constructs an empty Store from explicit dependencies. newID and now

--- a/pkg/services/chat_sessions/internal/service/store.go
+++ b/pkg/services/chat_sessions/internal/service/store.go
@@ -27,10 +27,16 @@ type Store struct {
 }
 
 // sessionRecord is the Store-owned mutable aggregate for one Chat Session.
-// Story 001 tracks only the Session value itself; later stories add the
-// episode, turn, attachment, and control-intent state that hangs off it.
+// episodes is the session's full, consecutively numbered TargetEpisode
+// history ordered by Number, index 0 being Number 1; it is never rewritten
+// in place, only replaced with a new slice on rollover. activeTurn is the
+// session's current non-terminal Turn, or nil when no turn is active; later
+// stories (003+) populate it via StartTurn/AdvanceTurn. attachments and
+// control-intent state are added by later stories as needed.
 type sessionRecord struct {
-	session chatsessions.Session
+	session    chatsessions.Session
+	episodes   []chatsessions.TargetEpisode
+	activeTurn *chatsessions.Turn
 }
 
 // New constructs an empty Store from explicit dependencies. newID and now

--- a/pkg/services/chat_sessions/internal/service/store.go
+++ b/pkg/services/chat_sessions/internal/service/store.go
@@ -41,8 +41,13 @@ type Store struct {
 // a real event stream. attachments holds every currently connected
 // Attachment keyed by its own ID; it is independent of session, episodes,
 // and turns -- attaching or detaching one connection never reads or writes
-// any of those fields. control-intent state is added by a later story as
-// needed.
+// any of those fields. controls holds every ControlIntent ever requested for
+// this session, keyed by its own RequestIdentity -- RequestIdentity is a
+// plain comparable struct with Kind as an explicit discriminator, so equal
+// JSON-RPC ids from distinct ConnectionIDs (or against a bare TransportUUID)
+// are already distinct map keys with no risk of collision, retrieval, or
+// overwrite between them. A control intent already present here is never
+// removed, only replaced in place with its advanced value, mirroring turns.
 type sessionRecord struct {
 	session      chatsessions.Session
 	episodes     []chatsessions.TargetEpisode
@@ -50,6 +55,7 @@ type sessionRecord struct {
 	turns        map[string]chatsessions.Turn
 	turnSequence uint64
 	attachments  map[string]chatsessions.Attachment
+	controls     map[chatsessions.RequestIdentity]chatsessions.ControlIntent
 }
 
 // New constructs an empty Store from explicit dependencies. newID and now

--- a/pkg/services/chat_sessions/internal/service/store.go
+++ b/pkg/services/chat_sessions/internal/service/store.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"sync"
+	"time"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+)
+
+// IDGenerator produces a new opaque, process-unique entity identity. Store
+// never chooses an ambient UUID source itself; chat_sessions/wire supplies
+// the production generator.
+type IDGenerator func() string
+
+// Clock returns the current time. Store never calls time.Now directly, so a
+// caller can supply a deterministic clock under test.
+type Clock func() time.Time
+
+// Store is the synchronized in-memory implementation of the L1 V1 Chat
+// Sessions engine. The zero value is not usable; construct with New.
+type Store struct {
+	mu       sync.RWMutex
+	sessions map[string]sessionRecord
+
+	newID IDGenerator
+	now   Clock
+}
+
+// sessionRecord is the Store-owned mutable aggregate for one Chat Session.
+// Story 001 tracks only the Session value itself; later stories add the
+// episode, turn, attachment, and control-intent state that hangs off it.
+type sessionRecord struct {
+	session chatsessions.Session
+}
+
+// New constructs an empty Store from explicit dependencies. newID and now
+// must be non-nil.
+func New(newID IDGenerator, now Clock) *Store {
+	return &Store{
+		sessions: make(map[string]sessionRecord),
+		newID:    newID,
+		now:      now,
+	}
+}

--- a/pkg/services/chat_sessions/internal/service/store.go
+++ b/pkg/services/chat_sessions/internal/service/store.go
@@ -4,8 +4,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
 )
+
+var _ chatsessions.Service = (*Store)(nil)
 
 // IDGenerator produces a new opaque, process-unique entity identity. Store
 // never chooses an ambient UUID source itself; chat_sessions/wire supplies
@@ -22,8 +25,9 @@ type Store struct {
 	mu       sync.RWMutex
 	sessions map[string]sessionRecord
 
-	newID IDGenerator
-	now   Clock
+	newID  IDGenerator
+	now    Clock
+	logger logging.Logger
 }
 
 // sessionRecord is the Store-owned mutable aggregate for one Chat Session.
@@ -59,11 +63,18 @@ type sessionRecord struct {
 }
 
 // New constructs an empty Store from explicit dependencies. newID and now
-// must be non-nil.
-func New(newID IDGenerator, now Clock) *Store {
+// must be non-nil. logger is optional and defaults to a no-op logger when
+// omitted, matching the repository's optional-logger construction
+// convention rather than a mutable reinjection path.
+func New(newID IDGenerator, now Clock, logger ...logging.Logger) *Store {
+	var provided logging.Logger
+	if len(logger) > 0 {
+		provided = logger[0]
+	}
 	return &Store{
 		sessions: make(map[string]sessionRecord),
 		newID:    newID,
 		now:      now,
+		logger:   logging.EnsureLogger(provided),
 	}
 }

--- a/pkg/services/chat_sessions/internal/service/store.go
+++ b/pkg/services/chat_sessions/internal/service/store.go
@@ -30,13 +30,22 @@ type Store struct {
 // episodes is the session's full, consecutively numbered TargetEpisode
 // history ordered by Number, index 0 being Number 1; it is never rewritten
 // in place, only replaced with a new slice on rollover. activeTurn is the
-// session's current non-terminal Turn, or nil when no turn is active; later
-// stories (003+) populate it via StartTurn/AdvanceTurn. attachments and
-// control-intent state are added by later stories as needed.
+// session's current non-terminal Turn, or nil when no turn is active.
+// turns holds every Turn ever admitted for this session, keyed by Turn.ID,
+// so AdvanceTurn can locate a turn by identity regardless of whether it is
+// still active; a turn already present here is never removed, only replaced
+// in place with its advanced value. turnSequence is a private, per-session
+// monotonic counter used solely to give each newly terminal Turn a distinct,
+// non-zero TerminalSequence -- it is unrelated to and never written into the
+// public Session.StreamHead, since this in-memory engine does not wire into
+// a real event stream. attachments and control-intent state are added by
+// later stories as needed.
 type sessionRecord struct {
-	session    chatsessions.Session
-	episodes   []chatsessions.TargetEpisode
-	activeTurn *chatsessions.Turn
+	session      chatsessions.Session
+	episodes     []chatsessions.TargetEpisode
+	activeTurn   *chatsessions.Turn
+	turns        map[string]chatsessions.Turn
+	turnSequence uint64
 }
 
 // New constructs an empty Store from explicit dependencies. newID and now

--- a/pkg/services/chat_sessions/internal/service/target.go
+++ b/pkg/services/chat_sessions/internal/service/target.go
@@ -13,7 +13,11 @@ import (
 // matches the session's current version, and *BusyError while a non-terminal
 // turn is active -- in every failure case, no episode is created and the
 // stored session and episode history are left byte-for-byte unchanged.
-func (s *Store) SetTarget(_ context.Context, req chatsessions.SetTargetRequest) (chatsessions.SetTargetResult, error) {
+func (s *Store) SetTarget(_ context.Context, req chatsessions.SetTargetRequest) (result chatsessions.SetTargetResult, err error) {
+	s.logStart("SetTarget", req.SessionID)
+	defer func() {
+		s.logOutcome("SetTarget", req.SessionID, err, "version", result.Session.Version, "target_episode", result.Session.TargetEpisode)
+	}()
 	if err := req.RequestID.Validate(); err != nil {
 		return chatsessions.SetTargetResult{}, err
 	}

--- a/pkg/services/chat_sessions/internal/service/target.go
+++ b/pkg/services/chat_sessions/internal/service/target.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"context"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+)
+
+// SetTarget changes a session's selected target under an optimistic-version
+// guard, closing the currently open TargetEpisode and opening the next
+// consecutively numbered one at the new target. It reports *NotFoundError
+// for an unknown SessionID, *ConflictError when ExpectedVersion no longer
+// matches the session's current version, and *BusyError while a non-terminal
+// turn is active -- in every failure case, no episode is created and the
+// stored session and episode history are left byte-for-byte unchanged.
+func (s *Store) SetTarget(_ context.Context, req chatsessions.SetTargetRequest) (chatsessions.SetTargetResult, error) {
+	if err := req.RequestID.Validate(); err != nil {
+		return chatsessions.SetTargetResult{}, err
+	}
+	if err := req.Target.Validate(); err != nil {
+		return chatsessions.SetTargetResult{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, ok := s.sessions[req.SessionID]
+	if !ok {
+		return chatsessions.SetTargetResult{}, &chatsessions.NotFoundError{Value: "Session", ID: req.SessionID}
+	}
+	if req.ExpectedVersion != record.session.Version {
+		return chatsessions.SetTargetResult{}, &chatsessions.ConflictError{
+			Value: "Session", ID: req.SessionID,
+			Expected: req.ExpectedVersion, Actual: record.session.Version,
+		}
+	}
+	if record.activeTurn != nil {
+		return chatsessions.SetTargetResult{}, &chatsessions.BusyError{
+			Value: "Session", ID: req.SessionID,
+			ActiveTurnID: record.activeTurn.ID, ActiveTurnState: record.activeTurn.State,
+		}
+	}
+
+	now := s.now()
+	priorIdx := len(record.episodes) - 1
+	closed, err := chatsessions.CloseTargetEpisode(record.episodes[priorIdx], now)
+	if err != nil {
+		return chatsessions.SetTargetResult{}, err
+	}
+	next, err := chatsessions.OpenNextTargetEpisode(closed, req.Target, "", now)
+	if err != nil {
+		return chatsessions.SetTargetResult{}, err
+	}
+
+	updated := record.session
+	updated.SelectedTarget = req.Target
+	updated.TargetEpisode = next.Number
+	updated.Version++
+	updated.UpdatedAt = now
+	if err := updated.Validate(); err != nil {
+		return chatsessions.SetTargetResult{}, err
+	}
+
+	record.episodes[priorIdx] = closed
+	record.episodes = append(record.episodes, next)
+	record.session = updated
+	s.sessions[req.SessionID] = record
+
+	return chatsessions.SetTargetResult{Session: updated}, nil
+}

--- a/pkg/services/chat_sessions/internal/service/target.go
+++ b/pkg/services/chat_sessions/internal/service/target.go
@@ -38,10 +38,10 @@ func (s *Store) SetTarget(_ context.Context, req chatsessions.SetTargetRequest) 
 			Expected: req.ExpectedVersion, Actual: record.session.Version,
 		}
 	}
-	if record.activeTurn != nil {
+	if active, ok := record.activeTurnValue(); ok {
 		return chatsessions.SetTargetResult{}, &chatsessions.BusyError{
 			Value: "Session", ID: req.SessionID,
-			ActiveTurnID: record.activeTurn.ID, ActiveTurnState: record.activeTurn.State,
+			ActiveTurnID: active.ID, ActiveTurnState: active.State,
 		}
 	}
 

--- a/pkg/services/chat_sessions/internal/service/target_test.go
+++ b/pkg/services/chat_sessions/internal/service/target_test.go
@@ -169,42 +169,56 @@ func TestStore_SetTarget_StaleVersionConflictLeavesStateUnchanged(t *testing.T) 
 
 // TestStore_SetTarget_BusyWhileTurnActive proves a target change while a
 // turn is non-terminal reports *BusyError, creates no episode, and leaves
-// the session unchanged.
+// the session unchanged. The turn is admitted and advanced through the
+// public StartTurn/AdvanceTurn API (not fabricated private state), and
+// advanced to RUNNING before the busy check: an earlier revision kept a
+// second, independently-mutable copy of the active turn that AdvanceTurn's
+// non-terminal path never refreshed, so a BusyError raised after a public
+// ADMITTED->RUNNING advancement reported the stale ADMITTED state instead of
+// the turn's live RUNNING state.
 func TestStore_SetTarget_BusyWhileTurnActive(t *testing.T) {
 	ctx := context.Background()
 	store, session := newSetTargetTestSession(t, time.Now())
 
-	activeTurn := &chatsessions.Turn{
-		ID:        "turn-1",
-		Episode:   session.TargetEpisode,
-		State:     chatsessions.TurnStateRunning,
-		RequestID: setTargetRequestID("req-turn"),
-	}
-	store.mu.Lock()
-	record := store.sessions[session.ID]
-	record.activeTurn = activeTurn
-	store.sessions[session.ID] = record
-	store.mu.Unlock()
-
-	_, err := store.SetTarget(ctx, chatsessions.SetTargetRequest{
-		RequestID:       setTargetRequestID("req-1"),
+	started, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       setTargetRequestID("req-turn"),
 		SessionID:       session.ID,
 		ExpectedVersion: session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn: %v", err)
+	}
+	advanced, err := store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: session.ID,
+		TurnID:    started.Turn.ID,
+		Next:      chatsessions.TurnStateRunning,
+	})
+	if err != nil {
+		t.Fatalf("AdvanceTurn to RUNNING: %v", err)
+	}
+
+	_, err = store.SetTarget(ctx, chatsessions.SetTargetRequest{
+		RequestID:       setTargetRequestID("req-1"),
+		SessionID:       session.ID,
+		ExpectedVersion: started.Session.Version,
 		Target:          otherTarget(),
 	})
 	var busy *chatsessions.BusyError
 	if !errors.As(err, &busy) {
 		t.Fatalf("SetTarget while active turn: got %v, want *BusyError", err)
 	}
-	if busy.ActiveTurnID != "turn-1" || busy.ActiveTurnState != chatsessions.TurnStateRunning {
-		t.Fatalf("BusyError = %+v, want ActiveTurnID=turn-1 ActiveTurnState=RUNNING", busy)
+	if busy.ActiveTurnID != started.Turn.ID || busy.ActiveTurnState != chatsessions.TurnStateRunning {
+		t.Fatalf("BusyError = %+v, want ActiveTurnID=%q ActiveTurnState=RUNNING", busy, started.Turn.ID)
+	}
+	if advanced.Turn.State != chatsessions.TurnStateRunning {
+		t.Fatalf("AdvanceTurn result state = %v, want RUNNING", advanced.Turn.State)
 	}
 
 	store.mu.RLock()
 	after := store.sessions[session.ID]
 	store.mu.RUnlock()
-	if after.session != session {
-		t.Fatalf("busy SetTarget mutated Session: got %+v, want %+v", after.session, session)
+	if after.session != started.Session {
+		t.Fatalf("busy SetTarget mutated Session: got %+v, want %+v", after.session, started.Session)
 	}
 	if len(after.episodes) != 1 {
 		t.Fatalf("busy SetTarget created %d episodes, want 1", len(after.episodes))

--- a/pkg/services/chat_sessions/internal/service/target_test.go
+++ b/pkg/services/chat_sessions/internal/service/target_test.go
@@ -1,0 +1,349 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+)
+
+func otherTarget() chatsessions.ChatTargetRef {
+	return chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "factory:@you/other"}
+}
+
+func setTargetRequestID(id string) chatsessions.RequestIdentity {
+	return chatsessions.RequestIdentity{Kind: chatsessions.RequestIdentityKindJSONRPCString, ConnectionID: "conn-1", JSONRPCStringID: id}
+}
+
+// newSetTargetTestSession constructs a Store and one created Session ready
+// for SetTarget calls.
+func newSetTargetTestSession(t *testing.T, now time.Time) (*Store, chatsessions.Session) {
+	t.Helper()
+	store := New(sequentialIDs("session"), fixedClock(now))
+	created, err := store.CreateSession(context.Background(), validCreateRequest())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	return store, created.Session
+}
+
+// TestStore_SetTarget_RolloverClosesAndOpensEpisode proves a target change
+// with the current version atomically closes the prior episode, opens the
+// next consecutively numbered episode at the new target, updates session
+// selection/episode number, and returns a strictly newer version.
+func TestStore_SetTarget_RolloverClosesAndOpensEpisode(t *testing.T) {
+	ctx := context.Background()
+	created := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	rollover := created.Add(time.Minute)
+	store, session := newSetTargetTestSession(t, created)
+	store.now = fixedClock(rollover)
+
+	result, err := store.SetTarget(ctx, chatsessions.SetTargetRequest{
+		RequestID:       setTargetRequestID("req-target"),
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+		Target:          otherTarget(),
+	})
+	if err != nil {
+		t.Fatalf("SetTarget: %v", err)
+	}
+	if result.Session.SelectedTarget != otherTarget() {
+		t.Fatalf("SelectedTarget = %+v, want %+v", result.Session.SelectedTarget, otherTarget())
+	}
+	if result.Session.TargetEpisode != 2 {
+		t.Fatalf("TargetEpisode = %d, want 2", result.Session.TargetEpisode)
+	}
+	if result.Session.Version <= session.Version {
+		t.Fatalf("Version = %d, want strictly greater than %d", result.Session.Version, session.Version)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[session.ID]
+	store.mu.RUnlock()
+	if len(record.episodes) != 2 {
+		t.Fatalf("got %d episodes, want 2", len(record.episodes))
+	}
+	prior := record.episodes[0]
+	if prior.Number != 1 || prior.State != chatsessions.TargetEpisodeStateClosed {
+		t.Fatalf("prior episode = %+v, want Number=1 State=CLOSED", prior)
+	}
+	if prior.Target.Ref != "factory:@you/review" {
+		t.Fatalf("prior episode Target = %+v, want original initial target", prior.Target)
+	}
+	if prior.ClosedAt == nil || !prior.ClosedAt.Equal(rollover) {
+		t.Fatalf("prior episode ClosedAt = %v, want %v", prior.ClosedAt, rollover)
+	}
+	next := record.episodes[1]
+	if next.Number != 2 || next.State != chatsessions.TargetEpisodeStateOpen {
+		t.Fatalf("next episode = %+v, want Number=2 State=OPEN", next)
+	}
+	if next.Target != otherTarget() {
+		t.Fatalf("next episode Target = %+v, want %+v", next.Target, otherTarget())
+	}
+	if next.ClosedAt != nil {
+		t.Fatalf("next episode ClosedAt = %v, want nil", next.ClosedAt)
+	}
+}
+
+// TestStore_SetTarget_PreviouslyReturnedValuesUnaffected proves a Session
+// value read before a rollover is not mutated by the rollover, and a
+// previously observed closed episode's fields are never rewritten by a
+// subsequent rollover.
+func TestStore_SetTarget_PreviouslyReturnedValuesUnaffected(t *testing.T) {
+	ctx := context.Background()
+	store, session := newSetTargetTestSession(t, time.Now())
+	before := session
+
+	if _, err := store.SetTarget(ctx, chatsessions.SetTargetRequest{
+		RequestID:       setTargetRequestID("req-1"),
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+		Target:          otherTarget(),
+	}); err != nil {
+		t.Fatalf("SetTarget first: %v", err)
+	}
+	if before.TargetEpisode != 1 || before.SelectedTarget.Ref != "factory:@you/review" {
+		t.Fatalf("previously returned Session was mutated: %+v", before)
+	}
+
+	store.mu.RLock()
+	firstClosed := store.sessions[session.ID].episodes[0]
+	store.mu.RUnlock()
+
+	second, err := store.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: session.ID})
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if _, err := store.SetTarget(ctx, chatsessions.SetTargetRequest{
+		RequestID:       setTargetRequestID("req-2"),
+		SessionID:       session.ID,
+		ExpectedVersion: second.Session.Version,
+		Target:          chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "factory:@you/third"},
+	}); err != nil {
+		t.Fatalf("SetTarget second: %v", err)
+	}
+
+	store.mu.RLock()
+	firstClosedAfter := store.sessions[session.ID].episodes[0]
+	store.mu.RUnlock()
+	if firstClosedAfter != firstClosed {
+		t.Fatalf("historical episode 1 was rewritten: got %+v, want %+v", firstClosedAfter, firstClosed)
+	}
+}
+
+// TestStore_SetTarget_StaleVersionConflictLeavesStateUnchanged proves a
+// stale ExpectedVersion reports *ConflictError with the expected/actual
+// facts and leaves selection, episode history, and version unchanged.
+func TestStore_SetTarget_StaleVersionConflictLeavesStateUnchanged(t *testing.T) {
+	ctx := context.Background()
+	store, session := newSetTargetTestSession(t, time.Now())
+
+	_, err := store.SetTarget(ctx, chatsessions.SetTargetRequest{
+		RequestID:       setTargetRequestID("req-1"),
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version + 1,
+		Target:          otherTarget(),
+	})
+	var conflict *chatsessions.ConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("SetTarget stale version: got %v, want *ConflictError", err)
+	}
+	if conflict.Expected != session.Version+1 || conflict.Actual != session.Version {
+		t.Fatalf("ConflictError = %+v, want Expected=%d Actual=%d", conflict, session.Version+1, session.Version)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[session.ID]
+	store.mu.RUnlock()
+	if record.session != session {
+		t.Fatalf("stale SetTarget mutated Session: got %+v, want %+v", record.session, session)
+	}
+	if len(record.episodes) != 1 {
+		t.Fatalf("stale SetTarget created %d episodes, want 1", len(record.episodes))
+	}
+}
+
+// TestStore_SetTarget_BusyWhileTurnActive proves a target change while a
+// turn is non-terminal reports *BusyError, creates no episode, and leaves
+// the session unchanged.
+func TestStore_SetTarget_BusyWhileTurnActive(t *testing.T) {
+	ctx := context.Background()
+	store, session := newSetTargetTestSession(t, time.Now())
+
+	activeTurn := &chatsessions.Turn{
+		ID:        "turn-1",
+		Episode:   session.TargetEpisode,
+		State:     chatsessions.TurnStateRunning,
+		RequestID: setTargetRequestID("req-turn"),
+	}
+	store.mu.Lock()
+	record := store.sessions[session.ID]
+	record.activeTurn = activeTurn
+	store.sessions[session.ID] = record
+	store.mu.Unlock()
+
+	_, err := store.SetTarget(ctx, chatsessions.SetTargetRequest{
+		RequestID:       setTargetRequestID("req-1"),
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+		Target:          otherTarget(),
+	})
+	var busy *chatsessions.BusyError
+	if !errors.As(err, &busy) {
+		t.Fatalf("SetTarget while active turn: got %v, want *BusyError", err)
+	}
+	if busy.ActiveTurnID != "turn-1" || busy.ActiveTurnState != chatsessions.TurnStateRunning {
+		t.Fatalf("BusyError = %+v, want ActiveTurnID=turn-1 ActiveTurnState=RUNNING", busy)
+	}
+
+	store.mu.RLock()
+	after := store.sessions[session.ID]
+	store.mu.RUnlock()
+	if after.session != session {
+		t.Fatalf("busy SetTarget mutated Session: got %+v, want %+v", after.session, session)
+	}
+	if len(after.episodes) != 1 {
+		t.Fatalf("busy SetTarget created %d episodes, want 1", len(after.episodes))
+	}
+}
+
+// TestStore_SetTarget_UnknownSessionIsTypedNotFound proves SetTarget against
+// an unknown SessionID reports *NotFoundError and mutates nothing.
+func TestStore_SetTarget_UnknownSessionIsTypedNotFound(t *testing.T) {
+	ctx := context.Background()
+	store := New(sequentialIDs("session"), fixedClock(time.Now()))
+
+	_, err := store.SetTarget(ctx, chatsessions.SetTargetRequest{
+		RequestID:       setTargetRequestID("req-1"),
+		SessionID:       "does-not-exist",
+		ExpectedVersion: 1,
+		Target:          otherTarget(),
+	})
+	var notFound *chatsessions.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("SetTarget unknown session: got %v, want *NotFoundError", err)
+	}
+	if notFound.Value != "Session" || notFound.ID != "does-not-exist" {
+		t.Fatalf("NotFoundError = %+v, want Value=Session ID=does-not-exist", notFound)
+	}
+}
+
+// TestStore_SetTarget_InvalidInputCreatesNoMutation proves an invalid
+// RequestID or Target reports the existing typed validation classification
+// and leaves the session and episode history untouched.
+func TestStore_SetTarget_InvalidInputCreatesNoMutation(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		mutate  func(chatsessions.SetTargetRequest) chatsessions.SetTargetRequest
+		wantErr error
+	}{
+		{"invalid request identity", func(r chatsessions.SetTargetRequest) chatsessions.SetTargetRequest {
+			r.RequestID = chatsessions.RequestIdentity{}
+			return r
+		}, chatsessions.ErrUnknownEnumValue},
+		{"invalid target", func(r chatsessions.SetTargetRequest) chatsessions.SetTargetRequest {
+			r.Target = chatsessions.ChatTargetRef{}
+			return r
+		}, chatsessions.ErrUnknownEnumValue},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, session := newSetTargetTestSession(t, time.Now())
+
+			req := chatsessions.SetTargetRequest{
+				RequestID:       setTargetRequestID("req-1"),
+				SessionID:       session.ID,
+				ExpectedVersion: session.Version,
+				Target:          otherTarget(),
+			}
+			_, err := store.SetTarget(ctx, tt.mutate(req))
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("SetTarget(%s): got %v, want %v", tt.name, err, tt.wantErr)
+			}
+
+			store.mu.RLock()
+			record := store.sessions[session.ID]
+			store.mu.RUnlock()
+			if record.session != session {
+				t.Fatalf("SetTarget(%s) mutated Session: got %+v, want %+v", tt.name, record.session, session)
+			}
+			if len(record.episodes) != 1 {
+				t.Fatalf("SetTarget(%s) created %d episodes, want 1", tt.name, len(record.episodes))
+			}
+		})
+	}
+}
+
+// TestStore_SetTarget_ConcurrentSameExpectedVersionSingleWinner proves
+// concurrent target changes issued with the same ExpectedVersion yield
+// exactly one successful commit; every other caller observes the committed
+// state as a typed conflict, and the final episode history has no skipped
+// or duplicate episode number.
+func TestStore_SetTarget_ConcurrentSameExpectedVersionSingleWinner(t *testing.T) {
+	ctx := context.Background()
+	store, session := newSetTargetTestSession(t, time.Now())
+
+	const n = 25
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := store.SetTarget(ctx, chatsessions.SetTargetRequest{
+				RequestID:       setTargetRequestID(fmt.Sprintf("req-%d", i)),
+				SessionID:       session.ID,
+				ExpectedVersion: session.Version,
+				Target:          otherTarget(),
+			})
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	successes, conflicts := 0, 0
+	for _, err := range errs {
+		var conflict *chatsessions.ConflictError
+		switch {
+		case err == nil:
+			successes++
+		case errors.As(err, &conflict):
+			conflicts++
+		default:
+			t.Fatalf("unexpected SetTarget error: %v", err)
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("successes = %d, want exactly 1", successes)
+	}
+	if conflicts != n-1 {
+		t.Fatalf("conflicts = %d, want %d", conflicts, n-1)
+	}
+
+	final, err := store.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: session.ID})
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if final.Session.Version != session.Version+1 {
+		t.Fatalf("final Version = %d, want %d", final.Session.Version, session.Version+1)
+	}
+	if final.Session.TargetEpisode != 2 {
+		t.Fatalf("final TargetEpisode = %d, want 2", final.Session.TargetEpisode)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[session.ID]
+	store.mu.RUnlock()
+	if len(record.episodes) != 2 {
+		t.Fatalf("final episode count = %d, want 2", len(record.episodes))
+	}
+	for idx, ep := range record.episodes {
+		if ep.Number != uint64(idx+1) {
+			t.Fatalf("episodes[%d].Number = %d, want %d", idx, ep.Number, idx+1)
+		}
+	}
+}

--- a/pkg/services/chat_sessions/internal/service/turn.go
+++ b/pkg/services/chat_sessions/internal/service/turn.go
@@ -1,0 +1,131 @@
+package service
+
+import (
+	"context"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+)
+
+// StartTurn admits a new Turn against the session's current target episode
+// under an optimistic-version guard. It reports *NotFoundError for an
+// unknown SessionID, *ConflictError when ExpectedVersion no longer matches
+// the session's current version (checked before the busy check, matching
+// SetTarget's ordering), and *BusyError while a non-terminal turn is already
+// active -- in every failure case no turn is created and the stored session
+// and turn state are left byte-for-byte unchanged. On success it moves a
+// CREATED session to ACTIVE on its first turn and leaves an already-ACTIVE
+// session's State unchanged.
+func (s *Store) StartTurn(_ context.Context, req chatsessions.StartTurnRequest) (chatsessions.StartTurnResult, error) {
+	if err := req.RequestID.Validate(); err != nil {
+		return chatsessions.StartTurnResult{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, ok := s.sessions[req.SessionID]
+	if !ok {
+		return chatsessions.StartTurnResult{}, &chatsessions.NotFoundError{Value: "Session", ID: req.SessionID}
+	}
+	if req.ExpectedVersion != record.session.Version {
+		return chatsessions.StartTurnResult{}, &chatsessions.ConflictError{
+			Value: "Session", ID: req.SessionID,
+			Expected: req.ExpectedVersion, Actual: record.session.Version,
+		}
+	}
+	if record.activeTurn != nil {
+		return chatsessions.StartTurnResult{}, &chatsessions.BusyError{
+			Value: "Session", ID: req.SessionID,
+			ActiveTurnID: record.activeTurn.ID, ActiveTurnState: record.activeTurn.State,
+		}
+	}
+
+	turn := chatsessions.Turn{
+		ID:        s.newID(),
+		Episode:   record.session.TargetEpisode,
+		State:     chatsessions.TurnStateAdmitted,
+		RequestID: req.RequestID,
+	}
+	if err := turn.Validate(); err != nil {
+		return chatsessions.StartTurnResult{}, err
+	}
+
+	updated := record.session
+	if updated.State == chatsessions.SessionStateCreated {
+		if err := updated.State.CanTransitionTo(chatsessions.SessionStateActive); err != nil {
+			return chatsessions.StartTurnResult{}, err
+		}
+		updated.State = chatsessions.SessionStateActive
+	}
+	updated.ActiveTurnID = turn.ID
+	updated.Version++
+	updated.UpdatedAt = s.now()
+	if err := updated.Validate(); err != nil {
+		return chatsessions.StartTurnResult{}, err
+	}
+
+	record.turns[turn.ID] = turn
+	record.activeTurn = &turn
+	record.session = updated
+	s.sessions[req.SessionID] = record
+
+	return chatsessions.StartTurnResult{Session: updated, Turn: turn}, nil
+}
+
+// AdvanceTurn moves one Turn to Next, enforcing the TurnState transition
+// table. It reports *NotFoundError when SessionID or TurnID does not
+// identify an existing turn and the turn's own *TransitionError when Next is
+// not a legal transition from its current state; on either failure the
+// stored turn and session are left byte-for-byte unchanged. Reaching a
+// terminal Next records that terminal state on the turn (assigning it a
+// distinct, non-zero TerminalSequence from the session's private turn
+// sequence counter), clears the session's ActiveTurnID, and advances the
+// session's version so later guarded callers observe the release.
+func (s *Store) AdvanceTurn(_ context.Context, req chatsessions.AdvanceTurnRequest) (chatsessions.AdvanceTurnResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, ok := s.sessions[req.SessionID]
+	if !ok {
+		return chatsessions.AdvanceTurnResult{}, &chatsessions.NotFoundError{Value: "Turn", ID: req.TurnID}
+	}
+	turn, ok := record.turns[req.TurnID]
+	if !ok {
+		return chatsessions.AdvanceTurnResult{}, &chatsessions.NotFoundError{Value: "Turn", ID: req.TurnID}
+	}
+	if err := turn.State.CanTransitionTo(req.Next); err != nil {
+		return chatsessions.AdvanceTurnResult{}, err
+	}
+
+	updated := turn
+	updated.State = req.Next
+	nextTurnSequence := record.turnSequence
+	if req.Next.IsTerminal() {
+		nextTurnSequence++
+		updated.TerminalSequence = nextTurnSequence
+	}
+	if err := updated.Validate(); err != nil {
+		return chatsessions.AdvanceTurnResult{}, err
+	}
+
+	updatedSession := record.session
+	releasesSession := req.Next.IsTerminal() && record.session.ActiveTurnID == req.TurnID
+	if releasesSession {
+		updatedSession.ActiveTurnID = ""
+		updatedSession.Version++
+		updatedSession.UpdatedAt = s.now()
+		if err := updatedSession.Validate(); err != nil {
+			return chatsessions.AdvanceTurnResult{}, err
+		}
+	}
+
+	record.turns[req.TurnID] = updated
+	record.turnSequence = nextTurnSequence
+	if releasesSession {
+		record.activeTurn = nil
+		record.session = updatedSession
+	}
+	s.sessions[req.SessionID] = record
+
+	return chatsessions.AdvanceTurnResult{Turn: updated}, nil
+}

--- a/pkg/services/chat_sessions/internal/service/turn.go
+++ b/pkg/services/chat_sessions/internal/service/turn.go
@@ -15,7 +15,11 @@ import (
 // and turn state are left byte-for-byte unchanged. On success it moves a
 // CREATED session to ACTIVE on its first turn and leaves an already-ACTIVE
 // session's State unchanged.
-func (s *Store) StartTurn(_ context.Context, req chatsessions.StartTurnRequest) (chatsessions.StartTurnResult, error) {
+func (s *Store) StartTurn(_ context.Context, req chatsessions.StartTurnRequest) (result chatsessions.StartTurnResult, err error) {
+	s.logStart("StartTurn", req.SessionID)
+	defer func() {
+		s.logOutcome("StartTurn", req.SessionID, err, "version", result.Session.Version, "turn_id", result.Turn.ID)
+	}()
 	if err := req.RequestID.Validate(); err != nil {
 		return chatsessions.StartTurnResult{}, err
 	}
@@ -81,7 +85,11 @@ func (s *Store) StartTurn(_ context.Context, req chatsessions.StartTurnRequest) 
 // distinct, non-zero TerminalSequence from the session's private turn
 // sequence counter), clears the session's ActiveTurnID, and advances the
 // session's version so later guarded callers observe the release.
-func (s *Store) AdvanceTurn(_ context.Context, req chatsessions.AdvanceTurnRequest) (chatsessions.AdvanceTurnResult, error) {
+func (s *Store) AdvanceTurn(_ context.Context, req chatsessions.AdvanceTurnRequest) (result chatsessions.AdvanceTurnResult, err error) {
+	s.logStart("AdvanceTurn", req.SessionID)
+	defer func() {
+		s.logOutcome("AdvanceTurn", req.SessionID, err, "turn_id", result.Turn.ID, "state", string(result.Turn.State))
+	}()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/pkg/services/chat_sessions/internal/service/turn.go
+++ b/pkg/services/chat_sessions/internal/service/turn.go
@@ -37,10 +37,10 @@ func (s *Store) StartTurn(_ context.Context, req chatsessions.StartTurnRequest) 
 			Expected: req.ExpectedVersion, Actual: record.session.Version,
 		}
 	}
-	if record.activeTurn != nil {
+	if active, ok := record.activeTurnValue(); ok {
 		return chatsessions.StartTurnResult{}, &chatsessions.BusyError{
 			Value: "Session", ID: req.SessionID,
-			ActiveTurnID: record.activeTurn.ID, ActiveTurnState: record.activeTurn.State,
+			ActiveTurnID: active.ID, ActiveTurnState: active.State,
 		}
 	}
 
@@ -69,7 +69,7 @@ func (s *Store) StartTurn(_ context.Context, req chatsessions.StartTurnRequest) 
 	}
 
 	record.turns[turn.ID] = turn
-	record.activeTurn = &turn
+	record.lastTurnID = turn.ID
 	record.session = updated
 	s.sessions[req.SessionID] = record
 
@@ -130,7 +130,6 @@ func (s *Store) AdvanceTurn(_ context.Context, req chatsessions.AdvanceTurnReque
 	record.turns[req.TurnID] = updated
 	record.turnSequence = nextTurnSequence
 	if releasesSession {
-		record.activeTurn = nil
 		record.session = updatedSession
 	}
 	s.sessions[req.SessionID] = record

--- a/pkg/services/chat_sessions/internal/service/turn_test.go
+++ b/pkg/services/chat_sessions/internal/service/turn_test.go
@@ -114,6 +114,58 @@ func TestStore_StartTurn_SecondAdmissionWhileActiveIsBusy(t *testing.T) {
 	}
 }
 
+// TestStore_StartTurn_BusyReportsLiveRunningState proves a second admission
+// against a turn already advanced to RUNNING reports *BusyError carrying the
+// turn's live RUNNING state, not the ADMITTED state it was created with. An
+// earlier revision cached a second, independently-mutable copy of the active
+// turn that AdvanceTurn's non-terminal path never refreshed, so this busy
+// check reported a stale ADMITTED state after a public ADMITTED->RUNNING
+// advancement.
+func TestStore_StartTurn_BusyReportsLiveRunningState(t *testing.T) {
+	ctx := context.Background()
+	store, session := newStartTurnTestSession(t, time.Now())
+
+	first, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-1"),
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn first: %v", err)
+	}
+	advanced, err := store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: session.ID,
+		TurnID:    first.Turn.ID,
+		Next:      chatsessions.TurnStateRunning,
+	})
+	if err != nil {
+		t.Fatalf("AdvanceTurn to RUNNING: %v", err)
+	}
+
+	_, err = store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-2"),
+		SessionID:       session.ID,
+		ExpectedVersion: first.Session.Version,
+	})
+	var busy *chatsessions.BusyError
+	if !errors.As(err, &busy) {
+		t.Fatalf("StartTurn while running: got %v, want *BusyError", err)
+	}
+	if busy.ActiveTurnID != first.Turn.ID || busy.ActiveTurnState != chatsessions.TurnStateRunning {
+		t.Fatalf("BusyError = %+v, want ActiveTurnID=%q ActiveTurnState=RUNNING", busy, first.Turn.ID)
+	}
+	if advanced.Turn.State != chatsessions.TurnStateRunning {
+		t.Fatalf("AdvanceTurn result state = %v, want RUNNING", advanced.Turn.State)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[session.ID]
+	store.mu.RUnlock()
+	if record.session.Version != first.Session.Version {
+		t.Fatalf("session mutated by busy StartTurn: version = %d, want %d", record.session.Version, first.Session.Version)
+	}
+}
+
 // TestStore_StartTurn_StaleVersionConflictLeavesStateUnchanged proves a
 // stale-version admission reports typed *ConflictError without creating a
 // turn or changing session state, timestamps, active-turn identity, or
@@ -144,8 +196,8 @@ func TestStore_StartTurn_StaleVersionConflictLeavesStateUnchanged(t *testing.T) 
 	if len(record.turns) != 0 {
 		t.Fatalf("stale StartTurn created %d turns, want 0", len(record.turns))
 	}
-	if record.activeTurn != nil {
-		t.Fatalf("stale StartTurn set an active turn: %+v", record.activeTurn)
+	if active, ok := record.activeTurnValue(); ok {
+		t.Fatalf("stale StartTurn set an active turn: %+v", active)
 	}
 }
 

--- a/pkg/services/chat_sessions/internal/service/turn_test.go
+++ b/pkg/services/chat_sessions/internal/service/turn_test.go
@@ -1,0 +1,655 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+)
+
+func startTurnRequestID(id string) chatsessions.RequestIdentity {
+	return chatsessions.RequestIdentity{Kind: chatsessions.RequestIdentityKindJSONRPCString, ConnectionID: "conn-1", JSONRPCStringID: id}
+}
+
+// newStartTurnTestSession constructs a Store and one created Session ready
+// for StartTurn calls.
+func newStartTurnTestSession(t *testing.T, now time.Time) (*Store, chatsessions.Session) {
+	t.Helper()
+	store := New(sequentialIDs("session"), fixedClock(now))
+	created, err := store.CreateSession(context.Background(), validCreateRequest())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	return store, created.Session
+}
+
+// TestStore_StartTurn_FirstTurnActivatesSession proves admitting the first
+// turn creates one ADMITTED turn bound to the current target episode and
+// full request identity, moves a CREATED session to ACTIVE, sets
+// ActiveTurnID, and returns a strictly newer session version.
+func TestStore_StartTurn_FirstTurnActivatesSession(t *testing.T) {
+	ctx := context.Background()
+	store, session := newStartTurnTestSession(t, time.Now())
+
+	reqID := startTurnRequestID("req-turn-1")
+	result, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       reqID,
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn: %v", err)
+	}
+	if result.Turn.ID == "" {
+		t.Fatal("StartTurn: expected a non-blank turn ID")
+	}
+	if result.Turn.State != chatsessions.TurnStateAdmitted {
+		t.Fatalf("Turn.State = %v, want ADMITTED", result.Turn.State)
+	}
+	if result.Turn.Episode != session.TargetEpisode {
+		t.Fatalf("Turn.Episode = %d, want %d", result.Turn.Episode, session.TargetEpisode)
+	}
+	if result.Turn.RequestID != reqID {
+		t.Fatalf("Turn.RequestID = %+v, want %+v", result.Turn.RequestID, reqID)
+	}
+	if result.Session.State != chatsessions.SessionStateActive {
+		t.Fatalf("Session.State = %v, want ACTIVE", result.Session.State)
+	}
+	if result.Session.ActiveTurnID != result.Turn.ID {
+		t.Fatalf("Session.ActiveTurnID = %q, want %q", result.Session.ActiveTurnID, result.Turn.ID)
+	}
+	if result.Session.Version <= session.Version {
+		t.Fatalf("Session.Version = %d, want strictly greater than %d", result.Session.Version, session.Version)
+	}
+	if err := result.Turn.Validate(); err != nil {
+		t.Fatalf("admitted Turn fails its own Validate: %v", err)
+	}
+}
+
+// TestStore_StartTurn_SecondAdmissionWhileActiveIsBusy proves a second
+// sequential admission while the first turn is non-terminal reports typed
+// *BusyError, creates no additional active turn, and leaves the accepted
+// turn unchanged.
+func TestStore_StartTurn_SecondAdmissionWhileActiveIsBusy(t *testing.T) {
+	ctx := context.Background()
+	store, session := newStartTurnTestSession(t, time.Now())
+
+	first, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-1"),
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn first: %v", err)
+	}
+
+	_, err = store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-2"),
+		SessionID:       session.ID,
+		ExpectedVersion: first.Session.Version,
+	})
+	var busy *chatsessions.BusyError
+	if !errors.As(err, &busy) {
+		t.Fatalf("StartTurn second: got %v, want *BusyError", err)
+	}
+	if busy.ActiveTurnID != first.Turn.ID || busy.ActiveTurnState != chatsessions.TurnStateAdmitted {
+		t.Fatalf("BusyError = %+v, want ActiveTurnID=%q ActiveTurnState=ADMITTED", busy, first.Turn.ID)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[session.ID]
+	store.mu.RUnlock()
+	if len(record.turns) != 1 {
+		t.Fatalf("turns after busy admission = %d, want 1", len(record.turns))
+	}
+	if got := record.turns[first.Turn.ID]; got != first.Turn {
+		t.Fatalf("accepted turn changed after busy admission: got %+v, want %+v", got, first.Turn)
+	}
+	if record.session != first.Session {
+		t.Fatalf("session changed after busy admission: got %+v, want %+v", record.session, first.Session)
+	}
+}
+
+// TestStore_StartTurn_StaleVersionConflictLeavesStateUnchanged proves a
+// stale-version admission reports typed *ConflictError without creating a
+// turn or changing session state, timestamps, active-turn identity, or
+// version.
+func TestStore_StartTurn_StaleVersionConflictLeavesStateUnchanged(t *testing.T) {
+	ctx := context.Background()
+	store, session := newStartTurnTestSession(t, time.Now())
+
+	_, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-1"),
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version + 1,
+	})
+	var conflict *chatsessions.ConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("StartTurn stale version: got %v, want *ConflictError", err)
+	}
+	if conflict.Expected != session.Version+1 || conflict.Actual != session.Version {
+		t.Fatalf("ConflictError = %+v, want Expected=%d Actual=%d", conflict, session.Version+1, session.Version)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[session.ID]
+	store.mu.RUnlock()
+	if record.session != session {
+		t.Fatalf("stale StartTurn mutated Session: got %+v, want %+v", record.session, session)
+	}
+	if len(record.turns) != 0 {
+		t.Fatalf("stale StartTurn created %d turns, want 0", len(record.turns))
+	}
+	if record.activeTurn != nil {
+		t.Fatalf("stale StartTurn set an active turn: %+v", record.activeTurn)
+	}
+}
+
+// TestStore_StartTurn_UnknownSessionIsTypedNotFound proves StartTurn against
+// an unknown SessionID reports *NotFoundError and creates no turn.
+func TestStore_StartTurn_UnknownSessionIsTypedNotFound(t *testing.T) {
+	ctx := context.Background()
+	store := New(sequentialIDs("session"), fixedClock(time.Now()))
+
+	_, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-1"),
+		SessionID:       "does-not-exist",
+		ExpectedVersion: 1,
+	})
+	var notFound *chatsessions.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("StartTurn unknown session: got %v, want *NotFoundError", err)
+	}
+	if notFound.Value != "Session" || notFound.ID != "does-not-exist" {
+		t.Fatalf("NotFoundError = %+v, want Value=Session ID=does-not-exist", notFound)
+	}
+}
+
+// TestStore_StartTurn_InvalidRequestIdentityCreatesNoMutation proves an
+// invalid RequestID reports the existing typed validation classification and
+// leaves the session and turn state untouched.
+func TestStore_StartTurn_InvalidRequestIdentityCreatesNoMutation(t *testing.T) {
+	ctx := context.Background()
+	store, session := newStartTurnTestSession(t, time.Now())
+
+	_, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       chatsessions.RequestIdentity{},
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+	})
+	if !errors.Is(err, chatsessions.ErrUnknownEnumValue) {
+		t.Fatalf("StartTurn invalid request identity: got %v, want ErrUnknownEnumValue", err)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[session.ID]
+	store.mu.RUnlock()
+	if record.session != session {
+		t.Fatalf("invalid StartTurn mutated Session: got %+v, want %+v", record.session, session)
+	}
+	if len(record.turns) != 0 {
+		t.Fatalf("invalid StartTurn created %d turns, want 0", len(record.turns))
+	}
+}
+
+// TestStore_StartTurn_SecondTurnAfterTerminalStaysActive proves a session
+// already ACTIVE (its first turn already terminated) admits a second turn
+// without an illegal ACTIVE->ACTIVE self-transition.
+func TestStore_StartTurn_SecondTurnAfterTerminalStaysActive(t *testing.T) {
+	ctx := context.Background()
+	store, session := newStartTurnTestSession(t, time.Now())
+
+	first, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-1"),
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn first: %v", err)
+	}
+	advanced, err := store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: session.ID,
+		TurnID:    first.Turn.ID,
+		Next:      chatsessions.TurnStateCanceled,
+	})
+	if err != nil {
+		t.Fatalf("AdvanceTurn to terminal: %v", err)
+	}
+	if advanced.Turn.State != chatsessions.TurnStateCanceled {
+		t.Fatalf("Turn.State = %v, want CANCELED", advanced.Turn.State)
+	}
+
+	released, err := store.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: session.ID})
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+
+	second, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-2"),
+		SessionID:       session.ID,
+		ExpectedVersion: released.Session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn second: %v", err)
+	}
+	if second.Session.State != chatsessions.SessionStateActive {
+		t.Fatalf("Session.State = %v, want ACTIVE", second.Session.State)
+	}
+	if second.Turn.ID == first.Turn.ID {
+		t.Fatal("second StartTurn reused the first turn's ID")
+	}
+
+	store.mu.RLock()
+	firstAfter := store.sessions[session.ID].turns[first.Turn.ID]
+	store.mu.RUnlock()
+	if firstAfter != advanced.Turn {
+		t.Fatalf("first turn rewritten by second admission: got %+v, want %+v", firstAfter, advanced.Turn)
+	}
+}
+
+// TestStore_StartTurn_ConcurrentAdmissionSingleWinner proves concurrent
+// admissions using the same ExpectedVersion serialize to exactly one
+// successful commit. Since StartTurn checks ExpectedVersion before the busy
+// precondition (matching SetTarget's ordering) and the winner's commit
+// itself advances Session.Version, every loser observes the committed state
+// as a typed *ConflictError, not *BusyError.
+func TestStore_StartTurn_ConcurrentAdmissionSingleWinner(t *testing.T) {
+	ctx := context.Background()
+	store, session := newStartTurnTestSession(t, time.Now())
+
+	const n = 25
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+				RequestID:       startTurnRequestID(fmt.Sprintf("req-turn-%d", i)),
+				SessionID:       session.ID,
+				ExpectedVersion: session.Version,
+			})
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	successes, conflicts := 0, 0
+	for _, err := range errs {
+		var conflict *chatsessions.ConflictError
+		switch {
+		case err == nil:
+			successes++
+		case errors.As(err, &conflict):
+			conflicts++
+		default:
+			t.Fatalf("unexpected StartTurn error: %v", err)
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("successes = %d, want exactly 1", successes)
+	}
+	if conflicts != n-1 {
+		t.Fatalf("conflicts = %d, want %d", conflicts, n-1)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[session.ID]
+	store.mu.RUnlock()
+	if len(record.turns) != 1 {
+		t.Fatalf("final turn count = %d, want 1", len(record.turns))
+	}
+}
+
+// TestStore_StartTurn_ConcurrentAdmissionWhileBusyAllBusy proves concurrent
+// admission attempts against an already-active turn, each supplying the
+// session's current (matching) version, all observe typed *BusyError and
+// create no additional active turn -- the direct concurrent counterpart of
+// AC4's "second sequential or concurrent admission ... returns typed
+// BusyError".
+func TestStore_StartTurn_ConcurrentAdmissionWhileBusyAllBusy(t *testing.T) {
+	ctx := context.Background()
+	store, session := newStartTurnTestSession(t, time.Now())
+
+	first, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-1"),
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn first: %v", err)
+	}
+
+	const n = 25
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+				RequestID:       startTurnRequestID(fmt.Sprintf("req-turn-busy-%d", i)),
+				SessionID:       session.ID,
+				ExpectedVersion: first.Session.Version,
+			})
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		var busy *chatsessions.BusyError
+		if !errors.As(err, &busy) {
+			t.Fatalf("StartTurn[%d] while busy: got %v, want *BusyError", i, err)
+		}
+		if busy.ActiveTurnID != first.Turn.ID {
+			t.Fatalf("BusyError[%d].ActiveTurnID = %q, want %q", i, busy.ActiveTurnID, first.Turn.ID)
+		}
+	}
+
+	store.mu.RLock()
+	record := store.sessions[session.ID]
+	store.mu.RUnlock()
+	if len(record.turns) != 1 {
+		t.Fatalf("final turn count = %d, want 1", len(record.turns))
+	}
+	if record.session != first.Session {
+		t.Fatalf("session changed after concurrent busy admissions: got %+v, want %+v", record.session, first.Session)
+	}
+}
+
+// TestStore_AdvanceTurn_LegalTransitions proves every legal TurnState
+// transition succeeds and, when terminal, releases the session for a later
+// turn without rewriting the earlier turn.
+func TestStore_AdvanceTurn_LegalTransitions(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		path []chatsessions.TurnState
+	}{
+		{"admitted to running to completed", []chatsessions.TurnState{chatsessions.TurnStateRunning, chatsessions.TurnStateCompleted}},
+		{"admitted to running to failed", []chatsessions.TurnState{chatsessions.TurnStateRunning, chatsessions.TurnStateFailed}},
+		{"admitted to running to canceled", []chatsessions.TurnState{chatsessions.TurnStateRunning, chatsessions.TurnStateCanceled}},
+		{"admitted directly to canceled", []chatsessions.TurnState{chatsessions.TurnStateCanceled}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, session := newStartTurnTestSession(t, time.Now())
+			started, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+				RequestID:       startTurnRequestID("req-turn-1"),
+				SessionID:       session.ID,
+				ExpectedVersion: session.Version,
+			})
+			if err != nil {
+				t.Fatalf("StartTurn: %v", err)
+			}
+
+			var last chatsessions.Turn
+			for _, next := range tt.path {
+				result, err := store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+					SessionID: session.ID,
+					TurnID:    started.Turn.ID,
+					Next:      next,
+				})
+				if err != nil {
+					t.Fatalf("AdvanceTurn to %s: %v", next, err)
+				}
+				last = result.Turn
+			}
+			if last.State != tt.path[len(tt.path)-1] {
+				t.Fatalf("final Turn.State = %v, want %v", last.State, tt.path[len(tt.path)-1])
+			}
+			if err := last.Validate(); err != nil {
+				t.Fatalf("terminal Turn fails its own Validate: %v", err)
+			}
+
+			released, err := store.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: session.ID})
+			if err != nil {
+				t.Fatalf("GetSession: %v", err)
+			}
+			if released.Session.ActiveTurnID != "" {
+				t.Fatalf("Session.ActiveTurnID = %q after terminal advancement, want blank", released.Session.ActiveTurnID)
+			}
+			if released.Session.Version <= started.Session.Version {
+				t.Fatalf("Session.Version = %d, want strictly greater than %d", released.Session.Version, started.Session.Version)
+			}
+		})
+	}
+}
+
+// TestStore_AdvanceTurn_IllegalTransitionLeavesStateUnchanged proves a
+// representative set of illegal transitions report typed *TransitionError
+// and leave the stored turn unchanged.
+func TestStore_AdvanceTurn_IllegalTransitionLeavesStateUnchanged(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		next chatsessions.TurnState
+	}{
+		{"admitted to completed", chatsessions.TurnStateCompleted},
+		{"admitted to failed", chatsessions.TurnStateFailed},
+		{"admitted to self", chatsessions.TurnStateAdmitted},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, session := newStartTurnTestSession(t, time.Now())
+			started, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+				RequestID:       startTurnRequestID("req-turn-1"),
+				SessionID:       session.ID,
+				ExpectedVersion: session.Version,
+			})
+			if err != nil {
+				t.Fatalf("StartTurn: %v", err)
+			}
+
+			_, err = store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+				SessionID: session.ID,
+				TurnID:    started.Turn.ID,
+				Next:      tt.next,
+			})
+			var transition *chatsessions.TransitionError
+			if !errors.As(err, &transition) {
+				t.Fatalf("AdvanceTurn(%s): got %v, want *TransitionError", tt.name, err)
+			}
+
+			store.mu.RLock()
+			after := store.sessions[session.ID]
+			store.mu.RUnlock()
+			if got := after.turns[started.Turn.ID]; got != started.Turn {
+				t.Fatalf("AdvanceTurn(%s) mutated turn: got %+v, want %+v", tt.name, got, started.Turn)
+			}
+			if after.session != started.Session {
+				t.Fatalf("AdvanceTurn(%s) mutated session: got %+v, want %+v", tt.name, after.session, started.Session)
+			}
+		})
+	}
+}
+
+// TestStore_AdvanceTurn_TerminalTurnRejectsFurtherAdvancement proves
+// advancing an already-terminal turn again reports typed *TransitionError
+// and leaves the turn unchanged, so it can never rewrite its own history.
+func TestStore_AdvanceTurn_TerminalTurnRejectsFurtherAdvancement(t *testing.T) {
+	ctx := context.Background()
+	store, session := newStartTurnTestSession(t, time.Now())
+	started, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-1"),
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn: %v", err)
+	}
+	terminal, err := store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: session.ID,
+		TurnID:    started.Turn.ID,
+		Next:      chatsessions.TurnStateCanceled,
+	})
+	if err != nil {
+		t.Fatalf("AdvanceTurn to terminal: %v", err)
+	}
+
+	_, err = store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: session.ID,
+		TurnID:    started.Turn.ID,
+		Next:      chatsessions.TurnStateRunning,
+	})
+	var transition *chatsessions.TransitionError
+	if !errors.As(err, &transition) {
+		t.Fatalf("AdvanceTurn after terminal: got %v, want *TransitionError", err)
+	}
+
+	store.mu.RLock()
+	after := store.sessions[session.ID].turns[started.Turn.ID]
+	store.mu.RUnlock()
+	if after != terminal.Turn {
+		t.Fatalf("terminal turn rewritten: got %+v, want %+v", after, terminal.Turn)
+	}
+}
+
+// TestStore_AdvanceTurn_UnknownTurnIsTypedNotFound proves AdvanceTurn against
+// an unknown TurnID (on a known or unknown session) reports typed
+// *NotFoundError naming the Turn, not the Session.
+func TestStore_AdvanceTurn_UnknownTurnIsTypedNotFound(t *testing.T) {
+	ctx := context.Background()
+	store, session := newStartTurnTestSession(t, time.Now())
+
+	_, err := store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: session.ID,
+		TurnID:    "does-not-exist",
+		Next:      chatsessions.TurnStateRunning,
+	})
+	var notFound *chatsessions.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("AdvanceTurn unknown turn: got %v, want *NotFoundError", err)
+	}
+	if notFound.Value != "Turn" || notFound.ID != "does-not-exist" {
+		t.Fatalf("NotFoundError = %+v, want Value=Turn ID=does-not-exist", notFound)
+	}
+
+	_, err = store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: "does-not-exist-session",
+		TurnID:    "does-not-exist-turn",
+		Next:      chatsessions.TurnStateRunning,
+	})
+	if !errors.As(err, &notFound) {
+		t.Fatalf("AdvanceTurn unknown session: got %v, want *NotFoundError", err)
+	}
+	if notFound.Value != "Turn" || notFound.ID != "does-not-exist-turn" {
+		t.Fatalf("NotFoundError = %+v, want Value=Turn ID=does-not-exist-turn", notFound)
+	}
+}
+
+// TestStore_AdvanceTurn_DistinctTerminalSequences proves two different
+// terminal turns in the same session never collide on TerminalSequence.
+func TestStore_AdvanceTurn_DistinctTerminalSequences(t *testing.T) {
+	ctx := context.Background()
+	store, session := newStartTurnTestSession(t, time.Now())
+
+	first, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-1"),
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn first: %v", err)
+	}
+	firstTerminal, err := store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: session.ID,
+		TurnID:    first.Turn.ID,
+		Next:      chatsessions.TurnStateCanceled,
+	})
+	if err != nil {
+		t.Fatalf("AdvanceTurn first to terminal: %v", err)
+	}
+
+	released, err := store.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: session.ID})
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	second, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-2"),
+		SessionID:       session.ID,
+		ExpectedVersion: released.Session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn second: %v", err)
+	}
+	secondTerminal, err := store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: session.ID,
+		TurnID:    second.Turn.ID,
+		Next:      chatsessions.TurnStateCanceled,
+	})
+	if err != nil {
+		t.Fatalf("AdvanceTurn second to terminal: %v", err)
+	}
+
+	if firstTerminal.Turn.TerminalSequence == 0 || secondTerminal.Turn.TerminalSequence == 0 {
+		t.Fatalf("terminal sequences must be non-zero: first=%d second=%d",
+			firstTerminal.Turn.TerminalSequence, secondTerminal.Turn.TerminalSequence)
+	}
+	if firstTerminal.Turn.TerminalSequence == secondTerminal.Turn.TerminalSequence {
+		t.Fatalf("two terminal turns collided on TerminalSequence %d", firstTerminal.Turn.TerminalSequence)
+	}
+}
+
+// TestStore_AdvanceTurn_ConcurrentAdvancementIsRaceFree proves concurrent
+// AdvanceTurn calls against the same turn serialize so exactly one legal
+// ADMITTED->RUNNING transition wins and every other caller observes a typed
+// *TransitionError, never a corrupted or partially applied turn.
+func TestStore_AdvanceTurn_ConcurrentAdvancementIsRaceFree(t *testing.T) {
+	ctx := context.Background()
+	store, session := newStartTurnTestSession(t, time.Now())
+	started, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-1"),
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn: %v", err)
+	}
+
+	const n = 25
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+				SessionID: session.ID,
+				TurnID:    started.Turn.ID,
+				Next:      chatsessions.TurnStateRunning,
+			})
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	successes, transitions := 0, 0
+	for _, err := range errs {
+		var transition *chatsessions.TransitionError
+		switch {
+		case err == nil:
+			successes++
+		case errors.As(err, &transition):
+			transitions++
+		default:
+			t.Fatalf("unexpected AdvanceTurn error: %v", err)
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("successes = %d, want exactly 1", successes)
+	}
+	if transitions != n-1 {
+		t.Fatalf("transitions = %d, want %d", transitions, n-1)
+	}
+
+	store.mu.RLock()
+	final := store.sessions[session.ID].turns[started.Turn.ID]
+	store.mu.RUnlock()
+	if final.State != chatsessions.TurnStateRunning {
+		t.Fatalf("final Turn.State = %v, want RUNNING", final.State)
+	}
+}

--- a/pkg/services/chat_sessions/transitions.go
+++ b/pkg/services/chat_sessions/transitions.go
@@ -194,8 +194,21 @@ func OpenNextTargetEpisode(prior TargetEpisode, target ChatTargetRef, factorySes
 // ControlIntent's COMMITTED->{COMPLETED,NOOP,SUPERSEDED} advancement must
 // follow. It evaluates only the identities and facts captured when the
 // intent was requested (capturedTurnID, capturedTurnState) against the
-// Session's currentActiveTurnID at completion time; it never rebinds the
-// intent to a different turn.
+// session's mostRecentTurnID at completion time; it never rebinds the intent
+// to a different turn.
+//
+// mostRecentTurnID identifies the most recently admitted turn, not merely
+// whichever turn is presently non-terminal: it stays equal to a turn's ID
+// through that turn's own termination and only changes once a later turn is
+// actually admitted. A "currently active" identity that clears the instant
+// its turn terminates cannot serve this role, since every captured turn
+// eventually terminates and such a value would then always mismatch,
+// collapsing COMPLETED and NOOP into SUPERSEDED. mostRecentTurnID is exactly
+// what lets the two outcomes stay distinguishable: a captured turn that
+// terminated with no newer turn admitted since resolves NOOP (nothing left
+// to cancel or close), while a captured turn superseded by an actually newer
+// admission resolves SUPERSEDED, regardless of the captured turn's own
+// state.
 //
 // This helper accepts raw captured facts rather than a validated
 // ControlIntent, so it independently enforces the same required-value rule
@@ -206,23 +219,23 @@ func OpenNextTargetEpisode(prior TargetEpisode, target ChatTargetRef, factorySes
 // a meaningless SUPERSEDED/COMPLETED outcome. capturedTurnState is validated
 // next, before any outcome is selected, so a zero or unknown captured state
 // always reports a typed invalid-state error -- an identity mismatch
-// (capturedTurnID no longer the current active turn) never hides an invalid
+// (capturedTurnID no longer the most recent turn) never hides an invalid
 // captured state behind a SUPERSEDED outcome. Once both facts are valid, a
-// captured turn that is no longer the session's current active turn resolves
+// captured turn that is no longer the most recently admitted turn resolves
 // to SUPERSEDED regardless of capturedTurnState -- including when
-// capturedTurnState is itself already terminal, since "no longer current" is
-// evaluated first and takes precedence. Otherwise, an already-terminal
-// captured turn (one that finished before the intent completed) resolves to
-// NOOP, since there is nothing left to cancel or close; a still-active
-// captured turn resolves to COMPLETED.
-func ResolveControlIntentOutcome(capturedTurnID string, capturedTurnState TurnState, currentActiveTurnID string) (ControlIntentState, error) {
+// capturedTurnState is itself already terminal, since "no longer most
+// recent" is evaluated first and takes precedence. Otherwise, an
+// already-terminal captured turn (one that finished before the intent
+// completed) resolves to NOOP, since there is nothing left to cancel or
+// close; a still-active captured turn resolves to COMPLETED.
+func ResolveControlIntentOutcome(capturedTurnID string, capturedTurnState TurnState, mostRecentTurnID string) (ControlIntentState, error) {
 	if capturedTurnID == "" {
 		return "", newValidationError("ControlIntent", "TurnID", ErrRequiredValue)
 	}
 	if err := capturedTurnState.Validate(); err != nil {
 		return "", err
 	}
-	if capturedTurnID != currentActiveTurnID {
+	if capturedTurnID != mostRecentTurnID {
 		return ControlIntentStateSuperseded, nil
 	}
 	if capturedTurnState.IsTerminal() {

--- a/pkg/services/chat_sessions/transitions_test.go
+++ b/pkg/services/chat_sessions/transitions_test.go
@@ -490,28 +490,28 @@ func TestResolveControlIntentOutcome_TableDriven(t *testing.T) {
 	tests := []struct {
 		name              string
 		capturedTurnState TurnState
-		currentActiveID   string
+		mostRecentTurnID  string
 		want              ControlIntentState
 	}{
-		{"still current and running -> completed", TurnStateRunning, resolveOutcomeCapturedTurn, ControlIntentStateCompleted},
-		{"still current and admitted -> completed", TurnStateAdmitted, resolveOutcomeCapturedTurn, ControlIntentStateCompleted},
-		{"still current but already completed -> noop", TurnStateCompleted, resolveOutcomeCapturedTurn, ControlIntentStateNoop},
-		{"still current but already failed -> noop", TurnStateFailed, resolveOutcomeCapturedTurn, ControlIntentStateNoop},
-		{"still current but already canceled -> noop", TurnStateCanceled, resolveOutcomeCapturedTurn, ControlIntentStateNoop},
-		{"no longer current, captured was running -> superseded", TurnStateRunning, resolveOutcomeOtherTurn, ControlIntentStateSuperseded},
-		{"no longer current, captured was terminal -> superseded, not noop", TurnStateCompleted, resolveOutcomeOtherTurn, ControlIntentStateSuperseded},
-		{"no longer current, no active turn at all -> superseded", TurnStateRunning, "", ControlIntentStateSuperseded},
+		{"still most recent and running -> completed", TurnStateRunning, resolveOutcomeCapturedTurn, ControlIntentStateCompleted},
+		{"still most recent and admitted -> completed", TurnStateAdmitted, resolveOutcomeCapturedTurn, ControlIntentStateCompleted},
+		{"still most recent but already completed -> noop", TurnStateCompleted, resolveOutcomeCapturedTurn, ControlIntentStateNoop},
+		{"still most recent but already failed -> noop", TurnStateFailed, resolveOutcomeCapturedTurn, ControlIntentStateNoop},
+		{"still most recent but already canceled -> noop", TurnStateCanceled, resolveOutcomeCapturedTurn, ControlIntentStateNoop},
+		{"no longer most recent, captured was running -> superseded", TurnStateRunning, resolveOutcomeOtherTurn, ControlIntentStateSuperseded},
+		{"no longer most recent, captured was terminal -> superseded, not noop", TurnStateCompleted, resolveOutcomeOtherTurn, ControlIntentStateSuperseded},
+		{"no longer most recent, no turn admitted yet -> superseded", TurnStateRunning, "", ControlIntentStateSuperseded},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ResolveControlIntentOutcome(resolveOutcomeCapturedTurn, tt.capturedTurnState, tt.currentActiveID)
+			got, err := ResolveControlIntentOutcome(resolveOutcomeCapturedTurn, tt.capturedTurnState, tt.mostRecentTurnID)
 			if err != nil {
 				t.Fatalf("ResolveControlIntentOutcome(%q, %s, %q) returned error %v, want nil",
-					resolveOutcomeCapturedTurn, tt.capturedTurnState, tt.currentActiveID, err)
+					resolveOutcomeCapturedTurn, tt.capturedTurnState, tt.mostRecentTurnID, err)
 			}
 			if got != tt.want {
 				t.Fatalf("ResolveControlIntentOutcome(%q, %s, %q) = %v, want %v",
-					resolveOutcomeCapturedTurn, tt.capturedTurnState, tt.currentActiveID, got, tt.want)
+					resolveOutcomeCapturedTurn, tt.capturedTurnState, tt.mostRecentTurnID, got, tt.want)
 			}
 		})
 	}
@@ -528,12 +528,12 @@ func TestResolveControlIntentOutcome_TableDriven(t *testing.T) {
 }
 
 // An invalid captured TurnState is rejected with a typed error before any
-// outcome is selected, both when the captured turn is still current and when
-// an identity mismatch would otherwise resolve to SUPERSEDED -- the mismatch
-// must never hide the invalid captured state.
+// outcome is selected, both when the captured turn is still the most recent
+// one and when an identity mismatch would otherwise resolve to SUPERSEDED --
+// the mismatch must never hide the invalid captured state.
 func TestResolveControlIntentOutcome_InvalidCapturedStateRejected(t *testing.T) {
 	for _, state := range []TurnState{"", "BOGUS"} {
-		t.Run("still current: "+string(state), func(t *testing.T) {
+		t.Run("still most recent: "+string(state), func(t *testing.T) {
 			got, err := ResolveControlIntentOutcome(resolveOutcomeCapturedTurn, state, resolveOutcomeCapturedTurn)
 			if !errors.Is(err, ErrUnknownEnumValue) {
 				t.Fatalf("ResolveControlIntentOutcome(captured state %q): got %v, want ErrUnknownEnumValue", state, err)
@@ -543,7 +543,7 @@ func TestResolveControlIntentOutcome_InvalidCapturedStateRejected(t *testing.T) 
 			}
 		})
 
-		t.Run("no longer current: "+string(state), func(t *testing.T) {
+		t.Run("no longer most recent: "+string(state), func(t *testing.T) {
 			got, err := ResolveControlIntentOutcome(resolveOutcomeCapturedTurn, state, resolveOutcomeOtherTurn)
 			if !errors.Is(err, ErrUnknownEnumValue) {
 				t.Fatalf("ResolveControlIntentOutcome(captured state %q, mismatched id): got %v, want ErrUnknownEnumValue", state, err)
@@ -556,20 +556,20 @@ func TestResolveControlIntentOutcome_InvalidCapturedStateRejected(t *testing.T) 
 }
 
 // A blank capturedTurnID is invalid under ControlIntent.Validate() and must
-// reject the outcome before an identity comparison (still current or
+// reject the outcome before an identity comparison (still most recent or
 // mismatched) could otherwise resolve a meaningless outcome.
 func TestResolveControlIntentOutcome_BlankCapturedTurnIDRejected(t *testing.T) {
-	t.Run("still current", func(t *testing.T) {
+	t.Run("still most recent", func(t *testing.T) {
 		got, err := ResolveControlIntentOutcome("", TurnStateRunning, "")
 		if !errors.Is(err, ErrRequiredValue) {
-			t.Fatalf("ResolveControlIntentOutcome(blank captured id, still current): got %v, want ErrRequiredValue", err)
+			t.Fatalf("ResolveControlIntentOutcome(blank captured id, still most recent): got %v, want ErrRequiredValue", err)
 		}
 		if got != "" {
-			t.Fatalf("ResolveControlIntentOutcome(blank captured id, still current): got outcome %v, want zero value on error", got)
+			t.Fatalf("ResolveControlIntentOutcome(blank captured id, still most recent): got outcome %v, want zero value on error", got)
 		}
 	})
 
-	t.Run("no longer current", func(t *testing.T) {
+	t.Run("no longer most recent", func(t *testing.T) {
 		got, err := ResolveControlIntentOutcome("", TurnStateRunning, resolveOutcomeOtherTurn)
 		if !errors.Is(err, ErrRequiredValue) {
 			t.Fatalf("ResolveControlIntentOutcome(blank captured id, mismatched): got %v, want ErrRequiredValue", err)

--- a/pkg/services/chat_sessions/types.go
+++ b/pkg/services/chat_sessions/types.go
@@ -216,10 +216,10 @@ func (s SessionState) IsTerminal() bool {
 type Session struct {
 	ID    string
 	State SessionState
-	// Cwd is the validated ACP editor working root this session was created
+	// WorkingRoot is the validated ACP editor working root this session was created
 	// with. It is set once at CreateSession and never changes for the life
 	// of the session.
-	Cwd            string
+	WorkingRoot    string
 	SelectedTarget ChatTargetRef
 	TargetEpisode  uint64
 	// ActiveTurnID is the non-terminal turn currently admitted for this
@@ -244,8 +244,8 @@ func (s Session) Validate() error {
 	if err := s.State.Validate(); err != nil {
 		return newValidationError("Session", "State", err)
 	}
-	if s.Cwd == "" {
-		return newValidationError("Session", "Cwd", ErrRequiredValue)
+	if s.WorkingRoot == "" {
+		return newValidationError("Session", "WorkingRoot", ErrRequiredValue)
 	}
 	if err := s.SelectedTarget.Validate(); err != nil {
 		return newValidationError("Session", "SelectedTarget", err)

--- a/pkg/services/chat_sessions/types.go
+++ b/pkg/services/chat_sessions/types.go
@@ -214,8 +214,12 @@ func (s SessionState) IsTerminal() bool {
 // captured turn/episode/version are three distinct positions and are never
 // conflated by this contract.
 type Session struct {
-	ID             string
-	State          SessionState
+	ID    string
+	State SessionState
+	// Cwd is the validated ACP editor working root this session was created
+	// with. It is set once at CreateSession and never changes for the life
+	// of the session.
+	Cwd            string
 	SelectedTarget ChatTargetRef
 	TargetEpisode  uint64
 	// ActiveTurnID is the non-terminal turn currently admitted for this
@@ -239,6 +243,9 @@ func (s Session) Validate() error {
 	}
 	if err := s.State.Validate(); err != nil {
 		return newValidationError("Session", "State", err)
+	}
+	if s.Cwd == "" {
+		return newValidationError("Session", "Cwd", ErrRequiredValue)
 	}
 	if err := s.SelectedTarget.Validate(); err != nil {
 		return newValidationError("Session", "SelectedTarget", err)

--- a/pkg/services/chat_sessions/types_test.go
+++ b/pkg/services/chat_sessions/types_test.go
@@ -281,7 +281,7 @@ func validSession() Session {
 	return Session{
 		ID:             "session-1",
 		State:          SessionStateActive,
-		Cwd:            "/workspace/project",
+		WorkingRoot:    "/workspace/project",
 		SelectedTarget: ChatTargetRef{Kind: ChatTargetKindFactory, Ref: "@you/review"},
 		TargetEpisode:  1,
 		ActiveTurnID:   "turn-1",
@@ -302,7 +302,7 @@ func TestSession_Validate(t *testing.T) {
 		{"blank id", func(s Session) Session { s.ID = ""; return s }, ErrRequiredValue},
 		{"unknown state", func(s Session) Session { s.State = "BOGUS"; return s }, ErrUnknownEnumValue},
 		{"invalid target", func(s Session) Session { s.SelectedTarget = ChatTargetRef{}; return s }, ErrUnknownEnumValue},
-		{"blank cwd", func(s Session) Session { s.Cwd = ""; return s }, ErrRequiredValue},
+		{"blank working root", func(s Session) Session { s.WorkingRoot = ""; return s }, ErrRequiredValue},
 		{"zero created at", func(s Session) Session { s.CreatedAt = time.Time{}; return s }, ErrRequiredValue},
 		{"zero updated at", func(s Session) Session { s.UpdatedAt = time.Time{}; return s }, ErrRequiredValue},
 		{"updated before created", func(s Session) Session {

--- a/pkg/services/chat_sessions/types_test.go
+++ b/pkg/services/chat_sessions/types_test.go
@@ -281,6 +281,7 @@ func validSession() Session {
 	return Session{
 		ID:             "session-1",
 		State:          SessionStateActive,
+		Cwd:            "/workspace/project",
 		SelectedTarget: ChatTargetRef{Kind: ChatTargetKindFactory, Ref: "@you/review"},
 		TargetEpisode:  1,
 		ActiveTurnID:   "turn-1",
@@ -301,6 +302,7 @@ func TestSession_Validate(t *testing.T) {
 		{"blank id", func(s Session) Session { s.ID = ""; return s }, ErrRequiredValue},
 		{"unknown state", func(s Session) Session { s.State = "BOGUS"; return s }, ErrUnknownEnumValue},
 		{"invalid target", func(s Session) Session { s.SelectedTarget = ChatTargetRef{}; return s }, ErrUnknownEnumValue},
+		{"blank cwd", func(s Session) Session { s.Cwd = ""; return s }, ErrRequiredValue},
 		{"zero created at", func(s Session) Session { s.CreatedAt = time.Time{}; return s }, ErrRequiredValue},
 		{"zero updated at", func(s Session) Session { s.UpdatedAt = time.Time{}; return s }, ErrRequiredValue},
 		{"updated before created", func(s Session) Session {

--- a/pkg/services/chat_sessions/wire/wire.go
+++ b/pkg/services/chat_sessions/wire/wire.go
@@ -1,0 +1,38 @@
+// Package wire is the Chat Sessions service composition boundary.
+//
+// Wire performs construction only, returns the singular chatsessions.Service
+// root interface, and starts no lifecycle components. The in-memory Store
+// implementation stays a chat_sessions-private detail; peers depend on
+// Service rather than Store or its construction ports.
+package wire
+
+import (
+	"fmt"
+
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	internalservice "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/service"
+)
+
+// IDGenerator produces a new opaque, process-unique entity identity for
+// every Session, Turn, and Attachment the constructed Service creates.
+type IDGenerator = internalservice.IDGenerator
+
+// Clock returns the current time for every timestamp the constructed
+// Service records.
+type Clock = internalservice.Clock
+
+// NewService constructs the singular in-memory Chat Sessions root from
+// explicit construction ports. newID and now are required; logger is
+// optional and defaults to a no-op logger when omitted. This is the one
+// canonical constructor for chatsessions.Service: production code has no
+// alternate path to a Service value.
+func NewService(newID IDGenerator, now Clock, logger ...logging.Logger) (chatsessions.Service, error) {
+	if newID == nil {
+		return nil, fmt.Errorf("construct chat sessions: id generator is required")
+	}
+	if now == nil {
+		return nil, fmt.Errorf("construct chat sessions: clock is required")
+	}
+	return internalservice.New(newID, now, logger...), nil
+}

--- a/pkg/services/chat_sessions/wire/wire_test.go
+++ b/pkg/services/chat_sessions/wire/wire_test.go
@@ -25,7 +25,7 @@ func fixedClock(at time.Time) Clock {
 func validCreateRequest() chatsessions.CreateSessionRequest {
 	return chatsessions.CreateSessionRequest{
 		RequestID:     chatsessions.RequestIdentity{Kind: chatsessions.RequestIdentityKindJSONRPCString, ConnectionID: "conn-1", JSONRPCStringID: "req-1"},
-		Cwd:           "/workspace/project",
+		WorkingRoot:   "/workspace/project",
 		InitialTarget: chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "factory:@you/review"},
 	}
 }

--- a/pkg/services/chat_sessions/wire/wire_test.go
+++ b/pkg/services/chat_sessions/wire/wire_test.go
@@ -1,0 +1,100 @@
+package wire
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+)
+
+func sequentialIDs(prefix string) IDGenerator {
+	n := 0
+	return func() string {
+		n++
+		return prefix + "-" + strconv.Itoa(n)
+	}
+}
+
+func fixedClock(at time.Time) Clock {
+	return func() time.Time { return at }
+}
+
+func validCreateRequest() chatsessions.CreateSessionRequest {
+	return chatsessions.CreateSessionRequest{
+		RequestID:     chatsessions.RequestIdentity{Kind: chatsessions.RequestIdentityKindJSONRPCString, ConnectionID: "conn-1", JSONRPCStringID: "req-1"},
+		Cwd:           "/workspace/project",
+		InitialTarget: chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "factory:@you/review"},
+	}
+}
+
+func TestNewService_RequiresIDGenerator(t *testing.T) {
+	service, err := NewService(nil, fixedClock(time.Now()))
+	if err == nil || service != nil {
+		t.Fatalf("NewService(nil id generator) = (%v, %v), want construction failure", service, err)
+	}
+}
+
+func TestNewService_RequiresClock(t *testing.T) {
+	service, err := NewService(sequentialIDs("session"), nil)
+	if err == nil || service != nil {
+		t.Fatalf("NewService(nil clock) = (%v, %v), want construction failure", service, err)
+	}
+}
+
+// TestNewService_ConstructsAWorkingService proves the canonically
+// constructed Service round-trips a session create/get through the public
+// chatsessions.Service interface, without depending on any Store-internal
+// detail.
+func TestNewService_ConstructsAWorkingService(t *testing.T) {
+	now := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	service, err := NewService(sequentialIDs("session"), fixedClock(now))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	if service == nil {
+		t.Fatal("NewService returned a nil Service with a nil error")
+	}
+
+	ctx := context.Background()
+	created, err := service.CreateSession(ctx, validCreateRequest())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	read, err := service.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: created.Session.ID})
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if read.Session.ID != created.Session.ID {
+		t.Fatalf("GetSession returned %q, want %q", read.Session.ID, created.Session.ID)
+	}
+
+	if _, err := service.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: "does-not-exist"}); !errors.Is(err, chatsessions.ErrNotFound) {
+		t.Fatalf("GetSession(unknown): got %v, want ErrNotFound", err)
+	}
+}
+
+// TestNewService_InstancesShareNoState proves two independently constructed
+// Service instances are fully isolated, matching the process-scoped-owner
+// guarantee the canonical provider must uphold.
+func TestNewService_InstancesShareNoState(t *testing.T) {
+	first, err := NewService(sequentialIDs("session"), fixedClock(time.Now()))
+	if err != nil {
+		t.Fatalf("NewService (first): %v", err)
+	}
+	second, err := NewService(sequentialIDs("session"), fixedClock(time.Now()))
+	if err != nil {
+		t.Fatalf("NewService (second): %v", err)
+	}
+
+	ctx := context.Background()
+	created, err := first.CreateSession(ctx, validCreateRequest())
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if _, err := second.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: created.Session.ID}); !errors.Is(err, chatsessions.ErrNotFound) {
+		t.Fatalf("second Service observed the first Service's session: got %v, want ErrNotFound", err)
+	}
+}

--- a/pkg/transports/acp/internal/stdio/server.go
+++ b/pkg/transports/acp/internal/stdio/server.go
@@ -1,14 +1,15 @@
 // Package stdio implements the ACP agent-side JSON-RPC stdio server:
 // caller-owned stream serving, one-connection lifecycle, connection-scoped
 // identity assignment, newline-delimited JSON-RPC framing and dispatch for
-// the "initialize" method, protocol-safe rejection of malformed input,
-// unsupported methods, and unsupported protocol versions, and deterministic
-// termination on clean EOF, context cancellation, a partial trailing frame,
-// or a writer failure. Every method other than "initialize" -- including
-// deferred ACP session and prompt methods -- is not yet implemented by this
-// transport and receives method-not-found rather than being dispatched. It
-// is internal to pkg/transports/acp; callers use the package root's
-// exported operations instead of this package directly.
+// the "initialize" and "session/new" methods, protocol-safe rejection of
+// malformed input, unsupported methods, and unsupported protocol versions,
+// and deterministic termination on clean EOF, context cancellation, a
+// partial trailing frame, or a writer failure. Every method other than
+// "initialize" and "session/new" -- including deferred ACP session and
+// prompt methods -- is not yet implemented by this transport and receives
+// method-not-found rather than being dispatched. It is internal to
+// pkg/transports/acp; callers use the package root's exported operations
+// instead of this package directly.
 package stdio
 
 import (
@@ -22,6 +23,7 @@ import (
 	acpsdk "github.com/coder/acp-go-sdk"
 
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/envelope"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/identity"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/negotiation"
@@ -45,15 +47,37 @@ var errNullInitializeParams = errors.New("acp: initialize params must not be nul
 // goroutine, process, listener, session, or persistence; each Serve call
 // begins one connection-scoped invocation over the streams the caller
 // supplies for that call.
+//
+// chatSessions and catalog are the canonical Chat Sessions collaborators
+// "session/new" dispatches to; resolveHomeDir supplies the operator home
+// directory used to derive the Operator Settings document path and Factory
+// discovery roots for one session/new call's catalog resolution. Any of the
+// three may be nil, in which case "session/new" reports a bounded internal
+// error instead of dispatching -- so a Server constructed for a slice of
+// this transport that never exercises session/new (for example the
+// "initialize"-only smoke tests in this package) never has to supply them.
 type Server struct {
-	logger logging.Logger
+	logger         logging.Logger
+	chatSessions   chatsessions.Service
+	catalog        chatsessions.FactoryTargetCatalogService
+	resolveHomeDir func() (string, error)
 }
 
 // New constructs an inert stdio Server. Construction alone performs no
 // reads, writes, goroutine starts, process starts, endpoint binding,
 // session creation, or persistence.
-func New(logger logging.Logger) *Server {
-	return &Server{logger: logging.EnsureLogger(logger)}
+func New(
+	logger logging.Logger,
+	chatSessions chatsessions.Service,
+	catalog chatsessions.FactoryTargetCatalogService,
+	resolveHomeDir func() (string, error),
+) *Server {
+	return &Server{
+		logger:         logging.EnsureLogger(logger),
+		chatSessions:   chatSessions,
+		catalog:        catalog,
+		resolveHomeDir: resolveHomeDir,
+	}
 }
 
 // Serve begins one connection-scoped serving invocation over caller-owned
@@ -78,7 +102,7 @@ func (s *Server) Serve(ctx context.Context, in io.Reader, out io.Writer) error {
 	logger := logging.EnsureLogger(s.logger)
 	logger.Info("acp stdio connection started", "connectionId", string(connectionID))
 
-	err := serveConnection(ctx, connectionID, in, out)
+	err := s.serveConnection(ctx, connectionID, in, out)
 
 	logger.Info("acp stdio connection terminated",
 		"connectionId", string(connectionID),
@@ -137,7 +161,7 @@ func scanCompleteLines(data []byte, atEOF bool) (advance int, token []byte, err 
 // deliberate shutdown is never mistaken for a fault. A partial trailing
 // frame at EOF and a response write failure both end the connection with
 // their own error instead of being treated as success.
-func serveConnection(ctx context.Context, connectionID identity.ConnectionID, in io.Reader, out io.Writer) error {
+func (s *Server) serveConnection(ctx context.Context, connectionID identity.ConnectionID, in io.Reader, out io.Writer) error {
 	scanner := bufio.NewScanner(in)
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 	scanner.Split(scanCompleteLines)
@@ -164,7 +188,7 @@ func serveConnection(ctx context.Context, connectionID identity.ConnectionID, in
 		}
 		raw := append(json.RawMessage(nil), line...)
 
-		env, result, rpcErr := dispatchRequest(connectionID, notificationSeq, raw)
+		env, result, rpcErr := s.dispatchRequest(ctx, connectionID, notificationSeq, raw)
 		if env.IsNotification {
 			notificationSeq++
 			continue
@@ -179,19 +203,20 @@ func serveConnection(ctx context.Context, connectionID identity.ConnectionID, in
 // connectionID. It returns the decoded envelope -- the zero Envelope, or an
 // Envelope carrying only a correlated Identity, for a message that never
 // successfully decoded -- alongside the outcome: a non-nil result for a
-// successful initialize exchange, or a bounded, protocol-safe
-// *acpsdk.RequestError for every rejection. An envelope.Decode failure is
-// classified by protocol.RejectEnvelope into a parse error (uncorrelated,
-// for unparseable JSON) or an invalid-request error (correlated to the
-// message's id when that id was itself syntactically valid); a decoded
-// envelope with valid params that Negotiate rejects becomes the richer
-// unsupported-protocol-version error unwrapped, and every other rejection
-// -- an unimplemented method, or params that fail to decode into the pinned
-// initialize request shape -- becomes method-not-found or invalid-params.
-// The only method this transport dispatches to an effect in this slice is
-// "initialize"; protocol-version policy is delegated entirely to the
-// existing V0 negotiation behavior rather than re-implemented here.
-func dispatchRequest(connectionID identity.ConnectionID, notificationSeq uint64, raw json.RawMessage) (envelope.Envelope, json.RawMessage, *acpsdk.RequestError) {
+// successful "initialize" or "session/new" exchange, or a bounded,
+// protocol-safe *acpsdk.RequestError for every rejection. An envelope.Decode
+// failure is classified by protocol.RejectEnvelope into a parse error
+// (uncorrelated, for unparseable JSON) or an invalid-request error
+// (correlated to the message's id when that id was itself syntactically
+// valid); a decoded "initialize" envelope with valid params that Negotiate
+// rejects becomes the richer unsupported-protocol-version error unwrapped,
+// and every other rejection -- an unimplemented method, or params that fail
+// to decode into the pinned request shape -- becomes method-not-found or
+// invalid-params. The only methods this transport dispatches to an effect in
+// this slice are "initialize" and "session/new"; protocol-version policy is
+// delegated entirely to the existing V0 negotiation behavior rather than
+// re-implemented here.
+func (s *Server) dispatchRequest(ctx context.Context, connectionID identity.ConnectionID, notificationSeq uint64, raw json.RawMessage) (envelope.Envelope, json.RawMessage, *acpsdk.RequestError) {
 	env, err := envelope.Decode(connectionID, notificationSeq, raw)
 	if err != nil {
 		rpcErr, wireID, hasID := protocol.RejectEnvelope(err)
@@ -208,16 +233,27 @@ func dispatchRequest(connectionID identity.ConnectionID, notificationSeq uint64,
 		return env, nil, nil
 	}
 
-	if env.Method != acpsdk.AgentMethodInitialize {
+	switch env.Method {
+	case acpsdk.AgentMethodInitialize:
+		result, rpcErr := dispatchInitialize(env.Params)
+		return env, result, rpcErr
+	case acpsdk.AgentMethodSessionNew:
+		result, rpcErr := s.handleSessionNew(ctx, env)
+		return env, result, rpcErr
+	default:
 		return env, nil, protocol.MethodNotFound(env.Method)
 	}
+}
 
-	if bytes.Equal(bytes.TrimSpace(env.Params), []byte("null")) {
-		return env, nil, protocol.SafeReject(errNullInitializeParams)
+// dispatchInitialize executes the "initialize" method against raw params,
+// negotiating the P0 text-first capability profile.
+func dispatchInitialize(params json.RawMessage) (json.RawMessage, *acpsdk.RequestError) {
+	if bytes.Equal(bytes.TrimSpace(params), []byte("null")) {
+		return nil, protocol.SafeReject(errNullInitializeParams)
 	}
 	var req acpsdk.InitializeRequest
-	if err := json.Unmarshal(env.Params, &req); err != nil {
-		return env, nil, protocol.SafeReject(err)
+	if err := json.Unmarshal(params, &req); err != nil {
+		return nil, protocol.SafeReject(err)
 	}
 
 	resp, negotiateErr := negotiation.Negotiate(req)
@@ -226,14 +262,14 @@ func dispatchRequest(connectionID identity.ConnectionID, notificationSeq uint64,
 		if !ok {
 			reqErr = protocol.SafeReject(negotiateErr)
 		}
-		return env, nil, reqErr
+		return nil, reqErr
 	}
 
 	result, err := json.Marshal(resp)
 	if err != nil {
-		return env, nil, protocol.SafeReject(err)
+		return nil, protocol.SafeReject(err)
 	}
-	return env, result, nil
+	return result, nil
 }
 
 // rpcMessage is the wire shape of one JSON-RPC 2.0 response: exactly one of

--- a/pkg/transports/acp/internal/stdio/server.go
+++ b/pkg/transports/acp/internal/stdio/server.go
@@ -2,14 +2,17 @@
 // caller-owned stream serving, one-connection lifecycle, connection-scoped
 // identity assignment, newline-delimited JSON-RPC framing and dispatch for
 // the "initialize", "session/new", and "session/set_config_option" methods,
-// protocol-safe rejection of malformed input, unsupported methods, and
-// unsupported protocol versions, and deterministic termination on clean EOF,
-// context cancellation, a partial trailing frame, or a writer failure. Every
-// method other than those three -- including deferred ACP session and prompt
-// methods -- is not yet implemented by this transport and receives
-// method-not-found rather than being dispatched. It is internal to
-// pkg/transports/acp; callers use the package root's exported operations
-// instead of this package directly.
+// plus the "/factory <value>" fallback command recognized within
+// "session/prompt" (final-proposal.md §3), protocol-safe rejection of
+// malformed input, unsupported methods, and unsupported protocol versions,
+// and deterministic termination on clean EOF, context cancellation, a
+// partial trailing frame, or a writer failure. "session/prompt" content
+// other than the exact "/factory <value>" command -- including every other
+// deferred ACP session and prompt behavior -- is not yet implemented by
+// this transport and receives method-not-found rather than being
+// dispatched to any effect. It is internal to pkg/transports/acp; callers
+// use the package root's exported operations instead of this package
+// directly.
 package stdio
 
 import (
@@ -49,7 +52,8 @@ var errNullInitializeParams = errors.New("acp: initialize params must not be nul
 // supplies for that call.
 //
 // chatSessions and catalog are the canonical Chat Sessions collaborators
-// "session/new" and "session/set_config_option" dispatch to; resolveHomeDir
+// "session/new", "session/set_config_option", and the "/factory" fallback
+// command dispatch to; resolveHomeDir
 // supplies the operator home directory used to derive the Operator Settings
 // document path and Factory discovery roots for a catalog resolution. Any of
 // the three may be nil, in which case a dispatched method reports a bounded
@@ -203,20 +207,23 @@ func (s *Server) serveConnection(ctx context.Context, connectionID identity.Conn
 // connectionID. It returns the decoded envelope -- the zero Envelope, or an
 // Envelope carrying only a correlated Identity, for a message that never
 // successfully decoded -- alongside the outcome: a non-nil result for a
-// successful "initialize", "session/new", or "session/set_config_option"
-// exchange, or a bounded, protocol-safe *acpsdk.RequestError for every
-// rejection. An envelope.Decode failure is classified by
-// protocol.RejectEnvelope into a parse error (uncorrelated, for unparseable
-// JSON) or an invalid-request error (correlated to the message's id when
-// that id was itself syntactically valid); a decoded "initialize" envelope
-// with valid params that Negotiate rejects becomes the richer
-// unsupported-protocol-version error unwrapped, and every other rejection --
-// an unimplemented method, or params that fail to decode into the pinned
-// request shape -- becomes method-not-found or invalid-params. The only
-// methods this transport dispatches to an effect in this slice are
-// "initialize", "session/new", and "session/set_config_option";
-// protocol-version policy is delegated entirely to the existing V0
-// negotiation behavior rather than re-implemented here.
+// successful "initialize", "session/new", "session/set_config_option", or
+// "/factory <value>"-recognized "session/prompt" exchange, or a bounded,
+// protocol-safe *acpsdk.RequestError for every rejection. An
+// envelope.Decode failure is classified by protocol.RejectEnvelope into a
+// parse error (uncorrelated, for unparseable JSON) or an invalid-request
+// error (correlated to the message's id when that id was itself
+// syntactically valid); a decoded "initialize" envelope with valid params
+// that Negotiate rejects becomes the richer unsupported-protocol-version
+// error unwrapped, and every other rejection -- an unimplemented method,
+// params that fail to decode into the pinned request shape, or
+// "session/prompt" content that is not the "/factory <value>" command --
+// becomes method-not-found or invalid-params. The only methods this
+// transport dispatches to an effect in this slice are "initialize",
+// "session/new", "session/set_config_option", and "session/prompt" (only
+// for its "/factory <value>" fallback command form); protocol-version
+// policy is delegated entirely to the existing V0 negotiation behavior
+// rather than re-implemented here.
 func (s *Server) dispatchRequest(ctx context.Context, connectionID identity.ConnectionID, notificationSeq uint64, raw json.RawMessage) (envelope.Envelope, json.RawMessage, *acpsdk.RequestError) {
 	env, err := envelope.Decode(connectionID, notificationSeq, raw)
 	if err != nil {
@@ -243,6 +250,9 @@ func (s *Server) dispatchRequest(ctx context.Context, connectionID identity.Conn
 		return env, result, rpcErr
 	case acpsdk.AgentMethodSessionSetConfigOption:
 		result, rpcErr := s.handleSessionSetConfigOption(ctx, env)
+		return env, result, rpcErr
+	case acpsdk.AgentMethodSessionPrompt:
+		result, rpcErr := s.handleSessionPrompt(ctx, env)
 		return env, result, rpcErr
 	default:
 		return env, nil, protocol.MethodNotFound(env.Method)

--- a/pkg/transports/acp/internal/stdio/server.go
+++ b/pkg/transports/acp/internal/stdio/server.go
@@ -1,12 +1,12 @@
 // Package stdio implements the ACP agent-side JSON-RPC stdio server:
 // caller-owned stream serving, one-connection lifecycle, connection-scoped
 // identity assignment, newline-delimited JSON-RPC framing and dispatch for
-// the "initialize" and "session/new" methods, protocol-safe rejection of
-// malformed input, unsupported methods, and unsupported protocol versions,
-// and deterministic termination on clean EOF, context cancellation, a
-// partial trailing frame, or a writer failure. Every method other than
-// "initialize" and "session/new" -- including deferred ACP session and
-// prompt methods -- is not yet implemented by this transport and receives
+// the "initialize", "session/new", and "session/set_config_option" methods,
+// protocol-safe rejection of malformed input, unsupported methods, and
+// unsupported protocol versions, and deterministic termination on clean EOF,
+// context cancellation, a partial trailing frame, or a writer failure. Every
+// method other than those three -- including deferred ACP session and prompt
+// methods -- is not yet implemented by this transport and receives
 // method-not-found rather than being dispatched. It is internal to
 // pkg/transports/acp; callers use the package root's exported operations
 // instead of this package directly.
@@ -49,12 +49,12 @@ var errNullInitializeParams = errors.New("acp: initialize params must not be nul
 // supplies for that call.
 //
 // chatSessions and catalog are the canonical Chat Sessions collaborators
-// "session/new" dispatches to; resolveHomeDir supplies the operator home
-// directory used to derive the Operator Settings document path and Factory
-// discovery roots for one session/new call's catalog resolution. Any of the
-// three may be nil, in which case "session/new" reports a bounded internal
-// error instead of dispatching -- so a Server constructed for a slice of
-// this transport that never exercises session/new (for example the
+// "session/new" and "session/set_config_option" dispatch to; resolveHomeDir
+// supplies the operator home directory used to derive the Operator Settings
+// document path and Factory discovery roots for a catalog resolution. Any of
+// the three may be nil, in which case a dispatched method reports a bounded
+// internal error instead of proceeding -- so a Server constructed for a
+// slice of this transport that never exercises them (for example the
 // "initialize"-only smoke tests in this package) never has to supply them.
 type Server struct {
 	logger         logging.Logger
@@ -203,19 +203,20 @@ func (s *Server) serveConnection(ctx context.Context, connectionID identity.Conn
 // connectionID. It returns the decoded envelope -- the zero Envelope, or an
 // Envelope carrying only a correlated Identity, for a message that never
 // successfully decoded -- alongside the outcome: a non-nil result for a
-// successful "initialize" or "session/new" exchange, or a bounded,
-// protocol-safe *acpsdk.RequestError for every rejection. An envelope.Decode
-// failure is classified by protocol.RejectEnvelope into a parse error
-// (uncorrelated, for unparseable JSON) or an invalid-request error
-// (correlated to the message's id when that id was itself syntactically
-// valid); a decoded "initialize" envelope with valid params that Negotiate
-// rejects becomes the richer unsupported-protocol-version error unwrapped,
-// and every other rejection -- an unimplemented method, or params that fail
-// to decode into the pinned request shape -- becomes method-not-found or
-// invalid-params. The only methods this transport dispatches to an effect in
-// this slice are "initialize" and "session/new"; protocol-version policy is
-// delegated entirely to the existing V0 negotiation behavior rather than
-// re-implemented here.
+// successful "initialize", "session/new", or "session/set_config_option"
+// exchange, or a bounded, protocol-safe *acpsdk.RequestError for every
+// rejection. An envelope.Decode failure is classified by
+// protocol.RejectEnvelope into a parse error (uncorrelated, for unparseable
+// JSON) or an invalid-request error (correlated to the message's id when
+// that id was itself syntactically valid); a decoded "initialize" envelope
+// with valid params that Negotiate rejects becomes the richer
+// unsupported-protocol-version error unwrapped, and every other rejection --
+// an unimplemented method, or params that fail to decode into the pinned
+// request shape -- becomes method-not-found or invalid-params. The only
+// methods this transport dispatches to an effect in this slice are
+// "initialize", "session/new", and "session/set_config_option";
+// protocol-version policy is delegated entirely to the existing V0
+// negotiation behavior rather than re-implemented here.
 func (s *Server) dispatchRequest(ctx context.Context, connectionID identity.ConnectionID, notificationSeq uint64, raw json.RawMessage) (envelope.Envelope, json.RawMessage, *acpsdk.RequestError) {
 	env, err := envelope.Decode(connectionID, notificationSeq, raw)
 	if err != nil {
@@ -239,6 +240,9 @@ func (s *Server) dispatchRequest(ctx context.Context, connectionID identity.Conn
 		return env, result, rpcErr
 	case acpsdk.AgentMethodSessionNew:
 		result, rpcErr := s.handleSessionNew(ctx, env)
+		return env, result, rpcErr
+	case acpsdk.AgentMethodSessionSetConfigOption:
+		result, rpcErr := s.handleSessionSetConfigOption(ctx, env)
 		return env, result, rpcErr
 	default:
 		return env, nil, protocol.MethodNotFound(env.Method)

--- a/pkg/transports/acp/internal/stdio/server_smoke_test.go
+++ b/pkg/transports/acp/internal/stdio/server_smoke_test.go
@@ -44,7 +44,7 @@ func TestServe_PipeSmoke_RealStdioInitializeExchangeAndCleanEOF(t *testing.T) {
 		_ = stdoutWrite.Close()
 	})
 
-	server := New(nil)
+	server := New(nil, nil, nil, nil)
 	serveErr := make(chan error, 1)
 	go func() {
 		serveErr <- server.Serve(context.Background(), stdinRead, stdoutWrite)

--- a/pkg/transports/acp/internal/stdio/server_test.go
+++ b/pkg/transports/acp/internal/stdio/server_test.go
@@ -58,7 +58,7 @@ var _ logging.Logger = (*recordingLogger)(nil)
 
 func TestNewPerformsNoIO(t *testing.T) {
 	logger := &recordingLogger{}
-	server := New(logger)
+	server := New(logger, nil, nil, nil)
 	if server == nil {
 		t.Fatal("New() returned nil")
 	}
@@ -68,7 +68,7 @@ func TestNewPerformsNoIO(t *testing.T) {
 }
 
 func TestServeRejectsMissingStreams(t *testing.T) {
-	server := New(nil)
+	server := New(nil, nil, nil, nil)
 	buf := &bytes.Buffer{}
 
 	cases := []struct {
@@ -103,7 +103,7 @@ func TestServeRejectsNilServer(t *testing.T) {
 }
 
 func TestServeReturnsOnCleanEOF(t *testing.T) {
-	server := New(nil)
+	server := New(nil, nil, nil, nil)
 	err := server.Serve(context.Background(), strings.NewReader("first line\nsecond line\n"), &bytes.Buffer{})
 	if err != nil {
 		t.Fatalf("Serve() error = %v, want nil on clean EOF", err)
@@ -114,7 +114,7 @@ func TestServeRejectsAlreadyCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	server := New(nil)
+	server := New(nil, nil, nil, nil)
 	err := server.Serve(ctx, strings.NewReader(""), &bytes.Buffer{})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Serve() error = %v, want context.Canceled", err)
@@ -123,7 +123,7 @@ func TestServeRejectsAlreadyCancelledContext(t *testing.T) {
 
 func TestServeMintsDistinctConnectionIDsPerInvocation(t *testing.T) {
 	logger := &recordingLogger{}
-	server := New(logger)
+	server := New(logger, nil, nil, nil)
 
 	if err := server.Serve(context.Background(), strings.NewReader(""), &bytes.Buffer{}); err != nil {
 		t.Fatalf("Serve() first call error = %v", err)
@@ -145,7 +145,7 @@ func TestServeMintsDistinctConnectionIDsPerInvocation(t *testing.T) {
 
 func TestServeLogsStartAndTerminalOutcomeWithoutPayload(t *testing.T) {
 	logger := &recordingLogger{}
-	server := New(logger)
+	server := New(logger, nil, nil, nil)
 
 	payload := "super-secret-prompt-content"
 	if err := server.Serve(context.Background(), strings.NewReader(payload+"\n"), &bytes.Buffer{}); err != nil {
@@ -255,7 +255,7 @@ func TestServeRespondsToValidInitializeRequests(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			out := &bytes.Buffer{}
-			server := New(nil)
+			server := New(nil, nil, nil, nil)
 			if err := server.Serve(context.Background(), strings.NewReader(initializeLine(tc.id)), out); err != nil {
 				t.Fatalf("Serve() error = %v", err)
 			}
@@ -279,7 +279,7 @@ func TestServeFramesOneResponsePerCompleteInputLine(t *testing.T) {
 	input := initializeLine("1") + initializeLine("2")
 
 	out := &bytes.Buffer{}
-	server := New(nil)
+	server := New(nil, nil, nil, nil)
 	if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
 		t.Fatalf("Serve() error = %v", err)
 	}
@@ -303,7 +303,7 @@ func TestServeSkipsEmptyLines(t *testing.T) {
 	input := "\n" + initializeLine("1") + "\n"
 
 	out := &bytes.Buffer{}
-	server := New(nil)
+	server := New(nil, nil, nil, nil)
 	if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
 		t.Fatalf("Serve() error = %v", err)
 	}
@@ -313,7 +313,7 @@ func TestServeSkipsEmptyLines(t *testing.T) {
 
 func TestServeIsolatesConnectionsReusingTheSameWireID(t *testing.T) {
 	logger := &recordingLogger{}
-	server := New(logger)
+	server := New(logger, nil, nil, nil)
 
 	firstOut := &bytes.Buffer{}
 	if err := server.Serve(context.Background(), strings.NewReader(initializeLine("1")), firstOut); err != nil {
@@ -351,7 +351,6 @@ func TestServeIsolatesConnectionsReusingTheSameWireID(t *testing.T) {
 // get method-not-found rather than being dispatched or hanging.
 func TestServeRespondsMethodNotFoundForEveryUnimplementedMethod(t *testing.T) {
 	methods := []string{
-		"session/new",
 		"session/load",
 		"session/resume",
 		"session/set_config_option",
@@ -365,7 +364,7 @@ func TestServeRespondsMethodNotFoundForEveryUnimplementedMethod(t *testing.T) {
 			input := fmt.Sprintf(`{"jsonrpc":"2.0","id":9,"method":%q,"params":{}}`, method) + "\n"
 
 			out := &bytes.Buffer{}
-			server := New(nil)
+			server := New(nil, nil, nil, nil)
 			if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
 				t.Fatalf("Serve() error = %v", err)
 			}
@@ -386,7 +385,7 @@ func TestServeRespondsMethodNotFoundForEveryUnimplementedMethod(t *testing.T) {
 // id could ever be recovered from input this broken.
 func TestServeRespondsWithParseErrorForMalformedJSON(t *testing.T) {
 	out := &bytes.Buffer{}
-	server := New(nil)
+	server := New(nil, nil, nil, nil)
 	if err := server.Serve(context.Background(), strings.NewReader("{not json\n"), out); err != nil {
 		t.Fatalf("Serve() error = %v", err)
 	}
@@ -450,7 +449,7 @@ func TestServeRespondsWithInvalidRequestForStructurallyInvalidShapes(t *testing.
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			out := &bytes.Buffer{}
-			server := New(nil)
+			server := New(nil, nil, nil, nil)
 			if err := server.Serve(context.Background(), strings.NewReader(tc.line), out); err != nil {
 				t.Fatalf("Serve() error = %v", err)
 			}
@@ -482,7 +481,7 @@ func TestServeRespondsWithInvalidParamsForBadInitializeParams(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			out := &bytes.Buffer{}
-			server := New(nil)
+			server := New(nil, nil, nil, nil)
 			if err := server.Serve(context.Background(), strings.NewReader(tc.line), out); err != nil {
 				t.Fatalf("Serve() error = %v", err)
 			}
@@ -507,7 +506,7 @@ func TestServeMapsUnsupportedProtocolVersionToCorrelatedFactsWithNoCapabilities(
 	line := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":99}}` + "\n"
 
 	out := &bytes.Buffer{}
-	server := New(nil)
+	server := New(nil, nil, nil, nil)
 	if err := server.Serve(context.Background(), strings.NewReader(line), out); err != nil {
 		t.Fatalf("Serve() error = %v", err)
 	}
@@ -544,7 +543,7 @@ func TestServeEmitsNoResponseForAValidNotification(t *testing.T) {
 	line := `{"jsonrpc":"2.0","method":"session/cancel","params":{"sessionId":"s"}}` + "\n"
 
 	out := &bytes.Buffer{}
-	server := New(nil)
+	server := New(nil, nil, nil, nil)
 	if err := server.Serve(context.Background(), strings.NewReader(line), out); err != nil {
 		t.Fatalf("Serve() error = %v", err)
 	}
@@ -572,7 +571,7 @@ func TestServeEmitsNoResponseForAnUnsupportedNoIDMessage(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			out := &bytes.Buffer{}
-			server := New(nil)
+			server := New(nil, nil, nil, nil)
 			if err := server.Serve(context.Background(), strings.NewReader(tc.line), out); err != nil {
 				t.Fatalf("Serve() error = %v", err)
 			}
@@ -590,7 +589,7 @@ func TestServeContinuesProcessingAfterARecoverableRequestError(t *testing.T) {
 	input := "{not json\n" + initializeLine("1")
 
 	out := &bytes.Buffer{}
-	server := New(nil)
+	server := New(nil, nil, nil, nil)
 	if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
 		t.Fatalf("Serve() error = %v", err)
 	}
@@ -648,7 +647,7 @@ func TestServeErrorResponsesAndDiagnosticsNeverLeakSeededSensitiveSentinels(t *t
 			t.Run(sentinel+"/"+name, func(t *testing.T) {
 				out := &bytes.Buffer{}
 				logger := &recordingLogger{}
-				server := New(logger)
+				server := New(logger, nil, nil, nil)
 				if err := server.Serve(context.Background(), strings.NewReader(line), out); err != nil {
 					t.Fatalf("Serve() error = %v", err)
 				}
@@ -723,7 +722,7 @@ func TestServeReturnsContextErrorOnMidReadCancellation(t *testing.T) {
 		return pr.Read(p)
 	})
 
-	server := New(nil)
+	server := New(nil, nil, nil, nil)
 	done := make(chan error, 1)
 	go func() {
 		done <- server.Serve(ctx, in, &bytes.Buffer{})
@@ -777,7 +776,7 @@ func TestServeLogsCancelledOutcomeDistinctFromError(t *testing.T) {
 	})
 
 	logger := &recordingLogger{}
-	server := New(logger)
+	server := New(logger, nil, nil, nil)
 	done := make(chan error, 1)
 	go func() {
 		done <- server.Serve(ctx, in, &bytes.Buffer{})
@@ -820,7 +819,7 @@ func TestServeRejectsPartialTrailingFrameAsProtocolFailure(t *testing.T) {
 	partial := strings.TrimSuffix(initializeLine("1"), "\n")
 
 	out := &bytes.Buffer{}
-	server := New(nil)
+	server := New(nil, nil, nil, nil)
 	err := server.Serve(context.Background(), strings.NewReader(partial), out)
 	if err == nil {
 		t.Fatal("Serve() error = nil, want a protocol failure for a partial trailing frame")
@@ -842,7 +841,7 @@ func TestServeRejectsPartialTrailingFrameAfterACompleteLine(t *testing.T) {
 	input := initializeLine("1") + `{"jsonrpc":"2.0","id":2,"method":"initialize"`
 
 	out := &bytes.Buffer{}
-	server := New(nil)
+	server := New(nil, nil, nil, nil)
 	err := server.Serve(context.Background(), strings.NewReader(input), out)
 	if !errors.Is(err, errPartialTrailingFrame) {
 		t.Fatalf("Serve() error = %v, want errPartialTrailingFrame", err)
@@ -882,7 +881,7 @@ func TestServeSurfacesWriterFailureAndStopsFurtherWrites(t *testing.T) {
 	wantErr := errors.New("acp test: simulated write failure")
 	writer := &countingErrorWriter{err: wantErr}
 
-	server := New(nil)
+	server := New(nil, nil, nil, nil)
 	input := initializeLine("1") + initializeLine("2")
 	err := server.Serve(context.Background(), strings.NewReader(input), writer)
 	if !errors.Is(err, wantErr) {
@@ -908,7 +907,7 @@ func (shortWriter) Write(p []byte) (int, error) {
 // reported as io.ErrShortWrite and ends the connection, so a truncated
 // response can never be mistaken for a successful initialize exchange.
 func TestServeTreatsShortWriteAsFailureNotSuccess(t *testing.T) {
-	server := New(nil)
+	server := New(nil, nil, nil, nil)
 	err := server.Serve(context.Background(), strings.NewReader(initializeLine("1")), shortWriter{})
 	if !errors.Is(err, io.ErrShortWrite) {
 		t.Fatalf("Serve() error = %v, want io.ErrShortWrite", err)
@@ -984,7 +983,7 @@ func TestServeHandlesConcurrentConnectionsWithoutRaces(t *testing.T) {
 	const concurrency = 20
 
 	logger := &syncRecordingLogger{}
-	server := New(logger)
+	server := New(logger, nil, nil, nil)
 
 	outs := make([]*bytes.Buffer, concurrency)
 	errs := make([]error, concurrency)

--- a/pkg/transports/acp/internal/stdio/server_test.go
+++ b/pkg/transports/acp/internal/stdio/server_test.go
@@ -343,17 +343,17 @@ func TestServeIsolatesConnectionsReusingTheSameWireID(t *testing.T) {
 }
 
 // TestServeRespondsMethodNotFoundForEveryUnimplementedMethod covers every
-// deferred ACP session/prompt method already listed in
-// protocol.SupportedMethods (a forward-looking closed set for the whole
-// future method surface, not what this transport slice actually
-// implements -- see the Codebase Patterns entry on protocol.SupportedMethods)
-// plus a method this transport never expects at all, proving all of them
-// get method-not-found rather than being dispatched or hanging.
+// deferred ACP method already listed in protocol.SupportedMethods (a
+// forward-looking closed set for the whole future method surface, not what
+// this transport slice actually implements -- see the Codebase Patterns
+// entry on protocol.SupportedMethods) plus a method this transport never
+// expects at all, proving all of them get method-not-found rather than
+// being dispatched or hanging. "session/prompt" is excluded: it is now
+// dispatched (for "/factory <value>" only), covered in session_prompt_test.go.
 func TestServeRespondsMethodNotFoundForEveryUnimplementedMethod(t *testing.T) {
 	methods := []string{
 		"session/load",
 		"session/resume",
-		"session/prompt",
 		"session/request_permission",
 		"totally/unrecognized_method",
 	}

--- a/pkg/transports/acp/internal/stdio/server_test.go
+++ b/pkg/transports/acp/internal/stdio/server_test.go
@@ -353,7 +353,6 @@ func TestServeRespondsMethodNotFoundForEveryUnimplementedMethod(t *testing.T) {
 	methods := []string{
 		"session/load",
 		"session/resume",
-		"session/set_config_option",
 		"session/prompt",
 		"session/request_permission",
 		"totally/unrecognized_method",

--- a/pkg/transports/acp/internal/stdio/session_new.go
+++ b/pkg/transports/acp/internal/stdio/session_new.go
@@ -1,0 +1,160 @@
+package stdio
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/envelope"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/identity"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/protocol"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/session"
+	"github.com/portpowered/infinite-you/pkg/transports/mapping/factorytarget"
+)
+
+// errSessionNewUnavailable marks a "session/new" call this Server was never
+// constructed with the collaborators to serve. It never reaches a client
+// verbatim -- classifyDependencyFailure maps it to a bounded internal-error
+// response the same way it maps every other dependency failure.
+var errSessionNewUnavailable = errors.New("acp: session/new collaborators are not configured")
+
+// handleSessionNew executes one "session/new" request: validate before any
+// effect, resolve the catalog-backed Factory target picker using the
+// validated editor cwd as the catalog client working root, create exactly
+// one Chat Session using the catalog's current target, and project the
+// catalog result into the response's single target select option. Any
+// failure -- validation, catalog resolution, or session creation -- returns
+// before the next effect and produces no successful response, so a rejected
+// "session/new" never leaves a transport-owned placeholder session behind.
+func (s *Server) handleSessionNew(ctx context.Context, env envelope.Envelope) (json.RawMessage, *acpsdk.RequestError) {
+	params, err := session.ValidateNewSession(env.Params)
+	if err != nil {
+		return nil, protocol.SafeReject(err)
+	}
+
+	if s.chatSessions == nil || s.catalog == nil || s.resolveHomeDir == nil {
+		return nil, classifyDependencyFailure(errSessionNewUnavailable)
+	}
+
+	reqIdentity, err := chatRequestIdentity(env.Identity)
+	if err != nil {
+		return nil, protocol.SafeReject(err)
+	}
+
+	homeDir, err := s.resolveHomeDir()
+	if err != nil {
+		return nil, classifyDependencyFailure(err)
+	}
+
+	roots, err := factorydefinitions.ResolveNamedFactoryRoots(homeDir, params.Cwd)
+	if err != nil {
+		return nil, classifyDependencyFailure(err)
+	}
+
+	catalogResult, err := s.catalog.ResolveFactoryTargetCatalog(ctx, chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: operatorsettings.DefaultConfigPath(homeDir),
+		FactoryDiscovery: chatsessions.FactoryDiscoveryRoots{
+			ProjectRoot: roots.Project,
+			GlobalRoot:  roots.Global,
+		},
+		ClientWorkingRoot: params.Cwd,
+	})
+	if err != nil {
+		return nil, classifyDependencyFailure(err)
+	}
+
+	option := factorytarget.FromCatalogResult(catalogResult)
+	configOption, err := option.ToSessionConfigOption()
+	if err != nil {
+		return nil, classifyDependencyFailure(err)
+	}
+
+	sessionResult, err := s.chatSessions.CreateSession(ctx, chatsessions.CreateSessionRequest{
+		RequestID: reqIdentity,
+		InitialTarget: chatsessions.ChatTargetRef{
+			Kind: chatsessions.ChatTargetKindFactory,
+			Ref:  catalogResult.CurrentTarget,
+		},
+	})
+	if err != nil {
+		return nil, classifyDependencyFailure(err)
+	}
+
+	resp := acpsdk.NewSessionResponse{
+		SessionId:     acpsdk.SessionId(sessionResult.Session.ID),
+		ConfigOptions: []acpsdk.SessionConfigOption{configOption},
+	}
+	result, err := json.Marshal(resp)
+	if err != nil {
+		return nil, classifyDependencyFailure(err)
+	}
+	return result, nil
+}
+
+// classifyDependencyFailure converts a downstream Chat Sessions/catalog
+// dependency failure into a bounded, protocol-safe *acpsdk.RequestError. A
+// context.Canceled or context.DeadlineExceeded cause -- discoverable via
+// errors.Is through the typed failures FactoryTargetCatalogService and
+// chatsessions.Service already preserve -- classifies as the ACP-defined
+// request-cancelled outcome; every other dependency failure classifies as a
+// bounded internal error. Neither branch ever serializes the cause's message
+// text, so a raw target value, cwd, credential, provider command, or private
+// topology detail the cause happens to mention can never reach the client.
+func classifyDependencyFailure(cause error) *acpsdk.RequestError {
+	if errors.Is(cause, context.Canceled) || errors.Is(cause, context.DeadlineExceeded) {
+		return acpsdk.NewRequestCancelled(map[string]any{"reason": "cancelled"})
+	}
+	return acpsdk.NewInternalError(map[string]any{"reason": "dependency_unavailable"})
+}
+
+// chatRequestIdentity converts one ACP transport-side, connection-correlated
+// RequestIdentity into the canonical chatsessions.RequestIdentity, so a
+// bare JSON-RPC id is never used alone as global Chat Sessions identity:
+// the connection id travels with it, and an equal wire id received on a
+// different connection converts to a distinct chatsessions.RequestIdentity.
+// It rejects a minted (non-connection-correlated) identity, since
+// "session/new" is always a request carrying a real JSON-RPC id.
+func chatRequestIdentity(id identity.RequestIdentity) (chatsessions.RequestIdentity, error) {
+	connectionID, ok := id.ConnectionID()
+	if !ok {
+		return chatsessions.RequestIdentity{}, errors.New("acp: request identity has no connection")
+	}
+	wireID, ok := id.WireID()
+	if !ok {
+		return chatsessions.RequestIdentity{}, errors.New("acp: request identity has no json-rpc id")
+	}
+	raw, err := wireID.MarshalJSON()
+	if err != nil {
+		return chatsessions.RequestIdentity{}, err
+	}
+
+	var converted chatsessions.RequestIdentity
+	if len(raw) > 0 && raw[0] == '"' {
+		var value string
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return chatsessions.RequestIdentity{}, err
+		}
+		converted = chatsessions.RequestIdentity{
+			Kind:            chatsessions.RequestIdentityKindJSONRPCString,
+			ConnectionID:    string(connectionID),
+			JSONRPCStringID: value,
+		}
+	} else {
+		converted = chatsessions.RequestIdentity{
+			Kind:            chatsessions.RequestIdentityKindJSONRPCNumber,
+			ConnectionID:    string(connectionID),
+			JSONRPCNumberID: string(bytes.TrimSpace(raw)),
+		}
+	}
+
+	if err := converted.Validate(); err != nil {
+		return chatsessions.RequestIdentity{}, err
+	}
+	return converted, nil
+}

--- a/pkg/transports/acp/internal/stdio/session_new.go
+++ b/pkg/transports/acp/internal/stdio/session_new.go
@@ -81,6 +81,7 @@ func (s *Server) handleSessionNew(ctx context.Context, env envelope.Envelope) (j
 			Kind: chatsessions.ChatTargetKindFactory,
 			Ref:  catalogResult.CurrentTarget,
 		},
+		WorkingRoot: params.Cwd,
 	})
 	if err != nil {
 		return nil, classifyDependencyFailure(err)

--- a/pkg/transports/acp/internal/stdio/session_new_test.go
+++ b/pkg/transports/acp/internal/stdio/session_new_test.go
@@ -1,0 +1,391 @@
+package stdio
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/envelope"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/identity"
+)
+
+// fakeChatSessionsService is a minimal chatsessions.Service test double.
+// Every method other than CreateSession fails: this slice's session/new
+// handler only ever calls CreateSession, and a call to any other method
+// would itself be a defect worth failing loudly on.
+type fakeChatSessionsService struct {
+	createCalled bool
+	created      chatsessions.CreateSessionRequest
+	createErr    error
+	sessionID    string
+}
+
+var _ chatsessions.Service = (*fakeChatSessionsService)(nil)
+
+func (f *fakeChatSessionsService) CreateSession(_ context.Context, req chatsessions.CreateSessionRequest) (chatsessions.CreateSessionResult, error) {
+	f.createCalled = true
+	f.created = req
+	if f.createErr != nil {
+		return chatsessions.CreateSessionResult{}, f.createErr
+	}
+	id := f.sessionID
+	if id == "" {
+		id = "session-1"
+	}
+	now := time.Unix(0, 1)
+	return chatsessions.CreateSessionResult{Session: chatsessions.Session{
+		ID:             id,
+		State:          chatsessions.SessionStateCreated,
+		SelectedTarget: req.InitialTarget,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}}, nil
+}
+
+func (f *fakeChatSessionsService) GetSession(context.Context, chatsessions.GetSessionRequest) (chatsessions.GetSessionResult, error) {
+	return chatsessions.GetSessionResult{}, errors.New("fakeChatSessionsService: GetSession not implemented")
+}
+
+func (f *fakeChatSessionsService) SetTarget(context.Context, chatsessions.SetTargetRequest) (chatsessions.SetTargetResult, error) {
+	return chatsessions.SetTargetResult{}, errors.New("fakeChatSessionsService: SetTarget not implemented")
+}
+
+func (f *fakeChatSessionsService) StartTurn(context.Context, chatsessions.StartTurnRequest) (chatsessions.StartTurnResult, error) {
+	return chatsessions.StartTurnResult{}, errors.New("fakeChatSessionsService: StartTurn not implemented")
+}
+
+func (f *fakeChatSessionsService) AdvanceTurn(context.Context, chatsessions.AdvanceTurnRequest) (chatsessions.AdvanceTurnResult, error) {
+	return chatsessions.AdvanceTurnResult{}, errors.New("fakeChatSessionsService: AdvanceTurn not implemented")
+}
+
+func (f *fakeChatSessionsService) Attach(context.Context, chatsessions.AttachRequest) (chatsessions.AttachResult, error) {
+	return chatsessions.AttachResult{}, errors.New("fakeChatSessionsService: Attach not implemented")
+}
+
+func (f *fakeChatSessionsService) Detach(context.Context, chatsessions.DetachRequest) (chatsessions.DetachResult, error) {
+	return chatsessions.DetachResult{}, errors.New("fakeChatSessionsService: Detach not implemented")
+}
+
+func (f *fakeChatSessionsService) RequestControl(context.Context, chatsessions.RequestControlRequest) (chatsessions.RequestControlResult, error) {
+	return chatsessions.RequestControlResult{}, errors.New("fakeChatSessionsService: RequestControl not implemented")
+}
+
+func (f *fakeChatSessionsService) AdvanceControl(context.Context, chatsessions.AdvanceControlRequest) (chatsessions.AdvanceControlResult, error) {
+	return chatsessions.AdvanceControlResult{}, errors.New("fakeChatSessionsService: AdvanceControl not implemented")
+}
+
+// fakeFactoryTargetCatalogService is a minimal
+// chatsessions.FactoryTargetCatalogService test double.
+type fakeFactoryTargetCatalogService struct {
+	calls  []chatsessions.ResolveFactoryTargetCatalogRequest
+	result chatsessions.ResolveFactoryTargetCatalogResult
+	err    error
+}
+
+var _ chatsessions.FactoryTargetCatalogService = (*fakeFactoryTargetCatalogService)(nil)
+
+func (f *fakeFactoryTargetCatalogService) ResolveFactoryTargetCatalog(
+	_ context.Context,
+	req chatsessions.ResolveFactoryTargetCatalogRequest,
+) (chatsessions.ResolveFactoryTargetCatalogResult, error) {
+	f.calls = append(f.calls, req)
+	if f.err != nil {
+		return chatsessions.ResolveFactoryTargetCatalogResult{}, f.err
+	}
+	return f.result, nil
+}
+
+func defaultTestCatalogResult() chatsessions.ResolveFactoryTargetCatalogResult {
+	return chatsessions.ResolveFactoryTargetCatalogResult{
+		CurrentTarget: "factory:@you/factory-builder",
+		Choices: []chatsessions.FactoryTargetCatalogChoice{
+			{Value: "factory:@you/factory-builder", Name: "Factory Builder"},
+			{Value: "factory:@you/review", Name: "Review"},
+		},
+	}
+}
+
+func newTestServer(chatSessions *fakeChatSessionsService, catalog *fakeFactoryTargetCatalogService, homeDir string) *Server {
+	resolveHomeDir := func() (string, error) { return homeDir, nil }
+	return New(nil, chatSessions, catalog, resolveHomeDir)
+}
+
+func numberIdentityEnvelope(t *testing.T, connID identity.ConnectionID, wireID int64, method string, params string) envelope.Envelope {
+	t.Helper()
+	reqIdentity, err := identity.NewCorrelated(connID, identity.NewNumberJSONRPCID(wireID))
+	if err != nil {
+		t.Fatalf("NewCorrelated: %v", err)
+	}
+	return envelope.Envelope{Identity: reqIdentity, Method: method, Params: json.RawMessage(params)}
+}
+
+func stringIdentityEnvelope(t *testing.T, connID identity.ConnectionID, wireID string, method string, params string) envelope.Envelope {
+	t.Helper()
+	reqIdentity, err := identity.NewCorrelated(connID, identity.NewStringJSONRPCID(wireID))
+	if err != nil {
+		t.Fatalf("NewCorrelated: %v", err)
+	}
+	return envelope.Envelope{Identity: reqIdentity, Method: method, Params: json.RawMessage(params)}
+}
+
+const validSessionNewParams = `{"cwd":"/work/project","mcpServers":[]}`
+
+func TestHandleSessionNewRejectsNonEmptyMcpServersBeforeAnyEffect(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{}
+	catalog := &fakeFactoryTargetCatalogService{result: defaultTestCatalogResult()}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionNew,
+		`{"cwd":"/work/project","mcpServers":[{"name":"x","command":"y"}]}`)
+
+	result, rpcErr := server.handleSessionNew(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionNew() error = nil, want a rejection for non-empty mcpServers")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionNew() result = %q, want nil on rejection", result)
+	}
+	if len(catalog.calls) != 0 {
+		t.Fatalf("catalog resolved %d times, want 0: mcpServers rejection must happen before catalog resolution", len(catalog.calls))
+	}
+	if chatSessions.createCalled {
+		t.Fatal("CreateSession was called, want no session creation for a rejected mcpServers request")
+	}
+}
+
+func TestHandleSessionNewCreatesOneSessionAndReturnsProjectedPicker(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{sessionID: "session-42"}
+	catalog := &fakeFactoryTargetCatalogService{result: defaultTestCatalogResult()}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	connID := identity.NewConnectionID()
+	env := numberIdentityEnvelope(t, connID, 7, acpsdk.AgentMethodSessionNew, validSessionNewParams)
+
+	result, rpcErr := server.handleSessionNew(context.Background(), env)
+	if rpcErr != nil {
+		t.Fatalf("handleSessionNew() error = %+v, want success", rpcErr)
+	}
+
+	var resp acpsdk.NewSessionResponse
+	if err := json.Unmarshal(result, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if string(resp.SessionId) != "session-42" {
+		t.Fatalf("sessionId = %q, want session-42", resp.SessionId)
+	}
+	if len(resp.ConfigOptions) != 1 || resp.ConfigOptions[0].Select == nil {
+		t.Fatalf("configOptions = %+v, want exactly one select option", resp.ConfigOptions)
+	}
+	option := resp.ConfigOptions[0].Select
+	if option.Id != "target" || option.Name != "Factory" || option.Type != "select" {
+		t.Fatalf("option = %+v, want id=target name=Factory type=select", option)
+	}
+	if string(option.CurrentValue) != "factory:@you/factory-builder" {
+		t.Fatalf("currentValue = %q, want factory:@you/factory-builder", option.CurrentValue)
+	}
+	if option.Options.Ungrouped == nil || len(*option.Options.Ungrouped) != 2 {
+		t.Fatalf("options = %+v, want 2 ungrouped choices", option.Options)
+	}
+
+	if len(catalog.calls) != 1 {
+		t.Fatalf("catalog resolved %d times, want exactly 1", len(catalog.calls))
+	}
+	if catalog.calls[0].ClientWorkingRoot != "/work/project" {
+		t.Fatalf("ClientWorkingRoot = %q, want the validated editor cwd /work/project", catalog.calls[0].ClientWorkingRoot)
+	}
+
+	if !chatSessions.createCalled {
+		t.Fatal("CreateSession was not called, want exactly one session creation")
+	}
+	wantTarget := chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "factory:@you/factory-builder"}
+	if chatSessions.created.InitialTarget != wantTarget {
+		t.Fatalf("InitialTarget = %+v, want %+v", chatSessions.created.InitialTarget, wantTarget)
+	}
+
+	wantIdentity := chatsessions.RequestIdentity{
+		Kind:            chatsessions.RequestIdentityKindJSONRPCNumber,
+		ConnectionID:    string(connID),
+		JSONRPCNumberID: "7",
+	}
+	if chatSessions.created.RequestID != wantIdentity {
+		t.Fatalf("RequestID = %+v, want %+v", chatSessions.created.RequestID, wantIdentity)
+	}
+}
+
+func TestHandleSessionNewConvertsStringWireIDs(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{}
+	catalog := &fakeFactoryTargetCatalogService{result: defaultTestCatalogResult()}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	connID := identity.NewConnectionID()
+	env := stringIdentityEnvelope(t, connID, "req-abc", acpsdk.AgentMethodSessionNew, validSessionNewParams)
+
+	if _, rpcErr := server.handleSessionNew(context.Background(), env); rpcErr != nil {
+		t.Fatalf("handleSessionNew() error = %+v, want success", rpcErr)
+	}
+
+	wantIdentity := chatsessions.RequestIdentity{
+		Kind:            chatsessions.RequestIdentityKindJSONRPCString,
+		ConnectionID:    string(connID),
+		JSONRPCStringID: "req-abc",
+	}
+	if chatSessions.created.RequestID != wantIdentity {
+		t.Fatalf("RequestID = %+v, want %+v", chatSessions.created.RequestID, wantIdentity)
+	}
+}
+
+func TestHandleSessionNewKeepsEqualWireIDsDistinctAcrossConnections(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{}
+	catalog := &fakeFactoryTargetCatalogService{result: defaultTestCatalogResult()}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	firstConn := identity.NewConnectionID()
+	firstEnv := numberIdentityEnvelope(t, firstConn, 1, acpsdk.AgentMethodSessionNew, validSessionNewParams)
+	if _, rpcErr := server.handleSessionNew(context.Background(), firstEnv); rpcErr != nil {
+		t.Fatalf("first handleSessionNew() error = %+v", rpcErr)
+	}
+	firstIdentity := chatSessions.created.RequestID
+
+	secondConn := identity.NewConnectionID()
+	secondEnv := numberIdentityEnvelope(t, secondConn, 1, acpsdk.AgentMethodSessionNew, validSessionNewParams)
+	if _, rpcErr := server.handleSessionNew(context.Background(), secondEnv); rpcErr != nil {
+		t.Fatalf("second handleSessionNew() error = %+v", rpcErr)
+	}
+	secondIdentity := chatSessions.created.RequestID
+
+	if firstIdentity == secondIdentity {
+		t.Fatalf("wire id 1 on two different connections converted to the same RequestIdentity %+v", firstIdentity)
+	}
+}
+
+func TestHandleSessionNewCatalogFailureReturnsNoSuccessAndNoSessionCreation(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{}
+	catalog := &fakeFactoryTargetCatalogService{err: &chatsessions.FactoryTargetCatalogError{Err: chatsessions.ErrFactoryTargetCatalogUnavailable}}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionNew, validSessionNewParams)
+	result, rpcErr := server.handleSessionNew(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionNew() error = nil, want a rejection for a catalog failure")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionNew() result = %q, want nil on catalog failure", result)
+	}
+	if chatSessions.createCalled {
+		t.Fatal("CreateSession was called, want no session creation after a catalog failure")
+	}
+}
+
+func TestHandleSessionNewCreateSessionFailureReturnsNoSuccess(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{createErr: errors.New("create session boom")}
+	catalog := &fakeFactoryTargetCatalogService{result: defaultTestCatalogResult()}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionNew, validSessionNewParams)
+	result, rpcErr := server.handleSessionNew(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionNew() error = nil, want a rejection for a session creation failure")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionNew() result = %q, want nil on session creation failure", result)
+	}
+}
+
+func TestHandleSessionNewFailureNeverLeaksRawCause(t *testing.T) {
+	sensitive := "sk_live_should_never_leak"
+	chatSessions := &fakeChatSessionsService{}
+	catalog := &fakeFactoryTargetCatalogService{err: errors.New(sensitive)}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionNew, validSessionNewParams)
+	_, rpcErr := server.handleSessionNew(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionNew() error = nil, want a rejection")
+	}
+	encoded, err := json.Marshal(rpcErr)
+	if err != nil {
+		t.Fatalf("marshal rpc error: %v", err)
+	}
+	if strings.Contains(string(encoded), sensitive) {
+		t.Fatalf("rpc error %s leaked the raw dependency cause", encoded)
+	}
+}
+
+// TestServeDispatchesSessionNewOverRealJSONRPCFraming proves session/new is
+// reachable through the same newline-delimited JSON-RPC stdio framing
+// "initialize" already uses, not just through handleSessionNew called
+// directly: the whole Serve -> scan line -> dispatchRequest ->
+// handleSessionNew -> writeResponse path produces one complete, correctly
+// correlated, successful JSON-RPC response.
+func TestServeDispatchesSessionNewOverRealJSONRPCFraming(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{sessionID: "session-real"}
+	catalog := &fakeFactoryTargetCatalogService{result: defaultTestCatalogResult()}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	input := `{"jsonrpc":"2.0","id":1,"method":"session/new","params":{"cwd":"/work/project","mcpServers":[]}}` + "\n"
+	out := &bytes.Buffer{}
+	if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	resp := assertSingleResponseLine(t, out)
+	if string(resp.ID) != "1" {
+		t.Fatalf("id = %s, want 1", resp.ID)
+	}
+	if resp.Error != nil {
+		t.Fatalf("error = %+v, want a successful result", resp.Error)
+	}
+
+	var sessionResp acpsdk.NewSessionResponse
+	if err := json.Unmarshal(resp.Result, &sessionResp); err != nil {
+		t.Fatalf("unmarshal session/new result: %v", err)
+	}
+	if string(sessionResp.SessionId) != "session-real" {
+		t.Fatalf("sessionId = %q, want session-real", sessionResp.SessionId)
+	}
+	if !chatSessions.createCalled {
+		t.Fatal("CreateSession was not called over the real Serve path")
+	}
+}
+
+// TestServeRespondsMethodNotFoundForEveryUnimplementedMethodStillExcludesSessionNew
+// guards against a regression that would put "session/new" back on the
+// unimplemented-methods list in TestServeRespondsMethodNotFoundForEveryUnimplementedMethod:
+// a server with no session/new collaborators configured must still dispatch
+// the method (and report a bounded internal failure), never method-not-found.
+func TestServeRespondsMethodNotFoundForEveryUnimplementedMethodStillExcludesSessionNew(t *testing.T) {
+	input := `{"jsonrpc":"2.0","id":9,"method":"session/new","params":{"cwd":"/work/project","mcpServers":[]}}` + "\n"
+	out := &bytes.Buffer{}
+	server := New(nil, nil, nil, nil)
+	if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	resp := assertSingleResponseLine(t, out)
+	if resp.Error == nil {
+		t.Fatal("error = nil, want a bounded failure for an unconfigured session/new server")
+	}
+	if resp.Error.Code == -32601 {
+		t.Fatal("error code = method-not-found (-32601), want session/new to be dispatched, not rejected as unsupported")
+	}
+}
+
+func TestHandleSessionNewWithoutCollaboratorsReportsBoundedFailure(t *testing.T) {
+	server := New(nil, nil, nil, nil)
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionNew, validSessionNewParams)
+
+	result, rpcErr := server.handleSessionNew(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionNew() error = nil, want a bounded failure when collaborators are unset")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionNew() result = %q, want nil", result)
+	}
+}

--- a/pkg/transports/acp/internal/stdio/session_new_test.go
+++ b/pkg/transports/acp/internal/stdio/session_new_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -415,5 +416,128 @@ func TestHandleSessionNewWithoutCollaboratorsReportsBoundedFailure(t *testing.T)
 	}
 	if result != nil {
 		t.Fatalf("handleSessionNew() result = %q, want nil", result)
+	}
+}
+
+// mintedIdentityEnvelope builds an envelope carrying a transport-minted
+// (non-connection-correlated) identity, the one RequestIdentity shape
+// chatRequestIdentity always rejects: "session/new" and "session/prompt" are
+// always real inbound JSON-RPC requests, so they only ever see a correlated
+// identity in production, but the boundary must still fail closed rather
+// than panic or fabricate a connection if it ever saw one.
+func mintedIdentityEnvelope(t *testing.T, method string, params string) envelope.Envelope {
+	t.Helper()
+	minted, err := identity.NewMinted("transport-minted-id")
+	if err != nil {
+		t.Fatalf("identity.NewMinted: %v", err)
+	}
+	return envelope.Envelope{Identity: minted, Method: method, Params: json.RawMessage(params)}
+}
+
+func TestChatRequestIdentityRejectsNonCorrelatedIdentity(t *testing.T) {
+	minted, err := identity.NewMinted("transport-minted-id")
+	if err != nil {
+		t.Fatalf("identity.NewMinted: %v", err)
+	}
+	if _, err := chatRequestIdentity(minted); err == nil {
+		t.Fatal("chatRequestIdentity() error = nil, want a rejection for a non-connection-correlated identity")
+	}
+}
+
+func TestHandleSessionNewIdentityFailureReturnsNoEffect(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{}
+	catalog := &fakeFactoryTargetCatalogService{result: defaultTestCatalogResult()}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := mintedIdentityEnvelope(t, acpsdk.AgentMethodSessionNew, validSessionNewParams)
+	result, rpcErr := server.handleSessionNew(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionNew() error = nil, want a rejection for a non-correlated identity")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionNew() result = %q, want nil on rejection", result)
+	}
+	if len(catalog.calls) != 0 {
+		t.Fatalf("catalog resolved %d times, want 0: identity conversion must fail before catalog resolution", len(catalog.calls))
+	}
+	if chatSessions.createCalled {
+		t.Fatal("CreateSession was called, want no session creation for a rejected identity")
+	}
+}
+
+func TestClassifyDependencyFailureMapsContextCauseToRequestCancelled(t *testing.T) {
+	cancelled := classifyDependencyFailure(context.Canceled)
+	deadlineExceeded := classifyDependencyFailure(fmt.Errorf("wrapped: %w", context.DeadlineExceeded))
+	generic := classifyDependencyFailure(errors.New("boom"))
+
+	wantCancelled := acpsdk.NewRequestCancelled(map[string]any{"reason": "cancelled"})
+	if cancelled.Code != wantCancelled.Code {
+		t.Fatalf("classifyDependencyFailure(context.Canceled) code = %d, want %d (request-cancelled)", cancelled.Code, wantCancelled.Code)
+	}
+	if deadlineExceeded.Code != wantCancelled.Code {
+		t.Fatalf("classifyDependencyFailure(wrapped DeadlineExceeded) code = %d, want %d (request-cancelled)", deadlineExceeded.Code, wantCancelled.Code)
+	}
+	if generic.Code == wantCancelled.Code {
+		t.Fatalf("classifyDependencyFailure(plain error) code = %d, want a code distinct from request-cancelled", generic.Code)
+	}
+}
+
+func TestHandleSessionNewResolveHomeDirFailureReturnsNoEffect(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{}
+	catalog := &fakeFactoryTargetCatalogService{result: defaultTestCatalogResult()}
+	server := New(nil, chatSessions, catalog, func() (string, error) { return "", errors.New("resolve home dir boom") })
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionNew, validSessionNewParams)
+	result, rpcErr := server.handleSessionNew(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionNew() error = nil, want a rejection when resolveHomeDir fails")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionNew() result = %q, want nil on rejection", result)
+	}
+	if len(catalog.calls) != 0 {
+		t.Fatalf("catalog resolved %d times, want 0 when resolveHomeDir fails", len(catalog.calls))
+	}
+	if chatSessions.createCalled {
+		t.Fatal("CreateSession was called, want no session creation when resolveHomeDir fails")
+	}
+}
+
+func TestHandleSessionNewBlankHomeDirFailureReturnsNoEffect(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{}
+	catalog := &fakeFactoryTargetCatalogService{result: defaultTestCatalogResult()}
+	server := New(nil, chatSessions, catalog, func() (string, error) { return "", nil })
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionNew, validSessionNewParams)
+	result, rpcErr := server.handleSessionNew(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionNew() error = nil, want a rejection when resolveHomeDir returns a blank home directory")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionNew() result = %q, want nil on rejection", result)
+	}
+	if len(catalog.calls) != 0 {
+		t.Fatalf("catalog resolved %d times, want 0 for a blank home directory", len(catalog.calls))
+	}
+}
+
+func TestHandleSessionNewConfigProjectionFailureReturnsNoSessionCreation(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{}
+	catalog := &fakeFactoryTargetCatalogService{result: chatsessions.ResolveFactoryTargetCatalogResult{
+		CurrentTarget: "factory:@you/factory-builder",
+		Choices:       nil,
+	}}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionNew, validSessionNewParams)
+	result, rpcErr := server.handleSessionNew(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionNew() error = nil, want a rejection when the catalog projects no picker choices")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionNew() result = %q, want nil on rejection", result)
+	}
+	if chatSessions.createCalled {
+		t.Fatal("CreateSession was called, want no session creation when picker projection fails")
 	}
 }

--- a/pkg/transports/acp/internal/stdio/session_new_test.go
+++ b/pkg/transports/acp/internal/stdio/session_new_test.go
@@ -17,14 +17,25 @@ import (
 )
 
 // fakeChatSessionsService is a minimal chatsessions.Service test double.
-// Every method other than CreateSession fails: this slice's session/new
-// handler only ever calls CreateSession, and a call to any other method
-// would itself be a defect worth failing loudly on.
+// CreateSession, GetSession, and SetTarget are configurable and tracked --
+// the methods this package's session/new and session/set_config_option
+// handlers actually call. Every other method fails loudly: neither handler
+// calls them, and a call to one would itself be a defect worth catching.
 type fakeChatSessionsService struct {
 	createCalled bool
 	created      chatsessions.CreateSessionRequest
 	createErr    error
 	sessionID    string
+
+	getSessionCalled bool
+	getSessionReq    chatsessions.GetSessionRequest
+	getSessionResult chatsessions.GetSessionResult
+	getSessionErr    error
+
+	setTargetCalled bool
+	setTargetReq    chatsessions.SetTargetRequest
+	setTargetResult chatsessions.SetTargetResult
+	setTargetErr    error
 }
 
 var _ chatsessions.Service = (*fakeChatSessionsService)(nil)
@@ -44,17 +55,28 @@ func (f *fakeChatSessionsService) CreateSession(_ context.Context, req chatsessi
 		ID:             id,
 		State:          chatsessions.SessionStateCreated,
 		SelectedTarget: req.InitialTarget,
+		WorkingRoot:    req.WorkingRoot,
 		CreatedAt:      now,
 		UpdatedAt:      now,
 	}}, nil
 }
 
-func (f *fakeChatSessionsService) GetSession(context.Context, chatsessions.GetSessionRequest) (chatsessions.GetSessionResult, error) {
-	return chatsessions.GetSessionResult{}, errors.New("fakeChatSessionsService: GetSession not implemented")
+func (f *fakeChatSessionsService) GetSession(_ context.Context, req chatsessions.GetSessionRequest) (chatsessions.GetSessionResult, error) {
+	f.getSessionCalled = true
+	f.getSessionReq = req
+	if f.getSessionErr != nil {
+		return chatsessions.GetSessionResult{}, f.getSessionErr
+	}
+	return f.getSessionResult, nil
 }
 
-func (f *fakeChatSessionsService) SetTarget(context.Context, chatsessions.SetTargetRequest) (chatsessions.SetTargetResult, error) {
-	return chatsessions.SetTargetResult{}, errors.New("fakeChatSessionsService: SetTarget not implemented")
+func (f *fakeChatSessionsService) SetTarget(_ context.Context, req chatsessions.SetTargetRequest) (chatsessions.SetTargetResult, error) {
+	f.setTargetCalled = true
+	f.setTargetReq = req
+	if f.setTargetErr != nil {
+		return chatsessions.SetTargetResult{}, f.setTargetErr
+	}
+	return f.setTargetResult, nil
 }
 
 func (f *fakeChatSessionsService) StartTurn(context.Context, chatsessions.StartTurnRequest) (chatsessions.StartTurnResult, error) {
@@ -207,6 +229,9 @@ func TestHandleSessionNewCreatesOneSessionAndReturnsProjectedPicker(t *testing.T
 	wantTarget := chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "factory:@you/factory-builder"}
 	if chatSessions.created.InitialTarget != wantTarget {
 		t.Fatalf("InitialTarget = %+v, want %+v", chatSessions.created.InitialTarget, wantTarget)
+	}
+	if chatSessions.created.WorkingRoot != "/work/project" {
+		t.Fatalf("WorkingRoot = %q, want the validated editor cwd /work/project", chatSessions.created.WorkingRoot)
 	}
 
 	wantIdentity := chatsessions.RequestIdentity{

--- a/pkg/transports/acp/internal/stdio/session_new_test.go
+++ b/pkg/transports/acp/internal/stdio/session_new_test.go
@@ -36,6 +36,8 @@ type fakeChatSessionsService struct {
 	setTargetReq    chatsessions.SetTargetRequest
 	setTargetResult chatsessions.SetTargetResult
 	setTargetErr    error
+
+	startTurnCalled bool
 }
 
 var _ chatsessions.Service = (*fakeChatSessionsService)(nil)
@@ -80,6 +82,7 @@ func (f *fakeChatSessionsService) SetTarget(_ context.Context, req chatsessions.
 }
 
 func (f *fakeChatSessionsService) StartTurn(context.Context, chatsessions.StartTurnRequest) (chatsessions.StartTurnResult, error) {
+	f.startTurnCalled = true
 	return chatsessions.StartTurnResult{}, errors.New("fakeChatSessionsService: StartTurn not implemented")
 }
 

--- a/pkg/transports/acp/internal/stdio/session_prompt.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt.go
@@ -1,0 +1,102 @@
+package stdio
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/envelope"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/protocol"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/session"
+)
+
+// factoryCommandName is the exact "/factory" slash-command token this
+// transport recognizes at the "session/prompt" input boundary
+// (final-proposal.md §3 "Fallback"), delegating to the same changeTarget
+// sequence "session/set_config_option" uses instead of duplicating catalog
+// filtering, reference parsing, expected-version policy, state mutation, or
+// error translation.
+const factoryCommandName = "/factory"
+
+// errMalformedFactoryCommand marks a recognized "/factory" command attempt
+// -- content whose first whitespace-delimited token is exactly
+// factoryCommandName -- whose value is missing or whose form carries
+// anything other than exactly one value token. It never reaches a client
+// verbatim: protocol.SafeReject maps it to the existing bounded
+// malformed_request classification, and the raw command text is never
+// included in that classification.
+var errMalformedFactoryCommand = errors.New("acp: malformed /factory command")
+
+// parseFactoryCommand inspects one validated prompt turn's content and
+// reports whether it is a "/factory <value>" command attempt. matched is
+// false only when the content is not an attempt at this command at all --
+// more than one content block, or a first token other than
+// factoryCommandName -- in which case content is a genuine prompt this L1
+// V0 transport slice does not dispatch to any effect. When matched is true
+// and err is non-nil, the content's leading token was factoryCommandName
+// but its value was missing or its form carried more than one token: a
+// recognized but malformed command attempt, distinct from an unrelated
+// prompt.
+func parseFactoryCommand(content []session.TextContent) (value string, matched bool, err error) {
+	if len(content) != 1 {
+		return "", false, nil
+	}
+	fields := strings.Fields(content[0].Text)
+	if len(fields) == 0 || fields[0] != factoryCommandName {
+		return "", false, nil
+	}
+	if len(fields) != 2 {
+		return "", true, errMalformedFactoryCommand
+	}
+	return fields[1], true, nil
+}
+
+// handleSessionPrompt executes one "session/prompt" request but only for
+// its "/factory <value>" fallback command form (final-proposal.md §3):
+// validate the request before any effect, recognize the exact command
+// shape, and delegate to the same changeTarget sequence
+// "session/set_config_option" uses -- no catalog filtering, reference
+// parsing, expected-version policy, state mutation, or error translation is
+// duplicated here. Content that is not an attempt at this command at all
+// falls through to method-not-found, matching this transport slice's
+// existing behavior for every other prompt: this story adds the
+// "/factory" fallback, not general prompt-turn admission or Factory
+// invocation, so no prompt turn is ever started and no Factory is ever
+// invoked by this handler.
+func (s *Server) handleSessionPrompt(ctx context.Context, env envelope.Envelope) (json.RawMessage, *acpsdk.RequestError) {
+	var req acpsdk.PromptRequest
+	if err := json.Unmarshal(env.Params, &req); err != nil {
+		return nil, protocol.SafeReject(err)
+	}
+	turn, err := session.ValidatePrompt(req)
+	if err != nil {
+		return nil, protocol.SafeReject(err)
+	}
+
+	value, matched, cmdErr := parseFactoryCommand(turn.Content)
+	if !matched {
+		return nil, protocol.MethodNotFound(env.Method)
+	}
+	if cmdErr != nil {
+		return nil, protocol.SafeReject(cmdErr)
+	}
+
+	reqIdentity, err := chatRequestIdentity(env.Identity)
+	if err != nil {
+		return nil, protocol.SafeReject(err)
+	}
+
+	if _, rpcErr := s.changeTarget(ctx, string(turn.SessionID), value, reqIdentity); rpcErr != nil {
+		return nil, rpcErr
+	}
+
+	resp := acpsdk.PromptResponse{StopReason: acpsdk.StopReasonEndTurn}
+	result, err := json.Marshal(resp)
+	if err != nil {
+		return nil, classifyDependencyFailure(err)
+	}
+	return result, nil
+}

--- a/pkg/transports/acp/internal/stdio/session_prompt_test.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt_test.go
@@ -270,6 +270,64 @@ func TestHandleSessionPromptNonCommandContentFallsThroughToMethodNotFound(t *tes
 	}
 }
 
+func TestHandleSessionPromptMalformedParamsRejectsBeforeAnyEffect(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt, `{not json`)
+
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a rejection for malformed params")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionPrompt() result = %q, want nil on rejection", result)
+	}
+	if chatSessions.getSessionCalled {
+		t.Fatal("GetSession was called, want no effect for malformed params")
+	}
+}
+
+func TestHandleSessionPromptValidationFailureRejectsBeforeAnyEffect(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("", "/factory factory:@you/review"))
+
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a rejection for a blank sessionId")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionPrompt() result = %q, want nil on rejection", result)
+	}
+	if chatSessions.getSessionCalled {
+		t.Fatal("GetSession was called, want no effect for a validation failure")
+	}
+}
+
+func TestHandleSessionPromptIdentityFailureReturnsNoEffect(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := mintedIdentityEnvelope(t, acpsdk.AgentMethodSessionPrompt, promptTextParams("session-1", "/factory factory:@you/review"))
+
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a rejection for a non-correlated identity")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionPrompt() result = %q, want nil on rejection", result)
+	}
+	if chatSessions.getSessionCalled {
+		t.Fatal("GetSession was called, want no effect for a rejected identity")
+	}
+}
+
 func TestServeDispatchesSessionPromptFactoryCommandOverRealJSONRPCFraming(t *testing.T) {
 	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}

--- a/pkg/transports/acp/internal/stdio/session_prompt_test.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt_test.go
@@ -1,0 +1,381 @@
+package stdio
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/identity"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/session"
+)
+
+// promptTextParams builds a raw session/prompt params payload carrying one
+// text content block, the shape a client sends for a typed "/factory
+// <value>" command or an ordinary chat message alike.
+func promptTextParams(sessionID, text string) string {
+	raw, err := json.Marshal(map[string]any{
+		"sessionId": sessionID,
+		"prompt":    []map[string]any{{"type": "text", "text": text}},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return string(raw)
+}
+
+func TestParseFactoryCommandRecognizesExactFormOnly(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     []session.TextContent
+		wantValue   string
+		wantMatched bool
+		wantErr     bool
+	}{
+		{name: "exact command", content: []session.TextContent{{Text: "/factory factory:@you/review"}}, wantValue: "factory:@you/review", wantMatched: true},
+		{name: "missing value", content: []session.TextContent{{Text: "/factory"}}, wantMatched: true, wantErr: true},
+		{name: "extra token", content: []session.TextContent{{Text: "/factory a b"}}, wantMatched: true, wantErr: true},
+		{name: "unrelated prompt", content: []session.TextContent{{Text: "hello there"}}, wantMatched: false},
+		{name: "similar but different command", content: []session.TextContent{{Text: "/factories factory:@you/review"}}, wantMatched: false},
+		{name: "multiple content blocks", content: []session.TextContent{{Text: "/factory"}, {Text: "factory:@you/review"}}, wantMatched: false},
+		{name: "leading whitespace", content: []session.TextContent{{Text: "   /factory factory:@you/review  "}}, wantValue: "factory:@you/review", wantMatched: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			value, matched, err := parseFactoryCommand(tc.content)
+			if matched != tc.wantMatched {
+				t.Fatalf("matched = %v, want %v", matched, tc.wantMatched)
+			}
+			if tc.wantErr && err == nil {
+				t.Fatal("err = nil, want a malformed-command error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("err = %v, want nil", err)
+			}
+			if value != tc.wantValue {
+				t.Fatalf("value = %q, want %q", value, tc.wantValue)
+			}
+		})
+	}
+}
+
+func TestHandleSessionPromptFactoryCommandDelegatesToChangeTarget(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "/factory factory:@you/review"))
+
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr != nil {
+		t.Fatalf("handleSessionPrompt() error = %+v, want success", rpcErr)
+	}
+
+	var resp acpsdk.PromptResponse
+	if err := json.Unmarshal(result, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.StopReason != acpsdk.StopReasonEndTurn {
+		t.Fatalf("stopReason = %q, want end_turn", resp.StopReason)
+	}
+
+	if !chatSessions.setTargetCalled {
+		t.Fatal("SetTarget was not called, want exactly one target change")
+	}
+	wantTarget := chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "factory:@you/review"}
+	if chatSessions.setTargetReq.Target != wantTarget {
+		t.Fatalf("SetTarget Target = %+v, want %+v", chatSessions.setTargetReq.Target, wantTarget)
+	}
+	if chatSessions.setTargetReq.ExpectedVersion != 3 {
+		t.Fatalf("SetTarget ExpectedVersion = %d, want 3", chatSessions.setTargetReq.ExpectedVersion)
+	}
+	if chatSessions.startTurnCalled {
+		t.Fatal("StartTurn was called, want no prompt turn started for the /factory fallback command")
+	}
+}
+
+func TestHandleSessionPromptFactoryCommandMissingValueRejectsWithNoMutation(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "/factory"))
+
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a rejection for a missing /factory value")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionPrompt() result = %q, want nil on rejection", result)
+	}
+	if chatSessions.getSessionCalled {
+		t.Fatal("GetSession was called, want no effect for a malformed /factory command")
+	}
+	if chatSessions.setTargetCalled {
+		t.Fatal("SetTarget was called, want no mutation for a malformed /factory command")
+	}
+	if len(catalog.calls) != 0 {
+		t.Fatalf("catalog resolved %d times, want 0 for a malformed /factory command", len(catalog.calls))
+	}
+}
+
+func TestHandleSessionPromptFactoryCommandExtraTokensRejectsWithNoMutation(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "/factory factory:@you/review extra"))
+
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a rejection for an extra-token /factory command")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionPrompt() result = %q, want nil on rejection", result)
+	}
+	if chatSessions.setTargetCalled {
+		t.Fatal("SetTarget was called, want no mutation for an extra-token /factory command")
+	}
+}
+
+func TestHandleSessionPromptFactoryCommandDisallowedTargetRejectsWithNoMutation(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{err: &chatsessions.FactoryTargetCatalogError{
+		Target: "factory:@you/not-allowed",
+		Err:    chatsessions.ErrFactoryTargetNotAllowed,
+	}}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "/factory factory:@you/not-allowed"))
+
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a rejection for a disallowed target")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionPrompt() result = %q, want nil on rejection", result)
+	}
+	if chatSessions.setTargetCalled {
+		t.Fatal("SetTarget was called, want no mutation for a disallowed target")
+	}
+}
+
+func TestHandleSessionPromptFactoryCommandStaleVersionRejectsWithNoMutation(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project"),
+		setTargetErr:     &chatsessions.ConflictError{Value: "Session", ID: "session-1", Expected: 3, Actual: 4},
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "/factory factory:@you/review"))
+
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a rejection for a stale expected version")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionPrompt() result = %q, want nil on rejection", result)
+	}
+}
+
+func TestHandleSessionPromptFactoryCommandWorkingRootIncompatibleRejects(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{err: &chatsessions.FactoryTargetCatalogError{
+		Target: "factory:@you/pinned",
+		Err:    chatsessions.ErrFactoryTargetWorkingRootIncompatible,
+	}}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "/factory factory:@you/pinned"))
+
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a rejection for a working-root-incompatible target")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionPrompt() result = %q, want nil on rejection", result)
+	}
+	if chatSessions.setTargetCalled {
+		t.Fatal("SetTarget was called, want no mutation for a working-root-incompatible target")
+	}
+}
+
+func TestHandleSessionPromptFactoryCommandFailureNeverLeaksRawValueOrRoot(t *testing.T) {
+	sensitiveTarget := "factory:@you/sk_live_should_never_leak"
+	sensitiveRoot := "/home/operator/should-never-leak"
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, sensitiveRoot)}
+	catalog := &fakeFactoryTargetCatalogService{err: &chatsessions.FactoryTargetCatalogError{
+		Target: sensitiveTarget,
+		Err:    chatsessions.ErrFactoryTargetNotInstalled,
+	}}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "/factory "+sensitiveTarget))
+
+	_, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a rejection")
+	}
+	encoded, err := json.Marshal(rpcErr)
+	if err != nil {
+		t.Fatalf("marshal rpc error: %v", err)
+	}
+	if strings.Contains(string(encoded), sensitiveTarget) {
+		t.Fatalf("rpc error %s leaked the raw requested target", encoded)
+	}
+	if strings.Contains(string(encoded), sensitiveRoot) {
+		t.Fatalf("rpc error %s leaked the raw working root", encoded)
+	}
+}
+
+// TestHandleSessionPromptNonCommandContentFallsThroughToMethodNotFound
+// proves ordinary prompt content -- anything not an exact "/factory
+// <value>" command attempt -- still receives method-not-found, exactly the
+// behavior "session/prompt" had before this command was recognized: this
+// story adds only the "/factory" fallback, not general prompt-turn
+// admission or Factory invocation.
+func TestHandleSessionPromptNonCommandContentFallsThroughToMethodNotFound(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil || rpcErr.Code != -32601 {
+		t.Fatalf("error = %+v, want method-not-found (-32601) for non-command prompt content", rpcErr)
+	}
+	if result != nil {
+		t.Fatalf("handleSessionPrompt() result = %q, want nil", result)
+	}
+	if chatSessions.getSessionCalled || chatSessions.setTargetCalled || chatSessions.startTurnCalled {
+		t.Fatal("a Chat Sessions call was made, want no effect for non-command prompt content")
+	}
+	if len(catalog.calls) != 0 {
+		t.Fatalf("catalog resolved %d times, want 0 for non-command prompt content", len(catalog.calls))
+	}
+}
+
+func TestServeDispatchesSessionPromptFactoryCommandOverRealJSONRPCFraming(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	input := `{"jsonrpc":"2.0","id":1,"method":"session/prompt","params":` +
+		promptTextParams("session-1", "/factory factory:@you/review") + `}` + "\n"
+	out := &bytes.Buffer{}
+	if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	resp := assertSingleResponseLine(t, out)
+	if string(resp.ID) != "1" {
+		t.Fatalf("id = %s, want 1", resp.ID)
+	}
+	if resp.Error != nil {
+		t.Fatalf("error = %+v, want a successful result", resp.Error)
+	}
+	if !chatSessions.setTargetCalled {
+		t.Fatal("SetTarget was not called over the real Serve path")
+	}
+}
+
+// TestFactoryFallbackAndSetConfigOptionProduceEquivalentEffects is the
+// parity test story 004 asks for: the same session, catalog, and requested
+// target run through both entry paths -- "session/set_config_option" and
+// the "/factory <value>" prompt fallback -- and produce the exact same
+// SetTarget call (target, session id, expected version), proving neither
+// path duplicates catalog filtering, reference parsing, expected-version
+// policy, state mutation, or error translation, and that success mutates
+// target exactly once per path with no prompt turn or Factory execution.
+func TestFactoryFallbackAndSetConfigOptionProduceEquivalentEffects(t *testing.T) {
+	buildFixtures := func() (*fakeChatSessionsService, *fakeFactoryTargetCatalogService, *Server) {
+		chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+		catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+		return chatSessions, catalog, newTestServer(chatSessions, catalog, "/home/operator")
+	}
+
+	t.Run("success", func(t *testing.T) {
+		viaConfigOption, _, configServer := buildFixtures()
+		env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionSetConfigOption,
+			setConfigOptionParams("session-1", "factory:@you/review"))
+		if _, rpcErr := configServer.handleSessionSetConfigOption(context.Background(), env); rpcErr != nil {
+			t.Fatalf("handleSessionSetConfigOption() error = %+v, want success", rpcErr)
+		}
+
+		viaPrompt, _, promptServer := buildFixtures()
+		promptEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+			promptTextParams("session-1", "/factory factory:@you/review"))
+		if _, rpcErr := promptServer.handleSessionPrompt(context.Background(), promptEnv); rpcErr != nil {
+			t.Fatalf("handleSessionPrompt() error = %+v, want success", rpcErr)
+		}
+
+		if viaConfigOption.setTargetReq.Target != viaPrompt.setTargetReq.Target {
+			t.Fatalf("SetTarget Target differs: config_option=%+v prompt=%+v", viaConfigOption.setTargetReq.Target, viaPrompt.setTargetReq.Target)
+		}
+		if viaConfigOption.setTargetReq.SessionID != viaPrompt.setTargetReq.SessionID {
+			t.Fatalf("SetTarget SessionID differs: config_option=%q prompt=%q", viaConfigOption.setTargetReq.SessionID, viaPrompt.setTargetReq.SessionID)
+		}
+		if viaConfigOption.setTargetReq.ExpectedVersion != viaPrompt.setTargetReq.ExpectedVersion {
+			t.Fatalf("SetTarget ExpectedVersion differs: config_option=%d prompt=%d", viaConfigOption.setTargetReq.ExpectedVersion, viaPrompt.setTargetReq.ExpectedVersion)
+		}
+		if viaPrompt.startTurnCalled {
+			t.Fatal("StartTurn was called via the /factory prompt fallback, want no prompt turn")
+		}
+	})
+
+	failureTable := []struct {
+		name  string
+		value string
+		err   error
+	}{
+		{name: "disallowed", value: "factory:@you/not-allowed", err: &chatsessions.FactoryTargetCatalogError{Target: "factory:@you/not-allowed", Err: chatsessions.ErrFactoryTargetNotAllowed}},
+		{name: "working-root-incompatible", value: "factory:@you/pinned", err: &chatsessions.FactoryTargetCatalogError{Target: "factory:@you/pinned", Err: chatsessions.ErrFactoryTargetWorkingRootIncompatible}},
+		{name: "not-installed", value: "factory:@you/missing", err: &chatsessions.FactoryTargetCatalogError{Target: "factory:@you/missing", Err: chatsessions.ErrFactoryTargetNotInstalled}},
+	}
+	for _, tc := range failureTable {
+		t.Run(tc.name, func(t *testing.T) {
+			viaConfigOption, catalogA, configServer := buildFixtures()
+			catalogA.err = tc.err
+			env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionSetConfigOption,
+				setConfigOptionParams("session-1", tc.value))
+			_, configErr := configServer.handleSessionSetConfigOption(context.Background(), env)
+			if configErr == nil {
+				t.Fatal("handleSessionSetConfigOption() error = nil, want a rejection")
+			}
+
+			viaPrompt, catalogB, promptServer := buildFixtures()
+			catalogB.err = tc.err
+			promptEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+				promptTextParams("session-1", "/factory "+tc.value))
+			_, promptErr := promptServer.handleSessionPrompt(context.Background(), promptEnv)
+			if promptErr == nil {
+				t.Fatal("handleSessionPrompt() error = nil, want a rejection")
+			}
+
+			if configErr.Code != promptErr.Code {
+				t.Fatalf("error classification differs: config_option=%d prompt=%d", configErr.Code, promptErr.Code)
+			}
+			if viaConfigOption.setTargetCalled || viaPrompt.setTargetCalled {
+				t.Fatal("SetTarget was called, want no mutation on either path for a rejected target")
+			}
+			if viaPrompt.startTurnCalled {
+				t.Fatal("StartTurn was called via the /factory prompt fallback, want no prompt turn")
+			}
+		})
+	}
+}

--- a/pkg/transports/acp/internal/stdio/session_set_config_option.go
+++ b/pkg/transports/acp/internal/stdio/session_set_config_option.go
@@ -78,9 +78,10 @@ func (s *Server) handleSessionSetConfigOption(ctx context.Context, env envelope.
 	return result, nil
 }
 
-// changeTarget executes the shared target-change sequence used by
-// "session/set_config_option" (and, in a later story, the "/factory"
-// command fallback): read the addressed Chat Session, resolve the
+// changeTarget executes the shared target-change sequence used by both
+// "session/set_config_option" and the "/factory" command fallback
+// (handleSessionPrompt in session_prompt.go): read the addressed Chat
+// Session, resolve the
 // requested value through the existing Factory target catalog using that
 // session's own WorkingRoot, and call Chat Sessions' SetTarget with the
 // canonical revalidated target, the caller's identity, the session id, and

--- a/pkg/transports/acp/internal/stdio/session_set_config_option.go
+++ b/pkg/transports/acp/internal/stdio/session_set_config_option.go
@@ -1,0 +1,201 @@
+package stdio
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	acp "github.com/portpowered/infinite-you/pkg/transports/acp"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/envelope"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/protocol"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/session"
+	"github.com/portpowered/infinite-you/pkg/transports/mapping/factorytarget"
+)
+
+// errSessionSetConfigOptionUnavailable marks a "session/set_config_option"
+// call this Server was never constructed with the collaborators to serve. It
+// never reaches a client verbatim -- classifyDependencyFailure maps it to a
+// bounded internal-error response the same way it maps every other
+// dependency failure.
+var errSessionSetConfigOptionUnavailable = errors.New("acp: session/set_config_option collaborators are not configured")
+
+// errUnsupportedConfigOption marks a "session/set_config_option" request
+// addressing a configId this transport does not implement: the Factory
+// target select option is the only configuration option this L1 V0
+// boundary exposes.
+var errUnsupportedConfigOption = errors.New("acp: unsupported session configuration option")
+
+// errUnsupportedConfigOptionShape marks a "session/set_config_option"
+// request carrying the boolean payload variant against the Factory target
+// option, which is always the select-option variant.
+var errUnsupportedConfigOptionShape = errors.New("acp: factory target configuration option requires a value-id payload")
+
+// errSessionWorkingRootUnknown marks an addressed Chat Session whose
+// WorkingRoot is blank: every session "session/new" creates carries the
+// validated editor cwd it was created with, so a blank WorkingRoot signals a
+// broken invariant in the session record itself, not a caller mistake.
+var errSessionWorkingRootUnknown = errors.New("acp: session working root is unknown")
+
+// handleSessionSetConfigOption executes one "session/set_config_option"
+// request: validate the option shape before any effect, reject any option
+// other than the Factory target select option, then delegate to
+// changeTarget for the shared read-revalidate-mutate sequence.
+func (s *Server) handleSessionSetConfigOption(ctx context.Context, env envelope.Envelope) (json.RawMessage, *acpsdk.RequestError) {
+	parsed, err := session.ValidateSetConfigOption(env.Params)
+	if err != nil {
+		return nil, protocol.SafeReject(err)
+	}
+	if parsed.ConfigID != string(acp.FactoryTargetOptionID) {
+		return nil, protocol.SafeReject(errUnsupportedConfigOption)
+	}
+	if parsed.Boolean != nil {
+		return nil, protocol.SafeReject(errUnsupportedConfigOptionShape)
+	}
+	if parsed.ValueID == nil || *parsed.ValueID == "" {
+		return nil, protocol.SafeReject(errors.New("acp: value is required"))
+	}
+
+	reqIdentity, err := chatRequestIdentity(env.Identity)
+	if err != nil {
+		return nil, protocol.SafeReject(err)
+	}
+
+	configOption, rpcErr := s.changeTarget(ctx, string(parsed.SessionID), *parsed.ValueID, reqIdentity)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+
+	resp := acpsdk.SetSessionConfigOptionResponse{ConfigOptions: []acpsdk.SessionConfigOption{configOption}}
+	result, err := json.Marshal(resp)
+	if err != nil {
+		return nil, classifyDependencyFailure(err)
+	}
+	return result, nil
+}
+
+// changeTarget executes the shared target-change sequence used by
+// "session/set_config_option" (and, in a later story, the "/factory"
+// command fallback): read the addressed Chat Session, resolve the
+// requested value through the existing Factory target catalog using that
+// session's own WorkingRoot, and call Chat Sessions' SetTarget with the
+// canonical revalidated target, the caller's identity, the session id, and
+// the version observed from the read. Any failure -- an unknown session, a
+// stale version, a disallowed/uninstalled/malformed/root-incompatible
+// target, or a dependency fault -- returns before the next effect, so a
+// rejected change never mutates target, episode history, or session
+// version.
+func (s *Server) changeTarget(ctx context.Context, sessionID string, requestedValue string, reqIdentity chatsessions.RequestIdentity) (acpsdk.SessionConfigOption, *acpsdk.RequestError) {
+	if s.chatSessions == nil || s.catalog == nil || s.resolveHomeDir == nil {
+		return acpsdk.SessionConfigOption{}, classifyDependencyFailure(errSessionSetConfigOptionUnavailable)
+	}
+
+	getResult, err := s.chatSessions.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: sessionID})
+	if err != nil {
+		return acpsdk.SessionConfigOption{}, classifyTargetSelectionFailure(err)
+	}
+
+	cwd := getResult.Session.WorkingRoot
+	if cwd == "" {
+		return acpsdk.SessionConfigOption{}, classifyDependencyFailure(errSessionWorkingRootUnknown)
+	}
+
+	homeDir, err := s.resolveHomeDir()
+	if err != nil {
+		return acpsdk.SessionConfigOption{}, classifyDependencyFailure(err)
+	}
+
+	roots, err := factorydefinitions.ResolveNamedFactoryRoots(homeDir, cwd)
+	if err != nil {
+		return acpsdk.SessionConfigOption{}, classifyDependencyFailure(err)
+	}
+
+	catalogResult, err := s.catalog.ResolveFactoryTargetCatalog(ctx, chatsessions.ResolveFactoryTargetCatalogRequest{
+		OperatorSettingsPath: operatorsettings.DefaultConfigPath(homeDir),
+		FactoryDiscovery: chatsessions.FactoryDiscoveryRoots{
+			ProjectRoot: roots.Project,
+			GlobalRoot:  roots.Global,
+		},
+		ClientWorkingRoot: cwd,
+		CurrentTarget:     requestedValue,
+	})
+	if err != nil {
+		return acpsdk.SessionConfigOption{}, classifyTargetSelectionFailure(err)
+	}
+
+	if _, err := s.chatSessions.SetTarget(ctx, chatsessions.SetTargetRequest{
+		RequestID:       reqIdentity,
+		SessionID:       getResult.Session.ID,
+		ExpectedVersion: getResult.Session.Version,
+		Target: chatsessions.ChatTargetRef{
+			Kind: chatsessions.ChatTargetKindFactory,
+			Ref:  catalogResult.CurrentTarget,
+		},
+	}); err != nil {
+		return acpsdk.SessionConfigOption{}, classifyTargetSelectionFailure(err)
+	}
+
+	option := factorytarget.FromCatalogResult(catalogResult)
+	configOption, err := option.ToSessionConfigOption()
+	if err != nil {
+		return acpsdk.SessionConfigOption{}, classifyDependencyFailure(err)
+	}
+	return configOption, nil
+}
+
+// classifyTargetSelectionFailure converts a failure from reading a Chat
+// Session, resolving the Factory target catalog, or calling SetTarget into
+// a bounded, protocol-safe *acpsdk.RequestError. A context.Canceled or
+// context.DeadlineExceeded cause classifies as the ACP-defined
+// request-cancelled outcome via classifyDependencyFailure. A failure this
+// package attributes to the caller's own request -- an unknown session
+// (*chatsessions.NotFoundError), a stale expected version
+// (*chatsessions.ConflictError), a malformed request value
+// (*chatsessions.ValidationError), or a target the catalog rejects as
+// malformed, uninstalled, disallowed, working-root-incompatible, or leaving
+// no target at all (the corresponding *chatsessions.FactoryTargetCatalogError
+// sentinels) -- classifies as a bounded invalid-params rejection via
+// protocol.SafeReject. Every other cause -- an unavailable profile or
+// catalog dependency -- classifies as a bounded internal error via
+// classifyDependencyFailure. No branch ever serializes the cause's message
+// text, so a raw target value, cwd, credential, provider command, or
+// private topology detail can never reach the client through this
+// classification.
+func classifyTargetSelectionFailure(cause error) *acpsdk.RequestError {
+	if errors.Is(cause, context.Canceled) || errors.Is(cause, context.DeadlineExceeded) {
+		return classifyDependencyFailure(cause)
+	}
+
+	var catalogErr *chatsessions.FactoryTargetCatalogError
+	if errors.As(cause, &catalogErr) {
+		switch {
+		case errors.Is(cause, chatsessions.ErrFactoryTargetReferenceMalformed),
+			errors.Is(cause, chatsessions.ErrFactoryTargetNotInstalled),
+			errors.Is(cause, chatsessions.ErrFactoryTargetNotAllowed),
+			errors.Is(cause, chatsessions.ErrFactoryTargetWorkingRootIncompatible),
+			errors.Is(cause, chatsessions.ErrFactoryTargetCatalogEmpty):
+			return protocol.SafeReject(cause)
+		default:
+			return classifyDependencyFailure(cause)
+		}
+	}
+
+	var notFoundErr *chatsessions.NotFoundError
+	if errors.As(cause, &notFoundErr) {
+		return protocol.SafeReject(cause)
+	}
+	var conflictErr *chatsessions.ConflictError
+	if errors.As(cause, &conflictErr) {
+		return protocol.SafeReject(cause)
+	}
+	var validationErr *chatsessions.ValidationError
+	if errors.As(cause, &validationErr) {
+		return protocol.SafeReject(cause)
+	}
+
+	return classifyDependencyFailure(cause)
+}

--- a/pkg/transports/acp/internal/stdio/session_set_config_option_test.go
+++ b/pkg/transports/acp/internal/stdio/session_set_config_option_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -88,6 +89,158 @@ func TestHandleSessionSetConfigOptionSucceedsAndRevalidatesThroughCatalog(t *tes
 	}
 	if chatSessions.setTargetReq.ExpectedVersion != 3 {
 		t.Fatalf("SetTarget ExpectedVersion = %d, want 3 (the version observed from GetSession)", chatSessions.setTargetReq.ExpectedVersion)
+	}
+}
+
+func TestHandleSessionSetConfigOptionMalformedParamsRejectsBeforeAnyEffect(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionSetConfigOption, `{not json`)
+
+	result, rpcErr := server.handleSessionSetConfigOption(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionSetConfigOption() error = nil, want a rejection for malformed params")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionSetConfigOption() result = %q, want nil on rejection", result)
+	}
+	if chatSessions.getSessionCalled {
+		t.Fatal("GetSession was called, want no effect for malformed params")
+	}
+}
+
+func TestHandleSessionSetConfigOptionIdentityFailureReturnsNoEffect(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := mintedIdentityEnvelope(t, acpsdk.AgentMethodSessionSetConfigOption, setConfigOptionParams("session-1", "factory:@you/review"))
+
+	result, rpcErr := server.handleSessionSetConfigOption(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionSetConfigOption() error = nil, want a rejection for a non-correlated identity")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionSetConfigOption() result = %q, want nil on rejection", result)
+	}
+	if chatSessions.getSessionCalled {
+		t.Fatal("GetSession was called, want no effect for a rejected identity")
+	}
+}
+
+func TestChangeTargetBlankWorkingRootRejectsWithNoCatalogResolution(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionSetConfigOption,
+		setConfigOptionParams("session-1", "factory:@you/review"))
+
+	result, rpcErr := server.handleSessionSetConfigOption(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionSetConfigOption() error = nil, want a rejection for an unknown working root")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionSetConfigOption() result = %q, want nil on rejection", result)
+	}
+	if len(catalog.calls) != 0 {
+		t.Fatalf("catalog resolved %d times, want 0 for a blank session working root", len(catalog.calls))
+	}
+}
+
+func TestChangeTargetResolveHomeDirFailureReturnsNoMutation(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := New(nil, chatSessions, catalog, func() (string, error) { return "", errors.New("resolve home dir boom") })
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionSetConfigOption,
+		setConfigOptionParams("session-1", "factory:@you/review"))
+
+	result, rpcErr := server.handleSessionSetConfigOption(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionSetConfigOption() error = nil, want a rejection when resolveHomeDir fails")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionSetConfigOption() result = %q, want nil on rejection", result)
+	}
+	if len(catalog.calls) != 0 {
+		t.Fatalf("catalog resolved %d times, want 0 when resolveHomeDir fails", len(catalog.calls))
+	}
+}
+
+func TestChangeTargetBlankHomeDirFailureReturnsNoMutation(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := New(nil, chatSessions, catalog, func() (string, error) { return "", nil })
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionSetConfigOption,
+		setConfigOptionParams("session-1", "factory:@you/review"))
+
+	result, rpcErr := server.handleSessionSetConfigOption(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionSetConfigOption() error = nil, want a rejection for a blank home directory")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionSetConfigOption() result = %q, want nil on rejection", result)
+	}
+	if len(catalog.calls) != 0 {
+		t.Fatalf("catalog resolved %d times, want 0 for a blank home directory", len(catalog.calls))
+	}
+}
+
+func TestChangeTargetConfigProjectionFailureReturnsMutatedButUnprojectedFailure(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: chatsessions.ResolveFactoryTargetCatalogResult{
+		CurrentTarget: "factory:@you/review",
+		Choices:       nil,
+	}}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionSetConfigOption,
+		setConfigOptionParams("session-1", "factory:@you/review"))
+
+	result, rpcErr := server.handleSessionSetConfigOption(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionSetConfigOption() error = nil, want a rejection when the catalog projects no picker choices")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionSetConfigOption() result = %q, want nil on rejection", result)
+	}
+}
+
+func TestClassifyTargetSelectionFailureMapsContextCauseThroughClassifyDependencyFailure(t *testing.T) {
+	got := classifyTargetSelectionFailure(context.Canceled)
+	want := classifyDependencyFailure(context.Canceled)
+	if got.Code != want.Code {
+		t.Fatalf("classifyTargetSelectionFailure(context.Canceled) code = %d, want %d (delegated to classifyDependencyFailure)", got.Code, want.Code)
+	}
+}
+
+func TestClassifyTargetSelectionFailureMapsUnclassifiedCatalogErrorToInternalError(t *testing.T) {
+	cause := &chatsessions.FactoryTargetCatalogError{Err: chatsessions.ErrFactoryTargetCatalogUnavailable}
+	got := classifyTargetSelectionFailure(cause)
+	want := classifyDependencyFailure(cause)
+	if got.Code != want.Code {
+		t.Fatalf("classifyTargetSelectionFailure(unclassified catalog error) code = %d, want %d (internal error, not invalid-params)", got.Code, want.Code)
+	}
+}
+
+func TestClassifyTargetSelectionFailureMapsValidationErrorToSafeReject(t *testing.T) {
+	cause := &chatsessions.ValidationError{Value: "Session", Field: "WorkingRoot", Err: chatsessions.ErrRequiredValue}
+	got := classifyTargetSelectionFailure(cause)
+	internal := classifyDependencyFailure(cause)
+	if got.Code == internal.Code {
+		t.Fatalf("classifyTargetSelectionFailure(*ValidationError) code = %d, want a caller-attributable rejection distinct from the generic internal error code %d", got.Code, internal.Code)
+	}
+}
+
+func TestClassifyTargetSelectionFailureMapsUnknownCauseToInternalError(t *testing.T) {
+	got := classifyTargetSelectionFailure(errors.New("boom"))
+	want := classifyDependencyFailure(errors.New("boom"))
+	if got.Code != want.Code {
+		t.Fatalf("classifyTargetSelectionFailure(plain error) code = %d, want %d (generic internal error fallback)", got.Code, want.Code)
 	}
 }
 

--- a/pkg/transports/acp/internal/stdio/session_set_config_option_test.go
+++ b/pkg/transports/acp/internal/stdio/session_set_config_option_test.go
@@ -1,0 +1,314 @@
+package stdio
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/identity"
+)
+
+// setConfigOptionParams builds a raw session/set_config_option value-id
+// params payload addressing the Factory target select option.
+func setConfigOptionParams(sessionID, value string) string {
+	return `{"sessionId":"` + sessionID + `","configId":"target","value":"` + value + `"}`
+}
+
+// sessionAt builds a GetSessionResult for a session addressed by id, with the
+// given selected target, version, and WorkingRoot -- mirroring what a prior
+// successful "session/new" call would have produced.
+func sessionAt(id string, target string, version uint64, workingRoot string) chatsessions.GetSessionResult {
+	now := time.Unix(0, 1)
+	return chatsessions.GetSessionResult{Session: chatsessions.Session{
+		ID:    id,
+		State: chatsessions.SessionStateCreated,
+		SelectedTarget: chatsessions.ChatTargetRef{
+			Kind: chatsessions.ChatTargetKindFactory,
+			Ref:  target,
+		},
+		Version:     version,
+		WorkingRoot: workingRoot,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}}
+}
+
+func TestHandleSessionSetConfigOptionSucceedsAndRevalidatesThroughCatalog(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionSetConfigOption,
+		setConfigOptionParams("session-1", "factory:@you/review"))
+
+	result, rpcErr := server.handleSessionSetConfigOption(context.Background(), env)
+	if rpcErr != nil {
+		t.Fatalf("handleSessionSetConfigOption() error = %+v, want success", rpcErr)
+	}
+
+	var resp acpsdk.SetSessionConfigOptionResponse
+	if err := json.Unmarshal(result, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(resp.ConfigOptions) != 1 || resp.ConfigOptions[0].Select == nil {
+		t.Fatalf("configOptions = %+v, want exactly one select option", resp.ConfigOptions)
+	}
+	if string(resp.ConfigOptions[0].Select.CurrentValue) != "factory:@you/review" {
+		t.Fatalf("currentValue = %q, want factory:@you/review", resp.ConfigOptions[0].Select.CurrentValue)
+	}
+
+	if !chatSessions.getSessionCalled {
+		t.Fatal("GetSession was not called, want the addressed session to be read")
+	}
+	if len(catalog.calls) != 1 {
+		t.Fatalf("catalog resolved %d times, want exactly 1", len(catalog.calls))
+	}
+	if catalog.calls[0].ClientWorkingRoot != "/work/project" {
+		t.Fatalf("ClientWorkingRoot = %q, want the session's recorded working root /work/project", catalog.calls[0].ClientWorkingRoot)
+	}
+	if catalog.calls[0].CurrentTarget != "factory:@you/review" {
+		t.Fatalf("CurrentTarget = %q, want the requested value revalidated through the catalog", catalog.calls[0].CurrentTarget)
+	}
+
+	if !chatSessions.setTargetCalled {
+		t.Fatal("SetTarget was not called, want exactly one target change")
+	}
+	wantTarget := chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "factory:@you/review"}
+	if chatSessions.setTargetReq.Target != wantTarget {
+		t.Fatalf("SetTarget Target = %+v, want %+v", chatSessions.setTargetReq.Target, wantTarget)
+	}
+	if chatSessions.setTargetReq.SessionID != "session-1" {
+		t.Fatalf("SetTarget SessionID = %q, want session-1", chatSessions.setTargetReq.SessionID)
+	}
+	if chatSessions.setTargetReq.ExpectedVersion != 3 {
+		t.Fatalf("SetTarget ExpectedVersion = %d, want 3 (the version observed from GetSession)", chatSessions.setTargetReq.ExpectedVersion)
+	}
+}
+
+func TestHandleSessionSetConfigOptionRejectsUnsupportedConfigIdBeforeAnyEffect(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionSetConfigOption,
+		`{"sessionId":"session-1","configId":"model","value":"some-model"}`)
+
+	result, rpcErr := server.handleSessionSetConfigOption(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionSetConfigOption() error = nil, want a rejection for an unsupported configId")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionSetConfigOption() result = %q, want nil on rejection", result)
+	}
+	if chatSessions.getSessionCalled {
+		t.Fatal("GetSession was called, want no effect for an unsupported configId")
+	}
+	if chatSessions.setTargetCalled {
+		t.Fatal("SetTarget was called, want no mutation for an unsupported configId")
+	}
+	if len(catalog.calls) != 0 {
+		t.Fatalf("catalog resolved %d times, want 0", len(catalog.calls))
+	}
+}
+
+func TestHandleSessionSetConfigOptionRejectsBooleanShapeForTargetOption(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionSetConfigOption,
+		`{"sessionId":"session-1","configId":"target","type":"boolean","value":true}`)
+
+	result, rpcErr := server.handleSessionSetConfigOption(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionSetConfigOption() error = nil, want a rejection for a boolean payload against the target option")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionSetConfigOption() result = %q, want nil on rejection", result)
+	}
+	if chatSessions.getSessionCalled {
+		t.Fatal("GetSession was called, want no effect for a malformed option shape")
+	}
+}
+
+func TestHandleSessionSetConfigOptionUnknownSessionRejectsWithNoMutation(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionErr: &chatsessions.NotFoundError{Value: "Session", ID: "session-missing"}}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionSetConfigOption,
+		setConfigOptionParams("session-missing", "factory:@you/review"))
+
+	result, rpcErr := server.handleSessionSetConfigOption(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionSetConfigOption() error = nil, want a rejection for an unknown session")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionSetConfigOption() result = %q, want nil on rejection", result)
+	}
+	if chatSessions.setTargetCalled {
+		t.Fatal("SetTarget was called, want no mutation for an unknown session")
+	}
+	if len(catalog.calls) != 0 {
+		t.Fatalf("catalog resolved %d times, want 0 for an unknown session", len(catalog.calls))
+	}
+}
+
+func TestHandleSessionSetConfigOptionStaleVersionRejectsWithNoMutation(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project"),
+		setTargetErr:     &chatsessions.ConflictError{Value: "Session", ID: "session-1", Expected: 3, Actual: 4},
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionSetConfigOption,
+		setConfigOptionParams("session-1", "factory:@you/review"))
+
+	result, rpcErr := server.handleSessionSetConfigOption(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionSetConfigOption() error = nil, want a rejection for a stale expected version")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionSetConfigOption() result = %q, want nil on rejection", result)
+	}
+}
+
+func TestHandleSessionSetConfigOptionDisallowedTargetRejectsBeforeMutation(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{err: &chatsessions.FactoryTargetCatalogError{
+		Target: "factory:@you/not-allowed",
+		Err:    chatsessions.ErrFactoryTargetNotAllowed,
+	}}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionSetConfigOption,
+		setConfigOptionParams("session-1", "factory:@you/not-allowed"))
+
+	result, rpcErr := server.handleSessionSetConfigOption(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionSetConfigOption() error = nil, want a rejection for a disallowed target")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionSetConfigOption() result = %q, want nil on rejection", result)
+	}
+	if chatSessions.setTargetCalled {
+		t.Fatal("SetTarget was called, want no mutation for a disallowed target")
+	}
+}
+
+func TestHandleSessionSetConfigOptionWorkingRootIncompatibleTargetRejects(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{err: &chatsessions.FactoryTargetCatalogError{
+		Target: "factory:@you/pinned",
+		Err:    chatsessions.ErrFactoryTargetWorkingRootIncompatible,
+	}}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionSetConfigOption,
+		setConfigOptionParams("session-1", "factory:@you/pinned"))
+
+	result, rpcErr := server.handleSessionSetConfigOption(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionSetConfigOption() error = nil, want a rejection for a working-root-incompatible target")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionSetConfigOption() result = %q, want nil on rejection", result)
+	}
+	if chatSessions.setTargetCalled {
+		t.Fatal("SetTarget was called, want no mutation for a working-root-incompatible target")
+	}
+}
+
+func TestHandleSessionSetConfigOptionFailureNeverLeaksRawValueOrRoot(t *testing.T) {
+	sensitiveTarget := "factory:@you/sk_live_should_never_leak"
+	sensitiveRoot := "/home/operator/should-never-leak"
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, sensitiveRoot)}
+	catalog := &fakeFactoryTargetCatalogService{err: &chatsessions.FactoryTargetCatalogError{
+		Target: sensitiveTarget,
+		Err:    chatsessions.ErrFactoryTargetNotInstalled,
+	}}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionSetConfigOption,
+		setConfigOptionParams("session-1", sensitiveTarget))
+
+	_, rpcErr := server.handleSessionSetConfigOption(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionSetConfigOption() error = nil, want a rejection")
+	}
+	encoded, err := json.Marshal(rpcErr)
+	if err != nil {
+		t.Fatalf("marshal rpc error: %v", err)
+	}
+	if strings.Contains(string(encoded), sensitiveTarget) {
+		t.Fatalf("rpc error %s leaked the raw requested target", encoded)
+	}
+	if strings.Contains(string(encoded), sensitiveRoot) {
+		t.Fatalf("rpc error %s leaked the raw working root", encoded)
+	}
+}
+
+func TestServeDispatchesSessionSetConfigOptionOverRealJSONRPCFraming(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	input := `{"jsonrpc":"2.0","id":1,"method":"session/set_config_option","params":` +
+		setConfigOptionParams("session-1", "factory:@you/review") + `}` + "\n"
+	out := &bytes.Buffer{}
+	if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	resp := assertSingleResponseLine(t, out)
+	if string(resp.ID) != "1" {
+		t.Fatalf("id = %s, want 1", resp.ID)
+	}
+	if resp.Error != nil {
+		t.Fatalf("error = %+v, want a successful result", resp.Error)
+	}
+	if !chatSessions.setTargetCalled {
+		t.Fatal("SetTarget was not called over the real Serve path")
+	}
+}
+
+// TestServeRespondsMethodNotFoundForEveryUnimplementedMethodStillExcludesSessionSetConfigOption
+// guards against a regression that would put "session/set_config_option"
+// back on the unimplemented-methods list in
+// TestServeRespondsMethodNotFoundForEveryUnimplementedMethod (server_test.go):
+// a server with no session/set_config_option collaborators configured must
+// still dispatch the method (and report a bounded internal failure), never
+// method-not-found.
+func TestServeRespondsMethodNotFoundForEveryUnimplementedMethodStillExcludesSessionSetConfigOption(t *testing.T) {
+	input := `{"jsonrpc":"2.0","id":9,"method":"session/set_config_option","params":{"sessionId":"s","configId":"target","value":"factory:@you/factory-builder"}}` + "\n"
+	out := &bytes.Buffer{}
+	server := New(nil, nil, nil, nil)
+	if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	resp := assertSingleResponseLine(t, out)
+	if resp.Error == nil {
+		t.Fatal("error = nil, want a bounded failure for an unconfigured session/set_config_option server")
+	}
+	if resp.Error.Code == -32601 {
+		t.Fatal("error code = method-not-found (-32601), want session/set_config_option to be dispatched, not rejected as unsupported")
+	}
+}
+
+func catalogResultWithCurrent(current string) chatsessions.ResolveFactoryTargetCatalogResult {
+	return chatsessions.ResolveFactoryTargetCatalogResult{
+		CurrentTarget: current,
+		Choices: []chatsessions.FactoryTargetCatalogChoice{
+			{Value: "factory:@you/factory-builder", Name: "Factory Builder"},
+			{Value: "factory:@you/review", Name: "Review"},
+		},
+	}
+}

--- a/pkg/transports/acp/wire/wire.go
+++ b/pkg/transports/acp/wire/wire.go
@@ -10,6 +10,7 @@ package wire
 
 import (
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
 	acp "github.com/portpowered/infinite-you/pkg/transports/acp"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/stdio"
 )
@@ -17,6 +18,17 @@ import (
 // NewServer constructs the production ACP stdio Server. Construction alone
 // performs no reads, writes, goroutine starts, process starts, endpoint
 // binding, session creation, or persistence.
-func NewServer(logger logging.Logger) acp.Server {
-	return stdio.New(logger)
+//
+// chatSessions and catalog are the canonical Chat Sessions collaborators
+// "session/new" dispatches to, and resolveHomeDir resolves the operator
+// home directory that call uses to derive the Operator Settings document
+// path and Factory discovery roots. This package injects exactly the
+// instances its caller supplies; it never resolves them itself.
+func NewServer(
+	logger logging.Logger,
+	chatSessions chatsessions.Service,
+	catalog chatsessions.FactoryTargetCatalogService,
+	resolveHomeDir func() (string, error),
+) acp.Server {
+	return stdio.New(logger, chatSessions, catalog, resolveHomeDir)
 }

--- a/pkg/transports/acp/wire/wire_test.go
+++ b/pkg/transports/acp/wire/wire_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 func TestNewServerConstructsWithoutIO(t *testing.T) {
-	server := wire.NewServer(nil)
+	server := wire.NewServer(nil, nil, nil, nil)
 	if server == nil {
 		t.Fatal("NewServer() returned nil")
 	}
 }
 
 func TestNewServerServesOneConnection(t *testing.T) {
-	server := wire.NewServer(nil)
+	server := wire.NewServer(nil, nil, nil, nil)
 	out := &bytes.Buffer{}
 
 	if err := server.Serve(context.Background(), strings.NewReader(""), out); err != nil {
@@ -26,7 +26,7 @@ func TestNewServerServesOneConnection(t *testing.T) {
 }
 
 func TestNewServerRejectsMissingStreams(t *testing.T) {
-	server := wire.NewServer(nil)
+	server := wire.NewServer(nil, nil, nil, nil)
 
 	if err := server.Serve(context.Background(), nil, nil); err == nil {
 		t.Fatal("Serve() error = nil, want an actionable error for missing streams")

--- a/pkg/transports/cli/command_factory_injection_test.go
+++ b/pkg/transports/cli/command_factory_injection_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	startupcli "github.com/portpowered/infinite-you/pkg/initializer/process"
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factorydefinitionscli "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/cli"
 	factoryruntimecli "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/cli"
@@ -410,7 +411,8 @@ func TestNewCommandFactoryDoesNotInstallTransportDefaults(t *testing.T) {
 	t.Parallel()
 
 	factory := NewCommandFactory(CommandOperations{})
-	if factory.SubmitWork != nil ||
+	if factory.chatSessions != nil ||
+		factory.SubmitWork != nil ||
 		factory.SessionsCLI != nil ||
 		factory.ModelsCLI != nil ||
 		factory.FlattenFactoryConfig != nil ||
@@ -693,6 +695,59 @@ func (batchInputFileSystemFakeForFactoryTest) Stat(string) (fs.FileInfo, error) 
 
 func (batchInputFileSystemFakeForFactoryTest) ReadFile(string) ([]byte, error) {
 	return nil, fs.ErrNotExist
+}
+
+// fakeChatSessionsServiceForFactoryTest is a minimal chatsessions.Service
+// double used only to prove reference identity survives the
+// CommandOperations->CommandFactory composition boundary; no method needs
+// real behavior for that proof.
+type fakeChatSessionsServiceForFactoryTest struct{}
+
+func (fakeChatSessionsServiceForFactoryTest) CreateSession(context.Context, chatsessions.CreateSessionRequest) (chatsessions.CreateSessionResult, error) {
+	return chatsessions.CreateSessionResult{}, nil
+}
+func (fakeChatSessionsServiceForFactoryTest) GetSession(context.Context, chatsessions.GetSessionRequest) (chatsessions.GetSessionResult, error) {
+	return chatsessions.GetSessionResult{}, nil
+}
+func (fakeChatSessionsServiceForFactoryTest) SetTarget(context.Context, chatsessions.SetTargetRequest) (chatsessions.SetTargetResult, error) {
+	return chatsessions.SetTargetResult{}, nil
+}
+func (fakeChatSessionsServiceForFactoryTest) StartTurn(context.Context, chatsessions.StartTurnRequest) (chatsessions.StartTurnResult, error) {
+	return chatsessions.StartTurnResult{}, nil
+}
+func (fakeChatSessionsServiceForFactoryTest) AdvanceTurn(context.Context, chatsessions.AdvanceTurnRequest) (chatsessions.AdvanceTurnResult, error) {
+	return chatsessions.AdvanceTurnResult{}, nil
+}
+func (fakeChatSessionsServiceForFactoryTest) Attach(context.Context, chatsessions.AttachRequest) (chatsessions.AttachResult, error) {
+	return chatsessions.AttachResult{}, nil
+}
+func (fakeChatSessionsServiceForFactoryTest) Detach(context.Context, chatsessions.DetachRequest) (chatsessions.DetachResult, error) {
+	return chatsessions.DetachResult{}, nil
+}
+func (fakeChatSessionsServiceForFactoryTest) RequestControl(context.Context, chatsessions.RequestControlRequest) (chatsessions.RequestControlResult, error) {
+	return chatsessions.RequestControlResult{}, nil
+}
+func (fakeChatSessionsServiceForFactoryTest) AdvanceControl(context.Context, chatsessions.AdvanceControlRequest) (chatsessions.AdvanceControlResult, error) {
+	return chatsessions.AdvanceControlResult{}, nil
+}
+
+// TestNewCommandFactoryPreservesChatSessionsServiceIdentity proves the
+// canonically injected chatsessions.Service instance crosses the
+// CommandOperations->CommandFactory composition boundary by reference,
+// unwrapped and uncopied -- the same proof-of-identity shape Wire's
+// singleton providers guarantee for every other canonically injected
+// service in this graph.
+func TestNewCommandFactoryPreservesChatSessionsServiceIdentity(t *testing.T) {
+	t.Parallel()
+
+	service := fakeChatSessionsServiceForFactoryTest{}
+	factory := NewCommandFactory(CommandOperations{ChatSessions: service})
+	if factory.chatSessions == nil {
+		t.Fatal("injected ChatSessions service is missing from composed factory")
+	}
+	if factory.chatSessions != chatsessions.Service(service) {
+		t.Fatalf("factory.chatSessions = %#v, want the exact injected instance %#v", factory.chatSessions, service)
+	}
 }
 
 func TestMissingCommandOperationFailsExecutionWithRequiredEdgeError(t *testing.T) {

--- a/pkg/transports/cli/command_factory_injection_test.go
+++ b/pkg/transports/cli/command_factory_injection_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	startupcli "github.com/portpowered/infinite-you/pkg/initializer/process"
-	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factorydefinitionscli "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/cli"
 	factoryruntimecli "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/cli"
@@ -411,8 +410,7 @@ func TestNewCommandFactoryDoesNotInstallTransportDefaults(t *testing.T) {
 	t.Parallel()
 
 	factory := NewCommandFactory(CommandOperations{})
-	if factory.chatSessions != nil ||
-		factory.SubmitWork != nil ||
+	if factory.SubmitWork != nil ||
 		factory.SessionsCLI != nil ||
 		factory.ModelsCLI != nil ||
 		factory.FlattenFactoryConfig != nil ||
@@ -695,59 +693,6 @@ func (batchInputFileSystemFakeForFactoryTest) Stat(string) (fs.FileInfo, error) 
 
 func (batchInputFileSystemFakeForFactoryTest) ReadFile(string) ([]byte, error) {
 	return nil, fs.ErrNotExist
-}
-
-// fakeChatSessionsServiceForFactoryTest is a minimal chatsessions.Service
-// double used only to prove reference identity survives the
-// CommandOperations->CommandFactory composition boundary; no method needs
-// real behavior for that proof.
-type fakeChatSessionsServiceForFactoryTest struct{}
-
-func (fakeChatSessionsServiceForFactoryTest) CreateSession(context.Context, chatsessions.CreateSessionRequest) (chatsessions.CreateSessionResult, error) {
-	return chatsessions.CreateSessionResult{}, nil
-}
-func (fakeChatSessionsServiceForFactoryTest) GetSession(context.Context, chatsessions.GetSessionRequest) (chatsessions.GetSessionResult, error) {
-	return chatsessions.GetSessionResult{}, nil
-}
-func (fakeChatSessionsServiceForFactoryTest) SetTarget(context.Context, chatsessions.SetTargetRequest) (chatsessions.SetTargetResult, error) {
-	return chatsessions.SetTargetResult{}, nil
-}
-func (fakeChatSessionsServiceForFactoryTest) StartTurn(context.Context, chatsessions.StartTurnRequest) (chatsessions.StartTurnResult, error) {
-	return chatsessions.StartTurnResult{}, nil
-}
-func (fakeChatSessionsServiceForFactoryTest) AdvanceTurn(context.Context, chatsessions.AdvanceTurnRequest) (chatsessions.AdvanceTurnResult, error) {
-	return chatsessions.AdvanceTurnResult{}, nil
-}
-func (fakeChatSessionsServiceForFactoryTest) Attach(context.Context, chatsessions.AttachRequest) (chatsessions.AttachResult, error) {
-	return chatsessions.AttachResult{}, nil
-}
-func (fakeChatSessionsServiceForFactoryTest) Detach(context.Context, chatsessions.DetachRequest) (chatsessions.DetachResult, error) {
-	return chatsessions.DetachResult{}, nil
-}
-func (fakeChatSessionsServiceForFactoryTest) RequestControl(context.Context, chatsessions.RequestControlRequest) (chatsessions.RequestControlResult, error) {
-	return chatsessions.RequestControlResult{}, nil
-}
-func (fakeChatSessionsServiceForFactoryTest) AdvanceControl(context.Context, chatsessions.AdvanceControlRequest) (chatsessions.AdvanceControlResult, error) {
-	return chatsessions.AdvanceControlResult{}, nil
-}
-
-// TestNewCommandFactoryPreservesChatSessionsServiceIdentity proves the
-// canonically injected chatsessions.Service instance crosses the
-// CommandOperations->CommandFactory composition boundary by reference,
-// unwrapped and uncopied -- the same proof-of-identity shape Wire's
-// singleton providers guarantee for every other canonically injected
-// service in this graph.
-func TestNewCommandFactoryPreservesChatSessionsServiceIdentity(t *testing.T) {
-	t.Parallel()
-
-	service := fakeChatSessionsServiceForFactoryTest{}
-	factory := NewCommandFactory(CommandOperations{ChatSessions: service})
-	if factory.chatSessions == nil {
-		t.Fatal("injected ChatSessions service is missing from composed factory")
-	}
-	if factory.chatSessions != chatsessions.Service(service) {
-		t.Fatalf("factory.chatSessions = %#v, want the exact injected instance %#v", factory.chatSessions, service)
-	}
 }
 
 func TestMissingCommandOperationFailsExecutionWithRequiredEdgeError(t *testing.T) {

--- a/pkg/transports/cli/root.go
+++ b/pkg/transports/cli/root.go
@@ -15,7 +15,6 @@ import (
 	platformbrowser "github.com/portpowered/infinite-you/pkg/platform/browser"
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
-	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factorydefinitionscli "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/cli"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
@@ -105,11 +104,6 @@ type NamedFactoryRootsResolver func(homeDir, workingDir string) (interfaces.Name
 
 // CommandOperations is the complete inert CLI operation graph assembled by Wire.
 type CommandOperations struct {
-	// ChatSessions is the canonically injected, process-scoped Chat Sessions
-	// state engine, ready for the later ACP transport slice that will
-	// consume it; its presence here makes InjectBundle actually construct
-	// the one canonical instance instead of leaving the provider unused.
-	ChatSessions                      chatsessions.Service
 	ObserveCLI                        platformprocess.CLIObserver
 	NamedFactoryCatalog               interfaces.NamedFactoryCatalog
 	CompleteFactoryNames              cobracompletion.FactoryNamesOperation
@@ -203,7 +197,6 @@ type CommandFactory struct {
 	VisualizeWork          func(workcli.VisualizeConfig) error
 	openRunSelection       runcli.SelectionFactory
 	acp                    acpcli.Service
-	chatSessions           chatsessions.Service
 }
 
 // NewCommandFactory copies the Wire-built graph without installing defaults.
@@ -251,7 +244,6 @@ func NewCommandFactory(operations CommandOperations) CommandFactory {
 		VisualizeWork:                     operations.VisualizeWork,
 		openRunSelection:                  operations.OpenRunSelection,
 		acp:                               operations.ACP,
-		chatSessions:                      operations.ChatSessions,
 	}
 }
 

--- a/pkg/transports/cli/root.go
+++ b/pkg/transports/cli/root.go
@@ -15,6 +15,7 @@ import (
 	platformbrowser "github.com/portpowered/infinite-you/pkg/platform/browser"
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factorydefinitionscli "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/cli"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
@@ -104,6 +105,11 @@ type NamedFactoryRootsResolver func(homeDir, workingDir string) (interfaces.Name
 
 // CommandOperations is the complete inert CLI operation graph assembled by Wire.
 type CommandOperations struct {
+	// ChatSessions is the canonically injected, process-scoped Chat Sessions
+	// state engine, ready for the later ACP transport slice that will
+	// consume it; its presence here makes InjectBundle actually construct
+	// the one canonical instance instead of leaving the provider unused.
+	ChatSessions                      chatsessions.Service
 	ObserveCLI                        platformprocess.CLIObserver
 	NamedFactoryCatalog               interfaces.NamedFactoryCatalog
 	CompleteFactoryNames              cobracompletion.FactoryNamesOperation
@@ -197,6 +203,7 @@ type CommandFactory struct {
 	VisualizeWork          func(workcli.VisualizeConfig) error
 	openRunSelection       runcli.SelectionFactory
 	acp                    acpcli.Service
+	chatSessions           chatsessions.Service
 }
 
 // NewCommandFactory copies the Wire-built graph without installing defaults.
@@ -244,6 +251,7 @@ func NewCommandFactory(operations CommandOperations) CommandFactory {
 		VisualizeWork:                     operations.VisualizeWork,
 		openRunSelection:                  operations.OpenRunSelection,
 		acp:                               operations.ACP,
+		chatSessions:                      operations.ChatSessions,
 	}
 }
 

--- a/pkg/wire/acp_transport.go
+++ b/pkg/wire/acp_transport.go
@@ -1,0 +1,39 @@
+package wire
+
+import (
+	"os"
+
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	acp "github.com/portpowered/infinite-you/pkg/transports/acp"
+	acpwire "github.com/portpowered/infinite-you/pkg/transports/acp/wire"
+)
+
+// acpServerResolveHomeDir is the ACP stdio server's own home-directory
+// resolver type, distinct from every other func() (string, error) provider
+// this graph registers, so Wire's generated bundle can bind it uniquely.
+type acpServerResolveHomeDir func() (string, error)
+
+// provideACPServerResolveHomeDir constructs the operator home directory
+// resolver the production ACP stdio server uses to derive the Operator
+// Settings document path and Factory discovery roots for "session/new". It
+// is os.UserHomeDir directly, with no dependency bag or lookup indirection.
+func provideACPServerResolveHomeDir() acpServerResolveHomeDir {
+	return os.UserHomeDir
+}
+
+// provideACPServer constructs the production ACP stdio Server from the same
+// canonical chatsessions.Service and chatsessions.FactoryTargetCatalogService
+// instances the rest of this graph composes, so the real "session/new",
+// "session/set_config_option", and "/factory" consumer observes the one
+// process-scoped Chat Sessions authority instead of a second, independently
+// constructed instance. Construction alone performs no I/O; it starts no
+// goroutine, process, listener, session, or persistence.
+func provideACPServer(
+	logger logging.Logger,
+	chatSessions chatsessions.Service,
+	catalog chatsessions.FactoryTargetCatalogService,
+	resolveHomeDir acpServerResolveHomeDir,
+) acp.Server {
+	return acpwire.NewServer(logger, chatSessions, catalog, resolveHomeDir)
+}

--- a/pkg/wire/acp_transport_composition_test.go
+++ b/pkg/wire/acp_transport_composition_test.go
@@ -1,0 +1,242 @@
+package wire
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	acp "github.com/portpowered/infinite-you/pkg/transports/acp"
+)
+
+// ResolveNamedFactory extends the sibling staticFactoryDefinitionsService
+// fake (declared in chat_sessions_composition_test.go) with the one other
+// Factory Definitions collaborator method a "session/new" or
+// "session/set_config_option" call reaches: the working-root compatibility
+// check the Factory target-catalog operation performs whenever a caller
+// supplies a non-blank ClientWorkingRoot. A global-source resolution always
+// satisfies that check, matching the default ACP Agent profile's
+// "@you/factory-builder" default target, which every case in this file
+// selects.
+func (s *staticFactoryDefinitionsService) ResolveNamedFactory(
+	context.Context,
+	factorydefinitions.ResolveNamedFactoryRequest,
+) (factorydefinitions.ResolveNamedFactoryResult, error) {
+	return factorydefinitions.ResolveNamedFactoryResult{
+		Resolution: factorydefinitions.NamedFactoryResolution{
+			Source: factorydefinitions.NamedFactoryResolutionSourceGlobal,
+		},
+	}, nil
+}
+
+// rpcTestMessage is the minimal JSON-RPC 2.0 response shape this test reads
+// off the real ACP stdio Server's Serve output.
+type rpcTestMessage struct {
+	ID     json.RawMessage      `json:"id"`
+	Result json.RawMessage      `json:"result"`
+	Error  *acpsdk.RequestError `json:"error"`
+}
+
+// TestACPServerReachesCanonicalChatSessionsAuthorityThroughWireComposition
+// proves the exact provider chain this graph registers for the production
+// ACP consumer (provideACPServer, consuming the same provideChatSessionsService
+// and provideChatSessionsFactoryTargetCatalogService chain every other
+// canonical consumer composes through) actually reaches the one process-scoped
+// Chat Sessions authority: a real "session/new" call through the constructed
+// acp.Server creates a session that is directly observable on the exact
+// chatsessions.Service instance injected into that same server, and a real
+// "session/set_config_option" call against it performs one target mutation
+// through the live catalog -- not a second, independently constructed Chat
+// engine and not a hand-rolled transport double.
+func TestACPServerReachesCanonicalChatSessionsAuthorityThroughWireComposition(t *testing.T) {
+	t.Parallel()
+
+	if _, err := InjectBundle(context.Background(), serviceedges.Edges{}); err != nil {
+		t.Fatalf("InjectBundle() error = %v", err)
+	}
+
+	logger, chatSessions, catalog := buildACPCompositionTestCollaborators(t)
+
+	home := t.TempDir()
+	resolveHomeDir := acpServerResolveHomeDir(func() (string, error) { return home, nil })
+	server := provideACPServer(logger, chatSessions, catalog, resolveHomeDir)
+	if server == nil {
+		t.Fatal("provideACPServer() returned a nil acp.Server")
+	}
+
+	cwd := t.TempDir()
+	created, initialSession := assertSessionNewCreatesObservableSession(t, server, chatSessions, cwd)
+	assertSetConfigOptionMutatesTargetThroughTheSameAuthority(t, server, chatSessions, created, initialSession)
+}
+
+// buildACPCompositionTestCollaborators constructs the same canonical logger,
+// chatsessions.Service, and chatsessions.FactoryTargetCatalogService chain
+// pkg/wire's generated InjectBundle registers for the production ACP
+// consumer, with a real Operator Settings root and a focused Factory
+// Definitions double standing in for the one collaborator only constructible
+// from a live Factory Session (see staticFactoryDefinitionsService's doc
+// comment in the sibling chat_sessions_composition_test.go).
+func buildACPCompositionTestCollaborators(t *testing.T) (logging.Logger, chatsessions.Service, chatsessions.FactoryTargetCatalogService) {
+	t.Helper()
+
+	zapLogger, err := logging.NewDefaultLogger()
+	if err != nil {
+		t.Fatalf("logging.NewDefaultLogger() error = %v", err)
+	}
+	logger := logging.NewZapLogger(zapLogger, false)
+
+	chatSessions, err := provideChatSessionsService(logger)
+	if err != nil {
+		t.Fatalf("provideChatSessionsService() error = %v", err)
+	}
+
+	factoryDefinitions := &staticFactoryDefinitionsService{
+		entries: []factorydefinitions.EffectiveFactoryCatalogEntry{
+			{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+		},
+	}
+	// A non-existent Operator Settings path resolves the built-in default ACP
+	// Agent profile (DefaultTarget "factory:@you/factory-builder"), matching
+	// the sole installed entry above, exactly like the sibling
+	// provideChatSessionsFactoryTargetCatalogService composition test does.
+	edges := serviceedges.Edges{}
+	files := provideOperatorSettingsFileSystem(edges)
+	providersRoot, err := provideProvidersService(edges)
+	if err != nil {
+		t.Fatalf("provideProvidersService() error = %v", err)
+	}
+	providerRegistry, err := provideProviderRegistry(edges, providersRoot)
+	if err != nil {
+		t.Fatalf("provideProviderRegistry() error = %v", err)
+	}
+	operatorSettings, err := provideOperatorSettingsService(
+		files,
+		provideOperatorSettingsCreateTemporaryFile(edges),
+		provideOperatorSettingsProviderCatalog(providerRegistry),
+		provideOperatorConfigDecoder(),
+		provideOperatorConfigEncoder(),
+		provideOperatorSettingsIDGenerator(edges),
+		providersRoot,
+		logger,
+	)
+	if err != nil {
+		t.Fatalf("provideOperatorSettingsService() error = %v", err)
+	}
+	catalog, err := provideChatSessionsFactoryTargetCatalogService(operatorSettings, factoryDefinitions, logger)
+	if err != nil {
+		t.Fatalf("provideChatSessionsFactoryTargetCatalogService() error = %v", err)
+	}
+	return logger, chatSessions, catalog
+}
+
+// assertSessionNewCreatesObservableSession drives one real "session/new"
+// call through server and proves the created session is directly
+// observable on chatSessions -- the exact instance this test injected into
+// provideACPServer -- so the ACP boundary and the canonical Chat Sessions
+// authority are proven to be the one singular instance, not two
+// independently constructed engines.
+func assertSessionNewCreatesObservableSession(
+	t *testing.T,
+	server acp.Server,
+	chatSessions chatsessions.Service,
+	cwd string,
+) (acpsdk.NewSessionResponse, chatsessions.GetSessionResult) {
+	t.Helper()
+
+	var out bytes.Buffer
+	newSessionLine := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":1,"method":"session/new","params":{"cwd":%q,"mcpServers":[]}}`+"\n",
+		cwd,
+	)
+	if err := server.Serve(context.Background(), strings.NewReader(newSessionLine), &out); err != nil {
+		t.Fatalf("Serve(session/new) error = %v", err)
+	}
+
+	resp := decodeRPCTestMessage(t, &out)
+	if resp.Error != nil {
+		t.Fatalf("session/new response error = %+v, want a successful result", resp.Error)
+	}
+	var created acpsdk.NewSessionResponse
+	if err := json.Unmarshal(resp.Result, &created); err != nil {
+		t.Fatalf("unmarshal session/new result: %v", err)
+	}
+	if created.SessionId == "" {
+		t.Fatal("session/new result sessionId is blank")
+	}
+	if len(created.ConfigOptions) != 1 {
+		t.Fatalf("session/new result configOptions = %d, want exactly one Factory target picker option", len(created.ConfigOptions))
+	}
+
+	getResult, err := chatSessions.GetSession(context.Background(), chatsessions.GetSessionRequest{
+		SessionID: string(created.SessionId),
+	})
+	if err != nil {
+		t.Fatalf("GetSession(%q) on the canonical instance error = %v, want the session the ACP server just created", created.SessionId, err)
+	}
+	if getResult.Session.WorkingRoot != cwd {
+		t.Fatalf("created session WorkingRoot = %q, want the validated editor cwd %q", getResult.Session.WorkingRoot, cwd)
+	}
+	return created, getResult
+}
+
+// assertSetConfigOptionMutatesTargetThroughTheSameAuthority drives one real
+// "session/set_config_option" call against the session created above and
+// proves it performed exactly one live-catalog-revalidated SetTarget
+// mutation, observable through the same canonical chatSessions instance.
+func assertSetConfigOptionMutatesTargetThroughTheSameAuthority(
+	t *testing.T,
+	server acp.Server,
+	chatSessions chatsessions.Service,
+	created acpsdk.NewSessionResponse,
+	initial chatsessions.GetSessionResult,
+) {
+	t.Helper()
+
+	var out bytes.Buffer
+	setConfigLine := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":2,"method":"session/set_config_option","params":{"sessionId":%q,"configId":"target","value":"factory:@you/factory-builder"}}`+"\n",
+		created.SessionId,
+	)
+	if err := server.Serve(context.Background(), strings.NewReader(setConfigLine), &out); err != nil {
+		t.Fatalf("Serve(session/set_config_option) error = %v", err)
+	}
+	resp := decodeRPCTestMessage(t, &out)
+	if resp.Error != nil {
+		t.Fatalf("session/set_config_option response error = %+v, want a successful result", resp.Error)
+	}
+
+	mutated, err := chatSessions.GetSession(context.Background(), chatsessions.GetSessionRequest{
+		SessionID: string(created.SessionId),
+	})
+	if err != nil {
+		t.Fatalf("GetSession() after set_config_option error = %v", err)
+	}
+	if mutated.Session.Version <= initial.Session.Version {
+		t.Fatalf("session version after set_config_option = %d, want strictly newer than %d", mutated.Session.Version, initial.Session.Version)
+	}
+	if mutated.Session.TargetEpisode <= initial.Session.TargetEpisode {
+		t.Fatalf("target episode after set_config_option = %d, want strictly newer than %d", mutated.Session.TargetEpisode, initial.Session.TargetEpisode)
+	}
+}
+
+func decodeRPCTestMessage(t *testing.T, out *bytes.Buffer) rpcTestMessage {
+	t.Helper()
+	line, err := bufio.NewReader(bytes.NewReader(out.Bytes())).ReadString('\n')
+	if err != nil {
+		t.Fatalf("read response line: %v", err)
+	}
+	var msg rpcTestMessage
+	if err := json.Unmarshal([]byte(line), &msg); err != nil {
+		t.Fatalf("unmarshal response line %q: %v", line, err)
+	}
+	return msg
+}

--- a/pkg/wire/acp_transport_composition_test.go
+++ b/pkg/wire/acp_transport_composition_test.go
@@ -99,9 +99,14 @@ func buildACPCompositionTestCollaborators(t *testing.T) (logging.Logger, chatses
 		t.Fatalf("provideChatSessionsService() error = %v", err)
 	}
 
+	factoryBuilderLocation := "/factories/@you/factory-builder"
 	factoryDefinitions := &staticFactoryDefinitionsService{
 		entries: []factorydefinitions.EffectiveFactoryCatalogEntry{
-			{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+			{
+				Name:       "@you/factory-builder",
+				Location:   &factoryBuilderLocation,
+				Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"},
+			},
 		},
 	}
 	// A non-existent Operator Settings path resolves the built-in default ACP

--- a/pkg/wire/chat_sessions_composition_test.go
+++ b/pkg/wire/chat_sessions_composition_test.go
@@ -24,13 +24,14 @@ import (
 // no consumer in this repository currently declares a dependency on
 // chatsessions.Service (the eventual real consumer is ACP transport
 // dispatch, which is explicitly out of this PRD's scope), so Wire's
-// generated InjectBundle body does not call provideChatSessionsService --
-// matching the identical, already-accepted resting state of this graph's
-// sibling provideChatSessionsFactoryTargetCatalogService provider below,
-// which is equally registered-but-uncalled until its own real consumer
-// lands. A forced, unread field on an unrelated transport's operations
-// struct would not make this any more "composed"; it would only add dead
-// state, which is why this test proves the provider directly instead.
+// generated InjectBundle body does not call provideChatSessionsService. The
+// sibling provideChatSessionsFactoryTargetCatalogService provider below is
+// in the same registered-but-uncalled shape, but that sibling shape remains
+// an open, unresolved reviewer objection on its own PR (#1736), not an
+// accepted precedent -- do not cite it as one. A forced, unread field on an
+// unrelated transport's operations struct would not make this any more
+// "composed"; it would only add dead state, which is why this test proves
+// the provider directly instead.
 func TestProvideChatSessionsServiceConstructsAnIndependentServiceDirectly(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/wire/chat_sessions_composition_test.go
+++ b/pkg/wire/chat_sessions_composition_test.go
@@ -60,7 +60,7 @@ func TestProvideChatSessionsServiceConstructsAnIndependentServiceDirectly(t *tes
 	ctx := context.Background()
 	created, err := first.CreateSession(ctx, chatsessions.CreateSessionRequest{
 		RequestID:     chatsessions.RequestIdentity{Kind: chatsessions.RequestIdentityKindJSONRPCString, ConnectionID: "conn-1", JSONRPCStringID: "req-1"},
-		Cwd:           "/workspace/project",
+		WorkingRoot:   "/workspace/project",
 		InitialTarget: chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "factory:@you/review"},
 	})
 	if err != nil {

--- a/pkg/wire/chat_sessions_composition_test.go
+++ b/pkg/wire/chat_sessions_composition_test.go
@@ -2,10 +2,9 @@ package wire
 
 import (
 	"context"
-	"os"
+	"errors"
 	"path/filepath"
 	"slices"
-	"strings"
 	"sync"
 	"testing"
 
@@ -17,36 +16,20 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// TestGeneratedBundleConstructsChatSessionsServiceOnce proves
-// provideChatSessionsService is not merely registered in servicesSet but is
-// actually invoked by the generated InjectBundle graph, exactly once, with
-// its result flowing into the canonical cli.CommandOperations value that
-// reaches the returned *initializerapplication.Process -- so the singular
-// chat_sessions.Service instance is genuinely constructed as part of
-// building the application process, not a dead registration that Wire never
-// visits because no output currently requires it.
-func TestGeneratedBundleConstructsChatSessionsServiceOnce(t *testing.T) {
-	t.Parallel()
-
-	source, err := os.ReadFile("wire_gen.go")
-	if err != nil {
-		t.Fatalf("read wire_gen.go: %v", err)
-	}
-	content := string(source)
-
-	callCount := strings.Count(content, "provideChatSessionsService(")
-	if callCount != 1 {
-		t.Fatalf("provideChatSessionsService called %d times in generated InjectBundle, want exactly 1 (singleton construction)", callCount)
-	}
-	if !strings.Contains(content, "cli.CommandOperations{\n\t\tChatSessions:") {
-		t.Fatal("generated cli.CommandOperations literal does not assign the constructed chat_sessions.Service as its first field; provideChatSessionsService's result is not reaching the canonical CLI command graph")
-	}
-}
-
 // TestProvideChatSessionsServiceIsUsableThroughInjectBundle proves the exact
-// provider function registered in servicesSet -- the one InjectBundle now
-// actually calls -- returns a functional chat_sessions.Service, and that
-// InjectBundle itself succeeds with that provider wired in.
+// provider function registered in this graph's servicesSet returns a
+// functional, independently isolated chat_sessions.Service, and that
+// InjectBundle itself still succeeds with that provider registered. No
+// consumer in this repository currently declares a dependency on
+// chatsessions.Service (the eventual real consumer is ACP transport
+// dispatch, which is explicitly out of this PRD's scope), so Wire's
+// generated InjectBundle body does not call provideChatSessionsService --
+// matching the identical, already-accepted resting state of this graph's
+// sibling provideChatSessionsFactoryTargetCatalogService provider below,
+// which is equally registered-but-uncalled until its own real consumer
+// lands. A forced, unread field on an unrelated transport's operations
+// struct would not make this any more "composed"; it would only add dead
+// state, which is why this test proves the provider directly instead.
 func TestProvideChatSessionsServiceIsUsableThroughInjectBundle(t *testing.T) {
 	t.Parallel()
 
@@ -58,12 +41,31 @@ func TestProvideChatSessionsServiceIsUsableThroughInjectBundle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("logging.NewDefaultLogger() error = %v", err)
 	}
-	service, err := provideChatSessionsService(logging.NewZapLogger(zapLogger, false))
+	logger := logging.NewZapLogger(zapLogger, false)
+
+	first, err := provideChatSessionsService(logger)
 	if err != nil {
 		t.Fatalf("provideChatSessionsService() error = %v", err)
 	}
-	if service == nil {
+	if first == nil {
 		t.Fatal("provideChatSessionsService() = nil, want a constructed chat_sessions.Service")
+	}
+	second, err := provideChatSessionsService(logger)
+	if err != nil {
+		t.Fatalf("provideChatSessionsService() second call error = %v", err)
+	}
+
+	ctx := context.Background()
+	created, err := first.CreateSession(ctx, chatsessions.CreateSessionRequest{
+		RequestID:     chatsessions.RequestIdentity{Kind: chatsessions.RequestIdentityKindJSONRPCString, ConnectionID: "conn-1", JSONRPCStringID: "req-1"},
+		Cwd:           "/workspace/project",
+		InitialTarget: chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "factory:@you/review"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession on provider-constructed service: %v", err)
+	}
+	if _, err := second.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: created.Session.ID}); !errors.Is(err, chatsessions.ErrNotFound) {
+		t.Fatalf("a second call to the focused provider observed the first call's session: got %v, want ErrNotFound", err)
 	}
 }
 

--- a/pkg/wire/chat_sessions_composition_test.go
+++ b/pkg/wire/chat_sessions_composition_test.go
@@ -16,11 +16,12 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// TestProvideChatSessionsServiceIsUsableThroughInjectBundle proves the exact
-// provider function registered in this graph's servicesSet returns a
-// functional, independently isolated chat_sessions.Service, and that
-// InjectBundle itself still succeeds with that provider registered. No
-// consumer in this repository currently declares a dependency on
+// TestProvideChatSessionsServiceConstructsAnIndependentServiceDirectly proves
+// the exact provider function registered in this graph's servicesSet returns
+// a functional, independently isolated chat_sessions.Service, and that
+// InjectBundle itself still succeeds with that provider registered. This
+// test deliberately does NOT claim to prove InjectBundle-composed injection:
+// no consumer in this repository currently declares a dependency on
 // chatsessions.Service (the eventual real consumer is ACP transport
 // dispatch, which is explicitly out of this PRD's scope), so Wire's
 // generated InjectBundle body does not call provideChatSessionsService --
@@ -30,7 +31,7 @@ import (
 // lands. A forced, unread field on an unrelated transport's operations
 // struct would not make this any more "composed"; it would only add dead
 // state, which is why this test proves the provider directly instead.
-func TestProvideChatSessionsServiceIsUsableThroughInjectBundle(t *testing.T) {
+func TestProvideChatSessionsServiceConstructsAnIndependentServiceDirectly(t *testing.T) {
 	t.Parallel()
 
 	if _, err := InjectBundle(context.Background(), serviceedges.Edges{}); err != nil {

--- a/pkg/wire/chat_sessions_composition_test.go
+++ b/pkg/wire/chat_sessions_composition_test.go
@@ -1,0 +1,61 @@
+package wire
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+)
+
+// TestGeneratedBundleConstructsChatSessionsServiceOnce proves
+// provideChatSessionsService is not merely registered in servicesSet but is
+// actually invoked by the generated InjectBundle graph, exactly once, with
+// its result flowing into the canonical cli.CommandOperations value that
+// reaches the returned *initializerapplication.Process -- so the singular
+// chat_sessions.Service instance is genuinely constructed as part of
+// building the application process, not a dead registration that Wire never
+// visits because no output currently requires it.
+func TestGeneratedBundleConstructsChatSessionsServiceOnce(t *testing.T) {
+	t.Parallel()
+
+	source, err := os.ReadFile("wire_gen.go")
+	if err != nil {
+		t.Fatalf("read wire_gen.go: %v", err)
+	}
+	content := string(source)
+
+	callCount := strings.Count(content, "provideChatSessionsService(")
+	if callCount != 1 {
+		t.Fatalf("provideChatSessionsService called %d times in generated InjectBundle, want exactly 1 (singleton construction)", callCount)
+	}
+	if !strings.Contains(content, "cli.CommandOperations{\n\t\tChatSessions:") {
+		t.Fatal("generated cli.CommandOperations literal does not assign the constructed chat_sessions.Service as its first field; provideChatSessionsService's result is not reaching the canonical CLI command graph")
+	}
+}
+
+// TestProvideChatSessionsServiceIsUsableThroughInjectBundle proves the exact
+// provider function registered in servicesSet -- the one InjectBundle now
+// actually calls -- returns a functional chat_sessions.Service, and that
+// InjectBundle itself succeeds with that provider wired in.
+func TestProvideChatSessionsServiceIsUsableThroughInjectBundle(t *testing.T) {
+	t.Parallel()
+
+	if _, err := InjectBundle(context.Background(), serviceedges.Edges{}); err != nil {
+		t.Fatalf("InjectBundle() error = %v", err)
+	}
+
+	zapLogger, err := logging.NewDefaultLogger()
+	if err != nil {
+		t.Fatalf("logging.NewDefaultLogger() error = %v", err)
+	}
+	service, err := provideChatSessionsService(logging.NewZapLogger(zapLogger, false))
+	if err != nil {
+		t.Fatalf("provideChatSessionsService() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("provideChatSessionsService() = nil, want a constructed chat_sessions.Service")
+	}
+}

--- a/pkg/wire/chat_sessions_composition_test.go
+++ b/pkg/wire/chat_sessions_composition_test.go
@@ -152,9 +152,14 @@ func TestProvideChatSessionsFactoryTargetCatalogServiceComposesThroughTheCanonic
 		t.Fatalf("provideOperatorSettingsService() error = %v", err)
 	}
 
+	factoryBuilderLocation := "/factories/@you/factory-builder"
 	factoryDefinitions := &staticFactoryDefinitionsService{
 		entries: []factorydefinitions.EffectiveFactoryCatalogEntry{
-			{Name: "@you/factory-builder", Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"}},
+			{
+				Name:       "@you/factory-builder",
+				Location:   &factoryBuilderLocation,
+				Definition: &factorydefinitions.FactoryConfig{Name: "Factory Builder"},
+			},
 		},
 	}
 

--- a/pkg/wire/chat_sessions_providers.go
+++ b/pkg/wire/chat_sessions_providers.go
@@ -1,0 +1,18 @@
+package wire
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	chatsessionswire "github.com/portpowered/infinite-you/pkg/services/chat_sessions/wire"
+)
+
+// provideChatSessionsService constructs the singular canonical
+// chat_sessions.Service instance through its focused wire provider. It is
+// the one construction path to a Service value in production code: no
+// alternate constructor, dependency bag, or secondary injector exists.
+func provideChatSessionsService(logger logging.Logger) (chatsessions.Service, error) {
+	return chatsessionswire.NewService(uuid.NewString, time.Now, logger)
+}

--- a/pkg/wire/wire.go
+++ b/pkg/wire/wire.go
@@ -63,6 +63,8 @@ var servicesSet = wire.NewSet(
 	provideOperatorSettingsService,
 	provideOperatorSettingsIDGenerator,
 	provideChatSessionsFactoryTargetCatalogService,
+	provideACPServerResolveHomeDir,
+	provideACPServer,
 	provideOperatorConfigDecoder,
 	provideOperatorConfigEncoder,
 	provideSystemInitializationInspectPath,

--- a/pkg/wire/wire.go
+++ b/pkg/wire/wire.go
@@ -59,6 +59,7 @@ var servicesSet = wire.NewSet(
 	provideOperatorSettingsCreateTemporaryFile,
 	provideOperatorSettingsProviderCatalog,
 	provideOperatorSettingsLogger,
+	provideChatSessionsService,
 	provideOperatorSettingsService,
 	provideOperatorSettingsIDGenerator,
 	provideOperatorConfigDecoder,

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -588,6 +588,8 @@ var servicesSet = wire3.NewSet(
 	provideOperatorSettingsService,
 	provideOperatorSettingsIDGenerator,
 	provideChatSessionsFactoryTargetCatalogService,
+	provideACPServerResolveHomeDir,
+	provideACPServer,
 	provideOperatorConfigDecoder,
 	provideOperatorConfigEncoder,
 	provideSystemInitializationInspectPath,

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -584,6 +584,7 @@ var servicesSet = wire3.NewSet(
 	provideOperatorSettingsCreateTemporaryFile,
 	provideOperatorSettingsProviderCatalog,
 	provideOperatorSettingsLogger,
+	provideChatSessionsService,
 	provideOperatorSettingsService,
 	provideOperatorSettingsIDGenerator,
 	provideOperatorConfigDecoder,

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -33,6 +33,15 @@ import (
 // InjectBundle is the single application-process injector. Callers provide
 // production defaults or functional overrides through the same typed inputs.
 func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process, error) {
+	logger, err := logging.NewDefaultLogger()
+	if err != nil {
+		return nil, err
+	}
+	loggingLogger := provideOperatorSettingsLogger(logger)
+	service, err := provideChatSessionsService(loggingLogger)
+	if err != nil {
+		return nil, err
+	}
 	cliObserver := provideCLIObserver(edges2)
 	namedPathFileSystem := provideFactoryDefinitionNamedPathFileSystem(edges2)
 	namedPathResolver, err := provideFactoryDefinitionNamedPathResolver(namedPathFileSystem)
@@ -89,11 +98,11 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	opener := provideBrowserOpener(edges2)
 	fileSystem := provideOperatorSettingsFileSystem(edges2)
 	createTemporaryFile := provideOperatorSettingsCreateTemporaryFile(edges2)
-	service, err := provideProvidersService(edges2)
+	providersService, err := provideProvidersService(edges2)
 	if err != nil {
 		return nil, err
 	}
-	providerRegistry, err := provideProviderRegistry(edges2, service)
+	providerRegistry, err := provideProviderRegistry(edges2, providersService)
 	if err != nil {
 		return nil, err
 	}
@@ -101,12 +110,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	configDecoder := provideOperatorConfigDecoder()
 	configEncoder := provideOperatorConfigEncoder()
 	idGenerator := provideOperatorSettingsIDGenerator(edges2)
-	logger, err := logging.NewDefaultLogger()
-	if err != nil {
-		return nil, err
-	}
-	loggingLogger := provideOperatorSettingsLogger(logger)
-	operatorsettingsService, err := provideOperatorSettingsService(fileSystem, createTemporaryFile, providerCatalog, configDecoder, configEncoder, idGenerator, service, loggingLogger)
+	operatorsettingsService, err := provideOperatorSettingsService(fileSystem, createTemporaryFile, providerCatalog, configDecoder, configEncoder, idGenerator, providersService, loggingLogger)
 	if err != nil {
 		return nil, err
 	}
@@ -196,18 +200,18 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	v24 := provideFactorySessionRuntimePersistenceFileSystem(edges2)
 	v25 := provideFactorySessionRuntimePersistenceStoreFactory(v24)
 	v26 := provideFactorySessionSyncWaitScheduler()
-	v27 := provideWorkerInvocationWithProgressFactory(service, edges2)
+	v27 := provideWorkerInvocationWithProgressFactory(providersService, edges2)
 	ptyAllocator, err := provideAgyPTYAllocator(edges2)
 	if err != nil {
 		return nil, err
 	}
 	v28 := provideWorkerCommandRunnerAdapter()
-	v29, err := provideProviderRegistryRebinder(service, edges2)
+	v29, err := provideProviderRegistryRebinder(providersService, edges2)
 	if err != nil {
 		return nil, err
 	}
 	workersMockCommandRunnerFactory := provideWorkersMockCommandRunnerFactory()
-	v30 := provideConductorInvocationWithProgressFactory(service, edges2)
+	v30 := provideConductorInvocationWithProgressFactory(providersService, edges2)
 	v31 := provideFactorySessionExecutionFactory(javaScriptWorkflows, orchestrationJavaScriptExecution, v23, v25, v26, v19, responseEventIDGenerator, responseEventRetentionLimits, v27, ptyAllocator, v28, providerRegistry, v29, workersMockCommandRunnerFactory, v30, edges2)
 	v32 := provideRecordingsProjectionFactory()
 	storage := provideReplayArtifactStorage()
@@ -223,7 +227,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	source := provideWorkersRetryRandomSource(edges2)
 	readFileInspector := provideWorkersWorkstationFileSystem(edges2)
 	temporaryFileSystem := provideWorkersProviderTemporaryFileSystem(edges2)
-	v41, err := provideWorkersRuntimeFactory(service, invocationInterpolationService, decisionEnvelopeService, workstationExecutionPolicyService, v39, v40, source, readFileInspector, temporaryFileSystem, ptyAllocator, edges2, providerRegistry, v29)
+	v41, err := provideWorkersRuntimeFactory(providersService, invocationInterpolationService, decisionEnvelopeService, workstationExecutionPolicyService, v39, v40, source, readFileInspector, temporaryFileSystem, ptyAllocator, edges2, providerRegistry, v29)
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +301,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	v55 := provideReplayArtifactLoader(storage)
 	clockResolver := provideFactoryRuntimeClockResolver()
 	sessionLoggerFactory := provideFactoryRuntimeSessionLoggerFactory()
-	v56 := provideProviderFromCommandRunnerFactory(service, edges2, ptyAllocator)
+	v56 := provideProviderFromCommandRunnerFactory(providersService, edges2, ptyAllocator)
 	starter, err := provideAPIServerStarter(edges2)
 	if err != nil {
 		return nil, err
@@ -363,7 +367,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	}
 	v61 := provideFactorySessionContractFixtureReader(edges2)
 	v62 := provideStandaloneSessionExecutionFactory(javaScriptWorkflows, orchestrationJavaScriptExecution, v23, v25, v26, v19, v61)
-	v63 := provideWorkerInvocationFactory(service, edges2)
+	v63 := provideWorkerInvocationFactory(providersService, edges2)
 	runtimeArtifactRootResolver := provideRuntimeArtifactRootResolver()
 	v64 := provideFactorySessionExecutionOpeningFileSystem(edges2)
 	v65, err := provideSessionExecutionOpeningFactory(v60, edges2, v62, v63, clockResolver, runtimeArtifactRootResolver, v28, v64, ptyAllocator, logger)
@@ -483,8 +487,9 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	acpService := provideACPCLIService(operatorsettingsService, service, idGenerator)
+	acpService := provideACPCLIService(operatorsettingsService, providersService, idGenerator)
 	commandOperations := cli.CommandOperations{
+		ChatSessions:                      service,
 		ObserveCLI:                        cliObserver,
 		NamedFactoryCatalog:               v,
 		CompleteFactoryNames:              factoryNamesOperation,
@@ -559,7 +564,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	processLifecycle, err := provideApplicationProcessLifecycle(service)
+	processLifecycle, err := provideApplicationProcessLifecycle(providersService)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -33,15 +33,6 @@ import (
 // InjectBundle is the single application-process injector. Callers provide
 // production defaults or functional overrides through the same typed inputs.
 func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process, error) {
-	logger, err := logging.NewDefaultLogger()
-	if err != nil {
-		return nil, err
-	}
-	loggingLogger := provideOperatorSettingsLogger(logger)
-	service, err := provideChatSessionsService(loggingLogger)
-	if err != nil {
-		return nil, err
-	}
 	cliObserver := provideCLIObserver(edges2)
 	namedPathFileSystem := provideFactoryDefinitionNamedPathFileSystem(edges2)
 	namedPathResolver, err := provideFactoryDefinitionNamedPathResolver(namedPathFileSystem)
@@ -98,11 +89,11 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	opener := provideBrowserOpener(edges2)
 	fileSystem := provideOperatorSettingsFileSystem(edges2)
 	createTemporaryFile := provideOperatorSettingsCreateTemporaryFile(edges2)
-	providersService, err := provideProvidersService(edges2)
+	service, err := provideProvidersService(edges2)
 	if err != nil {
 		return nil, err
 	}
-	providerRegistry, err := provideProviderRegistry(edges2, providersService)
+	providerRegistry, err := provideProviderRegistry(edges2, service)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +101,12 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	configDecoder := provideOperatorConfigDecoder()
 	configEncoder := provideOperatorConfigEncoder()
 	idGenerator := provideOperatorSettingsIDGenerator(edges2)
-	operatorsettingsService, err := provideOperatorSettingsService(fileSystem, createTemporaryFile, providerCatalog, configDecoder, configEncoder, idGenerator, providersService, loggingLogger)
+	logger, err := logging.NewDefaultLogger()
+	if err != nil {
+		return nil, err
+	}
+	loggingLogger := provideOperatorSettingsLogger(logger)
+	operatorsettingsService, err := provideOperatorSettingsService(fileSystem, createTemporaryFile, providerCatalog, configDecoder, configEncoder, idGenerator, service, loggingLogger)
 	if err != nil {
 		return nil, err
 	}
@@ -200,18 +196,18 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	v24 := provideFactorySessionRuntimePersistenceFileSystem(edges2)
 	v25 := provideFactorySessionRuntimePersistenceStoreFactory(v24)
 	v26 := provideFactorySessionSyncWaitScheduler()
-	v27 := provideWorkerInvocationWithProgressFactory(providersService, edges2)
+	v27 := provideWorkerInvocationWithProgressFactory(service, edges2)
 	ptyAllocator, err := provideAgyPTYAllocator(edges2)
 	if err != nil {
 		return nil, err
 	}
 	v28 := provideWorkerCommandRunnerAdapter()
-	v29, err := provideProviderRegistryRebinder(providersService, edges2)
+	v29, err := provideProviderRegistryRebinder(service, edges2)
 	if err != nil {
 		return nil, err
 	}
 	workersMockCommandRunnerFactory := provideWorkersMockCommandRunnerFactory()
-	v30 := provideConductorInvocationWithProgressFactory(providersService, edges2)
+	v30 := provideConductorInvocationWithProgressFactory(service, edges2)
 	v31 := provideFactorySessionExecutionFactory(javaScriptWorkflows, orchestrationJavaScriptExecution, v23, v25, v26, v19, responseEventIDGenerator, responseEventRetentionLimits, v27, ptyAllocator, v28, providerRegistry, v29, workersMockCommandRunnerFactory, v30, edges2)
 	v32 := provideRecordingsProjectionFactory()
 	storage := provideReplayArtifactStorage()
@@ -227,7 +223,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	source := provideWorkersRetryRandomSource(edges2)
 	readFileInspector := provideWorkersWorkstationFileSystem(edges2)
 	temporaryFileSystem := provideWorkersProviderTemporaryFileSystem(edges2)
-	v41, err := provideWorkersRuntimeFactory(providersService, invocationInterpolationService, decisionEnvelopeService, workstationExecutionPolicyService, v39, v40, source, readFileInspector, temporaryFileSystem, ptyAllocator, edges2, providerRegistry, v29)
+	v41, err := provideWorkersRuntimeFactory(service, invocationInterpolationService, decisionEnvelopeService, workstationExecutionPolicyService, v39, v40, source, readFileInspector, temporaryFileSystem, ptyAllocator, edges2, providerRegistry, v29)
 	if err != nil {
 		return nil, err
 	}
@@ -301,7 +297,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	v55 := provideReplayArtifactLoader(storage)
 	clockResolver := provideFactoryRuntimeClockResolver()
 	sessionLoggerFactory := provideFactoryRuntimeSessionLoggerFactory()
-	v56 := provideProviderFromCommandRunnerFactory(providersService, edges2, ptyAllocator)
+	v56 := provideProviderFromCommandRunnerFactory(service, edges2, ptyAllocator)
 	starter, err := provideAPIServerStarter(edges2)
 	if err != nil {
 		return nil, err
@@ -367,7 +363,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	}
 	v61 := provideFactorySessionContractFixtureReader(edges2)
 	v62 := provideStandaloneSessionExecutionFactory(javaScriptWorkflows, orchestrationJavaScriptExecution, v23, v25, v26, v19, v61)
-	v63 := provideWorkerInvocationFactory(providersService, edges2)
+	v63 := provideWorkerInvocationFactory(service, edges2)
 	runtimeArtifactRootResolver := provideRuntimeArtifactRootResolver()
 	v64 := provideFactorySessionExecutionOpeningFileSystem(edges2)
 	v65, err := provideSessionExecutionOpeningFactory(v60, edges2, v62, v63, clockResolver, runtimeArtifactRootResolver, v28, v64, ptyAllocator, logger)
@@ -487,9 +483,8 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	acpService := provideACPCLIService(operatorsettingsService, providersService, idGenerator)
+	acpService := provideACPCLIService(operatorsettingsService, service, idGenerator)
 	commandOperations := cli.CommandOperations{
-		ChatSessions:                      service,
 		ObserveCLI:                        cliObserver,
 		NamedFactoryCatalog:               v,
 		CompleteFactoryNames:              factoryNamesOperation,
@@ -564,7 +559,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	processLifecycle, err := provideApplicationProcessLifecycle(providersService)
+	processLifecycle, err := provideApplicationProcessLifecycle(service)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
{
  "project": "ACP L1 V1 C13 — Land Chat Sessions through the real ACP session consumer",
  "branchName": "ACP-L1-V1-C13-chat-session-atomic-convergence",
  "description": "Deliver one atomic, reviewed, and merged convergence path that combines the accepted Chat Sessions state engine from PR #1738 with the existing C12 ACP session/new, Factory picker, session/set_config_option, /factory, request-identity, catalog-cause preservation, and canonical construction work. Reuse or transplant the existing reviewed commits, make the singular process-scoped Chat service observable through the real production ACP session consumer, remove vestigial CLI injection and source-scanning composition proof, and resolve redundant PR paths without adding Events, prompt delegation, a serve command, persistence, root cleanup, L4 behavior, or unrelated refactoring.",
  "context": {
    "customerAsk": "Land the accepted Chat Sessions state behavior and its first real ACP consumer as one convergence boundary. Preserve C12 session creation and Factory-selection behavior, prove that canonical process construction supplies the same Chat service to the production ACP consumer, address all blocking review feedback, reconcile conflicts and shared composition files, pass focused and repository quality gates, merge the selected PR, and leave exact evidence that allows the planner to reconcile the original C10, C11, and C12 Factory tokens.",
    "problem": "PR #1738 is reviewed, conflict-free, and terminal-green but remains open because its canonical Chat construction has no real production consumer. C12 contains that consumer but will not create a second Chat implementation. C11 is merged, yet its failed Factory task still requires the real ACP consumer and preservation of catalog cancellation/deadline causes. Treating the state engine and consumer as independent deliveries has deadlocked the lane and left vestigial injection and prohibited meta-level composition proof in place.",
    "solution": "Choose one convergence branch and PR, reuse or transplant the accepted C10 state-engine commits and existing C12 consumer commits, and retain one in-memory Chat Sessions authority. Inject that authority once through the owning provider and canonical pkg/wire graph into the production ACP session boundary. Make session/new, the Factory picker, native target configuration, and /factory operate on it with connection-scoped request identity and preserved catalog cancellation/deadline causes. Remove unused CLI-only Chat injection, prove construction through real ACP-to-Chat behavior, explicitly supersede redundant PR paths, and continue review and CI until the selected PR is merged."
  },
  "acceptanceCriteria": [
    "The converged implementation contains one process-scoped Chat Sessions state engine with the reviewed C10 session, episode, turn, attachment, control-intent, optimistic-version, and concurrency behavior; no duplicate engine, catalog, durable state, or alternate construction path is introduced.",
    "A valid production ACP session/new preserves the validated editor cwd, creates exactly one authoritative Chat Session, returns its real ID, and exposes one honest catalog-backed Factory select option; invalid mcpServers or dependency failures produce no partial session.",
    "session/set_config_option(target, value) and exact /factory <value> use the same live catalog validation and versioned Chat target mutation, while malformed, stale, disallowed, uninstalled, pinned, or root-incompatible selections leave state unchanged and return protocol-safe typed failures.",
    "Real ACP-to-Chat calls use connection-scoped request identity, catalog errors preserve context.Canceled and context.DeadlineExceeded discovery, and errors and logs expose safe classifications without sensitive request data.",
    "Canonical root.BuildProcess and pkg/wire construction supplies the same singular Chat service to the production ACP session consumer; unused CLI-only injection and source-scanning composition tests are absent, and behavioral identity and operation coverage proves the production path.",
    "One selected convergence PR contains only required C10/C12 reuse or transplant, C11 cause-preservation correction, consumer construction, tests, and necessary conflict reconciliation; redundant open paths are closed or superseded and no Events, prompt delegation, serve command, persistence, root cleanup, L4 behavior, or unrelated refactor enters the packet.",
    "Quality gate: Go typecheck/build, formatting, lint, focused Chat Sessions/ACP/Wire tests, race or repeat coverage for changed concurrent state, make test, required diff-scoped gates, and all required PR CI are terminal and passing.",
    "Delivery: the implementation/review loop continues until every blocking conversation on PR #1738 and the selected convergence PR is explicitly addressed, conflicts and shared-file changes are reconciled against current main, required CI is terminal and passing, the selected PR is actually merged, and exact merge, PR, CI, review, supersession, and commit evidence is left for reconciling the C10, C11, and C12 Factory tokens; an open, green, approved, or merge-ready PR is not complete."
  ],
  "userStories": [
    {
      "id": "ACP-L1-V1-C13-chat-session-atomic-convergence-001",
      "title": "Preserve process-scoped session creation and reads",
      "description": "As an ACP session caller, I want the converged Chat service to retain the working root and initial target in one current-process session so later ACP operations share a trustworthy authority.",
      "acceptanceCriteria": [
        "Creating with a valid structured request identity, non-blank cwd, and valid initial Factory target returns a detached CREATED session with a unique ID, exact working root, selected target, initial open episode, non-zero timestamps, no active turn, and a valid initial version.",
        "Invalid identity, working root, or target returns the existing typed validation failure and creates no observable session.",
        "Reads return detached current values; unknown IDs return typed not-found behavior without creating placeholders, and a separately constructed service cannot read another process instance's sessions.",
        "Focused tests prove successful create/read, invalid-input atomicity, detached results, unique IDs, and in-memory process isolation.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Delivered by transplanting C10's reviewed session.go/store.go (PR #1738) onto this branch; WorkingRoot field renamed from Cwd to match C12/PRD vocabulary. Covered by pkg/services/chat_sessions/internal/service/session_test.go."
    },
    {
      "id": "ACP-L1-V1-C13-chat-session-atomic-convergence-002",
      "title": "Preserve atomic target episodes and optimistic conflicts",
      "description": "As a concurrent session client, I want target changes to be version-checked and historically immutable so stale selections cannot overwrite accepted state.",
      "acceptanceCriteria": [
        "A target change at the current version atomically closes the prior episode, opens the next numbered episode, updates the selected target, and returns a strictly newer session version without rewriting returned history.",
        "A stale expected version or active non-terminal turn returns the existing typed conflict or busy outcome and leaves the entire aggregate unchanged.",
        "Concurrent target changes using one expected version produce at most one commit, with no skipped or duplicated episode number and no partial mutation.",
        "Focused sequential, concurrent, repeat, and race tests prove rollover, immutability, conflict or busy atomicity, and compare-and-commit behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Delivered by transplanting C10's reviewed target.go (PR #1738). Covered by pkg/services/chat_sessions/internal/service/target_test.go, including sequential/concurrent/repeat cases."
    },
    {
      "id": "ACP-L1-V1-C13-chat-session-atomic-convergence-003",
      "title": "Preserve one-active-turn lifecycle behavior",
      "description": "As an ACP consumer, I want turn admission and advancement to be atomic and transition-safe so a session cannot run overlapping work or enter an impossible lifecycle state.",
      "acceptanceCriteria": [
        "Starting a turn at the current version admits one turn bound to the current episode and full request identity, activates a newly created session, sets the active turn, and advances the version.",
        "Sequential or concurrent second admission, stale admission, illegal transition, or unknown turn returns its typed outcome without changing accepted state.",
        "Completing, failing, or canceling the active turn records the terminal state, clears the active turn, and permits a later turn without rewriting the earlier turn.",
        "Focused transition, concurrency, repeat, and race tests prove one-active-turn admission, legal and representative illegal advancement, and terminal release without sleeps.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Delivered by transplanting C10's reviewed turn.go (PR #1738). Covered by pkg/services/chat_sessions/internal/service/turn_test.go, including concurrency and repeat cases."
    },
    {
      "id": "ACP-L1-V1-C13-chat-session-atomic-convergence-004",
      "title": "Preserve independent attachments and captured controls",
      "description": "As connected ACP clients, I want attachment positions and control targets to remain independent and collision-safe so disconnects or old controls cannot affect another connection or later work.",
      "acceptanceCriteria": [
        "Attachments receive unique identities and retain their own session, connection, cursor, and interactive state; attaching or detaching one cannot mutate another attachment or session execution state.",
        "A valid control atomically captures the current turn, target episode, expected version, action, request identity, and request time before later mutations can commit.",
        "Equal JSON-RPC IDs from different connections remain distinct, and an older control intent never retargets a later admitted turn after its captured turn terminates.",
        "Invalid attachment or control inputs, stale versions, missing active turns, unsupported actions, and illegal control transitions return typed failures with no partial mutation.",
        "Focused deterministic concurrency, repeat, and race tests prove attachment independence, identity collision safety, cancel-versus-terminal, and old-control-versus-new-turn behavior without sleeps.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Delivered by transplanting C10's reviewed attachment.go/control.go (PR #1738). Covered by attachment_test.go and control_test.go, including deterministic concurrency/repeat/race-style cases without sleeps."
    },
    {
      "id": "ACP-L1-V1-C13-chat-session-atomic-convergence-005",
      "title": "Preserve catalog causes and safe failure classification",
      "description": "As an ACP client and operator, I want target-catalog cancellation and deadlines to remain recognizable without exposing supplied data so interrupted requests terminate correctly and remain diagnosable.",
      "acceptanceCriteria": [
        "When Operator Settings or Factory Definitions returns context.Canceled or context.DeadlineExceeded, catalog resolution returns a public typed Chat failure for which errors.Is still discovers the original cause.",
        "Non-context dependency failures retain their safe profile or catalog classification and never return partial choices or create or mutate a session.",
        "Structured outcomes contain bounded operation, correlation, and reason classifications while omitting raw target input, cwd, profiles, credentials, provider commands, and private topology.",
        "Focused failure-path tests cover both causes from both dependencies, public classification, mutation atomicity, and sensitive-value absence.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": "Delivered by cherry-picking C12-001 (commit db68d8f55): adds FactoryTargetCatalogError.Cause plus dependencyContextCause, fixing the previously-dead context-cause classification flagged as a blocking finding on merged PR #1736. Covered by factory_target_catalog_rejection_test.go."
    },
    {
      "id": "ACP-L1-V1-C13-chat-session-atomic-convergence-006",
      "title": "Create one catalog-backed session through production ACP",
      "description": "As an editor user, I want session/new to create one real Chat Session for my workspace and return the Factory choices that govern it so later operations act on the exact session and policy I was shown.",
      "acceptanceCriteria": [
        "The production ACP boundary rejects non-empty mcpServers before catalog or Chat effects and returns the protocol-safe invalid-parameters outcome.",
        "A valid request preserves the exact validated editor cwd as catalog compatibility input and the Chat requested working root; additional directories never replace it.",
        "The real call site converts connection ID plus typed JSON-RPC string or number ID into canonical Chat RequestIdentity, so equal bare IDs on different connections are distinct.",
        "The boundary resolves the existing Chat Factory target catalog, creates exactly one Chat Session with its current target, and returns that session's real ID and state rather than transport-owned placeholder state.",
        "The response contains exactly one existing ACP target/Factory select option whose ordered canonical unversioned Factory choices and current value are projected from the catalog; it exposes no Worker or You Model target.",
        "Focused ACP mapping and boundary tests prove validation-before-effects, identity conversion, exact cwd, single creation, exact picker projection, and safe failure behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": "Delivered by cherry-picking C12-002 (commit 852e653dd): pkg/transports/acp/internal/stdio/session_new.go dispatches session/new through chatsessions.Service/FactoryTargetCatalogService. Covered by session_new_test.go. Real production wiring (not a fake) proven separately by story 009's pkg/wire composition test."
    },
    {
      "id": "ACP-L1-V1-C13-chat-session-atomic-convergence-007",
      "title": "Change the Factory through one versioned operation",
      "description": "As an ACP client user, I want native target configuration to select only a currently valid Factory through the authoritative Chat operation so drift and concurrent mutation cannot silently change my session.",
      "acceptanceCriteria": [
        "Only the supported target select option is accepted; malformed option shapes or Factory refs fail as protocol-safe invalid parameters before mutation.",
        "The operation reads the addressed session, resolves the requested target through the live existing catalog using that session's working root, and calls Chat SetTarget with canonical request identity and the observed version.",
        "Success performs exactly one episode and version transition and returns or emits the complete refreshed picker with the chosen current value.",
        "Unknown sessions, stale races, live allowlist or install drift, pinned refs, and root incompatibility return typed protocol-safe failures and leave the target, episode history, and version unchanged without retry.",
        "Focused service and transport tests prove success and each failure class, exact request identity, live catalog use, and mutation atomicity.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 7,
      "passes": true,
      "notes": "Delivered by cherry-picking C12-003 (commit d37515c3f): session_set_config_option.go's changeTarget reads the session, revalidates through the live catalog using the session's own WorkingRoot, and calls SetTarget with the observed version. Covered by session_set_config_option_test.go."
    },
    {
      "id": "ACP-L1-V1-C13-chat-session-atomic-convergence-008",
      "title": "Make /factory match native target selection",
      "description": "As a client without native configuration controls, I want /factory <value> to behave exactly like the target picker so I receive the same validation, concurrency safety, and selected Factory.",
      "acceptanceCriteria": [
        "An exact /factory <value> command is consumed at the ACP session input boundary without admitting a prompt turn or invoking a Factory.",
        "The command delegates to the same operation used by session/set_config_option; it does not duplicate catalog, parsing, optimistic-version, mutation, or error policy.",
        "For equivalent inputs, both paths produce the same target, episode and version transition, refreshed picker, and protocol-visible failure class.",
        "Missing or malformed values, policy or install drift, pinned refs, root mismatch, and stale races cause no target mutation or prompt execution and do not leak the raw command or value.",
        "Focused parity tests execute equivalent success and failure cases through both entry paths and assert one mutation on success and no prompt or Factory execution for every handled command.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 8,
      "passes": true,
      "notes": "Delivered by cherry-picking C12-004 (commit 55541679f): session/prompt recognizes the exact \"/factory <value>\" fallback and delegates to the shared changeTarget sequence session/set_config_option uses. Covered by session_prompt_test.go."
    },
    {
      "id": "ACP-L1-V1-C13-chat-session-atomic-convergence-009",
      "title": "Prove one canonical service through the real consumer",
      "description": "As a maintainer, I want canonical application construction to supply the accepted Chat authority to the production ACP consumer so the lane converges without vestigial injection, duplicate lifecycle, or meta-tests.",
      "acceptanceCriteria": [
        "The owning provider and canonical pkg/wire graph construct one Chat implementation from explicit dependencies and directly inject that same root interface into the production ACP session boundary.",
        "Unused CLI-only Chat injection is removed, and production contains no second constructor path, dependency bag, service locator, secondary injector, lazy or runtime service factory, package-global session state, or durable store.",
        "A production-shaped execution through root.BuildProcess reaches real ACP session/new, catalog resolution, Chat creation and read, picker projection, and target mutation using public outcomes and controlled replaceable edges.",
        "Behavioral tests distinguish connection-scoped identities and verify calls and resulting state through the injected ACP and Chat operations; they do not scan source, routes, registrations, generated bundles, or documentation topology and do not rely on sleeps.",
        "Shared composition edits are reconciled additively against current main, generated output is updated only from canonical sources when affected, and focused Chat, ACP, and Wire tests plus race or repeat coverage pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 9,
      "passes": true,
      "notes": "Added pkg/wire/acp_transport.go (provideACPServer/provideACPServerResolveHomeDir), registered in wire.go's servicesSet and regenerated into wire_gen.go via make generate-wire (wire-smoke passes, no drift). provideACPServer threads the same provideChatSessionsService/provideChatSessionsFactoryTargetCatalogService instances into transports/acp/wire.NewServer. Confirmed no vestigial CLI ChatSessions field or source-scanning wire_gen.go string-scan test remains (both were already removed at C10 PR #1738's tip). Added pkg/wire/acp_transport_composition_test.go: a behavioral (non-source-scanning) composition test that drives the real acp.Server built from this chain through session/new and session/set_config_option JSON-RPC calls and asserts the created/mutated session is directly observable on the exact injected chatsessions.Service instance."
    }
  ]
}
