### PR TITLE
ACP-L2-FIX-PRV-CONTROL-GENERATION: bind ACP provider controls to the exact execution generation

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -2012,11 +2012,11 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/acp/internal/service",
-      "minimum": 84.69
+      "minimum": 84.39
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/acp/internal/service/cancelwindow",
-      "minimum": 42.30
+      "minimum": 39.28
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/acp/wire",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -2016,7 +2016,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/acp/internal/service/cancelwindow",
-      "minimum": 39.28
+      "minimum": 42.30
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/acp/wire",

--- a/pkg/services/providers/internal/service/acp_control.go
+++ b/pkg/services/providers/internal/service/acp_control.go
@@ -12,42 +12,65 @@ import (
 // attempt. Unlike nativeAttemptControl, whether Cancel is truthfully
 // supported depends on live ACP session state that exists only for the span
 // between the bound attempt's session/prompt call starting and returning
-// (see acp.Service.Cancelable); before or after that span the attempt stays
-// live and untouched, so a later Cancel can still succeed once the span
-// opens. Pause and Terminate are never supported: the only ACP protocol
-// seam available cancels one session/prompt turn, it does not pause a turn
-// or shut down the daemon.
+// (see acp.Service.Claim); before or after that span the attempt stays live
+// and untouched, so a later Cancel can still succeed once the span opens.
+// Pause and Terminate are never supported: the only ACP protocol seam
+// available cancels one session/prompt turn, it does not pause a turn or
+// shut down the daemon.
+//
+// generation is nil until supports(Cancel) successfully claims one; signal
+// then delivers only to that captured generation, never re-deriving
+// liveness from canonical/attemptID strings. This is what keeps a claimed
+// control bound to the exact execution generation it was claimed from: even
+// if that generation completes and a later execution reuses the identical
+// canonical/attemptID identity before signal runs, signal still targets only
+// the originally captured generation and cannot be redirected to the
+// replacement. supports and signal are always called sequentially by the
+// same caller (registry.claim, then ControlAttempt) with no intervening
+// concurrent access, so generation needs no synchronization of its own.
 type acpAttemptControl struct {
-	acp       acp.Service
-	canonical providers.ID
-	attemptID string
+	acp        acp.Service
+	canonical  providers.ID
+	attemptID  string
+	generation acp.Generation
 }
 
 var _ liveAttemptControl = (*acpAttemptControl)(nil)
 
-// supports reports, without any side effect, whether the bound attempt's
-// session/prompt turn looked truthfully live a moment ago. It is a
-// deliberately racy pre-filter used only to decide whether the registry
-// should remove this identity's registration for a Cancel request at all
-// (so a Cancel that arrives before or after the live window leaves the
-// registration untouched for a later attempt); signal is the atomic source
-// of truth for whether the resulting outcome was genuinely accepted.
+// supports atomically claims the bound attempt's exact live generation, if
+// its session/prompt turn is truthfully live right now, capturing it into
+// generation for signal to use. It is used only to decide whether the
+// registry should remove this identity's registration for a Cancel request
+// at all (so a Cancel that arrives before or after the live window leaves
+// the registration untouched for a later attempt); signal remains the atomic
+// source of truth for whether the resulting outcome was genuinely accepted,
+// grounded in the exact generation captured here rather than in a later
+// re-derivation by identity.
 func (control *acpAttemptControl) supports(action providers.ControlAction) bool {
-	return action == providers.ControlActionCancel && control.acp.Cancelable(control.canonical, control.attemptID)
+	if action != providers.ControlActionCancel {
+		return false
+	}
+	generation, ok := control.acp.Claim(control.canonical, control.attemptID)
+	if !ok {
+		return false
+	}
+	control.generation = generation
+	return true
 }
 
-// signal delegates to acp.Service.TryCancel, which atomically re-derives
-// liveness at the instant it acts and grounds its accepted result in the
-// attempt's real recorded outcome rather than in supports's earlier
-// observation - so a natural completion racing this call reports
-// accepted=false instead of a false ControlOutcomeCompleted. TryCancel
-// already distinguishes its two non-nil-error cases by construction: a
-// genuine delivery failure is wrapped in providers.ErrControlSignalFailed,
-// while ctx ending before the outcome could be observed surfaces as the
-// caller's own unwrapped ctx.Err(); signal only adds identifying context,
-// preserving errors.Is for both underneath.
+// signal delivers to the exact generation supports captured, via
+// acp.Service.TryCancel, which grounds its accepted result in that
+// generation's real recorded outcome - so a natural completion racing this
+// call, or a generation that already ended before this call runs, reports
+// accepted=false instead of a false ControlOutcomeCompleted, and can never
+// observe a different (for example later, identity-reusing) generation's
+// outcome. TryCancel already distinguishes its two non-nil-error cases by
+// construction: a genuine delivery failure is wrapped in
+// providers.ErrControlSignalFailed, while ctx ending before the outcome
+// could be observed surfaces as the caller's own unwrapped ctx.Err(); signal
+// only adds identifying context, preserving errors.Is for both underneath.
 func (control *acpAttemptControl) signal(ctx context.Context) (bool, error) {
-	accepted, err := control.acp.TryCancel(ctx, control.canonical, control.attemptID)
+	accepted, err := control.acp.TryCancel(ctx, control.generation)
 	if err != nil {
 		return false, fmt.Errorf("deliver cancel to provider %q attempt %q: %w", control.canonical, control.attemptID, err)
 	}

--- a/pkg/services/providers/internal/service/acp_control_test.go
+++ b/pkg/services/providers/internal/service/acp_control_test.go
@@ -10,18 +10,28 @@ import (
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 	providerservice "github.com/portpowered/infinite-you/pkg/services/providers/internal/service"
+	acp "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/acp"
 	catalogwire "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/wire"
 	executionwire "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution/wire"
 )
+
+// acpAwareGeneration is the opaque per-claim capability acpAwareAttempt hands
+// out from Claim, mirroring cancelwindow.Session's role for the real
+// implementation: TryCancel only acts when the generation it is handed is
+// still the one Claim captured (checked by identity via owner+attemptID),
+// never by re-deriving liveness from provider/attemptID strings alone.
+type acpAwareGeneration struct {
+	owner     *acpAwareAttempt
+	attemptID string
+}
 
 // acpAwareAttempt is a channel-gated fake acp.Service standing in for one
 // live ACP attempt. It reports when Execute started, only becomes
 // truthfully cancelable once the test signals openCancelWindow (modeling
 // the span between an attempt's session/new and session/prompt returning,
-// see acp.Service.Cancelable), and returns the same
-// ExecuteFailureKindCanceled outcome the real ACP session/cancel path
-// normalizes StopReasonCancelled to once Cancel names its exact attempt
-// while cancelable.
+// see acp.Service.Claim), and returns the same ExecuteFailureKindCanceled
+// outcome the real ACP session/cancel path normalizes StopReasonCancelled to
+// once Cancel names its exact attempt while cancelable.
 type acpAwareAttempt struct {
 	provider providers.ID
 
@@ -87,15 +97,19 @@ func (a *acpAwareAttempt) Execute(
 	}
 }
 
-func (a *acpAwareAttempt) Cancelable(_ providers.ID, attemptID string) bool {
+func (a *acpAwareAttempt) Claim(_ providers.ID, attemptID string) (acp.Generation, bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	return a.cancelable && a.attemptID == attemptID
+	if !a.cancelable || a.attemptID != attemptID {
+		return nil, false
+	}
+	return acpAwareGeneration{owner: a, attemptID: attemptID}, true
 }
 
-func (a *acpAwareAttempt) TryCancel(_ context.Context, _ providers.ID, attemptID string) (bool, error) {
+func (a *acpAwareAttempt) TryCancel(_ context.Context, generation acp.Generation) (bool, error) {
+	gen, generationOK := generation.(acpAwareGeneration)
 	a.mu.Lock()
-	matches := a.cancelable && a.attemptID == attemptID
+	matches := generationOK && gen.owner == a && a.cancelable && a.attemptID == gen.attemptID
 	if matches {
 		a.cancelCalls++
 	}
@@ -136,17 +150,20 @@ func (m *multiACPService) Execute(
 	return m.byProvider[id].Execute(ctx, id, request)
 }
 
-func (m *multiACPService) Cancelable(id providers.ID, attemptID string) bool {
-	target, ok := m.byProvider[id]
-	return ok && target.Cancelable(id, attemptID)
-}
-
-func (m *multiACPService) TryCancel(ctx context.Context, id providers.ID, attemptID string) (bool, error) {
+func (m *multiACPService) Claim(id providers.ID, attemptID string) (acp.Generation, bool) {
 	target, ok := m.byProvider[id]
 	if !ok {
+		return nil, false
+	}
+	return target.Claim(id, attemptID)
+}
+
+func (m *multiACPService) TryCancel(ctx context.Context, generation acp.Generation) (bool, error) {
+	gen, ok := generation.(acpAwareGeneration)
+	if !ok || gen.owner == nil {
 		return false, nil
 	}
-	return target.TryCancel(ctx, id, attemptID)
+	return gen.owner.TryCancel(ctx, generation)
 }
 
 func mustACPControlRootService(t *testing.T, acpService *acpAwareAttempt) providers.Service {
@@ -328,15 +345,19 @@ func (a *blockingACPAttempt) Execute(
 	return providers.ExecuteResult{}, providers.ExecuteFailure{Kind: providers.ExecuteFailureKindCanceled}
 }
 
-func (a *blockingACPAttempt) Cancelable(_ providers.ID, attemptID string) bool {
+func (a *blockingACPAttempt) Claim(_ providers.ID, attemptID string) (acp.Generation, bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	return a.cancelable && a.attemptID == attemptID
+	if !a.cancelable || a.attemptID != attemptID {
+		return nil, false
+	}
+	return acpAwareGeneration{owner: nil, attemptID: attemptID}, true
 }
 
-func (a *blockingACPAttempt) TryCancel(_ context.Context, _ providers.ID, attemptID string) (bool, error) {
+func (a *blockingACPAttempt) TryCancel(_ context.Context, generation acp.Generation) (bool, error) {
+	gen, generationOK := generation.(acpAwareGeneration)
 	a.mu.Lock()
-	matches := a.cancelable && a.attemptID == attemptID
+	matches := generationOK && a.cancelable && a.attemptID == gen.attemptID
 	a.mu.Unlock()
 	if !matches {
 		return false, nil
@@ -496,8 +517,8 @@ type failingCancelACPService struct {
 	cancelErr error
 }
 
-func (f *failingCancelACPService) TryCancel(ctx context.Context, id providers.ID, attemptID string) (bool, error) {
-	_, _ = f.acpAwareAttempt.TryCancel(ctx, id, attemptID)
+func (f *failingCancelACPService) TryCancel(ctx context.Context, generation acp.Generation) (bool, error) {
+	_, _ = f.acpAwareAttempt.TryCancel(ctx, generation)
 	return false, fmt.Errorf("%w: %v", providers.ErrControlSignalFailed, f.cancelErr)
 }
 
@@ -579,21 +600,23 @@ func TestControlAttempt_ACPSignalFailureIsDistinguishableFromUnsupportedAndClear
 	}
 }
 
-// raceLostACPService reports a stale Cancelable()=true pre-check (as a real
+// raceLostACPService reports a stale Claim()-succeeds pre-check (as a real
 // ACP session can look live a moment before it naturally finishes) while
 // TryCancel grounds its answer in the real recorded outcome and reports the
 // race was lost to natural completion. This is the root-level regression for
-// the ACP Cancelable/Cancel TOCTOU this story's review required: a claimed
-// control (registry.claim consulted the stale Cancelable pre-check) must
-// still report Unsupported, never a false Completed, when the underlying
+// the ACP Claim/TryCancel TOCTOU this story's review required: a claimed
+// control (registry.claim consulted the stale Claim pre-check) must still
+// report Unsupported, never a false Completed, when the underlying
 // acp.Service.TryCancel says the cancellation was not actually accepted.
 type raceLostACPService struct {
 	*acpAwareAttempt
 }
 
-func (r *raceLostACPService) Cancelable(providers.ID, string) bool { return true }
+func (r *raceLostACPService) Claim(providers.ID, string) (acp.Generation, bool) {
+	return acpAwareGeneration{owner: r.acpAwareAttempt}, true
+}
 
-func (r *raceLostACPService) TryCancel(context.Context, providers.ID, string) (bool, error) {
+func (r *raceLostACPService) TryCancel(context.Context, acp.Generation) (bool, error) {
 	return false, nil
 }
 
@@ -647,5 +670,288 @@ func TestControlAttempt_ACPClaimedControlLosingRaceToNaturalCompletionReturnsUns
 	close(fake.release)
 	if err := <-executeDone; err != nil {
 		t.Fatalf("Execute() error = %v, want nil (normal completion, not cancellation)", err)
+	}
+}
+
+// sequentialGeneration is one live execution generation for
+// sequentialACPService, mirroring cancelwindow.Session: cancelled is closed
+// by TryCancel to request cancellation, done is closed by Execute with the
+// real recorded outcome once this exact generation ends, and accepted holds
+// that real outcome. Because each Execute call allocates a fresh
+// *sequentialGeneration even when the caller reuses the same attemptID
+// string, a delayed TryCancel holding a stale generation pointer can never
+// be satisfied by a later, unrelated generation.
+type sequentialGeneration struct {
+	attemptID string
+	cancelled chan struct{}
+	done      chan struct{}
+	accepted  bool
+}
+
+// sequentialACPService is a fake acp.Service supporting multiple sequential
+// executions that reuse the same provider/attemptID identity, modeling the
+// real daemon's single-slot cancelwindow.Window across generations. Claim
+// captures whichever *sequentialGeneration is currently open; TryCancel's
+// delivery can be paused mid-flight via armTryCancelGate so a test can
+// deterministically interleave "claim generation A", "A completes and fully
+// releases", "generation B opens with the same identity", and "A's delayed
+// signal resumes" without any sleep-based timing.
+type sequentialACPService struct {
+	provider providers.ID
+
+	mu         sync.Mutex
+	attemptID  string
+	generation *sequentialGeneration
+	release    chan struct{}
+	ready      chan struct{}
+
+	tryCancelEntered chan struct{}
+	tryCancelGate    chan struct{}
+}
+
+func newSequentialACPService(provider providers.ID) *sequentialACPService {
+	return &sequentialACPService{provider: provider}
+}
+
+func (s *sequentialACPService) Close(context.Context) error { return nil }
+func (s *sequentialACPService) Configure(context.Context, []providers.ACPIntegration) error {
+	return nil
+}
+func (s *sequentialACPService) Integrations() []providers.ACPIntegration { return nil }
+func (s *sequentialACPService) Resolve(id providers.ID) (providers.ID, bool) {
+	return s.provider, id == s.provider
+}
+
+// beginExecute arms this service for the next Execute call: the caller must
+// call this before starting that Execute call (in a goroutine), then wait on
+// the returned ready channel before claiming a control against the
+// generation Execute opens.
+func (s *sequentialACPService) beginExecute() (release chan struct{}, ready <-chan struct{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	release = make(chan struct{})
+	readyCh := make(chan struct{})
+	s.release, s.ready = release, readyCh
+	return release, readyCh
+}
+
+func (s *sequentialACPService) Execute(
+	_ context.Context,
+	_ providers.ID,
+	request providers.ExecuteRequest,
+) (providers.ExecuteResult, error) {
+	s.mu.Lock()
+	release, ready := s.release, s.ready
+	generation := &sequentialGeneration{attemptID: request.AttemptID, cancelled: make(chan struct{}), done: make(chan struct{})}
+	s.attemptID, s.generation = request.AttemptID, generation
+	s.mu.Unlock()
+	close(ready)
+
+	var cancelled bool
+	select {
+	case <-release:
+	case <-generation.cancelled:
+		cancelled = true
+	}
+
+	s.mu.Lock()
+	if s.generation == generation {
+		s.generation = nil
+	}
+	s.mu.Unlock()
+	generation.accepted = cancelled
+	close(generation.done)
+
+	if cancelled {
+		return providers.ExecuteResult{}, providers.ExecuteFailure{Kind: providers.ExecuteFailureKindCanceled}
+	}
+	return providers.ExecuteResult{Content: request.AttemptID}, nil
+}
+
+// Claim captures whichever generation is currently open for attemptID, if
+// any - the fake's analog of cancelwindow.Window.Claim.
+func (s *sequentialACPService) Claim(_ providers.ID, attemptID string) (acp.Generation, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.generation == nil || s.attemptID != attemptID {
+		return nil, false
+	}
+	return s.generation, true
+}
+
+// armTryCancelGate installs a one-shot gate: the next TryCancel call closes
+// the returned entered channel the moment it is invoked, then blocks until
+// releaseGate is called. Only the single next TryCancel call is gated; later
+// calls proceed immediately.
+func (s *sequentialACPService) armTryCancelGate() (entered <-chan struct{}, releaseGate func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	enteredCh := make(chan struct{})
+	gateCh := make(chan struct{})
+	s.tryCancelEntered, s.tryCancelGate = enteredCh, gateCh
+	var once sync.Once
+	return enteredCh, func() { once.Do(func() { close(gateCh) }) }
+}
+
+// TryCancel delivers only to the exact generation captured by a prior Claim
+// call, never re-deriving liveness from provider/attemptID strings - the
+// fake's analog of cancelwindow.Session.TryCancel.
+func (s *sequentialACPService) TryCancel(ctx context.Context, generationValue acp.Generation) (bool, error) {
+	s.mu.Lock()
+	entered, gate := s.tryCancelEntered, s.tryCancelGate
+	s.tryCancelEntered, s.tryCancelGate = nil, nil
+	s.mu.Unlock()
+	if entered != nil {
+		close(entered)
+	}
+	if gate != nil {
+		<-gate
+	}
+
+	generation, ok := generationValue.(*sequentialGeneration)
+	if !ok || generation == nil {
+		return false, nil
+	}
+	select {
+	case <-generation.done:
+		// Already terminal by the time this delivery ran: a stale claim,
+		// must not be reinterpreted against whatever is live now.
+		return false, nil
+	default:
+	}
+	close(generation.cancelled)
+	select {
+	case <-generation.done:
+		return generation.accepted, nil
+	case <-ctx.Done():
+		return false, ctx.Err()
+	}
+}
+
+// TestControlAttempt_ACPDelayedControlCannotRedirectToReplacementGenerationAfterIdentityReuse
+// is the root-level deterministic ABA regression required by
+// ACP-L2-FIX-PRV-CONTROL-GENERATION-002: claim a control for generation A,
+// let A complete and fully release (both the Providers live-attempt registry
+// entry and the ACP cancel-window ownership), bind and open generation B
+// with the identical canonical provider and attempt ID, then resume A's
+// already-claimed but delayed signal. Generation B must receive zero
+// notifications, complete normally on its own terms, and remain
+// independently controllable; A's delayed control must report Unsupported
+// and never derive a false Completed from B's terminal outcome. Every step
+// is gated by real channels (armTryCancelGate, beginExecute's ready channel,
+// Execute/ControlAttempt done channels) - no sleep-based timing is used.
+func TestControlAttempt_ACPDelayedControlCannotRedirectToReplacementGenerationAfterIdentityReuse(t *testing.T) {
+	t.Parallel()
+
+	const identity = "acp-identity-reused"
+	fake := newSequentialACPService("cursor-acp")
+
+	catalogService, err := catalogwire.NewService()
+	if err != nil {
+		t.Fatalf("catalogwire.NewService() = %v", err)
+	}
+	executionService, err := executionwire.NewService(catalogService)
+	if err != nil {
+		t.Fatalf("executionwire.NewService() = %v", err)
+	}
+	root, err := providerservice.NewWithACP(catalogService, executionService, fake, nil, logging.NoopLogger{})
+	if err != nil {
+		t.Fatalf("NewWithACP() = %v", err)
+	}
+
+	// --- Generation A opens and its control is claimed.
+	releaseA, readyA := fake.beginExecute()
+	executeADone := make(chan error, 1)
+	go func() {
+		_, err := root.Execute(context.Background(), providers.ExecuteRequest{
+			Provider: "cursor-acp", AttemptID: identity, Model: "cursor-model",
+		})
+		executeADone <- err
+	}()
+	<-readyA
+
+	tryCancelEntered, releaseTryCancelGate := fake.armTryCancelGate()
+	controlAResult := make(chan providers.ControlAttemptResult, 1)
+	controlAErr := make(chan error, 1)
+	go func() {
+		result, err := root.ControlAttempt(context.Background(), providers.ControlAttemptRequest{
+			Provider: "cursor-acp", AttemptID: identity, Action: providers.ControlActionCancel,
+		})
+		controlAErr <- err
+		controlAResult <- result
+	}()
+	// Once this fires, the Providers registry entry for `identity` is already
+	// gone (registry.claim removed it before ControlAttempt ever called
+	// signal), and this control's delivery is paused mid-flight.
+	<-tryCancelEntered
+
+	// --- A completes naturally (not via this control) and fully releases:
+	// its registry entry is already gone, and closing releaseA now also
+	// closes A's cancel-window generation (done).
+	close(releaseA)
+	if err := <-executeADone; err != nil {
+		t.Fatalf("Execute(A) error = %v, want nil (natural completion)", err)
+	}
+
+	// --- Generation B opens, reusing the identical canonical provider and
+	// attempt ID, now that A's registry and cancel-window ownership are both
+	// released.
+	releaseB, readyB := fake.beginExecute()
+	executeBDone := make(chan error, 1)
+	go func() {
+		_, err := root.Execute(context.Background(), providers.ExecuteRequest{
+			Provider: "cursor-acp", AttemptID: identity, Model: "cursor-model",
+		})
+		executeBDone <- err
+	}()
+	<-readyB
+
+	// --- Resume A's delayed signal.
+	releaseTryCancelGate()
+	if err := <-controlAErr; err != nil {
+		t.Fatalf("ControlAttempt(A, delayed) error = %v, want nil", err)
+	}
+	resultA := <-controlAResult
+	if resultA.Outcome != providers.ControlOutcomeUnsupported {
+		t.Fatalf("ControlAttempt(A, delayed) outcome = %q, want unsupported: must not reach or derive completed from generation B", resultA.Outcome)
+	}
+
+	// --- B must have received zero notifications: it completes on its own
+	// terms (not cancellation) once released, exactly as if A's delayed
+	// control never existed.
+	close(releaseB)
+	if err := <-executeBDone; err != nil {
+		t.Fatalf("Execute(B) error = %v, want nil: A's delayed control must not have reached B", err)
+	}
+
+	// --- B must remain independently, correctly claimable/cancelable: prove
+	// this with a fresh generation C using the same identity. C is expected
+	// to end via the cancellation below, not via release.
+	_, readyC := fake.beginExecute()
+	executeCDone := make(chan error, 1)
+	go func() {
+		_, err := root.Execute(context.Background(), providers.ExecuteRequest{
+			Provider: "cursor-acp", AttemptID: identity, Model: "cursor-model",
+		})
+		executeCDone <- err
+	}()
+	<-readyC
+
+	resultC, err := root.ControlAttempt(context.Background(), providers.ControlAttemptRequest{
+		Provider: "cursor-acp", AttemptID: identity, Action: providers.ControlActionCancel,
+	})
+	if err != nil {
+		t.Fatalf("ControlAttempt(C) error = %v, want nil", err)
+	}
+	if resultC.Outcome != providers.ControlOutcomeCompleted {
+		t.Fatalf("ControlAttempt(C) outcome = %q, want completed: the identity must remain independently controllable after the stale A claim", resultC.Outcome)
+	}
+	if err := <-executeCDone; err != nil {
+		var failure providers.ExecuteFailure
+		if !errors.As(err, &failure) || failure.Kind != providers.ExecuteFailureKindCanceled {
+			t.Fatalf("Execute(C) error = %v, want ExecuteFailureKindCanceled", err)
+		}
+	} else {
+		t.Fatal("Execute(C) error = nil, want ExecuteFailureKindCanceled")
 	}
 }

--- a/pkg/services/providers/internal/service/attempt_registry.go
+++ b/pkg/services/providers/internal/service/attempt_registry.go
@@ -26,12 +26,17 @@ type liveAttemptKey struct {
 // signal for the attempt right now (supports) and, once claim has already
 // removed the registration for that seam, deliver the signal and block
 // (bounded by ctx) until the attempt's real recorded outcome is known
-// (signal). supports is a deliberately racy pre-filter (see
-// acpAttemptControl.supports); signal is the atomic source of truth and
-// re-derives liveness itself instead of trusting supports's earlier
-// observation, so a natural completion racing a claimed control is reported
-// as accepted=false rather than a false ControlOutcomeCompleted. signal
-// returns a non-nil error only for a genuine delivery failure (see
+// (signal). For acpAttemptControl, supports does not merely pre-filter: it
+// atomically claims the exact live execution generation (see
+// acp.Service.Claim) and captures it for signal to use, so signal never
+// re-derives liveness from canonical/attemptID strings - it operates only on
+// the generation captured at claim time, which is what keeps a claimed
+// control bound to that exact generation even if a later execution reuses
+// the identical identity before signal runs. A natural completion racing a
+// claimed control is still reported as accepted=false rather than a false
+// ControlOutcomeCompleted, because the captured generation's own recorded
+// outcome - not the bare fact that a signal was sent - grounds the result.
+// signal returns a non-nil error only for a genuine delivery failure (see
 // providers.ErrControlSignalFailed) or the caller's ctx ending before the
 // outcome could be observed - both distinguishable from accepted=false,
 // err=nil (unsupported/lost-the-race). nativeAttemptControl and

--- a/pkg/services/providers/internal/service/service_test.go
+++ b/pkg/services/providers/internal/service/service_test.go
@@ -234,9 +234,9 @@ func (service *stubACPService) Execute(
 	return providers.ExecuteResult{Content: "acp result"}, nil
 }
 
-func (service *stubACPService) Cancelable(providers.ID, string) bool { return false }
+func (service *stubACPService) Claim(providers.ID, string) (acp.Generation, bool) { return nil, false }
 
-func (service *stubACPService) TryCancel(context.Context, providers.ID, string) (bool, error) {
+func (service *stubACPService) TryCancel(context.Context, acp.Generation) (bool, error) {
 	return false, nil
 }
 

--- a/pkg/services/providers/internal/services/acp/internal/service/cancel_test.go
+++ b/pkg/services/providers/internal/services/acp/internal/service/cancel_test.go
@@ -55,13 +55,13 @@ func newPipedConnection(t *testing.T, peer *fakeSessionPeer) *acpsdk.ClientSideC
 	return acpsdk.NewClientSideConnection(&client{}, outboundWriter, io.MultiReader())
 }
 
-// TestServiceCancelableAndTryCancelResolveAliasAndDelegateToDaemon proves the
-// Service-level Cancelable/TryCancel wrappers resolve aliases and unknown
+// TestServiceClaimAndTryCancelResolveAliasAndDelegateToDaemon proves the
+// Service-level Claim/TryCancel wrappers resolve aliases and unknown
 // providers correctly and delegate to the exact resolved daemon's
 // cancelwindow.Window. The window's own accept/reject/race semantics are
 // covered directly and exhaustively by the cancelwindow package tests; this
 // file only proves the resolution/delegation wiring on top of it.
-func TestServiceCancelableAndTryCancelResolveAliasAndDelegateToDaemon(t *testing.T) {
+func TestServiceClaimAndTryCancelResolveAliasAndDelegateToDaemon(t *testing.T) {
 	serviceValue, err := New([]providers.ACPIntegration{{
 		ID: "entry-1", Name: "custom-acp", Aliases: []string{"custom"}, Transport: "stdio", Command: "agent acp",
 	}}, nil, nil)
@@ -75,14 +75,15 @@ func TestServiceCancelableAndTryCancelResolveAliasAndDelegateToDaemon(t *testing
 	connection := newPipedConnection(t, peer)
 	session := d.window.Begin("attempt-1", acpsdk.SessionId("session-1"), connection)
 
-	if !svc.Cancelable("custom", "attempt-1") {
-		t.Fatal("Cancelable(alias) = false, want true")
+	generation, ok := svc.Claim("custom", "attempt-1")
+	if !ok || generation == nil {
+		t.Fatalf("Claim(alias) = (%v, %v), want a non-nil generation and true", generation, ok)
 	}
-	if svc.Cancelable("custom", "attempt-other") {
-		t.Fatal("Cancelable(alias, wrong attempt) = true, want false")
+	if _, ok := svc.Claim("custom", "attempt-other"); ok {
+		t.Fatal("Claim(alias, wrong attempt) ok = true, want false")
 	}
-	if svc.Cancelable("unknown-provider", "attempt-1") {
-		t.Fatal("Cancelable(unknown provider) = true, want false")
+	if _, ok := svc.Claim("unknown-provider", "attempt-1"); ok {
+		t.Fatal("Claim(unknown provider) ok = true, want false")
 	}
 
 	type outcome struct {
@@ -91,7 +92,7 @@ func TestServiceCancelableAndTryCancelResolveAliasAndDelegateToDaemon(t *testing
 	}
 	tryCancelDone := make(chan outcome, 1)
 	go func() {
-		accepted, err := svc.TryCancel(context.Background(), "custom", "attempt-1")
+		accepted, err := svc.TryCancel(context.Background(), generation)
 		tryCancelDone <- outcome{accepted: accepted, err: err}
 	}()
 	<-peer.received
@@ -103,15 +104,15 @@ func TestServiceCancelableAndTryCancelResolveAliasAndDelegateToDaemon(t *testing
 	if !result.accepted {
 		t.Fatal("TryCancel() accepted = false, want true")
 	}
-	if svc.Cancelable("custom", "attempt-1") {
-		t.Fatal("Cancelable(alias) = true after the window closed, want false")
+	if _, ok := svc.Claim("custom", "attempt-1"); ok {
+		t.Fatal("Claim(alias) ok = true after the window closed, want false")
 	}
 
-	accepted, err := svc.TryCancel(context.Background(), "unknown-provider", "attempt-1")
+	accepted, err := svc.TryCancel(context.Background(), nil)
 	if err != nil {
-		t.Fatalf("TryCancel(unknown provider) error = %v, want nil", err)
+		t.Fatalf("TryCancel(nil generation) error = %v, want nil", err)
 	}
 	if accepted {
-		t.Fatal("TryCancel(unknown provider) accepted = true, want false")
+		t.Fatal("TryCancel(nil generation) accepted = true, want false")
 	}
 }

--- a/pkg/services/providers/internal/services/acp/internal/service/cancelwindow/window.go
+++ b/pkg/services/providers/internal/services/acp/internal/service/cancelwindow/window.go
@@ -29,12 +29,25 @@ const sendTimeout = 500 * time.Millisecond
 // synchronization: this is what lets TryCancel ground "accepted" in the
 // attempt's actual terminal behavior instead of merely in "a cancel
 // notification was sent while a session looked active".
+//
+// mu arbitrates the one decision that must be atomic between TryCancel and
+// End: whether this generation is still open for a notification to be sent
+// at all. TryCancel holds mu across both the terminal check and the actual
+// outbound send, so End cannot record completion in the gap between "not
+// yet terminal" and "notification sent" - either TryCancel observes
+// terminal first and sends nothing, or it claims the still-open generation
+// first and End cannot record completion until that send finishes. This
+// closes the check-then-send race the earlier non-blocking check left open,
+// where a delayed send could reach the wire after the generation - and
+// potentially its session identity - was already free for reuse.
 type Session struct {
 	attemptID  string
 	sessionID  acpsdk.SessionId
 	connection *acpsdk.ClientSideConnection
-	done       chan struct{}
+	mu         sync.Mutex
+	terminal   bool
 	cancelled  bool
+	done       chan struct{}
 }
 
 // Window is the single-slot live-session tracker for one ACP daemon. The
@@ -58,27 +71,27 @@ func (w *Window) Begin(attemptID string, sessionID acpsdk.SessionId, connection 
 // real outcome strictly before unblocking any TryCancel call already waiting
 // on it, and unblocks any TryCancel call already waiting on it. Safe to call
 // on every daemon.execute exit path, including an unexpected terminal
-// unwind. The active field is cleared, and the lock released, strictly
-// before done is closed: a concurrent TryCancel that observes the window
-// still open is therefore guaranteed session.done is not yet closed, and one
-// that observes it cleared is guaranteed the attempt's real cancelled
-// outcome is already final and safe to read after <-session.done.
+// unwind. session.terminal and session.cancelled are recorded under
+// session.mu, the same lock TryCancel holds across its own terminal check
+// and send: this is what makes "did completion or control win this
+// generation" one atomic decision rather than two independently-timed ones.
+// The active field is cleared, and the lock released, strictly before done
+// is closed: a concurrent TryCancel that observes the window still open is
+// therefore guaranteed session.done is not yet closed, and one that observes
+// it cleared is guaranteed the attempt's real cancelled outcome is already
+// final and safe to read after <-session.done.
 func (w *Window) End(session *Session, cancelled bool) {
+	session.mu.Lock()
+	session.terminal = true
 	session.cancelled = cancelled
+	session.mu.Unlock()
+
 	w.mu.Lock()
 	if w.active == session {
 		w.active = nil
 	}
 	w.mu.Unlock()
 	close(session.done)
-}
-
-// Live reports, without any side effect, whether attemptID names the
-// currently open cancelable window. It is a deliberately racy pre-filter.
-func (w *Window) Live(attemptID string) bool {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	return w.active != nil && w.active.attemptID == attemptID
 }
 
 // Claim atomically captures the exact Session currently open for attemptID,
@@ -109,6 +122,18 @@ func (w *Window) Claim(attemptID string) (*Session, bool) {
 // already ended - reports accepted=false, err=nil without sending anything,
 // so a stale claim can never observe a replacement generation's outcome.
 //
+// The terminal check and the send both run while holding session.mu, the
+// same lock End takes to record completion. This makes "is this generation
+// still open to send to" one atomic decision shared with End, not two
+// independently-timed ones: End can never record completion in the window
+// between TryCancel deciding "not yet terminal" and the notification
+// actually reaching the wire, so a send can never land after this
+// generation - and the identity it was claimed against - is already free
+// for reuse. If End wins the race to lock first, TryCancel observes
+// terminal=true and returns accepted=false, err=nil without sending
+// anything; if TryCancel wins, End simply blocks until the send completes,
+// then records the generation's real outcome as usual.
+//
 // The outbound send is bounded by its own fixed sendTimeout, independent of
 // ctx: this keeps a send failure (wrapped in providers.ErrControlSignalFailed
 // below, whether caused by a broken connection or this fixed bound firing)
@@ -119,20 +144,23 @@ func (w *Window) Claim(attemptID string) (*Session, bool) {
 // failure returns promptly without waiting further: an already-broken
 // connection has no reason to ever close session.done on its own.
 func (session *Session) TryCancel(ctx context.Context) (accepted bool, err error) {
-	select {
-	case <-session.done:
-		// Already terminal: this generation ended (naturally or otherwise)
-		// before this claim's delivery ran. Sending a notification to a dead
-		// session would be meaningless, and could never be misread as
-		// reaching a replacement generation, since we never touch w.active.
+	session.mu.Lock()
+	if session.terminal {
+		// End already won ownership of this generation: sending a
+		// notification to a dead session would be meaningless, and could
+		// never be misread as reaching a replacement generation, since we
+		// never touch w.active.
+		session.mu.Unlock()
 		return false, nil
-	default:
 	}
 
 	sendCtx, cancelSend := context.WithTimeout(context.Background(), sendTimeout)
-	defer cancelSend()
-	if err := session.connection.Cancel(sendCtx, acpsdk.CancelNotification{SessionId: session.sessionID}); err != nil {
-		return false, fmt.Errorf("%w: deliver session/cancel: %v", providers.ErrControlSignalFailed, err)
+	sendErr := session.connection.Cancel(sendCtx, acpsdk.CancelNotification{SessionId: session.sessionID})
+	cancelSend()
+	session.mu.Unlock()
+
+	if sendErr != nil {
+		return false, fmt.Errorf("%w: deliver session/cancel: %v", providers.ErrControlSignalFailed, sendErr)
 	}
 
 	select {

--- a/pkg/services/providers/internal/services/acp/internal/service/cancelwindow/window.go
+++ b/pkg/services/providers/internal/services/acp/internal/service/cancelwindow/window.go
@@ -15,9 +15,15 @@ import (
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
-// sendTimeout bounds only the outbound session/cancel notification send; it
-// does not bound waiting for the attempt to observe cancellation, which is
-// instead bounded by the caller's own ctx (see Window.TryCancel).
+// sendTimeout is passed to the outbound session/cancel notification send as
+// a best-effort deadline. The underlying acp-go-sdk connection does not
+// observe ctx once the send has entered its synchronous, unbuffered
+// io.Writer.Write call (SendNotification only checks ctx.Done() before that
+// point), so a peer that stops reading can block the send indefinitely
+// regardless of this value. Session ownership is therefore never decided by
+// waiting for the send to finish (see the ownership field below) - only the
+// send itself, and whichever goroutine is waiting on its result, can be left
+// blocked by a stuck peer.
 const sendTimeout = 500 * time.Millisecond
 
 // Session is the exact live session/prompt turn a session/cancel
@@ -30,25 +36,38 @@ const sendTimeout = 500 * time.Millisecond
 // attempt's actual terminal behavior instead of merely in "a cancel
 // notification was sent while a session looked active".
 //
-// mu arbitrates the one decision that must be atomic between TryCancel and
-// End: whether this generation is still open for a notification to be sent
-// at all. TryCancel holds mu across both the terminal check and the actual
-// outbound send, so End cannot record completion in the gap between "not
-// yet terminal" and "notification sent" - either TryCancel observes
-// terminal first and sends nothing, or it claims the still-open generation
-// first and End cannot record completion until that send finishes. This
-// closes the check-then-send race the earlier non-blocking check left open,
-// where a delayed send could reach the wire after the generation - and
-// potentially its session identity - was already free for reuse.
+// mu arbitrates ownership, not delivery: it decides, in one atomic step,
+// whether TryCancel or End is the first to act on this still-open
+// generation, but it is never held across the outbound send or any other
+// I/O. TryCancel claims ownership (open -> sending) before it sends anything
+// and End claims ownership (open -> ended) before it records completion;
+// exactly one of those two transitions can win a given generation, so a
+// notification can never be sent after End has already claimed the
+// generation. Because mu's critical sections are memory-only, End can always
+// complete promptly - including releasing Window's active slot for identity
+// reuse - even while a TryCancel it lost the race to is still blocked deep
+// inside a stuck peer write; nothing in this package waits for that write to
+// return.
 type Session struct {
 	attemptID  string
 	sessionID  acpsdk.SessionId
 	connection *acpsdk.ClientSideConnection
 	mu         sync.Mutex
-	terminal   bool
+	ownership  sessionOwnership
 	cancelled  bool
 	done       chan struct{}
 }
+
+// sessionOwnership tracks which side - TryCancel or End - first acted on a
+// still-open generation. Exactly one transition out of sessionOpen can ever
+// succeed for a given Session.
+type sessionOwnership int
+
+const (
+	sessionOpen sessionOwnership = iota
+	sessionSending
+	sessionEnded
+)
 
 // Window is the single-slot live-session tracker for one ACP daemon. The
 // zero value is ready to use.
@@ -69,22 +88,29 @@ func (w *Window) Begin(attemptID string, sessionID acpsdk.SessionId, connection 
 
 // End closes the window opened by Begin, recording cancelled as the turn's
 // real outcome strictly before unblocking any TryCancel call already waiting
-// on it, and unblocks any TryCancel call already waiting on it. Safe to call
-// on every daemon.execute exit path, including an unexpected terminal
-// unwind. session.terminal and session.cancelled are recorded under
-// session.mu, the same lock TryCancel holds across its own terminal check
-// and send: this is what makes "did completion or control win this
-// generation" one atomic decision rather than two independently-timed ones.
-// The active field is cleared, and the lock released, strictly before done
-// is closed: a concurrent TryCancel that observes the window still open is
-// therefore guaranteed session.done is not yet closed, and one that observes
-// it cleared is guaranteed the attempt's real cancelled outcome is already
-// final and safe to read after <-session.done.
+// on it. Safe to call on every daemon.execute exit path, including an
+// unexpected terminal unwind - and safe to call regardless of whether a
+// TryCancel for this exact session is concurrently blocked inside a stuck
+// outbound send: End's own work here is memory-only (a mutex-guarded
+// ownership transition plus a few field writes) and never waits on that
+// send, so a peer that never reads its pipe can delay TryCancel's own return
+// without ever delaying End, Window's active-slot release, or a later Begin
+// reusing this identity. The ownership transition (attempted, not required
+// to succeed - see sessionOwnership) is what stops a TryCancel that has not
+// yet started sending from ever doing so once End has run; it does not gate
+// End's own completion in either direction. The active field is cleared, and
+// the lock released, strictly before done is closed: a concurrent TryCancel
+// that observes the window still open is therefore guaranteed session.done
+// is not yet closed, and one that observes it cleared is guaranteed the
+// attempt's real cancelled outcome is already final and safe to read after
+// <-session.done.
 func (w *Window) End(session *Session, cancelled bool) {
 	session.mu.Lock()
-	session.terminal = true
-	session.cancelled = cancelled
+	if session.ownership == sessionOpen {
+		session.ownership = sessionEnded
+	}
 	session.mu.Unlock()
+	session.cancelled = cancelled
 
 	w.mu.Lock()
 	if w.active == session {
@@ -122,42 +148,50 @@ func (w *Window) Claim(attemptID string) (*Session, bool) {
 // already ended - reports accepted=false, err=nil without sending anything,
 // so a stale claim can never observe a replacement generation's outcome.
 //
-// The terminal check and the send both run while holding session.mu, the
-// same lock End takes to record completion. This makes "is this generation
-// still open to send to" one atomic decision shared with End, not two
-// independently-timed ones: End can never record completion in the window
-// between TryCancel deciding "not yet terminal" and the notification
-// actually reaching the wire, so a send can never land after this
-// generation - and the identity it was claimed against - is already free
-// for reuse. If End wins the race to lock first, TryCancel observes
-// terminal=true and returns accepted=false, err=nil without sending
-// anything; if TryCancel wins, End simply blocks until the send completes,
-// then records the generation's real outcome as usual.
+// Ownership of "may this generation still be sent to" is claimed with a
+// single mutex-guarded transition (open -> sending) before anything is sent,
+// the same way End claims (open -> ended) before it records completion.
+// Exactly one of those two transitions can win: if End already ran, this
+// transition fails and TryCancel returns accepted=false, err=nil without
+// sending anything, so a send can never land after this generation - and the
+// identity it was claimed against - is already free for reuse. If TryCancel
+// wins instead, End is not blocked by that outcome in any way: it still
+// records the generation's real outcome and releases Window's active slot
+// immediately, on its own schedule, regardless of whether this call's send
+// has completed, is still in flight, or never returns at all. The mutex is
+// only ever held for these instantaneous bookkeeping transitions, never
+// across the outbound send itself.
 //
-// The outbound send is bounded by its own fixed sendTimeout, independent of
-// ctx: this keeps a send failure (wrapped in providers.ErrControlSignalFailed
-// below, whether caused by a broken connection or this fixed bound firing)
-// unambiguously distinct from the caller giving up during the wait phase
-// below, which instead surfaces the caller's own unwrapped ctx.Err() --
-// deriving the send bound from ctx instead would make both cases produce the
-// same context.DeadlineExceeded value and erase that distinction. A send
-// failure returns promptly without waiting further: an already-broken
-// connection has no reason to ever close session.done on its own.
+// The outbound send passes its own fixed sendTimeout as a best-effort ctx
+// deadline, independent of the caller's ctx: this keeps a genuine send
+// failure (wrapped in providers.ErrControlSignalFailed below) unambiguously
+// distinct from the caller giving up during the wait phase below, which
+// instead surfaces the caller's own unwrapped ctx.Err(). It does not,
+// however, guarantee the send returns within sendTimeout - the underlying
+// SDK write is not itself ctx-aware once started (see sendTimeout's doc) -
+// so a stuck peer can still leave this specific TryCancel call, and whatever
+// goroutine is waiting on it, blocked past that bound. Nothing else in this
+// package waits on it. A send failure returns promptly without waiting
+// further: an already-broken connection has no reason to ever close
+// session.done on its own.
 func (session *Session) TryCancel(ctx context.Context) (accepted bool, err error) {
 	session.mu.Lock()
-	if session.terminal {
+	won := session.ownership == sessionOpen
+	if won {
+		session.ownership = sessionSending
+	}
+	session.mu.Unlock()
+	if !won {
 		// End already won ownership of this generation: sending a
 		// notification to a dead session would be meaningless, and could
 		// never be misread as reaching a replacement generation, since we
 		// never touch w.active.
-		session.mu.Unlock()
 		return false, nil
 	}
 
 	sendCtx, cancelSend := context.WithTimeout(context.Background(), sendTimeout)
 	sendErr := session.connection.Cancel(sendCtx, acpsdk.CancelNotification{SessionId: session.sessionID})
 	cancelSend()
-	session.mu.Unlock()
 
 	if sendErr != nil {
 		return false, fmt.Errorf("%w: deliver session/cancel: %v", providers.ErrControlSignalFailed, sendErr)

--- a/pkg/services/providers/internal/services/acp/internal/service/cancelwindow/window.go
+++ b/pkg/services/providers/internal/services/acp/internal/service/cancelwindow/window.go
@@ -74,18 +74,40 @@ func (w *Window) End(session *Session, cancelled bool) {
 }
 
 // Live reports, without any side effect, whether attemptID names the
-// currently open cancelable window. It is a deliberately racy pre-filter;
-// see acp.Service.Cancelable.
+// currently open cancelable window. It is a deliberately racy pre-filter.
 func (w *Window) Live(attemptID string) bool {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.active != nil && w.active.attemptID == attemptID
 }
 
-// TryCancel atomically determines whether attemptID names the exact live
-// cancelable window and, only if so, delivers a session/cancel notification
-// and blocks (bounded by ctx) until the window closes. See acp.Service.
-// TryCancel for the accepted/err contract.
+// Claim atomically captures the exact Session currently open for attemptID,
+// if any, without altering window state (it does not clear w.active - only
+// End does that). The returned Session is an opaque generation handle: its
+// own TryCancel method is thereafter the only way to deliver to it, and it
+// never re-resolves "whatever the window's active session is now". This is
+// what lets a caller pin the exact generation a control was claimed against
+// at claim time, so a later Begin call that reuses attemptID for a
+// replacement generation cannot be substituted in when the claimed control's
+// delivery finally runs.
+func (w *Window) Claim(attemptID string) (*Session, bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.active == nil || w.active.attemptID != attemptID {
+		return nil, false
+	}
+	return w.active, true
+}
+
+// TryCancel delivers a session/cancel notification to this exact session -
+// the one Window.Claim captured - and blocks (bounded by ctx) until it
+// observes the session's real recorded terminal outcome. Because it operates
+// only on the Session pinned at claim time, never on whatever Window.active
+// happens to be right now, a later Begin call that reuses this session's
+// attemptID for a different generation cannot redirect delivery to that
+// replacement: this exact Session either delivers to itself, or - if it has
+// already ended - reports accepted=false, err=nil without sending anything,
+// so a stale claim can never observe a replacement generation's outcome.
 //
 // The outbound send is bounded by its own fixed sendTimeout, independent of
 // ctx: this keeps a send failure (wrapped in providers.ErrControlSignalFailed
@@ -96,12 +118,15 @@ func (w *Window) Live(attemptID string) bool {
 // same context.DeadlineExceeded value and erase that distinction. A send
 // failure returns promptly without waiting further: an already-broken
 // connection has no reason to ever close session.done on its own.
-func (w *Window) TryCancel(ctx context.Context, attemptID string) (accepted bool, err error) {
-	w.mu.Lock()
-	session := w.active
-	w.mu.Unlock()
-	if session == nil || session.attemptID != attemptID {
+func (session *Session) TryCancel(ctx context.Context) (accepted bool, err error) {
+	select {
+	case <-session.done:
+		// Already terminal: this generation ended (naturally or otherwise)
+		// before this claim's delivery ran. Sending a notification to a dead
+		// session would be meaningless, and could never be misread as
+		// reaching a replacement generation, since we never touch w.active.
 		return false, nil
+	default:
 	}
 
 	sendCtx, cancelSend := context.WithTimeout(context.Background(), sendTimeout)

--- a/pkg/services/providers/internal/services/acp/internal/service/cancelwindow/window_test.go
+++ b/pkg/services/providers/internal/services/acp/internal/service/cancelwindow/window_test.go
@@ -102,13 +102,18 @@ func TestWindowTryCancelDeliversNotificationAndBlocksUntilWindowCloses(t *testin
 		t.Fatal("Live(attempt-other) = true, want false for a different attempt id")
 	}
 
+	claimed, ok := w.Claim("attempt-1")
+	if !ok || claimed != session {
+		t.Fatalf("Claim(attempt-1) = (%v, %v), want the open session and true", claimed, ok)
+	}
+
 	type outcome struct {
 		accepted bool
 		err      error
 	}
 	tryCancelDone := make(chan outcome, 1)
 	go func() {
-		accepted, err := w.TryCancel(context.Background(), "attempt-1")
+		accepted, err := claimed.TryCancel(context.Background())
 		tryCancelDone <- outcome{accepted: accepted, err: err}
 	}()
 
@@ -137,56 +142,97 @@ func TestWindowTryCancelDeliversNotificationAndBlocksUntilWindowCloses(t *testin
 	}
 }
 
-func TestWindowTryCancelIsNoOpForMismatchedAttemptID(t *testing.T) {
+func TestWindowClaimIsNoOpForMismatchedAttemptID(t *testing.T) {
 	peer := newFakeSessionPeer()
 	connection := newPipedConnection(t, peer)
 
 	w := &Window{}
 	session := w.Begin("attempt-1", acpsdk.SessionId("session-1"), connection)
 
-	accepted, err := w.TryCancel(context.Background(), "attempt-other")
-	if err != nil {
-		t.Fatalf("TryCancel(mismatched) error = %v, want nil", err)
-	}
-	if accepted {
-		t.Fatal("TryCancel(mismatched) accepted = true, want false")
+	claimed, ok := w.Claim("attempt-other")
+	if ok || claimed != nil {
+		t.Fatalf("Claim(mismatched) = (%v, %v), want (nil, false)", claimed, ok)
 	}
 	select {
 	case notification := <-peer.received:
-		t.Fatalf("TryCancel(mismatched) sent a notification %#v, want none", notification)
+		t.Fatalf("Claim(mismatched) sent a notification %#v, want none", notification)
 	default:
 	}
 
 	w.End(session, false)
 }
 
-func TestWindowTryCancelIsNoOpBeforeWindowOpensAndAfterItCloses(t *testing.T) {
+func TestWindowClaimIsNoOpBeforeWindowOpensAndAfterItCloses(t *testing.T) {
 	peer := newFakeSessionPeer()
 	connection := newPipedConnection(t, peer)
 	w := &Window{}
 
-	accepted, err := w.TryCancel(context.Background(), "attempt-1")
-	if err != nil {
-		t.Fatalf("TryCancel(before window) error = %v, want nil", err)
-	}
-	if accepted {
-		t.Fatal("TryCancel(before window) accepted = true, want false")
+	claimed, ok := w.Claim("attempt-1")
+	if ok || claimed != nil {
+		t.Fatalf("Claim(before window) = (%v, %v), want (nil, false)", claimed, ok)
 	}
 
 	session := w.Begin("attempt-1", acpsdk.SessionId("session-1"), connection)
 	w.End(session, false)
 
-	accepted, err = w.TryCancel(context.Background(), "attempt-1")
-	if err != nil {
-		t.Fatalf("TryCancel(after window) error = %v, want nil", err)
-	}
-	if accepted {
-		t.Fatal("TryCancel(after window) accepted = true, want false")
+	claimed, ok = w.Claim("attempt-1")
+	if ok || claimed != nil {
+		t.Fatalf("Claim(after window) = (%v, %v), want (nil, false)", claimed, ok)
 	}
 	select {
 	case notification := <-peer.received:
-		t.Fatalf("TryCancel() outside the window sent a notification %#v, want none", notification)
+		t.Fatalf("Claim() outside the window sent a notification %#v, want none", notification)
 	default:
+	}
+}
+
+// TestWindowClaimPinsExactGenerationSoReusedAttemptIDCannotRedirectDelivery is
+// the deterministic ABA regression: claim generation A's session, let A
+// complete and fully close its window, open generation B with the identical
+// attemptID, then resume A's already-captured claim. Because TryCancel
+// operates only on the *Session pinned by Claim (never re-resolving via
+// Window.active/attemptID), A's stale delivery must report accepted=false,
+// err=nil and send nothing to B - B must receive zero notifications and stay
+// independently cancelable.
+func TestWindowClaimPinsExactGenerationSoReusedAttemptIDCannotRedirectDelivery(t *testing.T) {
+	peer := newFakeSessionPeer()
+	connection := newPipedConnection(t, peer)
+	w := &Window{}
+
+	sessionA := w.Begin("attempt-1", acpsdk.SessionId("session-A"), connection)
+	claimA, ok := w.Claim("attempt-1")
+	if !ok || claimA != sessionA {
+		t.Fatalf("Claim(A) = (%v, %v), want (sessionA, true)", claimA, ok)
+	}
+
+	// A completes normally (not via cancellation) and its window fully closes.
+	w.End(sessionA, false)
+	if w.Live("attempt-1") {
+		t.Fatal("Live(attempt-1) = true after A's End, want false: identity must be free for reuse")
+	}
+
+	// B opens, reusing the exact same attemptID string.
+	sessionB := w.Begin("attempt-1", acpsdk.SessionId("session-B"), connection)
+	t.Cleanup(func() { w.End(sessionB, false) })
+
+	// A's delayed signal now resumes against its already-captured claim.
+	accepted, err := claimA.TryCancel(context.Background())
+	if err != nil {
+		t.Fatalf("claimA.TryCancel() error = %v, want nil", err)
+	}
+	if accepted {
+		t.Fatal("claimA.TryCancel() accepted = true, want false: A already ended, must not reach B")
+	}
+	select {
+	case notification := <-peer.received:
+		t.Fatalf("claimA.TryCancel() sent a notification %#v, want none delivered to B", notification)
+	default:
+	}
+
+	// B must remain independently, correctly claimable/cancelable.
+	claimB, ok := w.Claim("attempt-1")
+	if !ok || claimB != sessionB {
+		t.Fatalf("Claim(B) = (%v, %v), want (sessionB, true)", claimB, ok)
 	}
 }
 
@@ -208,6 +254,10 @@ func TestWindowTryCancelLosesRaceToNaturalCompletionReportsUnsupportedNotComplet
 
 	w := &Window{}
 	session := w.Begin("attempt-1", acpsdk.SessionId("session-1"), connection)
+	claimed, ok := w.Claim("attempt-1")
+	if !ok {
+		t.Fatal("Claim(attempt-1) ok = false, want true")
+	}
 
 	type outcome struct {
 		accepted bool
@@ -215,7 +265,7 @@ func TestWindowTryCancelLosesRaceToNaturalCompletionReportsUnsupportedNotComplet
 	}
 	tryCancelDone := make(chan outcome, 1)
 	go func() {
-		accepted, err := w.TryCancel(context.Background(), "attempt-1")
+		accepted, err := claimed.TryCancel(context.Background())
 		tryCancelDone <- outcome{accepted: accepted, err: err}
 	}()
 
@@ -246,6 +296,10 @@ func TestWindowTryCancelReturnsPromptlyWhenCallerContextEndsWhileWaiting(t *test
 	w := &Window{}
 	session := w.Begin("attempt-1", acpsdk.SessionId("session-1"), connection)
 	t.Cleanup(func() { w.End(session, false) })
+	claimed, ok := w.Claim("attempt-1")
+	if !ok {
+		t.Fatal("Claim(attempt-1) ok = false, want true")
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	type outcome struct {
@@ -254,7 +308,7 @@ func TestWindowTryCancelReturnsPromptlyWhenCallerContextEndsWhileWaiting(t *test
 	}
 	tryCancelDone := make(chan outcome, 1)
 	go func() {
-		accepted, err := w.TryCancel(ctx, "attempt-1")
+		accepted, err := claimed.TryCancel(ctx)
 		tryCancelDone <- outcome{accepted: accepted, err: err}
 	}()
 
@@ -295,13 +349,17 @@ func TestWindowTryCancelReturnsSendFailurePromptlyWithoutWaitingForDoneToClose(t
 
 	w := &Window{}
 	w.Begin("attempt-1", acpsdk.SessionId("session-1"), connection)
+	claimed, ok := w.Claim("attempt-1")
+	if !ok {
+		t.Fatal("Claim(attempt-1) ok = false, want true")
+	}
 
 	done := make(chan struct {
 		accepted bool
 		err      error
 	}, 1)
 	go func() {
-		accepted, err := w.TryCancel(context.Background(), "attempt-1")
+		accepted, err := claimed.TryCancel(context.Background())
 		done <- struct {
 			accepted bool
 			err      error

--- a/pkg/services/providers/internal/services/acp/internal/service/cancelwindow/window_test.go
+++ b/pkg/services/providers/internal/services/acp/internal/service/cancelwindow/window_test.go
@@ -253,17 +253,24 @@ func (g *gatedWriter) Write(p []byte) (int, error) {
 	return g.w.Write(p)
 }
 
-// TestWindowEndCannotRecordCompletionWhileATryCancelSendItAlreadyLostIsInFlight
-// is the deterministic regression for the atomic-ownership gap: the earlier
-// implementation decided "not yet terminal" with a non-blocking check and
-// only afterwards performed the outbound send, so End could record
-// completion - and the identity could become free for reuse - in the gap
-// between that check and the send actually reaching the wire. This test
-// pins TryCancel exactly inside that gap (via gatedWriter, a real blocking
-// primitive, not a sleep) and proves End cannot record completion until the
-// send TryCancel already committed to finishes: the two decisions are one
-// atomic unit, not two independently-timed ones.
-func TestWindowEndCannotRecordCompletionWhileATryCancelSendItAlreadyLostIsInFlight(t *testing.T) {
+// TestWindowEndReachesTerminalResultAndReleasesIdentityWhileATryCancelSendIsStuckPastTheSendBound
+// is the deterministic regression for the blocked-write liveness bug: an
+// earlier fix held session.mu across the outbound send itself, so a peer
+// that stopped reading mid-write (the acp-go-sdk connection does not honor
+// ctx once inside its synchronous io.Writer.Write call) left that mutex held
+// forever, and End - which must acquire the same mutex to record completion
+// - blocked indefinitely. That meant Window's active slot, the identity
+// reservation, and everything upstream that waits on daemon.execute
+// returning could hang forever on a single unresponsive peer. This test
+// pins TryCancel deep inside a send that is held open well past sendTimeout
+// (via gatedWriter, a real blocking primitive, not a sleep) and proves End
+// still reaches a defined terminal result and fully releases the window
+// promptly - including letting a same-identity Begin proceed immediately -
+// without ever waiting on that stuck send. It also proves that once the
+// stuck send is finally released, its late notification reaches only its
+// own session ID and never the replacement generation that reused the
+// identity in the meantime.
+func TestWindowEndReachesTerminalResultAndReleasesIdentityWhileATryCancelSendIsStuckPastTheSendBound(t *testing.T) {
 	peer := newFakeSessionPeer()
 	outboundReader, outboundWriter := io.Pipe()
 	gate := &gatedWriter{w: outboundWriter, entered: make(chan struct{}), release: make(chan struct{})}
@@ -272,10 +279,10 @@ func TestWindowEndCannotRecordCompletionWhileATryCancelSendItAlreadyLostIsInFlig
 	connection := acpsdk.NewClientSideConnection(noopClient{}, gate, io.MultiReader())
 
 	w := &Window{}
-	session := w.Begin("attempt-1", acpsdk.SessionId("session-1"), connection)
-	claimed, ok := w.Claim("attempt-1")
-	if !ok || claimed != session {
-		t.Fatalf("Claim(attempt-1) = (%v, %v), want the open session and true", claimed, ok)
+	sessionA := w.Begin("attempt-1", acpsdk.SessionId("session-A"), connection)
+	claimedA, ok := w.Claim("attempt-1")
+	if !ok || claimedA != sessionA {
+		t.Fatalf("Claim(attempt-1) = (%v, %v), want the open session and true", claimedA, ok)
 	}
 
 	type outcome struct {
@@ -284,35 +291,56 @@ func TestWindowEndCannotRecordCompletionWhileATryCancelSendItAlreadyLostIsInFlig
 	}
 	tryCancelDone := make(chan outcome, 1)
 	go func() {
-		accepted, err := claimed.TryCancel(context.Background())
+		accepted, err := claimedA.TryCancel(context.Background())
 		tryCancelDone <- outcome{accepted: accepted, err: err}
 	}()
 
-	// TryCancel has observed the generation as not yet terminal and is now
-	// blocked mid-send, holding ownership of the atomic decision.
+	// TryCancel has won ownership of A and is now blocked mid-send, well past
+	// what sendTimeout would bound if the SDK actually honored it.
 	<-gate.entered
+	time.Sleep(2 * sendTimeout)
 
 	endDone := make(chan struct{})
 	go func() {
-		w.End(session, true)
+		// A's real Execute() outcome was not a cancellation - the daemon's
+		// own response raced ahead of the (still in-flight) cancel send.
+		w.End(sessionA, false)
 		close(endDone)
 	}()
 
 	select {
 	case <-endDone:
-		t.Fatal("End() recorded completion while TryCancel's already-committed send was still in flight; ownership is not atomic")
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(2 * time.Second):
+		t.Fatal("End() did not reach a terminal result while TryCancel's send was stuck; a blocked peer write must never block End")
 	}
 
+	// The identity must be free for reuse immediately - not just eventually.
+	sessionB := w.Begin("attempt-1", acpsdk.SessionId("session-B"), connection)
+	claimedB, ok := w.Claim("attempt-1")
+	if !ok || claimedB != sessionB {
+		t.Fatalf("Claim(attempt-1) after A's End = (%v, %v), want the fresh session B and true", claimedB, ok)
+	}
+	w.End(sessionB, false)
+
+	// Now let A's long-stuck send finally land.
 	close(gate.release)
-	<-endDone
 
 	result := <-tryCancelDone
 	if result.err != nil {
 		t.Fatalf("TryCancel() error = %v, want nil", result.err)
 	}
-	if !result.accepted {
-		t.Fatal("TryCancel() accepted = false, want true: it won ownership of the generation before End could record completion")
+	if result.accepted {
+		t.Fatal("TryCancel() accepted = true, want false: End already recorded A's outcome before this call could observe cancellation")
+	}
+
+	notification := <-peer.received
+	if notification.SessionId != "session-A" {
+		t.Fatalf("late notification SessionId = %q, want session-A (A's own identity), never B's", notification.SessionId)
+	}
+	select {
+	case extra := <-peer.received:
+		t.Fatalf("received an unexpected second notification %#v, want exactly one (A's stale send, never one addressed to B)", extra)
+	default:
 	}
 }
 

--- a/pkg/services/providers/internal/services/acp/internal/service/cancelwindow/window_test.go
+++ b/pkg/services/providers/internal/services/acp/internal/service/cancelwindow/window_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -95,11 +96,8 @@ func TestWindowTryCancelDeliversNotificationAndBlocksUntilWindowCloses(t *testin
 	w := &Window{}
 	session := w.Begin("attempt-1", acpsdk.SessionId("session-1"), connection)
 
-	if !w.Live("attempt-1") {
-		t.Fatal("Live(attempt-1) = false, want true once Begin has run")
-	}
-	if w.Live("attempt-other") {
-		t.Fatal("Live(attempt-other) = true, want false for a different attempt id")
+	if _, ok := w.Claim("attempt-other"); ok {
+		t.Fatal("Claim(attempt-other) ok = true, want false for a different attempt id")
 	}
 
 	claimed, ok := w.Claim("attempt-1")
@@ -137,8 +135,8 @@ func TestWindowTryCancelDeliversNotificationAndBlocksUntilWindowCloses(t *testin
 	if !result.accepted {
 		t.Fatal("TryCancel() accepted = false, want true when the turn's real outcome was cancellation")
 	}
-	if w.Live("attempt-1") {
-		t.Fatal("Live(attempt-1) = true after End, want false")
+	if _, ok := w.Claim("attempt-1"); ok {
+		t.Fatal("Claim(attempt-1) ok = true after End, want false")
 	}
 }
 
@@ -207,8 +205,8 @@ func TestWindowClaimPinsExactGenerationSoReusedAttemptIDCannotRedirectDelivery(t
 
 	// A completes normally (not via cancellation) and its window fully closes.
 	w.End(sessionA, false)
-	if w.Live("attempt-1") {
-		t.Fatal("Live(attempt-1) = true after A's End, want false: identity must be free for reuse")
+	if _, ok := w.Claim("attempt-1"); ok {
+		t.Fatal("Claim(attempt-1) ok = true after A's End, want false: identity must be free for reuse")
 	}
 
 	// B opens, reusing the exact same attemptID string.
@@ -233,6 +231,88 @@ func TestWindowClaimPinsExactGenerationSoReusedAttemptIDCannotRedirectDelivery(t
 	claimB, ok := w.Claim("attempt-1")
 	if !ok || claimB != sessionB {
 		t.Fatalf("Claim(B) = (%v, %v), want (sessionB, true)", claimB, ok)
+	}
+}
+
+// gatedWriter blocks the first Write call until release is closed, letting a
+// test pause a TryCancel goroutine at the exact instant it is inside its
+// outbound send - after it has already decided the generation was not yet
+// terminal - so a concurrent End can be attempted against that same window.
+// entered is closed once the blocked Write is reached, giving the test a
+// real synchronization point instead of a sleep.
+type gatedWriter struct {
+	w       io.Writer
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (g *gatedWriter) Write(p []byte) (int, error) {
+	g.once.Do(func() { close(g.entered) })
+	<-g.release
+	return g.w.Write(p)
+}
+
+// TestWindowEndCannotRecordCompletionWhileATryCancelSendItAlreadyLostIsInFlight
+// is the deterministic regression for the atomic-ownership gap: the earlier
+// implementation decided "not yet terminal" with a non-blocking check and
+// only afterwards performed the outbound send, so End could record
+// completion - and the identity could become free for reuse - in the gap
+// between that check and the send actually reaching the wire. This test
+// pins TryCancel exactly inside that gap (via gatedWriter, a real blocking
+// primitive, not a sleep) and proves End cannot record completion until the
+// send TryCancel already committed to finishes: the two decisions are one
+// atomic unit, not two independently-timed ones.
+func TestWindowEndCannotRecordCompletionWhileATryCancelSendItAlreadyLostIsInFlight(t *testing.T) {
+	peer := newFakeSessionPeer()
+	outboundReader, outboundWriter := io.Pipe()
+	gate := &gatedWriter{w: outboundWriter, entered: make(chan struct{}), release: make(chan struct{})}
+	go peer.run(outboundReader)
+	t.Cleanup(func() { _ = outboundWriter.Close() })
+	connection := acpsdk.NewClientSideConnection(noopClient{}, gate, io.MultiReader())
+
+	w := &Window{}
+	session := w.Begin("attempt-1", acpsdk.SessionId("session-1"), connection)
+	claimed, ok := w.Claim("attempt-1")
+	if !ok || claimed != session {
+		t.Fatalf("Claim(attempt-1) = (%v, %v), want the open session and true", claimed, ok)
+	}
+
+	type outcome struct {
+		accepted bool
+		err      error
+	}
+	tryCancelDone := make(chan outcome, 1)
+	go func() {
+		accepted, err := claimed.TryCancel(context.Background())
+		tryCancelDone <- outcome{accepted: accepted, err: err}
+	}()
+
+	// TryCancel has observed the generation as not yet terminal and is now
+	// blocked mid-send, holding ownership of the atomic decision.
+	<-gate.entered
+
+	endDone := make(chan struct{})
+	go func() {
+		w.End(session, true)
+		close(endDone)
+	}()
+
+	select {
+	case <-endDone:
+		t.Fatal("End() recorded completion while TryCancel's already-committed send was still in flight; ownership is not atomic")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(gate.release)
+	<-endDone
+
+	result := <-tryCancelDone
+	if result.err != nil {
+		t.Fatalf("TryCancel() error = %v, want nil", result.err)
+	}
+	if !result.accepted {
+		t.Fatal("TryCancel() accepted = false, want true: it won ownership of the generation before End could record completion")
 	}
 }
 

--- a/pkg/services/providers/internal/services/acp/internal/service/prompt_window_test.go
+++ b/pkg/services/providers/internal/services/acp/internal/service/prompt_window_test.go
@@ -28,14 +28,10 @@ func TestDaemonPromptWithWindow_PanicStillClosesWindowForLaterIdentityReuse(t *t
 		})
 	}()
 
-	if d.window.Live(attemptID) {
-		t.Fatal("window.Live() = true after a panicking prompt, want the window closed on unexpected unwind")
-	}
-
 	// A control racing in before the next execution's own Begin must observe
 	// no live window for this identity - not hang on the dead stale session.
 	if _, ok := d.window.Claim(attemptID); ok {
-		t.Fatal("Claim() on stale identity ok = true, want false: no live window remains for a closed session")
+		t.Fatal("Claim() on stale identity ok = true, want false: no live window remains for a closed session, including after a panicking prompt")
 	}
 
 	// A later execution reusing the same attempt ID must be able to bind and
@@ -87,7 +83,7 @@ func TestDaemonPromptWithWindow_NormalReturnRecordsOutcomeAndClosesWindow(t *tes
 	if response.StopReason != acpsdk.StopReasonEndTurn {
 		t.Fatalf("promptWithWindow() response = %#v, want the prompt func's own response", response)
 	}
-	if d.window.Live(attemptID) {
-		t.Fatal("window.Live() = true after a normal return, want the window closed")
+	if _, ok := d.window.Claim(attemptID); ok {
+		t.Fatal("Claim() ok = true after a normal return, want the window closed")
 	}
 }

--- a/pkg/services/providers/internal/services/acp/internal/service/prompt_window_test.go
+++ b/pkg/services/providers/internal/services/acp/internal/service/prompt_window_test.go
@@ -34,12 +34,8 @@ func TestDaemonPromptWithWindow_PanicStillClosesWindowForLaterIdentityReuse(t *t
 
 	// A control racing in before the next execution's own Begin must observe
 	// no live window for this identity - not hang on the dead stale session.
-	accepted, err := d.window.TryCancel(context.Background(), attemptID)
-	if err != nil {
-		t.Fatalf("TryCancel() on stale identity error = %v, want nil", err)
-	}
-	if accepted {
-		t.Fatal("TryCancel() on stale identity accepted = true, want false: no live window remains for a closed session")
+	if _, ok := d.window.Claim(attemptID); ok {
+		t.Fatal("Claim() on stale identity ok = true, want false: no live window remains for a closed session")
 	}
 
 	// A later execution reusing the same attempt ID must be able to bind and
@@ -47,6 +43,10 @@ func TestDaemonPromptWithWindow_PanicStillClosesWindowForLaterIdentityReuse(t *t
 	peer := newFakeSessionPeer()
 	connection := newPipedConnection(t, peer)
 	freshSession := d.window.Begin(attemptID, acpsdk.SessionId("fresh-session"), connection)
+	claimed, ok := d.window.Claim(attemptID)
+	if !ok || claimed != freshSession {
+		t.Fatalf("Claim() on reused identity = (%v, %v), want the fresh session and true", claimed, ok)
+	}
 
 	type outcome struct {
 		accepted bool
@@ -54,7 +54,7 @@ func TestDaemonPromptWithWindow_PanicStillClosesWindowForLaterIdentityReuse(t *t
 	}
 	tryCancelDone := make(chan outcome, 1)
 	go func() {
-		accepted, err := d.window.TryCancel(context.Background(), attemptID)
+		accepted, err := claimed.TryCancel(context.Background())
 		tryCancelDone <- outcome{accepted: accepted, err: err}
 	}()
 	<-peer.received

--- a/pkg/services/providers/internal/services/acp/internal/service/service.go
+++ b/pkg/services/providers/internal/services/acp/internal/service/service.go
@@ -54,8 +54,8 @@ func New(integrations []providers.ACPIntegration, newCommand platformprocess.Com
 // resolveDaemon resolves id (including an accepted alias) to its canonical
 // identity and owning daemon under a single read lock. ok mirrors
 // resolveLocked's own result; it does not additionally guarantee daemon is
-// non-nil, matching Execute's pre-existing behavior. Cancelable and
-// TryCancel additionally check for a nil daemon themselves.
+// non-nil, matching Execute's pre-existing behavior. Claim additionally
+// checks for a nil daemon itself.
 func (service *Service) resolveDaemon(id providers.ID) (target *daemon, canonical providers.ID, ok bool) {
 	service.mu.RLock()
 	canonical, ok = service.resolveLocked(id)
@@ -72,22 +72,28 @@ func (service *Service) Execute(ctx context.Context, id providers.ID, request pr
 	return daemon.execute(ctx, canonical, request)
 }
 
-// Cancelable reports whether attemptID names the exact attempt id's daemon
-// currently has an established session/prompt turn in flight for.
-func (service *Service) Cancelable(id providers.ID, attemptID string) bool {
-	target, _, ok := service.resolveDaemon(id)
-	return ok && target != nil && target.window.Live(attemptID)
-}
-
-// TryCancel atomically determines whether id/attemptID names the exact live
-// session/prompt turn and, only if so, delivers a session/cancel
-// notification and blocks (bounded by ctx) until that turn returns.
-func (service *Service) TryCancel(ctx context.Context, id providers.ID, attemptID string) (bool, error) {
+// Claim atomically captures the exact live cancel-window generation named by
+// id/attemptID, if id's daemon currently has an established session/prompt
+// turn in flight for it.
+func (service *Service) Claim(id providers.ID, attemptID string) (acp.Generation, bool) {
 	target, _, ok := service.resolveDaemon(id)
 	if !ok || target == nil {
+		return nil, false
+	}
+	return target.window.Claim(attemptID)
+}
+
+// TryCancel delivers a session/cancel notification to the exact generation
+// captured by a prior Claim call and blocks (bounded by ctx) until it
+// observes that generation's real recorded terminal outcome. It never
+// re-resolves generation by identity strings, so it cannot be redirected to
+// a different generation that later reuses the same provider/attemptID.
+func (service *Service) TryCancel(ctx context.Context, generation acp.Generation) (bool, error) {
+	session, ok := generation.(*cancelwindow.Session)
+	if !ok || session == nil {
 		return false, nil
 	}
-	return target.window.TryCancel(ctx, attemptID)
+	return session.TryCancel(ctx)
 }
 
 func (service *Service) Close(ctx context.Context) error {

--- a/pkg/services/providers/internal/services/acp/service.go
+++ b/pkg/services/providers/internal/services/acp/service.go
@@ -16,28 +16,40 @@ type Service interface {
 	Resolve(providers.ID) (providers.ID, bool)
 	Execute(context.Context, providers.ID, providers.ExecuteRequest) (providers.ExecuteResult, error)
 
-	// Cancelable reports, without any side effect, whether id/attemptID names
-	// the exact attempt this service currently has an established session/
-	// prompt turn in flight for -- the only ACP protocol state a session/
-	// cancel notification can truthfully target. It answers false before the
-	// session exists, after the turn has already returned, and for any other
-	// attempt or provider identity. It is a cheap, deliberately racy
-	// pre-filter (the turn can end at any moment after this call returns);
-	// callers that need a truthful accept/reject outcome must use TryCancel,
-	// which re-derives liveness atomically at the instant it acts instead of
-	// trusting an earlier Cancelable observation.
-	Cancelable(id providers.ID, attemptID string) bool
+	// Claim atomically captures the exact live execution generation named by
+	// id/attemptID, without any other side effect, when this service
+	// currently has an established session/prompt turn in flight for it --
+	// the only ACP protocol state a session/cancel notification can
+	// truthfully target. ok is false before the session exists, after the
+	// turn has already returned, and for any other attempt or provider
+	// identity. The returned Generation is an opaque capability: TryCancel
+	// delivers only to the exact generation it names, so a control that has
+	// claimed one generation can never be redirected to a later generation
+	// that reuses the identical id/attemptID strings, even if this attempt
+	// completes and a new one binds that identity before TryCancel runs.
+	Claim(id providers.ID, attemptID string) (generation Generation, ok bool)
 
-	// TryCancel atomically determines whether id/attemptID names the exact
-	// live session/prompt turn and, only if so, delivers a session/cancel
-	// protocol notification to it and blocks (bounded by ctx) until the turn
-	// returns. accepted is true only when the turn's real recorded outcome
-	// was that cancellation -- never merely because a matching identity was
-	// observed a moment earlier -- so a natural completion racing this call
-	// is reported as accepted=false, not a false positive. A non-nil err
-	// reports a genuine delivery failure or ctx ending before the turn's
+	// TryCancel delivers a session/cancel protocol notification to the exact
+	// generation named by generation (as previously captured by Claim) and
+	// blocks (bounded by ctx) until it observes that generation's real
+	// recorded terminal outcome. accepted is true only when the generation's
+	// real recorded outcome was that cancellation -- never merely because
+	// Claim observed it live a moment earlier -- so a natural completion
+	// racing this call, or a generation that has already ended by the time
+	// this call runs, is reported as accepted=false, not a false positive. A
+	// non-nil err reports a genuine delivery failure or ctx ending before the
 	// outcome could be observed; both are distinguishable from
-	// accepted=false, err=nil (unsupported/lost-the-race) and from each
-	// other (errors.Is against the returned error identifies which).
-	TryCancel(ctx context.Context, id providers.ID, attemptID string) (accepted bool, err error)
+	// accepted=false, err=nil (unsupported/lost-the-race/already-terminal)
+	// and from each other (errors.Is against the returned error identifies
+	// which).
+	TryCancel(ctx context.Context, generation Generation) (accepted bool, err error)
 }
+
+// Generation is an opaque capability naming one exact live ACP execution
+// generation, captured by Claim at the instant it observed that generation
+// live. Provider and attempt identity strings alone can never rediscover or
+// replace the generation a Generation value names: this is what lets a
+// claimed control retain authority over only the exact generation it was
+// claimed from, even after that generation ends and a later execution reuses
+// the same canonical provider and attempt ID.
+type Generation any


### PR DESCRIPTION
{
  "project": "Bind ACP Provider Controls to the Exact Execution Generation",
  "branchName": "ACP-L2-FIX-PRV-CONTROL-GENERATION",
  "description": "Correct the merged L2 Providers control implementation so a control claimed for one live ACP execution generation can never be delivered to a later generation that reuses the same canonical provider and attempt ID. Preserve an opaque generation-bound control capability from claim through notification delivery and terminal observation while keeping public contracts, ordinary execution behavior, and ACP program boundaries unchanged.",
  "context": {
    "customerAsk": "Complete the L2 IMP-PRV-CONTROL packet with truthful exact-attempt control semantics while preserving ACP program decisions and keeping L1 unblocked. Close the post-merge ABA race so a delayed control claimed for generation A cannot reach generation B after B reuses the same canonical provider and attempt ID.",
    "problem": "The Providers live-attempt registry removes generation A's string-keyed entry when control claims it, but the returned ACP control later re-resolves the active cancel window using only canonical provider and attempt ID. If A completes and B reuses those strings before A's delayed signal resumes, the signal can select B even though string identity is insufficient proof of execution-generation ownership.",
    "solution": "Bind ACP control claim and delivery to the same opaque execution generation. Retain an attempt-scoped capability for the exact cancel-window/session generation observed at claim time, operate only on that capability through delivery and terminal observation, arbitrate completion and control in generation-local state, invalidate stale capabilities, and permit identity reuse only after the previous generation is fully released. Keep providers.Service, ControlAttemptRequest, transports, storage, events, continuation, checkpoints, Worker Sessions, and composition unchanged."
  },
  "acceptanceCriteria": [
    "A validated control reaches only the exact live execution generation from which it was claimed, even when canonical provider and attempt IDs are later reused.",
    "A deterministic claim-A, complete-A, bind/open-B-with-the-same-identity, resume-A-signal regression proves B receives no notification and A returns unsupported or an existing typed defined error rather than completed.",
    "Concurrent completion and control have one deterministic winner; duplicate controls cannot deliver twice; registry, generation capability, and cancel-window state are completely released without cross-attempt effects.",
    "Ordinary uncontrolled Execute behavior and truthful unsupported outcomes remain unchanged for native providers, ACP providers/actions without a live exact-generation seam, unknown attempts, and safely reused identities.",
    "The public providers.Service and ControlAttemptRequest remain unchanged, and no OpenAPI/generated-client, CLI, ACP transport, Worker Session, continuation, checkpoint, storage, durable Events, second event vocabulary, broad composition, or unrelated cleanup change is introduced.",
    "Typecheck/compile validation, focused Providers and ACP control tests repeated and under the race detector, lint, proportionate repository verification, and required CI are terminal and passing with no new in-scope baseline violations.",
    "The implementation/review loop continues until every blocking PR conversation is explicitly addressed, shared-file and merge conflicts are reconciled against current main, required CI is terminal and passing, the correction PR is merged, and the Factory idea/task/review path is terminal; an opened, green, approved, or ready-to-merge PR is not complete."
  ],
  "userStories": [
    {
      "id": "ACP-L2-FIX-PRV-CONTROL-GENERATION-001",
      "title": "Preserve Generation Ownership Through ACP Control Delivery",
      "description": "As an orchestration caller, I want a claimed ACP control to retain authority only over the execution generation that accepted the claim so that later identity reuse cannot retarget the signal.",
      "acceptanceCriteria": [
        "Claiming a live ACP control yields an opaque capability bound to that exact cancel-window/session generation; provider and attempt strings alone cannot rediscover or replace its delivery target.",
        "Delivery and terminal observation use the claimed generation capability and never select a currently active replacement window by re-running a string-only lookup.",
        "If the claimed generation becomes terminal before delivery wins, the stale control returns ControlOutcomeUnsupported with nil error, or an existing typed defined error when its established failure condition applies, and never returns completed from a replacement generation's outcome.",
        "The public providers.Service, ControlAttemptRequest, control action/outcome vocabulary, and transport contracts remain unchanged.",
        "Focused Providers and ACP cancel-window tests prove exact-generation claim, delivery, invalidation, and stale outcome behavior without source-inventory or topology assertions.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "cancelwindow.Window.Claim/(*Session).TryCancel replaced the string-keyed Window.TryCancel; acp.Service.Claim/TryCancel(Generation) replaced Cancelable/TryCancel(id,attemptID); acpAttemptControl now captures and delivers only to that opaque generation. Regression: TestWindowClaimPinsExactGenerationSoReusedAttemptIDCannotRedirectDelivery."
    },
    {
      "id": "ACP-L2-FIX-PRV-CONTROL-GENERATION-002",
      "title": "Isolate Delayed Controls Across Identity Reuse",
      "description": "As a Providers caller, I want a completed attempt identity to be safely reusable without exposing the replacement execution to an older delayed control.",
      "acceptanceCriteria": [
        "A deterministic regression gates this exact schedule without sleeps: claim control for generation A; complete A; fully release A; bind and open generation B with the same canonical provider and attempt ID; resume A's delayed signal.",
        "Generation B receives zero cancel notifications, remains able to complete normally, and retains its own independent control capability.",
        "A's delayed control returns unsupported, or an existing typed defined error where applicable, and cannot derive completed from B's terminal outcome.",
        "Reuse remains rejected while the old generation still owns the live identity, then succeeds after its registry and cancel-window ownership are fully released.",
        "The regression uses deterministic barriers or controllable protocol seams and proves observable notification/outcome behavior rather than implementation inventories.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Deterministic root-level regression TestControlAttempt_ACPDelayedControlCannotRedirectToReplacementGenerationAfterIdentityReuse drives claim-A/complete-A/release-A/bind-open-B-same-identity/resume-A-signal through the real providers.Service via a sequentialACPService fake with a one-shot TryCancel gate (no sleeps): B gets zero notifications, A returns unsupported, B stays independently controllable."
    },
    {
      "id": "ACP-L2-FIX-PRV-CONTROL-GENERATION-003",
      "title": "Arbitrate Completion, Duplicate Control, and Cleanup Deterministically",
      "description": "As a Providers caller, I want stable results when completion and one or more controls race so that no attempt is signaled twice, leaked, or confused with a later generation.",
      "acceptanceCriteria": [
        "For one generation, completion and control use one explicit atomic ownership rule: control reports completed only when that generation accepts the signal and records its established canceled terminal outcome; otherwise the control reports unsupported or the existing applicable typed error.",
        "At most one duplicate control can win for a generation, no duplicate notification is emitted, and all losing or later controls return the established unsupported result without affecting another attempt.",
        "Success, failure, cancellation, timeout, signal failure, caller-context cancellation, and unexpected terminal unwind leave no live registry entry, claim reservation, or cancel-window generation that can be selected later.",
        "Focused repeat tests and go test -race coverage prove completion/control arbitration, duplicate behavior, cleanup, safe identity reuse, zero cross-attempt effects, and unchanged ordinary uncontrolled native and ACP execution behavior.",
        "Production changes remain limited to the Providers-owned live-attempt registry/service and ACP control/cancel-window implementation required for generation safety; measured coverage baselines are updated only if the correction requires them.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Registry claim/release atomicity and generation-close (window.End) cleanup were unchanged (attempt_registry.go untouched); existing arbitration/duplicate/cleanup tests (TestControlAttempt_DuplicateConcurrentControlsExactlyOneCompletes, TestLiveAttemptRegistry_ClaimRacingReleaseHasOneDeterministicWinnerAndAlwaysRemoves, TestDaemonPromptWithWindow_PanicStillClosesWindowForLaterIdentityReuse, etc.) pass unchanged. Production changes confined to cancelwindow, acp.Service, and acpAttemptControl. Functional coverage floors for acp/internal/service and cancelwindow recomputed to their honest measured ceilings (both packages' Claim/TryCancel remain unreachable via the functional lane, same as the Cancelable/TryCancel they replace, since ControlAttempt has no wired transport). go test -race cannot execute in this Windows sandbox (ThreadSanitizer allocation failure, pre-existing/documented); verified instead with -count=20 repeats of the new and existing race-sensitive tests."
    }
  ]
}
