### PR TITLE
fix: restore bun install in publish-release, remove OIDC debug logging

### DIFF
--- a/.github/workflows/development-package.yml
+++ b/.github/workflows/development-package.yml
@@ -217,17 +217,6 @@ jobs:
 
       - run: npm install --global npm@${{ env.NPM_VERSION }}
 
-      - name: Debug npm trusted-publishing OIDC token claims (temporary)
-        run: |
-          set -euo pipefail
-          token="$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:registry.npmjs.org" | jq -r .value)"
-          payload="$(echo "$token" | cut -d. -f2 | tr '_-' '/+')"
-          case $((${#payload} % 4)) in
-            2) payload="${payload}==" ;;
-            3) payload="${payload}=" ;;
-          esac
-          echo "$payload" | base64 -d | jq '{job_workflow_ref, workflow_ref, repository, repository_owner, repository_id, environment, ref, sha, event_name, runner_environment, aud, iss}'
-
       - name: Install dashboard dependencies
         working-directory: ui
         run: bun install --frozen-lockfile
@@ -277,6 +266,10 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dashboard dependencies
+        working-directory: ui
+        run: bun install --frozen-lockfile
 
       - name: Publish GitHub release assets from the tagged commit
         env:


### PR DESCRIPTION
## Summary
Good news: v0.0.6's npm publish finally succeeded on the real run — `publish-tagged-release` executed 13 real steps and reported success, and `@you-agent-factory/api@0.0.6` / `@you-agent-factory/client@0.0.6` are confirmed live on the npm registry. The reusable-workflow consolidation in #1809 fixed the actual OIDC issue.

`publish-release` then failed separately: `make ui-build` (GoReleaser's `before.hooks`) needs `ui/node_modules` populated, but the "Install dashboard dependencies" (`bun install --frozen-lockfile`) step was dropped when the release pipeline was consolidated into this file, on the mistaken assumption it was only needed for the npm-publish step that moved to a different job. This restores it.

Also removes the temporary OIDC token-claims debug step from `publish-tagged-release` now that the actual publish succeeded and it's no longer needed.

## Test plan
- [x] YAML syntax validated locally
- [ ] CI green on this PR
- [ ] Real v0.0.6 retag confirms `publish-release` (GitHub Release + binaries) completes this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)