### PR TITLE
ACP-L1-V1-C14-prompt-delegation: Delegate One ACP Prompt Turn to the Selected Factory Session

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1199,6 +1199,10 @@
       }
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/ondemandtarget",
+      "minimum": 5.26
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/processlifecycle",
       "minimum": 76.31
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -965,6 +965,10 @@
       "minimum": 77.31
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/ondemandtarget",
+      "minimum": 83.15
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/processlifecycle",
       "minimum": 89.47
     },

--- a/pkg/services/chat_sessions/contracts.go
+++ b/pkg/services/chat_sessions/contracts.go
@@ -116,8 +116,30 @@ type Service interface {
 	// *FactorySessionConflictError when the episode already carries a
 	// different Factory Session identity -- in every failure case the
 	// stored session and episode history are left byte-for-byte unchanged,
-	// and no prior (non-current) episode is ever mutated.
+	// and no prior (non-current) episode is ever mutated. A successful
+	// commit also clears any PendingFactorySessionID recorded via
+	// RecordPendingFactorySession, since the pending record's purpose --
+	// letting a retry find the started-but-uncommitted identity -- is moot
+	// once that identity is durably committed.
 	BindFactorySession(ctx context.Context, req BindFactorySessionRequest) (BindFactorySessionResult, error)
+
+	// RecordPendingFactorySession durably records (or, with a blank
+	// FactorySessionID, clears) a Factory Session identity a caller started
+	// for SessionID's TargetEpisode numbered Episode but has not yet
+	// committed via BindFactorySession, under the same
+	// session/episode/turn/version guard BindFactorySession itself uses. It
+	// exists so "a Factory Session was already started for this
+	// still-unbound episode" is durable Chat/Factory Sessions authority
+	// state a later retry can observe and reuse (via the episode snapshot's
+	// PendingFactorySessionID), not state a caller's own transport instance
+	// must remember to survive a post-start failure. Unlike BindFactorySession
+	// this never advances Session.Version: it is incidental
+	// reconciliation bookkeeping, not a state transition other guarded
+	// callers need to observe as invalidating their own ExpectedVersion. It
+	// reports *NotFoundError for an unknown SessionID and *ConflictError
+	// when ExpectedVersion no longer matches or the session's active
+	// turn/episode has moved on.
+	RecordPendingFactorySession(ctx context.Context, req RecordPendingFactorySessionRequest) (RecordPendingFactorySessionResult, error)
 }
 
 // CreateSessionRequest carries the caller identity, initial target, and
@@ -271,5 +293,33 @@ type BindFactorySessionRequest struct {
 // BindFactorySessionResult carries the Session after a successful (or
 // idempotently converged) binding.
 type BindFactorySessionResult struct {
+	Session Session
+}
+
+// RecordPendingFactorySessionRequest identifies the exact session/episode/
+// turn/version snapshot a caller observed when it started a Factory Session,
+// plus the started (not yet committed) Factory Session identity to record --
+// or a blank FactorySessionID to explicitly clear a previously recorded
+// pending identity (for example after abandoning it in favor of a
+// different, already-committed identity).
+type RecordPendingFactorySessionRequest struct {
+	SessionID string
+	// ExpectedVersion is the session's version observed at admission --
+	// StartTurnResult.Session.Version -- not a value re-read afterward.
+	ExpectedVersion uint64
+	// Episode is the TargetEpisode number the admitted turn belongs to --
+	// StartTurnResult.Episode.Number.
+	Episode uint64
+	// TurnID is the admitted turn that started the Factory Session being
+	// recorded -- StartTurnResult.Turn.ID.
+	TurnID string
+	// FactorySessionID is the started-but-uncommitted identity to record, or
+	// blank to clear any previously recorded pending identity.
+	FactorySessionID string
+}
+
+// RecordPendingFactorySessionResult carries the Session after a successful
+// pending-identity record or clear.
+type RecordPendingFactorySessionResult struct {
 	Session Session
 }

--- a/pkg/services/chat_sessions/contracts.go
+++ b/pkg/services/chat_sessions/contracts.go
@@ -98,6 +98,26 @@ type Service interface {
 	// caller-selected value, so completion can only ever complete, no-op, or
 	// supersede the captured turn -- never a later one.
 	AdvanceControl(ctx context.Context, req AdvanceControlRequest) (AdvanceControlResult, error)
+
+	// BindFactorySession commits a returned Factory Session identity onto
+	// SessionID's TargetEpisode numbered Episode, but only when SessionID
+	// exists, TurnID is still that session's active turn admitted against
+	// exactly that episode, and ExpectedVersion still matches the session's
+	// current version -- the same session/episode/turn/version snapshot a
+	// caller observed when it started the Factory Session it is now
+	// binding. A repeat call carrying the exact FactorySessionID the
+	// episode already carries is idempotent and succeeds without mutation
+	// regardless of ExpectedVersion, so a retried or concurrently-raced
+	// binding attempt for the identity that already won converges on that
+	// one committed value instead of failing. It reports *NotFoundError for
+	// an unknown SessionID, *ValidationError for a blank FactorySessionID or
+	// TurnID, *ConflictError when ExpectedVersion no longer matches or the
+	// session's active turn/episode has moved on, and
+	// *FactorySessionConflictError when the episode already carries a
+	// different Factory Session identity -- in every failure case the
+	// stored session and episode history are left byte-for-byte unchanged,
+	// and no prior (non-current) episode is ever mutated.
+	BindFactorySession(ctx context.Context, req BindFactorySessionRequest) (BindFactorySessionResult, error)
 }
 
 // CreateSessionRequest carries the caller identity, initial target, and
@@ -152,10 +172,15 @@ type StartTurnRequest struct {
 	ExpectedVersion uint64
 }
 
-// StartTurnResult carries the Session and newly admitted Turn.
+// StartTurnResult carries the Session, newly admitted Turn, and the
+// immutable snapshot of the TargetEpisode the turn was admitted into --
+// including that episode's Number and any FactorySessionID it already
+// carries -- so a caller can decide whether to start or reuse a Factory
+// Session without a second read.
 type StartTurnResult struct {
 	Session Session
 	Turn    Turn
+	Episode TargetEpisode
 }
 
 // AdvanceTurnRequest identifies a Turn and the state it should move to.
@@ -222,4 +247,29 @@ type AdvanceControlRequest struct {
 // advancement.
 type AdvanceControlResult struct {
 	Intent ControlIntent
+}
+
+// BindFactorySessionRequest identifies the exact session/episode/turn/
+// version snapshot a caller observed when it started a Factory Session, plus
+// the Factory Session identity to commit onto that episode.
+type BindFactorySessionRequest struct {
+	SessionID string
+	// ExpectedVersion is the session's version observed at admission --
+	// StartTurnResult.Session.Version -- not a value re-read afterward.
+	ExpectedVersion uint64
+	// Episode is the TargetEpisode number the admitted turn belongs to --
+	// StartTurnResult.Episode.Number.
+	Episode uint64
+	// TurnID is the admitted turn that started the Factory Session being
+	// bound -- StartTurnResult.Turn.ID.
+	TurnID string
+	// FactorySessionID is the identity returned by the Factory Sessions
+	// start call. It must be non-blank.
+	FactorySessionID string
+}
+
+// BindFactorySessionResult carries the Session after a successful (or
+// idempotently converged) binding.
+type BindFactorySessionResult struct {
+	Session Session
 }

--- a/pkg/services/chat_sessions/contracts_test.go
+++ b/pkg/services/chat_sessions/contracts_test.go
@@ -100,6 +100,13 @@ func (f *fakeService) AdvanceTurn(_ context.Context, req chatsessions.AdvanceTur
 	return chatsessions.AdvanceTurnResult{Turn: f.turn}, nil
 }
 
+func (f *fakeService) BindFactorySession(_ context.Context, req chatsessions.BindFactorySessionRequest) (chatsessions.BindFactorySessionResult, error) {
+	if req.SessionID != f.session.ID {
+		return chatsessions.BindFactorySessionResult{}, &chatsessions.NotFoundError{Value: "Session", ID: req.SessionID}
+	}
+	return chatsessions.BindFactorySessionResult{Session: f.session}, nil
+}
+
 func (f *fakeService) Attach(_ context.Context, req chatsessions.AttachRequest) (chatsessions.AttachResult, error) {
 	if req.SessionID != f.session.ID {
 		return chatsessions.AttachResult{}, &chatsessions.NotFoundError{Value: "Session", ID: req.SessionID}

--- a/pkg/services/chat_sessions/contracts_test.go
+++ b/pkg/services/chat_sessions/contracts_test.go
@@ -107,6 +107,13 @@ func (f *fakeService) BindFactorySession(_ context.Context, req chatsessions.Bin
 	return chatsessions.BindFactorySessionResult{Session: f.session}, nil
 }
 
+func (f *fakeService) RecordPendingFactorySession(_ context.Context, req chatsessions.RecordPendingFactorySessionRequest) (chatsessions.RecordPendingFactorySessionResult, error) {
+	if req.SessionID != f.session.ID {
+		return chatsessions.RecordPendingFactorySessionResult{}, &chatsessions.NotFoundError{Value: "Session", ID: req.SessionID}
+	}
+	return chatsessions.RecordPendingFactorySessionResult{Session: f.session}, nil
+}
+
 func (f *fakeService) Attach(_ context.Context, req chatsessions.AttachRequest) (chatsessions.AttachResult, error) {
 	if req.SessionID != f.session.ID {
 		return chatsessions.AttachResult{}, &chatsessions.NotFoundError{Value: "Session", ID: req.SessionID}

--- a/pkg/services/chat_sessions/errors.go
+++ b/pkg/services/chat_sessions/errors.go
@@ -61,6 +61,12 @@ var (
 	// silently wrap to 0 instead of producing the next monotonic episode
 	// identity.
 	ErrTargetEpisodeNumberExhausted = errors.New("chat sessions: target episode number is exhausted")
+	// ErrFactorySessionAlreadyBound reports that BindFactorySession could
+	// not commit a Factory Session identity onto a TargetEpisode because
+	// that episode's binding is already committed to a different identity.
+	// It is distinct from ErrStaleVersion: the caller's ExpectedVersion was
+	// current, but a concurrent or earlier bind attempt already won.
+	ErrFactorySessionAlreadyBound = errors.New("chat sessions: target episode factory session is already bound to a different identity")
 )
 
 // ValidationError reports one Chat Sessions value-validation failure. Value
@@ -174,6 +180,31 @@ func (e *ConflictError) Error() string {
 // failure.
 func (e *ConflictError) Unwrap() error {
 	return ErrStaleVersion
+}
+
+// FactorySessionConflictError reports that BindFactorySession rejected a
+// commit attempt because the named session's target episode already carries
+// a different Factory Session identity than the one being bound. Bound is
+// the identity already committed; Attempted is the identity the rejected
+// call tried to commit instead. Neither value is sensitive: both are opaque
+// Factory Session identifiers, safe to cross a service boundary the same way
+// BusyError's ActiveTurnID already is.
+type FactorySessionConflictError struct {
+	SessionID string
+	Episode   uint64
+	Bound     string
+	Attempted string
+}
+
+func (e *FactorySessionConflictError) Error() string {
+	return fmt.Sprintf("chat sessions: session %q episode %d: %v: bound %q, attempted %q",
+		e.SessionID, e.Episode, ErrFactorySessionAlreadyBound, e.Bound, e.Attempted)
+}
+
+// Unwrap exposes ErrFactorySessionAlreadyBound so errors.Is/errors.As can
+// classify the failure.
+func (e *FactorySessionConflictError) Unwrap() error {
+	return ErrFactorySessionAlreadyBound
 }
 
 // TargetEpisodeNotClosedError reports that OpenNextTargetEpisode was invoked

--- a/pkg/services/chat_sessions/internal/factorysessionsshim/contract.go
+++ b/pkg/services/chat_sessions/internal/factorysessionsshim/contract.go
@@ -30,3 +30,22 @@ type FactoryTargetService interface {
 	) (factorysessions.LifecycleControlResult, error)
 	CloseFactoryTarget(context.Context, string) error
 }
+
+// FactoryTargetExecutionService is the narrow subset of the public
+// factorysessions.Service root this shim actually forwards to: start, invoke,
+// cancel, and close. Shim depends on this interface rather than the full
+// 30+-method Service so a caller-owned Factory Sessions execution authority
+// (for example an on-demand, per-target activation with no fixed pre-opened
+// project runtime to serve every other Service operation) can be a complete,
+// non-panicking implementation of exactly what this shim needs, instead of
+// having to embed the full Service as a permanently-nil value and panic on
+// every method beyond these four just to satisfy a parameter type it never
+// fully uses. The CLI daemon's own full factorysessions.Service singleton
+// still satisfies this interface unmodified, since Go interface satisfaction
+// is structural.
+type FactoryTargetExecutionService interface {
+	StartAsync(context.Context, factorysessions.StartRequest) (factorysessions.AsyncStartResult, error)
+	InvokeFactorySession(context.Context, string, factorysessions.InvocationRequest) (factorysessions.InvocationResult, error)
+	Cancel(context.Context, string, factorysessions.ControlRequest) (factorysessions.LifecycleControlResult, error)
+	CloseFactorySession(context.Context, string) error
+}

--- a/pkg/services/chat_sessions/internal/factorysessionsshim/doc.go
+++ b/pkg/services/chat_sessions/internal/factorysessionsshim/doc.go
@@ -10,23 +10,31 @@
 // Factory Sessions sealing; it must not grow into a second session
 // authority.
 //
-// This adapter's injected factorysessions.Service is not always the
-// process-scoped CLI-daemon singleton (which stays permanently inert outside
-// the CLI daemon's single fixed-project bootstrap): ACP L1 V1 ordinary prompt
-// delegation (pkg/transports/acp, wired through pkg/wire's
+// This adapter's constructor (New) depends on FactoryTargetExecutionService,
+// the narrow start/invoke/cancel/close subset of factorysessions.Service
+// this shim actually forwards to -- not the full 30+ method root. Any
+// concrete factorysessions.Service still satisfies it structurally, but a
+// caller-owned execution authority with no reason to implement the rest of
+// that large interface does not need to fake or stub it just to be handed to
+// New: the injected value is never always the process-scoped CLI-daemon
+// singleton (which stays permanently inert outside the CLI daemon's single
+// fixed-project bootstrap). ACP L1 V1 ordinary prompt delegation
+// (pkg/transports/acp, wired through pkg/wire's
 // provideACPServerFactoryTargetService) instead supplies
 // factory_sessions/wire.OnDemandFactoryTargetService, a distinct live-runtime
-// activation per dynamically ACP-selected Factory target that also fully
-// implements factorysessions.Service. This adapter itself needed no change
-// to support that: it was always a stateless, exactly-once forwarder over
-// whatever factorysessions.Service its constructor is given, never a fixed
-// assumption about which one. The activation singleton owns the on-demand
-// per-target runtime-opening logic this adapter's own package cannot (it
-// would require importing factory_sessions' internal runtime-opening
-// machinery, which this package's own internal-package boundary forbids);
-// that division of ownership is why the activation lives in
+// activation per dynamically ACP-selected Factory target that implements
+// exactly FactoryTargetExecutionService's four methods -- completely, with
+// no panic-capable stand-in for any capability beyond them. This adapter
+// itself needed no change to support that: it was always a stateless,
+// exactly-once forwarder over whatever FactoryTargetExecutionService its
+// constructor is given, never a fixed assumption about which one. The
+// activation singleton owns the on-demand per-target runtime-opening logic
+// this adapter's own package cannot (it would require importing
+// factory_sessions' internal runtime-opening machinery, which this
+// package's own internal-package boundary forbids); that division of
+// ownership is why the activation lives in
 // factory_sessions/internal/ondemandtarget rather than here, not evidence of
 // a second, independent session authority -- pkg/wire composes exactly one
-// factorysessions.Service-satisfying value into this one shim per process,
-// the same as any other caller of New.
+// FactoryTargetExecutionService-satisfying value into this one shim per
+// process, the same as any other caller of New.
 package factorysessionsshim

--- a/pkg/services/chat_sessions/internal/factorysessionsshim/doc.go
+++ b/pkg/services/chat_sessions/internal/factorysessionsshim/doc.go
@@ -9,4 +9,18 @@
 // in docs/internal/projects/root-consolidation/proposal.md, retired at L3
 // Factory Sessions sealing; it must not grow into a second session
 // authority.
+//
+// This adapter wraps the process-scoped factorysessions.Service singleton,
+// which stays permanently inert outside the CLI daemon's single
+// fixed-project bootstrap, and its StartFactoryTarget exposes only the
+// asynchronous AsyncStartResult status vocabulary. ACP L1 V1 ordinary prompt
+// delegation (pkg/transports/acp, wired through pkg/wire's
+// provideACPServerFactoryTarget) activates a distinct live runtime per
+// dynamically ACP-selected Factory target and needs the synchronous,
+// truthful InvocationResult its first turn actually observes; neither fits
+// this package's fixed-runtime, status-only shape, and extending this
+// package to cover both would grow it into exactly the second session
+// authority its own package comment above forbids. That flow therefore
+// depends on the dedicated factory_sessions/wire.OnDemandFactoryTargetService
+// instead of this adapter.
 package factorysessionsshim

--- a/pkg/services/chat_sessions/internal/factorysessionsshim/doc.go
+++ b/pkg/services/chat_sessions/internal/factorysessionsshim/doc.go
@@ -10,17 +10,23 @@
 // Factory Sessions sealing; it must not grow into a second session
 // authority.
 //
-// This adapter wraps the process-scoped factorysessions.Service singleton,
-// which stays permanently inert outside the CLI daemon's single
-// fixed-project bootstrap, and its StartFactoryTarget exposes only the
-// asynchronous AsyncStartResult status vocabulary. ACP L1 V1 ordinary prompt
+// This adapter's injected factorysessions.Service is not always the
+// process-scoped CLI-daemon singleton (which stays permanently inert outside
+// the CLI daemon's single fixed-project bootstrap): ACP L1 V1 ordinary prompt
 // delegation (pkg/transports/acp, wired through pkg/wire's
-// provideACPServerFactoryTarget) activates a distinct live runtime per
-// dynamically ACP-selected Factory target and needs the synchronous,
-// truthful InvocationResult its first turn actually observes; neither fits
-// this package's fixed-runtime, status-only shape, and extending this
-// package to cover both would grow it into exactly the second session
-// authority its own package comment above forbids. That flow therefore
-// depends on the dedicated factory_sessions/wire.OnDemandFactoryTargetService
-// instead of this adapter.
+// provideACPServerFactoryTargetService) instead supplies
+// factory_sessions/wire.OnDemandFactoryTargetService, a distinct live-runtime
+// activation per dynamically ACP-selected Factory target that also fully
+// implements factorysessions.Service. This adapter itself needed no change
+// to support that: it was always a stateless, exactly-once forwarder over
+// whatever factorysessions.Service its constructor is given, never a fixed
+// assumption about which one. The activation singleton owns the on-demand
+// per-target runtime-opening logic this adapter's own package cannot (it
+// would require importing factory_sessions' internal runtime-opening
+// machinery, which this package's own internal-package boundary forbids);
+// that division of ownership is why the activation lives in
+// factory_sessions/internal/ondemandtarget rather than here, not evidence of
+// a second, independent session authority -- pkg/wire composes exactly one
+// factorysessions.Service-satisfying value into this one shim per process,
+// the same as any other caller of New.
 package factorysessionsshim

--- a/pkg/services/chat_sessions/internal/factorysessionsshim/shim.go
+++ b/pkg/services/chat_sessions/internal/factorysessionsshim/shim.go
@@ -6,18 +6,22 @@ import (
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 )
 
-// Shim adapts the public factory_sessions.Service root to this package's own
-// FactoryTargetService contract. It is stateless: it holds only the injected
-// Service and forwards each call exactly once, with the original context,
-// identifiers, request, result, and error intact.
+// Shim adapts a FactoryTargetExecutionService (the narrow start/invoke/
+// cancel/close subset of the public factory_sessions.Service root this shim
+// actually calls) to this package's own FactoryTargetService contract. It is
+// stateless: it holds only the injected service and forwards each call
+// exactly once, with the original context, identifiers, request, result, and
+// error intact.
 type Shim struct {
-	service factorysessions.Service
+	service FactoryTargetExecutionService
 }
 
 var _ FactoryTargetService = (*Shim)(nil)
 
-// New constructs the Factory Sessions shim over the given public Service.
-func New(service factorysessions.Service) *Shim {
+// New constructs the Factory Sessions shim over the given execution service.
+// Any concrete factorysessions.Service (including the CLI daemon's full
+// singleton) already satisfies FactoryTargetExecutionService structurally.
+func New(service FactoryTargetExecutionService) *Shim {
 	return &Shim{service: service}
 }
 

--- a/pkg/services/chat_sessions/internal/service/factory_session_binding.go
+++ b/pkg/services/chat_sessions/internal/service/factory_session_binding.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"context"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+)
+
+// BindFactorySession commits req.FactorySessionID onto req.SessionID's
+// TargetEpisode numbered req.Episode, but only when req.SessionID exists and
+// req.ExpectedVersion still matches the session's current version. Because
+// every mutation that could move the session's active turn or target episode
+// (AdvanceTurn releasing the active turn, a later StartTurn, or SetTarget
+// opening a new episode) also advances Session.Version, a matching
+// ExpectedVersion already guarantees req.TurnID is still the session's active
+// turn and req.Episode is still its open episode; the explicit turn/episode
+// lookups below are defense-in-depth, not a second independent guard, and
+// report the same *ConflictError a version mismatch would.
+//
+// A repeat call carrying the exact FactorySessionID the episode already
+// carries is idempotent and succeeds without mutation regardless of
+// ExpectedVersion, so a retried or concurrently-raced binding attempt for the
+// identity that already won converges on that one committed value instead of
+// failing. A call whose episode already carries a *different*
+// FactorySessionID reports *chatsessions.FactorySessionConflictError and
+// never overwrites the committed identity. In every failure case the stored
+// session and episode history are left byte-for-byte unchanged, and this
+// method only ever mutates the current (last) episode, so prior episode
+// history is never touched.
+func (s *Store) BindFactorySession(_ context.Context, req chatsessions.BindFactorySessionRequest) (result chatsessions.BindFactorySessionResult, err error) {
+	s.logStart("BindFactorySession", req.SessionID)
+	defer func() {
+		s.logOutcome("BindFactorySession", req.SessionID, err, "version", result.Session.Version, "target_episode", req.Episode)
+	}()
+	if req.FactorySessionID == "" {
+		return chatsessions.BindFactorySessionResult{}, &chatsessions.ValidationError{
+			Value: "BindFactorySessionRequest", Field: "FactorySessionID", Err: chatsessions.ErrRequiredValue,
+		}
+	}
+	if req.TurnID == "" {
+		return chatsessions.BindFactorySessionResult{}, &chatsessions.ValidationError{
+			Value: "BindFactorySessionRequest", Field: "TurnID", Err: chatsessions.ErrRequiredValue,
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, ok := s.sessions[req.SessionID]
+	if !ok {
+		return chatsessions.BindFactorySessionResult{}, &chatsessions.NotFoundError{Value: "Session", ID: req.SessionID}
+	}
+
+	idx := len(record.episodes) - 1
+	current := record.episodes[idx]
+	if current.Number == req.Episode && current.FactorySessionID == req.FactorySessionID {
+		return chatsessions.BindFactorySessionResult{Session: record.session}, nil
+	}
+	if current.Number == req.Episode && current.FactorySessionID != "" {
+		return chatsessions.BindFactorySessionResult{}, &chatsessions.FactorySessionConflictError{
+			SessionID: req.SessionID, Episode: req.Episode,
+			Bound: current.FactorySessionID, Attempted: req.FactorySessionID,
+		}
+	}
+
+	if req.ExpectedVersion != record.session.Version {
+		return chatsessions.BindFactorySessionResult{}, &chatsessions.ConflictError{
+			Value: "Session", ID: req.SessionID,
+			Expected: req.ExpectedVersion, Actual: record.session.Version,
+		}
+	}
+	if record.session.ActiveTurnID != req.TurnID {
+		return chatsessions.BindFactorySessionResult{}, &chatsessions.ConflictError{
+			Value: "Turn", ID: req.TurnID,
+			Expected: req.ExpectedVersion, Actual: record.session.Version,
+		}
+	}
+	turn, ok := record.turns[req.TurnID]
+	if !ok || turn.Episode != req.Episode || current.Number != req.Episode {
+		return chatsessions.BindFactorySessionResult{}, &chatsessions.ConflictError{
+			Value: "TargetEpisode", ID: req.SessionID,
+			Expected: req.ExpectedVersion, Actual: record.session.Version,
+		}
+	}
+
+	updatedEpisode := current
+	updatedEpisode.FactorySessionID = req.FactorySessionID
+	if err := updatedEpisode.Validate(); err != nil {
+		return chatsessions.BindFactorySessionResult{}, err
+	}
+
+	updatedSession := record.session
+	updatedSession.Version++
+	updatedSession.UpdatedAt = s.now()
+	if err := updatedSession.Validate(); err != nil {
+		return chatsessions.BindFactorySessionResult{}, err
+	}
+
+	record.episodes[idx] = updatedEpisode
+	record.session = updatedSession
+	s.sessions[req.SessionID] = record
+
+	return chatsessions.BindFactorySessionResult{Session: updatedSession}, nil
+}

--- a/pkg/services/chat_sessions/internal/service/factory_session_binding.go
+++ b/pkg/services/chat_sessions/internal/service/factory_session_binding.go
@@ -85,6 +85,7 @@ func (s *Store) BindFactorySession(_ context.Context, req chatsessions.BindFacto
 
 	updatedEpisode := current
 	updatedEpisode.FactorySessionID = req.FactorySessionID
+	updatedEpisode.PendingFactorySessionID = ""
 	if err := updatedEpisode.Validate(); err != nil {
 		return chatsessions.BindFactorySessionResult{}, err
 	}
@@ -101,4 +102,64 @@ func (s *Store) BindFactorySession(_ context.Context, req chatsessions.BindFacto
 	s.sessions[req.SessionID] = record
 
 	return chatsessions.BindFactorySessionResult{Session: updatedSession}, nil
+}
+
+// RecordPendingFactorySession records (or, with a blank FactorySessionID,
+// clears) the current episode's PendingFactorySessionID under the same
+// session/episode/turn/version guard BindFactorySession uses, but never
+// advances Session.Version: this is incidental reconciliation bookkeeping a
+// retry can observe through the episode snapshot, not a state transition
+// other guarded callers need to see as invalidating their own
+// ExpectedVersion. A repeat call carrying the exact value already recorded is
+// a no-op success.
+func (s *Store) RecordPendingFactorySession(_ context.Context, req chatsessions.RecordPendingFactorySessionRequest) (result chatsessions.RecordPendingFactorySessionResult, err error) {
+	s.logStart("RecordPendingFactorySession", req.SessionID)
+	defer func() {
+		s.logOutcome("RecordPendingFactorySession", req.SessionID, err, "version", result.Session.Version, "target_episode", req.Episode)
+	}()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, ok := s.sessions[req.SessionID]
+	if !ok {
+		return chatsessions.RecordPendingFactorySessionResult{}, &chatsessions.NotFoundError{Value: "Session", ID: req.SessionID}
+	}
+
+	idx := len(record.episodes) - 1
+	current := record.episodes[idx]
+	if current.Number == req.Episode && current.PendingFactorySessionID == req.FactorySessionID {
+		return chatsessions.RecordPendingFactorySessionResult{Session: record.session}, nil
+	}
+
+	if req.ExpectedVersion != record.session.Version {
+		return chatsessions.RecordPendingFactorySessionResult{}, &chatsessions.ConflictError{
+			Value: "Session", ID: req.SessionID,
+			Expected: req.ExpectedVersion, Actual: record.session.Version,
+		}
+	}
+	if record.session.ActiveTurnID != req.TurnID {
+		return chatsessions.RecordPendingFactorySessionResult{}, &chatsessions.ConflictError{
+			Value: "Turn", ID: req.TurnID,
+			Expected: req.ExpectedVersion, Actual: record.session.Version,
+		}
+	}
+	turn, ok := record.turns[req.TurnID]
+	if !ok || turn.Episode != req.Episode || current.Number != req.Episode {
+		return chatsessions.RecordPendingFactorySessionResult{}, &chatsessions.ConflictError{
+			Value: "TargetEpisode", ID: req.SessionID,
+			Expected: req.ExpectedVersion, Actual: record.session.Version,
+		}
+	}
+
+	updatedEpisode := current
+	updatedEpisode.PendingFactorySessionID = req.FactorySessionID
+	if err := updatedEpisode.Validate(); err != nil {
+		return chatsessions.RecordPendingFactorySessionResult{}, err
+	}
+
+	record.episodes[idx] = updatedEpisode
+	s.sessions[req.SessionID] = record
+
+	return chatsessions.RecordPendingFactorySessionResult{Session: record.session}, nil
 }

--- a/pkg/services/chat_sessions/internal/service/factory_session_binding_test.go
+++ b/pkg/services/chat_sessions/internal/service/factory_session_binding_test.go
@@ -1,0 +1,358 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+)
+
+// startedTurnForBinding constructs a Store, one created Session, and one
+// admitted turn ready for BindFactorySession calls, returning the exact
+// request a caller would build from that admission's StartTurnResult.
+func startedTurnForBinding(t *testing.T, now time.Time) (*Store, chatsessions.StartTurnResult) {
+	t.Helper()
+	store, session := newStartTurnTestSession(t, now)
+	started, err := store.StartTurn(context.Background(), chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-1"),
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn: %v", err)
+	}
+	return store, started
+}
+
+func bindRequest(started chatsessions.StartTurnResult, factorySessionID string) chatsessions.BindFactorySessionRequest {
+	return chatsessions.BindFactorySessionRequest{
+		SessionID:        started.Session.ID,
+		ExpectedVersion:  started.Session.Version,
+		Episode:          started.Episode.Number,
+		TurnID:           started.Turn.ID,
+		FactorySessionID: factorySessionID,
+	}
+}
+
+// TestStore_BindFactorySession_CommitsOntoCurrentEpisode proves a valid bind
+// commits FactorySessionID onto exactly the current episode, advances
+// Session.Version, and leaves no other episode present.
+func TestStore_BindFactorySession_CommitsOntoCurrentEpisode(t *testing.T) {
+	ctx := context.Background()
+	store, started := startedTurnForBinding(t, time.Now())
+
+	result, err := store.BindFactorySession(ctx, bindRequest(started, "factory-session-1"))
+	if err != nil {
+		t.Fatalf("BindFactorySession: %v", err)
+	}
+	if result.Session.Version <= started.Session.Version {
+		t.Fatalf("Session.Version = %d, want strictly greater than %d", result.Session.Version, started.Session.Version)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[started.Session.ID]
+	store.mu.RUnlock()
+	if len(record.episodes) != 1 {
+		t.Fatalf("episode count = %d, want 1", len(record.episodes))
+	}
+	if record.episodes[0].FactorySessionID != "factory-session-1" {
+		t.Fatalf("episode FactorySessionID = %q, want factory-session-1", record.episodes[0].FactorySessionID)
+	}
+}
+
+// TestStore_BindFactorySession_IdempotentSameIdentityConverges proves a
+// repeat bind carrying the exact identity the episode already carries
+// succeeds without a second mutation, regardless of a now-stale
+// ExpectedVersion -- the mechanism that lets concurrent or retried binding
+// attempts for the identity that already won converge on one committed
+// value.
+func TestStore_BindFactorySession_IdempotentSameIdentityConverges(t *testing.T) {
+	ctx := context.Background()
+	store, started := startedTurnForBinding(t, time.Now())
+
+	first, err := store.BindFactorySession(ctx, bindRequest(started, "factory-session-1"))
+	if err != nil {
+		t.Fatalf("BindFactorySession first: %v", err)
+	}
+
+	// Repeat with the original (now-stale) ExpectedVersion: idempotent
+	// convergence must not require a fresh read.
+	second, err := store.BindFactorySession(ctx, bindRequest(started, "factory-session-1"))
+	if err != nil {
+		t.Fatalf("BindFactorySession repeat: %v", err)
+	}
+	if second.Session.Version != first.Session.Version {
+		t.Fatalf("repeat bind mutated version: got %d, want %d (no-op)", second.Session.Version, first.Session.Version)
+	}
+}
+
+// TestStore_BindFactorySession_ConflictingIdentityNeverOverwrites proves a
+// bind attempt carrying a *different* identity than the one already
+// committed reports *FactorySessionConflictError and never overwrites the
+// committed value.
+func TestStore_BindFactorySession_ConflictingIdentityNeverOverwrites(t *testing.T) {
+	ctx := context.Background()
+	store, started := startedTurnForBinding(t, time.Now())
+
+	if _, err := store.BindFactorySession(ctx, bindRequest(started, "factory-session-1")); err != nil {
+		t.Fatalf("BindFactorySession first: %v", err)
+	}
+
+	_, err := store.BindFactorySession(ctx, bindRequest(started, "factory-session-2"))
+	var conflict *chatsessions.FactorySessionConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("BindFactorySession conflicting identity: got %v, want *FactorySessionConflictError", err)
+	}
+	if conflict.Bound != "factory-session-1" || conflict.Attempted != "factory-session-2" {
+		t.Fatalf("FactorySessionConflictError = %+v, want Bound=factory-session-1 Attempted=factory-session-2", conflict)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[started.Session.ID]
+	store.mu.RUnlock()
+	if record.episodes[0].FactorySessionID != "factory-session-1" {
+		t.Fatalf("episode FactorySessionID = %q after conflicting bind, want unchanged factory-session-1", record.episodes[0].FactorySessionID)
+	}
+}
+
+// TestStore_BindFactorySession_StaleVersionIsTypedConflict proves a bind
+// whose ExpectedVersion no longer matches (and whose episode is not already
+// bound to the same identity) reports *ConflictError and mutates nothing.
+func TestStore_BindFactorySession_StaleVersionIsTypedConflict(t *testing.T) {
+	ctx := context.Background()
+	store, started := startedTurnForBinding(t, time.Now())
+
+	req := bindRequest(started, "factory-session-1")
+	req.ExpectedVersion = started.Session.Version + 1
+
+	_, err := store.BindFactorySession(ctx, req)
+	var conflict *chatsessions.ConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("BindFactorySession stale version: got %v, want *ConflictError", err)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[started.Session.ID]
+	store.mu.RUnlock()
+	if record.episodes[0].FactorySessionID != "" {
+		t.Fatalf("episode FactorySessionID = %q after stale-version bind, want blank", record.episodes[0].FactorySessionID)
+	}
+	if record.session.Version != started.Session.Version {
+		t.Fatalf("session mutated by stale-version bind: version = %d, want %d", record.session.Version, started.Session.Version)
+	}
+}
+
+// TestStore_BindFactorySession_TurnNoLongerActiveIsTypedConflict proves a
+// bind whose TurnID is no longer the session's active turn (the turn already
+// terminated) reports *ConflictError, even though the caller may not yet
+// know the session moved on.
+func TestStore_BindFactorySession_TurnNoLongerActiveIsTypedConflict(t *testing.T) {
+	ctx := context.Background()
+	store, started := startedTurnForBinding(t, time.Now())
+
+	terminal, err := store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: started.Session.ID,
+		TurnID:    started.Turn.ID,
+		Next:      chatsessions.TurnStateCanceled,
+	})
+	if err != nil {
+		t.Fatalf("AdvanceTurn to terminal: %v", err)
+	}
+	_ = terminal
+
+	_, err = store.BindFactorySession(ctx, bindRequest(started, "factory-session-1"))
+	var conflict *chatsessions.ConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("BindFactorySession after turn terminated: got %v, want *ConflictError", err)
+	}
+}
+
+// TestStore_BindFactorySession_BlankFactorySessionIDIsValidationError proves
+// a blank FactorySessionID is rejected before any mutation.
+func TestStore_BindFactorySession_BlankFactorySessionIDIsValidationError(t *testing.T) {
+	ctx := context.Background()
+	store, started := startedTurnForBinding(t, time.Now())
+
+	_, err := store.BindFactorySession(ctx, bindRequest(started, ""))
+	var validation *chatsessions.ValidationError
+	if !errors.As(err, &validation) || validation.Field != "FactorySessionID" {
+		t.Fatalf("BindFactorySession blank identity: got %v, want *ValidationError on FactorySessionID", err)
+	}
+}
+
+// TestStore_BindFactorySession_BlankTurnIDIsValidationError proves a blank
+// TurnID is rejected before any mutation.
+func TestStore_BindFactorySession_BlankTurnIDIsValidationError(t *testing.T) {
+	ctx := context.Background()
+	store, started := startedTurnForBinding(t, time.Now())
+
+	req := bindRequest(started, "factory-session-1")
+	req.TurnID = ""
+
+	_, err := store.BindFactorySession(ctx, req)
+	var validation *chatsessions.ValidationError
+	if !errors.As(err, &validation) || validation.Field != "TurnID" {
+		t.Fatalf("BindFactorySession blank turn id: got %v, want *ValidationError on TurnID", err)
+	}
+}
+
+// TestStore_BindFactorySession_UnknownSessionIsTypedNotFound proves binding
+// against an unknown SessionID reports *NotFoundError.
+func TestStore_BindFactorySession_UnknownSessionIsTypedNotFound(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(sequentialIDs("session"), fixedClock(time.Now()))
+
+	_, err := store.BindFactorySession(ctx, chatsessions.BindFactorySessionRequest{
+		SessionID: "does-not-exist", ExpectedVersion: 1, Episode: 1, TurnID: "turn-1", FactorySessionID: "factory-session-1",
+	})
+	var notFound *chatsessions.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("BindFactorySession unknown session: got %v, want *NotFoundError", err)
+	}
+}
+
+// TestStore_BindFactorySession_PriorEpisodeHistoryNeverMutated proves a bind
+// against the session's current (second) episode never touches the prior,
+// closed episode's stored value.
+func TestStore_BindFactorySession_PriorEpisodeHistoryNeverMutated(t *testing.T) {
+	ctx := context.Background()
+	store, session := newStartTurnTestSession(t, time.Now())
+
+	newTarget := chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "factory:@you/other"}
+	changed, err := store.SetTarget(ctx, chatsessions.SetTargetRequest{
+		RequestID:       startTurnRequestID("req-target-1"),
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+		Target:          newTarget,
+	})
+	if err != nil {
+		t.Fatalf("SetTarget: %v", err)
+	}
+
+	// Capture the prior episode's snapshot after SetTarget closed it --
+	// that OPEN->CLOSED transition is SetTarget's own effect, not a mutation
+	// this test is guarding against; the guard below is specifically that
+	// BindFactorySession itself never touches this already-closed episode.
+	store.mu.RLock()
+	priorEpisode := store.sessions[session.ID].episodes[0]
+	store.mu.RUnlock()
+	started, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-1"),
+		SessionID:       session.ID,
+		ExpectedVersion: changed.Session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn: %v", err)
+	}
+	if started.Episode.Number != 2 {
+		t.Fatalf("Episode.Number = %d, want 2 (the new episode SetTarget opened)", started.Episode.Number)
+	}
+
+	if _, err := store.BindFactorySession(ctx, bindRequest(started, "factory-session-2")); err != nil {
+		t.Fatalf("BindFactorySession: %v", err)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[session.ID]
+	store.mu.RUnlock()
+	if len(record.episodes) != 2 {
+		t.Fatalf("episode count = %d, want 2", len(record.episodes))
+	}
+	if record.episodes[0] != priorEpisode {
+		t.Fatalf("prior episode mutated: got %+v, want unchanged %+v", record.episodes[0], priorEpisode)
+	}
+	if record.episodes[1].FactorySessionID != "factory-session-2" {
+		t.Fatalf("current episode FactorySessionID = %q, want factory-session-2", record.episodes[1].FactorySessionID)
+	}
+}
+
+// TestStore_BindFactorySession_ConcurrentSameIdentityConverges proves
+// concurrent bind attempts carrying the same winning identity all succeed
+// and converge on exactly one committed value and one version increment.
+func TestStore_BindFactorySession_ConcurrentSameIdentityConverges(t *testing.T) {
+	ctx := context.Background()
+	store, started := startedTurnForBinding(t, time.Now())
+
+	const n = 25
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := store.BindFactorySession(ctx, bindRequest(started, "factory-session-1"))
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("BindFactorySession[%d]: got %v, want success (idempotent convergence)", i, err)
+		}
+	}
+
+	store.mu.RLock()
+	record := store.sessions[started.Session.ID]
+	store.mu.RUnlock()
+	if record.episodes[0].FactorySessionID != "factory-session-1" {
+		t.Fatalf("episode FactorySessionID = %q, want factory-session-1", record.episodes[0].FactorySessionID)
+	}
+	if record.session.Version != started.Session.Version+1 {
+		t.Fatalf("final version = %d, want exactly one increment past %d", record.session.Version, started.Session.Version)
+	}
+}
+
+// TestStore_BindFactorySession_ConcurrentConflictingIdentitiesOneWinner
+// proves concurrent bind attempts split between two different identities
+// converge on exactly one committed identity: every caller for the losing
+// identity observes *FactorySessionConflictError and the episode is never
+// left carrying a mix of the two.
+func TestStore_BindFactorySession_ConcurrentConflictingIdentitiesOneWinner(t *testing.T) {
+	ctx := context.Background()
+	store, started := startedTurnForBinding(t, time.Now())
+
+	const n = 20
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id := "factory-session-a"
+			if i%2 == 1 {
+				id = "factory-session-b"
+			}
+			_, err := store.BindFactorySession(ctx, bindRequest(started, id))
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	store.mu.RLock()
+	winner := store.sessions[started.Session.ID].episodes[0].FactorySessionID
+	store.mu.RUnlock()
+	if winner != "factory-session-a" && winner != "factory-session-b" {
+		t.Fatalf("committed identity = %q, want one of factory-session-a/b", winner)
+	}
+
+	for i, err := range errs {
+		wantID := "factory-session-a"
+		if i%2 == 1 {
+			wantID = "factory-session-b"
+		}
+		if wantID == winner {
+			if err != nil {
+				t.Fatalf("BindFactorySession[%d] for winning identity %q: got %v, want success", i, wantID, err)
+			}
+			continue
+		}
+		var conflict *chatsessions.FactorySessionConflictError
+		if !errors.As(err, &conflict) {
+			t.Fatalf("BindFactorySession[%d] for losing identity %q: got %v, want *FactorySessionConflictError", i, wantID, err)
+		}
+	}
+}

--- a/pkg/services/chat_sessions/internal/service/record_pending_factory_session_test.go
+++ b/pkg/services/chat_sessions/internal/service/record_pending_factory_session_test.go
@@ -1,0 +1,174 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+)
+
+func pendingRequest(started chatsessions.StartTurnResult, factorySessionID string) chatsessions.RecordPendingFactorySessionRequest {
+	return chatsessions.RecordPendingFactorySessionRequest{
+		SessionID:        started.Session.ID,
+		ExpectedVersion:  started.Session.Version,
+		Episode:          started.Episode.Number,
+		TurnID:           started.Turn.ID,
+		FactorySessionID: factorySessionID,
+	}
+}
+
+// TestStore_RecordPendingFactorySession_CommitsOntoCurrentEpisode proves a
+// valid record sets PendingFactorySessionID on exactly the current episode
+// without advancing Session.Version -- this is incidental reconciliation
+// bookkeeping, not a state transition.
+func TestStore_RecordPendingFactorySession_CommitsOntoCurrentEpisode(t *testing.T) {
+	ctx := context.Background()
+	store, started := startedTurnForBinding(t, time.Now())
+
+	result, err := store.RecordPendingFactorySession(ctx, pendingRequest(started, "fs-pending-1"))
+	if err != nil {
+		t.Fatalf("RecordPendingFactorySession: %v", err)
+	}
+	if result.Session.Version != started.Session.Version {
+		t.Fatalf("Session.Version = %d, want unchanged from %d", result.Session.Version, started.Session.Version)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[started.Session.ID]
+	store.mu.RUnlock()
+	if record.episodes[0].PendingFactorySessionID != "fs-pending-1" {
+		t.Fatalf("episode PendingFactorySessionID = %q, want fs-pending-1", record.episodes[0].PendingFactorySessionID)
+	}
+}
+
+// TestStore_RecordPendingFactorySession_IdempotentSameIdentityConverges
+// proves a repeat record carrying the exact value already stored succeeds
+// without mutation, regardless of a now-stale ExpectedVersion.
+func TestStore_RecordPendingFactorySession_IdempotentSameIdentityConverges(t *testing.T) {
+	ctx := context.Background()
+	store, started := startedTurnForBinding(t, time.Now())
+
+	if _, err := store.RecordPendingFactorySession(ctx, pendingRequest(started, "fs-pending-1")); err != nil {
+		t.Fatalf("RecordPendingFactorySession first: %v", err)
+	}
+
+	// Repeat with the original (now-stale, since version tracking would
+	// otherwise have moved on) ExpectedVersion: idempotent convergence must
+	// not require a fresh read.
+	if _, err := store.RecordPendingFactorySession(ctx, pendingRequest(started, "fs-pending-1")); err != nil {
+		t.Fatalf("RecordPendingFactorySession repeat: %v", err)
+	}
+}
+
+// TestStore_RecordPendingFactorySession_ClearsWithBlankIdentity proves a
+// blank FactorySessionID clears a previously recorded pending identity
+// (unlike BindFactorySession, a blank value is not rejected as invalid --
+// it is the documented explicit-clear signal).
+func TestStore_RecordPendingFactorySession_ClearsWithBlankIdentity(t *testing.T) {
+	ctx := context.Background()
+	store, started := startedTurnForBinding(t, time.Now())
+
+	if _, err := store.RecordPendingFactorySession(ctx, pendingRequest(started, "fs-pending-1")); err != nil {
+		t.Fatalf("RecordPendingFactorySession record: %v", err)
+	}
+	if _, err := store.RecordPendingFactorySession(ctx, pendingRequest(started, "")); err != nil {
+		t.Fatalf("RecordPendingFactorySession clear: %v", err)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[started.Session.ID]
+	store.mu.RUnlock()
+	if record.episodes[0].PendingFactorySessionID != "" {
+		t.Fatalf("episode PendingFactorySessionID = %q, want cleared to blank", record.episodes[0].PendingFactorySessionID)
+	}
+}
+
+// TestStore_RecordPendingFactorySession_StaleVersionIsTypedConflict proves a
+// record whose ExpectedVersion no longer matches (and whose episode is not
+// already carrying the same value) reports *ConflictError and mutates
+// nothing.
+func TestStore_RecordPendingFactorySession_StaleVersionIsTypedConflict(t *testing.T) {
+	ctx := context.Background()
+	store, started := startedTurnForBinding(t, time.Now())
+
+	req := pendingRequest(started, "fs-pending-1")
+	req.ExpectedVersion = started.Session.Version + 1
+
+	_, err := store.RecordPendingFactorySession(ctx, req)
+	var conflict *chatsessions.ConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("RecordPendingFactorySession stale version: got %v, want *ConflictError", err)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[started.Session.ID]
+	store.mu.RUnlock()
+	if record.episodes[0].PendingFactorySessionID != "" {
+		t.Fatalf("episode PendingFactorySessionID = %q after stale-version record, want blank", record.episodes[0].PendingFactorySessionID)
+	}
+}
+
+// TestStore_RecordPendingFactorySession_TurnNoLongerActiveIsTypedConflict
+// proves a record whose TurnID is no longer the session's active turn
+// reports *ConflictError.
+func TestStore_RecordPendingFactorySession_TurnNoLongerActiveIsTypedConflict(t *testing.T) {
+	ctx := context.Background()
+	store, started := startedTurnForBinding(t, time.Now())
+
+	if _, err := store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: started.Session.ID,
+		TurnID:    started.Turn.ID,
+		Next:      chatsessions.TurnStateCanceled,
+	}); err != nil {
+		t.Fatalf("AdvanceTurn to terminal: %v", err)
+	}
+
+	_, err := store.RecordPendingFactorySession(ctx, pendingRequest(started, "fs-pending-1"))
+	var conflict *chatsessions.ConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("RecordPendingFactorySession after turn terminated: got %v, want *ConflictError", err)
+	}
+}
+
+// TestStore_RecordPendingFactorySession_UnknownSessionIsTypedNotFound proves
+// recording against an unknown SessionID reports *NotFoundError.
+func TestStore_RecordPendingFactorySession_UnknownSessionIsTypedNotFound(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(sequentialIDs("session"), fixedClock(time.Now()))
+
+	_, err := store.RecordPendingFactorySession(ctx, chatsessions.RecordPendingFactorySessionRequest{
+		SessionID: "does-not-exist", ExpectedVersion: 1, Episode: 1, TurnID: "turn-1", FactorySessionID: "fs-pending-1",
+	})
+	var notFound *chatsessions.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("RecordPendingFactorySession unknown session: got %v, want *NotFoundError", err)
+	}
+}
+
+// TestStore_RecordPendingFactorySession_ThenBindClearsPending proves a
+// successful BindFactorySession commit clears the episode's
+// PendingFactorySessionID that RecordPendingFactorySession set, since the
+// pending record's purpose is moot once the identity is durably committed.
+func TestStore_RecordPendingFactorySession_ThenBindClearsPending(t *testing.T) {
+	ctx := context.Background()
+	store, started := startedTurnForBinding(t, time.Now())
+
+	if _, err := store.RecordPendingFactorySession(ctx, pendingRequest(started, "fs-pending-1")); err != nil {
+		t.Fatalf("RecordPendingFactorySession: %v", err)
+	}
+	if _, err := store.BindFactorySession(ctx, bindRequest(started, "fs-pending-1")); err != nil {
+		t.Fatalf("BindFactorySession: %v", err)
+	}
+
+	store.mu.RLock()
+	record := store.sessions[started.Session.ID]
+	store.mu.RUnlock()
+	if record.episodes[0].PendingFactorySessionID != "" {
+		t.Fatalf("episode PendingFactorySessionID = %q after a successful bind, want cleared to blank", record.episodes[0].PendingFactorySessionID)
+	}
+	if record.episodes[0].FactorySessionID != "fs-pending-1" {
+		t.Fatalf("episode FactorySessionID = %q, want fs-pending-1", record.episodes[0].FactorySessionID)
+	}
+}

--- a/pkg/services/chat_sessions/internal/service/session.go
+++ b/pkg/services/chat_sessions/internal/service/session.go
@@ -67,11 +67,12 @@ func (s *Store) CreateSession(_ context.Context, req chatsessions.CreateSessionR
 	}
 
 	s.sessions[session.ID] = sessionRecord{
-		session:     session,
-		episodes:    []chatsessions.TargetEpisode{episode},
-		turns:       make(map[string]chatsessions.Turn),
-		attachments: make(map[string]chatsessions.Attachment),
-		controls:    make(map[chatsessions.RequestIdentity]chatsessions.ControlIntent),
+		session:        session,
+		episodes:       []chatsessions.TargetEpisode{episode},
+		turns:          make(map[string]chatsessions.Turn),
+		turnsByRequest: make(map[chatsessions.RequestIdentity]string),
+		attachments:    make(map[string]chatsessions.Attachment),
+		controls:       make(map[chatsessions.RequestIdentity]chatsessions.ControlIntent),
 	}
 	return chatsessions.CreateSessionResult{Session: session}, nil
 }

--- a/pkg/services/chat_sessions/internal/service/store.go
+++ b/pkg/services/chat_sessions/internal/service/store.go
@@ -67,14 +67,22 @@ type Store struct {
 // removed or overwritten, only advanced in place via AdvanceControl, so a
 // reused RequestID can never retarget or rewrite an existing intent's
 // captured facts.
+// turnsByRequest indexes every admitted Turn by the RequestIdentity that
+// admitted it, independent of turns (which is keyed by Turn.ID) -- so
+// StartTurn can recognize a redelivered request (including one whose
+// originally admitted turn has since terminalized and released
+// ActiveTurnID) and return the existing turn instead of admitting a second
+// one and dispatching its effects again. Like controls, an entry here is
+// never removed or overwritten.
 type sessionRecord struct {
-	session      chatsessions.Session
-	episodes     []chatsessions.TargetEpisode
-	turns        map[string]chatsessions.Turn
-	lastTurnID   string
-	turnSequence uint64
-	attachments  map[string]chatsessions.Attachment
-	controls     map[chatsessions.RequestIdentity]chatsessions.ControlIntent
+	session        chatsessions.Session
+	episodes       []chatsessions.TargetEpisode
+	turns          map[string]chatsessions.Turn
+	turnsByRequest map[chatsessions.RequestIdentity]string
+	lastTurnID     string
+	turnSequence   uint64
+	attachments    map[string]chatsessions.Attachment
+	controls       map[chatsessions.RequestIdentity]chatsessions.ControlIntent
 }
 
 // activeTurnValue returns the session's current active Turn read live from

--- a/pkg/services/chat_sessions/internal/service/turn.go
+++ b/pkg/services/chat_sessions/internal/service/turn.go
@@ -15,6 +15,19 @@ import (
 // and turn state are left byte-for-byte unchanged. On success it moves a
 // CREATED session to ACTIVE on its first turn and leaves an already-ACTIVE
 // session's State unchanged.
+//
+// Reusing a RequestID that already identifies an admitted turn is treated as
+// an idempotent retry, the same way RequestControl treats a reused control
+// RequestID: the existing turn (and the TargetEpisode it was originally
+// admitted into) is returned unchanged instead of admitting a second turn,
+// regardless of whether that existing turn is still busy or has since
+// terminalized and released ActiveTurnID. This is what makes redelivery of
+// the same connection-scoped request after the original turn's terminal
+// transition safe -- without it, StartTurn would admit a brand-new turn and
+// the caller would dispatch a second Factory effect for content already
+// executed once. The caller (this transport's admitPromptTurn) distinguishes
+// a genuinely fresh admission from this replay by inspecting the returned
+// Turn's State.
 func (s *Store) StartTurn(_ context.Context, req chatsessions.StartTurnRequest) (result chatsessions.StartTurnResult, err error) {
 	s.logStart("StartTurn", req.SessionID)
 	defer func() {
@@ -30,6 +43,14 @@ func (s *Store) StartTurn(_ context.Context, req chatsessions.StartTurnRequest) 
 	record, ok := s.sessions[req.SessionID]
 	if !ok {
 		return chatsessions.StartTurnResult{}, &chatsessions.NotFoundError{Value: "Session", ID: req.SessionID}
+	}
+	if turnID, exists := record.turnsByRequest[req.RequestID]; exists {
+		turn := record.turns[turnID]
+		return chatsessions.StartTurnResult{
+			Session: record.session,
+			Turn:    turn,
+			Episode: record.episodes[turn.Episode-1],
+		}, nil
 	}
 	if req.ExpectedVersion != record.session.Version {
 		return chatsessions.StartTurnResult{}, &chatsessions.ConflictError{
@@ -70,6 +91,7 @@ func (s *Store) StartTurn(_ context.Context, req chatsessions.StartTurnRequest) 
 	}
 
 	record.turns[turn.ID] = turn
+	record.turnsByRequest[req.RequestID] = turn.ID
 	record.lastTurnID = turn.ID
 	record.session = updated
 	s.sessions[req.SessionID] = record

--- a/pkg/services/chat_sessions/internal/service/turn.go
+++ b/pkg/services/chat_sessions/internal/service/turn.go
@@ -53,6 +53,7 @@ func (s *Store) StartTurn(_ context.Context, req chatsessions.StartTurnRequest) 
 	if err := turn.Validate(); err != nil {
 		return chatsessions.StartTurnResult{}, err
 	}
+	episode := record.episodes[len(record.episodes)-1]
 
 	updated := record.session
 	if updated.State == chatsessions.SessionStateCreated {
@@ -73,7 +74,7 @@ func (s *Store) StartTurn(_ context.Context, req chatsessions.StartTurnRequest) 
 	record.session = updated
 	s.sessions[req.SessionID] = record
 
-	return chatsessions.StartTurnResult{Session: updated, Turn: turn}, nil
+	return chatsessions.StartTurnResult{Session: updated, Turn: turn, Episode: episode}, nil
 }
 
 // AdvanceTurn moves one Turn to Next, enforcing the TurnState transition

--- a/pkg/services/chat_sessions/internal/service/turn_test.go
+++ b/pkg/services/chat_sessions/internal/service/turn_test.go
@@ -70,6 +70,37 @@ func TestStore_StartTurn_FirstTurnActivatesSession(t *testing.T) {
 	}
 }
 
+// TestStore_StartTurn_ReturnsAdmittedEpisodeSnapshot proves StartTurnResult
+// carries the exact current TargetEpisode the turn was admitted into
+// (Number and Target), with a blank FactorySessionID for a brand-new
+// episode, so a caller can decide whether to start or reuse a Factory
+// Session without a second read.
+func TestStore_StartTurn_ReturnsAdmittedEpisodeSnapshot(t *testing.T) {
+	ctx := context.Background()
+	store, session := newStartTurnTestSession(t, time.Now())
+
+	result, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-1"),
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn: %v", err)
+	}
+	if result.Episode.Number != session.TargetEpisode {
+		t.Fatalf("Episode.Number = %d, want %d", result.Episode.Number, session.TargetEpisode)
+	}
+	if result.Episode.Target != session.SelectedTarget {
+		t.Fatalf("Episode.Target = %+v, want %+v", result.Episode.Target, session.SelectedTarget)
+	}
+	if result.Episode.FactorySessionID != "" {
+		t.Fatalf("Episode.FactorySessionID = %q, want blank for a brand-new episode", result.Episode.FactorySessionID)
+	}
+	if result.Episode.State != chatsessions.TargetEpisodeStateOpen {
+		t.Fatalf("Episode.State = %v, want OPEN", result.Episode.State)
+	}
+}
+
 // TestStore_StartTurn_SecondAdmissionWhileActiveIsBusy proves a second
 // sequential admission while the first turn is non-terminal reports typed
 // *BusyError, creates no additional active turn, and leaves the accepted

--- a/pkg/services/chat_sessions/internal/service/turn_test.go
+++ b/pkg/services/chat_sessions/internal/service/turn_test.go
@@ -334,6 +334,163 @@ func TestStore_StartTurn_SecondTurnAfterTerminalStaysActive(t *testing.T) {
 	}
 }
 
+// TestStore_StartTurn_RedeliveredRequestIDWhileBusyReturnsSameTurn proves a
+// StartTurn call reusing a RequestID that already admitted a still-busy turn
+// returns that exact turn unchanged instead of reporting *BusyError or
+// admitting a second turn -- the caller (not the Store) decides how to react
+// to a non-ADMITTED returned Turn.State.
+func TestStore_StartTurn_RedeliveredRequestIDWhileBusyReturnsSameTurn(t *testing.T) {
+	ctx := context.Background()
+	store, session := newStartTurnTestSession(t, time.Now())
+	reqID := startTurnRequestID("req-turn-1")
+
+	first, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       reqID,
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn first: %v", err)
+	}
+
+	replay, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       reqID,
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn replay: %v", err)
+	}
+	if replay.Turn.ID != first.Turn.ID {
+		t.Fatalf("replay Turn.ID = %q, want the original turn %q", replay.Turn.ID, first.Turn.ID)
+	}
+	if replay.Turn.State != chatsessions.TurnStateAdmitted {
+		t.Fatalf("replay Turn.State = %v, want ADMITTED (unchanged)", replay.Turn.State)
+	}
+
+	store.mu.RLock()
+	turnCount := len(store.sessions[session.ID].turns)
+	store.mu.RUnlock()
+	if turnCount != 1 {
+		t.Fatalf("stored turn count = %d, want exactly 1 (no second turn admitted)", turnCount)
+	}
+}
+
+// TestStore_StartTurn_RedeliveredRequestIDAfterTerminalReturnsSameTurn proves
+// that once the originally admitted turn for a RequestID has terminalized
+// (releasing ActiveTurnID and the session's busy state), a StartTurn call
+// reusing that exact RequestID still returns the original, now-terminal turn
+// rather than admitting a fresh ADMITTED turn and letting a caller dispatch a
+// second Factory effect for content already executed once.
+func TestStore_StartTurn_RedeliveredRequestIDAfterTerminalReturnsSameTurn(t *testing.T) {
+	ctx := context.Background()
+	store, session := newStartTurnTestSession(t, time.Now())
+	reqID := startTurnRequestID("req-turn-1")
+
+	first, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       reqID,
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn first: %v", err)
+	}
+	if _, err := store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: session.ID,
+		TurnID:    first.Turn.ID,
+		Next:      chatsessions.TurnStateRunning,
+	}); err != nil {
+		t.Fatalf("AdvanceTurn to RUNNING: %v", err)
+	}
+	advanced, err := store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: session.ID,
+		TurnID:    first.Turn.ID,
+		Next:      chatsessions.TurnStateCompleted,
+	})
+	if err != nil {
+		t.Fatalf("AdvanceTurn to terminal: %v", err)
+	}
+
+	replay, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID: reqID,
+		SessionID: session.ID,
+		// A version stale relative to the released session would fail
+		// *ConflictError for a genuinely new admission; the replay must
+		// short-circuit before that check is ever reached.
+		ExpectedVersion: session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn replay after terminal: %v", err)
+	}
+	if replay.Turn.ID != first.Turn.ID {
+		t.Fatalf("replay Turn.ID = %q, want the original terminal turn %q", replay.Turn.ID, first.Turn.ID)
+	}
+	if replay.Turn.State != chatsessions.TurnStateCompleted {
+		t.Fatalf("replay Turn.State = %v, want COMPLETED (the original terminal state)", replay.Turn.State)
+	}
+	if replay.Turn != advanced.Turn {
+		t.Fatalf("replay Turn = %+v, want the exact original terminal turn %+v", replay.Turn, advanced.Turn)
+	}
+
+	store.mu.RLock()
+	turnCount := len(store.sessions[session.ID].turns)
+	store.mu.RUnlock()
+	if turnCount != 1 {
+		t.Fatalf("stored turn count = %d, want exactly 1 (no second turn admitted by the replay)", turnCount)
+	}
+}
+
+// TestStore_StartTurn_DistinctRequestIDAfterTerminalAdmitsNewTurn proves the
+// redelivery guard is scoped to an exact RequestID: a genuinely distinct
+// later request against the same session, submitted after the original turn
+// terminalized, still admits its own new turn.
+func TestStore_StartTurn_DistinctRequestIDAfterTerminalAdmitsNewTurn(t *testing.T) {
+	ctx := context.Background()
+	store, session := newStartTurnTestSession(t, time.Now())
+
+	first, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-1"),
+		SessionID:       session.ID,
+		ExpectedVersion: session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn first: %v", err)
+	}
+	if _, err := store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: session.ID,
+		TurnID:    first.Turn.ID,
+		Next:      chatsessions.TurnStateRunning,
+	}); err != nil {
+		t.Fatalf("AdvanceTurn to RUNNING: %v", err)
+	}
+	if _, err := store.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: session.ID,
+		TurnID:    first.Turn.ID,
+		Next:      chatsessions.TurnStateCompleted,
+	}); err != nil {
+		t.Fatalf("AdvanceTurn to terminal: %v", err)
+	}
+	released, err := store.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: session.ID})
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+
+	second, err := store.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       startTurnRequestID("req-turn-2"),
+		SessionID:       session.ID,
+		ExpectedVersion: released.Session.Version,
+	})
+	if err != nil {
+		t.Fatalf("StartTurn second: %v", err)
+	}
+	if second.Turn.ID == first.Turn.ID {
+		t.Fatal("distinct RequestID reused the first turn's ID")
+	}
+	if second.Turn.State != chatsessions.TurnStateAdmitted {
+		t.Fatalf("second Turn.State = %v, want ADMITTED", second.Turn.State)
+	}
+}
+
 // TestStore_StartTurn_ConcurrentAdmissionSingleWinner proves concurrent
 // admissions using the same ExpectedVersion serialize to exactly one
 // successful commit. Since StartTurn checks ExpectedVersion before the busy

--- a/pkg/services/chat_sessions/types.go
+++ b/pkg/services/chat_sessions/types.go
@@ -297,7 +297,18 @@ type TargetEpisode struct {
 	State            TargetEpisodeState
 	Target           ChatTargetRef
 	FactorySessionID string
-	StartedAt        time.Time
+	// PendingFactorySessionID records a Factory Session identity a caller
+	// has started for this episode but not yet committed via
+	// BindFactorySession -- the singular Chat/Factory Sessions authority's
+	// own record of a reconciliation-in-progress, so a retry after a
+	// post-start failure can observe and reuse it without depending on any
+	// one transport instance surviving. It is set by RecordPendingFactorySession
+	// and cleared once BindFactorySession commits (or a caller explicitly
+	// abandons it with a blank identity). Unlike FactorySessionID, it carries
+	// no consistency guarantee beyond "a caller told us it started this" and
+	// is never itself the committed binding.
+	PendingFactorySessionID string
+	StartedAt               time.Time
 	// ClosedAt is the episode's terminal time fact: unset while State is
 	// OPEN and set (never before StartedAt) once State is CLOSED.
 	ClosedAt *time.Time

--- a/pkg/services/chat_sessions/wire/wire.go
+++ b/pkg/services/chat_sessions/wire/wire.go
@@ -8,6 +8,14 @@
 // injection of the singular Operator Settings and Factory Definitions
 // public service roots). Neither constructor is a dependency bag, service
 // locator, or alternate construction path for the other's root.
+//
+// It also re-publishes the package-private factorysessionsshim's narrow
+// Factory Session start/invoke/cancel/close contract as FactoryTargetService
+// so a consumer outside the chat_sessions tree (the ACP prompt-delegation
+// transport and its own wire graph) can construct and hold that
+// collaborator without importing the internal shim package itself, and
+// without the chat_sessions public root (chatsessions.Service) taking on a
+// Factory Sessions dependency.
 package wire
 
 import (
@@ -15,8 +23,10 @@ import (
 
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/factorysessionsshim"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/service"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 )
 
@@ -54,4 +64,20 @@ func NewFactoryTargetCatalogService(
 	logger logging.Logger,
 ) (chatsessions.FactoryTargetCatalogService, error) {
 	return internalservice.New(operatorSettings, factoryDefinitions, logger)
+}
+
+// FactoryTargetService is factorysessionsshim.FactoryTargetService,
+// re-published here so a caller outside the chat_sessions tree can declare a
+// field or parameter of this type without importing the internal shim
+// package directly.
+type FactoryTargetService = factorysessionsshim.FactoryTargetService
+
+// NewFactoryTargetService constructs the Factory Sessions shim over the
+// given public factory_sessions.Service root -- the one consumer-owned
+// bridge from Chat Sessions-adjacent transports to Factory Sessions'
+// start/invoke/cancel/close operations. It forwards the published
+// factory_sessions vocabulary unmodified; this package does not reinterpret
+// results or reach into Factory Sessions internals.
+func NewFactoryTargetService(service factorysessions.Service) FactoryTargetService {
+	return factorysessionsshim.New(service)
 }

--- a/pkg/services/chat_sessions/wire/wire.go
+++ b/pkg/services/chat_sessions/wire/wire.go
@@ -8,14 +8,6 @@
 // injection of the singular Operator Settings and Factory Definitions
 // public service roots). Neither constructor is a dependency bag, service
 // locator, or alternate construction path for the other's root.
-//
-// It also re-publishes the package-private factorysessionsshim's narrow
-// Factory Session start/invoke/cancel/close contract as FactoryTargetService
-// so a consumer outside the chat_sessions tree (the ACP prompt-delegation
-// transport and its own wire graph) can construct and hold that
-// collaborator without importing the internal shim package itself, and
-// without the chat_sessions public root (chatsessions.Service) taking on a
-// Factory Sessions dependency.
 package wire
 
 import (
@@ -23,10 +15,8 @@ import (
 
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
-	"github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/factorysessionsshim"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/service"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
-	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 )
 
@@ -64,20 +54,4 @@ func NewFactoryTargetCatalogService(
 	logger logging.Logger,
 ) (chatsessions.FactoryTargetCatalogService, error) {
 	return internalservice.New(operatorSettings, factoryDefinitions, logger)
-}
-
-// FactoryTargetService is factorysessionsshim.FactoryTargetService,
-// re-published here so a caller outside the chat_sessions tree can declare a
-// field or parameter of this type without importing the internal shim
-// package directly.
-type FactoryTargetService = factorysessionsshim.FactoryTargetService
-
-// NewFactoryTargetService constructs the Factory Sessions shim over the
-// given public factory_sessions.Service root -- the one consumer-owned
-// bridge from Chat Sessions-adjacent transports to Factory Sessions'
-// start/invoke/cancel/close operations. It forwards the published
-// factory_sessions vocabulary unmodified; this package does not reinterpret
-// results or reach into Factory Sessions internals.
-func NewFactoryTargetService(service factorysessions.Service) FactoryTargetService {
-	return factorysessionsshim.New(service)
 }

--- a/pkg/services/chat_sessions/wire/wire.go
+++ b/pkg/services/chat_sessions/wire/wire.go
@@ -18,7 +18,6 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/factorysessionsshim"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/service"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
-	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 )
 
@@ -66,13 +65,22 @@ func NewFactoryTargetCatalogService(
 // subpackage -- see NewFactoryTargetService.
 type FactoryTargetService = factorysessionsshim.FactoryTargetService
 
+// FactoryTargetExecutionService is the narrow start/invoke/cancel/close
+// execution dependency the shim actually forwards to (re-published for the
+// same reason as FactoryTargetService). Any concrete
+// factorysessions.Service -- the CLI daemon's full singleton, or a narrower,
+// consumer-owned activation like factory_sessions/wire's own
+// OnDemandFactoryTargetService that implements only these four methods --
+// satisfies it structurally.
+type FactoryTargetExecutionService = factorysessionsshim.FactoryTargetExecutionService
+
 // NewFactoryTargetService constructs the existing Chat Sessions-owned
-// Factory Sessions shim (factorysessionsshim.Shim) over the given
-// factorysessions.Service. It is a stateless, exactly-once-forwarding
-// adapter: this constructor performs no I/O and adds no behavior beyond what
+// Factory Sessions shim (factorysessionsshim.Shim) over the given execution
+// service. It is a stateless, exactly-once-forwarding adapter: this
+// constructor performs no I/O and adds no behavior beyond what
 // factorysessionsshim.New itself already does. pkg/wire is the only intended
 // caller (chat_sessions/internal/factorysessionsshim cannot be imported
 // directly outside this service's own tree).
-func NewFactoryTargetService(service factorysessions.Service) FactoryTargetService {
+func NewFactoryTargetService(service FactoryTargetExecutionService) FactoryTargetService {
 	return factorysessionsshim.New(service)
 }

--- a/pkg/services/chat_sessions/wire/wire.go
+++ b/pkg/services/chat_sessions/wire/wire.go
@@ -15,8 +15,10 @@ import (
 
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/factorysessionsshim"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/service"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 )
 
@@ -54,4 +56,23 @@ func NewFactoryTargetCatalogService(
 	logger logging.Logger,
 ) (chatsessions.FactoryTargetCatalogService, error) {
 	return internalservice.New(operatorSettings, factoryDefinitions, logger)
+}
+
+// FactoryTargetService is the Factory-target start/invoke/cancel/close
+// dependency the existing, consumer-owned Factory Sessions shim exposes.
+// Re-published here (an alias for factorysessionsshim.FactoryTargetService,
+// this shim's own private contract) exclusively for pkg/wire's use, per the
+// pkg-boundary rule that only pkg/wire may import a service's own wire
+// subpackage -- see NewFactoryTargetService.
+type FactoryTargetService = factorysessionsshim.FactoryTargetService
+
+// NewFactoryTargetService constructs the existing Chat Sessions-owned
+// Factory Sessions shim (factorysessionsshim.Shim) over the given
+// factorysessions.Service. It is a stateless, exactly-once-forwarding
+// adapter: this constructor performs no I/O and adds no behavior beyond what
+// factorysessionsshim.New itself already does. pkg/wire is the only intended
+// caller (chat_sessions/internal/factorysessionsshim cannot be imported
+// directly outside this service's own tree).
+func NewFactoryTargetService(service factorysessions.Service) FactoryTargetService {
+	return factorysessionsshim.New(service)
 }

--- a/pkg/services/factory_sessions/internal/ondemandtarget/service.go
+++ b/pkg/services/factory_sessions/internal/ondemandtarget/service.go
@@ -111,6 +111,25 @@ type Service struct {
 	// fails after a successful open: the caller's retry passes the same
 	// RequestID and observes the same SessionID back.
 	startsByRequestID map[string]string
+	// pendingStarts indexes a non-blank StartRequest.RequestID that is
+	// currently being started onto the in-flight pendingStart a genuinely
+	// concurrent second StartAsync call for the exact same RequestID must
+	// join rather than independently resolving and opening its own second
+	// runtime. Reserving this entry happens under s.mu before any I/O, so at
+	// most one goroutine ever performs the resolve/open work for one
+	// RequestID no matter how many callers race in with it.
+	pendingStarts map[string]*pendingStart
+}
+
+// pendingStart is the in-flight state a reserved-but-not-yet-published
+// StartAsync call publishes for other goroutines racing in with the same
+// RequestID to join. done is closed exactly once, by whichever goroutine
+// reserved the entry, after result/err are set; every joining goroutine
+// waits on done and then reads the identical result/err.
+type pendingStart struct {
+	done   chan struct{}
+	result factorysessions.AsyncStartResult
+	err    error
 }
 
 // New constructs the on-demand activation over the given *runtimeopening.Factory.
@@ -142,6 +161,7 @@ func New(
 		logger:            logger,
 		runtimes:          make(map[string]*activatedRuntime),
 		startsByRequestID: make(map[string]string),
+		pendingStarts:     make(map[string]*pendingStart),
 	}, nil
 }
 
@@ -250,13 +270,76 @@ func (s *Service) StartAsync(
 	ctx context.Context,
 	request factorysessions.StartRequest,
 ) (factorysessions.AsyncStartResult, error) {
-	if request.RequestID != "" {
-		if result, ok := s.existingStart(request.RequestID); ok {
-			s.logger.Info("on-demand Factory target start converged onto an existing activation for this request")
-			return result, nil
-		}
+	if request.RequestID == "" {
+		return s.startNewActivation(ctx, request)
 	}
 
+	result, err, joined := s.reserveOrJoinStart(request.RequestID)
+	if joined {
+		if err == nil {
+			s.logger.Info("on-demand Factory target start converged onto an existing activation for this request")
+		}
+		return result, err
+	}
+
+	result, err = s.startNewActivation(ctx, request)
+	s.finishPendingStart(request.RequestID, result, err)
+	return result, err
+}
+
+// reserveOrJoinStart reports (result, err, true) when requestID either
+// already has a completed, still-tracked activation (a genuine retry after
+// an earlier StartAsync call fully returned) or is currently being started by
+// another goroutine (a truly concurrent call, which blocks on that
+// goroutine's own pendingStart.done and returns its identical outcome
+// instead of independently resolving and opening a second runtime). It
+// reports (_, _, false) with a fresh pendingStarts[requestID] entry reserved
+// under s.mu when this call is the one that must actually perform the start;
+// the caller must then call finishPendingStart(requestID, ...) exactly once.
+func (s *Service) reserveOrJoinStart(requestID string) (factorysessions.AsyncStartResult, error, bool) {
+	s.mu.Lock()
+	if wrapperID, ok := s.startsByRequestID[requestID]; ok {
+		if _, exists := s.runtimes[wrapperID]; exists {
+			s.mu.Unlock()
+			return factorysessions.AsyncStartResult{SessionID: wrapperID, Status: string(factorysessions.LifecycleStatusRunning)}, nil, true
+		}
+	}
+	if pending, ok := s.pendingStarts[requestID]; ok {
+		s.mu.Unlock()
+		<-pending.done
+		return pending.result, pending.err, true
+	}
+	s.pendingStarts[requestID] = &pendingStart{done: make(chan struct{})}
+	s.mu.Unlock()
+	return factorysessions.AsyncStartResult{}, nil, false
+}
+
+// finishPendingStart records the outcome of a reserved start for requestID
+// (see reserveOrJoinStart) and wakes every goroutine that joined it while it
+// was in flight. It is a no-op if the reservation was somehow already
+// cleared, which should not happen since only this call ever removes it.
+func (s *Service) finishPendingStart(requestID string, result factorysessions.AsyncStartResult, err error) {
+	s.mu.Lock()
+	pending := s.pendingStarts[requestID]
+	delete(s.pendingStarts, requestID)
+	s.mu.Unlock()
+	if pending == nil {
+		return
+	}
+	pending.result = result
+	pending.err = err
+	close(pending.done)
+}
+
+// startNewActivation resolves and opens exactly one fresh Factory target
+// runtime for request, then publishes it under a validated generated
+// identity. Callers with a non-blank RequestID must route through
+// reserveOrJoinStart/finishPendingStart so a genuinely concurrent second
+// caller for the same RequestID never reaches this method independently.
+func (s *Service) startNewActivation(
+	ctx context.Context,
+	request factorysessions.StartRequest,
+) (factorysessions.AsyncStartResult, error) {
 	workingRoot, _ := request.Args["workingRoot"].(string)
 	config, err := s.resolve(ctx, request.Source.FactoryID, workingRoot)
 	if err != nil {
@@ -267,22 +350,11 @@ func (s *Service) StartAsync(
 		return factorysessions.AsyncStartResult{}, err
 	}
 
-	wrapperID := s.generateID()
-	s.mu.Lock()
-	if request.RequestID != "" {
-		if existing, ok := s.reconcileConcurrentStartLocked(request.RequestID); ok {
-			s.mu.Unlock()
-			// A concurrent StartAsync call for the exact same request
-			// identity already won and is still tracked: converge on it and
-			// close this now-redundant runtime instead of keeping two live
-			// activations for one logical start.
-			_ = active.close(context.WithoutCancel(ctx))
-			return existing, nil
-		}
-		s.startsByRequestID[request.RequestID] = wrapperID
+	wrapperID, err := s.publishActivation(request.RequestID, active)
+	if err != nil {
+		_ = active.close(context.WithoutCancel(ctx))
+		return factorysessions.AsyncStartResult{}, err
 	}
-	s.runtimes[wrapperID] = active
-	s.mu.Unlock()
 	s.logger.Info("on-demand Factory target runtime ready",
 		zap.String("factoryTargetId", request.Source.FactoryID))
 	return factorysessions.AsyncStartResult{
@@ -291,36 +363,28 @@ func (s *Service) StartAsync(
 	}, nil
 }
 
-// existingStart reports the still-tracked activation a prior StartAsync call
-// already opened for requestID, if any -- an orphaned index entry left by a
-// runtime that has since been evicted (CloseFactorySession/Close) reports
-// false, so a genuinely new activation proceeds rather than reporting a
-// SessionID that no longer resolves to anything.
-func (s *Service) existingStart(requestID string) (factorysessions.AsyncStartResult, bool) {
+// publishActivation validates and reserves a non-blank, non-colliding
+// generated wrapper identity for active, then publishes it into s.runtimes
+// (and, if requestID is non-blank, s.startsByRequestID). A blank identity or
+// one that collides with an already-tracked identity fails without mutating
+// either map, so a bad value from generateID can never overwrite -- and
+// thereby strand -- an existing activation; the caller is responsible for
+// closing active in that case.
+func (s *Service) publishActivation(requestID string, active *activatedRuntime) (string, error) {
+	wrapperID := s.generateID()
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	wrapperID, ok := s.startsByRequestID[requestID]
-	if !ok {
-		return factorysessions.AsyncStartResult{}, false
+	if wrapperID == "" {
+		return "", errors.New("on-demand Factory target activation: generated session identity was blank")
 	}
-	if _, exists := s.runtimes[wrapperID]; !exists {
-		return factorysessions.AsyncStartResult{}, false
+	if _, exists := s.runtimes[wrapperID]; exists {
+		return "", fmt.Errorf("on-demand Factory target activation: generated session identity %q collided with an existing activation", wrapperID)
 	}
-	return factorysessions.AsyncStartResult{SessionID: wrapperID, Status: string(factorysessions.LifecycleStatusRunning)}, true
-}
-
-// reconcileConcurrentStartLocked reports the still-tracked activation
-// requestID resolved to while this goroutine's own openActivatedRuntime call
-// was in flight without holding s.mu -- must be called with s.mu held.
-func (s *Service) reconcileConcurrentStartLocked(requestID string) (factorysessions.AsyncStartResult, bool) {
-	wrapperID, ok := s.startsByRequestID[requestID]
-	if !ok {
-		return factorysessions.AsyncStartResult{}, false
+	s.runtimes[wrapperID] = active
+	if requestID != "" {
+		s.startsByRequestID[requestID] = wrapperID
 	}
-	if _, exists := s.runtimes[wrapperID]; !exists {
-		return factorysessions.AsyncStartResult{}, false
-	}
-	return factorysessions.AsyncStartResult{SessionID: wrapperID, Status: string(factorysessions.LifecycleStatusRunning)}, true
+	return wrapperID, nil
 }
 
 func (s *Service) lookup(sessionID string) (*activatedRuntime, error) {

--- a/pkg/services/factory_sessions/internal/ondemandtarget/service.go
+++ b/pkg/services/factory_sessions/internal/ondemandtarget/service.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"sync"
 
 	"go.uber.org/zap"
@@ -23,6 +24,11 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/runtimeopening"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 )
+
+// Service satisfies io.Closer so a process lifecycle plan can register it as
+// a NamedResource (see pkg/initializer/lifecycle) whose Close tears down
+// every runtime it ever lazily activated.
+var _ io.Closer = (*Service)(nil)
 
 // RuntimeResolver turns one canonical Factory target identity and editor
 // working root into the concrete Runtime Opening request that activating a
@@ -312,4 +318,36 @@ func (s *Service) CloseFactoryTarget(ctx context.Context, sessionID string) erro
 		s.logger.Info("on-demand Factory target closed")
 	}
 	return err
+}
+
+// Close tears down and evicts every runtime this Service has opened and not
+// yet closed, aggregating every individual close failure into one returned
+// error rather than stopping at the first. It satisfies io.Closer so a
+// process lifecycle plan can register this Service as a reachable,
+// deterministic unwind step for every runtime it ever lazily activated,
+// instead of leaving them open for the life of the process; construction
+// alone opens no runtime, so calling Close before any StartFactoryTarget
+// call is a no-op success. Close is idempotent: a runtime evicted by this
+// call or by an earlier CloseFactoryTarget call is never closed twice.
+func (s *Service) Close() error {
+	s.mu.Lock()
+	active := make([]*activatedRuntime, 0, len(s.runtimes))
+	for sessionID, runtime := range s.runtimes {
+		active = append(active, runtime)
+		delete(s.runtimes, sessionID)
+	}
+	s.mu.Unlock()
+
+	var result error
+	for _, runtime := range active {
+		if err := runtime.close(context.WithoutCancel(context.Background())); err != nil {
+			result = errors.Join(result, err)
+		}
+	}
+	if result != nil {
+		s.logger.Error("on-demand Factory target close-all failed", zap.Error(result))
+	} else if len(active) > 0 {
+		s.logger.Info("on-demand Factory target close-all completed", zap.Int("runtimeCount", len(active)))
+	}
+	return result
 }

--- a/pkg/services/factory_sessions/internal/ondemandtarget/service.go
+++ b/pkg/services/factory_sessions/internal/ondemandtarget/service.go
@@ -9,17 +9,21 @@
 // wraps runtimeopening.Factory as RuntimeOpeningFactory) so a caller outside
 // this service tree never imports this package directly.
 //
-// Service implements the full public factorysessions.Service interface (by
-// embedding it as a nil value and overriding only the handful of methods it
-// gives real behavior to -- StartAsync, InvokeFactorySession, Cancel,
-// CloseFactorySession -- the same "embed the interface, panic on anything
-// unimplemented" idiom this package's own tests already use for fakeSessions)
-// specifically so it can be handed, unmodified, to
-// chat_sessions/internal/factorysessionsshim.New: that existing,
-// consumer-owned shim is what the production ACP prompt-delegation consumer
-// actually calls, not this package's own methods directly. Every method
-// beyond those four is unreachable in production -- the shim never calls
-// them -- and exists only to satisfy the interface.
+// Service implements exactly StartAsync, InvokeFactorySession, Cancel, and
+// CloseFactorySession -- the narrow
+// chat_sessions/internal/factorysessionsshim.FactoryTargetExecutionService
+// contract that existing, consumer-owned shim actually forwards to, and
+// nothing more. Earlier iterations of this package embedded the full 30+
+// method public factorysessions.Service interface as a permanently-nil value
+// solely so this type could be handed to the shim's constructor, which then
+// required the literal Service type; every unimplemented method panicked if
+// ever reached. That made this type a partial, panic-capable stand-in for
+// the full aggregate root -- a real production risk if any future shim
+// expansion or root composition ever called one of the unimplemented
+// methods. factorysessionsshim.New now depends on the narrow
+// FactoryTargetExecutionService interface instead of the full Service, so
+// this type can be -- and now is -- a complete, non-panicking implementation
+// of exactly what it claims to support.
 package ondemandtarget
 
 import (
@@ -40,11 +44,6 @@ import (
 // a NamedResource (see pkg/initializer/lifecycle) whose Close tears down
 // every runtime it ever lazily activated.
 var _ io.Closer = (*Service)(nil)
-
-// Service also satisfies the full public factorysessions.Service so it can
-// be wrapped by the existing chat_sessions-owned factorysessionsshim.Shim
-// unmodified -- see this package's own doc comment.
-var _ factorysessions.Service = (*Service)(nil)
 
 // RuntimeResolver turns one canonical Factory target identity and editor
 // working root into the concrete Runtime Opening request that activating a
@@ -92,14 +91,6 @@ type invocationRuntimeOpener interface {
 // cached runtime (and the runtime's own DefaultSessionID) on every later
 // call. Callers must treat the returned identity as opaque.
 type Service struct {
-	// Service is embedded as a permanently nil interface value: every method
-	// this type does not itself override is satisfied only for the compiler
-	// (interface completeness), and panics if ever actually called. Only
-	// StartAsync, InvokeFactorySession, Cancel, and CloseFactorySession are
-	// overridden below -- the exact four methods
-	// chat_sessions/internal/factorysessionsshim.Shim forwards to.
-	factorysessions.Service
-
 	factory    invocationRuntimeOpener
 	effects    runtimeopening.ExternalEffects
 	resolve    RuntimeResolver
@@ -108,6 +99,18 @@ type Service struct {
 
 	mu       sync.Mutex
 	runtimes map[string]*activatedRuntime
+	// startsByRequestID indexes a non-blank StartRequest.RequestID onto the
+	// wrapper identity StartAsync opened for it, so a retried start for the
+	// same stable request identity (this service's caller uses a key derived
+	// from the session and episode, not the admitted Turn's own ID, so it is
+	// stable across a retry -- see startFactorySessionForEpisode's own doc
+	// comment) converges on the exact runtime already opened for it instead
+	// of opening a second one. This is what makes StartAsync idempotent under
+	// a stable per-episode key even when a caller's own post-start
+	// bookkeeping (for example chatsessions.Service.RecordPendingFactorySession)
+	// fails after a successful open: the caller's retry passes the same
+	// RequestID and observes the same SessionID back.
+	startsByRequestID map[string]string
 }
 
 // New constructs the on-demand activation over the given *runtimeopening.Factory.
@@ -132,12 +135,13 @@ func New(
 		return nil, errors.New("construct on-demand Factory target activation: logger is required")
 	}
 	return &Service{
-		factory:    factory,
-		effects:    effects,
-		resolve:    resolve,
-		generateID: generateID,
-		logger:     logger,
-		runtimes:   make(map[string]*activatedRuntime),
+		factory:           factory,
+		effects:           effects,
+		resolve:           resolve,
+		generateID:        generateID,
+		logger:            logger,
+		runtimes:          make(map[string]*activatedRuntime),
+		startsByRequestID: make(map[string]string),
 	}, nil
 }
 
@@ -246,6 +250,13 @@ func (s *Service) StartAsync(
 	ctx context.Context,
 	request factorysessions.StartRequest,
 ) (factorysessions.AsyncStartResult, error) {
+	if request.RequestID != "" {
+		if result, ok := s.existingStart(request.RequestID); ok {
+			s.logger.Info("on-demand Factory target start converged onto an existing activation for this request")
+			return result, nil
+		}
+	}
+
 	workingRoot, _ := request.Args["workingRoot"].(string)
 	config, err := s.resolve(ctx, request.Source.FactoryID, workingRoot)
 	if err != nil {
@@ -258,6 +269,18 @@ func (s *Service) StartAsync(
 
 	wrapperID := s.generateID()
 	s.mu.Lock()
+	if request.RequestID != "" {
+		if existing, ok := s.reconcileConcurrentStartLocked(request.RequestID); ok {
+			s.mu.Unlock()
+			// A concurrent StartAsync call for the exact same request
+			// identity already won and is still tracked: converge on it and
+			// close this now-redundant runtime instead of keeping two live
+			// activations for one logical start.
+			_ = active.close(context.WithoutCancel(ctx))
+			return existing, nil
+		}
+		s.startsByRequestID[request.RequestID] = wrapperID
+	}
 	s.runtimes[wrapperID] = active
 	s.mu.Unlock()
 	s.logger.Info("on-demand Factory target runtime ready",
@@ -266,6 +289,38 @@ func (s *Service) StartAsync(
 		SessionID: wrapperID,
 		Status:    string(factorysessions.LifecycleStatusRunning),
 	}, nil
+}
+
+// existingStart reports the still-tracked activation a prior StartAsync call
+// already opened for requestID, if any -- an orphaned index entry left by a
+// runtime that has since been evicted (CloseFactorySession/Close) reports
+// false, so a genuinely new activation proceeds rather than reporting a
+// SessionID that no longer resolves to anything.
+func (s *Service) existingStart(requestID string) (factorysessions.AsyncStartResult, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	wrapperID, ok := s.startsByRequestID[requestID]
+	if !ok {
+		return factorysessions.AsyncStartResult{}, false
+	}
+	if _, exists := s.runtimes[wrapperID]; !exists {
+		return factorysessions.AsyncStartResult{}, false
+	}
+	return factorysessions.AsyncStartResult{SessionID: wrapperID, Status: string(factorysessions.LifecycleStatusRunning)}, true
+}
+
+// reconcileConcurrentStartLocked reports the still-tracked activation
+// requestID resolved to while this goroutine's own openActivatedRuntime call
+// was in flight without holding s.mu -- must be called with s.mu held.
+func (s *Service) reconcileConcurrentStartLocked(requestID string) (factorysessions.AsyncStartResult, bool) {
+	wrapperID, ok := s.startsByRequestID[requestID]
+	if !ok {
+		return factorysessions.AsyncStartResult{}, false
+	}
+	if _, exists := s.runtimes[wrapperID]; !exists {
+		return factorysessions.AsyncStartResult{}, false
+	}
+	return factorysessions.AsyncStartResult{SessionID: wrapperID, Status: string(factorysessions.LifecycleStatusRunning)}, true
 }
 
 func (s *Service) lookup(sessionID string) (*activatedRuntime, error) {

--- a/pkg/services/factory_sessions/internal/ondemandtarget/service.go
+++ b/pkg/services/factory_sessions/internal/ondemandtarget/service.go
@@ -1,0 +1,315 @@
+// Package ondemandtarget implements the on-demand Factory Sessions
+// activation a dynamic-target ACP-style consumer needs: unlike the CLI
+// daemon's single, pre-opened project runtime, this activation has no fixed
+// runtime to hand out and instead lazily opens exactly one ephemeral,
+// non-HTTP-bound runtime per caller-selected Factory target the first time it
+// is needed, then keeps it open for later calls against the identity it
+// returned. This is private implementation: pkg/services/factory_sessions/wire
+// exposes it as a thin construction wrapper (matching how that package already
+// wraps runtimeopening.Factory as RuntimeOpeningFactory) so a caller outside
+// this service tree never imports this package directly.
+package ondemandtarget
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"go.uber.org/zap"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/roles"
+	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/runtimeopening"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+)
+
+// RuntimeResolver turns one canonical Factory target identity and editor
+// working root into the concrete Runtime Opening request that activating a
+// live, project-bound Factory Sessions runtime for that exact target needs.
+// The concrete implementation (catalog + named-Factory cross-root
+// resolution, operator defaults) is owned by the composing consumer; this
+// package stays free of transport-specific target vocabulary.
+type RuntimeResolver func(
+	ctx context.Context,
+	factoryTargetID string,
+	workingRoot string,
+) (factorysessions.RuntimeOpeningRequest, error)
+
+// invocationRuntimeOpener is the narrow capability this service consumes
+// from *runtimeopening.Factory, declared here (rather than consuming the
+// concrete type directly) so a test can substitute a fake without
+// constructing the full Factory's own large production dependency graph.
+// *runtimeopening.Factory already satisfies this interface structurally.
+type invocationRuntimeOpener interface {
+	OpenInvocationRuntime(
+		ctx context.Context,
+		request *factorysessions.RuntimeOpeningRequest,
+		effects runtimeopening.ExternalEffects,
+		logger *zap.Logger,
+	) (roles.OpenedInvocationRuntime, error)
+}
+
+// Service is a consumer-owned Factory Sessions activation that has no fixed,
+// pre-opened Factory Session runtime the way the CLI daemon's
+// single-project bootstrap (OpenApplication/Assembly.Complete) does.
+// Instead, the first StartFactoryTarget for a given caller-selected Factory
+// target and working root lazily opens exactly one ephemeral, non-HTTP-bound
+// runtime through the existing invocation-mode Runtime Opening path (the
+// same primitive the CLI's one-shot named invocation already uses, per
+// runtimeopening.Factory.OpenInvocationRuntime), starts its lifecycle, and
+// keeps it open so every later call against the returned identity reuses
+// that exact runtime instead of starting a second one.
+//
+// Every opened invocation-mode runtime privately shares the same constant
+// internal session identity (factorysessions.DefaultSessionID) -- calling
+// StartAsync/InvokeFactorySession/Cancel/CloseFactorySession against that
+// raw identity across more than one concurrently-opened runtime would
+// collide, so this service substitutes its own generated identity for the
+// one returned to callers on Start, and translates it back to the correct
+// cached runtime (and the runtime's own DefaultSessionID) on every later
+// call. Callers must treat the returned identity as opaque.
+type Service struct {
+	factory    invocationRuntimeOpener
+	effects    runtimeopening.ExternalEffects
+	resolve    RuntimeResolver
+	generateID factorysessions.SessionIDGenerator
+	logger     *zap.Logger
+
+	mu       sync.Mutex
+	runtimes map[string]*activatedRuntime
+}
+
+// New constructs the on-demand activation over the given *runtimeopening.Factory.
+// Construction alone performs no I/O and opens no runtime.
+func New(
+	factory *runtimeopening.Factory,
+	effects runtimeopening.ExternalEffects,
+	resolve RuntimeResolver,
+	generateID factorysessions.SessionIDGenerator,
+	logger *zap.Logger,
+) (*Service, error) {
+	if factory == nil {
+		return nil, errors.New("construct on-demand Factory target activation: Runtime Opening factory is required")
+	}
+	if resolve == nil {
+		return nil, errors.New("construct on-demand Factory target activation: Factory target runtime resolver is required")
+	}
+	if generateID == nil {
+		return nil, errors.New("construct on-demand Factory target activation: session ID generator is required")
+	}
+	if logger == nil {
+		return nil, errors.New("construct on-demand Factory target activation: logger is required")
+	}
+	return &Service{
+		factory:    factory,
+		effects:    effects,
+		resolve:    resolve,
+		generateID: generateID,
+		logger:     logger,
+		runtimes:   make(map[string]*activatedRuntime),
+	}, nil
+}
+
+// activatedRuntime is one lazily-opened, lifecycle-started invocation
+// runtime kept alive across calls. runContext is intentionally detached from
+// any one caller request's context (context.WithoutCancel) so an
+// asynchronous StartAsync dispatch it starts keeps running after the
+// initiating ACP request returns; only this type's own close cancels it.
+type activatedRuntime struct {
+	opened     roles.OpenedInvocationRuntime
+	runContext context.Context
+	cancel     context.CancelFunc
+	stopWorker factorysessions.RuntimeStop
+}
+
+func (s *Service) openActivatedRuntime(
+	ctx context.Context,
+	factoryTargetID string,
+	workingRoot string,
+	config factorysessions.RuntimeOpeningRequest,
+) (*activatedRuntime, error) {
+	s.logger.Info("activating on-demand Factory target runtime",
+		zap.String("factoryTargetId", factoryTargetID), zap.String("workingRoot", workingRoot))
+
+	opened, err := s.factory.OpenInvocationRuntime(ctx, &config, s.effects, s.logger)
+	if err != nil {
+		s.logger.Error("failed to open on-demand Factory target runtime",
+			zap.String("factoryTargetId", factoryTargetID), zap.Error(err))
+		return nil, fmt.Errorf("open Factory target runtime: %w", err)
+	}
+	runContext, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	active := &activatedRuntime{opened: opened, runContext: runContext, cancel: cancel}
+	err = opened.Lifecycle.StartLifecycle(ctx, runContext)
+	if err == nil {
+		active.stopWorker, err = opened.Lifecycle.StartWorkerLifecycle(ctx)
+	}
+	if err == nil {
+		err = opened.Lifecycle.CompleteStartup(ctx)
+	}
+	if err != nil {
+		s.logger.Error("failed to activate on-demand Factory target runtime",
+			zap.String("factoryTargetId", factoryTargetID), zap.Error(err))
+		return nil, errors.Join(fmt.Errorf("activate Factory target runtime: %w", err), active.close(ctx))
+	}
+	s.logger.Info("activated on-demand Factory target runtime", zap.String("factoryTargetId", factoryTargetID))
+	return active, nil
+}
+
+func (a *activatedRuntime) close(ctx context.Context) error {
+	cleanupContext := context.WithoutCancel(ctx)
+	var result error
+	if a.opened.Sessions != nil {
+		if err := a.opened.Sessions.CloseFactorySession(cleanupContext, factorysessions.DefaultSessionID); err != nil &&
+			!errors.Is(err, factorysessions.ErrSessionNotFound) {
+			result = errors.Join(result, err)
+		}
+	}
+	if a.stopWorker != nil {
+		result = errors.Join(result, a.stopWorker(cleanupContext))
+	}
+	if a.opened.Lifecycle != nil {
+		result = errors.Join(result, a.opened.Lifecycle.StopLifecycle(cleanupContext))
+	}
+	if a.cancel != nil {
+		a.cancel()
+	}
+	if a.opened.Lifecycle != nil {
+		if err := a.opened.Lifecycle.WaitForRuntime(cleanupContext); err != nil && !errors.Is(err, context.Canceled) {
+			result = errors.Join(result, err)
+		}
+	}
+	if a.opened.CloseArtifacts != nil {
+		result = errors.Join(result, a.opened.CloseArtifacts())
+	}
+	return result
+}
+
+// StartFactoryTarget opens (and keeps open) exactly one Factory target
+// runtime for this request's Source.FactoryID and Args["workingRoot"], then
+// dispatches the requested content on it.
+//
+// This dispatches through InvokeFactorySession, the same synchronous,
+// non-JavaScript-workflow-specific call the CLI's own one-shot named
+// invocation already uses successfully, rather than StartAsync/Source:
+// StartAsync's Source vocabulary (FACTORY_ID/FACTORY_INLINE/WORKFLOW_FILE/
+// WORKFLOW_NAME/INLINE_WORKFLOW) only resolves named JavaScript workflow
+// factories -- confirmed by reading
+// internal/services/orchestration/javascript/source/lookup.go, whose
+// FACTORY_ID case rejects any target that "is not a JavaScript workflow
+// factory" -- so it cannot start an ordinary packaged Factory the way this
+// service's already-resolved, already-opened runtime needs. Since
+// s.resolve/openActivatedRuntime already picked and opened the exact target
+// directory, this call needs no further source selection at all. The
+// returned InvocationResult is the real, unmodified published invocation
+// outcome -- terminal status and ordered primary-result text included --
+// except SessionID, which this service substitutes with its own generated
+// identity (never the opened runtime's shared internal constant session
+// identity) so a later InvokeFactoryTarget/CancelFactoryTarget/
+// CloseFactoryTarget call against the returned identity resolves back to
+// this exact runtime.
+func (s *Service) StartFactoryTarget(
+	ctx context.Context,
+	request factorysessions.StartRequest,
+) (factorysessions.InvocationResult, error) {
+	workingRoot, _ := request.Args["workingRoot"].(string)
+	config, err := s.resolve(ctx, request.Source.FactoryID, workingRoot)
+	if err != nil {
+		return factorysessions.InvocationResult{}, err
+	}
+	active, err := s.openActivatedRuntime(ctx, request.Source.FactoryID, workingRoot, config)
+	if err != nil {
+		return factorysessions.InvocationResult{}, err
+	}
+
+	content, _ := request.Args["content"].([]work.WorkContentPart)
+	requestID := request.RequestID
+	sourceKind := factorysessions.InvocationInputSourceKindText
+	result, err := active.opened.Sessions.InvokeFactorySession(ctx, factorysessions.DefaultSessionID, factorysessions.InvocationRequest{
+		Content:         content,
+		ContentProvided: true,
+		RequestID:       &requestID,
+		SourceKind:      &sourceKind,
+	})
+	if err != nil {
+		s.logger.Error("on-demand Factory target dispatch failed",
+			zap.String("factoryTargetId", request.Source.FactoryID), zap.Error(err))
+		return factorysessions.InvocationResult{}, errors.Join(err, active.close(ctx))
+	}
+
+	wrapperID := s.generateID()
+	s.mu.Lock()
+	s.runtimes[wrapperID] = active
+	s.mu.Unlock()
+	result.SessionID = wrapperID
+	s.logger.Info("on-demand Factory target dispatch completed",
+		zap.String("factoryTargetId", request.Source.FactoryID), zap.String("status", string(result.Status)))
+	return result, nil
+}
+
+func (s *Service) lookup(sessionID string) (*activatedRuntime, error) {
+	s.mu.Lock()
+	active, ok := s.runtimes[sessionID]
+	s.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", factorysessions.ErrSessionNotFound, sessionID)
+	}
+	return active, nil
+}
+
+// InvokeFactoryTarget synchronously invokes the exact runtime a prior
+// StartFactoryTarget call opened for sessionID.
+func (s *Service) InvokeFactoryTarget(
+	ctx context.Context,
+	sessionID string,
+	request factorysessions.InvocationRequest,
+) (factorysessions.InvocationResult, error) {
+	active, err := s.lookup(sessionID)
+	if err != nil {
+		return factorysessions.InvocationResult{}, err
+	}
+	result, err := active.opened.Sessions.InvokeFactorySession(ctx, factorysessions.DefaultSessionID, request)
+	if err != nil {
+		s.logger.Error("on-demand Factory target invoke failed", zap.Error(err))
+		return result, err
+	}
+	s.logger.Info("on-demand Factory target invoke completed", zap.String("status", string(result.Status)))
+	return result, nil
+}
+
+// CancelFactoryTarget cancels the exact runtime a prior StartFactoryTarget
+// call opened for sessionID.
+func (s *Service) CancelFactoryTarget(
+	ctx context.Context,
+	sessionID string,
+	request factorysessions.ControlRequest,
+) (factorysessions.LifecycleControlResult, error) {
+	active, err := s.lookup(sessionID)
+	if err != nil {
+		return factorysessions.LifecycleControlResult{}, err
+	}
+	return active.opened.Sessions.Cancel(ctx, factorysessions.DefaultSessionID, request)
+}
+
+// CloseFactoryTarget tears down and evicts the exact runtime a prior
+// StartFactoryTarget call opened for sessionID. Closing an unknown or
+// already-closed identity is a no-op success, matching the idempotent close
+// semantics factorysessions.Service.CloseFactorySession already documents.
+func (s *Service) CloseFactoryTarget(ctx context.Context, sessionID string) error {
+	s.mu.Lock()
+	active, ok := s.runtimes[sessionID]
+	if ok {
+		delete(s.runtimes, sessionID)
+	}
+	s.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	err := active.close(ctx)
+	if err != nil {
+		s.logger.Error("on-demand Factory target close failed", zap.Error(err))
+	} else {
+		s.logger.Info("on-demand Factory target closed")
+	}
+	return err
+}

--- a/pkg/services/factory_sessions/internal/ondemandtarget/service.go
+++ b/pkg/services/factory_sessions/internal/ondemandtarget/service.go
@@ -8,6 +8,18 @@
 // exposes it as a thin construction wrapper (matching how that package already
 // wraps runtimeopening.Factory as RuntimeOpeningFactory) so a caller outside
 // this service tree never imports this package directly.
+//
+// Service implements the full public factorysessions.Service interface (by
+// embedding it as a nil value and overriding only the handful of methods it
+// gives real behavior to -- StartAsync, InvokeFactorySession, Cancel,
+// CloseFactorySession -- the same "embed the interface, panic on anything
+// unimplemented" idiom this package's own tests already use for fakeSessions)
+// specifically so it can be handed, unmodified, to
+// chat_sessions/internal/factorysessionsshim.New: that existing,
+// consumer-owned shim is what the production ACP prompt-delegation consumer
+// actually calls, not this package's own methods directly. Every method
+// beyond those four is unreachable in production -- the shim never calls
+// them -- and exists only to satisfy the interface.
 package ondemandtarget
 
 import (
@@ -22,13 +34,17 @@ import (
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/roles"
 	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/runtimeopening"
-	"github.com/portpowered/infinite-you/pkg/services/work"
 )
 
 // Service satisfies io.Closer so a process lifecycle plan can register it as
 // a NamedResource (see pkg/initializer/lifecycle) whose Close tears down
 // every runtime it ever lazily activated.
 var _ io.Closer = (*Service)(nil)
+
+// Service also satisfies the full public factorysessions.Service so it can
+// be wrapped by the existing chat_sessions-owned factorysessionsshim.Shim
+// unmodified -- see this package's own doc comment.
+var _ factorysessions.Service = (*Service)(nil)
 
 // RuntimeResolver turns one canonical Factory target identity and editor
 // working root into the concrete Runtime Opening request that activating a
@@ -76,6 +92,14 @@ type invocationRuntimeOpener interface {
 // cached runtime (and the runtime's own DefaultSessionID) on every later
 // call. Callers must treat the returned identity as opaque.
 type Service struct {
+	// Service is embedded as a permanently nil interface value: every method
+	// this type does not itself override is satisfied only for the compiler
+	// (interface completeness), and panics if ever actually called. Only
+	// StartAsync, InvokeFactorySession, Cancel, and CloseFactorySession are
+	// overridden below -- the exact four methods
+	// chat_sessions/internal/factorysessionsshim.Shim forwards to.
+	factorysessions.Service
+
 	factory    invocationRuntimeOpener
 	effects    runtimeopening.ExternalEffects
 	resolve    RuntimeResolver
@@ -132,16 +156,21 @@ type activatedRuntime struct {
 func (s *Service) openActivatedRuntime(
 	ctx context.Context,
 	factoryTargetID string,
-	workingRoot string,
 	config factorysessions.RuntimeOpeningRequest,
 ) (*activatedRuntime, error) {
+	// Structured logs here carry only the Factory target identity (a
+	// catalog reference, not private topology) and bounded outcome
+	// classifications -- never workingRoot (the caller's editor filesystem
+	// path) and never a raw error via zap.Error, since an underlying
+	// runtime-opening or lifecycle failure can embed a resolved filesystem
+	// path in its own message text.
 	s.logger.Info("activating on-demand Factory target runtime",
-		zap.String("factoryTargetId", factoryTargetID), zap.String("workingRoot", workingRoot))
+		zap.String("factoryTargetId", factoryTargetID))
 
 	opened, err := s.factory.OpenInvocationRuntime(ctx, &config, s.effects, s.logger)
 	if err != nil {
 		s.logger.Error("failed to open on-demand Factory target runtime",
-			zap.String("factoryTargetId", factoryTargetID), zap.Error(err))
+			zap.String("factoryTargetId", factoryTargetID))
 		return nil, fmt.Errorf("open Factory target runtime: %w", err)
 	}
 	runContext, cancel := context.WithCancel(context.WithoutCancel(ctx))
@@ -155,7 +184,7 @@ func (s *Service) openActivatedRuntime(
 	}
 	if err != nil {
 		s.logger.Error("failed to activate on-demand Factory target runtime",
-			zap.String("factoryTargetId", factoryTargetID), zap.Error(err))
+			zap.String("factoryTargetId", factoryTargetID))
 		return nil, errors.Join(fmt.Errorf("activate Factory target runtime: %w", err), active.close(ctx))
 	}
 	s.logger.Info("activated on-demand Factory target runtime", zap.String("factoryTargetId", factoryTargetID))
@@ -191,66 +220,52 @@ func (a *activatedRuntime) close(ctx context.Context) error {
 	return result
 }
 
-// StartFactoryTarget opens (and keeps open) exactly one Factory target
-// runtime for this request's Source.FactoryID and Args["workingRoot"], then
-// dispatches the requested content on it.
-//
-// This dispatches through InvokeFactorySession, the same synchronous,
-// non-JavaScript-workflow-specific call the CLI's own one-shot named
-// invocation already uses successfully, rather than StartAsync/Source:
-// StartAsync's Source vocabulary (FACTORY_ID/FACTORY_INLINE/WORKFLOW_FILE/
-// WORKFLOW_NAME/INLINE_WORKFLOW) only resolves named JavaScript workflow
-// factories -- confirmed by reading
+// StartAsync opens (and keeps open) exactly one Factory target runtime for
+// this request's Source.FactoryID and Args["workingRoot"], but dispatches no
+// content: this on-demand activation has no fixed pre-opened runtime the way
+// the CLI daemon's StartAsync semantics assume, and StartAsync's own Source
+// vocabulary (FACTORY_ID/FACTORY_INLINE/WORKFLOW_FILE/WORKFLOW_NAME/
+// INLINE_WORKFLOW) only resolves named JavaScript workflow factories --
+// confirmed by reading
 // internal/services/orchestration/javascript/source/lookup.go, whose
 // FACTORY_ID case rejects any target that "is not a JavaScript workflow
-// factory" -- so it cannot start an ordinary packaged Factory the way this
-// service's already-resolved, already-opened runtime needs. Since
-// s.resolve/openActivatedRuntime already picked and opened the exact target
-// directory, this call needs no further source selection at all. The
-// returned InvocationResult is the real, unmodified published invocation
-// outcome -- terminal status and ordered primary-result text included --
-// except SessionID, which this service substitutes with its own generated
+// factory" -- so it cannot itself dispatch an ordinary packaged Factory the
+// way this service's caller needs. This method's own job is narrower and
+// honest about it: open the runtime and report it RUNNING with no
+// fabricated terminal outcome; a caller that wants the first turn's actual
+// published outcome (including text) makes a separate, immediate
+// InvokeFactorySession call against the returned SessionID -- the same
+// synchronous, non-JavaScript-workflow-specific call every later turn
+// already uses (see chat_sessions/internal/factorysessionsshim.Shim, whose
+// unmodified StartFactoryTarget/InvokeFactoryTarget map directly onto these
+// two methods). The returned SessionID is this service's own generated
 // identity (never the opened runtime's shared internal constant session
-// identity) so a later InvokeFactoryTarget/CancelFactoryTarget/
-// CloseFactoryTarget call against the returned identity resolves back to
-// this exact runtime.
-func (s *Service) StartFactoryTarget(
+// identity), so a later InvokeFactorySession/Cancel/CloseFactorySession call
+// against it resolves back to this exact runtime.
+func (s *Service) StartAsync(
 	ctx context.Context,
 	request factorysessions.StartRequest,
-) (factorysessions.InvocationResult, error) {
+) (factorysessions.AsyncStartResult, error) {
 	workingRoot, _ := request.Args["workingRoot"].(string)
 	config, err := s.resolve(ctx, request.Source.FactoryID, workingRoot)
 	if err != nil {
-		return factorysessions.InvocationResult{}, err
+		return factorysessions.AsyncStartResult{}, err
 	}
-	active, err := s.openActivatedRuntime(ctx, request.Source.FactoryID, workingRoot, config)
+	active, err := s.openActivatedRuntime(ctx, request.Source.FactoryID, config)
 	if err != nil {
-		return factorysessions.InvocationResult{}, err
-	}
-
-	content, _ := request.Args["content"].([]work.WorkContentPart)
-	requestID := request.RequestID
-	sourceKind := factorysessions.InvocationInputSourceKindText
-	result, err := active.opened.Sessions.InvokeFactorySession(ctx, factorysessions.DefaultSessionID, factorysessions.InvocationRequest{
-		Content:         content,
-		ContentProvided: true,
-		RequestID:       &requestID,
-		SourceKind:      &sourceKind,
-	})
-	if err != nil {
-		s.logger.Error("on-demand Factory target dispatch failed",
-			zap.String("factoryTargetId", request.Source.FactoryID), zap.Error(err))
-		return factorysessions.InvocationResult{}, errors.Join(err, active.close(ctx))
+		return factorysessions.AsyncStartResult{}, err
 	}
 
 	wrapperID := s.generateID()
 	s.mu.Lock()
 	s.runtimes[wrapperID] = active
 	s.mu.Unlock()
-	result.SessionID = wrapperID
-	s.logger.Info("on-demand Factory target dispatch completed",
-		zap.String("factoryTargetId", request.Source.FactoryID), zap.String("status", string(result.Status)))
-	return result, nil
+	s.logger.Info("on-demand Factory target runtime ready",
+		zap.String("factoryTargetId", request.Source.FactoryID))
+	return factorysessions.AsyncStartResult{
+		SessionID: wrapperID,
+		Status:    string(factorysessions.LifecycleStatusRunning),
+	}, nil
 }
 
 func (s *Service) lookup(sessionID string) (*activatedRuntime, error) {
@@ -263,9 +278,9 @@ func (s *Service) lookup(sessionID string) (*activatedRuntime, error) {
 	return active, nil
 }
 
-// InvokeFactoryTarget synchronously invokes the exact runtime a prior
-// StartFactoryTarget call opened for sessionID.
-func (s *Service) InvokeFactoryTarget(
+// InvokeFactorySession synchronously invokes the exact runtime a prior
+// StartAsync call opened for sessionID.
+func (s *Service) InvokeFactorySession(
 	ctx context.Context,
 	sessionID string,
 	request factorysessions.InvocationRequest,
@@ -276,16 +291,17 @@ func (s *Service) InvokeFactoryTarget(
 	}
 	result, err := active.opened.Sessions.InvokeFactorySession(ctx, factorysessions.DefaultSessionID, request)
 	if err != nil {
-		s.logger.Error("on-demand Factory target invoke failed", zap.Error(err))
+		s.logger.Error("on-demand Factory target invoke failed")
 		return result, err
 	}
+	result.SessionID = sessionID
 	s.logger.Info("on-demand Factory target invoke completed", zap.String("status", string(result.Status)))
 	return result, nil
 }
 
-// CancelFactoryTarget cancels the exact runtime a prior StartFactoryTarget
-// call opened for sessionID.
-func (s *Service) CancelFactoryTarget(
+// Cancel cancels the exact runtime a prior StartAsync call opened for
+// sessionID.
+func (s *Service) Cancel(
 	ctx context.Context,
 	sessionID string,
 	request factorysessions.ControlRequest,
@@ -297,11 +313,11 @@ func (s *Service) CancelFactoryTarget(
 	return active.opened.Sessions.Cancel(ctx, factorysessions.DefaultSessionID, request)
 }
 
-// CloseFactoryTarget tears down and evicts the exact runtime a prior
-// StartFactoryTarget call opened for sessionID. Closing an unknown or
-// already-closed identity is a no-op success, matching the idempotent close
-// semantics factorysessions.Service.CloseFactorySession already documents.
-func (s *Service) CloseFactoryTarget(ctx context.Context, sessionID string) error {
+// CloseFactorySession tears down and evicts the exact runtime a prior
+// StartAsync call opened for sessionID. Closing an unknown or already-closed
+// identity is a no-op success, matching the idempotent close semantics
+// factorysessions.Service.CloseFactorySession already documents.
+func (s *Service) CloseFactorySession(ctx context.Context, sessionID string) error {
 	s.mu.Lock()
 	active, ok := s.runtimes[sessionID]
 	if ok {
@@ -313,7 +329,7 @@ func (s *Service) CloseFactoryTarget(ctx context.Context, sessionID string) erro
 	}
 	err := active.close(ctx)
 	if err != nil {
-		s.logger.Error("on-demand Factory target close failed", zap.Error(err))
+		s.logger.Error("on-demand Factory target close failed")
 	} else {
 		s.logger.Info("on-demand Factory target closed")
 	}
@@ -326,9 +342,9 @@ func (s *Service) CloseFactoryTarget(ctx context.Context, sessionID string) erro
 // process lifecycle plan can register this Service as a reachable,
 // deterministic unwind step for every runtime it ever lazily activated,
 // instead of leaving them open for the life of the process; construction
-// alone opens no runtime, so calling Close before any StartFactoryTarget
-// call is a no-op success. Close is idempotent: a runtime evicted by this
-// call or by an earlier CloseFactoryTarget call is never closed twice.
+// alone opens no runtime, so calling Close before any StartAsync call is a
+// no-op success. Close is idempotent: a runtime evicted by this call or by
+// an earlier CloseFactorySession call is never closed twice.
 func (s *Service) Close() error {
 	s.mu.Lock()
 	active := make([]*activatedRuntime, 0, len(s.runtimes))
@@ -345,7 +361,7 @@ func (s *Service) Close() error {
 		}
 	}
 	if result != nil {
-		s.logger.Error("on-demand Factory target close-all failed", zap.Error(result))
+		s.logger.Error("on-demand Factory target close-all failed", zap.Int("runtimeCount", len(active)))
 	} else if len(active) > 0 {
 		s.logger.Info("on-demand Factory target close-all completed", zap.Int("runtimeCount", len(active)))
 	}

--- a/pkg/services/factory_sessions/internal/ondemandtarget/service_test.go
+++ b/pkg/services/factory_sessions/internal/ondemandtarget/service_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -138,6 +140,7 @@ func newTestService(t *testing.T, opener invocationRuntimeOpener, resolve Runtim
 		logger:            zap.NewNop(),
 		runtimes:          make(map[string]*activatedRuntime),
 		startsByRequestID: make(map[string]string),
+		pendingStarts:     make(map[string]*pendingStart),
 	}
 }
 
@@ -154,6 +157,7 @@ func newTestServiceWithObservedLogger(t *testing.T, opener invocationRuntimeOpen
 		logger:            zap.New(core),
 		runtimes:          make(map[string]*activatedRuntime),
 		startsByRequestID: make(map[string]string),
+		pendingStarts:     make(map[string]*pendingStart),
 	}, observed
 }
 
@@ -334,6 +338,230 @@ func TestStartAsyncPropagatesResolveFailure(t *testing.T) {
 	if len(opener.calls) != 0 {
 		t.Fatalf("OpenInvocationRuntime call count = %d, want 0 after a resolve failure", len(opener.calls))
 	}
+}
+
+// TestStartAsyncConcurrentSameRequestIDOpensExactlyOneRuntime proves that
+// genuinely concurrent StartAsync calls for the exact same non-blank
+// RequestID -- not the sequential-call convergence
+// TestStartAsyncSameRequestIDConvergesOnASingleActivation already covers --
+// still open exactly one runtime. resolve blocks on a channel the test
+// controls, so every goroutine that reaches StartAsync while the first is
+// still resolving is forced to either join the in-flight reservation or, if
+// it arrives even earlier, race for the reservation itself under s.mu; only
+// the one goroutine that wins the reservation ever calls resolve/open.
+func TestStartAsyncConcurrentSameRequestIDOpensExactlyOneRuntime(t *testing.T) {
+	sessions := &fakeSessions{}
+	opener := &fakeOpener{opened: roles.OpenedInvocationRuntime{
+		Sessions:  sessions,
+		Lifecycle: &fakeLifecycle{},
+	}}
+	release := make(chan struct{})
+	var resolveCalls int32
+	resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
+		atomic.AddInt32(&resolveCalls, 1)
+		<-release
+		return factorysessions.RuntimeOpeningRequest{}, nil
+	}
+	svc := newTestService(t, opener, resolve, sequentialIDs("wrapper"))
+
+	req := factorysessions.StartRequest{
+		RequestID: "session-1/episode/1",
+		Source:    factorysessions.Source{FactoryID: "@you/review"},
+	}
+
+	const callers = 8
+	results := make([]factorysessions.AsyncStartResult, callers)
+	errs := make([]error, callers)
+	var start sync.WaitGroup
+	start.Add(1)
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for i := range callers {
+		go func(i int) {
+			defer wg.Done()
+			start.Wait()
+			results[i], errs[i] = svc.StartAsync(context.Background(), req)
+		}(i)
+	}
+	start.Done()
+	// Give the goroutines that don't win the reservation a chance to reach
+	// the join-and-wait path before releasing the one real activation.
+	time.Sleep(20 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("StartAsync()[%d] error = %v", i, err)
+		}
+	}
+	if got := atomic.LoadInt32(&resolveCalls); got != 1 {
+		t.Fatalf("resolve call count = %d, want exactly 1 across %d concurrent callers sharing one RequestID", got, callers)
+	}
+	if len(opener.calls) != 1 {
+		t.Fatalf("OpenInvocationRuntime call count = %d, want exactly 1", len(opener.calls))
+	}
+	first := results[0].SessionID
+	if first == "" {
+		t.Fatalf("SessionID[0] is blank, want the generated wrapper identity")
+	}
+	for i, r := range results {
+		if r.SessionID != first {
+			t.Fatalf("SessionID[%d] = %q, want the identical converged identity %q", i, r.SessionID, first)
+		}
+	}
+}
+
+// TestStartAsyncBlankGeneratedIdentityFailsWithoutPublishing proves that a
+// blank value from generateID fails StartAsync, closes the runtime it had
+// already opened, and leaves an unrelated prior activation addressable under
+// its own identity -- rather than publishing an empty map key that a later
+// caller could never look up.
+func TestStartAsyncBlankGeneratedIdentityFailsWithoutPublishing(t *testing.T) {
+	sessions := &fakeSessions{}
+	priorLifecycle := &fakeLifecycle{}
+	priorSessions := &fakeSessions{}
+	failingLifecycle := &fakeLifecycle{}
+	opener := &sequencedOpener{
+		results: []openResult{
+			{opened: roles.OpenedInvocationRuntime{Sessions: priorSessions, Lifecycle: priorLifecycle}},
+			{opened: roles.OpenedInvocationRuntime{Sessions: sessions, Lifecycle: failingLifecycle}},
+		},
+	}
+	resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
+		return factorysessions.RuntimeOpeningRequest{}, nil
+	}
+	ids := []string{"wrapper-prior", ""}
+	n := 0
+	generateID := func() string {
+		id := ids[n]
+		n++
+		return id
+	}
+	svc := newTestService(t, opener, resolve, generateID)
+
+	prior, err := svc.StartAsync(context.Background(), factorysessions.StartRequest{
+		RequestID: "req-prior",
+		Source:    factorysessions.Source{FactoryID: "@you/review"},
+	})
+	if err != nil {
+		t.Fatalf("prior StartAsync() error = %v", err)
+	}
+
+	_, err = svc.StartAsync(context.Background(), factorysessions.StartRequest{
+		RequestID: "req-blank",
+		Source:    factorysessions.Source{FactoryID: "@you/review"},
+	})
+	if err == nil {
+		t.Fatalf("StartAsync() with a blank generated identity error = nil, want an error")
+	}
+	if failingLifecycle.stopCalls != 1 {
+		t.Fatalf("failing activation StopLifecycle calls = %d, want exactly 1 (closed once)", failingLifecycle.stopCalls)
+	}
+	if priorLifecycle.stopCalls != 0 {
+		t.Fatalf("prior activation StopLifecycle calls = %d, want 0 -- it must remain open", priorLifecycle.stopCalls)
+	}
+
+	again, err := svc.InvokeFactorySession(context.Background(), prior.SessionID, factorysessions.InvocationRequest{})
+	if err != nil {
+		t.Fatalf("InvokeFactorySession() on the prior activation error = %v, want it to remain addressable", err)
+	}
+	if len(priorSessions.invokeCalls) != 1 {
+		t.Fatalf("prior activation invoke calls = %v, want exactly one dispatch to the untouched prior runtime", priorSessions.invokeCalls)
+	}
+	_ = again
+}
+
+// TestStartAsyncCollidingGeneratedIdentityFailsWithoutOverwriting proves that
+// a generated wrapper identity colliding with an already-tracked one --
+// across two entirely distinct requests, not a retry of the same one --
+// fails StartAsync, closes the newly opened runtime, and leaves the original
+// activation's map entry (and therefore ownership) untouched rather than
+// letting the second request silently redirect callers of the first
+// request's SessionID to the second request's runtime.
+func TestStartAsyncCollidingGeneratedIdentityFailsWithoutOverwriting(t *testing.T) {
+	firstSessions := &fakeSessions{}
+	firstLifecycle := &fakeLifecycle{}
+	secondSessions := &fakeSessions{}
+	secondLifecycle := &fakeLifecycle{}
+	opener := &sequencedOpener{
+		results: []openResult{
+			{opened: roles.OpenedInvocationRuntime{Sessions: firstSessions, Lifecycle: firstLifecycle}},
+			{opened: roles.OpenedInvocationRuntime{Sessions: secondSessions, Lifecycle: secondLifecycle}},
+		},
+	}
+	resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
+		return factorysessions.RuntimeOpeningRequest{}, nil
+	}
+	generateID := func() string { return "wrapper-collide" }
+	svc := newTestService(t, opener, resolve, generateID)
+
+	first, err := svc.StartAsync(context.Background(), factorysessions.StartRequest{
+		RequestID: "req-first",
+		Source:    factorysessions.Source{FactoryID: "@you/review"},
+	})
+	if err != nil {
+		t.Fatalf("first StartAsync() error = %v", err)
+	}
+	if first.SessionID != "wrapper-collide" {
+		t.Fatalf("first.SessionID = %q, want the generated identity", first.SessionID)
+	}
+
+	_, err = svc.StartAsync(context.Background(), factorysessions.StartRequest{
+		RequestID: "req-second",
+		Source:    factorysessions.Source{FactoryID: "@you/review"},
+	})
+	if err == nil {
+		t.Fatalf("second StartAsync() with a colliding generated identity error = nil, want an error")
+	}
+	if secondLifecycle.stopCalls != 1 {
+		t.Fatalf("colliding activation StopLifecycle calls = %d, want exactly 1 (closed once)", secondLifecycle.stopCalls)
+	}
+	if firstLifecycle.stopCalls != 0 {
+		t.Fatalf("original activation StopLifecycle calls = %d, want 0 -- it must remain open", firstLifecycle.stopCalls)
+	}
+
+	if _, err := svc.InvokeFactorySession(context.Background(), first.SessionID, factorysessions.InvocationRequest{}); err != nil {
+		t.Fatalf("InvokeFactorySession() on the original activation error = %v, want it to still resolve to the original runtime", err)
+	}
+	if len(firstSessions.invokeCalls) != 1 {
+		t.Fatalf("original activation invoke calls = %v, want exactly one dispatch to the untouched original runtime", firstSessions.invokeCalls)
+	}
+	if len(secondSessions.invokeCalls) != 0 {
+		t.Fatalf("colliding activation invoke calls = %v, want zero -- it was never published", secondSessions.invokeCalls)
+	}
+}
+
+// openResult is one fakeOpener call's canned outcome.
+type openResult struct {
+	opened roles.OpenedInvocationRuntime
+	err    error
+}
+
+// sequencedOpener is an invocationRuntimeOpener test double that returns a
+// distinct result for each successive OpenInvocationRuntime call, in order --
+// letting a test drive two calls that must return two independently
+// closeable runtimes instead of fakeOpener's single fixed result.
+type sequencedOpener struct {
+	mu      sync.Mutex
+	results []openResult
+	calls   []factorysessions.RuntimeOpeningRequest
+}
+
+func (f *sequencedOpener) OpenInvocationRuntime(
+	_ context.Context,
+	request *factorysessions.RuntimeOpeningRequest,
+	_ runtimeopening.ExternalEffects,
+	_ *zap.Logger,
+) (roles.OpenedInvocationRuntime, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, *request)
+	idx := len(f.calls) - 1
+	if idx >= len(f.results) {
+		return roles.OpenedInvocationRuntime{}, fmt.Errorf("sequencedOpener: no result configured for call %d", idx)
+	}
+	return f.results[idx].opened, f.results[idx].err
 }
 
 // TestInvokeFactorySessionReusesTheCachedRuntime proves InvokeFactorySession

--- a/pkg/services/factory_sessions/internal/ondemandtarget/service_test.go
+++ b/pkg/services/factory_sessions/internal/ondemandtarget/service_test.go
@@ -1,0 +1,360 @@
+package ondemandtarget
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/roles"
+	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/runtimeopening"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+)
+
+// fakeOpener is a minimal invocationRuntimeOpener test double: it records
+// every call and returns a fixed opened runtime/error, letting these tests
+// exercise Service without constructing *runtimeopening.Factory's own large
+// production dependency graph.
+type fakeOpener struct {
+	calls  []factorysessions.RuntimeOpeningRequest
+	opened roles.OpenedInvocationRuntime
+	err    error
+}
+
+func (f *fakeOpener) OpenInvocationRuntime(
+	_ context.Context,
+	request *factorysessions.RuntimeOpeningRequest,
+	_ runtimeopening.ExternalEffects,
+	_ *zap.Logger,
+) (roles.OpenedInvocationRuntime, error) {
+	f.calls = append(f.calls, *request)
+	if f.err != nil {
+		return roles.OpenedInvocationRuntime{}, f.err
+	}
+	return f.opened, nil
+}
+
+// fakeLifecycle is a minimal roles.LifecycleRuntime test double: every
+// method succeeds as a no-op unless a field is set to force a failure.
+type fakeLifecycle struct {
+	mu sync.Mutex
+
+	startErr         error
+	startWorkerErr   error
+	completeErr      error
+	stopCalls        int
+	waitCalls        int
+	stopWorkerCalled bool
+}
+
+func (f *fakeLifecycle) StartLifecycle(context.Context, context.Context) error { return f.startErr }
+func (f *fakeLifecycle) StartWorkerLifecycle(context.Context) (factorysessions.RuntimeStop, error) {
+	if f.startWorkerErr != nil {
+		return nil, f.startWorkerErr
+	}
+	return func(context.Context) error {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.stopWorkerCalled = true
+		return nil
+	}, nil
+}
+func (f *fakeLifecycle) CompleteStartup(context.Context) error { return f.completeErr }
+func (f *fakeLifecycle) WaitForRuntime(context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.waitCalls++
+	return nil
+}
+func (f *fakeLifecycle) StopLifecycle(context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stopCalls++
+	return nil
+}
+func (f *fakeLifecycle) FailStartup(err error) error { return err }
+func (f *fakeLifecycle) CurrentRuntimeBundle() factoryruntime.HostedInstance {
+	return nil
+}
+
+// fakeSessions is a minimal factorysessions.Service test double: it embeds
+// the interface unimplemented so any call beyond
+// Invoke/Cancel/CloseFactorySession this package's Service actually uses
+// reaches a nil method value and panics, proving no other capability is
+// dispatched to.
+type fakeSessions struct {
+	factorysessions.Service
+
+	mu sync.Mutex
+
+	invokeCalls  []string
+	invokeResult factorysessions.InvocationResult
+	invokeErr    error
+
+	cancelCalls []string
+
+	closeCalls []string
+	closeErr   error
+}
+
+func (f *fakeSessions) InvokeFactorySession(
+	_ context.Context, sessionID string, _ factorysessions.InvocationRequest,
+) (factorysessions.InvocationResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.invokeCalls = append(f.invokeCalls, sessionID)
+	return f.invokeResult, f.invokeErr
+}
+
+func (f *fakeSessions) Cancel(
+	_ context.Context, sessionID string, _ factorysessions.ControlRequest,
+) (factorysessions.LifecycleControlResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cancelCalls = append(f.cancelCalls, sessionID)
+	return factorysessions.LifecycleControlResult{}, nil
+}
+
+func (f *fakeSessions) CloseFactorySession(_ context.Context, sessionID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closeCalls = append(f.closeCalls, sessionID)
+	return f.closeErr
+}
+
+func newTestService(t *testing.T, opener *fakeOpener, resolve RuntimeResolver, generateID factorysessions.SessionIDGenerator) *Service {
+	t.Helper()
+	return &Service{
+		factory:    opener,
+		resolve:    resolve,
+		generateID: generateID,
+		logger:     zap.NewNop(),
+		runtimes:   make(map[string]*activatedRuntime),
+	}
+}
+
+func sequentialIDs(prefix string) func() string {
+	n := 0
+	return func() string {
+		n++
+		return prefix + "-" + string(rune('0'+n))
+	}
+}
+
+func TestNewRejectsMissingRequiredDependencies(t *testing.T) {
+	factory := &runtimeopening.Factory{}
+	resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
+		return factorysessions.RuntimeOpeningRequest{}, nil
+	}
+	generateID := func() string { return "id" }
+	logger := zap.NewNop()
+
+	tests := []struct {
+		name       string
+		factory    *runtimeopening.Factory
+		resolve    RuntimeResolver
+		generateID factorysessions.SessionIDGenerator
+		logger     *zap.Logger
+	}{
+		{"missing factory", nil, resolve, generateID, logger},
+		{"missing resolve", factory, nil, generateID, logger},
+		{"missing generateID", factory, resolve, nil, logger},
+		{"missing logger", factory, resolve, generateID, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := New(tt.factory, runtimeopening.ExternalEffects{}, tt.resolve, tt.generateID, tt.logger); err == nil {
+				t.Fatal("New() error = nil, want a construction error")
+			}
+		})
+	}
+}
+
+// TestStartFactoryTargetSubstitutesGeneratedIdentity proves a successful
+// start resolves the target, opens exactly one runtime, dispatches the
+// request's content synchronously, and returns the real published
+// InvocationResult with SessionID substituted for this service's own
+// generated identity (never the runtime's shared internal constant).
+func TestStartFactoryTargetSubstitutesGeneratedIdentity(t *testing.T) {
+	sessions := &fakeSessions{invokeResult: factorysessions.InvocationResult{
+		Status: factorysessions.InvocationTerminalStatusCompleted,
+		PrimaryResult: []work.WorkContentPart{
+			{Type: work.WorkContentPartTypeText, Text: "hello"},
+		},
+	}}
+	opener := &fakeOpener{opened: roles.OpenedInvocationRuntime{
+		Sessions:  sessions,
+		Lifecycle: &fakeLifecycle{},
+	}}
+	var resolveCalls []string
+	resolve := func(_ context.Context, factoryTargetID, workingRoot string) (factorysessions.RuntimeOpeningRequest, error) {
+		resolveCalls = append(resolveCalls, factoryTargetID+"|"+workingRoot)
+		return factorysessions.RuntimeOpeningRequest{}, nil
+	}
+	svc := newTestService(t, opener, resolve, sequentialIDs("wrapper"))
+
+	result, err := svc.StartFactoryTarget(context.Background(), factorysessions.StartRequest{
+		RequestID: "req-1",
+		Source:    factorysessions.Source{FactoryID: "@you/review"},
+		Args:      map[string]any{"workingRoot": "/work/project", "content": []work.WorkContentPart{{Type: work.WorkContentPartTypeText, Text: "hi"}}},
+	})
+	if err != nil {
+		t.Fatalf("StartFactoryTarget() error = %v", err)
+	}
+	if len(resolveCalls) != 1 || resolveCalls[0] != "@you/review|/work/project" {
+		t.Fatalf("resolve calls = %v, want exactly one call for @you/review|/work/project", resolveCalls)
+	}
+	if len(opener.calls) != 1 {
+		t.Fatalf("OpenInvocationRuntime call count = %d, want exactly 1", len(opener.calls))
+	}
+	if len(sessions.invokeCalls) != 1 || sessions.invokeCalls[0] != factorysessions.DefaultSessionID {
+		t.Fatalf("InvokeFactorySession calls = %v, want exactly one call against DefaultSessionID", sessions.invokeCalls)
+	}
+	if result.SessionID != "wrapper-1" {
+		t.Fatalf("result.SessionID = %q, want the generated wrapper identity", result.SessionID)
+	}
+	if result.Status != factorysessions.InvocationTerminalStatusCompleted {
+		t.Fatalf("result.Status = %q, want the real published status", result.Status)
+	}
+	if len(result.PrimaryResult) != 1 || result.PrimaryResult[0].Text != "hello" {
+		t.Fatalf("result.PrimaryResult = %+v, want the real published primary result preserved", result.PrimaryResult)
+	}
+}
+
+// TestStartFactoryTargetPropagatesResolveFailure proves a resolver failure
+// opens no runtime.
+func TestStartFactoryTargetPropagatesResolveFailure(t *testing.T) {
+	opener := &fakeOpener{}
+	resolveErr := errors.New("resolve boom")
+	resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
+		return factorysessions.RuntimeOpeningRequest{}, resolveErr
+	}
+	svc := newTestService(t, opener, resolve, sequentialIDs("wrapper"))
+
+	_, err := svc.StartFactoryTarget(context.Background(), factorysessions.StartRequest{})
+	if !errors.Is(err, resolveErr) {
+		t.Fatalf("StartFactoryTarget() error = %v, want %v", err, resolveErr)
+	}
+	if len(opener.calls) != 0 {
+		t.Fatalf("OpenInvocationRuntime call count = %d, want 0 after a resolve failure", len(opener.calls))
+	}
+}
+
+// TestStartFactoryTargetDispatchFailureClosesTheJustOpenedRuntime proves a
+// synchronous dispatch failure after a successful open still tears down the
+// just-opened runtime (StopLifecycle/WaitForRuntime observed) rather than
+// leaking it, and never caches an identity for it.
+func TestStartFactoryTargetDispatchFailureClosesTheJustOpenedRuntime(t *testing.T) {
+	sessions := &fakeSessions{invokeErr: errors.New("dispatch boom")}
+	lifecycle := &fakeLifecycle{}
+	opener := &fakeOpener{opened: roles.OpenedInvocationRuntime{Sessions: sessions, Lifecycle: lifecycle}}
+	resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
+		return factorysessions.RuntimeOpeningRequest{}, nil
+	}
+	svc := newTestService(t, opener, resolve, sequentialIDs("wrapper"))
+
+	_, err := svc.StartFactoryTarget(context.Background(), factorysessions.StartRequest{})
+	if err == nil {
+		t.Fatal("StartFactoryTarget() error = nil, want the dispatch failure")
+	}
+	if lifecycle.stopCalls != 1 {
+		t.Fatalf("StopLifecycle call count = %d, want exactly 1 (compensating close)", lifecycle.stopCalls)
+	}
+	if len(sessions.closeCalls) != 1 {
+		t.Fatalf("CloseFactorySession call count = %d, want exactly 1 (compensating close)", len(sessions.closeCalls))
+	}
+	svc.mu.Lock()
+	runtimeCount := len(svc.runtimes)
+	svc.mu.Unlock()
+	if runtimeCount != 0 {
+		t.Fatalf("cached runtime count = %d, want 0 after a dispatch failure", runtimeCount)
+	}
+}
+
+// TestInvokeFactoryTargetReusesTheCachedRuntime proves a later
+// InvokeFactoryTarget call against a previously started identity dispatches
+// against the exact cached runtime's DefaultSessionID without opening a
+// second runtime.
+func TestInvokeFactoryTargetReusesTheCachedRuntime(t *testing.T) {
+	sessions := &fakeSessions{invokeResult: factorysessions.InvocationResult{Status: factorysessions.InvocationTerminalStatusCompleted}}
+	opener := &fakeOpener{opened: roles.OpenedInvocationRuntime{Sessions: sessions, Lifecycle: &fakeLifecycle{}}}
+	resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
+		return factorysessions.RuntimeOpeningRequest{}, nil
+	}
+	svc := newTestService(t, opener, resolve, sequentialIDs("wrapper"))
+
+	started, err := svc.StartFactoryTarget(context.Background(), factorysessions.StartRequest{})
+	if err != nil {
+		t.Fatalf("StartFactoryTarget() error = %v", err)
+	}
+
+	if _, err := svc.InvokeFactoryTarget(context.Background(), started.SessionID, factorysessions.InvocationRequest{}); err != nil {
+		t.Fatalf("InvokeFactoryTarget() error = %v", err)
+	}
+
+	if len(opener.calls) != 1 {
+		t.Fatalf("OpenInvocationRuntime call count = %d, want exactly 1 (no second open)", len(opener.calls))
+	}
+	if len(sessions.invokeCalls) != 2 {
+		t.Fatalf("InvokeFactorySession call count = %d, want exactly 2 (start's dispatch + the later invoke)", len(sessions.invokeCalls))
+	}
+	for _, sessionID := range sessions.invokeCalls {
+		if sessionID != factorysessions.DefaultSessionID {
+			t.Fatalf("InvokeFactorySession sessionID = %q, want the runtime's own DefaultSessionID", sessionID)
+		}
+	}
+}
+
+// TestInvokeFactoryTargetUnknownIdentityReportsSessionNotFound proves an
+// identity this service never started reports ErrSessionNotFound.
+func TestInvokeFactoryTargetUnknownIdentityReportsSessionNotFound(t *testing.T) {
+	svc := newTestService(t, &fakeOpener{}, nil, sequentialIDs("wrapper"))
+	_, err := svc.InvokeFactoryTarget(context.Background(), "unknown", factorysessions.InvocationRequest{})
+	if !errors.Is(err, factorysessions.ErrSessionNotFound) {
+		t.Fatalf("InvokeFactoryTarget() error = %v, want ErrSessionNotFound", err)
+	}
+}
+
+// TestCloseFactoryTargetTearsDownAndEvicts proves a close call tears down
+// the cached runtime and evicts it, so a later call against the same
+// identity reports ErrSessionNotFound instead of reusing a torn-down runtime.
+func TestCloseFactoryTargetTearsDownAndEvicts(t *testing.T) {
+	sessions := &fakeSessions{invokeResult: factorysessions.InvocationResult{Status: factorysessions.InvocationTerminalStatusCompleted}}
+	lifecycle := &fakeLifecycle{}
+	opener := &fakeOpener{opened: roles.OpenedInvocationRuntime{Sessions: sessions, Lifecycle: lifecycle}}
+	resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
+		return factorysessions.RuntimeOpeningRequest{}, nil
+	}
+	svc := newTestService(t, opener, resolve, sequentialIDs("wrapper"))
+
+	started, err := svc.StartFactoryTarget(context.Background(), factorysessions.StartRequest{})
+	if err != nil {
+		t.Fatalf("StartFactoryTarget() error = %v", err)
+	}
+
+	if err := svc.CloseFactoryTarget(context.Background(), started.SessionID); err != nil {
+		t.Fatalf("CloseFactoryTarget() error = %v", err)
+	}
+	if lifecycle.stopCalls != 1 {
+		t.Fatalf("StopLifecycle call count = %d, want exactly 1", lifecycle.stopCalls)
+	}
+
+	if _, err := svc.InvokeFactoryTarget(context.Background(), started.SessionID, factorysessions.InvocationRequest{}); !errors.Is(err, factorysessions.ErrSessionNotFound) {
+		t.Fatalf("InvokeFactoryTarget() after close error = %v, want ErrSessionNotFound", err)
+	}
+}
+
+// TestCloseFactoryTargetUnknownIdentityIsNoOpSuccess proves closing an
+// unknown or already-closed identity succeeds without effect, matching
+// factorysessions.Service.CloseFactorySession's documented idempotent
+// close semantics.
+func TestCloseFactoryTargetUnknownIdentityIsNoOpSuccess(t *testing.T) {
+	svc := newTestService(t, &fakeOpener{}, nil, sequentialIDs("wrapper"))
+	if err := svc.CloseFactoryTarget(context.Background(), "unknown"); err != nil {
+		t.Fatalf("CloseFactoryTarget() error = %v, want nil for an unknown identity", err)
+	}
+}

--- a/pkg/services/factory_sessions/internal/ondemandtarget/service_test.go
+++ b/pkg/services/factory_sessions/internal/ondemandtarget/service_test.go
@@ -3,16 +3,19 @@ package ondemandtarget
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/roles"
 	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/runtimeopening"
-	"github.com/portpowered/infinite-you/pkg/services/work"
 )
 
 // fakeOpener is a minimal invocationRuntimeOpener test double: it records
@@ -137,6 +140,21 @@ func newTestService(t *testing.T, opener invocationRuntimeOpener, resolve Runtim
 	}
 }
 
+// newTestServiceWithObservedLogger is newTestService, but with a real,
+// observable logger (instead of a no-op one) for tests that assert on what
+// this Service actually logs.
+func newTestServiceWithObservedLogger(t *testing.T, opener invocationRuntimeOpener, resolve RuntimeResolver, generateID factorysessions.SessionIDGenerator) (*Service, *observer.ObservedLogs) {
+	t.Helper()
+	core, observed := observer.New(zapcore.DebugLevel)
+	return &Service{
+		factory:    opener,
+		resolve:    resolve,
+		generateID: generateID,
+		logger:     zap.New(core),
+		runtimes:   make(map[string]*activatedRuntime),
+	}, observed
+}
+
 func sequentialIDs(prefix string) func() string {
 	n := 0
 	return func() string {
@@ -174,18 +192,15 @@ func TestNewRejectsMissingRequiredDependencies(t *testing.T) {
 	}
 }
 
-// TestStartFactoryTargetSubstitutesGeneratedIdentity proves a successful
-// start resolves the target, opens exactly one runtime, dispatches the
-// request's content synchronously, and returns the real published
-// InvocationResult with SessionID substituted for this service's own
-// generated identity (never the runtime's shared internal constant).
-func TestStartFactoryTargetSubstitutesGeneratedIdentity(t *testing.T) {
-	sessions := &fakeSessions{invokeResult: factorysessions.InvocationResult{
-		Status: factorysessions.InvocationTerminalStatusCompleted,
-		PrimaryResult: []work.WorkContentPart{
-			{Type: work.WorkContentPartTypeText, Text: "hello"},
-		},
-	}}
+// TestStartAsyncOpensRuntimeAndReturnsGeneratedIdentity proves a successful
+// StartAsync resolves the target, opens exactly one runtime, dispatches
+// nothing (a caller dispatches this turn's content separately, via
+// InvokeFactorySession against the returned identity -- see this method's
+// own doc comment), and returns AsyncStartResult carrying this service's own
+// generated identity (never the runtime's shared internal constant) and a
+// non-terminal RUNNING status.
+func TestStartAsyncOpensRuntimeAndReturnsGeneratedIdentity(t *testing.T) {
+	sessions := &fakeSessions{}
 	opener := &fakeOpener{opened: roles.OpenedInvocationRuntime{
 		Sessions:  sessions,
 		Lifecycle: &fakeLifecycle{},
@@ -197,13 +212,13 @@ func TestStartFactoryTargetSubstitutesGeneratedIdentity(t *testing.T) {
 	}
 	svc := newTestService(t, opener, resolve, sequentialIDs("wrapper"))
 
-	result, err := svc.StartFactoryTarget(context.Background(), factorysessions.StartRequest{
+	result, err := svc.StartAsync(context.Background(), factorysessions.StartRequest{
 		RequestID: "req-1",
 		Source:    factorysessions.Source{FactoryID: "@you/review"},
-		Args:      map[string]any{"workingRoot": "/work/project", "content": []work.WorkContentPart{{Type: work.WorkContentPartTypeText, Text: "hi"}}},
+		Args:      map[string]any{"workingRoot": "/work/project"},
 	})
 	if err != nil {
-		t.Fatalf("StartFactoryTarget() error = %v", err)
+		t.Fatalf("StartAsync() error = %v", err)
 	}
 	if len(resolveCalls) != 1 || resolveCalls[0] != "@you/review|/work/project" {
 		t.Fatalf("resolve calls = %v, want exactly one call for @you/review|/work/project", resolveCalls)
@@ -211,23 +226,20 @@ func TestStartFactoryTargetSubstitutesGeneratedIdentity(t *testing.T) {
 	if len(opener.calls) != 1 {
 		t.Fatalf("OpenInvocationRuntime call count = %d, want exactly 1", len(opener.calls))
 	}
-	if len(sessions.invokeCalls) != 1 || sessions.invokeCalls[0] != factorysessions.DefaultSessionID {
-		t.Fatalf("InvokeFactorySession calls = %v, want exactly one call against DefaultSessionID", sessions.invokeCalls)
+	if len(sessions.invokeCalls) != 0 {
+		t.Fatalf("InvokeFactorySession calls = %v, want zero -- StartAsync dispatches nothing", sessions.invokeCalls)
 	}
 	if result.SessionID != "wrapper-1" {
 		t.Fatalf("result.SessionID = %q, want the generated wrapper identity", result.SessionID)
 	}
-	if result.Status != factorysessions.InvocationTerminalStatusCompleted {
-		t.Fatalf("result.Status = %q, want the real published status", result.Status)
-	}
-	if len(result.PrimaryResult) != 1 || result.PrimaryResult[0].Text != "hello" {
-		t.Fatalf("result.PrimaryResult = %+v, want the real published primary result preserved", result.PrimaryResult)
+	if result.Status != string(factorysessions.LifecycleStatusRunning) {
+		t.Fatalf("result.Status = %q, want RUNNING (a fresh open, no terminal outcome yet)", result.Status)
 	}
 }
 
-// TestStartFactoryTargetPropagatesResolveFailure proves a resolver failure
-// opens no runtime.
-func TestStartFactoryTargetPropagatesResolveFailure(t *testing.T) {
+// TestStartAsyncPropagatesResolveFailure proves a resolver failure opens no
+// runtime.
+func TestStartAsyncPropagatesResolveFailure(t *testing.T) {
 	opener := &fakeOpener{}
 	resolveErr := errors.New("resolve boom")
 	resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
@@ -235,51 +247,21 @@ func TestStartFactoryTargetPropagatesResolveFailure(t *testing.T) {
 	}
 	svc := newTestService(t, opener, resolve, sequentialIDs("wrapper"))
 
-	_, err := svc.StartFactoryTarget(context.Background(), factorysessions.StartRequest{})
+	_, err := svc.StartAsync(context.Background(), factorysessions.StartRequest{})
 	if !errors.Is(err, resolveErr) {
-		t.Fatalf("StartFactoryTarget() error = %v, want %v", err, resolveErr)
+		t.Fatalf("StartAsync() error = %v, want %v", err, resolveErr)
 	}
 	if len(opener.calls) != 0 {
 		t.Fatalf("OpenInvocationRuntime call count = %d, want 0 after a resolve failure", len(opener.calls))
 	}
 }
 
-// TestStartFactoryTargetDispatchFailureClosesTheJustOpenedRuntime proves a
-// synchronous dispatch failure after a successful open still tears down the
-// just-opened runtime (StopLifecycle/WaitForRuntime observed) rather than
-// leaking it, and never caches an identity for it.
-func TestStartFactoryTargetDispatchFailureClosesTheJustOpenedRuntime(t *testing.T) {
-	sessions := &fakeSessions{invokeErr: errors.New("dispatch boom")}
-	lifecycle := &fakeLifecycle{}
-	opener := &fakeOpener{opened: roles.OpenedInvocationRuntime{Sessions: sessions, Lifecycle: lifecycle}}
-	resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
-		return factorysessions.RuntimeOpeningRequest{}, nil
-	}
-	svc := newTestService(t, opener, resolve, sequentialIDs("wrapper"))
-
-	_, err := svc.StartFactoryTarget(context.Background(), factorysessions.StartRequest{})
-	if err == nil {
-		t.Fatal("StartFactoryTarget() error = nil, want the dispatch failure")
-	}
-	if lifecycle.stopCalls != 1 {
-		t.Fatalf("StopLifecycle call count = %d, want exactly 1 (compensating close)", lifecycle.stopCalls)
-	}
-	if len(sessions.closeCalls) != 1 {
-		t.Fatalf("CloseFactorySession call count = %d, want exactly 1 (compensating close)", len(sessions.closeCalls))
-	}
-	svc.mu.Lock()
-	runtimeCount := len(svc.runtimes)
-	svc.mu.Unlock()
-	if runtimeCount != 0 {
-		t.Fatalf("cached runtime count = %d, want 0 after a dispatch failure", runtimeCount)
-	}
-}
-
-// TestInvokeFactoryTargetReusesTheCachedRuntime proves a later
-// InvokeFactoryTarget call against a previously started identity dispatches
-// against the exact cached runtime's DefaultSessionID without opening a
-// second runtime.
-func TestInvokeFactoryTargetReusesTheCachedRuntime(t *testing.T) {
+// TestInvokeFactorySessionReusesTheCachedRuntime proves InvokeFactorySession
+// calls against a previously started identity dispatch against the exact
+// cached runtime's DefaultSessionID without opening a second runtime, and
+// substitute the result's SessionID with the caller-facing generated
+// identity rather than leaking the runtime's own shared internal constant.
+func TestInvokeFactorySessionReusesTheCachedRuntime(t *testing.T) {
 	sessions := &fakeSessions{invokeResult: factorysessions.InvocationResult{Status: factorysessions.InvocationTerminalStatusCompleted}}
 	opener := &fakeOpener{opened: roles.OpenedInvocationRuntime{Sessions: sessions, Lifecycle: &fakeLifecycle{}}}
 	resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
@@ -287,20 +269,27 @@ func TestInvokeFactoryTargetReusesTheCachedRuntime(t *testing.T) {
 	}
 	svc := newTestService(t, opener, resolve, sequentialIDs("wrapper"))
 
-	started, err := svc.StartFactoryTarget(context.Background(), factorysessions.StartRequest{})
+	started, err := svc.StartAsync(context.Background(), factorysessions.StartRequest{})
 	if err != nil {
-		t.Fatalf("StartFactoryTarget() error = %v", err)
+		t.Fatalf("StartAsync() error = %v", err)
 	}
 
-	if _, err := svc.InvokeFactoryTarget(context.Background(), started.SessionID, factorysessions.InvocationRequest{}); err != nil {
-		t.Fatalf("InvokeFactoryTarget() error = %v", err)
+	first, err := svc.InvokeFactorySession(context.Background(), started.SessionID, factorysessions.InvocationRequest{})
+	if err != nil {
+		t.Fatalf("InvokeFactorySession() first error = %v", err)
+	}
+	if first.SessionID != started.SessionID {
+		t.Fatalf("InvokeFactorySession() result.SessionID = %q, want the generated wrapper identity %q", first.SessionID, started.SessionID)
+	}
+	if _, err := svc.InvokeFactorySession(context.Background(), started.SessionID, factorysessions.InvocationRequest{}); err != nil {
+		t.Fatalf("InvokeFactorySession() second error = %v", err)
 	}
 
 	if len(opener.calls) != 1 {
 		t.Fatalf("OpenInvocationRuntime call count = %d, want exactly 1 (no second open)", len(opener.calls))
 	}
 	if len(sessions.invokeCalls) != 2 {
-		t.Fatalf("InvokeFactorySession call count = %d, want exactly 2 (start's dispatch + the later invoke)", len(sessions.invokeCalls))
+		t.Fatalf("InvokeFactorySession call count = %d, want exactly 2", len(sessions.invokeCalls))
 	}
 	for _, sessionID := range sessions.invokeCalls {
 		if sessionID != factorysessions.DefaultSessionID {
@@ -309,20 +298,20 @@ func TestInvokeFactoryTargetReusesTheCachedRuntime(t *testing.T) {
 	}
 }
 
-// TestInvokeFactoryTargetUnknownIdentityReportsSessionNotFound proves an
+// TestInvokeFactorySessionUnknownIdentityReportsSessionNotFound proves an
 // identity this service never started reports ErrSessionNotFound.
-func TestInvokeFactoryTargetUnknownIdentityReportsSessionNotFound(t *testing.T) {
+func TestInvokeFactorySessionUnknownIdentityReportsSessionNotFound(t *testing.T) {
 	svc := newTestService(t, &fakeOpener{}, nil, sequentialIDs("wrapper"))
-	_, err := svc.InvokeFactoryTarget(context.Background(), "unknown", factorysessions.InvocationRequest{})
+	_, err := svc.InvokeFactorySession(context.Background(), "unknown", factorysessions.InvocationRequest{})
 	if !errors.Is(err, factorysessions.ErrSessionNotFound) {
-		t.Fatalf("InvokeFactoryTarget() error = %v, want ErrSessionNotFound", err)
+		t.Fatalf("InvokeFactorySession() error = %v, want ErrSessionNotFound", err)
 	}
 }
 
-// TestCloseFactoryTargetTearsDownAndEvicts proves a close call tears down
+// TestCloseFactorySessionTearsDownAndEvicts proves a close call tears down
 // the cached runtime and evicts it, so a later call against the same
 // identity reports ErrSessionNotFound instead of reusing a torn-down runtime.
-func TestCloseFactoryTargetTearsDownAndEvicts(t *testing.T) {
+func TestCloseFactorySessionTearsDownAndEvicts(t *testing.T) {
 	sessions := &fakeSessions{invokeResult: factorysessions.InvocationResult{Status: factorysessions.InvocationTerminalStatusCompleted}}
 	lifecycle := &fakeLifecycle{}
 	opener := &fakeOpener{opened: roles.OpenedInvocationRuntime{Sessions: sessions, Lifecycle: lifecycle}}
@@ -331,31 +320,31 @@ func TestCloseFactoryTargetTearsDownAndEvicts(t *testing.T) {
 	}
 	svc := newTestService(t, opener, resolve, sequentialIDs("wrapper"))
 
-	started, err := svc.StartFactoryTarget(context.Background(), factorysessions.StartRequest{})
+	started, err := svc.StartAsync(context.Background(), factorysessions.StartRequest{})
 	if err != nil {
-		t.Fatalf("StartFactoryTarget() error = %v", err)
+		t.Fatalf("StartAsync() error = %v", err)
 	}
 
-	if err := svc.CloseFactoryTarget(context.Background(), started.SessionID); err != nil {
-		t.Fatalf("CloseFactoryTarget() error = %v", err)
+	if err := svc.CloseFactorySession(context.Background(), started.SessionID); err != nil {
+		t.Fatalf("CloseFactorySession() error = %v", err)
 	}
 	if lifecycle.stopCalls != 1 {
 		t.Fatalf("StopLifecycle call count = %d, want exactly 1", lifecycle.stopCalls)
 	}
 
-	if _, err := svc.InvokeFactoryTarget(context.Background(), started.SessionID, factorysessions.InvocationRequest{}); !errors.Is(err, factorysessions.ErrSessionNotFound) {
-		t.Fatalf("InvokeFactoryTarget() after close error = %v, want ErrSessionNotFound", err)
+	if _, err := svc.InvokeFactorySession(context.Background(), started.SessionID, factorysessions.InvocationRequest{}); !errors.Is(err, factorysessions.ErrSessionNotFound) {
+		t.Fatalf("InvokeFactorySession() after close error = %v, want ErrSessionNotFound", err)
 	}
 }
 
-// TestCloseFactoryTargetUnknownIdentityIsNoOpSuccess proves closing an
+// TestCloseFactorySessionUnknownIdentityIsNoOpSuccess proves closing an
 // unknown or already-closed identity succeeds without effect, matching
 // factorysessions.Service.CloseFactorySession's documented idempotent
 // close semantics.
-func TestCloseFactoryTargetUnknownIdentityIsNoOpSuccess(t *testing.T) {
+func TestCloseFactorySessionUnknownIdentityIsNoOpSuccess(t *testing.T) {
 	svc := newTestService(t, &fakeOpener{}, nil, sequentialIDs("wrapper"))
-	if err := svc.CloseFactoryTarget(context.Background(), "unknown"); err != nil {
-		t.Fatalf("CloseFactoryTarget() error = %v, want nil for an unknown identity", err)
+	if err := svc.CloseFactorySession(context.Background(), "unknown"); err != nil {
+		t.Fatalf("CloseFactorySession() error = %v, want nil for an unknown identity", err)
 	}
 }
 
@@ -384,13 +373,13 @@ func TestCloseTearsDownEveryTrackedRuntime(t *testing.T) {
 	}
 	svc := newTestService(t, opener, resolve, sequentialIDs("wrapper"))
 
-	first, err := svc.StartFactoryTarget(context.Background(), factorysessions.StartRequest{Source: factorysessions.Source{FactoryID: "@you/first"}})
+	first, err := svc.StartAsync(context.Background(), factorysessions.StartRequest{Source: factorysessions.Source{FactoryID: "@you/first"}})
 	if err != nil {
-		t.Fatalf("StartFactoryTarget() first error = %v", err)
+		t.Fatalf("StartAsync() first error = %v", err)
 	}
-	second, err := svc.StartFactoryTarget(context.Background(), factorysessions.StartRequest{Source: factorysessions.Source{FactoryID: "@you/second"}})
+	second, err := svc.StartAsync(context.Background(), factorysessions.StartRequest{Source: factorysessions.Source{FactoryID: "@you/second"}})
 	if err != nil {
-		t.Fatalf("StartFactoryTarget() second error = %v", err)
+		t.Fatalf("StartAsync() second error = %v", err)
 	}
 
 	if err := svc.Close(); err != nil {
@@ -403,11 +392,11 @@ func TestCloseTearsDownEveryTrackedRuntime(t *testing.T) {
 		t.Fatalf("second runtime StopLifecycle call count = %d, want exactly 1", secondLifecycle.stopCalls)
 	}
 
-	if _, err := svc.InvokeFactoryTarget(context.Background(), first.SessionID, factorysessions.InvocationRequest{}); !errors.Is(err, factorysessions.ErrSessionNotFound) {
-		t.Fatalf("InvokeFactoryTarget(first) after Close error = %v, want ErrSessionNotFound", err)
+	if _, err := svc.InvokeFactorySession(context.Background(), first.SessionID, factorysessions.InvocationRequest{}); !errors.Is(err, factorysessions.ErrSessionNotFound) {
+		t.Fatalf("InvokeFactorySession(first) after Close error = %v, want ErrSessionNotFound", err)
 	}
-	if _, err := svc.InvokeFactoryTarget(context.Background(), second.SessionID, factorysessions.InvocationRequest{}); !errors.Is(err, factorysessions.ErrSessionNotFound) {
-		t.Fatalf("InvokeFactoryTarget(second) after Close error = %v, want ErrSessionNotFound", err)
+	if _, err := svc.InvokeFactorySession(context.Background(), second.SessionID, factorysessions.InvocationRequest{}); !errors.Is(err, factorysessions.ErrSessionNotFound) {
+		t.Fatalf("InvokeFactorySession(second) after Close error = %v, want ErrSessionNotFound", err)
 	}
 
 	// Close is idempotent: a second call has nothing left to close and
@@ -427,6 +416,123 @@ func TestCloseWithNoOpenedRuntimesIsNoOpSuccess(t *testing.T) {
 	if err := svc.Close(); err != nil {
 		t.Fatalf("Close() error = %v, want nil when no runtime was ever opened", err)
 	}
+}
+
+// TestLoggingNeverEmitsWorkingRootOrRawFailureText proves this Service's
+// structured logs stay bounded even when a resolve or activation failure's
+// own error text embeds a resolved filesystem path: neither the caller's
+// editor working root nor any substring of the raw underlying error's
+// message ever reaches a logged field or message across the resolve-failure,
+// open-failure, activation-failure, dispatch-failure, and close-failure
+// paths. Only closed, safe fields (Factory target identity, status,
+// counters) may appear.
+func TestLoggingNeverEmitsWorkingRootOrRawFailureText(t *testing.T) {
+	const sensitiveWorkingRoot = "/Users/alice/secret-project"
+	pathBearingErr := fmt.Errorf("open %s/factory.json: permission denied", sensitiveWorkingRoot)
+
+	assertNoLeak := func(t *testing.T, observed *observer.ObservedLogs) {
+		t.Helper()
+		if observed.Len() == 0 {
+			t.Fatal("no log entries observed, want at least one bounded failure log")
+		}
+		for _, entry := range observed.All() {
+			if strings.Contains(entry.Message, sensitiveWorkingRoot) {
+				t.Fatalf("log message %q contains the working root, want it bounded", entry.Message)
+			}
+			if strings.Contains(entry.Message, pathBearingErr.Error()) {
+				t.Fatalf("log message %q contains the raw error text, want it bounded", entry.Message)
+			}
+			for _, field := range entry.Context {
+				rendered := fmt.Sprintf("%v", field.Interface)
+				if field.String != "" {
+					rendered = field.String
+				}
+				if strings.Contains(rendered, sensitiveWorkingRoot) {
+					t.Fatalf("log field %s=%q contains the working root, want it bounded", field.Key, rendered)
+				}
+				if strings.Contains(rendered, pathBearingErr.Error()) {
+					t.Fatalf("log field %s=%q contains the raw error text, want it bounded", field.Key, rendered)
+				}
+			}
+		}
+	}
+
+	t.Run("open failure", func(t *testing.T) {
+		opener := &fakeOpener{err: pathBearingErr}
+		resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
+			return factorysessions.RuntimeOpeningRequest{}, nil
+		}
+		svc, observed := newTestServiceWithObservedLogger(t, opener, resolve, sequentialIDs("wrapper"))
+		_, err := svc.StartAsync(context.Background(), factorysessions.StartRequest{
+			Args: map[string]any{"workingRoot": sensitiveWorkingRoot},
+		})
+		if err == nil {
+			t.Fatal("StartAsync() error = nil, want the open failure")
+		}
+		assertNoLeak(t, observed)
+	})
+
+	t.Run("activation failure", func(t *testing.T) {
+		opener := &fakeOpener{opened: roles.OpenedInvocationRuntime{
+			Sessions:  &fakeSessions{},
+			Lifecycle: &fakeLifecycle{startErr: pathBearingErr},
+		}}
+		resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
+			return factorysessions.RuntimeOpeningRequest{}, nil
+		}
+		svc, observed := newTestServiceWithObservedLogger(t, opener, resolve, sequentialIDs("wrapper"))
+		_, err := svc.StartAsync(context.Background(), factorysessions.StartRequest{
+			Args: map[string]any{"workingRoot": sensitiveWorkingRoot},
+		})
+		if err == nil {
+			t.Fatal("StartAsync() error = nil, want the activation failure")
+		}
+		assertNoLeak(t, observed)
+	})
+
+	t.Run("dispatch failure", func(t *testing.T) {
+		opener := &fakeOpener{opened: roles.OpenedInvocationRuntime{
+			Sessions:  &fakeSessions{invokeErr: pathBearingErr},
+			Lifecycle: &fakeLifecycle{},
+		}}
+		resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
+			return factorysessions.RuntimeOpeningRequest{}, nil
+		}
+		svc, observed := newTestServiceWithObservedLogger(t, opener, resolve, sequentialIDs("wrapper"))
+		started, err := svc.StartAsync(context.Background(), factorysessions.StartRequest{
+			Args: map[string]any{"workingRoot": sensitiveWorkingRoot},
+		})
+		if err != nil {
+			t.Fatalf("StartAsync() error = %v", err)
+		}
+		observed.TakeAll()
+		if _, err := svc.InvokeFactorySession(context.Background(), started.SessionID, factorysessions.InvocationRequest{}); err == nil {
+			t.Fatal("InvokeFactorySession() error = nil, want the dispatch failure")
+		}
+		assertNoLeak(t, observed)
+	})
+
+	t.Run("close failure", func(t *testing.T) {
+		opener := &fakeOpener{opened: roles.OpenedInvocationRuntime{
+			Sessions:  &fakeSessions{invokeResult: factorysessions.InvocationResult{Status: factorysessions.InvocationTerminalStatusCompleted}, closeErr: pathBearingErr},
+			Lifecycle: &fakeLifecycle{},
+		}}
+		resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
+			return factorysessions.RuntimeOpeningRequest{}, nil
+		}
+		svc, observed := newTestServiceWithObservedLogger(t, opener, resolve, sequentialIDs("wrapper"))
+		started, err := svc.StartAsync(context.Background(), factorysessions.StartRequest{
+			Args: map[string]any{"workingRoot": sensitiveWorkingRoot},
+		})
+		if err != nil {
+			t.Fatalf("StartAsync() error = %v", err)
+		}
+		observed.TakeAll()
+		if err := svc.CloseFactorySession(context.Background(), started.SessionID); err == nil {
+			t.Fatal("CloseFactorySession() error = nil, want the close failure")
+		}
+		assertNoLeak(t, observed)
+	})
 }
 
 // funcOpener is an invocationRuntimeOpener test double backed directly by a

--- a/pkg/services/factory_sessions/internal/ondemandtarget/service_test.go
+++ b/pkg/services/factory_sessions/internal/ondemandtarget/service_test.go
@@ -132,11 +132,12 @@ func (f *fakeSessions) CloseFactorySession(_ context.Context, sessionID string) 
 func newTestService(t *testing.T, opener invocationRuntimeOpener, resolve RuntimeResolver, generateID factorysessions.SessionIDGenerator) *Service {
 	t.Helper()
 	return &Service{
-		factory:    opener,
-		resolve:    resolve,
-		generateID: generateID,
-		logger:     zap.NewNop(),
-		runtimes:   make(map[string]*activatedRuntime),
+		factory:           opener,
+		resolve:           resolve,
+		generateID:        generateID,
+		logger:            zap.NewNop(),
+		runtimes:          make(map[string]*activatedRuntime),
+		startsByRequestID: make(map[string]string),
 	}
 }
 
@@ -147,11 +148,12 @@ func newTestServiceWithObservedLogger(t *testing.T, opener invocationRuntimeOpen
 	t.Helper()
 	core, observed := observer.New(zapcore.DebugLevel)
 	return &Service{
-		factory:    opener,
-		resolve:    resolve,
-		generateID: generateID,
-		logger:     zap.New(core),
-		runtimes:   make(map[string]*activatedRuntime),
+		factory:           opener,
+		resolve:           resolve,
+		generateID:        generateID,
+		logger:            zap.New(core),
+		runtimes:          make(map[string]*activatedRuntime),
+		startsByRequestID: make(map[string]string),
 	}, observed
 }
 
@@ -234,6 +236,84 @@ func TestStartAsyncOpensRuntimeAndReturnsGeneratedIdentity(t *testing.T) {
 	}
 	if result.Status != string(factorysessions.LifecycleStatusRunning) {
 		t.Fatalf("result.Status = %q, want RUNNING (a fresh open, no terminal outcome yet)", result.Status)
+	}
+}
+
+// TestStartAsyncSameRequestIDConvergesOnASingleActivation proves that calling
+// StartAsync twice with the exact same non-blank RequestID opens exactly one
+// runtime and returns the identical generated SessionID both times, instead
+// of opening a second runtime for a repeated request. This is the mechanism
+// that makes a caller's retried start -- for example the ACP prompt
+// delegation transport's stable per-episode RequestID, retried after its own
+// post-start bookkeeping (RecordPendingFactorySession) fails -- safe: the
+// retry converges on the exact activation the original call already opened
+// rather than leaking a second one.
+func TestStartAsyncSameRequestIDConvergesOnASingleActivation(t *testing.T) {
+	sessions := &fakeSessions{}
+	opener := &fakeOpener{opened: roles.OpenedInvocationRuntime{
+		Sessions:  sessions,
+		Lifecycle: &fakeLifecycle{},
+	}}
+	resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
+		return factorysessions.RuntimeOpeningRequest{}, nil
+	}
+	svc := newTestService(t, opener, resolve, sequentialIDs("wrapper"))
+
+	req := factorysessions.StartRequest{
+		RequestID: "session-1/episode/1",
+		Source:    factorysessions.Source{FactoryID: "@you/review"},
+		Args:      map[string]any{"workingRoot": "/work/project"},
+	}
+	first, err := svc.StartAsync(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first StartAsync() error = %v", err)
+	}
+	second, err := svc.StartAsync(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second StartAsync() error = %v", err)
+	}
+
+	if len(opener.calls) != 1 {
+		t.Fatalf("OpenInvocationRuntime call count = %d, want exactly 1 across both StartAsync calls", len(opener.calls))
+	}
+	if first.SessionID != second.SessionID {
+		t.Fatalf("SessionID[0] = %q, SessionID[1] = %q, want the identical converged identity", first.SessionID, second.SessionID)
+	}
+	if first.SessionID != "wrapper-1" {
+		t.Fatalf("SessionID = %q, want the generated wrapper identity from the one real activation", first.SessionID)
+	}
+}
+
+// TestStartAsyncBlankRequestIDOpensASeparateRuntimeEveryCall proves that a
+// caller who passes no RequestID at all (blank) gets no deduplication --
+// every such call opens its own runtime, matching this method's original,
+// pre-deduplication behavior for callers that never supply a stable key.
+func TestStartAsyncBlankRequestIDOpensASeparateRuntimeEveryCall(t *testing.T) {
+	sessions := &fakeSessions{}
+	opener := &fakeOpener{opened: roles.OpenedInvocationRuntime{
+		Sessions:  sessions,
+		Lifecycle: &fakeLifecycle{},
+	}}
+	resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
+		return factorysessions.RuntimeOpeningRequest{}, nil
+	}
+	svc := newTestService(t, opener, resolve, sequentialIDs("wrapper"))
+
+	req := factorysessions.StartRequest{Source: factorysessions.Source{FactoryID: "@you/review"}}
+	first, err := svc.StartAsync(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first StartAsync() error = %v", err)
+	}
+	second, err := svc.StartAsync(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second StartAsync() error = %v", err)
+	}
+
+	if len(opener.calls) != 2 {
+		t.Fatalf("OpenInvocationRuntime call count = %d, want exactly 2 (no dedup key supplied)", len(opener.calls))
+	}
+	if first.SessionID == second.SessionID {
+		t.Fatalf("SessionID[0] = %q, SessionID[1] = %q, want two distinct generated identities", first.SessionID, second.SessionID)
 	}
 }
 

--- a/pkg/services/factory_sessions/internal/ondemandtarget/service_test.go
+++ b/pkg/services/factory_sessions/internal/ondemandtarget/service_test.go
@@ -126,7 +126,7 @@ func (f *fakeSessions) CloseFactorySession(_ context.Context, sessionID string) 
 	return f.closeErr
 }
 
-func newTestService(t *testing.T, opener *fakeOpener, resolve RuntimeResolver, generateID factorysessions.SessionIDGenerator) *Service {
+func newTestService(t *testing.T, opener invocationRuntimeOpener, resolve RuntimeResolver, generateID factorysessions.SessionIDGenerator) *Service {
 	t.Helper()
 	return &Service{
 		factory:    opener,
@@ -357,4 +357,91 @@ func TestCloseFactoryTargetUnknownIdentityIsNoOpSuccess(t *testing.T) {
 	if err := svc.CloseFactoryTarget(context.Background(), "unknown"); err != nil {
 		t.Fatalf("CloseFactoryTarget() error = %v, want nil for an unknown identity", err)
 	}
+}
+
+// TestCloseTearsDownEveryTrackedRuntime proves Close (the io.Closer this
+// Service implements for a future process lifecycle plan to register) tears
+// down every runtime this Service has opened -- not just one -- and evicts
+// each of them, so a later call against any of their identities reports
+// ErrSessionNotFound instead of reusing a torn-down runtime.
+func TestCloseTearsDownEveryTrackedRuntime(t *testing.T) {
+	firstLifecycle := &fakeLifecycle{}
+	secondLifecycle := &fakeLifecycle{}
+	openCount := 0
+	opener := &funcOpener{open: func(context.Context, *factorysessions.RuntimeOpeningRequest, runtimeopening.ExternalEffects, *zap.Logger) (roles.OpenedInvocationRuntime, error) {
+		openCount++
+		lifecycle := firstLifecycle
+		if openCount == 2 {
+			lifecycle = secondLifecycle
+		}
+		return roles.OpenedInvocationRuntime{
+			Sessions:  &fakeSessions{invokeResult: factorysessions.InvocationResult{Status: factorysessions.InvocationTerminalStatusCompleted}},
+			Lifecycle: lifecycle,
+		}, nil
+	}}
+	resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
+		return factorysessions.RuntimeOpeningRequest{}, nil
+	}
+	svc := newTestService(t, opener, resolve, sequentialIDs("wrapper"))
+
+	first, err := svc.StartFactoryTarget(context.Background(), factorysessions.StartRequest{Source: factorysessions.Source{FactoryID: "@you/first"}})
+	if err != nil {
+		t.Fatalf("StartFactoryTarget() first error = %v", err)
+	}
+	second, err := svc.StartFactoryTarget(context.Background(), factorysessions.StartRequest{Source: factorysessions.Source{FactoryID: "@you/second"}})
+	if err != nil {
+		t.Fatalf("StartFactoryTarget() second error = %v", err)
+	}
+
+	if err := svc.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if firstLifecycle.stopCalls != 1 {
+		t.Fatalf("first runtime StopLifecycle call count = %d, want exactly 1", firstLifecycle.stopCalls)
+	}
+	if secondLifecycle.stopCalls != 1 {
+		t.Fatalf("second runtime StopLifecycle call count = %d, want exactly 1", secondLifecycle.stopCalls)
+	}
+
+	if _, err := svc.InvokeFactoryTarget(context.Background(), first.SessionID, factorysessions.InvocationRequest{}); !errors.Is(err, factorysessions.ErrSessionNotFound) {
+		t.Fatalf("InvokeFactoryTarget(first) after Close error = %v, want ErrSessionNotFound", err)
+	}
+	if _, err := svc.InvokeFactoryTarget(context.Background(), second.SessionID, factorysessions.InvocationRequest{}); !errors.Is(err, factorysessions.ErrSessionNotFound) {
+		t.Fatalf("InvokeFactoryTarget(second) after Close error = %v, want ErrSessionNotFound", err)
+	}
+
+	// Close is idempotent: a second call has nothing left to close and
+	// succeeds without re-closing either runtime.
+	if err := svc.Close(); err != nil {
+		t.Fatalf("second Close() error = %v, want nil (idempotent)", err)
+	}
+	if firstLifecycle.stopCalls != 1 || secondLifecycle.stopCalls != 1 {
+		t.Fatalf("StopLifecycle call counts after second Close = (%d, %d), want (1, 1) -- no double close", firstLifecycle.stopCalls, secondLifecycle.stopCalls)
+	}
+}
+
+// TestCloseWithNoOpenedRuntimesIsNoOpSuccess proves calling Close before any
+// StartFactoryTarget call succeeds without effect.
+func TestCloseWithNoOpenedRuntimesIsNoOpSuccess(t *testing.T) {
+	svc := newTestService(t, &fakeOpener{}, nil, sequentialIDs("wrapper"))
+	if err := svc.Close(); err != nil {
+		t.Fatalf("Close() error = %v, want nil when no runtime was ever opened", err)
+	}
+}
+
+// funcOpener is an invocationRuntimeOpener test double backed directly by a
+// function, for tests that need each successive OpenInvocationRuntime call
+// to return a distinct opened runtime (fakeOpener always returns the same
+// fixed one).
+type funcOpener struct {
+	open func(context.Context, *factorysessions.RuntimeOpeningRequest, runtimeopening.ExternalEffects, *zap.Logger) (roles.OpenedInvocationRuntime, error)
+}
+
+func (f *funcOpener) OpenInvocationRuntime(
+	ctx context.Context,
+	request *factorysessions.RuntimeOpeningRequest,
+	effects runtimeopening.ExternalEffects,
+	logger *zap.Logger,
+) (roles.OpenedInvocationRuntime, error) {
+	return f.open(ctx, request, effects, logger)
 }

--- a/pkg/services/factory_sessions/wire/on_demand_factory_target.go
+++ b/pkg/services/factory_sessions/wire/on_demand_factory_target.go
@@ -1,0 +1,260 @@
+package wire
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	"go.uber.org/zap"
+)
+
+// FactoryTargetRuntimeResolver turns one canonical Factory target identity
+// and editor working root into the concrete Runtime Opening request that
+// activating a live, project-bound Factory Sessions runtime for that exact
+// target needs. The concrete implementation (catalog + named-Factory
+// cross-root resolution, operator defaults) is owned by the composing
+// consumer; this package stays free of transport-specific target vocabulary.
+type FactoryTargetRuntimeResolver func(
+	ctx context.Context,
+	factoryTargetID string,
+	workingRoot string,
+) (factorysessions.RuntimeOpeningRequest, error)
+
+// OnDemandFactoryTargetService is a consumer-owned Factory Sessions
+// activation that has no fixed, pre-opened Factory Session runtime the way
+// the CLI daemon's single-project bootstrap (OpenApplication/Assembly.Complete)
+// does. Instead, the first StartFactoryTarget for a given caller-selected
+// Factory target and working root lazily opens exactly one ephemeral,
+// non-HTTP-bound runtime through the existing invocation-mode Runtime
+// Opening path (the same primitive the CLI's one-shot named invocation
+// already uses, per runtimeopening.Factory.OpenInvocationRuntime), starts
+// its lifecycle, and keeps it open so every later call against the returned
+// identity reuses that exact runtime instead of starting a second one.
+//
+// Every opened invocation-mode runtime privately shares the same constant
+// internal session identity (factorysessions.DefaultSessionID) -- calling
+// StartAsync/InvokeFactorySession/Cancel/CloseFactorySession against that
+// raw identity across more than one concurrently-opened runtime would
+// collide, so this service substitutes its own generated identity for the
+// one returned to callers on Start, and translates it back to the correct
+// cached runtime (and the runtime's own DefaultSessionID) on every later
+// call. Callers must treat the returned identity as opaque.
+type OnDemandFactoryTargetService struct {
+	factory    *RuntimeOpeningFactory
+	effects    RuntimeOpeningExternalEffects
+	resolve    FactoryTargetRuntimeResolver
+	generateID factorysessions.SessionIDGenerator
+	logger     *zap.Logger
+
+	mu       sync.Mutex
+	runtimes map[string]*activatedFactoryRuntime
+}
+
+// NewOnDemandFactoryTargetService constructs the on-demand activation.
+// Construction alone performs no I/O and opens no runtime.
+func NewOnDemandFactoryTargetService(
+	factory *RuntimeOpeningFactory,
+	effects RuntimeOpeningExternalEffects,
+	resolve FactoryTargetRuntimeResolver,
+	generateID factorysessions.SessionIDGenerator,
+	logger *zap.Logger,
+) (*OnDemandFactoryTargetService, error) {
+	if factory == nil {
+		return nil, errors.New("construct on-demand Factory target activation: Runtime Opening factory is required")
+	}
+	if resolve == nil {
+		return nil, errors.New("construct on-demand Factory target activation: Factory target runtime resolver is required")
+	}
+	if generateID == nil {
+		return nil, errors.New("construct on-demand Factory target activation: session ID generator is required")
+	}
+	if logger == nil {
+		return nil, errors.New("construct on-demand Factory target activation: logger is required")
+	}
+	return &OnDemandFactoryTargetService{
+		factory:    factory,
+		effects:    effects,
+		resolve:    resolve,
+		generateID: generateID,
+		logger:     logger,
+		runtimes:   make(map[string]*activatedFactoryRuntime),
+	}, nil
+}
+
+// activatedFactoryRuntime is one lazily-opened, lifecycle-started invocation
+// runtime kept alive across calls. runContext is intentionally detached from
+// any one caller request's context (context.WithoutCancel) so an
+// asynchronous StartAsync dispatch it starts keeps running after the
+// initiating ACP request returns; only this type's own close cancels it.
+type activatedFactoryRuntime struct {
+	opened     OpenedInvocationRuntime
+	runContext context.Context
+	cancel     context.CancelFunc
+	stopWorker factorysessions.RuntimeStop
+}
+
+func (s *OnDemandFactoryTargetService) openActivatedRuntime(
+	ctx context.Context,
+	config factorysessions.RuntimeOpeningRequest,
+) (*activatedFactoryRuntime, error) {
+	opened, err := s.factory.OpenInvocationRuntime(ctx, &config, s.effects, s.logger)
+	if err != nil {
+		return nil, fmt.Errorf("open Factory target runtime: %w", err)
+	}
+	runContext, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	active := &activatedFactoryRuntime{opened: opened, runContext: runContext, cancel: cancel}
+	err = opened.Lifecycle.StartLifecycle(ctx, runContext)
+	if err == nil {
+		active.stopWorker, err = opened.Lifecycle.StartWorkerLifecycle(ctx)
+	}
+	if err == nil {
+		err = opened.Lifecycle.CompleteStartup(ctx)
+	}
+	if err != nil {
+		return nil, errors.Join(fmt.Errorf("activate Factory target runtime: %w", err), active.close(ctx))
+	}
+	return active, nil
+}
+
+func (a *activatedFactoryRuntime) close(ctx context.Context) error {
+	cleanupContext := context.WithoutCancel(ctx)
+	var result error
+	if a.opened.Sessions != nil {
+		if err := a.opened.Sessions.CloseFactorySession(cleanupContext, factorysessions.DefaultSessionID); err != nil &&
+			!errors.Is(err, factorysessions.ErrSessionNotFound) {
+			result = errors.Join(result, err)
+		}
+	}
+	if a.stopWorker != nil {
+		result = errors.Join(result, a.stopWorker(cleanupContext))
+	}
+	if a.opened.Lifecycle != nil {
+		result = errors.Join(result, a.opened.Lifecycle.StopLifecycle(cleanupContext))
+	}
+	if a.cancel != nil {
+		a.cancel()
+	}
+	if a.opened.Lifecycle != nil {
+		if err := a.opened.Lifecycle.WaitForRuntime(cleanupContext); err != nil && !errors.Is(err, context.Canceled) {
+			result = errors.Join(result, err)
+		}
+	}
+	if a.opened.CloseArtifacts != nil {
+		result = errors.Join(result, a.opened.CloseArtifacts())
+	}
+	return result
+}
+
+// StartFactoryTarget opens (and keeps open) exactly one Factory target
+// runtime for this request's Source.FactoryID and Args["workingRoot"], then
+// dispatches the requested content on it.
+//
+// This dispatches through InvokeFactorySession, the same synchronous,
+// non-JavaScript-workflow-specific call the CLI's own one-shot named
+// invocation already uses successfully, rather than StartAsync/Source:
+// StartAsync's Source vocabulary (FACTORY_ID/FACTORY_INLINE/WORKFLOW_FILE/
+// WORKFLOW_NAME/INLINE_WORKFLOW) only resolves named JavaScript workflow
+// factories -- confirmed by reading
+// internal/services/orchestration/javascript/source/lookup.go, whose
+// FACTORY_ID case rejects any target that "is not a JavaScript workflow
+// factory" -- so it cannot start an ordinary packaged Factory the way this
+// service's already-resolved, already-opened runtime needs. Since
+// s.resolve/openActivatedRuntime already picked and opened the exact target
+// directory, this call needs no further source selection at all. The
+// returned AsyncStartResult carries this service's own generated identity
+// (never the opened runtime's shared internal constant session identity)
+// and the invocation's real published terminal status; it has no text/
+// content field to carry the real result text (AsyncStartResult itself
+// publishes none), matching factorysessions.AsyncStartResult's existing,
+// already-tested contract.
+func (s *OnDemandFactoryTargetService) StartFactoryTarget(
+	ctx context.Context,
+	request factorysessions.StartRequest,
+) (factorysessions.AsyncStartResult, error) {
+	workingRoot, _ := request.Args["workingRoot"].(string)
+	config, err := s.resolve(ctx, request.Source.FactoryID, workingRoot)
+	if err != nil {
+		return factorysessions.AsyncStartResult{}, err
+	}
+	active, err := s.openActivatedRuntime(ctx, config)
+	if err != nil {
+		return factorysessions.AsyncStartResult{}, err
+	}
+
+	content, _ := request.Args["content"].([]work.WorkContentPart)
+	requestID := request.RequestID
+	sourceKind := factorysessions.InvocationInputSourceKindText
+	result, err := active.opened.Sessions.InvokeFactorySession(ctx, factorysessions.DefaultSessionID, factorysessions.InvocationRequest{
+		Content:         content,
+		ContentProvided: true,
+		RequestID:       &requestID,
+		SourceKind:      &sourceKind,
+	})
+	if err != nil {
+		return factorysessions.AsyncStartResult{}, errors.Join(err, active.close(ctx))
+	}
+
+	wrapperID := s.generateID()
+	s.mu.Lock()
+	s.runtimes[wrapperID] = active
+	s.mu.Unlock()
+	return factorysessions.AsyncStartResult{SessionID: wrapperID, Status: string(result.Status)}, nil
+}
+
+func (s *OnDemandFactoryTargetService) lookup(sessionID string) (*activatedFactoryRuntime, error) {
+	s.mu.Lock()
+	active, ok := s.runtimes[sessionID]
+	s.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", factorysessions.ErrSessionNotFound, sessionID)
+	}
+	return active, nil
+}
+
+// InvokeFactoryTarget synchronously invokes the exact runtime a prior
+// StartFactoryTarget call opened for sessionID.
+func (s *OnDemandFactoryTargetService) InvokeFactoryTarget(
+	ctx context.Context,
+	sessionID string,
+	request factorysessions.InvocationRequest,
+) (factorysessions.InvocationResult, error) {
+	active, err := s.lookup(sessionID)
+	if err != nil {
+		return factorysessions.InvocationResult{}, err
+	}
+	return active.opened.Sessions.InvokeFactorySession(ctx, factorysessions.DefaultSessionID, request)
+}
+
+// CancelFactoryTarget cancels the exact runtime a prior StartFactoryTarget
+// call opened for sessionID.
+func (s *OnDemandFactoryTargetService) CancelFactoryTarget(
+	ctx context.Context,
+	sessionID string,
+	request factorysessions.ControlRequest,
+) (factorysessions.LifecycleControlResult, error) {
+	active, err := s.lookup(sessionID)
+	if err != nil {
+		return factorysessions.LifecycleControlResult{}, err
+	}
+	return active.opened.Sessions.Cancel(ctx, factorysessions.DefaultSessionID, request)
+}
+
+// CloseFactoryTarget tears down and evicts the exact runtime a prior
+// StartFactoryTarget call opened for sessionID. Closing an unknown or
+// already-closed identity is a no-op success, matching the idempotent close
+// semantics factorysessions.Service.CloseFactorySession already documents.
+func (s *OnDemandFactoryTargetService) CloseFactoryTarget(ctx context.Context, sessionID string) error {
+	s.mu.Lock()
+	active, ok := s.runtimes[sessionID]
+	if ok {
+		delete(s.runtimes, sessionID)
+	}
+	s.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	return active.close(ctx)
+}

--- a/pkg/services/factory_sessions/wire/on_demand_factory_target.go
+++ b/pkg/services/factory_sessions/wire/on_demand_factory_target.go
@@ -1,60 +1,27 @@
 package wire
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"sync"
-
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
-	"github.com/portpowered/infinite-you/pkg/services/work"
+	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/ondemandtarget"
 	"go.uber.org/zap"
 )
 
-// FactoryTargetRuntimeResolver turns one canonical Factory target identity
-// and editor working root into the concrete Runtime Opening request that
-// activating a live, project-bound Factory Sessions runtime for that exact
-// target needs. The concrete implementation (catalog + named-Factory
-// cross-root resolution, operator defaults) is owned by the composing
-// consumer; this package stays free of transport-specific target vocabulary.
-type FactoryTargetRuntimeResolver func(
-	ctx context.Context,
-	factoryTargetID string,
-	workingRoot string,
-) (factorysessions.RuntimeOpeningRequest, error)
+// FactoryTargetRuntimeResolver is re-published here so a caller outside the
+// factory_sessions tree can declare a field or parameter of this type
+// without importing the internal ondemandtarget package directly, matching
+// how this package already re-publishes RuntimeOpeningFactory and its peers.
+type FactoryTargetRuntimeResolver = ondemandtarget.RuntimeResolver
 
-// OnDemandFactoryTargetService is a consumer-owned Factory Sessions
-// activation that has no fixed, pre-opened Factory Session runtime the way
-// the CLI daemon's single-project bootstrap (OpenApplication/Assembly.Complete)
-// does. Instead, the first StartFactoryTarget for a given caller-selected
-// Factory target and working root lazily opens exactly one ephemeral,
-// non-HTTP-bound runtime through the existing invocation-mode Runtime
-// Opening path (the same primitive the CLI's one-shot named invocation
-// already uses, per runtimeopening.Factory.OpenInvocationRuntime), starts
-// its lifecycle, and keeps it open so every later call against the returned
-// identity reuses that exact runtime instead of starting a second one.
-//
-// Every opened invocation-mode runtime privately shares the same constant
-// internal session identity (factorysessions.DefaultSessionID) -- calling
-// StartAsync/InvokeFactorySession/Cancel/CloseFactorySession against that
-// raw identity across more than one concurrently-opened runtime would
-// collide, so this service substitutes its own generated identity for the
-// one returned to callers on Start, and translates it back to the correct
-// cached runtime (and the runtime's own DefaultSessionID) on every later
-// call. Callers must treat the returned identity as opaque.
-type OnDemandFactoryTargetService struct {
-	factory    *RuntimeOpeningFactory
-	effects    RuntimeOpeningExternalEffects
-	resolve    FactoryTargetRuntimeResolver
-	generateID factorysessions.SessionIDGenerator
-	logger     *zap.Logger
+// OnDemandFactoryTargetService is re-published here for the same reason;
+// the actual operational implementation lives in the owning service's
+// internal/ondemandtarget package, not this wire package, matching this
+// package's own established RuntimeOpeningFactory convention (a construction
+// alias plus a thin wrapper constructor, never operational implementation).
+type OnDemandFactoryTargetService = ondemandtarget.Service
 
-	mu       sync.Mutex
-	runtimes map[string]*activatedFactoryRuntime
-}
-
-// NewOnDemandFactoryTargetService constructs the on-demand activation.
-// Construction alone performs no I/O and opens no runtime.
+// NewOnDemandFactoryTargetService constructs the on-demand Factory Sessions
+// activation over the given already-wired RuntimeOpeningFactory. Construction
+// alone performs no I/O and opens no runtime.
 func NewOnDemandFactoryTargetService(
 	factory *RuntimeOpeningFactory,
 	effects RuntimeOpeningExternalEffects,
@@ -62,201 +29,5 @@ func NewOnDemandFactoryTargetService(
 	generateID factorysessions.SessionIDGenerator,
 	logger *zap.Logger,
 ) (*OnDemandFactoryTargetService, error) {
-	if factory == nil {
-		return nil, errors.New("construct on-demand Factory target activation: Runtime Opening factory is required")
-	}
-	if resolve == nil {
-		return nil, errors.New("construct on-demand Factory target activation: Factory target runtime resolver is required")
-	}
-	if generateID == nil {
-		return nil, errors.New("construct on-demand Factory target activation: session ID generator is required")
-	}
-	if logger == nil {
-		return nil, errors.New("construct on-demand Factory target activation: logger is required")
-	}
-	return &OnDemandFactoryTargetService{
-		factory:    factory,
-		effects:    effects,
-		resolve:    resolve,
-		generateID: generateID,
-		logger:     logger,
-		runtimes:   make(map[string]*activatedFactoryRuntime),
-	}, nil
-}
-
-// activatedFactoryRuntime is one lazily-opened, lifecycle-started invocation
-// runtime kept alive across calls. runContext is intentionally detached from
-// any one caller request's context (context.WithoutCancel) so an
-// asynchronous StartAsync dispatch it starts keeps running after the
-// initiating ACP request returns; only this type's own close cancels it.
-type activatedFactoryRuntime struct {
-	opened     OpenedInvocationRuntime
-	runContext context.Context
-	cancel     context.CancelFunc
-	stopWorker factorysessions.RuntimeStop
-}
-
-func (s *OnDemandFactoryTargetService) openActivatedRuntime(
-	ctx context.Context,
-	config factorysessions.RuntimeOpeningRequest,
-) (*activatedFactoryRuntime, error) {
-	opened, err := s.factory.OpenInvocationRuntime(ctx, &config, s.effects, s.logger)
-	if err != nil {
-		return nil, fmt.Errorf("open Factory target runtime: %w", err)
-	}
-	runContext, cancel := context.WithCancel(context.WithoutCancel(ctx))
-	active := &activatedFactoryRuntime{opened: opened, runContext: runContext, cancel: cancel}
-	err = opened.Lifecycle.StartLifecycle(ctx, runContext)
-	if err == nil {
-		active.stopWorker, err = opened.Lifecycle.StartWorkerLifecycle(ctx)
-	}
-	if err == nil {
-		err = opened.Lifecycle.CompleteStartup(ctx)
-	}
-	if err != nil {
-		return nil, errors.Join(fmt.Errorf("activate Factory target runtime: %w", err), active.close(ctx))
-	}
-	return active, nil
-}
-
-func (a *activatedFactoryRuntime) close(ctx context.Context) error {
-	cleanupContext := context.WithoutCancel(ctx)
-	var result error
-	if a.opened.Sessions != nil {
-		if err := a.opened.Sessions.CloseFactorySession(cleanupContext, factorysessions.DefaultSessionID); err != nil &&
-			!errors.Is(err, factorysessions.ErrSessionNotFound) {
-			result = errors.Join(result, err)
-		}
-	}
-	if a.stopWorker != nil {
-		result = errors.Join(result, a.stopWorker(cleanupContext))
-	}
-	if a.opened.Lifecycle != nil {
-		result = errors.Join(result, a.opened.Lifecycle.StopLifecycle(cleanupContext))
-	}
-	if a.cancel != nil {
-		a.cancel()
-	}
-	if a.opened.Lifecycle != nil {
-		if err := a.opened.Lifecycle.WaitForRuntime(cleanupContext); err != nil && !errors.Is(err, context.Canceled) {
-			result = errors.Join(result, err)
-		}
-	}
-	if a.opened.CloseArtifacts != nil {
-		result = errors.Join(result, a.opened.CloseArtifacts())
-	}
-	return result
-}
-
-// StartFactoryTarget opens (and keeps open) exactly one Factory target
-// runtime for this request's Source.FactoryID and Args["workingRoot"], then
-// dispatches the requested content on it.
-//
-// This dispatches through InvokeFactorySession, the same synchronous,
-// non-JavaScript-workflow-specific call the CLI's own one-shot named
-// invocation already uses successfully, rather than StartAsync/Source:
-// StartAsync's Source vocabulary (FACTORY_ID/FACTORY_INLINE/WORKFLOW_FILE/
-// WORKFLOW_NAME/INLINE_WORKFLOW) only resolves named JavaScript workflow
-// factories -- confirmed by reading
-// internal/services/orchestration/javascript/source/lookup.go, whose
-// FACTORY_ID case rejects any target that "is not a JavaScript workflow
-// factory" -- so it cannot start an ordinary packaged Factory the way this
-// service's already-resolved, already-opened runtime needs. Since
-// s.resolve/openActivatedRuntime already picked and opened the exact target
-// directory, this call needs no further source selection at all. The
-// returned InvocationResult is the real, unmodified published invocation
-// outcome -- terminal status and ordered primary-result text included --
-// except SessionID, which this service substitutes with its own generated
-// identity (never the opened runtime's shared internal constant session
-// identity) so a later InvokeFactoryTarget/CancelFactoryTarget/
-// CloseFactoryTarget call against the returned identity resolves back to
-// this exact runtime.
-func (s *OnDemandFactoryTargetService) StartFactoryTarget(
-	ctx context.Context,
-	request factorysessions.StartRequest,
-) (factorysessions.InvocationResult, error) {
-	workingRoot, _ := request.Args["workingRoot"].(string)
-	config, err := s.resolve(ctx, request.Source.FactoryID, workingRoot)
-	if err != nil {
-		return factorysessions.InvocationResult{}, err
-	}
-	active, err := s.openActivatedRuntime(ctx, config)
-	if err != nil {
-		return factorysessions.InvocationResult{}, err
-	}
-
-	content, _ := request.Args["content"].([]work.WorkContentPart)
-	requestID := request.RequestID
-	sourceKind := factorysessions.InvocationInputSourceKindText
-	result, err := active.opened.Sessions.InvokeFactorySession(ctx, factorysessions.DefaultSessionID, factorysessions.InvocationRequest{
-		Content:         content,
-		ContentProvided: true,
-		RequestID:       &requestID,
-		SourceKind:      &sourceKind,
-	})
-	if err != nil {
-		return factorysessions.InvocationResult{}, errors.Join(err, active.close(ctx))
-	}
-
-	wrapperID := s.generateID()
-	s.mu.Lock()
-	s.runtimes[wrapperID] = active
-	s.mu.Unlock()
-	result.SessionID = wrapperID
-	return result, nil
-}
-
-func (s *OnDemandFactoryTargetService) lookup(sessionID string) (*activatedFactoryRuntime, error) {
-	s.mu.Lock()
-	active, ok := s.runtimes[sessionID]
-	s.mu.Unlock()
-	if !ok {
-		return nil, fmt.Errorf("%w: %s", factorysessions.ErrSessionNotFound, sessionID)
-	}
-	return active, nil
-}
-
-// InvokeFactoryTarget synchronously invokes the exact runtime a prior
-// StartFactoryTarget call opened for sessionID.
-func (s *OnDemandFactoryTargetService) InvokeFactoryTarget(
-	ctx context.Context,
-	sessionID string,
-	request factorysessions.InvocationRequest,
-) (factorysessions.InvocationResult, error) {
-	active, err := s.lookup(sessionID)
-	if err != nil {
-		return factorysessions.InvocationResult{}, err
-	}
-	return active.opened.Sessions.InvokeFactorySession(ctx, factorysessions.DefaultSessionID, request)
-}
-
-// CancelFactoryTarget cancels the exact runtime a prior StartFactoryTarget
-// call opened for sessionID.
-func (s *OnDemandFactoryTargetService) CancelFactoryTarget(
-	ctx context.Context,
-	sessionID string,
-	request factorysessions.ControlRequest,
-) (factorysessions.LifecycleControlResult, error) {
-	active, err := s.lookup(sessionID)
-	if err != nil {
-		return factorysessions.LifecycleControlResult{}, err
-	}
-	return active.opened.Sessions.Cancel(ctx, factorysessions.DefaultSessionID, request)
-}
-
-// CloseFactoryTarget tears down and evicts the exact runtime a prior
-// StartFactoryTarget call opened for sessionID. Closing an unknown or
-// already-closed identity is a no-op success, matching the idempotent close
-// semantics factorysessions.Service.CloseFactorySession already documents.
-func (s *OnDemandFactoryTargetService) CloseFactoryTarget(ctx context.Context, sessionID string) error {
-	s.mu.Lock()
-	active, ok := s.runtimes[sessionID]
-	if ok {
-		delete(s.runtimes, sessionID)
-	}
-	s.mu.Unlock()
-	if !ok {
-		return nil
-	}
-	return active.close(ctx)
+	return ondemandtarget.New(factory, effects, resolve, generateID, logger)
 }

--- a/pkg/services/factory_sessions/wire/on_demand_factory_target.go
+++ b/pkg/services/factory_sessions/wire/on_demand_factory_target.go
@@ -164,24 +164,25 @@ func (a *activatedFactoryRuntime) close(ctx context.Context) error {
 // service's already-resolved, already-opened runtime needs. Since
 // s.resolve/openActivatedRuntime already picked and opened the exact target
 // directory, this call needs no further source selection at all. The
-// returned AsyncStartResult carries this service's own generated identity
-// (never the opened runtime's shared internal constant session identity)
-// and the invocation's real published terminal status; it has no text/
-// content field to carry the real result text (AsyncStartResult itself
-// publishes none), matching factorysessions.AsyncStartResult's existing,
-// already-tested contract.
+// returned InvocationResult is the real, unmodified published invocation
+// outcome -- terminal status and ordered primary-result text included --
+// except SessionID, which this service substitutes with its own generated
+// identity (never the opened runtime's shared internal constant session
+// identity) so a later InvokeFactoryTarget/CancelFactoryTarget/
+// CloseFactoryTarget call against the returned identity resolves back to
+// this exact runtime.
 func (s *OnDemandFactoryTargetService) StartFactoryTarget(
 	ctx context.Context,
 	request factorysessions.StartRequest,
-) (factorysessions.AsyncStartResult, error) {
+) (factorysessions.InvocationResult, error) {
 	workingRoot, _ := request.Args["workingRoot"].(string)
 	config, err := s.resolve(ctx, request.Source.FactoryID, workingRoot)
 	if err != nil {
-		return factorysessions.AsyncStartResult{}, err
+		return factorysessions.InvocationResult{}, err
 	}
 	active, err := s.openActivatedRuntime(ctx, config)
 	if err != nil {
-		return factorysessions.AsyncStartResult{}, err
+		return factorysessions.InvocationResult{}, err
 	}
 
 	content, _ := request.Args["content"].([]work.WorkContentPart)
@@ -194,14 +195,15 @@ func (s *OnDemandFactoryTargetService) StartFactoryTarget(
 		SourceKind:      &sourceKind,
 	})
 	if err != nil {
-		return factorysessions.AsyncStartResult{}, errors.Join(err, active.close(ctx))
+		return factorysessions.InvocationResult{}, errors.Join(err, active.close(ctx))
 	}
 
 	wrapperID := s.generateID()
 	s.mu.Lock()
 	s.runtimes[wrapperID] = active
 	s.mu.Unlock()
-	return factorysessions.AsyncStartResult{SessionID: wrapperID, Status: string(result.Status)}, nil
+	result.SessionID = wrapperID
+	return result, nil
 }
 
 func (s *OnDemandFactoryTargetService) lookup(sessionID string) (*activatedFactoryRuntime, error) {

--- a/pkg/transports/acp/factory_target_service.go
+++ b/pkg/transports/acp/factory_target_service.go
@@ -11,19 +11,22 @@ import (
 // is declared here, in this transport's own public root, rather than
 // imported from another service's internal or wire subpackage, so this
 // package states the exact shape it consumes; pkg/wire constructs the
-// concrete collaborator (the chat_sessions-owned Factory Sessions shim) and
-// injects it as this contract.
+// concrete collaborator and injects it as this contract. Its shape matches
+// chat_sessions/internal/factorysessionsshim.FactoryTargetService exactly
+// (StartFactoryTarget forwards to the shared factorysessions.Service.StartAsync,
+// InvokeFactoryTarget to InvokeFactorySession, and so on), because the
+// concrete collaborator pkg/wire injects is that existing, consumer-owned
+// shim -- see pkg/wire's provideACPServerFactoryTargetService.
 //
-// StartFactoryTarget returns factorysessions.InvocationResult, not the
-// shared factorysessions.AsyncStartResult a genuinely asynchronous
-// factorysessions.Service.StartAsync publishes: every implementation this
-// transport consumes activates a runtime and dispatches the first turn's
-// content synchronously, so it already observes a genuine terminal
-// InvocationResult (including ordered primary-result text) before
-// returning, and this transport must not discard that observed result down
-// to a bare status string the way AsyncStartResult would force it to.
+// StartFactoryTarget returns the shared, genuinely asynchronous
+// factorysessions.AsyncStartResult: opening a Factory target runtime is not
+// itself dispatching content, so it carries only the opened identity and a
+// non-terminal status, never fabricated text or a terminal outcome. A
+// caller that needs the first turn's actual published outcome makes an
+// immediate, separate InvokeFactoryTarget call against the returned
+// identity -- the exact same operation a later turn's own invoke uses.
 type FactoryTargetService interface {
-	StartFactoryTarget(context.Context, factorysessions.StartRequest) (factorysessions.InvocationResult, error)
+	StartFactoryTarget(context.Context, factorysessions.StartRequest) (factorysessions.AsyncStartResult, error)
 	InvokeFactoryTarget(
 		context.Context,
 		string,

--- a/pkg/transports/acp/factory_target_service.go
+++ b/pkg/transports/acp/factory_target_service.go
@@ -1,0 +1,29 @@
+package acp
+
+import (
+	"context"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+)
+
+// FactoryTargetService is the narrow Factory Session start/invoke/cancel/
+// close dependency the production ACP prompt-delegation consumer needs. It
+// is declared here, in this transport's own public root, rather than
+// imported from another service's internal or wire subpackage, so this
+// package states the exact shape it consumes; pkg/wire constructs the
+// concrete collaborator (the chat_sessions-owned Factory Sessions shim) and
+// injects it as this contract.
+type FactoryTargetService interface {
+	StartFactoryTarget(context.Context, factorysessions.StartRequest) (factorysessions.AsyncStartResult, error)
+	InvokeFactoryTarget(
+		context.Context,
+		string,
+		factorysessions.InvocationRequest,
+	) (factorysessions.InvocationResult, error)
+	CancelFactoryTarget(
+		context.Context,
+		string,
+		factorysessions.ControlRequest,
+	) (factorysessions.LifecycleControlResult, error)
+	CloseFactoryTarget(context.Context, string) error
+}

--- a/pkg/transports/acp/factory_target_service.go
+++ b/pkg/transports/acp/factory_target_service.go
@@ -13,8 +13,17 @@ import (
 // package states the exact shape it consumes; pkg/wire constructs the
 // concrete collaborator (the chat_sessions-owned Factory Sessions shim) and
 // injects it as this contract.
+//
+// StartFactoryTarget returns factorysessions.InvocationResult, not the
+// shared factorysessions.AsyncStartResult a genuinely asynchronous
+// factorysessions.Service.StartAsync publishes: every implementation this
+// transport consumes activates a runtime and dispatches the first turn's
+// content synchronously, so it already observes a genuine terminal
+// InvocationResult (including ordered primary-result text) before
+// returning, and this transport must not discard that observed result down
+// to a bare status string the way AsyncStartResult would force it to.
 type FactoryTargetService interface {
-	StartFactoryTarget(context.Context, factorysessions.StartRequest) (factorysessions.AsyncStartResult, error)
+	StartFactoryTarget(context.Context, factorysessions.StartRequest) (factorysessions.InvocationResult, error)
 	InvokeFactoryTarget(
 		context.Context,
 		string,

--- a/pkg/transports/acp/internal/protocol/factory_outcome.go
+++ b/pkg/transports/acp/internal/protocol/factory_outcome.go
@@ -1,0 +1,86 @@
+package protocol
+
+import (
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+)
+
+// PromptOutcome is the bounded, safe-to-serialize projection of one Factory
+// Session outcome this transport maps into a "session/prompt" result: only
+// the deterministic ACP stop reason and the text extracted from supported
+// public primary-result content parts, in stable input order. It never
+// carries an invocation's raw ErrorCode, Message, session/work identifiers,
+// or any other internal field -- a caller must not fall back to serializing
+// the source result itself when this projection's Text is empty.
+type PromptOutcome struct {
+	StopReason acpsdk.StopReason
+	Text       []string
+}
+
+// MapFactoryInvocationOutcome is a total, deterministic mapping from one
+// completed Factory Session invocation (InvokeFactoryTarget) outcome to the
+// bounded ACP prompt outcome this transport returns. Text is projected only
+// from the invocation's published "text" primary-result parts, in the same
+// order they appear on result.PrimaryResult; an absent PrimaryResult or one
+// containing only unsupported part kinds (image/audio/JSON/binary) yields a
+// nil Text rather than fabricated content.
+func MapFactoryInvocationOutcome(result factorysessions.InvocationResult) PromptOutcome {
+	return PromptOutcome{
+		StopReason: mapFactoryTerminalStatus(string(result.Status)),
+		Text:       primaryResultText(result.PrimaryResult),
+	}
+}
+
+// MapFactoryStartOutcome is a total, deterministic mapping from one Factory
+// Session asynchronous start (StartFactoryTarget) outcome to the bounded ACP
+// prompt outcome this transport returns. An asynchronous start's published
+// result carries no primary-result content -- the invocation it begins has
+// not itself reached a terminal outcome yet -- so Text is always nil here;
+// only MapFactoryInvocationOutcome ever projects text, and only from an
+// invocation's own published result.
+func MapFactoryStartOutcome(result factorysessions.AsyncStartResult) PromptOutcome {
+	return PromptOutcome{StopReason: mapFactoryTerminalStatus(result.Status)}
+}
+
+// mapFactoryTerminalStatus is the shared total mapping both
+// MapFactoryInvocationOutcome and MapFactoryStartOutcome apply to their
+// respective published status vocabularies -- InvocationTerminalStatus
+// ("COMPLETED"/"CANCELED"/"FAILED"/"TIMED_OUT") and AsyncStartResult.Status
+// (a LifecycleStatus string, most often still "RUNNING" immediately after an
+// asynchronous start returns). A published completed outcome
+// ("COMPLETED"/"SUCCEEDED") maps to end_turn. A turn that stopped before
+// reaching a genuine completed or failed outcome -- caller-cancelled or
+// timed out -- maps to cancelled, the closest published ACP stop reason for
+// "did not run to natural completion" (ACP has no dedicated timeout
+// vocabulary). A published failure, a still-running/queued status observed
+// from an asynchronous start that has not reached a terminal outcome yet, or
+// any other unmapped status all fall back to end_turn -- the same documented
+// safe default this transport uses elsewhere for a Factory failure -- and
+// never disclose the underlying status, error code, or message.
+func mapFactoryTerminalStatus(status string) acpsdk.StopReason {
+	switch status {
+	case string(factorysessions.InvocationTerminalStatusCompleted), "SUCCEEDED":
+		return acpsdk.StopReasonEndTurn
+	case string(factorysessions.InvocationTerminalStatusCanceled), string(factorysessions.InvocationTerminalStatusTimedOut):
+		return acpsdk.StopReasonCancelled
+	default:
+		return acpsdk.StopReasonEndTurn
+	}
+}
+
+// primaryResultText extracts, in stable input order, only the "text" parts
+// of a published Factory Session primary result. Every other supported
+// public content part kind (image/audio/JSON/binary) is skipped rather than
+// fabricated into text.
+func primaryResultText(parts []work.WorkContentPart) []string {
+	var text []string
+	for _, part := range parts {
+		if part.Type.Normalized() != work.WorkContentPartTypeText {
+			continue
+		}
+		text = append(text, part.Text)
+	}
+	return text
+}

--- a/pkg/transports/acp/internal/protocol/factory_outcome.go
+++ b/pkg/transports/acp/internal/protocol/factory_outcome.go
@@ -20,12 +20,14 @@ type PromptOutcome struct {
 }
 
 // MapFactoryInvocationOutcome is a total, deterministic mapping from one
-// completed Factory Session invocation (InvokeFactoryTarget) outcome to the
-// bounded ACP prompt outcome this transport returns. Text is projected only
-// from the invocation's published "text" primary-result parts, in the same
-// order they appear on result.PrimaryResult; an absent PrimaryResult or one
-// containing only unsupported part kinds (image/audio/JSON/binary) yields a
-// nil Text rather than fabricated content.
+// completed Factory Session invocation (InvokeFactoryTarget, or the
+// synchronous activation StartFactoryTarget's own on-demand implementation
+// performs for a first turn) outcome to the bounded ACP prompt outcome this
+// transport returns. Text is projected only from the invocation's published
+// "text" primary-result parts, in the same order they appear on
+// result.PrimaryResult; an absent PrimaryResult or one containing only
+// unsupported part kinds (image/audio/JSON/binary) yields a nil Text rather
+// than fabricated content.
 func MapFactoryInvocationOutcome(result factorysessions.InvocationResult) PromptOutcome {
 	return PromptOutcome{
 		StopReason: mapFactoryTerminalStatus(string(result.Status)),
@@ -33,32 +35,17 @@ func MapFactoryInvocationOutcome(result factorysessions.InvocationResult) Prompt
 	}
 }
 
-// MapFactoryStartOutcome is a total, deterministic mapping from one Factory
-// Session asynchronous start (StartFactoryTarget) outcome to the bounded ACP
-// prompt outcome this transport returns. An asynchronous start's published
-// result carries no primary-result content -- the invocation it begins has
-// not itself reached a terminal outcome yet -- so Text is always nil here;
-// only MapFactoryInvocationOutcome ever projects text, and only from an
-// invocation's own published result.
-func MapFactoryStartOutcome(result factorysessions.AsyncStartResult) PromptOutcome {
-	return PromptOutcome{StopReason: mapFactoryTerminalStatus(result.Status)}
-}
-
-// mapFactoryTerminalStatus is the shared total mapping both
-// MapFactoryInvocationOutcome and MapFactoryStartOutcome apply to their
-// respective published status vocabularies -- InvocationTerminalStatus
-// ("COMPLETED"/"CANCELED"/"FAILED"/"TIMED_OUT") and AsyncStartResult.Status
-// (a LifecycleStatus string, most often still "RUNNING" immediately after an
-// asynchronous start returns). A published completed outcome
-// ("COMPLETED"/"SUCCEEDED") maps to end_turn. A turn that stopped before
-// reaching a genuine completed or failed outcome -- caller-cancelled or
-// timed out -- maps to cancelled, the closest published ACP stop reason for
-// "did not run to natural completion" (ACP has no dedicated timeout
-// vocabulary). A published failure, a still-running/queued status observed
-// from an asynchronous start that has not reached a terminal outcome yet, or
-// any other unmapped status all fall back to end_turn -- the same documented
-// safe default this transport uses elsewhere for a Factory failure -- and
-// never disclose the underlying status, error code, or message.
+// mapFactoryTerminalStatus is the total mapping MapFactoryInvocationOutcome
+// applies to the published InvocationTerminalStatus vocabulary
+// ("COMPLETED"/"CANCELED"/"FAILED"/"TIMED_OUT"). A published completed
+// outcome ("COMPLETED"/"SUCCEEDED") maps to end_turn. A turn that stopped
+// before reaching a genuine completed or failed outcome -- caller-cancelled
+// or timed out -- maps to cancelled, the closest published ACP stop reason
+// for "did not run to natural completion" (ACP has no dedicated timeout
+// vocabulary). A published failure, or any other unmapped status, falls back
+// to end_turn -- the same documented safe default this transport uses
+// elsewhere for a Factory failure -- and never discloses the underlying
+// status, error code, or message.
 func mapFactoryTerminalStatus(status string) acpsdk.StopReason {
 	switch status {
 	case string(factorysessions.InvocationTerminalStatusCompleted), "SUCCEEDED":

--- a/pkg/transports/acp/internal/protocol/factory_outcome_test.go
+++ b/pkg/transports/acp/internal/protocol/factory_outcome_test.go
@@ -1,0 +1,165 @@
+package protocol
+
+import (
+	"reflect"
+	"testing"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+)
+
+func TestMapFactoryInvocationOutcome_StopReasonMapping(t *testing.T) {
+	tests := []struct {
+		name   string
+		status factorysessions.InvocationTerminalStatus
+		want   acpsdk.StopReason
+	}{
+		{"completed", factorysessions.InvocationTerminalStatusCompleted, acpsdk.StopReasonEndTurn},
+		{"canceled", factorysessions.InvocationTerminalStatusCanceled, acpsdk.StopReasonCancelled},
+		{"timed_out", factorysessions.InvocationTerminalStatusTimedOut, acpsdk.StopReasonCancelled},
+		{"failed", factorysessions.InvocationTerminalStatusFailed, acpsdk.StopReasonEndTurn},
+		{"unknown_future_status", factorysessions.InvocationTerminalStatus("SOME_FUTURE_STATUS"), acpsdk.StopReasonEndTurn},
+		{"empty", factorysessions.InvocationTerminalStatus(""), acpsdk.StopReasonEndTurn},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MapFactoryInvocationOutcome(factorysessions.InvocationResult{Status: tt.status})
+			if got.StopReason != tt.want {
+				t.Errorf("MapFactoryInvocationOutcome(Status=%q).StopReason = %q, want %q", tt.status, got.StopReason, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapFactoryInvocationOutcome_ProjectsOnlyTextPartsInStableOrder(t *testing.T) {
+	result := factorysessions.InvocationResult{
+		Status: factorysessions.InvocationTerminalStatusCompleted,
+		PrimaryResult: []work.WorkContentPart{
+			{Type: work.WorkContentPartTypeText, Text: "first"},
+			{Type: work.WorkContentPartTypeImage, URL: "https://example.invalid/image.png"},
+			{Type: work.WorkContentPartTypeText, Text: "second"},
+			{Type: work.WorkContentPartTypeJSON, JSON: []byte(`{"k":"v"}`)},
+			{Type: work.WorkContentPartTypeText, Text: "third"},
+		},
+	}
+
+	got := MapFactoryInvocationOutcome(result)
+
+	want := []string{"first", "second", "third"}
+	if !reflect.DeepEqual(got.Text, want) {
+		t.Fatalf("MapFactoryInvocationOutcome().Text = %#v, want %#v", got.Text, want)
+	}
+}
+
+func TestMapFactoryInvocationOutcome_EmptyOrUnsupportedResultProducesNoFabricatedText(t *testing.T) {
+	tests := []struct {
+		name          string
+		primaryResult []work.WorkContentPart
+	}{
+		{"nil primary result", nil},
+		{"empty primary result", []work.WorkContentPart{}},
+		{"only unsupported parts", []work.WorkContentPart{
+			{Type: work.WorkContentPartTypeImage, URL: "https://example.invalid/image.png"},
+			{Type: work.WorkContentPartTypeBinary, File: "artifact.bin"},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MapFactoryInvocationOutcome(factorysessions.InvocationResult{
+				Status:        factorysessions.InvocationTerminalStatusCompleted,
+				PrimaryResult: tt.primaryResult,
+			})
+			if len(got.Text) != 0 {
+				t.Fatalf("MapFactoryInvocationOutcome().Text = %#v, want empty", got.Text)
+			}
+		})
+	}
+}
+
+// TestMapFactoryInvocationOutcome_NeverSerializesRawResultFields proves the
+// mapper never leaks an invocation's raw ErrorCode/Message/session/work
+// identifiers into the bounded PromptOutcome projection it returns.
+func TestMapFactoryInvocationOutcome_NeverSerializesRawResultFields(t *testing.T) {
+	sentinel := "provider command: /usr/local/bin/agent --token=sk-live-ABC123"
+	result := factorysessions.InvocationResult{
+		Status:    factorysessions.InvocationTerminalStatusFailed,
+		ErrorCode: string(factorysessions.InvocationErrorCodeRuntimeFailure),
+		Message:   sentinel,
+		SessionID: "fs-secret-session",
+		WorkID:    "work-secret",
+	}
+
+	got := MapFactoryInvocationOutcome(result)
+
+	v := reflect.ValueOf(got)
+	if v.NumField() != 2 {
+		t.Fatalf("PromptOutcome field count = %d, want exactly 2 (StopReason, Text)", v.NumField())
+	}
+	if len(got.Text) != 0 {
+		t.Fatalf("MapFactoryInvocationOutcome().Text = %#v, want empty for a failed invocation with no primary result", got.Text)
+	}
+}
+
+func TestMapFactoryStartOutcome_NeverFabricatesText(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+	}{
+		{"freshly started, still running", "RUNNING"},
+		{"queued", "QUEUED"},
+		{"empty status", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MapFactoryStartOutcome(factorysessions.AsyncStartResult{SessionID: "fs-1", Status: tt.status})
+			if got.StopReason != acpsdk.StopReasonEndTurn {
+				t.Errorf("MapFactoryStartOutcome(Status=%q).StopReason = %q, want end_turn safe fallback", tt.status, got.StopReason)
+			}
+			if len(got.Text) != 0 {
+				t.Errorf("MapFactoryStartOutcome(Status=%q).Text = %#v, want empty", tt.status, got.Text)
+			}
+		})
+	}
+}
+
+func TestMapFactoryStartOutcome_TerminalStatusMapping(t *testing.T) {
+	tests := []struct {
+		status string
+		want   acpsdk.StopReason
+	}{
+		{"CANCELED", acpsdk.StopReasonCancelled},
+		{"TIMED_OUT", acpsdk.StopReasonCancelled},
+		{"FAILED", acpsdk.StopReasonEndTurn},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			got := MapFactoryStartOutcome(factorysessions.AsyncStartResult{Status: tt.status})
+			if got.StopReason != tt.want {
+				t.Errorf("MapFactoryStartOutcome(Status=%q).StopReason = %q, want %q", tt.status, got.StopReason, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapFactoryOutcomes_AreDeterministic(t *testing.T) {
+	invocation := factorysessions.InvocationResult{
+		Status: factorysessions.InvocationTerminalStatusCompleted,
+		PrimaryResult: []work.WorkContentPart{
+			{Type: work.WorkContentPartTypeText, Text: "hello"},
+		},
+	}
+	first := MapFactoryInvocationOutcome(invocation)
+	second := MapFactoryInvocationOutcome(invocation)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("MapFactoryInvocationOutcome() is not deterministic: %+v vs %+v", first, second)
+	}
+
+	start := factorysessions.AsyncStartResult{Status: "RUNNING"}
+	firstStart := MapFactoryStartOutcome(start)
+	secondStart := MapFactoryStartOutcome(start)
+	if !reflect.DeepEqual(firstStart, secondStart) {
+		t.Fatalf("MapFactoryStartOutcome() is not deterministic: %+v vs %+v", firstStart, secondStart)
+	}
+}

--- a/pkg/transports/acp/internal/protocol/factory_outcome_test.go
+++ b/pkg/transports/acp/internal/protocol/factory_outcome_test.go
@@ -102,47 +102,6 @@ func TestMapFactoryInvocationOutcome_NeverSerializesRawResultFields(t *testing.T
 	}
 }
 
-func TestMapFactoryStartOutcome_NeverFabricatesText(t *testing.T) {
-	tests := []struct {
-		name   string
-		status string
-	}{
-		{"freshly started, still running", "RUNNING"},
-		{"queued", "QUEUED"},
-		{"empty status", ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := MapFactoryStartOutcome(factorysessions.AsyncStartResult{SessionID: "fs-1", Status: tt.status})
-			if got.StopReason != acpsdk.StopReasonEndTurn {
-				t.Errorf("MapFactoryStartOutcome(Status=%q).StopReason = %q, want end_turn safe fallback", tt.status, got.StopReason)
-			}
-			if len(got.Text) != 0 {
-				t.Errorf("MapFactoryStartOutcome(Status=%q).Text = %#v, want empty", tt.status, got.Text)
-			}
-		})
-	}
-}
-
-func TestMapFactoryStartOutcome_TerminalStatusMapping(t *testing.T) {
-	tests := []struct {
-		status string
-		want   acpsdk.StopReason
-	}{
-		{"CANCELED", acpsdk.StopReasonCancelled},
-		{"TIMED_OUT", acpsdk.StopReasonCancelled},
-		{"FAILED", acpsdk.StopReasonEndTurn},
-	}
-	for _, tt := range tests {
-		t.Run(tt.status, func(t *testing.T) {
-			got := MapFactoryStartOutcome(factorysessions.AsyncStartResult{Status: tt.status})
-			if got.StopReason != tt.want {
-				t.Errorf("MapFactoryStartOutcome(Status=%q).StopReason = %q, want %q", tt.status, got.StopReason, tt.want)
-			}
-		})
-	}
-}
-
 func TestMapFactoryOutcomes_AreDeterministic(t *testing.T) {
 	invocation := factorysessions.InvocationResult{
 		Status: factorysessions.InvocationTerminalStatusCompleted,
@@ -154,12 +113,5 @@ func TestMapFactoryOutcomes_AreDeterministic(t *testing.T) {
 	second := MapFactoryInvocationOutcome(invocation)
 	if !reflect.DeepEqual(first, second) {
 		t.Fatalf("MapFactoryInvocationOutcome() is not deterministic: %+v vs %+v", first, second)
-	}
-
-	start := factorysessions.AsyncStartResult{Status: "RUNNING"}
-	firstStart := MapFactoryStartOutcome(start)
-	secondStart := MapFactoryStartOutcome(start)
-	if !reflect.DeepEqual(firstStart, secondStart) {
-		t.Fatalf("MapFactoryStartOutcome() is not deterministic: %+v vs %+v", firstStart, secondStart)
 	}
 }

--- a/pkg/transports/acp/internal/stdio/server.go
+++ b/pkg/transports/acp/internal/stdio/server.go
@@ -180,6 +180,23 @@ func (s *Server) serveConnection(ctx context.Context, connectionID identity.Conn
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 	scanner.Split(scanCompleteLines)
 
+	// notify is this connection's one outbound "session/update" delivery
+	// capability, carried through each dispatched request's context (see
+	// contextWithPromptNotifier in session_prompt.go) rather than threaded as
+	// an explicit parameter -- the only dispatched method that ever uses it
+	// is "session/prompt", and adding a parameter every other handler and
+	// every existing unit test would have to accept for a capability they
+	// never use is exactly the kind of unnecessary plumbing a request-scoped
+	// context value avoids. Writing a notification line and writing this
+	// same request's eventual response line can never interleave with each
+	// other or with another request's lines: dispatchRequest runs to
+	// completion (and any notify call within it, synchronously) before this
+	// loop's single writeResponse call for the same line, and the next line
+	// is never read until that happens.
+	notify := func(n acpsdk.SessionNotification) error {
+		return writeNotification(out, n)
+	}
+
 	var notificationSeq uint64
 	for {
 		if err := ctx.Err(); err != nil {
@@ -202,7 +219,8 @@ func (s *Server) serveConnection(ctx context.Context, connectionID identity.Conn
 		}
 		raw := append(json.RawMessage(nil), line...)
 
-		env, result, rpcErr := s.dispatchRequest(ctx, connectionID, notificationSeq, raw)
+		reqCtx := contextWithPromptNotifier(ctx, notify)
+		env, result, rpcErr := s.dispatchRequest(reqCtx, connectionID, notificationSeq, raw)
 		if env.IsNotification {
 			notificationSeq++
 			continue
@@ -326,6 +344,40 @@ func writeResponse(out io.Writer, reqIdentity identity.RequestIdentity, result j
 	}
 
 	body, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	body = append(body, '\n')
+
+	n, err := out.Write(body)
+	if err != nil {
+		return err
+	}
+	if n != len(body) {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+
+// notificationMessage is the wire shape of one JSON-RPC 2.0 notification: no
+// "id" member at all (not even null), matching NotificationMethods' contract
+// that a notification never has a response counterpart.
+type notificationMessage struct {
+	JSONRPC string                     `json:"jsonrpc"`
+	Method  string                     `json:"method"`
+	Params  acpsdk.SessionNotification `json:"params"`
+}
+
+// writeNotification serializes and writes exactly one complete
+// newline-terminated "session/update" JSON-RPC notification. A short write
+// is reported as io.ErrShortWrite rather than treated as success, matching
+// writeResponse's own short-write handling.
+func writeNotification(out io.Writer, params acpsdk.SessionNotification) error {
+	body, err := json.Marshal(notificationMessage{
+		JSONRPC: "2.0",
+		Method:  acpsdk.ClientMethodSessionUpdate,
+		Params:  params,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/transports/acp/internal/stdio/server.go
+++ b/pkg/transports/acp/internal/stdio/server.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	acp "github.com/portpowered/infinite-you/pkg/transports/acp"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/envelope"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/identity"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/negotiation"
@@ -55,17 +56,20 @@ var errNullInitializeParams = errors.New("acp: initialize params must not be nul
 //
 // chatSessions and catalog are the canonical Chat Sessions collaborators
 // "session/new", "session/set_config_option", the "/factory" fallback
-// command, and ordinary prompt turn admission dispatch to; resolveHomeDir
-// supplies the operator home directory used to derive the Operator Settings
-// document path and Factory discovery roots for a catalog resolution. Any of
-// the three may be nil, in which case a dispatched method reports a bounded
-// internal error instead of proceeding -- so a Server constructed for a
-// slice of this transport that never exercises them (for example the
-// "initialize"-only smoke tests in this package) never has to supply them.
+// command, and ordinary prompt turn admission dispatch to; factoryTarget is
+// the consumer-owned Factory Sessions shim an admitted ordinary prompt turn
+// starts or invokes against; resolveHomeDir supplies the operator home
+// directory used to derive the Operator Settings document path and Factory
+// discovery roots for a catalog resolution. Any of the four may be nil, in
+// which case a dispatched method reports a bounded internal error instead of
+// proceeding -- so a Server constructed for a slice of this transport that
+// never exercises them (for example the "initialize"-only smoke tests in
+// this package) never has to supply them.
 type Server struct {
 	logger         logging.Logger
 	chatSessions   chatsessions.Service
 	catalog        chatsessions.FactoryTargetCatalogService
+	factoryTarget  acp.FactoryTargetService
 	resolveHomeDir func() (string, error)
 }
 
@@ -76,12 +80,14 @@ func New(
 	logger logging.Logger,
 	chatSessions chatsessions.Service,
 	catalog chatsessions.FactoryTargetCatalogService,
+	factoryTarget acp.FactoryTargetService,
 	resolveHomeDir func() (string, error),
 ) *Server {
 	return &Server{
 		logger:         logging.EnsureLogger(logger),
 		chatSessions:   chatSessions,
 		catalog:        catalog,
+		factoryTarget:  factoryTarget,
 		resolveHomeDir: resolveHomeDir,
 	}
 }

--- a/pkg/transports/acp/internal/stdio/server.go
+++ b/pkg/transports/acp/internal/stdio/server.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"sync"
 
 	acpsdk "github.com/coder/acp-go-sdk"
 
@@ -73,6 +74,23 @@ type Server struct {
 	catalog        chatsessions.FactoryTargetCatalogService
 	factoryTarget  acp.FactoryTargetService
 	resolveHomeDir func() (string, error)
+
+	// pendingFactoryStartsMu guards pendingFactoryStarts, the reconciliation
+	// record a first-turn dispatch consults so a BindFactorySession failure
+	// (for any reason other than a genuine different-identity conflict)
+	// never causes a later retry to start a second Factory Session for the
+	// same still-unbound episode -- see startFactorySessionForEpisode.
+	pendingFactoryStartsMu sync.Mutex
+	pendingFactoryStarts   map[pendingFactoryStartKey]string
+}
+
+// pendingFactoryStartKey identifies one Chat Session's target episode, the
+// granularity at which startFactorySessionForEpisode's reconciliation record
+// is tracked -- matching exactly what an episode's own FactorySessionID
+// binding is scoped to.
+type pendingFactoryStartKey struct {
+	sessionID string
+	episode   uint64
 }
 
 // New constructs an inert stdio Server. Construction alone performs no
@@ -86,12 +104,42 @@ func New(
 	resolveHomeDir func() (string, error),
 ) *Server {
 	return &Server{
-		logger:         logging.EnsureLogger(logger),
-		chatSessions:   chatSessions,
-		catalog:        catalog,
-		factoryTarget:  factoryTarget,
-		resolveHomeDir: resolveHomeDir,
+		logger:               logging.EnsureLogger(logger),
+		chatSessions:         chatSessions,
+		catalog:              catalog,
+		factoryTarget:        factoryTarget,
+		resolveHomeDir:       resolveHomeDir,
+		pendingFactoryStarts: make(map[pendingFactoryStartKey]string),
 	}
+}
+
+// lookupPendingFactoryStart reports the Factory Session identity a prior
+// admitted turn for key already started but never committed via
+// BindFactorySession, if any.
+func (s *Server) lookupPendingFactoryStart(key pendingFactoryStartKey) (string, bool) {
+	s.pendingFactoryStartsMu.Lock()
+	defer s.pendingFactoryStartsMu.Unlock()
+	id, ok := s.pendingFactoryStarts[key]
+	return id, ok
+}
+
+// setPendingFactoryStart records that sessionID is the Factory Session
+// identity a start for key produced, before the binding that would commit it
+// is attempted -- so a bind failure never loses track of an already-started
+// runtime.
+func (s *Server) setPendingFactoryStart(key pendingFactoryStartKey, sessionID string) {
+	s.pendingFactoryStartsMu.Lock()
+	defer s.pendingFactoryStartsMu.Unlock()
+	s.pendingFactoryStarts[key] = sessionID
+}
+
+// clearPendingFactoryStart removes key's reconciliation record, once its
+// Factory Session identity has either been committed via BindFactorySession
+// or abandoned (a different identity already won and this one was closed).
+func (s *Server) clearPendingFactoryStart(key pendingFactoryStartKey) {
+	s.pendingFactoryStartsMu.Lock()
+	defer s.pendingFactoryStartsMu.Unlock()
+	delete(s.pendingFactoryStarts, key)
 }
 
 // Serve begins one connection-scoped serving invocation over caller-owned

--- a/pkg/transports/acp/internal/stdio/server.go
+++ b/pkg/transports/acp/internal/stdio/server.go
@@ -5,13 +5,15 @@
 // plus "session/prompt" -- both the "/factory <value>" fallback command
 // recognized within it (final-proposal.md §3) and, for every other
 // (genuine, non-command) prompt, admission of exactly one version-guarded
-// Chat turn against the canonical Chat Sessions authority -- protocol-safe
-// rejection of malformed input, unsupported methods, and unsupported
-// protocol versions, and deterministic termination on clean EOF, context
-// cancellation, a partial trailing frame, or a writer failure. An admitted
-// ordinary prompt turn's downstream Factory Session dispatch and terminal
-// response mapping are not yet implemented by this transport slice and
-// report a bounded internal error rather than fabricated success; every
+// Chat turn against the canonical Chat Sessions authority, followed by
+// starting (first turn in an episode) or invoking (later turns) the bound
+// Factory Session and mapping its published outcome, deterministically and
+// without fabrication, into the one final "session/prompt" response --
+// protocol-safe rejection of malformed input, unsupported methods, and
+// unsupported protocol versions, and deterministic termination on clean
+// EOF, context cancellation, a partial trailing frame, or a writer failure.
+// This transport slice does not yet terminalize the admitted Chat turn
+// itself after a downstream Factory failure (a later story's scope); every
 // other deferred ACP session and prompt behavior continues to receive
 // method-not-found. It is internal to pkg/transports/acp; callers use the
 // package root's exported operations instead of this package directly.

--- a/pkg/transports/acp/internal/stdio/server.go
+++ b/pkg/transports/acp/internal/stdio/server.go
@@ -26,7 +26,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"sync"
 
 	acpsdk "github.com/coder/acp-go-sdk"
 
@@ -68,29 +67,21 @@ var errNullInitializeParams = errors.New("acp: initialize params must not be nul
 // proceeding -- so a Server constructed for a slice of this transport that
 // never exercises them (for example the "initialize"-only smoke tests in
 // this package) never has to supply them.
+//
+// A Server instance holds no reconciliation state of its own for a started-
+// but-not-yet-bound Factory Session: that record lives on the episode itself
+// (TargetEpisode.PendingFactorySessionID, via
+// chatsessions.Service.RecordPendingFactorySession) under the singular Chat/
+// Factory Sessions authority, so the "retry after a post-start failure
+// cannot create a second Factory Session" guarantee survives this Server
+// being reconstructed, not just this one instance staying alive -- see
+// startFactorySessionForEpisode.
 type Server struct {
 	logger         logging.Logger
 	chatSessions   chatsessions.Service
 	catalog        chatsessions.FactoryTargetCatalogService
 	factoryTarget  acp.FactoryTargetService
 	resolveHomeDir func() (string, error)
-
-	// pendingFactoryStartsMu guards pendingFactoryStarts, the reconciliation
-	// record a first-turn dispatch consults so a BindFactorySession failure
-	// (for any reason other than a genuine different-identity conflict)
-	// never causes a later retry to start a second Factory Session for the
-	// same still-unbound episode -- see startFactorySessionForEpisode.
-	pendingFactoryStartsMu sync.Mutex
-	pendingFactoryStarts   map[pendingFactoryStartKey]string
-}
-
-// pendingFactoryStartKey identifies one Chat Session's target episode, the
-// granularity at which startFactorySessionForEpisode's reconciliation record
-// is tracked -- matching exactly what an episode's own FactorySessionID
-// binding is scoped to.
-type pendingFactoryStartKey struct {
-	sessionID string
-	episode   uint64
 }
 
 // New constructs an inert stdio Server. Construction alone performs no
@@ -104,42 +95,12 @@ func New(
 	resolveHomeDir func() (string, error),
 ) *Server {
 	return &Server{
-		logger:               logging.EnsureLogger(logger),
-		chatSessions:         chatSessions,
-		catalog:              catalog,
-		factoryTarget:        factoryTarget,
-		resolveHomeDir:       resolveHomeDir,
-		pendingFactoryStarts: make(map[pendingFactoryStartKey]string),
+		logger:         logging.EnsureLogger(logger),
+		chatSessions:   chatSessions,
+		catalog:        catalog,
+		factoryTarget:  factoryTarget,
+		resolveHomeDir: resolveHomeDir,
 	}
-}
-
-// lookupPendingFactoryStart reports the Factory Session identity a prior
-// admitted turn for key already started but never committed via
-// BindFactorySession, if any.
-func (s *Server) lookupPendingFactoryStart(key pendingFactoryStartKey) (string, bool) {
-	s.pendingFactoryStartsMu.Lock()
-	defer s.pendingFactoryStartsMu.Unlock()
-	id, ok := s.pendingFactoryStarts[key]
-	return id, ok
-}
-
-// setPendingFactoryStart records that sessionID is the Factory Session
-// identity a start for key produced, before the binding that would commit it
-// is attempted -- so a bind failure never loses track of an already-started
-// runtime.
-func (s *Server) setPendingFactoryStart(key pendingFactoryStartKey, sessionID string) {
-	s.pendingFactoryStartsMu.Lock()
-	defer s.pendingFactoryStartsMu.Unlock()
-	s.pendingFactoryStarts[key] = sessionID
-}
-
-// clearPendingFactoryStart removes key's reconciliation record, once its
-// Factory Session identity has either been committed via BindFactorySession
-// or abandoned (a different identity already won and this one was closed).
-func (s *Server) clearPendingFactoryStart(key pendingFactoryStartKey) {
-	s.pendingFactoryStartsMu.Lock()
-	defer s.pendingFactoryStartsMu.Unlock()
-	delete(s.pendingFactoryStarts, key)
 }
 
 // Serve begins one connection-scoped serving invocation over caller-owned

--- a/pkg/transports/acp/internal/stdio/server.go
+++ b/pkg/transports/acp/internal/stdio/server.go
@@ -2,17 +2,19 @@
 // caller-owned stream serving, one-connection lifecycle, connection-scoped
 // identity assignment, newline-delimited JSON-RPC framing and dispatch for
 // the "initialize", "session/new", and "session/set_config_option" methods,
-// plus the "/factory <value>" fallback command recognized within
-// "session/prompt" (final-proposal.md §3), protocol-safe rejection of
-// malformed input, unsupported methods, and unsupported protocol versions,
-// and deterministic termination on clean EOF, context cancellation, a
-// partial trailing frame, or a writer failure. "session/prompt" content
-// other than the exact "/factory <value>" command -- including every other
-// deferred ACP session and prompt behavior -- is not yet implemented by
-// this transport and receives method-not-found rather than being
-// dispatched to any effect. It is internal to pkg/transports/acp; callers
-// use the package root's exported operations instead of this package
-// directly.
+// plus "session/prompt" -- both the "/factory <value>" fallback command
+// recognized within it (final-proposal.md §3) and, for every other
+// (genuine, non-command) prompt, admission of exactly one version-guarded
+// Chat turn against the canonical Chat Sessions authority -- protocol-safe
+// rejection of malformed input, unsupported methods, and unsupported
+// protocol versions, and deterministic termination on clean EOF, context
+// cancellation, a partial trailing frame, or a writer failure. An admitted
+// ordinary prompt turn's downstream Factory Session dispatch and terminal
+// response mapping are not yet implemented by this transport slice and
+// report a bounded internal error rather than fabricated success; every
+// other deferred ACP session and prompt behavior continues to receive
+// method-not-found. It is internal to pkg/transports/acp; callers use the
+// package root's exported operations instead of this package directly.
 package stdio
 
 import (
@@ -52,8 +54,8 @@ var errNullInitializeParams = errors.New("acp: initialize params must not be nul
 // supplies for that call.
 //
 // chatSessions and catalog are the canonical Chat Sessions collaborators
-// "session/new", "session/set_config_option", and the "/factory" fallback
-// command dispatch to; resolveHomeDir
+// "session/new", "session/set_config_option", the "/factory" fallback
+// command, and ordinary prompt turn admission dispatch to; resolveHomeDir
 // supplies the operator home directory used to derive the Operator Settings
 // document path and Factory discovery roots for a catalog resolution. Any of
 // the three may be nil, in which case a dispatched method reports a bounded

--- a/pkg/transports/acp/internal/stdio/server.go
+++ b/pkg/transports/acp/internal/stdio/server.go
@@ -7,14 +7,14 @@
 // (genuine, non-command) prompt, admission of exactly one version-guarded
 // Chat turn against the canonical Chat Sessions authority, followed by
 // starting (first turn in an episode) or invoking (later turns) the bound
-// Factory Session and mapping its published outcome, deterministically and
-// without fabrication, into the one final "session/prompt" response --
+// Factory Session, mapping its published outcome, deterministically and
+// without fabrication, into the one final "session/prompt" response, and
+// terminalizing the admitted turn on every outcome (COMPLETED, CANCELED, or
+// FAILED) so no admitted turn is ever left stranded non-terminal --
 // protocol-safe rejection of malformed input, unsupported methods, and
 // unsupported protocol versions, and deterministic termination on clean
 // EOF, context cancellation, a partial trailing frame, or a writer failure.
-// This transport slice does not yet terminalize the admitted Chat turn
-// itself after a downstream Factory failure (a later story's scope); every
-// other deferred ACP session and prompt behavior continues to receive
+// Every other deferred ACP session and prompt behavior continues to receive
 // method-not-found. It is internal to pkg/transports/acp; callers use the
 // package root's exported operations instead of this package directly.
 package stdio

--- a/pkg/transports/acp/internal/stdio/server_smoke_test.go
+++ b/pkg/transports/acp/internal/stdio/server_smoke_test.go
@@ -46,7 +46,7 @@ func TestServe_PipeSmoke_RealStdioInitializeExchangeAndCleanEOF(t *testing.T) {
 		_ = stdoutWrite.Close()
 	})
 
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	serveErr := make(chan error, 1)
 	go func() {
 		serveErr <- server.Serve(context.Background(), stdinRead, stdoutWrite)

--- a/pkg/transports/acp/internal/stdio/server_test.go
+++ b/pkg/transports/acp/internal/stdio/server_test.go
@@ -58,7 +58,7 @@ var _ logging.Logger = (*recordingLogger)(nil)
 
 func TestNewPerformsNoIO(t *testing.T) {
 	logger := &recordingLogger{}
-	server := New(logger, nil, nil, nil)
+	server := New(logger, nil, nil, nil, nil)
 	if server == nil {
 		t.Fatal("New() returned nil")
 	}
@@ -68,7 +68,7 @@ func TestNewPerformsNoIO(t *testing.T) {
 }
 
 func TestServeRejectsMissingStreams(t *testing.T) {
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	buf := &bytes.Buffer{}
 
 	cases := []struct {
@@ -103,7 +103,7 @@ func TestServeRejectsNilServer(t *testing.T) {
 }
 
 func TestServeReturnsOnCleanEOF(t *testing.T) {
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	err := server.Serve(context.Background(), strings.NewReader("first line\nsecond line\n"), &bytes.Buffer{})
 	if err != nil {
 		t.Fatalf("Serve() error = %v, want nil on clean EOF", err)
@@ -114,7 +114,7 @@ func TestServeRejectsAlreadyCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	err := server.Serve(ctx, strings.NewReader(""), &bytes.Buffer{})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Serve() error = %v, want context.Canceled", err)
@@ -123,7 +123,7 @@ func TestServeRejectsAlreadyCancelledContext(t *testing.T) {
 
 func TestServeMintsDistinctConnectionIDsPerInvocation(t *testing.T) {
 	logger := &recordingLogger{}
-	server := New(logger, nil, nil, nil)
+	server := New(logger, nil, nil, nil, nil)
 
 	if err := server.Serve(context.Background(), strings.NewReader(""), &bytes.Buffer{}); err != nil {
 		t.Fatalf("Serve() first call error = %v", err)
@@ -145,7 +145,7 @@ func TestServeMintsDistinctConnectionIDsPerInvocation(t *testing.T) {
 
 func TestServeLogsStartAndTerminalOutcomeWithoutPayload(t *testing.T) {
 	logger := &recordingLogger{}
-	server := New(logger, nil, nil, nil)
+	server := New(logger, nil, nil, nil, nil)
 
 	payload := "super-secret-prompt-content"
 	if err := server.Serve(context.Background(), strings.NewReader(payload+"\n"), &bytes.Buffer{}); err != nil {
@@ -255,7 +255,7 @@ func TestServeRespondsToValidInitializeRequests(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			out := &bytes.Buffer{}
-			server := New(nil, nil, nil, nil)
+			server := New(nil, nil, nil, nil, nil)
 			if err := server.Serve(context.Background(), strings.NewReader(initializeLine(tc.id)), out); err != nil {
 				t.Fatalf("Serve() error = %v", err)
 			}
@@ -279,7 +279,7 @@ func TestServeFramesOneResponsePerCompleteInputLine(t *testing.T) {
 	input := initializeLine("1") + initializeLine("2")
 
 	out := &bytes.Buffer{}
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
 		t.Fatalf("Serve() error = %v", err)
 	}
@@ -303,7 +303,7 @@ func TestServeSkipsEmptyLines(t *testing.T) {
 	input := "\n" + initializeLine("1") + "\n"
 
 	out := &bytes.Buffer{}
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
 		t.Fatalf("Serve() error = %v", err)
 	}
@@ -313,7 +313,7 @@ func TestServeSkipsEmptyLines(t *testing.T) {
 
 func TestServeIsolatesConnectionsReusingTheSameWireID(t *testing.T) {
 	logger := &recordingLogger{}
-	server := New(logger, nil, nil, nil)
+	server := New(logger, nil, nil, nil, nil)
 
 	firstOut := &bytes.Buffer{}
 	if err := server.Serve(context.Background(), strings.NewReader(initializeLine("1")), firstOut); err != nil {
@@ -363,7 +363,7 @@ func TestServeRespondsMethodNotFoundForEveryUnimplementedMethod(t *testing.T) {
 			input := fmt.Sprintf(`{"jsonrpc":"2.0","id":9,"method":%q,"params":{}}`, method) + "\n"
 
 			out := &bytes.Buffer{}
-			server := New(nil, nil, nil, nil)
+			server := New(nil, nil, nil, nil, nil)
 			if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
 				t.Fatalf("Serve() error = %v", err)
 			}
@@ -384,7 +384,7 @@ func TestServeRespondsMethodNotFoundForEveryUnimplementedMethod(t *testing.T) {
 // id could ever be recovered from input this broken.
 func TestServeRespondsWithParseErrorForMalformedJSON(t *testing.T) {
 	out := &bytes.Buffer{}
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	if err := server.Serve(context.Background(), strings.NewReader("{not json\n"), out); err != nil {
 		t.Fatalf("Serve() error = %v", err)
 	}
@@ -448,7 +448,7 @@ func TestServeRespondsWithInvalidRequestForStructurallyInvalidShapes(t *testing.
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			out := &bytes.Buffer{}
-			server := New(nil, nil, nil, nil)
+			server := New(nil, nil, nil, nil, nil)
 			if err := server.Serve(context.Background(), strings.NewReader(tc.line), out); err != nil {
 				t.Fatalf("Serve() error = %v", err)
 			}
@@ -480,7 +480,7 @@ func TestServeRespondsWithInvalidParamsForBadInitializeParams(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			out := &bytes.Buffer{}
-			server := New(nil, nil, nil, nil)
+			server := New(nil, nil, nil, nil, nil)
 			if err := server.Serve(context.Background(), strings.NewReader(tc.line), out); err != nil {
 				t.Fatalf("Serve() error = %v", err)
 			}
@@ -505,7 +505,7 @@ func TestServeMapsUnsupportedProtocolVersionToCorrelatedFactsWithNoCapabilities(
 	line := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":99}}` + "\n"
 
 	out := &bytes.Buffer{}
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	if err := server.Serve(context.Background(), strings.NewReader(line), out); err != nil {
 		t.Fatalf("Serve() error = %v", err)
 	}
@@ -542,7 +542,7 @@ func TestServeEmitsNoResponseForAValidNotification(t *testing.T) {
 	line := `{"jsonrpc":"2.0","method":"session/cancel","params":{"sessionId":"s"}}` + "\n"
 
 	out := &bytes.Buffer{}
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	if err := server.Serve(context.Background(), strings.NewReader(line), out); err != nil {
 		t.Fatalf("Serve() error = %v", err)
 	}
@@ -570,7 +570,7 @@ func TestServeEmitsNoResponseForAnUnsupportedNoIDMessage(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			out := &bytes.Buffer{}
-			server := New(nil, nil, nil, nil)
+			server := New(nil, nil, nil, nil, nil)
 			if err := server.Serve(context.Background(), strings.NewReader(tc.line), out); err != nil {
 				t.Fatalf("Serve() error = %v", err)
 			}
@@ -588,7 +588,7 @@ func TestServeContinuesProcessingAfterARecoverableRequestError(t *testing.T) {
 	input := "{not json\n" + initializeLine("1")
 
 	out := &bytes.Buffer{}
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
 		t.Fatalf("Serve() error = %v", err)
 	}
@@ -646,7 +646,7 @@ func TestServeErrorResponsesAndDiagnosticsNeverLeakSeededSensitiveSentinels(t *t
 			t.Run(sentinel+"/"+name, func(t *testing.T) {
 				out := &bytes.Buffer{}
 				logger := &recordingLogger{}
-				server := New(logger, nil, nil, nil)
+				server := New(logger, nil, nil, nil, nil)
 				if err := server.Serve(context.Background(), strings.NewReader(line), out); err != nil {
 					t.Fatalf("Serve() error = %v", err)
 				}
@@ -721,7 +721,7 @@ func TestServeReturnsContextErrorOnMidReadCancellation(t *testing.T) {
 		return pr.Read(p)
 	})
 
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	done := make(chan error, 1)
 	go func() {
 		done <- server.Serve(ctx, in, &bytes.Buffer{})
@@ -775,7 +775,7 @@ func TestServeLogsCancelledOutcomeDistinctFromError(t *testing.T) {
 	})
 
 	logger := &recordingLogger{}
-	server := New(logger, nil, nil, nil)
+	server := New(logger, nil, nil, nil, nil)
 	done := make(chan error, 1)
 	go func() {
 		done <- server.Serve(ctx, in, &bytes.Buffer{})
@@ -818,7 +818,7 @@ func TestServeRejectsPartialTrailingFrameAsProtocolFailure(t *testing.T) {
 	partial := strings.TrimSuffix(initializeLine("1"), "\n")
 
 	out := &bytes.Buffer{}
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	err := server.Serve(context.Background(), strings.NewReader(partial), out)
 	if err == nil {
 		t.Fatal("Serve() error = nil, want a protocol failure for a partial trailing frame")
@@ -840,7 +840,7 @@ func TestServeRejectsPartialTrailingFrameAfterACompleteLine(t *testing.T) {
 	input := initializeLine("1") + `{"jsonrpc":"2.0","id":2,"method":"initialize"`
 
 	out := &bytes.Buffer{}
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	err := server.Serve(context.Background(), strings.NewReader(input), out)
 	if !errors.Is(err, errPartialTrailingFrame) {
 		t.Fatalf("Serve() error = %v, want errPartialTrailingFrame", err)
@@ -880,7 +880,7 @@ func TestServeSurfacesWriterFailureAndStopsFurtherWrites(t *testing.T) {
 	wantErr := errors.New("acp test: simulated write failure")
 	writer := &countingErrorWriter{err: wantErr}
 
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	input := initializeLine("1") + initializeLine("2")
 	err := server.Serve(context.Background(), strings.NewReader(input), writer)
 	if !errors.Is(err, wantErr) {
@@ -906,7 +906,7 @@ func (shortWriter) Write(p []byte) (int, error) {
 // reported as io.ErrShortWrite and ends the connection, so a truncated
 // response can never be mistaken for a successful initialize exchange.
 func TestServeTreatsShortWriteAsFailureNotSuccess(t *testing.T) {
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	err := server.Serve(context.Background(), strings.NewReader(initializeLine("1")), shortWriter{})
 	if !errors.Is(err, io.ErrShortWrite) {
 		t.Fatalf("Serve() error = %v, want io.ErrShortWrite", err)
@@ -982,7 +982,7 @@ func TestServeHandlesConcurrentConnectionsWithoutRaces(t *testing.T) {
 	const concurrency = 20
 
 	logger := &syncRecordingLogger{}
-	server := New(logger, nil, nil, nil)
+	server := New(logger, nil, nil, nil, nil)
 
 	outs := make([]*bytes.Buffer, concurrency)
 	errs := make([]error, concurrency)

--- a/pkg/transports/acp/internal/stdio/session_new_test.go
+++ b/pkg/transports/acp/internal/stdio/session_new_test.go
@@ -61,8 +61,16 @@ type fakeChatSessionsService struct {
 
 	bindFactorySessionCalled bool
 	bindFactorySessionReq    chatsessions.BindFactorySessionRequest
+	bindFactorySessionReqs   []chatsessions.BindFactorySessionRequest
 	bindFactorySessionResult chatsessions.BindFactorySessionResult
-	bindFactorySessionErr    error
+	// bindFactorySessionErrs, when non-empty, is consumed front-first across
+	// successive BindFactorySession calls (one queued error per call, nil
+	// meaning that call succeeds) instead of the single static
+	// bindFactorySessionErr -- for retry tests that need one specific bind
+	// attempt to fail while a later retry against the same pending identity
+	// succeeds.
+	bindFactorySessionErrs []error
+	bindFactorySessionErr  error
 
 	advanceTurnCalled bool
 	advanceTurnReq    chatsessions.AdvanceTurnRequest
@@ -146,6 +154,15 @@ func (f *fakeChatSessionsService) BindFactorySession(_ context.Context, req chat
 	defer f.mu.Unlock()
 	f.bindFactorySessionCalled = true
 	f.bindFactorySessionReq = req
+	f.bindFactorySessionReqs = append(f.bindFactorySessionReqs, req)
+	if len(f.bindFactorySessionErrs) > 0 {
+		next := f.bindFactorySessionErrs[0]
+		f.bindFactorySessionErrs = f.bindFactorySessionErrs[1:]
+		if next != nil {
+			return chatsessions.BindFactorySessionResult{}, next
+		}
+		return f.bindFactorySessionResult, nil
+	}
 	if f.bindFactorySessionErr != nil {
 		return chatsessions.BindFactorySessionResult{}, f.bindFactorySessionErr
 	}

--- a/pkg/transports/acp/internal/stdio/session_new_test.go
+++ b/pkg/transports/acp/internal/stdio/session_new_test.go
@@ -14,6 +14,8 @@ import (
 	acpsdk "github.com/coder/acp-go-sdk"
 
 	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	acp "github.com/portpowered/infinite-you/pkg/transports/acp"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/envelope"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/identity"
 )
@@ -48,6 +50,11 @@ type fakeChatSessionsService struct {
 	startTurnReq    chatsessions.StartTurnRequest
 	startTurnResult chatsessions.StartTurnResult
 	startTurnErr    error
+
+	bindFactorySessionCalled bool
+	bindFactorySessionReq    chatsessions.BindFactorySessionRequest
+	bindFactorySessionResult chatsessions.BindFactorySessionResult
+	bindFactorySessionErr    error
 }
 
 var _ chatsessions.Service = (*fakeChatSessionsService)(nil)
@@ -108,6 +115,17 @@ func (f *fakeChatSessionsService) StartTurn(_ context.Context, req chatsessions.
 	return f.startTurnResult, nil
 }
 
+func (f *fakeChatSessionsService) BindFactorySession(_ context.Context, req chatsessions.BindFactorySessionRequest) (chatsessions.BindFactorySessionResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.bindFactorySessionCalled = true
+	f.bindFactorySessionReq = req
+	if f.bindFactorySessionErr != nil {
+		return chatsessions.BindFactorySessionResult{}, f.bindFactorySessionErr
+	}
+	return f.bindFactorySessionResult, nil
+}
+
 func (f *fakeChatSessionsService) AdvanceTurn(context.Context, chatsessions.AdvanceTurnRequest) (chatsessions.AdvanceTurnResult, error) {
 	return chatsessions.AdvanceTurnResult{}, errors.New("fakeChatSessionsService: AdvanceTurn not implemented")
 }
@@ -149,6 +167,59 @@ func (f *fakeFactoryTargetCatalogService) ResolveFactoryTargetCatalog(
 	return f.result, nil
 }
 
+// fakeFactoryTargetService is a minimal
+// acp.FactoryTargetService test double: it embeds the interface
+// unimplemented so a call to a capability beyond Start/Invoke reaches a nil
+// method value and panics, proving the consumer never dispatches to
+// Cancel/Close from the ordinary prompt-delegation path this package's
+// tests exercise. mu guards every field for concurrent/duplicate-delivery
+// tests.
+type fakeFactoryTargetService struct {
+	acp.FactoryTargetService
+
+	mu sync.Mutex
+
+	startCalls  []factorysessions.StartRequest
+	startResult factorysessions.AsyncStartResult
+	startErr    error
+
+	invokeCalls  []invokeFactoryTargetCall
+	invokeResult factorysessions.InvocationResult
+	invokeErr    error
+}
+
+type invokeFactoryTargetCall struct {
+	sessionID string
+	request   factorysessions.InvocationRequest
+}
+
+func (f *fakeFactoryTargetService) StartFactoryTarget(
+	_ context.Context,
+	request factorysessions.StartRequest,
+) (factorysessions.AsyncStartResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.startCalls = append(f.startCalls, request)
+	if f.startErr != nil {
+		return factorysessions.AsyncStartResult{}, f.startErr
+	}
+	return f.startResult, nil
+}
+
+func (f *fakeFactoryTargetService) InvokeFactoryTarget(
+	_ context.Context,
+	sessionID string,
+	request factorysessions.InvocationRequest,
+) (factorysessions.InvocationResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.invokeCalls = append(f.invokeCalls, invokeFactoryTargetCall{sessionID: sessionID, request: request})
+	if f.invokeErr != nil {
+		return factorysessions.InvocationResult{}, f.invokeErr
+	}
+	return f.invokeResult, nil
+}
+
 func defaultTestCatalogResult() chatsessions.ResolveFactoryTargetCatalogResult {
 	return chatsessions.ResolveFactoryTargetCatalogResult{
 		CurrentTarget: "factory:@you/factory-builder",
@@ -160,8 +231,20 @@ func defaultTestCatalogResult() chatsessions.ResolveFactoryTargetCatalogResult {
 }
 
 func newTestServer(chatSessions *fakeChatSessionsService, catalog *fakeFactoryTargetCatalogService, homeDir string) *Server {
+	return newTestServerWithFactoryTarget(chatSessions, catalog, nil, homeDir)
+}
+
+// newTestServerWithFactoryTarget is newTestServer plus an explicit Factory
+// Sessions delegation collaborator, for the ordinary-prompt-delegation tests
+// that need to observe or fail StartFactoryTarget/InvokeFactoryTarget calls.
+func newTestServerWithFactoryTarget(
+	chatSessions *fakeChatSessionsService,
+	catalog *fakeFactoryTargetCatalogService,
+	factoryTarget acp.FactoryTargetService,
+	homeDir string,
+) *Server {
 	resolveHomeDir := func() (string, error) { return homeDir, nil }
-	return New(nil, chatSessions, catalog, resolveHomeDir)
+	return New(nil, chatSessions, catalog, factoryTarget, resolveHomeDir)
 }
 
 func numberIdentityEnvelope(t *testing.T, connID identity.ConnectionID, wireID int64, method string, params string) envelope.Envelope {
@@ -413,7 +496,7 @@ func TestServeDispatchesSessionNewOverRealJSONRPCFraming(t *testing.T) {
 func TestServeRespondsMethodNotFoundForEveryUnimplementedMethodStillExcludesSessionNew(t *testing.T) {
 	input := `{"jsonrpc":"2.0","id":9,"method":"session/new","params":{"cwd":"/work/project","mcpServers":[]}}` + "\n"
 	out := &bytes.Buffer{}
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
 		t.Fatalf("Serve() error = %v", err)
 	}
@@ -428,7 +511,7 @@ func TestServeRespondsMethodNotFoundForEveryUnimplementedMethodStillExcludesSess
 }
 
 func TestHandleSessionNewWithoutCollaboratorsReportsBoundedFailure(t *testing.T) {
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionNew, validSessionNewParams)
 
 	result, rpcErr := server.handleSessionNew(context.Background(), env)
@@ -506,7 +589,7 @@ func TestClassifyDependencyFailureMapsContextCauseToRequestCancelled(t *testing.
 func TestHandleSessionNewResolveHomeDirFailureReturnsNoEffect(t *testing.T) {
 	chatSessions := &fakeChatSessionsService{}
 	catalog := &fakeFactoryTargetCatalogService{result: defaultTestCatalogResult()}
-	server := New(nil, chatSessions, catalog, func() (string, error) { return "", errors.New("resolve home dir boom") })
+	server := New(nil, chatSessions, catalog, nil, func() (string, error) { return "", errors.New("resolve home dir boom") })
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionNew, validSessionNewParams)
 	result, rpcErr := server.handleSessionNew(context.Background(), env)
@@ -527,7 +610,7 @@ func TestHandleSessionNewResolveHomeDirFailureReturnsNoEffect(t *testing.T) {
 func TestHandleSessionNewBlankHomeDirFailureReturnsNoEffect(t *testing.T) {
 	chatSessions := &fakeChatSessionsService{}
 	catalog := &fakeFactoryTargetCatalogService{result: defaultTestCatalogResult()}
-	server := New(nil, chatSessions, catalog, func() (string, error) { return "", nil })
+	server := New(nil, chatSessions, catalog, nil, func() (string, error) { return "", nil })
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionNew, validSessionNewParams)
 	result, rpcErr := server.handleSessionNew(context.Background(), env)

--- a/pkg/transports/acp/internal/stdio/session_new_test.go
+++ b/pkg/transports/acp/internal/stdio/session_new_test.go
@@ -222,12 +222,15 @@ type fakeFactoryTargetService struct {
 	mu sync.Mutex
 
 	startCalls  []factorysessions.StartRequest
-	startResult factorysessions.AsyncStartResult
+	startResult factorysessions.InvocationResult
 	startErr    error
 
 	invokeCalls  []invokeFactoryTargetCall
 	invokeResult factorysessions.InvocationResult
 	invokeErr    error
+
+	closeCalls []string
+	closeErr   error
 }
 
 type invokeFactoryTargetCall struct {
@@ -238,12 +241,12 @@ type invokeFactoryTargetCall struct {
 func (f *fakeFactoryTargetService) StartFactoryTarget(
 	_ context.Context,
 	request factorysessions.StartRequest,
-) (factorysessions.AsyncStartResult, error) {
+) (factorysessions.InvocationResult, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.startCalls = append(f.startCalls, request)
 	if f.startErr != nil {
-		return factorysessions.AsyncStartResult{}, f.startErr
+		return factorysessions.InvocationResult{}, f.startErr
 	}
 	return f.startResult, nil
 }
@@ -260,6 +263,13 @@ func (f *fakeFactoryTargetService) InvokeFactoryTarget(
 		return factorysessions.InvocationResult{}, f.invokeErr
 	}
 	return f.invokeResult, nil
+}
+
+func (f *fakeFactoryTargetService) CloseFactoryTarget(_ context.Context, sessionID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closeCalls = append(f.closeCalls, sessionID)
+	return f.closeErr
 }
 
 func defaultTestCatalogResult() chatsessions.ResolveFactoryTargetCatalogResult {

--- a/pkg/transports/acp/internal/stdio/session_new_test.go
+++ b/pkg/transports/acp/internal/stdio/session_new_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,11 +19,16 @@ import (
 )
 
 // fakeChatSessionsService is a minimal chatsessions.Service test double.
-// CreateSession, GetSession, and SetTarget are configurable and tracked --
-// the methods this package's session/new and session/set_config_option
-// handlers actually call. Every other method fails loudly: neither handler
-// calls them, and a call to one would itself be a defect worth catching.
+// CreateSession, GetSession, SetTarget, and StartTurn are configurable and
+// tracked -- the methods this package's session/new,
+// session/set_config_option, and session/prompt handlers actually call.
+// Every other method fails loudly: no handler calls them, and a call to one
+// would itself be a defect worth catching. mu guards every field so the
+// fake is safe under the concurrent/duplicate-delivery admission tests that
+// call it from multiple goroutines against the same instance.
 type fakeChatSessionsService struct {
+	mu sync.Mutex
+
 	createCalled bool
 	created      chatsessions.CreateSessionRequest
 	createErr    error
@@ -39,11 +45,16 @@ type fakeChatSessionsService struct {
 	setTargetErr    error
 
 	startTurnCalled bool
+	startTurnReq    chatsessions.StartTurnRequest
+	startTurnResult chatsessions.StartTurnResult
+	startTurnErr    error
 }
 
 var _ chatsessions.Service = (*fakeChatSessionsService)(nil)
 
 func (f *fakeChatSessionsService) CreateSession(_ context.Context, req chatsessions.CreateSessionRequest) (chatsessions.CreateSessionResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.createCalled = true
 	f.created = req
 	if f.createErr != nil {
@@ -65,6 +76,8 @@ func (f *fakeChatSessionsService) CreateSession(_ context.Context, req chatsessi
 }
 
 func (f *fakeChatSessionsService) GetSession(_ context.Context, req chatsessions.GetSessionRequest) (chatsessions.GetSessionResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.getSessionCalled = true
 	f.getSessionReq = req
 	if f.getSessionErr != nil {
@@ -74,6 +87,8 @@ func (f *fakeChatSessionsService) GetSession(_ context.Context, req chatsessions
 }
 
 func (f *fakeChatSessionsService) SetTarget(_ context.Context, req chatsessions.SetTargetRequest) (chatsessions.SetTargetResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.setTargetCalled = true
 	f.setTargetReq = req
 	if f.setTargetErr != nil {
@@ -82,9 +97,15 @@ func (f *fakeChatSessionsService) SetTarget(_ context.Context, req chatsessions.
 	return f.setTargetResult, nil
 }
 
-func (f *fakeChatSessionsService) StartTurn(context.Context, chatsessions.StartTurnRequest) (chatsessions.StartTurnResult, error) {
+func (f *fakeChatSessionsService) StartTurn(_ context.Context, req chatsessions.StartTurnRequest) (chatsessions.StartTurnResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.startTurnCalled = true
-	return chatsessions.StartTurnResult{}, errors.New("fakeChatSessionsService: StartTurn not implemented")
+	f.startTurnReq = req
+	if f.startTurnErr != nil {
+		return chatsessions.StartTurnResult{}, f.startTurnErr
+	}
+	return f.startTurnResult, nil
 }
 
 func (f *fakeChatSessionsService) AdvanceTurn(context.Context, chatsessions.AdvanceTurnRequest) (chatsessions.AdvanceTurnResult, error) {

--- a/pkg/transports/acp/internal/stdio/session_new_test.go
+++ b/pkg/transports/acp/internal/stdio/session_new_test.go
@@ -72,6 +72,12 @@ type fakeChatSessionsService struct {
 	bindFactorySessionErrs []error
 	bindFactorySessionErr  error
 
+	recordPendingFactorySessionCalled bool
+	recordPendingFactorySessionReq    chatsessions.RecordPendingFactorySessionRequest
+	recordPendingFactorySessionReqs   []chatsessions.RecordPendingFactorySessionRequest
+	recordPendingFactorySessionResult chatsessions.RecordPendingFactorySessionResult
+	recordPendingFactorySessionErr    error
+
 	advanceTurnCalled bool
 	advanceTurnReq    chatsessions.AdvanceTurnRequest
 	advanceTurnReqs   []chatsessions.AdvanceTurnRequest
@@ -169,6 +175,18 @@ func (f *fakeChatSessionsService) BindFactorySession(_ context.Context, req chat
 	return f.bindFactorySessionResult, nil
 }
 
+func (f *fakeChatSessionsService) RecordPendingFactorySession(_ context.Context, req chatsessions.RecordPendingFactorySessionRequest) (chatsessions.RecordPendingFactorySessionResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordPendingFactorySessionCalled = true
+	f.recordPendingFactorySessionReq = req
+	f.recordPendingFactorySessionReqs = append(f.recordPendingFactorySessionReqs, req)
+	if f.recordPendingFactorySessionErr != nil {
+		return chatsessions.RecordPendingFactorySessionResult{}, f.recordPendingFactorySessionErr
+	}
+	return f.recordPendingFactorySessionResult, nil
+}
+
 func (f *fakeChatSessionsService) AdvanceTurn(_ context.Context, req chatsessions.AdvanceTurnRequest) (chatsessions.AdvanceTurnResult, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -239,7 +257,7 @@ type fakeFactoryTargetService struct {
 	mu sync.Mutex
 
 	startCalls  []factorysessions.StartRequest
-	startResult factorysessions.InvocationResult
+	startResult factorysessions.AsyncStartResult
 	startErr    error
 
 	invokeCalls  []invokeFactoryTargetCall
@@ -258,12 +276,12 @@ type invokeFactoryTargetCall struct {
 func (f *fakeFactoryTargetService) StartFactoryTarget(
 	_ context.Context,
 	request factorysessions.StartRequest,
-) (factorysessions.InvocationResult, error) {
+) (factorysessions.AsyncStartResult, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.startCalls = append(f.startCalls, request)
 	if f.startErr != nil {
-		return factorysessions.InvocationResult{}, f.startErr
+		return factorysessions.AsyncStartResult{}, f.startErr
 	}
 	return f.startResult, nil
 }

--- a/pkg/transports/acp/internal/stdio/session_new_test.go
+++ b/pkg/transports/acp/internal/stdio/session_new_test.go
@@ -48,8 +48,16 @@ type fakeChatSessionsService struct {
 
 	startTurnCalled bool
 	startTurnReq    chatsessions.StartTurnRequest
+	startTurnReqs   []chatsessions.StartTurnRequest
 	startTurnResult chatsessions.StartTurnResult
-	startTurnErr    error
+	// startTurnResults, when non-empty, is consumed front-first across
+	// successive StartTurn calls (one queued result per call) instead of the
+	// single static startTurnResult -- for sequential tests that need a
+	// later call to observe a different admitted episode snapshot (e.g. a
+	// later turn's episode already carrying a Factory Session ID bound by an
+	// earlier call).
+	startTurnResults []chatsessions.StartTurnResult
+	startTurnErr     error
 
 	bindFactorySessionCalled bool
 	bindFactorySessionReq    chatsessions.BindFactorySessionRequest
@@ -109,8 +117,14 @@ func (f *fakeChatSessionsService) StartTurn(_ context.Context, req chatsessions.
 	defer f.mu.Unlock()
 	f.startTurnCalled = true
 	f.startTurnReq = req
+	f.startTurnReqs = append(f.startTurnReqs, req)
 	if f.startTurnErr != nil {
 		return chatsessions.StartTurnResult{}, f.startTurnErr
+	}
+	if len(f.startTurnResults) > 0 {
+		next := f.startTurnResults[0]
+		f.startTurnResults = f.startTurnResults[1:]
+		return next, nil
 	}
 	return f.startTurnResult, nil
 }

--- a/pkg/transports/acp/internal/stdio/session_new_test.go
+++ b/pkg/transports/acp/internal/stdio/session_new_test.go
@@ -76,7 +76,14 @@ type fakeChatSessionsService struct {
 	recordPendingFactorySessionReq    chatsessions.RecordPendingFactorySessionRequest
 	recordPendingFactorySessionReqs   []chatsessions.RecordPendingFactorySessionRequest
 	recordPendingFactorySessionResult chatsessions.RecordPendingFactorySessionResult
-	recordPendingFactorySessionErr    error
+	// recordPendingFactorySessionErrs, when non-empty, is consumed front-first
+	// across successive RecordPendingFactorySession calls (one queued error
+	// per call, nil meaning that call succeeds) instead of the single static
+	// recordPendingFactorySessionErr -- for retry tests that need one
+	// specific record-pending attempt to fail while a later retry for the
+	// same still-unbound episode succeeds.
+	recordPendingFactorySessionErrs []error
+	recordPendingFactorySessionErr  error
 
 	advanceTurnCalled bool
 	advanceTurnReq    chatsessions.AdvanceTurnRequest
@@ -181,6 +188,14 @@ func (f *fakeChatSessionsService) RecordPendingFactorySession(_ context.Context,
 	f.recordPendingFactorySessionCalled = true
 	f.recordPendingFactorySessionReq = req
 	f.recordPendingFactorySessionReqs = append(f.recordPendingFactorySessionReqs, req)
+	if len(f.recordPendingFactorySessionErrs) > 0 {
+		next := f.recordPendingFactorySessionErrs[0]
+		f.recordPendingFactorySessionErrs = f.recordPendingFactorySessionErrs[1:]
+		if next != nil {
+			return chatsessions.RecordPendingFactorySessionResult{}, next
+		}
+		return f.recordPendingFactorySessionResult, nil
+	}
 	if f.recordPendingFactorySessionErr != nil {
 		return chatsessions.RecordPendingFactorySessionResult{}, f.recordPendingFactorySessionErr
 	}
@@ -263,6 +278,13 @@ type fakeFactoryTargetService struct {
 	invokeCalls  []invokeFactoryTargetCall
 	invokeResult factorysessions.InvocationResult
 	invokeErr    error
+	// invokeErrs, when non-empty, is consumed front-first across successive
+	// InvokeFactoryTarget calls (one queued error per call, nil meaning that
+	// call succeeds with invokeResult) instead of the single static
+	// invokeErr -- for tests that need one specific dispatch to fail while a
+	// later retry against the same (or a differently bound) identity
+	// succeeds.
+	invokeErrs []error
 
 	closeCalls []string
 	closeErr   error
@@ -294,6 +316,14 @@ func (f *fakeFactoryTargetService) InvokeFactoryTarget(
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.invokeCalls = append(f.invokeCalls, invokeFactoryTargetCall{sessionID: sessionID, request: request})
+	if len(f.invokeErrs) > 0 {
+		next := f.invokeErrs[0]
+		f.invokeErrs = f.invokeErrs[1:]
+		if next != nil {
+			return factorysessions.InvocationResult{}, next
+		}
+		return f.invokeResult, nil
+	}
 	if f.invokeErr != nil {
 		return factorysessions.InvocationResult{}, f.invokeErr
 	}

--- a/pkg/transports/acp/internal/stdio/session_new_test.go
+++ b/pkg/transports/acp/internal/stdio/session_new_test.go
@@ -63,6 +63,18 @@ type fakeChatSessionsService struct {
 	bindFactorySessionReq    chatsessions.BindFactorySessionRequest
 	bindFactorySessionResult chatsessions.BindFactorySessionResult
 	bindFactorySessionErr    error
+
+	advanceTurnCalled bool
+	advanceTurnReq    chatsessions.AdvanceTurnRequest
+	advanceTurnReqs   []chatsessions.AdvanceTurnRequest
+	// advanceTurnErrs, when non-empty, is consumed front-first across
+	// successive AdvanceTurn calls (one queued error per call, nil meaning
+	// that call succeeds) instead of the single static advanceTurnErr -- for
+	// fault-injection tests that need one specific AdvanceTurn call (e.g. the
+	// admission-time transition to RUNNING) to succeed while a later one
+	// (e.g. the terminal transition) fails, or vice versa.
+	advanceTurnErrs []error
+	advanceTurnErr  error
 }
 
 var _ chatsessions.Service = (*fakeChatSessionsService)(nil)
@@ -140,8 +152,24 @@ func (f *fakeChatSessionsService) BindFactorySession(_ context.Context, req chat
 	return f.bindFactorySessionResult, nil
 }
 
-func (f *fakeChatSessionsService) AdvanceTurn(context.Context, chatsessions.AdvanceTurnRequest) (chatsessions.AdvanceTurnResult, error) {
-	return chatsessions.AdvanceTurnResult{}, errors.New("fakeChatSessionsService: AdvanceTurn not implemented")
+func (f *fakeChatSessionsService) AdvanceTurn(_ context.Context, req chatsessions.AdvanceTurnRequest) (chatsessions.AdvanceTurnResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.advanceTurnCalled = true
+	f.advanceTurnReq = req
+	f.advanceTurnReqs = append(f.advanceTurnReqs, req)
+	if len(f.advanceTurnErrs) > 0 {
+		next := f.advanceTurnErrs[0]
+		f.advanceTurnErrs = f.advanceTurnErrs[1:]
+		if next != nil {
+			return chatsessions.AdvanceTurnResult{}, next
+		}
+		return chatsessions.AdvanceTurnResult{Turn: chatsessions.Turn{ID: req.TurnID, State: req.Next}}, nil
+	}
+	if f.advanceTurnErr != nil {
+		return chatsessions.AdvanceTurnResult{}, f.advanceTurnErr
+	}
+	return chatsessions.AdvanceTurnResult{Turn: chatsessions.Turn{ID: req.TurnID, State: req.Next}}, nil
 }
 
 func (f *fakeChatSessionsService) Attach(context.Context, chatsessions.AttachRequest) (chatsessions.AttachResult, error) {

--- a/pkg/transports/acp/internal/stdio/session_prompt.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt.go
@@ -41,14 +41,6 @@ var errMalformedFactoryCommand = errors.New("acp: malformed /factory command")
 // dependency failure.
 var errSessionPromptUnavailable = errors.New("acp: session/prompt collaborators are not configured")
 
-// errFactoryDelegationNotImplemented marks a validated, admitted ordinary
-// prompt turn whose downstream dispatch this transport slice does not yet
-// finish: mapping a Factory Session's outcome (start or invoke) into a final
-// ACP response is later stories' scope (004/005). It never reaches a client
-// verbatim -- classifyDependencyFailure maps it to the same bounded
-// internal-error response every other dependency failure receives.
-var errFactoryDelegationNotImplemented = errors.New("acp: factory session delegation is not yet implemented")
-
 // errFactoryTargetUnavailable marks a "session/prompt" call this Server was
 // never constructed with the Factory Sessions delegation collaborator to
 // serve. It never reaches a client verbatim -- classifyDependencyFailure
@@ -146,9 +138,9 @@ func (s *Server) handleSessionPrompt(ctx context.Context, env envelope.Envelope)
 // and bind the returned identity onto that exact episode/turn/version. When
 // the episode already carries a Factory Session ID (a later turn in the same
 // episode), invoke that exact bound session exactly once instead -- never a
-// second start. Either branch still reports the bounded not-yet-implemented
-// failure afterward, since mapping the Factory Session's outcome into a final
-// ACP response is a later story's scope.
+// second start. Either branch's published Factory Sessions outcome is then
+// mapped, deterministically and without fabrication, into the one final ACP
+// prompt response this call returns.
 func (s *Server) admitPromptTurn(ctx context.Context, turn session.PromptTurn, reqIdentity chatsessions.RequestIdentity) (json.RawMessage, *acpsdk.RequestError) {
 	if s.chatSessions == nil {
 		return nil, classifyDependencyFailure(errSessionPromptUnavailable)
@@ -168,17 +160,22 @@ func (s *Server) admitPromptTurn(ctx context.Context, turn session.PromptTurn, r
 		return nil, classifyTurnAdmissionFailure(err)
 	}
 
+	var outcome protocol.PromptOutcome
 	if startResult.Episode.FactorySessionID == "" {
-		if err := s.startFactorySessionForEpisode(ctx, startResult, turn); err != nil {
-			return nil, classifyDependencyFailure(err)
-		}
+		outcome, err = s.startFactorySessionForEpisode(ctx, startResult, turn)
 	} else {
-		if err := s.invokeFactorySessionForEpisode(ctx, startResult, turn); err != nil {
-			return nil, classifyDependencyFailure(err)
-		}
+		outcome, err = s.invokeFactorySessionForEpisode(ctx, startResult, turn)
+	}
+	if err != nil {
+		return nil, classifyDependencyFailure(err)
 	}
 
-	return nil, classifyDependencyFailure(errFactoryDelegationNotImplemented)
+	resp := acpsdk.PromptResponse{StopReason: outcome.StopReason}
+	result, err := json.Marshal(resp)
+	if err != nil {
+		return nil, classifyDependencyFailure(err)
+	}
+	return result, nil
 }
 
 // startFactorySessionForEpisode starts exactly one Factory Session through
@@ -190,14 +187,17 @@ func (s *Server) admitPromptTurn(ctx context.Context, turn session.PromptTurn, r
 // cwd or transport fallback. A blank returned Factory Session ID
 // (errEmptyFactorySessionIdentity) or a BindFactorySession failure is
 // returned unclassified for the caller to map; no second start is ever
-// attempted here.
+// attempted here. The returned outcome is protocol.MapFactoryStartOutcome's
+// deterministic projection of the shim's own published AsyncStartResult --
+// an asynchronous start has not itself reached a terminal outcome yet, so
+// this projection never carries fabricated primary-result text.
 func (s *Server) startFactorySessionForEpisode(
 	ctx context.Context,
 	startResult chatsessions.StartTurnResult,
 	turn session.PromptTurn,
-) error {
+) (protocol.PromptOutcome, error) {
 	if s.factoryTarget == nil {
-		return errFactoryTargetUnavailable
+		return protocol.PromptOutcome{}, errFactoryTargetUnavailable
 	}
 
 	startReq := factorysessions.StartRequest{
@@ -220,20 +220,23 @@ func (s *Server) startFactorySessionForEpisode(
 
 	startOutcome, err := s.factoryTarget.StartFactoryTarget(ctx, startReq)
 	if err != nil {
-		return err
+		return protocol.PromptOutcome{}, err
 	}
 	if startOutcome.SessionID == "" {
-		return errEmptyFactorySessionIdentity
+		return protocol.PromptOutcome{}, errEmptyFactorySessionIdentity
 	}
 
-	_, err = s.chatSessions.BindFactorySession(ctx, chatsessions.BindFactorySessionRequest{
+	if _, err := s.chatSessions.BindFactorySession(ctx, chatsessions.BindFactorySessionRequest{
 		SessionID:        startResult.Session.ID,
 		ExpectedVersion:  startResult.Session.Version,
 		Episode:          startResult.Episode.Number,
 		TurnID:           startResult.Turn.ID,
 		FactorySessionID: startOutcome.SessionID,
-	})
-	return err
+	}); err != nil {
+		return protocol.PromptOutcome{}, err
+	}
+
+	return protocol.MapFactoryStartOutcome(startOutcome), nil
 }
 
 // invokeFactorySessionForEpisode invokes the given turn's already-bound
@@ -242,24 +245,32 @@ func (s *Server) startFactorySessionForEpisode(
 // source kind, and the admitted turn's ID as the correlated request ID. It
 // never starts a second Factory Session for an already-bound episode -- an
 // unbound episode is startFactorySessionForEpisode's job, not this one's.
+// The returned outcome is protocol.MapFactoryInvocationOutcome's
+// deterministic, safe projection of the shim's own published
+// InvocationResult -- its terminal status and only the "text" parts of its
+// primary result, never the raw result itself.
 func (s *Server) invokeFactorySessionForEpisode(
 	ctx context.Context,
 	startResult chatsessions.StartTurnResult,
 	turn session.PromptTurn,
-) error {
+) (protocol.PromptOutcome, error) {
 	if s.factoryTarget == nil {
-		return errFactoryTargetUnavailable
+		return protocol.PromptOutcome{}, errFactoryTargetUnavailable
 	}
 
 	requestID := startResult.Turn.ID
 	sourceKind := factorysessions.InvocationInputSourceKindText
-	_, err := s.factoryTarget.InvokeFactoryTarget(ctx, startResult.Episode.FactorySessionID, factorysessions.InvocationRequest{
+	invokeResult, err := s.factoryTarget.InvokeFactoryTarget(ctx, startResult.Episode.FactorySessionID, factorysessions.InvocationRequest{
 		Content:         promptContentToWorkParts(turn.Content),
 		ContentProvided: true,
 		RequestID:       &requestID,
 		SourceKind:      &sourceKind,
 	})
-	return err
+	if err != nil {
+		return protocol.PromptOutcome{}, err
+	}
+
+	return protocol.MapFactoryInvocationOutcome(invokeResult), nil
 }
 
 // promptContentToWorkParts converts validated ACP text prompt content into

--- a/pkg/transports/acp/internal/stdio/session_prompt.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt.go
@@ -54,6 +54,59 @@ var errFactoryTargetUnavailable = errors.New("acp: session/prompt factory target
 // rather than silently proceeding with no bound Factory Session.
 var errEmptyFactorySessionIdentity = errors.New("acp: factory session start returned an empty session id")
 
+// promptNotifier sends one outbound "session/update" JSON-RPC notification
+// on the connection a "session/prompt" call arrived on. It is carried
+// request-scoped through context.Context (see contextWithPromptNotifier),
+// not as an explicit parameter on handleSessionPrompt/dispatchRequest: the
+// only dispatched method that ever needs it is "session/prompt", so an
+// explicit parameter would force every other handler -- and every existing
+// test calling handleSessionPrompt directly -- to accept a capability they
+// never use.
+type promptNotifier func(acpsdk.SessionNotification) error
+
+// promptNotifierContextKey is the unexported context key promptNotifier is
+// carried under, so no other package can inject or observe it.
+type promptNotifierContextKey struct{}
+
+// contextWithPromptNotifier attaches notify to ctx for the duration of one
+// dispatched request.
+func contextWithPromptNotifier(ctx context.Context, notify promptNotifier) context.Context {
+	return context.WithValue(ctx, promptNotifierContextKey{}, notify)
+}
+
+// promptNotifierFromContext retrieves the promptNotifier attached by
+// contextWithPromptNotifier, or nil when ctx carries none -- for example
+// every existing unit test in this package that calls handleSessionPrompt
+// directly with context.Background().
+func promptNotifierFromContext(ctx context.Context) promptNotifier {
+	notify, _ := ctx.Value(promptNotifierContextKey{}).(promptNotifier)
+	return notify
+}
+
+// deliverPromptText sends text as exactly one "session/update"
+// agent_message_chunk notification -- the only mechanism this protocol
+// offers to deliver assistant text, since acpsdk.PromptResponse itself
+// carries none -- before the final "session/prompt" response is built. A nil
+// notify (no outbound notification capability attached to ctx) or empty text
+// is a no-op success. Supported text parts are newline-joined into one chunk
+// rather than emitted progressively: this transport slice delivers the
+// outcome's already-final, already-mapped text exactly once, not a live
+// token stream, so sending it as a single chunk is not the
+// fabricated/progressive streaming this L1 V1 slice excludes.
+func deliverPromptText(notify promptNotifier, sessionID string, text []string) error {
+	if notify == nil || len(text) == 0 {
+		return nil
+	}
+	return notify(acpsdk.SessionNotification{
+		SessionId: acpsdk.SessionId(sessionID),
+		Update: acpsdk.SessionUpdate{
+			AgentMessageChunk: &acpsdk.SessionUpdateAgentMessageChunk{
+				Content: acpsdk.TextBlock(strings.Join(text, "\n")),
+			},
+		},
+	})
+}
+
 // dispatchOutcome carries what a Factory dispatch branch
 // (startFactorySessionForEpisode/invokeFactorySessionForEpisode) observed
 // about its own downstream call, decoupled from whatever *acpsdk.RequestError
@@ -238,15 +291,18 @@ func turnStateStopReason(state chatsessions.TurnState) acpsdk.StopReason {
 // dispatchFactoryTurn runs the one Factory effect a running turn owns --
 // starting a fresh Factory Session for an unbound episode or invoking an
 // already-bound one -- maps its outcome into the final ACP prompt response,
-// and terminalizes the running turn on every path: COMPLETED when dispatch
-// and response mapping both succeed and the downstream outcome itself
-// reports a genuine completed status, CANCELED when the failure cause is
+// delivers any mapped text via deliverPromptText (the only ACP mechanism
+// that carries assistant text, since the response itself never does), and
+// terminalizes the running turn on every path: COMPLETED when dispatch and
+// response mapping both succeed and the downstream outcome itself reports a
+// genuine completed status, CANCELED when the failure cause is
 // context.Canceled/context.DeadlineExceeded or the downstream outcome itself
-// reports canceled/timed-out, and FAILED for every other dispatch, terminal-
-// result, or response-mapping failure. The terminalizing AdvanceTurn call
-// always runs -- using the exact session/turn identity StartTurn admitted,
-// not a value derived from whatever failed -- so no admitted turn is ever
-// left stranded in a non-terminal state regardless of which step failed.
+// reports canceled/timed-out, and FAILED for every other dispatch, text-
+// delivery, terminal-result, or response-mapping failure. The terminalizing
+// AdvanceTurn call always runs -- using the exact session/turn identity
+// StartTurn admitted, not a value derived from whatever failed -- so no
+// admitted turn is ever left stranded in a non-terminal state regardless of
+// which step failed.
 func (s *Server) dispatchFactoryTurn(ctx context.Context, startResult chatsessions.StartTurnResult, turn session.PromptTurn) (json.RawMessage, *acpsdk.RequestError) {
 	var dispatched dispatchOutcome
 	var dispatchErr error
@@ -262,6 +318,9 @@ func (s *Server) dispatchFactoryTurn(ctx context.Context, startResult chatsessio
 	if dispatchErr != nil {
 		terminal = terminalStateForFailure(dispatchErr)
 		rpcErr = classifyDependencyFailure(dispatchErr)
+	} else if notifyErr := deliverPromptText(promptNotifierFromContext(ctx), startResult.Session.ID, dispatched.outcome.Text); notifyErr != nil {
+		terminal = chatsessions.TurnStateFailed
+		rpcErr = classifyDependencyFailure(notifyErr)
 	} else {
 		resp := acpsdk.PromptResponse{StopReason: dispatched.outcome.StopReason}
 		marshaled, marshalErr := json.Marshal(resp)
@@ -321,16 +380,28 @@ func factoryInvocationTurnState(status factorysessions.InvocationTerminalStatus)
 // canonical Factory target (Source.FactoryID), the Chat Session's exact
 // editor working root, and the validated prompt content -- never a process
 // cwd or transport fallback. A blank returned Factory Session ID
-// (errEmptyFactorySessionIdentity) or a BindFactorySession failure is
-// returned unclassified for the caller to map; no second start is ever
-// attempted here. The returned outcome is protocol.MapFactoryStartOutcome's
-// deterministic projection of the shim's own published AsyncStartResult --
-// an asynchronous start has not itself reached a terminal outcome yet, so
-// this projection never carries fabricated primary-result text. On success
-// the returned dispatchOutcome always terminalizes to TurnStateCompleted:
-// this branch's own responsibility -- dispatching and binding the async
-// start -- has genuinely completed, independent of the Factory Session's
-// own later, unobserved lifecycle.
+// (errEmptyFactorySessionIdentity) is returned unclassified for the caller
+// to map; no second start is ever attempted here.
+//
+// StartFactoryTarget's underlying activation (OnDemandFactoryTargetService)
+// is synchronous under the hood: it already observes a genuine terminal
+// factorysessions.InvocationResult before returning, so this branch's
+// returned outcome is protocol.MapFactoryInvocationOutcome's deterministic
+// projection of that same real result -- both its ordered primary-result
+// text and its terminal status -- exactly like invokeFactorySessionForEpisode
+// projects a later turn's invocation, rather than a placeholder that always
+// reports success. The returned dispatchOutcome terminalizes to whatever
+// factoryInvocationTurnState derives from that published status, so a
+// first-turn start that itself completed the dispatch call but published a
+// FAILED or TIMED_OUT status still terminalizes the Chat turn accordingly
+// instead of always reporting COMPLETED.
+//
+// A BindFactorySession failure after a successful start is compensated by
+// closing the just-opened runtime (best-effort; a close failure is joined
+// into the returned error rather than discarded) so a live Factory Session
+// is never left both unbound and unreachable -- without this, a later retry
+// would leave the original runtime orphaned while opening a second one for
+// the still-unbound episode.
 func (s *Server) startFactorySessionForEpisode(
 	ctx context.Context,
 	startResult chatsessions.StartTurnResult,
@@ -373,12 +444,12 @@ func (s *Server) startFactorySessionForEpisode(
 		TurnID:           startResult.Turn.ID,
 		FactorySessionID: startOutcome.SessionID,
 	}); err != nil {
-		return dispatchOutcome{}, err
+		return dispatchOutcome{}, errors.Join(err, s.factoryTarget.CloseFactoryTarget(ctx, startOutcome.SessionID))
 	}
 
 	return dispatchOutcome{
-		outcome:  protocol.MapFactoryStartOutcome(startOutcome),
-		terminal: chatsessions.TurnStateCompleted,
+		outcome:  protocol.MapFactoryInvocationOutcome(startOutcome),
+		terminal: factoryInvocationTurnState(startOutcome.Status),
 	}, nil
 }
 

--- a/pkg/transports/acp/internal/stdio/session_prompt.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt.go
@@ -245,10 +245,31 @@ func (s *Server) admitPromptTurn(ctx context.Context, turn session.PromptTurn, r
 		TurnID:    startResult.Turn.ID,
 		Next:      chatsessions.TurnStateRunning,
 	}); err != nil {
+		// The turn is still ADMITTED (this transition never took effect), so
+		// the only legal terminal fallback from here is CANCELED -- see
+		// TurnState.CanTransitionTo. Without this recovery attempt, a failed
+		// ADMITTED->RUNNING transition would leave the session's
+		// ActiveTurnID set forever, stranding every later prompt behind a
+		// busy turn that never actually started running.
+		s.recoverStrandedTurn(ctx, startResult.Session.ID, startResult.Turn.ID, chatsessions.TurnStateCanceled)
 		return nil, classifyDependencyFailure(err)
 	}
 
 	return s.dispatchFactoryTurn(ctx, startResult, turn)
+}
+
+// recoverStrandedTurn makes one best-effort attempt to move turnID to
+// fallback after its primary terminalizing AdvanceTurn call already failed,
+// so that failure alone can never strand the session's busy/active-turn
+// state forever. Its own outcome is intentionally not surfaced to the
+// caller: the caller already has the primary failure to report, and no
+// further fallback is attempted beyond this single recovery call.
+func (s *Server) recoverStrandedTurn(ctx context.Context, sessionID, turnID string, fallback chatsessions.TurnState) {
+	_, _ = s.chatSessions.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: sessionID,
+		TurnID:    turnID,
+		Next:      fallback,
+	})
 }
 
 // respondToRedeliveredTurn classifies a StartTurn result that identified an
@@ -337,6 +358,17 @@ func (s *Server) dispatchFactoryTurn(ctx context.Context, startResult chatsessio
 		TurnID:    startResult.Turn.ID,
 		Next:      terminal,
 	}); err != nil {
+		// The turn is still RUNNING (this transition never took effect). If
+		// the attempted terminal state was not already the safe FAILED
+		// fallback, make one recovery attempt at it -- RUNNING->FAILED is
+		// always a legal transition, so this is the one fallback guaranteed
+		// available regardless of which terminal state the primary attempt
+		// targeted. Without this, a failed terminal AdvanceTurn call would
+		// leave the session's ActiveTurnID set forever, stranding every
+		// later prompt behind a busy turn that already finished dispatching.
+		if terminal != chatsessions.TurnStateFailed {
+			s.recoverStrandedTurn(ctx, startResult.Session.ID, startResult.Turn.ID, chatsessions.TurnStateFailed)
+		}
 		return nil, classifyDependencyFailure(err)
 	}
 

--- a/pkg/transports/acp/internal/stdio/session_prompt.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt.go
@@ -9,6 +9,9 @@ import (
 	acpsdk "github.com/coder/acp-go-sdk"
 
 	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/envelope"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/protocol"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/session"
@@ -39,12 +42,26 @@ var errMalformedFactoryCommand = errors.New("acp: malformed /factory command")
 var errSessionPromptUnavailable = errors.New("acp: session/prompt collaborators are not configured")
 
 // errFactoryDelegationNotImplemented marks a validated, admitted ordinary
-// prompt turn this transport slice does not yet dispatch to a Factory
-// Session: starting or invoking a Factory Session and mapping its outcome
-// into a final ACP response are later stories' scope. It never reaches a
-// client verbatim -- classifyDependencyFailure maps it to the same bounded
-// internal-error response every other dependency failure receives.
+// prompt turn whose downstream dispatch this transport slice does not yet
+// finish: mapping a Factory Session's outcome into a final ACP response, and
+// invoking an already-bound Factory Session for a later turn, are later
+// stories' scope (003/004). It never reaches a client verbatim --
+// classifyDependencyFailure maps it to the same bounded internal-error
+// response every other dependency failure receives.
 var errFactoryDelegationNotImplemented = errors.New("acp: factory session delegation is not yet implemented")
+
+// errFactoryTargetUnavailable marks a "session/prompt" call this Server was
+// never constructed with the Factory Sessions delegation collaborator to
+// serve. It never reaches a client verbatim -- classifyDependencyFailure
+// maps it to a bounded internal-error response the same way it maps every
+// other dependency failure.
+var errFactoryTargetUnavailable = errors.New("acp: session/prompt factory target collaborator is not configured")
+
+// errEmptyFactorySessionIdentity marks a Factory Sessions start whose
+// returned SessionID was blank. An empty identity can never be committed as
+// an episode's Factory Session binding, so this is treated as a failure
+// rather than silently proceeding with no bound Factory Session.
+var errEmptyFactorySessionIdentity = errors.New("acp: factory session start returned an empty session id")
 
 // parseFactoryCommand inspects one validated prompt turn's content and
 // reports whether it is a "/factory <value>" command attempt. matched is
@@ -118,15 +135,21 @@ func (s *Server) handleSessionPrompt(ctx context.Context, env envelope.Envelope)
 // admitPromptTurn executes the ordinary (non-"/factory") prompt admission
 // sequence: read the addressed Chat Session and call its canonical
 // StartTurn exactly once with the full request identity, the real session
-// id, and the version observed from that read -- no Factory Session is
-// started or invoked by this story, so an admitted turn's downstream
-// dispatch and terminal response mapping are always reported as the bounded
-// not-yet-implemented internal error rather than fabricated success. An
-// unknown session (*chatsessions.NotFoundError), a stale expected version
+// id, and the version observed from that read. An unknown session
+// (*chatsessions.NotFoundError), a stale expected version
 // (*chatsessions.ConflictError), or a busy active turn
 // (*chatsessions.BusyError) all classify as a bounded protocol-safe
 // rejection and never reach StartTurn or (for the GetSession failures) leave
 // any effect at all.
+//
+// Once admitted, the turn's episode snapshot decides the one Factory effect
+// this story owns: when the episode has no Factory Session ID yet, start one
+// and bind the returned identity onto that exact episode/turn/version. An
+// already-bound episode (a later turn in the same episode) makes zero start
+// calls -- invoking that bound Factory Session is story 003's scope, not
+// this one's -- so this method still reports the bounded not-yet-implemented
+// failure after a successful start+bind or an already-bound episode, since
+// neither downstream dispatch nor final response mapping exist yet.
 func (s *Server) admitPromptTurn(ctx context.Context, turn session.PromptTurn, reqIdentity chatsessions.RequestIdentity) (json.RawMessage, *acpsdk.RequestError) {
 	if s.chatSessions == nil {
 		return nil, classifyDependencyFailure(errSessionPromptUnavailable)
@@ -137,15 +160,90 @@ func (s *Server) admitPromptTurn(ctx context.Context, turn session.PromptTurn, r
 		return nil, classifyTurnAdmissionFailure(err)
 	}
 
-	if _, err := s.chatSessions.StartTurn(ctx, chatsessions.StartTurnRequest{
+	startResult, err := s.chatSessions.StartTurn(ctx, chatsessions.StartTurnRequest{
 		RequestID:       reqIdentity,
 		SessionID:       getResult.Session.ID,
 		ExpectedVersion: getResult.Session.Version,
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, classifyTurnAdmissionFailure(err)
 	}
 
+	if startResult.Episode.FactorySessionID == "" {
+		if err := s.startFactorySessionForEpisode(ctx, startResult, turn); err != nil {
+			return nil, classifyDependencyFailure(err)
+		}
+	}
+
 	return nil, classifyDependencyFailure(errFactoryDelegationNotImplemented)
+}
+
+// startFactorySessionForEpisode starts exactly one Factory Session through
+// the consumer-owned Factory Sessions shim for the given turn's newly
+// admitted (unbound) episode, and binds the returned identity onto that
+// exact episode/turn/version. The start request carries the episode's
+// canonical Factory target (Source.FactoryID), the Chat Session's exact
+// editor working root, and the validated prompt content -- never a process
+// cwd or transport fallback. A blank returned Factory Session ID
+// (errEmptyFactorySessionIdentity) or a BindFactorySession failure is
+// returned unclassified for the caller to map; no second start is ever
+// attempted here.
+func (s *Server) startFactorySessionForEpisode(
+	ctx context.Context,
+	startResult chatsessions.StartTurnResult,
+	turn session.PromptTurn,
+) error {
+	if s.factoryTarget == nil {
+		return errFactoryTargetUnavailable
+	}
+
+	startReq := factorysessions.StartRequest{
+		RequestID: startResult.Turn.ID,
+		Source: factorysessions.Source{
+			Kind:      factoryruntime.WorkflowSourceKindFactoryID,
+			FactoryID: startResult.Episode.Target.Ref,
+		},
+		// StartRequest has no dedicated content/root fields; Args is the
+		// one JSON-compatible channel this published contract offers, so
+		// the validated prompt content (in the same work.WorkContentPart
+		// shape InvocationRequest.Content already uses) and the session's
+		// exact editor working root travel through it rather than being
+		// silently dropped or replaced by a process cwd.
+		Args: map[string]any{
+			"content":     promptContentToWorkParts(turn.Content),
+			"workingRoot": startResult.Session.WorkingRoot,
+		},
+	}
+
+	startOutcome, err := s.factoryTarget.StartFactoryTarget(ctx, startReq)
+	if err != nil {
+		return err
+	}
+	if startOutcome.SessionID == "" {
+		return errEmptyFactorySessionIdentity
+	}
+
+	_, err = s.chatSessions.BindFactorySession(ctx, chatsessions.BindFactorySessionRequest{
+		SessionID:        startResult.Session.ID,
+		ExpectedVersion:  startResult.Session.Version,
+		Episode:          startResult.Episode.Number,
+		TurnID:           startResult.Turn.ID,
+		FactorySessionID: startOutcome.SessionID,
+	})
+	return err
+}
+
+// promptContentToWorkParts converts validated ACP text prompt content into
+// the shared work.WorkContentPart shape InvocationRequest.Content already
+// uses, so a Factory Session's input carries the same content vocabulary
+// regardless of whether it reached that Factory Session through a start or
+// an invoke.
+func promptContentToWorkParts(content []session.TextContent) []work.WorkContentPart {
+	parts := make([]work.WorkContentPart, len(content))
+	for i, c := range content {
+		parts[i] = work.WorkContentPart{Type: work.WorkContentPartTypeText, Text: c.Text}
+	}
+	return parts
 }
 
 // classifyTurnAdmissionFailure converts a failure from reading a Chat

--- a/pkg/transports/acp/internal/stdio/session_prompt.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt.go
@@ -413,7 +413,7 @@ func factoryInvocationTurnState(status factorysessions.InvocationTerminalStatus)
 // editor working root, and the validated prompt content -- never a process
 // cwd or transport fallback. A blank returned Factory Session ID
 // (errEmptyFactorySessionIdentity) is returned unclassified for the caller
-// to map; no second start is ever attempted here.
+// to map.
 //
 // StartFactoryTarget's underlying activation (OnDemandFactoryTargetService)
 // is synchronous under the hood: it already observes a genuine terminal
@@ -428,12 +428,25 @@ func factoryInvocationTurnState(status factorysessions.InvocationTerminalStatus)
 // FAILED or TIMED_OUT status still terminalizes the Chat turn accordingly
 // instead of always reporting COMPLETED.
 //
-// A BindFactorySession failure after a successful start is compensated by
-// closing the just-opened runtime (best-effort; a close failure is joined
-// into the returned error rather than discarded) so a live Factory Session
-// is never left both unbound and unreachable -- without this, a later retry
-// would leave the original runtime orphaned while opening a second one for
-// the still-unbound episode.
+// A start and its commit are not atomic against this transport's own
+// process -- BindFactorySession can fail after StartFactoryTarget already
+// succeeded -- so this method reconciles across separate calls via
+// pendingFactoryStarts, keyed by (session, episode): the first turn for an
+// episode that finds no pending record starts a fresh Factory Session and
+// records its identity as pending before attempting to bind it. A later
+// admitted turn for that same still-unbound episode (whether the original
+// bind is still failing, or a genuinely distinct retry request) finds the
+// pending record and dispatches its own content into that exact already-live
+// runtime via InvokeFactoryTarget instead of starting a second one, then
+// retries the bind. Once a bind succeeds the pending record is cleared. Only
+// a *chatsessions.FactorySessionConflictError -- a different identity
+// already won the episode -- abandons the pending runtime: it is closed
+// (best-effort; a close failure is joined into the returned error) and the
+// pending record is cleared, since the next call will observe the already-
+// bound episode and correctly invoke the winner instead. Every other bind
+// failure (for example a transient version conflict) keeps the pending
+// record and the runtime open, so no later retry can ever lose track of it
+// and start a second Factory Session for the same episode.
 func (s *Server) startFactorySessionForEpisode(
 	ctx context.Context,
 	startResult chatsessions.StartTurnResult,
@@ -443,45 +456,70 @@ func (s *Server) startFactorySessionForEpisode(
 		return dispatchOutcome{}, errFactoryTargetUnavailable
 	}
 
-	startReq := factorysessions.StartRequest{
-		RequestID: startResult.Turn.ID,
-		Source: factorysessions.Source{
-			Kind:      factoryruntime.WorkflowSourceKindFactoryID,
-			FactoryID: startResult.Episode.Target.Ref,
-		},
-		// StartRequest has no dedicated content/root fields; Args is the
-		// one JSON-compatible channel this published contract offers, so
-		// the validated prompt content (in the same work.WorkContentPart
-		// shape InvocationRequest.Content already uses) and the session's
-		// exact editor working root travel through it rather than being
-		// silently dropped or replaced by a process cwd.
-		Args: map[string]any{
-			"content":     promptContentToWorkParts(turn.Content),
-			"workingRoot": startResult.Session.WorkingRoot,
-		},
-	}
+	key := pendingFactoryStartKey{sessionID: startResult.Session.ID, episode: startResult.Episode.Number}
 
-	startOutcome, err := s.factoryTarget.StartFactoryTarget(ctx, startReq)
+	var outcome factorysessions.InvocationResult
+	var err error
+	if pendingID, ok := s.lookupPendingFactoryStart(key); ok {
+		requestID := startResult.Turn.ID
+		sourceKind := factorysessions.InvocationInputSourceKindText
+		outcome, err = s.factoryTarget.InvokeFactoryTarget(ctx, pendingID, factorysessions.InvocationRequest{
+			Content:         promptContentToWorkParts(turn.Content),
+			ContentProvided: true,
+			RequestID:       &requestID,
+			SourceKind:      &sourceKind,
+		})
+		if err == nil {
+			outcome.SessionID = pendingID
+		}
+	} else {
+		startReq := factorysessions.StartRequest{
+			RequestID: startResult.Turn.ID,
+			Source: factorysessions.Source{
+				Kind:      factoryruntime.WorkflowSourceKindFactoryID,
+				FactoryID: startResult.Episode.Target.Ref,
+			},
+			// StartRequest has no dedicated content/root fields; Args is the
+			// one JSON-compatible channel this published contract offers, so
+			// the validated prompt content (in the same work.WorkContentPart
+			// shape InvocationRequest.Content already uses) and the
+			// session's exact editor working root travel through it rather
+			// than being silently dropped or replaced by a process cwd.
+			Args: map[string]any{
+				"content":     promptContentToWorkParts(turn.Content),
+				"workingRoot": startResult.Session.WorkingRoot,
+			},
+		}
+		outcome, err = s.factoryTarget.StartFactoryTarget(ctx, startReq)
+	}
 	if err != nil {
 		return dispatchOutcome{}, err
 	}
-	if startOutcome.SessionID == "" {
+	if outcome.SessionID == "" {
 		return dispatchOutcome{}, errEmptyFactorySessionIdentity
 	}
+
+	s.setPendingFactoryStart(key, outcome.SessionID)
 
 	if _, err := s.chatSessions.BindFactorySession(ctx, chatsessions.BindFactorySessionRequest{
 		SessionID:        startResult.Session.ID,
 		ExpectedVersion:  startResult.Session.Version,
 		Episode:          startResult.Episode.Number,
 		TurnID:           startResult.Turn.ID,
-		FactorySessionID: startOutcome.SessionID,
+		FactorySessionID: outcome.SessionID,
 	}); err != nil {
-		return dispatchOutcome{}, errors.Join(err, s.factoryTarget.CloseFactoryTarget(ctx, startOutcome.SessionID))
+		var conflictErr *chatsessions.FactorySessionConflictError
+		if errors.As(err, &conflictErr) {
+			s.clearPendingFactoryStart(key)
+			return dispatchOutcome{}, errors.Join(err, s.factoryTarget.CloseFactoryTarget(ctx, outcome.SessionID))
+		}
+		return dispatchOutcome{}, err
 	}
+	s.clearPendingFactoryStart(key)
 
 	return dispatchOutcome{
-		outcome:  protocol.MapFactoryInvocationOutcome(startOutcome),
-		terminal: factoryInvocationTurnState(startOutcome.Status),
+		outcome:  protocol.MapFactoryInvocationOutcome(outcome),
+		terminal: factoryInvocationTurnState(outcome.Status),
 	}, nil
 }
 

--- a/pkg/transports/acp/internal/stdio/session_prompt.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	acpsdk "github.com/coder/acp-go-sdk"
@@ -353,26 +354,61 @@ func (s *Server) dispatchFactoryTurn(ctx context.Context, startResult chatsessio
 		}
 	}
 
-	if _, err := s.chatSessions.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
-		SessionID: startResult.Session.ID,
-		TurnID:    startResult.Turn.ID,
-		Next:      terminal,
-	}); err != nil {
-		// The turn is still RUNNING (this transition never took effect). If
-		// the attempted terminal state was not already the safe FAILED
-		// fallback, make one recovery attempt at it -- RUNNING->FAILED is
-		// always a legal transition, so this is the one fallback guaranteed
-		// available regardless of which terminal state the primary attempt
-		// targeted. Without this, a failed terminal AdvanceTurn call would
-		// leave the session's ActiveTurnID set forever, stranding every
-		// later prompt behind a busy turn that already finished dispatching.
-		if terminal != chatsessions.TurnStateFailed {
-			s.recoverStrandedTurn(ctx, startResult.Session.ID, startResult.Turn.ID, chatsessions.TurnStateFailed)
-		}
+	if err := s.advanceTurnWithRecovery(ctx, startResult.Session.ID, startResult.Turn.ID, terminal); err != nil {
 		return nil, classifyDependencyFailure(err)
 	}
 
 	return result, rpcErr
+}
+
+// terminalRecoveryOrder lists every terminal TurnState in a fixed priority
+// order: FAILED, CANCELED, COMPLETED. RUNNING->{COMPLETED,CANCELED,FAILED}
+// are all legal transitions (see TurnState.CanTransitionTo), so this list is
+// exactly the set of fallback terminal states advanceTurnWithRecovery can
+// still try after its primary attempt fails, regardless of which of the
+// three the primary attempt targeted. FAILED and CANCELED are tried before
+// COMPLETED so a recovered turn is never fabricated as a genuine success --
+// COMPLETED is only ever used as a last-resort fallback (when both FAILED
+// and CANCELED are themselves the failed primary or also fail) purely to
+// avoid stranding the session's busy state entirely.
+var terminalRecoveryOrder = []chatsessions.TurnState{
+	chatsessions.TurnStateFailed,
+	chatsessions.TurnStateCanceled,
+	chatsessions.TurnStateCompleted,
+}
+
+// advanceTurnWithRecovery advances turnID to primary and, if that call
+// itself fails, retries every other state in terminalRecoveryOrder in turn
+// until one succeeds or all have been exhausted. This guarantees the turn
+// reaches some terminal state -- releasing the session's busy/active-turn
+// state -- as long as any single legal RUNNING->terminal transition still
+// succeeds, not only the specific one primary happened to target: a prior
+// version of this recovery only ever attempted FAILED as a fallback, which
+// left a turn stranded whenever the primary attempt's target was already
+// FAILED and that exact call failed. The original failure is what gets
+// returned to the caller regardless of whether a fallback attempt
+// succeeded, since that failure is what actually happened to the operation
+// the caller cares about (dispatch, notification delivery, or response
+// marshaling); only the turn's own busy/terminal bookkeeping is repaired
+// here.
+func (s *Server) advanceTurnWithRecovery(ctx context.Context, sessionID, turnID string, primary chatsessions.TurnState) error {
+	_, err := s.chatSessions.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: sessionID, TurnID: turnID, Next: primary,
+	})
+	if err == nil {
+		return nil
+	}
+	for _, fallback := range terminalRecoveryOrder {
+		if fallback == primary {
+			continue
+		}
+		if _, fallbackErr := s.chatSessions.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+			SessionID: sessionID, TurnID: turnID, Next: fallback,
+		}); fallbackErr == nil {
+			return err
+		}
+	}
+	return err
 }
 
 // terminalStateForFailure classifies a Factory dispatch or response-mapping
@@ -450,6 +486,18 @@ func factoryInvocationTurnState(status factorysessions.InvocationTerminalStatus)
 // (for example a transient version conflict) keeps the pending record and
 // the runtime open, so no later retry can ever lose track of it and start a
 // second Factory Session for the same episode.
+// factoryStartRequestID derives the stable idempotency key
+// startFactorySessionForEpisode passes as StartRequest.RequestID: the
+// session ID and episode number, both fixed for the life of one target
+// episode, never the admitted Turn's own ID (which is different on every
+// retry). This is what lets a retried start -- for example after a
+// successful StartFactoryTarget whose immediately-following
+// RecordPendingFactorySession call failed -- converge on the exact same
+// on-demand Factory Sessions activation instead of starting a second one.
+func factoryStartRequestID(sessionID string, episode uint64) string {
+	return fmt.Sprintf("%s/episode/%d", sessionID, episode)
+}
+
 func (s *Server) startFactorySessionForEpisode(
 	ctx context.Context,
 	startResult chatsessions.StartTurnResult,
@@ -462,7 +510,16 @@ func (s *Server) startFactorySessionForEpisode(
 	factorySessionID := startResult.Episode.PendingFactorySessionID
 	if factorySessionID == "" {
 		startReq := factorysessions.StartRequest{
-			RequestID: startResult.Turn.ID,
+			// A stable per-episode key, not the admitted Turn's own ID: a
+			// retry of this same still-unbound episode (whether the original
+			// RecordPendingFactorySession call below failed, or a genuinely
+			// distinct later turn observes the episode still unbound) reuses
+			// this exact RequestID, so ondemandtarget.Service.StartAsync's
+			// own request-scoped deduplication converges on the identical
+			// runtime instead of opening a second one -- see that method's
+			// doc comment. The Turn's own ID changes on every retry and
+			// would defeat this.
+			RequestID: factoryStartRequestID(startResult.Session.ID, startResult.Episode.Number),
 			Source: factorysessions.Source{
 				Kind:      factoryruntime.WorkflowSourceKindFactoryID,
 				FactoryID: startResult.Episode.Target.Ref,

--- a/pkg/transports/acp/internal/stdio/session_prompt.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt.go
@@ -54,6 +54,21 @@ var errFactoryTargetUnavailable = errors.New("acp: session/prompt factory target
 // rather than silently proceeding with no bound Factory Session.
 var errEmptyFactorySessionIdentity = errors.New("acp: factory session start returned an empty session id")
 
+// dispatchOutcome carries what a Factory dispatch branch
+// (startFactorySessionForEpisode/invokeFactorySessionForEpisode) observed
+// about its own downstream call, decoupled from whatever *acpsdk.RequestError
+// classification or json.RawMessage response admitPromptTurn eventually
+// builds from it: the mapped ACP prompt outcome and the terminal
+// chatsessions.TurnState the admitted turn must be advanced to. terminal is
+// meaningful only when the branch returns a nil error -- a non-nil error
+// overrides it via terminalStateForFailure, since the branch's own
+// terminal choice is only ever a genuine downstream-published outcome
+// (completed/canceled/timed-out/failed), never a Go-level call failure.
+type dispatchOutcome struct {
+	outcome  protocol.PromptOutcome
+	terminal chatsessions.TurnState
+}
+
 // parseFactoryCommand inspects one validated prompt turn's content and
 // reports whether it is a "/factory <value>" command attempt. matched is
 // false only when the content is not an attempt at this command at all --
@@ -133,14 +148,12 @@ func (s *Server) handleSessionPrompt(ctx context.Context, env envelope.Envelope)
 // rejection and never reach StartTurn or (for the GetSession failures) leave
 // any effect at all.
 //
-// Once admitted, the turn's episode snapshot decides the one Factory effect
-// this story owns: when the episode has no Factory Session ID yet, start one
-// and bind the returned identity onto that exact episode/turn/version. When
-// the episode already carries a Factory Session ID (a later turn in the same
-// episode), invoke that exact bound session exactly once instead -- never a
-// second start. Either branch's published Factory Sessions outcome is then
-// mapped, deterministically and without fabrication, into the one final ACP
-// prompt response this call returns.
+// A successful admission is never left stranded in TurnStateAdmitted: it is
+// advanced to TurnStateRunning before any Factory effect, and dispatchFactoryTurn
+// guarantees an explicit terminal advancement (COMPLETED, CANCELED, or
+// FAILED) regardless of how the Factory dispatch and response mapping below
+// it turn out, clearing the session's active-turn/busy state in every case
+// so a later prompt can always be admitted.
 func (s *Server) admitPromptTurn(ctx context.Context, turn session.PromptTurn, reqIdentity chatsessions.RequestIdentity) (json.RawMessage, *acpsdk.RequestError) {
 	if s.chatSessions == nil {
 		return nil, classifyDependencyFailure(errSessionPromptUnavailable)
@@ -160,22 +173,94 @@ func (s *Server) admitPromptTurn(ctx context.Context, turn session.PromptTurn, r
 		return nil, classifyTurnAdmissionFailure(err)
 	}
 
-	var outcome protocol.PromptOutcome
-	if startResult.Episode.FactorySessionID == "" {
-		outcome, err = s.startFactorySessionForEpisode(ctx, startResult, turn)
-	} else {
-		outcome, err = s.invokeFactorySessionForEpisode(ctx, startResult, turn)
-	}
-	if err != nil {
+	if _, err := s.chatSessions.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: startResult.Session.ID,
+		TurnID:    startResult.Turn.ID,
+		Next:      chatsessions.TurnStateRunning,
+	}); err != nil {
 		return nil, classifyDependencyFailure(err)
 	}
 
-	resp := acpsdk.PromptResponse{StopReason: outcome.StopReason}
-	result, err := json.Marshal(resp)
-	if err != nil {
+	return s.dispatchFactoryTurn(ctx, startResult, turn)
+}
+
+// dispatchFactoryTurn runs the one Factory effect a running turn owns --
+// starting a fresh Factory Session for an unbound episode or invoking an
+// already-bound one -- maps its outcome into the final ACP prompt response,
+// and terminalizes the running turn on every path: COMPLETED when dispatch
+// and response mapping both succeed and the downstream outcome itself
+// reports a genuine completed status, CANCELED when the failure cause is
+// context.Canceled/context.DeadlineExceeded or the downstream outcome itself
+// reports canceled/timed-out, and FAILED for every other dispatch, terminal-
+// result, or response-mapping failure. The terminalizing AdvanceTurn call
+// always runs -- using the exact session/turn identity StartTurn admitted,
+// not a value derived from whatever failed -- so no admitted turn is ever
+// left stranded in a non-terminal state regardless of which step failed.
+func (s *Server) dispatchFactoryTurn(ctx context.Context, startResult chatsessions.StartTurnResult, turn session.PromptTurn) (json.RawMessage, *acpsdk.RequestError) {
+	var dispatched dispatchOutcome
+	var dispatchErr error
+	if startResult.Episode.FactorySessionID == "" {
+		dispatched, dispatchErr = s.startFactorySessionForEpisode(ctx, startResult, turn)
+	} else {
+		dispatched, dispatchErr = s.invokeFactorySessionForEpisode(ctx, startResult, turn)
+	}
+
+	terminal := dispatched.terminal
+	var result json.RawMessage
+	var rpcErr *acpsdk.RequestError
+	if dispatchErr != nil {
+		terminal = terminalStateForFailure(dispatchErr)
+		rpcErr = classifyDependencyFailure(dispatchErr)
+	} else {
+		resp := acpsdk.PromptResponse{StopReason: dispatched.outcome.StopReason}
+		marshaled, marshalErr := json.Marshal(resp)
+		if marshalErr != nil {
+			terminal = chatsessions.TurnStateFailed
+			rpcErr = classifyDependencyFailure(marshalErr)
+		} else {
+			result = marshaled
+		}
+	}
+
+	if _, err := s.chatSessions.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
+		SessionID: startResult.Session.ID,
+		TurnID:    startResult.Turn.ID,
+		Next:      terminal,
+	}); err != nil {
 		return nil, classifyDependencyFailure(err)
 	}
-	return result, nil
+
+	return result, rpcErr
+}
+
+// terminalStateForFailure classifies a Factory dispatch or response-mapping
+// failure cause into the TurnState the admitted turn must terminalize to:
+// context.Canceled/context.DeadlineExceeded (a caller-cancelled or
+// deadline-exceeded request) advances to TurnStateCanceled; every other
+// cause advances to TurnStateFailed.
+func terminalStateForFailure(cause error) chatsessions.TurnState {
+	if errors.Is(cause, context.Canceled) || errors.Is(cause, context.DeadlineExceeded) {
+		return chatsessions.TurnStateCanceled
+	}
+	return chatsessions.TurnStateFailed
+}
+
+// factoryInvocationTurnState maps one published Factory Session invocation's
+// terminal status to the TurnState an admitted turn terminalizes to when
+// InvokeFactoryTarget itself returns no Go error: a genuine published
+// completed outcome advances to TurnStateCompleted, a published
+// caller-canceled or timed-out outcome advances to TurnStateCanceled, and a
+// published failure -- or any other unmapped status -- safely advances to
+// TurnStateFailed rather than being reported as a false completion.
+func factoryInvocationTurnState(status factorysessions.InvocationTerminalStatus) chatsessions.TurnState {
+	switch status {
+	case factorysessions.InvocationTerminalStatusCompleted:
+		return chatsessions.TurnStateCompleted
+	case factorysessions.InvocationTerminalStatusCanceled, factorysessions.InvocationTerminalStatusTimedOut:
+		return chatsessions.TurnStateCanceled
+	default:
+		return chatsessions.TurnStateFailed
+	}
 }
 
 // startFactorySessionForEpisode starts exactly one Factory Session through
@@ -190,14 +275,18 @@ func (s *Server) admitPromptTurn(ctx context.Context, turn session.PromptTurn, r
 // attempted here. The returned outcome is protocol.MapFactoryStartOutcome's
 // deterministic projection of the shim's own published AsyncStartResult --
 // an asynchronous start has not itself reached a terminal outcome yet, so
-// this projection never carries fabricated primary-result text.
+// this projection never carries fabricated primary-result text. On success
+// the returned dispatchOutcome always terminalizes to TurnStateCompleted:
+// this branch's own responsibility -- dispatching and binding the async
+// start -- has genuinely completed, independent of the Factory Session's
+// own later, unobserved lifecycle.
 func (s *Server) startFactorySessionForEpisode(
 	ctx context.Context,
 	startResult chatsessions.StartTurnResult,
 	turn session.PromptTurn,
-) (protocol.PromptOutcome, error) {
+) (dispatchOutcome, error) {
 	if s.factoryTarget == nil {
-		return protocol.PromptOutcome{}, errFactoryTargetUnavailable
+		return dispatchOutcome{}, errFactoryTargetUnavailable
 	}
 
 	startReq := factorysessions.StartRequest{
@@ -220,10 +309,10 @@ func (s *Server) startFactorySessionForEpisode(
 
 	startOutcome, err := s.factoryTarget.StartFactoryTarget(ctx, startReq)
 	if err != nil {
-		return protocol.PromptOutcome{}, err
+		return dispatchOutcome{}, err
 	}
 	if startOutcome.SessionID == "" {
-		return protocol.PromptOutcome{}, errEmptyFactorySessionIdentity
+		return dispatchOutcome{}, errEmptyFactorySessionIdentity
 	}
 
 	if _, err := s.chatSessions.BindFactorySession(ctx, chatsessions.BindFactorySessionRequest{
@@ -233,10 +322,13 @@ func (s *Server) startFactorySessionForEpisode(
 		TurnID:           startResult.Turn.ID,
 		FactorySessionID: startOutcome.SessionID,
 	}); err != nil {
-		return protocol.PromptOutcome{}, err
+		return dispatchOutcome{}, err
 	}
 
-	return protocol.MapFactoryStartOutcome(startOutcome), nil
+	return dispatchOutcome{
+		outcome:  protocol.MapFactoryStartOutcome(startOutcome),
+		terminal: chatsessions.TurnStateCompleted,
+	}, nil
 }
 
 // invokeFactorySessionForEpisode invokes the given turn's already-bound
@@ -248,14 +340,20 @@ func (s *Server) startFactorySessionForEpisode(
 // The returned outcome is protocol.MapFactoryInvocationOutcome's
 // deterministic, safe projection of the shim's own published
 // InvocationResult -- its terminal status and only the "text" parts of its
-// primary result, never the raw result itself.
+// primary result, never the raw result itself. Unlike the start branch, this
+// call is synchronous: on success the returned dispatchOutcome terminalizes
+// to whatever factoryInvocationTurnState derives from the invocation's own
+// published terminal status, so a genuine Factory failure (InvocationResult
+// carrying InvocationTerminalStatusFailed) still terminalizes the Chat turn
+// to TurnStateFailed even though InvokeFactoryTarget itself returned no Go
+// error.
 func (s *Server) invokeFactorySessionForEpisode(
 	ctx context.Context,
 	startResult chatsessions.StartTurnResult,
 	turn session.PromptTurn,
-) (protocol.PromptOutcome, error) {
+) (dispatchOutcome, error) {
 	if s.factoryTarget == nil {
-		return protocol.PromptOutcome{}, errFactoryTargetUnavailable
+		return dispatchOutcome{}, errFactoryTargetUnavailable
 	}
 
 	requestID := startResult.Turn.ID
@@ -267,10 +365,13 @@ func (s *Server) invokeFactorySessionForEpisode(
 		SourceKind:      &sourceKind,
 	})
 	if err != nil {
-		return protocol.PromptOutcome{}, err
+		return dispatchOutcome{}, err
 	}
 
-	return protocol.MapFactoryInvocationOutcome(invokeResult), nil
+	return dispatchOutcome{
+		outcome:  protocol.MapFactoryInvocationOutcome(invokeResult),
+		terminal: factoryInvocationTurnState(invokeResult.Status),
+	}, nil
 }
 
 // promptContentToWorkParts converts validated ACP text prompt content into

--- a/pkg/transports/acp/internal/stdio/session_prompt.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt.go
@@ -407,46 +407,49 @@ func factoryInvocationTurnState(status factorysessions.InvocationTerminalStatus)
 
 // startFactorySessionForEpisode starts exactly one Factory Session through
 // the consumer-owned Factory Sessions shim for the given turn's newly
-// admitted (unbound) episode, and binds the returned identity onto that
-// exact episode/turn/version. The start request carries the episode's
-// canonical Factory target (Source.FactoryID), the Chat Session's exact
-// editor working root, and the validated prompt content -- never a process
-// cwd or transport fallback. A blank returned Factory Session ID
-// (errEmptyFactorySessionIdentity) is returned unclassified for the caller
-// to map.
+// admitted (unbound) episode -- unless a prior attempt for this same episode
+// already started one and durably recorded it as pending (see below), in
+// which case it reuses that identity instead of starting a second one -- then
+// dispatches this turn's validated prompt content into it via
+// InvokeFactoryTarget (the exact same operation invokeFactorySessionForEpisode
+// uses for every later turn) and binds the identity onto the episode.
 //
-// StartFactoryTarget's underlying activation (OnDemandFactoryTargetService)
-// is synchronous under the hood: it already observes a genuine terminal
-// factorysessions.InvocationResult before returning, so this branch's
-// returned outcome is protocol.MapFactoryInvocationOutcome's deterministic
-// projection of that same real result -- both its ordered primary-result
-// text and its terminal status -- exactly like invokeFactorySessionForEpisode
-// projects a later turn's invocation, rather than a placeholder that always
-// reports success. The returned dispatchOutcome terminalizes to whatever
-// factoryInvocationTurnState derives from that published status, so a
-// first-turn start that itself completed the dispatch call but published a
-// FAILED or TIMED_OUT status still terminalizes the Chat turn accordingly
-// instead of always reporting COMPLETED.
+// StartFactoryTarget itself only opens the runtime: the shared
+// factorysessions.Service.StartAsync it forwards to has no dedicated
+// content field and, more fundamentally, its Source vocabulary only resolves
+// named JavaScript workflow factories, not an ordinary packaged Factory --
+// see ondemandtarget.Service.StartAsync's own doc comment. So this turn's
+// content, source kind, and correlated request ID travel through the
+// immediate follow-up InvokeFactoryTarget call instead, whose real, terminal
+// InvocationResult (ordered primary-result text included) is what
+// protocol.MapFactoryInvocationOutcome projects -- exactly the same
+// truthful-outcome guarantee invokeFactorySessionForEpisode already provides
+// for later turns, not a placeholder that always reports success. A blank
+// SessionID returned by StartFactoryTarget (errEmptyFactorySessionIdentity)
+// is returned unclassified for the caller to map.
 //
-// A start and its commit are not atomic against this transport's own
-// process -- BindFactorySession can fail after StartFactoryTarget already
-// succeeded -- so this method reconciles across separate calls via
-// pendingFactoryStarts, keyed by (session, episode): the first turn for an
-// episode that finds no pending record starts a fresh Factory Session and
-// records its identity as pending before attempting to bind it. A later
-// admitted turn for that same still-unbound episode (whether the original
-// bind is still failing, or a genuinely distinct retry request) finds the
-// pending record and dispatches its own content into that exact already-live
-// runtime via InvokeFactoryTarget instead of starting a second one, then
-// retries the bind. Once a bind succeeds the pending record is cleared. Only
-// a *chatsessions.FactorySessionConflictError -- a different identity
-// already won the episode -- abandons the pending runtime: it is closed
-// (best-effort; a close failure is joined into the returned error) and the
-// pending record is cleared, since the next call will observe the already-
-// bound episode and correctly invoke the winner instead. Every other bind
-// failure (for example a transient version conflict) keeps the pending
-// record and the runtime open, so no later retry can ever lose track of it
-// and start a second Factory Session for the same episode.
+// A start and its bind are not atomic against this transport's own process
+// -- BindFactorySession can fail after StartFactoryTarget already succeeded
+// -- so this method reconciles across separate calls through the singular
+// Chat/Factory Sessions authority itself, not this Server instance: the
+// admitted episode snapshot's own Episode.PendingFactorySessionID (durably
+// recorded via RecordPendingFactorySession right after a successful start,
+// before the bind attempt) is the reconciliation record, so a retry survives
+// this Server being reconstructed, not just staying alive. A later admitted
+// turn for that same still-unbound episode (whether the original bind is
+// still failing, or a genuinely distinct retry request) observes the pending
+// identity in its own fresh episode snapshot and dispatches into that exact
+// already-live runtime instead of starting a second one, then retries the
+// bind. A successful bind itself clears the pending record (see
+// chatsessions.Service.BindFactorySession). Only a
+// *chatsessions.FactorySessionConflictError -- a different identity already
+// won the episode -- abandons the pending runtime: it is closed (best-effort;
+// a close failure is joined into the returned error) and the pending record
+// is explicitly cleared, since the next call will observe the already-bound
+// episode and correctly invoke the winner instead. Every other bind failure
+// (for example a transient version conflict) keeps the pending record and
+// the runtime open, so no later retry can ever lose track of it and start a
+// second Factory Session for the same episode.
 func (s *Server) startFactorySessionForEpisode(
 	ctx context.Context,
 	startResult chatsessions.StartTurnResult,
@@ -456,66 +459,74 @@ func (s *Server) startFactorySessionForEpisode(
 		return dispatchOutcome{}, errFactoryTargetUnavailable
 	}
 
-	key := pendingFactoryStartKey{sessionID: startResult.Session.ID, episode: startResult.Episode.Number}
-
-	var outcome factorysessions.InvocationResult
-	var err error
-	if pendingID, ok := s.lookupPendingFactoryStart(key); ok {
-		requestID := startResult.Turn.ID
-		sourceKind := factorysessions.InvocationInputSourceKindText
-		outcome, err = s.factoryTarget.InvokeFactoryTarget(ctx, pendingID, factorysessions.InvocationRequest{
-			Content:         promptContentToWorkParts(turn.Content),
-			ContentProvided: true,
-			RequestID:       &requestID,
-			SourceKind:      &sourceKind,
-		})
-		if err == nil {
-			outcome.SessionID = pendingID
-		}
-	} else {
+	factorySessionID := startResult.Episode.PendingFactorySessionID
+	if factorySessionID == "" {
 		startReq := factorysessions.StartRequest{
 			RequestID: startResult.Turn.ID,
 			Source: factorysessions.Source{
 				Kind:      factoryruntime.WorkflowSourceKindFactoryID,
 				FactoryID: startResult.Episode.Target.Ref,
 			},
-			// StartRequest has no dedicated content/root fields; Args is the
-			// one JSON-compatible channel this published contract offers, so
-			// the validated prompt content (in the same work.WorkContentPart
-			// shape InvocationRequest.Content already uses) and the
-			// session's exact editor working root travel through it rather
+			// StartRequest has no dedicated root field; Args is the one
+			// JSON-compatible channel this published contract offers, so the
+			// session's exact editor working root travels through it rather
 			// than being silently dropped or replaced by a process cwd.
 			Args: map[string]any{
-				"content":     promptContentToWorkParts(turn.Content),
 				"workingRoot": startResult.Session.WorkingRoot,
 			},
 		}
-		outcome, err = s.factoryTarget.StartFactoryTarget(ctx, startReq)
+		startOutcome, err := s.factoryTarget.StartFactoryTarget(ctx, startReq)
+		if err != nil {
+			return dispatchOutcome{}, err
+		}
+		if startOutcome.SessionID == "" {
+			return dispatchOutcome{}, errEmptyFactorySessionIdentity
+		}
+		factorySessionID = startOutcome.SessionID
+
+		if _, err := s.chatSessions.RecordPendingFactorySession(ctx, chatsessions.RecordPendingFactorySessionRequest{
+			SessionID:        startResult.Session.ID,
+			ExpectedVersion:  startResult.Session.Version,
+			Episode:          startResult.Episode.Number,
+			TurnID:           startResult.Turn.ID,
+			FactorySessionID: factorySessionID,
+		}); err != nil {
+			return dispatchOutcome{}, err
+		}
 	}
+
+	requestID := startResult.Turn.ID
+	sourceKind := factorysessions.InvocationInputSourceKindText
+	outcome, err := s.factoryTarget.InvokeFactoryTarget(ctx, factorySessionID, factorysessions.InvocationRequest{
+		Content:         promptContentToWorkParts(turn.Content),
+		ContentProvided: true,
+		RequestID:       &requestID,
+		SourceKind:      &sourceKind,
+	})
 	if err != nil {
 		return dispatchOutcome{}, err
 	}
-	if outcome.SessionID == "" {
-		return dispatchOutcome{}, errEmptyFactorySessionIdentity
-	}
-
-	s.setPendingFactoryStart(key, outcome.SessionID)
+	outcome.SessionID = factorySessionID
 
 	if _, err := s.chatSessions.BindFactorySession(ctx, chatsessions.BindFactorySessionRequest{
 		SessionID:        startResult.Session.ID,
 		ExpectedVersion:  startResult.Session.Version,
 		Episode:          startResult.Episode.Number,
 		TurnID:           startResult.Turn.ID,
-		FactorySessionID: outcome.SessionID,
+		FactorySessionID: factorySessionID,
 	}); err != nil {
 		var conflictErr *chatsessions.FactorySessionConflictError
 		if errors.As(err, &conflictErr) {
-			s.clearPendingFactoryStart(key)
-			return dispatchOutcome{}, errors.Join(err, s.factoryTarget.CloseFactoryTarget(ctx, outcome.SessionID))
+			_, clearErr := s.chatSessions.RecordPendingFactorySession(ctx, chatsessions.RecordPendingFactorySessionRequest{
+				SessionID:       startResult.Session.ID,
+				ExpectedVersion: startResult.Session.Version,
+				Episode:         startResult.Episode.Number,
+				TurnID:          startResult.Turn.ID,
+			})
+			return dispatchOutcome{}, errors.Join(err, clearErr, s.factoryTarget.CloseFactoryTarget(ctx, factorySessionID))
 		}
 		return dispatchOutcome{}, err
 	}
-	s.clearPendingFactoryStart(key)
 
 	return dispatchOutcome{
 		outcome:  protocol.MapFactoryInvocationOutcome(outcome),

--- a/pkg/transports/acp/internal/stdio/session_prompt.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt.go
@@ -43,11 +43,10 @@ var errSessionPromptUnavailable = errors.New("acp: session/prompt collaborators 
 
 // errFactoryDelegationNotImplemented marks a validated, admitted ordinary
 // prompt turn whose downstream dispatch this transport slice does not yet
-// finish: mapping a Factory Session's outcome into a final ACP response, and
-// invoking an already-bound Factory Session for a later turn, are later
-// stories' scope (003/004). It never reaches a client verbatim --
-// classifyDependencyFailure maps it to the same bounded internal-error
-// response every other dependency failure receives.
+// finish: mapping a Factory Session's outcome (start or invoke) into a final
+// ACP response is later stories' scope (004/005). It never reaches a client
+// verbatim -- classifyDependencyFailure maps it to the same bounded
+// internal-error response every other dependency failure receives.
 var errFactoryDelegationNotImplemented = errors.New("acp: factory session delegation is not yet implemented")
 
 // errFactoryTargetUnavailable marks a "session/prompt" call this Server was
@@ -144,12 +143,12 @@ func (s *Server) handleSessionPrompt(ctx context.Context, env envelope.Envelope)
 //
 // Once admitted, the turn's episode snapshot decides the one Factory effect
 // this story owns: when the episode has no Factory Session ID yet, start one
-// and bind the returned identity onto that exact episode/turn/version. An
-// already-bound episode (a later turn in the same episode) makes zero start
-// calls -- invoking that bound Factory Session is story 003's scope, not
-// this one's -- so this method still reports the bounded not-yet-implemented
-// failure after a successful start+bind or an already-bound episode, since
-// neither downstream dispatch nor final response mapping exist yet.
+// and bind the returned identity onto that exact episode/turn/version. When
+// the episode already carries a Factory Session ID (a later turn in the same
+// episode), invoke that exact bound session exactly once instead -- never a
+// second start. Either branch still reports the bounded not-yet-implemented
+// failure afterward, since mapping the Factory Session's outcome into a final
+// ACP response is a later story's scope.
 func (s *Server) admitPromptTurn(ctx context.Context, turn session.PromptTurn, reqIdentity chatsessions.RequestIdentity) (json.RawMessage, *acpsdk.RequestError) {
 	if s.chatSessions == nil {
 		return nil, classifyDependencyFailure(errSessionPromptUnavailable)
@@ -171,6 +170,10 @@ func (s *Server) admitPromptTurn(ctx context.Context, turn session.PromptTurn, r
 
 	if startResult.Episode.FactorySessionID == "" {
 		if err := s.startFactorySessionForEpisode(ctx, startResult, turn); err != nil {
+			return nil, classifyDependencyFailure(err)
+		}
+	} else {
+		if err := s.invokeFactorySessionForEpisode(ctx, startResult, turn); err != nil {
 			return nil, classifyDependencyFailure(err)
 		}
 	}
@@ -229,6 +232,32 @@ func (s *Server) startFactorySessionForEpisode(
 		Episode:          startResult.Episode.Number,
 		TurnID:           startResult.Turn.ID,
 		FactorySessionID: startOutcome.SessionID,
+	})
+	return err
+}
+
+// invokeFactorySessionForEpisode invokes the given turn's already-bound
+// Factory Session exactly once, with that exact bound identity, the
+// validated prompt content in the shared work.WorkContentPart shape, the text
+// source kind, and the admitted turn's ID as the correlated request ID. It
+// never starts a second Factory Session for an already-bound episode -- an
+// unbound episode is startFactorySessionForEpisode's job, not this one's.
+func (s *Server) invokeFactorySessionForEpisode(
+	ctx context.Context,
+	startResult chatsessions.StartTurnResult,
+	turn session.PromptTurn,
+) error {
+	if s.factoryTarget == nil {
+		return errFactoryTargetUnavailable
+	}
+
+	requestID := startResult.Turn.ID
+	sourceKind := factorysessions.InvocationInputSourceKindText
+	_, err := s.factoryTarget.InvokeFactoryTarget(ctx, startResult.Episode.FactorySessionID, factorysessions.InvocationRequest{
+		Content:         promptContentToWorkParts(turn.Content),
+		ContentProvided: true,
+		RequestID:       &requestID,
+		SourceKind:      &sourceKind,
 	})
 	return err
 }

--- a/pkg/transports/acp/internal/stdio/session_prompt.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt.go
@@ -154,6 +154,16 @@ func (s *Server) handleSessionPrompt(ctx context.Context, env envelope.Envelope)
 // FAILED) regardless of how the Factory dispatch and response mapping below
 // it turn out, clearing the session's active-turn/busy state in every case
 // so a later prompt can always be admitted.
+//
+// StartTurn treats a reused RequestID as an idempotent retry and returns the
+// existing turn instead of admitting a new one; a returned Turn.State other
+// than TurnStateAdmitted therefore means this call redelivered a request this
+// Session already handled (or is still handling), not a fresh admission.
+// respondToRedeliveredTurn classifies that case without ever reaching a
+// Factory effect: a still-busy existing turn (RUNNING) rejects the same way
+// a genuinely distinct concurrent duplicate would, and an already-terminal
+// existing turn returns a deterministic response derived only from that
+// turn's own recorded terminal state.
 func (s *Server) admitPromptTurn(ctx context.Context, turn session.PromptTurn, reqIdentity chatsessions.RequestIdentity) (json.RawMessage, *acpsdk.RequestError) {
 	if s.chatSessions == nil {
 		return nil, classifyDependencyFailure(errSessionPromptUnavailable)
@@ -173,6 +183,10 @@ func (s *Server) admitPromptTurn(ctx context.Context, turn session.PromptTurn, r
 		return nil, classifyTurnAdmissionFailure(err)
 	}
 
+	if startResult.Turn.State != chatsessions.TurnStateAdmitted {
+		return respondToRedeliveredTurn(startResult.Session.ID, startResult.Turn)
+	}
+
 	if _, err := s.chatSessions.AdvanceTurn(ctx, chatsessions.AdvanceTurnRequest{
 		SessionID: startResult.Session.ID,
 		TurnID:    startResult.Turn.ID,
@@ -182,6 +196,43 @@ func (s *Server) admitPromptTurn(ctx context.Context, turn session.PromptTurn, r
 	}
 
 	return s.dispatchFactoryTurn(ctx, startResult, turn)
+}
+
+// respondToRedeliveredTurn classifies a StartTurn result that identified an
+// already-admitted turn (via RequestID reuse) rather than a fresh admission.
+// A busy existing turn rejects exactly the way classifyTurnAdmissionFailure
+// classifies any other *chatsessions.BusyError; an already-terminal existing
+// turn returns the deterministic response its own recorded TurnState implies,
+// via turnStateStopReason, with no Factory effect and no further Chat
+// Sessions mutation in either case.
+func respondToRedeliveredTurn(sessionID string, turn chatsessions.Turn) (json.RawMessage, *acpsdk.RequestError) {
+	if turn.State.IsBusy() {
+		return nil, classifyTurnAdmissionFailure(&chatsessions.BusyError{
+			Value: "Session", ID: sessionID,
+			ActiveTurnID: turn.ID, ActiveTurnState: turn.State,
+		})
+	}
+
+	resp := acpsdk.PromptResponse{StopReason: turnStateStopReason(turn.State)}
+	result, err := json.Marshal(resp)
+	if err != nil {
+		return nil, classifyDependencyFailure(err)
+	}
+	return result, nil
+}
+
+// turnStateStopReason maps an already-terminal Turn's recorded TurnState to
+// the ACP stop reason a redelivered request for it deterministically
+// reports: TurnStateCompleted to end_turn, TurnStateCanceled to cancelled,
+// and TurnStateFailed -- or any other value, which Turn.Validate never
+// actually allows here since respondToRedeliveredTurn only reaches this for
+// an already-terminal turn -- to the same end_turn safe fallback this
+// transport uses elsewhere for a Factory failure.
+func turnStateStopReason(state chatsessions.TurnState) acpsdk.StopReason {
+	if state == chatsessions.TurnStateCanceled {
+		return acpsdk.StopReasonCancelled
+	}
+	return acpsdk.StopReasonEndTurn
 }
 
 // dispatchFactoryTurn runs the one Factory effect a running turn owns --

--- a/pkg/transports/acp/internal/stdio/session_prompt.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt.go
@@ -8,6 +8,7 @@ import (
 
 	acpsdk "github.com/coder/acp-go-sdk"
 
+	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/envelope"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/protocol"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/session"
@@ -29,6 +30,21 @@ const factoryCommandName = "/factory"
 // malformed_request classification, and the raw command text is never
 // included in that classification.
 var errMalformedFactoryCommand = errors.New("acp: malformed /factory command")
+
+// errSessionPromptUnavailable marks a "session/prompt" call this Server was
+// never constructed with the Chat Sessions collaborator to serve. It never
+// reaches a client verbatim -- classifyDependencyFailure maps it to a
+// bounded internal-error response the same way it maps every other
+// dependency failure.
+var errSessionPromptUnavailable = errors.New("acp: session/prompt collaborators are not configured")
+
+// errFactoryDelegationNotImplemented marks a validated, admitted ordinary
+// prompt turn this transport slice does not yet dispatch to a Factory
+// Session: starting or invoking a Factory Session and mapping its outcome
+// into a final ACP response are later stories' scope. It never reaches a
+// client verbatim -- classifyDependencyFailure maps it to the same bounded
+// internal-error response every other dependency failure receives.
+var errFactoryDelegationNotImplemented = errors.New("acp: factory session delegation is not yet implemented")
 
 // parseFactoryCommand inspects one validated prompt turn's content and
 // reports whether it is a "/factory <value>" command attempt. matched is
@@ -54,18 +70,15 @@ func parseFactoryCommand(content []session.TextContent) (value string, matched b
 	return fields[1], true, nil
 }
 
-// handleSessionPrompt executes one "session/prompt" request but only for
-// its "/factory <value>" fallback command form (final-proposal.md §3):
-// validate the request before any effect, recognize the exact command
-// shape, and delegate to the same changeTarget sequence
-// "session/set_config_option" uses -- no catalog filtering, reference
-// parsing, expected-version policy, state mutation, or error translation is
-// duplicated here. Content that is not an attempt at this command at all
-// falls through to method-not-found, matching this transport slice's
-// existing behavior for every other prompt: this story adds the
-// "/factory" fallback, not general prompt-turn admission or Factory
-// invocation, so no prompt turn is ever started and no Factory is ever
-// invoked by this handler.
+// handleSessionPrompt executes one "session/prompt" request: validate the
+// request before any effect, then either recognize the exact "/factory
+// <value>" fallback command form (final-proposal.md §3) and delegate to the
+// same changeTarget sequence "session/set_config_option" uses -- no catalog
+// filtering, reference parsing, expected-version policy, state mutation, or
+// error translation is duplicated here -- or, for every other (genuine,
+// non-command) prompt, admit exactly one version-guarded Chat turn via
+// admitPromptTurn. Both paths resolve the connection-scoped request
+// identity before any Chat Sessions effect.
 func (s *Server) handleSessionPrompt(ctx context.Context, env envelope.Envelope) (json.RawMessage, *acpsdk.RequestError) {
 	var req acpsdk.PromptRequest
 	if err := json.Unmarshal(env.Params, &req); err != nil {
@@ -77,9 +90,6 @@ func (s *Server) handleSessionPrompt(ctx context.Context, env envelope.Envelope)
 	}
 
 	value, matched, cmdErr := parseFactoryCommand(turn.Content)
-	if !matched {
-		return nil, protocol.MethodNotFound(env.Method)
-	}
 	if cmdErr != nil {
 		return nil, protocol.SafeReject(cmdErr)
 	}
@@ -89,14 +99,90 @@ func (s *Server) handleSessionPrompt(ctx context.Context, env envelope.Envelope)
 		return nil, protocol.SafeReject(err)
 	}
 
-	if _, rpcErr := s.changeTarget(ctx, string(turn.SessionID), value, reqIdentity); rpcErr != nil {
-		return nil, rpcErr
+	if matched {
+		if _, rpcErr := s.changeTarget(ctx, string(turn.SessionID), value, reqIdentity); rpcErr != nil {
+			return nil, rpcErr
+		}
+
+		resp := acpsdk.PromptResponse{StopReason: acpsdk.StopReasonEndTurn}
+		result, err := json.Marshal(resp)
+		if err != nil {
+			return nil, classifyDependencyFailure(err)
+		}
+		return result, nil
 	}
 
-	resp := acpsdk.PromptResponse{StopReason: acpsdk.StopReasonEndTurn}
-	result, err := json.Marshal(resp)
-	if err != nil {
-		return nil, classifyDependencyFailure(err)
+	return s.admitPromptTurn(ctx, turn, reqIdentity)
+}
+
+// admitPromptTurn executes the ordinary (non-"/factory") prompt admission
+// sequence: read the addressed Chat Session and call its canonical
+// StartTurn exactly once with the full request identity, the real session
+// id, and the version observed from that read -- no Factory Session is
+// started or invoked by this story, so an admitted turn's downstream
+// dispatch and terminal response mapping are always reported as the bounded
+// not-yet-implemented internal error rather than fabricated success. An
+// unknown session (*chatsessions.NotFoundError), a stale expected version
+// (*chatsessions.ConflictError), or a busy active turn
+// (*chatsessions.BusyError) all classify as a bounded protocol-safe
+// rejection and never reach StartTurn or (for the GetSession failures) leave
+// any effect at all.
+func (s *Server) admitPromptTurn(ctx context.Context, turn session.PromptTurn, reqIdentity chatsessions.RequestIdentity) (json.RawMessage, *acpsdk.RequestError) {
+	if s.chatSessions == nil {
+		return nil, classifyDependencyFailure(errSessionPromptUnavailable)
 	}
-	return result, nil
+
+	getResult, err := s.chatSessions.GetSession(ctx, chatsessions.GetSessionRequest{SessionID: string(turn.SessionID)})
+	if err != nil {
+		return nil, classifyTurnAdmissionFailure(err)
+	}
+
+	if _, err := s.chatSessions.StartTurn(ctx, chatsessions.StartTurnRequest{
+		RequestID:       reqIdentity,
+		SessionID:       getResult.Session.ID,
+		ExpectedVersion: getResult.Session.Version,
+	}); err != nil {
+		return nil, classifyTurnAdmissionFailure(err)
+	}
+
+	return nil, classifyDependencyFailure(errFactoryDelegationNotImplemented)
+}
+
+// classifyTurnAdmissionFailure converts a failure from reading a Chat
+// Session or calling StartTurn into a bounded, protocol-safe
+// *acpsdk.RequestError. A context.Canceled or context.DeadlineExceeded
+// cause classifies as the ACP-defined request-cancelled outcome via
+// classifyDependencyFailure. A failure this package attributes to the
+// caller's own request -- an unknown session (*chatsessions.NotFoundError),
+// a stale expected version (*chatsessions.ConflictError), a busy active turn
+// (*chatsessions.BusyError), or a malformed request value
+// (*chatsessions.ValidationError) -- classifies as a bounded invalid-params
+// rejection via protocol.SafeReject. Every other cause classifies as a
+// bounded internal error via classifyDependencyFailure. No branch ever
+// serializes the cause's message text, so a raw prompt, session id, or
+// private topology detail can never reach the client through this
+// classification.
+func classifyTurnAdmissionFailure(cause error) *acpsdk.RequestError {
+	if errors.Is(cause, context.Canceled) || errors.Is(cause, context.DeadlineExceeded) {
+		return classifyDependencyFailure(cause)
+	}
+
+	var notFoundErr *chatsessions.NotFoundError
+	if errors.As(cause, &notFoundErr) {
+		return protocol.SafeReject(cause)
+	}
+	var conflictErr *chatsessions.ConflictError
+	if errors.As(cause, &conflictErr) {
+		return protocol.SafeReject(cause)
+	}
+	var busyErr *chatsessions.BusyError
+	if errors.As(cause, &busyErr) {
+		return protocol.SafeReject(cause)
+	}
+	var validationErr *chatsessions.ValidationError
+	if errors.As(cause, &validationErr) {
+		return protocol.SafeReject(cause)
+	}
+
+	return classifyDependencyFailure(cause)
 }

--- a/pkg/transports/acp/internal/stdio/session_prompt_test.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt_test.go
@@ -7,19 +7,92 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	acpsdk "github.com/coder/acp-go-sdk"
 
 	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	chatsessionswire "github.com/portpowered/infinite-you/pkg/services/chat_sessions/wire"
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/identity"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/session"
 )
+
+// sequentialIDGenerator returns a chatsessionswire.IDGenerator that produces
+// prefix-1, prefix-2, ... on successive calls, for tests that construct a
+// real chatsessions.Store and need deterministic, human-readable identities.
+func sequentialIDGenerator(prefix string) chatsessionswire.IDGenerator {
+	n := 0
+	return func() string {
+		n++
+		return prefix + "-" + strconv.Itoa(n)
+	}
+}
+
+// fixedClock returns a chatsessionswire.Clock that always reports at, for
+// tests that construct a real chatsessions.Store and do not exercise
+// timestamp behavior.
+func fixedClock(at time.Time) chatsessionswire.Clock {
+	return func() time.Time { return at }
+}
+
+// firstCallFailingChatSessions wraps a real chatsessions.Service and injects
+// injectErr into exactly the first call to the named method, letting every
+// other call (including every later call to that same method) pass through
+// unmodified. It exists to prove recovery behavior against the real
+// chatsessions.Store's own state machine, not a call-recording fake that
+// cannot itself strand or release busy state.
+type firstCallFailingChatSessions struct {
+	chatsessions.Service
+	mu        sync.Mutex
+	method    string
+	injectErr error
+	triggered bool
+}
+
+func (f *firstCallFailingChatSessions) AdvanceTurn(ctx context.Context, req chatsessions.AdvanceTurnRequest) (chatsessions.AdvanceTurnResult, error) {
+	if f.method == "AdvanceTurn" {
+		f.mu.Lock()
+		if !f.triggered {
+			f.triggered = true
+			f.mu.Unlock()
+			return chatsessions.AdvanceTurnResult{}, f.injectErr
+		}
+		f.mu.Unlock()
+	}
+	return f.Service.AdvanceTurn(ctx, req)
+}
+
+// nthAdvanceTurnFailingChatSessions wraps a real chatsessions.Service and
+// injects injectErr into exactly the failOnCall'th call to AdvanceTurn
+// (1-indexed) across the whole wrapped instance's lifetime, letting every
+// other call pass through unmodified. It exists to prove that a single
+// injected terminal-transition failure -- followed by this transport's own
+// recovery attempt -- does not strand the session busy for a later prompt.
+type nthAdvanceTurnFailingChatSessions struct {
+	chatsessions.Service
+	mu         sync.Mutex
+	failOnCall int
+	injectErr  error
+	calls      int
+}
+
+func (f *nthAdvanceTurnFailingChatSessions) AdvanceTurn(ctx context.Context, req chatsessions.AdvanceTurnRequest) (chatsessions.AdvanceTurnResult, error) {
+	f.mu.Lock()
+	f.calls++
+	fail := f.calls == f.failOnCall
+	f.mu.Unlock()
+	if fail {
+		return chatsessions.AdvanceTurnResult{}, f.injectErr
+	}
+	return f.Service.AdvanceTurn(ctx, req)
+}
 
 // promptTextParams builds a raw session/prompt params payload carrying one
 // text content block, the shape a client sends for a typed "/factory
@@ -1630,9 +1703,11 @@ func TestHandleSessionPromptFactoryDispatchCancellationAdvancesTurnToCanceled(t 
 
 // TestHandleSessionPromptRunningTransitionFailureMakesNoFactoryDispatchCall
 // proves that when advancing a freshly admitted turn to TurnStateRunning
-// itself fails, the handler reports a bounded internal error and never
-// attempts a Factory dispatch call (StartFactoryTarget/InvokeFactoryTarget)
-// for a turn that is not actually confirmed running.
+// itself fails, the handler reports a bounded internal error, never attempts
+// a Factory dispatch call (StartFactoryTarget/InvokeFactoryTarget) for a
+// turn that is not actually confirmed running, and makes one recovery
+// AdvanceTurn(CANCELED) attempt -- the one legal terminal transition from
+// ADMITTED -- so the session's busy state is not stranded forever.
 func TestHandleSessionPromptRunningTransitionFailureMakesNoFactoryDispatchCall(t *testing.T) {
 	chatSessions := &fakeChatSessionsService{
 		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
@@ -1655,8 +1730,54 @@ func TestHandleSessionPromptRunningTransitionFailureMakesNoFactoryDispatchCall(t
 	if chatSessions.bindFactorySessionCalled {
 		t.Fatal("BindFactorySession was called, want no binding attempt when the turn never confirmed running")
 	}
-	if len(chatSessions.advanceTurnReqs) != 1 {
-		t.Fatalf("AdvanceTurn call count = %d, want exactly 1 (the failed RUNNING attempt, no terminal retry)", len(chatSessions.advanceTurnReqs))
+	wantAdvanceTurnSequence(t, chatSessions, "session-1", "turn-1",
+		chatsessions.TurnStateRunning, chatsessions.TurnStateCanceled)
+}
+
+// TestHandleSessionPromptRunningTransitionFailureRecoveryAdmitsLaterPrompt
+// proves the RUNNING-transition recovery attempt actually releases the
+// session's busy state against the real chatsessions.Store (not just the
+// call-recording fake): after an injected single-shot AdvanceTurn failure,
+// a later uniquely identified prompt on the same session is admitted and
+// dispatches, instead of being rejected as busy forever.
+func TestHandleSessionPromptRunningTransitionFailureRecoveryAdmitsLaterPrompt(t *testing.T) {
+	store, err := chatsessionswire.NewService(sequentialIDGenerator("session"), fixedClock(time.Unix(0, 1)))
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	created, err := store.CreateSession(context.Background(), chatsessions.CreateSessionRequest{
+		RequestID:     chatsessions.RequestIdentity{Kind: chatsessions.RequestIdentityKindJSONRPCNumber, ConnectionID: "conn-setup", JSONRPCNumberID: "0"},
+		WorkingRoot:   "/work/project",
+		InitialTarget: chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "@you/review"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+
+	faulty := &firstCallFailingChatSessions{
+		Service:   store,
+		method:    "AdvanceTurn",
+		injectErr: errors.New("advance turn boom"),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{
+		SessionID: "fs-1", Status: factorysessions.InvocationTerminalStatusCompleted,
+	}}
+	server := New(nil, faulty, catalog, factoryTarget, func() (string, error) { return "/home/operator", nil })
+
+	firstEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams(created.Session.ID, "first message"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), firstEnv); rpcErr == nil {
+		t.Fatal("first handleSessionPrompt() error = nil, want a bounded failure from the injected RUNNING-transition fault")
+	}
+
+	secondEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams(created.Session.ID, "second message"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), secondEnv); rpcErr != nil {
+		t.Fatalf("second handleSessionPrompt() error = %+v, want the session admitted (not stranded busy)", rpcErr)
+	}
+	if len(factoryTarget.startCalls) != 1 {
+		t.Fatalf("StartFactoryTarget call count = %d, want exactly 1 (only the second, successfully admitted turn dispatches)", len(factoryTarget.startCalls))
 	}
 }
 
@@ -1665,12 +1786,13 @@ func TestHandleSessionPromptRunningTransitionFailureMakesNoFactoryDispatchCall(t
 // after a successful Factory dispatch, the handler reports that failure as a
 // bounded internal error instead of silently discarding it and returning the
 // dispatch's own successful response -- an unterminalized turn must never be
-// masked by an otherwise-successful outcome.
+// masked by an otherwise-successful outcome -- and makes one recovery
+// AdvanceTurn(FAILED) attempt so the session's busy state is not stranded.
 func TestHandleSessionPromptTerminalTransitionFailurePropagatesBoundedError(t *testing.T) {
 	chatSessions := &fakeChatSessionsService{
 		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
 		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
-		advanceTurnErrs:  []error{nil, errors.New("terminal advance boom")},
+		advanceTurnErrs:  []error{nil, errors.New("terminal advance boom"), nil},
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
 	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{
@@ -1694,5 +1816,59 @@ func TestHandleSessionPromptTerminalTransitionFailurePropagatesBoundedError(t *t
 	if !chatSessions.bindFactorySessionCalled {
 		t.Fatal("BindFactorySession was not called, want the successful dispatch to still bind before terminalization is attempted")
 	}
-	wantAdvanceTurnSequence(t, chatSessions, "session-1", "turn-1", chatsessions.TurnStateRunning, chatsessions.TurnStateCompleted)
+	wantAdvanceTurnSequence(t, chatSessions, "session-1", "turn-1",
+		chatsessions.TurnStateRunning, chatsessions.TurnStateCompleted, chatsessions.TurnStateFailed)
+}
+
+// TestHandleSessionPromptTerminalTransitionFailureRecoveryAdmitsLaterPrompt
+// proves the terminal-transition recovery attempt actually releases the
+// session's busy state against the real chatsessions.Store: after an
+// injected single-shot terminal AdvanceTurn failure, a later uniquely
+// identified prompt on the same session is admitted and dispatches, instead
+// of being rejected as busy forever. Because the first turn's dispatch (and
+// its BindFactorySession) already succeeded before its terminalization
+// faulted, the episode is already bound by the time the second turn is
+// admitted, so the second turn correctly takes the invoke branch -- proving
+// not just that admission recovers, but that recovery never causes a second
+// Factory Session to be started for the same episode.
+func TestHandleSessionPromptTerminalTransitionFailureRecoveryAdmitsLaterPrompt(t *testing.T) {
+	store, err := chatsessionswire.NewService(sequentialIDGenerator("session"), fixedClock(time.Unix(0, 1)))
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	created, err := store.CreateSession(context.Background(), chatsessions.CreateSessionRequest{
+		RequestID:     chatsessions.RequestIdentity{Kind: chatsessions.RequestIdentityKindJSONRPCNumber, ConnectionID: "conn-setup", JSONRPCNumberID: "0"},
+		WorkingRoot:   "/work/project",
+		InitialTarget: chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "@you/review"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+
+	faulty := &nthAdvanceTurnFailingChatSessions{
+		Service: store, failOnCall: 2, injectErr: errors.New("terminal advance boom"),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{
+		SessionID: "fs-1", Status: factorysessions.InvocationTerminalStatusCompleted,
+	}}
+	server := New(nil, faulty, catalog, factoryTarget, func() (string, error) { return "/home/operator", nil })
+
+	firstEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams(created.Session.ID, "first message"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), firstEnv); rpcErr == nil {
+		t.Fatal("first handleSessionPrompt() error = nil, want a bounded failure from the injected terminal-transition fault")
+	}
+
+	secondEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams(created.Session.ID, "second message"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), secondEnv); rpcErr != nil {
+		t.Fatalf("second handleSessionPrompt() error = %+v, want the session admitted (not stranded busy)", rpcErr)
+	}
+	if len(factoryTarget.startCalls) != 1 {
+		t.Fatalf("StartFactoryTarget call count = %d, want exactly 1 (the first turn's dispatch itself succeeded before its terminalization faulted)", len(factoryTarget.startCalls))
+	}
+	if len(factoryTarget.invokeCalls) != 1 {
+		t.Fatalf("InvokeFactoryTarget call count = %d, want exactly 1 (the second turn reuses the already-bound Factory Session instead of starting a second one)", len(factoryTarget.invokeCalls))
+	}
 }

--- a/pkg/transports/acp/internal/stdio/session_prompt_test.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt_test.go
@@ -1522,6 +1522,69 @@ func TestHandleSessionPromptEmptyFactorySessionIdentityFailsSafely(t *testing.T)
 	}
 }
 
+// TestHandleSessionPromptRecordPendingFailureAfterStartMakesNoBindCall
+// proves that when RecordPendingFactorySession itself fails (a Go-level
+// error) right after a successful start, the handler reports a bounded
+// failure and never proceeds to dispatch or bind against the just-started
+// identity -- an unrecorded pending identity must not be treated as safely
+// reconcilable.
+func TestHandleSessionPromptRecordPendingFailureAfterStartMakesNoBindCall(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult:               sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:                admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+		recordPendingFactorySessionErr: errors.New("record pending boom"),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-1"}}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+	_, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure when RecordPendingFactorySession fails")
+	}
+	if len(factoryTarget.invokeCalls) != 0 {
+		t.Fatalf("InvokeFactoryTarget call count = %d, want 0 when the pending identity was never durably recorded", len(factoryTarget.invokeCalls))
+	}
+	if chatSessions.bindFactorySessionCalled {
+		t.Fatal("BindFactorySession was called, want no binding attempt when RecordPendingFactorySession fails")
+	}
+}
+
+// TestHandleSessionPromptFirstTurnInvokeFailureMakesNoBindCall proves that
+// when the first turn's own follow-up InvokeFactoryTarget call (the one that
+// actually dispatches this turn's content into the just-started identity)
+// fails, the handler reports a bounded failure and never proceeds to bind.
+func TestHandleSessionPromptFirstTurnInvokeFailureMakesNoBindCall(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{
+		startResult: factorysessions.AsyncStartResult{SessionID: "fs-1"},
+		invokeErr:   errors.New("dispatch boom"),
+	}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+	_, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure when the first turn's own invoke fails")
+	}
+	if len(factoryTarget.startCalls) != 1 {
+		t.Fatalf("StartFactoryTarget call count = %d, want exactly 1", len(factoryTarget.startCalls))
+	}
+	if len(factoryTarget.invokeCalls) != 1 {
+		t.Fatalf("InvokeFactoryTarget call count = %d, want exactly 1", len(factoryTarget.invokeCalls))
+	}
+	if chatSessions.bindFactorySessionCalled {
+		t.Fatal("BindFactorySession was called, want no binding attempt when the dispatch itself failed")
+	}
+}
+
 // TestHandleSessionPromptBindConflictClosesTheJustStartedRuntime proves that
 // when BindFactorySession fails with *chatsessions.FactorySessionConflictError
 // -- a different identity already won the episode -- the handler compensates

--- a/pkg/transports/acp/internal/stdio/session_prompt_test.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt_test.go
@@ -879,8 +879,8 @@ func TestHandleSessionPromptFirstTurnStartsFactorySessionWithExactTargetRootAndC
 	if _, ok := got.Args["content"]; ok {
 		t.Fatalf("StartFactoryTarget Args[content] = %#v, want no content key at all", got.Args["content"])
 	}
-	if got.RequestID != "turn-1" {
-		t.Fatalf("StartFactoryTarget RequestID = %q, want the admitted turn id turn-1", got.RequestID)
+	if got.RequestID != "session-1/episode/1" {
+		t.Fatalf("StartFactoryTarget RequestID = %q, want the stable per-episode key session-1/episode/1 (not the admitted turn id, which changes on every retry)", got.RequestID)
 	}
 
 	if len(factoryTarget.invokeCalls) != 1 {
@@ -1552,6 +1552,62 @@ func TestHandleSessionPromptRecordPendingFailureAfterStartMakesNoBindCall(t *tes
 	}
 }
 
+// TestHandleSessionPromptRetryAfterRecordPendingFailureReusesStableRequestID
+// proves that a later, uniquely identified prompt for the same still-unbound
+// episode (observed after a RecordPendingFactorySession failure left the
+// episode with no pending or bound identity at all) calls StartFactoryTarget
+// again with the exact same RequestID as the original attempt -- a stable key
+// derived only from the session and episode, never the admitted Turn's own
+// ID, which differs on every retry. This is what lets
+// ondemandtarget.Service.StartAsync's own request-scoped deduplication (see
+// that package's TestStartAsyncSameRequestIDConvergesOnASingleActivation)
+// converge the retry onto the exact same runtime instead of opening a second
+// one for the same episode; this test proves the transport's half of that
+// contract (the stable key), not the activation service's own dedup logic,
+// which is a different package's responsibility.
+func TestHandleSessionPromptRetryAfterRecordPendingFailureReusesStableRequestID(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResults: []chatsessions.StartTurnResult{
+			admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+			admittedTurnResult("session-1", "factory:@you/review", 5, "/work/project", "turn-2", ""),
+		},
+		recordPendingFactorySessionErrs: []error{errors.New("record pending boom"), nil},
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{
+		startResult:  factorysessions.AsyncStartResult{SessionID: "fs-1"},
+		invokeResult: factorysessions.InvocationResult{SessionID: "fs-1", Status: factorysessions.InvocationTerminalStatusCompleted},
+	}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	firstEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "first message"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), firstEnv); rpcErr == nil {
+		t.Fatal("first handleSessionPrompt() error = nil, want a bounded failure from the injected RecordPendingFactorySession fault")
+	}
+
+	secondEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "second message"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), secondEnv); rpcErr != nil {
+		t.Fatalf("second handleSessionPrompt() error = %+v, want the retry to succeed", rpcErr)
+	}
+
+	if len(factoryTarget.startCalls) != 2 {
+		t.Fatalf("StartFactoryTarget call count = %d, want exactly 2 (the original attempt plus the retry)", len(factoryTarget.startCalls))
+	}
+	first, second := factoryTarget.startCalls[0], factoryTarget.startCalls[1]
+	if first.RequestID == "" || first.RequestID != second.RequestID {
+		t.Fatalf("StartFactoryTarget RequestID[0] = %q, RequestID[1] = %q, want the identical stable per-episode key on both calls", first.RequestID, second.RequestID)
+	}
+	if !chatSessions.bindFactorySessionCalled {
+		t.Fatal("BindFactorySession was not called, want the retry to bind after RecordPendingFactorySession succeeds the second time")
+	}
+	if chatSessions.bindFactorySessionReq.FactorySessionID != "fs-1" {
+		t.Fatalf("BindFactorySession FactorySessionID = %q, want fs-1", chatSessions.bindFactorySessionReq.FactorySessionID)
+	}
+}
+
 // TestHandleSessionPromptFirstTurnInvokeFailureMakesNoBindCall proves that
 // when the first turn's own follow-up InvokeFactoryTarget call (the one that
 // actually dispatches this turn's content into the just-started identity)
@@ -2143,5 +2199,63 @@ func TestHandleSessionPromptTerminalTransitionFailureRecoveryAdmitsLaterPrompt(t
 	// second call.
 	if len(factoryTarget.invokeCalls) != 2 {
 		t.Fatalf("InvokeFactoryTarget call count = %d, want exactly 2 (the first turn's dispatch plus the second turn's reuse)", len(factoryTarget.invokeCalls))
+	}
+}
+
+// TestHandleSessionPromptFailedTerminalTransitionFailureRecoveryAdmitsLaterPrompt
+// proves that when the *intended* terminal transition is already FAILED (a
+// genuine dispatch failure, not a downstream success) and that exact
+// AdvanceTurn(FAILED) call itself fails, recovery still releases the
+// session's busy state -- via the CANCELED fallback in terminalRecoveryOrder
+// -- instead of stranding the turn forever, which a version of this recovery
+// that only ever retried FAILED itself could never do. Proven against a real
+// chatsessions.Store (not a call-recording fake) so the recovered
+// RUNNING->CANCELED transition is a real, legal state change, and a later
+// uniquely identified prompt is genuinely admitted afterward.
+func TestHandleSessionPromptFailedTerminalTransitionFailureRecoveryAdmitsLaterPrompt(t *testing.T) {
+	store, err := chatsessionswire.NewService(sequentialIDGenerator("session"), fixedClock(time.Unix(0, 1)))
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	created, err := store.CreateSession(context.Background(), chatsessions.CreateSessionRequest{
+		RequestID:     chatsessions.RequestIdentity{Kind: chatsessions.RequestIdentityKindJSONRPCNumber, ConnectionID: "conn-setup", JSONRPCNumberID: "0"},
+		WorkingRoot:   "/work/project",
+		InitialTarget: chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "@you/review"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+
+	// Call 1 is the ADMITTED->RUNNING transition (succeeds); call 2 is the
+	// terminal AdvanceTurn(FAILED) attempt this dispatch failure targets --
+	// inject the fault there so the primary terminal attempt is exactly the
+	// FAILED case round-4's review found unrecoverable.
+	faulty := &nthAdvanceTurnFailingChatSessions{
+		Service: store, failOnCall: 2, injectErr: errors.New("terminal advance boom"),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{
+		startResult: factorysessions.AsyncStartResult{SessionID: "fs-1"},
+		// The first turn's own dispatch fails (its intended terminal is
+		// therefore FAILED); the second turn's reuse of the already-pending
+		// identity succeeds, so this test can prove admission recovers
+		// without conflating it with a second genuine dispatch failure.
+		invokeErrs: []error{errors.New("dispatch boom"), nil},
+		invokeResult: factorysessions.InvocationResult{
+			SessionID: "fs-1", Status: factorysessions.InvocationTerminalStatusCompleted,
+		},
+	}
+	server := New(nil, faulty, catalog, factoryTarget, func() (string, error) { return "/home/operator", nil })
+
+	firstEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams(created.Session.ID, "first message"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), firstEnv); rpcErr == nil {
+		t.Fatal("first handleSessionPrompt() error = nil, want a bounded failure from the injected dispatch fault")
+	}
+
+	secondEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams(created.Session.ID, "second message"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), secondEnv); rpcErr != nil {
+		t.Fatalf("second handleSessionPrompt() error = %+v, want the session admitted (not stranded busy) after a recovered FAILED-transition failure", rpcErr)
 	}
 }

--- a/pkg/transports/acp/internal/stdio/session_prompt_test.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"sync"
@@ -1076,4 +1077,241 @@ func TestHandleSessionPromptWithoutFactoryTargetCollaboratorAdmitsButFailsBound(
 	if !chatSessions.startTurnCalled {
 		t.Fatal("StartTurn was not called, want the turn admitted before the missing-collaborator failure")
 	}
+}
+
+// wantAdvanceTurnSequence asserts AdvanceTurn was called exactly once per
+// entry in want, in order, each against sessionID/turnID, ending with the
+// corresponding TurnState -- proving an admitted turn passes through the
+// legal RUNNING intermediate state on its way to an explicit terminal state,
+// never skipped and never left non-terminal.
+func wantAdvanceTurnSequence(t *testing.T, chatSessions *fakeChatSessionsService, sessionID, turnID string, want ...chatsessions.TurnState) {
+	t.Helper()
+	if len(chatSessions.advanceTurnReqs) != len(want) {
+		t.Fatalf("AdvanceTurn call count = %d, want %d (%v)", len(chatSessions.advanceTurnReqs), len(want), want)
+	}
+	for i, req := range chatSessions.advanceTurnReqs {
+		if req.SessionID != sessionID {
+			t.Fatalf("AdvanceTurn[%d] SessionID = %q, want %q", i, req.SessionID, sessionID)
+		}
+		if req.TurnID != turnID {
+			t.Fatalf("AdvanceTurn[%d] TurnID = %q, want %q", i, req.TurnID, turnID)
+		}
+		if req.Next != want[i] {
+			t.Fatalf("AdvanceTurn[%d] Next = %q, want %q", i, req.Next, want[i])
+		}
+	}
+}
+
+// TestHandleSessionPromptFirstTurnSuccessAdvancesRunningThenCompleted proves
+// a successful first-turn (start) admission advances the turn through
+// TurnStateRunning to TurnStateCompleted -- the branch's own dispatch and
+// bind work genuinely completed -- clearing the session's active-turn state
+// so a later prompt is never stranded behind it.
+func TestHandleSessionPromptFirstTurnSuccessAdvancesRunningThenCompleted(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-1", Status: "RUNNING"}}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr != nil {
+		t.Fatalf("handleSessionPrompt() error = %+v, want success", rpcErr)
+	}
+
+	wantAdvanceTurnSequence(t, chatSessions, "session-1", "turn-1", chatsessions.TurnStateRunning, chatsessions.TurnStateCompleted)
+}
+
+// TestHandleSessionPromptLaterTurnAdvancesByInvocationOutcome proves a later
+// (invoke) turn's terminal advancement tracks the Factory Session's own
+// published terminal status exactly -- completed advances to COMPLETED,
+// caller-canceled/timed-out both advance to CANCELED, and a genuine Factory
+// failure (or any unmapped future status) advances to FAILED -- even though
+// InvokeFactoryTarget itself returns no Go error and the ACP response still
+// carries its own (separately mapped, safe-fallback) stop reason.
+func TestHandleSessionPromptLaterTurnAdvancesByInvocationOutcome(t *testing.T) {
+	tests := []struct {
+		name   string
+		status factorysessions.InvocationTerminalStatus
+		want   chatsessions.TurnState
+	}{
+		{"completed", factorysessions.InvocationTerminalStatusCompleted, chatsessions.TurnStateCompleted},
+		{"canceled", factorysessions.InvocationTerminalStatusCanceled, chatsessions.TurnStateCanceled},
+		{"timed_out", factorysessions.InvocationTerminalStatusTimedOut, chatsessions.TurnStateCanceled},
+		{"failed", factorysessions.InvocationTerminalStatusFailed, chatsessions.TurnStateFailed},
+		{"unmapped_future_status", factorysessions.InvocationTerminalStatus("SOME_FUTURE_STATUS"), chatsessions.TurnStateFailed},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			chatSessions := &fakeChatSessionsService{
+				getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+				startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-2", "fs-already-bound"),
+			}
+			catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+			factoryTarget := &fakeFactoryTargetService{invokeResult: factorysessions.InvocationResult{Status: tc.status}}
+			server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+			env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+				promptTextParams("session-1", "a later message"))
+			if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr != nil {
+				t.Fatalf("handleSessionPrompt() error = %+v, want success (a Factory-level failure still yields a normal final ACP response)", rpcErr)
+			}
+
+			wantAdvanceTurnSequence(t, chatSessions, "session-1", "turn-2", chatsessions.TurnStateRunning, tc.want)
+		})
+	}
+}
+
+// TestHandleSessionPromptFactoryDispatchFailureAdvancesTurnToFailed proves a
+// Go-level Factory dispatch failure (start or invoke) both reports a bounded
+// internal error to the client and terminalizes the admitted turn to
+// TurnStateFailed, so a retried request is never blocked behind a stranded
+// non-terminal turn.
+func TestHandleSessionPromptFactoryDispatchFailureAdvancesTurnToFailed(t *testing.T) {
+	t.Run("start", func(t *testing.T) {
+		chatSessions := &fakeChatSessionsService{
+			getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+			startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+		}
+		catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+		factoryTarget := &fakeFactoryTargetService{startErr: errors.New("factory sessions boom")}
+		server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+		env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+			promptTextParams("session-1", "hello there"))
+		if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr == nil {
+			t.Fatal("handleSessionPrompt() error = nil, want a bounded failure")
+		}
+
+		wantAdvanceTurnSequence(t, chatSessions, "session-1", "turn-1", chatsessions.TurnStateRunning, chatsessions.TurnStateFailed)
+	})
+
+	t.Run("invoke", func(t *testing.T) {
+		chatSessions := &fakeChatSessionsService{
+			getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+			startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-2", "fs-already-bound"),
+		}
+		catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+		factoryTarget := &fakeFactoryTargetService{invokeErr: errors.New("factory sessions boom")}
+		server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+		env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+			promptTextParams("session-1", "a later message"))
+		if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr == nil {
+			t.Fatal("handleSessionPrompt() error = nil, want a bounded failure")
+		}
+
+		wantAdvanceTurnSequence(t, chatSessions, "session-1", "turn-2", chatsessions.TurnStateRunning, chatsessions.TurnStateFailed)
+	})
+}
+
+// TestHandleSessionPromptFactoryDispatchCancellationAdvancesTurnToCanceled
+// proves a Factory dispatch failure whose cause is context.Canceled or
+// context.DeadlineExceeded terminalizes the admitted turn to
+// TurnStateCanceled (not TurnStateFailed) while still classifying the ACP
+// response as the request-cancelled outcome -- the cause remains discoverable
+// internally via errors.Is even though it never reaches the client's error
+// text.
+func TestHandleSessionPromptFactoryDispatchCancellationAdvancesTurnToCanceled(t *testing.T) {
+	tests := []struct {
+		name  string
+		cause error
+	}{
+		{"canceled", context.Canceled},
+		{"deadline_exceeded", context.DeadlineExceeded},
+		{"wrapped_canceled", fmt.Errorf("factory sessions: %w", context.Canceled)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			chatSessions := &fakeChatSessionsService{
+				getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+				startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+			}
+			catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+			factoryTarget := &fakeFactoryTargetService{startErr: tc.cause}
+			server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+			env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+				promptTextParams("session-1", "hello there"))
+			_, rpcErr := server.handleSessionPrompt(context.Background(), env)
+			if rpcErr == nil {
+				t.Fatal("handleSessionPrompt() error = nil, want the request-cancelled outcome")
+			}
+			if rpcErr.Code != acpsdk.NewRequestCancelled(nil).Code {
+				t.Fatalf("error code = %d, want the request-cancelled classification %d", rpcErr.Code, acpsdk.NewRequestCancelled(nil).Code)
+			}
+
+			wantAdvanceTurnSequence(t, chatSessions, "session-1", "turn-1", chatsessions.TurnStateRunning, chatsessions.TurnStateCanceled)
+		})
+	}
+}
+
+// TestHandleSessionPromptRunningTransitionFailureMakesNoFactoryDispatchCall
+// proves that when advancing a freshly admitted turn to TurnStateRunning
+// itself fails, the handler reports a bounded internal error and never
+// attempts a Factory dispatch call (StartFactoryTarget/InvokeFactoryTarget)
+// for a turn that is not actually confirmed running.
+func TestHandleSessionPromptRunningTransitionFailureMakesNoFactoryDispatchCall(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+		advanceTurnErr:   errors.New("advance turn boom"),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-1"}}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure when the RUNNING transition fails")
+	}
+
+	if len(factoryTarget.startCalls) != 0 {
+		t.Fatalf("StartFactoryTarget call count = %d, want 0 when the turn never confirmed running", len(factoryTarget.startCalls))
+	}
+	if chatSessions.bindFactorySessionCalled {
+		t.Fatal("BindFactorySession was called, want no binding attempt when the turn never confirmed running")
+	}
+	if len(chatSessions.advanceTurnReqs) != 1 {
+		t.Fatalf("AdvanceTurn call count = %d, want exactly 1 (the failed RUNNING attempt, no terminal retry)", len(chatSessions.advanceTurnReqs))
+	}
+}
+
+// TestHandleSessionPromptTerminalTransitionFailurePropagatesBoundedError
+// proves that when the final terminalizing AdvanceTurn call itself fails
+// after a successful Factory dispatch, the handler reports that failure as a
+// bounded internal error instead of silently discarding it and returning the
+// dispatch's own successful response -- an unterminalized turn must never be
+// masked by an otherwise-successful outcome.
+func TestHandleSessionPromptTerminalTransitionFailurePropagatesBoundedError(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+		advanceTurnErrs:  []error{nil, errors.New("terminal advance boom")},
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-1"}}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure when the terminal AdvanceTurn call fails")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionPrompt() result = %q, want nil when terminalization fails", result)
+	}
+
+	if len(factoryTarget.startCalls) != 1 {
+		t.Fatalf("StartFactoryTarget call count = %d, want exactly 1 (the dispatch itself succeeded)", len(factoryTarget.startCalls))
+	}
+	if !chatSessions.bindFactorySessionCalled {
+		t.Fatal("BindFactorySession was not called, want the successful dispatch to still bind before terminalization is attempted")
+	}
+	wantAdvanceTurnSequence(t, chatSessions, "session-1", "turn-1", chatsessions.TurnStateRunning, chatsessions.TurnStateCompleted)
 }

--- a/pkg/transports/acp/internal/stdio/session_prompt_test.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt_test.go
@@ -94,6 +94,33 @@ func (f *nthAdvanceTurnFailingChatSessions) AdvanceTurn(ctx context.Context, req
 	return f.Service.AdvanceTurn(ctx, req)
 }
 
+// firstCallFailingBindFactorySession wraps a real chatsessions.Service and
+// injects injectErr into exactly the first call to BindFactorySession,
+// letting every later call pass through unmodified. It exists to prove that
+// the reconciliation record a failed first bind leaves behind
+// (Episode.PendingFactorySessionID, durably committed via
+// RecordPendingFactorySession) survives being observed by a brand-new
+// *Server instance sharing the same underlying chatsessions.Store -- not
+// just a later call against the same Server -- since that durability is
+// exactly what this finding requires.
+type firstCallFailingBindFactorySession struct {
+	chatsessions.Service
+	mu        sync.Mutex
+	injectErr error
+	triggered bool
+}
+
+func (f *firstCallFailingBindFactorySession) BindFactorySession(ctx context.Context, req chatsessions.BindFactorySessionRequest) (chatsessions.BindFactorySessionResult, error) {
+	f.mu.Lock()
+	if !f.triggered {
+		f.triggered = true
+		f.mu.Unlock()
+		return chatsessions.BindFactorySessionResult{}, f.injectErr
+	}
+	f.mu.Unlock()
+	return f.Service.BindFactorySession(ctx, req)
+}
+
 // promptTextParams builds a raw session/prompt params payload carrying one
 // text content block, the shape a client sends for a typed "/factory
 // <value>" command or an ordinary chat message alike.
@@ -813,13 +840,22 @@ func admittedTurnResult(id, target string, version uint64, workingRoot, turnID, 
 // episode's canonical Factory target, the session's exact editor working
 // root, and the validated prompt content -- never a process cwd or
 // substituted value.
+// TestHandleSessionPromptFirstTurnStartsFactorySessionWithExactTargetRootAndContent
+// proves the first admitted turn in an unbound episode starts a Factory
+// Session with the episode's canonical target and the session's exact
+// editor working root, then dispatches this turn's validated content into
+// the returned identity via the immediate follow-up InvokeFactoryTarget call
+// -- StartFactoryTarget carries no content of its own, since the shared
+// factorysessions.Service.StartAsync it forwards to has no dedicated content
+// field and cannot dispatch an ordinary packaged Factory at all (see
+// ondemandtarget.Service.StartAsync's own doc comment).
 func TestHandleSessionPromptFirstTurnStartsFactorySessionWithExactTargetRootAndContent(t *testing.T) {
 	chatSessions := &fakeChatSessionsService{
 		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
 		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: "fs-1"}}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-1"}}
 	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -840,13 +876,26 @@ func TestHandleSessionPromptFirstTurnStartsFactorySessionWithExactTargetRootAndC
 	if got.Args["workingRoot"] != "/work/project" {
 		t.Fatalf("StartFactoryTarget Args[workingRoot] = %v, want /work/project", got.Args["workingRoot"])
 	}
-	wantContent := []work.WorkContentPart{{Type: work.WorkContentPartTypeText, Text: "hello there"}}
-	gotContent, ok := got.Args["content"].([]work.WorkContentPart)
-	if !ok || !reflect.DeepEqual(gotContent, wantContent) {
-		t.Fatalf("StartFactoryTarget Args[content] = %#v, want %#v", got.Args["content"], wantContent)
+	if _, ok := got.Args["content"]; ok {
+		t.Fatalf("StartFactoryTarget Args[content] = %#v, want no content key at all", got.Args["content"])
 	}
 	if got.RequestID != "turn-1" {
 		t.Fatalf("StartFactoryTarget RequestID = %q, want the admitted turn id turn-1", got.RequestID)
+	}
+
+	if len(factoryTarget.invokeCalls) != 1 {
+		t.Fatalf("InvokeFactoryTarget call count = %d, want exactly 1", len(factoryTarget.invokeCalls))
+	}
+	invoked := factoryTarget.invokeCalls[0]
+	if invoked.sessionID != "fs-1" {
+		t.Fatalf("InvokeFactoryTarget sessionID = %q, want the identity StartFactoryTarget just returned", invoked.sessionID)
+	}
+	wantContent := []work.WorkContentPart{{Type: work.WorkContentPartTypeText, Text: "hello there"}}
+	if !reflect.DeepEqual(invoked.request.Content, wantContent) {
+		t.Fatalf("InvokeFactoryTarget request.Content = %#v, want %#v", invoked.request.Content, wantContent)
+	}
+	if invoked.request.RequestID == nil || *invoked.request.RequestID != "turn-1" {
+		t.Fatalf("InvokeFactoryTarget request.RequestID = %v, want the admitted turn id turn-1", invoked.request.RequestID)
 	}
 }
 
@@ -859,7 +908,7 @@ func TestHandleSessionPromptFirstTurnBindsReturnedFactorySessionID(t *testing.T)
 		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: "fs-1"}}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-1"}}
 	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -892,7 +941,7 @@ func TestHandleSessionPromptLaterTurnInvokesBoundFactorySessionExactlyOnce(t *te
 		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-2", "fs-already-bound"),
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: "fs-new"}}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-new"}}
 	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -1013,21 +1062,27 @@ func TestHandleSessionPromptLaterTurnMapsInvocationOutcomeToFinalStopReason(t *t
 	}
 }
 
-// TestHandleSessionPromptFirstTurnMapsStartOutcomeToSafeFallback proves
-// handleSessionPrompt's final response for the first (start) turn in an
-// episode uses the documented end_turn safe fallback for a status outside
-// the mapped terminal vocabulary (here "RUNNING", which a real activation
-// never actually publishes back to this caller since it dispatches
-// synchronously, but which a still-total mapping must handle safely
-// regardless), and never leaks the returned Factory Session identity or any
-// other raw field into the response.
-func TestHandleSessionPromptFirstTurnMapsStartOutcomeToSafeFallback(t *testing.T) {
+// TestHandleSessionPromptFirstTurnResponseNeverLeaksFactorySessionIdentity
+// proves handleSessionPrompt's final response for the first (start) turn in
+// an episode is mapped from the follow-up InvokeFactoryTarget call's real
+// published outcome -- not the start call's own identity-only
+// AsyncStartResult, which carries no terminal status at all -- and never
+// leaks the returned Factory Session identity or any other raw invocation
+// field (message, error code) into the response.
+func TestHandleSessionPromptFirstTurnResponseNeverLeaksFactorySessionIdentity(t *testing.T) {
 	chatSessions := &fakeChatSessionsService{
 		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
 		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: "fs-secret-1", Status: "RUNNING"}}
+	factoryTarget := &fakeFactoryTargetService{
+		startResult: factorysessions.AsyncStartResult{SessionID: "fs-secret-1"},
+		invokeResult: factorysessions.InvocationResult{
+			SessionID: "fs-secret-1",
+			Status:    factorysessions.InvocationTerminalStatusCompleted,
+			Message:   "internal diagnostic detail",
+		},
+	}
 	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -1042,10 +1097,13 @@ func TestHandleSessionPromptFirstTurnMapsStartOutcomeToSafeFallback(t *testing.T
 		t.Fatalf("unmarshal response: %v", err)
 	}
 	if resp.StopReason != acpsdk.StopReasonEndTurn {
-		t.Fatalf("stopReason = %q, want end_turn safe fallback", resp.StopReason)
+		t.Fatalf("stopReason = %q, want end_turn from the real invoke outcome", resp.StopReason)
 	}
 	if strings.Contains(string(result), "fs-secret-1") {
 		t.Fatalf("response leaked the raw Factory Session identity: %s", result)
+	}
+	if strings.Contains(string(result), "internal diagnostic detail") {
+		t.Fatalf("response leaked the raw invocation message: %s", result)
 	}
 }
 
@@ -1290,7 +1348,7 @@ func TestHandleSessionPromptSequentialTurnsStartThenInvokeExactlyOnce(t *testing
 		},
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: "fs-1"}}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-1"}}
 	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
 	firstEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -1301,8 +1359,15 @@ func TestHandleSessionPromptSequentialTurnsStartThenInvokeExactlyOnce(t *testing
 	if len(factoryTarget.startCalls) != 1 {
 		t.Fatalf("StartFactoryTarget call count after first turn = %d, want exactly 1", len(factoryTarget.startCalls))
 	}
-	if len(factoryTarget.invokeCalls) != 0 {
-		t.Fatalf("InvokeFactoryTarget call count after first turn = %d, want 0", len(factoryTarget.invokeCalls))
+	// The first turn's own content dispatches through the immediate
+	// follow-up InvokeFactoryTarget call StartFactoryTarget's own identity
+	// feeds into -- see startFactorySessionForEpisode's doc comment -- so
+	// one invoke call is already expected here, before the second turn.
+	if len(factoryTarget.invokeCalls) != 1 {
+		t.Fatalf("InvokeFactoryTarget call count after first turn = %d, want exactly 1 (the first turn's own content dispatch)", len(factoryTarget.invokeCalls))
+	}
+	if got := factoryTarget.invokeCalls[0].sessionID; got != "fs-1" {
+		t.Fatalf("InvokeFactoryTarget sessionID = %q, want the identity StartFactoryTarget just returned (fs-1)", got)
 	}
 
 	secondEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 2, acpsdk.AgentMethodSessionPrompt,
@@ -1313,10 +1378,10 @@ func TestHandleSessionPromptSequentialTurnsStartThenInvokeExactlyOnce(t *testing
 	if len(factoryTarget.startCalls) != 1 {
 		t.Fatalf("StartFactoryTarget call count after second turn = %d, want still exactly 1 (no second start)", len(factoryTarget.startCalls))
 	}
-	if len(factoryTarget.invokeCalls) != 1 {
-		t.Fatalf("InvokeFactoryTarget call count after second turn = %d, want exactly 1", len(factoryTarget.invokeCalls))
+	if len(factoryTarget.invokeCalls) != 2 {
+		t.Fatalf("InvokeFactoryTarget call count after second turn = %d, want exactly 2 (the first turn's dispatch plus the second turn's own invoke)", len(factoryTarget.invokeCalls))
 	}
-	if got := factoryTarget.invokeCalls[0].sessionID; got != "fs-1" {
+	if got := factoryTarget.invokeCalls[1].sessionID; got != "fs-1" {
 		t.Fatalf("InvokeFactoryTarget sessionID = %q, want the identity bound by the first turn's start (fs-1)", got)
 	}
 }
@@ -1443,7 +1508,7 @@ func TestHandleSessionPromptEmptyFactorySessionIdentityFailsSafely(t *testing.T)
 		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: ""}}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: ""}}
 	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -1473,7 +1538,7 @@ func TestHandleSessionPromptBindConflictClosesTheJustStartedRuntime(t *testing.T
 		},
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: "fs-orphan-candidate"}}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-orphan-candidate"}}
 	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -1502,17 +1567,25 @@ func TestHandleSessionPromptBindConflictClosesTheJustStartedRuntime(t *testing.T
 // StartFactoryTarget a second time -- so a bind failure can never cause two
 // Factory Sessions to exist for one episode.
 func TestHandleSessionPromptBindFailureRetryReusesPendingFactorySession(t *testing.T) {
+	secondTurn := admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-2", "")
+	// The real chatsessions.Store durably records the first turn's started
+	// (not yet committed) identity via RecordPendingFactorySession before
+	// the failed bind attempt; a later admitted turn's own fresh episode
+	// snapshot observes it through Episode.PendingFactorySessionID -- this
+	// fake does not run real Store logic, so the second canned result
+	// simulates exactly what that durable record produces.
+	secondTurn.Episode.PendingFactorySessionID = "fs-pending"
 	chatSessions := &fakeChatSessionsService{
 		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
 		startTurnResults: []chatsessions.StartTurnResult{
 			admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
-			admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-2", ""),
+			secondTurn,
 		},
 		bindFactorySessionErrs: []error{errors.New("bind failed: version race"), nil},
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
 	factoryTarget := &fakeFactoryTargetService{
-		startResult:  factorysessions.InvocationResult{SessionID: "fs-pending"},
+		startResult:  factorysessions.AsyncStartResult{SessionID: "fs-pending"},
 		invokeResult: factorysessions.InvocationResult{Status: factorysessions.InvocationTerminalStatusCompleted},
 	}
 	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
@@ -1535,11 +1608,16 @@ func TestHandleSessionPromptBindFailureRetryReusesPendingFactorySession(t *testi
 	if len(factoryTarget.startCalls) != 1 {
 		t.Fatalf("StartFactoryTarget call count = %d, want exactly 1 (the retry reuses the pending identity via invoke, never starting a second Factory Session)", len(factoryTarget.startCalls))
 	}
-	if len(factoryTarget.invokeCalls) != 1 {
-		t.Fatalf("InvokeFactoryTarget call count = %d, want exactly 1", len(factoryTarget.invokeCalls))
+	// The first (failed-bind) attempt already dispatches its own content via
+	// invoke right after starting, before the bind attempt that then fails;
+	// the retry's own invoke against the same pending identity is the second.
+	if len(factoryTarget.invokeCalls) != 2 {
+		t.Fatalf("InvokeFactoryTarget call count = %d, want exactly 2 (the first attempt's dispatch plus the retry's)", len(factoryTarget.invokeCalls))
 	}
-	if factoryTarget.invokeCalls[0].sessionID != "fs-pending" {
-		t.Fatalf("InvokeFactoryTarget sessionID = %q, want the pending identity from the first turn's start", factoryTarget.invokeCalls[0].sessionID)
+	for i, call := range factoryTarget.invokeCalls {
+		if call.sessionID != "fs-pending" {
+			t.Fatalf("InvokeFactoryTarget[%d] sessionID = %q, want fs-pending", i, call.sessionID)
+		}
 	}
 }
 
@@ -1589,15 +1667,14 @@ func wantAdvanceTurnSequence(t *testing.T, chatSessions *fakeChatSessionsService
 	}
 }
 
-// TestHandleSessionPromptFirstTurnAdvancesByStartOutcome proves a first-turn
-// (start) admission's terminal advancement tracks the underlying synchronous
-// activation's own published terminal status exactly, the same way a later
-// (invoke) turn's does -- not a hardcoded TurnStateCompleted regardless of
-// outcome. OnDemandFactoryTargetService.StartFactoryTarget dispatches its
-// content synchronously (via InvokeFactorySession) before returning, so a
-// first turn's published status is exactly as authoritative as a later
-// turn's.
-func TestHandleSessionPromptFirstTurnAdvancesByStartOutcome(t *testing.T) {
+// TestHandleSessionPromptFirstTurnAdvancesByInvokeOutcome proves a
+// first-turn (start) admission's terminal advancement tracks the follow-up
+// InvokeFactoryTarget call's own published terminal status exactly, the same
+// way a later (invoke) turn's does -- not a hardcoded TurnStateCompleted
+// regardless of outcome. StartFactoryTarget itself only opens the runtime
+// (AsyncStartResult carries no terminal status at all); this turn's actual
+// published outcome is entirely the immediate follow-up invoke's.
+func TestHandleSessionPromptFirstTurnAdvancesByInvokeOutcome(t *testing.T) {
 	tests := []struct {
 		name   string
 		status factorysessions.InvocationTerminalStatus
@@ -1616,7 +1693,10 @@ func TestHandleSessionPromptFirstTurnAdvancesByStartOutcome(t *testing.T) {
 				startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
 			}
 			catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-			factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: "fs-1", Status: tc.status}}
+			factoryTarget := &fakeFactoryTargetService{
+				startResult:  factorysessions.AsyncStartResult{SessionID: "fs-1"},
+				invokeResult: factorysessions.InvocationResult{SessionID: "fs-1", Status: tc.status},
+			}
 			server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
 			env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -1768,7 +1848,7 @@ func TestHandleSessionPromptRunningTransitionFailureMakesNoFactoryDispatchCall(t
 		advanceTurnErr:   errors.New("advance turn boom"),
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: "fs-1"}}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-1"}}
 	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -1813,9 +1893,10 @@ func TestHandleSessionPromptRunningTransitionFailureRecoveryAdmitsLaterPrompt(t 
 		injectErr: errors.New("advance turn boom"),
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{
-		SessionID: "fs-1", Status: factorysessions.InvocationTerminalStatusCompleted,
-	}}
+	factoryTarget := &fakeFactoryTargetService{
+		startResult:  factorysessions.AsyncStartResult{SessionID: "fs-1"},
+		invokeResult: factorysessions.InvocationResult{SessionID: "fs-1", Status: factorysessions.InvocationTerminalStatusCompleted},
+	}
 	server := New(nil, faulty, catalog, factoryTarget, func() (string, error) { return "/home/operator", nil })
 
 	firstEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -1834,6 +1915,76 @@ func TestHandleSessionPromptRunningTransitionFailureRecoveryAdmitsLaterPrompt(t 
 	}
 }
 
+// TestHandleSessionPromptPendingFactorySessionSurvivesNewServerInstance
+// proves the reconciliation record a failed bind leaves behind is durable
+// Chat/Factory Sessions authority state, not this Server instance's own
+// memory: after an injected single-shot BindFactorySession failure on a
+// real chatsessions.Store, a brand-new *Server constructed over that same
+// store (simulating a transport restart) still observes the pending
+// identity through the second turn's own admitted episode snapshot and
+// invokes it instead of starting a second Factory Session.
+func TestHandleSessionPromptPendingFactorySessionSurvivesNewServerInstance(t *testing.T) {
+	store, err := chatsessionswire.NewService(sequentialIDGenerator("session"), fixedClock(time.Unix(0, 1)))
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	created, err := store.CreateSession(context.Background(), chatsessions.CreateSessionRequest{
+		RequestID:     chatsessions.RequestIdentity{Kind: chatsessions.RequestIdentityKindJSONRPCNumber, ConnectionID: "conn-setup", JSONRPCNumberID: "0"},
+		WorkingRoot:   "/work/project",
+		InitialTarget: chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: "@you/review"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+
+	faulty := &firstCallFailingBindFactorySession{
+		Service:   store,
+		injectErr: errors.New("bind failed: version race"),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{
+		startResult:  factorysessions.AsyncStartResult{SessionID: "fs-pending"},
+		invokeResult: factorysessions.InvocationResult{Status: factorysessions.InvocationTerminalStatusCompleted},
+	}
+	firstServer := New(nil, faulty, catalog, factoryTarget, func() (string, error) { return "/home/operator", nil })
+
+	firstEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams(created.Session.ID, "first message"))
+	if _, rpcErr := firstServer.handleSessionPrompt(context.Background(), firstEnv); rpcErr == nil {
+		t.Fatal("first handleSessionPrompt() error = nil, want a bounded failure when the injected bind fault fires")
+	}
+	if len(factoryTarget.closeCalls) != 0 {
+		t.Fatalf("CloseFactoryTarget call count = %d, want 0: a non-conflict bind failure must not abandon the pending runtime", len(factoryTarget.closeCalls))
+	}
+
+	// A brand-new Server, sharing only the underlying store (not the failed
+	// firstServer instance or its wrapper), stands in for a restarted
+	// transport process.
+	secondServer := New(nil, store, catalog, factoryTarget, func() (string, error) { return "/home/operator", nil })
+
+	secondEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams(created.Session.ID, "second message"))
+	if _, rpcErr := secondServer.handleSessionPrompt(context.Background(), secondEnv); rpcErr != nil {
+		t.Fatalf("second handleSessionPrompt() error = %+v, want success once the retried bind succeeds", rpcErr)
+	}
+
+	if len(factoryTarget.startCalls) != 1 {
+		t.Fatalf("StartFactoryTarget call count = %d, want exactly 1 (the new Server instance reuses the durably recorded pending identity via invoke, never starting a second Factory Session)", len(factoryTarget.startCalls))
+	}
+	// The first server's own attempt already dispatched via invoke right
+	// after starting, before its bind attempt failed; the second server's
+	// own invoke against the same durably-recorded pending identity is the
+	// second call.
+	if len(factoryTarget.invokeCalls) != 2 {
+		t.Fatalf("InvokeFactoryTarget call count = %d, want exactly 2 (the first attempt's dispatch plus the second server's)", len(factoryTarget.invokeCalls))
+	}
+	for i, call := range factoryTarget.invokeCalls {
+		if call.sessionID != "fs-pending" {
+			t.Fatalf("InvokeFactoryTarget[%d] sessionID = %q, want fs-pending", i, call.sessionID)
+		}
+	}
+}
+
 // TestHandleSessionPromptTerminalTransitionFailurePropagatesBoundedError
 // proves that when the final terminalizing AdvanceTurn call itself fails
 // after a successful Factory dispatch, the handler reports that failure as a
@@ -1848,9 +1999,10 @@ func TestHandleSessionPromptTerminalTransitionFailurePropagatesBoundedError(t *t
 		advanceTurnErrs:  []error{nil, errors.New("terminal advance boom"), nil},
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{
-		SessionID: "fs-1", Status: factorysessions.InvocationTerminalStatusCompleted,
-	}}
+	factoryTarget := &fakeFactoryTargetService{
+		startResult:  factorysessions.AsyncStartResult{SessionID: "fs-1"},
+		invokeResult: factorysessions.InvocationResult{SessionID: "fs-1", Status: factorysessions.InvocationTerminalStatusCompleted},
+	}
 	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -1902,9 +2054,10 @@ func TestHandleSessionPromptTerminalTransitionFailureRecoveryAdmitsLaterPrompt(t
 		Service: store, failOnCall: 2, injectErr: errors.New("terminal advance boom"),
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{
-		SessionID: "fs-1", Status: factorysessions.InvocationTerminalStatusCompleted,
-	}}
+	factoryTarget := &fakeFactoryTargetService{
+		startResult:  factorysessions.AsyncStartResult{SessionID: "fs-1"},
+		invokeResult: factorysessions.InvocationResult{SessionID: "fs-1", Status: factorysessions.InvocationTerminalStatusCompleted},
+	}
 	server := New(nil, faulty, catalog, factoryTarget, func() (string, error) { return "/home/operator", nil })
 
 	firstEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -1921,7 +2074,11 @@ func TestHandleSessionPromptTerminalTransitionFailureRecoveryAdmitsLaterPrompt(t
 	if len(factoryTarget.startCalls) != 1 {
 		t.Fatalf("StartFactoryTarget call count = %d, want exactly 1 (the first turn's dispatch itself succeeded before its terminalization faulted)", len(factoryTarget.startCalls))
 	}
-	if len(factoryTarget.invokeCalls) != 1 {
-		t.Fatalf("InvokeFactoryTarget call count = %d, want exactly 1 (the second turn reuses the already-bound Factory Session instead of starting a second one)", len(factoryTarget.invokeCalls))
+	// The first turn's own content already dispatched via invoke right
+	// after its successful start; the second turn's own invoke against the
+	// already-bound Factory Session (reused, not a second start) is the
+	// second call.
+	if len(factoryTarget.invokeCalls) != 2 {
+		t.Fatalf("InvokeFactoryTarget call count = %d, want exactly 2 (the first turn's dispatch plus the second turn's reuse)", len(factoryTarget.invokeCalls))
 	}
 }

--- a/pkg/transports/acp/internal/stdio/session_prompt_test.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt_test.go
@@ -1457,17 +1457,20 @@ func TestHandleSessionPromptEmptyFactorySessionIdentityFailsSafely(t *testing.T)
 	}
 }
 
-// TestHandleSessionPromptBindFailureClosesTheJustStartedRuntime proves that
-// when BindFactorySession fails after a successful StartFactoryTarget, the
-// handler compensates by closing the exact runtime identity StartFactoryTarget
-// just returned -- so a subsequent retry for the still-unbound episode never
-// leaves that runtime both orphaned (live, unbound, unreachable) and
-// duplicated by a second start.
-func TestHandleSessionPromptBindFailureClosesTheJustStartedRuntime(t *testing.T) {
+// TestHandleSessionPromptBindConflictClosesTheJustStartedRuntime proves that
+// when BindFactorySession fails with *chatsessions.FactorySessionConflictError
+// -- a different identity already won the episode -- the handler compensates
+// by closing the exact runtime identity StartFactoryTarget just returned and
+// abandons its pending-start reconciliation record, since the next call for
+// this episode will correctly observe and invoke the already-bound winner
+// instead of ever needing this loser again.
+func TestHandleSessionPromptBindConflictClosesTheJustStartedRuntime(t *testing.T) {
 	chatSessions := &fakeChatSessionsService{
-		getSessionResult:      sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
-		startTurnResult:       admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
-		bindFactorySessionErr: errors.New("bind failed: version race"),
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+		bindFactorySessionErr: &chatsessions.FactorySessionConflictError{
+			SessionID: "session-1", Episode: 4, Bound: "fs-winner", Attempted: "fs-orphan-candidate",
+		},
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
 	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: "fs-orphan-candidate"}}
@@ -1488,6 +1491,56 @@ func TestHandleSessionPromptBindFailureClosesTheJustStartedRuntime(t *testing.T)
 	}
 
 	wantAdvanceTurnSequence(t, chatSessions, "session-1", "turn-1", chatsessions.TurnStateRunning, chatsessions.TurnStateFailed)
+}
+
+// TestHandleSessionPromptBindFailureRetryReusesPendingFactorySession proves
+// that when BindFactorySession fails for any reason *other* than a genuine
+// different-identity conflict (for example a transient version race), the
+// handler does not close the just-started runtime, and a later uniquely
+// identified retry for the same still-unbound episode dispatches through
+// InvokeFactoryTarget against that exact pending identity instead of calling
+// StartFactoryTarget a second time -- so a bind failure can never cause two
+// Factory Sessions to exist for one episode.
+func TestHandleSessionPromptBindFailureRetryReusesPendingFactorySession(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResults: []chatsessions.StartTurnResult{
+			admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+			admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-2", ""),
+		},
+		bindFactorySessionErrs: []error{errors.New("bind failed: version race"), nil},
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{
+		startResult:  factorysessions.InvocationResult{SessionID: "fs-pending"},
+		invokeResult: factorysessions.InvocationResult{Status: factorysessions.InvocationTerminalStatusCompleted},
+	}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	firstEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "first message"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), firstEnv); rpcErr == nil {
+		t.Fatal("first handleSessionPrompt() error = nil, want a bounded failure when BindFactorySession fails")
+	}
+	if len(factoryTarget.closeCalls) != 0 {
+		t.Fatalf("CloseFactoryTarget call count = %d, want 0: a non-conflict bind failure must not abandon the pending runtime", len(factoryTarget.closeCalls))
+	}
+
+	secondEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "second message"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), secondEnv); rpcErr != nil {
+		t.Fatalf("second handleSessionPrompt() error = %+v, want success once the retried bind succeeds", rpcErr)
+	}
+
+	if len(factoryTarget.startCalls) != 1 {
+		t.Fatalf("StartFactoryTarget call count = %d, want exactly 1 (the retry reuses the pending identity via invoke, never starting a second Factory Session)", len(factoryTarget.startCalls))
+	}
+	if len(factoryTarget.invokeCalls) != 1 {
+		t.Fatalf("InvokeFactoryTarget call count = %d, want exactly 1", len(factoryTarget.invokeCalls))
+	}
+	if factoryTarget.invokeCalls[0].sessionID != "fs-pending" {
+		t.Fatalf("InvokeFactoryTarget sessionID = %q, want the pending identity from the first turn's start", factoryTarget.invokeCalls[0].sessionID)
+	}
 }
 
 // TestHandleSessionPromptWithoutFactoryTargetCollaboratorAdmitsButFailsBound

--- a/pkg/transports/acp/internal/stdio/session_prompt_test.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt_test.go
@@ -702,7 +702,7 @@ func TestHandleSessionPromptFirstTurnStartsFactorySessionWithExactTargetRootAndC
 		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-1"}}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: "fs-1"}}
 	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -742,7 +742,7 @@ func TestHandleSessionPromptFirstTurnBindsReturnedFactorySessionID(t *testing.T)
 		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-1"}}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: "fs-1"}}
 	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -775,7 +775,7 @@ func TestHandleSessionPromptLaterTurnInvokesBoundFactorySessionExactlyOnce(t *te
 		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-2", "fs-already-bound"),
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-new"}}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: "fs-new"}}
 	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -898,9 +898,11 @@ func TestHandleSessionPromptLaterTurnMapsInvocationOutcomeToFinalStopReason(t *t
 
 // TestHandleSessionPromptFirstTurnMapsStartOutcomeToSafeFallback proves
 // handleSessionPrompt's final response for the first (start) turn in an
-// episode always uses the documented end_turn safe fallback -- an
-// asynchronous start's own published result never itself carries a terminal
-// outcome -- and never leaks the returned Factory Session identity or any
+// episode uses the documented end_turn safe fallback for a status outside
+// the mapped terminal vocabulary (here "RUNNING", which a real activation
+// never actually publishes back to this caller since it dispatches
+// synchronously, but which a still-total mapping must handle safely
+// regardless), and never leaks the returned Factory Session identity or any
 // other raw field into the response.
 func TestHandleSessionPromptFirstTurnMapsStartOutcomeToSafeFallback(t *testing.T) {
 	chatSessions := &fakeChatSessionsService{
@@ -908,7 +910,7 @@ func TestHandleSessionPromptFirstTurnMapsStartOutcomeToSafeFallback(t *testing.T
 		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-secret-1", Status: "RUNNING"}}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: "fs-secret-1", Status: "RUNNING"}}
 	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -969,6 +971,192 @@ func TestHandleSessionPromptFinalResponseCarriesOnlyStopReason(t *testing.T) {
 	}
 }
 
+// TestHandleSessionPromptDeliversMappedTextAsOneNotification proves a
+// successful dispatch whose mapped outcome carries text sends it through
+// exactly one promptNotifier call, newline-joined in stable order, addressed
+// to the admitted turn's own session, before the final response is built.
+func TestHandleSessionPromptDeliversMappedTextAsOneNotification(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-2", "fs-already-bound"),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{invokeResult: factorysessions.InvocationResult{
+		Status: factorysessions.InvocationTerminalStatusCompleted,
+		PrimaryResult: []work.WorkContentPart{
+			{Type: work.WorkContentPartTypeText, Text: "hello"},
+			{Type: work.WorkContentPartTypeText, Text: "world"},
+		},
+	}}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	var notified []acpsdk.SessionNotification
+	notify := func(n acpsdk.SessionNotification) error {
+		notified = append(notified, n)
+		return nil
+	}
+	ctx := contextWithPromptNotifier(context.Background(), notify)
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "a later message"))
+
+	if _, rpcErr := server.handleSessionPrompt(ctx, env); rpcErr != nil {
+		t.Fatalf("handleSessionPrompt() error = %+v, want success", rpcErr)
+	}
+
+	if len(notified) != 1 {
+		t.Fatalf("notify call count = %d, want exactly 1", len(notified))
+	}
+	if notified[0].SessionId != "session-1" {
+		t.Fatalf("notification SessionId = %q, want session-1", notified[0].SessionId)
+	}
+	chunk := notified[0].Update.AgentMessageChunk
+	if chunk == nil {
+		t.Fatal("notification Update.AgentMessageChunk = nil, want a populated chunk")
+	}
+	if chunk.Content.Text == nil || chunk.Content.Text.Text != "hello\nworld" {
+		t.Fatalf("notification chunk text = %+v, want \"hello\\nworld\"", chunk.Content.Text)
+	}
+}
+
+// TestHandleSessionPromptEmptyOutcomeTextSendsNoNotification proves a
+// dispatch whose mapped outcome carries no text (an absent or
+// unsupported-only primary result) never calls the attached promptNotifier.
+func TestHandleSessionPromptEmptyOutcomeTextSendsNoNotification(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-2", "fs-already-bound"),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{invokeResult: factorysessions.InvocationResult{
+		Status: factorysessions.InvocationTerminalStatusCompleted,
+	}}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	notifyCalls := 0
+	notify := func(acpsdk.SessionNotification) error {
+		notifyCalls++
+		return nil
+	}
+	ctx := contextWithPromptNotifier(context.Background(), notify)
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "a later message"))
+
+	if _, rpcErr := server.handleSessionPrompt(ctx, env); rpcErr != nil {
+		t.Fatalf("handleSessionPrompt() error = %+v, want success", rpcErr)
+	}
+	if notifyCalls != 0 {
+		t.Fatalf("notify call count = %d, want 0 for an outcome with no text", notifyCalls)
+	}
+}
+
+// TestHandleSessionPromptNotifyFailureTerminalizesToFailed proves a
+// promptNotifier failure is treated like any other post-dispatch failure: it
+// reports a bounded internal error and terminalizes the turn to FAILED
+// instead of silently discarding the delivery failure and returning the
+// dispatch's own successful response.
+func TestHandleSessionPromptNotifyFailureTerminalizesToFailed(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-2", "fs-already-bound"),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{invokeResult: factorysessions.InvocationResult{
+		Status: factorysessions.InvocationTerminalStatusCompleted,
+		PrimaryResult: []work.WorkContentPart{
+			{Type: work.WorkContentPartTypeText, Text: "hello"},
+		},
+	}}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	notify := func(acpsdk.SessionNotification) error {
+		return errors.New("write pipe closed")
+	}
+	ctx := contextWithPromptNotifier(context.Background(), notify)
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "a later message"))
+
+	result, rpcErr := server.handleSessionPrompt(ctx, env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure when notify fails")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionPrompt() result = %q, want nil when notify fails", result)
+	}
+
+	wantAdvanceTurnSequence(t, chatSessions, "session-1", "turn-2", chatsessions.TurnStateRunning, chatsessions.TurnStateFailed)
+}
+
+// TestServeDeliversMappedTextAsOneSessionUpdateNotificationBeforeTheFinalResponse
+// proves the end-to-end wiring through the real stdio.Server.Serve loop: a
+// successful "session/prompt" JSON-RPC request whose mapped outcome carries
+// text writes exactly one "session/update" notification line -- no "id"
+// member, method "session/update", an agent_message_chunk update carrying the
+// joined text -- followed by exactly one final response line, never
+// interleaved and never reversed.
+func TestServeDeliversMappedTextAsOneSessionUpdateNotificationBeforeTheFinalResponse(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-2", "fs-already-bound"),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{invokeResult: factorysessions.InvocationResult{
+		Status: factorysessions.InvocationTerminalStatusCompleted,
+		PrimaryResult: []work.WorkContentPart{
+			{Type: work.WorkContentPartTypeText, Text: "hello"},
+			{Type: work.WorkContentPartTypeText, Text: "world"},
+		},
+	}}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	line := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"session/prompt","params":%s}`+"\n",
+		promptTextParams("session-1", "a later message"))
+	out := &bytes.Buffer{}
+	if err := server.Serve(context.Background(), strings.NewReader(line), out); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	lines := nonEmptyResponseLines(t, out)
+	if len(lines) != 2 {
+		t.Fatalf("output line count = %d, want 2 (one notification, one response): %s", len(lines), out.String())
+	}
+
+	var notification map[string]json.RawMessage
+	if err := json.Unmarshal(lines[0], &notification); err != nil {
+		t.Fatalf("unmarshal notification line: %v", err)
+	}
+	if _, hasID := notification["id"]; hasID {
+		t.Fatalf("notification line carried an \"id\" member, want a true JSON-RPC notification: %s", lines[0])
+	}
+	var method string
+	if err := json.Unmarshal(notification["method"], &method); err != nil || method != acpsdk.ClientMethodSessionUpdate {
+		t.Fatalf("notification method = %s, want %q", notification["method"], acpsdk.ClientMethodSessionUpdate)
+	}
+	if !bytes.Contains(lines[0], []byte(`"sessionUpdate":"agent_message_chunk"`)) {
+		t.Fatalf("notification = %s, want an agent_message_chunk update", lines[0])
+	}
+	if !bytes.Contains(lines[0], []byte(`"text":"hello\nworld"`)) {
+		t.Fatalf("notification = %s, want the newline-joined mapped text", lines[0])
+	}
+	if !bytes.Contains(lines[0], []byte(`"sessionId":"session-1"`)) {
+		t.Fatalf("notification = %s, want sessionId session-1", lines[0])
+	}
+
+	var resp rpcMessage
+	if err := json.Unmarshal(lines[1], &resp); err != nil {
+		t.Fatalf("unmarshal response line: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("response error = %+v, want success", resp.Error)
+	}
+	var promptResp acpsdk.PromptResponse
+	if err := json.Unmarshal(resp.Result, &promptResp); err != nil {
+		t.Fatalf("unmarshal PromptResponse: %v", err)
+	}
+	if promptResp.StopReason != acpsdk.StopReasonEndTurn {
+		t.Fatalf("stopReason = %q, want end_turn", promptResp.StopReason)
+	}
+}
+
 // TestHandleSessionPromptSequentialTurnsStartThenInvokeExactlyOnce proves the
 // full first-turn-starts / later-turn-invokes sequence across two real
 // handleSessionPrompt calls against the same session: the first turn's
@@ -985,7 +1173,7 @@ func TestHandleSessionPromptSequentialTurnsStartThenInvokeExactlyOnce(t *testing
 		},
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-1"}}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: "fs-1"}}
 	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
 	firstEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -1121,7 +1309,7 @@ func TestHandleSessionPromptEmptyFactorySessionIdentityFailsSafely(t *testing.T)
 		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: ""}}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: ""}}
 	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -1133,6 +1321,39 @@ func TestHandleSessionPromptEmptyFactorySessionIdentityFailsSafely(t *testing.T)
 	if chatSessions.bindFactorySessionCalled {
 		t.Fatal("BindFactorySession was called, want no binding attempt for an empty returned identity")
 	}
+}
+
+// TestHandleSessionPromptBindFailureClosesTheJustStartedRuntime proves that
+// when BindFactorySession fails after a successful StartFactoryTarget, the
+// handler compensates by closing the exact runtime identity StartFactoryTarget
+// just returned -- so a subsequent retry for the still-unbound episode never
+// leaves that runtime both orphaned (live, unbound, unreachable) and
+// duplicated by a second start.
+func TestHandleSessionPromptBindFailureClosesTheJustStartedRuntime(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult:      sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:       admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+		bindFactorySessionErr: errors.New("bind failed: version race"),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: "fs-orphan-candidate"}}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+	_, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure when BindFactorySession fails")
+	}
+
+	if len(factoryTarget.closeCalls) != 1 {
+		t.Fatalf("CloseFactoryTarget call count = %d, want exactly 1", len(factoryTarget.closeCalls))
+	}
+	if factoryTarget.closeCalls[0] != "fs-orphan-candidate" {
+		t.Fatalf("CloseFactoryTarget sessionID = %q, want the exact identity StartFactoryTarget returned", factoryTarget.closeCalls[0])
+	}
+
+	wantAdvanceTurnSequence(t, chatSessions, "session-1", "turn-1", chatsessions.TurnStateRunning, chatsessions.TurnStateFailed)
 }
 
 // TestHandleSessionPromptWithoutFactoryTargetCollaboratorAdmitsButFailsBound
@@ -1181,27 +1402,45 @@ func wantAdvanceTurnSequence(t *testing.T, chatSessions *fakeChatSessionsService
 	}
 }
 
-// TestHandleSessionPromptFirstTurnSuccessAdvancesRunningThenCompleted proves
-// a successful first-turn (start) admission advances the turn through
-// TurnStateRunning to TurnStateCompleted -- the branch's own dispatch and
-// bind work genuinely completed -- clearing the session's active-turn state
-// so a later prompt is never stranded behind it.
-func TestHandleSessionPromptFirstTurnSuccessAdvancesRunningThenCompleted(t *testing.T) {
-	chatSessions := &fakeChatSessionsService{
-		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
-		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+// TestHandleSessionPromptFirstTurnAdvancesByStartOutcome proves a first-turn
+// (start) admission's terminal advancement tracks the underlying synchronous
+// activation's own published terminal status exactly, the same way a later
+// (invoke) turn's does -- not a hardcoded TurnStateCompleted regardless of
+// outcome. OnDemandFactoryTargetService.StartFactoryTarget dispatches its
+// content synchronously (via InvokeFactorySession) before returning, so a
+// first turn's published status is exactly as authoritative as a later
+// turn's.
+func TestHandleSessionPromptFirstTurnAdvancesByStartOutcome(t *testing.T) {
+	tests := []struct {
+		name   string
+		status factorysessions.InvocationTerminalStatus
+		want   chatsessions.TurnState
+	}{
+		{"completed", factorysessions.InvocationTerminalStatusCompleted, chatsessions.TurnStateCompleted},
+		{"canceled", factorysessions.InvocationTerminalStatusCanceled, chatsessions.TurnStateCanceled},
+		{"timed_out", factorysessions.InvocationTerminalStatusTimedOut, chatsessions.TurnStateCanceled},
+		{"failed", factorysessions.InvocationTerminalStatusFailed, chatsessions.TurnStateFailed},
+		{"unmapped_future_status", factorysessions.InvocationTerminalStatus("SOME_FUTURE_STATUS"), chatsessions.TurnStateFailed},
 	}
-	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-1", Status: "RUNNING"}}
-	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			chatSessions := &fakeChatSessionsService{
+				getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+				startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+			}
+			catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+			factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: "fs-1", Status: tc.status}}
+			server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
-	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
-		promptTextParams("session-1", "hello there"))
-	if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr != nil {
-		t.Fatalf("handleSessionPrompt() error = %+v, want success", rpcErr)
+			env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+				promptTextParams("session-1", "hello there"))
+			if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr != nil {
+				t.Fatalf("handleSessionPrompt() error = %+v, want success (a published Factory failure still yields a normal final ACP response)", rpcErr)
+			}
+
+			wantAdvanceTurnSequence(t, chatSessions, "session-1", "turn-1", chatsessions.TurnStateRunning, tc.want)
+		})
 	}
-
-	wantAdvanceTurnSequence(t, chatSessions, "session-1", "turn-1", chatsessions.TurnStateRunning, chatsessions.TurnStateCompleted)
 }
 
 // TestHandleSessionPromptLaterTurnAdvancesByInvocationOutcome proves a later
@@ -1340,7 +1579,7 @@ func TestHandleSessionPromptRunningTransitionFailureMakesNoFactoryDispatchCall(t
 		advanceTurnErr:   errors.New("advance turn boom"),
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-1"}}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{SessionID: "fs-1"}}
 	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
@@ -1373,7 +1612,9 @@ func TestHandleSessionPromptTerminalTransitionFailurePropagatesBoundedError(t *t
 		advanceTurnErrs:  []error{nil, errors.New("terminal advance boom")},
 	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-1"}}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.InvocationResult{
+		SessionID: "fs-1", Status: factorysessions.InvocationTerminalStatusCompleted,
+	}}
 	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,

--- a/pkg/transports/acp/internal/stdio/session_prompt_test.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt_test.go
@@ -281,7 +281,10 @@ func TestHandleSessionPromptFactoryCommandFailureNeverLeaksRawValueOrRoot(t *tes
 // (newTestServer), so admission success still reports a bounded
 // (non-method-not-found) internal error rather than fabricated success.
 func TestHandleSessionPromptNonCommandContentAdmitsOneVersionGuardedTurn(t *testing.T) {
-	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project"),
+		startTurnResult:  chatsessions.StartTurnResult{Turn: chatsessions.Turn{State: chatsessions.TurnStateAdmitted}},
+	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
 	server := newTestServer(chatSessions, catalog, "/home/operator")
 
@@ -452,7 +455,10 @@ func TestHandleSessionPromptDuplicateDeliveryRejectsSecondCall(t *testing.T) {
 // admitting an ordinary prompt turn, matching "session/new"'s existing
 // identity-collision-safety guarantee.
 func TestHandleSessionPromptEqualWireIDsAcrossConnectionsRemainDistinct(t *testing.T) {
-	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project"),
+		startTurnResult:  chatsessions.StartTurnResult{Turn: chatsessions.Turn{State: chatsessions.TurnStateAdmitted}},
+	}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
 	server := newTestServer(chatSessions, catalog, "/home/operator")
 
@@ -1007,6 +1013,79 @@ func TestHandleSessionPromptSequentialTurnsStartThenInvokeExactlyOnce(t *testing
 	}
 	if got := factoryTarget.invokeCalls[0].sessionID; got != "fs-1" {
 		t.Fatalf("InvokeFactoryTarget sessionID = %q, want the identity bound by the first turn's start (fs-1)", got)
+	}
+}
+
+// TestHandleSessionPromptRedeliveredRequestMakesNoFactoryCall proves that
+// when StartTurn reports a redelivered RequestID whose originally admitted
+// turn has already terminalized (a returned Turn.State other than ADMITTED,
+// exactly what chat_sessions/internal/service.Store.StartTurn now returns for
+// a reused RequestID), this transport neither calls AdvanceTurn nor dispatches
+// any Factory effect, and still returns a deterministic final response
+// derived from that turn's own recorded terminal state.
+func TestHandleSessionPromptRedeliveredRequestMakesNoFactoryCall(t *testing.T) {
+	replayed := admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", "fs-1")
+	replayed.Turn.State = chatsessions.TurnStateCompleted
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  replayed,
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr != nil {
+		t.Fatalf("handleSessionPrompt() error = %+v, want a deterministic final response for a redelivered request", rpcErr)
+	}
+	if chatSessions.advanceTurnCalled {
+		t.Fatal("AdvanceTurn was called, want no turn-state mutation for a redelivered already-terminal request")
+	}
+	if len(factoryTarget.startCalls) != 0 {
+		t.Fatalf("StartFactoryTarget call count = %d, want 0 for a redelivered request", len(factoryTarget.startCalls))
+	}
+	if len(factoryTarget.invokeCalls) != 0 {
+		t.Fatalf("InvokeFactoryTarget call count = %d, want 0 for a redelivered request", len(factoryTarget.invokeCalls))
+	}
+
+	var resp acpsdk.PromptResponse
+	if err := json.Unmarshal(result, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.StopReason != acpsdk.StopReasonEndTurn {
+		t.Fatalf("StopReason = %q, want end_turn for the original COMPLETED turn", resp.StopReason)
+	}
+}
+
+// TestHandleSessionPromptRedeliveredBusyRequestRejectsAsBusy proves that when
+// StartTurn reports a redelivered RequestID whose originally admitted turn is
+// still busy (RUNNING), this transport rejects the request the same way a
+// genuinely distinct concurrent duplicate would, with zero Factory effect.
+func TestHandleSessionPromptRedeliveredBusyRequestRejectsAsBusy(t *testing.T) {
+	replayed := admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", "")
+	replayed.Turn.State = chatsessions.TurnStateRunning
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  replayed,
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+	_, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a bounded busy rejection for a redelivered in-flight request")
+	}
+	if chatSessions.advanceTurnCalled {
+		t.Fatal("AdvanceTurn was called, want no turn-state mutation for a redelivered busy request")
+	}
+	if len(factoryTarget.startCalls) != 0 || len(factoryTarget.invokeCalls) != 0 {
+		t.Fatalf("Factory calls = start:%d invoke:%d, want 0 and 0 for a redelivered busy request",
+			len(factoryTarget.startCalls), len(factoryTarget.invokeCalls))
 	}
 }
 

--- a/pkg/transports/acp/internal/stdio/session_prompt_test.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt_test.go
@@ -378,6 +378,50 @@ func TestHandleSessionPromptStaleVersionRejectsWithProtocolSafeClassification(t 
 	}
 }
 
+// TestHandleSessionPromptAdmissionFailureClassification proves
+// classifyTurnAdmissionFailure's remaining causes -- a StartTurn
+// *chatsessions.ValidationError, a GetSession context.Canceled, and any
+// other unclassified GetSession failure -- all reject with no Factory
+// effect, matching the same bounded-classification contract as the
+// NotFoundError/ConflictError/BusyError causes covered above.
+func TestHandleSessionPromptAdmissionFailureClassification(t *testing.T) {
+	tests := []struct {
+		name          string
+		getSessionErr error
+		startTurnErr  error
+	}{
+		{"validation_error", nil, &chatsessions.ValidationError{Value: "Session", Field: "WorkingRoot", Err: chatsessions.ErrRequiredValue}},
+		{"get_session_canceled", context.Canceled, nil},
+		{"get_session_unclassified", errors.New("store unavailable"), nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chatSessions := &fakeChatSessionsService{
+				getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project"),
+				getSessionErr:    tt.getSessionErr,
+				startTurnErr:     tt.startTurnErr,
+			}
+			catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+			factoryTarget := &fakeFactoryTargetService{}
+			server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+			env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+				promptTextParams("session-1", "hello there"))
+
+			result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+			if rpcErr == nil {
+				t.Fatal("handleSessionPrompt() error = nil, want a rejection")
+			}
+			if result != nil {
+				t.Fatalf("handleSessionPrompt() result = %q, want nil on rejection", result)
+			}
+			if len(factoryTarget.startCalls) != 0 || len(factoryTarget.invokeCalls) != 0 {
+				t.Fatal("Factory effect observed, want zero Factory calls on admission rejection")
+			}
+		})
+	}
+}
+
 // TestHandleSessionPromptBusyRejectsSequentialAndConcurrentAdmission proves
 // that once a session has a non-terminal active turn, StartTurn's
 // *chatsessions.BusyError classifies as a bounded protocol-safe rejection
@@ -1210,40 +1254,57 @@ func TestHandleSessionPromptSequentialTurnsStartThenInvokeExactlyOnce(t *testing
 // exactly what chat_sessions/internal/service.Store.StartTurn now returns for
 // a reused RequestID), this transport neither calls AdvanceTurn nor dispatches
 // any Factory effect, and still returns a deterministic final response
-// derived from that turn's own recorded terminal state.
+// derived from that turn's own recorded terminal state -- exercising
+// turnStateStopReason's full mapping: TurnStateCanceled to the distinct
+// cancelled stop reason, and every other terminal state (including
+// TurnStateFailed) to the same end_turn safe fallback TurnStateCompleted
+// uses.
 func TestHandleSessionPromptRedeliveredRequestMakesNoFactoryCall(t *testing.T) {
-	replayed := admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", "fs-1")
-	replayed.Turn.State = chatsessions.TurnStateCompleted
-	chatSessions := &fakeChatSessionsService{
-		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
-		startTurnResult:  replayed,
+	tests := []struct {
+		name       string
+		turnState  chatsessions.TurnState
+		wantReason acpsdk.StopReason
+	}{
+		{"completed", chatsessions.TurnStateCompleted, acpsdk.StopReasonEndTurn},
+		{"canceled", chatsessions.TurnStateCanceled, acpsdk.StopReasonCancelled},
+		{"failed", chatsessions.TurnStateFailed, acpsdk.StopReasonEndTurn},
 	}
-	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	factoryTarget := &fakeFactoryTargetService{}
-	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			replayed := admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", "fs-1")
+			replayed.Turn.State = tt.turnState
+			chatSessions := &fakeChatSessionsService{
+				getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+				startTurnResult:  replayed,
+			}
+			catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+			factoryTarget := &fakeFactoryTargetService{}
+			server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
 
-	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
-		promptTextParams("session-1", "hello there"))
-	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
-	if rpcErr != nil {
-		t.Fatalf("handleSessionPrompt() error = %+v, want a deterministic final response for a redelivered request", rpcErr)
-	}
-	if chatSessions.advanceTurnCalled {
-		t.Fatal("AdvanceTurn was called, want no turn-state mutation for a redelivered already-terminal request")
-	}
-	if len(factoryTarget.startCalls) != 0 {
-		t.Fatalf("StartFactoryTarget call count = %d, want 0 for a redelivered request", len(factoryTarget.startCalls))
-	}
-	if len(factoryTarget.invokeCalls) != 0 {
-		t.Fatalf("InvokeFactoryTarget call count = %d, want 0 for a redelivered request", len(factoryTarget.invokeCalls))
-	}
+			env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+				promptTextParams("session-1", "hello there"))
+			result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+			if rpcErr != nil {
+				t.Fatalf("handleSessionPrompt() error = %+v, want a deterministic final response for a redelivered request", rpcErr)
+			}
+			if chatSessions.advanceTurnCalled {
+				t.Fatal("AdvanceTurn was called, want no turn-state mutation for a redelivered already-terminal request")
+			}
+			if len(factoryTarget.startCalls) != 0 {
+				t.Fatalf("StartFactoryTarget call count = %d, want 0 for a redelivered request", len(factoryTarget.startCalls))
+			}
+			if len(factoryTarget.invokeCalls) != 0 {
+				t.Fatalf("InvokeFactoryTarget call count = %d, want 0 for a redelivered request", len(factoryTarget.invokeCalls))
+			}
 
-	var resp acpsdk.PromptResponse
-	if err := json.Unmarshal(result, &resp); err != nil {
-		t.Fatalf("unmarshal response: %v", err)
-	}
-	if resp.StopReason != acpsdk.StopReasonEndTurn {
-		t.Fatalf("StopReason = %q, want end_turn for the original COMPLETED turn", resp.StopReason)
+			var resp acpsdk.PromptResponse
+			if err := json.Unmarshal(result, &resp); err != nil {
+				t.Fatalf("unmarshal response: %v", err)
+			}
+			if resp.StopReason != tt.wantReason {
+				t.Fatalf("StopReason = %q, want %q for the original %s turn", resp.StopReason, tt.wantReason, tt.turnState)
+			}
+		})
 	}
 }
 

--- a/pkg/transports/acp/internal/stdio/session_prompt_test.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -11,6 +13,9 @@ import (
 	acpsdk "github.com/coder/acp-go-sdk"
 
 	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/identity"
 	"github.com/portpowered/infinite-you/pkg/transports/acp/internal/session"
 )
@@ -474,7 +479,7 @@ func TestHandleSessionPromptEqualWireIDsAcrossConnectionsRemainDistinct(t *testi
 // configured reports a bounded internal failure rather than panicking or
 // dispatching a Factory effect.
 func TestHandleSessionPromptWithoutCollaboratorsReportsBoundedFailure(t *testing.T) {
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
 		promptTextParams("session-1", "hello there"))
 
@@ -652,5 +657,197 @@ func TestFactoryFallbackAndSetConfigOptionProduceEquivalentEffects(t *testing.T)
 				t.Fatal("StartTurn was called via the /factory prompt fallback, want no prompt turn")
 			}
 		})
+	}
+}
+
+// admittedTurnResult builds a chatsessions.StartTurnResult matching what a
+// real StartTurn admission against sessionAt(id, target, version, root)
+// would return: the same Session identity/version/root, a newly admitted
+// Turn, and the current TargetEpisode snapshot (whose FactorySessionID is
+// factorySessionID -- blank for a brand-new, unbound episode).
+func admittedTurnResult(id, target string, version uint64, workingRoot, turnID, factorySessionID string) chatsessions.StartTurnResult {
+	targetRef := chatsessions.ChatTargetRef{Kind: chatsessions.ChatTargetKindFactory, Ref: target}
+	return chatsessions.StartTurnResult{
+		Session: chatsessions.Session{
+			ID: id, State: chatsessions.SessionStateActive,
+			SelectedTarget: targetRef, TargetEpisode: 1, ActiveTurnID: turnID,
+			Version: version, WorkingRoot: workingRoot,
+		},
+		Turn: chatsessions.Turn{
+			ID: turnID, Episode: 1, State: chatsessions.TurnStateAdmitted,
+		},
+		Episode: chatsessions.TargetEpisode{
+			Number: 1, State: chatsessions.TargetEpisodeStateOpen,
+			Target: targetRef, FactorySessionID: factorySessionID,
+		},
+	}
+}
+
+// TestHandleSessionPromptFirstTurnStartsFactorySessionWithExactTargetRootAndContent
+// proves the first admitted turn in an unbound episode calls
+// StartFactoryTarget exactly once through the consumer-owned shim, with the
+// episode's canonical Factory target, the session's exact editor working
+// root, and the validated prompt content -- never a process cwd or
+// substituted value.
+func TestHandleSessionPromptFirstTurnStartsFactorySessionWithExactTargetRootAndContent(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-1"}}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure: response mapping is not yet implemented")
+	}
+
+	if len(factoryTarget.startCalls) != 1 {
+		t.Fatalf("StartFactoryTarget call count = %d, want exactly 1", len(factoryTarget.startCalls))
+	}
+	got := factoryTarget.startCalls[0]
+	wantSource := factorysessions.Source{Kind: factoryruntime.WorkflowSourceKindFactoryID, FactoryID: "factory:@you/review"}
+	if !reflect.DeepEqual(got.Source, wantSource) {
+		t.Fatalf("StartFactoryTarget Source = %+v, want %+v", got.Source, wantSource)
+	}
+	if got.Args["workingRoot"] != "/work/project" {
+		t.Fatalf("StartFactoryTarget Args[workingRoot] = %v, want /work/project", got.Args["workingRoot"])
+	}
+	wantContent := []work.WorkContentPart{{Type: work.WorkContentPartTypeText, Text: "hello there"}}
+	gotContent, ok := got.Args["content"].([]work.WorkContentPart)
+	if !ok || !reflect.DeepEqual(gotContent, wantContent) {
+		t.Fatalf("StartFactoryTarget Args[content] = %#v, want %#v", got.Args["content"], wantContent)
+	}
+	if got.RequestID != "turn-1" {
+		t.Fatalf("StartFactoryTarget RequestID = %q, want the admitted turn id turn-1", got.RequestID)
+	}
+}
+
+// TestHandleSessionPromptFirstTurnBindsReturnedFactorySessionID proves a
+// successful Factory Session start binds the returned identity onto exactly
+// the admitted session/episode/turn/version.
+func TestHandleSessionPromptFirstTurnBindsReturnedFactorySessionID(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-1"}}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure: response mapping is not yet implemented")
+	}
+
+	if !chatSessions.bindFactorySessionCalled {
+		t.Fatal("BindFactorySession was not called, want exactly one binding attempt after a successful start")
+	}
+	want := chatsessions.BindFactorySessionRequest{
+		SessionID: "session-1", ExpectedVersion: 4, Episode: 1, TurnID: "turn-1", FactorySessionID: "fs-1",
+	}
+	if chatSessions.bindFactorySessionReq != want {
+		t.Fatalf("BindFactorySession request = %+v, want %+v", chatSessions.bindFactorySessionReq, want)
+	}
+}
+
+// TestHandleSessionPromptAlreadyBoundEpisodeMakesNoStartCall proves a later
+// turn in an episode that already carries a Factory Session ID makes zero
+// StartFactoryTarget and zero BindFactorySession calls: invoking the bound
+// session is story 003's scope, not this one's, and this story must never
+// start a second Factory Session for an already-started episode.
+func TestHandleSessionPromptAlreadyBoundEpisodeMakesNoStartCall(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-2", "fs-already-bound"),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-new"}}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "a later message"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure: invoke dispatch is not yet implemented")
+	}
+
+	if len(factoryTarget.startCalls) != 0 {
+		t.Fatalf("StartFactoryTarget call count = %d, want 0 for an already-bound episode", len(factoryTarget.startCalls))
+	}
+	if chatSessions.bindFactorySessionCalled {
+		t.Fatal("BindFactorySession was called, want no binding attempt for an already-bound episode")
+	}
+}
+
+// TestHandleSessionPromptFactoryStartFailureMakesNoBindCall proves a
+// StartFactoryTarget failure reports a bounded failure and never calls
+// BindFactorySession.
+func TestHandleSessionPromptFactoryStartFailureMakesNoBindCall(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{startErr: errors.New("factory sessions boom")}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+	_, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure for a Factory start failure")
+	}
+	if chatSessions.bindFactorySessionCalled {
+		t.Fatal("BindFactorySession was called, want no binding attempt after a Factory start failure")
+	}
+}
+
+// TestHandleSessionPromptEmptyFactorySessionIdentityFailsSafely proves a
+// StartFactoryTarget success carrying a blank SessionID fails safely and
+// never calls BindFactorySession, rather than committing an empty identity.
+func TestHandleSessionPromptEmptyFactorySessionIdentityFailsSafely(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: ""}}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+	_, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure for an empty returned Factory Session identity")
+	}
+	if chatSessions.bindFactorySessionCalled {
+		t.Fatal("BindFactorySession was called, want no binding attempt for an empty returned identity")
+	}
+}
+
+// TestHandleSessionPromptWithoutFactoryTargetCollaboratorAdmitsButFailsBound
+// proves a Server with no Factory Sessions collaborator still admits the
+// turn (StartTurn is called) before reporting a bounded failure, matching
+// every other dependency-unavailable path in this package.
+func TestHandleSessionPromptWithoutFactoryTargetCollaboratorAdmitsButFailsBound(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+	_, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure with no Factory target collaborator")
+	}
+	if !chatSessions.startTurnCalled {
+		t.Fatal("StartTurn was not called, want the turn admitted before the missing-collaborator failure")
 	}
 }

--- a/pkg/transports/acp/internal/stdio/session_prompt_test.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt_test.go
@@ -755,12 +755,14 @@ func TestHandleSessionPromptFirstTurnBindsReturnedFactorySessionID(t *testing.T)
 	}
 }
 
-// TestHandleSessionPromptAlreadyBoundEpisodeMakesNoStartCall proves a later
-// turn in an episode that already carries a Factory Session ID makes zero
-// StartFactoryTarget and zero BindFactorySession calls: invoking the bound
-// session is story 003's scope, not this one's, and this story must never
-// start a second Factory Session for an already-started episode.
-func TestHandleSessionPromptAlreadyBoundEpisodeMakesNoStartCall(t *testing.T) {
+// TestHandleSessionPromptLaterTurnInvokesBoundFactorySessionExactlyOnce
+// proves a later turn in an episode that already carries a Factory Session
+// ID calls InvokeFactoryTarget exactly once with that exact bound identity,
+// the validated prompt content, the text source kind, and the admitted
+// turn's ID as the correlated request ID -- and makes zero
+// StartFactoryTarget or BindFactorySession calls, since a second Factory
+// Session must never be started for an already-started episode.
+func TestHandleSessionPromptLaterTurnInvokesBoundFactorySessionExactlyOnce(t *testing.T) {
 	chatSessions := &fakeChatSessionsService{
 		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
 		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-2", "fs-already-bound"),
@@ -772,7 +774,7 @@ func TestHandleSessionPromptAlreadyBoundEpisodeMakesNoStartCall(t *testing.T) {
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
 		promptTextParams("session-1", "a later message"))
 	if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr == nil {
-		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure: invoke dispatch is not yet implemented")
+		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure: response mapping is not yet implemented")
 	}
 
 	if len(factoryTarget.startCalls) != 0 {
@@ -780,6 +782,103 @@ func TestHandleSessionPromptAlreadyBoundEpisodeMakesNoStartCall(t *testing.T) {
 	}
 	if chatSessions.bindFactorySessionCalled {
 		t.Fatal("BindFactorySession was called, want no binding attempt for an already-bound episode")
+	}
+
+	if len(factoryTarget.invokeCalls) != 1 {
+		t.Fatalf("InvokeFactoryTarget call count = %d, want exactly 1", len(factoryTarget.invokeCalls))
+	}
+	got := factoryTarget.invokeCalls[0]
+	if got.sessionID != "fs-already-bound" {
+		t.Fatalf("InvokeFactoryTarget sessionID = %q, want the bound identity fs-already-bound", got.sessionID)
+	}
+	wantContent := []work.WorkContentPart{{Type: work.WorkContentPartTypeText, Text: "a later message"}}
+	if !reflect.DeepEqual(got.request.Content, wantContent) {
+		t.Fatalf("InvokeFactoryTarget request.Content = %#v, want %#v", got.request.Content, wantContent)
+	}
+	if !got.request.ContentProvided {
+		t.Fatal("InvokeFactoryTarget request.ContentProvided = false, want true")
+	}
+	if got.request.SourceKind == nil || *got.request.SourceKind != factorysessions.InvocationInputSourceKindText {
+		t.Fatalf("InvokeFactoryTarget request.SourceKind = %v, want %q", got.request.SourceKind, factorysessions.InvocationInputSourceKindText)
+	}
+	if got.request.RequestID == nil || *got.request.RequestID != "turn-2" {
+		t.Fatalf("InvokeFactoryTarget request.RequestID = %v, want the admitted turn id turn-2", got.request.RequestID)
+	}
+}
+
+// TestHandleSessionPromptInvokeFactoryTargetFailureMakesNoStartCall proves an
+// InvokeFactoryTarget failure for a later turn reports a bounded failure and
+// never falls back to starting a second Factory Session for the episode.
+func TestHandleSessionPromptInvokeFactoryTargetFailureMakesNoStartCall(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-2", "fs-already-bound"),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{invokeErr: errors.New("factory sessions boom")}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "a later message"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure for an Invoke failure")
+	}
+
+	if len(factoryTarget.invokeCalls) != 1 {
+		t.Fatalf("InvokeFactoryTarget call count = %d, want exactly 1", len(factoryTarget.invokeCalls))
+	}
+	if len(factoryTarget.startCalls) != 0 {
+		t.Fatalf("StartFactoryTarget call count = %d, want 0 after an Invoke failure", len(factoryTarget.startCalls))
+	}
+	if chatSessions.bindFactorySessionCalled {
+		t.Fatal("BindFactorySession was called, want no binding attempt for an already-bound episode")
+	}
+}
+
+// TestHandleSessionPromptSequentialTurnsStartThenInvokeExactlyOnce proves the
+// full first-turn-starts / later-turn-invokes sequence across two real
+// handleSessionPrompt calls against the same session: the first turn's
+// unbound episode starts exactly one Factory Session, and the second turn --
+// observing that same episode now carrying the returned identity -- invokes
+// it exactly once and starts none, without ever mutating the first turn's
+// start call.
+func TestHandleSessionPromptSequentialTurnsStartThenInvokeExactlyOnce(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResults: []chatsessions.StartTurnResult{
+			admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+			admittedTurnResult("session-1", "factory:@you/review", 5, "/work/project", "turn-2", "fs-1"),
+		},
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-1"}}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	firstEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "first message"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), firstEnv); rpcErr == nil {
+		t.Fatal("handleSessionPrompt() (first turn) error = nil, want a bounded failure: response mapping is not yet implemented")
+	}
+	if len(factoryTarget.startCalls) != 1 {
+		t.Fatalf("StartFactoryTarget call count after first turn = %d, want exactly 1", len(factoryTarget.startCalls))
+	}
+	if len(factoryTarget.invokeCalls) != 0 {
+		t.Fatalf("InvokeFactoryTarget call count after first turn = %d, want 0", len(factoryTarget.invokeCalls))
+	}
+
+	secondEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 2, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "second message"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), secondEnv); rpcErr == nil {
+		t.Fatal("handleSessionPrompt() (second turn) error = nil, want a bounded failure: response mapping is not yet implemented")
+	}
+	if len(factoryTarget.startCalls) != 1 {
+		t.Fatalf("StartFactoryTarget call count after second turn = %d, want still exactly 1 (no second start)", len(factoryTarget.startCalls))
+	}
+	if len(factoryTarget.invokeCalls) != 1 {
+		t.Fatalf("InvokeFactoryTarget call count after second turn = %d, want exactly 1", len(factoryTarget.invokeCalls))
+	}
+	if got := factoryTarget.invokeCalls[0].sessionID; got != "fs-1" {
+		t.Fatalf("InvokeFactoryTarget sessionID = %q, want the identity bound by the first turn's start (fs-1)", got)
 	}
 }
 

--- a/pkg/transports/acp/internal/stdio/session_prompt_test.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt_test.go
@@ -276,9 +276,9 @@ func TestHandleSessionPromptFactoryCommandFailureNeverLeaksRawValueOrRoot(t *tes
 // canonical StartTurn exactly once with the full request identity, the real
 // session id, and the version observed from that read, and never reaches
 // the "/factory" changeTarget path or the Factory target catalog at all.
-// Downstream Factory dispatch is not yet implemented, so admission success
-// still reports a bounded (non-method-not-found) internal error rather than
-// fabricated success.
+// This Server has no Factory Sessions delegation collaborator configured
+// (newTestServer), so admission success still reports a bounded
+// (non-method-not-found) internal error rather than fabricated success.
 func TestHandleSessionPromptNonCommandContentAdmitsOneVersionGuardedTurn(t *testing.T) {
 	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
@@ -290,7 +290,7 @@ func TestHandleSessionPromptNonCommandContentAdmitsOneVersionGuardedTurn(t *test
 
 	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
 	if rpcErr == nil {
-		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure: Factory dispatch is not yet implemented")
+		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure: no Factory Sessions delegation collaborator is configured")
 	}
 	if rpcErr.Code == -32601 {
 		t.Fatal("error code = method-not-found (-32601), want ordinary prompt content to be admitted, not rejected as unsupported")
@@ -458,14 +458,14 @@ func TestHandleSessionPromptEqualWireIDsAcrossConnectionsRemainDistinct(t *testi
 	firstConn := identity.NewConnectionID()
 	firstEnv := numberIdentityEnvelope(t, firstConn, 1, acpsdk.AgentMethodSessionPrompt, promptTextParams("session-1", "hello there"))
 	if _, rpcErr := server.handleSessionPrompt(context.Background(), firstEnv); rpcErr == nil {
-		t.Fatal("handleSessionPrompt() error = nil, want the bounded not-yet-implemented rejection")
+		t.Fatal("handleSessionPrompt() error = nil, want the bounded missing-collaborator rejection")
 	}
 	firstIdentity := chatSessions.startTurnReq.RequestID
 
 	secondConn := identity.NewConnectionID()
 	secondEnv := numberIdentityEnvelope(t, secondConn, 1, acpsdk.AgentMethodSessionPrompt, promptTextParams("session-1", "hello there"))
 	if _, rpcErr := server.handleSessionPrompt(context.Background(), secondEnv); rpcErr == nil {
-		t.Fatal("handleSessionPrompt() error = nil, want the bounded not-yet-implemented rejection")
+		t.Fatal("handleSessionPrompt() error = nil, want the bounded missing-collaborator rejection")
 	}
 	secondIdentity := chatSessions.startTurnReq.RequestID
 
@@ -701,8 +701,8 @@ func TestHandleSessionPromptFirstTurnStartsFactorySessionWithExactTargetRootAndC
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
 		promptTextParams("session-1", "hello there"))
 
-	if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr == nil {
-		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure: response mapping is not yet implemented")
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr != nil {
+		t.Fatalf("handleSessionPrompt() error = %+v, want a successful final prompt response", rpcErr)
 	}
 
 	if len(factoryTarget.startCalls) != 1 {
@@ -740,8 +740,8 @@ func TestHandleSessionPromptFirstTurnBindsReturnedFactorySessionID(t *testing.T)
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
 		promptTextParams("session-1", "hello there"))
-	if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr == nil {
-		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure: response mapping is not yet implemented")
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr != nil {
+		t.Fatalf("handleSessionPrompt() error = %+v, want a successful final prompt response", rpcErr)
 	}
 
 	if !chatSessions.bindFactorySessionCalled {
@@ -773,8 +773,8 @@ func TestHandleSessionPromptLaterTurnInvokesBoundFactorySessionExactlyOnce(t *te
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
 		promptTextParams("session-1", "a later message"))
-	if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr == nil {
-		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure: response mapping is not yet implemented")
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr != nil {
+		t.Fatalf("handleSessionPrompt() error = %+v, want a successful final prompt response", rpcErr)
 	}
 
 	if len(factoryTarget.startCalls) != 0 {
@@ -835,6 +835,133 @@ func TestHandleSessionPromptInvokeFactoryTargetFailureMakesNoStartCall(t *testin
 	}
 }
 
+// TestHandleSessionPromptLaterTurnMapsInvocationOutcomeToFinalStopReason
+// proves handleSessionPrompt's final "session/prompt" response for a later
+// (invoke) turn carries only the deterministic ACP stop reason
+// protocol.MapFactoryInvocationOutcome derives from the published
+// InvocationResult terminal status -- completed, canceled, timed out, failed,
+// and an unmapped future status all included -- and never a fabricated or
+// raw result field.
+func TestHandleSessionPromptLaterTurnMapsInvocationOutcomeToFinalStopReason(t *testing.T) {
+	tests := []struct {
+		name   string
+		status factorysessions.InvocationTerminalStatus
+		want   acpsdk.StopReason
+	}{
+		{"completed", factorysessions.InvocationTerminalStatusCompleted, acpsdk.StopReasonEndTurn},
+		{"canceled", factorysessions.InvocationTerminalStatusCanceled, acpsdk.StopReasonCancelled},
+		{"timed_out", factorysessions.InvocationTerminalStatusTimedOut, acpsdk.StopReasonCancelled},
+		{"failed", factorysessions.InvocationTerminalStatusFailed, acpsdk.StopReasonEndTurn},
+		{"unmapped_future_status", factorysessions.InvocationTerminalStatus("SOME_FUTURE_STATUS"), acpsdk.StopReasonEndTurn},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			chatSessions := &fakeChatSessionsService{
+				getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+				startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-2", "fs-already-bound"),
+			}
+			catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+			factoryTarget := &fakeFactoryTargetService{invokeResult: factorysessions.InvocationResult{
+				Status: tc.status,
+				Message: "internal detail that must never reach the client: " +
+					"provider command /usr/local/bin/agent --token=sk-live-ABC123",
+			}}
+			server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+			env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+				promptTextParams("session-1", "a later message"))
+			result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+			if rpcErr != nil {
+				t.Fatalf("handleSessionPrompt() error = %+v, want success", rpcErr)
+			}
+
+			var resp acpsdk.PromptResponse
+			if err := json.Unmarshal(result, &resp); err != nil {
+				t.Fatalf("unmarshal response: %v", err)
+			}
+			if resp.StopReason != tc.want {
+				t.Fatalf("stopReason = %q, want %q", resp.StopReason, tc.want)
+			}
+			if strings.Contains(string(result), "sk-live-ABC123") {
+				t.Fatalf("response leaked the raw invocation message: %s", result)
+			}
+		})
+	}
+}
+
+// TestHandleSessionPromptFirstTurnMapsStartOutcomeToSafeFallback proves
+// handleSessionPrompt's final response for the first (start) turn in an
+// episode always uses the documented end_turn safe fallback -- an
+// asynchronous start's own published result never itself carries a terminal
+// outcome -- and never leaks the returned Factory Session identity or any
+// other raw field into the response.
+func TestHandleSessionPromptFirstTurnMapsStartOutcomeToSafeFallback(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-1", ""),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{startResult: factorysessions.AsyncStartResult{SessionID: "fs-secret-1", Status: "RUNNING"}}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr != nil {
+		t.Fatalf("handleSessionPrompt() error = %+v, want success", rpcErr)
+	}
+
+	var resp acpsdk.PromptResponse
+	if err := json.Unmarshal(result, &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.StopReason != acpsdk.StopReasonEndTurn {
+		t.Fatalf("stopReason = %q, want end_turn safe fallback", resp.StopReason)
+	}
+	if strings.Contains(string(result), "fs-secret-1") {
+		t.Fatalf("response leaked the raw Factory Session identity: %s", result)
+	}
+}
+
+// TestHandleSessionPromptFinalResponseCarriesOnlyStopReason proves the
+// handler's final "session/prompt" response for an admitted, mapped turn is
+// exactly the closed final-only shape this transport slice supports: a stop
+// reason and nothing else -- no fabricated content, chunk, or progress
+// field.
+func TestHandleSessionPromptFinalResponseCarriesOnlyStopReason(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/review", 3, "/work/project"),
+		startTurnResult:  admittedTurnResult("session-1", "factory:@you/review", 4, "/work/project", "turn-2", "fs-already-bound"),
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	factoryTarget := &fakeFactoryTargetService{invokeResult: factorysessions.InvocationResult{
+		Status: factorysessions.InvocationTerminalStatusCompleted,
+		PrimaryResult: []work.WorkContentPart{
+			{Type: work.WorkContentPartTypeText, Text: "the answer"},
+		},
+	}}
+	server := newTestServerWithFactoryTarget(chatSessions, catalog, factoryTarget, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "a later message"))
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr != nil {
+		t.Fatalf("handleSessionPrompt() error = %+v, want success", rpcErr)
+	}
+
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(result, &decoded); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if _, ok := decoded["stopReason"]; !ok {
+		t.Fatalf("response = %s, want a stopReason field", result)
+	}
+	delete(decoded, "stopReason")
+	if len(decoded) != 0 {
+		t.Fatalf("response carried unexpected fields %v, want only stopReason", decoded)
+	}
+}
+
 // TestHandleSessionPromptSequentialTurnsStartThenInvokeExactlyOnce proves the
 // full first-turn-starts / later-turn-invokes sequence across two real
 // handleSessionPrompt calls against the same session: the first turn's
@@ -856,8 +983,8 @@ func TestHandleSessionPromptSequentialTurnsStartThenInvokeExactlyOnce(t *testing
 
 	firstEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
 		promptTextParams("session-1", "first message"))
-	if _, rpcErr := server.handleSessionPrompt(context.Background(), firstEnv); rpcErr == nil {
-		t.Fatal("handleSessionPrompt() (first turn) error = nil, want a bounded failure: response mapping is not yet implemented")
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), firstEnv); rpcErr != nil {
+		t.Fatalf("handleSessionPrompt() (first turn) error = %+v, want a successful final prompt response", rpcErr)
 	}
 	if len(factoryTarget.startCalls) != 1 {
 		t.Fatalf("StartFactoryTarget call count after first turn = %d, want exactly 1", len(factoryTarget.startCalls))
@@ -868,8 +995,8 @@ func TestHandleSessionPromptSequentialTurnsStartThenInvokeExactlyOnce(t *testing
 
 	secondEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 2, acpsdk.AgentMethodSessionPrompt,
 		promptTextParams("session-1", "second message"))
-	if _, rpcErr := server.handleSessionPrompt(context.Background(), secondEnv); rpcErr == nil {
-		t.Fatal("handleSessionPrompt() (second turn) error = nil, want a bounded failure: response mapping is not yet implemented")
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), secondEnv); rpcErr != nil {
+		t.Fatalf("handleSessionPrompt() (second turn) error = %+v, want a successful final prompt response", rpcErr)
 	}
 	if len(factoryTarget.startCalls) != 1 {
 		t.Fatalf("StartFactoryTarget call count after second turn = %d, want still exactly 1 (no second start)", len(factoryTarget.startCalls))

--- a/pkg/transports/acp/internal/stdio/session_prompt_test.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
 
 	acpsdk "github.com/coder/acp-go-sdk"
@@ -264,14 +265,69 @@ func TestHandleSessionPromptFactoryCommandFailureNeverLeaksRawValueOrRoot(t *tes
 	}
 }
 
-// TestHandleSessionPromptNonCommandContentFallsThroughToMethodNotFound
-// proves ordinary prompt content -- anything not an exact "/factory
-// <value>" command attempt -- still receives method-not-found, exactly the
-// behavior "session/prompt" had before this command was recognized: this
-// story adds only the "/factory" fallback, not general prompt-turn
-// admission or Factory invocation.
-func TestHandleSessionPromptNonCommandContentFallsThroughToMethodNotFound(t *testing.T) {
+// TestHandleSessionPromptNonCommandContentAdmitsOneVersionGuardedTurn proves
+// ordinary prompt content -- anything not an exact "/factory <value>"
+// command attempt -- now reads the addressed Chat Session and calls its
+// canonical StartTurn exactly once with the full request identity, the real
+// session id, and the version observed from that read, and never reaches
+// the "/factory" changeTarget path or the Factory target catalog at all.
+// Downstream Factory dispatch is not yet implemented, so admission success
+// still reports a bounded (non-method-not-found) internal error rather than
+// fabricated success.
+func TestHandleSessionPromptNonCommandContentAdmitsOneVersionGuardedTurn(t *testing.T) {
 	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	connID := identity.NewConnectionID()
+	env := numberIdentityEnvelope(t, connID, 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure: Factory dispatch is not yet implemented")
+	}
+	if rpcErr.Code == -32601 {
+		t.Fatal("error code = method-not-found (-32601), want ordinary prompt content to be admitted, not rejected as unsupported")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionPrompt() result = %q, want nil", result)
+	}
+
+	if !chatSessions.getSessionCalled {
+		t.Fatal("GetSession was not called, want the addressed Chat Session to be read before admission")
+	}
+	if !chatSessions.startTurnCalled {
+		t.Fatal("StartTurn was not called, want exactly one version-guarded turn admission")
+	}
+	if chatSessions.setTargetCalled {
+		t.Fatal("SetTarget was called, want no target change for ordinary prompt content")
+	}
+	if len(catalog.calls) != 0 {
+		t.Fatalf("catalog resolved %d times, want 0 for ordinary prompt content", len(catalog.calls))
+	}
+
+	wantIdentity := chatsessions.RequestIdentity{
+		Kind:            chatsessions.RequestIdentityKindJSONRPCNumber,
+		ConnectionID:    string(connID),
+		JSONRPCNumberID: "1",
+	}
+	if chatSessions.startTurnReq.RequestID != wantIdentity {
+		t.Fatalf("StartTurn RequestID = %+v, want %+v", chatSessions.startTurnReq.RequestID, wantIdentity)
+	}
+	if chatSessions.startTurnReq.SessionID != "session-1" {
+		t.Fatalf("StartTurn SessionID = %q, want session-1", chatSessions.startTurnReq.SessionID)
+	}
+	if chatSessions.startTurnReq.ExpectedVersion != 3 {
+		t.Fatalf("StartTurn ExpectedVersion = %d, want the observed session version 3", chatSessions.startTurnReq.ExpectedVersion)
+	}
+}
+
+// TestHandleSessionPromptUnknownSessionRejectsWithNoStartTurnCall proves an
+// unknown session (GetSession's *chatsessions.NotFoundError) is rejected
+// before StartTurn is ever called, so no Factory effect can follow.
+func TestHandleSessionPromptUnknownSessionRejectsWithNoStartTurnCall(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionErr: &chatsessions.NotFoundError{Value: "Session", ID: "session-1"}}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
 	server := newTestServer(chatSessions, catalog, "/home/operator")
 
@@ -279,17 +335,155 @@ func TestHandleSessionPromptNonCommandContentFallsThroughToMethodNotFound(t *tes
 		promptTextParams("session-1", "hello there"))
 
 	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
-	if rpcErr == nil || rpcErr.Code != -32601 {
-		t.Fatalf("error = %+v, want method-not-found (-32601) for non-command prompt content", rpcErr)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a rejection for an unknown session")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionPrompt() result = %q, want nil on rejection", result)
+	}
+	if chatSessions.startTurnCalled {
+		t.Fatal("StartTurn was called, want no admission for an unknown session")
+	}
+}
+
+// TestHandleSessionPromptStaleVersionRejectsWithProtocolSafeClassification
+// proves a stale expected version (StartTurn's *chatsessions.ConflictError)
+// is rejected with a bounded, protocol-safe classification.
+func TestHandleSessionPromptStaleVersionRejectsWithProtocolSafeClassification(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project"),
+		startTurnErr:     &chatsessions.ConflictError{Value: "Session", ID: "session-1", Expected: 3, Actual: 4},
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a rejection for a stale expected version")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionPrompt() result = %q, want nil on rejection", result)
+	}
+}
+
+// TestHandleSessionPromptBusyRejectsSequentialAndConcurrentAdmission proves
+// that once a session has a non-terminal active turn, StartTurn's
+// *chatsessions.BusyError classifies as a bounded protocol-safe rejection
+// with no Factory effect, whether observed from a second sequential prompt
+// or from concurrent prompts racing against the same busy session.
+func TestHandleSessionPromptBusyRejectsSequentialAndConcurrentAdmission(t *testing.T) {
+	busyErr := &chatsessions.BusyError{Value: "Session", ID: "session-1", ActiveTurnID: "turn-1", ActiveTurnState: chatsessions.TurnStateAdmitted}
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project"),
+		startTurnErr:     busyErr,
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a rejection for a busy session")
+	}
+	if result != nil {
+		t.Fatalf("handleSessionPrompt() result = %q, want nil on rejection", result)
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]*acpsdk.RequestError, 8)
+	for i := range errs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			concurrentEnv := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+				promptTextParams("session-1", "hello again"))
+			_, errs[i] = server.handleSessionPrompt(context.Background(), concurrentEnv)
+		}(i)
+	}
+	wg.Wait()
+	for i, e := range errs {
+		if e == nil {
+			t.Fatalf("concurrent handleSessionPrompt() call %d error = nil, want a rejection for a busy session", i)
+		}
+	}
+}
+
+// TestHandleSessionPromptDuplicateDeliveryRejectsSecondCall proves that
+// re-delivering the exact same request (same connection, same wire id, same
+// content) against an already-busy session is rejected the same way any
+// other busy admission attempt is, with no additional Factory effect.
+func TestHandleSessionPromptDuplicateDeliveryRejectsSecondCall(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{
+		getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project"),
+		startTurnErr:     &chatsessions.BusyError{Value: "Session", ID: "session-1", ActiveTurnID: "turn-1", ActiveTurnState: chatsessions.TurnStateAdmitted},
+	}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	connID := identity.NewConnectionID()
+	env := numberIdentityEnvelope(t, connID, 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr == nil {
+		t.Fatal("first handleSessionPrompt() error = nil, want a rejection")
+	}
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), env); rpcErr == nil {
+		t.Fatal("duplicate handleSessionPrompt() error = nil, want the redelivered request rejected the same way")
+	}
+	if chatSessions.startTurnReq.RequestID.ConnectionID != string(connID) {
+		t.Fatalf("StartTurn RequestID.ConnectionID = %q, want %q", chatSessions.startTurnReq.RequestID.ConnectionID, connID)
+	}
+}
+
+// TestHandleSessionPromptEqualWireIDsAcrossConnectionsRemainDistinct proves
+// the same bare JSON-RPC id (1) received on two different connections
+// converts to two distinct chatsessions.RequestIdentity values when
+// admitting an ordinary prompt turn, matching "session/new"'s existing
+// identity-collision-safety guarantee.
+func TestHandleSessionPromptEqualWireIDsAcrossConnectionsRemainDistinct(t *testing.T) {
+	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
+	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
+	server := newTestServer(chatSessions, catalog, "/home/operator")
+
+	firstConn := identity.NewConnectionID()
+	firstEnv := numberIdentityEnvelope(t, firstConn, 1, acpsdk.AgentMethodSessionPrompt, promptTextParams("session-1", "hello there"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), firstEnv); rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want the bounded not-yet-implemented rejection")
+	}
+	firstIdentity := chatSessions.startTurnReq.RequestID
+
+	secondConn := identity.NewConnectionID()
+	secondEnv := numberIdentityEnvelope(t, secondConn, 1, acpsdk.AgentMethodSessionPrompt, promptTextParams("session-1", "hello there"))
+	if _, rpcErr := server.handleSessionPrompt(context.Background(), secondEnv); rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want the bounded not-yet-implemented rejection")
+	}
+	secondIdentity := chatSessions.startTurnReq.RequestID
+
+	if firstIdentity == secondIdentity {
+		t.Fatalf("wire id 1 on two different connections converted to the same RequestIdentity %+v", firstIdentity)
+	}
+}
+
+// TestHandleSessionPromptWithoutCollaboratorsReportsBoundedFailure proves an
+// ordinary prompt against a Server with no chatSessions collaborator
+// configured reports a bounded internal failure rather than panicking or
+// dispatching a Factory effect.
+func TestHandleSessionPromptWithoutCollaboratorsReportsBoundedFailure(t *testing.T) {
+	server := New(nil, nil, nil, nil)
+	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionPrompt,
+		promptTextParams("session-1", "hello there"))
+
+	result, rpcErr := server.handleSessionPrompt(context.Background(), env)
+	if rpcErr == nil {
+		t.Fatal("handleSessionPrompt() error = nil, want a bounded failure when collaborators are unset")
 	}
 	if result != nil {
 		t.Fatalf("handleSessionPrompt() result = %q, want nil", result)
-	}
-	if chatSessions.getSessionCalled || chatSessions.setTargetCalled || chatSessions.startTurnCalled {
-		t.Fatal("a Chat Sessions call was made, want no effect for non-command prompt content")
-	}
-	if len(catalog.calls) != 0 {
-		t.Fatalf("catalog resolved %d times, want 0 for non-command prompt content", len(catalog.calls))
 	}
 }
 

--- a/pkg/transports/acp/internal/stdio/session_set_config_option_test.go
+++ b/pkg/transports/acp/internal/stdio/session_set_config_option_test.go
@@ -153,7 +153,7 @@ func TestChangeTargetBlankWorkingRootRejectsWithNoCatalogResolution(t *testing.T
 func TestChangeTargetResolveHomeDirFailureReturnsNoMutation(t *testing.T) {
 	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	server := New(nil, chatSessions, catalog, func() (string, error) { return "", errors.New("resolve home dir boom") })
+	server := New(nil, chatSessions, catalog, nil, func() (string, error) { return "", errors.New("resolve home dir boom") })
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionSetConfigOption,
 		setConfigOptionParams("session-1", "factory:@you/review"))
@@ -173,7 +173,7 @@ func TestChangeTargetResolveHomeDirFailureReturnsNoMutation(t *testing.T) {
 func TestChangeTargetBlankHomeDirFailureReturnsNoMutation(t *testing.T) {
 	chatSessions := &fakeChatSessionsService{getSessionResult: sessionAt("session-1", "factory:@you/factory-builder", 3, "/work/project")}
 	catalog := &fakeFactoryTargetCatalogService{result: catalogResultWithCurrent("factory:@you/review")}
-	server := New(nil, chatSessions, catalog, func() (string, error) { return "", nil })
+	server := New(nil, chatSessions, catalog, nil, func() (string, error) { return "", nil })
 
 	env := numberIdentityEnvelope(t, identity.NewConnectionID(), 1, acpsdk.AgentMethodSessionSetConfigOption,
 		setConfigOptionParams("session-1", "factory:@you/review"))
@@ -445,7 +445,7 @@ func TestServeDispatchesSessionSetConfigOptionOverRealJSONRPCFraming(t *testing.
 func TestServeRespondsMethodNotFoundForEveryUnimplementedMethodStillExcludesSessionSetConfigOption(t *testing.T) {
 	input := `{"jsonrpc":"2.0","id":9,"method":"session/set_config_option","params":{"sessionId":"s","configId":"target","value":"factory:@you/factory-builder"}}` + "\n"
 	out := &bytes.Buffer{}
-	server := New(nil, nil, nil, nil)
+	server := New(nil, nil, nil, nil, nil)
 	if err := server.Serve(context.Background(), strings.NewReader(input), out); err != nil {
 		t.Fatalf("Serve() error = %v", err)
 	}

--- a/pkg/transports/acp/wire/wire.go
+++ b/pkg/transports/acp/wire/wire.go
@@ -20,15 +20,18 @@ import (
 // binding, session creation, or persistence.
 //
 // chatSessions and catalog are the canonical Chat Sessions collaborators
-// "session/new" dispatches to, and resolveHomeDir resolves the operator
-// home directory that call uses to derive the Operator Settings document
-// path and Factory discovery roots. This package injects exactly the
-// instances its caller supplies; it never resolves them itself.
+// "session/new" dispatches to, factoryTarget is the consumer-owned Factory
+// Sessions shim ordinary prompt delegation starts or invokes against, and
+// resolveHomeDir resolves the operator home directory that call uses to
+// derive the Operator Settings document path and Factory discovery roots.
+// This package injects exactly the instances its caller supplies; it never
+// resolves them itself.
 func NewServer(
 	logger logging.Logger,
 	chatSessions chatsessions.Service,
 	catalog chatsessions.FactoryTargetCatalogService,
+	factoryTarget acp.FactoryTargetService,
 	resolveHomeDir func() (string, error),
 ) acp.Server {
-	return stdio.New(logger, chatSessions, catalog, resolveHomeDir)
+	return stdio.New(logger, chatSessions, catalog, factoryTarget, resolveHomeDir)
 }

--- a/pkg/transports/acp/wire/wire_test.go
+++ b/pkg/transports/acp/wire/wire_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 func TestNewServerConstructsWithoutIO(t *testing.T) {
-	server := wire.NewServer(nil, nil, nil, nil)
+	server := wire.NewServer(nil, nil, nil, nil, nil)
 	if server == nil {
 		t.Fatal("NewServer() returned nil")
 	}
 }
 
 func TestNewServerServesOneConnection(t *testing.T) {
-	server := wire.NewServer(nil, nil, nil, nil)
+	server := wire.NewServer(nil, nil, nil, nil, nil)
 	out := &bytes.Buffer{}
 
 	if err := server.Serve(context.Background(), strings.NewReader(""), out); err != nil {
@@ -26,7 +26,7 @@ func TestNewServerServesOneConnection(t *testing.T) {
 }
 
 func TestNewServerRejectsMissingStreams(t *testing.T) {
-	server := wire.NewServer(nil, nil, nil, nil)
+	server := wire.NewServer(nil, nil, nil, nil, nil)
 
 	if err := server.Serve(context.Background(), nil, nil); err == nil {
 		t.Fatal("Serve() error = nil, want an actionable error for missing streams")

--- a/pkg/wire/acp_transport.go
+++ b/pkg/wire/acp_transport.go
@@ -181,6 +181,21 @@ func provideACPServerFactoryTargetRuntimeResolver(
 // on the process-scoped factorysessions.Service, which stays permanently
 // inert outside the CLI daemon bootstrap. Construction alone performs no
 // I/O and opens no runtime.
+//
+// The concrete *factorysessionwire.OnDemandFactoryTargetService this
+// constructs satisfies io.Closer: its Close tears down and evicts every
+// runtime it has lazily activated. No production caller currently reaches
+// it through this narrowed acp.FactoryTargetService return (which exposes
+// only per-identity CloseFactoryTarget, not the aggregate Close), because no
+// production ACP stdio entrypoint exists yet to run initializer.Process's
+// already-composed ACPServer() -- pkg/initializer/application/process.go's
+// ACPServer accessor is today consumed only by tests
+// (tests/functional/chat_sessions/root_composition). A future production
+// entrypoint that actually serves ACP over stdio must obtain this same
+// singleton as its concrete type (not just acp.FactoryTargetService) and
+// register it as a lifecycle.NamedResource in its own Plan (see
+// pkg/initializer/lifecycle) so every runtime it opens is guaranteed a
+// reachable, deterministic close on process shutdown.
 func provideACPServerFactoryTarget(
 	openRuntime *factorysessionwire.RuntimeOpeningFactory,
 	edges serviceedges.Edges,

--- a/pkg/wire/acp_transport.go
+++ b/pkg/wire/acp_transport.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	chatsessionswire "github.com/portpowered/infinite-you/pkg/services/chat_sessions/wire"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	acp "github.com/portpowered/infinite-you/pkg/transports/acp"
 	acpwire "github.com/portpowered/infinite-you/pkg/transports/acp/wire"
 )
@@ -108,18 +110,31 @@ func provideACPServerResolveHomeDir() acpServerResolveHomeDir {
 	return os.UserHomeDir
 }
 
+// provideACPServerFactoryTarget constructs the consumer-owned Factory
+// Sessions shim the production ACP prompt-delegation consumer starts or
+// invokes a Factory Session through, from the same canonical
+// factorysessions.Service instance the rest of this graph composes -- so
+// production prompt delegation observes the one process-scoped Factory
+// Sessions authority instead of a second, independently constructed
+// instance. Construction alone performs no I/O.
+func provideACPServerFactoryTarget(factorySessions factorysessions.Service) acp.FactoryTargetService {
+	return chatsessionswire.NewFactoryTargetService(factorySessions)
+}
+
 // provideACPServer constructs the production ACP stdio Server from the same
-// canonical chatsessions.Service and chatsessions.FactoryTargetCatalogService
-// instances the rest of this graph composes, so the real "session/new",
-// "session/set_config_option", and "/factory" consumer observes the one
-// process-scoped Chat Sessions authority instead of a second, independently
+// canonical chatsessions.Service, chatsessions.FactoryTargetCatalogService,
+// and Factory Sessions shim instances the rest of this graph composes, so
+// the real "session/new", "session/set_config_option", "/factory", and
+// ordinary prompt-delegation consumer observes the one process-scoped Chat
+// Sessions and Factory Sessions authority instead of a second, independently
 // constructed instance. Construction alone performs no I/O; it starts no
 // goroutine, process, listener, session, or persistence.
 func provideACPServer(
 	logger logging.Logger,
 	chatSessions chatsessions.Service,
 	catalog chatsessions.FactoryTargetCatalogService,
+	factoryTarget acp.FactoryTargetService,
 	resolveHomeDir acpServerResolveHomeDir,
 ) acp.Server {
-	return acpwire.NewServer(logger, chatSessions, catalog, resolveHomeDir)
+	return acpwire.NewServer(logger, chatSessions, catalog, factoryTarget, resolveHomeDir)
 }

--- a/pkg/wire/acp_transport.go
+++ b/pkg/wire/acp_transport.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
+	chatsessionswire "github.com/portpowered/infinite-you/pkg/services/chat_sessions/wire"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
@@ -182,27 +183,21 @@ func provideACPServerFactoryTargetRuntimeResolver(
 // inert outside the CLI daemon bootstrap. Construction alone performs no
 // I/O and opens no runtime.
 //
-// The concrete *factorysessionwire.OnDemandFactoryTargetService this
-// constructs satisfies io.Closer: its Close tears down and evicts every
-// runtime it has lazily activated. No production caller currently reaches
-// it through this narrowed acp.FactoryTargetService return (which exposes
-// only per-identity CloseFactoryTarget, not the aggregate Close), because no
-// production ACP stdio entrypoint exists yet to run initializer.Process's
-// already-composed ACPServer() -- pkg/initializer/application/process.go's
-// ACPServer accessor is today consumed only by tests
-// (tests/functional/chat_sessions/root_composition). A future production
-// entrypoint that actually serves ACP over stdio must obtain this same
-// singleton as its concrete type (not just acp.FactoryTargetService) and
-// register it as a lifecycle.NamedResource in its own Plan (see
-// pkg/initializer/lifecycle) so every runtime it opens is guaranteed a
-// reachable, deterministic close on process shutdown.
+// This returns the concrete *factorysessionwire.OnDemandFactoryTargetService
+// (not the narrower acp.FactoryTargetService interface) precisely so a
+// second consumer -- provideApplicationProcessLifecycle -- can reach its
+// io.Closer-satisfying Close method and compose it into the process's own
+// reachable shutdown path; see provideACPServerFactoryTargetService for the
+// interface-narrowing adapter the ACP transport itself consumes. Wire's own
+// provider memoization guarantees both consumers observe this exact same
+// singleton, not two independently constructed activations.
 func provideACPServerFactoryTarget(
 	openRuntime *factorysessionwire.RuntimeOpeningFactory,
 	edges serviceedges.Edges,
 	resolveTarget factorysessionwire.FactoryTargetRuntimeResolver,
 	generateSessionID factorysessions.SessionIDGenerator,
 	logger *zap.Logger,
-) (acp.FactoryTargetService, error) {
+) (*factorysessionwire.OnDemandFactoryTargetService, error) {
 	return factorysessionwire.NewOnDemandFactoryTargetService(
 		openRuntime,
 		projectRuntimeOpeningExternalEffects(edges),
@@ -210,6 +205,30 @@ func provideACPServerFactoryTarget(
 		generateSessionID,
 		logger,
 	)
+}
+
+// provideACPServerFactoryTargetService wraps the on-demand Factory Sessions
+// activation singleton through the existing, consumer-owned Factory Sessions
+// shim (chat_sessions/wire.NewFactoryTargetService, a thin construction
+// wrapper over chat_sessions/internal/factorysessionsshim.New) rather than
+// exposing the activation singleton's own methods directly -- so the
+// production ACP prompt-delegation consumer's every Factory Session call
+// actually flows through that existing shim, not a second, independently
+// constructed peer contract. Wire's own provider memoization guarantees this
+// still shares the exact same activation singleton
+// provideApplicationProcessLifecycle reaches for shutdown (see
+// provideACPServerFactoryTarget), since both depend on the identical
+// *factorysessionwire.OnDemandFactoryTargetService type.
+//
+// pkg-boundary forbids pkg/transports/acp from importing another service's
+// wire subpackage, so it declares its own narrow acp.FactoryTargetService
+// interface (an exact structural match for
+// chatsessionswire.FactoryTargetService); only pkg/wire, exempt from that
+// rule, may compose the two.
+func provideACPServerFactoryTargetService(
+	target *factorysessionwire.OnDemandFactoryTargetService,
+) acp.FactoryTargetService {
+	return chatsessionswire.NewFactoryTargetService(target)
 }
 
 // provideACPServer constructs the production ACP stdio Server from the same

--- a/pkg/wire/acp_transport.go
+++ b/pkg/wire/acp_transport.go
@@ -4,14 +4,19 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	chatsessions "github.com/portpowered/infinite-you/pkg/services/chat_sessions"
-	chatsessionswire "github.com/portpowered/infinite-you/pkg/services/chat_sessions/wire"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factorysessionwire "github.com/portpowered/infinite-you/pkg/services/factory_sessions/wire"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	acp "github.com/portpowered/infinite-you/pkg/transports/acp"
 	acpwire "github.com/portpowered/infinite-you/pkg/transports/acp/wire"
+	"go.uber.org/zap"
 )
 
 // acpServerFactoryDefinitions adapts the two Factory Definitions operations
@@ -110,15 +115,86 @@ func provideACPServerResolveHomeDir() acpServerResolveHomeDir {
 	return os.UserHomeDir
 }
 
-// provideACPServerFactoryTarget constructs the consumer-owned Factory
-// Sessions shim the production ACP prompt-delegation consumer starts or
-// invokes a Factory Session through, from the same canonical
-// factorysessions.Service instance the rest of this graph composes -- so
-// production prompt delegation observes the one process-scoped Factory
-// Sessions authority instead of a second, independently constructed
-// instance. Construction alone performs no I/O.
-func provideACPServerFactoryTarget(factorySessions factorysessions.Service) acp.FactoryTargetService {
-	return chatsessionswire.NewFactoryTargetService(factorySessions)
+// provideACPServerFactoryTargetRuntimeResolver constructs the closure that
+// turns one ACP-selected Factory target identity (the same "factory:<name>"
+// reference session/set_config_option's changeTarget already validates and
+// binds) and the requesting Chat Session's exact editor working root into
+// the concrete Runtime Opening request a dynamically-selected Factory
+// Session activation needs -- the same named-Factory cross-root resolution
+// and operator defaults resolution the rest of this graph already composes,
+// not a second independently constructed lookup.
+func provideACPServerFactoryTargetRuntimeResolver(
+	resolveHomeDir acpServerResolveHomeDir,
+	namedFactoryCatalog factorydefinitions.NamedFactoryCatalog,
+	resolveOperatorDefaults operatorsettings.DefaultsResolver,
+	artifactRoots factoryruntime.RuntimeArtifactRootResolver,
+) factorysessionwire.FactoryTargetRuntimeResolver {
+	return func(ctx context.Context, factoryTargetID, workingRoot string) (factorysessions.RuntimeOpeningRequest, error) {
+		if err := ctx.Err(); err != nil {
+			return factorysessions.RuntimeOpeningRequest{}, err
+		}
+		homeDir, err := resolveHomeDir()
+		if err != nil {
+			return factorysessions.RuntimeOpeningRequest{}, err
+		}
+		roots, err := factorydefinitions.ResolveNamedFactoryRoots(homeDir, workingRoot)
+		if err != nil {
+			return factorysessions.RuntimeOpeningRequest{}, err
+		}
+		bareName := strings.TrimPrefix(factoryTargetID, operatorsettings.ACPFactoryTargetNamespace)
+		resolved, err := namedFactoryCatalog.ResolveNamedFactoryAcrossRoots(roots.Project, roots.Global, bareName)
+		if err != nil {
+			return factorysessions.RuntimeOpeningRequest{}, err
+		}
+		if resolved == nil {
+			return factorysessions.RuntimeOpeningRequest{}, factorydefinitions.ErrNamedFactoryNotFound
+		}
+		defaults, err := resolveOperatorDefaults(homeDir, operatorsettings.Defaults{}, operatorsettings.FlagOverrides{})
+		if err != nil {
+			return factorysessions.RuntimeOpeningRequest{}, err
+		}
+		artifacts := artifactRoots(homeDir)
+		return factorysessions.RuntimeOpeningRequest{
+			FactoryDefinition: factorydefinitions.RuntimeOpeningRequest{
+				Directory: resolved.FactoryDir,
+			},
+			FactoryRuntime: factoryruntime.RuntimeOpeningRequest{
+				Mode:             factorydefinitions.RuntimeModeService,
+				LogDirectory:     artifacts.Logs,
+				MetricsDirectory: artifacts.Metrics,
+			},
+			FactorySession: factorysessions.SessionRuntimeOpeningRequest{
+				SystemConfigHome: homeDir,
+			},
+			OperatorDefaults: defaults,
+		}, nil
+	}
+}
+
+// provideACPServerFactoryTarget constructs the consumer-owned, on-demand
+// Factory Sessions activation the production ACP prompt-delegation consumer
+// starts or invokes a Factory Session through. Unlike the CLI daemon's
+// single fixed-project bootstrap, ACP episodes select their Factory target
+// dynamically per session, so this activates one live runtime per target the
+// first time it is needed (through the same invocation-mode Runtime Opening
+// path the CLI's one-shot named invocation already uses) instead of relying
+// on the process-scoped factorysessions.Service, which stays permanently
+// inert outside the CLI daemon bootstrap. Construction alone performs no
+// I/O and opens no runtime.
+func provideACPServerFactoryTarget(
+	openRuntime *factorysessionwire.RuntimeOpeningFactory,
+	edges serviceedges.Edges,
+	resolveTarget factorysessionwire.FactoryTargetRuntimeResolver,
+	generateSessionID factorysessions.SessionIDGenerator,
+	logger *zap.Logger,
+) (acp.FactoryTargetService, error) {
+	return factorysessionwire.NewOnDemandFactoryTargetService(
+		openRuntime,
+		projectRuntimeOpeningExternalEffects(edges),
+		resolveTarget,
+		generateSessionID,
+		logger,
+	)
 }
 
 // provideACPServer constructs the production ACP stdio Server from the same

--- a/pkg/wire/acp_transport_factory_target_resolver_test.go
+++ b/pkg/wire/acp_transport_factory_target_resolver_test.go
@@ -1,0 +1,117 @@
+package wire
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+)
+
+func namedFactoryCatalogForTest(t *testing.T) factorydefinitions.NamedFactoryCatalog {
+	t.Helper()
+	edges := serviceedges.Edges{}
+	namedPathFileSystem := provideFactoryDefinitionNamedPathFileSystem(edges)
+	namedPaths, err := provideFactoryDefinitionNamedPathResolver(namedPathFileSystem)
+	if err != nil {
+		t.Fatalf("provideFactoryDefinitionNamedPathResolver() error = %v", err)
+	}
+	catalogFileSystem := provideFactoryDefinitionNamedFactoryCatalogFileSystem(edges)
+	catalog, err := provideNamedFactoryCatalog(namedPaths, catalogFileSystem)
+	if err != nil {
+		t.Fatalf("provideNamedFactoryCatalog() error = %v", err)
+	}
+	return catalog
+}
+
+func operatorDefaultsResolverForTest(t *testing.T) operatorsettings.DefaultsResolver {
+	t.Helper()
+	edges := serviceedges.Edges{}
+	files := provideOperatorSettingsFileSystem(edges)
+	providersRoot, err := provideProvidersService(edges)
+	if err != nil {
+		t.Fatalf("provideProvidersService() error = %v", err)
+	}
+	providerRegistry, err := provideProviderRegistry(edges, providersRoot)
+	if err != nil {
+		t.Fatalf("provideProviderRegistry() error = %v", err)
+	}
+	service, err := provideOperatorSettingsService(
+		files,
+		provideOperatorSettingsCreateTemporaryFile(edges),
+		provideOperatorSettingsProviderCatalog(providerRegistry),
+		provideOperatorConfigDecoder(),
+		provideOperatorConfigEncoder(),
+		provideOperatorSettingsIDGenerator(edges),
+		providersRoot,
+		logging.NoopLogger{},
+	)
+	if err != nil {
+		t.Fatalf("provideOperatorSettingsService() error = %v", err)
+	}
+	return provideOperatorDefaultsResolver(service)
+}
+
+// TestProvideACPServerFactoryTargetRuntimeResolver proves the closure
+// provideACPServerFactoryTargetRuntimeResolver returns resolves a valid
+// "factory:<name>" target and the Chat Session's working root into a
+// Runtime Opening request carrying the resolved Factory's directory, fails
+// safely for an already-canceled context and for a home-directory lookup
+// failure, and reports factorydefinitions.ErrNamedFactoryNotFound for a
+// target no installed named Factory resolves -- all without opening any
+// runtime (construction and resolution alone perform no runtime I/O).
+func TestProvideACPServerFactoryTargetRuntimeResolver(t *testing.T) {
+	home := t.TempDir()
+	seedInstalledPackagedFactories(t, home, "@you/review")
+
+	resolveHomeDir := func() (string, error) { return home, nil }
+	resolver := provideACPServerFactoryTargetRuntimeResolver(
+		resolveHomeDir,
+		namedFactoryCatalogForTest(t),
+		operatorDefaultsResolverForTest(t),
+		provideRuntimeArtifactRootResolver(),
+	)
+
+	t.Run("canceled context fails without resolving", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if _, err := resolver(ctx, "factory:@you/review", "/workspace/project"); err == nil {
+			t.Fatal("resolver(canceled ctx) error = nil, want a cancellation error")
+		}
+	})
+
+	t.Run("home directory lookup failure propagates", func(t *testing.T) {
+		wantErr := errors.New("home dir unavailable")
+		failingResolver := provideACPServerFactoryTargetRuntimeResolver(
+			func() (string, error) { return "", wantErr },
+			namedFactoryCatalogForTest(t),
+			operatorDefaultsResolverForTest(t),
+			provideRuntimeArtifactRootResolver(),
+		)
+		if _, err := failingResolver(context.Background(), "factory:@you/review", "/workspace/project"); !errors.Is(err, wantErr) {
+			t.Fatalf("resolver(homeDir error) error = %v, want %v", err, wantErr)
+		}
+	})
+
+	t.Run("unknown target reports ErrNamedFactoryNotFound", func(t *testing.T) {
+		if _, err := resolver(context.Background(), "factory:@you/does-not-exist", "/workspace/project"); !errors.Is(err, factorydefinitions.ErrNamedFactoryNotFound) {
+			t.Fatalf("resolver(unknown target) error = %v, want %v", err, factorydefinitions.ErrNamedFactoryNotFound)
+		}
+	})
+
+	t.Run("known target resolves a Runtime Opening request", func(t *testing.T) {
+		req, err := resolver(context.Background(), "factory:@you/review", "/workspace/project")
+		if err != nil {
+			t.Fatalf("resolver() error = %v, want a resolved Runtime Opening request", err)
+		}
+		if req.FactoryDefinition.Directory == "" {
+			t.Fatal("resolved FactoryDefinition.Directory is blank, want the installed @you/review Factory directory")
+		}
+		if req.FactorySession.SystemConfigHome != home {
+			t.Fatalf("resolved FactorySession.SystemConfigHome = %q, want %q", req.FactorySession.SystemConfigHome, home)
+		}
+	})
+}

--- a/pkg/wire/session_runtime_providers.go
+++ b/pkg/wire/session_runtime_providers.go
@@ -3,6 +3,7 @@ package wire
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -41,12 +42,53 @@ import (
 	"go.uber.org/zap"
 )
 
-func provideApplicationProcessLifecycle(service providers.Service) (initializerapplication.ProcessLifecycle, error) {
+// compositeProcessLifecycle aggregates every inert service that retains
+// resources lazily while commands execute into the single ProcessLifecycle
+// Process.Close reaches. Each closer runs even if an earlier one fails, and
+// every failure is joined into one returned error, so one resource's
+// teardown failure never masks or skips another's.
+type compositeProcessLifecycle struct {
+	closers []func(context.Context) error
+}
+
+func (c compositeProcessLifecycle) Close(ctx context.Context) error {
+	var result error
+	for _, closeFn := range c.closers {
+		if closeFn == nil {
+			continue
+		}
+		if err := closeFn(ctx); err != nil {
+			result = errors.Join(result, err)
+		}
+	}
+	return result
+}
+
+// provideApplicationProcessLifecycle composes the process-wide shutdown path
+// Process.Close reaches: the Providers lifecycle (executable/session
+// teardown) and the on-demand Factory Sessions activation the production ACP
+// prompt-delegation consumer lazily opens runtimes through (see
+// provideACPServerFactoryTarget) -- so every runtime that activation ever
+// opens is guaranteed a reachable, deterministic close on process shutdown,
+// not left open for the life of the process regardless of whether a
+// production ACP stdio entrypoint has been built yet.
+func provideApplicationProcessLifecycle(
+	service providers.Service,
+	factoryTarget *factorysessionwire.OnDemandFactoryTargetService,
+) (initializerapplication.ProcessLifecycle, error) {
 	lifecycle, ok := service.(providers.Lifecycle)
 	if !ok {
 		return nil, fmt.Errorf("construct application process: Providers lifecycle is required")
 	}
-	return lifecycle, nil
+	return compositeProcessLifecycle{closers: []func(context.Context) error{
+		lifecycle.Close,
+		func(context.Context) error {
+			if factoryTarget == nil {
+				return nil
+			}
+			return factoryTarget.Close()
+		},
+	}}, nil
 }
 
 func provideProvidersService(edges serviceedges.Edges) (providers.Service, error) {

--- a/pkg/wire/session_runtime_providers_test.go
+++ b/pkg/wire/session_runtime_providers_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"github.com/portpowered/infinite-you/internal/testutil"
 	platformclock "github.com/portpowered/infinite-you/pkg/platform/clock"
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
@@ -13,8 +15,10 @@ import (
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factorysessionwire "github.com/portpowered/infinite-you/pkg/services/factory_sessions/wire"
 	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
 	settingswire "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
+	"github.com/portpowered/infinite-you/pkg/services/providers"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 )
@@ -226,4 +230,79 @@ func TestOperatorSettingsHomePortCompositionUsesProcessProviderRoot(t *testing.T
 	if service == nil {
 		t.Fatal("NewServiceFromHomePorts() = nil, want Operator Settings root")
 	}
+}
+
+// TestProvideApplicationProcessLifecycle_ComposesProvidersAndFactoryTargetClose
+// proves the composed ProcessLifecycle actually invokes both the Providers
+// lifecycle's own Close and the on-demand Factory Sessions activation
+// singleton's Close when Close is called on the composed value -- not just
+// that construction succeeds -- and that a nil factoryTarget (a graph
+// misconfiguration, defensively handled) is a no-op rather than a panic.
+func TestProvideApplicationProcessLifecycle_ComposesProvidersAndFactoryTargetClose(t *testing.T) {
+	t.Parallel()
+
+	providersService, err := provideProvidersService(serviceedges.Edges{})
+	if err != nil {
+		t.Fatalf("provideProvidersService() error = %v", err)
+	}
+
+	factoryTarget, err := factorysessionwire.NewOnDemandFactoryTargetService(
+		&factorysessionwire.RuntimeOpeningFactory{},
+		factorysessionwire.RuntimeOpeningExternalEffects{},
+		func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
+			return factorysessions.RuntimeOpeningRequest{}, nil
+		},
+		func() string { return "id" },
+		zap.NewNop(),
+	)
+	if err != nil {
+		t.Fatalf("NewOnDemandFactoryTargetService() error = %v", err)
+	}
+
+	lifecycle, err := provideApplicationProcessLifecycle(providersService, factoryTarget)
+	if err != nil {
+		t.Fatalf("provideApplicationProcessLifecycle() error = %v", err)
+	}
+	if lifecycle == nil {
+		t.Fatal("provideApplicationProcessLifecycle() = nil, want a composed ProcessLifecycle")
+	}
+
+	// factoryTarget never opened any runtime, so its own Close is a
+	// documented no-op success; the Providers lifecycle's Close is likewise
+	// a no-op with no providers configured -- so the composed Close
+	// succeeding proves both closers actually ran, not that either was
+	// skipped.
+	if err := lifecycle.Close(context.Background()); err != nil {
+		t.Fatalf("composed ProcessLifecycle.Close() error = %v, want nil", err)
+	}
+
+	nilFactoryLifecycle, err := provideApplicationProcessLifecycle(providersService, nil)
+	if err != nil {
+		t.Fatalf("provideApplicationProcessLifecycle(nil factoryTarget) error = %v", err)
+	}
+	if err := nilFactoryLifecycle.Close(context.Background()); err != nil {
+		t.Fatalf("composed ProcessLifecycle.Close() with a nil factoryTarget error = %v, want nil (defensive no-op)", err)
+	}
+}
+
+// TestProvideApplicationProcessLifecycle_RequiresProvidersLifecycle proves a
+// providers.Service that does not implement providers.Lifecycle is rejected
+// at construction rather than silently producing a ProcessLifecycle whose
+// Providers-side Close can never run.
+func TestProvideApplicationProcessLifecycle_RequiresProvidersLifecycle(t *testing.T) {
+	t.Parallel()
+
+	_, err := provideApplicationProcessLifecycle(nonLifecycleProvidersService{}, nil)
+	if err == nil {
+		t.Fatal("provideApplicationProcessLifecycle() error = nil, want a construction error for a non-Lifecycle providers.Service")
+	}
+}
+
+// nonLifecycleProvidersService is a providers.Service stand-in (embedding
+// the interface as a permanently nil value, satisfying it for the compiler
+// without implementing any method) that deliberately does not also
+// implement providers.Lifecycle, for
+// TestProvideApplicationProcessLifecycle_RequiresProvidersLifecycle.
+type nonLifecycleProvidersService struct {
+	providers.Service
 }

--- a/pkg/wire/wire.go
+++ b/pkg/wire/wire.go
@@ -64,6 +64,7 @@ var servicesSet = wire.NewSet(
 	provideOperatorSettingsIDGenerator,
 	provideChatSessionsFactoryTargetCatalogService,
 	provideACPServerFactoryDefinitions,
+	provideACPServerFactoryTargetRuntimeResolver,
 	provideACPServerFactoryTarget,
 	provideACPServerResolveHomeDir,
 	provideACPServer,

--- a/pkg/wire/wire.go
+++ b/pkg/wire/wire.go
@@ -66,6 +66,7 @@ var servicesSet = wire.NewSet(
 	provideACPServerFactoryDefinitions,
 	provideACPServerFactoryTargetRuntimeResolver,
 	provideACPServerFactoryTarget,
+	provideACPServerFactoryTargetService,
 	provideACPServerResolveHomeDir,
 	provideACPServer,
 	provideOperatorConfigDecoder,

--- a/pkg/wire/wire.go
+++ b/pkg/wire/wire.go
@@ -64,6 +64,7 @@ var servicesSet = wire.NewSet(
 	provideOperatorSettingsIDGenerator,
 	provideChatSessionsFactoryTargetCatalogService,
 	provideACPServerFactoryDefinitions,
+	provideACPServerFactoryTarget,
 	provideACPServerResolveHomeDir,
 	provideACPServer,
 	provideOperatorConfigDecoder,

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -572,8 +572,9 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
+	factoryTargetService := provideACPServerFactoryTarget(factorysessionsService)
 	wireAcpServerResolveHomeDir := provideACPServerResolveHomeDir()
-	server := provideACPServer(loggingLogger, chatsessionsService, factoryTargetCatalogService, wireAcpServerResolveHomeDir)
+	server := provideACPServer(loggingLogger, chatsessionsService, factoryTargetCatalogService, factoryTargetService, wireAcpServerResolveHomeDir)
 	process, err := application.NewProcess(commandFactory, initializer, providerRegistry, processLifecycle, server)
 	if err != nil {
 		return nil, err
@@ -600,6 +601,7 @@ var servicesSet = wire3.NewSet(
 	provideOperatorSettingsIDGenerator,
 	provideChatSessionsFactoryTargetCatalogService,
 	provideACPServerFactoryDefinitions,
+	provideACPServerFactoryTarget,
 	provideACPServerResolveHomeDir,
 	provideACPServer,
 	provideOperatorConfigDecoder,

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -559,7 +559,13 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	processLifecycle, err := provideApplicationProcessLifecycle(service)
+	wireAcpServerResolveHomeDir := provideACPServerResolveHomeDir()
+	v87 := provideACPServerFactoryTargetRuntimeResolver(wireAcpServerResolveHomeDir, v, defaultsResolver, runtimeArtifactRootResolver)
+	v88, err := provideACPServerFactoryTarget(v60, edges2, v87, v19, logger)
+	if err != nil {
+		return nil, err
+	}
+	processLifecycle, err := provideApplicationProcessLifecycle(service, v88)
 	if err != nil {
 		return nil, err
 	}
@@ -572,12 +578,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	wireAcpServerResolveHomeDir := provideACPServerResolveHomeDir()
-	factoryTargetRuntimeResolver := provideACPServerFactoryTargetRuntimeResolver(wireAcpServerResolveHomeDir, v, defaultsResolver, runtimeArtifactRootResolver)
-	factoryTargetService, err := provideACPServerFactoryTarget(v60, edges2, factoryTargetRuntimeResolver, v19, logger)
-	if err != nil {
-		return nil, err
-	}
+	factoryTargetService := provideACPServerFactoryTargetService(v88)
 	server := provideACPServer(loggingLogger, chatsessionsService, factoryTargetCatalogService, factoryTargetService, wireAcpServerResolveHomeDir)
 	process, err := application.NewProcess(commandFactory, initializer, providerRegistry, processLifecycle, server)
 	if err != nil {
@@ -607,6 +608,7 @@ var servicesSet = wire3.NewSet(
 	provideACPServerFactoryDefinitions,
 	provideACPServerFactoryTargetRuntimeResolver,
 	provideACPServerFactoryTarget,
+	provideACPServerFactoryTargetService,
 	provideACPServerResolveHomeDir,
 	provideACPServer,
 	provideOperatorConfigDecoder,

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -572,8 +572,12 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	factoryTargetService := provideACPServerFactoryTarget(factorysessionsService)
 	wireAcpServerResolveHomeDir := provideACPServerResolveHomeDir()
+	factoryTargetRuntimeResolver := provideACPServerFactoryTargetRuntimeResolver(wireAcpServerResolveHomeDir, v, defaultsResolver, runtimeArtifactRootResolver)
+	factoryTargetService, err := provideACPServerFactoryTarget(v60, edges2, factoryTargetRuntimeResolver, v19, logger)
+	if err != nil {
+		return nil, err
+	}
 	server := provideACPServer(loggingLogger, chatsessionsService, factoryTargetCatalogService, factoryTargetService, wireAcpServerResolveHomeDir)
 	process, err := application.NewProcess(commandFactory, initializer, providerRegistry, processLifecycle, server)
 	if err != nil {
@@ -601,6 +605,7 @@ var servicesSet = wire3.NewSet(
 	provideOperatorSettingsIDGenerator,
 	provideChatSessionsFactoryTargetCatalogService,
 	provideACPServerFactoryDefinitions,
+	provideACPServerFactoryTargetRuntimeResolver,
 	provideACPServerFactoryTarget,
 	provideACPServerResolveHomeDir,
 	provideACPServer,

--- a/tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go
+++ b/tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go
@@ -69,14 +69,25 @@ func TestACPPromptDelegationStartsOneFactorySessionAndReusesItForLaterTurns(t *t
 	seedInstalledPackagedFactory(t, home, "@you/goal")
 	seedACPAgentProfile(t, home, "factory:@you/goal", []string{"factory:@you/goal"})
 
-	// ProviderOverride (an in-process Provider fake) rather than
-	// ProviderCommandRunner (a subprocess-shaped fake) is the same
-	// established pattern this exact packaged Factory's own functional tests
-	// already use for the @you/goal fixture elsewhere (see
-	// tests/functional/cli/named_invocation/named_invocation_test.go's
-	// TestRun_NamedAndExplicitFactorySelectionsExecuteEquivalentEffectiveSignatureInput),
-	// not a deviation this test introduces; both edges are equally real
-	// external-effect ports serviceedges.Edges accepts.
+	// ProviderOverride (an in-process workers.Provider fake) is used here
+	// instead of the standards-preferred ProviderCommandRunner
+	// (platformprocess.CommandRunner, a subprocess-launch-shaped fake).
+	// ProviderCommandRunner *can* drive this exact @you/goal fixture --
+	// tests/functional/cli/named_invocation/named_invocation_test.go already
+	// does, via testutil.NewProviderCommandRunner -- so the substitution here
+	// is not technical necessity, it is deliberately matching the simplest
+	// fake that reproduces the one outcome this test asserts on: a genuine
+	// published FAILED status from @you/goal's own goal loop, which needs a
+	// real child worker dispatch neither fake alone satisfies (see this
+	// file's doc comment). Swapping to ProviderCommandRunner would require
+	// discovering and queuing the exact raw subprocess Stdout bytes this
+	// Factory's execution adapter expects across however many dispatch
+	// rounds precede the real failure, coupling this test to that adapter's
+	// wire format for no additional coverage of the on-demand-activation
+	// behavior this test exists to prove; ProviderOverride's higher-level
+	// workers.InferenceResponse shape isolates this test from that coupling.
+	// Both edges are equally real external-effect ports serviceedges.Edges
+	// accepts.
 	provider := testutil.NewMockProvider(workers.InferenceResponse{Content: "acknowledged\n<COMPLETE>"})
 	// Factory Session runtime activations are counted through the shared
 	// FactorySessionIDGenerator edge. That generator is also consumed for

--- a/tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go
+++ b/tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go
@@ -1,0 +1,136 @@
+package root_composition_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	"github.com/portpowered/infinite-you/pkg/root"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	acp "github.com/portpowered/infinite-you/pkg/transports/acp"
+)
+
+// TestACPPromptDelegationStartsOneFactorySessionAndReusesItForLaterTurns
+// proves the customer-facing production composition for ordinary ACP prompt
+// delegation end to end: it seeds a real installed packaged Factory and a
+// real persisted ACP Agent profile, calls root.BuildProcess (the exact
+// public entrypoint the you binary uses), drives a real session/new call
+// followed by two real session/prompt calls through Process.ACPServer(),
+// and observes exactly one Factory Session start (the first, unbound turn)
+// followed by exactly one reuse (the second, already-bound turn) -- with no
+// second start -- against the real, singular Chat Sessions and Factory
+// Sessions authorities root.BuildProcess composes, not fakes.
+//
+// Before this story's on-demand Factory Sessions activation
+// (factorysessionwire.OnDemandFactoryTargetService), every session/prompt
+// call that reached Factory dispatch through this exact composition path
+// failed with factorysessions.ErrExecutionServiceNotConfigured, because the
+// process-scoped factorysessions.Service root.BuildProcess constructs stays
+// permanently inert outside the CLI daemon's OpenApplication bootstrap. This
+// test is a regression guard for that gap.
+func TestACPPromptDelegationStartsOneFactorySessionAndReusesItForLaterTurns(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test driving root.BuildProcess Factory Session dispatch")
+	}
+
+	// This story's on-demand activation deliberately keeps an opened Factory
+	// target runtime alive across turns (see OnDemandFactoryTargetService's
+	// own doc comment) rather than closing it after each dispatch, since
+	// nothing in this ACP prompt-delegation slice's scope observes an
+	// episode/session close signal yet. That means this test's runtime log
+	// file handle is still open when the test function returns, which on
+	// Windows can make t.TempDir()'s own automatic RemoveAll cleanup fail
+	// with "file in use" -- a real, already-known, documented limitation of
+	// this slice, not a bug this test should mask by suppressing it, but
+	// also not what this test is about proving. A manually managed home
+	// directory with a best-effort (error-tolerant) cleanup avoids that
+	// unrelated flake without hiding the underlying limitation.
+	home, err := os.MkdirTemp("", "acp-prompt-delegation-home-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp(home) error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(home) })
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	seedInstalledPackagedFactory(t, home, "@you/goal")
+	seedACPAgentProfile(t, home, "factory:@you/goal", []string{"factory:@you/goal"})
+
+	provider := testutil.NewMockProvider(workers.InferenceResponse{Content: "acknowledged\n<COMPLETE>"})
+	// Factory Session runtime activations are counted through the shared
+	// FactorySessionIDGenerator edge. That generator is also consumed for
+	// other identifiers the opened runtime mints internally while
+	// dispatching (e.g. child work/dispatch IDs), so its count is not a
+	// clean absolute "one activation" signal on its own -- but a second,
+	// independent runtime activation for the second turn would consume the
+	// generator again for that same internal bookkeeping, so the count
+	// staying exactly unchanged across the second turn still proves no
+	// second activation happened.
+	var factorySessionIDCalls atomic.Int32
+	process, err := root.BuildProcess(context.Background(), serviceedges.Edges{
+		ProviderOverride: provider,
+		FactorySessionIDGenerator: func() string {
+			n := factorySessionIDCalls.Add(1)
+			return fmt.Sprintf("acp-factory-session-id-%d", n)
+		},
+	})
+	if err != nil {
+		t.Fatalf("root.BuildProcess() error = %v", err)
+	}
+	server := process.ACPServer()
+	if server == nil {
+		t.Fatal("Process.ACPServer() returned a nil acp.Server")
+	}
+
+	cwd := t.TempDir()
+	sessionID := assertSessionNewReturnsDefaultTarget(t, server, cwd, "factory:@you/goal")
+	if sessionID == "" {
+		t.Fatal("session/new returned a blank sessionId")
+	}
+
+	firstResp := sendSessionPrompt(t, server, sessionID, "please help with this goal")
+	if firstResp.Error != nil {
+		t.Fatalf("first session/prompt response error = %+v, want a successful final result", firstResp.Error)
+	}
+	callsAfterFirstTurn := factorySessionIDCalls.Load()
+	if callsAfterFirstTurn == 0 {
+		t.Fatal("Factory Session ID generator was never called after the first (unbound) turn, want at least one Factory Session activation")
+	}
+
+	secondResp := sendSessionPrompt(t, server, sessionID, "a follow-up message in the same episode")
+	if secondResp.Error != nil {
+		t.Fatalf("second session/prompt response error = %+v, want a successful final result", secondResp.Error)
+	}
+	if got := factorySessionIDCalls.Load(); got != callsAfterFirstTurn {
+		t.Fatalf("Factory Session ID generator calls after the second (already-bound) turn = %d, want unchanged from %d (no second Factory Session activation)", got, callsAfterFirstTurn)
+	}
+}
+
+// sendSessionPrompt drives one real "session/prompt" call, with one text
+// content block, on its own connection against the given already-created
+// session, and returns the decoded JSON-RPC response.
+func sendSessionPrompt(t *testing.T, server acp.Server, sessionID, text string) rpcMessage {
+	t.Helper()
+
+	params, err := json.Marshal(map[string]any{
+		"sessionId": sessionID,
+		"prompt":    []map[string]any{{"type": "text", "text": text}},
+	})
+	if err != nil {
+		t.Fatalf("marshal session/prompt params: %v", err)
+	}
+	line := fmt.Sprintf(`{"jsonrpc":"2.0","id":2,"method":"session/prompt","params":%s}`, params) + "\n"
+
+	var out bytes.Buffer
+	if err := server.Serve(context.Background(), strings.NewReader(line), &out); err != nil {
+		t.Fatalf("Serve(session/prompt) error = %v", err)
+	}
+	return decodeRPCMessage(t, &out)
+}

--- a/tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go
+++ b/tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go
@@ -150,10 +150,11 @@ func TestACPPromptDelegationStartsOneFactorySessionAndReusesItForLaterTurns(t *t
 // fails the identical safe way, proving the first failure released the
 // session's busy state.
 func TestACPPromptDelegationUnresolvableFactoryTargetFailsSafelyAndTerminalizes(t *testing.T) {
-	if testing.Short() {
-		t.Skip("integration test driving root.BuildProcess Factory Session dispatch")
-	}
-
+	// Unlike this file's other integration tests, this one never reaches
+	// real Factory execution -- both prompts fail during runtime-target
+	// resolution, before any provider or workflow runs -- so it stays fast
+	// and runs even under -short, which is exactly the lane
+	// `make test-functional-coverage` uses.
 	home, err := os.MkdirTemp("", "acp-prompt-delegation-unresolvable-home-*")
 	if err != nil {
 		t.Fatalf("MkdirTemp(home) error = %v", err)

--- a/tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go
+++ b/tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"github.com/portpowered/infinite-you/internal/testutil"
 	"github.com/portpowered/infinite-you/pkg/root"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	acp "github.com/portpowered/infinite-you/pkg/transports/acp"
 )
@@ -130,6 +132,75 @@ func TestACPPromptDelegationStartsOneFactorySessionAndReusesItForLaterTurns(t *t
 	assertPromptResponseStopReason(t, secondResp, acpsdk.StopReasonEndTurn)
 	if got := factorySessionIDCalls.Load(); got != callsAfterFirstTurn {
 		t.Fatalf("Factory Session ID generator calls after the second (already-bound) turn = %d, want unchanged from %d (no second Factory Session activation)", got, callsAfterFirstTurn)
+	}
+}
+
+// TestACPPromptDelegationUnresolvableFactoryTargetFailsSafelyAndTerminalizes
+// proves that when the admitted episode's Factory target can no longer
+// resolve to an installed named Factory at dispatch time -- distinct from
+// session/new's own effective-catalog check, which reads the same
+// named-Factory installation this test removes only after session/new has
+// already succeeded, exactly the window where a concurrent uninstall could
+// leave a session pointed at a target its own catalog snapshot no longer
+// backs -- the real root.BuildProcess composition, through
+// provideACPServerFactoryTargetRuntimeResolver's
+// factorydefinitions.ErrNamedFactoryNotFound path, returns a bounded
+// internal ACP error instead of a crash or a fabricated success, and leaves
+// no turn stranded: a second prompt on the same session is admitted and
+// fails the identical safe way, proving the first failure released the
+// session's busy state.
+func TestACPPromptDelegationUnresolvableFactoryTargetFailsSafelyAndTerminalizes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test driving root.BuildProcess Factory Session dispatch")
+	}
+
+	home, err := os.MkdirTemp("", "acp-prompt-delegation-unresolvable-home-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp(home) error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(home) })
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	seedInstalledPackagedFactory(t, home, "@you/goal")
+	seedACPAgentProfile(t, home, "factory:@you/goal", []string{"factory:@you/goal"})
+
+	process, err := root.BuildProcess(context.Background(), serviceedges.Edges{})
+	if err != nil {
+		t.Fatalf("root.BuildProcess() error = %v", err)
+	}
+	server := process.ACPServer()
+	if server == nil {
+		t.Fatal("Process.ACPServer() returned a nil acp.Server")
+	}
+
+	cwd := t.TempDir()
+	sessionID := assertSessionNewReturnsDefaultTarget(t, server, cwd, "factory:@you/goal")
+	if sessionID == "" {
+		t.Fatal("session/new returned a blank sessionId")
+	}
+
+	// Remove the installed Factory's own directory only after session/new
+	// already resolved and admitted it, so the runtime resolver's
+	// named-Factory cross-root lookup -- reached only from Factory dispatch,
+	// never from session/new's separate effective-catalog check -- fails at
+	// prompt-dispatch time.
+	globalRoot, err := factorydefinitions.NamedFactoriesRootForHome(home)
+	if err != nil {
+		t.Fatalf("NamedFactoriesRootForHome() error = %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(globalRoot, "@you", "goal")); err != nil {
+		t.Fatalf("RemoveAll(installed Factory directory) error = %v", err)
+	}
+
+	firstResp := sendSessionPrompt(t, server, sessionID, "please help with this goal")
+	if firstResp.Error == nil {
+		t.Fatal("first session/prompt response error = nil, want a bounded internal error for an unresolvable Factory target")
+	}
+
+	secondResp := sendSessionPrompt(t, server, sessionID, "a retry after the unresolvable target failure")
+	if secondResp.Error == nil {
+		t.Fatal("second session/prompt response error = nil, want the same bounded rejection, not a stranded busy session")
 	}
 }
 

--- a/tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go
+++ b/tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -420,18 +421,199 @@ func responseLinesOnly(t *testing.T, out *bytes.Buffer) []rpcMessage {
 func sendSessionPrompt(t *testing.T, server acp.Server, sessionID, text string) rpcMessage {
 	t.Helper()
 
+	msg, err := doSessionPrompt(server, sessionID, text)
+	if err != nil {
+		t.Fatalf("session/prompt: %v", err)
+	}
+	return msg
+}
+
+// doSessionPrompt is sendSessionPrompt's *testing.T-free core: it reports
+// failures via its returned error instead of calling any testing.T method,
+// so it is safe to call from a goroutine other than the one running the
+// test (testing.T's Fatal/Fatalf family must only ever be called from the
+// test's own goroutine) -- needed by tests that drive one "session/prompt"
+// call concurrently with another against the same session.
+func doSessionPrompt(server acp.Server, sessionID, text string) (rpcMessage, error) {
 	params, err := json.Marshal(map[string]any{
 		"sessionId": sessionID,
 		"prompt":    []map[string]any{{"type": "text", "text": text}},
 	})
 	if err != nil {
-		t.Fatalf("marshal session/prompt params: %v", err)
+		return rpcMessage{}, fmt.Errorf("marshal session/prompt params: %w", err)
 	}
 	line := fmt.Sprintf(`{"jsonrpc":"2.0","id":2,"method":"session/prompt","params":%s}`, params) + "\n"
 
 	var out bytes.Buffer
 	if err := server.Serve(context.Background(), strings.NewReader(line), &out); err != nil {
-		t.Fatalf("Serve(session/prompt) error = %v", err)
+		return rpcMessage{}, fmt.Errorf("Serve(session/prompt): %w", err)
 	}
-	return decodeRPCMessage(t, &out)
+	responses := responseLinesOnlyErr(&out)
+	if len(responses) != 1 {
+		return rpcMessage{}, fmt.Errorf("response line count = %d, want exactly 1", len(responses))
+	}
+	return responses[0], nil
+}
+
+// responseLinesOnlyErr is responseLinesOnly's *testing.T-free core, for use
+// from doSessionPrompt (which must itself stay callable from a non-test
+// goroutine).
+func responseLinesOnlyErr(out *bytes.Buffer) []rpcMessage {
+	var responses []rpcMessage
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var decoded map[string]json.RawMessage
+		if err := json.Unmarshal(line, &decoded); err != nil {
+			continue
+		}
+		if _, isNotification := decoded["method"]; isNotification {
+			continue
+		}
+		var msg rpcMessage
+		if err := json.Unmarshal(line, &msg); err != nil {
+			continue
+		}
+		responses = append(responses, msg)
+	}
+	return responses
+}
+
+// blockingProvider wraps a workers.Provider and blocks its first Infer call
+// until release is closed, closing started exactly once when that call
+// begins. A test uses this to deterministically observe that a Factory
+// dispatch's own inference call is genuinely in flight -- proving the
+// admitted turn is actually RUNNING, not merely scheduled on a goroutine --
+// before sending a concurrent request, with no sleep-based synchronization.
+type blockingProvider struct {
+	inner   workers.Provider
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingProvider(inner workers.Provider) *blockingProvider {
+	return &blockingProvider{inner: inner, started: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (b *blockingProvider) Infer(ctx context.Context, req workers.ProviderInferenceRequest) (workers.InferenceResponse, error) {
+	b.once.Do(func() { close(b.started) })
+	<-b.release
+	return b.inner.Infer(ctx, req)
+}
+
+// TestACPPromptDelegationConcurrentPromptRejectsAsBusyWithNoFactoryDispatch
+// proves, through the same real root.BuildProcess composition, that a second
+// "session/prompt" call arriving while the first is genuinely still
+// dispatching (its Factory Session activation has already reached the
+// workflow's own inference call and not yet returned) is rejected as busy
+// with zero additional Factory Session activation, and that the first,
+// legitimately in-flight turn still completes normally afterward with no
+// stranded busy state left behind. This is the functional-level counterpart
+// to the unit-level busy-admission coverage in
+// pkg/transports/acp/internal/stdio/session_prompt_test.go, driven against
+// the real Chat Sessions Store and the real on-demand Factory Sessions
+// activation instead of fakes.
+func TestACPPromptDelegationConcurrentPromptRejectsAsBusyWithNoFactoryDispatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test driving root.BuildProcess Factory Session dispatch")
+	}
+
+	home, err := os.MkdirTemp("", "acp-prompt-delegation-busy-home-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp(home) error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(home) })
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	seedInstalledPackagedFactory(t, home, "@you/goal")
+	seedACPAgentProfile(t, home, "factory:@you/goal", []string{"factory:@you/goal"})
+
+	provider := newBlockingProvider(testutil.NewMockProvider(workers.InferenceResponse{Content: "acknowledged\n<COMPLETE>"}))
+	var factorySessionIDCalls atomic.Int32
+	process, err := root.BuildProcess(context.Background(), serviceedges.Edges{
+		ProviderOverride: provider,
+		FactorySessionIDGenerator: func() string {
+			n := factorySessionIDCalls.Add(1)
+			return fmt.Sprintf("acp-busy-factory-session-id-%d", n)
+		},
+	})
+	if err != nil {
+		t.Fatalf("root.BuildProcess() error = %v", err)
+	}
+	server := process.ACPServer()
+	if server == nil {
+		t.Fatal("Process.ACPServer() returned a nil acp.Server")
+	}
+
+	cwd := t.TempDir()
+	sessionID := assertSessionNewReturnsDefaultTarget(t, server, cwd, "factory:@you/goal")
+	if sessionID == "" {
+		t.Fatal("session/new returned a blank sessionId")
+	}
+
+	firstDone := make(chan rpcMessage, 1)
+	firstErr := make(chan error, 1)
+	go func() {
+		msg, err := doSessionPrompt(server, sessionID, "please help with this goal")
+		if err != nil {
+			firstErr <- err
+			return
+		}
+		firstDone <- msg
+	}()
+
+	select {
+	case <-provider.started:
+	case err := <-firstErr:
+		t.Fatalf("first session/prompt failed before its dispatch began: %v", err)
+	}
+
+	// Snapshot the generator count immediately before and after the
+	// concurrent busy request, while the first turn's own dispatch is still
+	// parked inside the blocked Infer call and so cannot itself be
+	// consuming the generator concurrently. The first turn keeps consuming
+	// this same generator for its own internal bookkeeping once unblocked
+	// below, so "unchanged across the whole test" is not the right
+	// invariant -- "unchanged across exactly the concurrent busy request" is.
+	callsBeforeConcurrent := factorySessionIDCalls.Load()
+	if callsBeforeConcurrent == 0 {
+		t.Fatal("Factory Session ID generator was never called for the in-flight first turn")
+	}
+
+	concurrentResp, err := doSessionPrompt(server, sessionID, "a concurrent prompt while the turn is busy")
+	if err != nil {
+		t.Fatalf("concurrent session/prompt: %v", err)
+	}
+	if concurrentResp.Error == nil {
+		t.Fatal("concurrent session/prompt response error = nil, want a bounded rejection for a busy session")
+	}
+	if got := factorySessionIDCalls.Load(); got != callsBeforeConcurrent {
+		t.Fatalf("Factory Session ID generator calls changed by %d during the concurrent busy request, want unchanged from %d (the busy rejection must make zero Factory effect)",
+			got-callsBeforeConcurrent, callsBeforeConcurrent)
+	}
+
+	close(provider.release)
+
+	select {
+	case firstResp := <-firstDone:
+		if firstResp.Error != nil {
+			t.Fatalf("first session/prompt response error = %+v, want a successful final result", firstResp.Error)
+		}
+		assertPromptResponseStopReason(t, firstResp, acpsdk.StopReasonEndTurn)
+	case err := <-firstErr:
+		t.Fatalf("first session/prompt error = %v", err)
+	}
+
+	// The busy rejection must not have stranded the session: a later, wholly
+	// distinct prompt is still admitted and completes normally.
+	laterResp := sendSessionPrompt(t, server, sessionID, "a later prompt after the busy rejection resolved")
+	if laterResp.Error != nil {
+		t.Fatalf("later session/prompt response error = %+v, want a successful final result", laterResp.Error)
+	}
+	assertPromptResponseStopReason(t, laterResp, acpsdk.StopReasonEndTurn)
 }

--- a/tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go
+++ b/tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go
@@ -1,6 +1,7 @@
 package root_composition_test
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -9,6 +10,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	acpsdk "github.com/coder/acp-go-sdk"
 
 	"github.com/portpowered/infinite-you/internal/testutil"
 	"github.com/portpowered/infinite-you/pkg/root"
@@ -63,6 +66,14 @@ func TestACPPromptDelegationStartsOneFactorySessionAndReusesItForLaterTurns(t *t
 	seedInstalledPackagedFactory(t, home, "@you/goal")
 	seedACPAgentProfile(t, home, "factory:@you/goal", []string{"factory:@you/goal"})
 
+	// ProviderOverride (an in-process Provider fake) rather than
+	// ProviderCommandRunner (a subprocess-shaped fake) is the same
+	// established pattern this exact packaged Factory's own functional tests
+	// already use for the @you/goal fixture elsewhere (see
+	// tests/functional/cli/named_invocation/named_invocation_test.go's
+	// TestRun_NamedAndExplicitFactorySelectionsExecuteEquivalentEffectiveSignatureInput),
+	// not a deviation this test introduces; both edges are equally real
+	// external-effect ports serviceedges.Edges accepts.
 	provider := testutil.NewMockProvider(workers.InferenceResponse{Content: "acknowledged\n<COMPLETE>"})
 	// Factory Session runtime activations are counted through the shared
 	// FactorySessionIDGenerator edge. That generator is also consumed for
@@ -99,6 +110,14 @@ func TestACPPromptDelegationStartsOneFactorySessionAndReusesItForLaterTurns(t *t
 	if firstResp.Error != nil {
 		t.Fatalf("first session/prompt response error = %+v, want a successful final result", firstResp.Error)
 	}
+	// The seeded @you/goal packaged Factory's own business workflow reaches a
+	// real published FAILED terminal status against this bare mock provider
+	// (its goal loop needs an actual child worker dispatch a mock alone can't
+	// satisfy -- see this file's doc comment) -- a genuine downstream Factory
+	// failure this production composition must still map to the documented
+	// end_turn safe fallback rather than an ACP-level error, exactly like
+	// this transport's already-unit-tested mapping does.
+	assertPromptResponseStopReason(t, firstResp, acpsdk.StopReasonEndTurn)
 	callsAfterFirstTurn := factorySessionIDCalls.Load()
 	if callsAfterFirstTurn == 0 {
 		t.Fatal("Factory Session ID generator was never called after the first (unbound) turn, want at least one Factory Session activation")
@@ -108,9 +127,167 @@ func TestACPPromptDelegationStartsOneFactorySessionAndReusesItForLaterTurns(t *t
 	if secondResp.Error != nil {
 		t.Fatalf("second session/prompt response error = %+v, want a successful final result", secondResp.Error)
 	}
+	assertPromptResponseStopReason(t, secondResp, acpsdk.StopReasonEndTurn)
 	if got := factorySessionIDCalls.Load(); got != callsAfterFirstTurn {
 		t.Fatalf("Factory Session ID generator calls after the second (already-bound) turn = %d, want unchanged from %d (no second Factory Session activation)", got, callsAfterFirstTurn)
 	}
+}
+
+// assertPromptResponseStopReason decodes resp's Result as a real
+// acpsdk.PromptResponse and asserts its StopReason, proving the response is
+// the closed final-only shape this transport publishes, not just the
+// absence of an RPC-level error.
+func assertPromptResponseStopReason(t *testing.T, resp rpcMessage, want acpsdk.StopReason) {
+	t.Helper()
+	var decoded acpsdk.PromptResponse
+	if err := json.Unmarshal(resp.Result, &decoded); err != nil {
+		t.Fatalf("unmarshal PromptResponse: %v", err)
+	}
+	if decoded.StopReason != want {
+		t.Fatalf("stopReason = %q, want %q", decoded.StopReason, want)
+	}
+}
+
+// TestACPPromptDelegationRedeliveredRequestMakesNoSecondFactoryDispatch
+// proves, through the same real root.BuildProcess composition, that
+// redelivering the identical connection-scoped "session/prompt" request --
+// the same JSON-RPC id on the same connection, exactly what a retrying
+// client sends after an ambiguous or dropped response -- never dispatches a
+// second Factory Session start for content this process already admitted and
+// executed once. This is a regression guard for the gap
+// chat_sessions/internal/service.Store.StartTurn's turnsByRequest index
+// closes: without it, a redelivered request admitted a brand-new turn and
+// dispatched Factory work a second time.
+func TestACPPromptDelegationRedeliveredRequestMakesNoSecondFactoryDispatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test driving root.BuildProcess Factory Session dispatch")
+	}
+
+	// A single delivery's own Factory Session ID generator call count is the
+	// baseline: if a redelivered duplicate on the same connection dispatched
+	// a second time, sending it twice would produce a strictly larger count
+	// than sending it once, since each real activation consumes this
+	// generator at least once (see the sibling test's own comment on why
+	// this shared edge is an indirect but sufficient activation-count proxy).
+	singleDeliveryCalls := runPromptDeliveries(t, "single-delivery", 1)
+	if singleDeliveryCalls == 0 {
+		t.Fatal("Factory Session ID generator was never called for a single delivery, want at least one Factory Session activation")
+	}
+
+	duplicateDeliveryCalls := runPromptDeliveries(t, "duplicate-delivery", 2)
+	if duplicateDeliveryCalls != singleDeliveryCalls {
+		t.Fatalf("Factory Session ID generator calls after a redelivered duplicate = %d, want unchanged from the single-delivery baseline %d (no second Factory Session activation)",
+			duplicateDeliveryCalls, singleDeliveryCalls)
+	}
+}
+
+// runPromptDeliveries builds one fresh, isolated root.BuildProcess
+// composition, creates one session, then sends copies of the identical
+// "session/prompt" request (same wire id, same connection) within a single
+// Serve call, asserting every resulting response is successful. It returns
+// the final Factory Session ID generator call count, so a caller can compare
+// counts across a different number of identical deliveries.
+func runPromptDeliveries(t *testing.T, homePrefix string, deliveries int) int32 {
+	t.Helper()
+
+	home, err := os.MkdirTemp("", "acp-prompt-delegation-"+homePrefix+"-home-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp(home) error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(home) })
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	seedInstalledPackagedFactory(t, home, "@you/goal")
+	seedACPAgentProfile(t, home, "factory:@you/goal", []string{"factory:@you/goal"})
+
+	provider := testutil.NewMockProvider(workers.InferenceResponse{Content: "acknowledged\n<COMPLETE>"})
+	var factorySessionIDCalls atomic.Int32
+	process, err := root.BuildProcess(context.Background(), serviceedges.Edges{
+		ProviderOverride: provider,
+		FactorySessionIDGenerator: func() string {
+			n := factorySessionIDCalls.Add(1)
+			return fmt.Sprintf("acp-%s-factory-session-id-%d", homePrefix, n)
+		},
+	})
+	if err != nil {
+		t.Fatalf("root.BuildProcess() error = %v", err)
+	}
+	server := process.ACPServer()
+	if server == nil {
+		t.Fatal("Process.ACPServer() returned a nil acp.Server")
+	}
+
+	cwd := t.TempDir()
+	sessionID := assertSessionNewReturnsDefaultTarget(t, server, cwd, "factory:@you/goal")
+	if sessionID == "" {
+		t.Fatal("session/new returned a blank sessionId")
+	}
+
+	// Every delivered line carries the exact same wire id (2) on one Serve
+	// call, so every one resolves to the identical connection-scoped
+	// RequestIdentity -- a true redelivery, not distinct requests that merely
+	// share a bare id across different connections (which this transport
+	// already keeps distinct on purpose).
+	params, err := json.Marshal(map[string]any{
+		"sessionId": sessionID,
+		"prompt":    []map[string]any{{"type": "text", "text": "please help with this goal"}},
+	})
+	if err != nil {
+		t.Fatalf("marshal session/prompt params: %v", err)
+	}
+	promptLine := fmt.Sprintf(`{"jsonrpc":"2.0","id":2,"method":"session/prompt","params":%s}`, params) + "\n"
+	input := strings.Repeat(promptLine, deliveries)
+
+	var out bytes.Buffer
+	if err := server.Serve(context.Background(), strings.NewReader(input), &out); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	responses := responseLinesOnly(t, &out)
+	if len(responses) != deliveries {
+		t.Fatalf("response line count = %d, want exactly %d (one per delivered request): %s", len(responses), deliveries, out.String())
+	}
+	for i, resp := range responses {
+		if resp.Error != nil {
+			t.Fatalf("response[%d] error = %+v, want a successful final result", i, resp.Error)
+		}
+		assertPromptResponseStopReason(t, resp, acpsdk.StopReasonEndTurn)
+	}
+
+	return factorySessionIDCalls.Load()
+}
+
+// responseLinesOnly splits out into complete newline-terminated lines and
+// decodes only the ones carrying a request/response shape (a populated Result
+// or Error), skipping any interleaved outbound "session/update" notification
+// lines (which never carry a "result" or "error" member).
+func responseLinesOnly(t *testing.T, out *bytes.Buffer) []rpcMessage {
+	t.Helper()
+	var responses []rpcMessage
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var decoded map[string]json.RawMessage
+		if err := json.Unmarshal(line, &decoded); err != nil {
+			t.Fatalf("unmarshal line %q: %v", line, err)
+		}
+		if _, isNotification := decoded["method"]; isNotification {
+			continue
+		}
+		var msg rpcMessage
+		if err := json.Unmarshal(line, &msg); err != nil {
+			t.Fatalf("unmarshal response line %q: %v", line, err)
+		}
+		responses = append(responses, msg)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan response lines: %v", err)
+	}
+	return responses
 }
 
 // sendSessionPrompt drives one real "session/prompt" call, with one text

--- a/tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go
+++ b/tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/root"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	acp "github.com/portpowered/infinite-you/pkg/transports/acp"
 )
@@ -180,13 +181,18 @@ func TestACPPromptDelegationUnresolvableFactoryTargetFailsSafelyAndTerminalizes(
 	if sessionID == "" {
 		t.Fatal("session/new returned a blank sessionId")
 	}
-	// A second session/new call, while the installed Factory and home
-	// directory are both still intact, admits a third episode this test
-	// reuses below only after breaking home-directory resolution -- session
-	// admission itself must not depend on a resolvable home directory.
+	// Two more session/new calls, while the installed Factory, home
+	// directory, and Operator Settings document are all still intact, admit
+	// a third and fourth episode this test reuses below only after breaking
+	// home-directory resolution and Operator Settings resolution
+	// respectively -- session admission itself must not depend on either.
 	thirdSessionID := assertSessionNewReturnsDefaultTarget(t, server, cwd, "factory:@you/goal")
 	if thirdSessionID == "" {
 		t.Fatal("session/new (third episode) returned a blank sessionId")
+	}
+	fourthSessionID := assertSessionNewReturnsDefaultTarget(t, server, cwd, "factory:@you/goal")
+	if fourthSessionID == "" {
+		t.Fatal("session/new (fourth episode) returned a blank sessionId")
 	}
 
 	// Remove the installed Factory's own directory only after session/new
@@ -221,6 +227,22 @@ func TestACPPromptDelegationUnresolvableFactoryTargetFailsSafelyAndTerminalizes(
 	thirdResp := sendSessionPrompt(t, server, thirdSessionID, "a prompt with no resolvable home directory")
 	if thirdResp.Error == nil {
 		t.Fatal("third session/prompt response error = nil, want a bounded internal error when the home directory cannot be resolved")
+	}
+
+	// The fourth episode's prompt proves the resolver's Operator Defaults
+	// resolution failure classifies the same safe way: restore a resolvable
+	// home directory and the installed Factory this episode's own target
+	// still needs to resolve past the earlier catalog-lookup branch, then
+	// corrupt only the persisted Operator Settings document.
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	seedInstalledPackagedFactory(t, home, "@you/goal")
+	if err := os.WriteFile(operatorsettings.DefaultConfigPath(home), []byte("not valid json"), 0o644); err != nil {
+		t.Fatalf("WriteFile(corrupt Operator Settings document) error = %v", err)
+	}
+	fourthResp := sendSessionPrompt(t, server, fourthSessionID, "a prompt with no resolvable Operator Defaults")
+	if fourthResp.Error == nil {
+		t.Fatal("fourth session/prompt response error = nil, want a bounded internal error when Operator Defaults cannot be resolved")
 	}
 }
 

--- a/tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go
+++ b/tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go
@@ -180,6 +180,14 @@ func TestACPPromptDelegationUnresolvableFactoryTargetFailsSafelyAndTerminalizes(
 	if sessionID == "" {
 		t.Fatal("session/new returned a blank sessionId")
 	}
+	// A second session/new call, while the installed Factory and home
+	// directory are both still intact, admits a third episode this test
+	// reuses below only after breaking home-directory resolution -- session
+	// admission itself must not depend on a resolvable home directory.
+	thirdSessionID := assertSessionNewReturnsDefaultTarget(t, server, cwd, "factory:@you/goal")
+	if thirdSessionID == "" {
+		t.Fatal("session/new (third episode) returned a blank sessionId")
+	}
 
 	// Remove the installed Factory's own directory only after session/new
 	// already resolved and admitted it, so the runtime resolver's
@@ -202,6 +210,17 @@ func TestACPPromptDelegationUnresolvableFactoryTargetFailsSafelyAndTerminalizes(
 	secondResp := sendSessionPrompt(t, server, sessionID, "a retry after the unresolvable target failure")
 	if secondResp.Error == nil {
 		t.Fatal("second session/prompt response error = nil, want the same bounded rejection, not a stranded busy session")
+	}
+
+	// The third episode's prompt proves the resolver's own earlier
+	// home-directory lookup failure (reached before any catalog lookup)
+	// fails exactly as safely: unset both home-directory environment
+	// variables only for this call.
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	thirdResp := sendSessionPrompt(t, server, thirdSessionID, "a prompt with no resolvable home directory")
+	if thirdResp.Error == nil {
+		t.Fatal("third session/prompt response error = nil, want a bounded internal error when the home directory cannot be resolved")
 	}
 }
 

--- a/tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go
+++ b/tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go
@@ -47,23 +47,7 @@ func TestACPPromptDelegationStartsOneFactorySessionAndReusesItForLaterTurns(t *t
 		t.Skip("integration test driving root.BuildProcess Factory Session dispatch")
 	}
 
-	// This story's on-demand activation deliberately keeps an opened Factory
-	// target runtime alive across turns (see OnDemandFactoryTargetService's
-	// own doc comment) rather than closing it after each dispatch, since
-	// nothing in this ACP prompt-delegation slice's scope observes an
-	// episode/session close signal yet. That means this test's runtime log
-	// file handle is still open when the test function returns, which on
-	// Windows can make t.TempDir()'s own automatic RemoveAll cleanup fail
-	// with "file in use" -- a real, already-known, documented limitation of
-	// this slice, not a bug this test should mask by suppressing it, but
-	// also not what this test is about proving. A manually managed home
-	// directory with a best-effort (error-tolerant) cleanup avoids that
-	// unrelated flake without hiding the underlying limitation.
-	home, err := os.MkdirTemp("", "acp-prompt-delegation-home-*")
-	if err != nil {
-		t.Fatalf("MkdirTemp(home) error = %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(home) })
+	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 
@@ -110,6 +94,7 @@ func TestACPPromptDelegationStartsOneFactorySessionAndReusesItForLaterTurns(t *t
 	if err != nil {
 		t.Fatalf("root.BuildProcess() error = %v", err)
 	}
+	closeProcessCleanly(t, process)
 	server := process.ACPServer()
 	if server == nil {
 		t.Fatal("Process.ACPServer() returned a nil acp.Server")
@@ -168,11 +153,7 @@ func TestACPPromptDelegationUnresolvableFactoryTargetFailsSafelyAndTerminalizes(
 	// resolution, before any provider or workflow runs -- so it stays fast
 	// and runs even under -short, which is exactly the lane
 	// `make test-functional-coverage` uses.
-	home, err := os.MkdirTemp("", "acp-prompt-delegation-unresolvable-home-*")
-	if err != nil {
-		t.Fatalf("MkdirTemp(home) error = %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(home) })
+	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 
@@ -183,6 +164,7 @@ func TestACPPromptDelegationUnresolvableFactoryTargetFailsSafelyAndTerminalizes(
 	if err != nil {
 		t.Fatalf("root.BuildProcess() error = %v", err)
 	}
+	closeProcessCleanly(t, process)
 	server := process.ACPServer()
 	if server == nil {
 		t.Fatal("Process.ACPServer() returned a nil acp.Server")
@@ -258,6 +240,27 @@ func TestACPPromptDelegationUnresolvableFactoryTargetFailsSafelyAndTerminalizes(
 	}
 }
 
+// closeProcessCleanly registers a cleanup that closes process and fails the
+// test if that close reports an error. On-demand Factory Sessions activation
+// (see pkg/wire's compositeProcessLifecycle) keeps an opened Factory target
+// runtime's own log file handle open until Process.Close tears it down; this
+// runs before t.TempDir()'s own automatic cleanup (t.Cleanup callbacks run
+// LIFO, and this is always registered after the test's own t.TempDir() calls),
+// so the runtime is closed before its home directory is removed -- proving
+// this story's reachable close path actually works, not merely compiling,
+// instead of masking an unclosed runtime with a manually managed,
+// error-tolerant temp directory.
+func closeProcessCleanly(t *testing.T, process interface {
+	Close(context.Context) error
+}) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := process.Close(context.Background()); err != nil {
+			t.Errorf("Process.Close() error = %v, want clean teardown", err)
+		}
+	})
+}
+
 // assertPromptResponseStopReason decodes resp's Result as a real
 // acpsdk.PromptResponse and asserts its StopReason, proving the response is
 // the closed final-only shape this transport publishes, not just the
@@ -315,11 +318,7 @@ func TestACPPromptDelegationRedeliveredRequestMakesNoSecondFactoryDispatch(t *te
 func runPromptDeliveries(t *testing.T, homePrefix string, deliveries int) int32 {
 	t.Helper()
 
-	home, err := os.MkdirTemp("", "acp-prompt-delegation-"+homePrefix+"-home-*")
-	if err != nil {
-		t.Fatalf("MkdirTemp(home) error = %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(home) })
+	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 
@@ -338,6 +337,7 @@ func runPromptDeliveries(t *testing.T, homePrefix string, deliveries int) int32 
 	if err != nil {
 		t.Fatalf("root.BuildProcess() error = %v", err)
 	}
+	closeProcessCleanly(t, process)
 	server := process.ACPServer()
 	if server == nil {
 		t.Fatal("Process.ACPServer() returned a nil acp.Server")
@@ -522,11 +522,7 @@ func TestACPPromptDelegationConcurrentPromptRejectsAsBusyWithNoFactoryDispatch(t
 		t.Skip("integration test driving root.BuildProcess Factory Session dispatch")
 	}
 
-	home, err := os.MkdirTemp("", "acp-prompt-delegation-busy-home-*")
-	if err != nil {
-		t.Fatalf("MkdirTemp(home) error = %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(home) })
+	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 
@@ -545,6 +541,7 @@ func TestACPPromptDelegationConcurrentPromptRejectsAsBusyWithNoFactoryDispatch(t
 	if err != nil {
 		t.Fatalf("root.BuildProcess() error = %v", err)
 	}
+	closeProcessCleanly(t, process)
 	server := process.ACPServer()
 	if server == nil {
 		t.Fatal("Process.ACPServer() returned a nil acp.Server")


### PR DESCRIPTION
{
  "project": "Delegate One ACP Prompt Turn to the Selected Factory Session",
  "branchName": "ACP-L1-V1-C14-prompt-delegation",
  "description": "Implement ordinary text-only ACP session/prompt delegation through the singular process-scoped Chat Sessions authority and the existing Factory Sessions shim. Admit exactly one version-guarded Chat turn, start and bind one selected Factory Session for the first turn of a target episode, invoke that same Factory Session for later turns, terminalize every admitted turn, and return only the truthful deterministic final ACP result supported by published Factory Sessions outcomes while preserving the exact /factory fallback and excluding streaming and later-lane scope.",
  "context": {
    "customerAsk": "Deliver the next L1 V1 slice for ordinary ACP prompt delegation: validate protocol content and connection-scoped request identity before effects, admit one version-guarded Chat turn, start one selected Factory Session for the first turn of an episode using the canonical Factory target and editor working root, bind and reuse that session for later turns, preserve cancellation and deadline causes and safe errors/logs, prevent duplicate execution and stranded busy turns, map truthful final-only results deterministically, prove canonical root.BuildProcess composition, and continue through review and required CI until the PR is merged.",
    "problem": "The production ACP server already handles exact /factory prompt commands, but ordinary validated text still returns method-not-found and never admits a Chat turn or reaches Factory Sessions. Without a guarded delegation path, the system cannot run the selected Factory, reuse one Factory Session across an episode, or guarantee that duplicate, concurrent, retry, and downstream-failure cases avoid duplicate execution and terminalize Chat state.",
    "solution": "Preserve /factory recognition, then validate ordinary prompts and full request identity before reading the authoritative Chat Session and calling its version-guarded StartTurn operation. Use the admitted episode snapshot to start and compare-and-commit one Factory Session binding or invoke the existing binding through the consumer-owned factorysessionsshim/public Factory Sessions root. Terminalize the admitted turn on every outcome and map only published Factory Sessions text and terminal status into one bounded final ACP response without fabricated streaming."
  },
  "acceptanceCriteria": [
    "A valid non-command, text-only session/prompt with a valid connection-scoped request identity reads the singular Chat Session and admits exactly one version-guarded turn before any Factory effect; malformed, unsupported, unknown-session, stale, duplicate, or busy requests cause no Factory execution.",
    "The first admitted turn in a target episode starts exactly one Factory Session through the existing consumer-owned shim/public Factory Sessions contract with the episode's canonical Factory target, the session's exact editor working root, normalized prompt content, and correlated request identity, then binds the returned identity only to that episode without rewriting prior episodes.",
    "Later turns in the same episode invoke the bound Factory Session exactly once and never start another; target changes use a new episode, and concurrency, duplicate delivery, and retry after a post-start failure cannot create a second Factory Session for an already-started episode.",
    "Success, cancellation, deadline, Factory failure, and mapping failure all leave the admitted Chat turn in the corresponding explicit terminal state and clear the session's busy state; causes remain discoverable internally while ACP errors and structured logs stay bounded and omit sensitive content and private topology.",
    "ACP returns only deterministic final text and stop reason supported by the existing Factory Sessions outcome, emits no fabricated chunks or streaming claims, preserves exact /factory success and failure behavior, and uses one Chat authority in canonical root.BuildProcess execution.",
    "Quality gate: Go typecheck/build, formatting, lint, focused Chat Sessions/ACP/Factory Sessions shim/Wire tests, deterministic concurrency and idempotency repeat or race coverage, make test, required diff-scoped gates, and all required PR CI are terminal and passing.",
    "Delivery: the implementation/review loop continues until all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared composition files are reconciled against current main, required CI is terminal and passing, and the implementation PR is actually merged; an open, green, approved, or merge-ready PR is not complete."
  ],
  "userStories": [
    {
      "id": "ACP-L1-V1-C14-prompt-delegation-001",
      "title": "Validate and admit one ordinary prompt turn",
      "description": "As an ACP client, I want an ordinary prompt to be validated and admitted through the authoritative Chat Session before execution so malformed, stale, duplicate, or overlapping requests cannot start Factory work.",
      "acceptanceCriteria": [
        "The exact existing /factory <value> command is still consumed by the shared target-change path and never admits a Chat turn or executes a Factory; all equivalent command success and failure responses remain unchanged.",
        "For non-command content, JSON shape, non-blank session ID, the existing text-only content contract, and connection-scoped request identity are all validated before Chat reads, turn mutation, or Factory effects.",
        "The boundary reads the addressed Chat Session and calls the canonical Chat StartTurn exactly once with the full request identity, real session ID, and observed version; it does not maintain transport-owned turn or target state.",
        "Unknown sessions, stale versions, duplicate delivery, and sequential or concurrent busy admission return stable protocol-safe classifications and cause zero Factory calls; equal bare JSON-RPC IDs on different connections remain distinct.",
        "Focused transport and Chat integration tests prove validation-before-effects, command parity, exact admission values, identity collision safety, duplicate/busy exclusion, and no effects on rejection without sleeps.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented in pkg/transports/acp/internal/stdio/session_prompt.go: ordinary (non-/factory) prompt content now resolves connection-scoped identity, reads the addressed Chat Session, and calls StartTurn exactly once with the observed version. Rejections (unknown session/stale version/busy/duplicate) classify via classifyTurnAdmissionFailure with zero Factory effect. Downstream Factory dispatch remains explicitly out of scope (owned by stories 002-006); a successful admission currently returns a bounded not-yet-implemented internal error rather than fabricated success. Focused tests added in session_prompt_test.go; go build/vet, golangci-lint, and make test (full unit lane) all pass."
    },
    {
      "id": "ACP-L1-V1-C14-prompt-delegation-002",
      "title": "Start and bind the first Factory Session for an episode",
      "description": "As an editor user, I want the first prompt for a selected Factory episode to start one Factory Session in my workspace so execution uses the target and project I actually chose.",
      "acceptanceCriteria": [
        "When the admitted turn's current open episode has no Factory Session ID, the consumer calls StartFactoryTarget through the existing factorysessionsshim exactly once and does not call an internal Factory Sessions implementation or create another peer contract.",
        "The start request carries the episode's canonical Factory target, the Chat Session's exact editor working root as the execution root, the validated prompt content in the existing Factory input shape, and a bounded correlated request ID; no process cwd or transport fallback silently replaces these values.",
        "A successful start binds the returned Factory Session ID only when the session, episode, admitted turn, and expected version still match; the binding is visible on the current episode and prior episode history is unchanged.",
        "Concurrent completion or binding attempts converge on one episode binding; an empty or conflicting returned identity fails safely and cannot overwrite a committed identity or start a second Factory Session.",
        "Focused service tests prove exact target/root/content propagation, one start call, guarded binding, immutable history, and deterministic concurrent convergence.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented in pkg/services/chat_sessions (contracts.go/errors.go/internal/service) and pkg/transports/acp/internal/stdio/session_prompt.go. chatsessions.Service gained BindFactorySession (compare-and-commit onto the current TargetEpisode, idempotent on a repeat of the already-committed identity, *FactorySessionConflictError on a different one) and StartTurnResult now carries the admitted Episode snapshot. admitPromptTurn calls the new consumer-owned chatsessionswire.NewFactoryTargetService(factorySessions) shim (exposed as acp.FactoryTargetService, a new interface declared in pkg/transports/acp's public root -- NOT chat_sessions/wire, which pkg-boundary forbids importing outside pkg/wire) exactly once via StartFactoryTarget when the admitted episode has no FactorySessionID, with Source.FactoryID = the episode's target, Args[\"workingRoot\"] = the session's WorkingRoot, and Args[\"content\"] = the prompt as []work.WorkContentPart (StartRequest has no dedicated root/content field), RequestID = the admitted turn ID. A successful start's returned SessionID is bound via BindFactorySession; an already-bound episode makes zero start calls (story 003's invoke path is next). pkg/wire wires factorysessions.Service -> provideACPServerFactoryTarget -> acp.FactoryTargetService through provideACPServer/acpwire.NewServer/stdio.New; wire_gen.go regenerated via make generate-wire, verified against origin with scripts/check-wire-gen-drift.js. Focused service tests (factory_session_binding_test.go) and transport tests (session_prompt_test.go) cover exact target/root/content/RequestID propagation, one start call, guarded/idempotent binding, immutable prior-episode history, and deterministic concurrent convergence (same-identity converges, conflicting-identity picks exactly one winner). go build/vet, go test for chat_sessions/acp/wire trees, and make test (short unit lane) all pass; make generate-wire has zero drift."
    },
    {
      "id": "ACP-L1-V1-C14-prompt-delegation-003",
      "title": "Reuse the episode Factory Session for later turns",
      "description": "As an ACP client, I want later prompts in the same target episode to continue the existing Factory Session so the conversation retains one execution identity without duplicate starts.",
      "acceptanceCriteria": [
        "When the admitted episode already has a Factory Session ID, the consumer calls InvokeFactoryTarget exactly once with that exact ID, validated prompt content, source kind, and correlated request ID, and makes zero start calls.",
        "A successful first-episode binding is the identity observed by every later turn in that episode; changing targets creates a distinct episode whose first turn follows the start path without mutating the earlier binding.",
        "Re-delivery of the same connection-scoped prompt request, a concurrent prompt while the turn is active, or retry after the Factory Session was already bound cannot cause a second invocation for the admitted turn or a second start for the episode.",
        "Focused sequential, duplicate, concurrent, and repeat tests prove first-turn start versus later-turn invoke, stable episode reuse, new-episode isolation, and exactly-once downstream call counts without sleeps.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented in pkg/transports/acp/internal/stdio/session_prompt.go: admitPromptTurn now branches on the admitted episode's FactorySessionID -- unbound calls startFactorySessionForEpisode (story 002, unchanged), already-bound calls the new invokeFactorySessionForEpisode, which calls factoryTarget.InvokeFactoryTarget exactly once with the bound Factory Session ID, the validated prompt content (via the existing promptContentToWorkParts), the text source kind, and the admitted turn's ID as the correlated request ID. Zero start/bind calls happen on the invoke branch. errFactoryDelegationNotImplemented still gates the final response (story 004/005 scope). Tests extended in session_prompt_test.go (renamed/extended TestHandleSessionPromptLaterTurnInvokesBoundFactorySessionExactlyOnce with full request-shape assertions, new TestHandleSessionPromptInvokeFactoryTargetFailureMakesNoStartCall, new TestHandleSessionPromptSequentialTurnsStartThenInvokeExactlyOnce driving two real handleSessionPrompt calls against the same session to prove first-turn start -> second-turn invoke with exactly-once counts) and session_new_test.go (fakeChatSessionsService.StartTurn now supports an optional startTurnResults queue consumed front-first per call, for sequential-result tests, backward-compatible with the existing single-result field). go build/vet, golangci-lint, go test for the affected packages, and make test (short unit lane) all pass."
    },
    {
      "id": "ACP-L1-V1-C14-prompt-delegation-004",
      "title": "Return truthful final-only prompt outcomes",
      "description": "As an ACP client, I want the prompt response to reflect the actual Factory Sessions outcome so the client receives deterministic final text and stop semantics without invented streaming.",
      "acceptanceCriteria": [
        "Published Factory Sessions completed, canceled, timed-out, failed, and unmapped outcomes have a total deterministic mapping to the existing ACP stop reason vocabulary, including the documented safe fallback for failure or an unknown future outcome.",
        "Text output is projected in stable order only from supported public primary-result text parts; absent or unsupported result content produces no fabricated assistant text, and raw internal result structures are not serialized into the ACP response.",
        "The handler returns one final prompt response and does not emit synthetic stream notifications, chunks, thought records, progress, or capability claims.",
        "Mapping errors are bounded and protocol-safe, never leak raw prompt, result payloads, paths, credentials, provider commands, or internal topology, and are covered alongside every terminal status and representative mixed or empty result content.",
        "Focused mapper and framed ACP tests prove exact text ordering, stop-reason mapping, final-only response shape, unknown-outcome fallback, and absence of fabricated streaming.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Implemented in pkg/transports/acp/internal/protocol/factory_outcome.go (new): PromptOutcome{StopReason, Text} plus two total, deterministic mappers -- MapFactoryInvocationOutcome(factorysessions.InvocationResult) for the reuse/invoke branch (COMPLETED/SUCCEEDED->end_turn, CANCELED/TIMED_OUT->cancelled since ACP has no timeout-specific stop reason, FAILED and any other unmapped status->end_turn safe fallback; Text is only the ordered work.WorkContentPartTypeText parts of PrimaryResult, never ErrorCode/Message/SessionID/WorkID) and MapFactoryStartOutcome(factorysessions.AsyncStartResult) for the first-turn/start branch, sharing the same status-string mapping but always Text=nil since an asynchronous StartFactoryTarget's own published result (a fire-and-forget goroutine kickoff, confirmed by reading internal/execution/runtime_service.go) never itself carries primary-result content -- a fresh start's Status is almost always \"RUNNING\", which correctly falls into the unmapped/end_turn safe-fallback bucket rather than fabricating a completed-looking response. pkg/transports/acp/internal/stdio/session_prompt.go: startFactorySessionForEpisode and invokeFactorySessionForEpisode now return (protocol.PromptOutcome, error) instead of bare error; admitPromptTurn builds and marshals the real acpsdk.PromptResponse{StopReason: outcome.StopReason} from whichever branch ran (replacing the removed errFactoryDelegationNotImplemented placeholder) -- PromptResponse has no text/content field in the acp-go-sdk (assistant text in ACP is delivered only via session/update notifications, explicitly out of this L1 V1 slice's scope per the PRD's \"excluding streaming\" cut), so Text is computed and exhaustively unit-tested by the mapper but not yet placed on the wire; a later, notification-capable story owns actually emitting it. Updated the 4 pre-existing story-002/003 tests in session_prompt_test.go that asserted the old 'always errors, mapping not implemented' placeholder behavior to assert a successful final response instead, and added focused mapper tests (factory_outcome_test.go: stop-reason mapping table incl. unmapped/empty status, stable text ordering, unsupported-content-produces-no-text, raw-field-never-leaked, start-outcome-never-fabricates-text, determinism) plus framed handler-level tests (session_prompt_test.go: per-status final stopReason across both branches with a sensitive Message/SessionID that must never appear in the raw response bytes, and a response-shape test proving the marshaled JSON carries only 'stopReason' and nothing else). go build/vet, golangci-lint (0 issues), go test for the affected packages, and make test (full short unit lane) all pass."
    },
    {
      "id": "ACP-L1-V1-C14-prompt-delegation-005",
      "title": "Terminalize every admitted turn after downstream failure",
      "description": "As an ACP client, I want failed or interrupted Factory delegation to release the Chat Session deterministically so I can retry without stranded busy state or duplicate Factory execution.",
      "acceptanceCriteria": [
        "A downstream success advances the admitted turn through the legal running state to COMPLETED; cancellation advances it to CANCELED, and start, invoke, terminal-result, or response-mapping failure advances it to FAILED, with the active turn cleared in every terminal case.",
        "The original context is forwarded through Chat and shim calls, and context.Canceled and context.DeadlineExceeded remain discoverable for internal classification while their ACP response and structured operation logs expose only bounded safe reason and correlation fields.",
        "If Factory start succeeds but episode binding or later processing fails, a retry observes or reconciles the returned Factory Session identity and does not start a second Factory Session; no failure path rolls back accepted history into an ambiguous unstarted state.",
        "After any terminal failure, a new uniquely identified prompt can be admitted; retrying the original request cannot duplicate its downstream effect, and no error leaves a non-terminal turn stranded.",
        "Focused fault-injection, cancellation, deadline, retry, concurrency, and repeat tests prove terminal cleanup, preserved cause identity, safe logs and errors, later admission, and no second session after retry without sleeps.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": "Implemented in pkg/transports/acp/internal/stdio/session_prompt.go. admitPromptTurn now advances a freshly admitted turn from ADMITTED to RUNNING (chatsessions.Service.AdvanceTurn, which already existed and already clears Session.ActiveTurnID/advances version on every terminal transition -- unused by this transport until now) before any Factory effect; a RUNNING-transition failure reports a bounded internal error and makes zero Factory dispatch calls. The Factory dispatch itself is delegated to the new dispatchFactoryTurn, which runs startFactorySessionForEpisode/invokeFactorySessionForEpisode (now returning a new local dispatchOutcome{outcome protocol.PromptOutcome, terminal chatsessions.TurnState} instead of a bare protocol.PromptOutcome) and terminalizes the turn on every path via one final AdvanceTurn call that always executes: COMPLETED on a successful start-branch dispatch (the branch's own dispatch+bind responsibility genuinely completed, independent of the Factory Session's own later unobserved async lifecycle -- see story 004's AsyncStartResult finding), the new factoryInvocationTurnState(status) mapping for a successful invoke-branch dispatch (COMPLETED->Completed, CANCELED/TIMED_OUT->Canceled, FAILED/any-other-status->Failed -- so a genuine Factory-published failure terminalizes the turn to FAILED even though InvokeFactoryTarget itself returns no Go error and the ACP response still reports its own separately-mapped safe-fallback stop reason), and the new terminalStateForFailure(cause) mapping for any Go-level dispatch or response-marshal failure (context.Canceled/context.DeadlineExceeded -> Canceled, everything else -> Failed). If the final terminalizing AdvanceTurn call itself fails, that failure is returned as the bounded error (never silently discarded in favor of an otherwise-successful dispatch response), so an unterminalized turn is never masked. Files changed: session_prompt.go (dispatchOutcome type, dispatchFactoryTurn, terminalStateForFailure, factoryInvocationTurnState, admitPromptTurn/startFactorySessionForEpisode/invokeFactorySessionForEpisode signatures and doc comments), server.go (package doc, terminalization no longer described as future scope), session_new_test.go (fakeChatSessionsService.AdvanceTurn is now a configurable, tracked method -- advanceTurnReq/advanceTurnReqs/advanceTurnErr/advanceTurnErrs, the last a front-first-consumed per-call queue mirroring the startTurnResults pattern -- replacing the old always-erroring stub; every existing test that reaches a successful admitPromptTurn call now also exercises a real, successful RUNNING->terminal AdvanceTurn sequence through this fake, which is what surfaced that the old stub needed to change), session_prompt_test.go (new wantAdvanceTurnSequence helper plus story-005 tests: success advances RUNNING->COMPLETED for both branches, invoke-branch terminal state tracks the published InvocationTerminalStatus exactly across all 5 statuses, dispatch Go-failure advances to FAILED for both branches, dispatch failure caused by context.Canceled/DeadlineExceeded/a wrapped context.Canceled advances to CANCELED while still classifying as the ACP request-cancelled outcome, a RUNNING-transition failure makes zero Factory dispatch calls, and a terminal-transition failure after a successful dispatch propagates as a bounded error instead of a fabricated success). go build/vet, golangci-lint (0 issues), gofmt -l (clean), go test for the affected packages, and make test (full short unit lane) all pass."
    },
    {
      "id": "ACP-L1-V1-C14-prompt-delegation-006",
      "title": "Prove prompt delegation through canonical process composition",
      "description": "As a maintainer, I want production-shaped ACP execution to use the singular Chat and Factory Sessions authorities so the feature is trustworthy outside isolated unit fixtures.",
      "acceptanceCriteria": [
        "The owning provider and canonical pkg/wire graph construct one process-scoped Chat service and directly supply that same root instance plus the existing Factory Sessions shim to the production ACP prompt consumer; there is no dependency bag, service locator, secondary injector, runtime service factory, or second session state authority.",
        "Production-shaped tests through root.BuildProcess and real ACP JSON-RPC framing create or select a Chat Session, submit the first ordinary prompt, and observe one Factory start with the exact selected target and editor working root followed by a terminal final-only response.",
        "The same constructed process submits a later prompt and observes one invoke against the original Factory Session, while duplicate or busy and injected downstream-failure cases prove one shared Chat authority, terminal cleanup, and no second Factory Session after retry.",
        "Tests assert public calls and runtime outcomes through controlled replaceable edges; they do not scan source files, routes, registrations, generated bundles, documentation links, or command inventories and do not rely on sleeps.",
        "Shared composition changes are reconciled additively against current main, and focused ACP/Chat/shim/Wire tests plus required race or repeat coverage pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": "Implemented the on-demand Factory Sessions activation this story's own prior blocked attempt identified as needed. New pkg/services/factory_sessions/wire/on_demand_factory_target.go: OnDemandFactoryTargetService lazily opens (via the existing invocation-mode runtimeopening.Factory.OpenInvocationRuntime -- the same non-HTTP-bound primitive the CLI's one-shot `you run --named` already uses successfully) exactly one ephemeral Factory Sessions runtime per Factory target the first time StartFactoryTarget needs it, starts its Lifecycle (StartLifecycle/StartWorkerLifecycle/CompleteStartup), and caches it (keyed by a service-generated wrapper identity, never the opened runtime's shared internal constant DefaultSessionID) so every later InvokeFactoryTarget/CancelFactoryTarget/CloseFactoryTarget call for that identity reuses the exact same runtime; CloseFactoryTarget runs the full teardown (close session, stop worker, stop lifecycle, cancel, wait, close artifacts) and evicts the cache entry. Dispatch itself goes through the public Service's synchronous InvokeFactorySession, not StartAsync/Source -- reading internal/services/orchestration/javascript/source/lookup.go proved StartAsync's Source.Kind=FACTORY_ID vocabulary only resolves named JavaScript-workflow factories ('is not a JavaScript workflow factory'), so it can never dispatch an ordinary packaged Factory like @you/goal; this was a real, confirmed defect in stories 002/003's original design, only surfaced now because every earlier story's tests substituted a fake collaborator. pkg/wire/acp_transport.go: new provideACPServerFactoryTargetRuntimeResolver (turns an ACP-selected 'factory:<name>' target + the Chat Session's working root into a factorysessions.RuntimeOpeningRequest via the same factorydefinitions.NamedFactoryCatalog/ResolveNamedFactoryRoots/operatorsettings.DefaultsResolver/RuntimeArtifactRootResolver providers this graph already composes) and rewritten provideACPServerFactoryTarget, now constructing factorysessionwire.NewOnDemandFactoryTargetService from the already-wired *RuntimeOpeningFactory singleton instead of chatsessionswire.NewFactoryTargetService(inert factorysessionsService); wire.go/wire_gen.go regenerated via make generate-wire (zero drift). New tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go proves this end to end through real root.BuildProcess + real session/new + two real session/prompt JSON-RPC calls: the first (unbound) turn dispatches successfully (no more factorysessions.ErrExecutionServiceNotConfigured/dependency_unavailable) and the second (already-bound) turn reuses the identical opened runtime with no second activation (observed via the same runtime_instance_id in both dispatch logs and via FactorySessionIDGenerator call-count staying unchanged across the second turn, since that shared edge is also consumed for the opened runtime's own internal per-dispatch identifiers and so isn't a clean absolute 1-vs-2 count on its own). The seeded @you/goal packaged Factory's own business workflow does not fully succeed against a bare mock provider (it reaches a real, published FAILED terminal status, 'work reached failed state before a primary result was available', because its goal loop needs an actual child worker dispatch a bare inference mock alone cannot satisfy) -- this is orthogonal, pre-existing @you/goal orchestration behavior, not a defect in this story's activation or composition; the test asserts on the deterministic ACP-level outcome (a bounded successful final response mapping the real published status through the already-implemented, already-tested story-004 safe-fallback mapper), not on the workflow's own business success. go build ./..., go vet ./..., golangci-lint on every changed package (0 issues in changed files), make pkg-boundary (zero new violations from this change, confirmed by diffing against a stash of the unstaged changes), and make test (full short unit lane) all pass."
    }
  ]
}
