### PR TITLE
ACP-L2-FIX-MOD-DEAD-PATHS: finish Models ForRuntime dead-path removal

### DIFF
--- a/docs/internal/architectural-systems/managed-model-runtime.md
+++ b/docs/internal/architectural-systems/managed-model-runtime.md
@@ -77,18 +77,21 @@ invocation returns actionable outcomes derived from the managed contract through
 `apisurface.InvocationErrorFromManagedRuntime`. When a runtime is `READY`,
 packaged and authored factories invoke through the same managed runtime layer.
 
-Production composition constructs the root `models.Service` through
-`pkg/services/models/wire` and injects that service directly into Factory Sessions.
-Opening a Factory Session passes Models-owned runtime data to `Service.ForRuntime`;
-it does not receive or invoke a separate Models runtime opener or construct the
-Models dependency itself. The runtime view is bound from model-scoped dependencies:
-the dynamic active-runtime configuration reader,
-the process model host, asset puller, logger, clock, pull-metrics recorder,
-direct-invocation executor builder, and factory runner identity. Stable
-collaborators are supplied as direct values; only runtime configuration remains
-a callback because activating another factory changes it after construction.
-The model service does not receive `FactoryService`, `runtimehost.Host`, or an
-adapter around either coordinator.
+Production composition constructs one process-scoped root `models.Service` through
+`pkg/services/models/wire` and injects that singular service directly into Factory
+Sessions. Opening a Factory Session calls `Service.OpenRuntimeScope` with a detached
+`RuntimeScopeConfig` -- the selected model cache directory plus the current Models
+runtime configuration -- and receives back only an opaque `RuntimeScopeRef`; it does
+not receive or construct another Models service, host, runtime, puller, limiter,
+process, or storage handle. Factory Session shutdown, or a later opening failure,
+closes that scope exactly once through `Service.CloseRuntimeScope`. The runtime view
+the opened scope observes is bound from model-scoped dependencies: the dynamic
+active-runtime configuration reader, the process model host, asset puller, logger,
+clock, pull-metrics recorder, direct-invocation executor builder, and factory runner
+identity. Stable collaborators are supplied as direct values; only runtime
+configuration remains a callback because activating another factory changes it after
+construction. The model service does not receive `FactoryService`, `runtimehost.Host`,
+or an adapter around either coordinator.
 
 ## Pull or Install Lifecycle
 

--- a/docs/internal/baselines/package-structure-baseline.json
+++ b/docs/internal/baselines/package-structure-baseline.json
@@ -1604,11 +1604,6 @@
     },
     {
       "rule": "service-root-exported-function",
-      "filePath": "pkg/services/models/runtime_config_contract.go",
-      "target": "ValidateRuntimeBinding"
-    },
-    {
-      "rule": "service-root-exported-function",
       "filePath": "pkg/services/operator_settings/backend_scope.go",
       "target": "EnsureLocalBackendScope"
     },

--- a/pkg/services/factory_sessions/internal/runtimeopening/construction.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/construction.go
@@ -24,13 +24,13 @@ import (
 )
 
 type preparedRuntime struct {
-	Definition       factorydefinitions.RuntimeOpeningRequest
-	Runtime          factoryruntime.RuntimeOpeningRequest
-	Session          factorysessions.SessionRuntimeOpeningRequest
-	Workers          workers.RuntimeOpeningRequest
-	Recordings       recordings.RuntimeOpeningRequest
-	Models           models.RuntimeOpeningRequest
-	OperatorDefaults operatorconfig.ResolvedDefaults
+	Definition          factorydefinitions.RuntimeOpeningRequest
+	Runtime             factoryruntime.RuntimeOpeningRequest
+	Session             factorysessions.SessionRuntimeOpeningRequest
+	Workers             workers.RuntimeOpeningRequest
+	Recordings          recordings.RuntimeOpeningRequest
+	ModelCacheDirectory string
+	OperatorDefaults    operatorconfig.ResolvedDefaults
 }
 
 // backendsizecheck:ignore-function service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption.
@@ -43,7 +43,7 @@ func PrepareRuntime(
 	sessionRequest factorysessions.SessionRuntimeOpeningRequest,
 	workerRequest workers.RuntimeOpeningRequest,
 	recordingRequest recordings.RuntimeOpeningRequest,
-	modelRequest models.RuntimeOpeningRequest,
+	modelCacheDirectory string,
 	operatorDefaults operatorconfig.ResolvedDefaults,
 	baseLogger *zap.Logger,
 	runtimeEdges ExternalEffects,
@@ -89,7 +89,7 @@ func PrepareRuntime(
 	}
 	prepared = preparedRuntime{
 		Definition: definitionRequest, Runtime: runtimeRequest, Session: sessionRequest,
-		Workers: workerRequest, Recordings: recordingRequest, Models: modelRequest,
+		Workers: workerRequest, Recordings: recordingRequest, ModelCacheDirectory: modelCacheDirectory,
 		OperatorDefaults: operatorDefaults,
 	}
 	root, err = ResolveRuntimeRoot(prepared.Definition.Directory, baseLogger, prepared.Runtime.RuntimeInstanceID, generateRuntimeInstanceID, resolveHome)

--- a/pkg/services/factory_sessions/internal/runtimeopening/invocation/operation.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/invocation/operation.go
@@ -705,7 +705,7 @@ func (o *operation) runtimeConfig(target roles.InvocationTarget) factorysessions
 	config.Recordings.RecordPath = target.RecordPath
 	config.Recordings.ReplayPath = target.ReplayPath
 	config.Recordings.WorkflowID = target.WorkflowID
-	config.Models.CacheDirectory = target.ModelCacheDir
+	config.ModelCacheDirectory = target.ModelCacheDir
 	return config
 }
 

--- a/pkg/services/factory_sessions/internal/runtimeopening/models_bind_test.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/models_bind_test.go
@@ -341,8 +341,9 @@ func TestOpenRuntimeClosesModelsScopeExactlyOnceAfterLaterStepFails(t *testing.T
 	_, err := factory.openRuntime(
 		context.Background(),
 		&factorysessions.RuntimeOpeningRequest{
-			FactoryDefinition: factorydefinitions.RuntimeOpeningRequest{Directory: t.TempDir()},
-			FactorySession:    factorysessions.SessionRuntimeOpeningRequest{BackendScopeID: "test-scope"},
+			FactoryDefinition:   factorydefinitions.RuntimeOpeningRequest{Directory: t.TempDir()},
+			FactorySession:      factorysessions.SessionRuntimeOpeningRequest{BackendScopeID: "test-scope"},
+			ModelCacheDirectory: "/cache/models",
 		},
 		ExternalEffects{},
 		zap.NewNop(),
@@ -355,6 +356,12 @@ func TestOpenRuntimeClosesModelsScopeExactlyOnceAfterLaterStepFails(t *testing.T
 	}
 	if len(modelRoot.closeRequests) != 1 {
 		t.Fatalf("CloseRuntimeScope requests = %d, want exactly 1", len(modelRoot.closeRequests))
+	}
+	if len(modelRoot.openRequests) != 1 || modelRoot.openRequests[0].Config.CacheDirectory != "/cache/models" {
+		t.Fatalf(
+			"OpenRuntimeScope requests = %#v, want the Factory Sessions opening request's model cache directory",
+			modelRoot.openRequests,
+		)
 	}
 }
 

--- a/pkg/services/factory_sessions/internal/runtimeopening/open.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/open.go
@@ -82,7 +82,7 @@ func openRuntime(
 	sessionRequest := request.FactorySession
 	workerRequest := request.Workers
 	recordingRequest := request.Recordings
-	modelRequest := request.Models
+	modelCacheDirectory := request.ModelCacheDirectory
 	operatorDefaults := request.OperatorDefaults
 	configured, root, load, clock, logger, hostedPollers, err := PrepareRuntime(
 		ctx,
@@ -91,7 +91,7 @@ func openRuntime(
 		sessionRequest,
 		workerRequest,
 		recordingRequest,
-		modelRequest,
+		modelCacheDirectory,
 		operatorDefaults,
 		baseLogger,
 		edges,
@@ -208,7 +208,7 @@ func openRuntime(
 	modelsBind, err := bindModelsRuntimeScope(
 		ctx,
 		modelService,
-		configured.Models.CacheDirectory,
+		configured.ModelCacheDirectory,
 		currentRuntimeConfig,
 	)
 	if err != nil {

--- a/pkg/services/factory_sessions/opened_runtime.go
+++ b/pkg/services/factory_sessions/opened_runtime.go
@@ -3,7 +3,6 @@ package factorysessions
 import (
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
-	"github.com/portpowered/infinite-you/pkg/services/models"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
@@ -24,11 +23,11 @@ type SessionRuntimeOpeningRequest struct {
 // bounded owner requests. The complete service graph remains injected; this
 // value carries only per-runtime customer and process selections.
 type RuntimeOpeningRequest struct {
-	FactoryDefinition factorydefinitions.RuntimeOpeningRequest
-	FactoryRuntime    factoryruntime.RuntimeOpeningRequest
-	FactorySession    SessionRuntimeOpeningRequest
-	Workers           workers.RuntimeOpeningRequest
-	Recordings        recordings.RuntimeOpeningRequest
-	Models            models.RuntimeOpeningRequest
-	OperatorDefaults  operatorsettings.ResolvedDefaults
+	FactoryDefinition   factorydefinitions.RuntimeOpeningRequest
+	FactoryRuntime      factoryruntime.RuntimeOpeningRequest
+	FactorySession      SessionRuntimeOpeningRequest
+	Workers             workers.RuntimeOpeningRequest
+	Recordings          recordings.RuntimeOpeningRequest
+	ModelCacheDirectory string
+	OperatorDefaults    operatorsettings.ResolvedDefaults
 }

--- a/pkg/services/models/runtime_config_contract.go
+++ b/pkg/services/models/runtime_config_contract.go
@@ -92,13 +92,6 @@ type CloseRuntimeScopeResult struct {
 	Closed bool
 }
 
-// RuntimeOpeningRequest carries the Models-owned per-runtime-opening
-// selections assembled by the process-scoped composition boundary alongside
-// the sibling FactoryDefinitions, Workers, and Recordings opening requests.
-type RuntimeOpeningRequest struct {
-	CacheDirectory string
-}
-
 const (
 	RuntimeModelLocalityLocal  = "LOCAL"
 	RuntimeModelLocalityCloud  = "CLOUD"

--- a/pkg/services/models/transports/cli/adapter_owned_coverage_test.go
+++ b/pkg/services/models/transports/cli/adapter_owned_coverage_test.go
@@ -1,4 +1,4 @@
-package model_list_test
+package cli
 
 import (
 	"bytes"
@@ -12,12 +12,11 @@ import (
 
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	modelinference "github.com/portpowered/infinite-you/pkg/services/models"
-	modelscli "github.com/portpowered/infinite-you/pkg/services/models/transports/cli"
 	"github.com/portpowered/infinite-you/pkg/transports/cli/clihttp"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 )
 
-type functionalModelsRoot struct {
+type ownedCoverageModelsRoot struct {
 	listModels           func(context.Context) (modelinference.List, error)
 	getModel             func(context.Context, string) (modelinference.Detail, error)
 	pullModel            func(context.Context, string) (modelinference.PullResult, error)
@@ -26,15 +25,15 @@ type functionalModelsRoot struct {
 	invokeModelWithLease func(context.Context, modelinference.InvokeModelRequest) (modelinference.InvokeModelResult, error)
 }
 
-func (stub functionalModelsRoot) OpenRuntimeScope(context.Context, modelinference.OpenRuntimeScopeRequest) (modelinference.OpenRuntimeScopeResult, error) {
+func (stub ownedCoverageModelsRoot) OpenRuntimeScope(context.Context, modelinference.OpenRuntimeScopeRequest) (modelinference.OpenRuntimeScopeResult, error) {
 	return modelinference.OpenRuntimeScopeResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) CloseRuntimeScope(context.Context, modelinference.CloseRuntimeScopeRequest) (modelinference.CloseRuntimeScopeResult, error) {
+func (stub ownedCoverageModelsRoot) CloseRuntimeScope(context.Context, modelinference.CloseRuntimeScopeRequest) (modelinference.CloseRuntimeScopeResult, error) {
 	return modelinference.CloseRuntimeScopeResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) ListCatalog(ctx context.Context, request modelinference.ListModelsRequest) (modelinference.ListModelsResult, error) {
+func (stub ownedCoverageModelsRoot) ListCatalog(ctx context.Context, request modelinference.ListModelsRequest) (modelinference.ListModelsResult, error) {
 	if stub.listModels != nil {
 		list, err := stub.listModels(ctx)
 		if err != nil {
@@ -45,7 +44,7 @@ func (stub functionalModelsRoot) ListCatalog(ctx context.Context, request modeli
 	return modelinference.ListModelsResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) GetCatalogModel(ctx context.Context, request modelinference.GetModelRequest) (modelinference.GetModelResult, error) {
+func (stub ownedCoverageModelsRoot) GetCatalogModel(ctx context.Context, request modelinference.GetModelRequest) (modelinference.GetModelResult, error) {
 	if stub.getCatalogModel != nil {
 		return stub.getCatalogModel(ctx, request)
 	}
@@ -59,176 +58,176 @@ func (stub functionalModelsRoot) GetCatalogModel(ctx context.Context, request mo
 	return modelinference.GetModelResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) GetModelReadiness(context.Context, modelinference.GetModelReadinessRequest) (modelinference.GetModelReadinessResult, error) {
+func (stub ownedCoverageModelsRoot) GetModelReadiness(context.Context, modelinference.GetModelReadinessRequest) (modelinference.GetModelReadinessResult, error) {
 	return modelinference.GetModelReadinessResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) PullModelForScope(ctx context.Context, request modelinference.PullModelRequest) (modelinference.PullResult, error) {
+func (stub ownedCoverageModelsRoot) PullModelForScope(ctx context.Context, request modelinference.PullModelRequest) (modelinference.PullResult, error) {
 	if stub.pullModel != nil {
 		return stub.pullModel(ctx, request.Name)
 	}
 	return modelinference.PullResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) PrepareModelAssets(context.Context, modelinference.PrepareModelAssetsRequest) (modelinference.PrepareModelAssetsResult, error) {
+func (stub ownedCoverageModelsRoot) PrepareModelAssets(context.Context, modelinference.PrepareModelAssetsRequest) (modelinference.PrepareModelAssetsResult, error) {
 	return modelinference.PrepareModelAssetsResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) InspectModelAssets(context.Context, modelinference.InspectModelAssetsRequest) (modelinference.InspectModelAssetsResult, error) {
+func (stub ownedCoverageModelsRoot) InspectModelAssets(context.Context, modelinference.InspectModelAssetsRequest) (modelinference.InspectModelAssetsResult, error) {
 	return modelinference.InspectModelAssetsResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) RemoveModelAssets(context.Context, modelinference.RemoveModelAssetsRequest) (modelinference.RemoveModelAssetsResult, error) {
+func (stub ownedCoverageModelsRoot) RemoveModelAssets(context.Context, modelinference.RemoveModelAssetsRequest) (modelinference.RemoveModelAssetsResult, error) {
 	return modelinference.RemoveModelAssetsResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) EnsureModelHost(context.Context, modelinference.EnsureModelHostRequest) (modelinference.EnsureModelHostResult, error) {
+func (stub ownedCoverageModelsRoot) EnsureModelHost(context.Context, modelinference.EnsureModelHostRequest) (modelinference.EnsureModelHostResult, error) {
 	return modelinference.EnsureModelHostResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) InspectModelHost(context.Context, modelinference.InspectModelHostRequest) (modelinference.InspectModelHostResult, error) {
+func (stub ownedCoverageModelsRoot) InspectModelHost(context.Context, modelinference.InspectModelHostRequest) (modelinference.InspectModelHostResult, error) {
 	return modelinference.InspectModelHostResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) StopModelHost(context.Context, modelinference.StopModelHostRequest) (modelinference.StopModelHostResult, error) {
+func (stub ownedCoverageModelsRoot) StopModelHost(context.Context, modelinference.StopModelHostRequest) (modelinference.StopModelHostResult, error) {
 	return modelinference.StopModelHostResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) AcquireModelLease(ctx context.Context, request modelinference.AcquireModelLeaseRequest) (modelinference.AcquireModelLeaseResult, error) {
+func (stub ownedCoverageModelsRoot) AcquireModelLease(ctx context.Context, request modelinference.AcquireModelLeaseRequest) (modelinference.AcquireModelLeaseResult, error) {
 	if stub.acquireModelLease != nil {
 		return stub.acquireModelLease(ctx, request)
 	}
 	return modelinference.AcquireModelLeaseResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) GetModelLease(context.Context, modelinference.GetModelLeaseRequest) (modelinference.GetModelLeaseResult, error) {
+func (stub ownedCoverageModelsRoot) GetModelLease(context.Context, modelinference.GetModelLeaseRequest) (modelinference.GetModelLeaseResult, error) {
 	return modelinference.GetModelLeaseResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) ReleaseModelLease(context.Context, modelinference.ReleaseModelLeaseRequest) (modelinference.ReleaseModelLeaseResult, error) {
+func (stub ownedCoverageModelsRoot) ReleaseModelLease(context.Context, modelinference.ReleaseModelLeaseRequest) (modelinference.ReleaseModelLeaseResult, error) {
 	return modelinference.ReleaseModelLeaseResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) InvokeModelWithLease(ctx context.Context, request modelinference.InvokeModelRequest) (modelinference.InvokeModelResult, error) {
+func (stub ownedCoverageModelsRoot) InvokeModelWithLease(ctx context.Context, request modelinference.InvokeModelRequest) (modelinference.InvokeModelResult, error) {
 	if stub.invokeModelWithLease != nil {
 		return stub.invokeModelWithLease(ctx, request)
 	}
 	return modelinference.InvokeModelResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) CancelInvocation(context.Context, modelinference.CancelInvocationRequest) (modelinference.CancelInvocationResult, error) {
+func (stub ownedCoverageModelsRoot) CancelInvocation(context.Context, modelinference.CancelInvocationRequest) (modelinference.CancelInvocationResult, error) {
 	return modelinference.CancelInvocationResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) ListModels(ctx context.Context) (modelinference.List, error) {
+func (stub ownedCoverageModelsRoot) ListModels(ctx context.Context) (modelinference.List, error) {
 	if stub.listModels != nil {
 		return stub.listModels(ctx)
 	}
 	return modelinference.List{}, nil
 }
 
-func (stub functionalModelsRoot) GetModel(ctx context.Context, name string) (modelinference.Detail, error) {
+func (stub ownedCoverageModelsRoot) GetModel(ctx context.Context, name string) (modelinference.Detail, error) {
 	if stub.getModel != nil {
 		return stub.getModel(ctx, name)
 	}
 	return modelinference.Detail{}, modelinference.ErrNotFound
 }
 
-func (stub functionalModelsRoot) PullModel(ctx context.Context, name string) (modelinference.PullResult, error) {
+func (stub ownedCoverageModelsRoot) PullModel(ctx context.Context, name string) (modelinference.PullResult, error) {
 	if stub.pullModel != nil {
 		return stub.pullModel(ctx, name)
 	}
 	return modelinference.PullResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) InspectRuntime(context.Context, string) (modelinference.Runtime, error) {
+func (stub ownedCoverageModelsRoot) InspectRuntime(context.Context, string) (modelinference.Runtime, error) {
 	return modelinference.Runtime{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) AcquireLease(context.Context, modelinference.AcquireLeaseRequest) (modelinference.HostLease, error) {
+func (stub ownedCoverageModelsRoot) AcquireLease(context.Context, modelinference.AcquireLeaseRequest) (modelinference.HostLease, error) {
 	return modelinference.HostLease{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) ReleaseLease(context.Context, modelinference.ReleaseLeaseRequest) error {
+func (stub ownedCoverageModelsRoot) ReleaseLease(context.Context, modelinference.ReleaseLeaseRequest) error {
 	return modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) InvokeLocal(context.Context, modelinference.LocalInvocationRequest) (modelinference.LocalInvocationResult, error) {
+func (stub ownedCoverageModelsRoot) InvokeLocal(context.Context, modelinference.LocalInvocationRequest) (modelinference.LocalInvocationResult, error) {
 	return modelinference.LocalInvocationResult{}, modelinference.ErrUnsupportedOperation
 }
 
-type functionalHTTPClock struct{}
+type ownedCoverageHTTPClock struct{}
 
-func (functionalHTTPClock) Now() time.Time { return time.Unix(1, 0) }
+func (ownedCoverageHTTPClock) Now() time.Time { return time.Unix(1, 0) }
 
-func functionalHTTPProtocol(t *testing.T) clihttp.Protocol {
+func ownedCoverageHTTPProtocol(t *testing.T) clihttp.Protocol {
 	t.Helper()
-	protocol, err := clihttp.NewProtocol(&http.Client{}, functionalHTTPClock{})
+	protocol, err := clihttp.NewProtocol(&http.Client{}, ownedCoverageHTTPClock{})
 	if err != nil {
-		t.Fatalf("build functional HTTP protocol: %v", err)
+		t.Fatalf("build owned-coverage HTTP protocol: %v", err)
 	}
 	return protocol
 }
 
-type functionalCompositionInvocation struct {
-	root functionalModelsRoot
+type ownedCoverageCompositionInvocation struct {
+	root ownedCoverageModelsRoot
 }
 
-func (inv functionalCompositionInvocation) InvokeModel(
+func (inv ownedCoverageCompositionInvocation) InvokeModel(
 	context.Context,
 	factorysessions.InvocationTarget,
 	string,
 	modelinference.Request,
 ) (modelinference.Result, error) {
-	return modelinference.Result{}, errors.New("functional coverage does not invoke through bootstrap")
+	return modelinference.Result{}, errors.New("owned coverage does not invoke through bootstrap")
 }
 
-func (inv functionalCompositionInvocation) ResolveModelInvocationFactoryDir(string) (string, error) {
+func (inv ownedCoverageCompositionInvocation) ResolveModelInvocationFactoryDir(string) (string, error) {
 	return "/tmp/factory", nil
 }
 
-func (inv functionalCompositionInvocation) ExportModelInvocationArtifact(string, string) error {
+func (inv ownedCoverageCompositionInvocation) ExportModelInvocationArtifact(string, string) error {
 	return nil
 }
 
-func (inv functionalCompositionInvocation) CompositionModelsRoot() modelinference.Service {
+func (inv ownedCoverageCompositionInvocation) CompositionModelsRoot() modelinference.Service {
 	return inv.root
 }
 
-func (inv functionalCompositionInvocation) CompositionOpenCatalogScope(
+func (inv ownedCoverageCompositionInvocation) CompositionOpenCatalogScope(
 	context.Context,
-) (modelscli.InvokeRuntimeScope, error) {
-	scope, err := (modelinference.RuntimeScopeRef{}).Parse("functional-coverage:test-scope")
+) (InvokeRuntimeScope, error) {
+	scope, err := (modelinference.RuntimeScopeRef{}).Parse("owned-coverage:test-scope")
 	if err != nil {
-		return modelscli.InvokeRuntimeScope{}, err
+		return InvokeRuntimeScope{}, err
 	}
-	return modelscli.InvokeRuntimeScope{Scope: scope}, nil
+	return InvokeRuntimeScope{Scope: scope}, nil
 }
 
-func (inv functionalCompositionInvocation) CompositionOpenInvokeScope(
+func (inv ownedCoverageCompositionInvocation) CompositionOpenInvokeScope(
 	ctx context.Context,
-	_ modelscli.InvokeConfig,
-) (modelscli.InvokeRuntimeScope, error) {
-	scope, err := (modelinference.RuntimeScopeRef{}).Parse("functional-coverage:test-scope")
+	_ InvokeConfig,
+) (InvokeRuntimeScope, error) {
+	scope, err := (modelinference.RuntimeScopeRef{}).Parse("owned-coverage:test-scope")
 	if err != nil {
-		return modelscli.InvokeRuntimeScope{}, err
+		return InvokeRuntimeScope{}, err
 	}
-	return modelscli.InvokeRuntimeScope{Scope: scope}, nil
+	return InvokeRuntimeScope{Scope: scope}, nil
 }
 
-func functionalOwnedService(t *testing.T, root functionalModelsRoot) modelscli.Service {
+func ownedCoverageService(t *testing.T, root ownedCoverageModelsRoot) Service {
 	t.Helper()
-	openScope := func(context.Context) (modelscli.InvokeRuntimeScope, error) {
-		scope, err := (modelinference.RuntimeScopeRef{}).Parse("functional-coverage:test-scope")
+	openScope := func(context.Context) (InvokeRuntimeScope, error) {
+		scope, err := (modelinference.RuntimeScopeRef{}).Parse("owned-coverage:test-scope")
 		if err != nil {
-			return modelscli.InvokeRuntimeScope{}, err
+			return InvokeRuntimeScope{}, err
 		}
-		return modelscli.InvokeRuntimeScope{Scope: scope}, nil
+		return InvokeRuntimeScope{Scope: scope}, nil
 	}
-	service := modelscli.BindService(modelscli.Config{
+	service := BindService(Config{
 		Models:           root,
 		OpenCatalogScope: openScope,
-		OpenInvokeScope: func(context.Context, modelscli.InvokeConfig) (modelscli.InvokeRuntimeScope, error) {
+		OpenInvokeScope: func(context.Context, InvokeConfig) (InvokeRuntimeScope, error) {
 			return openScope(context.Background())
 		},
 	})
@@ -238,12 +237,12 @@ func functionalOwnedService(t *testing.T, root functionalModelsRoot) modelscli.S
 	return service
 }
 
-// TestFunctionalModelsOwnedAdapter_ListInspectPullPreserveAcceptedOutput proves
-// owned adapter list/inspect/pull behavior through the Models root.
-func TestFunctionalModelsOwnedAdapter_ListInspectPullPreserveAcceptedOutput(t *testing.T) {
+// TestOwnedAdapter_ListInspectPullPreserveAcceptedOutput proves owned adapter
+// list/inspect/pull behavior through the Models root.
+func TestOwnedAdapter_ListInspectPullPreserveAcceptedOutput(t *testing.T) {
 	t.Parallel()
 
-	root := functionalModelsRoot{
+	root := ownedCoverageModelsRoot{
 		listModels: func(context.Context) (modelinference.List, error) {
 			return modelinference.List{
 				Results: []modelinference.Summary{{
@@ -288,10 +287,10 @@ func TestFunctionalModelsOwnedAdapter_ListInspectPullPreserveAcceptedOutput(t *t
 			}, nil
 		},
 	}
-	service := functionalOwnedService(t, root)
+	service := ownedCoverageService(t, root)
 
 	var listHuman bytes.Buffer
-	if err := service.List(modelscli.ListConfig{
+	if err := service.List(ListConfig{
 		Context: context.Background(),
 		Output:  &listHuman,
 	}); err != nil {
@@ -304,7 +303,7 @@ func TestFunctionalModelsOwnedAdapter_ListInspectPullPreserveAcceptedOutput(t *t
 	}
 
 	var inspectHuman bytes.Buffer
-	if err := service.Inspect(modelscli.InspectConfig{
+	if err := service.Inspect(InspectConfig{
 		Context: context.Background(), ModelName: "OMNIVOICE_Q4_K_M", Output: &inspectHuman,
 	}); err != nil {
 		t.Fatalf("Inspect() error = %v", err)
@@ -316,7 +315,7 @@ func TestFunctionalModelsOwnedAdapter_ListInspectPullPreserveAcceptedOutput(t *t
 	}
 
 	var pullHuman bytes.Buffer
-	if err := service.Pull(modelscli.PullConfig{
+	if err := service.Pull(PullConfig{
 		Context: context.Background(), ModelName: "OMNIVOICE_Q4_K_M", Output: &pullHuman,
 	}); err != nil {
 		t.Fatalf("Pull() error = %v", err)
@@ -328,28 +327,28 @@ func TestFunctionalModelsOwnedAdapter_ListInspectPullPreserveAcceptedOutput(t *t
 	}
 }
 
-// TestFunctionalModelsCompositionFacade_RoutesOwnedListThroughModelsRoot proves
+// TestOwnedAdapter_CompositionFacadeRoutesOwnedListThroughModelsRoot proves
 // composition-stable New() delegates durable behavior through the owned adapter.
-func TestFunctionalModelsCompositionFacade_RoutesOwnedListThroughModelsRoot(t *testing.T) {
+func TestOwnedAdapter_CompositionFacadeRoutesOwnedListThroughModelsRoot(t *testing.T) {
 	t.Parallel()
 
-	root := functionalModelsRoot{
+	root := ownedCoverageModelsRoot{
 		listModels: func(context.Context) (modelinference.List, error) {
 			return modelinference.List{
 				Results: []modelinference.Summary{{Name: "OMNIVOICE_Q4_K_M"}},
 			}, nil
 		},
 	}
-	service := modelscli.New(
-		functionalHTTPProtocol(t),
-		functionalCompositionInvocation{root: root},
+	service := New(
+		ownedCoverageHTTPProtocol(t),
+		ownedCoverageCompositionInvocation{root: root},
 	)
 	if service == nil {
 		t.Fatal("New() = nil, want composition facade")
 	}
 
 	var out bytes.Buffer
-	if err := service.List(modelscli.ListConfig{
+	if err := service.List(ListConfig{
 		Context: context.Background(),
 		JSON:    true,
 		Output:  &out,
@@ -365,22 +364,22 @@ func TestFunctionalModelsCompositionFacade_RoutesOwnedListThroughModelsRoot(t *t
 	}
 }
 
-// TestFunctionalModelsOwnedAdapter_InvokeResolvesThroughModelsRoot proves invoke
-// catalog→lease→inference ordering through the owned adapter.
-func TestFunctionalModelsOwnedAdapter_InvokeResolvesThroughModelsRoot(t *testing.T) {
+// TestOwnedAdapter_InvokeResolvesThroughModelsRoot proves invoke
+// catalog->lease->inference ordering through the owned adapter.
+func TestOwnedAdapter_InvokeResolvesThroughModelsRoot(t *testing.T) {
 	t.Parallel()
 
-	scope, err := (modelinference.RuntimeScopeRef{}).Parse("functional-coverage:test-scope")
+	scope, err := (modelinference.RuntimeScopeRef{}).Parse("owned-coverage:test-scope")
 	if err != nil {
 		t.Fatalf("parse runtime scope: %v", err)
 	}
-	lease, err := (modelinference.ModelLeaseRef{}).Parse("functional-coverage:test-lease")
+	lease, err := (modelinference.ModelLeaseRef{}).Parse("owned-coverage:test-lease")
 	if err != nil {
 		t.Fatalf("parse model lease: %v", err)
 	}
 	var gotCatalog, gotAcquire, gotInvoke bool
-	service := modelscli.NewService(modelscli.Config{
-		Models: functionalModelsRoot{
+	service := NewService(Config{
+		Models: ownedCoverageModelsRoot{
 			getCatalogModel: func(_ context.Context, request modelinference.GetModelRequest) (modelinference.GetModelResult, error) {
 				gotCatalog = true
 				if request.Scope != scope || request.Name != "OMNIVOICE_Q4_K_M" || request.Operation != "TTS" {
@@ -409,13 +408,13 @@ func TestFunctionalModelsOwnedAdapter_InvokeResolvesThroughModelsRoot(t *testing
 				}, nil
 			},
 		},
-		OpenInvokeScope: func(context.Context, modelscli.InvokeConfig) (modelscli.InvokeRuntimeScope, error) {
-			return modelscli.InvokeRuntimeScope{Scope: scope}, nil
+		OpenInvokeScope: func(context.Context, InvokeConfig) (InvokeRuntimeScope, error) {
+			return InvokeRuntimeScope{Scope: scope}, nil
 		},
 	})
 
 	var out bytes.Buffer
-	if err := service.Invoke(modelscli.InvokeConfig{
+	if err := service.Invoke(InvokeConfig{
 		Context:   context.Background(),
 		ModelName: "OMNIVOICE_Q4_K_M",
 		Operation: "TTS",

--- a/pkg/services/workers/internal/progress_composition_test.go
+++ b/pkg/services/workers/internal/progress_composition_test.go
@@ -239,10 +239,6 @@ func (testRuntimeScopeUnsupported) CancelInvocation(
 	return models.CancelInvocationResult{}, models.ErrUnsupportedOperation
 }
 
-func (s testModelsService) ForRuntime(models.RuntimeBinding) (models.Service, error) {
-	return s, nil
-}
-
 type injectedProviderRunner struct{}
 
 type testFactoryWorktreePreparer struct{}

--- a/pkg/transports/cli/command_factory_injection_test.go
+++ b/pkg/transports/cli/command_factory_injection_test.go
@@ -529,10 +529,6 @@ func (compositionModelsRootForFactoryTest) CancelInvocation(context.Context, mod
 	return modelinference.CancelInvocationResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (compositionModelsRootForFactoryTest) ForRuntime(modelinference.RuntimeBinding) (modelinference.Service, error) {
-	return nil, modelinference.ErrUnsupportedOperation
-}
-
 func (compositionModelsRootForFactoryTest) InspectRuntime(context.Context, string) (modelinference.Runtime, error) {
 	return modelinference.Runtime{}, modelinference.ErrUnsupportedOperation
 }

--- a/pkg/transports/cli/run/run_builder_test.go
+++ b/pkg/transports/cli/run/run_builder_test.go
@@ -119,8 +119,8 @@ func testRuntimeOpeningRequestFactory(
 		Recordings: recordings.RuntimeOpeningRequest{
 			RecordPath: cfg.RecordPath, ReplayPath: cfg.ReplayPath, WorkflowID: cfg.Workflow,
 		},
-		Models:           models.RuntimeOpeningRequest{CacheDirectory: cfg.ModelCacheDir},
-		OperatorDefaults: cfg.OperatorDefaults,
+		ModelCacheDirectory: cfg.ModelCacheDir,
+		OperatorDefaults:    cfg.OperatorDefaults,
 	}, Ports: factorysessions.ApplicationOpeningPorts{
 		InvocationMetricsRecorder: cfg.InvocationMetricsRecorder,
 		RuntimeHostObserver:       observer,
@@ -155,7 +155,7 @@ func flattenTestRuntimeRequest(request *factorysessions.RuntimeOpeningRequest) *
 		InvocationSkipPermissionsOverride:       request.Workers.InvocationSkipPermissionsOverride,
 		RecordFlushInterval:                     request.Recordings.FlushInterval,
 		SkipBuiltInRunnerPrerequisiteValidation: request.Workers.SkipBuiltInPrerequisiteValidation,
-		ModelCacheDir:                           request.Models.CacheDirectory,
+		ModelCacheDir:                           request.ModelCacheDirectory,
 	}
 }
 

--- a/pkg/wire/runtime_inputs.go
+++ b/pkg/wire/runtime_inputs.go
@@ -18,7 +18,6 @@ import (
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	factorysessionwire "github.com/portpowered/infinite-you/pkg/services/factory_sessions/wire"
-	"github.com/portpowered/infinite-you/pkg/services/models"
 	modelswire "github.com/portpowered/infinite-you/pkg/services/models/wire"
 	providerswire "github.com/portpowered/infinite-you/pkg/services/providers/wire"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
@@ -102,10 +101,8 @@ func provideRuntimeOpeningRequestFactory() runcli.RuntimeOpeningRequestFactory {
 				ReplayPath: cfg.ReplayPath,
 				WorkflowID: cfg.Workflow,
 			},
-			Models: models.RuntimeOpeningRequest{
-				CacheDirectory: cfg.ModelCacheDir,
-			},
-			OperatorDefaults: cfg.OperatorDefaults,
+			ModelCacheDirectory: cfg.ModelCacheDir,
+			OperatorDefaults:    cfg.OperatorDefaults,
 		}
 		return factorysessionwire.ApplicationOpeningRequest{
 			Runtime: request,

--- a/pkg/wire/runtime_inputs_test.go
+++ b/pkg/wire/runtime_inputs_test.go
@@ -451,8 +451,8 @@ func TestRuntimeOpeningRequestFactoryMapsSelectionsIntoOwnerRequests(t *testing.
 	if request.Recordings.RecordPath != "record.json" || request.Recordings.ReplayPath != "replay.json" || request.Recordings.WorkflowID != "flow" {
 		t.Fatalf("Recordings request = %#v", request.Recordings)
 	}
-	if request.Models.CacheDirectory != "models" || opening.Ports.InvocationMetricsRecorder != nil || opening.Ports.RuntimeHostObserver == nil {
-		t.Fatalf("Models/ports = %#v / %#v", request.Models, opening.Ports)
+	if request.ModelCacheDirectory != "models" || opening.Ports.InvocationMetricsRecorder != nil || opening.Ports.RuntimeHostObserver == nil {
+		t.Fatalf("Models/ports = %#v / %#v", request.ModelCacheDirectory, opening.Ports)
 	}
 }
 

--- a/tests/functional/models/model_list/adapter_owned_coverage_test.go
+++ b/tests/functional/models/model_list/adapter_owned_coverage_test.go
@@ -120,10 +120,6 @@ func (stub functionalModelsRoot) CancelInvocation(context.Context, modelinferenc
 	return modelinference.CancelInvocationResult{}, modelinference.ErrUnsupportedOperation
 }
 
-func (stub functionalModelsRoot) ForRuntime(modelinference.RuntimeBinding) (modelinference.Service, error) {
-	return nil, modelinference.ErrUnsupportedOperation
-}
-
 func (stub functionalModelsRoot) ListModels(ctx context.Context) (modelinference.List, error) {
 	if stub.listModels != nil {
 		return stub.listModels(ctx)


### PR DESCRIPTION
```json
{
  "project": "Finish Models Dead-Path Removal After the Post-Merge Review",
  "branchName": "ACP-L2-FIX-MOD-DEAD-PATHS",
  "description": "Deliver a narrow correction on current origin/main that completes DEL-MOD-FORRUNTIME by removing three obsolete Models ForRuntime test fakes and the legacy models.RuntimeOpeningRequest projection, carrying the real model-cache selection through the existing Factory Sessions opening operation into models.OpenRuntimeScopeRequest.Config, and preserving all established Models lifecycle, invocation, Workers construction, Factory Runtime, E02/C14, provider-control, and L4 behavior.",
  "context": {
    "customerAsk": "Fully satisfy DEL-MOD-FORRUNTIME on current origin/main: remove the three obsolete Models ForRuntime fake methods, eliminate models.RuntimeOpeningRequest, preserve the real model-cache selection through the existing owner-aligned construction path, update directly stale Models architecture text, prove valid and invalid Models runtime behavior without prohibited meta tests, and continue implementation, review, CI, conflict resolution, merge, PR #1756 follow-up, and Factory evidence through terminal completion.",
    "problem": "Merged PR #1756 removed the private production ForRuntime methods but left obsolete ForRuntime methods in three test doubles and retained models.RuntimeOpeningRequest as a one-field cache-directory projection through Factory Sessions and pkg/wire. These remnants imply a retired Models service-factory contract and leave the original dead-path deletion incomplete even though OpenRuntimeScope is the live singular-root path.",
    "solution": "Keep one process-scoped models.Service injected through the canonical graph; carry the detached cache-directory selection explicitly in the existing Factory Sessions opening operation; combine it with the current detached Models runtime configuration only when calling models.Service.OpenRuntimeScope; remove the legacy projection and stale fake methods; update directly incorrect architecture text; and verify valid cache-backed behavior, typed scope failures, and exactly-once cleanup through public service and runtime-opening behavior."
  },
  "acceptanceCriteria": [
    "A Factory runtime opened with an explicit model cache directory passes that selection into the new Models runtime scope, and valid scoped Models catalog, readiness, asset, host, lease, and invocation behavior remains compatible for equivalent inputs.",
    "Models runtime opening uses the singular injected models.Service.OpenRuntimeScope operation and detached RuntimeScopeConfig; models.RuntimeOpeningRequest and test-only ForRuntime compatibility methods are removed without adding a second Models construction or lookup path.",
    "Missing required scope inputs and use of invalid, stale, closed, or foreign scope references retain explicit Models-owned failures, while successful shutdown and failed opening unwind each acquired Models scope exactly once.",
    "The correction preserves the single Workers constructor-injection path from PR #1770, current Factory Runtime contracts, E02/C14 and provider-control behavior, and every established L4 boundary; no unrelated E03, W3, ACP transport, Events, Chat, Worker Sessions, provider continuation, or control work is included.",
    "Directly stale Models architecture documentation describes the singular root and OpenRuntimeScope lifecycle accurately, and behavioral tests assert service/runtime outcomes rather than source topology or inventories.",
    "Focused Models, Factory Sessions, and canonical wiring tests, make test, typecheck/compile validation, formatting, relevant lint and boundary gates, and all required CI checks are terminal and passing.",
    "The implementation/review loop continues until all blocking PR conversation feedback is explicitly addressed, conflicts and shared-file changes are reconciled, required CI is terminal and passing, and the corrective PR is actually merged; afterward PR #1756 records a final comment linking the merged correction, and Factory task, review, and consume evidence is terminal before completion is reported."
  ],
  "userStories": [
    {
      "id": "ACP-L2-FIX-MOD-DEAD-PATHS-001",
      "title": "Open valid Models scopes without the legacy projection",
      "description": "As a Factory runtime operator, I want my selected model cache and runtime configuration applied through the singular Models root so that managed-model behavior remains correct without a dead ForRuntime compatibility path.",
      "priority": 1,
      "passes": true
    },
    {
      "id": "ACP-L2-FIX-MOD-DEAD-PATHS-002",
      "title": "Preserve Models scope failure and cleanup behavior",
      "description": "As a Models consumer, I want invalid scope use and runtime-opening failure to remain explicit and safely cleaned up so that removing the compatibility path cannot silently change lifecycle or invocation semantics.",
      "priority": 2,
      "passes": true
    }
  ]
}
```

## Summary
- Removed `models.RuntimeOpeningRequest` and threaded the model cache directory directly on `factorysessions.RuntimeOpeningRequest.ModelCacheDirectory`, through `PrepareRuntime`/`openRuntime`/`bindModelsRuntimeScope` into `models.OpenRuntimeScopeRequest.Config`.
- Removed the 3 obsolete `ForRuntime` test-double methods left over from PR #1756 (in `pkg/services/workers/internal/progress_composition_test.go`, `pkg/transports/cli/command_factory_injection_test.go`, `tests/functional/models/model_list/adapter_owned_coverage_test.go`).
- Updated `docs/internal/architectural-systems/managed-model-runtime.md` to describe `OpenRuntimeScope`/`CloseRuntimeScope` instead of the retired `Service.ForRuntime` pattern.
- Added an end-to-end assertion proving the model cache directory reaches `OpenRuntimeScope`'s request through the full `openRuntime` path.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (full unit lane)
- [x] Focused packages: `pkg/services/models/...`, `pkg/services/factory_sessions/...`, `pkg/wire/...`, `pkg/transports/cli/...`, `pkg/services/workers/...`, `tests/functional/models/...`
