### PR TITLE
ACP-L3-FS-SEAL-LIVE-CONTROL-PORT

### DIFF
--- a/pkg/services/factory_sessions/contracts.go
+++ b/pkg/services/factory_sessions/contracts.go
@@ -116,13 +116,18 @@ type RuntimeHTTPServices struct {
 	FactoryDefinitions interfaces.Service
 	WorkflowPreview    factoryruntime.WorkflowPreviewOperation
 	FactorySessions    Service
-	Work               work.Service
-	Models             models.Service
-	ModelsScope        models.RuntimeScopeRef
-	Workers            workers.Service
-	ProviderSessions   providersessions.Service
-	WorkerPrompts      workers.PromptTemplates
-	Logger             *zap.Logger
+	// LiveControl is the same runtime-bound Factory Sessions authority as
+	// FactorySessions, narrowed for clients that only manage live sessions.
+	// The broad root remains available here for stream, reconnect, invocation,
+	// durable, and inspection consumers that need excluded operations.
+	LiveControl      LiveControlService
+	Work             work.Service
+	Models           models.Service
+	ModelsScope      models.RuntimeScopeRef
+	Workers          workers.Service
+	ProviderSessions providersessions.Service
+	WorkerPrompts    workers.PromptTemplates
+	Logger           *zap.Logger
 }
 
 // HistoricalReplayInspection is the detached public read model restored from

--- a/pkg/services/factory_sessions/discovery_test.go
+++ b/pkg/services/factory_sessions/discovery_test.go
@@ -213,11 +213,12 @@ func TestCloneTargets_ReturnsDefensiveCopy(t *testing.T) {
 
 // --- merged from live_control_contract_characterization_test.go ---
 
-// peerLiveControlFake exercises the published live-control root slice through
-// the singular Service. It compiles against only the Sessions root package and
-// never imports factory_sessions/internal or live-runtime registry/host types.
+// peerLiveControlFake exercises the owner-published LiveControlService
+// capability. It has exactly the six live-control methods, never embeds the
+// broad Service aggregate, and never imports factory_sessions/internal or
+// live-runtime registry/host types.
 type peerLiveControlFake struct {
-	*peerRootServiceFake
+	sessions    map[string]LiveControlSnapshot
 	openResults map[string]*OpenResult
 	listed      []ReadProjection
 	lifecycle   map[string]LifecycleStatus
@@ -226,14 +227,32 @@ type peerLiveControlFake struct {
 
 func newPeerLiveControlFake() *peerLiveControlFake {
 	return &peerLiveControlFake{
-		peerRootServiceFake: newPeerRootServiceFake(),
-		openResults:         make(map[string]*OpenResult),
-		lifecycle:           make(map[string]LifecycleStatus),
-		closed:              make(map[string]bool),
+		sessions:    make(map[string]LiveControlSnapshot),
+		openResults: make(map[string]*OpenResult),
+		lifecycle:   make(map[string]LifecycleStatus),
+		closed:      make(map[string]bool),
 	}
 }
 
-var _ Service = (*peerLiveControlFake)(nil)
+var _ LiveControlService = (*peerLiveControlFake)(nil)
+
+// exactLiveControlService is a bidirectional compile-time check that the
+// published capability has precisely the six owner-defined live operations.
+// It protects the capability boundary without scanning source or depending on
+// private implementation types.
+type exactLiveControlService interface {
+	OpenFactorySession(context.Context, LiveControlOpenRequest) (*LiveControlOpenResult, error)
+	ListFactorySessions(context.Context) ([]LiveControlListItem, error)
+	GetFactorySession(context.Context, string) (LiveControlSnapshot, error)
+	PauseLiveFactorySession(context.Context, string, LiveControlRequest) (LiveControlResult, error)
+	ResumeLiveFactorySession(context.Context, string, LiveControlRequest) (LiveControlResult, error)
+	CloseFactorySession(context.Context, string) error
+}
+
+var (
+	_ exactLiveControlService = (LiveControlService)(nil)
+	_ LiveControlService      = (exactLiveControlService)(nil)
+)
 
 func (fake *peerLiveControlFake) OpenFactorySession(
 	_ context.Context,
@@ -416,7 +435,7 @@ func requireAcceptedPause(
 	}
 }
 
-func TestLiveControlRootContract_OpenListGetStableIdentity(t *testing.T) {
+func TestLiveControlCapability_OpenListGetStableIdentity(t *testing.T) {
 	t.Parallel()
 
 	fake := newPeerLiveControlFake()
@@ -424,7 +443,7 @@ func TestLiveControlRootContract_OpenListGetStableIdentity(t *testing.T) {
 	folder := "/workspace/factories/demo"
 	seedRunningLiveControlSession(fake, sessionID, folder)
 
-	var service Service = fake
+	var service LiveControlService = fake
 	ctx := context.Background()
 
 	opened, err := service.OpenFactorySession(ctx, LiveControlOpenRequest{FolderPath: folder})
@@ -456,7 +475,7 @@ func TestLiveControlRootContract_OpenListGetStableIdentity(t *testing.T) {
 	requireAcceptedPause(t, paused, sessionID)
 }
 
-func TestLiveControlRootContract_TypedMissingAndLifecycleFailures(t *testing.T) {
+func TestLiveControlCapability_TypedMissingAndLifecycleFailures(t *testing.T) {
 	t.Parallel()
 
 	fake := newPeerLiveControlFake()
@@ -467,7 +486,7 @@ func TestLiveControlRootContract_TypedMissingAndLifecycleFailures(t *testing.T) 
 		Runtime: RuntimeProjection{Status: "SUCCEEDED"},
 	}
 
-	var service Service = fake
+	var service LiveControlService = fake
 	ctx := context.Background()
 
 	_, err := service.GetFactorySession(ctx, "missing-live-session")

--- a/pkg/services/factory_sessions/internal/runtimeopening/models_bind_test.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/models_bind_test.go
@@ -269,6 +269,40 @@ func TestAssembleRuntimeProductsCarriesModelsRootAndScopeIntoOpenedRuntime(t *te
 	}
 }
 
+func TestAssembleRuntimeProductsExposesSameFactorySessionsInstanceAsLiveControl(t *testing.T) {
+	t.Parallel()
+
+	gateway := &runtimeProductsSessionsRole{}
+	opened := assembleRuntimeProducts(
+		nil,
+		gateway,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		modelsRuntimeBind{},
+		nil,
+		inertHostedInstance{},
+		nil,
+		nil,
+		nil,
+		nil,
+		"/factory",
+		"runtime-1",
+		"backend-1",
+		func() error { return nil },
+	)
+
+	if got := opened.application.HTTP.FactorySessions; got != gateway {
+		t.Fatalf("FactorySessions = %T, want original runtime gateway %T", got, gateway)
+	}
+	if got := opened.application.HTTP.LiveControl; got == nil || any(got) != any(gateway) {
+		t.Fatalf("LiveControl = %T, want the same runtime gateway %T", got, gateway)
+	}
+}
+
 func TestRuntimeOpeningCleanupClosesModelsScopeAfterLaterResourceOnFailure(t *testing.T) {
 	t.Parallel()
 
@@ -474,6 +508,10 @@ func openingCoordinatorAdaptCommandRunner(platformprocess.CommandRunner) workers
 }
 
 type openingCoordinatorSessionsRoot struct {
+	factorysessions.Service
+}
+
+type runtimeProductsSessionsRole struct {
 	factorysessions.Service
 }
 

--- a/pkg/services/factory_sessions/internal/runtimeopening/types.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/types.go
@@ -69,7 +69,8 @@ func assembleRuntimeProducts(
 	httpServices := roles.RuntimeHTTPServices{
 		FactoryRuntime: factoryRuntime, FactoryDefinitions: factoryDefinitions,
 		WorkflowPreview: workflowPreview,
-		FactorySessions: factorySessionGateway, Work: workService,
+		FactorySessions: factorySessionGateway, LiveControl: factorySessionGateway,
+		Work:   workService,
 		Models: modelsBind.Root, ModelsScope: modelsBind.Scope,
 		Workers: workerService, ProviderSessions: providerSessions,
 		WorkerPrompts: workerPrompts, Logger: resources.Logger,

--- a/pkg/services/factory_sessions/internal/sessionservice/live_runtime_lifecycle_control_test.go
+++ b/pkg/services/factory_sessions/internal/sessionservice/live_runtime_lifecycle_control_test.go
@@ -165,6 +165,140 @@ func TestLiveControlCapability_PreservesTypedRejectionAndCancellation(t *testing
 	}
 }
 
+func TestLiveControlCapability_CompletesLifecycleAndRetiresCanonicalSession(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "sess-live-control-close"
+	target := factorysessions.Target{
+		Ref:        factorysessions.TargetRef{Kind: factorysessions.TargetKindDefault},
+		FactoryDir: "/tmp/factory",
+		FolderPath: "/tmp",
+		Project:    "demo",
+	}
+	factory := &gatewayLifecycleFactory{factoryState: string(interfaces.FactoryStateRunning)}
+	session := &livesession.LiveSession{
+		ID: sessionID,
+		SessionState: livesession.SessionState{
+			FactoryDir: target.FactoryDir,
+			FolderPath: target.FolderPath,
+		},
+		Project: target.Project,
+		Target:  target.Ref,
+		Runtime: &factorysessions.LiveRuntime{Factory: factory},
+	}
+	host := &retiringLiveRuntimeHost{
+		liveRuntimeEffectHost: liveRuntimeEffectHost{
+			openTestHost: openTestHost{
+				targets:        []factorysessions.Target{target},
+				openSessionID:  sessionID,
+				requireSession: session,
+				sessionIDs:     []string{sessionID},
+				sessions:       map[string]*livesession.LiveSession{sessionID: session},
+			},
+			factory: factory,
+		},
+	}
+
+	// This client intentionally receives no durable, invocation, stream,
+	// inspection, or runtime-opening operations.
+	var client factorysessions.LiveControlService = newLiveRuntimeCompositionGateway(t, host)
+	ctx := context.Background()
+
+	opened, err := client.OpenFactorySession(ctx, factorysessions.LiveControlOpenRequest{
+		FolderPath: target.FolderPath,
+	})
+	if err != nil || opened == nil || opened.SessionID != sessionID {
+		t.Fatalf("OpenFactorySession = (%#v, %v), want canonical session %q", opened, err, sessionID)
+	}
+	listed, err := client.ListFactorySessions(ctx)
+	if err != nil || len(listed) != 1 || listed[0].Context.FactorySessionID != opened.SessionID {
+		t.Fatalf("ListFactorySessions = (%#v, %v), want opened session %q", listed, err, opened.SessionID)
+	}
+	read, err := client.GetFactorySession(ctx, opened.SessionID)
+	if err != nil || read.Context.FactorySessionID != opened.SessionID {
+		t.Fatalf("GetFactorySession = (%#v, %v), want opened session %q", read, err, opened.SessionID)
+	}
+
+	paused, err := client.PauseLiveFactorySession(ctx, opened.SessionID, factorysessions.LiveControlRequest{})
+	if err != nil || paused.SessionID != opened.SessionID ||
+		paused.Outcome != factorysessions.LifecycleControlOutcomeAccepted ||
+		paused.Status != factorysessions.LifecycleStatusPaused {
+		t.Fatalf("PauseLiveFactorySession = (%#v, %v), want accepted pause for %q", paused, err, opened.SessionID)
+	}
+	// The gateway double observes state at the Factory Runtime boundary; the
+	// production runtime advances this state as part of the pause operation.
+	factory.factoryState = string(interfaces.FactoryStatePaused)
+	resumed, err := client.ResumeLiveFactorySession(ctx, opened.SessionID, factorysessions.LiveControlRequest{})
+	if err != nil || resumed.SessionID != opened.SessionID ||
+		resumed.Outcome != factorysessions.LifecycleControlOutcomeAccepted ||
+		resumed.Status != factorysessions.LifecycleStatusRunning {
+		t.Fatalf("ResumeLiveFactorySession = (%#v, %v), want accepted resume for %q", resumed, err, opened.SessionID)
+	}
+
+	if err := client.CloseFactorySession(ctx, opened.SessionID); err != nil {
+		t.Fatalf("CloseFactorySession: %v", err)
+	}
+	if factory.terminateCalls != 1 || host.stopCalls != 1 || host.stoppedSessionID != opened.SessionID {
+		t.Fatalf(
+			"close cleanup = terminate:%d stop:%d session:%q, want terminate:1 stop:1 session:%q",
+			factory.terminateCalls, host.stopCalls, host.stoppedSessionID, opened.SessionID,
+		)
+	}
+	listed, err = client.ListFactorySessions(ctx)
+	if err != nil || len(listed) != 0 {
+		t.Fatalf("ListFactorySessions after close = (%#v, %v), want no live sessions", listed, err)
+	}
+	_, err = client.GetFactorySession(ctx, opened.SessionID)
+	if !errors.Is(err, factorysessions.ErrSessionNotFound) {
+		t.Fatalf("GetFactorySession after close = %v, want ErrSessionNotFound", err)
+	}
+
+	// The established repeated-close outcome is a typed missing-session error;
+	// it must not repeat teardown after the first successful close.
+	err = client.CloseFactorySession(ctx, opened.SessionID)
+	if !errors.Is(err, factorysessions.ErrSessionNotFound) {
+		t.Fatalf("repeated CloseFactorySession = %v, want ErrSessionNotFound", err)
+	}
+	if factory.terminateCalls != 1 || host.stopCalls != 1 {
+		t.Fatalf("repeated close cleanup = terminate:%d stop:%d, want no additional cleanup", factory.terminateCalls, host.stopCalls)
+	}
+}
+
+func TestLiveControlCapability_CanceledClosePreservesLiveSession(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "sess-live-control-canceled-close"
+	factory := &gatewayLifecycleFactory{factoryState: string(interfaces.FactoryStateRunning)}
+	session := &livesession.LiveSession{
+		ID:      sessionID,
+		Runtime: &factorysessions.LiveRuntime{Factory: factory},
+	}
+	host := &retiringLiveRuntimeHost{
+		liveRuntimeEffectHost: liveRuntimeEffectHost{
+			openTestHost: openTestHost{
+				sessionIDs: []string{sessionID},
+				sessions:   map[string]*livesession.LiveSession{sessionID: session},
+			},
+			factory: factory,
+		},
+	}
+	var client factorysessions.LiveControlService = newLiveRuntimeCompositionGateway(t, host)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := client.CloseFactorySession(ctx, sessionID)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("CloseFactorySession canceled error = %v, want context canceled", err)
+	}
+	if factory.terminateCalls != 0 || host.stopCalls != 0 {
+		t.Fatalf("canceled close cleanup = terminate:%d stop:%d, want none", factory.terminateCalls, host.stopCalls)
+	}
+	read, readErr := client.GetFactorySession(context.Background(), sessionID)
+	if readErr != nil || read.Context.FactorySessionID != sessionID {
+		t.Fatalf("GetFactorySession after canceled close = (%#v, %v), want active session", read, readErr)
+	}
+}
+
 func TestService_LivePauseRejectsInvalidStateWithoutRegistryMutation(t *testing.T) {
 	t.Parallel()
 
@@ -230,6 +364,7 @@ func TestService_CloseFactorySessionThroughLiveRuntimeRetiresRegistryEntry(t *te
 
 type retiringLiveRuntimeHost struct {
 	liveRuntimeEffectHost
+	stoppedSessionID string
 }
 
 func (h *retiringLiveRuntimeHost) RequireSession(sessionID string) (*livesession.LiveSession, error) {
@@ -241,6 +376,7 @@ func (h *retiringLiveRuntimeHost) RequireSession(sessionID string) (*livesession
 
 func (h *retiringLiveRuntimeHost) StopLiveSession(sessionID string) error {
 	h.stopCalls++
+	h.stoppedSessionID = sessionID
 	delete(h.sessions, sessionID)
 	return nil
 }

--- a/pkg/services/factory_sessions/internal/sessionservice/live_runtime_lifecycle_control_test.go
+++ b/pkg/services/factory_sessions/internal/sessionservice/live_runtime_lifecycle_control_test.go
@@ -42,6 +42,129 @@ func TestService_LivePauseResumeThroughLiveRuntimeOwnerReturnsAcceptedOutcomeOnc
 	}
 }
 
+func TestLiveControlCapability_OpenPauseResumePreservesLifecycleResults(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "sess-live-control-pause-resume"
+	target := factorysessions.Target{
+		Ref:        factorysessions.TargetRef{Kind: factorysessions.TargetKindDefault},
+		FactoryDir: "/tmp/factory",
+		FolderPath: "/tmp",
+		Project:    "demo",
+	}
+	factory := &gatewayLifecycleFactory{factoryState: string(interfaces.FactoryStateRunning)}
+	session := &livesession.LiveSession{
+		ID: sessionID,
+		SessionState: livesession.SessionState{
+			FactoryDir: target.FactoryDir,
+			FolderPath: target.FolderPath,
+		},
+		Project: target.Project,
+		Target:  target.Ref,
+	}
+	host := &liveRuntimeEffectHost{
+		openTestHost: openTestHost{
+			targets:        []factorysessions.Target{target},
+			openSessionID:  sessionID,
+			requireSession: session,
+			sessionIDs:     []string{sessionID},
+			sessions:       map[string]*livesession.LiveSession{sessionID: session},
+		},
+		factory: factory,
+	}
+
+	// The client holds only the owner-published live-control capability.
+	var client factorysessions.LiveControlService = newLiveRuntimeCompositionGateway(t, host)
+	opened, err := client.OpenFactorySession(context.Background(), factorysessions.LiveControlOpenRequest{
+		FolderPath: target.FolderPath,
+	})
+	if err != nil {
+		t.Fatalf("OpenFactorySession: %v", err)
+	}
+	if opened == nil || opened.SessionID != sessionID {
+		t.Fatalf("open result = %#v, want session id %q", opened, sessionID)
+	}
+
+	paused, err := client.PauseLiveFactorySession(
+		context.Background(),
+		opened.SessionID,
+		factorysessions.LiveControlRequest{Reason: "operator-pause"},
+	)
+	if err != nil || paused.SessionID != opened.SessionID ||
+		paused.Operation != factorysessions.LifecycleControlPause ||
+		paused.Outcome != factorysessions.LifecycleControlOutcomeAccepted ||
+		paused.Status != factorysessions.LifecycleStatusPaused {
+		t.Fatalf("PauseLiveFactorySession = (%#v, %v), want accepted paused result", paused, err)
+	}
+	if factory.pauseCalls != 1 {
+		t.Fatalf("pause calls = %d, want 1", factory.pauseCalls)
+	}
+
+	// The gateway test double models the runtime's state observation boundary.
+	// Production pause transitions this state inside the Factory Runtime.
+	factory.factoryState = string(interfaces.FactoryStatePaused)
+	resumed, err := client.ResumeLiveFactorySession(
+		context.Background(),
+		opened.SessionID,
+		factorysessions.LiveControlRequest{Reason: "operator-resume"},
+	)
+	if err != nil || resumed.SessionID != opened.SessionID ||
+		resumed.Operation != factorysessions.LifecycleControlResume ||
+		resumed.Outcome != factorysessions.LifecycleControlOutcomeAccepted ||
+		resumed.Status != factorysessions.LifecycleStatusRunning {
+		t.Fatalf("ResumeLiveFactorySession = (%#v, %v), want accepted running result", resumed, err)
+	}
+	if factory.resumeCalls != 1 {
+		t.Fatalf("resume calls = %d, want 1", factory.resumeCalls)
+	}
+}
+
+func TestLiveControlCapability_PreservesTypedRejectionAndCancellation(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "sess-live-control-rejection"
+	factory := &gatewayLifecycleFactory{factoryState: string(interfaces.FactoryStateCompleted)}
+	session := &livesession.LiveSession{ID: sessionID}
+	host := &liveRuntimeEffectHost{
+		openTestHost: openTestHost{
+			requireSession: session,
+			sessionIDs:     []string{sessionID},
+			sessions:       map[string]*livesession.LiveSession{sessionID: session},
+		},
+		factory: factory,
+	}
+
+	var client factorysessions.LiveControlService = newLiveRuntimeCompositionGateway(t, host)
+	_, err := client.ResumeLiveFactorySession(context.Background(), sessionID, factorysessions.LiveControlRequest{})
+	var controlErr *factorysessions.LiveControlError
+	if !errors.As(err, &controlErr) {
+		t.Fatalf("ResumeLiveFactorySession terminal error = %v, want *LiveControlError", err)
+	}
+	if controlErr.Outcome != factorysessions.LifecycleControlOutcomeTerminalSession {
+		t.Fatalf("terminal resume outcome = %q, want TERMINAL_SESSION", controlErr.Outcome)
+	}
+	if errors.Is(err, factorysessions.ErrSessionNotFound) {
+		t.Fatal("terminal lifecycle rejection must remain distinct from ErrSessionNotFound")
+	}
+	if factory.resumeCalls != 0 {
+		t.Fatalf("resume calls = %d after terminal rejection, want none", factory.resumeCalls)
+	}
+
+	factory.factoryState = string(interfaces.FactoryStateRunning)
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = client.PauseLiveFactorySession(canceledCtx, sessionID, factorysessions.LiveControlRequest{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("PauseLiveFactorySession canceled error = %v, want context canceled", err)
+	}
+	if factory.pauseCalls != 0 {
+		t.Fatalf("pause calls = %d after cancellation, want none", factory.pauseCalls)
+	}
+	if factory.factoryState != string(interfaces.FactoryStateRunning) {
+		t.Fatalf("factory state = %q after canceled pause, want RUNNING", factory.factoryState)
+	}
+}
+
 func TestService_LivePauseRejectsInvalidStateWithoutRegistryMutation(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_sessions/internal/sessionservice/live_runtime_registry_read_test.go
+++ b/pkg/services/factory_sessions/internal/sessionservice/live_runtime_registry_read_test.go
@@ -9,6 +9,81 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/livesession"
 )
 
+func TestLiveControlCapability_OpenListReadPreservesCanonicalIdentity(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "sess-live-control-discovery"
+	target := factorysessions.Target{
+		Ref:        factorysessions.TargetRef{Kind: factorysessions.TargetKindDefault},
+		FactoryDir: "/tmp/factory",
+		FolderPath: "/tmp",
+		Project:    "demo",
+	}
+	session := &livesession.LiveSession{
+		ID: sessionID,
+		SessionState: livesession.SessionState{
+			FactoryDir: target.FactoryDir,
+			FolderPath: target.FolderPath,
+		},
+		Project: target.Project,
+		Target:  target.Ref,
+	}
+	host := &liveRuntimeEffectHost{
+		openTestHost: openTestHost{
+			targets:        []factorysessions.Target{target},
+			openSessionID:  sessionID,
+			requireSession: session,
+			sessionIDs:     []string{sessionID},
+			sessions:       map[string]*livesession.LiveSession{sessionID: session},
+		},
+	}
+	gateway := newLiveRuntimeCompositionGateway(t, host)
+
+	// The client receives only the owner-published capability. All lifecycle
+	// interactions below must stay inside that narrow boundary.
+	var client factorysessions.LiveControlService = gateway
+	ctx := context.Background()
+
+	opened, err := client.OpenFactorySession(ctx, factorysessions.LiveControlOpenRequest{
+		FolderPath: target.FolderPath,
+	})
+	if err != nil {
+		t.Fatalf("OpenFactorySession: %v", err)
+	}
+	if opened == nil || opened.SessionID != sessionID {
+		t.Fatalf("open result = %#v, want session id %q", opened, sessionID)
+	}
+	if opened.Session == nil || opened.Session.ID != sessionID || opened.Session.Target != target.Ref {
+		t.Fatalf("open session summary = %#v, want canonical identity and target %#v", opened.Session, target.Ref)
+	}
+
+	listed, err := client.ListFactorySessions(ctx)
+	if err != nil {
+		t.Fatalf("ListFactorySessions: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("ListFactorySessions count = %d, want 1", len(listed))
+	}
+	if listed[0].Context.FactorySessionID != opened.SessionID ||
+		listed[0].Context.Session == nil || listed[0].Context.Session.ID != opened.SessionID {
+		t.Fatalf("listed projection = %#v, want canonical identity %q", listed[0], opened.SessionID)
+	}
+
+	read, err := client.GetFactorySession(ctx, opened.SessionID)
+	if err != nil {
+		t.Fatalf("GetFactorySession: %v", err)
+	}
+	if read.Context.FactorySessionID != opened.SessionID ||
+		read.Context.Session == nil || read.Context.Session.ID != opened.SessionID {
+		t.Fatalf("read projection = %#v, want canonical identity %q", read, opened.SessionID)
+	}
+
+	_, err = client.GetFactorySession(ctx, "missing-live-session")
+	if !errors.Is(err, factorysessions.ErrSessionNotFound) {
+		t.Fatalf("GetFactorySession missing = %v, want errors.Is ErrSessionNotFound", err)
+	}
+}
+
 func TestService_LiveOpenRecordsCanonicalIdentityThroughLiveRuntimeOwner(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_sessions/service_contracts.go
+++ b/pkg/services/factory_sessions/service_contracts.go
@@ -58,9 +58,10 @@ type RuntimeBinding struct {
 // typed errors; peers must not import the private identity subservice.
 // The published live-control slice uses OpenRequest/OpenResult,
 // ReadProjection, SessionProjection, ControlRequest, LifecycleControlResult,
-// ErrSessionNotFound, and *ControlError on these Service methods; peers must
-// not import private live-runtime registry or host types and must not depend
-// on a second peer-facing live-session interface.
+// ErrSessionNotFound, and *ControlError through LiveControlService; peers
+// that only manage live sessions depend on that narrow capability rather than
+// this broader aggregate and never import private live-runtime registry or
+// host types.
 // The published durable-execution slice uses DurableStartRequest,
 // DurableAsyncStartResult, DurableResumeRequest, DurableControlRequest,
 // DurableControlResult, DurableInspectResult, *DurableValidationError,
@@ -86,9 +87,9 @@ type RuntimeBinding struct {
 // ForRuntime; peers supply already-constructed peer root capabilities through
 // plain binding inputs without downcasting or bundling nested opening
 // interfaces. Binding stays inert during construction characterization.
-// The process-scoped root uses ForRuntime to create an isolated runtime view; a
-// bound view serves the remaining application operations. Peers must depend on
-// Service rather than introducing a second peer-facing session authority.
+// The process-scoped root uses ForRuntime to create an isolated runtime view;
+// a bound view serves the remaining application operations. Peers that need
+// operations outside an owner-published narrow capability depend on Service.
 type Service interface {
 	StartAsync(context.Context, StartRequest) (AsyncStartResult, error)
 	StartSync(context.Context, StartRequest) (SyncStartResult, error)
@@ -154,8 +155,32 @@ type Service interface {
 //   - *ControlError for rejected lifecycle transitions (Outcome InvalidState or
 //     TerminalSession), without nested live-runtime imports
 //
-// Live-control operations remain methods on Service; this file does not publish
-// a separate peer-facing live-session interface.
+// Live-control operations remain methods on Service and are also exposed as
+// the narrow LiveControlService capability for peers that need no other
+// Factory Sessions behavior.
+
+// LiveControlService is the owner-published Factory Sessions capability for
+// opening, listing, reading, pausing, resuming, and closing live Factory
+// Sessions. It uses the existing public request, projection, result, and
+// typed-error vocabulary, so the authoritative Service satisfies it
+// structurally without an adapter, duplicate registry, or second construction
+// path.
+//
+// A peer that receives only this capability cannot access durable execution,
+// invocation, response-event streaming, inspection, or runtime-opening
+// operations through its dependency.
+type LiveControlService interface {
+	OpenFactorySession(context.Context, LiveControlOpenRequest) (*LiveControlOpenResult, error)
+	ListFactorySessions(context.Context) ([]LiveControlListItem, error)
+	GetFactorySession(context.Context, string) (LiveControlSnapshot, error)
+	PauseLiveFactorySession(context.Context, string, LiveControlRequest) (LiveControlResult, error)
+	ResumeLiveFactorySession(context.Context, string, LiveControlRequest) (LiveControlResult, error)
+	CloseFactorySession(context.Context, string) error
+}
+
+// Service satisfies LiveControlService structurally. This assertion keeps the
+// narrow public capability synchronized with its authoritative implementation.
+var _ LiveControlService = (Service)(nil)
 
 // LiveControlOpenRequest is the plain root open request for live session control.
 // It is the published name for OpenRequest on the live-control slice.

--- a/pkg/services/factory_sessions/transports/http/handler.go
+++ b/pkg/services/factory_sessions/transports/http/handler.go
@@ -21,6 +21,7 @@ import (
 // Sessions and their session-scoped Factory and Work resources.
 type Adapter struct {
 	sessionsRoot       factorysessions.Service
+	liveControl        factorysessions.LiveControlService
 	sessionEvents      SessionEventAPI
 	runtime            apisurface.RuntimeAPI
 	factoryStatus      apisurface.FactoryStatusAPI
@@ -45,6 +46,7 @@ type Adapter struct {
 // adapter. They are supplied by the already-opened runtime composition.
 type Dependencies struct {
 	SessionsRoot       factorysessions.Service
+	LiveControl        factorysessions.LiveControlService
 	SessionEvents      SessionEventAPI
 	Runtime            apisurface.RuntimeAPI
 	FactoryStatus      apisurface.FactoryStatusAPI
@@ -88,8 +90,9 @@ func NewHandler(deps Dependencies, logger *zap.Logger) *Adapter {
 		logger = zap.NewNop()
 	}
 	return &Adapter{
-		sessionsRoot: deps.SessionsRoot, sessionEvents: deps.SessionEvents,
-		runtime: deps.Runtime, factoryStatus: deps.FactoryStatus,
+		sessionsRoot: deps.SessionsRoot, liveControl: deps.LiveControl,
+		sessionEvents: deps.SessionEvents,
+		runtime:       deps.Runtime, factoryStatus: deps.FactoryStatus,
 		sessions:           deps.Sessions,
 		invocation:         deps.Invocation,
 		factoryDefinitions: deps.FactoryDefinitions, factoryValidation: deps.FactoryValidation,

--- a/pkg/services/factory_sessions/transports/http/handlers_common.go
+++ b/pkg/services/factory_sessions/transports/http/handlers_common.go
@@ -271,7 +271,7 @@ func (s *Server) handleLiveLifecycleControl(
 		return
 	}
 
-	if s.sessionsRoot != nil {
+	if s.liveControl != nil {
 		s.invokeRootLiveLifecycleControl(w, r.Context(), sessionID, operation, control)
 		return
 	}

--- a/pkg/services/factory_sessions/transports/http/handlers_factory.go
+++ b/pkg/services/factory_sessions/transports/http/handlers_factory.go
@@ -139,11 +139,11 @@ func (s *Server) GetFactorySession(w http.ResponseWriter, r *http.Request, sessi
 		return
 	}
 
-	if s.sessionsRoot != nil {
+	if s.liveControl != nil {
 		if s.guardSessionsRequestContext(w, r) {
 			return
 		}
-		projection, err := s.sessionsRoot.GetFactorySession(r.Context(), decodeGetFactorySessionRequest(sessionID))
+		projection, err := s.liveControl.GetFactorySession(r.Context(), decodeGetFactorySessionRequest(sessionID))
 		if err != nil {
 			if s.writeSessionsRootError(w, string(sessionID), err) {
 				return
@@ -369,11 +369,11 @@ func (s *Server) OpenFactorySession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if s.sessionsRoot != nil {
+	if s.liveControl != nil {
 		if s.guardSessionsRequestContext(w, r) {
 			return
 		}
-		result, err := s.sessionsRoot.OpenFactorySession(r.Context(), factorysession.OpenRequestFromAPI(req))
+		result, err := s.liveControl.OpenFactorySession(r.Context(), factorysession.OpenRequestFromAPI(req))
 		if err != nil {
 			s.writeOpenFactorySessionRejected(w, err)
 			return
@@ -432,11 +432,11 @@ func (s *Server) writeOpenFactorySessionRejected(w http.ResponseWriter, err erro
 }
 
 func (s *Server) CloseFactorySession(w http.ResponseWriter, r *http.Request, sessionID string) {
-	if s.sessionsRoot != nil {
+	if s.liveControl != nil {
 		if s.guardSessionsRequestContext(w, r) {
 			return
 		}
-		if err := s.sessionsRoot.CloseFactorySession(r.Context(), sessionID); err != nil {
+		if err := s.liveControl.CloseFactorySession(r.Context(), sessionID); err != nil {
 			if s.writeSessionsRootError(w, sessionID, err) {
 				return
 			}
@@ -698,7 +698,7 @@ func (s *Server) mergeScopedFactorySessionList(
 	var durable scopedDurableReader
 
 	if s.sessionsRoot != nil {
-		live = ReadProjectionSessionListReader{Reader: s.sessionsRoot}
+		live = ReadProjectionSessionListReader{Reader: s.liveControl}
 		durable = s.sessionsRoot
 	} else {
 		live = s.liveSessionLister

--- a/pkg/services/factory_sessions/transports/http/root_binding.go
+++ b/pkg/services/factory_sessions/transports/http/root_binding.go
@@ -30,6 +30,7 @@ func NewHandlerFromRoot(binding RootBinding, logger *zap.Logger) *Adapter {
 	}
 	return NewHandler(Dependencies{
 		SessionsRoot:    binding.Sessions,
+		LiveControl:     binding.Sessions,
 		SessionRequests: binding.Prepare,
 	}, logger)
 }

--- a/pkg/services/factory_sessions/transports/http/session_control.go
+++ b/pkg/services/factory_sessions/transports/http/session_control.go
@@ -146,10 +146,10 @@ func (s *Server) invokeRootLiveLifecycleControl(
 ) {
 	switch operation {
 	case "pause":
-		result, err := s.sessionsRoot.PauseLiveFactorySession(ctx, string(sessionID), control)
+		result, err := s.liveControl.PauseLiveFactorySession(ctx, string(sessionID), control)
 		s.finishRootLifecycleControl(w, string(sessionID), operation, result, err)
 	case "resume":
-		result, err := s.sessionsRoot.ResumeLiveFactorySession(ctx, string(sessionID), control)
+		result, err := s.liveControl.ResumeLiveFactorySession(ctx, string(sessionID), control)
 		s.finishRootLifecycleControl(w, string(sessionID), operation, result, err)
 	default:
 		s.writeError(w, http.StatusInternalServerError, "live factory session lifecycle control failed", "INTERNAL_ERROR")

--- a/pkg/services/factory_sessions/wire/wire_test.go
+++ b/pkg/services/factory_sessions/wire/wire_test.go
@@ -63,6 +63,13 @@ func TestNewServiceConstructsPublishedRoot(t *testing.T) {
 	if root == nil {
 		t.Fatal("constructed root is nil")
 	}
+	var liveControl factorysessions.LiveControlService = service
+	if liveControl == nil {
+		t.Fatal("constructed live-control capability is nil")
+	}
+	if any(liveControl) != any(root) {
+		t.Fatalf("LiveControlService = %T, want the same authoritative Service instance %T", liveControl, root)
+	}
 }
 
 func TestNewServiceConstructsInertRoot(t *testing.T) {

--- a/pkg/transports/http/application/handler.go
+++ b/pkg/transports/http/application/handler.go
@@ -72,21 +72,21 @@ func (handler *Handler) Bind(opened factorysessions.RuntimeHTTPServices) (http.H
 		return nil, fmt.Errorf("bind HTTP handler: Models service, invoker, content preparation, and logger are required")
 	}
 	mapped, err := handler.mappings.Bind(
-		opened.FactoryRuntime, opened.FactoryDefinitions, opened.FactorySessions,
+		opened.FactoryRuntime, opened.FactoryDefinitions, opened.FactorySessions, opened.LiveControl,
 	)
 	if err != nil {
 		return nil, err
 	}
 	sessionsHandler := factorysessionshttp.NewHandler(factorysessionshttp.Dependencies{
-		SessionsRoot: opened.FactorySessions,
-		Runtime:      mapped.Runtime, FactoryStatus: mapped.FactoryStatus,
+		SessionsRoot: opened.FactorySessions, LiveControl: opened.LiveControl,
+		Runtime: mapped.Runtime, FactoryStatus: mapped.FactoryStatus,
 		Sessions: mapped.Sessions, SessionEvents: opened.FactorySessions,
 		Invocation: mapped.Invocation, FactoryDefinitions: mapped.FactoryDefinitions,
 		FactoryValidation: handler.validation, WorkflowPreview: opened.WorkflowPreview,
 		DurableExecution: mapped.Durable, DurableLifecycle: mapped.Durable,
 		DurableListing: mapped.Durable, DurableProjection: mapped.Durable,
 		DurableLister:      opened.FactorySessions,
-		LiveSessionLister:  factorysessionshttp.ReadProjectionSessionListReader{Reader: opened.FactorySessions},
+		LiveSessionLister:  factorysessionshttp.ReadProjectionSessionListReader{Reader: opened.LiveControl},
 		WorkerPrompts:      opened.WorkerPrompts,
 		InvocationWorkType: handler.invocationWorkType,
 		SessionRequests:    handler.sessionRequests,

--- a/pkg/transports/http/application/handler_test.go
+++ b/pkg/transports/http/application/handler_test.go
@@ -42,6 +42,7 @@ func (*runtimeRole) SubscribeFactoryEvents(
 
 type definitionRole struct{ factorydefinitions.Service }
 type sessionRole struct{ factorysessions.Service }
+type sessionRootRole struct{ factorysessions.Service }
 
 func (*sessionRole) GetFactorySession(context.Context, string) (factorysessions.SessionProjection, error) {
 	return factorysessions.SessionProjection{
@@ -104,9 +105,11 @@ func TestHandlerBindsOpenedRolesWithoutReconstructingStableGraph(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}
+	sessions := &sessionRole{}
 	opened := factorysessions.RuntimeHTTPServices{
 		FactoryRuntime: &runtimeRole{}, FactoryDefinitions: &definitionRole{},
-		FactorySessions: &sessionRole{}, Work: &workRole{}, Models: &modelRole{},
+		FactorySessions: sessions, LiveControl: sessions,
+		Work: &workRole{}, Models: &modelRole{},
 		Workers: &workerRole{}, ProviderSessions: &providerSessionRole{},
 	}
 	opened.Logger = zap.NewNop()
@@ -123,7 +126,7 @@ func TestHandlerBindsOpenedRolesWithoutReconstructingStableGraph(t *testing.T) {
 	}
 }
 
-func TestHandlerBindsSessionsRootAtApplicationEdge(t *testing.T) {
+func TestHandlerBindsLiveControlAtApplicationEdge(t *testing.T) {
 	t.Parallel()
 
 	mappings, err := mappingcomposition.NewHTTPBinder(statusProjectorRole{}, &contentPreparationRole{})
@@ -145,7 +148,8 @@ func TestHandlerBindsSessionsRootAtApplicationEdge(t *testing.T) {
 	}
 	opened := factorysessions.RuntimeHTTPServices{
 		FactoryRuntime: &runtimeRole{}, FactoryDefinitions: &definitionRole{},
-		FactorySessions: &sessionRole{}, Work: &workRole{}, Models: &modelRole{},
+		FactorySessions: &sessionRootRole{}, LiveControl: &sessionRole{},
+		Work: &workRole{}, Models: &modelRole{},
 		Workers: &workerRole{}, ProviderSessions: &providerSessionRole{},
 		Logger: zap.NewNop(),
 	}
@@ -186,7 +190,7 @@ func TestHandlerBindRejectsRuntimeWithoutLegacyHTTPRole(t *testing.T) {
 
 	bound, err := handler.Bind(factorysessions.RuntimeHTTPServices{
 		FactoryRuntime:     &runtimeWithoutAPIRole{},
-		FactoryDefinitions: &definitionRole{}, FactorySessions: &sessionRole{},
+		FactoryDefinitions: &definitionRole{}, FactorySessions: &sessionRole{}, LiveControl: &sessionRole{},
 		Work: &workRole{}, Models: &modelRole{}, Workers: &workerRole{},
 		ProviderSessions: &providerSessionRole{}, Logger: zap.NewNop(),
 	})

--- a/pkg/transports/mapping/composition/http_binding.go
+++ b/pkg/transports/mapping/composition/http_binding.go
@@ -45,8 +45,9 @@ func (binder *HTTPBinder) Bind(
 	runtime factoryruntime.Service,
 	definitions factorydefinitions.Service,
 	sessions factorysessions.Service,
+	liveControl factorysessions.LiveControlService,
 ) (HTTPBinding, error) {
-	if runtime == nil || definitions == nil || sessions == nil ||
+	if runtime == nil || definitions == nil || sessions == nil || liveControl == nil ||
 		binder == nil || binder.content == nil {
 		return HTTPBinding{}, fmt.Errorf("bind HTTP mappings: opened Factory Session roles are required")
 	}
@@ -58,7 +59,7 @@ func (binder *HTTPBinder) Bind(
 	return HTTPBinding{
 		Runtime:            NewRuntimeAPI(legacyObservation, definitions),
 		FactoryStatus:      newFactoryStatusAPI(runtime, sessions),
-		Sessions:           NewLiveSessionAPI(sessions),
+		Sessions:           NewLiveSessionAPI(liveControl, sessions),
 		Invocation:         NewInvocationAPI(rootInvocationAdapter{root: sessions}),
 		FactoryDefinitions: NewFactoryDefinitionAPI(definitions),
 		Durable:            durable,

--- a/pkg/transports/mapping/composition/services.go
+++ b/pkg/transports/mapping/composition/services.go
@@ -20,9 +20,10 @@ func NewRuntimeAPI(
 }
 
 func NewLiveSessionAPI(
+	liveControl factorysessions.LiveControlService,
 	sessions factorysessions.Service,
 ) apisurface.LiveSessionAPI {
-	return factorysessionmapping.NewLiveAPI(sessions)
+	return factorysessionmapping.NewLiveAPI(liveControl, sessions)
 }
 
 func NewFactoryDefinitionAPI(service factorydefinitions.Service) apisurface.FactorySaveAPI {

--- a/pkg/transports/mapping/factorysession/live_api.go
+++ b/pkg/transports/mapping/factorysession/live_api.go
@@ -8,7 +8,6 @@ import (
 
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	workflowresult "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
-	factorysessionexecution "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	apisurface "github.com/portpowered/infinite-you/pkg/transports/mapping"
@@ -17,29 +16,33 @@ import (
 // LiveAPI maps generated live-session contracts onto the canonical Factory
 // Session application gateway and registry.
 type LiveAPI struct {
+	control factorysessions.LiveControlService
 	gateway LiveGateway
 }
 
 var _ apisurface.LiveSessionAPI = (*LiveAPI)(nil)
 
-// LiveGateway is the narrow domain boundary required by the live-session
-// transport mapper.
+// LiveGateway is the non-control live-session boundary retained by the
+// transport mapper for response streams, reconnect, and result inspection.
+// Live control itself is injected separately through the owner-published
+// factorysessions.LiveControlService capability.
 type LiveGateway interface {
-	OpenFactorySession(context.Context, factorysessions.OpenRequest) (*factorysessions.OpenResult, error)
-	ListFactorySessions(context.Context) ([]factorysessions.ReadProjection, error)
-	GetFactorySession(context.Context, string) (factorysessions.SessionProjection, error)
 	SubscribeFactoryResponseEvents(context.Context, factorysessions.ResponseEventSubscriptionRequest) (*factorysessions.ResponseEventCursor, error)
 	GetFactorySessionSyncPreflight(context.Context, string, *interfaces.FactoryEventReconnectCursor, *interfaces.FactorySessionLogicalResolveHint) (factorysessions.SyncPreflightResult, error)
 	GetFactorySessionResult(context.Context, string) (workflowresult.LiveSessionResult, error)
 	GetFactorySessionPartialResult(context.Context, string) (workflowresult.PartialSessionResult, error)
-	PauseLiveFactorySession(context.Context, string, factorysessionexecution.ControlRequest) (factorysessionexecution.LifecycleControlResult, error)
-	ResumeLiveFactorySession(context.Context, string, factorysessionexecution.ControlRequest) (factorysessionexecution.LifecycleControlResult, error)
-	CloseFactorySession(context.Context, string) error
 }
 
 // NewLiveAPI constructs the transport-facing live Factory Session service.
-func NewLiveAPI(gateway LiveGateway) *LiveAPI {
-	return &LiveAPI{gateway: gateway}
+func NewLiveAPI(control factorysessions.LiveControlService, gateway LiveGateway) *LiveAPI {
+	return &LiveAPI{control: control, gateway: gateway}
+}
+
+func (a *LiveAPI) requireControl() (factorysessions.LiveControlService, error) {
+	if a == nil || a.control == nil {
+		return nil, fmt.Errorf("Factory Session live-control service is required")
+	}
+	return a.control, nil
 }
 
 func (a *LiveAPI) requireGateway() (LiveGateway, error) {
@@ -50,11 +53,11 @@ func (a *LiveAPI) requireGateway() (LiveGateway, error) {
 }
 
 func (a *LiveAPI) ListFactorySessions(ctx context.Context) (factoryapi.ListFactorySessionsResponse, error) {
-	gateway, err := a.requireGateway()
+	control, err := a.requireControl()
 	if err != nil {
 		return factoryapi.ListFactorySessionsResponse{}, err
 	}
-	reads, err := gateway.ListFactorySessions(ctx)
+	reads, err := control.ListFactorySessions(ctx)
 	if err != nil {
 		return factoryapi.ListFactorySessionsResponse{}, err
 	}
@@ -62,11 +65,11 @@ func (a *LiveAPI) ListFactorySessions(ctx context.Context) (factoryapi.ListFacto
 }
 
 func (a *LiveAPI) GetFactorySession(ctx context.Context, sessionID string) (factoryapi.FactorySession, error) {
-	gateway, err := a.requireGateway()
+	control, err := a.requireControl()
 	if err != nil {
 		return factoryapi.FactorySession{}, err
 	}
-	projection, err := gateway.GetFactorySession(ctx, sessionID)
+	projection, err := control.GetFactorySession(ctx, sessionID)
 	if err != nil {
 		return factoryapi.FactorySession{}, err
 	}
@@ -124,11 +127,11 @@ func (a *LiveAPI) GetFactorySessionPartialResult(ctx context.Context, sessionID 
 }
 
 func (a *LiveAPI) OpenFactorySession(ctx context.Context, request factoryapi.OpenFactorySessionRequest) (factoryapi.OpenFactorySessionResponse, error) {
-	gateway, err := a.requireGateway()
+	control, err := a.requireControl()
 	if err != nil {
 		return factoryapi.OpenFactorySessionResponse{}, err
 	}
-	result, err := gateway.OpenFactorySession(ctx, OpenRequestFromAPI(request))
+	result, err := control.OpenFactorySession(ctx, OpenRequestFromAPI(request))
 	if err != nil {
 		return factoryapi.OpenFactorySessionResponse{}, err
 	}
@@ -139,31 +142,31 @@ func (a *LiveAPI) OpenFactorySession(ctx context.Context, request factoryapi.Ope
 }
 
 func (a *LiveAPI) CloseFactorySession(ctx context.Context, sessionID string) error {
-	gateway, err := a.requireGateway()
+	control, err := a.requireControl()
 	if err != nil {
 		return err
 	}
-	return gateway.CloseFactorySession(ctx, sessionID)
+	return control.CloseFactorySession(ctx, sessionID)
 }
 
-func (a *LiveAPI) PauseLiveFactorySession(ctx context.Context, sessionID string, control factorysessionexecution.ControlRequest) (factoryapi.FactorySessionLifecycleControlResponse, error) {
-	gateway, err := a.requireGateway()
+func (a *LiveAPI) PauseLiveFactorySession(ctx context.Context, sessionID string, request factorysessions.LiveControlRequest) (factoryapi.FactorySessionLifecycleControlResponse, error) {
+	control, err := a.requireControl()
 	if err != nil {
 		return factoryapi.FactorySessionLifecycleControlResponse{}, err
 	}
-	result, err := gateway.PauseLiveFactorySession(ctx, sessionID, control)
+	result, err := control.PauseLiveFactorySession(ctx, sessionID, request)
 	if err != nil {
 		return factoryapi.FactorySessionLifecycleControlResponse{}, err
 	}
 	return LifecycleControlResponseToAPI(result), nil
 }
 
-func (a *LiveAPI) ResumeLiveFactorySession(ctx context.Context, sessionID string, control factorysessionexecution.ControlRequest) (factoryapi.FactorySessionLifecycleControlResponse, error) {
-	gateway, err := a.requireGateway()
+func (a *LiveAPI) ResumeLiveFactorySession(ctx context.Context, sessionID string, request factorysessions.LiveControlRequest) (factoryapi.FactorySessionLifecycleControlResponse, error) {
+	control, err := a.requireControl()
 	if err != nil {
 		return factoryapi.FactorySessionLifecycleControlResponse{}, err
 	}
-	result, err := gateway.ResumeLiveFactorySession(ctx, sessionID, control)
+	result, err := control.ResumeLiveFactorySession(ctx, sessionID, request)
 	if err != nil {
 		return factoryapi.FactorySessionLifecycleControlResponse{}, err
 	}

--- a/pkg/transports/mapping/factorysession/live_api_test.go
+++ b/pkg/transports/mapping/factorysession/live_api_test.go
@@ -1,0 +1,173 @@
+package factorysession_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/pkg/transports/mapping/factorysession"
+)
+
+func TestLiveAPI_MapsCompleteLifecycleThroughNarrowControl(t *testing.T) {
+	t.Parallel()
+
+	control := &liveControlSpy{}
+	api := factorysession.NewLiveAPI(control, nil)
+	ctx := context.Background()
+	name := "goal"
+
+	opened, err := api.OpenFactorySession(ctx, factoryapi.OpenFactorySessionRequest{
+		FolderPath: "/workspace",
+		Target: &factoryapi.FactorySessionTargetRef{
+			Kind: factoryapi.FactorySessionTargetRefKindNamed,
+			Name: &name,
+		},
+	})
+	if err != nil {
+		t.Fatalf("OpenFactorySession: %v", err)
+	}
+	if opened.Session == nil || opened.Session.Id != liveControlSessionID {
+		t.Fatalf("opened session = %#v, want %q", opened.Session, liveControlSessionID)
+	}
+	if control.openRequest.Target == nil || control.openRequest.Target.Name != name {
+		t.Fatalf("open request = %#v, want named target %q", control.openRequest, name)
+	}
+
+	listed, err := api.ListFactorySessions(ctx)
+	if err != nil {
+		t.Fatalf("ListFactorySessions: %v", err)
+	}
+	if len(listed.Sessions) != 1 || listed.Sessions[0].Id != liveControlSessionID {
+		t.Fatalf("listed sessions = %#v, want %q", listed.Sessions, liveControlSessionID)
+	}
+
+	read, err := api.GetFactorySession(ctx, liveControlSessionID)
+	if err != nil {
+		t.Fatalf("GetFactorySession: %v", err)
+	}
+	if read.Id != liveControlSessionID {
+		t.Fatalf("read session = %#v, want %q", read, liveControlSessionID)
+	}
+
+	pause, err := api.PauseLiveFactorySession(ctx, liveControlSessionID, factorysessions.LiveControlRequest{
+		RequestID: "pause-1",
+		Reason:    "operator pause",
+	})
+	if err != nil {
+		t.Fatalf("PauseLiveFactorySession: %v", err)
+	}
+	if string(pause.Operation) != "PAUSE" || string(pause.Outcome) != "ACCEPTED" {
+		t.Fatalf("pause response = %#v, want accepted pause", pause)
+	}
+
+	resume, err := api.ResumeLiveFactorySession(ctx, liveControlSessionID, factorysessions.LiveControlRequest{
+		RequestID: "resume-1",
+		Reason:    "operator resume",
+	})
+	if err != nil {
+		t.Fatalf("ResumeLiveFactorySession: %v", err)
+	}
+	if string(resume.Operation) != "RESUME" || string(resume.Outcome) != "ACCEPTED" {
+		t.Fatalf("resume response = %#v, want accepted resume", resume)
+	}
+
+	if err := api.CloseFactorySession(ctx, liveControlSessionID); err != nil {
+		t.Fatalf("CloseFactorySession: %v", err)
+	}
+
+	if got, want := control.calls, []string{"open", "list", "get", "pause", "resume", "close"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("control calls = %#v, want %#v", got, want)
+	}
+	if control.pauseRequest.RequestID != "pause-1" || control.resumeRequest.RequestID != "resume-1" || control.closedID != liveControlSessionID {
+		t.Fatalf("control requests = pause:%#v resume:%#v close:%q", control.pauseRequest, control.resumeRequest, control.closedID)
+	}
+}
+
+const liveControlSessionID = "live-session-1"
+
+type liveControlSpy struct {
+	calls         []string
+	openRequest   factorysessions.LiveControlOpenRequest
+	pauseRequest  factorysessions.LiveControlRequest
+	resumeRequest factorysessions.LiveControlRequest
+	closedID      string
+}
+
+var _ factorysessions.LiveControlService = (*liveControlSpy)(nil)
+
+func (s *liveControlSpy) OpenFactorySession(
+	_ context.Context,
+	request factorysessions.LiveControlOpenRequest,
+) (*factorysessions.LiveControlOpenResult, error) {
+	s.calls = append(s.calls, "open")
+	s.openRequest = request
+	return &factorysessions.OpenResult{SessionID: liveControlSessionID, Session: liveControlSummary()}, nil
+}
+
+func (s *liveControlSpy) ListFactorySessions(context.Context) ([]factorysessions.LiveControlListItem, error) {
+	s.calls = append(s.calls, "list")
+	return []factorysessions.ReadProjection{{
+		Context: factorysessions.ProjectionContext{
+			Session: liveControlSummary(), FactorySessionID: liveControlSessionID,
+		},
+	}}, nil
+}
+
+func (s *liveControlSpy) GetFactorySession(context.Context, string) (factorysessions.LiveControlSnapshot, error) {
+	s.calls = append(s.calls, "get")
+	return factorysessions.SessionProjection{
+		Context: factorysessions.ProjectionContext{
+			Session: liveControlSummary(), FactorySessionID: liveControlSessionID,
+		},
+	}, nil
+}
+
+func (s *liveControlSpy) PauseLiveFactorySession(
+	_ context.Context,
+	_ string,
+	request factorysessions.LiveControlRequest,
+) (factorysessions.LiveControlResult, error) {
+	s.calls = append(s.calls, "pause")
+	s.pauseRequest = request
+	return liveControlResult("PAUSE", "PAUSED"), nil
+}
+
+func (s *liveControlSpy) ResumeLiveFactorySession(
+	_ context.Context,
+	_ string,
+	request factorysessions.LiveControlRequest,
+) (factorysessions.LiveControlResult, error) {
+	s.calls = append(s.calls, "resume")
+	s.resumeRequest = request
+	return liveControlResult("RESUME", "RUNNING"), nil
+}
+
+func (s *liveControlSpy) CloseFactorySession(_ context.Context, sessionID string) error {
+	s.calls = append(s.calls, "close")
+	s.closedID = sessionID
+	return nil
+}
+
+func liveControlSummary() *factorysessions.ScopedLiveSessionSummary {
+	return &factorysessions.ScopedLiveSessionSummary{
+		ID:         liveControlSessionID,
+		FactoryDir: "/workspace/factory/goal",
+		FolderPath: "/workspace",
+		Project:    "demo",
+		Target: factorysessions.TargetRef{
+			Kind: factorysessions.TargetKindNamed,
+			Name: "goal",
+		},
+	}
+}
+
+func liveControlResult(operation, status string) factorysessions.LiveControlResult {
+	return factorysessions.LifecycleControlResult{
+		SessionID: liveControlSessionID,
+		Operation: factorysessions.LifecycleControlKind(operation),
+		Outcome:   factorysessions.LifecycleControlOutcome("ACCEPTED"),
+		Status:    factorysessions.LifecycleStatus(status),
+	}
+}


### PR DESCRIPTION
{
  "project": "Seal Factory Sessions Live Control Behind a Narrow Capability",
  "branchName": "ACP-L3-FS-SEAL-LIVE-CONTROL-PORT",
  "description": "Publish and compose a Factory Sessions-owned narrow capability for opening, listing, reading, pausing, resuming, and closing live Factory Sessions; migrate eligible root-composed consumers while preserving identity, projections, typed failures, cancellation, and close cleanup.",
  "context": {
    "customerAsk": "Seal live Factory Session control behind a narrow Factory Sessions-owned capability, migrate eligible root-composed consumers, and prove that a client with only that capability can complete the live lifecycle. Deliver through merge with blocking behavioral feedback resolved, without changing T03 stream/reconnect behavior or introducing a separate lint-only gate.",
    "problem": "Live-control vocabulary already belongs to Factory Sessions, but consumers that only manage live sessions still receive the broad factory_sessions.Service aggregate and can compile against unrelated durable, invocation, stream, inspection, and runtime-binding operations.",
    "solution": "Publish an owner-defined live-control interface containing only open, list, read, pause, resume, and close; compose it from the existing authoritative Factory Sessions instance; migrate only eligible consumers; and prove the complete lifecycle and failure semantics through focused narrow-client tests while retaining the aggregate for demonstrated callers that need excluded operations."
  },
  "acceptanceCriteria": [
    "Factory Sessions publishes a root-owned live-control capability limited to open, list, read, pause, resume, and close using the existing public request, result, projection, and error vocabulary.",
    "Production composition supplies the narrow capability from the same authoritative Factory Sessions instance, and eligible consumers no longer depend on the broad aggregate.",
    "A narrow client can open a live Factory Session, observe the same session identity in list and read projections, pause it, resume it, and close it successfully.",
    "Missing sessions and rejected lifecycle transitions remain distinguishable through the existing typed errors, canceled contexts remain canceled, and close performs the established teardown and registry cleanup without identity drift.",
    "Event stream/reconnect behavior, durable operations, invocation behavior, runtime-opening construction, transports, generated contracts, and unrelated code remain unchanged; broad Service dependencies remain only for demonstrated callers that require excluded operations.",
    "Focused typecheck, lint, and tests pass, including direct behavioral coverage at the Factory Sessions capability/composition boundary; no separate repository-wide lint-only task or gate is created or awaited.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file churn are reconciled, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "ACP-L3-FS-SEAL-LIVE-CONTROL-PORT-001",
      "title": "Publish and compose the narrow live-control capability",
      "description": "As a root-composed consumer that only manages live Factory Sessions, I want a Factory Sessions-owned capability limited to live control so that unrelated session operations are not part of my dependency.",
      "acceptanceCriteria": [
        "The published capability exposes only open, list, read, pause, resume, and close operations with the existing Factory Sessions root vocabulary.",
        "The authoritative Factory Sessions service satisfies the capability directly, and production composition returns the same underlying service instance rather than an adapter, duplicate registry, or secondary construction path.",
        "Consumers that require only these six operations can be constructed with the narrow capability and cannot access durable, invocation, event-stream, inspection, or ForRuntime operations through that dependency.",
        "Callers that demonstrably need excluded operations continue to receive the broad aggregate, with no speculative migration or unrelated cleanup.",
        "Focused contract and composition tests pass.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Published factorysessions.LiveControlService with exactly open, list, read, pause, resume, and close. The authoritative Service satisfies it structurally. Review follow-up: the runtime-opening composition exposes the capability from the same bound Factory Sessions instance, and the eligible HTTP live-control paths consume it while their stream/reconnect, durable, invocation, and inspection paths retain the broad root. Added direct live-control mapper lifecycle coverage after the PR's unit-coverage gate reported a 0.0442 percentage-point regression. Focused go test and go vet checks pass."
    },
    {
      "id": "ACP-L3-FS-SEAL-LIVE-CONTROL-PORT-002",
      "title": "Preserve live session identity and projections through discovery and read",
      "description": "As a live-control client, I want open, list, and read to agree on session identity and projections so that narrowing the dependency does not change which live session I am controlling.",
      "acceptanceCriteria": [
        "Opening through the narrow capability returns the established session identity and target information without translation or replacement.",
        "Listing after open includes that same live session identity and canonical read projection.",
        "Reading that identity returns the established session projection for the same live runtime state.",
        "Reading a missing live session remains distinguishable with errors.Is against ErrSessionNotFound through the narrow capability.",
        "Focused lifecycle discovery/read tests pass without using durable, invocation, stream, or private runtime-opening access from the client.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added direct narrow-client behavioral coverage against the real Factory Sessions live gateway. Open, list, and read now prove the same canonical identity and target projection, while missing read remains distinguishable with errors.Is(ErrSessionNotFound). Focused and full Factory Sessions tests plus go vet pass."
    },
    {
      "id": "ACP-L3-FS-SEAL-LIVE-CONTROL-PORT-003",
      "title": "Preserve pause and resume lifecycle outcomes",
      "description": "As a live-control client, I want pause and resume to retain their success, invalid-state, and cancellation behavior so that lifecycle control remains predictable through the narrow capability.",
      "acceptanceCriteria": [
        "A live session opened through the narrow capability can be paused and then resumed, with the existing lifecycle result and projection transitions preserved.",
        "A rejected pause or resume remains inspectable with errors.As as the existing typed live-control error and retains its invalid-state or terminal-session outcome.",
        "A canceled context is propagated by live control without performing a later state transition or masking cancellation with an unrelated error.",
        "Focused pause/resume tests exercise success and failure paths through only the narrow capability.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added real-gateway narrow-client lifecycle coverage. A client restricted to LiveControlService opens a session, pauses it, resumes it, and observes the established accepted results and identities. Terminal resume rejection remains errors.As(*LiveControlError) with TERMINAL_SESSION, distinct from ErrSessionNotFound; canceled pause remains errors.Is(context.Canceled) and performs no transition. Focused and full Factory Sessions tests plus go vet pass."
    },
    {
      "id": "ACP-L3-FS-SEAL-LIVE-CONTROL-PORT-004",
      "title": "Complete close cleanup through the narrow client lifecycle",
      "description": "As a live-control client, I want close to tear down and remove the exact session I opened so that completing the lifecycle releases runtime resources and leaves no stale live projection.",
      "acceptanceCriteria": [
        "Closing through the narrow capability targets the exact identity returned by open and performs the established runtime teardown and registry cleanup.",
        "After successful close, the session is absent from list and read reports the established missing-session failure.",
        "Repeated or missing-session close preserves the existing idempotency contract, and a canceled close preserves established cancellation and cleanup behavior.",
        "A focused end-to-end capability test completes open, list, read, pause, resume, and close while the client has no durable, invocation, event-stream, inspection, or private runtime-opening access.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Added narrow-client end-to-end coverage for open, list, read, pause, resume, and close against the real Factory Sessions live gateway. Close proves the opened identity is terminated and removed from the live registry; post-close list is empty, read and repeated close retain ErrSessionNotFound, and canceled close retains the active session without teardown. Focused and full Factory Sessions tests plus go vet pass."
    }
  ]
}
