### PR TITLE
wo-a3-three-input-join-validation

### DIFF
--- a/pkg/services/factory_definitions/internal/services/validation/impl/service.go
+++ b/pkg/services/factory_definitions/internal/services/validation/impl/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 )
@@ -166,11 +167,39 @@ func (s *Service) ValidateTopology(
 	requiredToolChecker factorydefinitions.RequiredToolChecker,
 ) factorydefinitions.TopologyValidationResult {
 	result := NewConfigValidator(requiredToolChecker).Validate(cfg)
-	result.Findings = append(
+	result.Findings = appendUniqueTopologyFindings(
 		result.Findings,
-		FactoryDefinitionFindings(s.Validate(ctx, cfg, nil).Targets)...,
+		FactoryDefinitionFindings(s.Validate(ctx, cfg, nil).Targets),
 	)
 	return *result
+}
+
+func appendUniqueTopologyFindings(
+	existing []factorydefinitions.TopologyFinding,
+	additional []Finding,
+) []factorydefinitions.TopologyFinding {
+	seen := make(map[string]struct{}, len(existing)+len(additional))
+	for _, finding := range existing {
+		seen[topologyFindingKey(finding)] = struct{}{}
+	}
+	for _, finding := range additional {
+		key := topologyFindingKey(finding)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		existing = append(existing, finding)
+		seen[key] = struct{}{}
+	}
+	return existing
+}
+
+func topologyFindingKey(finding factorydefinitions.TopologyFinding) string {
+	return strings.Join([]string{
+		string(finding.Severity),
+		strings.TrimPrefix(finding.Path, validationRoot+"."),
+		finding.Message,
+		finding.Rule,
+	}, "\x00")
 }
 
 func (*Service) WorkerWorkstationBehaviorCompatibility(

--- a/pkg/services/factory_definitions/internal/services/validation/impl/topology_guards_test.go
+++ b/pkg/services/factory_definitions/internal/services/validation/impl/topology_guards_test.go
@@ -2,6 +2,7 @@ package impl
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -836,6 +837,200 @@ func TestRulePerInputGuards_ValidSameNameGuard(t *testing.T) {
 	findings := rulePerInputGuards(cfg)
 	if len(findings) != 0 {
 		t.Fatalf("expected no findings, got %v", findings)
+	}
+}
+
+func TestConfigValidator_UnsupportedSameNameAllChildrenCompleteJoinArity(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputs       []factorydefinitions.IOConfig
+		wantFinding  bool
+		wantArity    int
+		messageParts []string
+	}{
+		{
+			name: "one input remains accepted",
+			inputs: []factorydefinitions.IOConfig{
+				{WorkTypeName: "parent", StateName: "ready"},
+			},
+		},
+		{
+			name: "two input same-name join remains accepted",
+			inputs: []factorydefinitions.IOConfig{
+				{WorkTypeName: "parent", StateName: "ready"},
+				{
+					WorkTypeName: "same",
+					StateName:    "ready",
+					Guard: &factorydefinitions.InputGuardConfig{
+						Type:       factorydefinitions.GuardTypeSameName,
+						MatchInput: "parent",
+					},
+				},
+			},
+		},
+		{
+			name: "two input child-complete join remains accepted",
+			inputs: []factorydefinitions.IOConfig{
+				{WorkTypeName: "parent", StateName: "ready"},
+				{
+					WorkTypeName: "child",
+					StateName:    "complete",
+					Guard: &factorydefinitions.InputGuardConfig{
+						Type:        factorydefinitions.GuardTypeAllChildrenComplete,
+						ParentInput: "parent",
+					},
+				},
+			},
+		},
+		{
+			name: "two input combined join remains accepted",
+			inputs: []factorydefinitions.IOConfig{
+				{
+					WorkTypeName: "parent",
+					StateName:    "ready",
+					Guard: &factorydefinitions.InputGuardConfig{
+						Type:       factorydefinitions.GuardTypeSameName,
+						MatchInput: "child",
+					},
+				},
+				{
+					WorkTypeName: "child",
+					StateName:    "complete",
+					Guard: &factorydefinitions.InputGuardConfig{
+						Type:        factorydefinitions.GuardTypeAllChildrenComplete,
+						ParentInput: "parent",
+					},
+				},
+			},
+		},
+		{
+			name: "three input same-name plus child-complete join is rejected",
+			inputs: []factorydefinitions.IOConfig{
+				{WorkTypeName: "parent", StateName: "ready"},
+				{
+					WorkTypeName: "same",
+					StateName:    "ready",
+					Guard: &factorydefinitions.InputGuardConfig{
+						Type:       factorydefinitions.GuardTypeSameName,
+						MatchInput: "parent",
+					},
+				},
+				{
+					WorkTypeName: "child",
+					StateName:    "complete",
+					Guard: &factorydefinitions.InputGuardConfig{
+						Type:        factorydefinitions.GuardTypeAllChildrenComplete,
+						ParentInput: "parent",
+					},
+				},
+			},
+			wantFinding: true,
+			wantArity:   3,
+			messageParts: []string{
+				`workstation "fan-in"`,
+				"unsupported SAME_NAME plus ALL_CHILDREN_COMPLETE join arity",
+				"observed arity is 3 inputs",
+				"at most 2 inputs are supported",
+				"Split the fan-in into supported two-input workstation stages",
+				"reduce the joined inputs",
+			},
+		},
+		{
+			name: "four input same-name plus child-complete join is rejected",
+			inputs: append([]factorydefinitions.IOConfig{
+				{WorkTypeName: "parent", StateName: "ready"},
+				{
+					WorkTypeName: "same",
+					StateName:    "ready",
+					Guard: &factorydefinitions.InputGuardConfig{
+						Type:       factorydefinitions.GuardTypeSameName,
+						MatchInput: "parent",
+					},
+				},
+				{
+					WorkTypeName: "child",
+					StateName:    "complete",
+					Guard: &factorydefinitions.InputGuardConfig{
+						Type:        factorydefinitions.GuardTypeAllChildrenComplete,
+						ParentInput: "parent",
+					},
+				},
+			}, factorydefinitions.IOConfig{WorkTypeName: "extra", StateName: "ready"}),
+			wantFinding: true,
+			wantArity:   4,
+		},
+		{
+			name: "three input same-name without child-complete remains accepted",
+			inputs: []factorydefinitions.IOConfig{
+				{WorkTypeName: "parent", StateName: "ready"},
+				{
+					WorkTypeName: "same",
+					StateName:    "ready",
+					Guard: &factorydefinitions.InputGuardConfig{
+						Type:       factorydefinitions.GuardTypeSameName,
+						MatchInput: "parent",
+					},
+				},
+				{WorkTypeName: "extra", StateName: "ready"},
+			},
+		},
+		{
+			name: "three input child-complete without same-name remains accepted",
+			inputs: []factorydefinitions.IOConfig{
+				{WorkTypeName: "parent", StateName: "ready"},
+				{
+					WorkTypeName: "child",
+					StateName:    "complete",
+					Guard: &factorydefinitions.InputGuardConfig{
+						Type:        factorydefinitions.GuardTypeAllChildrenComplete,
+						ParentInput: "parent",
+					},
+				},
+				{WorkTypeName: "extra", StateName: "ready"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testBaseConfig()
+			cfg.Workstations = []factorydefinitions.FactoryWorkstationConfig{{
+				Name:   "fan-in",
+				Inputs: tt.inputs,
+			}}
+
+			result := NewConfigValidator(nil).Validate(cfg)
+			var finding *Finding
+			for index := range result.Findings {
+				if result.Findings[index].Rule == "same-name-all-children-complete-join-arity" {
+					finding = &result.Findings[index]
+					break
+				}
+			}
+
+			if !tt.wantFinding {
+				if finding != nil {
+					t.Fatalf("unexpected unsupported join arity finding: %#v", *finding)
+				}
+				return
+			}
+			if finding == nil {
+				t.Fatalf("expected unsupported join arity finding, got %#v", result.Findings)
+			}
+			if finding.Severity != SeverityError {
+				t.Fatalf("finding severity = %q, want %q", finding.Severity, SeverityError)
+			}
+			wantPath := "workstations[0](fan-in).inputs"
+			if finding.Path != wantPath {
+				t.Fatalf("finding path = %q, want %q", finding.Path, wantPath)
+			}
+			if tt.messageParts != nil && !containsAll(finding.Message, tt.messageParts...) {
+				t.Fatalf("finding message = %q, want parts %v", finding.Message, tt.messageParts)
+			}
+			if !strings.Contains(finding.Message, fmt.Sprintf("observed arity is %d inputs", tt.wantArity)) {
+				t.Fatalf("finding message = %q, want arity %d", finding.Message, tt.wantArity)
+			}
+		})
 	}
 }
 

--- a/pkg/services/factory_definitions/internal/services/validation/impl/topology_rules.go
+++ b/pkg/services/factory_definitions/internal/services/validation/impl/topology_rules.go
@@ -631,7 +631,40 @@ func validateUnsupportedHostedWorkerFields(basePath string, worker factorydefini
 
 // --- Rule: per-input guard validation ---
 
-const maxSupportedSameNameAllChildrenCompleteJoinInputs = 2
+const (
+	maxSupportedSameNameAllChildrenCompleteJoinInputs = 2
+	unsupportedSameNameAllChildrenCompleteJoinRule    = "same-name-all-children-complete-join-arity"
+)
+
+func unsupportedSameNameAllChildrenCompleteJoinArity(ws factorydefinitions.FactoryWorkstationConfig) bool {
+	if len(ws.Inputs) <= maxSupportedSameNameAllChildrenCompleteJoinInputs {
+		return false
+	}
+
+	hasSameName := false
+	hasAllChildrenComplete := false
+	for _, input := range ws.Inputs {
+		if input.Guard == nil {
+			continue
+		}
+		switch input.Guard.Type {
+		case factorydefinitions.GuardTypeSameName:
+			hasSameName = true
+		case factorydefinitions.GuardTypeAllChildrenComplete:
+			hasAllChildrenComplete = true
+		}
+	}
+	return hasSameName && hasAllChildrenComplete
+}
+
+func unsupportedSameNameAllChildrenCompleteJoinMessage(ws factorydefinitions.FactoryWorkstationConfig) string {
+	return fmt.Sprintf(
+		"workstation %q uses an unsupported SAME_NAME plus ALL_CHILDREN_COMPLETE join arity: observed arity is %d inputs, and at most %d inputs are supported for this join shape. Split the fan-in into supported two-input workstation stages or reduce the joined inputs.",
+		ws.Name,
+		len(ws.Inputs),
+		maxSupportedSameNameAllChildrenCompleteJoinInputs,
+	)
+}
 
 // ruleUnsupportedSameNameAllChildrenCompleteJoinArity rejects the only
 // currently unsupported multi-input combination before it reaches the runtime
@@ -644,40 +677,45 @@ func ruleUnsupportedSameNameAllChildrenCompleteJoinArity(cfg *factorydefinitions
 
 	var findings []Finding
 	for wi, ws := range cfg.Workstations {
-		if len(ws.Inputs) <= maxSupportedSameNameAllChildrenCompleteJoinInputs {
-			continue
-		}
-
-		hasSameName := false
-		hasAllChildrenComplete := false
-		for _, input := range ws.Inputs {
-			if input.Guard == nil {
-				continue
-			}
-			switch input.Guard.Type {
-			case factorydefinitions.GuardTypeSameName:
-				hasSameName = true
-			case factorydefinitions.GuardTypeAllChildrenComplete:
-				hasAllChildrenComplete = true
-			}
-		}
-		if !hasSameName || !hasAllChildrenComplete {
+		if !unsupportedSameNameAllChildrenCompleteJoinArity(ws) {
 			continue
 		}
 
 		findings = append(findings, Finding{
 			Severity: SeverityError,
 			Path:     fmt.Sprintf("workstations[%d](%s).inputs", wi, ws.Name),
-			Message: fmt.Sprintf(
-				"workstation %q uses an unsupported SAME_NAME plus ALL_CHILDREN_COMPLETE join arity: observed arity is %d inputs, and at most %d inputs are supported for this join shape. Split the fan-in into supported two-input workstation stages or reduce the joined inputs.",
-				ws.Name,
-				len(ws.Inputs),
-				maxSupportedSameNameAllChildrenCompleteJoinInputs,
-			),
-			Rule: "same-name-all-children-complete-join-arity",
+			Message:  unsupportedSameNameAllChildrenCompleteJoinMessage(ws),
+			Rule:     unsupportedSameNameAllChildrenCompleteJoinRule,
 		})
 	}
 	return findings
+}
+
+func unsupportedSameNameAllChildrenCompleteJoinArityTargets(cfg *factorydefinitions.FactoryConfig) []Target {
+	if cfg == nil {
+		return nil
+	}
+
+	var targets []Target
+	for workstationIndex, workstation := range cfg.Workstations {
+		if !unsupportedSameNameAllChildrenCompleteJoinArity(workstation) {
+			continue
+		}
+
+		basePath := fmt.Sprintf("%s.workstations[%d](%s)", validationRoot, workstationIndex, workstation.Name)
+		targets = append(targets, Target{
+			Code:     unsupportedSameNameAllChildrenCompleteJoinRule,
+			Severity: SeverityError,
+			Message:  unsupportedSameNameAllChildrenCompleteJoinMessage(workstation),
+			Subject: Subject{
+				Type:     SubjectTypeWorkstation,
+				ID:       factorydefinitions.CanonicalFactoryGraphWorkstationID(workstation),
+				Location: SubjectLocationInputs,
+			},
+			Path: basePath + ".inputs",
+		})
+	}
+	return targets
 }
 
 func rulePerInputGuards(cfg *factorydefinitions.FactoryConfig) []Finding {

--- a/pkg/services/factory_definitions/internal/services/validation/impl/topology_rules.go
+++ b/pkg/services/factory_definitions/internal/services/validation/impl/topology_rules.go
@@ -631,6 +631,55 @@ func validateUnsupportedHostedWorkerFields(basePath string, worker factorydefini
 
 // --- Rule: per-input guard validation ---
 
+const maxSupportedSameNameAllChildrenCompleteJoinInputs = 2
+
+// ruleUnsupportedSameNameAllChildrenCompleteJoinArity rejects the only
+// currently unsupported multi-input combination before it reaches the runtime
+// mapper. SAME_NAME and ALL_CHILDREN_COMPLETE are each supported independently,
+// but their combined join shape is bounded to two inputs.
+func ruleUnsupportedSameNameAllChildrenCompleteJoinArity(cfg *factorydefinitions.FactoryConfig) []Finding {
+	if cfg == nil {
+		return nil
+	}
+
+	var findings []Finding
+	for wi, ws := range cfg.Workstations {
+		if len(ws.Inputs) <= maxSupportedSameNameAllChildrenCompleteJoinInputs {
+			continue
+		}
+
+		hasSameName := false
+		hasAllChildrenComplete := false
+		for _, input := range ws.Inputs {
+			if input.Guard == nil {
+				continue
+			}
+			switch input.Guard.Type {
+			case factorydefinitions.GuardTypeSameName:
+				hasSameName = true
+			case factorydefinitions.GuardTypeAllChildrenComplete:
+				hasAllChildrenComplete = true
+			}
+		}
+		if !hasSameName || !hasAllChildrenComplete {
+			continue
+		}
+
+		findings = append(findings, Finding{
+			Severity: SeverityError,
+			Path:     fmt.Sprintf("workstations[%d](%s).inputs", wi, ws.Name),
+			Message: fmt.Sprintf(
+				"workstation %q uses an unsupported SAME_NAME plus ALL_CHILDREN_COMPLETE join arity: observed arity is %d inputs, and at most %d inputs are supported for this join shape. Split the fan-in into supported two-input workstation stages or reduce the joined inputs.",
+				ws.Name,
+				len(ws.Inputs),
+				maxSupportedSameNameAllChildrenCompleteJoinInputs,
+			),
+			Rule: "same-name-all-children-complete-join-arity",
+		})
+	}
+	return findings
+}
+
 func rulePerInputGuards(cfg *factorydefinitions.FactoryConfig) []Finding {
 	var findings []Finding
 	validWorkstations := buildValidWorkstations(cfg)

--- a/pkg/services/factory_definitions/internal/services/validation/impl/topology_validator.go
+++ b/pkg/services/factory_definitions/internal/services/validation/impl/topology_validator.go
@@ -57,6 +57,7 @@ func NewConfigValidator(requiredToolChecker RequiredToolChecker) *ConfigValidato
 		ruleAgentWorkerTools,
 		ruleModelInvokeWorkstations,
 		rulePerInputGuards,
+		ruleUnsupportedSameNameAllChildrenCompleteJoinArity,
 		ruleResourceDefinitions,
 		ruleResourceUsage,
 		ruleRequiredTools(cv.requiredToolChecker),

--- a/pkg/services/factory_definitions/internal/services/validation/impl/validate.go
+++ b/pkg/services/factory_definitions/internal/services/validation/impl/validate.go
@@ -23,6 +23,7 @@ func ValidateStructural(cfg *factorydefinitions.FactoryConfig) Result {
 	targets = append(targets, duplicateIdentifierTargets(cfg)...)
 	targets = append(targets, duplicateWorkStateTargets(cfg)...)
 	targets = append(targets, ValidateGraphTopology(cfg).Targets...)
+	targets = append(targets, unsupportedSameNameAllChildrenCompleteJoinArityTargets(cfg)...)
 	targets = append(targets, conflictingWorkstationOutputTargets(cfg)...)
 	targets = append(targets, missingOutcomeRouteTargets(cfg)...)
 	targets = append(targets, ManagedRuntimeDependencyTargets(cfg)...)

--- a/tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go
+++ b/tests/functional/factory_definitions/transports/cli/validate_persist/validate_persist_test.go
@@ -2,6 +2,7 @@ package validate_persist
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
@@ -41,6 +43,136 @@ const invalidFactoryWithDanglingWorker = `{
 		"type":"MODEL_WORKSTATION"
 	}]
 }`
+
+const unsupportedThreeInputJoinFactory = `{
+	"name":"unsupported-three-input-join",
+	"workTypes":[
+		{"name":"parent","states":[
+			{"name":"ready","type":"INITIAL"},
+			{"name":"complete","type":"TERMINAL"},
+			{"name":"failed","type":"FAILED"}
+		]},
+		{"name":"same","states":[
+			{"name":"ready","type":"INITIAL"},
+			{"name":"complete","type":"TERMINAL"},
+			{"name":"failed","type":"FAILED"}
+		]},
+		{"name":"child","states":[
+			{"name":"ready","type":"INITIAL"},
+			{"name":"complete","type":"TERMINAL"},
+			{"name":"failed","type":"FAILED"}
+		]}
+	],
+	"workstations":[{
+		"name":"fan-in",
+		"type":"LOGICAL_MOVE",
+		"worker":"",
+		"inputs":[
+			{"workType":"parent","state":"ready"},
+			{"workType":"same","state":"ready","guards":[{"type":"SAME_NAME","matchInput":"parent"}]},
+			{"workType":"child","state":"complete","guards":[{"type":"ALL_CHILDREN_COMPLETE","parentInput":"parent"}]}
+		],
+		"outputs":[{"workType":"parent","state":"complete"}]
+	}]
+}`
+
+const supportedTwoInputJoinFactory = `{
+	"name":"supported-two-input-join",
+	"workTypes":[
+		{"name":"parent","states":[
+			{"name":"ready","type":"INITIAL"},
+			{"name":"complete","type":"TERMINAL"},
+			{"name":"failed","type":"FAILED"}
+		]},
+		{"name":"child","states":[
+			{"name":"ready","type":"INITIAL"},
+			{"name":"complete","type":"TERMINAL"},
+			{"name":"failed","type":"FAILED"}
+		]}
+	],
+	"workstations":[{
+		"name":"two-input-join",
+		"type":"LOGICAL_MOVE",
+		"worker":"",
+		"inputs":[
+			{"workType":"parent","state":"ready","guards":[{"type":"SAME_NAME","matchInput":"child"}]},
+			{"workType":"child","state":"complete","guards":[{"type":"ALL_CHILDREN_COMPLETE","parentInput":"parent"}]}
+		],
+		"outputs":[{"workType":"parent","state":"complete"}]
+	}]
+}`
+
+// TestFactoryValidateRejectsUnsupportedJoinArity proves the supported Factory
+// CLI validate command rejects the regression topology before it can start a
+// runtime, invoke a provider, or persist the invalid definition.
+func TestFactoryValidateRejectsUnsupportedJoinArity(t *testing.T) {
+	home := t.TempDir()
+	sourcePath := writeFactoryFile(t, unsupportedThreeInputJoinFactory)
+	runner := support.NewRecordingCommandRunner("runtime must not execute")
+	apiStarts := 0
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "factory", "config", "validate", sourcePath,
+	})
+	inputs.Input.Env = customerHomeEnvironment(home)
+	inputs.Input.WorkingDirectory = filepath.Dir(sourcePath)
+	process := support.BuildProcess(t, serviceedges.Edges{
+		ProviderCommandRunner: runner,
+		APIServerStarter: func(context.Context, platformhttpserver.StartRequest) error {
+			apiStarts++
+			return nil
+		},
+	})
+
+	err := process.Execute(inputs.Input)
+	if err == nil {
+		t.Fatal("Process.Execute(factory config validate) error = nil, want rejection")
+	}
+
+	diagnostic := err.Error() + "\n" + inputs.Stdout() + "\n" + inputs.Stderr()
+	for _, want := range []string{
+		"Factory validation failed.",
+		"fan-in",
+		"unsupported SAME_NAME plus ALL_CHILDREN_COMPLETE join arity",
+		"observed arity is 3 inputs",
+		"at most 2 inputs are supported",
+		"Split the fan-in into supported two-input workstation stages",
+		"reduce the joined inputs",
+	} {
+		if !strings.Contains(diagnostic, want) {
+			t.Fatalf("validate diagnostic missing %q:\n%s", want, diagnostic)
+		}
+	}
+	if runner.CallCount() != 0 {
+		t.Fatalf("provider command runner call count = %d, want 0", runner.CallCount())
+	}
+	if apiStarts != 0 {
+		t.Fatalf("API/runtime host starts = %d, want 0", apiStarts)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".you-agent-factory", "factories", "unsupported-three-input-join")); !os.IsNotExist(err) {
+		t.Fatalf("invalid Factory persistence check error = %v, want not-exist", err)
+	}
+}
+
+// TestFactoryValidateAcceptsSupportedTwoInputJoinArity proves the new
+// rejection rule does not change the existing supported two-input behavior.
+func TestFactoryValidateAcceptsSupportedTwoInputJoinArity(t *testing.T) {
+	sourcePath := writeFactoryFile(t, supportedTwoInputJoinFactory)
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "factory", "config", "validate", sourcePath,
+	})
+	inputs.Input.WorkingDirectory = filepath.Dir(sourcePath)
+	if err := support.BuildProcess(t, serviceedges.Edges{}).Execute(inputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(factory config validate) error = %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+	if !strings.Contains(inputs.Stdout(), "Factory validation passed.") {
+		t.Fatalf("factory validation output = %q", inputs.Stdout())
+	}
+}
 
 // TestCLIFactoryValidateRejectsInvalidDefinitionActionably proves the public
 // Factory CLI validate command rejects an invalid authored definition with


### PR DESCRIPTION
{
  "project": "Reject Unsupported Three-Input SAME_NAME and ALL_CHILDREN_COMPLETE Joins",
  "branchName": "wo-a3-three-input-join-validation",
  "description": "Prevent a Factory from entering a silent runtime deadlock by statically rejecting workstations with the unsupported three-or-more-input SAME_NAME plus ALL_CHILDREN_COMPLETE join shape and surfacing actionable diagnostics through the supported Factory validation CLI before execution.",
  "context": {
    "customerAsk": "Replace the observed silent deadlock for a three-input SAME_NAME plus ALL_CHILDREN join with supported behavior or a clear pre-runtime validation error. Prefer the bounded work-order outcome, add focused definition-validation and CLI functional regressions, run go test ./tests/functional/factory_definitions/... -run TestFactoryValidateRejectsUnsupportedJoinArity -count=1, and run make verify-fast.",
    "problem": "A workstation with a third input participating in a SAME_NAME and ALL_CHILDREN_COMPLETE fan-in topology is currently accepted as a valid Factory Definition, but at runtime it never dispatches and emits no explanatory error. Operators can therefore start a Factory that cannot make progress even though the unsupported topology is knowable before execution.",
    "solution": "Add one deterministic, side-effect-free rule to canonical Factory Definitions topology validation. Reject three or more inputs in the affected SAME_NAME plus ALL_CHILDREN_COMPLETE join shape, emit a blocking finding that names the workstation, observed and supported arity, and remediation, and reuse the existing validation contract so the supported you factory config validate <path> command exits non-zero before runtime. Preserve supported one- and two-input behavior and unrelated multi-input definitions."
  },
  "acceptanceCriteria": [
    "Canonical Factory Definition validation returns a blocking finding for a workstation with three or more inputs in the unsupported SAME_NAME plus ALL_CHILDREN_COMPLETE join shape that was previously accepted and then deadlocked; validation completes before Factory Runtime, worker, provider, or persistence side effects begin.",
    "The finding identifies the affected workstation, states that the join arity is unsupported, reports the observed arity and the supported maximum of two inputs for this join shape, and recommends splitting the fan-in into supported two-input workstation stages or otherwise reducing the joined inputs.",
    "Supported one- and two-input join definitions continue to validate as before, and factories with three inputs outside the affected guard combination are not rejected by this rule.",
    "Running you factory config validate <path> against the regression Factory exits non-zero and its combined customer-visible diagnostic names the workstation, the unsupported arity, and the remediation; the command does not start runtime or invoke a provider. This is the discovered exact replacement for the retired you factory validate command in the work order.",
    "Focused evidence includes a definition-validation unit regression for the previously accepted three-input topology and a CLI functional regression named TestFactoryValidateRejectsUnsupportedJoinArity, exercised by go test ./tests/functional/factory_definitions/... -run TestFactoryValidateRejectsUnsupportedJoinArity -count=1.",
    "Scope remains limited to WO-A3 static validation and its behavioral tests: no N-way runtime join implementation, no broad WO-D4 diagnostics, no new ACP lanes, no storage engine, no local-model or llama-server harness, no Gemma validation, no ACP SDK expansion, no wrapper-layer file-reference transformation, and no unrelated cleanup.",
    "Quality gate: Go typecheck/compilation, formatting, lint, focused unit and functional tests, go test ./tests/functional/factory_definitions/... -run TestFactoryValidateRejectsUnsupportedJoinArity -count=1, make verify-fast, and all required CI checks are terminal and passing.",
    "Delivery: the implementation/review loop continues until required CI is terminal and passing, every blocking PR conversation item is explicitly addressed, merge conflicts and shared-file churn are reconciled against the target branch, and the PR is actually merged. Opening, approval, green CI, or merge readiness alone is not completion."
  ],
  "userStories": [
    {
      "id": "wo-a3-three-input-join-validation-001",
      "title": "Reject the unsupported join arity during definition validation",
      "description": "As a Factory author, I want canonical validation to reject the known unsupported three-input join so I cannot start a Factory that will silently deadlock.",
      "acceptanceCriteria": [
        "A Factory Definition containing a named workstation with three inputs in the affected SAME_NAME plus ALL_CHILDREN_COMPLETE join shape returns a blocking topology finding instead of validating successfully.",
        "The finding names the workstation, reports the observed arity of three and the supported maximum of two for this shape, and recommends splitting the join into supported two-input workstation stages or reducing the joined inputs.",
        "The validation rule is deterministic and side-effect free in the Factory Definitions validation owner; it does not add runtime state, scheduler behavior, IO, or a parallel validation contract.",
        "Focused table-driven unit coverage proves rejection for the known three-input regression and representative greater arity, acceptance for supported one- and two-input shapes, and non-interference with three-input definitions that do not use the affected guard combination.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added and registered the canonical side-effect-free topology rule. Table-driven validation coverage covers one-, two-, three-, and four-input shapes plus unrelated three-input guard combinations. Focused and Factory Definitions package tests, go vet, dashboard typecheck, MCP contract check, and UI unit tests pass. The short Go suite still has the unrelated Windows runtime-artifact mode failure; CLI functional coverage remains in story wo-a3-three-input-join-validation-002."
    },
    {
      "id": "wo-a3-three-input-join-validation-002",
      "title": "Surface the actionable failure through the supported CLI",
      "description": "As a Factory operator, I want the validation command to fail clearly before execution so I can correct an unsupported join without diagnosing a stalled session.",
      "acceptanceCriteria": [
        "you factory config validate <path> executed through root.BuildProcess and Process.Execute exits non-zero for the regression Factory Definition.",
        "The combined customer-visible CLI diagnostic names the affected workstation, states that arity three is unsupported and at most two inputs are supported for this join shape, and tells the operator to split the fan-in into supported two-input workstation stages or reduce the joined inputs.",
        "The CLI regression proves validation causes no provider invocation and does not start Factory Runtime or persist the invalid definition.",
        "The functional regression is named TestFactoryValidateRejectsUnsupportedJoinArity and passes with go test ./tests/functional/factory_definitions/... -run TestFactoryValidateRejectsUnsupportedJoinArity -count=1.",
        "Existing successful you factory config validate behavior remains unchanged for a supported two-input SAME_NAME plus ALL_CHILDREN_COMPLETE Factory.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added canonical target wiring and root-process CLI coverage. TestFactoryValidateRejectsUnsupportedJoinArity and the full Factory Definitions functional suite pass; the supported two-input validation case remains successful. Provider invocation, runtime/API start, and invalid persistence are asserted absent. Factory Definitions package tests and vet pass. make verify-fast reaches and passes dashboard typecheck, MCP contract checks, and UI tests, then fails only at the pre-existing Windows runtime-artifact mode assertion (0666 vs 0600) in the short Go lane."
    }
  ]
}
