### PR TITLE
ACP-L1-V1-C13-010: Fix changeTarget mutation-before-projection ordering

### DIFF
--- a/pkg/transports/acp/internal/stdio/session_prompt_test.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt_test.go
@@ -212,6 +212,29 @@ func TestHandleSessionPromptFactoryCommandWorkingRootIncompatibleRejects(t *test
 	}
 }
 
+func TestHandleSessionPromptFactoryCommandProjectionFailureRejectsWithNoMutation(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: chatsessions.ResolveFactoryTargetCatalogResult{
+		CurrentTarget: "factory:@you/review",
+		Choices:       nil,
+	}}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "/factory factory:@you/review"))
+
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a rejection when the catalog projects no picker choices")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionPrompt() result = %q, want nil on rejection", result)
+	}
+	if chatSessions.setTargetCalled {
+		t.Fatal("SetTarget was called, want zero mutation calls when picker projection fails")
+	}
+}
+
 func TestHandleSessionPromptFactoryCommandFailureNeverLeaksRawValueOrRoot(t *testing.T) {
 	sensitiveTarget := "factory:@you/sk_live_should_never_leak"
 	sensitiveRoot := "/home/operator/should-never-leak"

--- a/pkg/transports/acp/internal/stdio/session_set_config_option.go
+++ b/pkg/transports/acp/internal/stdio/session_set_config_option.go
@@ -81,15 +81,17 @@ func (s *Server) handleSessionSetConfigOption(ctx context.Context, env envelope.
 // changeTarget executes the shared target-change sequence used by both
 // "session/set_config_option" and the "/factory" command fallback
 // (handleSessionPrompt in session_prompt.go): read the addressed Chat
-// Session, resolve the
-// requested value through the existing Factory target catalog using that
-// session's own WorkingRoot, and call Chat Sessions' SetTarget with the
-// canonical revalidated target, the caller's identity, the session id, and
-// the version observed from the read. Any failure -- an unknown session, a
-// stale version, a disallowed/uninstalled/malformed/root-incompatible
-// target, or a dependency fault -- returns before the next effect, so a
-// rejected change never mutates target, episode history, or session
-// version.
+// Session, resolve the requested value through the existing Factory target
+// catalog using that session's own WorkingRoot, project the refreshed picker
+// from that catalog result, and only once projection succeeds call Chat
+// Sessions' SetTarget with the canonical revalidated target, the caller's
+// identity, the session id, and the version observed from the read.
+// Projection runs before SetTarget precisely so a picker-projection failure
+// (e.g. an empty catalog) never mutates the session: any failure -- an
+// unknown session, a stale version, a disallowed/uninstalled/malformed/
+// root-incompatible target, a picker-projection failure, or a dependency
+// fault -- returns before the mutating effect, so a rejected change never
+// mutates target, episode history, or session version.
 func (s *Server) changeTarget(ctx context.Context, sessionID string, requestedValue string, reqIdentity chatsessions.RequestIdentity) (acpsdk.SessionConfigOption, *acpsdk.RequestError) {
 	if s.chatSessions == nil || s.catalog == nil || s.resolveHomeDir == nil {
 		return acpsdk.SessionConfigOption{}, classifyDependencyFailure(errSessionSetConfigOptionUnavailable)
@@ -128,6 +130,12 @@ func (s *Server) changeTarget(ctx context.Context, sessionID string, requestedVa
 		return acpsdk.SessionConfigOption{}, classifyTargetSelectionFailure(err)
 	}
 
+	option := factorytarget.FromCatalogResult(catalogResult)
+	configOption, err := option.ToSessionConfigOption()
+	if err != nil {
+		return acpsdk.SessionConfigOption{}, classifyDependencyFailure(err)
+	}
+
 	if _, err := s.chatSessions.SetTarget(ctx, chatsessions.SetTargetRequest{
 		RequestID:       reqIdentity,
 		SessionID:       getResult.Session.ID,
@@ -140,11 +148,6 @@ func (s *Server) changeTarget(ctx context.Context, sessionID string, requestedVa
 		return acpsdk.SessionConfigOption{}, classifyTargetSelectionFailure(err)
 	}
 
-	option := factorytarget.FromCatalogResult(catalogResult)
-	configOption, err := option.ToSessionConfigOption()
-	if err != nil {
-		return acpsdk.SessionConfigOption{}, classifyDependencyFailure(err)
-	}
 	return configOption, nil
 }
 

--- a/pkg/transports/acp/internal/stdio/session_set_config_option_test.go
+++ b/pkg/transports/acp/internal/stdio/session_set_config_option_test.go
@@ -190,7 +190,7 @@ func TestChangeTargetBlankHomeDirFailureReturnsNoMutation(t *testing.T) {
 	}
 }
 
-func TestChangeTargetConfigProjectionFailureReturnsMutatedButUnprojectedFailure(t *testing.T) {
+func TestChangeTargetConfigProjectionFailureReturnsNoMutation(t *testing.T) {
 	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
 	catalog := &fakeFactoryTargetCatalogService{result: chatsessions.ResolveFactoryTargetCatalogResult{
 		CurrentTarget: "factory:@you/review",
@@ -207,6 +207,9 @@ func TestChangeTargetConfigProjectionFailureReturnsMutatedButUnprojectedFailure(
 	}
 	if result != nil {
 		t.Fatalf("handleSessionSetConfigOption() result = %q, want nil on rejection", result)
+	}
+	if chatSessions.setTargetCalled {
+		t.Fatal("SetTarget was called, want zero mutation calls when picker projection fails")
 	}
 }
 


### PR DESCRIPTION
## Summary

Corrective follow-up to the post-merge blocking review on #1748 (work-task-213). #1750 (merged) fixed the canonical-composition finding but did not address the second blocking finding: `changeTarget` in `pkg/transports/acp/internal/stdio/session_set_config_option.go` called `Chat Sessions.SetTarget` *before* projecting the refreshed picker via `factorytarget.FromCatalogResult(...).ToSessionConfigOption()`. If projection failed (e.g. an empty catalog), the caller received an error response even though the target mutation had already committed — violating the "no mutation on failure" guarantee required for both native `session/set_config_option` and the `/factory <value>` command fallback, which share this exact sequence.

## Changes

- Reordered `changeTarget` so picker projection happens before `SetTarget`; `SetTarget` now only runs once projection succeeds. Both entry points share this function, so the fix applies to both.
- Renamed `TestChangeTargetConfigProjectionFailureReturnsMutatedButUnprojectedFailure` to `TestChangeTargetConfigProjectionFailureReturnsNoMutation` and added an assertion that `SetTarget` is never called when projection fails.
- Added the equivalent assertion for the `/factory` path (`TestHandleSessionPromptFactoryCommandProjectionFailureRejectsWithNoMutation`).

## Test plan

- [x] `go build ./...`, `go vet ./pkg/transports/acp/...`, `gofmt -l` clean
- [x] `go test ./pkg/transports/acp/...` — all pass, including new/renamed atomicity assertions
- [x] Full unit lane (`go run ./cmd/unitlane`) — 429 packages ok, 0 fail
- [x] `go run ./cmd/gocoveragecheck -suite functional ...` — exits 0, no package coverage regression
- [x] `go run ./cmd/backendsizecheck` — 73 violations, identical to main, none in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)