### PR TITLE
debug: log actual npm trusted-publishing OIDC token claims (temporary)

### DIFF
--- a/.github/workflows/development-package.yml
+++ b/.github/workflows/development-package.yml
@@ -91,6 +91,16 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - run: npm install --global npm@${{ env.NPM_VERSION }}
+      - name: Debug npm trusted-publishing OIDC token claims (temporary)
+        run: |
+          set -euo pipefail
+          token="$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:registry.npmjs.org" | jq -r .value)"
+          payload="$(echo "$token" | cut -d. -f2 | tr '_-' '/+')"
+          case $((${#payload} % 4)) in
+            2) payload="${payload}==" ;;
+            3) payload="${payload}=" ;;
+          esac
+          echo "$payload" | base64 -d | jq '{job_workflow_ref, workflow_ref, repository, repository_owner, repository_id, environment, ref, sha, event_name, runner_environment, aud, iss}'
       - uses: actions/download-artifact@v4
         with:
           name: public-development-main-candidate-${{ github.run_id }}
@@ -125,6 +135,17 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - run: npm install --global npm@${{ env.NPM_VERSION }}
+
+      - name: Debug npm trusted-publishing OIDC token claims (temporary)
+        run: |
+          set -euo pipefail
+          token="$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:registry.npmjs.org" | jq -r .value)"
+          payload="$(echo "$token" | cut -d. -f2 | tr '_-' '/+')"
+          case $((${#payload} % 4)) in
+            2) payload="${payload}==" ;;
+            3) payload="${payload}=" ;;
+          esac
+          echo "$payload" | base64 -d | jq '{job_workflow_ref, workflow_ref, repository, repository_owner, repository_id, environment, ref, sha, event_name, runner_environment, aud, iss}'
 
       - name: Install dashboard dependencies
         working-directory: ui


### PR DESCRIPTION
## Summary
v0.0.6's publish still fails with `npm trusted-publishing authentication failed` even after confirming `publish-tagged-release` runs under `development-package.yml` (12 real steps executed, not skipped). Two fix attempts targeting the OIDC `job_workflow_ref` theory have both failed identically, so it's time for hard evidence instead of a third guess.

Adds a temporary diagnostic step to both `publish-main-candidate` (known-working dev-snapshot path) and `publish-tagged-release` (failing path) that requests the same `audience=npm:registry.npmjs.org` OIDC token npm's CLI requests, decodes its JWT payload, and prints the identity claims (`job_workflow_ref`, `repository`, `environment`, etc.) — so we can directly diff what a working publish sends against what the failing one sends.

Pure logging addition, no behavior change to the actual publish logic. To be removed once we have the data we need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)