### PR TITLE
fix: gate development-package.yml jobs on workflow_call inputs, not event_name

### DIFF
--- a/.github/workflows/development-package.yml
+++ b/.github/workflows/development-package.yml
@@ -27,11 +27,15 @@ permissions:
 # publishing npm packages itself, so the OIDC token's job_workflow_ref
 # claim always says development-package.yml regardless of which workflow
 # triggered the run.
+#
+# Jobs here cannot gate on github.event_name to tell a direct push apart
+# from a workflow_call invocation: within a job defined by a called
+# reusable workflow, github.event_name reflects the CALLING workflow's
+# original trigger event (e.g. workflow_run for release.yml), not
+# workflow_call. Gate on whether the workflow_call-only
+# expected-source-commit input was actually provided instead.
 concurrency:
-  group: >-
-    development-package-${{ github.event_name }}-${{
-      github.event_name == 'workflow_call' && inputs.expected-source-commit || github.ref
-    }}
+  group: development-package-${{ inputs.expected-source-commit || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -42,7 +46,7 @@ env:
 jobs:
   prepare-main-candidate:
     name: Prepare Protected Main Candidate
-    if: github.event_name == 'push' && github.repository == 'portpowered/you-agent-factory'
+    if: ${{ inputs.expected-source-commit == '' && github.repository == 'portpowered/you-agent-factory' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -70,7 +74,7 @@ jobs:
 
   publish-main-candidate:
     name: Publish and Verify Protected Main Candidate
-    if: github.event_name == 'push' && github.repository == 'portpowered/you-agent-factory'
+    if: ${{ inputs.expected-source-commit == '' && github.repository == 'portpowered/you-agent-factory' }}
     needs: prepare-main-candidate
     environment: development-publishing
     runs-on: ubuntu-latest
@@ -99,7 +103,7 @@ jobs:
 
   publish-tagged-release:
     name: Publish Tagged Release Candidate
-    if: github.event_name == 'workflow_call'
+    if: ${{ inputs.expected-source-commit != '' }}
     environment: development-publishing
     runs-on: ubuntu-latest
     timeout-minutes: 25


### PR DESCRIPTION
## Summary
v0.0.6's publish run (#1806's fix) reported **success** but every job silently ran skipped — zero steps executed anywhere, including `publish-tagged-release`, so nothing was actually published.

**Root cause:** within a job defined by a called reusable workflow, `github.event_name` reflects the **calling** workflow's original trigger event, not `workflow_call`. `release.yml` is itself triggered by `workflow_run`, so every job in the called `development-package.yml` saw `github.event_name == 'workflow_run'` — neither `== 'push'` nor `== 'workflow_call'` ever matched, so everything skipped cleanly (no failure, hence the misleading green run).

**Fix:** gate on whether the `workflow_call`-only `expected-source-commit` input was actually provided, which is unambiguous regardless of how the run reached this workflow (`''`, coerced from `null`, on a direct push; non-empty when called from `release.yml`).

## Verified
- No publish actually happened on the previous attempt (confirmed via the GitHub API: all downstream jobs showed `"conclusion":"skipped"` with an empty `steps` array) — clean, safe state, nothing to roll back.
- The regular dev-snapshot push-to-main flow already passed once with the `github.event_name == 'push'` version of this same gating logic, confirming that path works; this only changes the *mechanism* used to distinguish the two cases, not its correctness for the push case.
- YAML syntax validated locally.

## Note
Same limitation as #1806: this can't be dry-run tested, since `release.yml` only triggers via `workflow_run` of a *push*-triggered Release Candidate Verification. Needs another real `v0.0.6` retag to confirm end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)