### PR TITLE
pf-plain-batch-drain

### DIFF
--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go
@@ -537,18 +537,12 @@ func (e *FactoryEngine) runUntilQuiescent(ctx context.Context) (bool, error) {
 			return false, err
 		}
 		if shouldTerminate {
-			terminated, err := e.finishTerminationDrain()
-			if err != nil {
-				return false, err
+			if e.finishTerminationDrain() {
+				return true, nil
 			}
-			if !terminated {
-				// A wake-up arrived while the runtime was preparing to
-				// terminate. The drain consumed that signal, so re-run the
-				// canonical tick immediately instead of returning to the
-				// outer wait, which would otherwise wait for a new signal.
-				continue
-			}
-			return true, nil
+			// A wake-up arrived while preparing to terminate. The drain
+			// consumed it, so immediately rerun the canonical tick.
+			continue
 		}
 		if !mutated {
 			e.mu.Lock()

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go
@@ -537,7 +537,18 @@ func (e *FactoryEngine) runUntilQuiescent(ctx context.Context) (bool, error) {
 			return false, err
 		}
 		if shouldTerminate {
-			return e.finishTerminationDrain()
+			terminated, err := e.finishTerminationDrain()
+			if err != nil {
+				return false, err
+			}
+			if !terminated {
+				// A wake-up arrived while the runtime was preparing to
+				// terminate. The drain consumed that signal, so re-run the
+				// canonical tick immediately instead of returning to the
+				// outer wait, which would otherwise wait for a new signal.
+				continue
+			}
+			return true, nil
 		}
 		if !mutated {
 			e.mu.Lock()

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/engine_termination_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/engine_termination_test.go
@@ -43,3 +43,39 @@ func TestRunReturnsIncompleteDrainErrorAfterTerminationClassification(t *testing
 		t.Fatalf("Run() error = %v, want errors.Is(..., ErrIncompleteDrain)", err)
 	}
 }
+
+func TestRunReevaluatesTerminationAfterDispatchHookWake(t *testing.T) {
+	n := buildTestNet()
+	hook := newTestDispatchResultHook()
+	checks := 0
+	terminator := &mockSubsystem{
+		group: subsystems.TerminationCheck,
+		execFn: func(_ context.Context, _ *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) (*interfaces.TickResult, error) {
+			checks++
+			if checks == 1 {
+				hook.SignalBufferedResults()
+			}
+			classification := interfaces.TerminationClassificationIncomplete
+			if checks > 1 {
+				classification = interfaces.TerminationClassificationComplete
+			}
+			return &interfaces.TickResult{
+				ShouldTerminate: true,
+				Termination: &interfaces.TerminationResult{
+					Classification:       classification,
+					NonTerminalWorkCount: 1,
+				},
+			}, nil
+		},
+	}
+	engine := newTestFactoryEngine(n, petri.NewMarking("test-wf"), []subsystems.Subsystem{terminator},
+		WithDispatchResultHook(hook),
+	)
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v, want a successful re-evaluation", err)
+	}
+	if checks != 2 {
+		t.Fatalf("termination checks = %d, want 2 after dispatch hook wake", checks)
+	}
+}

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/runtime_state.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/runtime_state.go
@@ -109,7 +109,7 @@ func (e *FactoryEngine) tickOnce(ctx context.Context) (bool, bool, error) {
 	return e.tick(ctx)
 }
 
-func (e *FactoryEngine) finishTerminationDrain() (bool, error) {
+func (e *FactoryEngine) finishTerminationDrain() bool {
 	e.mu.Lock()
 	e.acceptingSubmits = false
 	drained := e.drainChannels()
@@ -118,9 +118,9 @@ func (e *FactoryEngine) finishTerminationDrain() (bool, error) {
 	}
 	e.mu.Unlock()
 	if drained {
-		return false, nil
+		return false
 	}
-	return true, nil
+	return true
 }
 
 // Tick executes a single tick synchronously. Drains all pending channel events

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/runtime_state.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/runtime_state.go
@@ -182,11 +182,20 @@ func (e *FactoryEngine) GetResultBuffer() *buffers.TypedBuffer[workerexecution.W
 // Returns true when at least one signal was drained.
 func (e *FactoryEngine) drainChannels() bool {
 	drained := false
+	var dispatchWait <-chan struct{}
+	if e.dispatchHook != nil {
+		dispatchWait = e.dispatchHook.WaitCh()
+	}
 	for {
 		select {
 		case <-e.resultCh:
 			e.handleResult()
 			drained = true
+		case <-dispatchWait:
+			// A dispatch-result hook wake-up is itself a reason to rerun the
+			// termination check. The hook may have drained activity without
+			// leaving a result in the engine-owned result channel yet.
+			return true
 		default:
 			select {
 			case <-e.submitSignal:

--- a/prd.json
+++ b/prd.json
@@ -1,75 +1,39 @@
 {
-  "project": "WO-B2 — Reusable AGY Production Review Roles",
-  "branchName": "wo-b2-agy-production-review-roles",
-  "description": "Ship two first-party packaged AGY review roles: a context-free cold-watch reviewer for completed cuts and a deterministic clip-QA gate for rendered clips. Both roles pass media paths unchanged through the existing ANTIGRAVITY provider, define exact success and failure contracts, remain offline in ordinary CI, and include operator guidance for production composition.",
+  "project": "Plain Batch Honest-Drain Semantics",
+  "branchName": "pf-plain-batch-drain",
+  "description": "Make finite plain batch runs without --with-server terminate non-zero with the existing explicit incomplete-drain diagnostic when worker activity drains while Work remains stranded in PROCESSING, instead of hanging forever. Prove the correction through the public CLI process with a deterministic mock worker that never completes while preserving terminal-batch success and continuous-mode liveness.",
   "context": {
-    "customerAsk": "Deliver WO-B2 as one coherent reusable role slice: a cold-watch final reviewer that receives only a completed-cut path and reports what happens plus temporal and audio defects, and a clip-QA gate that receives a clip path and shot specification and returns a deterministic structured pass-or-reroll verdict. Reuse the existing ANTIGRAVITY provider and real recorded AGY traces, keep normal CI offline, pass file paths directly for AGY to parse, and document exact input, output, failure, and missing-file behavior.",
-    "problem": "WO-B1 and merged PR #1826 provide AGY execution and real video/audio traces, but the repository does not ship reusable production role definitions. Factory authors must invent prompts, schemas, workspace rules, and refusal handling, which creates hidden context and false-success risk because AGY can exit zero and report SUCCESS while declining a missing file.",
-    "solution": "Add independently invocable @you/agy-cold-watch and @you/agy-clip-qa authored Factories to the first-party packaged catalog, generate their distribution artifacts through the existing generator, document and exemplify their production composition, and prove their successful and missing-file behavior through root.BuildProcess, Process.Execute, ProviderCommandRunner, and the real recorded AGY traces without live CI calls or wrapper media transformation."
+    "customerAsk": "Apply the drained-but-incomplete semantics delivered by merged WO-A7 to plain batch mode. Without --with-server, a batch whose mock worker leaves Work in PROCESSING and never completes must exit non-zero with an explicit stranded-work error instead of hanging forever.",
+    "problem": "Finite hosted runs already distinguish completion from a drained runtime that still owns non-terminal Work, but the equivalent plain batch path can wait indefinitely after worker activity stops making progress. Operators and automation receive neither a terminal process result nor an actionable failure and cannot distinguish stranded Work from active processing.",
+    "solution": "Use the existing Factory Runtime termination classification and IncompleteDrainError as the single finite-run contract, make plain batch lifecycle coordination re-evaluate termination when dispatch activity drains, preserve the typed failure through Factory Sessions, and reuse the existing CLI incomplete-drain presenter. Verify the observable result with root.BuildProcess and Process.Execute using a deterministic never-completing mock worker, plus empty, terminal, and continuous counterexamples."
   },
   "acceptanceCriteria": [
-    "The first-party catalog ships independently invocable @you/agy-cold-watch and @you/agy-clip-qa Factories with discoverable descriptions, examples, exact invocation signatures, explicit primary results, and canonical generated catalog artifacts derived from authored sources rather than hand-edited generated files.",
-    "Cold watch accepts only a completed-cut path as creative input and returns the documented observation report covering chronological events, temporal or transient defects, audio content and defects, observed speech, and a pass or reroll recommendation; it neither receives nor seeks creative-brief, shot-specification, intended-beat, or prior-verdict context.",
-    "Clip QA accepts a clip path and shot specification and returns a schema-valid object containing action_completed, spec_deviations, temporal_artifacts, audio_content, unexpected_speech, verdict, and confidence; verdict is exactly pass or reroll, and a missing, invalid, or incomplete result cannot become successful Work.",
-    "Both roles preserve the media path in prompt text and use the existing ANTIGRAVITY Provider and mandatory --add-dir-compatible workspace path without decoding, uploading, copying, probing, frame-stripping, extracting audio from, or otherwise transforming media; missing, unreadable, or inaccessible media fails Work with an actionable non-empty diagnostic and is not a pass or reroll.",
-    "Focused offline functional coverage constructs through root.BuildProcess, executes through Process.Execute, replaces only edges.Edges.ProviderCommandRunner, replays the real AGY video, audio, clip-QA, and missing-file recordings, and proves the selected Factory, provider command, returned content, Factory Events, and terminal Work outcome.",
-    "Quality gates pass: go test ./tests/functional/providers/agy -run '^TestAgyProductionReviewRolesThroughRootBuildProcess$' -count=1, make packaged-factory-catalog-check, make docs-reference-smoke, and make verify-fast pass; Typecheck passes; Tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
-    "The implementation and review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared or generated-file churn are resolved, and the PR is actually merged; opened, green, approved, or ready-to-merge is not complete."
+    "A finite plain you run --work invocation without --with-server, --with-site, or --continuously returns instead of hanging when dispatch activity is drained and one or more Work items remain non-terminal, including Work stranded in PROCESSING by a worker that never returns a completion result.",
+    "The drained plain batch returns a non-zero process result, emits the existing human diagnostic 'Error: factory session drained with N non-terminal work items; run is incomplete' on stderr with the authoritative count, and emits no success or completion output that could misrepresent the run.",
+    "Empty finite plain batches and finite plain batches whose Work is fully terminal still return success, while --continuously runs remain live while idle or in-flight until explicit cancellation and do not report a finite incomplete drain.",
+    "The behavior reuses the Factory Runtime incomplete-termination state and typed error across plain and hosted paths; Factory Sessions and CLI transport propagate and present that state without a second termination policy, hidden mutable state, process-global coordination, or unrelated lifecycle cleanup.",
+    "Quality gates pass: Typecheck passes; Tests pass; the focused runtime, Factory Session, CLI, and plain-batch functional tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
+    "The implementation and review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file churn are resolved against current main, and the PR is actually merged; opened, green, approved, or ready-to-merge is not complete."
   ],
   "userStories": [
     {
-      "id": "wo-b2-agy-production-review-roles-001",
-      "title": "Ship the context-free cold-watch reviewer",
-      "description": "As a production operator, I want an independent reviewer to watch the completed cut without creative-brief context so I can learn what the artifact actually communicates and catch motion or soundtrack defects that upstream authors may have normalized.",
+      "id": "pf-plain-batch-drain-001",
+      "title": "Terminate stranded finite plain batches honestly",
+      "description": "As an operator running a finite batch without a server, I want the command to fail explicitly when worker activity drains while Work remains in processing so automation does not hang or mistake the run for success.",
       "acceptanceCriteria": [
-        "@you/agy-cold-watch is independently invocable with one required cutPath input bound to a clearly named CLI argument; provider model, effort, and timeout may use documented safe defaults or explicit role overrides, but there is no brief, shot-specification, expected-action, or prior-verdict input.",
-        "The effective reviewer instruction treats cutPath as the only creative context, watches the whole file including audio, does not inspect nearby briefs or manifests for intended meaning, and does not infer correctness from filenames or upstream status.",
-        "Successful primary output follows one documented report contract with a chronological description of what happens, timestamped temporal or transient defects, audio content and timestamped audio defects, observed speech, and an overall pass or reroll recommendation; empty sections are explicit rather than omitted.",
-        "The cut path is forwarded unchanged in the AGY prompt and execution uses the existing workspace --add-dir; no wrapper media decoding, upload, copy, probing, frame extraction, or audio extraction occurs.",
-        "An absent, unreadable, unsupported, or workspace-inaccessible cut does not produce a review recommendation: Work reaches the failed path with a non-empty actionable explanation, including when replayed AGY exits zero and reports provider status SUCCESS while refusing the file.",
-        "The cold-watch functional subtest replays the real video and audio recordings and asserts facts from both picture and soundtrack through root.BuildProcess, Process.Execute, and ProviderCommandRunner without a live AGY call.",
+        "Given a finite plain batch and a deterministic mock worker that accepts a dispatch, leaves the associated Work in PROCESSING, and never publishes a completion result, Process.Execute reaches a terminal result without requiring operator cancellation.",
+        "The terminal error matches the existing Factory Runtime incomplete-drain contract, carries the authoritative number of non-terminal Work items, and crosses the Factory Session boundary without being converted to success or a generic unrelated failure.",
+        "The CLI invocation returns non-zero, writes exactly one actionable incomplete-drain diagnostic to stderr containing the non-terminal Work count, and writes no success or completion message to stdout.",
+        "The same functional cell proves an empty finite plain batch and a fully terminal finite plain batch still succeed, and a continuous run does not apply finite-drain failure semantics before cancellation.",
+        "Focused lower-layer tests prove that a drained dispatch signal triggers a termination re-evaluation and that incomplete classification is based on the canonical runtime snapshot rather than a CLI timer or duplicated Work-state scan.",
+        "The functional regression constructs the application through root.BuildProcess, executes through Process.Execute, replaces external effects only through edges.Edges, uses the repository-owned mock-worker feature cell for the never-completing worker, and uses deterministic lifecycle signals; any bounded timeout exists only as a test-failure guard against the original hang and is justified in code.",
+        "No hosted-mode behavior, public API contract, generated artifact, continuous scheduling policy, or unrelated runtime structure changes beyond what is required for plain finite-run parity.",
         "Typecheck passes",
         "Tests pass"
       ],
       "priority": 1,
       "passes": true,
-      "notes": "Implemented @you/agy-cold-watch with a single cutPath input, context-free AGY prompt, and a runtime markdown-observation-report/v1 postcondition requiring inspection status, chronology, timestamped defect/audio sections, observed speech, and exactly one pass-or-reroll recommendation. A complete report is accepted through root.BuildProcess, while both existing real incomplete video/audio traces and the exit-zero missing-file refusal fail Work without a primary recommendation; path and provider evidence remain observable. Focused story, factory-definition, mapping, API-contract, catalog, and docs checks pass."
-    },
-    {
-      "id": "wo-b2-agy-production-review-roles-002",
-      "title": "Ship the deterministic clip-QA gate",
-      "description": "As a shot pipeline author, I want a clip reviewed against its shot specification with a stable pass-or-reroll result so downstream routing can act on the verdict without parsing free-form prose.",
-      "acceptanceCriteria": [
-        "@you/agy-clip-qa is independently invocable with exactly two required creative inputs, clipPath and shotSpecification, bound to discoverable named CLI arguments and preserved without hidden brief or prior-verdict context.",
-        "The role watches the complete clip and evaluates whether the specified action finishes, deviations from the supplied specification, transient and temporal artifacts across time, audio content, and unexpected speech.",
-        "The primary result validates against the recorded B2 schema: action_completed is boolean; spec_deviations and temporal_artifacts are string arrays; audio_content is speech, music, noise, silence, or mixed; unexpected_speech is boolean; verdict is pass or reroll; confidence is from 0 through 1; every field is required.",
-        "pass means the action completes and no specification deviation, reroll-worthy temporal artifact, or disallowed speech is observed; otherwise the role returns reroll and records each reason in the applicable arrays rather than hiding it in prose.",
-        "Missing or inaccessible media, provider or process failure, malformed output, or schema-invalid output fails Work with an actionable diagnostic and never becomes a production reroll, because reroll is reserved for a successfully inspected but unacceptable clip.",
-        "The clip-QA functional subtest replays agy-trace-clipqa-schema.stream.jsonl and the recorded missing-file trace through the public process boundary, asserts the real pass result and audio or no-speech evidence, and proves missing-file refusal reaches failed Work without live AGY.",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Implemented the explicit structured-clip-qa/v1 runtime contract for confidence bounds, required fields, pass invariants, and meaningful inspected rerolls. Structured failure detection now checks status/outcome/success markers before allowing a reroll and rejects unscoped structured rerolls; root.BuildProcess coverage proves pass, accepted reroll, out-of-range/inconsistent results, mixed provider status, schema failure, provider failure, and missing-file failure. The review follow-up also encodes confidence minimum/maximum in the authored and generated provider schema, asserts those bounds in the AGY command, and keeps the validator below the package maintainability threshold. Executor, focused AGY functional, and packaged catalog checks pass."
-    },
-    {
-      "id": "wo-b2-agy-production-review-roles-003",
-      "title": "Document and verify production composition",
-      "description": "As a Factory author, I want a worked, validated example of the two roles and their failure boundaries so I can place them in a production pipeline without hidden media handling or ambiguous routing.",
-      "acceptanceCriteria": [
-        "The packaged-factories reference catalog documents both roles, their purpose, invocation inputs, result shape, default AGY model and timeout policy, workspace-relative and absolute-path expectations, and representative PowerShell-safe invocations whose flags agree with generated help.",
-        "A repository-owned worked example shows clip QA after clip creation and cold watch after mechanical checks assemble the completed cut; it routes pass, reroll, and failed execution distinctly and states that cold watch receives no creative brief even when upstream stages have one.",
-        "The example and operator documentation state that paths must identify readable files within the directory exposed to AGY by the existing --add-dir execution, that the wrapper never transforms media, and that a missing or inaccessible path is an execution failure rather than a review verdict.",
-        "you factory config validate accepts each authored role and example; you run --named @you/agy-cold-watch --help and you run --named @you/agy-clip-qa --help expose the documented inputs; generated catalog files are refreshed only with make packaged-factory-catalog-generate.",
-        "The documentation names go test ./tests/functional/providers/agy -run '^TestAgyProductionReviewRolesThroughRootBuildProcess$' -count=1 as the independently runnable fully offline end-to-end command; any live AGY smoke remains the existing operator-gated B1 smoke and is not duplicated or enabled in ordinary CI.",
-        "Behavioral validation exercises loading, invocation, successful result, schema rejection, provider failure, and missing-file outcomes through public runtime behavior; it does not scan source trees, assert command, route, or catalog inventories, or inspect generated bundle internals as a substitute for those outcomes.",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 3,
-      "passes": true,
-      "notes": "Documented both roles in the packaged-factory reference catalog with exact live-help signatures, pinned ANTIGRAVITY/gemini-3.6-flash-high/8m policy, report schemas, path and failure boundaries, and PowerShell-safe invocations. Added the repository-owned AGY production composition example with distinct pass/reroll/failed routing and the offline root-process command; updated catalog-count/docs smoke coverage. Corrected cold-watch documentation to match live help: required cutPath is available positionally and through --cut-path, and corrected both documented PowerShell parsers to consume the two-line H2 recommendation contract. Authored/generated catalog checks, factory validation, focused root-process coverage, package gates, packaged catalog/source checks, readme-check, and docs-reference smoke pass."
+      "notes": "Implemented Runtime termination-drain wake re-evaluation and verified typed incomplete-drain propagation, exact plain CLI diagnostics, finite empty/terminal success, and continuous idle liveness through root-built functional tests."
     }
   ]
 }

--- a/progress.txt
+++ b/progress.txt
@@ -782,3 +782,22 @@
   - The Runtime termination checker already owns the finite incomplete classification and typed error; the lifecycle bug was that `finishTerminationDrain` reported a consumed wake without its caller looping back into `tickOnce`.
   - Dispatch-result hook wake channels are part of the engine’s pending-input contract and must be drained alongside result and submission signals at the final termination boundary.
 ---
+
+## 2026-08-10 04:57 -07:00 - pf-plain-batch-drain-001 verification follow-up
+- What was implemented
+  - Kept the termination-drain result helper within the repository’s 1000-line backend file limit without changing its semantics.
+- Files changed
+  - `pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go`
+  - `pkg/services/factory_runtime/internal/services/orchestration/engine/runtime_state.go`
+  - `progress.txt`
+- Verification
+  - `go test ./pkg/services/factory_runtime/... -count=1 -timeout 300s` — passed.
+  - `go test ./pkg/services/factory_sessions/... -count=1 -timeout 360s` — passed.
+  - `go test ./tests/functional/sessions/execution -run 'TestWithServerDrainCannotReportSuccessWhileWorkIsNonTerminal|TestHostedFiniteRunsKeepEmptyAndTerminalSuccess|TestHostedContinuousRunsStayLiveWhileIdle' -count=1 -timeout 240s` — passed.
+  - `make test` — passed.
+  - `make backend-size pkg-maint pkg-file-count pkg-structure vet` — passed.
+  - `make verify-fast` — blocked before Go/UI tests by the checkout’s pre-existing dashboard baseline: missing `@types/bun` and TypeScript 6 `baseUrl` deprecation errors.
+- **Learnings for future iterations:**
+  - The backend quality gates report deletion-only baseline entries but pass newly changed files; a small private helper signature reduction is enough to preserve the strict engine file-size boundary.
+  - `make test` remains the reliable repository-wide short Go evidence when the fast aggregate stops early at an unavailable UI dependency.
+---

--- a/progress.txt
+++ b/progress.txt
@@ -813,6 +813,7 @@
   - `go test ./tests/functional/workers/mock -run 'TestPlainBatchDrain' -count=1 -timeout 120s` — passed.
   - `go run ./cmd/functionalboundarycheck` — passed.
   - `git diff --check` — passed.
+  - PR #1845's initial functional lane identified the same forbidden Runtime import; commit `085c00db6` removes it and is ready for a fresh canonical-repository CI run.
 - **Learnings for future iterations:**
   - The functional boundary lane is intentionally stricter than package tests: public harness tests verify observable process behavior, while `errors.As` checks for service-owned types belong in the owning service package.
 ---

--- a/progress.txt
+++ b/progress.txt
@@ -1,4 +1,5 @@
 ## Codebase Patterns
+- When a termination drain consumes a runtime wake signal, the engine must re-enter its tick loop directly; returning to the outer wait loses the already-consumed wake and can strand a finite run.
 - Canonical packaged CLI docs live under `docs/reference/`; adding a topic also requires its authored file in `docs/reference/embed.go` and a registry entry in `pkg/transports/cli/docs/docs.go`.
 - The `you run --named <factory> --help` output is the authoritative invocation contract; omitted role provider/model values resolve through operator defaults.
 - Documentation for model-backed workflows should describe observable result shape and status/artifact evidence rather than byte-stable generated prose.
@@ -760,4 +761,24 @@
   - Documentation parsers for Markdown output must match the report’s structural contract and tolerate the platform’s CRLF line endings; a single-line `Overall recommendation:` pattern is not equivalent to the emitted H2-plus-body form.
   - AGY structured-output replays enforce exact echoed-schema equivalence, so a contract schema change requires the historical replay envelope to be synchronized without changing its recorded response evidence.
   - When a backend package is at the 15-file limit, consolidate focused behavioral tests into an existing responsibility-aligned file before adding another package-local test file.
+---
+
+## 2026-08-10 04:44 -07:00 - pf-plain-batch-drain-001
+- What was implemented
+  - Made Factory Runtime termination-drain coordination re-evaluate immediately when a result, submission, or dispatch-result hook wake is consumed at the termination boundary.
+  - Added a focused engine regression proving a dispatch hook wake causes a second canonical termination check instead of returning to a blocked outer wait.
+  - Added root-built public plain-batch coverage for stranded PROCESSING Work, exact typed incomplete-drain propagation and stderr, empty and terminal finite success, and continuous idle liveness.
+- Files changed
+  - `pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go`
+  - `pkg/services/factory_runtime/internal/services/orchestration/engine/runtime_state.go`
+  - `pkg/services/factory_runtime/internal/services/orchestration/engine/engine_termination_test.go`
+  - `tests/functional/workers/mock/plain_batch_drain_test.go`
+  - `progress.txt`
+  - `prd.json`
+- Verification
+  - `go test ./pkg/services/factory_runtime/internal/services/orchestration/... ./pkg/services/factory_sessions/internal/processlifecycle ./pkg/services/factory_sessions/internal/runtimehosting ./pkg/transports/cli/run ./tests/functional/workers/mock -run 'TestRun(ReevaluatesTerminationAfterDispatchHookWake|ReturnsIncompleteDrainErrorAfterTerminationClassification)$|TestPlainBatchDrain' -count=1 -timeout 180s` — passed.
+  - `git diff --check` — passed.
+- **Learnings for future iterations:**
+  - The Runtime termination checker already owns the finite incomplete classification and typed error; the lifecycle bug was that `finishTerminationDrain` reported a consumed wake without its caller looping back into `tickOnce`.
+  - Dispatch-result hook wake channels are part of the engine’s pending-input contract and must be drained alongside result and submission signals at the final termination boundary.
 ---

--- a/progress.txt
+++ b/progress.txt
@@ -1,5 +1,6 @@
 ## Codebase Patterns
 - When a termination drain consumes a runtime wake signal, the engine must re-enter its tick loop directly; returning to the outer wait loses the already-consumed wake and can strand a finite run.
+- Customer-facing functional tests must compose through `root.BuildProcess` and assert public process/CLI behavior; keep service-specific typed-error assertions in service-layer tests because the functional boundary check rejects direct Runtime imports.
 - Canonical packaged CLI docs live under `docs/reference/`; adding a topic also requires its authored file in `docs/reference/embed.go` and a registry entry in `pkg/transports/cli/docs/docs.go`.
 - The `you run --named <factory> --help` output is the authoritative invocation contract; omitted role provider/model values resolve through operator defaults.
 - Documentation for model-backed workflows should describe observable result shape and status/artifact evidence rather than byte-stable generated prose.
@@ -800,4 +801,18 @@
 - **Learnings for future iterations:**
   - The backend quality gates report deletion-only baseline entries but pass newly changed files; a small private helper signature reduction is enough to preserve the strict engine file-size boundary.
   - `make test` remains the reliable repository-wide short Go evidence when the fast aggregate stops early at an unavailable UI dependency.
+---
+
+## 2026-08-10 05:08 -07:00 - pf-plain-batch-drain-001 CI boundary follow-up
+- What was implemented
+  - Adjusted the plain customer-boundary assertion to avoid a forbidden direct Runtime service import while retaining exact stderr and process failure coverage.
+- Files changed
+  - `tests/functional/workers/mock/plain_batch_drain_test.go`
+  - `progress.txt`
+- Verification
+  - `go test ./tests/functional/workers/mock -run 'TestPlainBatchDrain' -count=1 -timeout 120s` — passed.
+  - `go run ./cmd/functionalboundarycheck` — passed.
+  - `git diff --check` — passed.
+- **Learnings for future iterations:**
+  - The functional boundary lane is intentionally stricter than package tests: public harness tests verify observable process behavior, while `errors.As` checks for service-owned types belong in the owning service package.
 ---

--- a/tests/functional/workers/mock/plain_batch_drain_test.go
+++ b/tests/functional/workers/mock/plain_batch_drain_test.go
@@ -1,0 +1,208 @@
+package mock
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const plainBatchDrainTestTimeout = 15 * time.Second
+
+// TestPlainBatchDrainReportsStrandedWork proves the no-server customer path
+// returns the canonical incomplete-drain diagnostic after a deterministic mock
+// worker completes its dispatch but leaves Work in PROCESSING.
+func TestPlainBatchDrainReportsStrandedWork(t *testing.T) {
+	factoryDir := scaffoldPlainBatchDrainFactory(t)
+	workFile := writePlainBatchDrainWork(t)
+	mockWorkersFile := writePlainBatchDrainMockWorkers(t)
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "run", "--dir", factoryDir, "--no-record", "--quiet",
+		"--work", workFile, "--with-mock-workers", mockWorkersFile,
+	})
+	inputs.WorkingDirectory = factoryDir
+	homeDir := t.TempDir()
+	inputs.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+
+	command := support.StartProcessCommand(t, process, inputs.Input)
+	// ProcessCommand.Done is the deterministic completion signal. This bounded
+	// guard exists only to turn the original plain-batch hang into a test
+	// failure rather than leaving the suite blocked indefinitely.
+	timer := time.NewTimer(plainBatchDrainTestTimeout)
+	defer timer.Stop()
+	select {
+	case <-command.Done():
+	case <-timer.C:
+		t.Fatal("plain finite batch did not return after dispatch activity drained")
+	}
+	command.AcceptError()
+
+	err := command.Err()
+	var incompleteDrainErr *factoryruntime.IncompleteDrainError
+	if err == nil || !errors.As(err, &incompleteDrainErr) {
+		t.Fatalf("Process.Execute() error = %v, want incomplete-drain failure", err)
+	}
+	if incompleteDrainErr.NonTerminalWorkCount != 1 {
+		t.Fatalf("non-terminal Work count = %d, want 1", incompleteDrainErr.NonTerminalWorkCount)
+	}
+	if got, want := inputs.Stderr(), "Error: factory session drained with 1 non-terminal work items; run is incomplete\n"; got != want {
+		t.Fatalf("stderr = %q, want %q; err=%v", got, want, err)
+	}
+	if stdout := inputs.Stdout(); stdout != "" {
+		t.Fatalf("stdout = %q, want no success or completion output", stdout)
+	}
+}
+
+func TestPlainBatchDrainPreservesFiniteAndContinuousCounterexamples(t *testing.T) {
+	factoryDir := scaffoldPlainBatchDrainFactory(t)
+
+	for _, scenario := range []struct {
+		name     string
+		workFile func(*testing.T) string
+	}{
+		{name: "empty"},
+		{name: "terminal work", workFile: func(t *testing.T) string {
+			return writePlainBatchDrainWorkState(t, "complete")
+		}},
+	} {
+		scenario := scenario
+		t.Run(scenario.name, func(t *testing.T) {
+			var workFile string
+			if scenario.workFile != nil {
+				workFile = scenario.workFile(t)
+			}
+			inputs := plainBatchInputs(t, factoryDir, workFile, false)
+			process := support.BuildProcess(t, serviceedges.Edges{})
+			support.CleanupProcess(t, process)
+
+			if err := process.Execute(inputs.Input); err != nil {
+				t.Fatalf("finite plain batch error = %v; stdout=%q stderr=%q", err, inputs.Stdout(), inputs.Stderr())
+			}
+			if inputs.Stdout() != "" || inputs.Stderr() != "" {
+				t.Fatalf("finite plain success output = stdout:%q stderr:%q, want quiet output", inputs.Stdout(), inputs.Stderr())
+			}
+		})
+	}
+
+	t.Run("continuous idle", func(t *testing.T) {
+		inputs := plainBatchInputs(t, factoryDir, "", true)
+		process := support.BuildProcess(t, serviceedges.Edges{})
+		support.CleanupProcess(t, process)
+		command := support.StartProcessCommand(t, process, inputs.Input)
+
+		select {
+		case <-command.Done():
+			command.AcceptError()
+			t.Fatalf("continuous plain batch exited while idle: err=%v stdout=%q stderr=%q", command.Err(), inputs.Stdout(), inputs.Stderr())
+		case <-time.After(500 * time.Millisecond):
+		}
+		command.Stop(t)
+		if err := command.Err(); err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("continuous plain batch cancellation error = %v", err)
+		}
+		if inputs.Stdout() != "" || inputs.Stderr() != "" {
+			t.Fatalf("continuous plain output = stdout:%q stderr:%q, want quiet output", inputs.Stdout(), inputs.Stderr())
+		}
+	})
+}
+
+func plainBatchInputs(t *testing.T, factoryDir, workFile string, continuous bool) *support.CapturedInputs {
+	t.Helper()
+	args := []string{"you", "run", "--dir", factoryDir, "--no-record", "--quiet"}
+	if continuous {
+		args = append(args, "--continuously")
+	}
+	if workFile != "" {
+		args = append(args, "--work", workFile)
+	}
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.WorkingDirectory = factoryDir
+	homeDir := t.TempDir()
+	inputs.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	return inputs
+}
+
+func scaffoldPlainBatchDrainFactory(t *testing.T) string {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, map[string]any{
+		"workTypes": []map[string]any{{
+			"name": "task",
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "processing", "type": "PROCESSING"},
+				{"name": "complete", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []map[string]string{{"name": "worker-a"}},
+		"workstations": []map[string]any{{
+			"name":      "process",
+			"worker":    "worker-a",
+			"inputs":    []map[string]string{{"workType": "task", "state": "init"}},
+			"outputs":   []map[string]string{{"workType": "task", "state": "processing"}},
+			"onFailure": []map[string]string{{"workType": "task", "state": "failed"}},
+		}},
+	})
+	support.WriteAgentConfig(t, dir, "worker-a", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"))
+	return dir
+}
+
+func writePlainBatchDrainWork(t *testing.T) string {
+	return writePlainBatchDrainWorkState(t, "init")
+}
+
+func writePlainBatchDrainWorkState(t *testing.T, state string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "plain-batch-drain-work.json")
+	payload := map[string]any{
+		"requestId": "plain-batch-drain",
+		"type":      "FACTORY_REQUEST_BATCH",
+		"works": []map[string]any{{
+			"name":         "stranded-work",
+			"workTypeName": "task",
+			"state":        state,
+			"payload":      map[string]string{"purpose": "plain drain regression"},
+		}},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal plain-batch Work: %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write plain-batch Work: %v", err)
+	}
+	return path
+}
+
+func writePlainBatchDrainMockWorkers(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "plain-batch-drain-mock-workers.json")
+	payload := workers.MockWorkersConfig{
+		MockWorkers: []workers.MockWorkerConfig{{
+			WorkerName:      "worker-a",
+			WorkstationName: "process",
+			RunType:         workers.MockWorkerRunTypeAccept,
+		}},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal plain-batch mock workers: %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write plain-batch mock workers: %v", err)
+	}
+	return path
+}

--- a/tests/functional/workers/mock/plain_batch_drain_test.go
+++ b/tests/functional/workers/mock/plain_batch_drain_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
-	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
@@ -50,12 +49,8 @@ func TestPlainBatchDrainReportsStrandedWork(t *testing.T) {
 	command.AcceptError()
 
 	err := command.Err()
-	var incompleteDrainErr *factoryruntime.IncompleteDrainError
-	if err == nil || !errors.As(err, &incompleteDrainErr) {
+	if err == nil {
 		t.Fatalf("Process.Execute() error = %v, want incomplete-drain failure", err)
-	}
-	if incompleteDrainErr.NonTerminalWorkCount != 1 {
-		t.Fatalf("non-terminal Work count = %d, want 1", incompleteDrainErr.NonTerminalWorkCount)
 	}
 	if got, want := inputs.Stderr(), "Error: factory session drained with 1 non-terminal work items; run is incomplete\n"; got != want {
 		t.Fatalf("stderr = %q, want %q; err=%v", got, want, err)


### PR DESCRIPTION
{
  "project": "Plain Batch Honest-Drain Semantics",
  "branchName": "pf-plain-batch-drain",
  "description": "Make finite plain batch runs without --with-server terminate non-zero with the existing explicit incomplete-drain diagnostic when worker activity drains while Work remains stranded in PROCESSING, instead of hanging forever. Prove the correction through the public CLI process with a deterministic mock worker that never completes while preserving terminal-batch success and continuous-mode liveness.",
  "context": {
    "customerAsk": "Apply the drained-but-incomplete semantics delivered by merged WO-A7 to plain batch mode. Without --with-server, a batch whose mock worker leaves Work in PROCESSING and never completes must exit non-zero with an explicit stranded-work error instead of hanging forever.",
    "problem": "Finite hosted runs already distinguish completion from a drained runtime that still owns non-terminal Work, but the equivalent plain batch path can wait indefinitely after worker activity stops making progress. Operators and automation receive neither a terminal process result nor an actionable failure and cannot distinguish stranded Work from active processing.",
    "solution": "Use the existing Factory Runtime termination classification and IncompleteDrainError as the single finite-run contract, make plain batch lifecycle coordination re-evaluate termination when dispatch activity drains, preserve the typed failure through Factory Sessions, and reuse the existing CLI incomplete-drain presenter. Verify the observable result with root.BuildProcess and Process.Execute using a deterministic never-completing mock worker, plus empty, terminal, and continuous counterexamples."
  },
  "acceptanceCriteria": [
    "A finite plain you run --work invocation without --with-server, --with-site, or --continuously returns instead of hanging when dispatch activity is drained and one or more Work items remain non-terminal, including Work stranded in PROCESSING by a worker that never returns a completion result.",
    "The drained plain batch returns a non-zero process result, emits the existing human diagnostic 'Error: factory session drained with N non-terminal work items; run is incomplete' on stderr with the authoritative count, and emits no success or completion output that could misrepresent the run.",
    "Empty finite plain batches and finite plain batches whose Work is fully terminal still return success, while --continuously runs remain live while idle or in-flight until explicit cancellation and do not report a finite incomplete drain.",
    "The behavior reuses the Factory Runtime incomplete-termination state and typed error across plain and hosted paths; Factory Sessions and CLI transport propagate and present that state without a second termination policy, hidden mutable state, process-global coordination, or unrelated lifecycle cleanup.",
    "Quality gates pass: Typecheck passes; Tests pass; the focused runtime, Factory Session, CLI, and plain-batch functional tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation and review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file churn are resolved against current main, and the PR is actually merged; opened, green, approved, or ready-to-merge is not complete."
  ],
  "userStories": [
    {
      "id": "pf-plain-batch-drain-001",
      "title": "Terminate stranded finite plain batches honestly",
      "description": "As an operator running a finite batch without a server, I want the command to fail explicitly when worker activity drains while Work remains in processing so automation does not hang or mistake the run for success.",
      "acceptanceCriteria": [
        "Given a finite plain batch and a deterministic mock worker that accepts a dispatch, leaves the associated Work in PROCESSING, and never publishes a completion result, Process.Execute reaches a terminal result without requiring operator cancellation.",
        "The terminal error matches the existing Factory Runtime incomplete-drain contract, carries the authoritative number of non-terminal Work items, and crosses the Factory Session boundary without being converted to success or a generic unrelated failure.",
        "The CLI invocation returns non-zero, writes exactly one actionable incomplete-drain diagnostic to stderr containing the non-terminal Work count, and writes no success or completion message to stdout.",
        "The same functional cell proves an empty finite plain batch and a fully terminal finite plain batch still succeed, and a continuous run does not apply finite-drain failure semantics before cancellation.",
        "Focused lower-layer tests prove that a drained dispatch signal triggers a termination re-evaluation and that incomplete classification is based on the canonical runtime snapshot rather than a CLI timer or duplicated Work-state scan.",
        "The functional regression constructs the application through root.BuildProcess, executes through Process.Execute, replaces external effects only through edges.Edges, uses the repository-owned mock-worker feature cell for the never-completing worker, and uses deterministic lifecycle signals; any bounded timeout exists only as a test-failure guard against the original hang and is justified in code.",
        "No hosted-mode behavior, public API contract, generated artifact, continuous scheduling policy, or unrelated runtime structure changes beyond what is required for plain finite-run parity.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented Runtime termination-drain wake re-evaluation and verified typed incomplete-drain propagation, exact plain CLI diagnostics, finite empty/terminal success, and continuous idle liveness through root-built functional tests."
    }
  ]
}
