### PR TITLE
ACP-L3-FS-RUNTIME-OPENING-LEGACY-RETIREMENT

### DIFF
--- a/pkg/root/root_test.go
+++ b/pkg/root/root_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	modelproviders "github.com/portpowered/infinite-you/packages/model-providers"
@@ -206,6 +207,53 @@ func TestBuildProcessOpensFactoryWithRegisteredExternalProviderWithoutProviderIO
 			integration.capabilityCalls,
 			integration.invokeCalls,
 		)
+	}
+}
+
+// TestBuildProcessDefersAndOpensOneFactoryRuntime proves that the canonical
+// process graph remains inert across repeated construction, then opens one
+// Factory Session runtime for one selected live application execution.
+func TestBuildProcessDefersAndOpensOneFactoryRuntime(t *testing.T) {
+	t.Parallel()
+
+	var openedRuntimeIDs atomic.Int32
+	edges := serviceedges.Edges{
+		FactorySessionRuntimeInstanceIDGenerator: func() string {
+			openedRuntimeIDs.Add(1)
+			return "root-runtime-opening"
+		},
+	}
+	process, err := BuildProcess(context.Background(), edges)
+	if err != nil {
+		t.Fatalf("BuildProcess() error = %v", err)
+	}
+	second, err := BuildProcess(context.Background(), edges)
+	if err != nil {
+		t.Fatalf("second BuildProcess() error = %v", err)
+	}
+	if got := openedRuntimeIDs.Load(); got != 0 {
+		t.Fatalf("runtime IDs generated during process construction = %d, want 0", got)
+	}
+
+	factoryDir := rootFactoryWithProvider(t, "codex")
+	if err := process.Execute(Input{
+		Args: []string{
+			"you", "run", "--dir", factoryDir, "--with-mock-workers", "--quiet", "--no-record",
+		},
+		Env:              homeEnvironment(t.TempDir()),
+		Context:          context.Background(),
+		WorkingDirectory: factoryDir,
+	}); err != nil {
+		t.Fatalf("Process.Execute(run) error = %v", err)
+	}
+	if got := openedRuntimeIDs.Load(); got != 1 {
+		t.Fatalf("runtime IDs generated during one process execution = %d, want 1", got)
+	}
+	if err := process.Close(context.Background()); err != nil {
+		t.Fatalf("Process.Close() error = %v", err)
+	}
+	if err := second.Close(context.Background()); err != nil {
+		t.Fatalf("second Process.Close() error = %v", err)
 	}
 }
 

--- a/pkg/services/factory_sessions/internal/applicationopening/service.go
+++ b/pkg/services/factory_sessions/internal/applicationopening/service.go
@@ -31,15 +31,6 @@ type RuntimeInputResolver func(
 	*zap.Logger,
 ) (RuntimeInputs, error)
 
-type RuntimeOpener interface {
-	OpenApplicationRuntime(
-		context.Context,
-		*factorysessions.RuntimeOpeningRequest,
-		runtimeopening.ExternalEffects,
-		*zap.Logger,
-	) (roles.OpenedApplicationRuntime, error)
-}
-
 // RuntimeAdapter binds the exact HTTP and optional visualization components
 // selected by Wire to one opened Factory Session. It contains no product
 // lifecycle selection or ordering policy.
@@ -54,14 +45,14 @@ type RuntimeAdapter func(
 // runtime-opening and application-binding operations.
 type Service struct {
 	resolveInputs RuntimeInputResolver
-	openRuntime   RuntimeOpener
+	openRuntime   runtimeopening.ApplicationRuntimeOpening
 	adaptRuntime  RuntimeAdapter
 	planLifecycle roles.LifecyclePlanOperation
 }
 
 func New(
 	resolveInputs RuntimeInputResolver,
-	openRuntime RuntimeOpener,
+	openRuntime runtimeopening.ApplicationRuntimeOpening,
 	adaptRuntime RuntimeAdapter,
 	planLifecycle roles.LifecyclePlanOperation,
 ) (*Service, error) {

--- a/pkg/services/factory_sessions/internal/executionopening/factory.go
+++ b/pkg/services/factory_sessions/internal/executionopening/factory.go
@@ -43,7 +43,7 @@ type WorkerInvocationWithProgressFactory = func(
 
 // Factory owns provider selection and lazy runtime-backed execution scopes.
 type Factory struct {
-	runtimes       *runtimeopening.Factory
+	runtimes       runtimeopening.ExecutionRuntimeOpening
 	runtimeEffects runtimeopening.ExternalEffects
 	commandRunner  workers.CommandRunner
 	allocator      workers.PTYAllocator
@@ -59,7 +59,7 @@ type Factory struct {
 var _ roles.StdioExecutionOpening = (*Factory)(nil)
 
 func NewFactory(
-	runtimes *runtimeopening.Factory,
+	runtimes runtimeopening.ExecutionRuntimeOpening,
 	runtimeEffects runtimeopening.ExternalEffects,
 	commandRunner workers.CommandRunner,
 	allocator workers.PTYAllocator,

--- a/pkg/services/factory_sessions/internal/executionopening/runtime_opening_test.go
+++ b/pkg/services/factory_sessions/internal/executionopening/runtime_opening_test.go
@@ -1,0 +1,74 @@
+package executionopening
+
+import (
+	"context"
+	"testing"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/roles"
+	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/runtimeopening"
+	durableexecution "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/durable_execution"
+	"go.uber.org/zap"
+)
+
+// TestExecutionOpeningUsesItsNarrowRuntimeView proves runtime-backed direct
+// execution opens exactly one execution view through the grouped Factory
+// Sessions capability and preserves its selected runtime inputs.
+func TestExecutionOpeningUsesItsNarrowRuntimeView(t *testing.T) {
+	t.Parallel()
+
+	wantExecution := &runtimeOpeningExecutionStub{}
+	opening := &executionRuntimeOpeningStub{
+		opened: roles.OpenedExecutionRuntime{Execution: wantExecution},
+	}
+	factory := &Factory{
+		runtimes: opening,
+		artifactRoots: func(home string) factoryruntime.RuntimeArtifactRoots {
+			if home != "home" {
+				t.Fatalf("artifact roots home = %q, want home", home)
+			}
+			return factoryruntime.RuntimeArtifactRoots{Logs: "logs", Metrics: "metrics"}
+		},
+		logger: zap.NewNop(),
+	}
+
+	opened, err := factory.OpenExecutionRuntime(t.Context(), factorysessions.ExecutionRuntimeOpeningRequest{
+		ProjectRoot: "project", SystemConfigHome: "home",
+	})
+	if err != nil {
+		t.Fatalf("OpenExecutionRuntime: %v", err)
+	}
+	if opened.Execution != wantExecution {
+		t.Fatalf("opened execution = %#v, want injected execution", opened.Execution)
+	}
+	if opening.calls != 1 {
+		t.Fatalf("execution runtime openings = %d, want 1", opening.calls)
+	}
+	if opening.request == nil || opening.request.FactoryDefinition.Directory != "project" ||
+		opening.request.FactoryDefinition.ExecutionBaseDir != "project" ||
+		opening.request.FactorySession.SystemConfigHome != "home" ||
+		opening.request.FactoryRuntime.LogDirectory != "logs" ||
+		opening.request.FactoryRuntime.MetricsDirectory != "metrics" {
+		t.Fatalf("execution runtime request = %#v", opening.request)
+	}
+}
+
+type executionRuntimeOpeningStub struct {
+	calls   int
+	request *factorysessions.RuntimeOpeningRequest
+	opened  roles.OpenedExecutionRuntime
+}
+
+func (stub *executionRuntimeOpeningStub) OpenExecutionRuntime(
+	_ context.Context,
+	request *factorysessions.RuntimeOpeningRequest,
+	_ runtimeopening.ExternalEffects,
+	_ *zap.Logger,
+) (roles.OpenedExecutionRuntime, error) {
+	stub.calls++
+	stub.request = request
+	return stub.opened, nil
+}
+
+type runtimeOpeningExecutionStub struct{ durableexecution.Service }

--- a/pkg/services/factory_sessions/internal/ondemandtarget/service.go
+++ b/pkg/services/factory_sessions/internal/ondemandtarget/service.go
@@ -5,9 +5,8 @@
 // non-HTTP-bound runtime per caller-selected Factory target the first time it
 // is needed, then keeps it open for later calls against the identity it
 // returned. This is private implementation: pkg/services/factory_sessions/wire
-// exposes it as a thin construction wrapper (matching how that package already
-// wraps runtimeopening.Factory as RuntimeOpeningFactory) so a caller outside
-// this service tree never imports this package directly.
+// exposes it as a thin construction wrapper so a caller outside this service
+// tree never imports this package directly.
 //
 // Service implements exactly StartAsync, InvokeFactorySession, Cancel, and
 // CloseFactorySession -- the narrow, owner-published
@@ -29,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"sync"
 
 	"go.uber.org/zap"
@@ -57,20 +57,6 @@ type RuntimeResolver func(
 	workingRoot string,
 ) (factorysessions.RuntimeOpeningRequest, error)
 
-// invocationRuntimeOpener is the narrow capability this service consumes
-// from *runtimeopening.Factory, declared here (rather than consuming the
-// concrete type directly) so a test can substitute a fake without
-// constructing the full Factory's own large production dependency graph.
-// *runtimeopening.Factory already satisfies this interface structurally.
-type invocationRuntimeOpener interface {
-	OpenInvocationRuntime(
-		ctx context.Context,
-		request *factorysessions.RuntimeOpeningRequest,
-		effects runtimeopening.ExternalEffects,
-		logger *zap.Logger,
-	) (roles.OpenedInvocationRuntime, error)
-}
-
 // Service is Factory Sessions' own on-demand target-execution activation
 // (published to peers as factorysessions.TargetExecutionService) that has no
 // fixed, pre-opened Factory Session runtime the way the CLI daemon's
@@ -78,8 +64,8 @@ type invocationRuntimeOpener interface {
 // Instead, the first StartAsync for a given caller-selected Factory
 // target and working root lazily opens exactly one ephemeral, non-HTTP-bound
 // runtime through the existing invocation-mode Runtime Opening path (the
-// same primitive the CLI's one-shot named invocation already uses, per
-// runtimeopening.Factory.OpenInvocationRuntime), starts its lifecycle, and
+// same primitive the CLI's one-shot named invocation already uses), starts
+// its lifecycle, and
 // keeps it open so every later call against the returned identity reuses
 // that exact runtime instead of starting a second one.
 //
@@ -92,7 +78,7 @@ type invocationRuntimeOpener interface {
 // cached runtime (and the runtime's own DefaultSessionID) on every later
 // call. Callers must treat the returned identity as opaque.
 type Service struct {
-	factory    invocationRuntimeOpener
+	opening    runtimeopening.InvocationRuntimeOpening
 	effects    runtimeopening.ExternalEffects
 	resolve    RuntimeResolver
 	generateID factorysessions.SessionIDGenerator
@@ -146,17 +132,18 @@ type activationControl struct {
 	mu sync.Mutex
 }
 
-// New constructs the on-demand activation over the given *runtimeopening.Factory.
-// Construction alone performs no I/O and opens no runtime.
+// New constructs the on-demand activation over the given Factory Sessions
+// invocation-opening capability. Construction alone performs no I/O and
+// opens no runtime.
 func New(
-	factory *runtimeopening.Factory,
+	opening runtimeopening.InvocationRuntimeOpening,
 	effects runtimeopening.ExternalEffects,
 	resolve RuntimeResolver,
 	generateID factorysessions.SessionIDGenerator,
 	logger *zap.Logger,
 ) (*Service, error) {
-	if factory == nil {
-		return nil, errors.New("construct on-demand Factory target activation: Runtime Opening factory is required")
+	if missingInvocationRuntimeOpening(opening) {
+		return nil, errors.New("construct on-demand Factory target activation: invocation runtime opening is required")
 	}
 	if resolve == nil {
 		return nil, errors.New("construct on-demand Factory target activation: Factory target runtime resolver is required")
@@ -168,7 +155,7 @@ func New(
 		return nil, errors.New("construct on-demand Factory target activation: logger is required")
 	}
 	return &Service{
-		factory:           factory,
+		opening:           opening,
 		effects:           effects,
 		resolve:           resolve,
 		generateID:        generateID,
@@ -178,6 +165,19 @@ func New(
 		startsByRequestID: make(map[string]string),
 		pendingStarts:     make(map[string]*pendingStart),
 	}, nil
+}
+
+func missingInvocationRuntimeOpening(opening runtimeopening.InvocationRuntimeOpening) bool {
+	if opening == nil {
+		return true
+	}
+	value := reflect.ValueOf(opening)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 // activatedRuntime is one lazily-opened, lifecycle-started invocation
@@ -236,7 +236,7 @@ func (s *Service) openActivatedRuntime(
 	s.logger.Info("activating on-demand Factory target runtime",
 		zap.String("factoryTargetId", factoryTargetID))
 
-	opened, err := s.factory.OpenInvocationRuntime(ctx, &config, s.effects, s.logger)
+	opened, err := s.opening.OpenInvocationRuntime(ctx, &config, s.effects, s.logger)
 	if err != nil {
 		s.logger.Error("failed to open on-demand Factory target runtime",
 			zap.String("factoryTargetId", factoryTargetID))

--- a/pkg/services/factory_sessions/internal/ondemandtarget/service_test.go
+++ b/pkg/services/factory_sessions/internal/ondemandtarget/service_test.go
@@ -610,7 +610,7 @@ type openResult struct {
 	err    error
 }
 
-// sequencedOpener is an invocationRuntimeOpener test double that returns a
+// sequencedOpener is an invocation runtime-opening test double that returns a
 // distinct result for each successive OpenInvocationRuntime call, in order --
 // letting a test drive two calls that must return two independently
 // closeable runtimes instead of fakeOpener's single fixed result.

--- a/pkg/services/factory_sessions/internal/ondemandtarget/service_test.go
+++ b/pkg/services/factory_sessions/internal/ondemandtarget/service_test.go
@@ -19,10 +19,10 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/runtimeopening"
 )
 
-// fakeOpener is a minimal invocationRuntimeOpener test double: it records
+// fakeOpener is a minimal InvocationRuntimeOpening test double: it records
 // every call and returns a fixed opened runtime/error, letting these tests
-// exercise Service without constructing *runtimeopening.Factory's own large
-// production dependency graph.
+// exercise Service without constructing the grouped production dependency
+// graph.
 type fakeOpener struct {
 	calls  []factorysessions.RuntimeOpeningRequest
 	opened roles.OpenedInvocationRuntime
@@ -156,10 +156,10 @@ func (f *fakeSessions) CloseFactorySession(ctx context.Context, sessionID string
 	return err
 }
 
-func newTestService(t *testing.T, opener invocationRuntimeOpener, resolve RuntimeResolver, generateID factorysessions.SessionIDGenerator) *Service {
+func newTestService(t *testing.T, opener runtimeopening.InvocationRuntimeOpening, resolve RuntimeResolver, generateID factorysessions.SessionIDGenerator) *Service {
 	t.Helper()
 	return &Service{
-		factory:           opener,
+		opening:           opener,
 		resolve:           resolve,
 		generateID:        generateID,
 		logger:            zap.NewNop(),
@@ -173,11 +173,11 @@ func newTestService(t *testing.T, opener invocationRuntimeOpener, resolve Runtim
 // newTestServiceWithObservedLogger is newTestService, but with a real,
 // observable logger (instead of a no-op one) for tests that assert on what
 // this Service actually logs.
-func newTestServiceWithObservedLogger(t *testing.T, opener invocationRuntimeOpener, resolve RuntimeResolver, generateID factorysessions.SessionIDGenerator) (*Service, *observer.ObservedLogs) {
+func newTestServiceWithObservedLogger(t *testing.T, opener runtimeopening.InvocationRuntimeOpening, resolve RuntimeResolver, generateID factorysessions.SessionIDGenerator) (*Service, *observer.ObservedLogs) {
 	t.Helper()
 	core, observed := observer.New(zapcore.DebugLevel)
 	return &Service{
-		factory:           opener,
+		opening:           opener,
 		resolve:           resolve,
 		generateID:        generateID,
 		logger:            zap.New(core),
@@ -197,7 +197,7 @@ func sequentialIDs(prefix string) func() string {
 }
 
 func TestNewRejectsMissingRequiredDependencies(t *testing.T) {
-	factory := &runtimeopening.Factory{}
+	var factory runtimeopening.InvocationRuntimeOpening = &runtimeopening.Factory{}
 	resolve := func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
 		return factorysessions.RuntimeOpeningRequest{}, nil
 	}
@@ -206,22 +206,67 @@ func TestNewRejectsMissingRequiredDependencies(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		factory    *runtimeopening.Factory
+		opening    runtimeopening.InvocationRuntimeOpening
 		resolve    RuntimeResolver
 		generateID factorysessions.SessionIDGenerator
 		logger     *zap.Logger
 	}{
-		{"missing factory", nil, resolve, generateID, logger},
+		{"missing opening", nil, resolve, generateID, logger},
 		{"missing resolve", factory, nil, generateID, logger},
 		{"missing generateID", factory, resolve, nil, logger},
 		{"missing logger", factory, resolve, generateID, nil},
+		{"typed nil opening", typedNilInvocationRuntimeOpening(), resolve, generateID, logger},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := New(tt.factory, runtimeopening.ExternalEffects{}, tt.resolve, tt.generateID, tt.logger); err == nil {
+			if _, err := New(tt.opening, runtimeopening.ExternalEffects{}, tt.resolve, tt.generateID, tt.logger); err == nil {
 				t.Fatal("New() error = nil, want a construction error")
 			}
 		})
+	}
+}
+
+func typedNilInvocationRuntimeOpening() runtimeopening.InvocationRuntimeOpening {
+	var opening *runtimeopening.Factory
+	return opening
+}
+
+// TestNewUsesInvocationOpeningCapabilityLazily proves construction accepts
+// the owner-published invocation opening capability without opening a runtime,
+// then opens the selected target exactly once when StartAsync actually runs.
+func TestNewUsesInvocationOpeningCapabilityLazily(t *testing.T) {
+	opener := &fakeOpener{opened: roles.OpenedInvocationRuntime{
+		Sessions:  &fakeSessions{},
+		Lifecycle: &fakeLifecycle{},
+	}}
+	var opening runtimeopening.InvocationRuntimeOpening = opener
+	svc, err := New(
+		opening,
+		runtimeopening.ExternalEffects{},
+		func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
+			return factorysessions.RuntimeOpeningRequest{}, nil
+		},
+		func() string { return "target-runtime" },
+		zap.NewNop(),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if len(opener.calls) != 0 {
+		t.Fatalf("OpenInvocationRuntime calls after New() = %d, want 0", len(opener.calls))
+	}
+
+	started, err := svc.StartAsync(context.Background(), factorysessions.StartRequest{
+		Source: factorysessions.Source{FactoryID: "@you/review"},
+	})
+	if err != nil {
+		t.Fatalf("StartAsync() error = %v", err)
+	}
+	if started.SessionID != "target-runtime" {
+		t.Fatalf("StartAsync() SessionID = %q, want target-runtime", started.SessionID)
+	}
+	if len(opener.calls) != 1 {
+		t.Fatalf("OpenInvocationRuntime calls after StartAsync() = %d, want 1", len(opener.calls))
 	}
 }
 

--- a/pkg/services/factory_sessions/internal/ondemandtarget/target_execution_test.go
+++ b/pkg/services/factory_sessions/internal/ondemandtarget/target_execution_test.go
@@ -949,7 +949,7 @@ func TestServiceViaTargetExecutionCapabilityRejectsUnsupportedTarget(t *testing.
 	}
 }
 
-// funcOpener is an invocationRuntimeOpener test double backed directly by a
+// funcOpener is an invocation runtime-opening test double backed directly by a
 // function, for tests that need each successive OpenInvocationRuntime call
 // to return a distinct opened runtime (fakeOpener always returns the same
 // fixed one).

--- a/pkg/services/factory_sessions/internal/runtimeopening/factory.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/factory.go
@@ -23,6 +23,18 @@ import (
 // into the Workers-owned command port.
 type WorkerCommandRunnerAdapter func(platformprocess.CommandRunner) workers.CommandRunner
 
+// ApplicationRuntimeOpening opens the application view of one Factory Sessions
+// runtime. Consumers receive this narrow operation rather than the
+// process-scoped grouped construction type.
+type ApplicationRuntimeOpening interface {
+	OpenApplicationRuntime(
+		context.Context,
+		*factorysessions.RuntimeOpeningRequest,
+		ExternalEffects,
+		*zap.Logger,
+	) (roles.OpenedApplicationRuntime, error)
+}
+
 // InvocationRuntimeOpening opens the invocation-only view of one Factory
 // Sessions runtime. Consumers receive this narrow operation rather than the
 // process-scoped grouped construction type.
@@ -204,8 +216,9 @@ type Factory struct {
 }
 
 var (
-	_ InvocationRuntimeOpening = (*Factory)(nil)
-	_ ExecutionRuntimeOpening  = (*Factory)(nil)
+	_ ApplicationRuntimeOpening = (*Factory)(nil)
+	_ InvocationRuntimeOpening  = (*Factory)(nil)
+	_ ExecutionRuntimeOpening   = (*Factory)(nil)
 )
 
 func NewFactory(dependencies Dependencies) (*Factory, error) {

--- a/pkg/services/factory_sessions/internal/runtimeopening/factory.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/factory.go
@@ -23,6 +23,30 @@ import (
 // into the Workers-owned command port.
 type WorkerCommandRunnerAdapter func(platformprocess.CommandRunner) workers.CommandRunner
 
+// InvocationRuntimeOpening opens the invocation-only view of one Factory
+// Sessions runtime. Consumers receive this narrow operation rather than the
+// process-scoped grouped construction type.
+type InvocationRuntimeOpening interface {
+	OpenInvocationRuntime(
+		context.Context,
+		*factorysessions.RuntimeOpeningRequest,
+		ExternalEffects,
+		*zap.Logger,
+	) (roles.OpenedInvocationRuntime, error)
+}
+
+// ExecutionRuntimeOpening opens the durable-execution view of one Factory
+// Sessions runtime. It keeps direct execution on the same authoritative
+// opening capability while preserving its smaller operation surface.
+type ExecutionRuntimeOpening interface {
+	OpenExecutionRuntime(
+		context.Context,
+		*factorysessions.RuntimeOpeningRequest,
+		ExternalEffects,
+		*zap.Logger,
+	) (roles.OpenedExecutionRuntime, error)
+}
+
 // Dependencies is the Factory Sessions-owned construction input for the one
 // process-scoped runtime-opening factory. Groups are construction vocabulary:
 // they select fixed collaborators once in canonical Wire composition and do
@@ -178,6 +202,11 @@ type Factory struct {
 	resolveHome                      factorysessions.HomeDirectoryResolver
 	providerIdentities               factorysessions.ProviderIdentityResolver
 }
+
+var (
+	_ InvocationRuntimeOpening = (*Factory)(nil)
+	_ ExecutionRuntimeOpening  = (*Factory)(nil)
+)
 
 func NewFactory(dependencies Dependencies) (*Factory, error) {
 	if err := dependencies.validate(); err != nil {

--- a/pkg/services/factory_sessions/internal/runtimeopening/invocation/models_cli_collaboration.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/invocation/models_cli_collaboration.go
@@ -13,7 +13,7 @@ func (o *operation) ModelsPresentationRoot() models.Service {
 	if o == nil || o.openRuntime == nil {
 		return nil
 	}
-	return o.openRuntime.ModelsRoot()
+	return o.modelsRoot
 }
 
 func (o *operation) OpenModelsCatalogScope(
@@ -30,7 +30,7 @@ func (o *operation) OpenModelsCatalogScope(
 			Close: o.catalogScopeClose,
 		}, nil
 	}
-	root := o.openRuntime.ModelsRoot()
+	root := o.modelsRoot
 	if root == nil {
 		return models.PresentationScope{}, errors.New("models presentation root is unavailable")
 	}

--- a/pkg/services/factory_sessions/internal/runtimeopening/invocation/models_cli_collaboration_test.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/invocation/models_cli_collaboration_test.go
@@ -105,6 +105,7 @@ func TestOpenModelsPresentationScope_PropagatesRuntimeOpenFailure(t *testing.T) 
 	factoryDir := t.TempDir()
 	op, err := NewOperation(
 		&runtimeopening.Factory{},
+		nil,
 		runtimeopening.ExternalEffects{},
 		workingDirectoryStub{dir: factoryDir},
 		func(root string) (string, error) {

--- a/pkg/services/factory_sessions/internal/runtimeopening/invocation/models_cli_collaboration_test.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/invocation/models_cli_collaboration_test.go
@@ -68,7 +68,7 @@ func TestModelsPresentationRoot_ReturnsNilForUnsetOperation(t *testing.T) {
 	}
 }
 
-func TestModelsPresentationRoot_DelegatesToRuntimeOpeningFactory(t *testing.T) {
+func TestModelsPresentationRoot_DelegatesToRuntimeOpening(t *testing.T) {
 	t.Parallel()
 
 	op := &operation{openRuntime: &runtimeopening.Factory{}}

--- a/pkg/services/factory_sessions/internal/runtimeopening/invocation/operation.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/invocation/operation.go
@@ -23,7 +23,8 @@ import (
 )
 
 type operation struct {
-	openRuntime       *runtimeopening.Factory
+	openRuntime       runtimeopening.InvocationRuntimeOpening
+	modelsRoot        models.Service
 	effects           runtimeopening.ExternalEffects
 	workingDirectory  platformfilesystem.WorkingDirectory
 	resolveCurrentDir factorydefinitions.CurrentFactoryDirectoryResolver
@@ -40,7 +41,8 @@ type operation struct {
 // invocations. Each call opens dynamic Factory Session state without rebuilding
 // or selecting application dependencies.
 func NewOperation(
-	openRuntime *runtimeopening.Factory,
+	openRuntime runtimeopening.InvocationRuntimeOpening,
+	modelsRoot models.Service,
 	effects runtimeopening.ExternalEffects,
 	workingDirectory platformfilesystem.WorkingDirectory,
 	resolveCurrentDir factorydefinitions.CurrentFactoryDirectoryResolver,
@@ -72,6 +74,7 @@ func NewOperation(
 	}
 	return &operation{
 		openRuntime:       openRuntime,
+		modelsRoot:        modelsRoot,
 		effects:           effects,
 		workingDirectory:  workingDirectory,
 		resolveCurrentDir: resolveCurrentDir,

--- a/pkg/services/factory_sessions/internal/runtimeopening/invocation/operation_dependencies_test.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/invocation/operation_dependencies_test.go
@@ -1,6 +1,7 @@
 package invocation
 
 import (
+	"context"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -11,7 +12,9 @@ import (
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/roles"
 	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/runtimeopening"
+	"go.uber.org/zap"
 )
 
 type workingDirectoryStub struct {
@@ -76,13 +79,99 @@ func TestNewOperation_RequiresModelInvocationBoundaryDependencies(t *testing.T) 
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := NewOperation(openRuntime, runtimeopening.ExternalEffects{}, test.workingDir, test.resolver, test.exporter, test.timeout, func(string) factoryruntime.RuntimeArtifactRoots { return factoryruntime.RuntimeArtifactRoots{} }, func() string { return "session-test-id" })
+			_, err := NewOperation(openRuntime, nil, runtimeopening.ExternalEffects{}, test.workingDir, test.resolver, test.exporter, test.timeout, func(string) factoryruntime.RuntimeArtifactRoots { return factoryruntime.RuntimeArtifactRoots{} }, func() string { return "session-test-id" })
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("NewOperation() error = %v, want %q", err, test.want)
 			}
 		})
 	}
 }
+
+// TestInvocationOperationOpensItsNarrowRuntimeView proves the invocation
+// operation uses the grouped Factory Sessions opening capability supplied by
+// Wire without requiring the concrete grouped construction type.
+func TestInvocationOperationOpensItsNarrowRuntimeView(t *testing.T) {
+	t.Parallel()
+
+	opening := &invocationRuntimeOpeningStub{
+		opened: roles.OpenedInvocationRuntime{Lifecycle: invocationLifecycleStub{}},
+	}
+	invocation, err := NewOperation(
+		opening,
+		nil,
+		runtimeopening.ExternalEffects{},
+		workingDirectoryStub{},
+		factorydefinitions.CurrentFactoryDirectoryResolver(func(root string) (string, error) { return root, nil }),
+		artifactExporterStub{},
+		factorysessions.DefaultModelInvocationTimeout,
+		func(string) factoryruntime.RuntimeArtifactRoots {
+			return factoryruntime.RuntimeArtifactRoots{Logs: "logs", Metrics: "metrics"}
+		},
+		func() string { return "session-id" },
+	)
+	if err != nil {
+		t.Fatalf("NewOperation: %v", err)
+	}
+
+	concrete, ok := invocation.(*operation)
+	if !ok {
+		t.Fatalf("NewOperation returned %T, want *operation", invocation)
+	}
+	opened, active, err := concrete.open(t.Context(), roles.InvocationTarget{
+		FactoryDir: "factory", HomeDir: "home", RunnerID: "runner",
+	})
+	if err != nil {
+		t.Fatalf("open invocation runtime: %v", err)
+	}
+	if active == nil || opened.Lifecycle == nil {
+		t.Fatalf("opened invocation runtime = %#v, lifecycle = %#v", opened, active)
+	}
+	active.cancel()
+	if opening.calls != 1 {
+		t.Fatalf("invocation runtime openings = %d, want 1", opening.calls)
+	}
+	if opening.request == nil || opening.request.FactoryDefinition.Directory != "factory" ||
+		opening.request.Workers.RunnerID != "runner" ||
+		opening.request.FactoryRuntime.LogDirectory != "logs" ||
+		opening.request.FactoryRuntime.MetricsDirectory != "metrics" {
+		t.Fatalf("invocation runtime request = %#v", opening.request)
+	}
+}
+
+type invocationRuntimeOpeningStub struct {
+	calls   int
+	request *factorysessions.RuntimeOpeningRequest
+	opened  roles.OpenedInvocationRuntime
+}
+
+func (stub *invocationRuntimeOpeningStub) OpenInvocationRuntime(
+	_ context.Context,
+	request *factorysessions.RuntimeOpeningRequest,
+	_ runtimeopening.ExternalEffects,
+	_ *zap.Logger,
+) (roles.OpenedInvocationRuntime, error) {
+	stub.calls++
+	stub.request = request
+	return stub.opened, nil
+}
+
+type invocationLifecycleStub struct{}
+
+func (invocationLifecycleStub) StartLifecycle(context.Context, context.Context) error { return nil }
+
+func (invocationLifecycleStub) StartWorkerLifecycle(context.Context) (factorysessions.RuntimeStop, error) {
+	return nil, nil
+}
+
+func (invocationLifecycleStub) CompleteStartup(context.Context) error { return nil }
+
+func (invocationLifecycleStub) WaitForRuntime(context.Context) error { return nil }
+
+func (invocationLifecycleStub) StopLifecycle(context.Context) error { return nil }
+
+func (invocationLifecycleStub) FailStartup(error) error { return nil }
+
+func (invocationLifecycleStub) CurrentRuntimeBundle() factoryruntime.HostedInstance { return nil }
 
 func TestModelInvocationContextAppliesOwnerTimeout(t *testing.T) {
 	t.Parallel()

--- a/pkg/services/factory_sessions/internal/runtimeopening/workers_consumer_boundary_test.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/workers_consumer_boundary_test.go
@@ -21,10 +21,10 @@ const workersImportRoot = "github.com/portpowered/infinite-you/pkg/services/work
 // TestRuntimeOpeningPackagesImportWorkersOnlyThroughRoot seals runtime-opening
 // and construction call sites to the Workers service root contract.
 
-// TestRuntimeOpeningFactoryRolesNameWorkersRootContracts proves runtime-opening
+// TestRuntimeOpeningRolesNameWorkersRootContracts proves runtime-opening
 // construction helpers type Workers-facing bindings only through the Workers
 // service root.
-func TestRuntimeOpeningFactoryRolesNameWorkersRootContracts(t *testing.T) {
+func TestRuntimeOpeningRolesNameWorkersRootContracts(t *testing.T) {
 	t.Parallel()
 
 	var (

--- a/pkg/services/factory_sessions/internal/services/invocation/wire/wire.go
+++ b/pkg/services/factory_sessions/internal/services/invocation/wire/wire.go
@@ -13,13 +13,15 @@ import (
 	legacyopening "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/runtimeopening/invocation"
 	invocationservice "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/invocation"
 	internalservice "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/invocation/internal/service"
+	"github.com/portpowered/infinite-you/pkg/services/models"
 )
 
 // NewOperation is the service-owned construction entrypoint for process-scoped
 // one-shot invocation lifecycle. The implementation remains private to Factory
 // Sessions and root Wire depends only on this service-local constructor.
 func NewOperation(
-	openRuntime *runtimeopening.Factory,
+	openRuntime runtimeopening.InvocationRuntimeOpening,
+	modelsRoot models.Service,
 	effects runtimeopening.ExternalEffects,
 	workingDirectory platformfilesystem.WorkingDirectory,
 	resolveCurrentDir factorydefinitions.CurrentFactoryDirectoryResolver,
@@ -30,6 +32,7 @@ func NewOperation(
 ) (roles.InvocationOperation, error) {
 	return legacyopening.NewOperation(
 		openRuntime,
+		modelsRoot,
 		effects,
 		workingDirectory,
 		resolveCurrentDir,

--- a/pkg/services/factory_sessions/wire/application_graph.go
+++ b/pkg/services/factory_sessions/wire/application_graph.go
@@ -18,6 +18,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/runtimeopening"
 	durableexecution "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/durable_execution"
 	invocationwire "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/invocation/wire"
+	"github.com/portpowered/infinite-you/pkg/services/models"
 )
 
 // The aliases in this file are the service-owned construction vocabulary used
@@ -91,6 +92,8 @@ type (
 
 	RuntimeOpeningExternalEffects                = runtimeopening.ExternalEffects
 	RuntimeOpeningDependencies                   = runtimeopening.Dependencies
+	InvocationRuntimeOpening                     = runtimeopening.InvocationRuntimeOpening
+	ExecutionRuntimeOpening                      = runtimeopening.ExecutionRuntimeOpening
 	ProviderSessionsRuntimeOpeningDependencies   = runtimeopening.ProviderSessionsDependencies
 	FactoryRuntimeOpeningDependencies            = runtimeopening.FactoryRuntimeDependencies
 	FactoryDefinitionsRuntimeOpeningDependencies = runtimeopening.FactoryDefinitionsDependencies
@@ -163,7 +166,8 @@ func NewApplicationService(
 }
 
 func NewInvocationOperation(
-	openRuntime *RuntimeOpeningFactory,
+	openRuntime InvocationRuntimeOpening,
+	modelsRoot models.Service,
 	effects RuntimeOpeningExternalEffects,
 	workingDirectory platformfilesystem.WorkingDirectory,
 	resolveCurrentDir factorydefinitions.CurrentFactoryDirectoryResolver,
@@ -174,6 +178,7 @@ func NewInvocationOperation(
 ) (InvocationOperation, error) {
 	return invocationwire.NewOperation(
 		openRuntime,
+		modelsRoot,
 		effects,
 		workingDirectory,
 		resolveCurrentDir,

--- a/pkg/services/factory_sessions/wire/application_graph.go
+++ b/pkg/services/factory_sessions/wire/application_graph.go
@@ -76,7 +76,6 @@ type (
 
 	ApplicationRuntimeInputs        = applicationopening.RuntimeInputs
 	ApplicationRuntimeInputResolver = applicationopening.RuntimeInputResolver
-	RuntimeOpener                   = applicationopening.RuntimeOpener
 	RuntimeAdapter                  = applicationopening.RuntimeAdapter
 	ApplicationService              = applicationopening.Service
 
@@ -92,6 +91,7 @@ type (
 
 	RuntimeOpeningExternalEffects                = runtimeopening.ExternalEffects
 	RuntimeOpeningDependencies                   = runtimeopening.Dependencies
+	ApplicationRuntimeOpening                    = runtimeopening.ApplicationRuntimeOpening
 	InvocationRuntimeOpening                     = runtimeopening.InvocationRuntimeOpening
 	ExecutionRuntimeOpening                      = runtimeopening.ExecutionRuntimeOpening
 	ProviderSessionsRuntimeOpeningDependencies   = runtimeopening.ProviderSessionsDependencies
@@ -122,7 +122,7 @@ type (
 	WorkerCommandRunnerAdapter                   = runtimeopening.WorkerCommandRunnerAdapter
 	ProviderFromCommandRunnerFactory             = runtimeopening.ProviderFromCommandRunnerFactory
 	FactoryRuntimeAssembler                      = runtimeopening.FactoryRuntimeAssembler
-	RuntimeOpeningFactory                        = runtimeopening.Factory
+	RuntimeOpening                               = runtimeopening.Factory
 	RuntimeRoot                                  = runtimeopening.RuntimeRoot
 	ModelPullMetricsRecorder                     = factorysessioncontracts.ModelPullMetricsRecorder
 	InvocationArtifactFileSystem                 = factorysessioncontracts.InvocationArtifactFileSystem
@@ -148,7 +148,7 @@ var (
 	NewExecutionOpeningFactory = executionopening.NewFactory
 )
 
-func NewRuntimeOpeningFactory(deps RuntimeOpeningDependencies) (*RuntimeOpeningFactory, error) {
+func NewRuntimeOpening(deps RuntimeOpeningDependencies) (*RuntimeOpening, error) {
 	return runtimeopening.NewFactory(deps)
 }
 
@@ -158,7 +158,7 @@ func NewLifecyclePlanOperation() LifecyclePlanOperation {
 
 func NewApplicationService(
 	resolveInputs ApplicationRuntimeInputResolver,
-	openRuntime RuntimeOpener,
+	openRuntime ApplicationRuntimeOpening,
 	adaptRuntime RuntimeAdapter,
 	planLifecycle LifecyclePlanOperation,
 ) (*ApplicationService, error) {

--- a/pkg/services/factory_sessions/wire/on_demand_factory_target.go
+++ b/pkg/services/factory_sessions/wire/on_demand_factory_target.go
@@ -8,15 +8,12 @@ import (
 
 // FactoryTargetRuntimeResolver is re-published here so a caller outside the
 // factory_sessions tree can declare a field or parameter of this type
-// without importing the internal ondemandtarget package directly, matching
-// how this package already re-publishes RuntimeOpeningFactory and its peers.
+// without importing the internal ondemandtarget package directly.
 type FactoryTargetRuntimeResolver = ondemandtarget.RuntimeResolver
 
 // OnDemandFactoryTargetService is re-published here for the same reason;
 // the actual operational implementation lives in the owning service's
-// internal/ondemandtarget package, not this wire package, matching this
-// package's own established RuntimeOpeningFactory convention (a construction
-// alias plus a thin wrapper constructor, never operational implementation).
+// internal/ondemandtarget package, not this wire package.
 type OnDemandFactoryTargetService = ondemandtarget.Service
 
 // The on-demand activation this package constructs satisfies the
@@ -29,10 +26,10 @@ type OnDemandFactoryTargetService = ondemandtarget.Service
 var _ factorysessions.TargetExecutionService = (*OnDemandFactoryTargetService)(nil)
 
 // NewOnDemandFactoryTargetService constructs the on-demand Factory Sessions
-// activation over the given already-wired RuntimeOpeningFactory. Construction
-// alone performs no I/O and opens no runtime.
+// activation over the given already-wired invocation-opening capability.
+// Construction alone performs no I/O and opens no runtime.
 func NewOnDemandFactoryTargetService(
-	factory *RuntimeOpeningFactory,
+	factory InvocationRuntimeOpening,
 	effects RuntimeOpeningExternalEffects,
 	resolve FactoryTargetRuntimeResolver,
 	generateID factorysessions.SessionIDGenerator,

--- a/pkg/services/factory_sessions/wire/wire_test.go
+++ b/pkg/services/factory_sessions/wire/wire_test.go
@@ -72,15 +72,15 @@ func TestNewServiceConstructsPublishedRoot(t *testing.T) {
 	}
 }
 
-func TestNewRuntimeOpeningFactoryRejectsIncompleteGroupsAtCompositionBoundary(t *testing.T) {
+func TestNewRuntimeOpeningRejectsIncompleteGroupsAtCompositionBoundary(t *testing.T) {
 	t.Parallel()
 
-	factory, err := NewRuntimeOpeningFactory(RuntimeOpeningDependencies{})
+	factory, err := NewRuntimeOpening(RuntimeOpeningDependencies{})
 	if factory != nil {
-		t.Fatalf("NewRuntimeOpeningFactory() = %#v, want nil factory", factory)
+		t.Fatalf("NewRuntimeOpening() = %#v, want nil factory", factory)
 	}
 	if got, want := err.Error(), "Factory Sessions runtime-opening Provider Sessions group is required"; got != want {
-		t.Fatalf("NewRuntimeOpeningFactory() error = %q, want %q", got, want)
+		t.Fatalf("NewRuntimeOpening() error = %q, want %q", got, want)
 	}
 }
 

--- a/pkg/wire/acp_transport.go
+++ b/pkg/wire/acp_transport.go
@@ -110,7 +110,7 @@ func provideACPServerFactoryTargetRuntimeResolver(
 // guarantees both consumers observe this exact same singleton, not two
 // independently constructed activations.
 func provideACPServerFactoryTarget(
-	openRuntime *factorysessionwire.RuntimeOpeningFactory,
+	openRuntime factorysessionwire.InvocationRuntimeOpening,
 	edges serviceedges.Edges,
 	resolveTarget factorysessionwire.FactoryTargetRuntimeResolver,
 	generateSessionID factorysessions.SessionIDGenerator,

--- a/pkg/wire/profiles.go
+++ b/pkg/wire/profiles.go
@@ -874,10 +874,6 @@ func provideResponsePresentation() factoryvisualization.ResponsePresentation {
 	return factoryvisualizationwire.NewResponsePresentation()
 }
 
-func provideRuntimeOpener(factory *factorysessionwire.RuntimeOpeningFactory) factorysessionwire.RuntimeOpener {
-	return factory
-}
-
 func provideDirectJavaScriptSyncRunner() factorysessionwire.DirectJavaScriptSyncRunner {
 	return sessionexecutioncli.RunNormalizedSync
 }

--- a/pkg/wire/runtime_inputs.go
+++ b/pkg/wire/runtime_inputs.go
@@ -18,6 +18,7 @@ import (
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	factorysessionwire "github.com/portpowered/infinite-you/pkg/services/factory_sessions/wire"
+	"github.com/portpowered/infinite-you/pkg/services/models"
 	modelswire "github.com/portpowered/infinite-you/pkg/services/models/wire"
 	providerswire "github.com/portpowered/infinite-you/pkg/services/providers/wire"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
@@ -186,7 +187,7 @@ func isNilRuntimeInput(value any) bool {
 }
 
 func provideSessionExecutionOpeningFactory(
-	runtimes *factorysessionwire.RuntimeOpeningFactory,
+	runtimes factorysessionwire.ExecutionRuntimeOpening,
 	edges serviceedges.Edges,
 	build factorysessionwire.StandaloneSessionExecutionFactory,
 	invocation factorysessionwire.WorkerInvocationFactory,
@@ -208,7 +209,8 @@ func provideSessionExecutionOpeningFactory(
 }
 
 func provideInvocationOperation(
-	openRuntime *factorysessionwire.RuntimeOpeningFactory,
+	openRuntime factorysessionwire.InvocationRuntimeOpening,
+	modelsRoot models.Service,
 	edges serviceedges.Edges,
 	workingDirectory platformfilesystem.WorkingDirectory,
 	resolveCurrentDir factorydefinitions.CurrentFactoryDirectoryResolver,
@@ -219,6 +221,7 @@ func provideInvocationOperation(
 ) (factorysessionwire.InvocationOperation, error) {
 	return factorysessionwire.NewInvocationOperation(
 		openRuntime,
+		modelsRoot,
 		projectRuntimeOpeningExternalEffects(edges),
 		workingDirectory,
 		resolveCurrentDir,

--- a/pkg/wire/session_runtime_providers_test.go
+++ b/pkg/wire/session_runtime_providers_test.go
@@ -3,11 +3,14 @@ package wire
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"slices"
 	"testing"
 
 	"go.uber.org/zap"
 
 	"github.com/portpowered/infinite-you/internal/testutil"
+	initializerapplication "github.com/portpowered/infinite-you/pkg/initializer/application"
 	platformclock "github.com/portpowered/infinite-you/pkg/platform/clock"
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
@@ -299,6 +302,48 @@ func TestProvideApplicationProcessLifecycle_ComposesProvidersAndFactoryTargetClo
 	}
 	if err := nilFactoryLifecycle.Close(context.Background()); err != nil {
 		t.Fatalf("composed ProcessLifecycle.Close() with a nil factoryTarget error = %v, want nil (defensive no-op)", err)
+	}
+}
+
+// TestProcessCloseContinuesThroughEveryLifecycleOwnerAfterFailure proves the
+// Process.Close path does not let a failure from an earlier process-owned
+// closer make later owners unreachable. This is important for the lazily
+// opened ACP Factory target: it must still receive its teardown attempt even
+// when another process lifecycle owner reports a failure.
+func TestProcessCloseContinuesThroughEveryLifecycleOwnerAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	providersCloseErr := errors.New("close Providers")
+	eventsCloseErr := errors.New("close Events")
+	targetCloseErr := errors.New("close ACP Factory target")
+	var closed []string
+	lifecycle := compositeProcessLifecycle{closers: []func(context.Context) error{
+		func(context.Context) error {
+			closed = append(closed, "providers")
+			return providersCloseErr
+		},
+		func(context.Context) error {
+			closed = append(closed, "events")
+			return eventsCloseErr
+		},
+		func(context.Context) error {
+			closed = append(closed, "factory-target")
+			return targetCloseErr
+		},
+	}}
+	process, err := initializerapplication.NewProcess(nil, nil, wireTestProviderRegistry{}, lifecycle, nil)
+	if err != nil {
+		t.Fatalf("NewProcess() error = %v", err)
+	}
+
+	err = process.Close(context.Background())
+	for _, expected := range []error{providersCloseErr, eventsCloseErr, targetCloseErr} {
+		if !errors.Is(err, expected) {
+			t.Fatalf("Process.Close() error = %v, want it to retain %v", err, expected)
+		}
+	}
+	if !slices.Equal(closed, []string{"providers", "events", "factory-target"}) {
+		t.Fatalf("Process.Close() closer calls = %v, want every process lifecycle owner in order", closed)
 	}
 }
 

--- a/pkg/wire/session_runtime_providers_test.go
+++ b/pkg/wire/session_runtime_providers_test.go
@@ -252,8 +252,9 @@ func TestProvideApplicationProcessLifecycle_ComposesProvidersAndFactoryTargetClo
 		t.Fatalf("provideProvidersService() error = %v", err)
 	}
 
+	var opening factorysessionwire.InvocationRuntimeOpening = &factorysessionwire.RuntimeOpeningFactory{}
 	factoryTarget, err := factorysessionwire.NewOnDemandFactoryTargetService(
-		&factorysessionwire.RuntimeOpeningFactory{},
+		opening,
 		factorysessionwire.RuntimeOpeningExternalEffects{},
 		func(context.Context, string, string) (factorysessions.RuntimeOpeningRequest, error) {
 			return factorysessions.RuntimeOpeningRequest{}, nil

--- a/pkg/wire/session_runtime_providers_test.go
+++ b/pkg/wire/session_runtime_providers_test.go
@@ -255,7 +255,7 @@ func TestProvideApplicationProcessLifecycle_ComposesProvidersAndFactoryTargetClo
 		t.Fatalf("provideProvidersService() error = %v", err)
 	}
 
-	var opening factorysessionwire.InvocationRuntimeOpening = &factorysessionwire.RuntimeOpeningFactory{}
+	var opening factorysessionwire.InvocationRuntimeOpening = &factorysessionwire.RuntimeOpening{}
 	factoryTarget, err := factorysessionwire.NewOnDemandFactoryTargetService(
 		opening,
 		factorysessionwire.RuntimeOpeningExternalEffects{},

--- a/pkg/wire/wire.go
+++ b/pkg/wire/wire.go
@@ -331,7 +331,7 @@ var BundleSet = wire.NewSet(
 	providePackagedFactoryCatalog,
 	provideSystemInitializationService,
 	provideSystemInitializationOperation,
-	provideRuntimeOpener,
+	wire.Bind(new(factorysessionwire.RuntimeOpener), new(*factorysessionwire.RuntimeOpeningFactory)),
 	provideApplicationRuntimeAdapter,
 	provideLifecycleRunnerFactory,
 	provideWorkStopSummaryProjector,

--- a/pkg/wire/wire.go
+++ b/pkg/wire/wire.go
@@ -227,7 +227,7 @@ var servicesSet = wire.NewSet(
 	provideLoadedFactoryLoader,
 	provideReplayArtifactLoader,
 	provideReplayRuntimeConfigDecoder,
-	factorysessionwire.NewRuntimeOpeningFactory,
+	factorysessionwire.NewRuntimeOpening,
 )
 
 var providerSessionServiceSet = wire.NewSet(
@@ -331,9 +331,9 @@ var BundleSet = wire.NewSet(
 	providePackagedFactoryCatalog,
 	provideSystemInitializationService,
 	provideSystemInitializationOperation,
-	wire.Bind(new(factorysessionwire.RuntimeOpener), new(*factorysessionwire.RuntimeOpeningFactory)),
-	wire.Bind(new(factorysessionwire.InvocationRuntimeOpening), new(*factorysessionwire.RuntimeOpeningFactory)),
-	wire.Bind(new(factorysessionwire.ExecutionRuntimeOpening), new(*factorysessionwire.RuntimeOpeningFactory)),
+	wire.Bind(new(factorysessionwire.ApplicationRuntimeOpening), new(*factorysessionwire.RuntimeOpening)),
+	wire.Bind(new(factorysessionwire.InvocationRuntimeOpening), new(*factorysessionwire.RuntimeOpening)),
+	wire.Bind(new(factorysessionwire.ExecutionRuntimeOpening), new(*factorysessionwire.RuntimeOpening)),
 	provideApplicationRuntimeAdapter,
 	provideLifecycleRunnerFactory,
 	provideWorkStopSummaryProjector,

--- a/pkg/wire/wire.go
+++ b/pkg/wire/wire.go
@@ -332,6 +332,8 @@ var BundleSet = wire.NewSet(
 	provideSystemInitializationService,
 	provideSystemInitializationOperation,
 	wire.Bind(new(factorysessionwire.RuntimeOpener), new(*factorysessionwire.RuntimeOpeningFactory)),
+	wire.Bind(new(factorysessionwire.InvocationRuntimeOpening), new(*factorysessionwire.RuntimeOpeningFactory)),
+	wire.Bind(new(factorysessionwire.ExecutionRuntimeOpening), new(*factorysessionwire.RuntimeOpeningFactory)),
 	provideApplicationRuntimeAdapter,
 	provideLifecycleRunnerFactory,
 	provideWorkStopSummaryProjector,

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -472,7 +472,6 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		return nil, err
 	}
 	v71 := provideRuntimeInputResolver(edges2, clockResolver)
-	v72 := provideRuntimeOpener(v57)
 	runtimeFactory := provideFactoryVisualizationFactory()
 	factoryStatusProjector := factory.NewFactoryStatusProjector()
 	contentPreparation := work.NewContentPreparation()
@@ -492,30 +491,30 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		return nil, err
 	}
 	runnerFactory := provideLifecycleRunnerFactory()
-	v73, err := provideApplicationRuntimeAdapter(runtimeFactory, applicationHandler, runnerFactory)
+	v72, err := provideApplicationRuntimeAdapter(runtimeFactory, applicationHandler, runnerFactory)
 	if err != nil {
 		return nil, err
 	}
-	v74 := wire.NewLifecyclePlanOperation()
-	v75, err := wire.NewApplicationService(v71, v72, v73, v74)
+	v73 := wire.NewLifecyclePlanOperation()
+	v74, err := wire.NewApplicationService(v71, v57, v72, v73)
 	if err != nil {
 		return nil, err
 	}
-	runRuntimeRunnerBuilder, err := provideRunRuntimeRunnerBuilder(runtimeRunnerBuilder, v75)
+	runRuntimeRunnerBuilder, err := provideRunRuntimeRunnerBuilder(runtimeRunnerBuilder, v74)
 	if err != nil {
 		return nil, err
 	}
-	v76 := provideResponsePresentation()
-	v77 := provideDirectJavaScriptSyncRunner()
+	v75 := provideResponsePresentation()
+	v76 := provideDirectJavaScriptSyncRunner()
 	directJavaScriptHostAdapter, err := provideDirectJavaScriptHostAdapter(applicationHandler, starter, runnerFactory)
 	if err != nil {
 		return nil, err
 	}
-	v78, err := wire.NewDirectJavaScriptRunOperation(v63, v77, v25, directJavaScriptHostAdapter)
+	v77, err := wire.NewDirectJavaScriptRunOperation(v63, v76, v25, directJavaScriptHostAdapter)
 	if err != nil {
 		return nil, err
 	}
-	selectionFactory, err := provideRunSelectionFactory(runOpener, runRuntimeRunnerBuilder, v65, v76, v78, runtimeRunnerBuilder)
+	selectionFactory, err := provideRunSelectionFactory(runOpener, runRuntimeRunnerBuilder, v65, v75, v77, runtimeRunnerBuilder)
 	if err != nil {
 		return nil, err
 	}
@@ -533,14 +532,14 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		return nil, err
 	}
 	wireAcpServerResolveHomeDir := provideACPServerResolveHomeDir()
-	v79 := provideACPServerFactoryTargetRuntimeResolver(wireAcpServerResolveHomeDir, v, defaultsResolver, runtimeArtifactRootResolver)
-	v80, err := provideACPServerFactoryTarget(v57, edges2, v79, v25, logger)
+	v78 := provideACPServerFactoryTargetRuntimeResolver(wireAcpServerResolveHomeDir, v, defaultsResolver, runtimeArtifactRootResolver)
+	v79, err := provideACPServerFactoryTarget(v57, edges2, v78, v25, logger)
 	if err != nil {
 		return nil, err
 	}
-	targetExecutionService := provideACPServerFactoryTargetService(v80)
-	v81 := provideChatSessionsResponseBridge(chatsessionsService, targetExecutionService, loggingLogger)
-	responseBridge := provideACPServerResponseBridge(v81)
+	targetExecutionService := provideACPServerFactoryTargetService(v79)
+	v80 := provideChatSessionsResponseBridge(chatsessionsService, targetExecutionService, loggingLogger)
+	responseBridge := provideACPServerResponseBridge(v80)
 	server := provideACPServer(loggingLogger, chatsessionsService, factoryTargetCatalogService, targetExecutionService, eventsService, wireAcpServerResolveHomeDir, responseBridge)
 	commandOperations := cli.CommandOperations{
 		ObserveCLI:                        cliObserver,
@@ -593,23 +592,23 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		return nil, err
 	}
 	stdioOpener := stdio.NewOpener()
-	v82 := provideFixtureStdioApplicationBuilder(stdioRunnerBuilder, runnerFactory, stdioOpener, v66, workflowPreviewOperation)
+	v81 := provideFixtureStdioApplicationBuilder(stdioRunnerBuilder, runnerFactory, stdioOpener, v66, workflowPreviewOperation)
 	openedStdioRunnerBuilder, err := application.NewOpenedStdioRunnerBuilder(managedRunnerFactory)
 	if err != nil {
 		return nil, err
 	}
-	v83 := provideRuntimeStdioApplicationBuilder(openedStdioRunnerBuilder, runnerFactory, stdioOpener, v66)
-	v84, err := wire.NewStdioOpeningService(v62, v82, v83)
+	v82 := provideRuntimeStdioApplicationBuilder(openedStdioRunnerBuilder, runnerFactory, stdioOpener, v66)
+	v83, err := wire.NewStdioOpeningService(v62, v81, v82)
 	if err != nil {
 		return nil, err
 	}
-	processStdioApplicationOpener, err := provideStdioApplicationOpener(v84)
+	processStdioApplicationOpener, err := provideStdioApplicationOpener(v83)
 	if err != nil {
 		return nil, err
 	}
-	v85 := provideSystemInitializationInspectPath(edges2)
-	v86 := provideSystemInitializationLegacyFactoryMigrationFileSystem(edges2)
-	systeminitializationService, err := provideSystemInitializationService(v20, packagedInstallationFileSystem, packagedFactoryCatalogOperations, configLoader, backendScopeEnsurer, v85, v86)
+	v84 := provideSystemInitializationInspectPath(edges2)
+	v85 := provideSystemInitializationLegacyFactoryMigrationFileSystem(edges2)
+	systeminitializationService, err := provideSystemInitializationService(v20, packagedInstallationFileSystem, packagedFactoryCatalogOperations, configLoader, backendScopeEnsurer, v84, v85)
 	if err != nil {
 		return nil, err
 	}
@@ -618,7 +617,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	processLifecycle, err := provideApplicationProcessLifecycle(service, eventsService, v80)
+	processLifecycle, err := provideApplicationProcessLifecycle(service, eventsService, v79)
 	if err != nil {
 		return nil, err
 	}
@@ -884,9 +883,7 @@ var BundleSet = wire4.NewSet(
 	providePackagedFactoryDefinitions,
 	providePackagedFactoryCatalog,
 	provideSystemInitializationService,
-	provideSystemInitializationOperation,
-	provideRuntimeOpener,
-	provideApplicationRuntimeAdapter,
+	provideSystemInitializationOperation, wire4.Bind(new(wire.RuntimeOpener), new(*wire.RuntimeOpeningFactory)), provideApplicationRuntimeAdapter,
 	provideLifecycleRunnerFactory,
 	provideWorkStopSummaryProjector,
 	provideRuntimeOpeningRequestFactory,

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -418,7 +418,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		return nil, err
 	}
 	modelInvocationTimeout := provideModelInvocationTimeout()
-	v65, err := provideInvocationOperation(v57, edges2, workingDirectory, v4, v64, modelInvocationTimeout, runtimeArtifactRootResolver, v25)
+	v65, err := provideInvocationOperation(v57, modelsService, edges2, workingDirectory, v4, v64, modelInvocationTimeout, runtimeArtifactRootResolver, v25)
 	if err != nil {
 		return nil, err
 	}
@@ -883,7 +883,7 @@ var BundleSet = wire4.NewSet(
 	providePackagedFactoryDefinitions,
 	providePackagedFactoryCatalog,
 	provideSystemInitializationService,
-	provideSystemInitializationOperation, wire4.Bind(new(wire.RuntimeOpener), new(*wire.RuntimeOpeningFactory)), provideApplicationRuntimeAdapter,
+	provideSystemInitializationOperation, wire4.Bind(new(wire.RuntimeOpener), new(*wire.RuntimeOpeningFactory)), wire4.Bind(new(wire.InvocationRuntimeOpening), new(*wire.RuntimeOpeningFactory)), wire4.Bind(new(wire.ExecutionRuntimeOpening), new(*wire.RuntimeOpeningFactory)), provideApplicationRuntimeAdapter,
 	provideLifecycleRunnerFactory,
 	provideWorkStopSummaryProjector,
 	provideRuntimeOpeningRequestFactory,

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -393,7 +393,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		Workers:            workersDependencies,
 		OperatorSettings:   operatorSettingsDependencies,
 	}
-	v57, err := wire.NewRuntimeOpeningFactory(v56)
+	v57, err := wire.NewRuntimeOpening(v56)
 	if err != nil {
 		return nil, err
 	}
@@ -782,7 +782,7 @@ var servicesSet = wire4.NewSet(
 	provideInitialFactorySnapshotFactory, wire2.NewRuntimeFactory, wire2.NewAssembly, wire4.Bind(new(wire.FactoryRuntimeAssembler), new(*wire2.Assembly)), wire4.Struct(new(wire.ProviderSessionsRuntimeOpeningDependencies), "*"), wire4.Struct(new(wire.FactoryRuntimeOpeningDependencies), "*"), wire4.Struct(new(wire.FactoryDefinitionsRuntimeOpeningDependencies), "*"), wire4.Struct(new(wire.FactorySessionsRuntimeOpeningDependencies), "*"), wire4.Struct(new(wire.WorkRuntimeOpeningDependencies), "*"), wire4.Struct(new(wire.AutomationsRuntimeOpeningDependencies), "*"), wire4.Struct(new(wire.ModelsRuntimeOpeningDependencies), "*"), wire4.Struct(new(wire.RecordingsRuntimeOpeningDependencies), "*"), wire4.Struct(new(wire.WorkersRuntimeOpeningDependencies), "*"), wire4.Struct(new(wire.OperatorSettingsRuntimeOpeningDependencies), "*"), wire4.Struct(new(wire.RuntimeOpeningDependencies), "*"), provideLoadedFactorySourceFactory,
 	provideLoadedFactoryLoader,
 	provideReplayArtifactLoader,
-	provideReplayRuntimeConfigDecoder, wire.NewRuntimeOpeningFactory,
+	provideReplayRuntimeConfigDecoder, wire.NewRuntimeOpening,
 )
 
 var providerSessionServiceSet = wire4.NewSet(
@@ -883,7 +883,7 @@ var BundleSet = wire4.NewSet(
 	providePackagedFactoryDefinitions,
 	providePackagedFactoryCatalog,
 	provideSystemInitializationService,
-	provideSystemInitializationOperation, wire4.Bind(new(wire.RuntimeOpener), new(*wire.RuntimeOpeningFactory)), wire4.Bind(new(wire.InvocationRuntimeOpening), new(*wire.RuntimeOpeningFactory)), wire4.Bind(new(wire.ExecutionRuntimeOpening), new(*wire.RuntimeOpeningFactory)), provideApplicationRuntimeAdapter,
+	provideSystemInitializationOperation, wire4.Bind(new(wire.ApplicationRuntimeOpening), new(*wire.RuntimeOpening)), wire4.Bind(new(wire.InvocationRuntimeOpening), new(*wire.RuntimeOpening)), wire4.Bind(new(wire.ExecutionRuntimeOpening), new(*wire.RuntimeOpening)), provideApplicationRuntimeAdapter,
 	provideLifecycleRunnerFactory,
 	provideWorkStopSummaryProjector,
 	provideRuntimeOpeningRequestFactory,

--- a/tests/functional/sessions/root_composition/lifecycle_runtime_opening_test.go
+++ b/tests/functional/sessions/root_composition/lifecycle_runtime_opening_test.go
@@ -27,7 +27,7 @@ func TestSessionsLifecycleAndRuntimeOpeningActivateThroughRootBuildProcessAfterL
 	t.Parallel()
 
 	recorder := newSessionActivationRecorder(t)
-	dir := support.ScaffoldFactory(t, sessionsLifecycleRuntimeOpeningFactoryConfig())
+	dir := support.ScaffoldFactory(t, sessionsLifecycleRuntimeOpeningConfig())
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:                dir,
 		UseMockWorkers:            true,
@@ -128,7 +128,7 @@ func TestSessionsLifecycleAndRuntimeOpeningActivateThroughRootBuildProcessAfterL
 	}
 }
 
-func sessionsLifecycleRuntimeOpeningFactoryConfig() map[string]any {
+func sessionsLifecycleRuntimeOpeningConfig() map[string]any {
 	return map[string]any{
 		"workTypes": []map[string]any{{
 			"name": "task",

--- a/tests/functional/sessions/root_composition/lifecycle_runtime_opening_test.go
+++ b/tests/functional/sessions/root_composition/lifecycle_runtime_opening_test.go
@@ -27,7 +27,7 @@ func TestSessionsLifecycleAndRuntimeOpeningActivateThroughRootBuildProcessAfterL
 	t.Parallel()
 
 	recorder := newSessionActivationRecorder(t)
-	dir := support.ScaffoldFactory(t, sessionsLifecycleRuntimeOpeningConfig())
+	dir := support.ScaffoldFactory(t, sessionsLifecycleRuntimeOpeningFactoryConfig())
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:                dir,
 		UseMockWorkers:            true,
@@ -128,7 +128,7 @@ func TestSessionsLifecycleAndRuntimeOpeningActivateThroughRootBuildProcessAfterL
 	}
 }
 
-func sessionsLifecycleRuntimeOpeningConfig() map[string]any {
+func sessionsLifecycleRuntimeOpeningFactoryConfig() map[string]any {
 	return map[string]any{
 		"workTypes": []map[string]any{{
 			"name": "task",


### PR DESCRIPTION
{
  "project": "Retire Legacy Factory Sessions Runtime-Opening Bridges",
  "branchName": "ACP-L3-FS-RUNTIME-OPENING-LEGACY-RETIREMENT",
  "description": "Complete the Factory Sessions runtime-opening migration by moving every remaining production consumer onto the grouped authoritative opening path, then remove only obsolete aliases, forwarding constructors, and unreachable compatibility bridges while preserving inert construction, exact-one activation, runtime selection, errors, cancellation, cleanup, shutdown reachability, and existing CLI, direct, invocation, recording, replay, and ACP behavior.",
  "context": {
    "customerAsk": "Migrate the remaining root Wire bootstrap, ACP on-demand target activation, direct execution, invocation, replay, and shutdown consumers to the grouped authoritative Factory Sessions runtime-opening path. Once all preceding completion-batch slices are finished, remove only obsolete RuntimeOpeningFactory/RuntimeOpener aliases, duplicate forwarding construction, and unreachable legacy bridges. Preserve one intended process or target activation, selection, cancellation, errors, reverse cleanup, Process.Close, ACP teardown, and existing CLI/direct/replay behavior; prove inert startup, no duplicate construction, and exact-once cleanup; keep supported Factory Sessions, Events, Recordings, Worker Sessions/L4, and persistence scope unchanged; and deliver through review and merge.",
    "problem": "Grouped runtime-opening construction establishes the intended Factory Sessions ownership boundary, but remaining consumers still depend on legacy aliases and forwarding constructors. Those parallel paths obscure which opener is authoritative, make duplicate runtime construction and unreachable cleanup ownership harder to rule out, and cannot be safely deleted until process, invocation, direct, replay, ACP, and shutdown behavior have converged.",
    "solution": "Make the grouped Factory Sessions opening capability the sole injected runtime-opening authority for process/application bootstrap, invocation, direct execution, historical replay, and ACP target activation. Preserve operation-specific opened views and lifecycle ownership, prove the invariants with focused behavioral tests, and only after every consumer and prerequisite completion-batch slice has converged, mechanically delete unreferenced aliases, forwarding constructors, and legacy bridges and regenerate canonical Wire output when required."
  },
  "acceptanceCriteria": [
    "Root process/application bootstrap, invocation, direct execution, historical replay, and ACP target activation all consume the grouped authoritative Factory Sessions opening capability, with no production consumer constructing or selecting a second runtime opener.",
    "root.BuildProcess and equivalent composition remain inert; runtime effects begin only when the selected operation or target opens, and each process opening or stable ACP target activation creates exactly one intended runtime.",
    "Runtime selection, Factory Session results, CLI/direct/invocation behavior, recording and replay branches, cancellation, and primary error behavior remain equivalent for representative success and failure scenarios.",
    "Partial opening failures and normal shutdown close only acquired resources, exactly once and in the established reverse order; ACP target teardown and Process.Close remain reachable, retry-safe where already supported, and free of stranded runtimes.",
    "Obsolete RuntimeOpeningFactory/RuntimeOpener aliases, duplicate forwarding constructors, and unreachable legacy bridges are removed only after every production consumer and prerequisite completion-batch slice has migrated; supported Factory Sessions operations remain available.",
    "Factory Events and Recordings retain their current ownership and semantics, Worker Sessions/L4 behavior and public transport contracts remain unchanged, and no persistence or unrelated cleanup is introduced.",
    "Typecheck, focused lint, relevant Factory Sessions/Wire/root/ACP tests, representative functional tests, make verify-fast, and required CI are terminal and passing, with direct behavioral evidence for inert construction, exact-one opening, preserved selection, failure cleanup, and teardown.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file/generated-Wire reconciliation are resolved, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "ACP-L3-FS-RUNTIME-OPENING-LEGACY-RETIREMENT-001",
      "title": "Open process applications through the authoritative Factory Sessions path",
      "description": "As an operator starting a process-backed Factory application, I want composition to remain inert and use one authoritative opener at execution time so that startup does not create duplicate runtimes or side effects.",
      "acceptanceCriteria": [
        "Building the root process and composing application roles performs no runtime opening, filesystem, provider, worker, recording, host, goroutine, or lifecycle-start effect.",
        "Executing a representative live application reaches the grouped Factory Sessions opening capability once and produces one process runtime with the same selected Factory, runtime inputs, exposed application roles, and lifecycle readiness as before.",
        "Repeated construction without execution opens nothing, and one execution does not traverse a legacy forwarding constructor or create a second runtime authority.",
        "The opened application's shutdown owner remains connected to the process lifecycle so later Process.Close can reach every process-owned resource.",
        "Focused root, canonical Wire, application-opening, and inert-construction tests pass without source-inventory or sleep-based assertions.",
        "Typecheck passes.",
        "Tests pass."
      ],
      "priority": 1,
      "passes": true,
      "notes": "Completed 2026-08-04: root Wire binds the already-constructed grouped Factory Sessions runtime opener directly to the application-opening capability. Added behavioral evidence that repeated BuildProcess construction is inert and one live run opens exactly one runtime; focused root/Wire/application tests, Factory Sessions root-composition tests, and make verify-fast pass."
    },
    {
      "id": "ACP-L3-FS-RUNTIME-OPENING-LEGACY-RETIREMENT-002",
      "title": "Preserve invocation, direct execution, and replay selection",
      "description": "As a customer invoking or directly executing Factory work, I want every supported execution mode to use the authoritative opener while retaining its established runtime selection and observable outcome.",
      "acceptanceCriteria": [
        "Named and current-Factory invocation, direct execution, and CLI application flows route through the same grouped Factory Sessions opening authority without duplicate runtime construction.",
        "Live and recording-enabled requests retain their current Factory resolution, model/provider/worker inputs, emitted Factory Session and Factory Event outcomes, response behavior, and exit/error classification.",
        "Historical replay selects the replay branch, preserves replay inputs, ordering, results, and cleanup, and does not start live-only worker, provider, automation, or recording effects.",
        "Operation-specific application, invocation, and execution views remain available; no supported Factory Sessions operation is deleted or narrowed as part of bridge retirement.",
        "Focused invocation, direct-execution, CLI, recording, and replay regression tests pass through real behavior boundaries rather than topology checks.",
        "Typecheck passes.",
        "Tests pass."
      ],
      "priority": 2,
      "passes": true,
      "notes": "Completed 2026-08-04: invocation and runtime-backed execution now consume narrow Factory Sessions opening capabilities, both directly bound by canonical Wire to the single grouped runtime-opening instance. Models presentation uses the injected Models root directly. Added deterministic invocation and execution request/one-opening behavior tests; focused Factory Sessions/Wire/root/CLI/session-composition suites, make wire-smoke, and make verify-fast pass."
    },
    {
      "id": "ACP-L3-FS-RUNTIME-OPENING-LEGACY-RETIREMENT-003",
      "title": "Activate and tear down ACP Factory targets exactly once",
      "description": "As an ACP user selecting a Factory target, I want on-demand activation to open and retain exactly one runtime for my stable target request and tear it down reliably so that retries, concurrency, cancellation, and process shutdown do not duplicate or strand work.",
      "acceptanceCriteria": [
        "The first activation of a resolved ACP Factory target opens through the grouped authoritative Factory Sessions capability and preserves the target's Factory/runtime selection and opaque session identity behavior.",
        "Sequential retries and concurrent starts using the same stable request identity converge on the same activated runtime and do not duplicate provider, worker, lifecycle, or recording startup.",
        "Distinct supported targets remain independently activatable and route later invoke and cancel operations to the correct retained runtime.",
        "Cancellation preserves the current request interruption, outcome classification, and replacement/retry behavior; it does not report success while an owned runtime remains unintentionally live.",
        "CloseFactorySession and process-wide close reach ACP-owned runtimes, perform the established teardown phases exactly once, and leave successfully closed targets unavailable for further invocation.",
        "Focused deterministic ACP activation, concurrency, cancellation, target-close, and process-close tests pass without timing sleeps.",
        "Typecheck passes.",
        "Tests pass."
      ],
      "priority": 3,
      "passes": true,
      "notes": "Completed 2026-08-04: ACP on-demand target activation now consumes the grouped Factory Sessions invocation-opening capability directly instead of the concrete RuntimeOpeningFactory alias. Existing deterministic activation, retry, cancellation, target-close, and process-close behavior remains on the one shared opener; added inert-construction and exact-one-open constructor-path coverage. Focused ACP/Factory Sessions/Wire tests, make wire-smoke, and make verify-fast pass."
    },
    {
      "id": "ACP-L3-FS-RUNTIME-OPENING-LEGACY-RETIREMENT-004",
      "title": "Preserve failure rollback and shutdown cleanup",
      "description": "As an operator encountering an opening or shutdown failure, I want the authoritative path to retain the original error and deterministic cleanup so that failures are diagnosable and no partially acquired runtime resources leak.",
      "acceptanceCriteria": [
        "Representative failures before acquisition, between opening stages, during lifecycle activation, and after multiple resources are acquired return the established primary error or cancellation classification and do not publish a usable partial runtime.",
        "Only resources successfully acquired before a failure are unwound, each exactly once and in the established reverse acquisition order; resources never acquired receive no close call.",
        "Cleanup failures retain established joining/precedence behavior, do not mask the primary opening failure, and leave retryable ACP cleanup retryable only where current behavior supports it.",
        "Successful application, invocation, direct, replay, and ACP runtimes close their owned resources once; repeated supported close calls are idempotent and do not replay completed teardown phases.",
        "Process.Close continues through all registered owners even when one close fails and returns the established combined failure without leaving another owner unreachable.",
        "Focused deterministic failure-injection, reverse-order cleanup, close-once, retry, and composed-shutdown tests pass.",
        "Typecheck passes.",
        "Tests pass."
      ],
      "priority": 4,
      "passes": true,
      "notes": "Completed 2026-08-04: the authoritative Factory Sessions opening cleanup preserves primary errors, unwinds acquired resources once in reverse order, and retains retry-safe ACP target cleanup. Added direct Process.Close evidence that every registered lifecycle owner is attempted and all close failures remain observable; focused Factory Sessions/Wire/root tests and make verify-fast pass."
    },
    {
      "id": "ACP-L3-FS-RUNTIME-OPENING-LEGACY-RETIREMENT-005",
      "title": "Remove obsolete runtime-opening bridges after convergence",
      "description": "As a maintainer, I want obsolete runtime-opening aliases and forwarding bridges removed after every consumer has converged so that Factory Sessions has one understandable construction and opening authority without reducing supported behavior.",
      "acceptanceCriteria": [
        "This deletion begins only after the grouped-construction and all other prerequisite runtime-opening completion-batch slices are present on the target branch and stories 001-004 are satisfied against that baseline.",
        "Production composition and consumers use owner-published Factory Sessions capabilities or the grouped construction vocabulary directly; obsolete RuntimeOpeningFactory/RuntimeOpener aliases, duplicate forwarding constructors, and unreachable legacy bridges have no remaining production responsibility and are removed.",
        "Canonical Wire generation completes from authored composition, and the generated graph retains one authoritative opener, inert construction, and the same lifecycle owners without hand-editing generated output.",
        "Supported Factory Sessions application, invocation, execution, live control, observation, and session operations remain callable with their established results; retirement does not remove an operation merely to shrink an API.",
        "Factory Events, Recordings/replay, Worker Sessions/L4, public API/CLI contracts, and persistence behavior remain unchanged, and the diff contains no broad unrelated cleanup.",
        "Focused post-retirement behavior tests from stories 001-004 pass; verification does not add a meta-test that scans source files or enforces alias, constructor, route, or registration inventories.",
        "Typecheck passes.",
        "Tests pass."
      ],
      "priority": 5,
      "passes": true,
      "notes": "Completed 2026-08-04: replaced the obsolete RuntimeOpeningFactory and RuntimeOpener aliases with grouped RuntimeOpening construction and an owner-published ApplicationRuntimeOpening capability; deleted the unreachable forwarding provider and renamed the public constructor. Regenerated canonical Wire and preserved the existing application, invocation, direct execution, replay, ACP, and shutdown behavior. Follow-up 2026-08-04: reverted an unrelated functional-test helper rename so this PR does not alter an out-of-scope MockWorkers scenario; the runtime-opening behavior and focused evidence remain unchanged. The affected functional scenario, make verify-fast, and the required terminal GitHub CI checks pass. Focused Factory Sessions/Wire tests, make wire-smoke, and make verify-fast pass."
    }
  ]
}
