### PR TITLE
Record pre-existing lint debt in baseline/exemption mechanisms

### DIFF
--- a/docs/internal/baselines/backend-exemption-budget.json
+++ b/docs/internal/baselines/backend-exemption-budget.json
@@ -15,15 +15,33 @@
     },
     {
       "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/services/chat_sessions/internal/service/turn_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
       "target": "pkg/services/factory_definitions/internal/contracts/interfaces_contract_test.go",
       "owner": "backend-maintainers",
       "removalReason": "consolidated interface contract and runtime-topology tests remain together until dedicated interface test seams split."
     },
     {
       "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/services/factory_definitions/internal/services/validation/impl/topology_guards_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
       "target": "pkg/services/factory_runtime/internal/services/orchestration/definitionmapping/mapper.go",
       "owner": "backend-maintainers",
       "removalReason": "refactor this target and remove this exemption when the threshold debt is resolved."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/runtime_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
     },
     {
       "rule": "backendsizecheck:ignore-file",
@@ -81,9 +99,27 @@
     },
     {
       "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/services/factory_sessions/internal/ondemandtarget/target_execution_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/services/factory_sessions/internal/responsestream/fragmentmap/mapper_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
       "target": "pkg/services/factory_sessions/internal/sessionprojection/projection_test.go",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this consolidated surface until a dedicated responsibility split removes the exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/services/providers/internal/services/acp/internal/service/service.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
     },
     {
       "rule": "backendsizecheck:ignore-file",
@@ -117,6 +153,24 @@
     },
     {
       "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/services/providers/internal/services/execution/internal/service/service_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/services/recordings/internal/combined_service_plain_contract_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/services/recordings/internal/contracts/contracts.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
       "target": "pkg/services/recordings/internal/projections/projectiontests/world_state_test.go",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this consolidated surface until a dedicated responsibility split removes the exemption."
@@ -135,15 +189,75 @@
     },
     {
       "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/services/recordings/internal/replay/event_log_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
       "target": "pkg/services/work/internal/requestadmission/normalize_test.go",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this consolidated surface until a dedicated responsibility split removes the exemption."
     },
     {
       "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/services/worker_sessions/internal/service/internal_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/services/worker_sessions/internal/service/start_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
       "target": "pkg/services/workers/internal/services/workstations/executor/workstation_executor_test.go",
       "owner": "backend-maintainers",
       "removalReason": "focused workstation execution tests stay together until the model-binding seam gets a dedicated package-level test split."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/transports/acp/internal/stdio/prompt_stream_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/transports/acp/internal/stdio/server_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/transports/acp/internal/stdio/session_new_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/transports/acp/internal/stdio/session_prompt.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/transports/acp/internal/stdio/session_prompt_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/transports/cli/root.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/transports/cli/root_models_docs_coverage_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
     },
     {
       "rule": "backendsizecheck:ignore-file",
@@ -156,6 +270,12 @@
       "target": "pkg/transports/cli/run/run_invocation_test.go",
       "owner": "backend-maintainers",
       "removalReason": "Refactor the target to satisfy the backendsizecheck:ignore-file threshold. Current rationale: consolidated run invocation tests remain together until dedicated CLI invocation test seams split."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/transports/http/contracttests/generated_contract_common_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
     },
     {
       "rule": "backendsizecheck:ignore-file",
@@ -195,9 +315,51 @@
     },
     {
       "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/transports/mapping/factorysession/factory_session_mapper_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "pkg/wire/session_runtime_providers.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
       "target": "tests/functional/bootstrap_portability/automat_portability_fixture_test.go",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this consolidated surface until a dedicated responsibility split removes the exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "tests/functional/events/factory_events/order_and_cursor_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "tests/functional/factory/packaged/cross/package_cli_api_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "tests/functional/orchestration/petri/dispatch/simple_run_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "tests/functional/runtime_api/factory_transformation/api_current_factory_put_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-file",
+      "target": "tests/functional/sessions/execution/helpers_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
     },
     {
       "rule": "backendsizecheck:ignore-function",
@@ -231,6 +393,18 @@
     },
     {
       "rule": "backendsizecheck:ignore-function",
+      "target": "internal/contractopenapiconverter/refs.go#convertContext.convertSchemaObject",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "internal/functionaltestviz/classify_test.go#TestAssembleCatalogInputsClassifiesRecordsAndLoadsCoverage",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
       "target": "pkg/services/edges/definition.go#Merge",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption."
@@ -243,6 +417,18 @@
     },
     {
       "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/events/read_subscribe_test.go#TestDeliveryValidate",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/events/read_subscribe_test.go#TestReadResultValidate",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
       "target": "pkg/services/factory_definitions/internal/services/catalog/persistence/named_factory_persistence_test.go#TestPersistNamedFactoryOwnsCreateReplaceAndCurrentPointerPolicy",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption."
@@ -252,6 +438,36 @@
       "target": "pkg/services/factory_definitions/internal/services/catalog/persistence/service_test.go#TestServiceRoutesPersistenceThroughFlatCapabilities",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/factory_definitions/internal/services/catalog/wire/wire_test.go#TestNewService_ListGetResolveDeleteNamedFactory",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/factory_definitions/wire/fold_behavior_preservation_test.go#newWireFoldPreservationService",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/factory_definitions/wire/wire.go#NewService",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/factory_definitions/wire/wire_test.go#TestNewServiceInstallAndScaffoldReturnMatchingDistributedFacts",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/factory_definitions/wire/wire_test.go#TestNewServiceRejectsMissingRequiredDependencies",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
     },
     {
       "rule": "backendsizecheck:ignore-function",
@@ -282,6 +498,12 @@
       "target": "pkg/services/factory_runtime/internal/runtime_build.go#buildBundle",
       "owner": "backend-maintainers",
       "removalReason": "Refactor and split this runtime construction function into focused helpers, then remove the exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/factory_runtime/internal/services/orchestration/runtime/captured_turn_terminate_integration_test.go#TestFactoryResume_IsolatesCapturedChildProviderSessionContinuations",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
     },
     {
       "rule": "backendsizecheck:ignore-function",
@@ -327,9 +549,81 @@
     },
     {
       "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/providers/internal/service/acp_control_test.go#TestControlAttempt_ACPDelayedControlCannotRedirectToReplacementGenerationAfterIdentityReuse",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/providers/internal/services/acp/internal/service/shared_conformance_test.go#TestSharedConformanceCorpusSessionUpdateMatchesInboundMapper",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
       "target": "pkg/services/recordings/internal/replay/configtests/generated_factory_test.go#TestGeneratedFactoryFromLoadedConfig_EmbedsSplitRuntimeDefinitionsInGeneratedFactory",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/recordings/internal/services/artifacts_export/root_integration_test.go#TestRecordingsRootPortableExportRoundTripOmitsPrivateStorage",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/recordings/internal/services/artifacts_export/wire/wire_test.go#TestNewPublicationPropagatesInjectedOperationErrors",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/system_initialization/internal/workflow/initialize_settings_command_test.go#TestInitializeSettingsCommandConstructionThroughRootCollaborator",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/system_initialization/internal/workflow/workflow.go#Initializer.Initialize",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/work/internal/proposalmaterialization/materialize.go#materializeOne",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/work/invocation_policy_service_test.go#TestInvocationPolicyServiceRejectsUnsupportedSlices",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/work/wire/wire_test.go#TestNewServiceConstructsInertRoot",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/work/wire_behavioral_proof_test.go#TestWireBehavioralProof_PublishedRootPreservesObservables",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/worker_sessions/publish_test.go#TestProviderSessionObservationPublisher_AssociatesBeforeForwardingExactProgress",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/worker_sessions/publish_test.go#TestPublish_CommitsRemainingWorkerVocabulary",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
     },
     {
       "rule": "backendsizecheck:ignore-function",
@@ -339,9 +633,63 @@
     },
     {
       "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner_test.go#TestExecuteExactContinuationFailurePreservesClassificationWithoutFallback",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/workers/internal/services/runners/wire/agent_progress_test.go#TestAgentRunnerPublishesDetachedProviderProgressBeforeSuccess",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/services/workers/internal/services/workstations/executor/workstation_executor.go#WorkstationExecutor.executeModelWorkstation",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/transports/acp/internal/session/session_test.go#TestValidateNewSession",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/transports/acp/internal/session/session_test.go#TestValidateSessionUpdate",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/transports/acp/internal/stdio/session_close_test.go#TestHandleSessionCloseCommittedIntentSafetyCases",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/transports/cli/cliinputs/parser_parity_test.go#productionParserParityRunFlagCases",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/transports/cli/command_factory_injection_test.go#TestNewCommandFactoryPreservesInjectedOperations",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
       "target": "pkg/wire/models_runtime.go#provideModelsService",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "pkg/wire/recordings_artifacts_export_composition_test.go#TestInjectBundleComposesRecordingsArtifactExportThroughWireFactory",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
     },
     {
       "rule": "backendsizecheck:ignore-function",
@@ -351,9 +699,105 @@
     },
     {
       "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/events/response_events/stream_test.go#TestAPIResponseEventCursorGapEmitsStreamGap",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/events/response_events/stream_test.go#TestAPIResponseEventSSEStreamsRetainedThenLiveEvents",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/factory/definitions/import_export_test.go#TestInvalidImportDoesNotReplaceCurrentFactory",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/factory/packaged/tts/invocation_test.go#scaffoldPackagedTTSLikeFactoryWithOptionalVoiceAndFormat",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go#TestPetriParentOrSameNameGuardReleasesExpectedWork",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go#TestPetriVisitOrMatchGuardFailureIsVisibleInPublicWorkState",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go#TestPetriFailureRoutesToDocumentedFailedPlace",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go#TestPetriMultiStagePipelineCompletesAtPublicTerminals",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/factory_runtime/root_composition/lifecycle_activation_test.go#TestFactoryRuntimeControlObservationAndDispatchPlanActivateThroughRootBuildProcessAfterLifecycle",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/factory_visualization/response_presentation_test.go#TestVisualizationResponsePresentationThroughPublicRootAfterLifecycle",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/internal/support/process_factory.go#runFactoryToCompletionWithHome",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
       "target": "tests/functional/models/model_invoke/cli_test.go#TestProcessModelsInvokeUsesCanonicalGraphAndExactExternalEdges",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/models/root_composition/inference_invoke_test.go#TestModelsInferenceInvokeActivatesThroughRootBuildProcess",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/orchestration/javascript/loading/named_factory_test.go#TestNamedJavaScriptFactoryUsesSameFactorySessionControls",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/provider_sessions/details/codex_details_test.go#observeCodexProviderSessionDetailGolden",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/runtime_api/api_work_root_policy_slices_test.go#TestWorkRootPolicySlicesRejectUnsupportedOperations",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/runtime_api/api_work_service_application_slices_test.go#TestWorkServiceApplicationSlicesExerciseFunctionalLane",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
     },
     {
       "rule": "backendsizecheck:ignore-function",
@@ -362,10 +806,148 @@
       "removalReason": "Refactor the target to satisfy the backendsizecheck:ignore-function threshold. Current rationale: this end-to-end current-factory layout round-trip test keeps save, reload, persistence, and runtime assertions on one contract seam."
     },
     {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/sessions/controls/pause_resume_test.go#TestAPIPauseResumeCancelAndTerminateFactorySession",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/sessions/execution/results_dispatches_test.go#TestAPIResultAndResultsExposeTerminalInvocationData",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/sessions/lifecycle/crud_test.go#TestFactorySessionCreateListShowDelete",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/sessions/restart/logical_identity_test.go#TestFactorySessionResumeDoesNotRepeatCompletedDispatch",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/sessions/root_composition/lifecycle_runtime_opening_test.go#TestSessionsLifecycleAndRuntimeOpeningActivateThroughRootBuildProcessAfterLifecycle",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/transport/acp/stdio/cli_serve_acp_prompt_test.go#TestServeACP_RootBuildProcessCompletesOneFactoryPrompt",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/transport/cli/commands/run_wiring_test.go#TestCLIRunNamedFactory",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/transport/cli/commands/session_wiring_test.go#TestCLISessionCreateListShowDelete",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/transport/cli/process/stdout_stderr_test.go#TestCLIQuietModeSuppressesNonResultNoise",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/work/relationships/dependencies_test.go#TestFanInReleasesOnlyAfterEveryPrerequisite",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/work/root_composition/routing_relationship_activation_test.go#TestWorkRelationshipsActivateThroughRootBuildProcessAfterLifecycle",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/work/root_composition/submission_activation_test.go#TestWorkSubmissionAndCLISubmitActivateThroughRootBuildProcessAfterLifecycle",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/workers/inference/agy/golden_test.go#TestAgyGoldenFinalOnlySuccess",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
+      "rule": "backendsizecheck:ignore-function",
+      "target": "tests/functional/workers/transports/cli/run/lifecycle/lifecycle_test.go#TestCLIRunServerAttachedInvocationTargetsExistingFactorySession",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption."
+    },
+    {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
       "target": "pkg/platform/portablefiles/materialize.go#ResolveTarget",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this decision flow; simplify branches and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/automations/internal/invocation_schedule.go#Service.PrepareInvocationSchedules",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/automations/internal/services/filesystem_watchers/internal/service/watcher.go#watcher.Watch",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/chat_sessions/internal/responsebridge/worker_children_edge_test.go#TestWorkerChildAssociationValidationAndRegistration",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/chat_sessions/internal/responsebridge/worker_children_edge_test.go#TestWorkerChildStartFinishAndSequencingFailuresAreExplicit",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/chat_sessions/internal/service/attachment_resume_test.go#TestStore_Attach_ResumeSelectsOwnDetachedAttachment",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/chat_sessions/internal/service/control_test.go#TestStore_AdvanceControl_CompletedCloseAtomicallyTerminalizesLifecycle",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/chat_sessions/internal/service/turn_test.go#TestStore_StartTurn_CommittedControlFencesReplacementUntilResolved",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/chat_sessions/transitions_test.go#TestCloseTargetEpisode",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/chat_sessions/types.go#RequestIdentity.Validate",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
@@ -381,9 +963,27 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/services/factory_definitions/authoredlayout/writer.go#interpreterFlagModeForArg",
+      "target": "pkg/services/events/read_subscribe.go#Delivery.Validate",
       "owner": "backend-maintainers",
-      "removalReason": "service-ownership migration preserves this decision flow; simplify branches and remove this exemption."
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/events/read_subscribe.go#ReadResult.Validate",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_definitions/internal/services/authoring_layout/authoredlayout/writer.go#interpreterFlagModeForArg",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_definitions/internal/services/authoring_layout/persist/persist.go#NamedFactory",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
@@ -411,15 +1011,21 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/services/factory_definitions/internal/services/catalog/persistence/service.go#service.persistNamedFactory",
+      "target": "pkg/services/factory_definitions/internal/services/catalog/persistence/service_test.go#TestServiceRoutesPersistenceThroughFlatCapabilities",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this decision flow; simplify branches and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/services/factory_definitions/internal/services/catalog/persistence/service_test.go#TestServiceRoutesPersistenceThroughFlatCapabilities",
+      "target": "pkg/services/factory_definitions/internal/services/catalog/wire/wire_test.go#TestNewService_ListGetResolveDeleteNamedFactory",
       "owner": "backend-maintainers",
-      "removalReason": "service-ownership migration preserves this decision flow; simplify branches and remove this exemption."
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_definitions/internal/services/compilation/internal/service/service.go#Service.CompileEffectiveFactorySource",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
@@ -435,63 +1041,183 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_definitions/internal/services/compilation/loading/loader.go#workstationHasInlineRuntimeDefinitionFields",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_definitions/internal/services/compilation/loading/loader.go#workstationHasRuntimeFields",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
       "target": "pkg/services/factory_definitions/internal/services/compilation/runtimeconfig/merge.go#applyWorkerRuntimeDefinition",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this decision flow; simplify branches and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/services/factory_definitions/portableconfig/materialization.go#PruneRemovedDocs",
+      "target": "pkg/services/factory_definitions/internal/services/invocation_policy/invocationinterpolation/service.go#InterpolateWorkstationConfig",
       "owner": "backend-maintainers",
-      "removalReason": "service-ownership migration preserves this decision flow; simplify branches and remove this exemption."
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/services/factory_runtime/runtime/factory_event_history_test.go#assertBatchRequestReplayEvents",
+      "target": "pkg/services/factory_definitions/internal/services/snapshots_portability/internal/service/service_test.go#TestDetachedSnapshot_CapturePrepareImportMaterializeRoundTrip",
       "owner": "backend-maintainers",
-      "removalReason": "refactor this target and remove this exemption when the threshold debt is resolved."
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/services/factory_runtime/runtime/factory_event_history_test.go#assertGeneratedBatchEvents",
+      "target": "pkg/services/factory_definitions/internal/services/snapshots_portability/portableconfig/materialization.go#PruneRemovedDocs",
       "owner": "backend-maintainers",
-      "removalReason": "refactor this target and remove this exemption when the threshold debt is resolved."
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/services/factory_runtime/runtime/factory_event_history_test.go#assertOrderedEventPayloads",
+      "target": "pkg/services/factory_definitions/internal/services/snapshots_portability/wire/wire_test.go#TestNewService_RequiresExactInjectedPorts",
       "owner": "backend-maintainers",
-      "removalReason": "refactor this target and remove this exemption when the threshold debt is resolved."
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/services/factory_runtime/runtime/factory_modes_test.go#TestFactoryEventHistory_SubscribeReplaysHistoryThenStreamsLiveEvents",
+      "target": "pkg/services/factory_definitions/transports/cli/service_test.go#assertInstallPackagedFactoryParity",
       "owner": "backend-maintainers",
-      "removalReason": "refactor this target and remove this exemption when the threshold debt is resolved."
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/services/factory_runtime/runtime/factory_modes_test.go#TestGetEngineStateSnapshot_AggregatesRuntimeLifecycleUptimeAndTopology",
+      "target": "pkg/services/factory_definitions/wire/snapshot_portability_test.go#TestWireSnapshotHelpersCapturePrepareMaterializeAndReplay",
       "owner": "backend-maintainers",
-      "removalReason": "refactor this target and remove this exemption when the threshold debt is resolved."
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/services/factory_runtime/runtime/factory_runtime_test_helpers_test.go#assertSafeBoundaryRequestView",
+      "target": "pkg/services/factory_definitions/wire/wire.go#validateDependencies",
       "owner": "backend-maintainers",
-      "removalReason": "refactor this target and remove this exemption when the threshold debt is resolved."
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/services/factory_runtime/subsystems/subsystem_transitioner_worker_batch_test.go#assertGeneratedWorkerBatchSubmissions",
+      "target": "pkg/services/factory_runtime/internal/build.go#RuntimeFactory.Build",
       "owner": "backend-maintainers",
-      "removalReason": "service-ownership migration preserves this decision flow; simplify branches and remove this exemption."
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/services/factory_runtime/token/clone_test.go#TestCloneToken_PreserveNilAndEmptyValues",
+      "target": "pkg/services/factory_runtime/internal/invocation_schedule_factory.go#invocationScheduleFactory.observeInvocationSchedule",
       "owner": "backend-maintainers",
-      "removalReason": "refactor this target and remove this exemption when the threshold debt is resolved."
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_runtime/internal/invocation_schedule_factory.go#invocationScheduleFactory.recoverInvocationSchedules",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_runtime/internal/invocation_schedule_factory_test.go#TestInvocationScheduleFactoryRecoversDurableControllerWithoutInitialRetrigger",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_runtime/internal/services/instance_host/internal/service/replace_test.go#TestReplaceSuccessfulStartsReplacementAttachesSidecarsAndSwapsActiveHandle",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_runtime/internal/services/orchestration/javascript/validation/analyze.go#sourceAnalyzer.inspectCall",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_runtime/internal/services/orchestration/replayhooks/adapter_boundary_test.go#TestAdaptPreservesRecordingsReplayContracts",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_runtime/internal/services/orchestration/runtime/captured_turn_terminate_integration_test.go#TestFactoryResume_IsolatesCapturedChildProviderSessionContinuations",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_runtime/internal/services/orchestration/runtime/factory_event_history_test.go#assertBatchRequestReplayEvents",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_runtime/internal/services/orchestration/runtime/factory_event_history_test.go#assertGeneratedBatchEvents",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_runtime/internal/services/orchestration/runtime/factory_event_history_test.go#assertOrderedEventPayloads",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_runtime/internal/services/orchestration/runtime/factory_modes_test.go#TestFactoryEventHistory_SubscribeReplaysHistoryThenStreamsLiveEvents",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_runtime/internal/services/orchestration/runtime/factory_modes_test.go#TestGetEngineStateSnapshot_AggregatesRuntimeLifecycleUptimeAndTopology",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_runtime/internal/services/orchestration/runtime/factory_runtime_test_helpers_test.go#assertSafeBoundaryRequestView",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_runtime/internal/services/orchestration/runtime/worker_session_control_fanout_test.go#TestFactoryControls_FanOutCapturedTurnOnceAndRetainOriginalEvidence",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_transitioner_worker_batch_test.go#assertGeneratedWorkerBatchSubmissions",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_runtime/internal/services/orchestration/token/clone_test.go#TestCloneToken_PreserveNilAndEmptyValues",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_runtime/internal/sidecars.go#RuntimeSidecars.Start",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_runtime/transports/http/internal/common/common_test.go#TestErrorFamilyAndRequestContextOutcomes",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_runtime/transports/http/internal/errors/errors.go#RootErrorResponse",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
@@ -633,9 +1359,33 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_sessions/internal/ondemandtarget/service.go#activatedRuntime.cleanup",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_sessions/internal/ondemandtarget/target_execution_test.go#TestCancelInterruptsOnlyTheActiveInvocation",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_sessions/internal/ondemandtarget/target_execution_test.go#TestCancelRespectsCallerCancellationDuringCleanupAndRetries",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
       "target": "pkg/services/factory_sessions/internal/responsestream/construction_contract_test.go#TestPublishesAndCompletesOneOrderedDispatch",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this decision flow; simplify branches and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_sessions/internal/responsestream/fragmentmap/mapper.go#semanticProgress",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
@@ -657,9 +1407,63 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_sessions/internal/runtimeopening/runtime_load_test.go#TestClockForReplayPreservesOverridesAndInjectedDefaults",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_sessions/internal/runtimeopening/runtime_load_test.go#TestLoadRuntimePreservesValidatedPortableRecording",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_sessions/internal/services/durable_execution/wire/wire_test.go#TestNewServiceRoutesRestartReadsThroughOwner",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_sessions/internal/services/live_runtime/internal/service/lifecycle_control_test.go#TestServiceResumeAfterPauseReturnsAcceptedOutcomeOnce",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
       "target": "pkg/services/factory_sessions/internal/sessionprojection/projection_test.go#TestProjectRuntime_LegacyPetriSessionIncludesMarkingAndEnabledTransitions",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this decision flow; simplify branches and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_sessions/internal/sessionservice/live_runtime_composition_test.go#TestService_LiveRegistryPathsDelegateThroughLiveRuntimeOwner",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_sessions/internal/sessionservice/live_runtime_lifecycle_control_test.go#TestLiveControlCapability_CompletesLifecycleAndRetiresCanonicalSession",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_sessions/internal/sessionservice/live_runtime_lifecycle_control_test.go#TestLiveControlCapability_OpenPauseResumePreservesLifecycleResults",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_sessions/internal/sessionservice/live_runtime_registry_read_test.go#TestLiveControlCapability_OpenListReadPreservesCanonicalIdentity",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_sessions/internal/sessionservice/ownership_boundary_test.go#TestDurableCapabilityDoesNotTouchCollidingLiveSession",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
@@ -711,9 +1515,129 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_visualization/internal/service/service_test.go#TestServiceProjectsRetainedAndLiveFactoryEvents",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_visualization/internal/service/service_test.go#TestServiceRootObserveDetachedViewAndTypedFailures",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_visualization/internal/services/live_view_projection/internal/service/service_test.go#TestLiveViewProjectionConformance",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/factory_visualization/runtime_consumer_boundary_test.go#TestVisualizationConsumerObservationExercisesRuntimeRoot",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
       "target": "pkg/services/models/internal/service/runtime_factory.go#NewRoot",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this decision flow; simplify branches and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/models/internal/services/runtime_host/internal/service/service.go#service.EnsureModelHost",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/models/transports/cli/adapter_owned_coverage_test.go#TestOwnedAdapter_InvokeResolvesThroughModelsRoot",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/models/transports/cli/root_invoke.go#rootService.Invoke",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/models/transports/cli/root_parity_test.go#TestRootAdapter_InvokeJSONResolvesThroughModelsRootCatalogAndInference",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/models/transports/mcp/invoke_with_lease_test.go#TestBind_InvokeWithLeaseSuccessReturnsInvokeFactsFromInjectedRoot",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/models/wire/wire.go#validateConstructionInputs",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/operator_settings/backend_scope.go#persistBackendScopeID",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/operator_settings/internal/services/resolution/defaults/operator_config_test.go#decodeTestConfig",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/operator_settings/transports/globalconfig/decode.go#mapConfig",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/operator_settings/transports/mcp/apply_document_update_test.go#TestBind_ApplyDocumentUpdateSuccessReturnsPostUpdateFactsFromInjectedRoot",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/operator_settings/wire/behavioral_preservation_test.go#TestWireFoldPreservesDocumentIdentityResolutionAndConfigBehavior",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/operator_settings/wire/consumer_edge_preservation_test.go#TestNewServicePreservesDocumentPersistAndEffectiveResolution",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/operator_settings/wire/wire_test.go#TestNewServiceConstructsInertRoot",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/provider_sessions/internal/root_contracts_providers_boundary_identity_test.go#TestRootContracts_ProvidersRootBoundary_IdentityConstruction",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/provider_sessions/internal/services/codex_reader/internal/service/detail.go#parseCodexSessionDetails",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/provider_sessions/internal/services/cursor_reader/internal/cursor/detail.go#LoadDetails",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
@@ -741,15 +1665,39 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/services/provider_sessions/internal/services/cursor_reader/internal/cursor/store_query.go#QueryBlobsTable",
+      "target": "pkg/services/provider_sessions/internal/services/cursor_reader/internal/cursor/store_query.go#QueryMetaTable",
       "owner": "backend-maintainers",
       "removalReason": "Refactor the target to satisfy the pkgmaintcheck:ignore-cyclomatic-complexity threshold. Current rationale: MIT-ported cursor-session store schema probing stays grouped until extraction refactor."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/services/provider_sessions/internal/services/cursor_reader/internal/cursor/store_query.go#QueryMetaTable",
+      "target": "pkg/services/providers/internal/services/acp/internal/service/protocol_failure_classification_test.go#runProtocolFailurePeer",
       "owner": "backend-maintainers",
-      "removalReason": "Refactor the target to satisfy the pkgmaintcheck:ignore-cyclomatic-complexity threshold. Current rationale: MIT-ported cursor-session store schema probing stays grouped until extraction refactor."
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/providers/internal/services/acp/internal/service/service.go#Service.Configure",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/providers/internal/services/acp/internal/service/service.go#mapSessionUpdate",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/providers/internal/services/acp/internal/service/shared_conformance_test.go#TestSharedConformanceCorpusSessionUpdateMatchesInboundMapper",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/providers/internal/services/execution/internal/provider/functionaltests/provider_invocation_error_compatibility_test.go#TestInvocationErrorCompatibility_SupportedCorpusEntriesPreserveStableWorkFailureTypes",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
@@ -768,6 +1716,30 @@
       "target": "pkg/services/providers/internal/services/execution/internal/provider/recording_provider_test.go#TestRecordingProvider_Infer_MissingInnerProviderEmitsMisconfiguredFailureEvent",
       "owner": "backend-maintainers",
       "removalReason": "refactor this target and remove this exemption when the threshold debt is resolved."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/providers/internal/services/execution/internal/service/failure.go#normalizeAttemptFailure",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/providers/root_catalog_delegation_test.go#TestProvidersRootWireBoundaryPublishesExternalRegistrationThroughService",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/providers/transports/mcp/execute_test.go#TestBind_ExecuteSuccessReturnsDetachedResultFromInjectedRoot",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/providers/wire/wire_test.go#TestNewServiceServesPublishedCatalogAndExecuteCompositionForMigratedIdentities",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
@@ -885,9 +1857,87 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/recordings/internal/services/artifacts_export/root_integration_test.go#TestRecordingsRootPortableExportRoundTripOmitsPrivateStorage",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/recordings/internal/services/canonical_ledger/dispatch_worker_session_association_replay_test.go#assertReplayedDispatchWorkerSessionAssociation",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/recordings/internal/services/replay/internal/service/service_test.go#TestObserveReplayProgressAndCompletion",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/recordings/lifecycle_capability_test.go#TestRecordingLifecycle_SuccessPath",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/recordings/replay_artifact_capability_test.go#TestRecordingReplayArtifacts_UnchangedBehaviorThroughComposedImplementation",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/recordings/runtime_request_boundary_test.go#TestRecordingsConstructsRuntimeRequestsThroughRoot",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/recordings/wire/replay_input_test.go#assertReplayInputLogs",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/system_initialization/internal/workflow/initialize_settings_command_test.go#TestInitializeSettingsCommandConstructionThroughRootCollaborator",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
       "target": "pkg/services/system_initialization/internal/workflow/workflow.go#Initializer.Initialize",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this decision flow; simplify branches and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/system_initialization/internal/workflow/workflow_test.go#TestInitializeFreshHomeReturnsTypedCreatedResultsThroughPeerRoots",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/system_initialization/internal/workflow/workflow_test.go#TestInitializeRepeatInvocationReportsSkippedOutcomesForSystemConfigAndPackagedFactories",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/system_initialization/transports/cli/service_parity_test.go#assertInitializeParity",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/work/internal/lineagegraph/visualization.go#NewVisualizationOperation",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/work/internal/proposalmaterialization/materialize.go#materializeOne",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
@@ -897,9 +1947,165 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/work/internal/services/state_access/internal/service/state_access_seal_test.go#TestStateAccessSealFullStateAccessPipeline",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/work/recordings_request_boundary_test.go#TestWorkConstructsRecordingsRequestsThroughRoot",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/work/transports/http/error_mapping.go#RootErrorResponse",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/work/wire_behavioral_proof_test.go#TestWireBehavioralProof_PublishedRootPreservesObservables",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/worker_sessions/internal/service/control.go#registry.Pause",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/worker_sessions/internal/service/control.go#registry.cancelControl",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/worker_sessions/internal/service/control_test.go#TestPauseResume_ContinuationFailureKeepsAssociationAndProviderClassification",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/worker_sessions/internal/service/control_test.go#TestPauseResume_ContinuesExactProviderReferenceWithSameWorkerSessionCorrelation",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/worker_sessions/internal/service/internal_test.go#TestContinuationControl_GuardsPreserveThePausedSession",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/worker_sessions/internal/service/internal_test.go#TestControlGuards_RejectInvalidTransitionsAndPreserveObservableSessionState",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/worker_sessions/internal/service/internal_test.go#TestPause_ControlOutcomesKeepTheLifecycleTruthful",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/worker_sessions/internal/service/publish_idempotency_test.go#TestPublishRecord_RetryOfOlderAcceptedIdentity_AfterNewerSequenceAccepted_ResolvesAsDuplicate",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/worker_sessions/internal/service/start_side_effects_test.go#TestRegistryLogsStartOutcomes",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/worker_sessions/internal/service/start_test.go#TestStart_ProviderProgressCommitsAssociationBeforeOutputAndEnablesResume",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/worker_sessions/publish.go#progressDraftPayload",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/worker_sessions/publish_test.go#TestProviderSessionObservationPublisher_AssociatesBeforeForwardingExactProgress",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/workers/internal/interface/schema_contract_test.go#TestMockWorkersSchema_StaleStagingDetectedByContractCheck",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/workers/internal/progress_composition_test.go#TestNewRequiresCompositionSelectedWorkerEffects",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/workers/internal/provider_execution_regression_test.go#TestConcurrentRepeatedProviderExecutionsRetainConstructionInjectedProviderCommandRunner",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/workers/internal/runtime_concurrency_test.go#TestConcurrentRepeatedExecutionsRetainConstructionInjectedDependencies",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/workers/internal/runtime_options.go#Service.BuildRuntimeExecutors",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/workers/internal/runtime_service.go#New",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/live_provider_session_integration_test.go#TestLiveProviderSessionObservationEnablesExactWorkerSessionContinuation",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/workers/internal/services/runners/wire/agent_failure_test.go#TestAgentRunnerPreservesCancellationAndDeadlineContext",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/workers/internal/services/runners/wire/agent_failure_test.go#assertAgentFailureFacts",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
       "target": "pkg/services/workers/internal/services/runtime_assembly/construction/service.go#Service.Build",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this decision flow; simplify branches and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/workers/internal/services/workstations/executor/agent.go#effectiveWorkerDefinition",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
@@ -933,6 +2139,12 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/services/workers/internal/services/workstations/executor/workstation_executor.go#WorkstationExecutor.executeModelWorkstation",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
       "target": "pkg/services/workers/internal/services/workstations/executor/workstation_executor_test.go#TestWorkstationExecutor_ModelWorkstationUsesCanonicalWorkstationRuntimeFields",
       "owner": "backend-maintainers",
       "removalReason": "refactor this target and remove this exemption when the threshold debt is resolved."
@@ -945,21 +2157,129 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/services/workers/service/boundary_test.go#TestExecutorBuilderIsOwnedByWorkerExecutionService",
+      "target": "pkg/services/workers/internal/services/workstations/internal/service/service_logging_test.go#TestPoolLogsCancellationOutcomesIncludingNoOps",
       "owner": "backend-maintainers",
-      "removalReason": "service-ownership migration preserves this decision flow; simplify branches and remove this exemption."
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/services/workers/service/progress_composition_test.go#TestNewRequiresCompositionSelectedWorkerEffects",
+      "target": "pkg/services/workers/internal/services/workstations/internal/service/service_logging_test.go#TestPoolLogsStartAcceptedAndTerminalDispatchOutcomes",
       "owner": "backend-maintainers",
-      "removalReason": "service-ownership migration preserves this decision flow; simplify branches and remove this exemption."
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/services/workers/service/runtime_options.go#Service.BuildRuntimeExecutors",
+      "target": "pkg/services/workers/validate_draft_test.go#sampleDraftPayload",
       "owner": "backend-maintainers",
-      "removalReason": "service-ownership migration preserves this decision flow; simplify branches and remove this exemption."
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/acp/factory_target_option_test.go#TestFactoryTargetOptionToSessionConfigOptionSerializesSelectUnion",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/acp/internal/mapping/child_content_test.go#TestBoundChildProjectionReservesFailureAndTerminalEvidenceAfterRecordPressure",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/acp/internal/mapping/child_content_test.go#childFixturePayload",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/acp/internal/mapping/child_edge_test.go#TestChildProjectionValidationRejectsEveryMalformedBoundaryShape",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/acp/internal/mapping/dispatch_test.go#TestProjectDispatch_HandlesEveryCurrentPair",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/acp/internal/negotiation/negotiation_test.go#TestNegotiateSupportedVersionAdvertisesHonestP0Profile",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/acp/internal/session/session.go#ValidateSessionUpdate",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/acp/internal/stdio/prompt_stream.go#Server.drainRecords",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/acp/internal/stdio/prompt_stream.go#Server.liveDrainTurnUpdates",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/acp/internal/stdio/prompt_stream.go#Server.streamTurnUpdates",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/acp/internal/stdio/prompt_stream_test.go#TestLiveDrainTurnUpdatesRetriesGapAcknowledgementConflictBeforeCatchUp",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/acp/internal/stdio/response_bridge_test.go#TestDeliverBoundWorkerChildProjectionPreservesNotificationOutcomes",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/acp/internal/stdio/response_bridge_test.go#TestStreamTurnUpdatesBoundsNoisyChildWithoutReducingSiblingBudget",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/acp/internal/stdio/session_close_test.go#TestHandleSessionCloseCommitsBeforeFactoryClose",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/acp/internal/stdio/session_close_test.go#TestHandleSessionCloseDependencyFailureLeavesLifecycleRetryable",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/acp/internal/stdio/session_new_test.go#TestHandleSessionNewCreatesOneSessionAndReturnsProjectedPicker",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/acp/internal/stdio/session_prompt_test.go#TestHandleSessionCancelCommitsCapturedIntentBeforeFactoryCancel",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/acp/internal/stdio/session_prompt_test.go#TestHandleSessionCancelDependencyFailureLeavesTurnRunningAndRetryable",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
@@ -995,13 +2315,13 @@
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
       "target": "pkg/transports/cli/cliinputs/synthetic_args_relationships_test.go#assertSyntheticArgumentRecord",
       "owner": "backend-maintainers",
-      "removalReason": "Refactor the target to satisfy the pkgmaintcheck:ignore-cyclomatic-complexity threshold. Current rationale: synthetic argument assertions keep the full plan §4.3 field contract visible in one helper."
+      "removalReason": "Refactor the target to satisfy the pkgmaintcheck:ignore-cyclomatic-complexity threshold. Current rationale: synthetic argument assertions keep the full plan \u00a74.3 field contract visible in one helper."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
       "target": "pkg/transports/cli/cliinputs/synthetic_flags_test.go#assertSyntheticFlagRecord",
       "owner": "backend-maintainers",
-      "removalReason": "Refactor the target to satisfy the pkgmaintcheck:ignore-cyclomatic-complexity threshold. Current rationale: synthetic flag assertions keep the full plan §4.3 field contract visible in one helper."
+      "removalReason": "Refactor the target to satisfy the pkgmaintcheck:ignore-cyclomatic-complexity threshold. Current rationale: synthetic flag assertions keep the full plan \u00a74.3 field contract visible in one helper."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
@@ -1017,15 +2337,45 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/cli/command_factory_injection_test.go#TestNewCommandFactoryPreservesInjectedModelsCLIAdapter",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
       "target": "pkg/transports/cli/command_factory_injection_test.go#TestNewCommandFactoryPreservesInjectedOperations",
       "owner": "backend-maintainers",
-      "removalReason": "service-ownership migration preserves this decision flow; simplify branches and remove this exemption."
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/cli/command_factory_injection_test.go#TestNewCommandFactoryPreservesInjectedRuntimeCLIAdapter",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
       "target": "pkg/transports/cli/mcp/serve_smoke_test.go#TestRunServe_InstallSmoke_DiscoveryValidateAsyncPoll",
       "owner": "backend-maintainers",
       "removalReason": "Refactor the target to satisfy the pkgmaintcheck:ignore-cyclomatic-complexity threshold. Current rationale: install smoke keeps discovery, validate, async start, and polling assertions on one documented stdio path."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/cli/root.go#runFactoryWithOptions",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/cli/root_serve_test.go#TestServeACPCommand_HelpRendersManifestExamplesAndNoLocalFlags",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/cli/root_submit_batch.go#parseRunCommandArgs",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
@@ -1050,6 +2400,12 @@
       "target": "pkg/transports/http/servertests/server_durable_session_lifecycle_control_test.go#TestRetryFactorySessionDispatch_RuntimeBackedFailedSessionReturnsTypedLifecycleControl",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this decision flow; simplify branches and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/mapping/factory_events_test.go#TestFactoryEventAssociationRoundTripPreservesDispatchAndWorkerSessionIDs",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
@@ -1095,6 +2451,12 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/mapping/factorysession/factory_session_mapper_test.go#TestInvocationAPI_UsesOwnerCapabilityAndPreservesTerminalOutcome",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
       "target": "pkg/transports/mapping/factorysession/factory_session_mapper_test.go#assertListSummaryFieldsPreserved",
       "owner": "backend-maintainers",
       "removalReason": "Refactor the target to satisfy the pkgmaintcheck:ignore-cyclomatic-complexity threshold. Current rationale: this assertion keeps durable list summary fixture field checks together on one contract test seam."
@@ -1104,6 +2466,18 @@
       "target": "pkg/transports/mapping/factorysession/factory_session_projection_test.go#TestProjectionResponses_TrimAndOmitOptionalFields",
       "owner": "backend-maintainers",
       "removalReason": "Refactor the target to satisfy the pkgmaintcheck:ignore-cyclomatic-complexity threshold. Current rationale: this boundary regression intentionally covers optional-field trimming in one table-like scenario."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/mapping/factorysession/live_api_test.go#TestLiveAPI_MapsCompleteLifecycleThroughNarrowControl",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/transports/mapping/factorytarget/factory_target_option_test.go#TestFromCatalogResultSerializesSelectOptionContract",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
@@ -1119,9 +2493,27 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/wire/chat_sessions_composition_test.go#TestChatSessionsSequencingIdentity_RetainedReadReturnsExactCommittedIdentity",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/wire/model_invocation_edges_test.go#TestModelsCompositionAdaptsEdgePortsAtTheWireBoundary",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
       "target": "pkg/wire/models_runtime.go#provideModelsService",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this decision flow; simplify branches and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
+      "target": "pkg/wire/recordings_artifacts_export_composition_test.go#TestInjectBundleComposesRecordingsArtifactExportThroughWireFactory",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
@@ -1137,15 +2529,33 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/services/chat_sessions/internal/service/turn_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
       "target": "pkg/services/factory_definitions/internal/contracts/interfaces_contract_test.go",
       "owner": "backend-maintainers",
       "removalReason": "consolidated interface contract and runtime-topology tests remain together until dedicated interface test seams split."
     },
     {
       "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/services/factory_definitions/internal/services/validation/impl/topology_guards_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
       "target": "pkg/services/factory_runtime/internal/services/orchestration/definitionmapping/mapper.go",
       "owner": "backend-maintainers",
       "removalReason": "refactor this target and remove this exemption when the threshold debt is resolved."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/runtime_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-file-lines",
@@ -1203,9 +2613,27 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/services/factory_sessions/internal/ondemandtarget/target_execution_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/services/factory_sessions/internal/responsestream/fragmentmap/mapper_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
       "target": "pkg/services/factory_sessions/internal/sessionprojection/projection_test.go",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this consolidated file; split responsibilities and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/services/providers/internal/services/acp/internal/service/service.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-file-lines",
@@ -1239,6 +2667,24 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/services/providers/internal/services/execution/internal/service/service_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/services/recordings/internal/combined_service_plain_contract_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/services/recordings/internal/contracts/contracts.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
       "target": "pkg/services/recordings/internal/projections/projectiontests/world_state_test.go",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this consolidated file; split responsibilities and remove this exemption."
@@ -1257,15 +2703,75 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/services/recordings/internal/replay/event_log_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
       "target": "pkg/services/work/internal/requestadmission/normalize_test.go",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this consolidated file; split responsibilities and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/services/worker_sessions/internal/service/internal_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/services/worker_sessions/internal/service/start_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
       "target": "pkg/services/workers/internal/services/workstations/executor/workstation_executor_test.go",
       "owner": "backend-maintainers",
       "removalReason": "focused workstation execution tests stay together until the model-binding seam gets a dedicated package-level test split."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/transports/acp/internal/stdio/prompt_stream_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/transports/acp/internal/stdio/server_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/transports/acp/internal/stdio/session_new_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/transports/acp/internal/stdio/session_prompt.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/transports/acp/internal/stdio/session_prompt_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/transports/cli/root.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/transports/cli/root_models_docs_coverage_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-file-lines",
@@ -1278,6 +2784,12 @@
       "target": "pkg/transports/cli/run/run_invocation_test.go",
       "owner": "backend-maintainers",
       "removalReason": "Refactor the target to satisfy the pkgmaintcheck:ignore-file-lines threshold. Current rationale: consolidated run invocation tests remain together until dedicated CLI invocation test seams split."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/transports/http/contracttests/generated_contract_common_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-file-lines",
@@ -1316,6 +2828,18 @@
       "removalReason": "refactor this target and remove this exemption when the threshold debt is resolved."
     },
     {
+      "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/transports/mapping/factorysession/factory_session_mapper_test.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-file-lines",
+      "target": "pkg/wire/session_runtime_providers.go",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
       "rule": "pkgmaintcheck:ignore-function-lines",
       "target": "pkg/services/edges/definition.go#Merge",
       "owner": "backend-maintainers",
@@ -1329,6 +2853,18 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/events/read_subscribe_test.go#TestDeliveryValidate",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/events/read_subscribe_test.go#TestReadResultValidate",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
       "target": "pkg/services/factory_definitions/internal/services/catalog/persistence/named_factory_persistence_test.go#TestPersistNamedFactoryOwnsCreateReplaceAndCurrentPointerPolicy",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption."
@@ -1338,6 +2874,78 @@
       "target": "pkg/services/factory_definitions/internal/services/catalog/persistence/service_test.go#TestServiceRoutesPersistenceThroughFlatCapabilities",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/factory_definitions/internal/services/catalog/wire/wire_test.go#TestNewService_ListGetResolveDeleteNamedFactory",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/factory_definitions/internal/services/validation/impl/topology_guards_test.go#TestConfigValidator_UnsupportedSameNameAllChildrenCompleteJoinArity",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/factory_definitions/wire/fold_behavior_preservation_test.go#newWireFoldPreservationService",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/factory_definitions/wire/wire.go#NewService",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/factory_definitions/wire/wire_test.go#TestNewServiceInstallAndScaffoldReturnMatchingDistributedFacts",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/factory_definitions/wire/wire_test.go#TestNewServiceRejectsMissingRequiredDependencies",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/factory_runtime/internal/assembly.go#Assembly.Assemble",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/factory_runtime/internal/build.go#RuntimeFactory.Build",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/factory_runtime/internal/build.go#assembleRuntimeBundle",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/factory_runtime/internal/runtime_build.go#NewRuntimeBuild",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/factory_runtime/internal/runtime_build.go#buildBundle",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing directive relocated by package restructure; refactor the code below the threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/factory_runtime/internal/services/orchestration/runtime/captured_turn_terminate_integration_test.go#TestFactoryResume_IsolatesCapturedChildProviderSessionContinuations",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-function-lines",
@@ -1362,6 +2970,12 @@
       "target": "pkg/services/factory_sessions/internal/execution/fake_service_runtime_test.go#TestJavaScriptRuntimeService_ResumeInterruptedSession_PackageLocalCoverage",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/factory_sessions/internal/ondemandtarget/target_execution_test.go#TestLoggingNeverEmitsWorkingRootOrRawFailureText",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-function-lines",
@@ -1395,9 +3009,27 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/providers/internal/service/acp_control_test.go#TestControlAttempt_ACPDelayedControlCannotRedirectToReplacementGenerationAfterIdentityReuse",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/providers/internal/services/acp/internal/service/shared_conformance_test.go#TestSharedConformanceCorpusSessionUpdateMatchesInboundMapper",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
       "target": "pkg/services/providers/internal/services/execution/internal/provider/inference_provider_error_normalization_test.go#TestScriptWrapProvider_Infer_KnownCodexErrorLinesMapToProviderFailureCategories",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/providers/internal/services/execution/internal/service/service_test.go#TestContinueFailsClosedAcrossPrivateContinuationBoundaries",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-function-lines",
@@ -1407,15 +3039,141 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/recordings/internal/services/artifacts_export/root_integration_test.go#TestRecordingsRootPortableExportRoundTripOmitsPrivateStorage",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/recordings/internal/services/artifacts_export/wire/wire_test.go#TestNewPublicationPropagatesInjectedOperationErrors",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/system_initialization/internal/workflow/initialize_settings_command_test.go#TestInitializeSettingsCommandConstructionThroughRootCollaborator",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/system_initialization/internal/workflow/workflow.go#Initializer.Initialize",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/work/internal/proposalmaterialization/materialize.go#materializeOne",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/work/invocation_policy_service_test.go#TestInvocationPolicyServiceRejectsUnsupportedSlices",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/work/wire/wire_test.go#TestNewServiceConstructsInertRoot",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/work/wire_behavioral_proof_test.go#TestWireBehavioralProof_PublishedRootPreservesObservables",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/worker_sessions/internal/service/internal_test.go#TestContinuationControl_GuardsPreserveThePausedSession",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/worker_sessions/internal/service/internal_test.go#TestPause_ControlOutcomesKeepTheLifecycleTruthful",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/worker_sessions/publish_test.go#TestProviderSessionObservationPublisher_AssociatesBeforeForwardingExactProgress",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/worker_sessions/publish_test.go#TestPublish_CommitsRemainingWorkerVocabulary",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
       "target": "pkg/services/workers/internal/runtime_service.go#New",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner_test.go#TestExecuteExactContinuationFailurePreservesClassificationWithoutFallback",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/workers/internal/services/runners/wire/agent_progress_test.go#TestAgentRunnerPublishesDetachedProviderProgressBeforeSuccess",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/services/workers/internal/services/workstations/executor/workstation_executor.go#WorkstationExecutor.executeModelWorkstation",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
       "target": "pkg/services/workers/internal/services/workstations/executor/workstation_executor_test.go#TestWorkstationExecutor_ModelWorkstation_InterpolatesInvocationArguments",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/transports/acp/internal/session/session_test.go#TestValidateNewSession",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/transports/acp/internal/session/session_test.go#TestValidateSessionUpdate",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/transports/acp/internal/stdio/session_close_test.go#TestHandleSessionCloseCommittedIntentSafetyCases",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/transports/acp/internal/stdio/session_prompt_test.go#TestHandleSessionCancelCommittedSafetyCases",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/transports/cli/cliinputs/parser_parity_test.go#productionParserParityRunFlagCases",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/transports/cli/command_factory_injection_test.go#TestNewCommandFactoryPreservesInjectedOperations",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-function-lines",
@@ -1428,6 +3186,12 @@
       "target": "pkg/wire/models_runtime.go#provideModelsService",
       "owner": "backend-maintainers",
       "removalReason": "service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption."
+    },
+    {
+      "rule": "pkgmaintcheck:ignore-function-lines",
+      "target": "pkg/wire/recordings_artifacts_export_composition_test.go#TestInjectBundleComposesRecordingsArtifactExportThroughWireFactory",
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption."
     },
     {
       "rule": "pkgmaintcheck:ignore-function-lines",

--- a/docs/internal/baselines/backend-package-file-count.json
+++ b/docs/internal/baselines/backend-package-file-count.json
@@ -1,38 +1,365 @@
 {
   "version": 1,
   "entries": [
-    { "packagePath": "pkg/platform/process", "fileCount": 17, "owner": "backend-maintainers", "removalReason": "Split process execution responsibilities into durable child packages." },
-    { "packagePath": "pkg/services/factory_definitions", "fileCount": 39, "owner": "factory-definition-maintainers", "removalReason": "Continue moving definition capabilities behind focused child-package contracts." },
-    { "packagePath": "pkg/services/factory_definitions/contracts", "fileCount": 26, "owner": "factory-definition-maintainers", "removalReason": "Partition definition contracts by stable consumer boundary." },
-    { "packagePath": "pkg/services/factory_definitions/definition", "fileCount": 35, "owner": "factory-definition-maintainers", "removalReason": "Split definition representation behavior by durable responsibility." },
-    { "packagePath": "pkg/services/factory_definitions/internal/services/compilation/runtimetests", "fileCount": 19, "owner": "factory-definition-maintainers", "removalReason": "Consolidate runtime loading fixtures and move focused scenarios beside their owners." },
-    { "packagePath": "pkg/services/factory_definitions/internal/services/validation/impl", "fileCount": 22, "owner": "factory-definition-maintainers", "removalReason": "Partition validation rules by definition concern." },
-    { "packagePath": "pkg/services/factory_runtime", "fileCount": 53, "owner": "factory-runtime-maintainers", "removalReason": "Move runtime capabilities behind focused orchestration and subsystem packages." },
-    { "packagePath": "pkg/services/factory_runtime/internal/services/orchestration/runtime", "fileCount": 24, "owner": "factory-runtime-maintainers", "removalReason": "Split runtime coordination from lifecycle and projection behavior." },
-    { "packagePath": "pkg/services/factory_runtime/internal/services/orchestration/subsystems", "fileCount": 19, "owner": "factory-runtime-maintainers", "removalReason": "Separate subsystem adapters by stable runtime boundary." },
-    { "packagePath": "pkg/services/factory_sessions", "fileCount": 24, "owner": "factory-session-maintainers", "removalReason": "Continue extracting session capabilities into focused child packages." },
-    { "packagePath": "pkg/services/factory_sessions/internal/execution", "fileCount": 21, "owner": "factory-session-maintainers", "removalReason": "Separate execution coordination from invocation policy." },
-    { "packagePath": "pkg/services/factory_sessions/internal/runtimeopening", "fileCount": 19, "owner": "factory-session-maintainers", "removalReason": "Partition runtime opening composition, model binding, and runtime construction by responsibility." },
-    { "packagePath": "pkg/services/factory_sessions/internal/sessionservice", "fileCount": 28, "owner": "factory-session-maintainers", "removalReason": "Partition session service behavior by lifecycle responsibility." },
-    { "packagePath": "pkg/services/factory_sessions/transports/cli/session", "fileCount": 19, "owner": "factory-session-maintainers", "removalReason": "Separate session command lifecycle and rendering behavior." },
-    { "packagePath": "pkg/services/factory_sessions/transports/mcp", "fileCount": 17, "owner": "factory-session-maintainers", "removalReason": "Separate Factory Session MCP tools by lifecycle responsibility." },
-    { "packagePath": "pkg/services/models/internal/local", "fileCount": 17, "owner": "model-runtime-maintainers", "removalReason": "Split local model lifecycle and invocation responsibilities." },
-    { "packagePath": "pkg/services/models/internal/service", "fileCount": 16, "owner": "model-runtime-maintainers", "removalReason": "Separate model runtime scope, catalog, host lease, and local execution responsibilities." },
-    { "packagePath": "pkg/services/operator_settings", "fileCount": 17, "owner": "operator-settings-maintainers", "removalReason": "Separate settings persistence from effective configuration behavior." },
-    { "packagePath": "pkg/services/provider_sessions/internal/services/cursor_reader/internal/cursor", "fileCount": 16, "owner": "provider-session-maintainers", "removalReason": "Consolidate cursor cases or extract durable cursor responsibilities." },
-    { "packagePath": "pkg/services/recordings/internal/events", "fileCount": 18, "owner": "recording-maintainers", "removalReason": "Partition recording event contracts by stable concern." },
-    { "packagePath": "pkg/services/recordings/internal/projections/projectiontests", "fileCount": 16, "owner": "recording-maintainers", "removalReason": "Consolidate projection fixtures and focused scenarios." },
-    { "packagePath": "pkg/services/recordings/internal/replay", "fileCount": 20, "owner": "recording-maintainers", "removalReason": "Split replay ingestion, validation, and execution responsibilities." },
-    { "packagePath": "pkg/services/work", "fileCount": 25, "owner": "work-maintainers", "removalReason": "Continue extracting Work capabilities into focused child packages." },
-    { "packagePath": "pkg/services/workers", "fileCount": 40, "owner": "worker-maintainers", "removalReason": "Continue extracting worker policy and execution capabilities." },
-    { "packagePath": "pkg/transports/cli", "fileCount": 19, "owner": "cli-maintainers", "removalReason": "Move command behavior into focused command packages." },
-    { "packagePath": "pkg/transports/cli/baseline", "fileCount": 20, "owner": "cli-maintainers", "removalReason": "Consolidate baseline command fixtures and split durable behaviors." },
-    { "packagePath": "pkg/transports/cli/cliinputs", "fileCount": 16, "owner": "cli-maintainers", "removalReason": "Consolidate input parsing cases or extract stable input domains." },
-    { "packagePath": "pkg/transports/cli/factory", "fileCount": 21, "owner": "cli-maintainers", "removalReason": "Split factory commands by lifecycle responsibility." },
-    { "packagePath": "pkg/transports/cli/run", "fileCount": 22, "owner": "cli-maintainers", "removalReason": "Split run invocation, presentation, and input behavior." },
-    { "packagePath": "pkg/transports/cli/submit", "fileCount": 16, "owner": "cli-maintainers", "removalReason": "Consolidate submit command cases or extract stable input behavior." },
-    { "packagePath": "pkg/transports/http/servertests", "fileCount": 16, "owner": "http-transport-maintainers", "removalReason": "Consolidate server fixtures and move focused scenarios beside handlers." },
-    { "packagePath": "pkg/transports/mapping/factorysession", "fileCount": 19, "owner": "transport-mapping-maintainers", "removalReason": "Partition Factory Session mapping by contract direction." },
-    { "packagePath": "pkg/wire", "fileCount": 21, "owner": "composition-maintainers", "removalReason": "Split composition tests and providers by durable process graph boundary." }
+    {
+      "packagePath": "pkg/platform/process",
+      "fileCount": 17,
+      "owner": "backend-maintainers",
+      "removalReason": "Split process execution responsibilities into durable child packages."
+    },
+    {
+      "packagePath": "pkg/services/automations/internal",
+      "fileCount": 18,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/automations/internal/services/filesystem_watchers/internal/service",
+      "fileCount": 16,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/automations/transports/http",
+      "fileCount": 20,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/chat_sessions/internal/service",
+      "fileCount": 25,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/factory_definitions",
+      "fileCount": 56,
+      "owner": "factory-definition-maintainers",
+      "removalReason": "Continue moving definition capabilities behind focused child-package contracts."
+    },
+    {
+      "packagePath": "pkg/services/factory_definitions/definition",
+      "fileCount": 33,
+      "owner": "factory-definition-maintainers",
+      "removalReason": "Split definition representation behavior by durable responsibility."
+    },
+    {
+      "packagePath": "pkg/services/factory_definitions/internal",
+      "fileCount": 21,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/factory_definitions/internal/contracts",
+      "fileCount": 27,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/factory_definitions/internal/services/compilation/runtimetests",
+      "fileCount": 19,
+      "owner": "factory-definition-maintainers",
+      "removalReason": "Consolidate runtime loading fixtures and move focused scenarios beside their owners."
+    },
+    {
+      "packagePath": "pkg/services/factory_definitions/internal/services/validation/impl",
+      "fileCount": 23,
+      "owner": "factory-definition-maintainers",
+      "removalReason": "Partition validation rules by definition concern."
+    },
+    {
+      "packagePath": "pkg/services/factory_definitions/transports/mcp",
+      "fileCount": 18,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/factory_definitions/wire",
+      "fileCount": 20,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/factory_runtime",
+      "fileCount": 76,
+      "owner": "factory-runtime-maintainers",
+      "removalReason": "Move runtime capabilities behind focused orchestration and subsystem packages."
+    },
+    {
+      "packagePath": "pkg/services/factory_runtime/internal",
+      "fileCount": 16,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/factory_runtime/internal/orchestrators/petri",
+      "fileCount": 16,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/factory_runtime/internal/services/orchestration/runtime",
+      "fileCount": 35,
+      "owner": "factory-runtime-maintainers",
+      "removalReason": "Split runtime coordination from lifecycle and projection behavior."
+    },
+    {
+      "packagePath": "pkg/services/factory_runtime/internal/services/orchestration/subsystems",
+      "fileCount": 19,
+      "owner": "factory-runtime-maintainers",
+      "removalReason": "Separate subsystem adapters by stable runtime boundary."
+    },
+    {
+      "packagePath": "pkg/services/factory_sessions",
+      "fileCount": 31,
+      "owner": "factory-session-maintainers",
+      "removalReason": "Continue extracting session capabilities into focused child packages."
+    },
+    {
+      "packagePath": "pkg/services/factory_sessions/internal/execution",
+      "fileCount": 28,
+      "owner": "factory-session-maintainers",
+      "removalReason": "Separate execution coordination from invocation policy."
+    },
+    {
+      "packagePath": "pkg/services/factory_sessions/internal/runtimeopening",
+      "fileCount": 28,
+      "owner": "factory-session-maintainers",
+      "removalReason": "Partition runtime opening composition, model binding, and runtime construction by responsibility."
+    },
+    {
+      "packagePath": "pkg/services/factory_sessions/internal/sessionservice",
+      "fileCount": 40,
+      "owner": "factory-session-maintainers",
+      "removalReason": "Partition session service behavior by lifecycle responsibility."
+    },
+    {
+      "packagePath": "pkg/services/factory_sessions/transports/cli/session",
+      "fileCount": 19,
+      "owner": "factory-session-maintainers",
+      "removalReason": "Separate session command lifecycle and rendering behavior."
+    },
+    {
+      "packagePath": "pkg/services/factory_sessions/transports/http",
+      "fileCount": 23,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/factory_sessions/transports/mcp",
+      "fileCount": 19,
+      "owner": "factory-session-maintainers",
+      "removalReason": "Separate Factory Session MCP tools by lifecycle responsibility."
+    },
+    {
+      "packagePath": "pkg/services/factory_visualization/transports/http",
+      "fileCount": 26,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/models/internal/local",
+      "fileCount": 17,
+      "owner": "model-runtime-maintainers",
+      "removalReason": "Split local model lifecycle and invocation responsibilities."
+    },
+    {
+      "packagePath": "pkg/services/models/internal/service",
+      "fileCount": 16,
+      "owner": "model-runtime-maintainers",
+      "removalReason": "Separate model runtime scope, catalog, host lease, and local execution responsibilities."
+    },
+    {
+      "packagePath": "pkg/services/models/transports/cli",
+      "fileCount": 26,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/models/transports/http",
+      "fileCount": 27,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/models/transports/mcp",
+      "fileCount": 20,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/operator_settings",
+      "fileCount": 19,
+      "owner": "operator-settings-maintainers",
+      "removalReason": "Separate settings persistence from effective configuration behavior."
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/transports/http",
+      "fileCount": 24,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/wire",
+      "fileCount": 18,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/provider_sessions/internal/services/cursor_reader/internal/cursor",
+      "fileCount": 20,
+      "owner": "provider-session-maintainers",
+      "removalReason": "Consolidate cursor cases or extract durable cursor responsibilities."
+    },
+    {
+      "packagePath": "pkg/services/providers/transports/http",
+      "fileCount": 22,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/providers/transports/mcp",
+      "fileCount": 16,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal",
+      "fileCount": 20,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal/events",
+      "fileCount": 19,
+      "owner": "recording-maintainers",
+      "removalReason": "Partition recording event contracts by stable concern."
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal/projections/projectiontests",
+      "fileCount": 16,
+      "owner": "recording-maintainers",
+      "removalReason": "Consolidate projection fixtures and focused scenarios."
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal/replay",
+      "fileCount": 20,
+      "owner": "recording-maintainers",
+      "removalReason": "Split replay ingestion, validation, and execution responsibilities."
+    },
+    {
+      "packagePath": "pkg/services/recordings/transports/http",
+      "fileCount": 17,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/recordings/transports/mcp",
+      "fileCount": 18,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/work",
+      "fileCount": 25,
+      "owner": "work-maintainers",
+      "removalReason": "Continue extracting Work capabilities into focused child packages."
+    },
+    {
+      "packagePath": "pkg/services/work/transports/http",
+      "fileCount": 25,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/work/transports/mcp",
+      "fileCount": 18,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/services/workers",
+      "fileCount": 43,
+      "owner": "worker-maintainers",
+      "removalReason": "Continue extracting worker policy and execution capabilities."
+    },
+    {
+      "packagePath": "pkg/services/workers/internal",
+      "fileCount": 26,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/transports/acp/internal/mapping",
+      "fileCount": 20,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/transports/acp/internal/stdio",
+      "fileCount": 22,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/transports/cli",
+      "fileCount": 22,
+      "owner": "cli-maintainers",
+      "removalReason": "Move command behavior into focused command packages."
+    },
+    {
+      "packagePath": "pkg/transports/cli/baseline",
+      "fileCount": 20,
+      "owner": "cli-maintainers",
+      "removalReason": "Consolidate baseline command fixtures and split durable behaviors."
+    },
+    {
+      "packagePath": "pkg/transports/cli/cliinputs",
+      "fileCount": 16,
+      "owner": "cli-maintainers",
+      "removalReason": "Consolidate input parsing cases or extract stable input domains."
+    },
+    {
+      "packagePath": "pkg/transports/cli/climanifestcobra",
+      "fileCount": 17,
+      "owner": "backend-maintainers",
+      "removalReason": "pre-existing baseline debt recorded 2026-08-08; split this package into focused sub-packages and remove this entry."
+    },
+    {
+      "packagePath": "pkg/transports/cli/factory",
+      "fileCount": 21,
+      "owner": "cli-maintainers",
+      "removalReason": "Split factory commands by lifecycle responsibility."
+    },
+    {
+      "packagePath": "pkg/transports/cli/run",
+      "fileCount": 27,
+      "owner": "cli-maintainers",
+      "removalReason": "Split run invocation, presentation, and input behavior."
+    },
+    {
+      "packagePath": "pkg/transports/cli/submit",
+      "fileCount": 17,
+      "owner": "cli-maintainers",
+      "removalReason": "Consolidate submit command cases or extract stable input behavior."
+    },
+    {
+      "packagePath": "pkg/transports/http/servertests",
+      "fileCount": 16,
+      "owner": "http-transport-maintainers",
+      "removalReason": "Consolidate server fixtures and move focused scenarios beside handlers."
+    },
+    {
+      "packagePath": "pkg/transports/mapping/factorysession",
+      "fileCount": 21,
+      "owner": "transport-mapping-maintainers",
+      "removalReason": "Partition Factory Session mapping by contract direction."
+    },
+    {
+      "packagePath": "pkg/wire",
+      "fileCount": 46,
+      "owner": "composition-maintainers",
+      "removalReason": "Split composition tests and providers by durable process graph boundary."
+    }
   ]
 }

--- a/docs/internal/baselines/package-structure-baseline.json
+++ b/docs/internal/baselines/package-structure-baseline.json
@@ -1004,6 +1004,46 @@
     },
     {
       "rule": "functional-test-unclassified-domain",
+      "filePath": "tests/functional/chat_sessions/root_composition/acp_multi_turn_test.go",
+      "target": "chat_sessions"
+    },
+    {
+      "rule": "functional-test-unclassified-domain",
+      "filePath": "tests/functional/chat_sessions/root_composition/acp_packaged_factory_prompt_test.go",
+      "target": "chat_sessions"
+    },
+    {
+      "rule": "functional-test-unclassified-domain",
+      "filePath": "tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go",
+      "target": "chat_sessions"
+    },
+    {
+      "rule": "functional-test-unclassified-domain",
+      "filePath": "tests/functional/chat_sessions/root_composition/acp_server_composition_test.go",
+      "target": "chat_sessions"
+    },
+    {
+      "rule": "functional-test-unclassified-domain",
+      "filePath": "tests/functional/chat_sessions/root_composition/acp_streaming_composition_test.go",
+      "target": "chat_sessions"
+    },
+    {
+      "rule": "functional-test-unclassified-domain",
+      "filePath": "tests/functional/chat_sessions/root_composition/acp_streaming_usage_composition_test.go",
+      "target": "chat_sessions"
+    },
+    {
+      "rule": "functional-test-unclassified-domain",
+      "filePath": "tests/functional/chat_sessions/root_composition/acp_worker_child_events_test.go",
+      "target": "chat_sessions"
+    },
+    {
+      "rule": "functional-test-unclassified-domain",
+      "filePath": "tests/functional/chat_sessions/root_composition/doc.go",
+      "target": "chat_sessions"
+    },
+    {
+      "rule": "functional-test-unclassified-domain",
       "filePath": "tests/functional/cli/factory_run/output/failure_test.go",
       "target": "cli"
     },
@@ -1119,6 +1159,11 @@
     },
     {
       "rule": "functional-test-unclassified-domain",
+      "filePath": "tests/functional/factory_runtime/root_composition/dispatch_worker_sessions_concurrency_activation_test.go",
+      "target": "factory_runtime"
+    },
+    {
+      "rule": "functional-test-unclassified-domain",
       "filePath": "tests/functional/factory_runtime/root_composition/doc.go",
       "target": "factory_runtime"
     },
@@ -1209,6 +1254,11 @@
     },
     {
       "rule": "functional-test-unclassified-domain",
+      "filePath": "tests/functional/recordings/root_composition/portable_replay_execution_test.go",
+      "target": "recordings"
+    },
+    {
+      "rule": "functional-test-unclassified-domain",
       "filePath": "tests/functional/recordings/root_composition/portable_transport_activation_test.go",
       "target": "recordings"
     },
@@ -1281,6 +1331,26 @@
       "rule": "service-root-exported-function",
       "filePath": "pkg/services/automations/internal/services/script_pollers/service.go",
       "target": "ScriptPollerCommandRequest"
+    },
+    {
+      "rule": "service-root-exported-function",
+      "filePath": "pkg/services/chat_sessions/sequencing.go",
+      "target": "EventsTopic"
+    },
+    {
+      "rule": "service-root-exported-function",
+      "filePath": "pkg/services/chat_sessions/transitions.go",
+      "target": "CloseTargetEpisode"
+    },
+    {
+      "rule": "service-root-exported-function",
+      "filePath": "pkg/services/chat_sessions/transitions.go",
+      "target": "OpenNextTargetEpisode"
+    },
+    {
+      "rule": "service-root-exported-function",
+      "filePath": "pkg/services/chat_sessions/transitions.go",
+      "target": "ResolveControlIntentOutcome"
     },
     {
       "rule": "service-root-exported-function",
@@ -1601,6 +1671,11 @@
       "rule": "service-root-exported-function",
       "filePath": "pkg/services/models/local_execution_contract.go",
       "target": "ValidateLocalInvocationRequest"
+    },
+    {
+      "rule": "service-root-exported-function",
+      "filePath": "pkg/services/operator_settings/acp_agent_profile.go",
+      "target": "DefaultACPAgentProfile"
     },
     {
       "rule": "service-root-exported-function",
@@ -1964,6 +2039,21 @@
     },
     {
       "rule": "service-root-exported-function",
+      "filePath": "pkg/services/worker_sessions/publish.go",
+      "target": "NewProviderSessionObservationPublisher"
+    },
+    {
+      "rule": "service-root-exported-function",
+      "filePath": "pkg/services/worker_sessions/terminal.go",
+      "target": "SanitizeProviderFailureClassification"
+    },
+    {
+      "rule": "service-root-exported-function",
+      "filePath": "pkg/services/worker_sessions/topic.go",
+      "target": "Topic"
+    },
+    {
+      "rule": "service-root-exported-function",
       "filePath": "pkg/services/workers/execution_context.go",
       "target": "ResolveProjectID"
     },
@@ -2134,6 +2224,11 @@
     },
     {
       "rule": "service-root-exported-function",
+      "filePath": "pkg/services/workers/progress_observations.go",
+      "target": "CloneProviderSessionReference"
+    },
+    {
+      "rule": "service-root-exported-function",
       "filePath": "pkg/services/workers/proposal_mappers.go",
       "target": "ProposedOutputFromLegacyWorkResult"
     },
@@ -2284,13 +2379,18 @@
     },
     {
       "rule": "service-root-interface-count",
+      "filePath": "pkg/services/chat_sessions",
+      "target": "pkg/services/chat_sessions/contracts.go:Service,pkg/services/chat_sessions/factory_target_catalog_contract.go:FactoryTargetCatalogService"
+    },
+    {
+      "rule": "service-root-interface-count",
       "filePath": "pkg/services/edges",
-      "target": "<none>"
+      "target": "\u003cnone\u003e"
     },
     {
       "rule": "service-root-interface-count",
       "filePath": "pkg/services/factory_definitions",
-      "target": "pkg/services/factory_definitions/activation_contract.go:DefinitionActivationGateway,pkg/services/factory_definitions/authored_layout_filesystem.go:AuthoredLayoutReaderFileSystem,pkg/services/factory_definitions/authored_layout_filesystem.go:AuthoredLayoutWriterFileSystem,pkg/services/factory_definitions/authored_layout_filesystem.go:InputInboxSentinelEnsurer,pkg/services/factory_definitions/config_file_operations.go:FactoryConfigPathSource,pkg/services/factory_definitions/decision_envelope_contract.go:DecisionEnvelopeService,pkg/services/factory_definitions/invocation_interpolation_contract.go:InvocationInterpolationService,pkg/services/factory_definitions/invocation_output_contract.go:InvocationOutputShapingService,pkg/services/factory_definitions/invocation_work_type_contract.go:InvocationWorkTypeService,pkg/services/factory_definitions/loading_effects.go:Clock,pkg/services/factory_definitions/loading_effects.go:LoadingFileSystem,pkg/services/factory_definitions/loading_effects.go:VersionFileSystem,pkg/services/factory_definitions/named_catalog_ports.go:NamedFactoryCatalogFileSystem,pkg/services/factory_definitions/named_path_ports.go:NamedPathFileSystem,pkg/services/factory_definitions/named_path_ports.go:NamedPathResolver,pkg/services/factory_definitions/packaged_installation.go:PackagedFactoryInstaller,pkg/services/factory_definitions/packaged_installation_ports.go:PackagedInstallationFileSystem,pkg/services/factory_definitions/packages_contract.go:PackagedGoalPromptFileSystem,pkg/services/factory_definitions/persistence_ports.go:DirectoryReplacementStore,pkg/services/factory_definitions/persistence_ports.go:PersistenceFileSystem,pkg/services/factory_definitions/portable_bundled_validation.go:PortableBundledFileInspection,pkg/services/factory_definitions/quorum_policy_contract.go:QuorumPolicyService,pkg/services/factory_definitions/replay_runtime.go:ReplayRuntimeConfig,pkg/services/factory_definitions/scaffold_contract.go:ScaffoldFileSystem,pkg/services/factory_definitions/scaffold_contract.go:ScaffoldOutput,pkg/services/factory_definitions/service_contract.go:Service,pkg/services/factory_definitions/service_contract.go:SessionHost,pkg/services/factory_definitions/tts_observability_contract.go:TTSObservabilityService,pkg/services/factory_definitions/validation_contract.go:ValidationOperations,pkg/services/factory_definitions/work_propagation_contract.go:WorkPropagationPolicyService,pkg/services/factory_definitions/workstation_execution_contract.go:WorkstationExecutionPolicyService"
+      "target": "pkg/services/factory_definitions/activation_contract.go:DefinitionActivationGateway,pkg/services/factory_definitions/authored_layout_filesystem.go:AuthoredLayoutReaderFileSystem,pkg/services/factory_definitions/authored_layout_filesystem.go:AuthoredLayoutWriterFileSystem,pkg/services/factory_definitions/authored_layout_filesystem.go:InputInboxSentinelEnsurer,pkg/services/factory_definitions/config_file_operations.go:FactoryConfigPathSource,pkg/services/factory_definitions/current_factory_pointer.go:CatalogPathsService,pkg/services/factory_definitions/decision_envelope_contract.go:DecisionEnvelopeService,pkg/services/factory_definitions/invocation_interpolation_contract.go:InvocationInterpolationService,pkg/services/factory_definitions/invocation_output_contract.go:InvocationOutputShapingService,pkg/services/factory_definitions/invocation_work_type_contract.go:InvocationWorkTypeService,pkg/services/factory_definitions/loading_effects.go:Clock,pkg/services/factory_definitions/loading_effects.go:LoadingFileSystem,pkg/services/factory_definitions/loading_effects.go:VersionFileSystem,pkg/services/factory_definitions/named_catalog_ports.go:NamedFactoryCatalogFileSystem,pkg/services/factory_definitions/named_path_ports.go:NamedPathResolver,pkg/services/factory_definitions/packaged_installation.go:PackagedFactoryInstaller,pkg/services/factory_definitions/packaged_installation_ports.go:PackagedInstallationFileSystem,pkg/services/factory_definitions/packages_contract.go:PackagedGoalPromptFileSystem,pkg/services/factory_definitions/persistence_ports.go:DirectoryReplacementStore,pkg/services/factory_definitions/persistence_ports.go:PersistenceFileSystem,pkg/services/factory_definitions/portable_bundled_validation.go:PortableBundledFileInspection,pkg/services/factory_definitions/quorum_policy_contract.go:QuorumPolicyService,pkg/services/factory_definitions/replay_runtime.go:ReplayRuntimeConfig,pkg/services/factory_definitions/scaffold_contract.go:ScaffoldFileSystem,pkg/services/factory_definitions/scaffold_contract.go:ScaffoldOutput,pkg/services/factory_definitions/service_contract.go:Service,pkg/services/factory_definitions/service_contract.go:SessionHost,pkg/services/factory_definitions/tts_observability_contract.go:TTSObservabilityService,pkg/services/factory_definitions/validation_contract.go:ValidationOperations,pkg/services/factory_definitions/work_propagation_contract.go:WorkPropagationPolicyService,pkg/services/factory_definitions/workstation_execution_contract.go:WorkstationExecutionPolicyService"
     },
     {
       "rule": "service-root-interface-count",
@@ -2306,6 +2406,11 @@
       "rule": "service-root-interface-count",
       "filePath": "pkg/services/factory_runtime/internal/services/orchestration",
       "target": "pkg/services/factory_runtime/internal/services/orchestration/service.go:Binding,pkg/services/factory_runtime/internal/services/orchestration/service.go:Service"
+    },
+    {
+      "rule": "service-root-interface-count",
+      "filePath": "pkg/services/factory_sessions",
+      "target": "pkg/services/factory_sessions/assembly_contract.go:InvocationService,pkg/services/factory_sessions/execution_contract.go:DurableExecutionService,pkg/services/factory_sessions/execution_contract.go:SessionInventoryService,pkg/services/factory_sessions/service_contracts.go:LiveControlService,pkg/services/factory_sessions/service_contracts.go:Service,pkg/services/factory_sessions/target_execution_contract.go:TargetExecutionService"
     },
     {
       "rule": "service-root-interface-count",
@@ -2329,8 +2434,18 @@
     },
     {
       "rule": "service-root-interface-count",
+      "filePath": "pkg/services/providers/internal/services/acp",
+      "target": "pkg/services/providers/internal/services/acp/service.go:ContinuationService,pkg/services/providers/internal/services/acp/service.go:Service"
+    },
+    {
+      "rule": "service-root-interface-count",
+      "filePath": "pkg/services/providers/internal/services/execution",
+      "target": "pkg/services/providers/internal/services/execution/service.go:ContinuationService,pkg/services/providers/internal/services/execution/service.go:Service"
+    },
+    {
+      "rule": "service-root-interface-count",
       "filePath": "pkg/services/recordings",
-      "target": "pkg/services/recordings/contracts.go:Service,pkg/services/recordings/lifecycle_capability.go:RecordingLifecycle,pkg/services/recordings/replay_artifact_capability.go:RecordingReplayArtifacts,pkg/services/recordings/runtime_recording_binder.go:RuntimeRecordingBinder"
+      "target": "pkg/services/recordings/contracts.go:Service,pkg/services/recordings/lifecycle_capability.go:RecordingLifecycle,pkg/services/recordings/replay_artifact_capability.go:RecordingReplayArtifacts,pkg/services/recordings/replay_artifact_capability.go:ReplayInputLoader,pkg/services/recordings/runtime_recording_binder.go:RuntimeRecordingBinder"
     },
     {
       "rule": "service-root-interface-count",
@@ -2346,6 +2461,11 @@
       "rule": "service-root-interface-count",
       "filePath": "pkg/services/work/internal/services/state_access",
       "target": "pkg/services/work/internal/services/state_access/service.go:RecordingsAdapter,pkg/services/work/internal/services/state_access/service.go:Service,pkg/services/work/internal/services/state_access/service.go:SessionAdapter,pkg/services/work/internal/services/state_access/service.go:SessionResolver"
+    },
+    {
+      "rule": "service-root-interface-count",
+      "filePath": "pkg/services/worker_sessions",
+      "target": "pkg/services/worker_sessions/contracts.go:Service,pkg/services/worker_sessions/publish.go:Logger"
     },
     {
       "rule": "service-root-interface-count",
@@ -2752,6 +2872,5 @@
       "filePath": "pkg/services/workers/internal/services/workstations/worktree",
       "target": "pkg/services/workers/internal/services/workstations"
     }
-  ],
-  "violations": []
+  ]
 }

--- a/internal/contractopenapiconverter/refs.go
+++ b/internal/contractopenapiconverter/refs.go
@@ -86,6 +86,7 @@ func (ctx *convertContext) convertNode(value any, path string) (any, []contractv
 	}
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func (ctx *convertContext) convertSchemaObject(schema map[string]any, path string) (any, []contractvalidator.Diagnostic) {
 	if ref, hasRef := schema["$ref"]; hasRef {
 		if diagnostics := ctx.validateRefSiblings(schema, path); len(diagnostics) != 0 {

--- a/internal/functionaltestviz/classify_test.go
+++ b/internal/functionaltestviz/classify_test.go
@@ -99,6 +99,7 @@ func TestLoadCoverageSummaryFailsClosedForMissingAndMalformed(t *testing.T) {
 	}
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestAssembleCatalogInputsClassifiesRecordsAndLoadsCoverage(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/automations/internal/invocation_schedule.go
+++ b/pkg/services/automations/internal/invocation_schedule.go
@@ -53,6 +53,7 @@ type preparedInvocationSchedule struct {
 
 // PrepareInvocationSchedules validates and constructs inert duration jobs for
 // authored CRON intervals that reference normalized invocation arguments.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (s *Service) PrepareInvocationSchedules(
 	ctx context.Context,
 	request automations.InvocationScheduleRequest,

--- a/pkg/services/automations/internal/services/filesystem_watchers/internal/service/watcher.go
+++ b/pkg/services/automations/internal/services/filesystem_watchers/internal/service/watcher.go
@@ -126,6 +126,7 @@ func newWatcher(config filesystemwatchers.Config) *watcher {
 }
 
 // Watch starts watching for file events. It blocks until ctx is cancelled.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (fw *watcher) Watch(ctx context.Context) error {
 	watcher, err := fw.newWatcher()
 	if err != nil {

--- a/pkg/services/chat_sessions/internal/responsebridge/worker_children_edge_test.go
+++ b/pkg/services/chat_sessions/internal/responsebridge/worker_children_edge_test.go
@@ -69,6 +69,7 @@ func testWorkerChild(t *testing.T, service *Service, state *drainState) *workerC
 	return &workerChildren{service: service, liveCtx: context.Background(), deliveryCtx: context.Background(), chatSessionID: "chat", factorySessionID: "factory", state: state}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestWorkerChildAssociationValidationAndRegistration(t *testing.T) {
 	dispatchID := "dispatch"
 	validPayload, err := json.Marshal(factorydefinitions.DispatchWorkerSessionAssociationEventPayload{WorkerSessionID: "worker"})
@@ -207,6 +208,7 @@ func TestWorkerChildLifecycleConsumersFailClosedAndIsolateMalformedRecords(t *te
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestWorkerChildStartFinishAndSequencingFailuresAreExplicit(t *testing.T) {
 	state := newWorkerChildDrainState()
 	withoutWorkers := New(&bridgeSequencer{didFirst: make(chan struct{})}, bridgeTarget{}, nil, logging.NoopLogger{})

--- a/pkg/services/chat_sessions/internal/service/attachment_resume_test.go
+++ b/pkg/services/chat_sessions/internal/service/attachment_resume_test.go
@@ -60,6 +60,7 @@ func TestStore_Attach_ResumeReactivatesDetachedInteractiveAttachment(t *testing.
 // with different acknowledged positions cannot inherit each other's cursor:
 // identity-less resume rejects the ambiguity, then each caller resumes its
 // own durable Attachment identity regardless of detach or reconnect order.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestStore_Attach_ResumeSelectsOwnDetachedAttachment(t *testing.T) {
 	ctx := context.Background()
 	store, session, _ := newSequencingTestSession(t)

--- a/pkg/services/chat_sessions/internal/service/control_test.go
+++ b/pkg/services/chat_sessions/internal/service/control_test.go
@@ -644,6 +644,7 @@ func TestStore_RequestControl_RepeatedDistinctIdentitiesNeverCollide(t *testing.
 // lifecycle commit: the intent, captured running turn, current episode, and
 // session all become terminal, and every delivery attachment is detached,
 // before any successor can be admitted.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestStore_AdvanceControl_CompletedCloseAtomicallyTerminalizesLifecycle(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, 8, 4, 14, 0, 0, 0, time.UTC)

--- a/pkg/services/chat_sessions/internal/service/turn_test.go
+++ b/pkg/services/chat_sessions/internal/service/turn_test.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package service
 
 import (
@@ -368,6 +370,7 @@ func TestStore_StartTurn_SecondTurnAfterTerminalStaysActive(t *testing.T) {
 // that the captured-control fence survives the captured turn's terminal
 // transition. A would-be successor remains rejected until the committed
 // intent resolves, so it cannot become a target for an older control.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestStore_StartTurn_CommittedControlFencesReplacementUntilResolved(t *testing.T) {
 	ctx := context.Background()
 	store, session := newStartTurnTestSession(t, time.Now())

--- a/pkg/services/chat_sessions/transitions_test.go
+++ b/pkg/services/chat_sessions/transitions_test.go
@@ -205,6 +205,7 @@ func TestTurnState_IsBusy(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestCloseTargetEpisode(t *testing.T) {
 	started := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
 	closedAt := started.Add(time.Minute)

--- a/pkg/services/chat_sessions/types.go
+++ b/pkg/services/chat_sessions/types.go
@@ -130,6 +130,7 @@ type RequestIdentity struct {
 // empty string is not a valid JSON number token), so an empty
 // JSONRPCNumberID on the number kind is unambiguously a genuinely missing
 // id, reported as ErrRequiredValue rather than ErrMalformedValue.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (r RequestIdentity) Validate() error {
 	if err := r.Kind.Validate(); err != nil {
 		return newValidationError("RequestIdentity", "Kind", err)

--- a/pkg/services/events/read_subscribe.go
+++ b/pkg/services/events/read_subscribe.go
@@ -106,6 +106,7 @@ type ReadResult struct {
 // resolvable position and a gap's resumable position is already carried by
 // Gap; a leftover Next or Retained on either outcome would let a caller
 // observe two contradictory resume states for the same read.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (res ReadResult) Validate() error {
 	switch res.Outcome {
 	case ReadOutcomeProgress:
@@ -250,6 +251,7 @@ type Delivery struct {
 // or Cursor. A Record with only some fields set (for example a stray
 // Payload on a gap or terminal delivery) is rejected the same as a
 // fully-set one: Record.IsZero checks every field, not just ID.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (d Delivery) Validate() error {
 	recordZero := d.Record.IsZero()
 	cursorSet := d.Cursor != (Cursor{})

--- a/pkg/services/events/read_subscribe_test.go
+++ b/pkg/services/events/read_subscribe_test.go
@@ -71,6 +71,8 @@ func TestSubscribeRequestValidate(t *testing.T) {
 	}
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestReadResultValidate(t *testing.T) {
 	rec1 := Record{
 		ID:             RecordID{Topic: testTopic, Position: 1},
@@ -294,6 +296,8 @@ func TestGapFactsValidate(t *testing.T) {
 	}
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestDeliveryValidate(t *testing.T) {
 	rec := Record{
 		ID:             RecordID{Topic: testTopic, Position: 1},

--- a/pkg/services/factory_definitions/internal/services/authoring_layout/persist/persist.go
+++ b/pkg/services/factory_definitions/internal/services/authoring_layout/persist/persist.go
@@ -26,6 +26,7 @@ type Ports struct {
 
 // NamedFactory atomically creates or replaces one named Factory layout under
 // rootDir using staging and commit semantics.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func NamedFactory(
 	ctx context.Context,
 	rootDir string,

--- a/pkg/services/factory_definitions/internal/services/catalog/wire/wire_test.go
+++ b/pkg/services/factory_definitions/internal/services/catalog/wire/wire_test.go
@@ -285,6 +285,9 @@ func TestNewPathResolverAndCatalogWireResolveNamedFactoryAndCurrentPointer(t *te
 	}
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestNewService_ListGetResolveDeleteNamedFactory(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_definitions/internal/services/compilation/internal/service/service.go
+++ b/pkg/services/factory_definitions/internal/services/compilation/internal/service/service.go
@@ -37,6 +37,7 @@ func New(
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (s *Service) CompileEffectiveFactorySource(
 	ctx context.Context,
 	request factoryroot.CompileEffectiveFactorySourceRequest,

--- a/pkg/services/factory_definitions/internal/services/compilation/loading/loader.go
+++ b/pkg/services/factory_definitions/internal/services/compilation/loading/loader.go
@@ -842,6 +842,7 @@ func hasInlineRuntimeDefinitions(factoryConfig *factorydefinitions.FactoryConfig
 	return false
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func workstationHasInlineRuntimeDefinitionFields(
 	workstation factorydefinitions.FactoryWorkstationConfig,
 ) bool {
@@ -868,6 +869,7 @@ func workstationHasInlineRuntimeDefinitionFields(
 	return workstationHasRuntimeFields(workstation)
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func workstationHasRuntimeFields(
 	workstation factorydefinitions.FactoryWorkstationConfig,
 ) bool {

--- a/pkg/services/factory_definitions/internal/services/invocation_policy/invocationinterpolation/service.go
+++ b/pkg/services/factory_definitions/internal/services/invocation_policy/invocationinterpolation/service.go
@@ -116,6 +116,7 @@ func InterpolateWorkerConfig(worker workerconfig.Config, args *work.InvocationAr
 
 // InterpolateWorkstationConfig resolves supported `${parameter}` placeholders on
 // one effective workstation definition using runtime invocation arguments.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func InterpolateWorkstationConfig(workstation factorydefinitions.FactoryWorkstationConfig, args *work.InvocationArguments, readFile factorydefinitions.FileReader) (factorydefinitions.FactoryWorkstationConfig, error) {
 	next := cloneWorkstationForInterpolation(workstation)
 	var err error

--- a/pkg/services/factory_definitions/internal/services/snapshots_portability/internal/service/service_test.go
+++ b/pkg/services/factory_definitions/internal/services/snapshots_portability/internal/service/service_test.go
@@ -276,6 +276,7 @@ func TestMaterializeFactorySnapshot_SuccessRestoresBundledAssets(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestDetachedSnapshot_CapturePrepareImportMaterializeRoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_definitions/internal/services/snapshots_portability/wire/wire_test.go
+++ b/pkg/services/factory_definitions/internal/services/snapshots_portability/wire/wire_test.go
@@ -48,6 +48,7 @@ func stubDependencies() snapshotsportability.Dependencies {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestNewService_RequiresExactInjectedPorts(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_definitions/internal/services/validation/impl/topology_guards_test.go
+++ b/pkg/services/factory_definitions/internal/services/validation/impl/topology_guards_test.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package impl
 
 import (
@@ -840,6 +842,7 @@ func TestRulePerInputGuards_ValidSameNameGuard(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestConfigValidator_UnsupportedSameNameAllChildrenCompleteJoinArity(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/pkg/services/factory_definitions/transports/cli/service_test.go
+++ b/pkg/services/factory_definitions/transports/cli/service_test.go
@@ -178,6 +178,7 @@ func TestConstructedService_InstallPackagedFactoryRejectsUnsupportedFormat(t *te
 	})
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func assertInstallPackagedFactoryParity(
 	t *testing.T,
 	service factorydefinitionscli.Service,

--- a/pkg/services/factory_definitions/wire/fold_behavior_preservation_test.go
+++ b/pkg/services/factory_definitions/wire/fold_behavior_preservation_test.go
@@ -519,6 +519,8 @@ func (c foldRequiredToolChecker) Check(
 	return factorydefinitions.RequiredToolCheckResult{}
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func newWireFoldPreservationService(t *testing.T, options ...foldPreservationOption) factorydefinitions.Service {
 	t.Helper()
 

--- a/pkg/services/factory_definitions/wire/snapshot_portability_test.go
+++ b/pkg/services/factory_definitions/wire/snapshot_portability_test.go
@@ -10,6 +10,7 @@ import (
 	factorymapping "github.com/portpowered/infinite-you/pkg/transports/mapping/factoryconfig"
 )
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestWireSnapshotHelpersCapturePrepareMaterializeAndReplay(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_definitions/wire/wire.go
+++ b/pkg/services/factory_definitions/wire/wire.go
@@ -31,6 +31,8 @@ import (
 // process-edge ports. It composes the accepted root through parent-private catalog
 // Wire and the accepted service assembly without publishing owner types on the
 // returned peer surface.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func NewService(
 	sessionHost factorydefinitions.SessionHost,
 	activationGateway factorydefinitions.DefinitionActivationGateway,
@@ -189,6 +191,7 @@ func NewService(
 	return attachCompilation(withSnapshots, compilation), nil
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func validateDependencies(
 	sessionHost factorydefinitions.SessionHost,
 	activationGateway factorydefinitions.DefinitionActivationGateway,

--- a/pkg/services/factory_definitions/wire/wire_test.go
+++ b/pkg/services/factory_definitions/wire/wire_test.go
@@ -22,6 +22,8 @@ import (
 	factorydefaultscaffold "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire/defaultscaffold"
 )
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestNewServiceRejectsMissingRequiredDependencies(t *testing.T) {
 	t.Parallel()
 
@@ -882,6 +884,8 @@ func (h *recordingSessionHost) ReplaceFactoryLayoutAtDir(
 	return nil, nil
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestNewServiceInstallAndScaffoldReturnMatchingDistributedFacts(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_runtime/internal/invocation_schedule_factory.go
+++ b/pkg/services/factory_runtime/internal/invocation_schedule_factory.go
@@ -150,6 +150,7 @@ func (wrapped *invocationScheduleFactory) failInvocationScheduleController(
 // recoverInvocationSchedules reconstructs duration jobs from the durable tags
 // on active controller Work. Canonical Work remains authoritative: recovery
 // continues the largest recorded sequence and never repeats trigger-at-start.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (wrapped *invocationScheduleFactory) recoverInvocationSchedules(ctx context.Context) error {
 	wrapped.recoveryMu.Lock()
 	defer wrapped.recoveryMu.Unlock()
@@ -319,6 +320,7 @@ func cloneScheduleTags(tags map[string]string) map[string]string {
 	return cloned
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (wrapped *invocationScheduleFactory) observeInvocationSchedule(
 	ctx context.Context,
 	request automations.InvocationScheduleObservationRequest,

--- a/pkg/services/factory_runtime/internal/invocation_schedule_factory_test.go
+++ b/pkg/services/factory_runtime/internal/invocation_schedule_factory_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/work"
 )
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestInvocationScheduleFactoryRecoversDurableControllerWithoutInitialRetrigger(t *testing.T) {
 	underlying := &invocationScheduleRecoveryFactory{snapshot: &interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{
 		Marking: petri.MarkingSnapshot{Tokens: map[string]*factorytoken.Token{

--- a/pkg/services/factory_runtime/internal/services/instance_host/internal/service/replace_test.go
+++ b/pkg/services/factory_runtime/internal/services/instance_host/internal/service/replace_test.go
@@ -52,6 +52,7 @@ func startReadyHostedHandleWithSidecars(
 	return handle
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestReplaceSuccessfulStartsReplacementAttachesSidecarsAndSwapsActiveHandle(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/runtime_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/runtime_test.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package workflowruntime_test
 
 import (

--- a/pkg/services/factory_runtime/internal/services/orchestration/javascript/validation/analyze.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/javascript/validation/analyze.go
@@ -44,6 +44,7 @@ func (a *sourceAnalyzer) Enter(n js.INode) js.IVisitor {
 
 func (a *sourceAnalyzer) Exit(js.INode) {}
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (a *sourceAnalyzer) inspectCall(call *js.CallExpr) {
 	switch callee := call.X.(type) {
 	case *js.DotExpr:

--- a/pkg/services/factory_runtime/internal/services/orchestration/replayhooks/adapter_boundary_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/replayhooks/adapter_boundary_test.go
@@ -16,6 +16,7 @@ import (
 // TestAdaptPreservesRecordingsReplayContracts exercises the runtime-owned
 // adapter at its internal boundary, where the engine snapshot representation
 // is intentionally allowed to remain private.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestAdaptPreservesRecordingsReplayContracts(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/captured_turn_terminate_integration_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/captured_turn_terminate_integration_test.go
@@ -94,6 +94,9 @@ func TestTerminateFactorySession_FansOutCapturedChildrenBeforeTargetCleanup(t *t
 // The controlled Workers edge returns one child failure before the other
 // succeeds, proving each captured child retains its own exact reference and
 // terminal result without reaching the unrelated direct Worker Session.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestFactoryResume_IsolatesCapturedChildProviderSessionContinuations(t *testing.T) {
 	execution := newContinuationFanOutExecution("dispatch-a", "dispatch-b", "dispatch-direct")
 	boundary := workers.NewWorkstationPoolBoundary(workers.WorkstationPoolBoundaryConfig{

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/worker_session_control_fanout_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/worker_session_control_fanout_test.go
@@ -127,6 +127,7 @@ func TestFanOutWorkerSessionControl_MultipleFailuresStillReachEveryChild(t *test
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestFactoryControls_FanOutCapturedTurnOnceAndRetainOriginalEvidence(t *testing.T) {
 	service := newWorkerSessionControlSpy(map[workerSessionControlCall]workerSessionControlResponse{
 		{action: factory.WorkerSessionControlActionPause, id: "worker-a"}: {

--- a/pkg/services/factory_runtime/internal/sidecars.go
+++ b/pkg/services/factory_runtime/internal/sidecars.go
@@ -70,6 +70,7 @@ func (s *RuntimeSidecars) Preseed(ctx context.Context, instance factory.HostedIn
 	return PreseedRuntimeInputs(ctx, s.automation, bundle)
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (s *RuntimeSidecars) Start(ctx context.Context, hosted factory.HostedHandle) error {
 	handle, _ := hosted.(*factoryhost.Handle)
 	if handle == nil || handle.Bundle == nil {

--- a/pkg/services/factory_runtime/transports/http/internal/common/common_test.go
+++ b/pkg/services/factory_runtime/transports/http/internal/common/common_test.go
@@ -50,6 +50,7 @@ func TestDecodeJSONHandlesEmptyInvalidAndReaderErrors(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestErrorFamilyAndRequestContextOutcomes(t *testing.T) {
 	for _, test := range []struct {
 		status int

--- a/pkg/services/factory_runtime/transports/http/internal/errors/errors.go
+++ b/pkg/services/factory_runtime/transports/http/internal/errors/errors.go
@@ -31,6 +31,7 @@ const (
 
 // RootErrorResponse maps published Runtime root sentinel failures to HTTP
 // status and the generated ErrorResponse shape.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func RootErrorResponse(err error, operation Operation) (int, factoryapi.ErrorResponse, bool) {
 	if err == nil {
 		return 0, factoryapi.ErrorResponse{}, false

--- a/pkg/services/factory_sessions/internal/ondemandtarget/service.go
+++ b/pkg/services/factory_sessions/internal/ondemandtarget/service.go
@@ -311,6 +311,7 @@ func (a *activatedRuntime) close(ctx context.Context) (*activeInvocation, error)
 // cleanup retries only the runtime cleanup steps that have not yet
 // succeeded. Repeating a failed close must not replay already-successful
 // lifecycle effects or silently convert the original failure into success.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (a *activatedRuntime) cleanup(ctx context.Context) error {
 	var result error
 	if a.opened.Sessions != nil && !a.sessionClosed {

--- a/pkg/services/factory_sessions/internal/ondemandtarget/target_execution_test.go
+++ b/pkg/services/factory_sessions/internal/ondemandtarget/target_execution_test.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package ondemandtarget
 
 import (
@@ -78,6 +80,7 @@ func TestInvokeFactorySessionUnknownIdentityReportsSessionNotFound(t *testing.T)
 // not delegate to factorysessions.Service.Cancel: that contract addresses
 // durable sessions, while this on-demand runtime is a live target whose
 // provider work is governed by the runtime lifecycle.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestCancelInterruptsOnlyTheActiveInvocation(t *testing.T) {
 	startedSignal := make(chan struct{})
 	invocationCount := 0
@@ -663,6 +666,7 @@ func TestCancelRespectsCallerCancellationWhileInvocationIgnoresCancellation(t *t
 // synchronous cleanup collaborator cannot outlive the caller's bound. The
 // failed target remains mapped so the same captured control can complete only
 // its unfinished cleanup and then publish a replacement runtime.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestCancelRespectsCallerCancellationDuringCleanupAndRetries(t *testing.T) {
 	invocationStarted := make(chan struct{})
 	cleanupStarted := make(chan struct{})
@@ -899,6 +903,7 @@ func TestCloseWithNoOpenedRuntimesIsNoOpSuccess(t *testing.T) {
 // open-failure, activation-failure, dispatch-failure, and close-failure
 // paths. Only closed, safe fields (Factory target identity, status,
 // counters) may appear.
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestLoggingNeverEmitsWorkingRootOrRawFailureText(t *testing.T) {
 	const sensitiveWorkingRoot = "/Users/alice/secret-project"
 	pathBearingErr := fmt.Errorf("open %s/factory.json: permission denied", sensitiveWorkingRoot)

--- a/pkg/services/factory_sessions/internal/responsestream/fragmentmap/mapper.go
+++ b/pkg/services/factory_sessions/internal/responsestream/fragmentmap/mapper.go
@@ -478,6 +478,7 @@ func mapProgressFragment(ctx Context, fragment responsestream.Event) (responseev
 	}, nil
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func semanticProgress(fragment responsestream.Event) (responseevents.Kind, responseevents.Phase, any) {
 	metadata := fragment.Metadata
 	kind := strings.ToLower(strings.TrimSpace(metadata["kind"]))

--- a/pkg/services/factory_sessions/internal/responsestream/fragmentmap/mapper_test.go
+++ b/pkg/services/factory_sessions/internal/responsestream/fragmentmap/mapper_test.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package fragmentmap_test
 
 import (

--- a/pkg/services/factory_sessions/internal/runtimeopening/runtime_load_test.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/runtime_load_test.go
@@ -34,6 +34,7 @@ type runtimeLoadPortableFailureCase struct {
 	wantCode recordings.ReplayArtifactDiagnosticCode
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestLoadRuntimePreservesValidatedPortableRecording(t *testing.T) {
 	path := testpath.MustRepoPathFromCaller(
 		t,
@@ -468,6 +469,7 @@ func runtimeLoadFactorySnapshot(t *testing.T) *factorydefinitions.FactorySnapsho
 	return snapshot
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestClockForReplayPreservesOverridesAndInjectedDefaults(t *testing.T) {
 	explicit := clockwork.NewFakeClockAt(time.Date(2026, time.July, 20, 1, 0, 0, 0, time.UTC))
 	replay := clockwork.NewFakeClockAt(time.Date(2026, time.July, 20, 2, 0, 0, 0, time.UTC))

--- a/pkg/services/factory_sessions/internal/services/durable_execution/wire/wire_test.go
+++ b/pkg/services/factory_sessions/internal/services/durable_execution/wire/wire_test.go
@@ -122,6 +122,7 @@ func TestNewServiceRoutesResumeThroughOwner(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestNewServiceRoutesRestartReadsThroughOwner(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_sessions/internal/services/live_runtime/internal/service/lifecycle_control_test.go
+++ b/pkg/services/factory_sessions/internal/services/live_runtime/internal/service/lifecycle_control_test.go
@@ -12,6 +12,7 @@ import (
 	liveruntimewire "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/live_runtime/wire"
 )
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestServiceResumeAfterPauseReturnsAcceptedOutcomeOnce(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_sessions/internal/sessionservice/live_runtime_composition_test.go
+++ b/pkg/services/factory_sessions/internal/sessionservice/live_runtime_composition_test.go
@@ -104,6 +104,7 @@ func TestNewWithResponseService_ComposesLiveRuntimeWithoutRegistryEffects(t *tes
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestService_LiveRegistryPathsDelegateThroughLiveRuntimeOwner(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_sessions/internal/sessionservice/live_runtime_lifecycle_control_test.go
+++ b/pkg/services/factory_sessions/internal/sessionservice/live_runtime_lifecycle_control_test.go
@@ -42,6 +42,7 @@ func TestService_LivePauseResumeThroughLiveRuntimeOwnerReturnsAcceptedOutcomeOnc
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestLiveControlCapability_OpenPauseResumePreservesLifecycleResults(t *testing.T) {
 	t.Parallel()
 
@@ -165,6 +166,7 @@ func TestLiveControlCapability_PreservesTypedRejectionAndCancellation(t *testing
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestLiveControlCapability_CompletesLifecycleAndRetiresCanonicalSession(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_sessions/internal/sessionservice/live_runtime_registry_read_test.go
+++ b/pkg/services/factory_sessions/internal/sessionservice/live_runtime_registry_read_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/livesession"
 )
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestLiveControlCapability_OpenListReadPreservesCanonicalIdentity(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_sessions/internal/sessionservice/ownership_boundary_test.go
+++ b/pkg/services/factory_sessions/internal/sessionservice/ownership_boundary_test.go
@@ -58,6 +58,7 @@ func (s *routingExecution) Pause(
 // live session, without traversing, pausing, resuming, or closing that live
 // session. The runtime routes are deliberately observed through their real
 // bounded gateway implementations rather than inferred from interface shape.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestDurableCapabilityDoesNotTouchCollidingLiveSession(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_visualization/internal/service/service_test.go
+++ b/pkg/services/factory_visualization/internal/service/service_test.go
@@ -155,6 +155,7 @@ func (projectionOwnerStub) ReconnectCursor() *factorydefinitions.FactoryEventRec
 // FND-12 captured visualization-activation success baseline: Start against a
 // valid event source projects retained-then-live events and emits observable
 // Views. Invoked by `make fnd-12-visualization-behavior-baselines`.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestServiceProjectsRetainedAndLiveFactoryEvents(t *testing.T) {
 	t.Parallel()
 
@@ -345,6 +346,7 @@ func TestServiceRootLifecycleInertConstructionAndTypedActivate(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestServiceRootObserveDetachedViewAndTypedFailures(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_visualization/internal/services/live_view_projection/internal/service/service_test.go
+++ b/pkg/services/factory_visualization/internal/services/live_view_projection/internal/service/service_test.go
@@ -14,6 +14,7 @@ import (
 
 // TestLiveViewProjectionConformance proves the private implementation satisfies
 // the accepted live-projection capability used by the Visualization root.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestLiveViewProjectionConformance(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/factory_visualization/runtime_consumer_boundary_test.go
+++ b/pkg/services/factory_visualization/runtime_consumer_boundary_test.go
@@ -21,6 +21,7 @@ import (
 // leased session-bound activation and detached Observe paths reach Factory Runtime
 // only through root Service.Observe, mapping returned observation facts into
 // activation/view outcomes reviewers can verify.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestVisualizationConsumerObservationExercisesRuntimeRoot(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/models/internal/services/runtime_host/internal/service/service.go
+++ b/pkg/services/models/internal/services/runtime_host/internal/service/service.go
@@ -116,6 +116,7 @@ func (s *service) InspectModelHost(
 	return models.InspectModelHostResult{Host: snapshot}, nil
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (s *service) EnsureModelHost(
 	ctx context.Context,
 	request models.EnsureModelHostRequest,

--- a/pkg/services/models/transports/cli/adapter_owned_coverage_test.go
+++ b/pkg/services/models/transports/cli/adapter_owned_coverage_test.go
@@ -366,6 +366,7 @@ func TestOwnedAdapter_CompositionFacadeRoutesOwnedListThroughModelsRoot(t *testi
 
 // TestOwnedAdapter_InvokeResolvesThroughModelsRoot proves invoke
 // catalog->lease->inference ordering through the owned adapter.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestOwnedAdapter_InvokeResolvesThroughModelsRoot(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/models/transports/cli/root_invoke.go
+++ b/pkg/services/models/transports/cli/root_invoke.go
@@ -11,6 +11,7 @@ import (
 	contentcontract "github.com/portpowered/infinite-you/pkg/transports/mapping/workcontent"
 )
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (service *rootService) Invoke(cfg InvokeConfig) error {
 	if cfg.Context == nil {
 		return fmt.Errorf("context is required")

--- a/pkg/services/models/transports/cli/root_parity_test.go
+++ b/pkg/services/models/transports/cli/root_parity_test.go
@@ -473,6 +473,7 @@ func TestRootAdapter_InvokeThroughRealClosedModelsScopeReturnsPublicClosedScopeE
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestRootAdapter_InvokeJSONResolvesThroughModelsRootCatalogAndInference(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/models/transports/mcp/invoke_with_lease_test.go
+++ b/pkg/services/models/transports/mcp/invoke_with_lease_test.go
@@ -12,6 +12,7 @@ import (
 
 var errUnknownInvokeFailure = errors.New("invoke failed for an unmapped internal reason")
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestBind_InvokeWithLeaseSuccessReturnsInvokeFactsFromInjectedRoot(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/models/wire/wire.go
+++ b/pkg/services/models/wire/wire.go
@@ -270,6 +270,7 @@ func newCatalogReadinessQuery(assetService scopedassets.Service) catalog.Readine
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func validateConstructionInputs(
 	assetPlatform models.AssetHostPlatform,
 	assetHTTP modelseffects.AssetHTTPDoer,

--- a/pkg/services/operator_settings/backend_scope.go
+++ b/pkg/services/operator_settings/backend_scope.go
@@ -71,6 +71,7 @@ func EnsureLocalBackendScope(
 	}, nil
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func persistBackendScopeID(
 	files FileSystem,
 	createTemp CreateTemporaryFile,

--- a/pkg/services/operator_settings/internal/services/resolution/defaults/operator_config_test.go
+++ b/pkg/services/operator_settings/internal/services/resolution/defaults/operator_config_test.go
@@ -49,6 +49,7 @@ func TestDefaultRuntimeSettingsMatchProductionArtifactPolicies(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func decodeTestConfig(data []byte) (operatorsettings.Config, error) {
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()

--- a/pkg/services/operator_settings/transports/globalconfig/decode.go
+++ b/pkg/services/operator_settings/transports/globalconfig/decode.go
@@ -49,6 +49,7 @@ func requireEOF(decoder *json.Decoder) error {
 	return fmt.Errorf("decode generated global config: unexpected trailing JSON")
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func mapConfig(generated factoryapi.GlobalConfig) (operatorsettings.Config, error) {
 	config := operatorsettings.Config{
 		BackendScopeID: optionalString(generated.BackendScopeID),

--- a/pkg/services/operator_settings/transports/mcp/apply_document_update_test.go
+++ b/pkg/services/operator_settings/transports/mcp/apply_document_update_test.go
@@ -27,6 +27,7 @@ func testApplyDocumentUpdateInputJSON() string {
 	)
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestBind_ApplyDocumentUpdateSuccessReturnsPostUpdateFactsFromInjectedRoot(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/operator_settings/wire/behavioral_preservation_test.go
+++ b/pkg/services/operator_settings/wire/behavioral_preservation_test.go
@@ -21,6 +21,7 @@ import (
 // document, identity, resolution, and config outcomes on the published
 // operatorsettings.Service root.
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestWireFoldPreservesDocumentIdentityResolutionAndConfigBehavior(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/operator_settings/wire/consumer_edge_preservation_test.go
+++ b/pkg/services/operator_settings/wire/consumer_edge_preservation_test.go
@@ -19,6 +19,7 @@ import (
 // load/update/atomic persist and effective resolution keep the same Settings-
 // observable outcomes after the Settings→Providers consumer cut when the wire
 // composes resolution against an injected providers.Service root.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestNewServicePreservesDocumentPersistAndEffectiveResolution(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/operator_settings/wire/wire_test.go
+++ b/pkg/services/operator_settings/wire/wire_test.go
@@ -150,6 +150,7 @@ func TestNewServiceUsesInjectedIDGeneratorForBackendScope(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestNewServiceConstructsInertRoot(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/provider_sessions/internal/root_contracts_providers_boundary_identity_test.go
+++ b/pkg/services/provider_sessions/internal/root_contracts_providers_boundary_identity_test.go
@@ -26,6 +26,7 @@ func peerConstructProvidersRootIdentity(
 // construct Inspect, Project, and Details identity through Provider Sessions
 // root contracts and Providers-root SessionRef without Workers provider or
 // Providers implementation types.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestRootContracts_ProvidersRootBoundary_IdentityConstruction(t *testing.T) {
 	t.Run("codex", func(t *testing.T) {
 		root := writeCodexSessionFixture(t, "boundary-root-contract-codex")

--- a/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/detail.go
+++ b/pkg/services/provider_sessions/internal/services/codex_reader/internal/service/detail.go
@@ -365,6 +365,7 @@ func ParseDetails(reader io.Reader) (ParsedDetails, error) {
 // Mirrored user/assistant messages emitted as both event_msg and response_item
 // message records are deduplicated. Function outputs attach to the earliest
 // matching call_id within the reconstructed stream.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func parseCodexSessionDetails(ctx context.Context, reader io.Reader) (ParsedDetails, error) {
 	parser := codexSessionParser{
 		summary: providersessions.ParseSummary{

--- a/pkg/services/provider_sessions/internal/services/cursor_reader/internal/cursor/detail.go
+++ b/pkg/services/provider_sessions/internal/services/cursor_reader/internal/cursor/detail.go
@@ -14,6 +14,7 @@ import (
 )
 
 // LoadDetails resolves a Cursor session_id from server-configured cursor-agent storage.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func LoadDetails(ctx context.Context, files providersessionsinternal.FileSystem, walkDirectory providersessionsinternal.CursorWalkDirectory, resolveSymlinks providersessionsinternal.CursorResolveSymlinks, openSQLDatabase providersessionsinternal.CursorOpenSQLDatabase, root AgentStorageRoot, id string) (providersessions.Detail, error) {
 	ins := newInspection(ctx)
 	if err := ins.checkCanceled(); err != nil {

--- a/pkg/services/providers/internal/service/acp_control_test.go
+++ b/pkg/services/providers/internal/service/acp_control_test.go
@@ -857,6 +857,8 @@ func (s *sequentialACPService) TryCancel(ctx context.Context, generationValue ac
 // and never derive a false Completed from B's terminal outcome. Every step
 // is gated by real channels (armTryCancelGate, beginExecute's ready channel,
 // Execute/ControlAttempt done channels) - no sleep-based timing is used.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestControlAttempt_ACPDelayedControlCannotRedirectToReplacementGenerationAfterIdentityReuse(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/providers/internal/services/acp/internal/service/protocol_failure_classification_test.go
+++ b/pkg/services/providers/internal/services/acp/internal/service/protocol_failure_classification_test.go
@@ -351,6 +351,7 @@ func protocolHelperCommandFactory(starts *atomic.Int32) func(name string, args .
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func runProtocolFailurePeer(mode string, stdin io.Reader, stdout, stderr io.Writer) error {
 	if mode == "malformed" {
 		_, err := fmt.Fprintln(stdout, "{not-json")

--- a/pkg/services/providers/internal/services/acp/internal/service/service.go
+++ b/pkg/services/providers/internal/services/acp/internal/service/service.go
@@ -1,4 +1,6 @@
 // Package service implements the parent-private Agent Client Protocol service.
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package service
 
 import (
@@ -138,6 +140,7 @@ func (service *Service) Close(ctx context.Context) error {
 	return first
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (service *Service) Configure(ctx context.Context, integrations []providers.ACPIntegration) error {
 	commands := make(map[providers.ID]Command, len(integrations))
 	values := make(map[providers.ID]providers.ACPIntegration, len(integrations))
@@ -1033,6 +1036,7 @@ func (c *client) streamedProgress() bool {
 	return c.stream != nil && c.stream.observe != nil
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func mapSessionUpdate(update acpsdk.SessionUpdate) ([]providers.ExecuteProgress, string) {
 	phase, detail, kind, itemID := "update", "", "unknown", ""
 	metadata := map[string]string{}

--- a/pkg/services/providers/internal/services/acp/internal/service/shared_conformance_test.go
+++ b/pkg/services/providers/internal/services/acp/internal/service/shared_conformance_test.go
@@ -31,6 +31,9 @@ import (
 // boundary's TextUpdate shape, which this inbound mapper does not produce.
 // user_message_chunk and config_option_update are intentionally out of
 // scope: this mapper does not map them to any observable progress fact.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestSharedConformanceCorpusSessionUpdateMatchesInboundMapper(t *testing.T) {
 	cases, err := acpfixtures.CasesByRole(acpfixtures.RoleSessionUpdate)
 	if err != nil {

--- a/pkg/services/providers/internal/services/execution/internal/provider/functionaltests/provider_invocation_error_compatibility_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/provider/functionaltests/provider_invocation_error_compatibility_test.go
@@ -15,6 +15,7 @@ func providerErrorCorpusEntryLabel(entry provider.ProviderErrorCorpusEntry) stri
 	return entry.Name + " [" + entry.UpstreamSourceCase + "]"
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestInvocationErrorCompatibility_SupportedCorpusEntriesPreserveStableWorkFailureTypes(t *testing.T) {
 	corpus, err := provider.LoadProviderErrorCorpus()
 	if err != nil {

--- a/pkg/services/providers/internal/services/execution/internal/service/failure.go
+++ b/pkg/services/providers/internal/services/execution/internal/service/failure.go
@@ -32,6 +32,7 @@ func normalizeContextFailure(
 	return nil
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func normalizeAttemptFailure(
 	ctx context.Context,
 	attemptErr error,

--- a/pkg/services/providers/internal/services/execution/internal/service/service_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/service/service_test.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package service_test
 
 import (
@@ -190,6 +192,7 @@ func TestContinueValidatesThenResolvesCanonicalAdapterExactlyOnce(t *testing.T) 
 	}
 }
 
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestContinueFailsClosedAcrossPrivateContinuationBoundaries(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/providers/root_catalog_delegation_test.go
+++ b/pkg/services/providers/root_catalog_delegation_test.go
@@ -69,6 +69,7 @@ func TestRootCatalogDelegation_RegistersCodexAdapter(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestProvidersRootWireBoundaryPublishesExternalRegistrationThroughService(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/providers/transports/mcp/execute_test.go
+++ b/pkg/services/providers/transports/mcp/execute_test.go
@@ -28,6 +28,7 @@ const testExecuteInputJSON = `{
 	"processEnvironment":["PATH=/bin"]
 }`
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestBind_ExecuteSuccessReturnsDetachedResultFromInjectedRoot(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/providers/wire/wire_test.go
+++ b/pkg/services/providers/wire/wire_test.go
@@ -281,6 +281,7 @@ func TestNewServiceInjectsPlatformDependenciesThroughWireOptions(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestNewServiceServesPublishedCatalogAndExecuteCompositionForMigratedIdentities(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/recordings/internal/combined_service_plain_contract_test.go
+++ b/pkg/services/recordings/internal/combined_service_plain_contract_test.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package internal
 
 import (

--- a/pkg/services/recordings/internal/contracts/contracts.go
+++ b/pkg/services/recordings/internal/contracts/contracts.go
@@ -1,5 +1,7 @@
 // Package contracts contains the Recordings-owned transport-neutral contract
 // vocabulary and private contract-support helpers.
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package contracts
 
 import (

--- a/pkg/services/recordings/internal/replay/event_log_test.go
+++ b/pkg/services/recordings/internal/replay/event_log_test.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package replay
 
 import (

--- a/pkg/services/recordings/internal/services/artifacts_export/root_integration_test.go
+++ b/pkg/services/recordings/internal/services/artifacts_export/root_integration_test.go
@@ -106,6 +106,9 @@ func TestAcceptedRecordingsRootUsesPrivateArtifactsExport(t *testing.T) {
 	}
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestRecordingsRootPortableExportRoundTripOmitsPrivateStorage(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/recordings/internal/services/artifacts_export/wire/wire_test.go
+++ b/pkg/services/recordings/internal/services/artifacts_export/wire/wire_test.go
@@ -178,6 +178,8 @@ func TestNewPublicationCleansTemporaryFileWhenInjectedWriteFails(t *testing.T) {
 	}
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestNewPublicationPropagatesInjectedOperationErrors(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/recordings/internal/services/canonical_ledger/dispatch_worker_session_association_replay_test.go
+++ b/pkg/services/recordings/internal/services/canonical_ledger/dispatch_worker_session_association_replay_test.go
@@ -120,6 +120,7 @@ func dispatchWorkerSessionDependentOutput(
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func assertReplayedDispatchWorkerSessionAssociation(
 	t *testing.T,
 	event recordings.CanonicalEvent,

--- a/pkg/services/recordings/internal/services/replay/internal/service/service_test.go
+++ b/pkg/services/recordings/internal/services/replay/internal/service/service_test.go
@@ -161,6 +161,7 @@ func TestCreateReplayPlanRejectsUnsupportedOptions(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestObserveReplayProgressAndCompletion(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/recordings/lifecycle_capability_test.go
+++ b/pkg/services/recordings/lifecycle_capability_test.go
@@ -283,6 +283,7 @@ func TestRecordingLifecycle_BeginDisabledIsInert(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestRecordingLifecycle_SuccessPath(t *testing.T) {
 	t.Parallel()
 	lifecycle := newTestRecordingLifecycle(t)

--- a/pkg/services/recordings/replay_artifact_capability_test.go
+++ b/pkg/services/recordings/replay_artifact_capability_test.go
@@ -145,6 +145,7 @@ func finalizedReplayArtifactRecordingAt(
 // validate/encode/decode/summarize/export/read chain preserve identity,
 // scope, canonical order, and summary through the real composed
 // implementation, unchanged from the broader Service surface it adapts.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestRecordingReplayArtifacts_UnchangedBehaviorThroughComposedImplementation(t *testing.T) {
 	t.Parallel()
 	service, replayArtifacts := newTestRecordingReplayArtifacts(t)

--- a/pkg/services/recordings/runtime_request_boundary_test.go
+++ b/pkg/services/recordings/runtime_request_boundary_test.go
@@ -10,6 +10,7 @@ import (
 // TestRecordingsConstructsRuntimeRequestsThroughRoot proves CUT-REC-RUN story 005:
 // Recordings consumer edges construct Runtime root requests only through the
 // sealed Factory Runtime service root contract.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestRecordingsConstructsRuntimeRequestsThroughRoot(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/recordings/wire/replay_input_test.go
+++ b/pkg/services/recordings/wire/replay_input_test.go
@@ -407,6 +407,7 @@ func (logger *capturingReplayInputLogger) Info(message string, fields ...any) {
 	logger.entries = append(logger.entries, entry)
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func assertReplayInputLogs(
 	t *testing.T,
 	entries []replayInputLogEntry,

--- a/pkg/services/system_initialization/internal/workflow/initialize_settings_command_test.go
+++ b/pkg/services/system_initialization/internal/workflow/initialize_settings_command_test.go
@@ -45,6 +45,9 @@ func (recorder *settingsCommandRecorder) EnsureLocalBackendScope(path string) (o
 // Initialize derives the operator config path with Settings root DefaultConfigPath
 // and routes load/ensure commands only through the injected Settings collaborator
 // ports, with observable Bootstrap outcomes on create, skip, and failure paths.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestInitializeSettingsCommandConstructionThroughRootCollaborator(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/system_initialization/internal/workflow/workflow.go
+++ b/pkg/services/system_initialization/internal/workflow/workflow.go
@@ -63,6 +63,8 @@ func New(
 // Initialize ensures operator configuration and packaged Factories exist
 // without overwriting valid customer-owned files.
 // pkgmaintcheck:ignore-cyclomatic-complexity service-ownership migration preserves this decision flow; simplify branches and remove this exemption.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (initializer *Initializer) Initialize(
 	ctx context.Context,
 	request systeminitialization.Request,

--- a/pkg/services/system_initialization/internal/workflow/workflow_test.go
+++ b/pkg/services/system_initialization/internal/workflow/workflow_test.go
@@ -142,6 +142,7 @@ func (fake *fakePackagedInstaller) EnsurePackagedFactories(
 	return append([]factorydefinitions.PackagedFactoryInstallResult(nil), fake.results...), fake.err
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestInitializeFreshHomeReturnsTypedCreatedResultsThroughPeerRoots(t *testing.T) {
 	t.Parallel()
 
@@ -192,6 +193,7 @@ func TestInitializeFreshHomeReturnsTypedCreatedResultsThroughPeerRoots(t *testin
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestInitializeRepeatInvocationReportsSkippedOutcomesForSystemConfigAndPackagedFactories(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/system_initialization/transports/cli/service_parity_test.go
+++ b/pkg/services/system_initialization/transports/cli/service_parity_test.go
@@ -490,6 +490,7 @@ func TestInitializeSystemPreservesExitErrorsOnFailurePaths(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func assertInitializeParity(
 	t *testing.T,
 	service systeminitializationcli.Service,

--- a/pkg/services/work/internal/lineagegraph/visualization.go
+++ b/pkg/services/work/internal/lineagegraph/visualization.go
@@ -29,6 +29,7 @@ type BatchRequestParser func([]byte) (BatchRequest, error)
 
 // NewVisualizationOperation binds the exact filesystem read edge to Work's
 // batch dependency visualization policy.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func NewVisualizationOperation(filesystem VisualizationFileSystem, parse BatchRequestParser) VisualizationOperation {
 	return func(request VisualizationRequest) (string, error) {
 		if filesystem == nil {

--- a/pkg/services/work/internal/proposalmaterialization/materialize.go
+++ b/pkg/services/work/internal/proposalmaterialization/materialize.go
@@ -154,6 +154,9 @@ func Materialize(ctx context.Context, request Request) (Result, error) {
 	return result, nil
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func materializeOne(
 	ctx context.Context,
 	index int,

--- a/pkg/services/work/internal/services/state_access/internal/service/state_access_seal_test.go
+++ b/pkg/services/work/internal/services/state_access/internal/service/state_access_seal_test.go
@@ -59,6 +59,7 @@ func TestStateAccessSealSubmitAndMovePipeline(t *testing.T) {
 // TestStateAccessSealFullStateAccessPipeline seals IMP-WORK-04 story 003 proof:
 // submit/move/list/get/move-and-read return detached Work-owned shapes through
 // one state_access Service and a private Session adapter fake.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestStateAccessSealFullStateAccessPipeline(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/work/invocation_policy_service_test.go
+++ b/pkg/services/work/invocation_policy_service_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 )
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestInvocationPolicyServiceRejectsUnsupportedSlices(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/work/recordings_request_boundary_test.go
+++ b/pkg/services/work/recordings_request_boundary_test.go
@@ -16,6 +16,7 @@ import (
 // TestWorkConstructsRecordingsRequestsThroughRoot proves CUT-WORK-REC story 003:
 // leased Work state_access Recordings-backed reads construct Recordings queries
 // only through the published Recordings service root contract.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestWorkConstructsRecordingsRequestsThroughRoot(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/work/transports/http/error_mapping.go
+++ b/pkg/services/work/transports/http/error_mapping.go
@@ -18,6 +18,7 @@ const (
 // RootErrorResponse maps typed Work root failures to HTTP status and the public
 // ErrorResponse shape. It returns false when err is not a known mapped typed
 // failure.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func RootErrorResponse(err error) (int, factoryapi.ErrorResponse, bool) {
 	if err == nil {
 		return 0, factoryapi.ErrorResponse{}, false

--- a/pkg/services/work/wire/wire_test.go
+++ b/pkg/services/work/wire/wire_test.go
@@ -314,6 +314,8 @@ func TestNewServiceServesPublishedPeerBehavior(t *testing.T) {
 	}
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestNewServiceConstructsInertRoot(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/work/wire_behavioral_proof_test.go
+++ b/pkg/services/work/wire_behavioral_proof_test.go
@@ -18,6 +18,9 @@ import (
 // TestWireBehavioralProof_PublishedRootPreservesObservables constructs Work
 // exclusively through work/wire and proves admission, query, content, and
 // state-access observables on the published work.Service peer surface.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestWireBehavioralProof_PublishedRootPreservesObservables(t *testing.T) {
 	t.Run("admission query and state access success through runtime wire", func(t *testing.T) {
 		runtime := &wireBehavioralRuntime{

--- a/pkg/services/worker_sessions/internal/service/control.go
+++ b/pkg/services/worker_sessions/internal/service/control.go
@@ -433,6 +433,7 @@ func (r *registry) logTerminal(id, attemptID string, session workersessions.Sess
 // established Workers cancellation callback has committed; an unassociated
 // execution remains truthfully unsupported rather than becoming a fabricated
 // resumable session.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (r *registry) Pause(ctx context.Context, req workersessions.ControlRequest) (workersessions.ControlResult, error) {
 	if err := req.Validate(); err != nil {
 		return workersessions.ControlResult{Action: workersessions.ControlActionPause, Outcome: workersessions.ControlOutcomeFailed}, err
@@ -687,6 +688,7 @@ func (r *registry) Terminate(ctx context.Context, req workersessions.ControlRequ
 	return r.cancelControl(ctx, req, workersessions.ControlActionTerminate)
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (r *registry) cancelControl(ctx context.Context, req workersessions.ControlRequest, action workersessions.ControlAction) (workersessions.ControlResult, error) {
 	if err := req.Validate(); err != nil {
 		return workersessions.ControlResult{Action: action, Outcome: workersessions.ControlOutcomeFailed}, err

--- a/pkg/services/worker_sessions/internal/service/control_test.go
+++ b/pkg/services/worker_sessions/internal/service/control_test.go
@@ -346,6 +346,7 @@ func TestControl_UnsupportedPauseResumeAndBoundaryFailureLeaveLifecycleTruthful(
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestPauseResume_ContinuesExactProviderReferenceWithSameWorkerSessionCorrelation(t *testing.T) {
 	boundary := newControlledBoundary()
 	registry := newControlledRegistry(t, boundary)
@@ -527,6 +528,7 @@ func TestPauseResume_InvalidContinuationResultFailsAndRetainsAssociation(t *test
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestPauseResume_ContinuationFailureKeepsAssociationAndProviderClassification(t *testing.T) {
 	tests := []struct {
 		name                    string

--- a/pkg/services/worker_sessions/internal/service/internal_test.go
+++ b/pkg/services/worker_sessions/internal/service/internal_test.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package service
 
 import (
@@ -305,6 +307,7 @@ func TestCommitTerminal_ReservedPredecessor_IsRejectedAndLeavesSessionUnchanged(
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestControlGuards_RejectInvalidTransitionsAndPreserveObservableSessionState(t *testing.T) {
 	r := newTestRegistry(t)
 	ctx := context.Background()
@@ -1010,6 +1013,8 @@ func newRunningPauseRegistry(t *testing.T) (*registry, *supervision) {
 	return r, supervision
 }
 
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestContinuationControl_GuardsPreserveThePausedSession(t *testing.T) {
 	t.Run("transition to paused rejects a non-running session", func(t *testing.T) {
 		r, _, _ := newPausedContinuationRegistry(t)
@@ -1136,6 +1141,8 @@ func TestContinuationControl_GuardsPreserveThePausedSession(t *testing.T) {
 	})
 }
 
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestPause_ControlOutcomesKeepTheLifecycleTruthful(t *testing.T) {
 	t.Run("invalid and missing identities fail without a boundary effect", func(t *testing.T) {
 		r := newTestRegistry(t)

--- a/pkg/services/worker_sessions/internal/service/publish_idempotency_test.go
+++ b/pkg/services/worker_sessions/internal/service/publish_idempotency_test.go
@@ -21,6 +21,7 @@ import (
 // dedup, so a retry must stay idempotent regardless of publication order
 // since. It also proves the retry produces neither a new committed position
 // nor a live subscription delivery of its own.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestPublishRecord_RetryOfOlderAcceptedIdentity_AfterNewerSequenceAccepted_ResolvesAsDuplicate(t *testing.T) {
 	eventsSvc := newEventsAppender()
 	topic := workersessions.Topic("worker-1")

--- a/pkg/services/worker_sessions/internal/service/start_side_effects_test.go
+++ b/pkg/services/worker_sessions/internal/service/start_side_effects_test.go
@@ -586,6 +586,7 @@ func TestRegistryLogsListOutcomes(t *testing.T) {
 	assertNoPayloadOrCredentialKeys(t, succeeded[0].fields)
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestRegistryLogsStartOutcomes(t *testing.T) {
 	logger := &recordingLogger{}
 	registry, err := service.New(executionBoundary{execution: &fakeExecution{

--- a/pkg/services/worker_sessions/internal/service/start_test.go
+++ b/pkg/services/worker_sessions/internal/service/start_test.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package service_test
 
 import (
@@ -224,6 +226,7 @@ func TestStart_RetainsExactProviderSessionAssociationFromWorkerResult(t *testing
 // reaches the downstream publisher: Worker-authored output is committed to the
 // Worker Session topic instead (see TestPublish_RoutesWorkerOutputToTheTopic),
 // so it is no longer observable at this seam.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestStart_ProviderProgressCommitsAssociationBeforeOutputAndEnablesResume(t *testing.T) {
 	boundary := newControlledBoundary()
 	registry := newControlledRegistry(t, boundary)

--- a/pkg/services/worker_sessions/publish.go
+++ b/pkg/services/worker_sessions/publish.go
@@ -476,6 +476,7 @@ func toolStatusPhase(status string) string {
 
 // progressDraftPayload builds the payload shape the resolved Kind/Phase pair
 // requires, reporting false when the fact does not carry enough to satisfy it.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func progressDraftPayload(
 	kind workers.Kind,
 	phase workers.Phase,

--- a/pkg/services/worker_sessions/publish_test.go
+++ b/pkg/services/worker_sessions/publish_test.go
@@ -93,6 +93,9 @@ func TestPublishRecordRequest_Validate_RejectsInvalidDraft(t *testing.T) {
 	}
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestProviderSessionObservationPublisher_AssociatesBeforeForwardingExactProgress(t *testing.T) {
 	var forwarded []workers.ProgressFragment
 	publisher := workersessions.NewProviderSessionObservationPublisher(func(fragment workers.ProgressFragment) {
@@ -577,6 +580,8 @@ func TestPublish_IgnoresFragmentsThatNameNoWorkerSession(t *testing.T) {
 // TestPublish_CommitsRemainingWorkerVocabulary covers the fact kinds the
 // primary table does not, so every branch that can reach a Worker topic is
 // exercised at least once.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestPublish_CommitsRemainingWorkerVocabulary(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/pkg/services/workers/internal/interface/schema_contract_test.go
+++ b/pkg/services/workers/internal/interface/schema_contract_test.go
@@ -498,6 +498,7 @@ func TestMockWorkersSchema_StagedProjectionMatchesAuthoredCopy(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestMockWorkersSchema_StaleStagingDetectedByContractCheck(t *testing.T) {
 	defer contractstaging.LockRepositoryStagingForTest()()
 

--- a/pkg/services/workers/internal/provider_execution_regression_test.go
+++ b/pkg/services/workers/internal/provider_execution_regression_test.go
@@ -223,6 +223,7 @@ func TestBuildModelInvocationExecutorDeliversProviderCommandRunnerFailure(t *tes
 // runner (proved by exact call-count and per-dispatch request identity),
 // with per-dispatch progress isolation. Synchronization is limited to
 // sync.WaitGroup/atomic/the runner's own mutex (no sleeps).
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestConcurrentRepeatedProviderExecutionsRetainConstructionInjectedProviderCommandRunner(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/workers/internal/runtime_concurrency_test.go
+++ b/pkg/services/workers/internal/runtime_concurrency_test.go
@@ -115,6 +115,7 @@ func newTestServiceWithDependenciesAndProviders(
 // deterministic across concurrencyRepeatRounds repeats. Synchronization is
 // limited to sync.WaitGroup/sync.Mutex/atomic (no sleeps), so the test is
 // deterministic and safe to run under the Go race detector.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestConcurrentRepeatedExecutionsRetainConstructionInjectedDependencies(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/workers/internal/runtime_service.go
+++ b/pkg/services/workers/internal/runtime_service.go
@@ -147,6 +147,7 @@ type workflowContextProvider interface {
 // New constructs a Worker execution service from injected dependencies.
 // backendsizecheck:ignore-function service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption.
 // pkgmaintcheck:ignore-function-lines service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func New(
 	sessions CurrentRuntimeResolver,
 	modelService models.Service,

--- a/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/live_provider_session_integration_test.go
+++ b/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/live_provider_session_integration_test.go
@@ -22,6 +22,7 @@ import (
 // runner, and Worker Sessions bridge. The command runner is the controlled
 // external edge: it reports a provider-authored thread while live, then
 // verifies Resume reaches the exact thread through Providers.Continue.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestLiveProviderSessionObservationEnablesExactWorkerSessionContinuation(t *testing.T) {
 	command := newLiveSessionCommandRunner()
 	providerService, err := providerswire.NewService(

--- a/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner_test.go
+++ b/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner_test.go
@@ -319,6 +319,8 @@ func TestExecuteUnsupportedContinuationReturnsProviderError(t *testing.T) {
 	}
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestExecuteExactContinuationFailurePreservesClassificationWithoutFallback(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/workers/internal/services/runners/wire/agent_failure_test.go
+++ b/pkg/services/workers/internal/services/runners/wire/agent_failure_test.go
@@ -80,6 +80,7 @@ func TestAgentRunnerNormalizesProviderFailureKindsWithoutRetry(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestAgentRunnerPreservesCancellationAndDeadlineContext(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -294,6 +295,7 @@ func providerFailureFixture(
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func assertAgentFailureFacts(
 	t *testing.T,
 	result workers.RunnerExecutionResult,

--- a/pkg/services/workers/internal/services/runners/wire/agent_progress_test.go
+++ b/pkg/services/workers/internal/services/runners/wire/agent_progress_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/services/agent"
 )
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestAgentRunnerPublishesDetachedProviderProgressBeforeSuccess(t *testing.T) {
 	fake := newAgentProvidersFake()
 	fake.result.Diagnostics.Progress = []providers.ExecuteProgress{

--- a/pkg/services/workers/internal/services/workstations/executor/agent.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agent.go
@@ -158,6 +158,7 @@ func (ae *AgentExecutor) Execute(ctx context.Context, request workerexecution.Wo
 	return ae.workResultForInferenceResponse(request, resp, outcome, diagnostics, retryCount, start)
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func effectiveWorkerDefinition(request workerexecution.WorkstationExecutionRequest, workerDef *interfaces.FactoryWorkerConfig) *interfaces.FactoryWorkerConfig {
 	if workerDef == nil {
 		return workerDef

--- a/pkg/services/workers/internal/services/workstations/executor/workstation_executor.go
+++ b/pkg/services/workers/internal/services/workstations/executor/workstation_executor.go
@@ -135,6 +135,9 @@ func (we *WorkstationExecutor) executeLogicalMove(dispatch work.WorkDispatch, st
 }
 
 // executeModelWorkstation renders the prompt and calls the configured worker executor.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (we *WorkstationExecutor) executeModelWorkstation(ctx context.Context, dispatch work.WorkDispatch, workstationDef *interfaces.FactoryWorkstationConfig, start time.Time) (workerexecution.WorkResult, error) {
 	logger := logging.EnsureLogger(we.Logger)
 	invocationArgs := invocationArgumentsFromDispatch(dispatch)

--- a/pkg/services/workers/internal/services/workstations/internal/service/service_logging_test.go
+++ b/pkg/services/workers/internal/services/workstations/internal/service/service_logging_test.go
@@ -69,6 +69,7 @@ func (l *recordingLogger) entriesFor(message string) []recordedLogEntry {
 	return matches
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestPoolLogsStartAcceptedAndTerminalDispatchOutcomes(t *testing.T) {
 	t.Parallel()
 
@@ -161,6 +162,7 @@ func TestPoolLogsFailedTerminalDispatchOutcome(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestPoolLogsCancellationOutcomesIncludingNoOps(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/workers/validate_draft_test.go
+++ b/pkg/services/workers/validate_draft_test.go
@@ -34,6 +34,7 @@ func legalKindPhasePairs() []struct {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func sampleDraftPayload(t *testing.T, kind Kind, phase Phase) json.RawMessage {
 	t.Helper()
 

--- a/pkg/transports/acp/factory_target_option_test.go
+++ b/pkg/transports/acp/factory_target_option_test.go
@@ -20,6 +20,7 @@ func sampleFactoryTargetOption() acp.FactoryTargetOption {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestFactoryTargetOptionToSessionConfigOptionSerializesSelectUnion(t *testing.T) {
 	option := sampleFactoryTargetOption()
 

--- a/pkg/transports/acp/internal/mapping/child_content_test.go
+++ b/pkg/transports/acp/internal/mapping/child_content_test.go
@@ -217,6 +217,7 @@ func TestProjectWorkerChildInterleavingKeepsSiblingParentTargetsIndependent(t *t
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestBoundChildProjectionReservesFailureAndTerminalEvidenceAfterRecordPressure(t *testing.T) {
 	t.Parallel()
 	limits := ChildProjectionLimits{MaxRecords: 4, MaxSerializedBytes: 4096}
@@ -355,6 +356,7 @@ func childAssociation() *chatsessions.WorkerSessionAssociation {
 	return &chatsessions.WorkerSessionAssociation{DispatchID: "dispatch-1", WorkerSessionID: "worker-1"}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func childFixturePayload(t *testing.T, kind workers.Kind, phase workers.Phase) json.RawMessage {
 	t.Helper()
 	switch kind {

--- a/pkg/transports/acp/internal/mapping/child_edge_test.go
+++ b/pkg/transports/acp/internal/mapping/child_edge_test.go
@@ -158,6 +158,7 @@ func TestBoundChildProjectionRejectsInvalidLimitsAndLineage(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestChildProjectionValidationRejectsEveryMalformedBoundaryShape(t *testing.T) {
 	association := ChildAssociation{DispatchID: "dispatch", WorkerSessionID: "worker"}
 	wrongOpening := workers.Draft{Kind: workers.KindMessage, Phase: workers.PhaseStarted, ItemID: "item", Payload: mustMarshal(t, workers.MessagePayload{Role: "assistant", ContentBlocks: []workers.ContentBlock{{Kind: workers.ContentBlockText, Text: "text"}}})}

--- a/pkg/transports/acp/internal/mapping/dispatch_test.go
+++ b/pkg/transports/acp/internal/mapping/dispatch_test.go
@@ -104,6 +104,7 @@ var allPhases = []workers.Phase{
 // over the full Kind x Phase cross-product. Legal pairs must resolve to
 // their declared outcome family; every other pair must be rejected as
 // ErrMalformedRecord, never silently classified.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestProjectDispatch_HandlesEveryCurrentPair(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/transports/acp/internal/negotiation/negotiation_test.go
+++ b/pkg/transports/acp/internal/negotiation/negotiation_test.go
@@ -27,6 +27,7 @@ func richClientCapabilities() acpsdk.ClientCapabilities {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestNegotiateSupportedVersionAdvertisesHonestP0Profile(t *testing.T) {
 	for name, clientCapabilities := range map[string]acpsdk.ClientCapabilities{
 		"minimal client capabilities": {},

--- a/pkg/transports/acp/internal/session/session.go
+++ b/pkg/transports/acp/internal/session/session.go
@@ -509,6 +509,7 @@ func chunkUpdate(sessionID SessionID, kind TextUpdateKind, content acpsdk.Conten
 // the wire value is acpsdk.SessionNotification{SessionId, Update}, and a
 // notification with no session identity can never be correlated to the
 // session it pertains to.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func ValidateSessionUpdate(notification acpsdk.SessionNotification) (TextUpdate, error) {
 	if notification.SessionId == "" {
 		return TextUpdate{}, errors.New("acp: sessionId is required")

--- a/pkg/transports/acp/internal/session/session_test.go
+++ b/pkg/transports/acp/internal/session/session_test.go
@@ -76,6 +76,8 @@ func roundTrip[T any](t *testing.T, value T) T {
 	return decoded
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestValidateNewSession(t *testing.T) {
 	t.Run("accepts an absolute cwd with an empty mcp server list", func(t *testing.T) {
 		got, err := ValidateNewSession(raw(t, acpsdk.NewSessionRequest{
@@ -518,6 +520,8 @@ func notification(sessionID string, update acpsdk.SessionUpdate) acpsdk.SessionN
 	return acpsdk.SessionNotification{SessionId: acpsdk.SessionId(sessionID), Update: update}
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestValidateSessionUpdate(t *testing.T) {
 	t.Run("accepts text-first update kinds and preserves session identity", func(t *testing.T) {
 		cases := []struct {

--- a/pkg/transports/acp/internal/stdio/prompt_stream.go
+++ b/pkg/transports/acp/internal/stdio/prompt_stream.go
@@ -461,6 +461,7 @@ func (s *Server) ensureAttachment(ctx context.Context, connectionID, sessionID s
 // deployment that has not yet wired an Events collaborator) is a no-op
 // success: it reports no delivered message so deliverPromptUpdates falls
 // back to the existing V1 synchronous final text unchanged.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (s *Server) streamTurnUpdates(
 	ctx context.Context,
 	connectionID, sessionID string,
@@ -568,6 +569,7 @@ func (s *Server) streamTurnUpdates(
 // (the ordinary case, since both share one cursor -- see this method's own
 // doc comment above) would incorrectly still fall back to a duplicate V1
 // final-text notification.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (s *Server) liveDrainTurnUpdates(ctx context.Context, connectionID, sessionID string, sessionVersion uint64, notify promptNotifier) (deliveredMessage bool) {
 	if s.events == nil {
 		return false
@@ -706,6 +708,7 @@ func (s *Server) deliverPromptUpdates(
 // latest known position rather than the position it had when this drain
 // started. stop reports that the drain should end without an error -- the
 // StreamHead-lag case documented on streamTurnUpdates.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func (s *Server) drainRecords(
 	ctx context.Context,
 	sessionID string,

--- a/pkg/transports/acp/internal/stdio/prompt_stream_test.go
+++ b/pkg/transports/acp/internal/stdio/prompt_stream_test.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package stdio
 
 import (
@@ -1217,6 +1219,7 @@ func TestStreamTurnUpdatesPropagatesGapAcknowledgeGenericFailure(t *testing.T) {
 // The refreshed acknowledgement must preserve exactly-once delivery through
 // the subsequent retained sweep and allow the retained record after the gap
 // to continue in the live drain.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestLiveDrainTurnUpdatesRetriesGapAcknowledgementConflictBeforeCatchUp(t *testing.T) {
 	factoryTarget := &fakeFactoryTargetService{}
 	server, eventsSvc := newStreamingTestServer(t, factoryTarget)

--- a/pkg/transports/acp/internal/stdio/response_bridge_test.go
+++ b/pkg/transports/acp/internal/stdio/response_bridge_test.go
@@ -115,6 +115,7 @@ func TestDispatchFactoryInvocation_CallsInjectedResponseBridge(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestDeliverBoundWorkerChildProjectionPreservesNotificationOutcomes(t *testing.T) {
 	item, update := projectedWorkerChildMessage(t)
 	notifyErr := errors.New("notification failed")
@@ -496,6 +497,7 @@ func TestStreamTurnUpdatesKeepsInterleavedWorkerContentInsideItsOwningToolCall(t
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestStreamTurnUpdatesBoundsNoisyChildWithoutReducingSiblingBudget(t *testing.T) {
 	server, eventsSvc := newStreamingTestServer(t, &fakeFactoryTargetService{})
 	eventsSvc.seedWorkerChildItem(t, streamingTestSessionID, "worker-a", "", "dispatch-a", "worker-a-session", workers.PhaseStarted, "STARTING")

--- a/pkg/transports/acp/internal/stdio/server_test.go
+++ b/pkg/transports/acp/internal/stdio/server_test.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package stdio
 
 import (

--- a/pkg/transports/acp/internal/stdio/session_close_test.go
+++ b/pkg/transports/acp/internal/stdio/session_close_test.go
@@ -22,6 +22,7 @@ func closeRequestEnvelope(t *testing.T, requestID int64, sessionID string) envel
 // TestHandleSessionCloseCommitsBeforeFactoryClose proves the ACP close path
 // captures and commits a CLOSE intent before it reaches the bound Factory
 // Session, then exposes success only after Chat Sessions is terminal.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestHandleSessionCloseCommitsBeforeFactoryClose(t *testing.T) {
 	base, session, turn := newActiveBoundControlSession(t, "fs-close-bound")
 	chatSessions := &controlRecordingChatSessions{Service: base}
@@ -415,6 +416,7 @@ func TestHandleSessionCloseStaleCaptureCannotReachReplacement(t *testing.T) {
 // Factory Sessions close error does not partially close the Chat aggregate,
 // exposes only the bounded protocol failure, and leaves the captured intent
 // retryable by its exact request identity.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestHandleSessionCloseDependencyFailureLeavesLifecycleRetryable(t *testing.T) {
 	base, session, turn := newActiveBoundControlSession(t, "fs-close-failure")
 	chatSessions := &controlRecordingChatSessions{Service: base}
@@ -479,6 +481,8 @@ func TestHandleSessionCloseDependencyFailureLeavesLifecycleRetryable(t *testing.
 // TestHandleSessionCloseCommittedIntentSafetyCases proves every re-read and
 // intent-state rejection after the immutable CLOSE capture stays bounded and
 // cannot reach an unrelated Factory Session.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestHandleSessionCloseCommittedIntentSafetyCases(t *testing.T) {
 	current := chatsessions.GetSessionResult{
 		Session: chatsessions.Session{ID: "session-close-safety", State: chatsessions.SessionStateActive, Version: 7, ActiveTurnID: "turn-close-safety"},

--- a/pkg/transports/acp/internal/stdio/session_new_test.go
+++ b/pkg/transports/acp/internal/stdio/session_new_test.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package stdio
 
 import (
@@ -754,6 +756,7 @@ func TestHandleSessionNewRejectsNonEmptyMcpServersBeforeAnyEffect(t *testing.T) 
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestHandleSessionNewCreatesOneSessionAndReturnsProjectedPicker(t *testing.T) {
 	chatSessions := &fakeChatSessionsService{sessionID: "session-42"}
 	catalog := &fakeFactoryTargetCatalogService{result: defaultTestCatalogResult()}

--- a/pkg/transports/acp/internal/stdio/session_prompt.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package stdio
 
 import (

--- a/pkg/transports/acp/internal/stdio/session_prompt_test.go
+++ b/pkg/transports/acp/internal/stdio/session_prompt_test.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package stdio
 
 import (
@@ -2721,6 +2723,7 @@ func waitForChannel(t *testing.T, ch <-chan struct{}, description string) {
 // control order at the ACP boundary: a notification's full transport identity
 // is captured, the immutable CANCEL intent commits, and only then can the
 // exact bound Factory Session observe Cancel.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestHandleSessionCancelCommitsCapturedIntentBeforeFactoryCancel(t *testing.T) {
 	base, session, turn := newActiveBoundControlSession(t, "fs-control-1")
 	chatSessions := &controlRecordingChatSessions{Service: base}
@@ -2891,6 +2894,7 @@ func TestHandleSessionCancelRepeatedIdentityDoesNotDuplicateFactoryCancel(t *tes
 // target or collaborator after capture remains silent and cannot reach an
 // unintended Factory Session. Each case exercises the notification boundary
 // with a minted identity, so no JSON-RPC response is manufactured.
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestHandleSessionCancelCommittedSafetyCases(t *testing.T) {
 	current := chatsessions.GetSessionResult{
 		Session: chatsessions.Session{ID: "session-cancel-safety", State: chatsessions.SessionStateActive, Version: 7, ActiveTurnID: "turn-cancel-safety"},
@@ -3264,6 +3268,7 @@ func TestServeSessionCancelBlankSessionIDIsNoOp(t *testing.T) {
 // proves a Factory Sessions failure neither fabricates a cancelled turn nor
 // resolves the captured intent. Retrying the same notification identity can
 // later complete the original control without reaching another target.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestHandleSessionCancelDependencyFailureLeavesTurnRunningAndRetryable(t *testing.T) {
 	base, session, turn := newActiveBoundControlSession(t, "fs-cancel-failure")
 	chatSessions := &controlRecordingChatSessions{Service: base}

--- a/pkg/transports/cli/cliinputs/parser_parity_test.go
+++ b/pkg/transports/cli/cliinputs/parser_parity_test.go
@@ -201,6 +201,8 @@ func productionParserParityRunVariadicCases() []productionParserParityCase {
 }
 
 // pkgmaintcheck:ignore-cyclomatic-complexity run parser parity cases keep inline verify closures beside argv fixtures for reviewer readability.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func productionParserParityRunFlagCases() []productionParserParityCase {
 	return []productionParserParityCase{
 		{

--- a/pkg/transports/cli/command_factory_injection_test.go
+++ b/pkg/transports/cli/command_factory_injection_test.go
@@ -558,6 +558,9 @@ func TestNewCommandFactoryPreservesInjectedRuntimeCLIAdapter(t *testing.T) {
 	}
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestNewCommandFactoryPreservesInjectedOperations(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/transports/cli/root.go
+++ b/pkg/transports/cli/root.go
@@ -1,5 +1,7 @@
 // Package cli defines Cobra commands for the agent-factory CLI.
 // Commands contain only flag parsing and delegate to command-specific packages.
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package cli
 
 import (
@@ -365,6 +367,7 @@ func newMCPCommand(options CommandFactory) (*cobra.Command, error) {
 	}))
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func runFactoryWithOptions(cmd *cobra.Command, cfg runcli.RunConfig, promptArgs []string, globals *cliGlobalOptions, operatorDefaults *cliOperatorDefaultsOptions, policy terminalpolicy.Policy, rootOptions CommandFactory, defaultInvocation bool) error {
 	cfg = applyRunScopedServerMode(cfg)
 	logger, err := policy.BuildLogger(rootOptions.buildTerminalLogger)

--- a/pkg/transports/cli/root_models_docs_coverage_test.go
+++ b/pkg/transports/cli/root_models_docs_coverage_test.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package cli
 
 import (

--- a/pkg/transports/cli/root_serve_test.go
+++ b/pkg/transports/cli/root_serve_test.go
@@ -100,6 +100,7 @@ func TestServeFamily_VisibleInRootHelpAndDistinctFromWorkersAcpAndMcpServe(t *te
 // asserts the complete rendered flag surface (local and inherited) instead
 // of only local flags, so an undeclared or unexpected flag -- including a
 // resurfaced --json/--server -- would fail this test too.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestServeACPCommand_HelpRendersManifestExamplesAndNoLocalFlags(t *testing.T) {
 	var stdout bytes.Buffer
 	root := withTestInjectedPlatformRoles(CommandFactory{ModelsCLI: rootModelsCLI}).NewCommand(nil, nil, nil)

--- a/pkg/transports/cli/root_submit_batch.go
+++ b/pkg/transports/cli/root_submit_batch.go
@@ -109,6 +109,7 @@ func applyRunResolvedInputs(cfg runcli.RunConfig, values map[string]any) (runcli
 	return cfg, nil
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func parseRunCommandArgs(cmd *cobra.Command, args []string) ([]string, error) {
 	remainder := make([]string, 0, len(args))
 	flagsByToken := indexRunCommandFlags(cmd)

--- a/pkg/transports/http/contracttests/generated_contract_common_test.go
+++ b/pkg/transports/http/contracttests/generated_contract_common_test.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package apicontract_test
 
 import (

--- a/pkg/transports/mapping/factory_events_test.go
+++ b/pkg/transports/mapping/factory_events_test.go
@@ -22,6 +22,7 @@ func TestFactoryEventsToAPIRejectsMalformedCanonicalPayload(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestFactoryEventAssociationRoundTripPreservesDispatchAndWorkerSessionIDs(t *testing.T) {
 	dispatchID := "dispatch-actual-7"
 	eventTime := time.Date(2026, 8, 4, 16, 30, 0, 0, time.UTC)

--- a/pkg/transports/mapping/factorysession/factory_session_mapper_test.go
+++ b/pkg/transports/mapping/factorysession/factory_session_mapper_test.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package factorysession_test
 
 import (
@@ -974,6 +976,7 @@ func (fake *invocationServiceFake) InvokeFactorySession(
 	return fake.result, fake.err
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestInvocationAPI_UsesOwnerCapabilityAndPreservesTerminalOutcome(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/transports/mapping/factorysession/live_api_test.go
+++ b/pkg/transports/mapping/factorysession/live_api_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/transports/mapping/factorysession"
 )
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestLiveAPI_MapsCompleteLifecycleThroughNarrowControl(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/transports/mapping/factorytarget/factory_target_option_test.go
+++ b/pkg/transports/mapping/factorytarget/factory_target_option_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/transports/mapping/factorytarget"
 )
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestFromCatalogResultSerializesSelectOptionContract(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/wire/chat_sessions_composition_test.go
+++ b/pkg/wire/chat_sessions_composition_test.go
@@ -451,6 +451,7 @@ func mustAcknowledgeAttachment(t *testing.T, svc chatsessions.Service, sessionID
 // record with the exact aggregate sequence, ItemID, ParentItemID, source
 // identity, kind, schema, and payload the sequencer committed -- not a
 // regenerated or reconstructed value.
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestChatSessionsSequencingIdentity_RetainedReadReturnsExactCommittedIdentity(t *testing.T) {
 	t.Parallel()
 	chatSessionsService, eventsService := newChatSessionsIdentityTestServices(t)

--- a/pkg/wire/model_invocation_edges_test.go
+++ b/pkg/wire/model_invocation_edges_test.go
@@ -172,6 +172,7 @@ func TestModelAssetHostPlatformPreservesOverrideAndSelectsProcessDefault(t *test
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestModelsCompositionAdaptsEdgePortsAtTheWireBoundary(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/wire/recordings_artifacts_export_composition_test.go
+++ b/pkg/wire/recordings_artifacts_export_composition_test.go
@@ -21,6 +21,9 @@ type inertRecordingsLedger struct {
 // TestInjectBundleComposesRecordingsArtifactExportThroughWireFactory proves the
 // Wire recordings factory wires artifact close/export/read through the singular
 // Recordings root rather than a second peer authority.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-function-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
+// pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 func TestInjectBundleComposesRecordingsArtifactExportThroughWireFactory(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/wire/session_runtime_providers.go
+++ b/pkg/wire/session_runtime_providers.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
+// pkgmaintcheck:ignore-file-lines pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption
 package wire
 
 import (

--- a/tests/functional/events/factory_events/order_and_cursor_test.go
+++ b/tests/functional/events/factory_events/order_and_cursor_test.go
@@ -1,3 +1,4 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 package factory_events
 
 import (

--- a/tests/functional/events/response_events/stream_test.go
+++ b/tests/functional/events/response_events/stream_test.go
@@ -208,6 +208,7 @@ func TestAPIResponseEventSessionExpiryReturnsTypedGone(t *testing.T) {
 // SSE API emits STREAM_GAP with explicit lost-range bounds when after_sequence
 // predates the currently retained response-event window instead of silently
 // skipping unavailable sequences.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestAPIResponseEventCursorGapEmitsStreamGap(t *testing.T) {
 	t.Parallel()
 
@@ -318,6 +319,7 @@ func TestAPIResponseEventCursorGapEmitsStreamGap(t *testing.T) {
 // Response Event SSE API first delivers retained matching records in ascending
 // FactoryResponseEvent.sequence and then continues with later live matching
 // records on the same connection without reordering retained catch-up history.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestAPIResponseEventSSEStreamsRetainedThenLiveEvents(t *testing.T) {
 	t.Parallel()
 

--- a/tests/functional/factory/definitions/import_export_test.go
+++ b/tests/functional/factory/definitions/import_export_test.go
@@ -226,6 +226,7 @@ func TestImportExportPreservesNestedDocsScriptsAndMetadata(t *testing.T) {
 // TestInvalidImportDoesNotReplaceCurrentFactory proves an invalid import through
 // the public update path is rejected with a customer-visible failure and leaves
 // the prior Current Factory definition unchanged on public readback.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestInvalidImportDoesNotReplaceCurrentFactory(t *testing.T) {
 	runner := support.NewRecordingCommandRunner("runtime must not execute during invalid import")
 	edges := serviceedges.Edges{ProviderCommandRunner: runner}

--- a/tests/functional/factory/packaged/cross/package_cli_api_test.go
+++ b/tests/functional/factory/packaged/cross/package_cli_api_test.go
@@ -1,3 +1,4 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 package cross
 
 import (

--- a/tests/functional/factory/packaged/tts/invocation_test.go
+++ b/tests/functional/factory/packaged/tts/invocation_test.go
@@ -437,6 +437,7 @@ func scaffoldPackagedTTSLikeFactory(t *testing.T) string {
 	})
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func scaffoldPackagedTTSLikeFactoryWithOptionalVoiceAndFormat(t *testing.T) string {
 	t.Helper()
 	return support.ScaffoldFactory(t, map[string]any{

--- a/tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go
+++ b/tests/functional/factory_runtime/orchestrators/petri/guards/eligibility_test.go
@@ -102,6 +102,7 @@ func TestPetriAuthoredEligibilityGuardBlocksDispatchUntilSatisfied(t *testing.T)
 // guard dispatches only when peer Work names correlate, releasing the expected
 // matched Work to its public terminal state while mismatched peers remain idle
 // without the guarded workstation's success outcome.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestPetriParentOrSameNameGuardReleasesExpectedWork(t *testing.T) {
 	t.Run("matching peer names release correlated work", func(t *testing.T) {
 		dir := support.ScaffoldFactory(t, sameNameGuardFactoryConfig())
@@ -231,6 +232,7 @@ func TestPetriParentOrSameNameGuardReleasesExpectedWork(t *testing.T) {
 // VISIT_COUNT and MATCHES_FIELDS eligibility guard failures are observable
 // through public Work and Factory Session surfaces without inspecting internal
 // Petri markings.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestPetriVisitOrMatchGuardFailureIsVisibleInPublicWorkState(t *testing.T) {
 	t.Run("visit count loop breaker routes over-limit work to failed", func(t *testing.T) {
 		dir := support.ScaffoldFactory(t, visitCountLoopBreakerFactoryConfig())

--- a/tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go
+++ b/tests/functional/factory_runtime/orchestrators/petri/routing/multi_transition_test.go
@@ -18,6 +18,7 @@ import (
 // public success terminal location(s) at quiescence. Scenarios cover two-stage
 // same-work-type pipelines, cross-work-type dispatcher flows, and three-stage
 // ideation pipelines without inspecting internal Petri markings.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestPetriMultiStagePipelineCompletesAtPublicTerminals(t *testing.T) {
 	t.Run("two_stage_service_simple_completes_at_terminal", func(t *testing.T) {
 		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "service_simple"))
@@ -150,6 +151,7 @@ func TestPetriMultiStagePipelineCompletesAtPublicTerminals(t *testing.T) {
 // dispatch outcomes are asserted on Factory Events when that is the natural
 // observation surface, without routing the same Work to success terminals or
 // inspecting internal Petri markings.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestPetriFailureRoutesToDocumentedFailedPlace(t *testing.T) {
 	t.Run("two_stage_service_simple_second_stage_exit_routes_to_failed", func(t *testing.T) {
 		dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "service_simple"))

--- a/tests/functional/factory_runtime/root_composition/lifecycle_activation_test.go
+++ b/tests/functional/factory_runtime/root_composition/lifecycle_activation_test.go
@@ -27,6 +27,7 @@ import (
 // proves Factory Runtime control, observation, and dispatch-plan activate through
 // published public HTTP surfaces after runtime lifecycle on a process constructed
 // only through root.BuildProcess with Factory Runtime effects replaced via edges.Edges.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestFactoryRuntimeControlObservationAndDispatchPlanActivateThroughRootBuildProcessAfterLifecycle(
 	t *testing.T,
 ) {

--- a/tests/functional/factory_visualization/response_presentation_test.go
+++ b/tests/functional/factory_visualization/response_presentation_test.go
@@ -35,6 +35,7 @@ func (tracker *rootPresentationTracker) openCallsCount() int {
 // presentation sessions are not opened as a side effect of root.BuildProcess
 // construction alone and that public Open/PresentProgress/Finalize/Close
 // operations yield observable outcomes through the published Root.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestVisualizationResponsePresentationThroughPublicRootAfterLifecycle(t *testing.T) {
 	t.Parallel()
 

--- a/tests/functional/internal/support/process_factory.go
+++ b/tests/functional/internal/support/process_factory.go
@@ -243,6 +243,7 @@ func runFactoryToCompletionWithMode(
 	)
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func runFactoryToCompletionWithHome(
 	t testing.TB,
 	dir string,

--- a/tests/functional/models/root_composition/inference_invoke_test.go
+++ b/tests/functional/models/root_composition/inference_invoke_test.go
@@ -21,6 +21,7 @@ import (
 // constructed only through root.BuildProcess executes public Models invoke and
 // returns observable inference output while host, runtime, and asset external
 // effects are replaced exclusively through published edges.Edges fields.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestModelsInferenceInvokeActivatesThroughRootBuildProcess(t *testing.T) {
 	t.Parallel()
 

--- a/tests/functional/orchestration/javascript/loading/named_factory_test.go
+++ b/tests/functional/orchestration/javascript/loading/named_factory_test.go
@@ -122,6 +122,7 @@ func TestNamedJavaScriptFactoryRunsThroughAPIInvocation(t *testing.T) {
 // Factory Session lifecycle controls apply to a named JavaScript Factory session
 // started through the public HTTP customer boundary and remain observable on the
 // public session surface for that named Factory identity through HTTP and CLI.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestNamedJavaScriptFactoryUsesSameFactorySessionControls(t *testing.T) {
 	t.Parallel()
 

--- a/tests/functional/orchestration/petri/dispatch/simple_run_test.go
+++ b/tests/functional/orchestration/petri/dispatch/simple_run_test.go
@@ -1,3 +1,4 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 package dispatch
 
 import (

--- a/tests/functional/provider_sessions/details/codex_details_test.go
+++ b/tests/functional/provider_sessions/details/codex_details_test.go
@@ -271,6 +271,7 @@ func writeCodexGoldenRolloutFixtureAt(t *testing.T, root, relativeDir, sessionID
 	}
 }
 
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func observeCodexProviderSessionDetailGolden(
 	detail factoryapi.ProviderSessionDetailResponse,
 ) json.RawMessage {

--- a/tests/functional/runtime_api/api_work_root_policy_slices_test.go
+++ b/tests/functional/runtime_api/api_work_root_policy_slices_test.go
@@ -12,6 +12,7 @@ import (
 // TestWorkRootPolicySlicesRejectUnsupportedOperations proves published Work root
 // policy/materialization/admission binders fail closed on slices they do not own.
 // The functional lane measures coverage for pkg/services/work when these tests run.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestWorkRootPolicySlicesRejectUnsupportedOperations(t *testing.T) {
 	t.Parallel()
 

--- a/tests/functional/runtime_api/api_work_service_application_slices_test.go
+++ b/tests/functional/runtime_api/api_work_service_application_slices_test.go
@@ -12,6 +12,7 @@ import (
 // TestWorkServiceApplicationSlicesExerciseFunctionalLane proves published Work
 // application-service methods used by Factory Sessions admission and invocation
 // edges execute in the functional coverage lane.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestWorkServiceApplicationSlicesExerciseFunctionalLane(t *testing.T) {
 	t.Parallel()
 

--- a/tests/functional/runtime_api/factory_transformation/api_current_factory_put_test.go
+++ b/tests/functional/runtime_api/factory_transformation/api_current_factory_put_test.go
@@ -1,3 +1,4 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 package factory_transformation
 
 import (

--- a/tests/functional/sessions/controls/pause_resume_test.go
+++ b/tests/functional/sessions/controls/pause_resume_test.go
@@ -308,6 +308,7 @@ func TestInterruptedWorkInspectSurfacesDispatchAndStopSummary(t *testing.T) {
 // TestAPIPauseResumeCancelAndTerminateFactorySession proves public API pause,
 // resume, cancel, and terminate controls return typed lifecycle-control outcomes
 // and leave each Factory Session in the expected lifecycle state after control.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestAPIPauseResumeCancelAndTerminateFactorySession(t *testing.T) {
 	factoryDir := pauseResumeControlsFactoryDirWithBusyLoop(t)
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{

--- a/tests/functional/sessions/execution/helpers_test.go
+++ b/tests/functional/sessions/execution/helpers_test.go
@@ -1,3 +1,4 @@
+// backendsizecheck:ignore-file pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 package execution_test
 
 import (

--- a/tests/functional/sessions/execution/results_dispatches_test.go
+++ b/tests/functional/sessions/execution/results_dispatches_test.go
@@ -22,6 +22,7 @@ import (
 // typed non-success terminal statuses, invalid invocation inputs are rejected
 // with typed public errors, and canceled request context stops in-flight
 // invocations without fabricating terminal success results.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestAPIResultAndResultsExposeTerminalInvocationData(t *testing.T) {
 	t.Run("successfulInvocationExposesPrimaryResultOnInvocationAndWorkReads", func(t *testing.T) {
 		dir := scaffoldInvocationFactory(t, nil)

--- a/tests/functional/sessions/lifecycle/crud_test.go
+++ b/tests/functional/sessions/lifecycle/crud_test.go
@@ -28,6 +28,7 @@ const sessionLifecycleCRUDMissingSessionID = "dur-sess-missing-999"
 // and session show with matching folder identity and live runtime status markers,
 // and session delete removes it so subsequent list/show no longer treat it as
 // an open session participating in the owned runtime lifecycle.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestFactorySessionCreateListShowDelete(t *testing.T) {
 	primaryFactoryDir := support.ScaffoldFactory(t, sessionLifecycleCRUDFactoryConfig())
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{

--- a/tests/functional/sessions/restart/logical_identity_test.go
+++ b/tests/functional/sessions/restart/logical_identity_test.go
@@ -109,6 +109,7 @@ func TestFactorySessionRestartRemapsLiveIDToLogicalIdentity(t *testing.T) {
 // the public resume boundary without replaying those completed children:
 // completed Dispatch identities stay COMPLETED, only remaining work continues,
 // and progress on public session surfaces reflects durable continuity.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestFactorySessionResumeDoesNotRepeatCompletedDispatch(t *testing.T) {
 	const workflowName = "resumable-two-step-fake-children"
 	factoryDir := setupResumableTwoStepWorkflowFixture(t, workflowName)

--- a/tests/functional/sessions/root_composition/lifecycle_runtime_opening_test.go
+++ b/tests/functional/sessions/root_composition/lifecycle_runtime_opening_test.go
@@ -23,6 +23,7 @@ import (
 // HTTP surfaces after runtime lifecycle on a process constructed only through
 // root.BuildProcess with Sessions effects replaced via published edges.Edges
 // fields.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestSessionsLifecycleAndRuntimeOpeningActivateThroughRootBuildProcessAfterLifecycle(t *testing.T) {
 	t.Parallel()
 

--- a/tests/functional/transport/acp/stdio/cli_serve_acp_prompt_test.go
+++ b/tests/functional/transport/acp/stdio/cli_serve_acp_prompt_test.go
@@ -62,6 +62,7 @@ type rpcFrame struct {
 // which drives Process.ACPServer() directly rather than the CLI command
 // tree; both share support.SeedACPAgentProfile instead of each owning a
 // private copy of that fixture-seeding helper.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestServeACP_RootBuildProcessCompletesOneFactoryPrompt(t *testing.T) {
 	if testing.Short() {
 		t.Skip("integration test driving you serve acp through root.BuildProcess")

--- a/tests/functional/transport/cli/commands/run_wiring_test.go
+++ b/tests/functional/transport/cli/commands/run_wiring_test.go
@@ -27,6 +27,7 @@ const (
 
 // TestCLIRunNamedFactory proves you run resolves named and packaged Factory
 // identities through the CLI and writes the expected primary-result outcome to stdout on success.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestCLIRunNamedFactory(t *testing.T) {
 	if testing.Short() {
 		t.Skip("slow CLI run named/packaged factory wiring")

--- a/tests/functional/transport/cli/commands/session_wiring_test.go
+++ b/tests/functional/transport/cli/commands/session_wiring_test.go
@@ -26,6 +26,7 @@ const (
 // TestCLISessionCreateListShowDelete proves you session create, list, show, and
 // delete work as a thin CLI lifecycle against a running Factory Session server,
 // yielding observable session identity and success or failure exit behavior.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestCLISessionCreateListShowDelete(t *testing.T) {
 	primaryFactoryDir := support.ScaffoldFactory(t, sessionWiringFactoryConfig())
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{

--- a/tests/functional/transport/cli/process/stdout_stderr_test.go
+++ b/tests/functional/transport/cli/process/stdout_stderr_test.go
@@ -188,6 +188,7 @@ const quietPrimaryResultSeparator = "--- primary result ---"
 // stdout/stderr at the public built you CLI process boundary: success writes
 // only the raw primary result without operator or lifecycle noise, and failure
 // keeps stdout empty while diagnostics stay on stderr.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestCLIQuietModeSuppressesNonResultNoise(t *testing.T) {
 	harness := builtcliacceptance.NewHarness(t, testutil.MustRepoRoot(t))
 	session := harness.NewSession(t).WithNoExternalServer(t)

--- a/tests/functional/work/relationships/dependencies_test.go
+++ b/tests/functional/work/relationships/dependencies_test.go
@@ -255,6 +255,7 @@ func TestWorkWithoutDependsOnRelationsDispatchesNormally(t *testing.T) {
 // undispatched while only a proper subset of prerequisites has reached the
 // declared requiredState, then proceeds only after every prerequisite target
 // state is satisfied.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestFanInReleasesOnlyAfterEveryPrerequisite(t *testing.T) {
 	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "dependency_tracking_dir"))
 

--- a/tests/functional/work/root_composition/routing_relationship_activation_test.go
+++ b/tests/functional/work/root_composition/routing_relationship_activation_test.go
@@ -107,6 +107,7 @@ func TestWorkRoutingActivatesThroughRootBuildProcessAfterLifecycle(t *testing.T)
 // and edges.Edges. Detailed relationship coverage remains under
 // tests/functional/work/relationships; this test closes the explicit public-process
 // activation gap.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestWorkRelationshipsActivateThroughRootBuildProcessAfterLifecycle(t *testing.T) {
 	t.Parallel()
 

--- a/tests/functional/work/root_composition/submission_activation_test.go
+++ b/tests/functional/work/root_composition/submission_activation_test.go
@@ -36,6 +36,7 @@ const (
 // coverage under tests/functional/work/submission and
 // tests/functional/work/transports/cli/submit retains the detailed contract
 // proofs; this test closes the explicit public-process activation gap.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestWorkSubmissionAndCLISubmitActivateThroughRootBuildProcessAfterLifecycle(t *testing.T) {
 	t.Parallel()
 

--- a/tests/functional/workers/inference/agy/golden_test.go
+++ b/tests/functional/workers/inference/agy/golden_test.go
@@ -33,6 +33,7 @@ const (
 // transcript through the customer process boundary and proves public final-only
 // success without fabricated streaming deltas or structured snapshot events.
 // golden: tests/functional/internal/support/testdata/provider-sessions/agy/final-only-success/manifest.json
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestAgyGoldenFinalOnlySuccess(t *testing.T) {
 	repoRoot := testutil.MustRepoRoot(t)
 	caseDir := filepath.Join(

--- a/tests/functional/workers/transports/cli/run/lifecycle/lifecycle_test.go
+++ b/tests/functional/workers/transports/cli/run/lifecycle/lifecycle_test.go
@@ -86,6 +86,7 @@ func TestCLIRunCleanInvocationCompletesWithoutDashboardStartup(t *testing.T) {
 // hosted public you run --with-server invocation routes through the already-open
 // Factory Session on the live runtime host rather than a detached local one-shot
 // lifecycle, with Factory Event correlation on that hosted session identity.
+// backendsizecheck:ignore-function pre-existing baseline debt recorded 2026-08-08; split this oversized code into focused units and remove this exemption
 func TestCLIRunServerAttachedInvocationTargetsExistingFactorySession(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Why

`make lint` is red on main independent of any change, which currently blocks every factory delivery lane at the review merge gate (first hit on PR #1818's review: 98 backend-size violations none of which the branch introduced).

## What

Grandfather the existing debt through each tool's own approved ratchet mechanism — new violations remain fatal:

| gate | debt recorded | mechanism |
|---|---|---|
| backend-size | 98 (27 file, 71 fn — 61 directives after file-level suppression) | `backendsizecheck:ignore-*` directives + exemption-budget entries |
| pkg-maint | 202 (145 complexity, 35 fn-lines, 22 file-lines) | `pkgmaintcheck:ignore-*` directives + budget entries |
| exemption budget | 16 stale + 20 unregistered entries from package restructures | reconciled |
| pkg-file-count | 48 drifted exact counts | baseline regenerated |
| pkg-structure | 26 new / 2 stale | regenerated via `-create-baseline` |

## Verification

All four gate commands pass; `go test` for backendsizecheck, pkgmaintcheck, pkgfilecountcheck, pkgstructurecheck, exemptionbudget passes; `make test` passes.

## Explicitly out of scope

pkg-boundary's 172 domain→transport violations and the drifted packagetargetmanifestcheck committed inventories (incl. the missing `worker_sessions` owner) — real packaged-service-structure migration work, tracked for the factory backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)