### PR TITLE
ACP-L2-DEL-WRK-EXECUTE: restore coverage floors after Execute deletion

### DIFF
--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -778,7 +778,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/runtime",
-      "minimum": 82.36
+      "minimum": 82.40
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/runtime/buffers",
@@ -2050,7 +2050,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers",
-      "minimum": 78.71
+      "minimum": 79.81
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal",
@@ -2256,7 +2256,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/wire",
-      "minimum": 79.15
+      "minimum": 82.14
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/acp",

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/work_output_materialization_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/work_output_materialization_test.go
@@ -137,6 +137,128 @@ func TestMaterializeWorkerOutputForDispatchNoopWithoutProposals(t *testing.T) {
 	}
 }
 
+func TestMaterializeWorkerOutputForDispatchFailsWithoutWorkService(t *testing.T) {
+	t.Parallel()
+
+	result := materializeWorkerOutputForDispatch(
+		context.Background(),
+		nil,
+		nil,
+		func() string { return "1" },
+		workerexecution.WorkstationDispatchRequest{
+			Execution: workerexecution.WorkstationExecutionRequest{
+				Dispatch: work.WorkDispatch{DispatchID: "dispatch-1"},
+			},
+		},
+		workerexecution.WorkResult{
+			Outcome: workerexecution.OutcomeAccepted,
+			RecordedOutputWork: []work.FactoryWorkItem{{
+				ID:          "agent-id",
+				WorkTypeID:  "task",
+				DisplayName: "proposal",
+			}},
+		},
+	)
+	if result.Outcome != workerexecution.OutcomeFailed {
+		t.Fatalf("outcome = %q, want FAILED", result.Outcome)
+	}
+	if len(result.RecordedOutputWork) != 0 {
+		t.Fatalf("RecordedOutputWork = %#v, want empty when Work service is unavailable", result.RecordedOutputWork)
+	}
+	if !strings.Contains(result.Error, "Work service is required") {
+		t.Fatalf("error = %q, want Work-service-required detail", result.Error)
+	}
+}
+
+func TestMaterializeWorkerOutputForDispatchPreservesExistingErrorOnFailure(t *testing.T) {
+	t.Parallel()
+
+	result := materializeWorkerOutputForDispatch(
+		context.Background(),
+		testMaterializationService(),
+		&state.Net{WorkTypes: map[string]*state.WorkType{"task": {ID: "task"}}},
+		func() string { return "1" },
+		workerexecution.WorkstationDispatchRequest{
+			Execution: workerexecution.WorkstationExecutionRequest{
+				Dispatch: work.WorkDispatch{DispatchID: "dispatch-1"},
+			},
+		},
+		workerexecution.WorkResult{
+			Outcome: workerexecution.OutcomeAccepted,
+			Error:   "prior warning",
+			RecordedOutputWork: []work.FactoryWorkItem{{
+				ID:          "agent-id",
+				WorkTypeID:  "missing",
+				DisplayName: "bad",
+			}},
+		},
+	)
+	if result.Outcome != workerexecution.OutcomeFailed {
+		t.Fatalf("outcome = %q, want FAILED", result.Outcome)
+	}
+	if !strings.Contains(result.Error, "prior warning") || !strings.Contains(result.Error, "worker output materialization") {
+		t.Fatalf("error = %q, want both prior warning and materialization detail preserved", result.Error)
+	}
+}
+
+func TestMaterializeWorkerOutputForDispatchAppliesFeedbackAndClassificationWithoutNet(t *testing.T) {
+	t.Parallel()
+
+	result := materializeWorkerOutputForDispatch(
+		context.Background(),
+		testMaterializationService(),
+		nil,
+		func() string { return "owned" },
+		workerexecution.WorkstationDispatchRequest{
+			Execution: workerexecution.WorkstationExecutionRequest{
+				Dispatch: work.WorkDispatch{DispatchID: "dispatch-1"},
+			},
+		},
+		workerexecution.WorkResult{
+			Outcome:                     workerexecution.OutcomeAccepted,
+			Feedback:                    "needs another pass",
+			SelectedClassificationLabel: "accepted",
+			RecordedOutputWork: []work.FactoryWorkItem{{
+				ID:          "agent-id",
+				WorkTypeID:  "any-type",
+				DisplayName: "proposal",
+				State:       "any-state",
+			}},
+		},
+	)
+	if result.Outcome != workerexecution.OutcomeAccepted {
+		t.Fatalf("outcome = %q, want ACCEPTED", result.Outcome)
+	}
+	if result.Feedback != "needs another pass" {
+		t.Fatalf("Feedback = %q, want propagated materialized feedback", result.Feedback)
+	}
+	if result.SelectedClassificationLabel != "accepted" {
+		t.Fatalf("SelectedClassificationLabel = %q, want propagated materialized classification", result.SelectedClassificationLabel)
+	}
+	if len(result.RecordedOutputWork) != 1 {
+		t.Fatalf("RecordedOutputWork = %#v, want a materialized item without a net's type/state restriction", result.RecordedOutputWork)
+	}
+}
+
+func TestValidStatesByTypeFromNetHandlesNilNet(t *testing.T) {
+	t.Parallel()
+
+	if got := validStatesByTypeFromNet(nil); got != nil {
+		t.Fatalf("validStatesByTypeFromNet(nil) = %#v, want nil", got)
+	}
+}
+
+func TestValidWorkTypesFromNetHandlesNilAndEmptyNet(t *testing.T) {
+	t.Parallel()
+
+	if got := validWorkTypesFromNet(nil); got != nil {
+		t.Fatalf("validWorkTypesFromNet(nil) = %#v, want nil", got)
+	}
+	if got := validWorkTypesFromNet(&state.Net{}); got != nil {
+		t.Fatalf("validWorkTypesFromNet(empty) = %#v, want nil", got)
+	}
+}
+
 func testMaterializationService() work.Service {
 	return workwire.NewRuntimeService(nil, nil, nil, nil)
 }

--- a/pkg/services/workers/proposed_output_contracts_test.go
+++ b/pkg/services/workers/proposed_output_contracts_test.go
@@ -1,0 +1,101 @@
+package workers_test
+
+import (
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+)
+
+func TestProposedWorkCloneDetachesMutableFields(t *testing.T) {
+	t.Parallel()
+
+	source := workers.ProposedWork{
+		WorkTypeID: "task",
+		Name:       "a",
+		State:      "init",
+		Content:    []work.WorkContentPart{{Type: work.WorkContentPartTypeText, Text: "body"}},
+		Tags:       map[string]string{"k": "v"},
+		Relations:  []work.Relation{{Type: work.RelationDependsOn, TargetWorkID: "other"}},
+	}
+
+	clone := source.Clone()
+
+	source.Content[0].Text = "mutated"
+	source.Tags["k"] = "mutated"
+	source.Relations[0].TargetWorkID = "mutated"
+
+	if clone.Content[0].Text != "body" {
+		t.Fatalf("Content mutation leaked into clone: %#v", clone.Content)
+	}
+	if clone.Tags["k"] != "v" {
+		t.Fatalf("Tags mutation leaked into clone: %#v", clone.Tags)
+	}
+	if clone.Relations[0].TargetWorkID != "other" {
+		t.Fatalf("Relations mutation leaked into clone: %#v", clone.Relations)
+	}
+	if clone.WorkTypeID != "task" || clone.Name != "a" || clone.State != "init" {
+		t.Fatalf("scalar fields not preserved: %#v", clone)
+	}
+}
+
+func TestProposedWorkCloneHandlesEmptyFields(t *testing.T) {
+	t.Parallel()
+
+	clone := workers.ProposedWork{WorkTypeID: "task"}.Clone()
+	if clone.Content != nil || clone.Tags != nil || clone.Relations != nil {
+		t.Fatalf("expected nil slices/maps to stay nil, got %#v", clone)
+	}
+}
+
+func TestProposedOutputCloneDetachesNestedProposalsAndArtifacts(t *testing.T) {
+	t.Parallel()
+
+	source := workers.ProposedOutput{
+		Primary:        []work.WorkContentPart{{Type: work.WorkContentPartTypeText, Text: "primary"}},
+		Feedback:       "ok",
+		Classification: "accepted",
+		ProposedWork: []workers.ProposedWork{{
+			WorkTypeID: "task",
+			Name:       "a",
+			Content:    []work.WorkContentPart{{Type: work.WorkContentPartTypeText, Text: "body"}},
+			Tags:       map[string]string{"k": "v"},
+		}},
+		ArtifactRefs: []workers.ArtifactRef{{ArtifactID: "art-1", Label: "l", URI: "u"}},
+	}
+
+	clone := source.Clone()
+
+	source.Primary[0].Text = "mutated"
+	source.ProposedWork[0].Content[0].Text = "mutated"
+	source.ProposedWork[0].Tags["k"] = "mutated"
+	source.ArtifactRefs[0].ArtifactID = "mutated"
+
+	if clone.Primary[0].Text != "primary" {
+		t.Fatalf("Primary mutation leaked into clone: %#v", clone.Primary)
+	}
+	if clone.ProposedWork[0].Content[0].Text != "body" {
+		t.Fatalf("nested ProposedWork Content mutation leaked into clone: %#v", clone.ProposedWork)
+	}
+	if clone.ProposedWork[0].Tags["k"] != "v" {
+		t.Fatalf("nested ProposedWork Tags mutation leaked into clone: %#v", clone.ProposedWork)
+	}
+	if clone.ArtifactRefs[0].ArtifactID != "art-1" {
+		t.Fatalf("ArtifactRefs mutation leaked into clone: %#v", clone.ArtifactRefs)
+	}
+	if clone.Feedback != "ok" || clone.Classification != "accepted" {
+		t.Fatalf("scalar fields not preserved: %#v", clone)
+	}
+}
+
+func TestProposedOutputCloneHandlesEmptyFields(t *testing.T) {
+	t.Parallel()
+
+	clone := workers.ProposedOutput{Feedback: "ok"}.Clone()
+	if clone.Primary != nil || clone.ProposedWork != nil || clone.ArtifactRefs != nil {
+		t.Fatalf("expected nil slices to stay nil, got %#v", clone)
+	}
+	if clone.Feedback != "ok" {
+		t.Fatalf("Feedback not preserved: %#v", clone)
+	}
+}

--- a/pkg/services/workers/wire/provider_registry_test.go
+++ b/pkg/services/workers/wire/provider_registry_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/portpowered/infinite-you/pkg/services/providers"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
 )
 
 func TestNewProviderRegistryProjectsProvidersAuthority(t *testing.T) {
@@ -35,6 +36,55 @@ func TestNewProviderRegistryProjectsProvidersAuthority(t *testing.T) {
 	err = registry.ValidateRunnerPrerequisites(nil, "cursor")
 	if !errors.Is(err, providers.ErrUnknownProvider) {
 		t.Fatalf("ValidateRunnerPrerequisites(cursor) = %v, want ErrUnknownProvider", err)
+	}
+}
+
+func TestNewProviderRegistryProjectsRunnerVocabulary(t *testing.T) {
+	t.Parallel()
+
+	registry, err := NewProviderRegistry(context.Background(), &registryProvidersFake{})
+	if err != nil {
+		t.Fatalf("NewProviderRegistry() = %v", err)
+	}
+
+	if !registry.UsesNativeRunner("codex") {
+		t.Fatalf("UsesNativeRunner(codex) = false, want true")
+	}
+
+	identities := registry.RunnerIdentities()
+	if len(identities) != 1 || identities[0] != "codex" {
+		t.Fatalf("RunnerIdentities() = %v, want [codex]", identities)
+	}
+
+	metadata, err := registry.RunnerMetadata("openai")
+	if err != nil {
+		t.Fatalf("RunnerMetadata(openai) = %v", err)
+	}
+	if metadata.ID != "codex" || metadata.DisplayName != "Codex" {
+		t.Fatalf("RunnerMetadata(openai) = %#v", metadata)
+	}
+
+	if _, err := registry.RunnerMetadata("cursor"); !errors.Is(err, providers.ErrUnknownProvider) {
+		t.Fatalf("RunnerMetadata(cursor) = %v, want ErrUnknownProvider", err)
+	}
+
+	selection, err := registry.ResolveRunnerSelection("codex", "", "")
+	if err != nil {
+		t.Fatalf("ResolveRunnerSelection(codex) = %v", err)
+	}
+	if selection.RunnerID != "codex" || selection.Source != workers.RunnerSelectionSourceWorkstation {
+		t.Fatalf("ResolveRunnerSelection(codex) = %#v", selection)
+	}
+}
+
+func TestNewProviderRegistryRejectsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := NewProviderRegistry(ctx, &registryProvidersFake{}); err == nil {
+		t.Fatalf("NewProviderRegistry() with canceled context = nil error, want non-nil")
 	}
 }
 

--- a/pkg/services/workers/wire/runtime_bridge_test.go
+++ b/pkg/services/workers/wire/runtime_bridge_test.go
@@ -24,6 +24,35 @@ func TestRuntimeBridgeNewMockCommandRunnerDecoratesNext(t *testing.T) {
 	}
 }
 
+func TestResolveTemplateFieldsResolvesTemplates(t *testing.T) {
+	t.Parallel()
+
+	resolved, err := ResolveTemplateFields(
+		"{{.Context.WorkDir}}/sub",
+		map[string]string{"NAME": "{{.Context.WorkDir}}"},
+		nil,
+		&workers.Context{WorkDirectory: "reviewer"},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("ResolveTemplateFields() = %v", err)
+	}
+	if resolved.WorkingDirectory != "reviewer/sub" {
+		t.Fatalf("WorkingDirectory = %q, want reviewer/sub", resolved.WorkingDirectory)
+	}
+	if resolved.Env["NAME"] != "reviewer" {
+		t.Fatalf("Env[NAME] = %q, want reviewer", resolved.Env["NAME"])
+	}
+}
+
+func TestResolveTemplateFieldsPropagatesTemplateError(t *testing.T) {
+	t.Parallel()
+
+	if _, err := ResolveTemplateFields("{{.Bogus", nil, nil, &workers.Context{}, ""); err == nil {
+		t.Fatal("ResolveTemplateFields() with malformed template = nil error, want non-nil")
+	}
+}
+
 type stubRuntimeBridgeCommandRunner struct{}
 
 func (stubRuntimeBridgeCommandRunner) Run(


### PR DESCRIPTION
## Follow-up to #1757

PR #1757 (merged as `f8531f6a1`) deleted the obsolete Workers root `Execute` path. A post-merge review comment on that PR flagged a **blocking** quality-ratchet bypass: commit `f425d7d` manually lowered three unit-coverage floors after the coverage lane reported regressions, instead of restoring coverage. `cmd/gocoveragecheck -update-manifest` only raises floors; hand-lowering them weakens the required gate rather than producing real evidence.

This PR:
- Restores the three floors in `docs/internal/baselines/go-unit-coverage-package-minimums.json` to their pre-lowering values:
  - `pkg/services/factory_runtime/internal/services/orchestration/runtime`: 82.36 -> 82.40
  - `pkg/services/workers`: 78.71 -> 79.81
  - `pkg/services/workers/wire`: 79.15 -> 82.14
- Adds focused unit tests for retained (non-Execute) behavior to recover each floor, per the reviewer's suggested targets:
  - `ProposedOutput.Clone` / `ProposedWork.Clone` deep-copy semantics (`pkg/services/workers/proposed_output_contracts_test.go`)
  - The Workers provider-registry runner vocabulary (`RunnerIdentities`, `RunnerMetadata`, `UsesNativeRunner`, canceled-context construction) and the `ResolveTemplateFields` wire wrapper (`pkg/services/workers/wire`)
  - Retained worker-output materialization branches: missing Work service, preserved prior error text on failure, feedback/classification propagation, and the nil-net helper paths (`pkg/services/factory_runtime/.../orchestration/runtime/work_output_materialization_test.go`)
- Does **not** restore any tests for the deleted Execute API.

No production code changed; this is coverage-manifest and test-only.

## Original PRD

```json
{
  "project": "Remove the Dead Workers Execute Root Path",
  "branchName": "ACP-L2-DEL-WRK-EXECUTE",
  "description": "Remove the obsolete workers.Service.Execute operation, ExecuteRequest, ExecuteResult, and only their dead private normalize/adapt/provider path so WorkstationExecutionService is the sole production Workers execution boundary. Preserve its workstation dispatch lifecycle and explicit boundary-routed cancellation semantics, prove canonical construction and a narrow Factory execution path still behave correctly, and deliver the reviewed change through actual PR merge.",
  "context": {
    "customerAsk": "Deliver a reviewed and merged deletion slice that removes the obsolete Workers root Execute operation, its request/result contracts, and only its now-dead private normalize/adapt/provider path. Preserve the sealed WorkstationExecutionService production route and its explicit cancellation behavior, prove the application and a narrow Factory execution path no longer depend on the removed model, pass required verification, address review, reconcile conflicts, and merge.",
    "problem": "Workers presents two execution models even though production Factory Runtime uses only the sealed WorkstationExecutionService path. The unused workers.Service.Execute contract and its separate normalization/provider-adaptation branch can mislead consumers into adopting a synchronous model that does not represent supervised workstation lifecycle or boundary-routed cancellation, while compile-only callers and dedicated tests keep the dead branch alive.",
    "solution": "Delete Service.Execute, ExecuteRequest, ExecuteResult, root/runtime forwarding, and only the private normalization, adaptation, provider glue, result normalization, callers, and tests exclusive to that operation. Keep WorkstationExecutionService unchanged as the sole production execution contract, preserve explicit CancelWorkstationDispatch behavior, and verify canonical construction plus a narrow Factory functional execution path without adding a compatibility replacement or unrelated cleanup."
  },
  "acceptanceCriteria": [
    "The public Workers root no longer offers Service.Execute, ExecuteRequest, or ExecuteResult, and production consumers compile against WorkstationExecutionService without a replacement compatibility operation.",
    "The private normalize/adapt/provider execution branch and forwarding methods used only by the removed operation are gone, while canonical Workers and application construction remain valid without dead Execute-specific provider coupling.",
    "Dispatch through WorkstationExecutionService retains the established workstation pool admission, execution, result-acceptance, and terminal outcome behavior.",
    "Cancellation remains an explicit CancelWorkstationDispatch operation routed through the sealed boundary, and caller-context cancellation is not reinterpreted as the dispatch-control mechanism.",
    "A focused application/Factory execution path that succeeded before deletion still completes with the same terminal result through the sealed workstation route and without a replacement root Execute API.",
    "Focused Workers tests, the narrowest applicable functional test, Go typecheck/compile validation, lint, tests, and required CI are terminal and passing.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, shared-file changes and merge conflicts are reconciled against current main, and the PR is actually merged; opened, green, approved, or ready-to-merge is not complete."
  ],
  "userStories": [
    {
      "id": "ACP-L2-DEL-WRK-EXECUTE-001",
      "title": "Retire the alternate Workers root execution model",
      "description": "As a Workers consumer, I want the obsolete root Execute model removed so that new and existing production code can depend on only the sealed workstation execution lifecycle.",
      "acceptanceCriteria": [
        "The Workers public root cannot be invoked with Service.Execute, and the obsolete ExecuteRequest and ExecuteResult contracts are no longer available.",
        "Compile-only consumers use the existing sealed workstation execution contract when they represent production behavior; callers and tests that exist only to exercise the dead model are deleted.",
        "The root and runtime implementation no longer forward requests into the obsolete execution branch.",
        "Normalize/adapt/provider logic exclusively reachable from the removed operation is deleted without removing private runner or workstation behavior used by the sealed route.",
        "Canonical Workers and application construction succeeds without a second execution service view, replacement compatibility API, or dead Execute-specific provider dependency.",
        "Focused Workers contract and construction tests prove consumers can build and execute through the sealed boundary after deletion without scanning file, symbol, route, command, or registration inventories.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Deleted Service.Execute, ExecuteRequest/ExecuteResult, and the private normalize/adapt/provider branch (pkg/services/workers/internal/service package). WorkstationExecutionService remains the sole execution surface. go build/vet clean; go test ./pkg/services/workers/... ./pkg/services/factory_runtime/... ./pkg/wire/... ./pkg/root/... all pass."
    },
    {
      "id": "ACP-L2-DEL-WRK-EXECUTE-002",
      "title": "Preserve sealed dispatch and explicit cancellation behavior",
      "description": "As a Factory operator, I want workstation execution and cancellation to behave exactly as before the dead API is removed so that existing Factory runs and supervised cancellation remain reliable.",
      "acceptanceCriteria": [
        "A workstation dispatch admitted through WorkstationExecutionService reaches the configured workstation executor and reports the established terminal result through the existing result-acceptance path.",
        "Cancelling queued or running work through CancelWorkstationDispatch retains its existing typed outcome and reaches the boundary-owned cancellation mechanism.",
        "Caller-context cancellation is not introduced as a replacement for explicit dispatch cancellation, including at the asynchronous workstation publish boundary.",
        "The narrowest applicable Factory functional path constructs the process through root.BuildProcess, executes through the normal customer entry path, and preserves the pre-deletion successful terminal outcome without exercising a replacement Workers Execute API.",
        "Verification uses deterministic observation or injected command-runner edges and does not add sleeps, timeout-padded polling, custom service construction outside the canonical graph, or unrelated functional scenarios.",
        "Focused Workers dispatch/cancel tests and the selected Factory functional test pass; race or repeat coverage is run if the touched cancellation path changes concurrency-sensitive code.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "No behavior change required: WorkstationExecutionService, DispatchWorkstation, CancelWorkstationDispatch, and the workstation pool implementation were never touched. Verified via full existing focused/functional suite (unchanged pass rate). Baseline doc/manifest checks (package-target-manifest-check, pkg-structure, ownership-inventory-check) reconciled for this change's own deletions; their remaining unrelated failures confirmed pre-existing on plain main."
    }
  ]
}
```

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./pkg/services/workers/... ./pkg/services/factory_runtime/... ./pkg/wire/... ./pkg/root/...` pass
- [x] `make test` (full unit lane, 430 packages) passes with no failures
- [x] `make package-target-manifest-check pkg-structure ownership-inventory-check compatibility-alias-check retired-surface-check` re-verified: remaining violations confirmed pre-existing on `origin/main` (unrelated chat_sessions/operator_settings/providers/worker_sessions/transports packages), not introduced by this change
- [ ] CI-reported actual coverage for the three restored packages meets the restored floors (pending CI run)