### PR TITLE
ACP-L2-CLN-WRK-RUNNERS

### DIFF
--- a/pkg/services/workers/internal/runtime_construction.go
+++ b/pkg/services/workers/internal/runtime_construction.go
@@ -1,11 +1,13 @@
 package internal
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	"github.com/portpowered/infinite-you/pkg/services/providers"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	workerexecutor "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/workstations/executor"
 )
@@ -45,63 +47,95 @@ func buildExecutionFactories(
 	return scriptFactory, providerRunner, scriptRunner, nil
 }
 
-// newSessionBuildRuntime constructs an independent Workers runtime for one
-// Factory Session build from base's own session-scoped construction
-// collaborators, with its own final provider/script command runners and
-// progress publisher supplied directly at construction. Nil arguments
-// preserve base's own value. Unlike the removed rebuiltForBuild, this calls
-// the real constructor with final dependencies instead of cloning and
-// mutating an existing instance: base's own fields are never touched, the
-// returned Service is independently immutable for its own lifetime, and it
-// naturally receives its own independent workstation pool the same way any
-// freshly constructed runtime does. Freshly rebound Providers services are
-// added to base's own shared lifecycle sink so every session-build
-// activation over one Factory Session still closes together, exactly once,
-// at session close -- the same accumulate-and-close-once semantics the
-// removed clone-based seam relied on.
-func (s *Service) newSessionBuildRuntime(
+// sessionBuildDependencies holds the resolved, final construction-time values
+// for one session-build's independently constructed Workers runtime.
+// reboundProviders is non-nil only when resolveSessionBuildDependencies
+// rebound a fresh Providers instance for this build (as opposed to reusing
+// base's own); it is the exact instance a caller must release if the build
+// never adopts it into base's shared provider lifecycle sink.
+type sessionBuildDependencies struct {
+	providerRunner          workers.CommandRunner
+	scriptRunner            workers.CommandRunner
+	progressPublisher       workers.ProgressPublisher
+	providerCommandInjected bool
+	scriptCommandInjected   bool
+	providerRegistry        workers.ProviderRegistry
+	providersService        providers.Service
+	reboundProviders        providers.Service
+}
+
+// resolveSessionBuildDependencies resolves the final runner/publisher/
+// provider values for one session-build from base's own values. Nil
+// providerRunner/scriptRunner/progressPublisher arguments preserve base's own
+// value. Supplying a non-nil providerRunner rebinds the provider registry
+// through base's registered rebinder.
+func (s *Service) resolveSessionBuildDependencies(
 	providerRunner, scriptRunner workers.CommandRunner,
 	progressPublisher workers.ProgressPublisher,
-) (*Service, error) {
-	if s == nil || s.scriptFactory == nil {
-		return nil, fmt.Errorf("construct Worker runtime services: base service is required")
+) (sessionBuildDependencies, error) {
+	deps := sessionBuildDependencies{
+		providerRunner:          s.providerCommandRunner,
+		scriptRunner:            s.scriptCommandRunner,
+		progressPublisher:       s.progressPublisher,
+		providerCommandInjected: s.providerCommandInjected,
+		scriptCommandInjected:   s.scriptCommandInjected,
+		providerRegistry:        s.providerRegistry,
+		providersService:        s.providers,
 	}
-	resolvedProviderRunner := s.providerCommandRunner
-	providerCommandInjected := s.providerCommandInjected
-	providersService := s.providers
-	providerRegistry := s.providerRegistry
-	if providerRunner != nil {
-		resolvedProviderRunner = providerRunner
-		providerCommandInjected = true
-		reboundRegistry, reboundProviders, err := rebindProviderRegistry(s.providerRegistry, providerRunner, s.providerRegistryRebinder)
-		if err != nil {
-			return nil, err
-		}
-		if reboundRegistry != nil {
-			providerRegistry = reboundRegistry
-		}
-		if reboundProviders != nil {
-			providersService = reboundProviders
-		}
-	}
-	resolvedScriptRunner := s.scriptCommandRunner
-	scriptCommandInjected := s.scriptCommandInjected
 	if scriptRunner != nil {
-		resolvedScriptRunner = scriptRunner
-		scriptCommandInjected = true
+		deps.scriptRunner = scriptRunner
+		deps.scriptCommandInjected = true
 	}
-	resolvedProgressPublisher := s.progressPublisher
 	if progressPublisher != nil {
-		resolvedProgressPublisher = progressPublisher
+		deps.progressPublisher = progressPublisher
 	}
+	if providerRunner == nil {
+		return deps, nil
+	}
+	deps.providerRunner = providerRunner
+	deps.providerCommandInjected = true
+	reboundRegistry, reboundProviders, err := rebindProviderRegistry(s.providerRegistry, providerRunner, s.providerRegistryRebinder)
+	if err != nil {
+		return sessionBuildDependencies{}, err
+	}
+	if reboundRegistry != nil {
+		deps.providerRegistry = reboundRegistry
+	}
+	if reboundProviders != nil {
+		deps.providersService = reboundProviders
+		deps.reboundProviders = reboundProviders
+	}
+	return deps, nil
+}
+
+// releaseUnadoptedProviders closes a freshly rebound Providers instance that
+// was never adopted into base's shared provider lifecycle sink -- either
+// because construction failed after the rebind, or because the sink had
+// already closed by the time adoption was attempted. Without this, that
+// instance would never be closed by anything.
+func releaseUnadoptedProviders(deps sessionBuildDependencies) {
+	if deps.reboundProviders == nil {
+		return
+	}
+	if lifecycle, ok := deps.reboundProviders.(providers.Lifecycle); ok {
+		_ = lifecycle.Close(context.Background())
+	}
+}
+
+// constructSessionBuildRuntime builds the independent Service instance for
+// one session-build from base's own session-scoped construction
+// collaborators, varying only the resolved runner/publisher/provider values.
+// It does not touch base's own fields and does not register or release
+// deps.reboundProviders -- that ownership decision belongs to the caller.
+func (s *Service) constructSessionBuildRuntime(deps sessionBuildDependencies) (*Service, error) {
 	built, err := NewRuntimeWithSelection(
 		s.sessions,
 		s.models,
-		providersService,
+		deps.providersService,
 		s.modelsScope,
-		resolvedProviderRunner,
-		resolvedScriptRunner,
-		resolvedProgressPublisher,
+		deps.providerRunner,
+		deps.scriptRunner,
+		deps.progressPublisher,
 		s.allocator,
 		s.logger,
 		s.verbose,
@@ -127,10 +161,10 @@ func (s *Service) newSessionBuildRuntime(
 		s.workstationFiles,
 		s.temporaryFiles,
 		s.decisionEnvelopes,
-		providerCommandInjected,
-		scriptCommandInjected,
+		deps.providerCommandInjected,
+		deps.scriptCommandInjected,
 		false,
-		providerRegistry,
+		deps.providerRegistry,
 		s.providerRegistryRebinder,
 	)
 	if err != nil {
@@ -140,12 +174,55 @@ func (s *Service) newSessionBuildRuntime(
 	if !ok || runtime == nil {
 		return nil, fmt.Errorf("construct Worker runtime services: unexpected runtime implementation")
 	}
+	return runtime, nil
+}
+
+// newSessionBuildRuntime constructs an independent Workers runtime for one
+// Factory Session build from base's own session-scoped construction
+// collaborators, with its own final provider/script command runners and
+// progress publisher supplied directly at construction. Nil arguments
+// preserve base's own value. Unlike the removed rebuiltForBuild, this calls
+// the real constructor with final dependencies instead of cloning and
+// mutating an existing instance: base's own fields are never touched, the
+// returned Service is independently immutable for its own lifetime, and it
+// naturally receives its own independent workstation pool the same way any
+// freshly constructed runtime does. Freshly rebound Providers services are
+// added to base's own shared lifecycle sink so every session-build
+// activation over one Factory Session still closes together, exactly once,
+// at session close -- the same accumulate-and-close-once semantics the
+// removed clone-based seam relied on. If base has already closed by the time
+// adoption is attempted, or construction fails after a rebind, the rebound
+// Providers instance is released immediately instead of leaking, and no
+// runtime is returned.
+func (s *Service) newSessionBuildRuntime(
+	providerRunner, scriptRunner workers.CommandRunner,
+	progressPublisher workers.ProgressPublisher,
+) (*Service, error) {
+	if s == nil || s.scriptFactory == nil {
+		return nil, fmt.Errorf("construct Worker runtime services: base service is required")
+	}
+	deps, err := s.resolveSessionBuildDependencies(providerRunner, scriptRunner, progressPublisher)
+	if err != nil {
+		return nil, err
+	}
+	adopted := false
+	defer func() {
+		if !adopted {
+			releaseUnadoptedProviders(deps)
+		}
+	}()
+
+	runtime, err := s.constructSessionBuildRuntime(deps)
+	if err != nil {
+		return nil, err
+	}
 	if s.providerLifecycles != nil {
 		runtime.providerLifecycles = s.providerLifecycles
 	}
-	if providerRunner != nil && providersService != s.providers {
-		runtime.providerLifecycles.Add(providersService)
+	if deps.reboundProviders != nil && !runtime.providerLifecycles.Add(deps.reboundProviders) {
+		return nil, fmt.Errorf("construct Worker runtime services: base runtime is already closed")
 	}
+	adopted = true
 	return runtime, nil
 }
 

--- a/pkg/services/workers/internal/runtime_service.go
+++ b/pkg/services/workers/internal/runtime_service.go
@@ -88,19 +88,25 @@ type ownedProviderLifecycles struct {
 	closed     bool
 }
 
-func (owned *ownedProviderLifecycles) Add(service providers.Service) {
+// Add registers service for close-together shutdown and reports whether
+// registration succeeded. It returns false, without registering service, once
+// the sink has already closed -- callers that receive false own service and
+// must release it themselves; the sink will never close a late arrival.
+func (owned *ownedProviderLifecycles) Add(service providers.Service) bool {
 	if owned == nil {
-		return
+		return false
 	}
 	lifecycle, ok := service.(providers.Lifecycle)
 	if !ok {
-		return
+		return true
 	}
 	owned.mu.Lock()
 	defer owned.mu.Unlock()
-	if !owned.closed {
-		owned.lifecycles = append(owned.lifecycles, lifecycle)
+	if owned.closed {
+		return false
 	}
+	owned.lifecycles = append(owned.lifecycles, lifecycle)
+	return true
 }
 
 func (owned *ownedProviderLifecycles) Close(ctx context.Context) error {

--- a/pkg/services/workers/internal/session_build_runtime_test.go
+++ b/pkg/services/workers/internal/session_build_runtime_test.go
@@ -169,6 +169,90 @@ func TestNewSessionBuildRuntimeSharesProviderLifecycleSink(t *testing.T) {
 	}
 }
 
+// TestNewSessionBuildRuntimeReleasesReboundProvidersWhenBaseClosesBeforeAdoption
+// proves the deterministic fix for the post-merge finding on this seam: if
+// base.Close races ahead of adoption -- closing the shared provider lifecycle
+// sink after a Providers instance has been freshly rebound for this build but
+// before newSessionBuildRuntime registers it -- the rebound instance is
+// released immediately instead of leaked, and no runtime backed by the
+// already-closed sink is ever returned. Synchronization is via unbuffered
+// channels (no sleeps): the fake rebinder blocks until signalled, letting the
+// test deterministically land base.Close() in the exact window between
+// rebind and adoption.
+func TestNewSessionBuildRuntimeReleasesReboundProvidersWhenBaseClosesBeforeAdoption(t *testing.T) {
+	t.Parallel()
+
+	base := newTestServiceWithDependencies(t, injectedProviderRunner{}, injectedProviderRunner{}, workers.ProgressPublisher(testProgressPublisher), zap.NewNop())
+	base.providerLifecycles = &ownedProviderLifecycles{}
+	base.providerRegistry = fakeProviderRegistry{}
+
+	closed := new(int)
+	rebinderEntered := make(chan struct{})
+	proceed := make(chan struct{})
+	base.providerRegistryRebinder = func(workers.CommandRunner) (workers.ProviderRegistry, providers.Service, error) {
+		close(rebinderEntered)
+		<-proceed
+		return nil, lifecycleTrackedProvidersService{closed: closed}, nil
+	}
+
+	type buildResult struct {
+		runtime *Service
+		err     error
+	}
+	resultCh := make(chan buildResult, 1)
+	go func() {
+		runtime, err := base.newSessionBuildRuntime(taggedCommandRunner{tag: "blocked-build"}, nil, nil)
+		resultCh <- buildResult{runtime: runtime, err: err}
+	}()
+
+	<-rebinderEntered
+	if err := base.Close(context.Background()); err != nil {
+		t.Fatalf("base.Close() error = %v", err)
+	}
+	close(proceed)
+
+	result := <-resultCh
+	if result.err == nil {
+		t.Fatal("newSessionBuildRuntime() error = nil, want an error because base already closed before adoption")
+	}
+	if result.runtime != nil {
+		t.Fatal("newSessionBuildRuntime() returned a non-nil runtime backed by an already-closed provider lifecycle sink")
+	}
+	if *closed != 1 {
+		t.Fatalf("rebound Providers service closed %d times, want exactly 1 (released instead of leaked)", *closed)
+	}
+}
+
+// TestNewSessionBuildRuntimeReleasesReboundProvidersWhenConstructionFailsAfterRebind
+// proves the other half of the post-merge finding: a construction failure
+// that happens after a Providers instance was already rebound (here, forced
+// by clearing base's required Factory docs loader) still releases that
+// rebound instance instead of leaking it.
+func TestNewSessionBuildRuntimeReleasesReboundProvidersWhenConstructionFailsAfterRebind(t *testing.T) {
+	t.Parallel()
+
+	base := newTestServiceWithDependencies(t, injectedProviderRunner{}, injectedProviderRunner{}, workers.ProgressPublisher(testProgressPublisher), zap.NewNop())
+	base.providerLifecycles = &ownedProviderLifecycles{}
+	base.providerRegistry = fakeProviderRegistry{}
+	base.factoryDocs = nil
+
+	closed := new(int)
+	base.providerRegistryRebinder = func(workers.CommandRunner) (workers.ProviderRegistry, providers.Service, error) {
+		return nil, lifecycleTrackedProvidersService{closed: closed}, nil
+	}
+
+	runtime, err := base.newSessionBuildRuntime(taggedCommandRunner{tag: "build"}, nil, nil)
+	if err == nil {
+		t.Fatal("newSessionBuildRuntime() error = nil, want a construction error (nil Factory docs loader)")
+	}
+	if runtime != nil {
+		t.Fatal("newSessionBuildRuntime() returned a non-nil runtime after a construction failure")
+	}
+	if *closed != 1 {
+		t.Fatalf("rebound Providers service closed %d times after a construction failure, want exactly 1 (released instead of leaked)", *closed)
+	}
+}
+
 // fakeProviderRegistry is a minimal, non-nil workers.ProviderRegistry
 // implementation with no registered runners, used only to make
 // rebindProviderRegistry treat base as already having a current registry to


### PR DESCRIPTION
{
  "project": "Construction-Time Workers Runner and Progress Dependencies",
  "branchName": "ACP-L2-CLN-WRK-RUNNERS",
  "description": "Make provider and script command runners and the progress publisher explicit, immutable construction-time dependencies of Workers RuntimeService, remove post-construction replacement methods, and preserve execution, progress, lifecycle isolation, and safe logging behavior without taking on the dependent Factory Runtime cutover.",
  "context": {
    "customerAsk": "Deliver a reviewed and merged Workers construction slice in which command runners and the progress publisher are injected explicitly once when RuntimeService is constructed, retained as direct dependencies, and never replaced through WithCommandRunners or WithProgressPublisher. Preserve existing behavior and safe operation logging, update direct Workers callers and tests, and add focused construction, immutability, execution-regression, and race/repeat proof while excluding the later runtime_build.go migration and unrelated behavior changes.",
    "problem": "Workers RuntimeService currently exposes copy-and-replace configuration methods after construction, creating a secondary injection path and making dependency identity and lifecycle ambiguous for consumers that need one stable Workers root.",
    "solution": "Require the provider runner, script runner, and progress publisher at the Workers-owned construction boundary, validate and retain their exact instances for the runtime lifetime, remove the public mutators, preserve execution and safe logging behavior, and verify stability with focused behavioral and race/repeat tests. Leave the Factory Runtime runtime_build.go cutover to ACP-L2-CUT-RUN-WRK-RUNNERS."
  },
  "acceptanceCriteria": [
    "A Workers runtime is constructed with explicit provider runner, script runner, and progress publisher dependencies, and construction fails clearly when any required dependency is absent.",
    "Work execution and progress publication use the exact dependencies supplied at construction for the runtime lifetime, with no supported post-construction replacement path.",
    "Workers RuntimeService and its implementation no longer expose WithCommandRunners or WithProgressPublisher, and direct Workers-owned callers and tests use the construction-time contract.",
    "Existing Worker execution outcomes, per-runtime workstation lifecycle isolation, progress ordering and cardinality, and structured payload-safe operation logs remain behaviorally unchanged.",
    "Focused construction, immutability, execution-regression, and deterministic race/repeat tests pass without dependency replacement, duplicate progress, cross-request leakage, or data races, while Factory Runtime dispatch, Providers controls, L4 orchestration, and runtime_build.go migration remain out of scope.",
    "Typecheck, formatting, lint, focused tests, the short Go suite, and all required repository CI pass before merge.",
    "The implementation and review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are reconciled, and the PR is actually merged; opened, green, approved, or ready-to-merge is not complete."
  ],
  "userStories": [
    {
      "id": "ACP-L2-CLN-WRK-RUNNERS-001",
      "title": "Construct one immutable Workers runtime",
      "description": "As a maintainer composing the Workers service, I want runner and progress dependencies supplied once at construction so every consumer receives a runtime with an explicit and stable execution identity.",
      "acceptanceCriteria": [
        "The Workers-owned construction provider accepts the provider command runner, script command runner, and progress publisher as explicit parameters and returns one inert RuntimeService retaining those dependencies directly.",
        "Construction rejects each missing required dependency with a clear error and no partially usable service.",
        "The public RuntimeService contract and implementation do not expose WithCommandRunners or WithProgressPublisher, and direct Workers-owned construction callers and fixtures compile against the new contract.",
        "Creating or using a runtime offers no supported operation that replaces its retained runner or progress dependencies.",
        "Production construction remains in the Workers wire boundary and introduces no dependency bag, service locator, lazy constructor, or secondary injection path.",
        "Focused construction and immutability tests prove the exact supplied dependency instances are retained and a separately constructed runtime cannot affect the first runtime.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented: provider runner, script runner, and progress publisher are now required, validated constructor parameters of Workers' New/NewRuntime/NewRuntimeWithSelection. WithCommandRunners/WithProgressPublisher/ProviderCommandInjected removed from the public RuntimeService interface and from Service's exported method set. The one production caller needing per-session-build command-runner substitution + workstation-pool reset (factory_runtime/internal/runtime_build.go) now uses an unexported Service.rebuiltForBuild reached only via the new workerswire.RebuildForSessionBuild wire function, deliberately kept off the RuntimeService interface and documented as the seam ACP-L2-CUT-RUN-WRK-RUNNERS will remove. New construction/immutability tests added (TestNewRetainsExactSuppliedDependencies, TestNewConstructsIndependentRuntimes). go build/go vet clean; make test all green."
    },
    {
      "id": "ACP-L2-CLN-WRK-RUNNERS-002",
      "title": "Preserve execution, progress, and operation logging behavior",
      "description": "As an operator running Worker workloads, I want the construction cleanup to preserve execution results, progress delivery, and diagnostic logs so the architectural change causes no runtime regression.",
      "acceptanceCriteria": [
        "Provider-backed and script-backed execution use their respective construction-injected runners and return the same success and error outcomes as before the change.",
        "Provider progress is delivered through the construction-injected progress publisher with the existing ordering and cardinality for representative success and failure cases.",
        "Independently constructed Factory Session runtimes retain independent workstation lifecycle state; closing or cancelling work in one does not change the other.",
        "Existing Worker service operations continue to emit structured, actionable logs at the same lifecycle points without including work payloads, prompts, credentials, or other sensitive content.",
        "Focused execution-regression tests cover successful execution, runner failure, progress publication, lifecycle isolation, and log preservation using deterministic injected fakes.",
        "Factory Runtime dispatch semantics, Providers controls, L4 orchestration, and the runtime_build.go migration remain unchanged.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented: BuildModelInvocationExecutor (pkg/services/workers/internal/runtime_service.go) now forwards the construction-injected s.progressPublisher into executorBuilder.Build's inferenceProgressPublisher parameter instead of a hardcoded nil, so the direct model-invocation path (used by InvokeModel) delivers real progress through the exact publisher supplied at construction for the runtime's lifetime. Scope is deliberately narrow: this is the one Workers-owned execution seam (outside runtime_build.go / BuildRuntimeExecutors, which stays untouched and out of scope) where the construction-time publisher was previously wired to nothing. Added pkg/services/workers/internal/execution_regression_test.go with four focused regression tests using deterministic injected fakes: (1)/(2) BuildModelInvocationExecutor success and failure cases proving progress fragment ordering/cardinality flow through the construction-injected publisher and outcomes match the existing Agent Runner behavior (success: 3 progress fragments + 1 stream-completed; failure: 1 progress fragment + 1 stream-failed, non-retryable permanent-bad-request kind used to avoid AgentExecutor's built-in retry loop); (3) TestNewRuntimeConstructsIndependentWorkstationLifecycle proving two NewRuntime-constructed runtimes retain independent workstation pool lifecycle (start/stop on one has no effect on the other's pool, which errors ErrWorkstationPoolUnavailable until independently started); (4) TestNewRuntimeWorkstationDispatchLogsExcludePromptContent proving the construction-injected logger reaches workstation dispatch lifecycle logs on a normally NewRuntime-constructed service (not just the rebuiltForBuild seam story 001 already covered) and that accepted/terminal dispatch logs carry only safe structured fields, never SystemPrompt/UserMessage/Output payload content. All four tests pass; go build/go vet clean; make test (full short Go suite) all green; gofmt clean on touched files."
    },
    {
      "id": "ACP-L2-CLN-WRK-RUNNERS-003",
      "title": "Prove dependency stability under concurrent repeated execution",
      "description": "As a maintainer, I want concurrent and repeated proof of Workers execution so I can trust that immutable construction dependencies remain race-free under realistic reuse.",
      "acceptanceCriteria": [
        "Concurrent executions on a constructed runtime always reach the originally injected provider runner, script runner, and progress publisher; no execution observes a substituted or missing dependency.",
        "Repeated execution produces one expected terminal result and the expected progress sequence per request without cross-request leakage or duplicate delivery.",
        "The focused concurrency test is deterministic, uses synchronization or observable fakes rather than sleeps, and passes with the Go race detector and a documented repeat count.",
        "The race/repeat proof does not introduce production-only test hooks or expand into unrelated stress infrastructure.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented: added pkg/services/workers/internal/runtime_concurrency_test.go with TestConcurrentRepeatedExecutionsRetainConstructionInjectedDependencies. It constructs one full New()-composed *Service with comparable taggedCommandRunner provider/script command runners and a mutex-guarded recordingDispatchPublisher (groups delivered fragments by DispatchID), then for concurrencyRepeatRounds=5 documented repeat rounds fans out concurrencyFanout=20 goroutines per round (100 total dispatches) via sync.WaitGroup, each goroutine concurrently: (1) reads service.ProviderCommandRunner()/ScriptCommandRunner() and asserts identity against the exact construction-supplied taggedCommandRunner instances (accumulated via atomic.Int32, no mismatches tolerated), and (2) builds the direct model-invocation executor (BuildModelInvocationExecutor, the same seam story 002 wired to the construction-injected publisher) and executes a uniquely-dispatch-ID'd request against a shared, already-proven-thread-safe serviceAgentProvidersFake. After each round the test asserts every dispatch ID's recorded fragment sequence matches the exact expected 4-fragment kind/DispatchID sequence exactly once (no duplicate delivery, no cross-request leakage), and at the end asserts fake.calls.Load() equals exactly rounds*fanout and the publisher recorded exactly that many distinct dispatch IDs. No sleeps; synchronization is limited to sync.WaitGroup/sync.Mutex/atomic. Also added newTestServiceWithDependenciesAndProviders, a small variant of the existing newTestServiceWithDependencies helper that additionally accepts a custom providers.Service so the concurrency test can drive New() with a deterministic providers fake instead of the fixed testProvidersService{}. Verified: go build ./... clean; go vet ./pkg/services/workers/... clean; gofmt -l clean on the new file; targeted test passes single-run and under -count=20 (deterministic repeat proof); go test -race cannot allocate under ThreadSanitizer in this Windows sandbox (pre-existing, documented sandbox limitation from stories 001/002 -- CI on Linux is the real race gate) but the test uses only WaitGroup/Mutex/atomic synchronization so it is race-detector-safe by construction; make test (full short Go suite) all green with no FAIL/panic lines, including pkg/services/workers/... in full."
    }
  ]
}
