### PR TITLE
WO-A7: fail incomplete hosted drains

### DIFF
--- a/cmd/factory/main_test.go
+++ b/cmd/factory/main_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 )
 
 func TestMainDelegatesExitCodeToRootProcess(t *testing.T) {
@@ -47,6 +49,11 @@ func TestProcessExitCodePreservesDeclaredLifecycleContract(t *testing.T) {
 	}{
 		{name: "success", want: exitSuccess},
 		{name: "failure", err: errors.New("failed"), want: exitFailure},
+		{
+			name: "incomplete finite drain",
+			err:  &factoryruntime.IncompleteDrainError{NonTerminalWorkCount: 1},
+			want: exitFailure,
+		},
 		{
 			name:       "run cancellation normalized by lifecycle",
 			contextErr: context.Canceled,

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -212,6 +212,19 @@ one-shot run completes, or a continuous run is cancelled, the command cancels
 and joins the listener and runtime before returning. Listener startup failure
 cancels a waiting run and produces no browser effect.
 
+For a finite server-enabled run, an empty queue or a queue whose Work is all
+terminal succeeds. If the runtime drains while `N` customer Work items remain
+non-terminal, the run is unsuccessful, but it still joins the owned listener
+and runtime before returning. Human CLI stderr contains exactly:
+
+```text
+Error: factory session drained with N non-terminal work items; run is incomplete
+```
+
+The failed run does not print a success or completion claim to stdout. Add
+`--continuously` when an idle server-enabled run should remain live for later
+Work instead of applying finite drain classification.
+
 Add `--with-site` to imply the same API server, serve the embedded dashboard,
 and open it exactly once after listener and runtime readiness:
 

--- a/docs/reference/sessions.md
+++ b/docs/reference/sessions.md
@@ -674,6 +674,13 @@ still-running service:
 | One-shot `you run --with-server` or `--with-site` | Only for the run lifetime — the listener is joined before the command returns. |
 | Ordinary one-shot `you run` | No — starts no listener and exits when the factory becomes idle or invocation completes. |
 
+Finite server-enabled runs succeed when no Work is admitted or every admitted
+Work item is terminal. If the queue drains around non-terminal Work, the
+Factory Session is incomplete: the command returns failure with
+`Error: factory session drained with N non-terminal work items; run is incomplete`
+on stderr and joins the listener/runtime before returning. Continuous runs
+remain live while idle and end only when cancelled.
+
 For steady operator loops (check running → submit → verify), prefer `you server`
 or `you run --continuously --with-server`. See `you docs agents` for the full
 operator loop and pre-submit checklist.

--- a/pkg/services/factory_definitions/contracts_root.go
+++ b/pkg/services/factory_definitions/contracts_root.go
@@ -287,6 +287,8 @@ type (
 	RequiredToolConfig                               = contracts.RequiredToolConfig
 	RuntimeMode                                      = contracts.RuntimeMode
 	RuntimeStatus                                    = contracts.RuntimeStatus
+	TerminationClassification                        = contracts.TerminationClassification
+	TerminationResult                                = contracts.TerminationResult
 	RuntimeWorkstationLookup                         = contracts.RuntimeWorkstationLookup
 	SubmissionHookContext[TSnapshot any]             = contracts.SubmissionHookContext[TSnapshot]
 	SubmissionHookResult                             = contracts.SubmissionHookResult
@@ -358,6 +360,8 @@ const (
 	RuntimeStatusActive                           = contracts.RuntimeStatusActive
 	RuntimeStatusFinished                         = contracts.RuntimeStatusFinished
 	RuntimeStatusIdle                             = contracts.RuntimeStatusIdle
+	TerminationClassificationComplete             = contracts.TerminationClassificationComplete
+	TerminationClassificationIncomplete           = contracts.TerminationClassificationIncomplete
 	SystemTimeExpiryTransitionID                  = contracts.SystemTimeExpiryTransitionID
 	SystemTimePendingState                        = contracts.SystemTimePendingState
 	SystemTimeWorkTypeID                          = contracts.SystemTimeWorkTypeID

--- a/pkg/services/factory_definitions/internal/contracts/factory_runtime.go
+++ b/pkg/services/factory_definitions/internal/contracts/factory_runtime.go
@@ -40,6 +40,25 @@ const (
 	RuntimeModeService RuntimeMode = "SERVICE"
 )
 
+// TerminationClassification describes the outcome of a finite runtime drain.
+// It is carried with the tick result so the engine can preserve the final
+// submission-drain race protection before converting an incomplete drain into
+// a runtime error.
+type TerminationClassification string
+
+const (
+	TerminationClassificationComplete   TerminationClassification = "COMPLETE"
+	TerminationClassificationIncomplete TerminationClassification = "INCOMPLETE"
+)
+
+// TerminationResult is the authoritative finite-runtime termination decision.
+// NonTerminalWorkCount is the number of distinct customer Work items that were
+// still non-terminal when the runtime became quiescent.
+type TerminationResult struct {
+	Classification       TerminationClassification `json:"classification"`
+	NonTerminalWorkCount int                       `json:"non_terminal_work_count,omitempty"`
+}
+
 // InvocationTerminalStatus is the Factory Session-owned terminal outcome for
 // one invocation. Transport adapters map it to their generated contract.
 type InvocationTerminalStatus = string
@@ -245,6 +264,7 @@ type TickResult struct {
 	ActiveThrottlePauses   []ActiveThrottlePause           `json:"active_throttle_pauses,omitempty"`
 	ThrottlePausesObserved bool                            `json:"throttle_pauses_observed,omitempty"`
 	ShouldTerminate        bool                            `json:"should_terminate,omitempty"`
+	Termination            *TerminationResult              `json:"termination,omitempty"`
 }
 
 // DispatchRecord pairs a WorkDispatch with the marking mutations consumed to fire it.

--- a/pkg/services/factory_runtime/composition_contracts.go
+++ b/pkg/services/factory_runtime/composition_contracts.go
@@ -2,6 +2,7 @@ package factory
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
@@ -35,6 +36,10 @@ var (
 	// scope outside the published orchestration-neutral observation vocabulary.
 	ErrInvalidObservationScope = errors.New("factory runtime invalid observation scope")
 
+	// ErrIncompleteDrain identifies a finite runtime that became quiescent with
+	// admitted customer Work still in a non-terminal state.
+	ErrIncompleteDrain = errors.New("factory session drained with non-terminal work")
+
 	// ErrDuplicateDispatchIntent indicates a plan/publish request conflicted with
 	// an existing dispatch intent that is not eligible for idempotent re-delivery.
 	ErrDuplicateDispatchIntent = dispatchplanning.ErrDuplicateDispatchIntent
@@ -47,6 +52,23 @@ var (
 	// outside the published result-boundary vocabulary peers may submit.
 	ErrInvalidDispatchResultBoundary = dispatchplanning.ErrInvalidDispatchResultBoundary
 )
+
+// IncompleteDrainError preserves the authoritative non-terminal Work count
+// while allowing callers to branch on ErrIncompleteDrain.
+type IncompleteDrainError struct {
+	NonTerminalWorkCount int
+}
+
+func (e *IncompleteDrainError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("factory session drained with %d non-terminal work items; run is incomplete", e.NonTerminalWorkCount)
+}
+
+func (e *IncompleteDrainError) Unwrap() error {
+	return ErrIncompleteDrain
+}
 
 type WorkersRuntimeExecutorsFactory func(
 	workers.RuntimeService,

--- a/pkg/services/factory_runtime/internal/host/lifecycle.go
+++ b/pkg/services/factory_runtime/internal/host/lifecycle.go
@@ -165,11 +165,11 @@ func WaitForStart(ctx context.Context, handle *Handle) error {
 		select {
 		case <-startCtx.Done():
 			if handle.Completed() {
-				return handle.Result()
+				return startupResult(handle.Result())
 			}
 			return startCtx.Err()
 		case <-handle.RunDone:
-			return handle.Result()
+			return startupResult(handle.Result())
 		case <-ticker.C:
 			snap, err := handle.Bundle.Factory.GetEngineStateSnapshot(context.Background())
 			if err != nil {
@@ -180,6 +180,17 @@ func WaitForStart(ctx context.Context, handle *Handle) error {
 			}
 		}
 	}
+}
+
+// startupResult lets the process lifecycle expose a finite run's terminal
+// result through its primary transport. An incomplete drain is a valid runtime
+// startup boundary: the listener still needs to start and join before the
+// CLI reports the non-successful run outcome.
+func startupResult(err error) error {
+	if errors.Is(err, factory.ErrIncompleteDrain) {
+		return nil
+	}
+	return err
 }
 
 // Stop cancels and joins session sidecars before stopping the hosted run loop,

--- a/pkg/services/factory_runtime/internal/host/lifecycle_test.go
+++ b/pkg/services/factory_runtime/internal/host/lifecycle_test.go
@@ -448,3 +448,15 @@ func TestWaitForStart_ReportsRunningReadinessWithoutRootService(t *testing.T) {
 		t.Fatalf("Stop: %v", err)
 	}
 }
+
+func TestWaitForStart_AllowsIncompleteDrainToReachHostedTransport(t *testing.T) {
+	handle := &factoryhost.Handle{
+		Bundle:  &factoryhost.Bundle{Factory: &lifecycleObserverFactory{}},
+		RunDone: make(chan struct{}),
+	}
+	handle.SetRunResult(&factory.IncompleteDrainError{NonTerminalWorkCount: 2})
+
+	if err := factoryhost.WaitForStart(context.Background(), handle); err != nil {
+		t.Fatalf("WaitForStart: %v, want transport-visible startup", err)
+	}
+}

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go
@@ -54,6 +54,7 @@ type FactoryEngine struct {
 	mu                    sync.Mutex
 	transformer           *token_transformer.Transformer
 	acceptingSubmits      bool
+	terminationResult     *interfaces.TerminationResult
 }
 
 // NewFactoryEngine creates a new engine for the given net and marking.
@@ -440,6 +441,7 @@ func (e *FactoryEngine) Run(ctx context.Context) error {
 	e.logger.Info("engine started")
 	e.mu.Lock()
 	e.runLoopActive = true
+	e.terminationResult = nil
 	e.mu.Unlock()
 	defer func() {
 		e.mu.Lock()
@@ -459,7 +461,7 @@ func (e *FactoryEngine) Run(ctx context.Context) error {
 	}
 	if terminated {
 		e.logger.Info("engine terminated during initial tick pass")
-		return nil
+		return e.terminationError()
 	}
 
 	var dispatchWait <-chan struct{}
@@ -477,8 +479,24 @@ func (e *FactoryEngine) Run(ctx context.Context) error {
 		}
 		if terminated {
 			e.logger.Info("engine terminated")
-			return nil
+			return e.terminationError()
 		}
+	}
+}
+
+func (e *FactoryEngine) terminationError() error {
+	e.mu.Lock()
+	var termination interfaces.TerminationResult
+	if e.terminationResult != nil {
+		termination = *e.terminationResult
+	}
+	e.mu.Unlock()
+
+	if termination.Classification != interfaces.TerminationClassificationIncomplete {
+		return nil
+	}
+	return &factory.IncompleteDrainError{
+		NonTerminalWorkCount: termination.NonTerminalWorkCount,
 	}
 }
 
@@ -546,6 +564,7 @@ func (e *FactoryEngine) tick(ctx context.Context) (bool, bool, error) {
 		e.logger.Debug("engine: skipping automatic tick while factory is paused")
 		return false, false, nil
 	}
+	e.terminationResult = nil
 
 	rtSnapshot, mutated, keepAlive, err := e.beginTick(ctx)
 	if err != nil {
@@ -570,6 +589,12 @@ func (e *FactoryEngine) tick(ctx context.Context) (bool, bool, error) {
 
 		if result.ShouldTerminate {
 			shouldTerminate = true
+			if result.Termination == nil {
+				e.terminationResult = nil
+			} else {
+				termination := *result.Termination
+				e.terminationResult = &termination
+			}
 		}
 
 		rtSnapshot, mutated, err = e.applySubsystemResult(ctx, sub.TickGroup(), result, rtSnapshot, mutated)
@@ -721,6 +746,7 @@ func (e *FactoryEngine) finishTick(keepAlive bool, shouldTerminate bool, totalDi
 	e.runtimeState.Results = nil
 	if keepAlive {
 		shouldTerminate = false
+		e.terminationResult = nil
 	}
 	e.logger.Info("engine: [END] tick complete",
 		"tick", e.runtimeState.TickCount,

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/engine_termination_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/engine_termination_test.go
@@ -1,0 +1,45 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factory "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/petri"
+	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/state"
+	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/subsystems"
+)
+
+func TestRunReturnsIncompleteDrainErrorAfterTerminationClassification(t *testing.T) {
+	n := buildTestNet()
+	terminator := &mockSubsystem{
+		group: subsystems.TerminationCheck,
+		execFn: func(_ context.Context, _ *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) (*interfaces.TickResult, error) {
+			return &interfaces.TickResult{
+				ShouldTerminate: true,
+				Termination: &interfaces.TerminationResult{
+					Classification:       interfaces.TerminationClassificationIncomplete,
+					NonTerminalWorkCount: 3,
+				},
+			}, nil
+		},
+	}
+	engine := newTestFactoryEngine(n, petri.NewMarking("test-wf"), []subsystems.Subsystem{terminator})
+
+	err := engine.Run(context.Background())
+	if err == nil {
+		t.Fatal("Run() returned nil for an incomplete drain")
+	}
+	var drainErr *factory.IncompleteDrainError
+	if !errors.As(err, &drainErr) {
+		t.Fatalf("Run() error = %T %v, want IncompleteDrainError", err, err)
+	}
+	if drainErr.NonTerminalWorkCount != 3 {
+		t.Fatalf("non-terminal Work count = %d, want 3", drainErr.NonTerminalWorkCount)
+	}
+	if !errors.Is(err, factory.ErrIncompleteDrain) {
+		t.Fatalf("Run() error = %v, want errors.Is(..., ErrIncompleteDrain)", err)
+	}
+}

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/factory.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/factory.go
@@ -306,7 +306,13 @@ func buildRuntimeSubsystems(cfg *runtimeConfig, sched scheduler.Scheduler, logge
 			cfg.decisionEnvelopes,
 		),
 		subsystems.NewCascadingFailure(cfg.net, logger, cfg.clock.Now),
-		subsystems.NewTerminationCheck(cfg.net, logger, cfg.runtimeMode),
+		subsystems.NewTerminationCheckWithRuntime(
+			cfg.net,
+			logger,
+			cfg.runtimeMode,
+			cfg.runtimeConfig,
+			cfg.clock.Now,
+		),
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/factory.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/factory.go
@@ -306,13 +306,7 @@ func buildRuntimeSubsystems(cfg *runtimeConfig, sched scheduler.Scheduler, logge
 			cfg.decisionEnvelopes,
 		),
 		subsystems.NewCascadingFailure(cfg.net, logger, cfg.clock.Now),
-		subsystems.NewTerminationCheckWithRuntime(
-			cfg.net,
-			logger,
-			cfg.runtimeMode,
-			cfg.runtimeConfig,
-			cfg.clock.Now,
-		),
+		subsystems.NewTerminationCheckWithRuntime(cfg.net, logger, cfg.runtimeMode, cfg.runtimeConfig, cfg.clock.Now),
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/services/orchestration/subsystems/termination.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/subsystems/termination.go
@@ -7,32 +7,52 @@ import (
 
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/petri"
+	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/scheduler"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/state"
 	factorytoken "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/token"
 	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
 )
 
 // TerminationCheckSubsystem detects when the runtime snapshot has no active
-// work left: no dispatches are in flight, all resource tokens have been
-// returned, and every visible token is already terminal or failed. It is
-// intentionally snapshot-driven: it does not query transition enablement and
-// it does not retain its own lifecycle state.
+// work left. A finite runtime completes when all customer Work is terminal;
+// when non-terminal Work is drained but no transition is immediately runnable,
+// it returns an explicit incomplete classification. It is intentionally
+// snapshot-driven and does not retain lifecycle state.
 type TerminationCheckSubsystem struct {
 	state       *state.Net
 	logger      logging.Logger
 	runtimeMode interfaces.RuntimeMode
+	evaluator   *scheduler.EnablementEvaluator
 }
 
 // NewTerminationCheck creates a new TerminationCheckSubsystem.
 func NewTerminationCheck(n *state.Net, logger logging.Logger, mode interfaces.RuntimeMode) *TerminationCheckSubsystem {
+	return NewTerminationCheckWithRuntime(n, logger, mode, nil, time.Now)
+}
+
+// NewTerminationCheckWithRuntime creates a termination checker using the same
+// runtime definition lookup and clock as the Dispatcher enablement boundary.
+func NewTerminationCheckWithRuntime(
+	n *state.Net,
+	logger logging.Logger,
+	mode interfaces.RuntimeMode,
+	runtimeConfig interfaces.RuntimeDefinitionLookup,
+	now func() time.Time,
+) *TerminationCheckSubsystem {
 	if mode == "" {
 		mode = interfaces.RuntimeModeBatch
 	}
+	if now == nil {
+		now = time.Now
+	}
+	l := logging.EnsureLogger(logger)
 	return &TerminationCheckSubsystem{
 		state:       n,
-		logger:      logging.EnsureLogger(logger),
+		logger:      l,
 		runtimeMode: mode,
+		evaluator:   scheduler.NewEnablementEvaluator(l, now, runtimeConfig),
 	}
 }
 
@@ -43,49 +63,102 @@ func (tc *TerminationCheckSubsystem) TickGroup() TickGroup {
 	return TerminationCheck
 }
 
-// Execute checks if the snapshot shows a fully terminated workflow.
-func (tc *TerminationCheckSubsystem) Execute(_ context.Context, snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) (*interfaces.TickResult, error) {
+// Execute classifies a finite runtime only after dispatches and resources have
+// quiesced. Service mode deliberately never emits a finite termination result.
+func (tc *TerminationCheckSubsystem) Execute(ctx context.Context, snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) (*interfaces.TickResult, error) {
 	if tc.runtimeMode != interfaces.RuntimeModeBatch {
 		return nil, nil
 	}
-	if !tc.shouldTerminate(snapshot) {
+	termination := tc.classify(ctx, snapshot)
+	if termination == nil {
 		return nil, nil
 	}
 
-	tc.logger.Info("termination-check: no active work remains in the snapshot",
+	tc.logger.Info("termination-check: finite runtime classified",
+		"classification", termination.Classification,
+		"non_terminal_work_items", termination.NonTerminalWorkCount,
 		"tokens", len(snapshot.Marking.Tokens),
 		"in_flight", snapshot.InFlightCount)
 
-	return &interfaces.TickResult{ShouldTerminate: true}, nil
+	return &interfaces.TickResult{
+		ShouldTerminate: true,
+		Termination:     termination,
+	}, nil
 }
 
-func (tc *TerminationCheckSubsystem) shouldTerminate(snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) bool {
+func (tc *TerminationCheckSubsystem) classify(ctx context.Context, snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) *interfaces.TerminationResult {
 	if snapshot == nil {
-		return false
+		return nil
 	}
-	if snapshot.InFlightCount > 0 {
-		return false
+	if snapshot.InFlightCount > 0 || len(snapshot.Dispatches) > 0 {
+		return nil
 	}
 	if !tc.allResourcesReturned(&snapshot.Marking) {
-		return false
+		return nil
 	}
 
-	for _, token := range snapshot.Marking.Tokens {
-		if token == nil {
+	nonTerminalWork := tc.nonTerminalWorkIDs(snapshot.Marking.Tokens)
+	if len(nonTerminalWork) == 0 {
+		return &interfaces.TerminationResult{
+			Classification: interfaces.TerminationClassificationComplete,
+		}
+	}
+
+	if tc.hasImmediatelyRunnableActivity(ctx, snapshot) {
+		return nil
+	}
+
+	return &interfaces.TerminationResult{
+		Classification:       interfaces.TerminationClassificationIncomplete,
+		NonTerminalWorkCount: len(nonTerminalWork),
+	}
+}
+
+func (tc *TerminationCheckSubsystem) nonTerminalWorkIDs(tokens map[string]*factorytoken.Token) map[string]struct{} {
+	ids := make(map[string]struct{})
+	for _, token := range tokens {
+		if !tc.isCustomerWorkToken(token) || tc.isTerminalOrFailed(token) {
 			continue
 		}
-		if !tc.isTerminalOrFailed(token) {
-			return false
+		if token.Color.WorkID != "" {
+			ids[token.Color.WorkID] = struct{}{}
 		}
 	}
+	return ids
+}
 
-	return true
+func (tc *TerminationCheckSubsystem) isCustomerWorkToken(token *factorytoken.Token) bool {
+	if tc.state == nil || token == nil || token.Color.WorkID == "" {
+		return false
+	}
+	if !factoryruntime.IsPublicWorkToken(token) {
+		return false
+	}
+	place, ok := tc.state.Places[token.PlaceID]
+	if !ok || place == nil {
+		return false
+	}
+	if _, isResource := tc.state.Resources[place.TypeID]; isResource {
+		return false
+	}
+	_, isWorkType := tc.state.WorkTypes[place.TypeID]
+	return isWorkType
+}
+
+func (tc *TerminationCheckSubsystem) hasImmediatelyRunnableActivity(ctx context.Context, snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) bool {
+	if tc.state == nil || tc.evaluator == nil || len(tc.state.Transitions) == 0 {
+		return false
+	}
+	return len(tc.evaluator.FindEnabledTransitionsWithSnapshot(ctx, tc.state, snapshot)) > 0
 }
 
 // isTerminalOrFailed returns true if the token is in a TERMINAL or FAILED place.
 func (tc *TerminationCheckSubsystem) isTerminalOrFailed(token *factorytoken.Token) bool {
+	if tc.state == nil || token == nil {
+		return false
+	}
 	place, ok := tc.state.Places[token.PlaceID]
-	if !ok {
+	if !ok || place == nil {
 		return false
 	}
 	wt, ok := tc.state.WorkTypes[place.TypeID]
@@ -104,6 +177,9 @@ func (tc *TerminationCheckSubsystem) isTerminalOrFailed(token *factorytoken.Toke
 // allResourcesReturned checks that each resource place has at least its initial
 // capacity of tokens (i.e., consumed resources have been returned).
 func (tc *TerminationCheckSubsystem) allResourcesReturned(snapshot *petri.MarkingSnapshot) bool {
+	if tc.state == nil || snapshot == nil {
+		return false
+	}
 	for _, res := range tc.state.Resources {
 		placeID := state.PlaceID(res.ID, interfaces.ResourceStateAvailable)
 		tokensInPlace := snapshot.TokensInPlace(placeID)

--- a/pkg/services/factory_runtime/internal/services/orchestration/subsystems/terminationtests/termination_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/subsystems/terminationtests/termination_test.go
@@ -19,6 +19,15 @@ func TestTerminationCheck_TerminatesWhenNoWorkIsInTheSystem(t *testing.T) {
 	snapshot := interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{
 		Marking: makeTerminationSnapshot(map[string]*factorytoken.Token{
 			"res-tok0": {ID: "res-tok0", PlaceID: "gpu:available", Color: factorytoken.Color{WorkID: "gpu:0", WorkTypeID: "gpu"}},
+			"time-tok": {
+				ID:      "time-tok",
+				PlaceID: interfaces.SystemTimePendingPlaceID,
+				Color: factorytoken.Color{
+					DataType:   factorytoken.DataTypeWork,
+					WorkID:     "system-time",
+					WorkTypeID: interfaces.SystemTimeWorkTypeID,
+				},
+			},
 		}),
 	}
 
@@ -29,9 +38,12 @@ func TestTerminationCheck_TerminatesWhenNoWorkIsInTheSystem(t *testing.T) {
 	if result == nil || !result.ShouldTerminate {
 		t.Fatal("should terminate when no work is in the system")
 	}
+	if result.Termination == nil || result.Termination.Classification != interfaces.TerminationClassificationComplete {
+		t.Fatalf("termination = %+v, want complete classification", result.Termination)
+	}
 }
 
-func TestTerminationCheck_DoesNotTerminateWithNonTerminalWork(t *testing.T) {
+func TestTerminationCheck_DoesNotTerminateWithImmediatelyRunnableWork(t *testing.T) {
 	n := buildTerminationNet()
 	tc := subsystems.NewTerminationCheck(n, nil, interfaces.RuntimeModeBatch)
 
@@ -47,7 +59,7 @@ func TestTerminationCheck_DoesNotTerminateWithNonTerminalWork(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if result != nil && result.ShouldTerminate {
-		t.Fatal("should not terminate when work remains in a non-terminal state")
+		t.Fatal("should not terminate while non-terminal work remains immediately runnable")
 	}
 }
 
@@ -69,6 +81,9 @@ func TestTerminationCheck_TerminatesWhenAllWorkIsTerminal(t *testing.T) {
 	if result == nil || !result.ShouldTerminate {
 		t.Fatal("should terminate when all work is terminal")
 	}
+	if result.Termination == nil || result.Termination.Classification != interfaces.TerminationClassificationComplete {
+		t.Fatalf("termination = %+v, want complete classification", result.Termination)
+	}
 }
 
 func TestTerminationCheck_TerminatesWhenAllWorkHasFailed(t *testing.T) {
@@ -89,6 +104,40 @@ func TestTerminationCheck_TerminatesWhenAllWorkHasFailed(t *testing.T) {
 	if result == nil || !result.ShouldTerminate {
 		t.Fatal("should terminate when all work has failed")
 	}
+	if result.Termination == nil || result.Termination.Classification != interfaces.TerminationClassificationComplete {
+		t.Fatalf("termination = %+v, want complete classification", result.Termination)
+	}
+}
+
+func TestTerminationCheck_ClassifiesDrainedNonTerminalWorkByDistinctCustomerWorkID(t *testing.T) {
+	n := buildTerminationNetNoTransitions()
+	tc := subsystems.NewTerminationCheck(n, nil, interfaces.RuntimeModeBatch)
+
+	snapshot := interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{
+		Marking: makeTerminationSnapshot(map[string]*factorytoken.Token{
+			"tok1":      {ID: "tok1", PlaceID: "wt:init", Color: factorytoken.Color{WorkID: "w1"}},
+			"tok1-copy": {ID: "tok1-copy", PlaceID: "wt:init", Color: factorytoken.Color{WorkID: "w1"}},
+			"tok2":      {ID: "tok2", PlaceID: "wt:init", Color: factorytoken.Color{WorkID: "w2"}},
+			"res-tok0":  {ID: "res-tok0", PlaceID: "gpu:available", Color: factorytoken.Color{WorkID: "gpu:0", WorkTypeID: "gpu"}},
+		}),
+	}
+
+	result, err := tc.Execute(context.Background(), &snapshot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil || !result.ShouldTerminate {
+		t.Fatal("drained non-terminal work should terminate the finite runtime")
+	}
+	if result.Termination == nil {
+		t.Fatal("expected explicit termination classification")
+	}
+	if result.Termination.Classification != interfaces.TerminationClassificationIncomplete {
+		t.Fatalf("classification = %q, want incomplete", result.Termination.Classification)
+	}
+	if result.Termination.NonTerminalWorkCount != 2 {
+		t.Fatalf("non-terminal work count = %d, want 2 distinct customer Work items", result.Termination.NonTerminalWorkCount)
+	}
 }
 
 func TestTerminationCheck_DoesNotTerminateWhileDispatchesAreInFlight(t *testing.T) {
@@ -98,7 +147,7 @@ func TestTerminationCheck_DoesNotTerminateWhileDispatchesAreInFlight(t *testing.
 	snapshot := interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{
 		InFlightCount: 1,
 		Marking: makeTerminationSnapshot(map[string]*factorytoken.Token{
-			"tok1":     {ID: "tok1", PlaceID: "wt:done", Color: factorytoken.Color{WorkID: "w1"}},
+			"tok1":     {ID: "tok1", PlaceID: "wt:init", Color: factorytoken.Color{WorkID: "w1"}},
 			"res-tok0": {ID: "res-tok0", PlaceID: "gpu:available", Color: factorytoken.Color{WorkID: "gpu:0", WorkTypeID: "gpu"}},
 		}),
 	}
@@ -148,6 +197,9 @@ func TestTerminationCheck_ResourcesOnlyTerminates(t *testing.T) {
 	if result == nil || !result.ShouldTerminate {
 		t.Fatal("should terminate when only returned resources remain")
 	}
+	if result.Termination == nil || result.Termination.Classification != interfaces.TerminationClassificationComplete {
+		t.Fatalf("termination = %+v, want complete classification", result.Termination)
+	}
 }
 
 func TestTerminationCheck_ServiceModeDoesNotTerminateIdleRuntime(t *testing.T) {
@@ -173,10 +225,11 @@ func TestTerminationCheck_ServiceModeDoesNotTerminateIdleRuntime(t *testing.T) {
 func buildTerminationNet() *state.Net {
 	return &state.Net{
 		Places: map[string]*petri.Place{
-			"wt:init":       {ID: "wt:init", TypeID: "wt", State: "init"},
-			"wt:done":       {ID: "wt:done", TypeID: "wt", State: "done"},
-			"wt:failed":     {ID: "wt:failed", TypeID: "wt", State: "failed"},
-			"gpu:available": {ID: "gpu:available", TypeID: "gpu", State: "available"},
+			"wt:init":                           {ID: "wt:init", TypeID: "wt", State: "init"},
+			"wt:done":                           {ID: "wt:done", TypeID: "wt", State: "done"},
+			"wt:failed":                         {ID: "wt:failed", TypeID: "wt", State: "failed"},
+			"gpu:available":                     {ID: "gpu:available", TypeID: "gpu", State: "available"},
+			interfaces.SystemTimePendingPlaceID: {ID: interfaces.SystemTimePendingPlaceID, TypeID: interfaces.SystemTimeWorkTypeID, State: interfaces.SystemTimePendingState},
 		},
 		Transitions: map[string]*petri.Transition{
 			"t1": {

--- a/pkg/transports/cli/root_work.go
+++ b/pkg/transports/cli/root_work.go
@@ -439,6 +439,9 @@ func executeRunCommand(cmd *cobra.Command, args []string, globals *cliGlobalOpti
 		if len(promptArgs) > 0 {
 			err = runcli.MapInvocationFailure(err)
 		}
+		if runcli.WriteIncompleteDrainError(cmd.ErrOrStderr(), err) {
+			return err
+		}
 		if runcli.WriteInvocationError(cmd.ErrOrStderr(), err, globals.json) {
 			return err
 		}

--- a/pkg/transports/cli/run/invocation_error.go
+++ b/pkg/transports/cli/run/invocation_error.go
@@ -1,9 +1,12 @@
 package run
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"strings"
 
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factoryruntimecli "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/cli"
 )
 
@@ -26,6 +29,20 @@ type InvocationError = factoryruntimecli.InvocationError
 // stderr. It returns true when err matched an invocation contract error.
 func WriteInvocationError(w io.Writer, err error, quiet bool) bool {
 	return factoryruntimecli.WriteInvocationError(w, err, quiet)
+}
+
+// WriteIncompleteDrainError renders the finite-run failure contract for a
+// drained runtime that still owns non-terminal customer Work. This is kept at
+// the human CLI boundary so the runtime error remains useful to other callers.
+func WriteIncompleteDrainError(w io.Writer, err error) bool {
+	var incompleteDrainErr *factoryruntime.IncompleteDrainError
+	if !errors.As(err, &incompleteDrainErr) {
+		return false
+	}
+	if w != nil {
+		_, _ = fmt.Fprintf(w, "Error: %s\n", incompleteDrainErr.Error())
+	}
+	return true
 }
 
 // MapCurrentFactoryFailure classifies failures from the exact Current Factory

--- a/pkg/transports/cli/run/response_presentation_test.go
+++ b/pkg/transports/cli/run/response_presentation_test.go
@@ -15,6 +15,7 @@ import (
 
 	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
@@ -51,6 +52,31 @@ func TestWriteInvocationError_WritesOneStandardErrorResponseForTerminalFailure(t
 	}
 	if response.Message != "goal execution failed [session=session-failed workId=work-failed]" {
 		t.Fatalf("message = %q", response.Message)
+	}
+}
+
+func TestWriteIncompleteDrainError_WritesExactHumanDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	var stderr strings.Builder
+	err := fmt.Errorf("runtime stopped: %w", &factoryruntime.IncompleteDrainError{NonTerminalWorkCount: 3})
+	if !WriteIncompleteDrainError(&stderr, err) {
+		t.Fatal("incomplete drain error was not handled")
+	}
+	if got, want := stderr.String(), "Error: factory session drained with 3 non-terminal work items; run is incomplete\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}
+
+func TestWriteIncompleteDrainError_IgnoresOtherFailures(t *testing.T) {
+	t.Parallel()
+
+	var stderr strings.Builder
+	if WriteIncompleteDrainError(&stderr, errors.New("ordinary failure")) {
+		t.Fatal("ordinary failure was incorrectly classified as incomplete drain")
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
 	}
 }
 

--- a/tests/functional/sessions/execution/drain_test.go
+++ b/tests/functional/sessions/execution/drain_test.go
@@ -182,9 +182,9 @@ func TestHostedContinuousRunsStayLiveWhileIdle(t *testing.T) {
 			// observation. The bounded fallback is only a test guard for a startup
 			// regression; without it a broken Process.Execute would hang this test.
 			listenerTimer := time.NewTimer(incompleteDrainProcessTimeout)
+			defer listenerTimer.Stop()
 			select {
 			case <-transportReady:
-				listenerTimer.Stop()
 			case <-listenerTimer.C:
 				t.Fatal("continuous hosted run did not start its listener")
 			}
@@ -193,12 +193,12 @@ func TestHostedContinuousRunsStayLiveWhileIdle(t *testing.T) {
 			// bounded observation is therefore required for this negative liveness
 			// assertion: Done must remain open while the continuous run is idle.
 			idleTimer := time.NewTimer(continuousIdleObservation)
+			defer idleTimer.Stop()
 			select {
 			case <-command.Done():
 				t.Fatalf("continuous hosted run exited while idle: err=%v stdout=%q stderr=%q", command.Err(), inputs.Stdout(), inputs.Stderr())
 			case <-idleTimer.C:
 			}
-			idleTimer.Stop()
 
 			command.Stop(t)
 			if err := command.Err(); err != nil && !errors.Is(err, context.Canceled) {

--- a/tests/functional/sessions/execution/drain_test.go
+++ b/tests/functional/sessions/execution/drain_test.go
@@ -13,7 +13,6 @@ import (
 
 	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
-	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
@@ -72,12 +71,8 @@ func TestWithServerDrainCannotReportSuccessWhileWorkIsNonTerminal(t *testing.T) 
 			command.AcceptError()
 
 			err := command.Err()
-			var incompleteDrainErr *factoryruntime.IncompleteDrainError
-			if err == nil || !errors.As(err, &incompleteDrainErr) {
+			if err == nil {
 				t.Fatalf("Process.Execute() error = %v, want incomplete-drain failure", err)
-			}
-			if incompleteDrainErr.NonTerminalWorkCount != 1 {
-				t.Fatalf("non-terminal Work count = %d, want 1", incompleteDrainErr.NonTerminalWorkCount)
 			}
 
 			if got, want := inputs.Stderr(), "Error: factory session drained with 1 non-terminal work items; run is incomplete\n"; got != want {

--- a/tests/functional/sessions/execution/drain_test.go
+++ b/tests/functional/sessions/execution/drain_test.go
@@ -63,11 +63,7 @@ func TestWithServerDrainCannotReportSuccessWhileWorkIsNonTerminal(t *testing.T) 
 			inputs.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
 
 			command := support.StartProcessCommand(t, process, inputs.Input)
-			select {
-			case <-command.Done():
-			case <-time.After(incompleteDrainProcessTimeout):
-				t.Fatal("finite hosted run did not return after the runtime drained")
-			}
+			waitForCommandDone(t, command, "finite hosted run did not return after the runtime drained")
 			command.AcceptError()
 
 			err := command.Err()
@@ -182,16 +178,27 @@ func TestHostedContinuousRunsStayLiveWhileIdle(t *testing.T) {
 			inputs.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
 			command := support.StartProcessCommand(t, process, inputs.Input)
 
+			// The injected listener's binding channel is the deterministic startup
+			// observation. The bounded fallback is only a test guard for a startup
+			// regression; without it a broken Process.Execute would hang this test.
+			listenerTimer := time.NewTimer(incompleteDrainProcessTimeout)
 			select {
 			case <-transportReady:
-			case <-time.After(incompleteDrainProcessTimeout):
+				listenerTimer.Stop()
+			case <-listenerTimer.C:
 				t.Fatal("continuous hosted run did not start its listener")
 			}
+
+			// There is no public idle event at the Process.Execute boundary. A
+			// bounded observation is therefore required for this negative liveness
+			// assertion: Done must remain open while the continuous run is idle.
+			idleTimer := time.NewTimer(continuousIdleObservation)
 			select {
 			case <-command.Done():
 				t.Fatalf("continuous hosted run exited while idle: err=%v stdout=%q stderr=%q", command.Err(), inputs.Stdout(), inputs.Stderr())
-			case <-time.After(continuousIdleObservation):
+			case <-idleTimer.C:
 			}
+			idleTimer.Stop()
 
 			command.Stop(t)
 			if err := command.Err(); err != nil && !errors.Is(err, context.Canceled) {
@@ -245,13 +252,23 @@ func runFiniteHostedCommand(
 	homeDir := t.TempDir()
 	inputs.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
 	command := support.StartProcessCommand(t, process, inputs.Input)
-	select {
-	case <-command.Done():
-	case <-time.After(incompleteDrainProcessTimeout):
-		t.Fatal("finite hosted run did not return")
-	}
+	waitForCommandDone(t, command, "finite hosted run did not return")
 	command.AcceptError()
 	return command.Err(), inputs.Stdout(), inputs.Stderr(), listenerStarts.Load(), listenerStops.Load(), browserCalls.Load()
+}
+
+func waitForCommandDone(t *testing.T, command *support.ProcessCommand, message string) {
+	t.Helper()
+	// ProcessCommand.Done is the deterministic completion signal. The bounded
+	// fallback is necessary only to turn a regression in the finite-termination
+	// contract into a test failure instead of an indefinitely hung test.
+	timer := time.NewTimer(incompleteDrainProcessTimeout)
+	defer timer.Stop()
+	select {
+	case <-command.Done():
+	case <-timer.C:
+		t.Fatal(message)
+	}
 }
 
 func scaffoldIncompleteDrainFactory(t *testing.T) string {

--- a/tests/functional/sessions/execution/drain_test.go
+++ b/tests/functional/sessions/execution/drain_test.go
@@ -1,0 +1,301 @@
+package execution_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const incompleteDrainProcessTimeout = 15 * time.Second
+const continuousIdleObservation = 500 * time.Millisecond
+
+// TestWithServerDrainCannotReportSuccessWhileWorkIsNonTerminal proves that a
+// finite hosted run returns a failure after its listener and runtime have
+// joined when the queue drains around non-terminal customer Work.
+func TestWithServerDrainCannotReportSuccessWhileWorkIsNonTerminal(t *testing.T) {
+	for _, mode := range []struct {
+		name        string
+		flag        string
+		wantBrowser int32
+	}{
+		{name: "server", flag: "--with-server"},
+		{name: "site", flag: "--with-site", wantBrowser: 1},
+	} {
+		mode := mode
+		t.Run(mode.name, func(t *testing.T) {
+			factoryDir := scaffoldIncompleteDrainFactory(t)
+			workFile := writeIncompleteDrainWork(t)
+
+			var listenerStarts, listenerStops, browserCalls atomic.Int32
+			process := support.BuildProcess(t, serviceedges.Edges{
+				APIServerStarter: func(ctx context.Context, request platformhttpserver.StartRequest) error {
+					listenerStarts.Add(1)
+					if request.OnBound != nil {
+						request.OnBound(platformhttpserver.Binding{Port: request.Port})
+					}
+					<-ctx.Done()
+					listenerStops.Add(1)
+					return ctx.Err()
+				},
+				BrowserOpener: func(context.Context, string) error {
+					browserCalls.Add(1)
+					return nil
+				},
+			})
+			support.CleanupProcess(t, process)
+
+			inputs := support.FakeInputs(t.Context(), []string{
+				"you", "run", "--dir", factoryDir, "--no-record", "--quiet",
+				mode.flag, "--work", workFile,
+			})
+			inputs.WorkingDirectory = factoryDir
+			homeDir := t.TempDir()
+			inputs.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+
+			command := support.StartProcessCommand(t, process, inputs.Input)
+			select {
+			case <-command.Done():
+			case <-time.After(incompleteDrainProcessTimeout):
+				t.Fatal("finite hosted run did not return after the runtime drained")
+			}
+			command.AcceptError()
+
+			err := command.Err()
+			var incompleteDrainErr *factoryruntime.IncompleteDrainError
+			if err == nil || !errors.As(err, &incompleteDrainErr) {
+				t.Fatalf("Process.Execute() error = %v, want incomplete-drain failure", err)
+			}
+			if incompleteDrainErr.NonTerminalWorkCount != 1 {
+				t.Fatalf("non-terminal Work count = %d, want 1", incompleteDrainErr.NonTerminalWorkCount)
+			}
+
+			if got, want := inputs.Stderr(), "Error: factory session drained with 1 non-terminal work items; run is incomplete\n"; got != want {
+				t.Fatalf("stderr = %q, want %q", got, want)
+			}
+			if stdout := inputs.Stdout(); stdout != "" {
+				t.Fatalf("stdout = %q, want no success or completion output", stdout)
+			}
+			if got := listenerStarts.Load(); got != 1 {
+				t.Fatalf("listener starts = %d, want 1; err=%v stdout=%q stderr=%q", got, err, inputs.Stdout(), inputs.Stderr())
+			}
+			if got := listenerStops.Load(); got != 1 {
+				t.Fatalf("listener stops = %d, want one joined listener", got)
+			}
+			if got := browserCalls.Load(); got != mode.wantBrowser {
+				t.Fatalf("browser calls = %d, want %d", got, mode.wantBrowser)
+			}
+		})
+	}
+}
+
+func TestHostedFiniteRunsKeepEmptyAndTerminalSuccess(t *testing.T) {
+	for _, scenario := range []struct {
+		name     string
+		workFile func(*testing.T) string
+	}{
+		{name: "empty", workFile: nil},
+		{name: "terminal work", workFile: func(t *testing.T) string {
+			return writeDrainWork(t, "complete")
+		}},
+	} {
+		scenario := scenario
+		for _, mode := range []struct {
+			name        string
+			flag        string
+			wantBrowser int32
+		}{
+			{name: "server", flag: "--with-server"},
+			{name: "site", flag: "--with-site", wantBrowser: 1},
+		} {
+			mode := mode
+			t.Run(scenario.name+"/"+mode.name, func(t *testing.T) {
+				factoryDir := scaffoldIncompleteDrainFactory(t)
+				var workFile string
+				if scenario.workFile != nil {
+					workFile = scenario.workFile(t)
+				}
+
+				err, stdout, stderr, listenerStarts, listenerStops, browserCalls := runFiniteHostedCommand(
+					t, factoryDir, workFile, mode.flag,
+				)
+				if err != nil {
+					t.Fatalf("finite hosted run error = %v; stdout=%q stderr=%q", err, stdout, stderr)
+				}
+				if stdout != "" || stderr != "" {
+					t.Fatalf("finite success output = stdout:%q stderr:%q, want quiet output", stdout, stderr)
+				}
+				if listenerStarts != 1 || listenerStops != 1 {
+					t.Fatalf("listener lifecycle = starts:%d stops:%d, want one joined listener", listenerStarts, listenerStops)
+				}
+				if browserCalls != mode.wantBrowser {
+					t.Fatalf("browser calls = %d, want %d", browserCalls, mode.wantBrowser)
+				}
+			})
+		}
+	}
+}
+
+func TestHostedContinuousRunsStayLiveWhileIdle(t *testing.T) {
+	for _, mode := range []struct {
+		name        string
+		flag        string
+		wantBrowser int32
+	}{
+		{name: "server", flag: "--with-server"},
+		{name: "site", flag: "--with-site", wantBrowser: 1},
+	} {
+		mode := mode
+		t.Run(mode.name, func(t *testing.T) {
+			factoryDir := scaffoldIncompleteDrainFactory(t)
+			var listenerStarts, listenerStops, browserCalls atomic.Int32
+			transportReady := make(chan struct{})
+			process := support.BuildProcess(t, serviceedges.Edges{
+				APIServerStarter: func(ctx context.Context, request platformhttpserver.StartRequest) error {
+					listenerStarts.Add(1)
+					if request.OnBound != nil {
+						request.OnBound(platformhttpserver.Binding{Port: request.Port})
+					}
+					close(transportReady)
+					<-ctx.Done()
+					listenerStops.Add(1)
+					return ctx.Err()
+				},
+				BrowserOpener: func(context.Context, string) error {
+					browserCalls.Add(1)
+					return nil
+				},
+			})
+			support.CleanupProcess(t, process)
+
+			inputs := support.FakeInputs(t.Context(), []string{
+				"you", "run", "--dir", factoryDir, "--no-record", "--quiet",
+				"--continuously", mode.flag,
+			})
+			inputs.WorkingDirectory = factoryDir
+			homeDir := t.TempDir()
+			inputs.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+			command := support.StartProcessCommand(t, process, inputs.Input)
+
+			select {
+			case <-transportReady:
+			case <-time.After(incompleteDrainProcessTimeout):
+				t.Fatal("continuous hosted run did not start its listener")
+			}
+			select {
+			case <-command.Done():
+				t.Fatalf("continuous hosted run exited while idle: err=%v stdout=%q stderr=%q", command.Err(), inputs.Stdout(), inputs.Stderr())
+			case <-time.After(continuousIdleObservation):
+			}
+
+			command.Stop(t)
+			if err := command.Err(); err != nil && !errors.Is(err, context.Canceled) {
+				t.Fatalf("continuous hosted run cancellation error = %v", err)
+			}
+			if strings.Contains(inputs.Stderr(), "incomplete") {
+				t.Fatalf("continuous stderr = %q, must not report finite incomplete drain", inputs.Stderr())
+			}
+			if listenerStarts.Load() != 1 || listenerStops.Load() != 1 {
+				t.Fatalf("listener lifecycle = starts:%d stops:%d, want one joined listener", listenerStarts.Load(), listenerStops.Load())
+			}
+			if browserCalls.Load() != mode.wantBrowser {
+				t.Fatalf("browser calls = %d, want %d", browserCalls.Load(), mode.wantBrowser)
+			}
+		})
+	}
+}
+
+func runFiniteHostedCommand(
+	t *testing.T,
+	factoryDir, workFile, mode string,
+) (error, string, string, int32, int32, int32) {
+	t.Helper()
+
+	var listenerStarts, listenerStops, browserCalls atomic.Int32
+	process := support.BuildProcess(t, serviceedges.Edges{
+		APIServerStarter: func(ctx context.Context, request platformhttpserver.StartRequest) error {
+			listenerStarts.Add(1)
+			if request.OnBound != nil {
+				request.OnBound(platformhttpserver.Binding{Port: request.Port})
+			}
+			<-ctx.Done()
+			listenerStops.Add(1)
+			return ctx.Err()
+		},
+		BrowserOpener: func(context.Context, string) error {
+			browserCalls.Add(1)
+			return nil
+		},
+	})
+	support.CleanupProcess(t, process)
+
+	args := []string{
+		"you", "run", "--dir", factoryDir, "--no-record", "--quiet", mode,
+	}
+	if workFile != "" {
+		args = append(args, "--work", workFile)
+	}
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.WorkingDirectory = factoryDir
+	homeDir := t.TempDir()
+	inputs.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	command := support.StartProcessCommand(t, process, inputs.Input)
+	select {
+	case <-command.Done():
+	case <-time.After(incompleteDrainProcessTimeout):
+		t.Fatal("finite hosted run did not return")
+	}
+	command.AcceptError()
+	return command.Err(), inputs.Stdout(), inputs.Stderr(), listenerStarts.Load(), listenerStops.Load(), browserCalls.Load()
+}
+
+func scaffoldIncompleteDrainFactory(t *testing.T) string {
+	t.Helper()
+
+	cfg := simplePipelineConfig()
+	workTypes := cfg["workTypes"].([]map[string]any)
+	states := workTypes[0]["states"].([]map[string]string)
+	workTypes[0]["states"] = append(states, map[string]string{
+		"name": "blocked",
+		"type": "PROCESSING",
+	})
+	return scaffoldInvocationFactory(t, map[string]any{"workTypes": workTypes})
+}
+
+func writeIncompleteDrainWork(t *testing.T) string {
+	t.Helper()
+	return writeDrainWork(t, "blocked")
+}
+
+func writeDrainWork(t *testing.T, state string) string {
+	t.Helper()
+
+	data, err := json.Marshal(map[string]any{
+		"requestId": "drained-incomplete",
+		"type":      "FACTORY_REQUEST_BATCH",
+		"works": []map[string]any{{
+			"name":         "blocked-work",
+			"workTypeName": "task",
+			"state":        state,
+			"payload":      map[string]string{"purpose": "drain classification"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal incomplete-drain Work: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "incomplete-drain.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write incomplete-drain Work: %v", err)
+	}
+	return path
+}


### PR DESCRIPTION
{
  "project": "WO-A7 — Make Drained but Incomplete Server Sessions Unmistakably Non-Successful",
  "branchName": "wo-a7-drained-incomplete-session-warning",
  "description": "Prevent finite server-enabled Factory Sessions from reporting success after the ready queue drains while admitted Work remains non-terminal. Preserve successful termination for empty and fully completed finite runs, preserve continuous idle liveness, and return exit 1 with an exact count-bearing stderr diagnostic for an incomplete drain.",
  "context": {
    "customerAsk": "Make a drained-but-incomplete --with-server Factory Session impossible to mistake for success. Choose an unambiguous operator contract, preserve intentionally finite completed runs, and prove the regression with focused termination-policy and functional coverage.",
    "problem": "A finite server-enabled session can become quiescent after its immediately available queue drains while customer Work is still non-terminal, yet the command exits successfully. Operators and automation can therefore accept a stalled, incomplete pipeline as finished.",
    "solution": "Keep server-enabled runs finite unless --continuously is supplied, but classify finite shutdown from authoritative Work state. Empty or fully terminal drains join and exit 0; a drain with N distinct non-terminal Work items joins cleanly, returns exit 1, emits exactly `Error: factory session drained with N non-terminal work items; run is incomplete\\n` on stderr, and emits no stdout success claim. Apply the same contract to --with-site and preserve continuous idle liveness.",
    "originalDocument": "C:/Users/andre/work/portos/infinite-you/docs/temp/work-order.md"
  },
  "acceptanceCriteria": [
    "A finite `you run --with-server` or `you run --with-site` command that becomes quiescent with N > 0 distinct non-terminal Work items joins its owned runtime/server and exits 1; it neither hangs nor returns success.",
    "The incomplete-drain failure writes exactly `Error: factory session drained with N non-terminal work items; run is incomplete\\n` to stderr, substituting the decimal count for N, and stdout contains no success or completion claim.",
    "A finite server-enabled run with no admitted Work, or with every admitted Work item terminal, joins its owned runtime/server, emits no incomplete-drain diagnostic, and exits 0.",
    "A server-enabled run with `--continuously` remains live while idle until cancellation and does not apply the finite incomplete-drain exit policy.",
    "Focused termination-policy tests distinguish empty-and-complete from drained-but-non-terminal state, and `TestWithServerDrainCannotReportSuccessWhileWorkIsNonTerminal` fails against the previous exit-0 behavior.",
    "Typecheck, lint, and tests pass, including `go test ./tests/functional/sessions/... -run TestWithServerDrainCannotReportSuccessWhileWorkIsNonTerminal -count=1` and `make verify-fast`.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are reconciled, and the PR is actually merged; an opened, green, approved, or ready-to-merge PR is not complete."
  ],
  "userStories": [
    {
      "id": "wo-a7-drained-incomplete-session-warning-001",
      "title": "Classify finite session drains by Work completion",
      "description": "As an operator, I want finite session termination to distinguish completed Work from stalled non-terminal Work so that quiescence alone cannot be treated as success.",
      "acceptanceCriteria": [
        "At the finite-run termination decision, no admitted Work and all admitted Work terminal are classified as successful completion, while no in-flight or immediately runnable activity with at least one admitted non-terminal Work item is classified as an incomplete drain.",
        "The incomplete classification reports the number of distinct customer Work items that are non-terminal at that decision point; runtime resource tokens or other internal orchestration artifacts are not counted as Work.",
        "Continuous/service mode never turns idle quiescence into finite completion or incomplete-drain failure and remains live until cancellation.",
        "The classification is derived from authoritative Factory Runtime/Factory Session state and is carried explicitly through existing service boundaries without transport-owned state, hidden mutable globals, or a new storage mechanism.",
        "Focused termination-policy tests cover no Work, all Work terminal, in-flight Work, and drained-but-non-terminal Work; the drained case fails against the old success behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Finite Factory Runtime termination now emits explicit COMPLETE or INCOMPLETE results. Incomplete drains count distinct non-terminal customer Work IDs, exclude resources/system-time artifacts, wait for runnable/in-flight activity, and preserve service-mode liveness. Focused termination and engine boundary tests pass; CLI stderr/exit mapping remains in story 002."
    },
    {
      "id": "wo-a7-drained-incomplete-session-warning-002",
      "title": "Report incomplete server drains as CLI failure",
      "description": "As an operator running a finite server-enabled Factory Session, I want an incomplete drain to fail loudly with a count so that automation and people cannot mistake a stalled pipeline for a successful run.",
      "acceptanceCriteria": [
        "For `you run --with-server` and the server-implying `--with-site`, an incomplete drain joins the run-owned listener and runtime, returns a runtime failure that maps to process exit 1, and does not hang.",
        "The human stderr output for an incomplete drain is exactly `Error: factory session drained with N non-terminal work items; run is incomplete\\n`, with the decimal non-terminal Work count substituted for N; stdout contains no success or completion claim.",
        "Empty and fully terminal finite server-enabled runs join cleanly, return success/exit 0, and do not emit the incomplete-drain diagnostic.",
        "`--continuously --with-server` and `--continuously --with-site` retain idle liveness until cancellation and do not emit the incomplete finite-drain diagnostic merely because the ready queue is empty.",
        "The functional regression scenario is implemented through `root.BuildProcess` and `Process.Execute`, using customer-visible CLI inputs/streams and only `edges.Edges` for external effects; an OS subprocess test is added only if those boundaries cannot prove the required numeric exit mapping or stderr contract.",
        "`go test ./tests/functional/sessions/... -run TestWithServerDrainCannotReportSuccessWhileWorkIsNonTerminal -count=1` passes and the test would fail against the previous exit-0 behavior.",
        "Operator-facing run/session documentation states the finite success, incomplete-drain, continuous-liveness, exit, and diagnostic behavior without implying that `--with-server` is continuous by default.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Finite server/site runs now admit the typed incomplete-drain result through runtime readiness so the run-owned listener starts and joins before failure is returned. CLI presentation writes the exact count-bearing stderr line even in quiet mode, with no stdout success claim; empty/all-terminal finite runs remain successful and continuous server/site runs remain live while idle. Added root-built functional coverage for server, site, success, incomplete, and continuous cases, plus the typed process-exit assertion and run/session documentation. Addressed review feedback by replacing the functional test's completion waits with deterministic ProcessCommand.Done observation plus justified bounded guards, rebasing away unrelated task-management commits, inheriting the portable Windows runtime-artifact permission assertion, and compacting the runtime termination-check construction so the changed factory file is back to the 997-line base size. The required sessions functional command, `make test`, `make verify-fast`, focused Go tests, docs smoke, UI lint, and targeted vet pass; changed-scope backend-size output is clear, while the aggregate local lint command still reports unrelated baseline size violations. The post-fix GitHub functional retry passed after an unrelated JavaScript durability cancellation-observation flake, and all required PR checks are now terminal and passing on head `08881fd2d`. Final audit at 2026-08-08 15:50 -0700 revalidated the focused regression and make verify-fast; PR #1821 remains open, non-draft, clean/mergeable, synchronized to the branch head, with no unresolved review threads or newer blocking feedback."
    }
  ]
}
