### PR TITLE
ACP-L2-DEL-MOD-FORRUNTIME: remove dead Models ForRuntime path

### DIFF
--- a/pkg/services/factory_sessions/internal/runtimeopening/models_bind_test.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/models_bind_test.go
@@ -22,10 +22,9 @@ import (
 )
 
 type recordingModelsService struct {
-	openRequests    []models.OpenRuntimeScopeRequest
-	closeRequests   []models.CloseRuntimeScopeRequest
-	forRuntimeCalls int
-	events          *[]string
+	openRequests  []models.OpenRuntimeScopeRequest
+	closeRequests []models.CloseRuntimeScopeRequest
+	events        *[]string
 }
 
 func (fake *recordingModelsService) OpenRuntimeScope(
@@ -52,11 +51,6 @@ func (fake *recordingModelsService) CloseRuntimeScope(
 		*fake.events = append(*fake.events, "models-close")
 	}
 	return models.CloseRuntimeScopeResult{Scope: request.Scope, Closed: true}, nil
-}
-
-func (fake *recordingModelsService) ForRuntime(models.RuntimeBinding) (models.Service, error) {
-	fake.forRuntimeCalls++
-	return fake, nil
 }
 
 func (fake *recordingModelsService) ListCatalog(
@@ -201,7 +195,7 @@ func (fake *recordingModelsService) InvokeLocal(
 	return models.LocalInvocationResult{}, models.ErrUnsupportedOperation
 }
 
-func TestBindModelsRuntimeScopeOpensDetachedScopeWithoutForRuntime(t *testing.T) {
+func TestBindModelsRuntimeScopeOpensDetachedScope(t *testing.T) {
 	t.Parallel()
 
 	fake := &recordingModelsService{}
@@ -223,9 +217,6 @@ func TestBindModelsRuntimeScopeOpensDetachedScopeWithoutForRuntime(t *testing.T)
 	}
 	if bind.Scope.IsZero() {
 		t.Fatal("bindModelsRuntimeScope() returned zero runtime scope")
-	}
-	if fake.forRuntimeCalls != 0 {
-		t.Fatalf("ForRuntime calls = %d, want 0", fake.forRuntimeCalls)
 	}
 	if len(fake.openRequests) != 1 {
 		t.Fatalf("OpenRuntimeScope requests = %d, want 1", len(fake.openRequests))
@@ -275,9 +266,6 @@ func TestAssembleRuntimeProductsCarriesModelsRootAndScopeIntoOpenedRuntime(t *te
 	}
 	if opened.application.HTTP.ModelsScope != scope {
 		t.Fatalf("opened HTTP Models scope = %q, want %q", opened.application.HTTP.ModelsScope, scope)
-	}
-	if root.forRuntimeCalls != 0 {
-		t.Fatalf("ForRuntime calls = %d, want 0", root.forRuntimeCalls)
 	}
 }
 

--- a/pkg/services/models/catalog_scope_characterization_test.go
+++ b/pkg/services/models/catalog_scope_characterization_test.go
@@ -37,10 +37,6 @@ type catalogPeerService struct {
 	entries     map[string]models.Detail
 }
 
-func (catalogPeerService) ForRuntime(models.RuntimeBinding) (models.Service, error) {
-	return catalogPeerService{runtimeScopePeerService: newRuntimeScopePeerService("legacy")}, nil
-}
-
 func (s catalogPeerService) ListModels(context.Context) (models.List, error) {
 	if s.unavailable {
 		return models.List{}, models.ErrUnavailable

--- a/pkg/services/models/internal/service/runtime_factory.go
+++ b/pkg/services/models/internal/service/runtime_factory.go
@@ -120,29 +120,6 @@ func NewRoot(
 	}, nil
 }
 
-// ForRuntime binds the injected Models service to one Factory Session.
-func (o *Root) ForRuntime(binding models.RuntimeBinding) (models.Service, error) {
-	if o == nil {
-		return nil, missingDependencyError("Models service")
-	}
-	if err := models.ValidateRuntimeBinding(binding); err != nil {
-		return nil, err
-	}
-	privateScope, err := o.runtimeScopes.Open(binding)
-	if err != nil {
-		return nil, err
-	}
-	scope, err := (models.RuntimeScopeRef{}).Parse(string(privateScope))
-	if err != nil {
-		return nil, err
-	}
-	assets, err := localmodels.NewScopedAssetPuller(o.assets, scope)
-	if err != nil {
-		return nil, err
-	}
-	return o.runtimeForBindingWithAssets(scope, binding, assets)
-}
-
 func (o *Root) runtimeForBindingWithAssets(
 	scope models.RuntimeScopeRef,
 	binding models.RuntimeBinding,
@@ -550,10 +527,6 @@ type runtimeService struct {
 }
 
 var _ models.Service = (*runtimeService)(nil)
-
-func (s *runtimeService) ForRuntime(models.RuntimeBinding) (models.Service, error) {
-	return s, nil
-}
 
 func (s *runtimeService) OpenRuntimeScope(
 	context.Context,

--- a/pkg/services/models/internal/services/runtime_scopes/internal/service/service.go
+++ b/pkg/services/models/internal/services/runtime_scopes/internal/service/service.go
@@ -34,8 +34,8 @@ func (s *service) Open(binding models.RuntimeBinding) (runtimescopes.Reference, 
 	if s == nil {
 		return "", fmt.Errorf("%w: service is required", runtimescopes.ErrScopeUnknown)
 	}
-	if err := models.ValidateRuntimeBinding(binding); err != nil {
-		return "", err
+	if binding.RuntimeConfig == nil {
+		return "", fmt.Errorf("%w: runtime configuration lookup is required", runtimescopes.ErrInvalidBinding)
 	}
 
 	snapshot := cloneRuntimeConfig(binding.RuntimeConfig())

--- a/pkg/services/models/internal/services/runtime_scopes/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/runtime_scopes/internal/service/service_test.go
@@ -71,8 +71,8 @@ func TestOpenRejectsInvalidBindingWithoutIssuingReference(t *testing.T) {
 
 	service := newService(t, "invalid-binding")
 	ref, err := service.Open(models.RuntimeBinding{CacheDirectory: "cache"})
-	if !errors.Is(err, models.ErrInvalidRuntimeBinding) {
-		t.Fatalf("Open error = %v, want ErrInvalidRuntimeBinding", err)
+	if !errors.Is(err, runtimescopes.ErrInvalidBinding) {
+		t.Fatalf("Open error = %v, want ErrInvalidBinding", err)
 	}
 	if ref != "" {
 		t.Fatalf("Open reference = %q, want empty", ref)

--- a/pkg/services/models/internal/services/runtime_scopes/service.go
+++ b/pkg/services/models/internal/services/runtime_scopes/service.go
@@ -20,6 +20,10 @@ var ErrScopeForeign = errors.New("models runtime scope is foreign")
 // and explicitly closed.
 var ErrScopeClosed = errors.New("models runtime scope is closed")
 
+// ErrInvalidBinding reports a binding submitted to Open that is missing
+// required runtime-scope configuration.
+var ErrInvalidBinding = errors.New("models runtime binding is invalid")
+
 // Reference is an opaque identifier issued by a Runtime Scopes service.
 type Reference string
 

--- a/pkg/services/models/root_authority_seal_characterization_test.go
+++ b/pkg/services/models/root_authority_seal_characterization_test.go
@@ -16,10 +16,6 @@ type peerModelsService struct {
 	unsupportedRuntimeScopePeer
 }
 
-func (peerModelsService) ForRuntime(models.RuntimeBinding) (models.Service, error) {
-	return peerModelsService{}, nil
-}
-
 func (peerModelsService) ListModels(context.Context) (models.List, error) {
 	return models.List{Results: nil}, nil
 }
@@ -66,12 +62,21 @@ func TestRootServiceAuthority_AggregateSurfaceRemainsOnSingularService(t *testin
 
 	service := peerModelsService{}
 
-	bound, err := service.ForRuntime(models.RuntimeBinding{CacheDirectory: "cache"})
-	if err != nil {
-		t.Fatalf("ForRuntime: %v", err)
+	var sealed models.Service = peerModelsService{}
+	if _, err := sealed.OpenRuntimeScope(context.Background(), models.OpenRuntimeScopeRequest{}); !errors.Is(
+		err, models.ErrUnsupportedOperation,
+	) {
+		t.Fatalf("OpenRuntimeScope = %v, want ErrUnsupportedOperation", err)
 	}
-	if bound == nil {
-		t.Fatal("ForRuntime returned nil Service view")
+	if _, err := service.AcquireLease(context.Background(), models.AcquireLeaseRequest{}); !errors.Is(
+		err, models.ErrHostRuntimeNotReady,
+	) {
+		t.Fatalf("AcquireLease = %v, want ErrHostRuntimeNotReady", err)
+	}
+	if err := service.ReleaseLease(context.Background(), models.ReleaseLeaseRequest{}); !errors.Is(
+		err, models.ErrHostLeaseNotFound,
+	) {
+		t.Fatalf("ReleaseLease = %v, want ErrHostLeaseNotFound", err)
 	}
 
 	list, err := service.ListModels(context.Background())
@@ -453,16 +458,6 @@ func TestRootContractSeal_OpenScopeNeedsNoConstructionEffects(t *testing.T) {
 func TestRootContractSeal_LegacyRequestValidationRemainsObservable(t *testing.T) {
 	t.Parallel()
 
-	if err := models.ValidateRuntimeBinding(models.RuntimeBinding{}); !errors.Is(
-		err, models.ErrInvalidRuntimeBinding,
-	) {
-		t.Fatalf("ValidateRuntimeBinding = %v, want ErrInvalidRuntimeBinding", err)
-	}
-	if err := models.ValidateRuntimeBinding(models.RuntimeBinding{
-		RuntimeConfig: func() *models.RuntimeConfig { return &models.RuntimeConfig{} },
-	}); err != nil {
-		t.Fatalf("ValidateRuntimeBinding valid: %v", err)
-	}
 	validations := []struct {
 		name    string
 		invalid error

--- a/pkg/services/models/root_slice_characterization_test.go
+++ b/pkg/services/models/root_slice_characterization_test.go
@@ -100,10 +100,6 @@ func (*runtimeScopePeerService) GetModelReadiness(
 	return models.GetModelReadinessResult{}, models.ErrUnsupportedOperation
 }
 
-func (s *runtimeScopePeerService) ForRuntime(models.RuntimeBinding) (models.Service, error) {
-	return s, nil
-}
-
 func (*runtimeScopePeerService) ListModels(context.Context) (models.List, error) {
 	return models.List{Results: []models.Summary{}}, nil
 }

--- a/pkg/services/models/runtime_config_contract.go
+++ b/pkg/services/models/runtime_config_contract.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 )
 
@@ -93,9 +92,9 @@ type CloseRuntimeScopeResult struct {
 	Closed bool
 }
 
-// RuntimeOpeningRequest is retained as the legacy ForRuntime input projection.
-//
-// Deprecated: use OpenRuntimeScopeRequest with detached RuntimeScopeConfig.
+// RuntimeOpeningRequest carries the Models-owned per-runtime-opening
+// selections assembled by the process-scoped composition boundary alongside
+// the sibling FactoryDefinitions, Workers, and Recordings opening requests.
 type RuntimeOpeningRequest struct {
 	CacheDirectory string
 }
@@ -224,21 +223,4 @@ func (worker RuntimeWorker) IsInference() bool {
 // IsAgent recognizes the agent Worker taxonomy value.
 func (worker RuntimeWorker) IsAgent() bool {
 	return strings.TrimSpace(worker.Type) == RuntimeWorkerTypeAgent
-}
-
-// ErrInvalidRuntimeBinding classifies missing or invalid runtime-scope inputs
-// supplied to ForRuntime. Peers fail closed on this typed outcome without
-// importing local-runtime construction or process-launcher types.
-var ErrInvalidRuntimeBinding = errors.New("models runtime binding is invalid")
-
-// ValidateRuntimeBinding checks the plain runtime-scope inputs required to bind
-// a constructed Models service to one Factory Session. CacheDirectory may be
-// empty; the asset puller resolves a default managed-model cache root at use
-// time. RuntimeConfig lookup is required. Validation does not start host
-// processes or touch local-runtime implementation packages.
-func ValidateRuntimeBinding(binding RuntimeBinding) error {
-	if binding.RuntimeConfig == nil {
-		return fmt.Errorf("%w: runtime configuration lookup is required", ErrInvalidRuntimeBinding)
-	}
-	return nil
 }

--- a/pkg/services/models/transports/cli/composition_test.go
+++ b/pkg/services/models/transports/cli/composition_test.go
@@ -119,10 +119,6 @@ func (stub compositionModelsRoot) CancelInvocation(context.Context, modelinferen
 	return modelinference.CancelInvocationResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub compositionModelsRoot) ForRuntime(modelinference.RuntimeBinding) (modelinference.Service, error) {
-	return nil, modelinference.ErrUnsupportedOperation
-}
-
 func (stub compositionModelsRoot) ListModels(ctx context.Context) (modelinference.List, error) {
 	if stub.listModels != nil {
 		return stub.listModels(ctx)

--- a/pkg/services/models/transports/cli/service_test.go
+++ b/pkg/services/models/transports/cli/service_test.go
@@ -114,10 +114,6 @@ func (stub stubModelsRoot) CancelInvocation(context.Context, modelinference.Canc
 	return modelinference.CancelInvocationResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub stubModelsRoot) ForRuntime(modelinference.RuntimeBinding) (modelinference.Service, error) {
-	return nil, modelinference.ErrUnsupportedOperation
-}
-
 func (stub stubModelsRoot) ListModels(ctx context.Context) (modelinference.List, error) {
 	if stub.listModels != nil {
 		return stub.listModels(ctx)

--- a/pkg/services/models/transports/http/fake_root_test.go
+++ b/pkg/services/models/transports/http/fake_root_test.go
@@ -22,10 +22,6 @@ type rootFake struct {
 
 var _ models.Service = (*rootFake)(nil)
 
-func (fake *rootFake) ForRuntime(models.RuntimeBinding) (models.Service, error) {
-	return fake, nil
-}
-
 func (fake *rootFake) ListModels(ctx context.Context) (models.List, error) {
 	if fake.list != nil {
 		return fake.list(ctx)


### PR DESCRIPTION
{
  "project": "Remove Dead Models ForRuntime Projections",
  "branchName": "ACP-L2-DEL-MOD-FORRUNTIME",
  "description": "Deliver the Models-only DEL-MOD-FORRUNTIME cleanup by deleting private ForRuntime implementation methods and deprecated ForRuntime-specific input and validation projections, together with only their obsolete callers and tests, while preserving canonical Models root construction, detached runtime-scope configuration, scoped invocation, transports, generated interfaces, and current model runtime semantics.",
  "context": {
    "customerAsk": "Remove the private Models ForRuntime leftovers and legacy input projections at the documented runtime factory and configuration-contract seams, together with only their obsolete callers and tests, while preserving the sealed Models root and current runtime behavior.",
    "problem": "Models exposes one sealed public runtime-scope lifecycle, but dead private ForRuntime construction and legacy input projections still imply a second runtime factory path and retain obsolete callers and tests.",
    "solution": "Make the existing OpenRuntimeScope, scope-qualified invocation, and CloseRuntimeScope lifecycle the sole Models runtime path; delete the unused ForRuntime implementation methods and deprecated compatibility projections; keep required validation private to Models runtime-scope ownership; and add focused regression evidence that canonical construction and representative scoped invocation remain unchanged."
  },
  "acceptanceCriteria": [
    "A canonically constructed Models root opens a detached runtime scope, performs representative scope-qualified model work through the same injected runtime, host, and asset edges and result semantics as before, and closes the scope with existing lifecycle behavior.",
    "No Models implementation or active consumer offers or calls a ForRuntime method; removal does not introduce a replacement runtime factory, secondary service construction path, dependency bag, or service locator.",
    "Deprecated ForRuntime-specific input and validation projections are removed, while active runtime-scope configuration is still cloned, validated before use, and rejected deterministically when required data is absent.",
    "The sealed models.Service contract, current OpenRuntimeScope, CloseRuntimeScope, and invocation behavior, transports, OpenAPI sources, generated Go and TypeScript interfaces, Providers behavior, model catalog behavior, and Factory Runtime behavior are unchanged.",
    "The diff contains only dead-path deletion, the minimum directly affected caller, fake, and test updates, and focused behavioral regression proof; it does not include unrelated Models, Providers, HTTP or CLI, catalog, or Factory Runtime cleanup.",
    "Typecheck and compile validation, focused Models and canonical wiring tests, lint, make verify-fast, and all required CI checks are terminal and passing.",
    "The implementation and review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, shared-file and merge conflicts are resolved against current main, and the PR is actually merged; an opened, green, approved, or ready-to-merge PR is not complete."
  ],
  "userStories": [
    {
      "id": "ACP-L2-DEL-MOD-FORRUNTIME-001",
      "title": "Keep canonical Models scope invocation as the sole runtime path",
      "description": "As a Factory runtime consumer, I want the sealed Models root to remain the only way to open a runtime scope and invoke scoped model behavior so that removing the private runtime factory cannot change construction or execution semantics.",
      "acceptanceCriteria": [
        "The Models root constructed through canonical Models wiring opens a scope from detached configuration, returns a non-zero opaque scope reference, and performs a representative scope-qualified invocation through that root with the same observable request, result, and injected-edge behavior as before deletion.",
        "Closing the opened scope retains the existing successful close result, and subsequent stale, closed, foreign, or invalid scope use retains the established typed outcome applicable to each case.",
        "The private root-level and runtime-view ForRuntime methods and only their obsolete callers, fake methods, and characterization assertions are removed; no alternate method constructs or returns another Models service view during scope opening or invocation.",
        "Models construction remains inert and singular: scope opening registers detached configuration but does not construct another Models root, host, runtime, puller, limiter, process, or storage handle.",
        "Focused Models wire and service tests directly prove canonical construction, scope lifecycle, lazy scoped runtime use, and representative invocation rather than checking a source-file or method inventory.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Removed Root.ForRuntime and runtimeService.ForRuntime (internal/service/runtime_factory.go); OpenRuntimeScope/CloseRuntimeScope/scoped invocation paths untouched and covered by existing wire and root_wire_behavioral_boundary tests. Removed obsolete ForRuntime fakes/assertions across models_test package tests and the factory_sessions recordingModelsService fake."
    },
    {
      "id": "ACP-L2-DEL-MOD-FORRUNTIME-002",
      "title": "Retire ForRuntime-specific configuration projections",
      "description": "As a Models maintainer, I want obsolete ForRuntime input and validation projections removed while active scope configuration remains validated so that the contract describes only the sealed runtime-scope model.",
      "acceptanceCriteria": [
        "The deprecated RuntimeOpeningRequest projection and the ForRuntime-specific ErrInvalidRuntimeBinding and ValidateRuntimeBinding compatibility surface are removed after all obsolete callers and tests are migrated or deleted.",
        "Live runtime-scope registration still accepts the same valid detached cache and runtime configuration, retains a defensive copy, and does not observe later caller mutation.",
        "Missing configuration required by the internal runtime-scope binding still fails deterministically before registration or runtime side effects; validation ownership remains inside Models and does not expose a new public compatibility projection.",
        "The public models.Service methods and active runtime-scope request and result types are unchanged, and no OpenAPI, generated interface, HTTP, CLI, MCP, dashboard, Providers, model catalog, or Factory Runtime behavior changes are produced.",
        "Focused scope-service and Models package tests prove valid registration, defensive detachment, invalid-input failure, and unchanged scoped invocation after the legacy projections are gone.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Removed models.ErrInvalidRuntimeBinding and models.ValidateRuntimeBinding; equivalent required-config validation now lives privately in internal/services/runtime_scopes (new runtimescopes.ErrInvalidBinding, checked inline in the internal Open()). Did NOT delete models.RuntimeOpeningRequest: verified it is not actually ForRuntime-dead code -- it is the live Models-domain per-runtime opening input, aggregated by factorysessions.RuntimeOpeningRequest.Models and consumed via configured.Models.CacheDirectory in pkg/services/factory_sessions/internal/runtimeopening/open.go, matching the same-shaped RuntimeOpeningRequest convention every other domain service (factory_definitions, workers, recordings, factory_runtime) already follows. Deleting it would break 4 files (construction.go, opened_runtime.go, wire/runtime_inputs.go, run_builder_test.go) and violate the 'preserve current runtime behavior' / 'minimum diff' constraints. Fixed the stale 'Deprecated: legacy ForRuntime input projection' doc comment on the type instead, since it was factually incorrect."
    }
  ]
}
