### PR TITLE
fix: include factory-graph in the public package release set

### DIFF
--- a/scripts/public-package-set.mjs
+++ b/scripts/public-package-set.mjs
@@ -6,6 +6,7 @@ export const FRONTEND_PUBLIC_PACKAGE_NAMES = Object.freeze([
 	"@you-agent-factory/factory-replay",
 	"@you-agent-factory/factory-emulator",
 	"@you-agent-factory/components",
+	"@you-agent-factory/factory-graph",
 	"@you-agent-factory/factory-visualizers",
 ]);
 

--- a/ui/scripts/public-package-publish.mjs
+++ b/ui/scripts/public-package-publish.mjs
@@ -34,6 +34,7 @@ export const PUBLIC_PACKAGES = Object.freeze([
     directory: "factory-emulator",
   },
   { name: "@you-agent-factory/components", directory: "components" },
+  { name: "@you-agent-factory/factory-graph", directory: "factory-graph" },
   {
     name: "@you-agent-factory/factory-visualizers",
     directory: "factory-visualizers",

--- a/ui/scripts/public-package-publish.test.mjs
+++ b/ui/scripts/public-package-publish.test.mjs
@@ -21,6 +21,7 @@ describe("public package publishing", () => {
       "@you-agent-factory/factory-replay",
       "@you-agent-factory/factory-emulator",
       "@you-agent-factory/components",
+      "@you-agent-factory/factory-graph",
       "@you-agent-factory/factory-visualizers",
     ]);
   });


### PR DESCRIPTION
## Summary
- `factory-visualizers` has a real runtime dependency on `@you-agent-factory/factory-graph`, but `factory-graph` was never included in the public frontend release set (`PUBLIC_PACKAGES` / `FRONTEND_PUBLIC_PACKAGE_NAMES`).
- As a result, the already-published `factory-visualizers@0.0.6` on npm pins `factory-graph` to its one-off `0.0.0` placeholder version instead of a matching release.
- Adds `factory-graph` to both package-name manifests so it publishes alongside the rest of the frontend set, gets its version rewritten correctly in dependents, and is covered by the existing candidate-set/boundary checks.

## Test plan
- [x] `node --test scripts/public-package-set.test.mjs`
- [x] `bun run test:public-package-release` (ui/)
- [x] `bun run check:public-package-boundaries` (ui/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)