### PR TITLE
fix: publish npm packages from development-package.yml, not release.yml

### DIFF
--- a/.github/workflows/development-package.yml
+++ b/.github/workflows/development-package.yml
@@ -3,12 +3,35 @@ name: Development Package
 on:
   push:
     branches: [main]
+  workflow_call:
+    inputs:
+      candidate-artifact-name:
+        description: >-
+          Name of the already-uploaded artifact holding the complete,
+          reviewed public package candidate (api + packaged-factories +
+          frontend) to reconcile and publish as a tagged release.
+        required: true
+        type: string
+      expected-source-commit:
+        description: Commit SHA the candidate must have been built from.
+        required: true
+        type: string
 
 permissions:
   contents: read
 
+# npm's Trusted Publisher (OIDC) configuration for these packages has no
+# GitHub Environment restriction, but it does pin the trusted workflow
+# filename to this one. release.yml therefore calls the
+# publish-tagged-release job below as a reusable workflow instead of
+# publishing npm packages itself, so the OIDC token's job_workflow_ref
+# claim always says development-package.yml regardless of which workflow
+# triggered the run.
 concurrency:
-  group: development-package-${{ github.ref }}
+  group: >-
+    development-package-${{ github.event_name }}-${{
+      github.event_name == 'workflow_call' && inputs.expected-source-commit || github.ref
+    }}
   cancel-in-progress: true
 
 env:
@@ -19,7 +42,7 @@ env:
 jobs:
   prepare-main-candidate:
     name: Prepare Protected Main Candidate
-    if: github.repository == 'portpowered/you-agent-factory'
+    if: github.event_name == 'push' && github.repository == 'portpowered/you-agent-factory'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -47,7 +70,7 @@ jobs:
 
   publish-main-candidate:
     name: Publish and Verify Protected Main Candidate
-    if: github.repository == 'portpowered/you-agent-factory'
+    if: github.event_name == 'push' && github.repository == 'portpowered/you-agent-factory'
     needs: prepare-main-candidate
     environment: development-publishing
     runs-on: ubuntu-latest
@@ -73,3 +96,45 @@ jobs:
           npm run publish:public-packages --
           --candidate-directory ../.artifacts/public-development-candidate
           --tag dev --provenance
+
+  publish-tagged-release:
+    name: Publish Tagged Release Candidate
+    if: github.event_name == 'workflow_call'
+    environment: development-publishing
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.expected-source-commit }}
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - run: npm install --global npm@${{ env.NPM_VERSION }}
+
+      - name: Install dashboard dependencies
+        working-directory: ui
+        run: bun install --frozen-lockfile
+
+      - name: Download the preserved complete public package candidate
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.candidate-artifact-name }}
+          path: .artifacts/public-release-candidate
+
+      - name: Reconcile, publish, and verify the complete reviewed public package set
+        run: >-
+          node scripts/public-release-package-publish.mjs
+          --candidate-directory .artifacts/public-release-candidate
+          --expected-source-commit "${{ inputs.expected-source-commit }}"
+          --workspace-directory .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ env:
   BUN_VERSION: 1.3.12
   GORELEASER_VERSION: v2.12.7
   NODE_VERSION: 24
-  NPM_VERSION: 11.15.0
 
 jobs:
   resolve-release-tag:
@@ -111,15 +110,33 @@ jobs:
           path: .artifacts/public-release-candidate/
           if-no-files-found: error
 
+  # npm's Trusted Publisher (OIDC) configuration for these packages pins the
+  # trusted workflow to development-package.yml (no Environment restriction
+  # is configured, so the workflow filename is the whole trust boundary).
+  # Publish npm packages by calling that workflow's publish-tagged-release
+  # job as a reusable workflow, so the OIDC token's job_workflow_ref claim
+  # says development-package.yml even though this run was started here.
+  publish-npm-packages:
+    name: Publish npm Packages (via Development Package)
+    needs:
+      - resolve-release-tag
+      - prepare-public-package-candidate
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/development-package.yml
+    with:
+      candidate-artifact-name: public-release-candidate-${{ github.run_id }}
+      expected-source-commit: ${{ github.event.workflow_run.head_sha }}
+
   publish-release:
     name: Publish GitHub Release
     needs:
       - resolve-release-tag
-      - prepare-public-package-candidate
+      - publish-npm-packages
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write
     steps:
       - name: Check out release commit
         uses: actions/checkout@v4
@@ -144,31 +161,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Set up trusted-publishing-compatible Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Pin trusted-publishing-compatible npm
-        run: npm install --global npm@${{ env.NPM_VERSION }}
-
-      - name: Install dashboard dependencies
-        working-directory: ui
-        run: bun install --frozen-lockfile
-
-      - name: Download the preserved complete public package candidate
-        uses: actions/download-artifact@v4
-        with:
-          name: public-release-candidate-${{ github.run_id }}
-          path: .artifacts/public-release-candidate
-
-      - name: Reconcile, publish, and verify the complete reviewed public package set
-        run: >-
-          node scripts/public-release-package-publish.mjs
-          --candidate-directory .artifacts/public-release-candidate
-          --expected-source-commit "${{ github.event.workflow_run.head_sha }}"
-          --workspace-directory .
 
       - name: Publish GitHub release assets from the tagged commit
         env:


### PR DESCRIPTION
## Summary
v0.0.6's real publish failed with `npm trusted-publishing authentication failed` (401/ENEEDAUTH). Root cause: npm's Trusted Publisher (OIDC) config for these packages has no GitHub Environment restriction, but it does pin the trusted **workflow filename** to `development-package.yml` — confirmed working (its push-triggered dev-snapshot publish succeeds on every push to main) — not `release.yml` (which has never once successfully published).

## Fix
- `development-package.yml`: add a `workflow_call` trigger and a new `publish-tagged-release` job (gated on `github.event_name == 'workflow_call'`) that runs the same npm-publish reconciliation `release.yml` used to run itself.
- `release.yml`: replace the in-line npm-publish step with a new `publish-npm-packages` job that calls `uses: ./.github/workflows/development-package.yml`. Jobs defined by a called reusable workflow get an OIDC `job_workflow_ref` claim naming the *reusable* workflow file, regardless of which workflow invoked it — so this satisfies npm's trust check without touching npm's registry-side config at all.
- `publish-release` (GitHub Release / goreleaser / installer upload) never needed npm/OIDC trust — it drops `id-token: write` and now depends on `publish-npm-packages` instead of doing the npm publish itself.
- Existing dev-snapshot publishing on every push to `main` is unchanged (gated behind the new `github.event_name == 'push'` condition so it doesn't also fire when called by `release.yml`).

## Important: cannot be dry-run tested
`release.yml` only triggers via `workflow_run` of "Release Candidate Verification" completing for a `push` event — a `workflow_dispatch` candidate-only run doesn't satisfy that condition, so there's no safe way to exercise the new `publish-npm-packages` job without an actual tag push. This needs to be validated with a real `v0.0.6` retag after merge.

## Test plan
- [x] YAML syntax validated locally
- [ ] CI green on this PR
- [ ] Real v0.0.6 retag confirms the full publish pipeline (npm + GitHub Release + binaries) end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)