### PR TITLE
fix: normalize staged file mtimes so package tarballs are reproducible

### DIFF
--- a/scripts/package-release-candidate.mjs
+++ b/scripts/package-release-candidate.mjs
@@ -6,6 +6,7 @@ import {
 	readFile,
 	readdir,
 	rm,
+	utimes,
 	writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -13,6 +14,28 @@ import { join, resolve } from "node:path";
 
 export const DEVELOPMENT_DIST_TAG = "dev";
 export const SHORT_SHA_LENGTH = 12;
+
+// npm pack embeds each staged file's mtime into the tarball. Left alone, a
+// re-publish attempt of an already-published version -- from a fresh
+// checkout at a different wall-clock time, but the exact same source
+// commit -- packs different tarball bytes and trips the registry's
+// immutable-version-digest check even though nothing about the release
+// actually changed. Normalize every staged file to a fixed timestamp
+// before packing so identical source always packs identical bytes.
+const DETERMINISTIC_STAGED_MTIME = new Date("2020-01-01T00:00:00Z");
+
+export async function normalizeStagedMtimes(root, timestamp = DETERMINISTIC_STAGED_MTIME) {
+	const entries = await readdir(root, { withFileTypes: true });
+	await Promise.all(
+		entries.map(async (entry) => {
+			const entryPath = join(root, entry.name);
+			if (entry.isDirectory()) {
+				await normalizeStagedMtimes(entryPath, timestamp);
+			}
+			await utimes(entryPath, timestamp, timestamp);
+		}),
+	);
+}
 
 const STABLE_SEMVER_PATTERN =
 	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
@@ -164,6 +187,7 @@ export async function prepareReleaseCandidate({
 			contractManifestPath,
 			validatedSourceCommit,
 		);
+		await normalizeStagedMtimes(stagedPackage);
 
 		const packed = await pack({
 			packageDirectory: stagedPackage,

--- a/ui/scripts/public-package-publish.mjs
+++ b/ui/scripts/public-package-publish.mjs
@@ -16,6 +16,7 @@ import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 
 import { assertPackedExportTargets } from "../../scripts/package-export-validation.mjs";
+import { normalizeStagedMtimes } from "../../scripts/package-release-candidate.mjs";
 import {
   assertCandidateSetEvidence,
   FRONTEND_ONLY_CANDIDATE_SCOPE,
@@ -151,6 +152,7 @@ async function stagePackage({ packageSpec, version, stagingRoot }) {
     );
   }
   await writeFile(manifestPath, `${JSON.stringify(patched, null, 2)}\n`);
+  await normalizeStagedMtimes(stagedDirectory);
   return { manifest: patched, stagedDirectory };
 }
 


### PR DESCRIPTION
## Summary
v0.0.6's npm publish for `@you-agent-factory/api` and `client` succeeded on an earlier attempt within this same tag cycle. A later retry (after an unrelated workflow fix) failed the registry reconciliation check with `existing registry version has a different immutable tarball digest` — npm correctly refusing to let a divergent rebuild masquerade as the already-published version.

**Root cause:** `npm pack` embeds each staged file's mtime into the tarball. Every retry re-checks out the source at a new wall-clock time before staging and packing, so even byte-identical source produces a different tarball (and a different sha256) across separate build attempts — tripping the immutable-version check on any retry of a version that's already live, even though nothing about the release actually changed.

**Fix:** normalize every staged file to a fixed timestamp right before packing, in the one function (`prepareReleaseCandidate` in `package-release-candidate.mjs`) all three release targets funnel through: directly for `api` and `packaged-factories`, and via the frontend staging path in `ui/scripts/public-package-publish.mjs`'s `stagePackage` (imported across the existing `ui/scripts` → root `scripts/` boundary, matching how this same file already imports `assertPackedExportTargets`).

This is the proper fix rather than weakening npm's immutability check — that check is legitimately valuable and should stay strict.

## Verification
- Manually prepared the same api package candidate twice with different run IDs → identical `artifactDigest` both times.
- Repeated with a source file's mtime deliberately touched in between → still identical (previously this would have differed).
- All existing test suites still pass: api-package (24 tests), packaged-factories/public-release candidate (13 tests), public-package-publish (5 tests).
- `biome check` clean on the ui-scoped file; the root `scripts/*.mjs` file isn't covered by any lint/biome target (no config exists for it) — its tab indentation is the file's pre-existing, unenforced convention, matched as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)