### PR TITLE
ACP-L2-CLN-RUN-CAPUNAVAIL: fix unchecked APIFactory assertion panic (follow-up to #1762)

### DIFF
--- a/pkg/services/factory_sessions/internal/sessionservice/work_runtime_adapter.go
+++ b/pkg/services/factory_sessions/internal/sessionservice/work_runtime_adapter.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
@@ -20,7 +21,11 @@ type workRuntimeAdapter struct {
 }
 
 func (a workRuntimeAdapter) SubmitWorkRequest(ctx context.Context, request work.WorkRequest) (work.WorkRequestSubmitResult, error) {
-	return a.runtime.(factoryruntime.APIFactory).SubmitWorkRequest(ctx, request)
+	submitter, ok := a.runtime.(factoryruntime.APIFactory)
+	if !ok {
+		return work.WorkRequestSubmitResult{}, fmt.Errorf("legacy Factory Runtime submission is required")
+	}
+	return submitter.SubmitWorkRequest(ctx, request)
 }
 
 func (a workRuntimeAdapter) MoveWork(ctx context.Context, workID, state string, source work.WorkStateChangeSource, requestID string) (work.OperatorMoveResult, error) {

--- a/pkg/services/factory_sessions/internal/sessionservice/work_runtime_resolver_test.go
+++ b/pkg/services/factory_sessions/internal/sessionservice/work_runtime_resolver_test.go
@@ -110,6 +110,19 @@ func TestWorkRuntimeAdapterSubmitWorkRequestDelegatesToCanonicalRuntime(t *testi
 	}
 }
 
+type serviceOnlyRuntime struct {
+	factory.Service
+}
+
+func TestWorkRuntimeAdapterSubmitWorkRequestRejectsServiceOnlyRuntimeSafely(t *testing.T) {
+	adapter := workRuntimeAdapter{runtime: serviceOnlyRuntime{}}
+
+	_, err := adapter.SubmitWorkRequest(context.Background(), work.WorkRequest{RequestID: "request-1"})
+	if err == nil || !strings.Contains(err.Error(), "legacy Factory Runtime submission is required") {
+		t.Fatalf("SubmitWorkRequest() error = %v, want safe legacy-submission-required error", err)
+	}
+}
+
 type conflictingRootRuntime struct {
 	factory.Service
 }


### PR DESCRIPTION
Corrective follow-up to #1762 (merged), addressing a BLOCKING post-merge review comment: https://github.com/portpowered/you-agent-factory/pull/1762#issuecomment-5172871836

## Summary
- `work_runtime_adapter.go`'s `SubmitWorkRequest` used an unchecked `a.runtime.(factoryruntime.APIFactory)` type assertion introduced when the stale `ErrCapabilityUnavailable` fallback was removed. This panics for any runtime that implements `factoryruntime.Service` but not `factoryruntime.APIFactory`, instead of failing safely.
- Restored a checked assertion that returns a plain, adapter-local error (`legacy Factory Runtime submission is required`) on failure, matching the established pattern in `pkg/services/work/internal/live_session_runtime.go`.
- Added `TestWorkRuntimeAdapterSubmitWorkRequestRejectsServiceOnlyRuntimeSafely`, which constructs a Service-only runtime fixture and proves `SubmitWorkRequest` returns a safe error instead of panicking.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` on changed files (clean)
- [x] `go test ./pkg/services/factory_sessions/...`
- [x] `make test` (full short Go suite, exit 0)
