### PR TITLE
Fix Work-watch retry ordering conflicts

### DIFF
--- a/pkg/services/work/transports/cli/watch_reducer.go
+++ b/pkg/services/work/transports/cli/watch_reducer.go
@@ -72,23 +72,37 @@ func (r *watchReducer) Accept(event factoryapi.FactoryEvent) (WatchTransition, b
 
 // acceptOrdering validates and records event's canonical ordering position.
 // It reports true when event is an exact replay or a non-projecting model
-// request retry of an already-accepted event.
+// request retry at a strictly later canonical position.
 func (r *watchReducer) acceptOrdering(event factoryapi.FactoryEvent) (bool, error) {
 	signature, err := json.Marshal(event)
 	if err != nil {
 		return false, fmt.Errorf("fingerprint work watch event %q: %w", event.Id, err)
 	}
 	if prior, ok := r.accepted[event.Id]; ok {
+		if prior.sequence == event.Context.Sequence && bytes.Equal(prior.signature, signature) {
+			return true, nil
+		}
 		if prior.eventType == factoryapi.FactoryEventTypeModelRequest &&
 			event.Type == factoryapi.FactoryEventTypeModelRequest {
 			// Provider retries can refresh the canonical MODEL_REQUEST payload
 			// while retaining the request ordinal and event identity. MODEL_REQUEST
-			// events do not project Work state, so accept the enrichment without
-			// emitting a transition or moving the cursor backwards.
-			if event.Context.Sequence > r.last {
-				r.last = event.Context.Sequence
-				r.lastID = event.Id
+			// events do not project Work state, so accept later enrichment without
+			// emitting a transition. A non-increasing position is a conflicting
+			// reuse, not a provider retry.
+			if !r.hasLast || event.Context.Sequence <= r.last {
+				return false, fmt.Errorf(
+					"work watch model request retry %q has non-increasing canonical sequence %d after %d",
+					event.Id, event.Context.Sequence, r.last,
+				)
 			}
+			r.accepted[event.Id] = watchAcceptedEvent{
+				eventType: event.Type,
+				sequence:  event.Context.Sequence,
+				signature: append([]byte(nil), signature...),
+			}
+			r.last = event.Context.Sequence
+			r.lastID = event.Id
+			r.hasLast = true
 			return true, nil
 		}
 		if prior.sequence != event.Context.Sequence || !bytes.Equal(prior.signature, signature) {

--- a/pkg/services/work/transports/cli/watch_retry_test.go
+++ b/pkg/services/work/transports/cli/watch_retry_test.go
@@ -54,6 +54,32 @@ func TestWatchReducerAcceptsRefreshedModelRequestRetryWithoutProjectingWork(t *t
 	}
 }
 
+func TestWatchReducerRejectsNonIncreasingConflictingModelRequestRetry(t *testing.T) {
+	reducer := newWatchReducer("session-retry-conflict")
+	initial := watchModelRequestEvent(t, watchRetryModelRequestEventID, 4, "gpt-5-codex")
+	if _, _, _, err := reducer.Accept(initial); err != nil {
+		t.Fatalf("Accept(initial) error = %v", err)
+	}
+
+	for _, test := range []struct {
+		name     string
+		sequence int
+	}{
+		{name: "same sequence", sequence: 4},
+		{name: "backward sequence", sequence: 3},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			conflicting := watchModelRequestEvent(t, watchRetryModelRequestEventID, test.sequence, "gpt-5-codex-mini")
+			if _, _, _, err := reducer.Accept(conflicting); err == nil || !strings.Contains(err.Error(), "non-increasing canonical sequence") {
+				t.Fatalf("Accept(conflicting retry) error = %v, want non-increasing sequence failure", err)
+			}
+			if cursor := reducer.Cursor(); cursor == nil || cursor.EventID != initial.Id || cursor.Sequence != initial.Context.Sequence {
+				t.Fatalf("cursor after rejected retry = %#v, want initial model request at sequence %d", cursor, initial.Context.Sequence)
+			}
+		})
+	}
+}
+
 func TestWatchFiniteStreamIgnoresRefreshedModelRequestRetry(t *testing.T) {
 	metadata, request, firstTransition := watchRetrySetup(t)
 	retryInitial := watchModelRequestEvent(t, watchRetryModelRequestEventID, 4, "gpt-5-codex")

--- a/prd.json
+++ b/prd.json
@@ -32,7 +32,7 @@
       ],
       "priority": 1,
       "passes": true,
-      "notes": "Implemented retry-safe Work-watch reduction for repeated MODEL_REQUEST IDs with refreshed canonical data, preserving strict conflicts for Work events and monotonic ephemeral cursors. Added finite, --follow, exact replay, reconnect, NDJSON, and invalid-transition behavioral coverage. Review follow-up now uses the observed later-sequence/later-event-time retry shape with realistic dispatch context and an intervening model response, and proves reconnect from the later canonical cursor. Removed the unrelated manifest/inventory meta-test during review follow-up. The focused Work/watch/process command and make verify-fast pass."
+      "notes": "Implemented retry-safe Work-watch reduction for repeated MODEL_REQUEST IDs with refreshed canonical data, preserving strict conflicts for Work events and monotonic ephemeral cursors. Added finite, --follow, exact replay, reconnect, NDJSON, and invalid-transition behavioral coverage. Review follow-up now uses the observed later-sequence/later-event-time retry shape with realistic dispatch context and an intervening model response, and proves reconnect from the later canonical cursor. Corrective follow-up now accepts changed MODEL_REQUEST data only at a strictly later canonical position, updates the remembered retry version, and rejects same-sequence or backward conflicting reuse. Removed the unrelated manifest/inventory meta-test during review follow-up. The focused Work/watch/process command and make verify-fast pass."
     },
     {
       "id": "wo-c2-fix-watch-event-id-conflict-002",


### PR DESCRIPTION
{
  "project": "Make you work watch Retry-Safe and Preserve Failure Exit Codes",
  "branchName": "wo-c2-fix-watch-event-id-conflict",
  "description": "Correct you work watch so finite and --follow streams survive legitimate provider dispatch retries that re-emit a model-request event ID with refreshed canonical data, while preserving the you.work.watch.v1 NDJSON contract and making genuine stream aborts exit non-zero.",
  "context": {
    "customerAsk": "Make finite and --follow Work watches stream successfully for real Factory Sessions that contain provider dispatch retries, without changing the you.work.watch.v1 NDJSON shape or adding storage; genuine stream aborts must return a non-zero CLI process exit.",
    "problem": "The strict watch reducer treats any event ID reused with differing payload data as corruption. Real Factory ledgers re-emit model-request IDs at the same request ordinal across provider dispatch retries with refreshed canonical data, so legitimate live history aborts both finite and following watches. The CLI then prints the abort but can leave the shell with exit code 0.",
    "solution": "Align invocation-local Work watch reduction with canonical Factory Event ordering and Work-transition projection so unrelated retry enrichment cannot abort or distort transition output, then propagate genuine stream errors through the root CLI process boundary as non-zero exits while retaining stderr diagnostics and the existing NDJSON contract."
  },
  "acceptanceCriteria": [
    "A fixture ledger containing the same model-request event ID twice with differing canonical data, matching the observed provider retry shape, is accepted without aborting the Work watch.",
    "Finite and --follow watches emit the fixture's complete ordered Work state-transition history exactly once, and unrelated retry enrichment emits no extra NDJSON lines.",
    "Watch output retains the exact you.work.watch.v1 NDJSON contract shape, and reconnect/cursor behavior continues from the last accepted canonical Factory Event without durable state.",
    "Genuine stream-abort errors remain actionable on stderr and cause the built you CLI process to exit non-zero, while successful finite completion remains exit code 0.",
    "No storage engine, public contract expansion, unrelated event-ledger rewrite, or cut-list item from docs/temp/work-order.md is introduced.",
    "The named focused verification command go test ./pkg/services/work/transports/cli ./tests/functional/work/watch ./tests/functional/transport/cli/process and make verify-fast pass; Typecheck passes, Tests pass, no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, shared-file and baseline conflicts are reconciled, merge conflicts are resolved, and the PR is actually merged; an opened, green, approved, or ready-to-merge PR is not complete."
  ],
  "userStories": [
    {
      "id": "wo-c2-fix-watch-event-id-conflict-001",
      "title": "Stream Work transitions through provider retry events",
      "description": "As a factory operator, I want finite and following Work watches to tolerate legitimate provider dispatch retry history so that I can observe every Work transition in a live session without the monitor aborting.",
      "acceptanceCriteria": [
        "A behavioral fixture places Work state transitions before, between, and after two model-request events that reuse the same event ID with differing canonical data in the observed retry shape.",
        "Finite mode consumes that ledger, emits the full ordered Work transition history exactly once, and exits successfully when the observed Work cohort becomes terminal.",
        "--follow consumes the conflicting retry events without aborting and emits Work transitions that occur after them until normal cancellation.",
        "Model-request retry events do not themselves produce you.work.watch.v1 output, and emitted transition objects retain the existing fields and meanings.",
        "Exact replay remains idempotent, canonical resume position remains monotonic, and genuinely invalid Work transition data still returns an actionable reducer or stream error.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented retry-safe Work-watch reduction for repeated MODEL_REQUEST IDs with refreshed canonical data, preserving strict conflicts for Work events and monotonic ephemeral cursors. Added finite, --follow, exact replay, reconnect, NDJSON, and invalid-transition behavioral coverage. Review follow-up now uses the observed later-sequence/later-event-time retry shape with realistic dispatch context and an intervening model response, and proves reconnect from the later canonical cursor. Corrective follow-up now accepts changed MODEL_REQUEST data only at a strictly later canonical position, updates the remembered retry version, and rejects same-sequence or backward conflicting reuse. Removed the unrelated manifest/inventory meta-test during review follow-up. The focused Work/watch/process command and make verify-fast pass."
    },
    {
      "id": "wo-c2-fix-watch-event-id-conflict-002",
      "title": "Exit non-zero when a Work watch genuinely aborts",
      "description": "As an operator or automation author, I want an aborted Work watch to return a non-zero process exit code so that monitoring scripts cannot mistake a failed stream for successful completion.",
      "acceptanceCriteria": [
        "A process-boundary behavioral test runs the built you work watch command against a deterministic genuine stream-abort condition and observes a non-zero exit code.",
        "The abort diagnostic is written to stderr with enough session and stream context to identify the failed watch, while stdout contains only complete NDJSON transition lines produced before the abort.",
        "Successful finite completion retains exit code 0, and normal --follow cancellation retains the repository's established cancellation semantics.",
        "Stream failures are propagated through command execution and the root process boundary rather than being printed and converted to success.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added a true built cmd/factory process-boundary Work-watch fixture that emits complete NDJSON before a malformed SSE frame, then proves the genuine stream-abort error stays actionable on stderr with session and decode context, returns the child process's non-zero exit code, and leaves stdout with exactly the complete NDJSON transition produced before the abort. The same built binary also proves successful finite completion returns exit code 0. Removed the unrelated manifest/inventory meta-test during review follow-up. The focused Work/watch/process command and make verify-fast pass."
    }
  ]
}
