### PR TITLE
wo-a2-all-children-terminal-gating

### DIFF
--- a/pkg/services/factory_runtime/internal/orchestrators/petri/guard.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/petri/guard.go
@@ -306,51 +306,46 @@ func (g *AllWithParentGuard) evaluate(ctx RuntimeGuardContext, candidates []fact
 		return nil, false
 	}
 
-	childWorkTypeID := firstWorkTypeID(matched)
-	if ctx.StateCategoryForPlace != nil {
-		for _, candidate := range matched {
-			if ctx.StateCategoryForPlace(candidate.PlaceID) != runtimeStateCategoryTerminal {
-				return nil, false
-			}
-		}
+	if !allTokensTerminal(ctx, matched) {
+		return nil, false
 	}
 
 	if ctx.ParentChildRegistrations != nil {
-		registration, known := ctx.ParentChildRegistrations[parentWorkID]
-		if !known || !registration.Complete || len(registration.Children) == 0 {
-			return nil, false
-		}
-		registered := parentChildTokens(marking, ctx.ActiveDispatches, parentWorkID, "")
-		registeredIDs := tokenIdentitySet(registration.Children)
-		if len(registered) != len(registeredIDs) {
-			return nil, false
-		}
-		targetPlaces := tokenPlaceSet(matched)
-		for identity, child := range registered {
-			if !registeredIDs[identity] {
-				return nil, false
-			}
-			if ctx.StateCategoryForPlace != nil && ctx.StateCategoryForPlace(child.PlaceID) != runtimeStateCategoryTerminal {
-				return nil, false
-			}
-			if ctx.StateCategoryForPlace == nil && !targetPlaces[child.PlaceID] {
-				return nil, false
-			}
-		}
-		matchedIDs := tokenIdentitySet(matched)
-		for identity := range matchedIDs {
-			if !registeredIDs[identity] {
-				return nil, false
-			}
-		}
-		// The guarded arc is the binding surface for the transition and may
-		// expose only one of several terminal places. The registration
-		// projection above is the completeness denominator; requiring its
-		// identities to equal matchedIDs would reject valid fan-in when
-		// another registered child is terminal in a different place.
-		return matched, true
+		return evaluateRegisteredParentChildren(ctx, parentWorkID, matched, marking)
 	}
 
+	return evaluateVisibleParentChildren(ctx, parentWorkID, firstWorkTypeID(matched), matched, marking)
+}
+
+func evaluateRegisteredParentChildren(ctx RuntimeGuardContext, parentWorkID string, matched []factorytoken.Token, marking *MarkingSnapshot) ([]factorytoken.Token, bool) {
+	registration, known := ctx.ParentChildRegistrations[parentWorkID]
+	if !known || !registration.Complete || len(registration.Children) == 0 {
+		return nil, false
+	}
+
+	registered := parentChildTokens(marking, ctx.ActiveDispatches, parentWorkID, "")
+	registeredIDs := tokenIdentitySet(registration.Children)
+	if len(registered) != len(registeredIDs) {
+		return nil, false
+	}
+
+	targetPlaces := tokenPlaceSet(matched)
+	if !registeredChildrenTerminal(ctx, registered, registeredIDs, targetPlaces) {
+		return nil, false
+	}
+	if !tokensRegistered(matched, registeredIDs) {
+		return nil, false
+	}
+
+	// The guarded arc is the binding surface for the transition and may
+	// expose only one of several terminal places. The registration projection
+	// above is the completeness denominator; requiring its identities to equal
+	// matchedIDs would reject valid fan-in when another registered child is
+	// terminal in a different place.
+	return matched, true
+}
+
+func evaluateVisibleParentChildren(ctx RuntimeGuardContext, parentWorkID, childWorkTypeID string, matched []factorytoken.Token, marking *MarkingSnapshot) ([]factorytoken.Token, bool) {
 	registered := parentChildTokens(marking, ctx.ActiveDispatches, parentWorkID, childWorkTypeID)
 	if len(registered) == 0 {
 		// Preserve direct guard use with no runtime snapshot. The scheduler
@@ -364,22 +359,60 @@ func (g *AllWithParentGuard) evaluate(ctx RuntimeGuardContext, candidates []fact
 
 	matchedIDs := tokenIdentitySet(matched)
 	targetPlaces := tokenPlaceSet(matched)
-	for identity, child := range registered {
-		if !matchedIDs[identity] {
-			return nil, false
-		}
-		if ctx.StateCategoryForPlace == nil && !targetPlaces[child.PlaceID] {
-			return nil, false
-		}
-		if ctx.StateCategoryForPlace != nil && ctx.StateCategoryForPlace(child.PlaceID) != runtimeStateCategoryTerminal {
-			return nil, false
-		}
-	}
-	if len(matchedIDs) != len(registered) {
+	if !visibleChildrenTerminal(ctx, registered, matchedIDs, targetPlaces) {
 		return nil, false
 	}
 
 	return matched, true
+}
+
+func allTokensTerminal(ctx RuntimeGuardContext, tokens []factorytoken.Token) bool {
+	if ctx.StateCategoryForPlace == nil {
+		return true
+	}
+	for _, token := range tokens {
+		if ctx.StateCategoryForPlace(token.PlaceID) != runtimeStateCategoryTerminal {
+			return false
+		}
+	}
+	return true
+}
+
+func registeredChildrenTerminal(ctx RuntimeGuardContext, registered map[string]factorytoken.Token, registeredIDs, targetPlaces map[string]bool) bool {
+	for identity, child := range registered {
+		if !registeredIDs[identity] || !childIsTerminal(ctx, child, targetPlaces) {
+			return false
+		}
+	}
+	return true
+}
+
+func visibleChildrenTerminal(ctx RuntimeGuardContext, registered map[string]factorytoken.Token, matchedIDs, targetPlaces map[string]bool) bool {
+	if len(matchedIDs) != len(registered) {
+		return false
+	}
+	for identity, child := range registered {
+		if !matchedIDs[identity] || !childIsTerminal(ctx, child, targetPlaces) {
+			return false
+		}
+	}
+	return true
+}
+
+func childIsTerminal(ctx RuntimeGuardContext, child factorytoken.Token, targetPlaces map[string]bool) bool {
+	if ctx.StateCategoryForPlace != nil {
+		return ctx.StateCategoryForPlace(child.PlaceID) == runtimeStateCategoryTerminal
+	}
+	return targetPlaces[child.PlaceID]
+}
+
+func tokensRegistered(tokens []factorytoken.Token, registeredIDs map[string]bool) bool {
+	for _, token := range tokens {
+		if !registeredIDs[tokenIdentity(token)] {
+			return false
+		}
+	}
+	return true
 }
 
 // AnyWithParentGuard matches the first candidate whose ParentID matches a bound token's WorkID.

--- a/pkg/services/factory_runtime/internal/orchestrators/petri/guard.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/petri/guard.go
@@ -325,6 +325,7 @@ func (g *AllWithParentGuard) evaluate(ctx RuntimeGuardContext, candidates []fact
 		if len(registered) != len(registeredIDs) {
 			return nil, false
 		}
+		targetPlaces := tokenPlaceSet(matched)
 		for identity, child := range registered {
 			if !registeredIDs[identity] {
 				return nil, false
@@ -332,16 +333,21 @@ func (g *AllWithParentGuard) evaluate(ctx RuntimeGuardContext, candidates []fact
 			if ctx.StateCategoryForPlace != nil && ctx.StateCategoryForPlace(child.PlaceID) != runtimeStateCategoryTerminal {
 				return nil, false
 			}
-		}
-		matchedIDs := tokenIdentitySet(matched)
-		if len(matchedIDs) != len(registeredIDs) {
-			return nil, false
-		}
-		for identity := range registeredIDs {
-			if !matchedIDs[identity] {
+			if ctx.StateCategoryForPlace == nil && !targetPlaces[child.PlaceID] {
 				return nil, false
 			}
 		}
+		matchedIDs := tokenIdentitySet(matched)
+		for identity := range matchedIDs {
+			if !registeredIDs[identity] {
+				return nil, false
+			}
+		}
+		// The guarded arc is the binding surface for the transition and may
+		// expose only one of several terminal places. The registration
+		// projection above is the completeness denominator; requiring its
+		// identities to equal matchedIDs would reject valid fan-in when
+		// another registered child is terminal in a different place.
 		return matched, true
 	}
 

--- a/pkg/services/factory_runtime/internal/orchestrators/petri/guard.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/petri/guard.go
@@ -274,25 +274,73 @@ type AllWithParentGuard struct {
 }
 
 var _ Guard = (*AllWithParentGuard)(nil)
+var _ RuntimeGuard = (*AllWithParentGuard)(nil)
 
 // Evaluate returns all candidates whose ParentID equals the WorkID of the
 // bound token identified by MatchBinding.
-func (g *AllWithParentGuard) Evaluate(candidates []factorytoken.Token, bindings map[string]*factorytoken.Token, _ *MarkingSnapshot) ([]factorytoken.Token, bool) {
+func (g *AllWithParentGuard) Evaluate(candidates []factorytoken.Token, bindings map[string]*factorytoken.Token, marking *MarkingSnapshot) ([]factorytoken.Token, bool) {
+	return g.evaluate(RuntimeGuardContext{}, candidates, bindings, marking)
+}
+
+// EvaluateRuntime checks the complete parent-scoped child population before
+// returning the terminal candidates used by the fan-in transition. The
+// terminal input place is only the binding surface; it is not the population
+// denominator because processing children may be in another place or in an
+// active dispatch.
+func (g *AllWithParentGuard) EvaluateRuntime(ctx RuntimeGuardContext, candidates []factorytoken.Token, bindings map[string]*factorytoken.Token, marking *MarkingSnapshot) ([]factorytoken.Token, bool) {
+	return g.evaluate(ctx, candidates, bindings, marking)
+}
+
+func (g *AllWithParentGuard) evaluate(ctx RuntimeGuardContext, candidates []factorytoken.Token, bindings map[string]*factorytoken.Token, marking *MarkingSnapshot) ([]factorytoken.Token, bool) {
 	bound, exists := bindings[g.MatchBinding]
-	if !exists {
+	if !exists || bound == nil || bound.Color.WorkID == "" {
 		return nil, false
 	}
 
 	parentWorkID := bound.Color.WorkID
+	matched := matchingParentChildren(candidates, parentWorkID, "")
+	if len(matched) == 0 {
+		return nil, false
+	}
 
-	var matched []factorytoken.Token
-	for _, c := range candidates {
-		if c.Color.ParentID == parentWorkID {
-			matched = append(matched, c)
+	childWorkTypeID := firstWorkTypeID(matched)
+	if ctx.StateCategoryForPlace != nil {
+		for _, candidate := range matched {
+			if ctx.StateCategoryForPlace(candidate.PlaceID) != runtimeStateCategoryTerminal {
+				return nil, false
+			}
 		}
 	}
 
-	return matched, len(matched) > 0
+	registered := parentChildTokens(marking, ctx.ActiveDispatches, parentWorkID, childWorkTypeID)
+	if len(registered) == 0 {
+		// Preserve direct guard use with no runtime snapshot. The scheduler
+		// always supplies a marking, where the full-population check below is
+		// authoritative.
+		if marking == nil {
+			return matched, true
+		}
+		return nil, false
+	}
+
+	matchedIDs := tokenIdentitySet(matched)
+	targetPlaces := tokenPlaceSet(matched)
+	for identity, child := range registered {
+		if !matchedIDs[identity] {
+			return nil, false
+		}
+		if ctx.StateCategoryForPlace == nil && !targetPlaces[child.PlaceID] {
+			return nil, false
+		}
+		if ctx.StateCategoryForPlace != nil && ctx.StateCategoryForPlace(child.PlaceID) != runtimeStateCategoryTerminal {
+			return nil, false
+		}
+	}
+	if len(matchedIDs) != len(registered) {
+		return nil, false
+	}
+
+	return matched, true
 }
 
 // AnyWithParentGuard matches the first candidate whose ParentID matches a bound token's WorkID.
@@ -413,12 +461,24 @@ type FanoutCountGuard struct {
 }
 
 var _ Guard = (*FanoutCountGuard)(nil)
+var _ RuntimeGuard = (*FanoutCountGuard)(nil)
 
 // Evaluate returns all candidates whose ParentID matches the parent token's WorkID,
 // but only if the total count equals the expected count from the count token.
-func (g *FanoutCountGuard) Evaluate(candidates []factorytoken.Token, bindings map[string]*factorytoken.Token, _ *MarkingSnapshot) ([]factorytoken.Token, bool) {
+func (g *FanoutCountGuard) Evaluate(candidates []factorytoken.Token, bindings map[string]*factorytoken.Token, marking *MarkingSnapshot) ([]factorytoken.Token, bool) {
+	return g.evaluate(RuntimeGuardContext{}, candidates, bindings, marking)
+}
+
+// EvaluateRuntime includes active dispatch inputs in the registered set so a
+// processing child that has already been claimed by a worker cannot disappear
+// from the fan-in denominator while it is out of the marking.
+func (g *FanoutCountGuard) EvaluateRuntime(ctx RuntimeGuardContext, candidates []factorytoken.Token, bindings map[string]*factorytoken.Token, marking *MarkingSnapshot) ([]factorytoken.Token, bool) {
+	return g.evaluate(ctx, candidates, bindings, marking)
+}
+
+func (g *FanoutCountGuard) evaluate(ctx RuntimeGuardContext, candidates []factorytoken.Token, bindings map[string]*factorytoken.Token, marking *MarkingSnapshot) ([]factorytoken.Token, bool) {
 	parent, exists := bindings[g.MatchBinding]
-	if !exists {
+	if !exists || parent == nil || parent.Color.WorkID == "" {
 		return nil, false
 	}
 
@@ -437,19 +497,119 @@ func (g *FanoutCountGuard) Evaluate(candidates []factorytoken.Token, bindings ma
 	}
 
 	parentWorkID := parent.Color.WorkID
-
-	var matched []factorytoken.Token
-	for _, c := range candidates {
-		if c.Color.ParentID == parentWorkID {
-			matched = append(matched, c)
-		}
-	}
-
+	matched := matchingParentChildren(candidates, parentWorkID, "")
 	if len(matched) != expectedCount {
 		return nil, false
 	}
 
+	if ctx.StateCategoryForPlace != nil {
+		for _, candidate := range matched {
+			if ctx.StateCategoryForPlace(candidate.PlaceID) != runtimeStateCategoryTerminal {
+				return nil, false
+			}
+		}
+	}
+
+	if marking != nil {
+		childWorkTypeID := firstWorkTypeID(matched)
+		registered := parentChildTokens(marking, ctx.ActiveDispatches, parentWorkID, childWorkTypeID)
+		if len(registered) != expectedCount {
+			return nil, false
+		}
+		matchedIDs := tokenIdentitySet(matched)
+		for identity, child := range registered {
+			if !matchedIDs[identity] {
+				return nil, false
+			}
+			if ctx.StateCategoryForPlace != nil && ctx.StateCategoryForPlace(child.PlaceID) != runtimeStateCategoryTerminal {
+				return nil, false
+			}
+		}
+	}
+
 	return matched, true
+}
+
+const runtimeStateCategoryTerminal = "TERMINAL"
+
+func matchingParentChildren(candidates []factorytoken.Token, parentWorkID, childWorkTypeID string) []factorytoken.Token {
+	matched := make([]factorytoken.Token, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.Color.ParentID != parentWorkID {
+			continue
+		}
+		if childWorkTypeID != "" && candidate.Color.WorkTypeID != childWorkTypeID {
+			continue
+		}
+		matched = append(matched, candidate)
+	}
+	return matched
+}
+
+func firstWorkTypeID(tokens []factorytoken.Token) string {
+	for _, token := range tokens {
+		if token.Color.WorkTypeID != "" {
+			return token.Color.WorkTypeID
+		}
+	}
+	return ""
+}
+
+func parentChildTokens(marking *MarkingSnapshot, activeDispatches map[string]*interfaces.DispatchEntry, parentWorkID, childWorkTypeID string) map[string]factorytoken.Token {
+	children := make(map[string]factorytoken.Token)
+	if marking != nil {
+		for _, token := range marking.Tokens {
+			if token == nil || !isRegisteredChild(*token, parentWorkID, childWorkTypeID) {
+				continue
+			}
+			children[tokenIdentity(*token)] = *token
+		}
+	}
+	for _, dispatch := range activeDispatches {
+		if dispatch == nil {
+			continue
+		}
+		for _, token := range dispatch.ConsumedTokens {
+			if !isRegisteredChild(token, parentWorkID, childWorkTypeID) {
+				continue
+			}
+			identity := tokenIdentity(token)
+			if _, exists := children[identity]; !exists {
+				children[identity] = token
+			}
+		}
+	}
+	return children
+}
+
+func isRegisteredChild(token factorytoken.Token, parentWorkID, childWorkTypeID string) bool {
+	if token.Color.DataType == factorytoken.DataTypeResource || token.Color.ParentID != parentWorkID || token.Color.WorkID == "" {
+		return false
+	}
+	return childWorkTypeID == "" || token.Color.WorkTypeID == childWorkTypeID
+}
+
+func tokenIdentity(token factorytoken.Token) string {
+	if token.Color.WorkID != "" {
+		return "work:" + token.Color.WorkID
+	}
+	return "token:" + token.ID
+}
+
+func tokenIdentitySet(tokens []factorytoken.Token) map[string]bool {
+	identities := make(map[string]bool, len(tokens))
+	for _, token := range tokens {
+		identities[tokenIdentity(token)] = true
+	}
+	return identities
+}
+
+func tokenPlaceSet(tokens []factorytoken.Token) map[string]bool {
+	places := make(map[string]bool, len(tokens))
+	for _, token := range tokens {
+		places[token.PlaceID] = true
+	}
+	return places
 }
 
 // tokenColorField returns the value of a named field on a TokenColor.

--- a/pkg/services/factory_runtime/internal/orchestrators/petri/guard.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/petri/guard.go
@@ -288,6 +288,9 @@ func (g *AllWithParentGuard) Evaluate(candidates []factorytoken.Token, bindings 
 // denominator because processing children may be in another place or in an
 // active dispatch.
 func (g *AllWithParentGuard) EvaluateRuntime(ctx RuntimeGuardContext, candidates []factorytoken.Token, bindings map[string]*factorytoken.Token, marking *MarkingSnapshot) ([]factorytoken.Token, bool) {
+	if ctx.ParentChildRegistrations == nil {
+		return nil, false
+	}
 	return g.evaluate(ctx, candidates, bindings, marking)
 }
 
@@ -310,6 +313,36 @@ func (g *AllWithParentGuard) evaluate(ctx RuntimeGuardContext, candidates []fact
 				return nil, false
 			}
 		}
+	}
+
+	if ctx.ParentChildRegistrations != nil {
+		registration, known := ctx.ParentChildRegistrations[parentWorkID]
+		if !known || !registration.Complete || len(registration.Children) == 0 {
+			return nil, false
+		}
+		registered := parentChildTokens(marking, ctx.ActiveDispatches, parentWorkID, "")
+		registeredIDs := tokenIdentitySet(registration.Children)
+		if len(registered) != len(registeredIDs) {
+			return nil, false
+		}
+		for identity, child := range registered {
+			if !registeredIDs[identity] {
+				return nil, false
+			}
+			if ctx.StateCategoryForPlace != nil && ctx.StateCategoryForPlace(child.PlaceID) != runtimeStateCategoryTerminal {
+				return nil, false
+			}
+		}
+		matchedIDs := tokenIdentitySet(matched)
+		if len(matchedIDs) != len(registeredIDs) {
+			return nil, false
+		}
+		for identity := range registeredIDs {
+			if !matchedIDs[identity] {
+				return nil, false
+			}
+		}
+		return matched, true
 	}
 
 	registered := parentChildTokens(marking, ctx.ActiveDispatches, parentWorkID, childWorkTypeID)
@@ -461,24 +494,12 @@ type FanoutCountGuard struct {
 }
 
 var _ Guard = (*FanoutCountGuard)(nil)
-var _ RuntimeGuard = (*FanoutCountGuard)(nil)
 
 // Evaluate returns all candidates whose ParentID matches the parent token's WorkID,
 // but only if the total count equals the expected count from the count token.
-func (g *FanoutCountGuard) Evaluate(candidates []factorytoken.Token, bindings map[string]*factorytoken.Token, marking *MarkingSnapshot) ([]factorytoken.Token, bool) {
-	return g.evaluate(RuntimeGuardContext{}, candidates, bindings, marking)
-}
-
-// EvaluateRuntime includes active dispatch inputs in the registered set so a
-// processing child that has already been claimed by a worker cannot disappear
-// from the fan-in denominator while it is out of the marking.
-func (g *FanoutCountGuard) EvaluateRuntime(ctx RuntimeGuardContext, candidates []factorytoken.Token, bindings map[string]*factorytoken.Token, marking *MarkingSnapshot) ([]factorytoken.Token, bool) {
-	return g.evaluate(ctx, candidates, bindings, marking)
-}
-
-func (g *FanoutCountGuard) evaluate(ctx RuntimeGuardContext, candidates []factorytoken.Token, bindings map[string]*factorytoken.Token, marking *MarkingSnapshot) ([]factorytoken.Token, bool) {
+func (g *FanoutCountGuard) Evaluate(candidates []factorytoken.Token, bindings map[string]*factorytoken.Token, _ *MarkingSnapshot) ([]factorytoken.Token, bool) {
 	parent, exists := bindings[g.MatchBinding]
-	if !exists || parent == nil || parent.Color.WorkID == "" {
+	if !exists {
 		return nil, false
 	}
 
@@ -497,34 +518,15 @@ func (g *FanoutCountGuard) evaluate(ctx RuntimeGuardContext, candidates []factor
 	}
 
 	parentWorkID := parent.Color.WorkID
-	matched := matchingParentChildren(candidates, parentWorkID, "")
+	var matched []factorytoken.Token
+	for _, c := range candidates {
+		if c.Color.ParentID == parentWorkID {
+			matched = append(matched, c)
+		}
+	}
+
 	if len(matched) != expectedCount {
 		return nil, false
-	}
-
-	if ctx.StateCategoryForPlace != nil {
-		for _, candidate := range matched {
-			if ctx.StateCategoryForPlace(candidate.PlaceID) != runtimeStateCategoryTerminal {
-				return nil, false
-			}
-		}
-	}
-
-	if marking != nil {
-		childWorkTypeID := firstWorkTypeID(matched)
-		registered := parentChildTokens(marking, ctx.ActiveDispatches, parentWorkID, childWorkTypeID)
-		if len(registered) != expectedCount {
-			return nil, false
-		}
-		matchedIDs := tokenIdentitySet(matched)
-		for identity, child := range registered {
-			if !matchedIDs[identity] {
-				return nil, false
-			}
-			if ctx.StateCategoryForPlace != nil && ctx.StateCategoryForPlace(child.PlaceID) != runtimeStateCategoryTerminal {
-				return nil, false
-			}
-		}
 	}
 
 	return matched, true

--- a/pkg/services/factory_runtime/internal/orchestrators/petri/guard_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/petri/guard_test.go
@@ -755,6 +755,66 @@ func TestAllWithParentGuard_RuntimeStateAndPopulationChecks(t *testing.T) {
 	}
 }
 
+func TestAllWithParentGuard_AllConfiguredTerminalPlacesSatisfyCompleteness(t *testing.T) {
+	parent := &factorytoken.Token{ID: "parent-token", Color: factorytoken.Color{WorkID: "parent-1"}}
+	complete := factorytoken.Token{
+		ID:      "child-complete",
+		PlaceID: "child:complete",
+		Color:   factorytoken.Color{WorkID: "child-1", WorkTypeID: "child", ParentID: "parent-1"},
+	}
+	skipped := complete
+	skipped.ID = "child-skipped"
+	skipped.PlaceID = "child:skipped"
+	processing := skipped
+	processing.ID = "child-processing"
+	processing.PlaceID = "child:processing"
+
+	category := func(placeID string) string {
+		switch placeID {
+		case "child:complete", "child:skipped":
+			return runtimeStateCategoryTerminal
+		default:
+			return "PROCESSING"
+		}
+	}
+	guard := &AllWithParentGuard{MatchBinding: "parent"}
+	bindings := map[string]*factorytoken.Token{"parent": parent}
+	projection := ParentChildRegistrationProjection{
+		"parent-1": {Children: []factorytoken.Token{complete, skipped}, Complete: true},
+	}
+	snapshot := &MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
+		complete.ID: &complete,
+		skipped.ID:  &skipped,
+	}}
+
+	matched, ok := guard.EvaluateRuntime(
+		RuntimeGuardContext{StateCategoryForPlace: category, ParentChildRegistrations: projection},
+		[]factorytoken.Token{complete},
+		bindings,
+		snapshot,
+	)
+	if !ok || len(matched) != 1 || matched[0].ID != complete.ID {
+		t.Fatalf("terminal children in distinct places should satisfy fan-in: matched=%v ok=%t", matched, ok)
+	}
+
+	processingSnapshot := &MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
+		complete.ID:   &complete,
+		processing.ID: &processing,
+	}}
+	processingProjection := ParentChildRegistrationProjection{
+		"parent-1": {Children: []factorytoken.Token{complete, processing}, Complete: true},
+	}
+	matched, ok = guard.EvaluateRuntime(
+		RuntimeGuardContext{StateCategoryForPlace: category, ParentChildRegistrations: processingProjection},
+		[]factorytoken.Token{complete},
+		bindings,
+		processingSnapshot,
+	)
+	if ok || len(matched) != 0 {
+		t.Fatalf("processing child in another place should keep fan-in blocked: matched=%v ok=%t", matched, ok)
+	}
+}
+
 func TestAllWithParentGuard_RejectsUnknownAndMismatchedRegistrationProjection(t *testing.T) {
 	parent := &factorytoken.Token{ID: "parent-token", Color: factorytoken.Color{WorkID: "parent-1"}}
 	first := factorytoken.Token{

--- a/pkg/services/factory_runtime/internal/orchestrators/petri/guard_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/petri/guard_test.go
@@ -755,6 +755,96 @@ func TestAllWithParentGuard_RuntimeStateAndPopulationChecks(t *testing.T) {
 	}
 }
 
+func TestAllWithParentGuard_RejectsUnknownAndMismatchedRegistrationProjection(t *testing.T) {
+	parent := &factorytoken.Token{ID: "parent-token", Color: factorytoken.Color{WorkID: "parent-1"}}
+	first := factorytoken.Token{
+		ID:      "child-first",
+		PlaceID: "child:complete",
+		Color:   factorytoken.Color{WorkID: "child-1", WorkTypeID: "child", ParentID: "parent-1"},
+	}
+	second := first
+	second.ID = "child-second"
+	second.Color.WorkID = "child-2"
+	bindings := map[string]*factorytoken.Token{"parent": parent}
+	guard := &AllWithParentGuard{MatchBinding: "parent"}
+
+	assertBlocked := func(ctx RuntimeGuardContext, candidates []factorytoken.Token, marking *MarkingSnapshot) {
+		t.Helper()
+		matched, ok := guard.EvaluateRuntime(ctx, candidates, bindings, marking)
+		if ok || len(matched) != 0 {
+			t.Fatalf("mismatched registration projection enabled fan-in: matched=%v ok=%t", matched, ok)
+		}
+	}
+
+	baseSnapshot := func(tokens ...factorytoken.Token) *MarkingSnapshot {
+		snapshot := &MarkingSnapshot{Tokens: make(map[string]*factorytoken.Token, len(tokens))}
+		for i := range tokens {
+			token := tokens[i]
+			snapshot.Tokens[token.ID] = &token
+		}
+		return snapshot
+	}
+
+	assertBlocked(RuntimeGuardContext{ParentChildRegistrations: ParentChildRegistrationProjection{
+		"other-parent": {Children: []factorytoken.Token{first}, Complete: true},
+	}}, []factorytoken.Token{first}, baseSnapshot(first))
+	assertBlocked(RuntimeGuardContext{ParentChildRegistrations: ParentChildRegistrationProjection{
+		"parent-1": {Children: []factorytoken.Token{first}, Complete: false},
+	}}, []factorytoken.Token{first}, baseSnapshot(first))
+	assertBlocked(RuntimeGuardContext{ParentChildRegistrations: ParentChildRegistrationProjection{
+		"parent-1": {Complete: true},
+	}}, []factorytoken.Token{first}, baseSnapshot(first))
+
+	// A visible child outside the registered set is a population mismatch.
+	assertBlocked(RuntimeGuardContext{ParentChildRegistrations: ParentChildRegistrationProjection{
+		"parent-1": {Children: []factorytoken.Token{first}, Complete: true},
+	}}, []factorytoken.Token{first}, baseSnapshot(first, second))
+	// A registered child that is not visible is also incomplete.
+	assertBlocked(RuntimeGuardContext{ParentChildRegistrations: ParentChildRegistrationProjection{
+		"parent-1": {Children: []factorytoken.Token{first, second}, Complete: true},
+	}}, []factorytoken.Token{first}, baseSnapshot(first))
+	// The visible runtime identity must agree with the registration identity.
+	assertBlocked(RuntimeGuardContext{ParentChildRegistrations: ParentChildRegistrationProjection{
+		"parent-1": {Children: []factorytoken.Token{first}, Complete: true},
+	}}, []factorytoken.Token{second}, baseSnapshot(first))
+}
+
+func TestAllWithParentGuard_DirectEvaluationChecksSnapshotPopulation(t *testing.T) {
+	parent := &factorytoken.Token{ID: "parent-token", Color: factorytoken.Color{WorkID: "parent-1"}}
+	terminal := factorytoken.Token{
+		ID:      "child-terminal",
+		PlaceID: "child:complete",
+		Color:   factorytoken.Color{WorkID: "child-1", WorkTypeID: "child", ParentID: "parent-1"},
+	}
+	processing := terminal
+	processing.ID = "child-processing"
+	processing.Color.WorkID = "child-2"
+	processing.PlaceID = "child:processing"
+	guard := &AllWithParentGuard{MatchBinding: "parent"}
+	bindings := map[string]*factorytoken.Token{"parent": parent}
+
+	matched, ok := guard.Evaluate(
+		[]factorytoken.Token{terminal},
+		bindings,
+		&MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
+			terminal.ID:   &terminal,
+			processing.ID: &processing,
+		}},
+	)
+	if ok || len(matched) != 0 {
+		t.Fatalf("direct evaluation ignored a sibling in another place: matched=%v ok=%t", matched, ok)
+	}
+
+	matched, ok = guard.Evaluate(
+		[]factorytoken.Token{terminal},
+		bindings,
+		&MarkingSnapshot{Tokens: map[string]*factorytoken.Token{terminal.ID: &terminal}},
+	)
+	if !ok || len(matched) != 1 || matched[0].ID != terminal.ID {
+		t.Fatalf("direct evaluation with one visible terminal child = %v, %t; want terminal child", matched, ok)
+	}
+}
+
 func TestParentChildTokenHelpersFilterAndDeduplicateRuntimeFacts(t *testing.T) {
 	valid := factorytoken.Token{ID: "valid", PlaceID: "child:complete", Color: factorytoken.Color{WorkID: "child-1", WorkTypeID: "child", ParentID: "parent-1"}}
 	resource := valid

--- a/pkg/services/factory_runtime/internal/orchestrators/petri/guard_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/petri/guard_test.go
@@ -583,7 +583,10 @@ func TestAllWithParentGuard_BlocksWhenRegisteredSiblingIsProcessing(t *testing.T
 	processing.Color.WorkID = "child-2"
 
 	guard := &AllWithParentGuard{MatchBinding: "parent"}
-	matched, ok := guard.Evaluate(
+	matched, ok := guard.EvaluateRuntime(
+		RuntimeGuardContext{ParentChildRegistrations: ParentChildRegistrationProjection{
+			"parent-1": {Children: []factorytoken.Token{terminal, processing}, Complete: true},
+		}},
 		[]factorytoken.Token{terminal},
 		map[string]*factorytoken.Token{"parent": parent},
 		&MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
@@ -614,16 +617,25 @@ func TestAllWithParentGuard_LateRegistrationStaysBlockedUntilTerminal(t *testing
 	bindings := map[string]*factorytoken.Token{"parent": parent}
 
 	initial := MarkingSnapshot{Tokens: map[string]*factorytoken.Token{first.ID: &first}}
-	if matched, ok := guard.Evaluate([]factorytoken.Token{first}, bindings, &initial); !ok || len(matched) != 1 {
-		t.Fatalf("initial terminal child should enable before late registration: matched=%v ok=%t", matched, ok)
+	if matched, ok := guard.EvaluateRuntime(RuntimeGuardContext{}, []factorytoken.Token{first}, bindings, &initial); ok || len(matched) != 0 {
+		t.Fatalf("runtime fan-in should fail closed without a registration projection: matched=%v ok=%t", matched, ok)
+	}
+	initialProjection := ParentChildRegistrationProjection{
+		"parent-1": {Children: []factorytoken.Token{first}, Complete: false},
+	}
+	if matched, ok := guard.EvaluateRuntime(RuntimeGuardContext{ParentChildRegistrations: initialProjection}, []factorytoken.Token{first}, bindings, &initial); ok || len(matched) != 0 {
+		t.Fatalf("fan-in should fail closed before the registered set is complete: matched=%v ok=%t", matched, ok)
 	}
 
 	withLateChild := MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
 		first.ID: &first,
 		late.ID:  &late,
 	}}
-	if matched, ok := guard.Evaluate([]factorytoken.Token{first}, bindings, &withLateChild); ok || len(matched) != 0 {
-		t.Fatalf("late processing child should keep fan-in blocked: matched=%v ok=%t", matched, ok)
+	lateProjection := ParentChildRegistrationProjection{
+		"parent-1": {Children: []factorytoken.Token{first, late}, Complete: false},
+	}
+	if matched, ok := guard.EvaluateRuntime(RuntimeGuardContext{ParentChildRegistrations: lateProjection}, []factorytoken.Token{first}, bindings, &withLateChild); ok || len(matched) != 0 {
+		t.Fatalf("late processing child should keep fan-in blocked until registration closes: matched=%v ok=%t", matched, ok)
 	}
 
 	late.PlaceID = "child:complete"
@@ -631,7 +643,9 @@ func TestAllWithParentGuard_LateRegistrationStaysBlockedUntilTerminal(t *testing
 		first.ID: &first,
 		late.ID:  &late,
 	}}
-	matched, ok := guard.Evaluate([]factorytoken.Token{first, late}, bindings, &terminalSnapshot)
+	matched, ok := guard.EvaluateRuntime(RuntimeGuardContext{ParentChildRegistrations: ParentChildRegistrationProjection{
+		"parent-1": {Children: []factorytoken.Token{first, late}, Complete: true},
+	}}, []factorytoken.Token{first, late}, bindings, &terminalSnapshot)
 	if !ok || len(matched) != 2 {
 		t.Fatalf("fan-in should enable exactly after the late child becomes terminal: matched=%v ok=%t", matched, ok)
 	}
@@ -651,9 +665,14 @@ func TestAllWithParentGuard_UsesActiveDispatchAsProcessingChild(t *testing.T) {
 
 	guard := &AllWithParentGuard{MatchBinding: "parent"}
 	matched, ok := guard.EvaluateRuntime(
-		RuntimeGuardContext{ActiveDispatches: map[string]*interfaces.DispatchEntry{
-			"dispatch-child": {ConsumedTokens: []factorytoken.Token{processing}},
-		}},
+		RuntimeGuardContext{
+			ActiveDispatches: map[string]*interfaces.DispatchEntry{
+				"dispatch-child": {ConsumedTokens: []factorytoken.Token{processing}},
+			},
+			ParentChildRegistrations: ParentChildRegistrationProjection{
+				"parent-1": {Children: []factorytoken.Token{terminal, processing}, Complete: true},
+			},
+		},
 		[]factorytoken.Token{terminal},
 		map[string]*factorytoken.Token{"parent": parent},
 		&MarkingSnapshot{Tokens: map[string]*factorytoken.Token{terminal.ID: &terminal}},
@@ -681,13 +700,16 @@ func TestAllWithParentGuard_RuntimeStateAndPopulationChecks(t *testing.T) {
 		return "PROCESSING"
 	}
 	guard := &AllWithParentGuard{MatchBinding: "parent"}
+	projection := ParentChildRegistrationProjection{
+		"parent-1": {Children: []factorytoken.Token{first, second}, Complete: true},
+	}
 
 	snapshot := &MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
 		first.ID:  &first,
 		second.ID: &second,
 	}}
 	matched, ok := guard.EvaluateRuntime(
-		RuntimeGuardContext{StateCategoryForPlace: category},
+		RuntimeGuardContext{StateCategoryForPlace: category, ParentChildRegistrations: projection},
 		[]factorytoken.Token{first, second},
 		bindings,
 		snapshot,
@@ -699,7 +721,7 @@ func TestAllWithParentGuard_RuntimeStateAndPopulationChecks(t *testing.T) {
 	processingCandidate := second
 	processingCandidate.PlaceID = "child:processing"
 	if matched, ok := guard.EvaluateRuntime(
-		RuntimeGuardContext{StateCategoryForPlace: category},
+		RuntimeGuardContext{StateCategoryForPlace: category, ParentChildRegistrations: projection},
 		[]factorytoken.Token{first, processingCandidate},
 		bindings,
 		&MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
@@ -713,7 +735,7 @@ func TestAllWithParentGuard_RuntimeStateAndPopulationChecks(t *testing.T) {
 	processingRegistered := second
 	processingRegistered.PlaceID = "child:processing"
 	if matched, ok := guard.EvaluateRuntime(
-		RuntimeGuardContext{StateCategoryForPlace: category},
+		RuntimeGuardContext{StateCategoryForPlace: category, ParentChildRegistrations: projection},
 		[]factorytoken.Token{first, second},
 		bindings,
 		&MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
@@ -730,92 +752,6 @@ func TestAllWithParentGuard_RuntimeStateAndPopulationChecks(t *testing.T) {
 		&MarkingSnapshot{Tokens: map[string]*factorytoken.Token{}},
 	); ok || len(matched) != 0 {
 		t.Fatalf("incomplete runtime population passed: %v, %t", matched, ok)
-	}
-}
-
-func TestFanoutCountGuard_RuntimePopulationAndTerminalChecks(t *testing.T) {
-	parent := &factorytoken.Token{ID: "parent-token", Color: factorytoken.Color{WorkID: "parent-1"}}
-	count := &factorytoken.Token{ID: "count-token", Color: factorytoken.Color{Tags: map[string]string{"expected_count": "2"}}}
-	first := factorytoken.Token{
-		ID:      "child-first",
-		PlaceID: "child:complete",
-		Color:   factorytoken.Color{WorkID: "child-1", WorkTypeID: "child", ParentID: "parent-1"},
-	}
-	second := first
-	second.ID = "child-second"
-	second.Color.WorkID = "child-2"
-	bindings := map[string]*factorytoken.Token{"parent": parent, "count": count}
-	category := func(placeID string) string {
-		if placeID == "child:complete" {
-			return runtimeStateCategoryTerminal
-		}
-		return "PROCESSING"
-	}
-	guard := &FanoutCountGuard{MatchBinding: "parent", CountBinding: "count"}
-	snapshot := &MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
-		first.ID:  &first,
-		second.ID: &second,
-	}}
-
-	matched, ok := guard.EvaluateRuntime(
-		RuntimeGuardContext{StateCategoryForPlace: category},
-		[]factorytoken.Token{first, second},
-		bindings,
-		snapshot,
-	)
-	if !ok || len(matched) != 2 {
-		t.Fatalf("terminal fanout = %v, %t; want both children", matched, ok)
-	}
-
-	processingCandidate := second
-	processingCandidate.PlaceID = "child:processing"
-	if matched, ok := guard.EvaluateRuntime(
-		RuntimeGuardContext{StateCategoryForPlace: category},
-		[]factorytoken.Token{first, processingCandidate},
-		bindings,
-		snapshot,
-	); ok || len(matched) != 0 {
-		t.Fatalf("non-terminal fanout candidate passed: %v, %t", matched, ok)
-	}
-
-	processingRegistered := second
-	processingRegistered.PlaceID = "child:processing"
-	if matched, ok := guard.EvaluateRuntime(
-		RuntimeGuardContext{StateCategoryForPlace: category},
-		[]factorytoken.Token{first, second},
-		bindings,
-		&MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
-			first.ID:  &first,
-			second.ID: &processingRegistered,
-		}},
-	); ok || len(matched) != 0 {
-		t.Fatalf("non-terminal registered fanout passed: %v, %t", matched, ok)
-	}
-
-	third := second
-	third.ID = "child-third"
-	third.Color.WorkID = "child-3"
-	if matched, ok := guard.EvaluateRuntime(
-		RuntimeGuardContext{ActiveDispatches: map[string]*interfaces.DispatchEntry{
-			"dispatch-child": {ConsumedTokens: []factorytoken.Token{third}},
-		}},
-		[]factorytoken.Token{first, second},
-		bindings,
-		snapshot,
-	); ok || len(matched) != 0 {
-		t.Fatalf("in-flight child was omitted from fanout count: %v, %t", matched, ok)
-	}
-
-	if matched, ok := guard.EvaluateRuntime(
-		RuntimeGuardContext{},
-		[]factorytoken.Token{first, second},
-		bindings,
-		&MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
-			first.ID: &first,
-			third.ID: &third,
-		}},
-	); ok || len(matched) != 0 {
-		t.Fatalf("fanout accepted a registered child not present in candidates: %v, %t", matched, ok)
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/orchestrators/petri/guard_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/petri/guard_test.go
@@ -3,6 +3,7 @@ package petri
 import (
 	"testing"
 
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factorytoken "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/token"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 )
@@ -559,6 +560,106 @@ func TestAllWithParentGuard_MissingBinding(t *testing.T) {
 	}
 	if matched != nil {
 		t.Fatalf("expected nil matches, got %v", matched)
+	}
+}
+
+func TestAllWithParentGuard_BlocksWhenRegisteredSiblingIsProcessing(t *testing.T) {
+	parent := &factorytoken.Token{
+		ID:    "parent-token",
+		Color: factorytoken.Color{WorkID: "parent-1"},
+	}
+	terminal := factorytoken.Token{
+		ID:      "child-terminal",
+		PlaceID: "child:complete",
+		Color: factorytoken.Color{
+			WorkID:     "child-1",
+			WorkTypeID: "child",
+			ParentID:   "parent-1",
+		},
+	}
+	processing := terminal
+	processing.ID = "child-processing"
+	processing.PlaceID = "child:processing"
+	processing.Color.WorkID = "child-2"
+
+	guard := &AllWithParentGuard{MatchBinding: "parent"}
+	matched, ok := guard.Evaluate(
+		[]factorytoken.Token{terminal},
+		map[string]*factorytoken.Token{"parent": parent},
+		&MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
+			terminal.ID:   &terminal,
+			processing.ID: &processing,
+		}},
+	)
+	if ok || len(matched) != 0 {
+		t.Fatalf("fan-in enabled with a processing sibling: matched=%v ok=%t", matched, ok)
+	}
+}
+
+func TestAllWithParentGuard_LateRegistrationStaysBlockedUntilTerminal(t *testing.T) {
+	parent := &factorytoken.Token{
+		ID:    "parent-token",
+		Color: factorytoken.Color{WorkID: "parent-1"},
+	}
+	first := factorytoken.Token{
+		ID:      "child-first",
+		PlaceID: "child:complete",
+		Color:   factorytoken.Color{WorkID: "child-1", WorkTypeID: "child", ParentID: "parent-1"},
+	}
+	late := first
+	late.ID = "child-late"
+	late.Color.WorkID = "child-2"
+	late.PlaceID = "child:processing"
+	guard := &AllWithParentGuard{MatchBinding: "parent"}
+	bindings := map[string]*factorytoken.Token{"parent": parent}
+
+	initial := MarkingSnapshot{Tokens: map[string]*factorytoken.Token{first.ID: &first}}
+	if matched, ok := guard.Evaluate([]factorytoken.Token{first}, bindings, &initial); !ok || len(matched) != 1 {
+		t.Fatalf("initial terminal child should enable before late registration: matched=%v ok=%t", matched, ok)
+	}
+
+	withLateChild := MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
+		first.ID: &first,
+		late.ID:  &late,
+	}}
+	if matched, ok := guard.Evaluate([]factorytoken.Token{first}, bindings, &withLateChild); ok || len(matched) != 0 {
+		t.Fatalf("late processing child should keep fan-in blocked: matched=%v ok=%t", matched, ok)
+	}
+
+	late.PlaceID = "child:complete"
+	terminalSnapshot := MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
+		first.ID: &first,
+		late.ID:  &late,
+	}}
+	matched, ok := guard.Evaluate([]factorytoken.Token{first, late}, bindings, &terminalSnapshot)
+	if !ok || len(matched) != 2 {
+		t.Fatalf("fan-in should enable exactly after the late child becomes terminal: matched=%v ok=%t", matched, ok)
+	}
+}
+
+func TestAllWithParentGuard_UsesActiveDispatchAsProcessingChild(t *testing.T) {
+	parent := &factorytoken.Token{ID: "parent-token", Color: factorytoken.Color{WorkID: "parent-1"}}
+	terminal := factorytoken.Token{
+		ID:      "child-terminal",
+		PlaceID: "child:complete",
+		Color:   factorytoken.Color{WorkID: "child-1", WorkTypeID: "child", ParentID: "parent-1"},
+	}
+	processing := terminal
+	processing.ID = "child-processing"
+	processing.Color.WorkID = "child-2"
+	processing.PlaceID = "child:processing"
+
+	guard := &AllWithParentGuard{MatchBinding: "parent"}
+	matched, ok := guard.EvaluateRuntime(
+		RuntimeGuardContext{ActiveDispatches: map[string]*interfaces.DispatchEntry{
+			"dispatch-child": {ConsumedTokens: []factorytoken.Token{processing}},
+		}},
+		[]factorytoken.Token{terminal},
+		map[string]*factorytoken.Token{"parent": parent},
+		&MarkingSnapshot{Tokens: map[string]*factorytoken.Token{terminal.ID: &terminal}},
+	)
+	if ok || len(matched) != 0 {
+		t.Fatalf("fan-in enabled while a processing child was in flight: matched=%v ok=%t", matched, ok)
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/orchestrators/petri/guard_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/petri/guard_test.go
@@ -755,66 +755,6 @@ func TestAllWithParentGuard_RuntimeStateAndPopulationChecks(t *testing.T) {
 	}
 }
 
-func TestAllWithParentGuard_AllConfiguredTerminalPlacesSatisfyCompleteness(t *testing.T) {
-	parent := &factorytoken.Token{ID: "parent-token", Color: factorytoken.Color{WorkID: "parent-1"}}
-	complete := factorytoken.Token{
-		ID:      "child-complete",
-		PlaceID: "child:complete",
-		Color:   factorytoken.Color{WorkID: "child-1", WorkTypeID: "child", ParentID: "parent-1"},
-	}
-	skipped := complete
-	skipped.ID = "child-skipped"
-	skipped.PlaceID = "child:skipped"
-	processing := skipped
-	processing.ID = "child-processing"
-	processing.PlaceID = "child:processing"
-
-	category := func(placeID string) string {
-		switch placeID {
-		case "child:complete", "child:skipped":
-			return runtimeStateCategoryTerminal
-		default:
-			return "PROCESSING"
-		}
-	}
-	guard := &AllWithParentGuard{MatchBinding: "parent"}
-	bindings := map[string]*factorytoken.Token{"parent": parent}
-	projection := ParentChildRegistrationProjection{
-		"parent-1": {Children: []factorytoken.Token{complete, skipped}, Complete: true},
-	}
-	snapshot := &MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
-		complete.ID: &complete,
-		skipped.ID:  &skipped,
-	}}
-
-	matched, ok := guard.EvaluateRuntime(
-		RuntimeGuardContext{StateCategoryForPlace: category, ParentChildRegistrations: projection},
-		[]factorytoken.Token{complete},
-		bindings,
-		snapshot,
-	)
-	if !ok || len(matched) != 1 || matched[0].ID != complete.ID {
-		t.Fatalf("terminal children in distinct places should satisfy fan-in: matched=%v ok=%t", matched, ok)
-	}
-
-	processingSnapshot := &MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
-		complete.ID:   &complete,
-		processing.ID: &processing,
-	}}
-	processingProjection := ParentChildRegistrationProjection{
-		"parent-1": {Children: []factorytoken.Token{complete, processing}, Complete: true},
-	}
-	matched, ok = guard.EvaluateRuntime(
-		RuntimeGuardContext{StateCategoryForPlace: category, ParentChildRegistrations: processingProjection},
-		[]factorytoken.Token{complete},
-		bindings,
-		processingSnapshot,
-	)
-	if ok || len(matched) != 0 {
-		t.Fatalf("processing child in another place should keep fan-in blocked: matched=%v ok=%t", matched, ok)
-	}
-}
-
 func TestAllWithParentGuard_RejectsUnknownAndMismatchedRegistrationProjection(t *testing.T) {
 	parent := &factorytoken.Token{ID: "parent-token", Color: factorytoken.Color{WorkID: "parent-1"}}
 	first := factorytoken.Token{

--- a/pkg/services/factory_runtime/internal/orchestrators/petri/guard_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/petri/guard_test.go
@@ -663,6 +663,205 @@ func TestAllWithParentGuard_UsesActiveDispatchAsProcessingChild(t *testing.T) {
 	}
 }
 
+func TestAllWithParentGuard_RuntimeStateAndPopulationChecks(t *testing.T) {
+	parent := &factorytoken.Token{ID: "parent-token", Color: factorytoken.Color{WorkID: "parent-1"}}
+	first := factorytoken.Token{
+		ID:      "child-first",
+		PlaceID: "child:complete",
+		Color:   factorytoken.Color{WorkID: "child-1", WorkTypeID: "child", ParentID: "parent-1"},
+	}
+	second := first
+	second.ID = "child-second"
+	second.Color.WorkID = "child-2"
+	bindings := map[string]*factorytoken.Token{"parent": parent}
+	category := func(placeID string) string {
+		if placeID == "child:complete" {
+			return runtimeStateCategoryTerminal
+		}
+		return "PROCESSING"
+	}
+	guard := &AllWithParentGuard{MatchBinding: "parent"}
+
+	snapshot := &MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
+		first.ID:  &first,
+		second.ID: &second,
+	}}
+	matched, ok := guard.EvaluateRuntime(
+		RuntimeGuardContext{StateCategoryForPlace: category},
+		[]factorytoken.Token{first, second},
+		bindings,
+		snapshot,
+	)
+	if !ok || len(matched) != 2 {
+		t.Fatalf("terminal registered children = %v, %t; want both children", matched, ok)
+	}
+
+	processingCandidate := second
+	processingCandidate.PlaceID = "child:processing"
+	if matched, ok := guard.EvaluateRuntime(
+		RuntimeGuardContext{StateCategoryForPlace: category},
+		[]factorytoken.Token{first, processingCandidate},
+		bindings,
+		&MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
+			first.ID:  &first,
+			second.ID: &second,
+		}},
+	); ok || len(matched) != 0 {
+		t.Fatalf("non-terminal candidate passed runtime state check: %v, %t", matched, ok)
+	}
+
+	processingRegistered := second
+	processingRegistered.PlaceID = "child:processing"
+	if matched, ok := guard.EvaluateRuntime(
+		RuntimeGuardContext{StateCategoryForPlace: category},
+		[]factorytoken.Token{first, second},
+		bindings,
+		&MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
+			first.ID:  &first,
+			second.ID: &processingRegistered,
+		}},
+	); ok || len(matched) != 0 {
+		t.Fatalf("non-terminal registered child passed runtime state check: %v, %t", matched, ok)
+	}
+
+	if matched, ok := guard.Evaluate(
+		[]factorytoken.Token{first},
+		bindings,
+		&MarkingSnapshot{Tokens: map[string]*factorytoken.Token{}},
+	); ok || len(matched) != 0 {
+		t.Fatalf("incomplete runtime population passed: %v, %t", matched, ok)
+	}
+}
+
+func TestFanoutCountGuard_RuntimePopulationAndTerminalChecks(t *testing.T) {
+	parent := &factorytoken.Token{ID: "parent-token", Color: factorytoken.Color{WorkID: "parent-1"}}
+	count := &factorytoken.Token{ID: "count-token", Color: factorytoken.Color{Tags: map[string]string{"expected_count": "2"}}}
+	first := factorytoken.Token{
+		ID:      "child-first",
+		PlaceID: "child:complete",
+		Color:   factorytoken.Color{WorkID: "child-1", WorkTypeID: "child", ParentID: "parent-1"},
+	}
+	second := first
+	second.ID = "child-second"
+	second.Color.WorkID = "child-2"
+	bindings := map[string]*factorytoken.Token{"parent": parent, "count": count}
+	category := func(placeID string) string {
+		if placeID == "child:complete" {
+			return runtimeStateCategoryTerminal
+		}
+		return "PROCESSING"
+	}
+	guard := &FanoutCountGuard{MatchBinding: "parent", CountBinding: "count"}
+	snapshot := &MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
+		first.ID:  &first,
+		second.ID: &second,
+	}}
+
+	matched, ok := guard.EvaluateRuntime(
+		RuntimeGuardContext{StateCategoryForPlace: category},
+		[]factorytoken.Token{first, second},
+		bindings,
+		snapshot,
+	)
+	if !ok || len(matched) != 2 {
+		t.Fatalf("terminal fanout = %v, %t; want both children", matched, ok)
+	}
+
+	processingCandidate := second
+	processingCandidate.PlaceID = "child:processing"
+	if matched, ok := guard.EvaluateRuntime(
+		RuntimeGuardContext{StateCategoryForPlace: category},
+		[]factorytoken.Token{first, processingCandidate},
+		bindings,
+		snapshot,
+	); ok || len(matched) != 0 {
+		t.Fatalf("non-terminal fanout candidate passed: %v, %t", matched, ok)
+	}
+
+	processingRegistered := second
+	processingRegistered.PlaceID = "child:processing"
+	if matched, ok := guard.EvaluateRuntime(
+		RuntimeGuardContext{StateCategoryForPlace: category},
+		[]factorytoken.Token{first, second},
+		bindings,
+		&MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
+			first.ID:  &first,
+			second.ID: &processingRegistered,
+		}},
+	); ok || len(matched) != 0 {
+		t.Fatalf("non-terminal registered fanout passed: %v, %t", matched, ok)
+	}
+
+	third := second
+	third.ID = "child-third"
+	third.Color.WorkID = "child-3"
+	if matched, ok := guard.EvaluateRuntime(
+		RuntimeGuardContext{ActiveDispatches: map[string]*interfaces.DispatchEntry{
+			"dispatch-child": {ConsumedTokens: []factorytoken.Token{third}},
+		}},
+		[]factorytoken.Token{first, second},
+		bindings,
+		snapshot,
+	); ok || len(matched) != 0 {
+		t.Fatalf("in-flight child was omitted from fanout count: %v, %t", matched, ok)
+	}
+
+	if matched, ok := guard.EvaluateRuntime(
+		RuntimeGuardContext{},
+		[]factorytoken.Token{first, second},
+		bindings,
+		&MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
+			first.ID: &first,
+			third.ID: &third,
+		}},
+	); ok || len(matched) != 0 {
+		t.Fatalf("fanout accepted a registered child not present in candidates: %v, %t", matched, ok)
+	}
+}
+
+func TestParentChildTokenHelpersFilterAndDeduplicateRuntimeFacts(t *testing.T) {
+	valid := factorytoken.Token{ID: "valid", PlaceID: "child:complete", Color: factorytoken.Color{WorkID: "child-1", WorkTypeID: "child", ParentID: "parent-1"}}
+	resource := valid
+	resource.ID = "resource"
+	resource.Color.DataType = factorytoken.DataTypeResource
+	wrongParent := valid
+	wrongParent.ID = "wrong-parent"
+	wrongParent.Color.ParentID = "parent-2"
+	wrongType := valid
+	wrongType.ID = "wrong-type"
+	wrongType.Color.WorkTypeID = "other"
+	missingWorkID := valid
+	missingWorkID.ID = "missing-work-id"
+	missingWorkID.Color.WorkID = ""
+
+	children := parentChildTokens(
+		&MarkingSnapshot{Tokens: map[string]*factorytoken.Token{
+			valid.ID:         &valid,
+			"nil-token":      nil,
+			resource.ID:      &resource,
+			wrongParent.ID:   &wrongParent,
+			wrongType.ID:     &wrongType,
+			missingWorkID.ID: &missingWorkID,
+		}},
+		map[string]*interfaces.DispatchEntry{
+			"nil-dispatch":      nil,
+			"matching-dispatch": {ConsumedTokens: []factorytoken.Token{valid}},
+		},
+		"parent-1",
+		"child",
+	)
+	if len(children) != 1 || children["work:child-1"].ID != valid.ID {
+		t.Fatalf("filtered child population = %#v, want one deduplicated child", children)
+	}
+
+	if got := matchingParentChildren([]factorytoken.Token{valid, wrongType}, "parent-1", "child"); len(got) != 1 || got[0].ID != valid.ID {
+		t.Fatalf("typed parent matches = %#v, want valid child only", got)
+	}
+	if got := tokenIdentity(factorytoken.Token{ID: "token-only"}); got != "token:token-only" {
+		t.Fatalf("token-only identity = %q, want token:token-only", got)
+	}
+}
+
 func TestAnyWithParentGuard_PositiveMatch(t *testing.T) {
 	candidates := []factorytoken.Token{
 		{ID: "child-1", Color: factorytoken.Color{ParentID: "req-100"}},

--- a/pkg/services/factory_runtime/internal/orchestrators/petri/inference_throttle_guard.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/petri/inference_throttle_guard.go
@@ -21,6 +21,10 @@ type RuntimeGuardContext struct {
 	// compiled Factory definition without coupling Petri guards to the state
 	// package. It is nil for callers that only have a raw marking.
 	StateCategoryForPlace func(placeID string) string
+	// ParentChildRegistrations is the runtime-owned, ordered registration
+	// projection. Runtime fan-in guards use it as the complete population
+	// denominator instead of inferring registration from one place.
+	ParentChildRegistrations ParentChildRegistrationProjection
 }
 
 type RuntimeGuard interface {

--- a/pkg/services/factory_runtime/internal/orchestrators/petri/inference_throttle_guard.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/petri/inference_throttle_guard.go
@@ -14,8 +14,13 @@ type RuntimeGuardContext struct {
 	Now                 time.Time
 	CurrentTransitionID string
 	DispatchHistory     []interfaces.CompletedDispatch
+	ActiveDispatches    map[string]*interfaces.DispatchEntry
 	RuntimeConfig       interfaces.RuntimeDefinitionLookup
 	TransitionWorkers   map[string]string
+	// StateCategoryForPlace lets runtime guards classify a token using the
+	// compiled Factory definition without coupling Petri guards to the state
+	// package. It is nil for callers that only have a raw marking.
+	StateCategoryForPlace func(placeID string) string
 }
 
 type RuntimeGuard interface {

--- a/pkg/services/factory_runtime/internal/orchestrators/petri/marking.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/petri/marking.go
@@ -10,21 +10,74 @@ import (
 // Marking represents the complete state of tokens across places in a petri net.
 // It is the single source of truth. The factory loop reads and writes markings.
 type Marking struct {
-	Tokens       map[string]*factorytoken.Token `json:"tokens"`       // token ID → token (all live tokens)
-	PlaceTokens  map[string][]string            `json:"place_tokens"` // place ID → token IDs (index for fast lookup)
-	TickCount    int                            `json:"tick_count"`
-	WorkflowID   string                         `json:"workflow_id"`
-	TraceContext map[string]string              `json:"trace_context"` // workflow-level trace metadata
+	Tokens                   map[string]*factorytoken.Token    `json:"tokens"`       // token ID → token (all live tokens)
+	PlaceTokens              map[string][]string               `json:"place_tokens"` // place ID → token IDs (index for fast lookup)
+	ParentChildRegistrations ParentChildRegistrationProjection `json:"parent_child_registrations,omitempty"`
+	TickCount                int                               `json:"tick_count"`
+	WorkflowID               string                            `json:"workflow_id"`
+	TraceContext             map[string]string                 `json:"trace_context"` // workflow-level trace metadata
 }
+
+// ParentChildRegistrationSet is the ordered runtime projection of the
+// parent-scoped child work items admitted by canonical work-request facts.
+// Complete is deliberately explicit: a fan-in guard must not infer that the
+// currently visible children are the complete registered population.
+type ParentChildRegistrationSet struct {
+	Children []factorytoken.Token `json:"children"`
+	Complete bool                 `json:"complete"`
+}
+
+// ParentChildRegistrationProjection stores registration facts by parent work
+// ID. The child slice preserves canonical admission order for deterministic
+// snapshots and guard evaluation.
+type ParentChildRegistrationProjection map[string]ParentChildRegistrationSet
 
 // NewMarking creates an empty Marking for the given workflow.
 func NewMarking(workflowID string) *Marking {
 	return &Marking{
-		Tokens:       make(map[string]*factorytoken.Token),
-		PlaceTokens:  make(map[string][]string),
-		WorkflowID:   workflowID,
-		TraceContext: make(map[string]string),
+		Tokens:                   make(map[string]*factorytoken.Token),
+		PlaceTokens:              make(map[string][]string),
+		ParentChildRegistrations: make(ParentChildRegistrationProjection),
+		WorkflowID:               workflowID,
+		TraceContext:             make(map[string]string),
 	}
+}
+
+// RecordParentChildRegistration appends one admitted child to the ordered
+// parent-scoped registration projection. Completion is recorded separately so
+// callers can add every child from an atomic request before exposing the set to
+// the scheduler.
+func (m *Marking) RecordParentChildRegistration(token *factorytoken.Token) {
+	if m == nil || token == nil || token.Color.ParentID == "" || token.Color.WorkID == "" || token.Color.DataType == factorytoken.DataTypeResource {
+		return
+	}
+	if m.ParentChildRegistrations == nil {
+		m.ParentChildRegistrations = make(ParentChildRegistrationProjection)
+	}
+	parentID := token.Color.ParentID
+	set := m.ParentChildRegistrations[parentID]
+	identity := registrationTokenIdentity(*token)
+	for _, child := range set.Children {
+		if registrationTokenIdentity(child) == identity {
+			return
+		}
+	}
+	set.Children = append(set.Children, deepCopyToken(token))
+	set.Complete = false
+	m.ParentChildRegistrations[parentID] = set
+}
+
+// CompleteParentChildRegistration publishes the complete registration fact
+// for a parent after all children from the current canonical request have been
+// recorded. A later request may append another ordered fact and temporarily
+// reopen the set until that request is complete.
+func (m *Marking) CompleteParentChildRegistration(parentID string) {
+	if m == nil || parentID == "" || len(m.ParentChildRegistrations[parentID].Children) == 0 {
+		return
+	}
+	set := m.ParentChildRegistrations[parentID]
+	set.Complete = true
+	m.ParentChildRegistrations[parentID] = set
 }
 
 // AddToken adds a token to the marking and updates the place index.
@@ -72,11 +125,12 @@ func (m *Marking) TokensInPlace(placeID string) []factorytoken.Token {
 // MarkingSnapshot is an immutable deep copy of a Marking, used for
 // subsystem reads and history.
 type MarkingSnapshot struct {
-	Tokens       map[string]*factorytoken.Token `json:"tokens"`
-	PlaceTokens  map[string][]string            `json:"place_tokens"`
-	TickCount    int                            `json:"tick_count"`
-	WorkflowID   string                         `json:"workflow_id"`
-	TraceContext map[string]string              `json:"trace_context"`
+	Tokens                   map[string]*factorytoken.Token    `json:"tokens"`
+	PlaceTokens              map[string][]string               `json:"place_tokens"`
+	ParentChildRegistrations ParentChildRegistrationProjection `json:"parent_child_registrations,omitempty"`
+	TickCount                int                               `json:"tick_count"`
+	WorkflowID               string                            `json:"workflow_id"`
+	TraceContext             map[string]string                 `json:"trace_context"`
 }
 
 // Snapshot returns a deep copy of the marking as an immutable MarkingSnapshot.
@@ -97,13 +151,33 @@ func (m *Marking) Snapshot() MarkingSnapshot {
 	traceCtx := make(map[string]string, len(m.TraceContext))
 	maps.Copy(traceCtx, m.TraceContext)
 
-	return MarkingSnapshot{
-		Tokens:       tokens,
-		PlaceTokens:  placeTokens,
-		TickCount:    m.TickCount,
-		WorkflowID:   m.WorkflowID,
-		TraceContext: traceCtx,
+	registrations := make(ParentChildRegistrationProjection, len(m.ParentChildRegistrations))
+	for parentID, set := range m.ParentChildRegistrations {
+		children := make([]factorytoken.Token, len(set.Children))
+		for i := range set.Children {
+			children[i] = deepCopyToken(&set.Children[i])
+		}
+		registrations[parentID] = ParentChildRegistrationSet{
+			Children: children,
+			Complete: set.Complete,
+		}
 	}
+
+	return MarkingSnapshot{
+		Tokens:                   tokens,
+		PlaceTokens:              placeTokens,
+		ParentChildRegistrations: registrations,
+		TickCount:                m.TickCount,
+		WorkflowID:               m.WorkflowID,
+		TraceContext:             traceCtx,
+	}
+}
+
+func registrationTokenIdentity(token factorytoken.Token) string {
+	if token.Color.WorkID != "" {
+		return "work:" + token.Color.WorkID
+	}
+	return "token:" + token.ID
 }
 
 // TokensInPlace returns all tokens in the given place from the snapshot.

--- a/pkg/services/factory_runtime/internal/orchestrators/petri/marking_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/petri/marking_test.go
@@ -241,3 +241,42 @@ func TestMarkingParentChildRegistrationProjectionPreservesOrderAndCompleteness(t
 		t.Fatalf("registration snapshot retained caller mutation at place %q", got)
 	}
 }
+
+func TestMarkingParentChildRegistrationProjectionRejectsInvalidAndDuplicateFacts(t *testing.T) {
+	var nilMarking *Marking
+	nilMarking.RecordParentChildRegistration(nil)
+	nilMarking.CompleteParentChildRegistration("parent-1")
+
+	marking := &Marking{}
+	marking.RecordParentChildRegistration(nil)
+	marking.RecordParentChildRegistration(&factorytoken.Token{ID: "no-parent", Color: factorytoken.Color{WorkID: "work-1"}})
+	marking.RecordParentChildRegistration(&factorytoken.Token{ID: "no-work", Color: factorytoken.Color{ParentID: "parent-1"}})
+	marking.RecordParentChildRegistration(&factorytoken.Token{
+		ID:    "resource",
+		Color: factorytoken.Color{WorkID: "resource-1", ParentID: "parent-1", DataType: factorytoken.DataTypeResource},
+	})
+	marking.CompleteParentChildRegistration("missing-parent")
+
+	child := factorytoken.Token{
+		ID:      "child-token-1",
+		PlaceID: "child:complete",
+		Color:   factorytoken.Color{WorkID: "child-1", ParentID: "parent-1"},
+	}
+	marking.RecordParentChildRegistration(&child)
+	marking.CompleteParentChildRegistration("parent-1")
+	duplicate := child
+	duplicate.ID = "duplicate-token"
+	duplicate.PlaceID = "child:processing"
+	marking.RecordParentChildRegistration(&duplicate)
+
+	registration := marking.ParentChildRegistrations["parent-1"]
+	if !registration.Complete || len(registration.Children) != 1 {
+		t.Fatalf("registration projection = %#v, want one complete child after duplicate admission", registration)
+	}
+	if got := registration.Children[0].ID; got != child.ID {
+		t.Fatalf("registration child ID = %q, want original %q", got, child.ID)
+	}
+	if got := registrationTokenIdentity(factorytoken.Token{ID: "token-only"}); got != "token:token-only" {
+		t.Fatalf("token-only registration identity = %q, want token:token-only", got)
+	}
+}

--- a/pkg/services/factory_runtime/internal/orchestrators/petri/marking_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/petri/marking_test.go
@@ -99,7 +99,7 @@ func TestMarking_TokensInPlace(t *testing.T) {
 
 	tokensC := m.TokensInPlace("place-c")
 	if len(tokensC) != 0 {
-		t.Fatalf("expected 0 tokens in place-c, got %d", len(tokensC))
+		t.Fatalf("expected 0 tokens for place-c, got %d", len(tokensC))
 	}
 }
 
@@ -196,5 +196,48 @@ func TestMarking_PlaceTokensIndexConsistency(t *testing.T) {
 	// p2 should still have t3
 	if ids := m.PlaceTokens["p2"]; len(ids) != 1 || ids[0] != "t3" {
 		t.Fatalf("expected [t3] in p2, got %v", ids)
+	}
+}
+
+func TestMarkingParentChildRegistrationProjectionPreservesOrderAndCompleteness(t *testing.T) {
+	first := factorytoken.Token{
+		ID:      "child-token-1",
+		PlaceID: "child:complete",
+		Color: factorytoken.Color{
+			WorkID:   "child-1",
+			ParentID: "parent-1",
+		},
+	}
+	second := first
+	second.ID = "child-token-2"
+	second.Color.WorkID = "child-2"
+
+	marking := NewMarking("workflow-1")
+	marking.RecordParentChildRegistration(&first)
+	marking.CompleteParentChildRegistration("parent-1")
+
+	initial := marking.Snapshot()
+	registration := initial.ParentChildRegistrations["parent-1"]
+	if !registration.Complete || len(registration.Children) != 1 || registration.Children[0].Color.WorkID != "child-1" {
+		t.Fatalf("initial registration projection = %#v, want one complete child in admission order", registration)
+	}
+
+	marking.RecordParentChildRegistration(&second)
+	if marking.ParentChildRegistrations["parent-1"].Complete {
+		t.Fatal("late registration should reopen the set until the new canonical fact is complete")
+	}
+	marking.CompleteParentChildRegistration("parent-1")
+	second.PlaceID = "child:processing"
+
+	snapshot := marking.Snapshot()
+	registration = snapshot.ParentChildRegistrations["parent-1"]
+	if !registration.Complete || len(registration.Children) != 2 {
+		t.Fatalf("complete registration projection = %#v, want two children", registration)
+	}
+	if got := registration.Children[0].Color.WorkID + "," + registration.Children[1].Color.WorkID; got != "child-1,child-2" {
+		t.Fatalf("registration order = %q, want child-1,child-2", got)
+	}
+	if got := registration.Children[1].PlaceID; got != "child:complete" {
+		t.Fatalf("registration snapshot retained caller mutation at place %q", got)
 	}
 }

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go
@@ -941,7 +941,12 @@ func (e *FactoryEngine) recordGeneratedSubmissionTokens(
 	normalized []workdomain.SubmitRequest,
 	tokens []*factorytoken.Token,
 ) {
+	parentIDs := make(map[string]struct{})
 	for index, token := range tokens {
+		e.runtimeState.Marking.RecordParentChildRegistration(token)
+		if token.Color.ParentID != "" {
+			parentIDs[token.Color.ParentID] = struct{}{}
+		}
 		if e.recordSubmission != nil {
 			e.recordSubmission(work.FactorySubmissionRecord{
 				SubmissionID: submissionRecordID(e.runtimeState.TickCount, source, index),
@@ -955,20 +960,31 @@ func (e *FactoryEngine) recordGeneratedSubmissionTokens(
 			e.recordWorkInput(e.runtimeState.TickCount, normalized[index], *token)
 		}
 	}
+	for parentID := range parentIDs {
+		e.runtimeState.Marking.CompleteParentChildRegistration(parentID)
+	}
 }
 
 // injectTokens creates tokens from submit requests and places them in INITIAL places.
 func (e *FactoryEngine) injectTokens(requests []workdomain.SubmitRequest) {
 	e.logger.Info("engine: injecting tokens", "count", len(requests))
+	parentIDs := make(map[string]struct{})
 	for _, req := range requests {
 		token, err := e.transformer.InitialTokenFromSubmit(req, e.clock.Now())
 		if err != nil {
 			e.logger.Error("engine: failed to convert submit request to token", "work_type_id", req.WorkTypeID, "error", err)
 			continue
 		}
+		e.runtimeState.Marking.RecordParentChildRegistration(token)
 		e.runtimeState.Marking.AddToken(token)
+		if token.Color.ParentID != "" {
+			parentIDs[token.Color.ParentID] = struct{}{}
+		}
 		if e.recordWorkInput != nil {
 			e.recordWorkInput(e.runtimeState.TickCount, req, *token)
 		}
+	}
+	for parentID := range parentIDs {
+		e.runtimeState.Marking.CompleteParentChildRegistration(parentID)
 	}
 }

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/engine_submission_hook_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/engine_submission_hook_test.go
@@ -89,6 +89,44 @@ func TestSubmissionHook_GeneratedBatchRecordsCanonicalHistoryBeforeInjection(t *
 	}
 }
 
+func TestSubmissionHook_GeneratedParentChildBatchCompletesRegistrationProjection(t *testing.T) {
+	n := buildTestNet()
+	marking := petri.NewMarking("test-wf")
+	hook := &testSubmissionHook{
+		name:     "generated-parent-child",
+		priority: 1,
+		onTick: func(_ context.Context, _ interfaces.SubmissionHookContext[submissionSnapshot]) (interfaces.SubmissionHookResult, error) {
+			return interfaces.SubmissionHookResult{GeneratedBatches: []work.GeneratedSubmissionBatch{{
+				Request: work.WorkRequest{
+					Type: work.WorkRequestTypeFactoryRequestBatch,
+					Works: []work.Work{
+						{Name: "parent", WorkID: "parent-work", WorkTypeID: "task"},
+						{Name: "child", WorkID: "child-work", WorkTypeID: "task"},
+					},
+					Relations: []work.WorkRelation{{
+						Type:           work.WorkRelationParentChild,
+						SourceWorkName: "child",
+						TargetWorkName: "parent",
+					}},
+				},
+			}}}, nil
+		},
+	}
+
+	eng := newTestFactoryEngine(n, marking, nil, WithSubmissionHook(hook))
+	if err := eng.Tick(context.Background()); err != nil {
+		t.Fatalf("Tick() error: %v", err)
+	}
+
+	registration := eng.GetMarking().ParentChildRegistrations["parent-work"]
+	if !registration.Complete || len(registration.Children) != 1 {
+		t.Fatalf("generated parent-child registration = %#v, want one complete child", registration)
+	}
+	if got := registration.Children[0].Color.WorkID; got != "child-work" {
+		t.Fatalf("generated registered child WorkID = %q, want child-work", got)
+	}
+}
+
 func TestSubmissionHooks_RunInPriorityThenNameOrderAndCarryContinuationState(t *testing.T) {
 	n := buildTestNet()
 	marking := petri.NewMarking("test-wf")

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/engine_submit_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/engine_submit_test.go
@@ -38,6 +38,34 @@ func TestInjectTokensCreatesTokenInInitialPlace(t *testing.T) {
 	}
 }
 
+func TestInjectTokensRecordsCompleteParentChildRegistrationProjection(t *testing.T) {
+	n := buildTestNet()
+	marking := petri.NewMarking("test-wf")
+	engine := newTestFactoryEngine(n, marking, nil)
+
+	engine.mu.Lock()
+	engine.injectTokens([]work.SubmitRequest{
+		{WorkID: "parent-work", WorkTypeID: "task"},
+		{
+			WorkID:     "child-work",
+			WorkTypeID: "task",
+			Relations: []work.Relation{{
+				Type:         work.RelationParentChild,
+				TargetWorkID: "parent-work",
+			}},
+		},
+	})
+	engine.mu.Unlock()
+
+	registration := engine.GetMarking().ParentChildRegistrations["parent-work"]
+	if !registration.Complete || len(registration.Children) != 1 {
+		t.Fatalf("parent-child registration = %#v, want one complete child", registration)
+	}
+	if got := registration.Children[0].Color.WorkID; got != "child-work" {
+		t.Fatalf("registered child WorkID = %q, want child-work", got)
+	}
+}
+
 func TestInjectTokensSkipsUnknownWorkType(t *testing.T) {
 	n := buildTestNet()
 	marking := petri.NewMarking("test-wf")

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/factory.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/factory.go
@@ -749,7 +749,7 @@ func (f *factoryImpl) GetEngineStateSnapshot(ctx context.Context) (*interfaces.E
 		f.logger,
 		f.clock.Now,
 		f.cfg.runtimeConfig,
-	).FindEnabledTransitions(ctx, f.topology, &snap.Marking)
+	).FindEnabledTransitionsWithSnapshot(ctx, f.topology, &snap)
 	return &snap, nil
 }
 

--- a/pkg/services/factory_runtime/internal/services/orchestration/scheduler/enablement.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/scheduler/enablement.go
@@ -174,13 +174,14 @@ func (e *EnablementEvaluator) evaluateGuardedArc(
 ) bool {
 	candidates := stableTokens(marking.TokensInPlace(arc.PlaceID))
 	guardMatched, ok := e.evaluateGuard(arc.Guard, petri.RuntimeGuardContext{
-		Now:                   e.now(),
-		CurrentTransitionID:   tr.ID,
-		DispatchHistory:       snapshot.DispatchHistory,
-		ActiveDispatches:      snapshot.Dispatches,
-		RuntimeConfig:         e.runtimeConfig,
-		TransitionWorkers:     transitionWorkerTypes(snapshot.Topology, tr),
-		StateCategoryForPlace: stateCategoryForPlace(snapshot.Topology),
+		Now:                      e.now(),
+		CurrentTransitionID:      tr.ID,
+		DispatchHistory:          snapshot.DispatchHistory,
+		ActiveDispatches:         snapshot.Dispatches,
+		RuntimeConfig:            e.runtimeConfig,
+		TransitionWorkers:        transitionWorkerTypes(snapshot.Topology, tr),
+		StateCategoryForPlace:    stateCategoryForPlace(snapshot.Topology),
+		ParentChildRegistrations: marking.ParentChildRegistrations,
 	}, candidates, guardBindings, marking)
 	if !ok {
 		e.logger.Debug("enablement: transition disabled",
@@ -296,13 +297,14 @@ func singleTokenBindingOrder(tr *petri.Transition) []int {
 
 func singleTokenRuntimeContext(e *EnablementEvaluator, tr *petri.Transition, snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) petri.RuntimeGuardContext {
 	return petri.RuntimeGuardContext{
-		Now:                   e.now(),
-		CurrentTransitionID:   tr.ID,
-		DispatchHistory:       snapshot.DispatchHistory,
-		ActiveDispatches:      snapshot.Dispatches,
-		RuntimeConfig:         e.runtimeConfig,
-		TransitionWorkers:     transitionWorkerTypes(snapshot.Topology, tr),
-		StateCategoryForPlace: stateCategoryForPlace(snapshot.Topology),
+		Now:                      e.now(),
+		CurrentTransitionID:      tr.ID,
+		DispatchHistory:          snapshot.DispatchHistory,
+		ActiveDispatches:         snapshot.Dispatches,
+		RuntimeConfig:            e.runtimeConfig,
+		TransitionWorkers:        transitionWorkerTypes(snapshot.Topology, tr),
+		StateCategoryForPlace:    stateCategoryForPlace(snapshot.Topology),
+		ParentChildRegistrations: snapshot.Marking.ParentChildRegistrations,
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/services/orchestration/scheduler/enablement.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/scheduler/enablement.go
@@ -44,7 +44,8 @@ func NewEnablementEvaluator(
 // in the current marking. Each transition evaluation is logged with its result.
 func (e *EnablementEvaluator) FindEnabledTransitions(ctx context.Context, n *state.Net, marking *petri.MarkingSnapshot) []interfaces.EnabledTransition {
 	return e.FindEnabledTransitionsWithSnapshot(ctx, n, &interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{
-		Marking: *marking,
+		Marking:  *marking,
+		Topology: n,
 	})
 }
 
@@ -173,11 +174,13 @@ func (e *EnablementEvaluator) evaluateGuardedArc(
 ) bool {
 	candidates := stableTokens(marking.TokensInPlace(arc.PlaceID))
 	guardMatched, ok := e.evaluateGuard(arc.Guard, petri.RuntimeGuardContext{
-		Now:                 e.now(),
-		CurrentTransitionID: tr.ID,
-		DispatchHistory:     snapshot.DispatchHistory,
-		RuntimeConfig:       e.runtimeConfig,
-		TransitionWorkers:   transitionWorkerTypes(snapshot.Topology, tr),
+		Now:                   e.now(),
+		CurrentTransitionID:   tr.ID,
+		DispatchHistory:       snapshot.DispatchHistory,
+		ActiveDispatches:      snapshot.Dispatches,
+		RuntimeConfig:         e.runtimeConfig,
+		TransitionWorkers:     transitionWorkerTypes(snapshot.Topology, tr),
+		StateCategoryForPlace: stateCategoryForPlace(snapshot.Topology),
 	}, candidates, guardBindings, marking)
 	if !ok {
 		e.logger.Debug("enablement: transition disabled",
@@ -293,11 +296,22 @@ func singleTokenBindingOrder(tr *petri.Transition) []int {
 
 func singleTokenRuntimeContext(e *EnablementEvaluator, tr *petri.Transition, snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) petri.RuntimeGuardContext {
 	return petri.RuntimeGuardContext{
-		Now:                 e.now(),
-		CurrentTransitionID: tr.ID,
-		DispatchHistory:     snapshot.DispatchHistory,
-		RuntimeConfig:       e.runtimeConfig,
-		TransitionWorkers:   transitionWorkerTypes(snapshot.Topology, tr),
+		Now:                   e.now(),
+		CurrentTransitionID:   tr.ID,
+		DispatchHistory:       snapshot.DispatchHistory,
+		ActiveDispatches:      snapshot.Dispatches,
+		RuntimeConfig:         e.runtimeConfig,
+		TransitionWorkers:     transitionWorkerTypes(snapshot.Topology, tr),
+		StateCategoryForPlace: stateCategoryForPlace(snapshot.Topology),
+	}
+}
+
+func stateCategoryForPlace(topology *state.Net) func(string) string {
+	if topology == nil || len(topology.WorkTypes) == 0 {
+		return nil
+	}
+	return func(placeID string) string {
+		return string(topology.StateCategoryForPlace(placeID))
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/services/orchestration/scheduler/enablement_runtime_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/scheduler/enablement_runtime_test.go
@@ -24,6 +24,26 @@ func TestEnablementEvaluator_ContextPassedThrough(t *testing.T) {
 	}
 }
 
+func TestEnablementEvaluator_NilSnapshotReturnsNoTransitions(t *testing.T) {
+	eval := NewEnablementEvaluator(nil, testNow, nil)
+	if enabled := eval.FindEnabledTransitionsWithSnapshot(
+		context.Background(),
+		&state.Net{Transitions: map[string]*petri.Transition{"unused": {ID: "unused"}}},
+		nil,
+	); len(enabled) != 0 {
+		t.Fatalf("enabled transitions for nil snapshot = %v, want none", enabled)
+	}
+}
+
+func TestStateCategoryForPlaceWithoutTopologyIsUnavailable(t *testing.T) {
+	if category := stateCategoryForPlace(nil); category != nil {
+		t.Fatal("expected nil state-category lookup without topology")
+	}
+	if category := stateCategoryForPlace(&state.Net{}); category != nil {
+		t.Fatal("expected nil state-category lookup without work types")
+	}
+}
+
 func TestEnablementEvaluator_UsesInjectedClockForCronTimeWindowGuard(t *testing.T) {
 	base := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
 	dueAt := base.Add(2 * time.Minute)

--- a/pkg/services/factory_runtime/internal/services/orchestration/scheduler/enablement_runtime_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/scheduler/enablement_runtime_test.go
@@ -44,6 +44,17 @@ func TestStateCategoryForPlaceWithoutTopologyIsUnavailable(t *testing.T) {
 	}
 }
 
+func TestSortedTransitionsUsesNameWhenIDsMatch(t *testing.T) {
+	ordered := sortedTransitions(map[string]*petri.Transition{
+		"z":   {ID: "same", Name: "zulu"},
+		"a":   {ID: "same", Name: "alpha"},
+		"nil": nil,
+	})
+	if len(ordered) != 3 || ordered[0] != nil || ordered[1].Name != "alpha" || ordered[2].Name != "zulu" {
+		t.Fatalf("sorted transitions = %#v, want nil, alpha, zulu", ordered)
+	}
+}
+
 func TestEnablementEvaluator_UsesInjectedClockForCronTimeWindowGuard(t *testing.T) {
 	base := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
 	dueAt := base.Add(2 * time.Minute)

--- a/pkg/services/factory_runtime/internal/services/orchestration/scheduler/enablement_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/scheduler/enablement_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/petri"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/state"
 	factorytoken "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/token"
@@ -223,6 +224,50 @@ func TestEnablementEvaluator_BindsAllTokensForMatchingParentGuard(t *testing.T) 
 	}
 	if got := tokenIDs(enabled[0].Bindings["children"]); strings.Join(got, ",") != "tok-child-a,tok-child-b" {
 		t.Fatalf("children binding tokens = %v, want [tok-child-a tok-child-b]", got)
+	}
+}
+
+func TestEnablementEvaluator_AllChildrenCompleteWaitsForProcessingAndLateChild(t *testing.T) {
+	eval := NewEnablementEvaluator(nil, testNow, nil)
+	n := &state.Net{
+		Places: map[string]*petri.Place{
+			"parent:waiting":   {ID: "parent:waiting", TypeID: "parent", State: "waiting"},
+			"child:complete":   {ID: "child:complete", TypeID: "child", State: "complete"},
+			"child:processing": {ID: "child:processing", TypeID: "child", State: "processing"},
+		},
+		WorkTypes: map[string]*state.WorkType{
+			"parent": {ID: "parent", States: []state.StateDefinition{{Value: "waiting", Category: state.StateCategoryProcessing}}},
+			"child":  {ID: "child", States: []state.StateDefinition{{Value: "processing", Category: state.StateCategoryProcessing}, {Value: "complete", Category: state.StateCategoryTerminal}}},
+		},
+		Transitions: map[string]*petri.Transition{
+			"join": {
+				ID:   "join",
+				Name: "join",
+				InputArcs: []petri.Arc{
+					{ID: "parent-in", Name: "parent", PlaceID: "parent:waiting", Direction: petri.ArcInput, Cardinality: petri.ArcCardinality{Mode: petri.CardinalityOne}},
+					{ID: "children-in", Name: "children", PlaceID: "child:complete", Direction: petri.ArcInput, Mode: interfaces.ArcModeObserve, Cardinality: petri.ArcCardinality{Mode: petri.CardinalityAll}, Guard: &petri.AllWithParentGuard{MatchBinding: "parent"}},
+				},
+			},
+		},
+	}
+
+	parent := &factorytoken.Token{ID: "tok-parent", PlaceID: "parent:waiting", Color: factorytoken.Color{WorkID: "parent-1", WorkTypeID: "parent", DataType: factorytoken.DataTypeWork}}
+	first := &factorytoken.Token{ID: "tok-child-1", PlaceID: "child:complete", Color: factorytoken.Color{WorkID: "child-1", WorkTypeID: "child", ParentID: "parent-1", DataType: factorytoken.DataTypeWork}}
+	processing := &factorytoken.Token{ID: "tok-child-2", PlaceID: "child:processing", Color: factorytoken.Color{WorkID: "child-2", WorkTypeID: "child", ParentID: "parent-1", DataType: factorytoken.DataTypeWork}}
+
+	blocked := makeTestSnapshot(map[string]*factorytoken.Token{parent.ID: parent, first.ID: first, processing.ID: processing})
+	if enabled := eval.FindEnabledTransitions(context.Background(), n, &blocked); len(enabled) != 0 {
+		t.Fatalf("fan-in enabled with processing child: %#v", enabled)
+	}
+
+	processing.PlaceID = "child:complete"
+	terminal := makeTestSnapshot(map[string]*factorytoken.Token{parent.ID: parent, first.ID: first, processing.ID: processing})
+	enabled := eval.FindEnabledTransitions(context.Background(), n, &terminal)
+	if len(enabled) != 1 {
+		t.Fatalf("fan-in enabled transitions = %d, want exactly 1 after final child terminal", len(enabled))
+	}
+	if got := tokenIDs(enabled[0].Bindings["children"]); strings.Join(got, ",") != "tok-child-1,tok-child-2" {
+		t.Fatalf("fan-in child binding = %v, want both registered children", got)
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/services/orchestration/scheduler/enablement_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/scheduler/enablement_test.go
@@ -288,6 +288,50 @@ func TestEnablementEvaluator_AllChildrenCompleteWaitsForProcessingAndLateChild(t
 	}
 }
 
+func TestEnablementEvaluator_AllChildrenCompleteAcceptsDistinctTerminalPlaces(t *testing.T) {
+	eval := NewEnablementEvaluator(nil, testNow, nil)
+	n := &state.Net{
+		Places: map[string]*petri.Place{
+			"parent:waiting": {ID: "parent:waiting", TypeID: "parent", State: "waiting"},
+			"child:complete": {ID: "child:complete", TypeID: "child", State: "complete"},
+			"child:skipped":  {ID: "child:skipped", TypeID: "child", State: "skipped"},
+		},
+		WorkTypes: map[string]*state.WorkType{
+			"parent": {ID: "parent", States: []state.StateDefinition{{Value: "waiting", Category: state.StateCategoryProcessing}}},
+			"child": {ID: "child", States: []state.StateDefinition{
+				{Value: "complete", Category: state.StateCategoryTerminal},
+				{Value: "skipped", Category: state.StateCategoryTerminal},
+			}},
+		},
+		Transitions: map[string]*petri.Transition{
+			"join": {
+				ID:   "join",
+				Name: "join",
+				InputArcs: []petri.Arc{
+					{ID: "parent-in", Name: "parent", PlaceID: "parent:waiting", Direction: petri.ArcInput, Cardinality: petri.ArcCardinality{Mode: petri.CardinalityOne}},
+					{ID: "children-in", Name: "children", PlaceID: "child:complete", Direction: petri.ArcInput, Mode: interfaces.ArcModeObserve, Cardinality: petri.ArcCardinality{Mode: petri.CardinalityAll}, Guard: &petri.AllWithParentGuard{MatchBinding: "parent"}},
+				},
+			},
+		},
+	}
+
+	parent := &factorytoken.Token{ID: "tok-parent", PlaceID: "parent:waiting", Color: factorytoken.Color{WorkID: "parent-1", WorkTypeID: "parent", DataType: factorytoken.DataTypeWork}}
+	complete := &factorytoken.Token{ID: "tok-child-complete", PlaceID: "child:complete", Color: factorytoken.Color{WorkID: "child-1", WorkTypeID: "child", ParentID: "parent-1", DataType: factorytoken.DataTypeWork}}
+	skipped := &factorytoken.Token{ID: "tok-child-skipped", PlaceID: "child:skipped", Color: factorytoken.Color{WorkID: "child-2", WorkTypeID: "child", ParentID: "parent-1", DataType: factorytoken.DataTypeWork}}
+	marking := makeTestSnapshot(map[string]*factorytoken.Token{parent.ID: parent, complete.ID: complete, skipped.ID: skipped})
+	marking.ParentChildRegistrations = petri.ParentChildRegistrationProjection{
+		"parent-1": {Children: []factorytoken.Token{*complete, *skipped}, Complete: true},
+	}
+
+	enabled := eval.FindEnabledTransitions(context.Background(), n, &marking)
+	if len(enabled) != 1 {
+		t.Fatalf("fan-in enabled transitions = %d, want exactly 1", len(enabled))
+	}
+	if got := tokenIDs(enabled[0].Bindings["children"]); strings.Join(got, ",") != complete.ID {
+		t.Fatalf("fan-in binding surface = %v, want [%s] while validating both terminal places", got, complete.ID)
+	}
+}
+
 func TestEnablementEvaluator_SameNameGuardEnablesOnMatchingNames(t *testing.T) {
 	eval := NewEnablementEvaluator(nil, testNow, nil)
 	n := sameNameGuardNet()

--- a/pkg/services/factory_runtime/internal/services/orchestration/scheduler/enablement_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/scheduler/enablement_test.go
@@ -214,6 +214,9 @@ func TestEnablementEvaluator_BindsAllTokensForMatchingParentGuard(t *testing.T) 
 		"tok-child-b":     {ID: "tok-child-b", PlaceID: "p-children", Color: factorytoken.Color{WorkID: "c2", ParentID: "w1"}},
 		"tok-child-other": {ID: "tok-child-other", PlaceID: "p-children", Color: factorytoken.Color{WorkID: "c3", ParentID: "other"}},
 	})
+	marking.ParentChildRegistrations = petri.ParentChildRegistrationProjection{
+		"w1": {Children: []factorytoken.Token{*marking.Tokens["tok-child-a"], *marking.Tokens["tok-child-b"]}, Complete: true},
+	}
 
 	enabled := eval.FindEnabledTransitions(context.Background(), n, &marking)
 	if len(enabled) != 1 {
@@ -255,13 +258,27 @@ func TestEnablementEvaluator_AllChildrenCompleteWaitsForProcessingAndLateChild(t
 	first := &factorytoken.Token{ID: "tok-child-1", PlaceID: "child:complete", Color: factorytoken.Color{WorkID: "child-1", WorkTypeID: "child", ParentID: "parent-1", DataType: factorytoken.DataTypeWork}}
 	processing := &factorytoken.Token{ID: "tok-child-2", PlaceID: "child:processing", Color: factorytoken.Color{WorkID: "child-2", WorkTypeID: "child", ParentID: "parent-1", DataType: factorytoken.DataTypeWork}}
 
-	blocked := makeTestSnapshot(map[string]*factorytoken.Token{parent.ID: parent, first.ID: first, processing.ID: processing})
-	if enabled := eval.FindEnabledTransitions(context.Background(), n, &blocked); len(enabled) != 0 {
-		t.Fatalf("fan-in enabled with processing child: %#v", enabled)
+	initial := makeTestSnapshot(map[string]*factorytoken.Token{parent.ID: parent, first.ID: first})
+	initial.ParentChildRegistrations = petri.ParentChildRegistrationProjection{
+		"parent-1": {Children: []factorytoken.Token{*first}, Complete: false},
+	}
+	if enabled := eval.FindEnabledTransitions(context.Background(), n, &initial); len(enabled) != 0 {
+		t.Fatalf("fan-in enabled before the registered set was complete: %#v", enabled)
+	}
+
+	late := makeTestSnapshot(map[string]*factorytoken.Token{parent.ID: parent, first.ID: first, processing.ID: processing})
+	late.ParentChildRegistrations = petri.ParentChildRegistrationProjection{
+		"parent-1": {Children: []factorytoken.Token{*first, *processing}, Complete: false},
+	}
+	if enabled := eval.FindEnabledTransitions(context.Background(), n, &late); len(enabled) != 0 {
+		t.Fatalf("fan-in enabled with a late registration still open: %#v", enabled)
 	}
 
 	processing.PlaceID = "child:complete"
 	terminal := makeTestSnapshot(map[string]*factorytoken.Token{parent.ID: parent, first.ID: first, processing.ID: processing})
+	terminal.ParentChildRegistrations = petri.ParentChildRegistrationProjection{
+		"parent-1": {Children: []factorytoken.Token{*first, *processing}, Complete: true},
+	}
 	enabled := eval.FindEnabledTransitions(context.Background(), n, &terminal)
 	if len(enabled) != 1 {
 		t.Fatalf("fan-in enabled transitions = %d, want exactly 1 after final child terminal", len(enabled))

--- a/tests/functional/guards/batch/all_children_complete_test.go
+++ b/tests/functional/guards/batch/all_children_complete_test.go
@@ -1,4 +1,4 @@
-package guards_batch
+package batch
 
 import (
 	"context"
@@ -12,6 +12,7 @@ import (
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/work"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
@@ -211,6 +212,15 @@ func commandWorkerType(request platformprocess.CommandRequest) string {
 		return "holder"
 	}
 	return "unknown"
+}
+
+func assertGuardSessionPlaces(t *testing.T, listed factoryapi.ListWorkResponse, wants map[string]int) {
+	t.Helper()
+	for placeID, want := range wants {
+		if got := support.CountWorkAtCustomerState(listed, placeID); got != want {
+			t.Errorf("%s token count = %d, want %d", placeID, got, want)
+		}
+	}
 }
 
 func (r *fanInGateCommandRunner) releaseHold() {

--- a/tests/functional/guards_batch/all_children_complete_test.go
+++ b/tests/functional/guards_batch/all_children_complete_test.go
@@ -2,16 +2,16 @@ package guards_batch
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/portpowered/infinite-you/internal/testutil"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/work"
-	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
-	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
@@ -19,65 +19,66 @@ func TestAllChildrenCompleteWaitsForLastTerminalChild(t *testing.T) {
 	dir := testutil.ScaffoldFactoryDir(t, allChildrenCompleteFactoryConfig())
 	support.WriteAgentConfig(t, dir, "processor", support.BuildModelWorkerConfig("codex", "test-model"))
 	support.WriteAgentConfig(t, dir, "completer", support.BuildModelWorkerConfig("codex", "test-model"))
+	support.WriteAgentConfig(t, dir, "reopener", support.BuildModelWorkerConfig("codex", "test-model"))
+	support.WriteAgentConfig(t, dir, "holder", "---\ntype: MODEL_WORKER\nmodel: test-model\nmodelProvider: codex\n---\nHold the parent while the late child is registered.\n")
 	support.WriteWorkstationConfig(t, dir, "process-child", "---\ntype: MODEL_WORKSTATION\n---\nProcess the child.\n")
 	support.WriteWorkstationConfig(t, dir, "complete-parent", "---\ntype: MODEL_WORKSTATION\n---\nComplete the parent.\n")
+	support.WriteWorkstationConfig(t, dir, "reopen-parent", "---\ntype: MODEL_WORKSTATION\n---\nReopen the parent.\n")
+	support.WriteWorkstationConfig(t, dir, "a-hold-fan-in", "---\ntype: MODEL_WORKSTATION\n---\nHold the fan-in resource.\n")
 	testutil.WriteSeedBatchFile(t, dir, work.WorkRequest{
 		RequestID: "all-children-complete-regression",
 		Type:      work.WorkRequestTypeFactoryRequestBatch,
 		Works: []work.Work{
 			{Name: "parent", WorkID: "parent-1", WorkTypeID: "parent", State: "waiting"},
 			{Name: "early-child", WorkID: "child-1", WorkTypeID: "child", State: "complete"},
-			{Name: "slow-child", WorkID: "child-2", WorkTypeID: "child", State: "processing"},
 		},
 		Relations: []work.WorkRelation{
 			{Type: work.WorkRelationParentChild, SourceWorkName: "early-child", TargetWorkName: "parent"},
-			{Type: work.WorkRelationParentChild, SourceWorkName: "slow-child", TargetWorkName: "parent"},
 		},
 	})
 
-	provider := newFanInGateProvider()
-	type runResult struct {
-		session factoryapi.FactorySession
-		work    factoryapi.ListWorkResponse
-		events  []factoryapi.FactoryEvent
-	}
-	done := make(chan runResult, 1)
-	go func() {
-		session, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
-			t,
-			dir,
-			serviceedges.Edges{ProviderOverride: provider},
-			10*time.Second,
-		)
-		done <- runResult{session: session, work: listed, events: events}
-	}()
+	runner := newFanInGateCommandRunner()
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		WaitForServiceModeRuntime: true,
+		Edges:                     serviceedges.Edges{ProviderCommandRunner: runner},
+	})
+	baseURL := server.URL()
+	session := support.GetDefaultSession(t, baseURL)
 
 	// The channel is the deterministic synchronization point; the timeout only
 	// turns a missing dispatch into a bounded test failure instead of a hang.
 	select {
-	case <-provider.slowChildStarted:
+	case <-runner.holdStarted:
 	case <-time.After(10 * time.Second):
-		provider.releaseSlowChild()
-		result := <-done
-		t.Fatalf("timed out waiting for controlled child dispatch: calls=%#v session=%#v work=%#v events=%d", provider.callsSnapshot(), result.session, result.work, len(result.events))
+		runner.releaseHold()
+		t.Fatalf("timed out waiting for the resource-holding dispatch: calls=%#v", runner.callsSnapshot())
 	}
-	if got := provider.callCount("completer"); got != 0 {
-		t.Errorf("fan-in dispatched before the slow child was released: completer calls=%d", got)
+	preLate := support.ListDefaultSessionWork(t, baseURL)
+	assertGuardSessionPlaces(t, preLate, map[string]int{
+		"child:complete": 1,
+	})
+	if got := runner.callCount("completer"); got != 0 {
+		t.Errorf("fan-in dispatched before the late child was registered: completer calls=%d", got)
 	}
-	provider.releaseSlowChild()
+	// Releasing the parent dispatch makes its worker-emitted request enter the
+	// canonical runtime stream. That request registers child-2 after child-1
+	// was already terminal, then the child must reach terminal before the join.
+	runner.releaseHold()
+	support.WaitForSessionTerminalStatus(t, baseURL, session.Id, 10*time.Second)
 
-	result := <-done
-	assertGuardSessionPlaces(t, result.work, map[string]int{
+	listed := support.ListDefaultSessionWork(t, baseURL)
+	assertGuardSessionPlaces(t, listed, map[string]int{
 		"parent:complete":  1,
 		"parent:waiting":   0,
 		"child:complete":   2,
 		"child:processing": 0,
 	})
-	if got := provider.callCount("completer"); got != 1 {
+	if got := runner.callCount("completer"); got != 1 {
 		t.Fatalf("completer calls = %d, want exactly one", got)
 	}
 
-	observations := support.ObserveDispatchEvents(t, result.events)
+	observations := support.ObserveDispatchEvents(t, server.GetFactoryEvents(t))
 	processorIndex := -1
 	completerIndex := -1
 	for index, observation := range observations {
@@ -89,12 +90,12 @@ func TestAllChildrenCompleteWaitsForLastTerminalChild(t *testing.T) {
 		}
 	}
 	if processorIndex < 0 || completerIndex < 0 {
-		t.Fatalf("public dispatch events missing slow child or parent fan-in: %#v", observations)
+		t.Fatalf("public dispatch events missing late child or parent fan-in: %#v", observations)
 	}
 	if completerIndex <= processorIndex {
 		t.Fatalf("public fan-in dispatch index = %d, slow child dispatch index = %d; fan-in fired too early", completerIndex, processorIndex)
 	}
-	if result.session.Id == "" {
+	if session.Id == "" {
 		t.Fatal("expected a public Factory Session outcome")
 	}
 }
@@ -116,8 +117,22 @@ func allChildrenCompleteFactoryConfig() *interfaces.FactoryConfig {
 		Workers: []interfaces.FactoryWorkerConfig{
 			{Name: "processor"},
 			{Name: "completer"},
+			{Name: "holder"},
+			{Name: "reopener"},
 		},
 		Workstations: []interfaces.FactoryWorkstationConfig{
+			{
+				Name:           "a-hold-fan-in",
+				WorkerTypeName: "holder",
+				Inputs:         []interfaces.IOConfig{{WorkTypeName: "parent", StateName: "waiting"}},
+				Outputs:        []interfaces.IOConfig{{WorkTypeName: "parent", StateName: "init"}},
+			},
+			{
+				Name:           "reopen-parent",
+				WorkerTypeName: "reopener",
+				Inputs:         []interfaces.IOConfig{{WorkTypeName: "parent", StateName: "init"}},
+				Outputs:        []interfaces.IOConfig{{WorkTypeName: "parent", StateName: "waiting"}},
+			},
 			{
 				Name:           "process-child",
 				WorkerTypeName: "processor",
@@ -142,62 +157,80 @@ func allChildrenCompleteFactoryConfig() *interfaces.FactoryConfig {
 	}
 }
 
-type fanInGateProvider struct {
-	slowChildStarted chan struct{}
-	release          chan struct{}
-	startOnce        sync.Once
-	releaseOnce      sync.Once
+// fanInGateCommandRunner exercises the production ProviderCommandRunner edge.
+// It records the low-level provider requests and gates only the resource-holder
+// workstation request, allowing the test to observe an attempted parent
+// dispatch without replacing the provider service with an in-process fake.
+type fanInGateCommandRunner struct {
+	holdStarted chan struct{}
+	release     chan struct{}
+	startOnce   sync.Once
+	releaseOnce sync.Once
 
 	mu    sync.Mutex
 	calls map[string]int
 }
 
-func newFanInGateProvider() *fanInGateProvider {
-	return &fanInGateProvider{
-		slowChildStarted: make(chan struct{}),
-		release:          make(chan struct{}),
-		calls:            make(map[string]int),
+func newFanInGateCommandRunner() *fanInGateCommandRunner {
+	return &fanInGateCommandRunner{
+		holdStarted: make(chan struct{}),
+		release:     make(chan struct{}),
+		calls:       make(map[string]int),
 	}
 }
 
-func (p *fanInGateProvider) Infer(ctx context.Context, request workerexecution.ProviderInferenceRequest) (workerexecution.InferenceResponse, error) {
-	workerType := request.WorkerType
-	if workerType == "" {
-		workerType = request.Dispatch.WorkerType
-	}
-	p.mu.Lock()
-	p.calls[workerType]++
-	p.mu.Unlock()
+func (r *fanInGateCommandRunner) Run(ctx context.Context, request platformprocess.CommandRequest) (platformprocess.CommandResult, error) {
+	workerType := commandWorkerType(request)
+	r.mu.Lock()
+	r.calls[workerType]++
+	r.mu.Unlock()
 
-	if workerType == "processor" {
-		p.startOnce.Do(func() { close(p.slowChildStarted) })
+	if workerType == "holder" {
+		r.startOnce.Do(func() { close(r.holdStarted) })
 		select {
-		case <-p.release:
+		case <-r.release:
 		case <-ctx.Done():
-			return workerexecution.InferenceResponse{}, ctx.Err()
+			return platformprocess.CommandResult{}, ctx.Err()
 		}
+		return platformprocess.CommandResult{Stdout: support.CodexSuccessStdout(`{"request":{"type":"FACTORY_REQUEST_BATCH","works":[{"name":"late-child","workId":"child-2","workTypeName":"child","state":"processing"}]}}`)}, nil
 	}
-	return workerexecution.InferenceResponse{Content: "COMPLETE"}, nil
+	return platformprocess.CommandResult{Stdout: support.CodexSuccessStdout("COMPLETE")}, nil
 }
 
-func (p *fanInGateProvider) releaseSlowChild() {
-	p.releaseOnce.Do(func() { close(p.release) })
+func commandWorkerType(request platformprocess.CommandRequest) string {
+	if strings.Contains(string(request.Stdin), "Process the child.") {
+		return "processor"
+	}
+	if strings.Contains(string(request.Stdin), "Complete the parent.") {
+		return "completer"
+	}
+	if strings.Contains(string(request.Stdin), "Reopen the parent.") {
+		return "reopener"
+	}
+	if strings.Contains(string(request.Stdin), "Hold the fan-in resource.") {
+		return "holder"
+	}
+	return "unknown"
 }
 
-func (p *fanInGateProvider) callCount(workerType string) int {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.calls[workerType]
+func (r *fanInGateCommandRunner) releaseHold() {
+	r.releaseOnce.Do(func() { close(r.release) })
 }
 
-func (p *fanInGateProvider) callsSnapshot() map[string]int {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	copy := make(map[string]int, len(p.calls))
-	for workerType, count := range p.calls {
+func (r *fanInGateCommandRunner) callCount(workerType string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls[workerType]
+}
+
+func (r *fanInGateCommandRunner) callsSnapshot() map[string]int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	copy := make(map[string]int, len(r.calls))
+	for workerType, count := range r.calls {
 		copy[workerType] = count
 	}
 	return copy
 }
 
-var _ workerexecution.Provider = (*fanInGateProvider)(nil)
+var _ platformprocess.CommandRunner = (*fanInGateCommandRunner)(nil)

--- a/tests/functional/guards_batch/all_children_complete_test.go
+++ b/tests/functional/guards_batch/all_children_complete_test.go
@@ -1,0 +1,203 @@
+package guards_batch
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+func TestAllChildrenCompleteWaitsForLastTerminalChild(t *testing.T) {
+	dir := testutil.ScaffoldFactoryDir(t, allChildrenCompleteFactoryConfig())
+	support.WriteAgentConfig(t, dir, "processor", support.BuildModelWorkerConfig("codex", "test-model"))
+	support.WriteAgentConfig(t, dir, "completer", support.BuildModelWorkerConfig("codex", "test-model"))
+	support.WriteWorkstationConfig(t, dir, "process-child", "---\ntype: MODEL_WORKSTATION\n---\nProcess the child.\n")
+	support.WriteWorkstationConfig(t, dir, "complete-parent", "---\ntype: MODEL_WORKSTATION\n---\nComplete the parent.\n")
+	testutil.WriteSeedBatchFile(t, dir, work.WorkRequest{
+		RequestID: "all-children-complete-regression",
+		Type:      work.WorkRequestTypeFactoryRequestBatch,
+		Works: []work.Work{
+			{Name: "parent", WorkID: "parent-1", WorkTypeID: "parent", State: "waiting"},
+			{Name: "early-child", WorkID: "child-1", WorkTypeID: "child", State: "complete"},
+			{Name: "slow-child", WorkID: "child-2", WorkTypeID: "child", State: "processing"},
+		},
+		Relations: []work.WorkRelation{
+			{Type: work.WorkRelationParentChild, SourceWorkName: "early-child", TargetWorkName: "parent"},
+			{Type: work.WorkRelationParentChild, SourceWorkName: "slow-child", TargetWorkName: "parent"},
+		},
+	})
+
+	provider := newFanInGateProvider()
+	type runResult struct {
+		session factoryapi.FactorySession
+		work    factoryapi.ListWorkResponse
+		events  []factoryapi.FactoryEvent
+	}
+	done := make(chan runResult, 1)
+	go func() {
+		session, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
+			t,
+			dir,
+			serviceedges.Edges{ProviderOverride: provider},
+			10*time.Second,
+		)
+		done <- runResult{session: session, work: listed, events: events}
+	}()
+
+	// The channel is the deterministic synchronization point; the timeout only
+	// turns a missing dispatch into a bounded test failure instead of a hang.
+	select {
+	case <-provider.slowChildStarted:
+	case <-time.After(10 * time.Second):
+		provider.releaseSlowChild()
+		result := <-done
+		t.Fatalf("timed out waiting for controlled child dispatch: calls=%#v session=%#v work=%#v events=%d", provider.callsSnapshot(), result.session, result.work, len(result.events))
+	}
+	if got := provider.callCount("completer"); got != 0 {
+		t.Errorf("fan-in dispatched before the slow child was released: completer calls=%d", got)
+	}
+	provider.releaseSlowChild()
+
+	result := <-done
+	assertGuardSessionPlaces(t, result.work, map[string]int{
+		"parent:complete":  1,
+		"parent:waiting":   0,
+		"child:complete":   2,
+		"child:processing": 0,
+	})
+	if got := provider.callCount("completer"); got != 1 {
+		t.Fatalf("completer calls = %d, want exactly one", got)
+	}
+
+	observations := support.ObserveDispatchEvents(t, result.events)
+	processorIndex := -1
+	completerIndex := -1
+	for index, observation := range observations {
+		if observation.Request.TransitionId == "process-child" {
+			processorIndex = index
+		}
+		if observation.Request.TransitionId == "complete-parent" {
+			completerIndex = index
+		}
+	}
+	if processorIndex < 0 || completerIndex < 0 {
+		t.Fatalf("public dispatch events missing slow child or parent fan-in: %#v", observations)
+	}
+	if completerIndex <= processorIndex {
+		t.Fatalf("public fan-in dispatch index = %d, slow child dispatch index = %d; fan-in fired too early", completerIndex, processorIndex)
+	}
+	if result.session.Id == "" {
+		t.Fatal("expected a public Factory Session outcome")
+	}
+}
+
+func allChildrenCompleteFactoryConfig() *interfaces.FactoryConfig {
+	return &interfaces.FactoryConfig{
+		WorkTypes: []interfaces.WorkTypeConfig{
+			{Name: "parent", States: []interfaces.StateConfig{
+				{Name: "init", Type: interfaces.StateTypeInitial},
+				{Name: "waiting", Type: interfaces.StateTypeProcessing},
+				{Name: "complete", Type: interfaces.StateTypeTerminal},
+			}},
+			{Name: "child", States: []interfaces.StateConfig{
+				{Name: "init", Type: interfaces.StateTypeInitial},
+				{Name: "processing", Type: interfaces.StateTypeProcessing},
+				{Name: "complete", Type: interfaces.StateTypeTerminal},
+			}},
+		},
+		Workers: []interfaces.FactoryWorkerConfig{
+			{Name: "processor"},
+			{Name: "completer"},
+		},
+		Workstations: []interfaces.FactoryWorkstationConfig{
+			{
+				Name:           "process-child",
+				WorkerTypeName: "processor",
+				Inputs:         []interfaces.IOConfig{{WorkTypeName: "child", StateName: "processing"}},
+				Outputs:        []interfaces.IOConfig{{WorkTypeName: "child", StateName: "complete"}},
+			},
+			{
+				Name: "complete-parent", WorkerTypeName: "completer",
+				Inputs: []interfaces.IOConfig{
+					{WorkTypeName: "parent", StateName: "waiting"},
+					{
+						WorkTypeName: "child", StateName: "complete",
+						Guard: &interfaces.InputGuardConfig{
+							Type:        interfaces.GuardTypeAllChildrenComplete,
+							ParentInput: "parent",
+						},
+					},
+				},
+				Outputs: []interfaces.IOConfig{{WorkTypeName: "parent", StateName: "complete"}},
+			},
+		},
+	}
+}
+
+type fanInGateProvider struct {
+	slowChildStarted chan struct{}
+	release          chan struct{}
+	startOnce        sync.Once
+	releaseOnce      sync.Once
+
+	mu    sync.Mutex
+	calls map[string]int
+}
+
+func newFanInGateProvider() *fanInGateProvider {
+	return &fanInGateProvider{
+		slowChildStarted: make(chan struct{}),
+		release:          make(chan struct{}),
+		calls:            make(map[string]int),
+	}
+}
+
+func (p *fanInGateProvider) Infer(ctx context.Context, request workerexecution.ProviderInferenceRequest) (workerexecution.InferenceResponse, error) {
+	workerType := request.WorkerType
+	if workerType == "" {
+		workerType = request.Dispatch.WorkerType
+	}
+	p.mu.Lock()
+	p.calls[workerType]++
+	p.mu.Unlock()
+
+	if workerType == "processor" {
+		p.startOnce.Do(func() { close(p.slowChildStarted) })
+		select {
+		case <-p.release:
+		case <-ctx.Done():
+			return workerexecution.InferenceResponse{}, ctx.Err()
+		}
+	}
+	return workerexecution.InferenceResponse{Content: "COMPLETE"}, nil
+}
+
+func (p *fanInGateProvider) releaseSlowChild() {
+	p.releaseOnce.Do(func() { close(p.release) })
+}
+
+func (p *fanInGateProvider) callCount(workerType string) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls[workerType]
+}
+
+func (p *fanInGateProvider) callsSnapshot() map[string]int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	copy := make(map[string]int, len(p.calls))
+	for workerType, count := range p.calls {
+		copy[workerType] = count
+	}
+	return copy
+}
+
+var _ workerexecution.Provider = (*fanInGateProvider)(nil)

--- a/ui/packages/factory-emulator/scripts/verify-installed-consumer.mjs
+++ b/ui/packages/factory-emulator/scripts/verify-installed-consumer.mjs
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 
 import { packAndVerify as packClient } from "../../client/scripts/verify-package-pack.mjs";
@@ -11,10 +11,6 @@ import { packAndVerify as packEmulator } from "./verify-package-pack.mjs";
 
 const execFileAsync = promisify(execFile);
 const require = createRequire(import.meta.url);
-const packageRoot = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "..",
-);
 
 async function npmCommand() {
   if (process.platform !== "win32") return { args: [], executable: "npm" };


### PR DESCRIPTION
{
  "project": "WO-A2 — Prevent ALL_CHILDREN_COMPLETE from firing before every registered child is terminal",
  "branchName": "wo-a2-all-children-terminal-gating",
  "description": "Correct parent-aware Factory Runtime fan-in so ALL_CHILDREN_COMPLETE derives completeness from the full registered child set and each child's terminal state, including late registration, and never dispatches downstream work while a registered child is still processing.",
  "context": {
    "customerAsk": "Make parent-aware fan-in derive completeness from the full registered child set and terminal states, including late registration, so processing children can never satisfy the guard.",
    "problem": "ALL_CHILDREN_COMPLETE can treat the terminal children currently visible at fan-in as the entire child population, enabling downstream work while another registered or late-registered child is still processing.",
    "solution": "Keep the decision in Factory Runtime, project the complete parent-scoped registered child set and current child state from ordered runtime facts, fail closed until the set is known and every member is terminal, and prove the behavior with focused unit and deterministic functional regressions."
  },
  "acceptanceCriteria": [
    "For a parent with a registered fan-out set, ALL_CHILDREN_COMPLETE enables its downstream transition if and only if the complete registered child set is known and every registered child is in a configured terminal-category state; a PROCESSING or otherwise non-terminal child never counts as complete.",
    "When a child is registered after one or more siblings have already become terminal, the fan-in remains blocked until that late-registered child is terminal, and the downstream transition fires exactly once after the final child reaches terminal state.",
    "The correction is owned by Factory Runtime's explicit runtime state/projection and guard evaluation, uses ordered canonical facts without a new side-effect or persistence path, and preserves existing public guard configuration and unrelated guard semantics.",
    "A focused guard/projection unit regression includes terminal, processing, and late-registered children and fails against the old premature-enable behavior; a deterministic functional scenario observes fan-out/fan-in through customer-visible process/event behavior without arbitrary sleeps.",
    "Quality gate: go test ./pkg/services/factory_runtime/internal/orchestrators/petri/... ./pkg/services/factory_runtime/internal/services/orchestration/state/... ./pkg/services/factory_runtime/internal/services/orchestration/scheduler/..., go test ./tests/functional/guards/batch/... -run TestAllChildrenCompleteWaitsForLastTerminalChild -count=1, make verify-fast, typecheck, lint, tests, and required PR CI are terminal and passing.",
    "Delivery: the implementation/review loop continues until all blocking PR conversation feedback is explicitly addressed, shared-file changes and merge conflicts are reconciled, required CI is terminal and passing, and the PR is actually merged; an opened, green, approved, or merge-ready PR is not complete."
  ],
  "userStories": [
    {
      "id": "wo-a2-all-children-terminal-gating-001",
      "title": "Hold parent fan-in until every registered child is terminal",
      "description": "As a Factory operator, I want ALL_CHILDREN_COMPLETE to wait for every child registered to a parent so downstream work cannot start while a slow or late-registered child is still processing.",
      "acceptanceCriteria": [
        "Given a parent with multiple registered children, the guard remains unsatisfied while any registered child is PROCESSING or in another non-terminal state, even when all other children are terminal.",
        "Child completeness is derived from the full parent-scoped registered child set and current terminal-state facts, rather than treating the currently visible terminal candidates as the full population.",
        "If a sibling becomes terminal before another child is registered, registering the later child keeps the fan-in blocked until that child becomes terminal; terminal sibling facts are retained and no arbitrary event ordering can cause premature enablement.",
        "After the last registered child becomes terminal, the downstream transition becomes eligible and fires exactly once with the expected parent/child correlation; unrelated parents and unrelated guards do not affect the result.",
        "A focused guard/projection unit regression covers processing and late-registered children and demonstrably fails on the old premature-fire behavior.",
        "A deterministic functional fan-out/fan-in scenario, entered through root.BuildProcess and Process.Execute and observed through public Factory, Work, or Factory Event outcomes, proves the downstream transition does not fire before the last child is terminal and does fire afterward without arbitrary sleeps or timeout-padded polling.",
        "go test ./pkg/services/factory_runtime/internal/orchestrators/petri/... ./pkg/services/factory_runtime/internal/services/orchestration/state/... ./pkg/services/factory_runtime/internal/services/orchestration/scheduler/... passes.",
    "go test ./tests/functional/guards/batch/... -run TestAllChildrenCompleteWaitsForLastTerminalChild -count=1 passes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented runtime-owned ALL_CHILDREN_COMPLETE gating over an ordered, explicit parent-scoped registered-child projection. Canonical seed and worker-generated batch admission records each child and publishes completeness only after the atomic batch; runtime evaluation fails closed when the projection is absent or incomplete, includes active dispatches, and requires every registered child to be in a configured terminal category. FanoutCountGuard remains exact-count-only. The deterministic public guards/batch regression emits the late child through ProviderCommandRunner after its sibling is terminal and observes public Work state plus exactly-once Factory dispatch ordering. Review follow-up head 52f10bbef is rebased onto current fork/main d7b401b6f, with full-population terminal validation split into focused helpers and the regression under tests/functional/guards/batch. Focused runtime and functional commands, make verify-fast, make typecheck, affected-package go vet, pkg-maint, pkg-file-count, pkg-structure, and git diff --check pass. make lint reaches only the pre-existing 176-entry package-boundary baseline; no changed story file is reported. Required PR CI run 31286109188 is terminal and green across Backend Functional Coverage including pinned real ACP evidence, Backend Unit Coverage, Local Inference, Verification Policy, frontend, UI backend integration, API/package, and classification lanes. Final review audit at 2026-08-08 17:38 -07:00 found no unresolved inline threads or formal requested-change reviews; PR #1817 remains mergeable at this head and its body is synchronized to this file."
    }
  ]
}
