### PR TITLE
wo-a5-classifier-script-mocks

### DIFF
--- a/pkg/platform/runtimeartifact/reserve_test.go
+++ b/pkg/platform/runtimeartifact/reserve_test.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -125,6 +126,16 @@ func TestReserveCreatesTheArtifactOwnerReadableOnly(t *testing.T) {
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatalf("Stat: %v", err)
+	}
+	if runtime.GOOS == "windows" {
+		// Windows has no POSIX permission bits: os.Chmod only toggles the
+		// read-only attribute, so a 0o600 reservation reads back as 0o666.
+		// Owner-only protection there comes from the profile directory ACL;
+		// assert the mode is not widened beyond the default instead.
+		if perm := info.Mode().Perm(); perm&0o600 != 0o600 {
+			t.Fatalf("reserved artifact mode = %#o, want owner read/write retained", perm)
+		}
+		return
 	}
 	if perm := info.Mode().Perm(); perm != 0o600 {
 		t.Fatalf("reserved artifact mode = %#o, want %#o (owner read/write only)", perm, 0o600)

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go
@@ -224,6 +224,7 @@ func completedDispatchReasonFromResult(result workerexecution.WorkResult) string
 
 func workResultForCompletedDispatch(result workerexecution.WorkResult, completed interfaces.CompletedDispatch) workerexecution.WorkResult {
 	result.Outcome = completed.Outcome
+	result.SelectedClassificationLabel = completed.SelectedClassificationLabel
 	switch completed.Outcome {
 	case workerexecution.OutcomeFailed:
 		result.Error = completed.Reason

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/engine_dispatch_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/engine_dispatch_test.go
@@ -81,6 +81,23 @@ func TestDispatchRecordsTrackedInRunningDispatches(t *testing.T) {
 	}
 }
 
+func TestWorkResultForCompletedDispatchPreservesResolvedClassificationLabel(t *testing.T) {
+	result := workerexecution.WorkResult{
+		Outcome: workerexecution.OutcomeAccepted,
+		Output:  "needs_review",
+	}
+	completed := interfaces.CompletedDispatch{
+		Outcome:                     workerexecution.OutcomeAccepted,
+		SelectedClassificationLabel: "needs_review",
+	}
+
+	got := workResultForCompletedDispatch(result, completed)
+
+	if got.SelectedClassificationLabel != completed.SelectedClassificationLabel {
+		t.Fatalf("selected classification label = %q, want %q", got.SelectedClassificationLabel, completed.SelectedClassificationLabel)
+	}
+}
+
 func TestDispatchResultHook_RecordsDispatchBeforeSubmittingToHook(t *testing.T) {
 	n := buildTestNet()
 	marking := petri.NewMarking("test-wf")

--- a/pkg/services/workers/internal/services/workstations/executor/workstation_executor.go
+++ b/pkg/services/workers/internal/services/workstations/executor/workstation_executor.go
@@ -245,7 +245,10 @@ func (we *WorkstationExecutor) executeModelWorkstation(ctx context.Context, disp
 		return result, err
 	}
 	if workstationDef.Type == factorydefinitions.WorkstationTypeClassify {
-		return normalizeClassifierWorkResult(result), nil
+		return normalizeClassifierWorkResult(
+			result,
+			workerDef.Type == factorydefinitions.WorkerTypeScript,
+		), nil
 	}
 	return result, nil
 }
@@ -762,14 +765,20 @@ func (we *WorkstationExecutor) executeInnerWorker(ctx context.Context, request w
 	return result, nil
 }
 
-func normalizeClassifierWorkResult(result workerexecution.WorkResult) workerexecution.WorkResult {
+func normalizeClassifierWorkResult(result workerexecution.WorkResult, scriptBacked bool) workerexecution.WorkResult {
 	if result.Outcome == workerexecution.OutcomeFailed {
+		result.SelectedClassificationLabel = ""
 		return result
 	}
 
-	label, err := normalizeClassifierLabel(result.Output)
+	output := result.Output
+	if scriptBacked {
+		output = finalScriptClassifierLine(result)
+	}
+	label, err := normalizeClassifierLabel(output)
 	if err != nil {
 		result.Outcome = workerexecution.OutcomeFailed
+		result.SelectedClassificationLabel = ""
 		result.Error = classifierOutputErrorDetail(result.Output, err)
 		return result
 	}
@@ -778,6 +787,19 @@ func normalizeClassifierWorkResult(result workerexecution.WorkResult) workerexec
 	result.Output = label
 	result.Feedback = ""
 	return result
+}
+
+func finalScriptClassifierLine(result workerexecution.WorkResult) string {
+	output := result.Output
+	if result.Diagnostics != nil && result.Diagnostics.Command != nil {
+		output = result.Diagnostics.Command.Stdout
+	}
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return ""
+	}
+	lines := strings.Split(trimmed, "\n")
+	return strings.TrimSpace(lines[len(lines)-1])
 }
 
 func normalizeClassifierLabel(output string) (string, error) {

--- a/pkg/services/workers/internal/services/workstations/executor/workstation_executor_test.go
+++ b/pkg/services/workers/internal/services/workstations/executor/workstation_executor_test.go
@@ -1434,6 +1434,163 @@ func TestWorkstationExecutor_ClassifierTrimsLabelAndIgnoresNonFailureOutcomeKind
 	}
 }
 
+func TestWorkstationExecutor_ScriptClassifierUsesFinalStdoutLineAndPreservesDiagnostics(t *testing.T) {
+	stdout := "checking payload\r\n\t needs_review \t\r\n\r\n"
+	stderr := "script diagnostic\n"
+	mock := &wsMockExecutor{result: workerexecution.WorkResult{
+		Outcome: workerexecution.OutcomeAccepted,
+		// Script runners trim the result content, while command diagnostics
+		// retain the exact streams for inspection.
+		Output: strings.TrimSpace(stdout),
+		Diagnostics: &workerexecution.WorkDiagnostics{Command: &workerexecution.CommandDiagnostic{
+			Stdout: stdout,
+			Stderr: stderr,
+		}},
+	}}
+	we := newTestWorkstationExecutor(
+		staticRuntimeConfig{
+			Workers: map[string]*interfaces.FactoryWorkerConfig{
+				"script-worker": {Type: interfaces.WorkerTypeScript, Body: "script"},
+			},
+			Workstations: map[string]*interfaces.FactoryWorkstationConfig{
+				"classifier": {Type: interfaces.WorkstationTypeClassify, PromptTemplate: "classify"},
+			},
+		},
+		mock,
+	)
+
+	result, err := we.Execute(context.Background(), work.WorkDispatch{
+		DispatchID:      "d-script-classifier-line",
+		TransitionID:    "t-script-classifier-line",
+		WorkerType:      "script-worker",
+		WorkstationName: "classifier",
+		InputTokens:     InputTokens(factoryruntime.RuntimeToken{ID: "tok-1"}),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Outcome != workerexecution.OutcomeAccepted || result.Output != "needs_review" {
+		t.Fatalf("result = %#v, want accepted needs_review label", result)
+	}
+	if result.SelectedClassificationLabel != "" {
+		t.Fatalf("selected classification label = %q, want empty before route matching", result.SelectedClassificationLabel)
+	}
+	if result.Diagnostics == nil || result.Diagnostics.Command == nil {
+		t.Fatalf("diagnostics = %#v, want command diagnostics", result.Diagnostics)
+	}
+	if result.Diagnostics.Command.Stdout != stdout || result.Diagnostics.Command.Stderr != stderr {
+		t.Fatalf("command diagnostics = %#v, want unmodified stdout/stderr", result.Diagnostics.Command)
+	}
+}
+
+func TestWorkstationExecutor_ScriptClassifierRejectsWhitespaceOnlyStdoutAndPreservesDiagnostics(t *testing.T) {
+	stdout := " \r\n\t  \n"
+	stderr := "script warning"
+	mock := &wsMockExecutor{result: workerexecution.WorkResult{
+		Outcome: workerexecution.OutcomeAccepted,
+		Output:  "",
+		Diagnostics: &workerexecution.WorkDiagnostics{Command: &workerexecution.CommandDiagnostic{
+			Stdout: stdout,
+			Stderr: stderr,
+		}},
+	}}
+	we := newTestWorkstationExecutor(
+		staticRuntimeConfig{
+			Workers: map[string]*interfaces.FactoryWorkerConfig{
+				"script-worker": {Type: interfaces.WorkerTypeScript, Body: "script"},
+			},
+			Workstations: map[string]*interfaces.FactoryWorkstationConfig{
+				"classifier": {Type: interfaces.WorkstationTypeClassify, PromptTemplate: "classify"},
+			},
+		},
+		mock,
+	)
+
+	result, err := we.Execute(context.Background(), work.WorkDispatch{
+		DispatchID:      "d-script-classifier-empty",
+		TransitionID:    "t-script-classifier-empty",
+		WorkerType:      "script-worker",
+		WorkstationName: "classifier",
+		InputTokens:     InputTokens(factoryruntime.RuntimeToken{ID: "tok-1"}),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Outcome != workerexecution.OutcomeFailed {
+		t.Fatalf("Outcome = %s, want %s", result.Outcome, workerexecution.OutcomeFailed)
+	}
+	if result.Error != "classifier output invalid: empty label" {
+		t.Fatalf("Error = %q, want actionable missing-label diagnostic", result.Error)
+	}
+	if result.SelectedClassificationLabel != "" {
+		t.Fatalf("selected classification label = %q, want empty on failure", result.SelectedClassificationLabel)
+	}
+	if result.Diagnostics == nil || result.Diagnostics.Command == nil ||
+		result.Diagnostics.Command.Stdout != stdout || result.Diagnostics.Command.Stderr != stderr {
+		t.Fatalf("command diagnostics = %#v, want unmodified stdout/stderr", result.Diagnostics)
+	}
+}
+
+func TestWorkstationExecutor_InferenceClassifierRetainsWholeOutputInterpretation(t *testing.T) {
+	output := "provider diagnostic\nneeds_review"
+	mock := &wsMockExecutor{result: workerexecution.WorkResult{Outcome: workerexecution.OutcomeAccepted, Output: output}}
+	we := newTestWorkstationExecutor(
+		staticRuntimeConfig{
+			Workers: map[string]*interfaces.FactoryWorkerConfig{
+				"model-worker": {Type: interfaces.WorkerTypeModel, Body: "model"},
+			},
+			Workstations: map[string]*interfaces.FactoryWorkstationConfig{
+				"classifier": {Type: interfaces.WorkstationTypeClassify, PromptTemplate: "classify"},
+			},
+		},
+		mock,
+	)
+
+	result, err := we.Execute(context.Background(), work.WorkDispatch{
+		DispatchID:      "d-inference-classifier-whole-output",
+		TransitionID:    "t-inference-classifier-whole-output",
+		WorkerType:      "model-worker",
+		WorkstationName: "classifier",
+		InputTokens:     InputTokens(factoryruntime.RuntimeToken{ID: "tok-1"}),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Outcome != workerexecution.OutcomeAccepted || result.Output != output {
+		t.Fatalf("result = %#v, want accepted whole inference output", result)
+	}
+}
+
+func TestWorkstationExecutor_NonClassifierScriptRetainsWholeOutputInterpretation(t *testing.T) {
+	output := "script diagnostic\nscript result"
+	mock := &wsMockExecutor{result: workerexecution.WorkResult{Outcome: workerexecution.OutcomeAccepted, Output: output}}
+	we := newTestWorkstationExecutor(
+		staticRuntimeConfig{
+			Workers: map[string]*interfaces.FactoryWorkerConfig{
+				"script-worker": {Type: interfaces.WorkerTypeScript, Body: "script"},
+			},
+			Workstations: map[string]*interfaces.FactoryWorkstationConfig{
+				"standard": {Type: interfaces.WorkstationTypeModel, PromptTemplate: "run"},
+			},
+		},
+		mock,
+	)
+
+	result, err := we.Execute(context.Background(), work.WorkDispatch{
+		DispatchID:      "d-script-whole-output",
+		TransitionID:    "t-script-whole-output",
+		WorkerType:      "script-worker",
+		WorkstationName: "standard",
+		InputTokens:     InputTokens(factoryruntime.RuntimeToken{ID: "tok-1"}),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Outcome != workerexecution.OutcomeAccepted || result.Output != output {
+		t.Fatalf("result = %#v, want accepted whole script output", result)
+	}
+}
+
 func TestWorkstationExecutor_ClassifierRejectsJSONStringLabel(t *testing.T) {
 	mock := &wsMockExecutor{result: workerexecution.WorkResult{Outcome: workerexecution.OutcomeAccepted, Output: "\"needs_review\""}}
 	we := newTestWorkstationExecutor(

--- a/tests/functional/workers/mock/classifier_test.go
+++ b/tests/functional/workers/mock/classifier_test.go
@@ -1,0 +1,160 @@
+package mock
+
+import (
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	scriptClassifierWorkType       = "review-task"
+	scriptClassifierWorker         = "script-classifier"
+	scriptClassifierWorkstation    = "classifier"
+	scriptClassifierWorkID         = "script-classifier-work"
+	scriptClassifierLabel          = "needs_review"
+	scriptClassifierDiagnosticLine = "checking payload"
+)
+
+// TestScriptWorkerClassifierRoutesWithoutModelCalls proves the workers/mock
+// ownership cell can route a script-backed classifier through the canonical
+// process and Factory Event flow without invoking a model provider.
+func TestScriptWorkerClassifierRoutesWithoutModelCalls(t *testing.T) {
+	dir := scaffoldScriptClassifierFactory(t)
+
+	scriptRunner := testutil.NewProviderCommandRunner(platformprocess.CommandResult{
+		Stdout: []byte(scriptClassifierDiagnosticLine + "\n  " + scriptClassifierLabel + "  \n\n"),
+		Stderr: []byte("script diagnostic"),
+	})
+	providerRunner := testutil.NewProviderCommandRunner()
+
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir: dir,
+		MockWorkersConfig: &workers.MockWorkersConfig{
+			MockWorkers: []workers.MockWorkerConfig{{
+				WorkerName:      scriptClassifierWorker,
+				WorkstationName: scriptClassifierWorkstation,
+				RunType:         workers.MockWorkerRunTypeScript,
+				ScriptConfig: &workers.MockWorkerScriptConfig{
+					Command: "mock-classifier-script",
+				},
+			}},
+		},
+		Edges: serviceedges.Edges{
+			ProviderCommandRunner: providerRunner,
+			ScriptCommandRunner:   scriptRunner,
+		},
+	})
+	defer server.Stop(t)
+
+	support.WaitForTerminalStatus(t, server.URL(), 20*time.Second)
+	listed := support.ListDefaultSessionWork(t, server.URL())
+	for placeID, want := range map[string]int{
+		support.WorkCustomerLocation(scriptClassifierWorkType, "done"):   1,
+		support.WorkCustomerLocation(scriptClassifierWorkType, "init"):   0,
+		support.WorkCustomerLocation(scriptClassifierWorkType, "failed"): 0,
+	} {
+		if got := support.CountWorkAtCustomerState(listed, placeID); got != want {
+			t.Fatalf("%s token count = %d, want %d; listed=%#v", placeID, got, want, listed)
+		}
+	}
+	if scriptRunner.CallCount() != 1 {
+		t.Fatalf("script command runner calls = %d, want exactly one classifier dispatch", scriptRunner.CallCount())
+	}
+	if providerRunner.CallCount() != 0 {
+		t.Fatalf("provider command runner calls = %d, want zero model-provider invocations", providerRunner.CallCount())
+	}
+
+	dispatches := support.ObserveDispatchEvents(t, server.GetFactoryEvents(t))
+	classifierDispatches := make([]support.DispatchEventObservation, 0, 1)
+	for _, dispatch := range dispatches {
+		if dispatch.Request.TransitionId == scriptClassifierWorkstation {
+			classifierDispatches = append(classifierDispatches, dispatch)
+		}
+	}
+	if len(classifierDispatches) != 1 {
+		t.Fatalf(
+			"classifier dispatch count = %d, want one accepted dispatch without retries; dispatches=%#v",
+			len(classifierDispatches),
+			classifierDispatches,
+		)
+	}
+	response := classifierDispatches[0].Response
+	if response == nil {
+		t.Fatal("classifier dispatch response missing")
+	}
+	if response.Outcome != factoryapi.WorkOutcomeAccepted {
+		t.Fatalf("classifier outcome = %s, want ACCEPTED", response.Outcome)
+	}
+	if support.StringPointerValue(response.Output) != scriptClassifierLabel {
+		t.Fatalf("classifier output = %q, want %q", support.StringPointerValue(response.Output), scriptClassifierLabel)
+	}
+	if support.StringPointerValue(response.SelectedClassificationLabel) != scriptClassifierLabel {
+		t.Fatalf(
+			"selected classification label = %q, want %q",
+			support.StringPointerValue(response.SelectedClassificationLabel),
+			scriptClassifierLabel,
+		)
+	}
+	if response.Error != nil || response.ProviderFailure != nil {
+		t.Fatalf("classifier response = %#v, want no failure or circuit-breaker sequence", response)
+	}
+
+	events := server.GetFactoryEvents(t)
+	for _, event := range events {
+		if event.Type == factoryapi.FactoryEventTypeInferenceRequest ||
+			event.Type == factoryapi.FactoryEventTypeInferenceResponse {
+			t.Fatalf("script classifier emitted model inference event: %#v", event)
+		}
+	}
+}
+
+func scaffoldScriptClassifierFactory(t *testing.T) string {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, map[string]any{
+		"workTypes": []map[string]any{{
+			"name": scriptClassifierWorkType,
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "done", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []map[string]string{{"name": scriptClassifierWorker}},
+		"workstations": []map[string]any{{
+			"name":   scriptClassifierWorkstation,
+			"type":   "CLASSIFIER_WORKSTATION",
+			"worker": scriptClassifierWorker,
+			"inputs": []map[string]string{{"workType": scriptClassifierWorkType, "state": "init"}},
+			"classificationRoutes": []map[string]any{{
+				"label":   scriptClassifierLabel,
+				"outputs": []map[string]string{{"workType": scriptClassifierWorkType, "state": "done"}},
+			}},
+			"onFailure": []map[string]string{{"workType": scriptClassifierWorkType, "state": "failed"}},
+		}},
+	})
+	support.WriteAgentConfig(t, dir, scriptClassifierWorker, "---\n"+
+		"type: SCRIPT_WORKER\n"+
+		"command: authored-classifier-command\n"+
+		"args:\n"+
+		"  - authored-argument\n"+
+		"---\n")
+	support.WriteWorkstationConfig(t, dir, scriptClassifierWorkstation, "---\n"+
+		"type: CLASSIFIER_WORKSTATION\n"+
+		"---\n"+
+		"Classify the review task.\n")
+	testutil.WriteSeedRequest(t, dir, work.SubmitRequest{
+		WorkID:     scriptClassifierWorkID,
+		WorkTypeID: scriptClassifierWorkType,
+		TraceID:    "script-classifier-trace",
+		Payload:    []byte("classifier payload"),
+	})
+	return dir
+}


### PR DESCRIPTION
{
  "project": "Script-Backed Mock Classifier Routing Without Model Calls",
  "branchName": "wo-a5-classifier-script-mocks",
  "description": "Extend the existing Workers/classifier contract narrowly so a script-backed classifier uses its trimmed final stdout line as the label, preserves complete command diagnostics, applies the same validation and authored-route failures as inference-backed classification, and can route a functional factory end to end with zero model-provider calls.",
  "context": {
    "customerAsk": "Let a SCRIPT_WORKER, or a mock worker using script mode, drive a classifier workstation by printing diagnostic output followed by the classification label on its final stdout line, using existing routing validation and failure diagnostics without live model calls.",
    "problem": "Script stdout is currently interpreted as one whole classifier label, so diagnostic lines plus a final label do not match an authored route. Dispatch then fails repeatedly and may open the circuit breaker, leaving classifier topology untestable without a model provider.",
    "solution": "At the Workers-owned workstation result-shaping boundary, use the trimmed final stdout line only for script-backed classifier routing, preserve full stdout and stderr diagnostics, and pass the candidate through existing classifier normalization and Factory Runtime route matching. Prove the behavior under the workers/mock ownership cell through canonical process composition with exactly zero provider calls."
  },
  "acceptanceCriteria": [
    "A successful script-backed classifier whose stdout contains diagnostic lines followed by an authored label routes only to that label's configured output, and the primary multiline regression fails under the old whole-stdout behavior.",
    "Trailing newlines and surrounding whitespace on the final stdout line are ignored, while label matching remains case-sensitive and otherwise uses the existing classifier contract.",
    "Empty or whitespace-only stdout fails classification with an actionable missing-label diagnostic; an unknown final label fails with the existing authored-route mismatch behavior, emits no successful branch, and does not retain a selected classification label.",
    "Full command diagnostics, including unmodified stdout and stderr, remain available on successful and failed script-backed classifier results even though routing consumes only the final stdout line.",
    "A functional factory scenario under the workers/mock ownership cell routes through a script classifier to the expected terminal branch with zero model-provider calls and without repeated classifier failure or circuit-breaker activation.",
    "Typecheck, lint, focused unit tests, go test ./tests/functional/workers/mock/... -run TestScriptWorkerClassifierRoutesWithoutModelCalls -count=1, make verify-fast, and all required CI checks are terminal and passing.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, shared-file or baseline changes and merge conflicts are reconciled, and the PR is actually merged; opening, approving, or making the PR green or ready to merge is not completion."
  ],
  "userStories": [
    {
      "id": "wo-a5-classifier-script-mocks-001",
      "title": "Interpret script classifier stdout without losing diagnostics",
      "description": "As a factory author, I want a script-backed classifier to use its final stdout line as its label so that the script can print useful diagnostics before making a routing decision.",
      "acceptanceCriteria": [
        "For a successful script-backed classifier result such as checking payload followed by needs_review on the final line, the candidate label is needs_review and earlier stdout lines do not become part of the label.",
        "Leading and trailing whitespace around the final label and trailing blank line terminators are ignored, while matching remains case-sensitive.",
        "Empty or whitespace-only stdout fails with the existing classifier-invalid missing-label behavior and emits no selected label.",
        "A final label that has no authored classification route fails with the existing unknown-label routing diagnostic, emits no successful routed output, and leaves the selected classification label empty.",
        "Complete raw stdout and stderr remain unchanged in command diagnostics for both successful and failed classification; only the routing candidate is narrowed to the final stdout line.",
        "Inference-backed classifier output and non-classifier script output retain their existing interpretation.",
        "Focused unit tests cover multiline stdout parsing, surrounding and trailing whitespace, missing labels, unknown labels, and preserved diagnostics; the multiline-success test fails against the old whole-stdout behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented script-backed classifier final-line parsing at the Workers workstation result boundary with preserved command diagnostics and focused regression coverage."
    },
    {
      "id": "wo-a5-classifier-script-mocks-002",
      "title": "Route a functional factory through a script mock with zero provider calls",
      "description": "As a factory maintainer, I want to run a classifier topology through a script-mode mock so that I can validate the selected branch end to end without model credentials, cost, or nondeterminism.",
      "acceptanceCriteria": [
        "A functional scenario owned by tests/functional/workers/mock constructs the application through root.BuildProcess, executes it through Process.Execute, and replaces subprocess and provider effects only through edges.Edges using established command-runner seams.",
        "The configured mock script emits at least one diagnostic line followed by an authored label, and the Work reaches only that label's expected terminal branch through the canonical dispatch and Factory Event flow.",
        "The scenario observes one accepted classifier dispatch with the expected selected classification label and no classifier failure or circuit-breaker sequence.",
        "The provider command runner records exactly zero model-provider invocations for the complete scenario.",
        "go test ./tests/functional/workers/mock/... -run TestScriptWorkerClassifierRoutesWithoutModelCalls -count=1 passes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added a workers/mock functional factory scenario using root process composition, script/provider command-runner seams, canonical Factory Events, and zero provider calls. Also propagated the route-resolved selected classification label into dispatch response events. Focused tests, make test, and make verify-fast pass; make lint still reports the repository's existing 98 backend-size baseline violations."
    }
  ]
}
