### PR TITLE
PSS-I05-D2-event-boundary-rescope: narrow PSS-I05 to residual D2 metadata

### DIFF
--- a/docs/internal/projects/packaged-service-structure/README.md
+++ b/docs/internal/projects/packaged-service-structure/README.md
@@ -162,9 +162,10 @@ Consequences for PSS packets:
 
 - `FND-08` (`event-contract`, `pkg/services/recordings/events/kinds/`) stays
   Recordings-owned and is unaffected — event *kinds* are contract, not stream.
-- `PSS-I05` (`event-backbone`) must be re-scoped against D2 before dispatch. An
-  "event backbone convergence" that merges persistence with streaming
-  contradicts this split.
+- `PSS-I05` was re-scoped against D2 before dispatch (see "Applied manifest
+  narrowing — PSS-I05" below): the prior `event-backbone` lease class implied
+  an "event backbone convergence" that merges persistence with streaming,
+  contradicting this split.
 - `factory_sessions/internal/{responseeventstore,responsestream,cursors}` migrate
   into `pkg/services/events` under L1. **PSS packets must not touch those paths
   while L1 is active.**
@@ -290,7 +291,32 @@ exclusive" expressed directly, that requires a change-kind dimension in
 `internal/psslease` which does not exist today. Narrowing the paths is the
 change that fits the current mechanism.
 
-`PSS-I05` re-scoping under D2 is a second follow-up and is described above.
+## Applied manifest narrowing — PSS-I05
+
+D2 required a second `path-lease-packet-manifest.json` change, now **applied**:
+the committed ledger's `PSS-I05` packet no longer claims a combined
+persistence-and-streaming event backbone.
+
+| Packet | `leaseClass` | Prior exclusive paths | Applied exclusive paths |
+| --- | --- | --- | --- |
+| `PSS-I05` | Prior: `event-backbone`; Applied: `event-boundary-metadata` | `pkg/factory/contracts/` ; `docs/internal/projects/packaged-service-structure/event-backbone-convergence.md` | `docs/internal/projects/packaged-service-structure/event-boundary-d2-rescope.md` |
+
+- `PSS-I05` remains present exactly once, in its existing undispatched
+  `blocked` state with its `FND-08` prerequisite unchanged. The packet is
+  **narrowed, not deleted**, and `exclusivePaths` stays non-empty.
+- The retained path is a single dedicated PSS-owned metadata file
+  ([`event-boundary-d2-rescope.md`](./event-boundary-d2-rescope.md)) recording
+  the settled D2 boundary: Recordings keeps canonical JSONL history and
+  replay, `FND-08` keeps event kinds, and L1 Events keeps the process-local
+  stream and Factory Sessions response-event extraction. The packet claims no
+  `pkg/factory/contracts/` path and no other production service, Events,
+  Recordings, Factory Sessions, composition, or generated-code path.
+- `internal/psslease` regression coverage proves both halves: the re-scoped
+  ledger validates and admits `PSS-I05` as a lease-holding dispatch candidate
+  without mutating committed state, and a genuine equal or path-prefix
+  overlap on the retained metadata file while `PSS-I05` holds a lease is
+  rejected before activation, with both packet identities and the
+  conflicting path in the diagnostic.
 
 ## Planner state updates
 

--- a/docs/internal/projects/packaged-service-structure/event-boundary-d2-rescope.md
+++ b/docs/internal/projects/packaged-service-structure/event-boundary-d2-rescope.md
@@ -1,0 +1,23 @@
+# PSS-I05 — D2 event boundary (residual metadata)
+
+`PSS-I05` no longer claims an "event backbone convergence" implementation.
+This file is PSS-I05's entire exclusive-path lease: a residual metadata record
+of the settled D2 boundary, not a package, service, or generated artifact.
+
+## Settled boundary (see `README.md` § D2 for the full decision)
+
+- **Recordings** remains the canonical JSONL Factory history and replay
+  ledger. It cedes nothing to a streaming layer.
+- **FND-08** (`event-contract`) retains ownership of Factory event *kinds*
+  under `pkg/services/recordings/events/kinds/`.
+- **L1 Events** owns the process-local stream: ordering, cursors,
+  subscriptions, retention, gaps, backpressure, and Factory Sessions
+  response-event extraction.
+
+## Scope fence
+
+PSS-I05 authorizes none of the above implementations. It records that the
+three concerns stay separately owned, and its purpose is satisfied once this
+record is committed and validated. It introduces no convergence service, no
+persistent Events store, no legacy package, no event-kind migration, and no
+response-event implementation.

--- a/docs/internal/projects/packaged-service-structure/path-lease-packet-manifest.json
+++ b/docs/internal/projects/packaged-service-structure/path-lease-packet-manifest.json
@@ -183,10 +183,9 @@
     },
     {
       "packetId": "PSS-I05",
-      "leaseClass": "event-backbone",
+      "leaseClass": "event-boundary-metadata",
       "exclusivePaths": [
-        "pkg/factory/contracts/",
-        "docs/internal/projects/packaged-service-structure/event-backbone-convergence.md"
+        "docs/internal/projects/packaged-service-structure/event-boundary-d2-rescope.md"
       ],
       "state": "blocked",
       "prerequisites": [

--- a/internal/psslease/testdata/invalid-pss-i05-narrowed-boundary-conflict.json
+++ b/internal/psslease/testdata/invalid-pss-i05-narrowed-boundary-conflict.json
@@ -1,0 +1,20 @@
+{
+  "formatVersion": "pss-path-lease-packet-manifest/v1",
+  "packets": [
+    {
+      "packetId": "PSS-I05",
+      "leaseClass": "event-boundary-metadata",
+      "exclusivePaths": [
+        "docs/internal/projects/packaged-service-structure/event-boundary-d2-rescope.md"
+      ],
+      "state": "active"
+    },
+    {
+      "packetId": "PKT-BOUNDARY-CONFLICT",
+      "exclusivePaths": [
+        "docs/internal/projects/packaged-service-structure/event-boundary-d2-rescope.md"
+      ],
+      "state": "blocked"
+    }
+  ]
+}

--- a/internal/psslease/validate_test.go
+++ b/internal/psslease/validate_test.go
@@ -485,6 +485,71 @@ func TestValidateDispatchCandidateRejectsClaimOnRetainedPSSI01StructuralPath(t *
 	}
 }
 
+// TestValidateDispatchCandidateAdmitsNarrowedPSSI05WithoutMutatingState proves
+// the committed ledger's re-scoped PSS-I05 (single dedicated
+// event-boundary-d2-rescope.md metadata path instead of the prior
+// pkg/factory/contracts/ and event-backbone-convergence.md event-backbone
+// lease) is admissible into a lease-holding state before dispatch, and that
+// ValidateDispatchCandidate never mutates the candidate's committed state.
+func TestValidateDispatchCandidateAdmitsNarrowedPSSI05WithoutMutatingState(t *testing.T) {
+	t.Parallel()
+
+	manifest := loadCommittedCatalog(t)
+	before := packetByID(t, manifest, "PSS-I05")
+	if len(before.ExclusivePaths) != 1 {
+		t.Fatalf("PSS-I05 exclusivePaths = %v, want exactly one residual metadata path", before.ExclusivePaths)
+	}
+	wantPath := "docs/internal/projects/packaged-service-structure/event-boundary-d2-rescope.md"
+	if before.ExclusivePaths[0] != wantPath {
+		t.Fatalf("PSS-I05 exclusivePaths[0] = %q, want %q", before.ExclusivePaths[0], wantPath)
+	}
+	for _, forbidden := range []string{"pkg/factory/contracts/", "event-backbone-convergence.md"} {
+		for _, path := range before.ExclusivePaths {
+			if strings.Contains(path, forbidden) {
+				t.Fatalf("PSS-I05 exclusivePaths %v still references forbidden path %q", before.ExclusivePaths, forbidden)
+			}
+		}
+	}
+
+	if err := psslease.ValidateDispatchCandidate(manifest, "PSS-I05", psslease.StateActive); err != nil {
+		t.Fatalf("ValidateDispatchCandidate(PSS-I05, active) error = %v, want nil for re-scoped candidate", err)
+	}
+
+	after := packetByID(t, manifest, "PSS-I05")
+	if after.State != before.State {
+		t.Fatalf("PSS-I05 state = %q after ValidateDispatchCandidate, want unchanged %q (candidate check must not commit a state change)", after.State, before.State)
+	}
+	if after.ExclusivePaths[0] != wantPath {
+		t.Fatalf("PSS-I05 exclusivePaths[0] = %q after ValidateDispatchCandidate, want unchanged %q", after.ExclusivePaths[0], wantPath)
+	}
+}
+
+// TestValidateDispatchCandidateRejectsClaimOnRetainedPSSI05BoundaryPath proves
+// a genuine equal/path-prefix claim on the retained PSS-I05 residual metadata
+// path is rejected before activation, with both packet identities and the
+// conflicting path in the diagnostic, and that the rejected packet remains
+// non-holding.
+func TestValidateDispatchCandidateRejectsClaimOnRetainedPSSI05BoundaryPath(t *testing.T) {
+	t.Parallel()
+
+	manifest := loadFixture(t, "invalid-pss-i05-narrowed-boundary-conflict.json")
+
+	err := psslease.SetPacketState(manifest, "PKT-BOUNDARY-CONFLICT", psslease.StateActive)
+	if err == nil {
+		t.Fatal("SetPacketState(PKT-BOUNDARY-CONFLICT, active) error = nil, want rejection for overlap with PSS-I05's retained metadata path")
+	}
+	message := err.Error()
+	for _, want := range []string{"PSS-I05", "PKT-BOUNDARY-CONFLICT", "docs/internal/projects/packaged-service-structure/event-boundary-d2-rescope.md"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("SetPacketState() error = %v, want substring %q", err, want)
+		}
+	}
+
+	if got := packetByID(t, manifest, "PKT-BOUNDARY-CONFLICT").State; got != psslease.StateBlocked {
+		t.Fatalf("PKT-BOUNDARY-CONFLICT state = %q after rejected promotion, want unchanged %q (non-holding)", got, psslease.StateBlocked)
+	}
+}
+
 func loadCommittedCatalog(t *testing.T) *psslease.Manifest {
 	t.Helper()
 	path := filepath.Join("..", "..", "docs", "internal", "projects", "packaged-service-structure", "path-lease-packet-manifest.json")


### PR DESCRIPTION
```json
{
  "project": "Re-scope PSS-I05 to the D2 Event Boundary",
  "branchName": "PSS-I05-D2-event-boundary-rescope",
  "description": "Correct PSS-I05 program metadata so the required packet remains cataloged exactly once with a non-empty minimal PSS-owned metadata lease, but no longer implies one combined persistence-and-streaming event backbone. Record the settled D2 boundary that preserves Recordings as the canonical JSONL history and replay ledger, leaves event kinds with FND-08, and leaves the process-local stream and active Factory Sessions extraction to L1 Events; prove valid catalog and dispatch behavior plus genuine overlap rejection without changing production services.",
  "context": {
    "customerAsk": "Deliver a reviewed and merged D2 metadata correction for PSS-I05. Preserve its required catalog identity with a non-empty minimal PSS-owned exclusive-path set, remove obsolete legacy ownership that implies a combined event backbone, explicitly record the residual Recordings/Event kinds/L1 Events boundary, and prove catalog validity, dispatch-candidate validity, and genuine overlap rejection using only PSS program metadata and co-located internal/psslease fixtures and tests.",
    "problem": "The committed ledger still gives PSS-I05 the event-backbone identity and leases nonexistent pkg/factory/contracts/ and event-backbone-convergence.md paths. Those claims contradict D2's separation of Recordings JSONL history from the process-local Events stream, obscure the active L1 ownership of Factory Sessions response-event extraction, and prevent PSS-I05 from being a trustworthy dispatch candidate.",
    "solution": "Narrow the existing PSS-I05 entry in place to a residual D2 boundary-metadata packet with one dedicated PSS-owned metadata path and no production package lease. Document that Recordings retains canonical JSONL history and replay, FND-08 retains event kinds, and L1 Events retains stream behavior and Factory Sessions extraction. Add focused lease-validator evidence that the committed catalog is valid, dispatch preflight is accepted without mutation, and a real equal or prefix-overlapping claimant is rejected before activation."
  },
  "acceptanceCriteria": [
    "The committed catalog contains exactly one PSS-I05 entry with a non-empty minimal PSS-owned metadata lease and no claim on pkg/factory/contracts/, an event-backbone convergence artifact, or any production service path.",
    "Committed PSS metadata explicitly preserves Recordings ownership of canonical JSONL history and replay, FND-08 ownership of existing event kinds, and L1 Events ownership of the process-local stream and active Factory Sessions extraction concerns.",
    "PSS-I05 remains a residual metadata packet, while unrelated packet identities, leases, prerequisites, and lifecycle states including PSS-I01 and FND-08 remain unchanged unless a PSS-I05 field adjustment is strictly required by D2.",
    "Focused internal/psslease coverage proves that the corrected committed catalog validates and that PSS-I05 is admitted as a lease-holding dispatch candidate without mutation.",
    "Focused overlap coverage proves that a genuine equal or path-prefix collision with the re-scoped PSS-I05 lease is rejected before activation with both packet identities and the conflicting path in the diagnostic.",
    "No Events, Recordings implementation, Factory Sessions, pkg/wire, pkg/root, pkg/initializer, generated-file, old pkg/factory/contracts, PSS-I01, FND-08, or unrelated packet changes are included.",
    "Quality gates pass: go test ./internal/psslease -count=1, applicable PSS metadata verification, typecheck, lint, and required tests and CI.",
    "The implementation and review loop continues until required CI is terminal and passing, every blocking PR conversation is explicitly addressed, merge conflicts and shared-file churn are reconciled, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "PSS-I05-D2-event-boundary-rescope-001",
      "title": "Publish the residual D2 packet boundary",
      "description": "As a PSS planner, I need the required PSS-I05 catalog entry to describe only its residual D2 metadata purpose so dispatch does not imply that PSS owns a combined persistence-and-streaming backbone.",
      "acceptanceCriteria": [
        "The committed catalog contains PSS-I05 exactly once with one non-empty narrowly named path under docs/internal/projects/packaged-service-structure/ that records its residual boundary purpose.",
        "The PSS-I05 lease class and purpose no longer describe event-backbone convergence, and its paths contain neither pkg/factory/contracts/ nor a production Events, Recordings, Factory Sessions, composition, or generated-code path.",
        "The residual metadata states that Recordings remains the canonical JSONL history and replay ledger, FND-08 retains event kinds, and L1 Events retains ordering, cursors, subscriptions, retention, gaps, backpressure, and Factory Sessions response-event extraction.",
        "The packet authorizes no convergence service, persistent Events store, legacy package creation, event-kind migration, or response-event implementation.",
        "PSS-I05 remains in its existing undispatched lifecycle state, and PSS-I01, FND-08, and unrelated packet entries remain semantically unchanged.",
        "The corrected committed manifest passes catalog and lease-holder validation.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Narrowed PSS-I05 in path-lease-packet-manifest.json to leaseClass event-boundary-metadata with a single exclusive path (docs/internal/projects/packaged-service-structure/event-boundary-d2-rescope.md); removed pkg/factory/contracts/ and event-backbone-convergence.md. New residual doc records the Recordings/FND-08/L1 Events boundary. README.md gained an 'Applied manifest narrowing — PSS-I05' section mirroring the PSS-I01 precedent. State (blocked), prerequisites (FND-08), PSS-I01, and all other packets unchanged."
    },
    {
      "id": "PSS-I05-D2-event-boundary-rescope-002",
      "title": "Prove safe dispatch admission and real conflict rejection",
      "description": "As a dispatcher and reviewer, I need focused lease-validator evidence for the re-scoped packet so I can admit its metadata work safely while still rejecting another active claimant on the same path.",
      "acceptanceCriteria": [
        "A focused test loads the committed catalog, confirms the required PSS-I05 identity and minimal lease, and shows ValidateDispatchCandidate accepts promotion to a lease-holding target state without changing committed state.",
        "A co-located fixture models a genuine equal or path-prefix overlap with the retained PSS-I05 metadata path while the competing packet holds a lease.",
        "Dispatching the overlapping candidate is rejected before state mutation, and the diagnostic identifies PSS-I05, the competing packet, and the conflicting path.",
        "The positive and negative cases exercise internal/psslease validation behavior rather than scanning repository files or asserting command, route, registration, or documentation-link inventories.",
        "go test ./internal/psslease -count=1 and applicable PSS metadata verification pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added TestValidateDispatchCandidateAdmitsNarrowedPSSI05WithoutMutatingState (loads committed catalog, asserts the single residual path, admits PSS-I05 into active without mutating state) and TestValidateDispatchCandidateRejectsClaimOnRetainedPSSI05BoundaryPath (new fixture invalid-pss-i05-narrowed-boundary-conflict.json models an equal-path overlap; SetPacketState rejection names PSS-I05, PKT-BOUNDARY-CONFLICT, and the conflicting path; rejected packet stays blocked). go test ./internal/psslease -count=1 passes; go build ./... and make test (existing suite) unaffected — pre-existing unrelated internal/ownershipinventory failures confirmed present on base commit before this change."
    }
  ]
}

```
